### PR TITLE
Provisioning: change job result struct to use a factory method for better error handling/ownership.

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/delete/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/delete/worker_test.go
@@ -184,10 +184,10 @@ func TestDeleteWorker_ProcessDeleteFilesSuccess(t *testing.T) {
 	mockRepo.On("Delete", mock.Anything, "test/path2", "main", "Delete test/path2").Return(nil)
 
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "test/path1" && result.Action == repository.FileActionDeleted && result.Error == nil
+		return result.Path() == "test/path1" && result.Action() == repository.FileActionDeleted && result.Error() == nil
 	})).Return()
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "test/path2" && result.Action == repository.FileActionDeleted && result.Error == nil
+		return result.Path() == "test/path2" && result.Action() == repository.FileActionDeleted && result.Error() == nil
 	})).Return()
 
 	worker := NewWorker(nil, mockWrapFn.Execute, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
@@ -224,7 +224,7 @@ func TestDeleteWorker_ProcessDeleteFilesWithError(t *testing.T) {
 	mockRepo.On("Delete", mock.Anything, "test/path1", "main", "Delete test/path1").Return(deleteError)
 
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "test/path1" && result.Action == repository.FileActionDeleted && errors.Is(result.Error, deleteError)
+		return result.Path() == "test/path1" && result.Action() == repository.FileActionDeleted && errors.Is(result.Error(), deleteError)
 	})).Return()
 	mockProgress.On("TooManyErrors").Return(errors.New("too many errors"))
 
@@ -263,7 +263,7 @@ func TestDeleteWorker_ProcessWithSyncWorker(t *testing.T) {
 	mockRepo.On("Delete", mock.Anything, "test/path", "", "Delete test/path").Return(nil)
 
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "test/path" && result.Action == repository.FileActionDeleted && result.Error == nil
+		return result.Path() == "test/path" && result.Action() == repository.FileActionDeleted && result.Error() == nil
 	})).Return()
 
 	mockProgress.On("ResetResults").Return()
@@ -371,7 +371,7 @@ func TestDeleteWorker_deleteFiles(t *testing.T) {
 					mockRepo.On("Delete", mock.Anything, path, "main", "Delete "+path).Return(tt.deleteResults[i]).Once()
 					mockProgress.On("SetMessage", mock.Anything, "Deleting "+path).Return().Once()
 					mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-						return result.Path == path && result.Action == repository.FileActionDeleted
+						return result.Path() == path && result.Action() == repository.FileActionDeleted
 					})).Return().Once()
 
 					if tt.tooManyErrors != nil && i == 0 {
@@ -469,13 +469,13 @@ func TestDeleteWorker_ProcessWithResourceRefs(t *testing.T) {
 
 	// Mock progress records
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "test/path1" && result.Action == repository.FileActionDeleted && result.Error == nil
+		return result.Path() == "test/path1" && result.Action() == repository.FileActionDeleted && result.Error() == nil
 	})).Return()
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "dashboards/test-dashboard.json" && result.Action == repository.FileActionDeleted && result.Error == nil
+		return result.Path() == "dashboards/test-dashboard.json" && result.Action() == repository.FileActionDeleted && result.Error() == nil
 	})).Return()
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "folders/test-folder.json" && result.Action == repository.FileActionDeleted && result.Error == nil
+		return result.Path() == "folders/test-folder.json" && result.Action() == repository.FileActionDeleted && result.Error() == nil
 	})).Return()
 
 	worker := NewWorker(nil, mockWrapFn.Execute, mockResourcesFactory, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
@@ -534,7 +534,7 @@ func TestDeleteWorker_ProcessResourceRefsOnly(t *testing.T) {
 	mockRepo.On("Delete", mock.Anything, "dashboards/test-dashboard.json", "main", "Delete dashboards/test-dashboard.json").Return(nil)
 
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "dashboards/test-dashboard.json" && result.Action == repository.FileActionDeleted && result.Error == nil
+		return result.Path() == "dashboards/test-dashboard.json" && result.Action() == repository.FileActionDeleted && result.Error() == nil
 	})).Return()
 
 	worker := NewWorker(nil, mockWrapFn.Execute, mockResourcesFactory, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
@@ -587,10 +587,10 @@ func TestDeleteWorker_ProcessResourceResolutionError(t *testing.T) {
 
 	// Expect error to be recorded, not thrown
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Name == "nonexistent-dashboard" &&
-			result.Group == "dashboard.grafana.app" &&
-			result.Action == repository.FileActionDeleted &&
-			result.Error != nil
+		return result.Name() == "nonexistent-dashboard" &&
+			result.Group() == "dashboard.grafana.app" &&
+			result.Action() == repository.FileActionDeleted &&
+			result.Error() != nil
 	})).Return()
 	mockProgress.On("TooManyErrors").Return(nil)
 
@@ -727,7 +727,7 @@ func TestDeleteWorker_ProcessResourceResolutionTooManyErrors(t *testing.T) {
 
 	// Mock recording error and TooManyErrors returning error
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Name == "nonexistent-dashboard" && result.Error != nil
+		return result.Name() == "nonexistent-dashboard" && result.Error() != nil
 	})).Return()
 	mockProgress.On("TooManyErrors").Return(errors.New("too many errors"))
 
@@ -810,7 +810,7 @@ func TestDeleteWorker_ProcessMixedResourcesWithPartialFailure(t *testing.T) {
 	mockProgress.On("Complete", mock.Anything, mock.Anything).Return(v0alpha1.JobStatus{})
 	// Record the error for the failed resource
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Name == "nonexistent-dashboard" && result.Error != nil
+		return result.Name() == "nonexistent-dashboard" && result.Error() != nil
 	})).Return()
 
 	// Allow continuing after error
@@ -822,10 +822,10 @@ func TestDeleteWorker_ProcessMixedResourcesWithPartialFailure(t *testing.T) {
 
 	// Record successful deletions
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "dashboards/valid-dashboard.json" && result.Error == nil
+		return result.Path() == "dashboards/valid-dashboard.json" && result.Error() == nil
 	})).Return()
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "folders/valid-folder.json" && result.Error == nil
+		return result.Path() == "folders/valid-folder.json" && result.Error() == nil
 	})).Return()
 
 	worker := NewWorker(nil, mockWrapFn.Execute, mockResourcesFactory, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
@@ -910,20 +910,20 @@ func TestDeleteWorker_ProcessWithPathDeduplication(t *testing.T) {
 	mockProgress.On("SetMessage", mock.Anything, "Deleting dashboards/test-dashboard.json").Return()
 	mockRepo.On("Delete", mock.Anything, "dashboards/test-dashboard.json", "main", "Delete dashboards/test-dashboard.json").Return(nil)
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "dashboards/test-dashboard.json" && result.Action == repository.FileActionDeleted && result.Error == nil
+		return result.Path() == "dashboards/test-dashboard.json" && result.Action() == repository.FileActionDeleted && result.Error() == nil
 	})).Return()
 	mockProgress.On("TooManyErrors").Return(nil)
 
 	mockProgress.On("SetMessage", mock.Anything, "Deleting folders/test-folder/").Return()
 	mockRepo.On("Delete", mock.Anything, "folders/test-folder/", "main", "Delete folders/test-folder/").Return(nil)
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "folders/test-folder/" && result.Action == repository.FileActionDeleted && result.Error == nil
+		return result.Path() == "folders/test-folder/" && result.Action() == repository.FileActionDeleted && result.Error() == nil
 	})).Return()
 
 	mockProgress.On("SetMessage", mock.Anything, "Deleting dashboards/unique-dashboard.json").Return()
 	mockRepo.On("Delete", mock.Anything, "dashboards/unique-dashboard.json", "main", "Delete dashboards/unique-dashboard.json").Return(nil)
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "dashboards/unique-dashboard.json" && result.Action == repository.FileActionDeleted && result.Error == nil
+		return result.Path() == "dashboards/unique-dashboard.json" && result.Action() == repository.FileActionDeleted && result.Error() == nil
 	})).Return()
 
 	worker := NewWorker(nil, mockWrapFn.Execute, mockResourcesFactory, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))

--- a/pkg/registry/apis/provisioning/jobs/export/folders_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/folders_test.go
@@ -128,10 +128,10 @@ func TestExportFolders(t *testing.T) {
 				progress.On("SetMessage", mock.Anything, "read folder tree from API server").Return()
 				progress.On("SetMessage", mock.Anything, "write folders to repository").Return()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-					return result.Name == "folder-1-uid" && result.Action == repository.FileActionCreated
+					return result.Name() == "folder-1-uid" && result.Action() == repository.FileActionCreated
 				})).Return()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-					return result.Name == "folder-2-uid" && result.Action == repository.FileActionCreated
+					return result.Name() == "folder-2-uid" && result.Action() == repository.FileActionCreated
 				})).Return()
 				progress.On("TooManyErrors").Return(nil)
 				progress.On("TooManyErrors").Return(nil)
@@ -189,10 +189,10 @@ func TestExportFolders(t *testing.T) {
 				progress.On("SetMessage", mock.Anything, "read folder tree from API server").Return()
 				progress.On("SetMessage", mock.Anything, "write folders to repository").Return()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-					return result.Name == "folder-1-uid" && result.Action == repository.FileActionIgnored && result.Error != nil && result.Error.Error() == "creating folder folder-1-uid at path grafana/folder-1: didn't work"
+					return result.Name() == "folder-1-uid" && result.Action() == repository.FileActionIgnored && result.Error() != nil && result.Error().Error() == "creating folder folder-1-uid at path grafana/folder-1: didn't work"
 				})).Return()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-					return result.Name == "folder-2-uid" && result.Action == repository.FileActionCreated
+					return result.Name() == "folder-2-uid" && result.Action() == repository.FileActionCreated
 				})).Return()
 				progress.On("TooManyErrors").Return(nil)
 				progress.On("TooManyErrors").Return(nil)
@@ -298,10 +298,10 @@ func TestExportFolders(t *testing.T) {
 				progress.On("SetMessage", mock.Anything, "read folder tree from API server").Return()
 				progress.On("SetMessage", mock.Anything, "write folders to repository").Return()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-					return result.Name == "parent-folder" && result.Action == repository.FileActionCreated
+					return result.Name() == "parent-folder" && result.Action() == repository.FileActionCreated
 				})).Return()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-					return result.Name == "child-folder" && result.Action == repository.FileActionCreated
+					return result.Name() == "child-folder" && result.Action() == repository.FileActionCreated
 				})).Return()
 				progress.On("TooManyErrors").Return(nil)
 				progress.On("TooManyErrors").Return(nil)

--- a/pkg/registry/apis/provisioning/jobs/export/resources_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources_test.go
@@ -88,10 +88,10 @@ func TestExportResources_Dashboards_Success(t *testing.T) {
 		progress.On("SetMessage", mock.Anything, "start resource export").Return()
 		progress.On("SetMessage", mock.Anything, "export dashboards").Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Name == "dashboard-1" && result.Action == repository.FileActionCreated
+			return result.Name() == "dashboard-1" && result.Action() == repository.FileActionCreated
 		})).Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Name == "dashboard-2" && result.Action == repository.FileActionCreated
+			return result.Name() == "dashboard-2" && result.Action() == repository.FileActionCreated
 		})).Return()
 		progress.On("TooManyErrors").Return(nil)
 		progress.On("TooManyErrors").Return(nil)
@@ -141,10 +141,10 @@ func TestExportResources_Dashboards_WithErrors(t *testing.T) {
 		progress.On("SetMessage", mock.Anything, "start resource export").Return()
 		progress.On("SetMessage", mock.Anything, "export dashboards").Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Name == "dashboard-1" && result.Action == repository.FileActionIgnored && result.Error != nil && result.Error.Error() == "writing resource file for dashboard-1: failed to export dashboard"
+			return result.Name() == "dashboard-1" && result.Action() == repository.FileActionIgnored && result.Error() != nil && result.Error().Error() == "writing resource file for dashboard-1: failed to export dashboard"
 		})).Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Name == "dashboard-2" && result.Action == repository.FileActionCreated
+			return result.Name() == "dashboard-2" && result.Action() == repository.FileActionCreated
 		})).Return()
 		progress.On("TooManyErrors").Return(nil)
 		progress.On("TooManyErrors").Return(nil)
@@ -179,7 +179,7 @@ func TestExportResources_Dashboards_TooManyErrors(t *testing.T) {
 		progress.On("SetMessage", mock.Anything, "start resource export").Return()
 		progress.On("SetMessage", mock.Anything, "export dashboards").Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Name == "dashboard-1" && result.Action == repository.FileActionIgnored && result.Error != nil && result.Error.Error() == "writing resource file for dashboard-1: failed to export dashboard"
+			return result.Name() == "dashboard-1" && result.Action() == repository.FileActionIgnored && result.Error() != nil && result.Error().Error() == "writing resource file for dashboard-1: failed to export dashboard"
 		})).Return()
 		progress.On("TooManyErrors").Return(fmt.Errorf("too many errors encountered"))
 	}
@@ -209,7 +209,7 @@ func TestExportResources_Dashboards_IgnoresExisting(t *testing.T) {
 		progress.On("SetMessage", mock.Anything, "start resource export").Return()
 		progress.On("SetMessage", mock.Anything, "export dashboards").Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Name == "existing-dashboard" && result.Action == repository.FileActionIgnored
+			return result.Name() == "existing-dashboard" && result.Action() == repository.FileActionIgnored
 		})).Return()
 		progress.On("TooManyErrors").Return(nil)
 	}
@@ -256,7 +256,7 @@ func TestExportResources_Dashboards_SavedVersion(t *testing.T) {
 		progress.On("SetMessage", mock.Anything, "start resource export").Return()
 		progress.On("SetMessage", mock.Anything, "export dashboards").Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Name == "existing-dashboard" && result.Action == repository.FileActionIgnored
+			return result.Name() == "existing-dashboard" && result.Action() == repository.FileActionIgnored
 		})).Return()
 		progress.On("TooManyErrors").Return(nil)
 	}
@@ -320,9 +320,9 @@ func TestExportResources_Dashboards_FailedConversionNoStoredVersion(t *testing.T
 		progress.On("SetMessage", mock.Anything, "start resource export").Return()
 		progress.On("SetMessage", mock.Anything, "export dashboards").Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Name == "dashboard-no-stored-version" &&
-				result.Action == repository.FileActionIgnored &&
-				result.Error != nil
+			return result.Name() == "dashboard-no-stored-version" &&
+				result.Action() == repository.FileActionIgnored &&
+				result.Error() != nil
 		})).Return()
 		progress.On("TooManyErrors").Return(nil)
 	}
@@ -469,20 +469,20 @@ func TestExportResources_Dashboards_Versions(t *testing.T) {
 				progress.On("SetMessage", mock.Anything, "export dashboards").Return()
 				if tt.expectSuccess {
 					progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-						return result.Name == tt.dashboardName && result.Action == repository.FileActionCreated
+						return result.Name() == tt.dashboardName && result.Action() == repository.FileActionCreated
 					})).Return()
 				} else {
 					progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-						if result.Name != tt.dashboardName {
+						if result.Name() != tt.dashboardName {
 							return false
 						}
-						if result.Action != repository.FileActionIgnored {
+						if result.Action() != repository.FileActionIgnored {
 							return false
 						}
-						if result.Error == nil {
+						if result.Error() == nil {
 							return false
 						}
-						return result.Error.Error() == tt.expectedError
+						return result.Error().Error() == tt.expectedError
 					})).Return()
 				}
 				progress.On("TooManyErrors").Return(nil)
@@ -540,7 +540,7 @@ func TestExportResources_Dashboards_SkipsManagedResources(t *testing.T) {
 		progress.On("SetMessage", mock.Anything, "start resource export").Return()
 		progress.On("SetMessage", mock.Anything, "export dashboards").Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Name == "managed-dashboard" && result.Action == repository.FileActionIgnored
+			return result.Name() == "managed-dashboard" && result.Action() == repository.FileActionIgnored
 		})).Return()
 		progress.On("TooManyErrors").Return(nil).Maybe()
 	}
@@ -608,8 +608,8 @@ func TestExportResources_Dashboards_MultipleVersions(t *testing.T) {
 		progress.On("SetMessage", mock.Anything, "start resource export").Return()
 		progress.On("SetMessage", mock.Anything, "export dashboards").Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return (result.Name == "v2alpha-dashboard" || result.Name == "v2beta-dashboard" || result.Name == "v3-dashboard") &&
-				result.Action == repository.FileActionCreated
+			return (result.Name() == "v2alpha-dashboard" || result.Name() == "v2beta-dashboard" || result.Name() == "v3-dashboard") &&
+				result.Action() == repository.FileActionCreated
 		})).Return().Times(3)
 		progress.On("TooManyErrors").Return(nil).Times(3)
 	}

--- a/pkg/registry/apis/provisioning/jobs/job_resource_result.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result.go
@@ -1,0 +1,158 @@
+package jobs
+
+import (
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// JobResourceResult represents the result of a resource operation in a job.
+type JobResourceResult struct {
+	name    string
+	group   string
+	kind    string
+	path    string
+	action  repository.FileAction
+	err     error
+	warning error
+}
+
+// jobResourceResultBuilder is a builder for creating JobResourceResult instances using a fluent API.
+type jobResourceResultBuilder struct {
+	result JobResourceResult
+}
+
+// NewResourceResult creates a new builder for JobResourceResult.
+func NewResourceResult() *jobResourceResultBuilder {
+	return &jobResourceResultBuilder{
+		result: JobResourceResult{},
+	}
+}
+
+// NewPathOnlyResult creates a new builder with the path already set.
+// This is used for operations that cannot be references to a Grafana resource or when the resource is not yet known.
+func NewPathOnlyResult(path string) *jobResourceResultBuilder {
+	return NewResourceResult().WithPath(path)
+}
+
+func NewGroupKindResult(name string, group, kind string) *jobResourceResultBuilder {
+	return NewResourceResult().
+		WithName(name).
+		WithGroup(group).
+		WithKind(kind)
+}
+
+func NewGVKResult(name string, gvk schema.GroupVersionKind) *jobResourceResultBuilder {
+	return NewResourceResult().
+		WithName(name).
+		WithGVK(gvk)
+}
+
+func NewFolderResult(name string) *jobResourceResultBuilder {
+	return NewResourceResult().
+		WithPath(name).
+		WithGroup(resources.FolderResource.Group).
+		WithKind(resources.FolderKind.Kind)
+}
+
+// WithName sets the name of the resource.
+func (b *jobResourceResultBuilder) WithName(name string) *jobResourceResultBuilder {
+	b.result.name = name
+	return b
+}
+
+// WithGroup sets the group of the resource.
+func (b *jobResourceResultBuilder) WithGroup(group string) *jobResourceResultBuilder {
+	b.result.group = group
+	return b
+}
+
+// WithKind sets the kind of the resource.
+func (b *jobResourceResultBuilder) WithKind(kind string) *jobResourceResultBuilder {
+	b.result.kind = kind
+	return b
+}
+
+// WithGVK sets the group and kind of the resource.
+func (b *jobResourceResultBuilder) WithGVK(gvk schema.GroupVersionKind) *jobResourceResultBuilder {
+	b.result.group = gvk.Group
+	b.result.kind = gvk.Kind
+	return b
+}
+
+// WithGKR sets the name, group, and kind of the resource in one call.
+// This is a convenience method for setting Group/Kind/Resource information together.
+func (b *jobResourceResultBuilder) WithGKR(name, group, kind string) *jobResourceResultBuilder {
+	b.result.name = name
+	b.result.group = group
+	b.result.kind = kind
+	return b
+}
+
+// WithPath sets the path of the resource.
+func (b *jobResourceResultBuilder) WithPath(path string) *jobResourceResultBuilder {
+	b.result.path = path
+	return b
+}
+
+// WithAction sets the action performed on the resource.
+func (b *jobResourceResultBuilder) WithAction(action repository.FileAction) *jobResourceResultBuilder {
+	b.result.action = action
+	return b
+}
+
+// WithError sets the error associated with the resource operation.
+func (b *jobResourceResultBuilder) WithError(err error) *jobResourceResultBuilder {
+	b.result.err = err
+	return b
+}
+
+// AsSkipped marks the resource as skipped by setting the action to Ignored and converting the error to a warning.
+func (b *jobResourceResultBuilder) AsSkipped() *jobResourceResultBuilder {
+	b.result.action = repository.FileActionIgnored
+	if b.result.err != nil {
+		b.result.warning = b.result.err
+		b.result.err = nil
+	}
+	return b
+}
+
+// Build returns the final JobResourceResult.
+func (b *jobResourceResultBuilder) Build() JobResourceResult {
+	return b.result
+}
+
+// Name returns the name of the resource.
+func (r JobResourceResult) Name() string {
+	return r.name
+}
+
+// Group returns the group of the resource.
+func (r JobResourceResult) Group() string {
+	return r.group
+}
+
+// Kind returns the kind of the resource.
+func (r JobResourceResult) Kind() string {
+	return r.kind
+}
+
+// Path returns the path of the resource.
+func (r JobResourceResult) Path() string {
+	return r.path
+}
+
+// Action returns the action performed on the resource.
+func (r JobResourceResult) Action() repository.FileAction {
+	return r.action
+}
+
+// Error returns the error associated with the resource operation.
+func (r JobResourceResult) Error() error {
+	return r.err
+}
+
+// Warning returns the warning associated with the resource operation.
+func (r JobResourceResult) Warning() error {
+	return r.warning
+}

--- a/pkg/registry/apis/provisioning/jobs/job_resource_result_test.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result_test.go
@@ -1,0 +1,95 @@
+package jobs
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSkippedJobResourceResult(t *testing.T) {
+	name := "test-resource"
+	group := "test-group"
+	kind := "test-kind"
+	path := "/test/path"
+	err := errors.New("skip reason")
+
+	result := NewResourceResult().
+		WithName(name).
+		WithGroup(group).
+		WithKind(kind).
+		WithPath(path).
+		WithError(err).
+		AsSkipped().
+		Build()
+
+	assert.Equal(t, name, result.Name())
+	assert.Equal(t, group, result.Group())
+	assert.Equal(t, kind, result.Kind())
+	assert.Equal(t, path, result.Path())
+	assert.Equal(t, repository.FileActionIgnored, result.Action())
+	assert.Equal(t, err, result.Warning())
+	assert.Nil(t, result.Error())
+}
+
+func TestNewJobResourceResult_WithError(t *testing.T) {
+	name := "test-resource"
+	group := "test-group"
+	kind := "test-kind"
+	path := "/test/path"
+	action := repository.FileActionCreated
+	err := errors.New("operation failed")
+
+	result := NewResourceResult().
+		WithName(name).
+		WithGroup(group).
+		WithKind(kind).
+		WithPath(path).
+		WithAction(action).
+		WithError(err).
+		Build()
+
+	assert.Equal(t, name, result.Name())
+	assert.Equal(t, group, result.Group())
+	assert.Equal(t, kind, result.Kind())
+	assert.Equal(t, path, result.Path())
+	assert.Equal(t, action, result.Action())
+	assert.NotNil(t, result.Error())
+	assert.Equal(t, err, result.Error())
+}
+
+func TestNewJobResourceResult_WithoutError(t *testing.T) {
+	name := "test-resource"
+	group := "test-group"
+	kind := "test-kind"
+	path := "/test/path"
+	action := repository.FileActionUpdated
+
+	result := NewResourceResult().
+		WithName(name).
+		WithGroup(group).
+		WithKind(kind).
+		WithPath(path).
+		WithAction(action).
+		Build()
+
+	assert.Equal(t, name, result.Name())
+	assert.Equal(t, group, result.Group())
+	assert.Equal(t, kind, result.Kind())
+	assert.Equal(t, path, result.Path())
+	assert.Equal(t, action, result.Action())
+	assert.Nil(t, result.Error())
+}
+
+func TestNewJobResourceResult_WithFolderResult(t *testing.T) {
+	path := "/test/path"
+	action := repository.FileActionCreated
+
+	result := NewFolderResult(path).WithAction(action).Build()
+	assert.Equal(t, resources.FolderResource.Group, result.Group())
+	assert.Equal(t, resources.FolderKind.Kind, result.Kind())
+	assert.Equal(t, path, result.Path())
+	assert.Equal(t, action, result.Action())
+}

--- a/pkg/registry/apis/provisioning/jobs/migrate/clean.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/clean.go
@@ -40,37 +40,33 @@ func (c *namespaceCleaner) Clean(ctx context.Context, namespace string, progress
 		}
 
 		if err = resources.ForEach(ctx, client, func(item *unstructured.Unstructured) error {
-			result := jobs.JobResourceResult{
-				Name:   item.GetName(),
-				Kind:   item.GetKind(),
-				Group:  item.GroupVersionKind().Group,
-				Action: repository.FileActionDeleted,
-			}
+			gvk := item.GroupVersionKind()
+			resultBuilder := jobs.NewGVKResult(item.GetName(), gvk).WithAction(repository.FileActionDeleted)
 
 			// Skip provisioned resources - only delete unprovisioned (unmanaged) resources
 			meta, err := utils.MetaAccessor(item)
 			if err != nil {
-				result.Error = fmt.Errorf("extracting meta accessor for resource %s: %w", result.Name, err)
-				progress.Record(ctx, result)
+				resultBuilder.WithError(fmt.Errorf("extracting meta accessor for resource %s: %w", item.GetName(), err))
+				progress.Record(ctx, resultBuilder.Build())
 				return nil // Continue with next resource
 			}
 
 			manager, _ := meta.GetManagerProperties()
 			// Skip if resource is managed by any provisioning system
 			if manager.Identity != "" {
-				result.Action = repository.FileActionIgnored
-				progress.Record(ctx, result)
+				resultBuilder.WithAction(repository.FileActionIgnored)
+				progress.Record(ctx, resultBuilder.Build())
 				return nil // Skip this resource
 			}
 
 			// Deletion works by name, so we can use any client regardless of version
 			if err := client.Delete(ctx, item.GetName(), metav1.DeleteOptions{}); err != nil {
-				result.Error = fmt.Errorf("deleting resource %s/%s %s: %w", result.Group, result.Kind, result.Name, err)
-				progress.Record(ctx, result)
+				resultBuilder.WithError(fmt.Errorf("deleting resource %s/%s %s: %w", item.GroupVersionKind().Group, item.GetKind(), item.GetName(), err))
+				progress.Record(ctx, resultBuilder.Build())
 				return fmt.Errorf("delete resource: %w", err)
 			}
 
-			progress.Record(ctx, result)
+			progress.Record(ctx, resultBuilder.Build())
 			return nil
 		}); err != nil {
 			return err

--- a/pkg/registry/apis/provisioning/jobs/migrate/clean_test.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/clean_test.go
@@ -124,10 +124,10 @@ func TestNamespaceCleaner_Clean(t *testing.T) {
 		progress := jobs.NewMockJobProgressRecorder(t)
 		progress.On("SetMessage", mock.Anything, mock.Anything).Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Action == repository.FileActionDeleted &&
-				result.Name == "test-folder" &&
-				result.Error != nil &&
-				result.Error.Error() == "deleting resource folder.grafana.app/Folder test-folder: delete failed"
+			return result.Action() == repository.FileActionDeleted &&
+				result.Name() == "test-folder" &&
+				result.Error() != nil &&
+				result.Error().Error() == "deleting resource folder.grafana.app/Folder test-folder: delete failed"
 		})).Return()
 
 		err := cleaner.Clean(context.Background(), "test-namespace", progress)
@@ -194,21 +194,21 @@ func TestNamespaceCleaner_Clean(t *testing.T) {
 
 		// Expect only unprovisioned resources to be deleted (2 deletions)
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Action == repository.FileActionDeleted &&
-				result.Name == "unprovisioned-folder" &&
-				result.Error == nil
+			return result.Action() == repository.FileActionDeleted &&
+				result.Name() == "unprovisioned-folder" &&
+				result.Error() == nil
 		})).Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Action == repository.FileActionDeleted &&
-				result.Name == "unprovisioned-dashboard" &&
-				result.Error == nil
+			return result.Action() == repository.FileActionDeleted &&
+				result.Name() == "unprovisioned-dashboard" &&
+				result.Error() == nil
 		})).Return()
 
 		// Expect provisioned resource to be ignored (1 ignore)
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Action == repository.FileActionIgnored &&
-				result.Name == "provisioned-dashboard" &&
-				result.Error == nil
+			return result.Action() == repository.FileActionIgnored &&
+				result.Name() == "provisioned-dashboard" &&
+				result.Error() == nil
 		})).Return()
 
 		err := cleaner.Clean(context.Background(), "test-namespace", progress)
@@ -267,14 +267,14 @@ func TestNamespaceCleaner_Clean(t *testing.T) {
 
 		// Expect both resources to be ignored (no deletions)
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Action == repository.FileActionIgnored &&
-				result.Name == "repo-managed-dashboard" &&
-				result.Error == nil
+			return result.Action() == repository.FileActionIgnored &&
+				result.Name() == "repo-managed-dashboard" &&
+				result.Error() == nil
 		})).Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Action == repository.FileActionIgnored &&
-				result.Name == "file-provisioned-folder" &&
-				result.Error == nil
+			return result.Action() == repository.FileActionIgnored &&
+				result.Name() == "file-provisioned-folder" &&
+				result.Error() == nil
 		})).Return()
 
 		err := cleaner.Clean(context.Background(), "test-namespace", progress)

--- a/pkg/registry/apis/provisioning/jobs/move/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/move/worker_test.go
@@ -220,10 +220,10 @@ func TestMoveWorker_ProcessMoveFilesSuccess(t *testing.T) {
 	mockRepo.On("Move", mock.Anything, "test/path2", "new/location/path2", "main", "Move test/path2 to new/location/path2").Return(nil)
 
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "test/path1" && result.Action == repository.FileActionRenamed && result.Error == nil
+		return result.Path() == "test/path1" && result.Action() == repository.FileActionRenamed && result.Error() == nil
 	})).Return()
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "test/path2" && result.Action == repository.FileActionRenamed && result.Error == nil
+		return result.Path() == "test/path2" && result.Action() == repository.FileActionRenamed && result.Error() == nil
 	})).Return()
 
 	worker := NewWorker(nil, mockWrapFn.Execute, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
@@ -261,7 +261,7 @@ func TestMoveWorker_ProcessMoveFilesWithError(t *testing.T) {
 	mockRepo.On("Move", mock.Anything, "test/path1", "new/location/path1", "main", "Move test/path1 to new/location/path1").Return(moveError)
 
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "test/path1" && result.Action == repository.FileActionRenamed && errors.Is(result.Error, moveError)
+		return result.Path() == "test/path1" && result.Action() == repository.FileActionRenamed && errors.Is(result.Error(), moveError)
 	})).Return()
 	mockProgress.On("TooManyErrors").Return(errors.New("too many errors"))
 
@@ -300,7 +300,7 @@ func TestMoveWorker_ProcessWithSyncWorker(t *testing.T) {
 	mockRepo.On("Move", mock.Anything, "test/path", "new/location/path", "", "Move test/path to new/location/path").Return(nil)
 
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "test/path" && result.Action == repository.FileActionRenamed && result.Error == nil
+		return result.Path() == "test/path" && result.Action() == repository.FileActionRenamed && result.Error() == nil
 	})).Return()
 
 	mockProgress.On("ResetResults").Return()
@@ -422,7 +422,7 @@ func TestMoveWorker_moveFiles(t *testing.T) {
 					mockRepo.On("Move", mock.Anything, path, expectedTarget, "main", "Move "+path+" to "+expectedTarget).Return(tt.moveResults[i]).Once()
 					mockProgress.On("SetMessage", mock.Anything, "Moving "+path+" to "+expectedTarget).Return().Once()
 					mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-						return result.Path == path && result.Action == repository.FileActionRenamed
+						return result.Path() == path && result.Action() == repository.FileActionRenamed
 					})).Return().Once()
 
 					if tt.tooManyErrors != nil && i == 0 {
@@ -545,10 +545,10 @@ func TestMoveWorker_ProcessWithResourceReferences(t *testing.T) {
 	mockRepo.On("Move", mock.Anything, "dashboard/file.yaml", "new/location/file.yaml", "", "Move dashboard/file.yaml to new/location/file.yaml").Return(nil)
 
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "test/path1" && result.Action == repository.FileActionRenamed && result.Error == nil
+		return result.Path() == "test/path1" && result.Action() == repository.FileActionRenamed && result.Error() == nil
 	})).Return()
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Path == "dashboard/file.yaml" && result.Action == repository.FileActionRenamed && result.Error == nil
+		return result.Path() == "dashboard/file.yaml" && result.Action() == repository.FileActionRenamed && result.Error() == nil
 	})).Return()
 
 	// Add expectations for sync worker (called when ref is empty)
@@ -607,9 +607,9 @@ func TestMoveWorker_ProcessResourceReferencesError(t *testing.T) {
 	}).Return("", resourceError)
 
 	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Name == "non-existent-uid" && result.Group == "dashboard.grafana.app" &&
-			result.Action == repository.FileActionRenamed &&
-			result.Error != nil && result.Error.Error() == "find path for resource dashboard.grafana.app/Dashboard/non-existent-uid: resource not found"
+		return result.Name() == "non-existent-uid" && result.Group() == "dashboard.grafana.app" &&
+			result.Action() == repository.FileActionRenamed &&
+			result.Error() != nil && result.Error().Error() == "find path for resource dashboard.grafana.app/Dashboard/non-existent-uid: resource not found"
 	})).Return()
 
 	// Add expectations for sync worker (called when ref is empty)
@@ -766,8 +766,8 @@ func TestMoveWorker_resolveResourcesToPaths(t *testing.T) {
 					} else if err, ok := tt.resourceErrors[resource.Name]; ok {
 						mockRepoResources.On("FindResourcePath", mock.Anything, resource.Name, gvk).Return("", err)
 						mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-							return result.Name == resource.Name && result.Group == resource.Group &&
-								result.Action == repository.FileActionRenamed && result.Error != nil
+							return result.Name() == resource.Name && result.Group() == resource.Group &&
+								result.Action() == repository.FileActionRenamed && result.Error() != nil
 						})).Return()
 						if tt.tooManyErrors != nil {
 							mockProgress.On("TooManyErrors").Return(tt.tooManyErrors)

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -37,16 +37,6 @@ func maybeNotifyProgress(threshold time.Duration, fn ProgressFn) ProgressFn {
 }
 
 // FIXME: ProgressRecorder should be initialized in the queue
-type JobResourceResult struct {
-	Name    string
-	Group   string
-	Kind    string
-	Path    string
-	Action  repository.FileAction
-	Error   error
-	Warning error
-}
-
 type jobProgressRecorder struct {
 	mu                  sync.RWMutex
 	started             time.Time
@@ -86,14 +76,14 @@ func (r *jobProgressRecorder) Record(ctx context.Context, result JobResourceResu
 	r.mu.Lock()
 	r.resultCount++
 
-	if result.Error != nil {
+	if result.Error() != nil {
 		shouldLogError = true
-		logErr = result.Error
+		logErr = result.Error()
 
 		// Don't count ignored actions as errors in error count or error list
-		if result.Action != repository.FileActionIgnored {
+		if result.Action() != repository.FileActionIgnored {
 			if len(r.errors) < 20 {
-				r.errors = append(r.errors, result.Error.Error())
+				r.errors = append(r.errors, result.Error().Error())
 			}
 			r.errorCount++
 		}
@@ -101,20 +91,21 @@ func (r *jobProgressRecorder) Record(ctx context.Context, result JobResourceResu
 		// Automatically track failed operations based on error type and action
 		// Check if this is a PathCreationError (folder creation failure)
 		var pathErr *resources.PathCreationError
-		if errors.As(result.Error, &pathErr) {
+		if errors.As(result.Error(), &pathErr) {
 			r.failedCreations = append(r.failedCreations, pathErr.Path)
 		}
 
 		// Track failed deletions, any deletion will stop the deletion of the parent folder (as it won't be empty)
-		if result.Action == repository.FileActionDeleted {
-			r.failedDeletions = append(r.failedDeletions, result.Path)
+
+		if result.Action() == repository.FileActionDeleted {
+			r.failedDeletions = append(r.failedDeletions, result.Path())
 		}
 	}
 
 	r.updateSummary(result)
 	r.mu.Unlock()
 
-	logger := logging.FromContext(ctx).With("path", result.Path, "group", result.Group, "kind", result.Kind, "action", result.Action, "name", result.Name)
+	logger := logging.FromContext(ctx).With("path", result.Path(), "group", result.Group(), "kind", result.Kind(), "action", result.Action(), "name", result.Name())
 	if shouldLogError {
 		logger.Error("job resource operation failed", "err", logErr)
 	} else {
@@ -203,26 +194,26 @@ func (r *jobProgressRecorder) summary() []*provisioning.JobResourceSummary {
 
 func (r *jobProgressRecorder) updateSummary(result JobResourceResult) {
 	// Note: This method is called from Record() which already holds the lock
-	key := result.Group + ":" + result.Kind
+	key := result.Group() + ":" + result.Kind()
 	summary, exists := r.summaries[key]
 	if !exists {
 		summary = &provisioning.JobResourceSummary{
-			Group: result.Group,
-			Kind:  result.Kind,
+			Group: result.Group(),
+			Kind:  result.Kind(),
 		}
 		r.summaries[key] = summary
 	}
 
-	if result.Error != nil {
-		errorMsg := fmt.Sprintf("%s (file: %s, name: %s, action: %s)", result.Error.Error(), result.Path, result.Name, result.Action)
+	if result.Error() != nil {
+		errorMsg := fmt.Sprintf("%s (file: %s, name: %s, action: %s)", result.Error().Error(), result.Path(), result.Name(), result.Action())
 		summary.Errors = append(summary.Errors, errorMsg)
 		summary.Error++
-	} else if result.Warning != nil {
-		warningMsg := fmt.Sprintf("%s (file: %s, name: %s, action: %s)", result.Warning.Error(), result.Path, result.Name, result.Action)
+	} else if result.Warning() != nil {
+		warningMsg := fmt.Sprintf("%s (file: %s, name: %s, action: %s)", result.Warning().Error(), result.Path(), result.Name(), result.Action())
 		summary.Warnings = append(summary.Warnings, warningMsg)
 		summary.Warning++
 	} else {
-		switch result.Action {
+		switch result.Action() {
 		case repository.FileActionDeleted:
 			summary.Delete++
 		case repository.FileActionUpdated:

--- a/pkg/registry/apis/provisioning/jobs/progress_test.go
+++ b/pkg/registry/apis/provisioning/jobs/progress_test.go
@@ -99,36 +99,36 @@ func TestJobProgressRecorderWarningStatus(t *testing.T) {
 	// Record a result with a warning
 	warningErr := errors.New("deprecated API used")
 	result := JobResourceResult{
-		Name:    "test-resource",
-		Group:   "test.grafana.app",
-		Kind:    "Dashboard",
-		Path:    "dashboards/test.json",
-		Action:  repository.FileActionUpdated,
-		Warning: warningErr,
+		name:    "test-resource",
+		group:   "test.grafana.app",
+		kind:    "Dashboard",
+		path:    "dashboards/test.json",
+		action:  repository.FileActionUpdated,
+		warning: warningErr,
 	}
 	recorder.Record(ctx, result)
 
 	// Record another result with a different warning
 	warningErr2 := errors.New("missing optional field")
 	result2 := JobResourceResult{
-		Name:    "test-resource-2",
-		Group:   "test.grafana.app",
-		Kind:    "Dashboard",
-		Path:    "dashboards/test2.json",
-		Action:  repository.FileActionCreated,
-		Warning: warningErr2,
+		name:    "test-resource-2",
+		group:   "test.grafana.app",
+		kind:    "Dashboard",
+		path:    "dashboards/test2.json",
+		action:  repository.FileActionCreated,
+		warning: warningErr2,
 	}
 	recorder.Record(ctx, result2)
 
 	// Record a result with a warning from a different resource type
 	warningErr3 := errors.New("validation warning")
 	result3 := JobResourceResult{
-		Name:    "test-resource-3",
-		Group:   "test.grafana.app",
-		Kind:    "DataSource",
-		Path:    "datasources/test.yaml",
-		Action:  repository.FileActionCreated,
-		Warning: warningErr3,
+		name:    "test-resource-3",
+		group:   "test.grafana.app",
+		kind:    "DataSource",
+		path:    "datasources/test.yaml",
+		action:  repository.FileActionCreated,
+		warning: warningErr3,
 	}
 	recorder.Record(ctx, result3)
 
@@ -185,24 +185,24 @@ func TestJobProgressRecorderWarningWithErrors(t *testing.T) {
 	// Record a result with an error (errors take precedence)
 	errorErr := errors.New("failed to process")
 	result := JobResourceResult{
-		Name:   "test-resource",
-		Group:  "test.grafana.app",
-		Kind:   "Dashboard",
-		Path:   "dashboards/test.json",
-		Action: repository.FileActionUpdated,
-		Error:  errorErr,
+		name:   "test-resource",
+		group:  "test.grafana.app",
+		kind:   "Dashboard",
+		path:   "dashboards/test.json",
+		action: repository.FileActionUpdated,
+		err:    errorErr,
 	}
 	recorder.Record(ctx, result)
 
 	// Record a result with only a warning
 	warningErr := errors.New("deprecated API used")
 	result2 := JobResourceResult{
-		Name:    "test-resource-2",
-		Group:   "test.grafana.app",
-		Kind:    "Dashboard",
-		Path:    "dashboards/test2.json",
-		Action:  repository.FileActionCreated,
-		Warning: warningErr,
+		name:    "test-resource-2",
+		group:   "test.grafana.app",
+		kind:    "Dashboard",
+		path:    "dashboards/test2.json",
+		action:  repository.FileActionCreated,
+		warning: warningErr,
 	}
 	recorder.Record(ctx, result2)
 
@@ -234,12 +234,12 @@ func TestJobProgressRecorderWarningOnlyNoErrors(t *testing.T) {
 	// Record only warnings, no errors
 	warningErr := errors.New("deprecated API used")
 	result := JobResourceResult{
-		Name:    "test-resource",
-		Group:   "test.grafana.app",
-		Kind:    "Dashboard",
-		Path:    "dashboards/test.json",
-		Action:  repository.FileActionUpdated,
-		Warning: warningErr,
+		name:    "test-resource",
+		group:   "test.grafana.app",
+		kind:    "Dashboard",
+		path:    "dashboards/test.json",
+		action:  repository.FileActionUpdated,
+		warning: warningErr,
 	}
 	recorder.Record(ctx, result)
 
@@ -268,36 +268,34 @@ func TestJobProgressRecorderFolderFailureTracking(t *testing.T) {
 		Path: "folder1/",
 		Err:  assert.AnError,
 	}
-	recorder.Record(ctx, JobResourceResult{
-		Path:   "folder1/file.json",
-		Action: repository.FileActionCreated,
-		Error:  pathErr,
-	})
+	recorder.Record(ctx, NewPathOnlyResult("folder1/file.json").
+		WithError(pathErr).
+		WithAction(repository.FileActionCreated).
+		Build())
 
 	// Record another PathCreationError for a different folder
 	pathErr2 := &resources.PathCreationError{
 		Path: "folder2/subfolder/",
 		Err:  assert.AnError,
 	}
-	recorder.Record(ctx, JobResourceResult{
-		Path:   "folder2/subfolder/file.json",
-		Action: repository.FileActionCreated,
-		Error:  pathErr2,
-	})
+	recorder.Record(ctx, NewPathOnlyResult("folder2/subfolder/file.json").
+		WithError(pathErr2).
+		WithAction(repository.FileActionCreated).
+		Build())
 
 	// Record a deletion failure
-	recorder.Record(ctx, JobResourceResult{
-		Path:   "folder3/file1.json",
-		Action: repository.FileActionDeleted,
-		Error:  assert.AnError,
-	})
+	recorder.Record(ctx,
+		NewPathOnlyResult("folder3/file1.json").
+			WithError(assert.AnError).
+			WithAction(repository.FileActionDeleted).
+			Build())
 
 	// Record another deletion failure
-	recorder.Record(ctx, JobResourceResult{
-		Path:   "folder4/subfolder/file2.json",
-		Action: repository.FileActionDeleted,
-		Error:  assert.AnError,
-	})
+	recorder.Record(ctx,
+		NewPathOnlyResult("folder4/subfolder/file2.json").
+			WithError(assert.AnError).
+			WithAction(repository.FileActionDeleted).
+			Build())
 
 	// Verify failed creations are tracked
 	recorder.mu.RLock()
@@ -326,21 +324,19 @@ func TestJobProgressRecorderHasDirPathFailedCreation(t *testing.T) {
 		Path: "folder1/",
 		Err:  assert.AnError,
 	}
-	recorder.Record(ctx, JobResourceResult{
-		Path:   "folder1/file.json",
-		Action: repository.FileActionCreated,
-		Error:  pathErr1,
-	})
+	recorder.Record(ctx, NewPathOnlyResult("folder1/file.json").
+		WithError(pathErr1).
+		WithAction(repository.FileActionCreated).
+		Build())
 
 	pathErr2 := &resources.PathCreationError{
 		Path: "folder2/subfolder/",
 		Err:  assert.AnError,
 	}
-	recorder.Record(ctx, JobResourceResult{
-		Path:   "folder2/subfolder/file.json",
-		Action: repository.FileActionCreated,
-		Error:  pathErr2,
-	})
+	recorder.Record(ctx, NewPathOnlyResult("folder2/subfolder/file.json").
+		WithError(pathErr2).
+		WithAction(repository.FileActionCreated).
+		Build())
 
 	// Test nested paths
 	assert.True(t, recorder.HasDirPathFailedCreation("folder1/file.json"))
@@ -365,23 +361,20 @@ func TestJobProgressRecorderHasDirPathFailedDeletion(t *testing.T) {
 	recorder := newJobProgressRecorder(mockProgressFn).(*jobProgressRecorder)
 
 	// Add failed deletions via Record
-	recorder.Record(ctx, JobResourceResult{
-		Path:   "folder1/file1.json",
-		Action: repository.FileActionDeleted,
-		Error:  assert.AnError,
-	})
+	recorder.Record(ctx, NewPathOnlyResult("folder1/file1.json").
+		WithError(assert.AnError).
+		WithAction(repository.FileActionDeleted).
+		Build())
 
-	recorder.Record(ctx, JobResourceResult{
-		Path:   "folder2/subfolder/file2.json",
-		Action: repository.FileActionDeleted,
-		Error:  assert.AnError,
-	})
+	recorder.Record(ctx, NewPathOnlyResult("folder2/subfolder/file2.json").
+		WithError(assert.AnError).
+		WithAction(repository.FileActionDeleted).
+		Build())
 
-	recorder.Record(ctx, JobResourceResult{
-		Path:   "folder3/nested/deep/file3.json",
-		Action: repository.FileActionDeleted,
-		Error:  assert.AnError,
-	})
+	recorder.Record(ctx, NewPathOnlyResult("folder3/nested/deep/file3.json").
+		WithError(assert.AnError).
+		WithAction(repository.FileActionDeleted).
+		Build())
 
 	// Test folder paths with failed deletions
 	assert.True(t, recorder.HasDirPathFailedDeletion("folder1/"))
@@ -414,17 +407,15 @@ func TestJobProgressRecorderResetResults(t *testing.T) {
 		Path: "folder1/",
 		Err:  assert.AnError,
 	}
-	recorder.Record(ctx, JobResourceResult{
-		Path:   "folder1/file.json",
-		Action: repository.FileActionCreated,
-		Error:  pathErr,
-	})
+	recorder.Record(ctx, NewPathOnlyResult("folder1/file.json").
+		WithError(pathErr).
+		WithAction(repository.FileActionCreated).
+		Build())
 
-	recorder.Record(ctx, JobResourceResult{
-		Path:   "folder2/file.json",
-		Action: repository.FileActionDeleted,
-		Error:  assert.AnError,
-	})
+	recorder.Record(ctx, NewPathOnlyResult("folder2/file.json").
+		WithError(assert.AnError).
+		WithAction(repository.FileActionDeleted).
+		Build())
 
 	// Verify data is stored
 	recorder.mu.RLock()
@@ -452,18 +443,16 @@ func TestJobProgressRecorderIgnoredActionsDontCountAsErrors(t *testing.T) {
 	recorder := newJobProgressRecorder(mockProgressFn).(*jobProgressRecorder)
 
 	// Record an ignored action with error
-	recorder.Record(ctx, JobResourceResult{
-		Path:   "folder1/file1.json",
-		Action: repository.FileActionIgnored,
-		Error:  assert.AnError,
-	})
+	recorder.Record(ctx, NewPathOnlyResult("folder1/file1.json").
+		WithError(assert.AnError).
+		WithAction(repository.FileActionIgnored).
+		Build())
 
 	// Record a real error for comparison
-	recorder.Record(ctx, JobResourceResult{
-		Path:   "folder2/file2.json",
-		Action: repository.FileActionCreated,
-		Error:  assert.AnError,
-	})
+	recorder.Record(ctx, NewPathOnlyResult("folder2/file2.json").
+		WithError(assert.AnError).
+		WithAction(repository.FileActionCreated).
+		Build())
 
 	// Verify error count doesn't include ignored actions
 	recorder.mu.RLock()

--- a/pkg/registry/apis/provisioning/jobs/sync/full_hierarchical_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_hierarchical_test.go
@@ -72,7 +72,7 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 
 				// File will be recorded with error, triggering automatic tracking of folder1/ failure
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/file.json" && r.Error != nil && r.Action == repository.FileActionCreated
+					return r.Path() == "folder1/file.json" && r.Error() != nil && r.Action() == repository.FileActionCreated
 				})).Return().Once()
 			},
 		},
@@ -92,24 +92,24 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 					Return("", schema.GroupVersionKind{}, folderErr).Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/file1.json" && r.Error != nil
+					return r.Path() == "folder1/file1.json" && r.Error() != nil
 				})).Return().Once()
 
 				// Subsequent files in same folder are skipped
 				progress.On("HasDirPathFailedCreation", "folder1/subfolder/file2.json").Return(true).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/subfolder/file2.json" &&
-						r.Action == repository.FileActionIgnored &&
-						r.Warning != nil &&
-						r.Warning.Error() == "resource was not processed because the parent folder could not be created"
+					return r.Path() == "folder1/subfolder/file2.json" &&
+						r.Action() == repository.FileActionIgnored &&
+						r.Warning() != nil &&
+						r.Warning().Error() == "resource was not processed because the parent folder could not be created"
 				})).Return().Once()
 
 				progress.On("HasDirPathFailedCreation", "folder1/file3.json").Return(true).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/file3.json" &&
-						r.Action == repository.FileActionIgnored &&
-						r.Warning != nil &&
-						r.Warning.Error() == "resource was not processed because the parent folder could not be created"
+					return r.Path() == "folder1/file3.json" &&
+						r.Action() == repository.FileActionIgnored &&
+						r.Warning() != nil &&
+						r.Warning().Error() == "resource was not processed because the parent folder could not be created"
 				})).Return().Once()
 			},
 		},
@@ -142,9 +142,9 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 
 				// File deletion recorded with error, automatically tracked in failedDeletions
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/file.json" &&
-						r.Action == repository.FileActionDeleted &&
-						r.Error != nil
+					return r.Path() == "folder1/file.json" &&
+						r.Action() == repository.FileActionDeleted &&
+						r.Error() != nil
 				})).Return().Once()
 			},
 		},
@@ -171,7 +171,7 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 					Return("", schema.GroupVersionKind{}, folderErr).Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/file1.json" && r.Error != nil
+					return r.Path() == "folder1/file1.json" && r.Error() != nil
 				})).Return().Once()
 
 				// Deletion proceeds (NOT checking HasDirPathFailedCreation for deletions)
@@ -185,8 +185,8 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 
 				// Record deletion attempt (will have error since resource doesn't exist, but that's ok)
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/file2.json" &&
-						r.Action == repository.FileActionDeleted
+					return r.Path() == "folder1/file2.json" &&
+						r.Action() == repository.FileActionDeleted
 					// Not checking r.Error because resource doesn't exist in fake client
 				})).Return().Once()
 			},
@@ -207,14 +207,14 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 					Return("", schema.GroupVersionKind{}, folderErr).Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "level1/file1.json" && r.Error != nil
+					return r.Path() == "level1/file1.json" && r.Error() != nil
 				})).Return().Once()
 
 				// All nested files are skipped
 				for _, path := range []string{"level1/level2/file2.json", "level1/level2/level3/file3.json"} {
 					progress.On("HasDirPathFailedCreation", path).Return(true).Once()
 					progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-						return r.Path == path && r.Action == repository.FileActionIgnored
+						return r.Path() == path && r.Action() == repository.FileActionIgnored
 					})).Return().Once()
 				}
 			},
@@ -233,7 +233,7 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 				repoResources.On("WriteResourceFromFile", mock.Anything, "success/file1.json", "").
 					Return("resource1", schema.GroupVersionKind{Kind: "Dashboard"}, nil).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "success/file1.json" && r.Error == nil
+					return r.Path() == "success/file1.json" && r.Error() == nil
 				})).Return().Once()
 
 				// Failure path fails
@@ -242,13 +242,13 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 				repoResources.On("WriteResourceFromFile", mock.Anything, "failure/file2.json", "").
 					Return("", schema.GroupVersionKind{}, folderErr).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "failure/file2.json" && r.Error != nil
+					return r.Path() == "failure/file2.json" && r.Error() != nil
 				})).Return().Once()
 
 				// Nested file in failure path is skipped
 				progress.On("HasDirPathFailedCreation", "failure/nested/file3.json").Return(true).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "failure/nested/file3.json" && r.Action == repository.FileActionIgnored
+					return r.Path() == "failure/nested/file3.json" && r.Action() == repository.FileActionIgnored
 				})).Return().Once()
 			},
 		},
@@ -271,19 +271,19 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 				progress.On("HasDirPathFailedCreation", "folder1/subfolder/file2.json").Return(true).Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/" && r.Error != nil
+					return r.Path() == "folder1/" && r.Error() != nil
 				})).Return().Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/subfolder/" && r.Action == repository.FileActionIgnored
+					return r.Path() == "folder1/subfolder/" && r.Action() == repository.FileActionIgnored
 				})).Return().Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/file1.json" && r.Action == repository.FileActionIgnored
+					return r.Path() == "folder1/file1.json" && r.Action() == repository.FileActionIgnored
 				})).Return().Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/subfolder/file2.json" && r.Action == repository.FileActionIgnored
+					return r.Path() == "folder1/subfolder/file2.json" && r.Action() == repository.FileActionIgnored
 				})).Return().Once()
 			},
 		},
@@ -311,13 +311,13 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 				})
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/file1.json" && r.Error != nil
+					return r.Path() == "folder1/file1.json" && r.Error() != nil
 				})).Return().Once()
 
 				progress.On("HasDirPathFailedDeletion", "folder1/").Return(true).Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/" && r.Action == repository.FileActionIgnored
+					return r.Path() == "folder1/" && r.Action() == repository.FileActionIgnored
 				})).Return().Once()
 			},
 		},
@@ -343,7 +343,7 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 
 				for _, path := range []string{"folder1/file1.json", "folder2/file2.json"} {
 					progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-						return r.Path == path && r.Error != nil
+						return r.Path() == path && r.Error() != nil
 					})).Return().Once()
 				}
 
@@ -352,7 +352,7 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 
 				for _, path := range []string{"folder1/", "folder2/"} {
 					progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-						return r.Path == path && r.Action == repository.FileActionIgnored
+						return r.Path() == path && r.Action() == repository.FileActionIgnored
 					})).Return().Once()
 				}
 			},
@@ -377,7 +377,7 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 				})
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "parent/subfolder/file.json" && r.Error != nil
+					return r.Path() == "parent/subfolder/file.json" && r.Error() != nil
 				})).Return().Once()
 
 				progress.On("HasDirPathFailedDeletion", "parent/subfolder/").Return(true).Once()
@@ -385,7 +385,7 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 
 				for _, path := range []string{"parent/subfolder/", "parent/"} {
 					progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-						return r.Path == path && r.Action == repository.FileActionIgnored
+						return r.Path() == path && r.Action() == repository.FileActionIgnored
 					})).Return().Once()
 				}
 			},

--- a/pkg/registry/apis/provisioning/jobs/sync/full_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_test.go
@@ -222,8 +222,8 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 				}), "").Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil).Maybe()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-					return result.Action == repository.FileActionCreated &&
-						(result.Path == "dashboards/one.json" || result.Path == "dashboards/two.json" || result.Path == "dashboards/three.json")
+					return result.Action() == repository.FileActionCreated &&
+						(result.Path() == "dashboards/one.json" || result.Path() == "dashboards/two.json" || result.Path() == "dashboards/three.json")
 				})).Return().Maybe()
 			},
 			expectedError: "too many errors",
@@ -244,13 +244,8 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 				repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/test.json", "").
 					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
 
-				progress.On("Record", mock.Anything, jobs.JobResourceResult{
-					Action: repository.FileActionCreated,
-					Path:   "dashboards/test.json",
-					Name:   "test-dashboard",
-					Kind:   "Dashboard",
-					Group:  "dashboards",
-				}).Return()
+				progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
+					"test-dashboard", "dashboards", "Dashboard").WithAction(repository.FileActionCreated).WithPath("dashboards/test.json").Build()).Return()
 			},
 		},
 		{
@@ -270,13 +265,13 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, fmt.Errorf("write error"))
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-					return result.Action == repository.FileActionCreated &&
-						result.Path == "dashboards/test.json" &&
-						result.Name == "test-dashboard" &&
-						result.Kind == "Dashboard" &&
-						result.Group == "dashboards" &&
-						result.Error != nil &&
-						result.Error.Error() == "writing resource from file dashboards/test.json: write error"
+					return result.Action() == repository.FileActionCreated &&
+						result.Path() == "dashboards/test.json" &&
+						result.Name() == "test-dashboard" &&
+						result.Kind() == "Dashboard" &&
+						result.Group() == "dashboards" &&
+						result.Error() != nil &&
+						result.Error().Error() == "writing resource from file dashboards/test.json: write error"
 				})).Return()
 			},
 		},
@@ -296,13 +291,13 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 				repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/test.json", "").
 					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
 
-				progress.On("Record", mock.Anything, jobs.JobResourceResult{
-					Action: repository.FileActionUpdated,
-					Path:   "dashboards/test.json",
-					Name:   "test-dashboard",
-					Kind:   "Dashboard",
-					Group:  "dashboards",
-				}).Return()
+				progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
+					"test-dashboard",
+					"dashboards",
+					"Dashboard",
+				).WithPath("dashboards/test.json").
+					WithAction(repository.FileActionUpdated).
+					Build()).Return()
 			},
 		},
 		{
@@ -322,13 +317,13 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 					Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, fmt.Errorf("write error"))
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-					return result.Action == repository.FileActionUpdated &&
-						result.Path == "dashboards/test.json" &&
-						result.Name == "test-dashboard" &&
-						result.Kind == "Dashboard" &&
-						result.Group == "dashboards" &&
-						result.Error != nil &&
-						result.Error.Error() == "writing resource from file dashboards/test.json: write error"
+					return result.Action() == repository.FileActionUpdated &&
+						result.Path() == "dashboards/test.json" &&
+						result.Name() == "test-dashboard" &&
+						result.Kind() == "Dashboard" &&
+						result.Group() == "dashboards" &&
+						result.Error() != nil &&
+						result.Error().Error() == "writing resource from file dashboards/test.json: write error"
 				})).Return()
 			},
 		},
@@ -346,13 +341,13 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 				progress.On("HasDirPathFailedCreation", "one/two/three/").Return(false)
 
 				repoResources.On("EnsureFolderPathExist", mock.Anything, "one/two/three/").Return("some-folder", nil)
-				progress.On("Record", mock.Anything, jobs.JobResourceResult{
-					Action: repository.FileActionCreated,
-					Path:   "one/two/three/",
-					Name:   "some-folder",
-					Kind:   "Folder",
-					Group:  "folder.grafana.app",
-				}).Return()
+				progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
+					"some-folder",
+					"folder.grafana.app",
+					"Folder",
+				).WithPath("one/two/three/").
+					WithAction(repository.FileActionCreated).
+					Build()).Return()
 			},
 		},
 		{
@@ -374,13 +369,13 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 					"one/two/three/",
 				).Return("some-folder", errors.New("folder creation error"))
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-					return result.Action == repository.FileActionCreated &&
-						result.Path == "one/two/three/" &&
-						result.Name == "" &&
-						result.Kind == "Folder" &&
-						result.Group == "folder.grafana.app" &&
-						result.Error != nil &&
-						result.Error.Error() == "ensuring folder exists at path one/two/three/: folder creation error"
+					return result.Action() == repository.FileActionCreated &&
+						result.Path() == "one/two/three/" &&
+						result.Name() == "" &&
+						result.Kind() == "Folder" &&
+						result.Group() == "folder.grafana.app" &&
+						result.Error() != nil &&
+						result.Error().Error() == "ensuring folder exists at path one/two/three/: folder creation error"
 				})).Return()
 			},
 		},
@@ -433,14 +428,13 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 					Version: "v1",
 				}, nil)
 
-				progress.On("Record", mock.Anything, jobs.JobResourceResult{
-					Action: repository.FileActionDeleted,
-					Path:   "dashboards/test.json",
-					Name:   "test-dashboard",
-					Kind:   "Dashboard",
-					Group:  "dashboards",
-					Error:  nil,
-				}).Return()
+				progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
+					"test-dashboard",
+					"dashboards",
+					"Dashboard",
+				).WithPath("dashboards/test.json").
+					WithAction(repository.FileActionDeleted).
+					Build()).Return()
 			},
 		},
 		{
@@ -493,13 +487,13 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 				}, nil)
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-					return result.Action == repository.FileActionDeleted &&
-						result.Path == "dashboards/test.json" &&
-						result.Name == "test-dashboard" &&
-						result.Kind == "Dashboard" &&
-						result.Group == "dashboards" &&
-						result.Error != nil &&
-						result.Error.Error() == "deleting resource dashboards/Dashboard test-dashboard: delete failed"
+					return result.Action() == repository.FileActionDeleted &&
+						result.Path() == "dashboards/test.json" &&
+						result.Name() == "test-dashboard" &&
+						result.Kind() == "Dashboard" &&
+						result.Group() == "dashboards" &&
+						result.Error() != nil &&
+						result.Error().Error() == "deleting resource dashboards/Dashboard test-dashboard: delete failed"
 				})).Return()
 			},
 		},
@@ -516,10 +510,10 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 			setupMocks: func(repo *repository.MockRepository, repoResources *resources.MockRepositoryResources, clients *resources.MockResourceClients, progress *jobs.MockJobProgressRecorder, compareFn *MockCompareFn) {
 				progress.On("TooManyErrors").Return(nil)
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-					return result.Action == repository.FileActionDeleted &&
-						result.Path == "dashboards/test.json" &&
-						result.Error != nil &&
-						result.Error.Error() == "processing deletion for file dashboards/test.json: missing existing reference"
+					return result.Action() == repository.FileActionDeleted &&
+						result.Path() == "dashboards/test.json" &&
+						result.Error() != nil &&
+						result.Error().Error() == "processing deletion for file dashboards/test.json: missing existing reference"
 				})).Return()
 			},
 		},
@@ -536,10 +530,10 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 			setupMocks: func(repo *repository.MockRepository, repoResources *resources.MockRepositoryResources, clients *resources.MockResourceClients, progress *jobs.MockJobProgressRecorder, compareFn *MockCompareFn) {
 				progress.On("TooManyErrors").Return(nil)
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-					return result.Action == repository.FileActionDeleted &&
-						result.Path == "dashboards/test.json" &&
-						result.Error != nil &&
-						result.Error.Error() == "processing deletion for file dashboards/test.json: missing existing reference"
+					return result.Action() == repository.FileActionDeleted &&
+						result.Path() == "dashboards/test.json" &&
+						result.Error() != nil &&
+						result.Error().Error() == "processing deletion for file dashboards/test.json: missing existing reference"
 				})).Return()
 			},
 		},
@@ -565,14 +559,14 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 					Resource: "dashboards",
 				}).Return(nil, schema.GroupVersionKind{}, errors.New("didn't work"))
 
-				progress.On("Record", mock.Anything, jobs.JobResourceResult{
-					Name:   "test-dashboard",
-					Group:  "dashboards",
-					Kind:   "dashboards", // could not find a real kind
-					Action: repository.FileActionDeleted,
-					Path:   "dashboards/test.json",
-					Error:  fmt.Errorf("get client for deleted object: %w", errors.New("didn't work")),
-				}).Return()
+				progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
+					"test-dashboard",
+					"dashboards",
+					"dashboards", // could not find a real kind
+				).WithPath("dashboards/test.json").
+					WithAction(repository.FileActionDeleted).
+					WithError(fmt.Errorf("get client for deleted object: %w", errors.New("didn't work"))).
+					Build()).Return()
 			},
 		},
 		{
@@ -625,14 +619,13 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 					Version: "v1",
 				}, nil)
 
-				progress.On("Record", mock.Anything, jobs.JobResourceResult{
-					Action: repository.FileActionDeleted,
-					Path:   "to-be-deleted/",
-					Name:   "test-folder",
-					Kind:   "Folder",
-					Group:  "folders",
-					Error:  nil,
-				}).Return()
+				progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
+					"test-folder",
+					"folders",
+					"Folder",
+				).WithPath("to-be-deleted/").
+					WithAction(repository.FileActionDeleted).
+					Build()).Return()
 			},
 		},
 		{
@@ -686,13 +679,13 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 				}, nil)
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-					return result.Action == repository.FileActionDeleted &&
-						result.Path == "to-be-deleted/" &&
-						result.Name == "test-folder" &&
-						result.Kind == "Folder" &&
-						result.Group == "folders" &&
-						result.Error != nil &&
-						result.Error.Error() == "deleting resource folders/Folder test-folder: delete failed"
+					return result.Action() == repository.FileActionDeleted &&
+						result.Path() == "to-be-deleted/" &&
+						result.Name() == "test-folder" &&
+						result.Kind() == "Folder" &&
+						result.Group() == "folders" &&
+						result.Error() != nil &&
+						result.Error().Error() == "deleting resource folders/Folder test-folder: delete failed"
 				})).Return()
 			},
 		},
@@ -723,10 +716,10 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 
 				// applyChange records the error from WriteResourceFromFile
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-					return result.Action == repository.FileActionCreated &&
-						result.Path == "dashboards/slow.json" &&
-						result.Error != nil &&
-						result.Error.Error() == "writing resource from file dashboards/slow.json: context deadline exceeded"
+					return result.Action() == repository.FileActionCreated &&
+						result.Path() == "dashboards/slow.json" &&
+						result.Error() != nil &&
+						result.Error().Error() == "writing resource from file dashboards/slow.json: context deadline exceeded"
 				})).Return().Once()
 			},
 		},

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_hierarchical_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_hierarchical_test.go
@@ -73,18 +73,18 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 
 				// First file recorded with error (note: error is from folder creation, but recorded against file)
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "unsupported/file.txt" &&
-						r.Action == repository.FileActionIgnored &&
-						r.Error != nil
+					return r.Path() == "unsupported/file.txt" &&
+						r.Action() == repository.FileActionIgnored &&
+						r.Error() != nil
 				})).Return().Once()
 
 				// Second file is skipped because parent folder failed
 				progress.On("HasDirPathFailedCreation", "unsupported/nested/file2.txt").Return(true).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "unsupported/nested/file2.txt" &&
-						r.Action == repository.FileActionIgnored &&
-						r.Warning != nil &&
-						r.Warning.Error() == "resource was not processed because the parent folder could not be created"
+					return r.Path() == "unsupported/nested/file2.txt" &&
+						r.Action() == repository.FileActionIgnored &&
+						r.Warning() != nil &&
+						r.Warning().Error() == "resource was not processed because the parent folder could not be created"
 				})).Return().Once()
 			},
 		},
@@ -107,20 +107,20 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 
 				// First file recorded with error, automatically tracked
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/file1.json" &&
-						r.Action == repository.FileActionCreated &&
-						r.Error != nil
+					return r.Path() == "folder1/file1.json" &&
+						r.Action() == repository.FileActionCreated &&
+						r.Error() != nil
 				})).Return().Once()
 
 				// Subsequent files are skipped
 				progress.On("HasDirPathFailedCreation", "folder1/file2.json").Return(true).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/file2.json" && r.Action == repository.FileActionIgnored && r.Warning != nil
+					return r.Path() == "folder1/file2.json" && r.Action() == repository.FileActionIgnored && r.Warning() != nil
 				})).Return().Once()
 
 				progress.On("HasDirPathFailedCreation", "folder1/nested/file3.json").Return(true).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/nested/file3.json" && r.Action == repository.FileActionIgnored && r.Warning != nil
+					return r.Path() == "folder1/nested/file3.json" && r.Action() == repository.FileActionIgnored && r.Warning() != nil
 				})).Return().Once()
 			},
 		},
@@ -139,9 +139,9 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 
 				// Error recorded, automatically tracked in failedDeletions
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "dashboards/file1.json" &&
-						r.Action == repository.FileActionDeleted &&
-						r.Error != nil
+					return r.Path() == "dashboards/file1.json" &&
+						r.Action() == repository.FileActionDeleted &&
+						r.Error() != nil
 				})).Return().Once()
 
 				// During cleanup, folder deletion is skipped
@@ -167,7 +167,7 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 					Return("", schema.GroupVersionKind{}, folderErr).Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/new.json" && r.Error != nil
+					return r.Path() == "folder1/new.json" && r.Error() != nil
 				})).Return().Once()
 
 				// Deletion proceeds (NOT checking HasDirPathFailedCreation for deletions)
@@ -175,9 +175,9 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 					Return("old-resource", "", schema.GroupVersionKind{Kind: "Dashboard"}, nil).Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/old.json" &&
-						r.Action == repository.FileActionDeleted &&
-						r.Error == nil // Deletion succeeds!
+					return r.Path() == "folder1/old.json" &&
+						r.Action() == repository.FileActionDeleted &&
+						r.Error() == nil // Deletion succeeds!
 				})).Return().Once()
 			},
 		},
@@ -198,14 +198,14 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 				repoResources.On("EnsureFolderPathExist", mock.Anything, "level1/").Return("", folderErr).Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "level1/file.txt" && r.Action == repository.FileActionIgnored
+					return r.Path() == "level1/file.txt" && r.Action() == repository.FileActionIgnored
 				})).Return().Once()
 
 				// All nested files are skipped
 				for _, path := range []string{"level1/level2/file.txt", "level1/level2/level3/file.txt"} {
 					progress.On("HasDirPathFailedCreation", path).Return(true).Once()
 					progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-						return r.Path == path && r.Action == repository.FileActionIgnored
+						return r.Path() == path && r.Action() == repository.FileActionIgnored
 					})).Return().Once()
 				}
 			},
@@ -227,14 +227,14 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 				repoResources.On("WriteResourceFromFile", mock.Anything, "success/file1.json", "new-ref").
 					Return("resource-1", schema.GroupVersionKind{Kind: "Dashboard"}, nil).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "success/file1.json" && r.Error == nil
+					return r.Path() == "success/file1.json" && r.Error() == nil
 				})).Return().Once()
 
 				progress.On("HasDirPathFailedCreation", "success/nested/file2.json").Return(false).Once()
 				repoResources.On("WriteResourceFromFile", mock.Anything, "success/nested/file2.json", "new-ref").
 					Return("resource-2", schema.GroupVersionKind{Kind: "Dashboard"}, nil).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "success/nested/file2.json" && r.Error == nil
+					return r.Path() == "success/nested/file2.json" && r.Error() == nil
 				})).Return().Once()
 
 				// Failure path fails
@@ -242,13 +242,13 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 				folderErr := &resources.PathCreationError{Path: "failure/", Err: fmt.Errorf("disk full")}
 				repoResources.On("EnsureFolderPathExist", mock.Anything, "failure/").Return("", folderErr).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "failure/file3.txt" && r.Action == repository.FileActionIgnored
+					return r.Path() == "failure/file3.txt" && r.Action() == repository.FileActionIgnored
 				})).Return().Once()
 
 				// Nested file in failure path is skipped
 				progress.On("HasDirPathFailedCreation", "failure/nested/file4.txt").Return(true).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "failure/nested/file4.txt" && r.Action == repository.FileActionIgnored
+					return r.Path() == "failure/nested/file4.txt" && r.Action() == repository.FileActionIgnored
 				})).Return().Once()
 			},
 		},
@@ -274,9 +274,9 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 					Return("", "", schema.GroupVersionKind{}, folderErr).Once()
 
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "newfolder/file.json" &&
-						r.Action == repository.FileActionRenamed &&
-						r.Error != nil
+					return r.Path() == "newfolder/file.json" &&
+						r.Action() == repository.FileActionRenamed &&
+						r.Error() != nil
 				})).Return().Once()
 			},
 		},
@@ -293,15 +293,15 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 				// Rename is NOT skipped for creation failures (it's checking the destination path)
 				progress.On("HasDirPathFailedCreation", "folder1/file1.json").Return(true).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/file1.json" &&
-						r.Action == repository.FileActionIgnored &&
-						r.Warning != nil && r.Warning.Error() == "resource was not processed because the parent folder could not be created"
+					return r.Path() == "folder1/file1.json" &&
+						r.Action() == repository.FileActionIgnored &&
+						r.Warning() != nil && r.Warning().Error() == "resource was not processed because the parent folder could not be created"
 				})).Return().Once()
 
 				// Second file also skipped
 				progress.On("HasDirPathFailedCreation", "folder1/file2.json").Return(true).Once()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path == "folder1/file2.json" && r.Action == repository.FileActionIgnored && r.Warning != nil
+					return r.Path() == "folder1/file2.json" && r.Action() == repository.FileActionIgnored && r.Warning() != nil
 				})).Return().Once()
 			},
 		},
@@ -397,26 +397,26 @@ func TestIncrementalSync_HierarchicalErrorHandling_FailedFolderCreation(t *testi
 	repoResources.On("EnsureFolderPathExist", mock.Anything, "unsupported/").Return("", folderErr).Once()
 
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-		return r.Path == "unsupported/file.txt" && r.Action == repository.FileActionIgnored && r.Error != nil
+		return r.Path() == "unsupported/file.txt" && r.Action() == repository.FileActionIgnored && r.Error() != nil
 	})).Return().Once()
 
 	progress.On("HasDirPathFailedCreation", "unsupported/subfolder/file2.txt").Return(true).Once()
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-		return r.Path == "unsupported/subfolder/file2.txt" && r.Action == repository.FileActionIgnored &&
-			r.Warning != nil && r.Warning.Error() == "resource was not processed because the parent folder could not be created"
+		return r.Path() == "unsupported/subfolder/file2.txt" && r.Action() == repository.FileActionIgnored &&
+			r.Warning() != nil && r.Warning().Error() == "resource was not processed because the parent folder could not be created"
 	})).Return().Once()
 
 	progress.On("HasDirPathFailedCreation", "unsupported/file3.json").Return(true).Once()
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-		return r.Path == "unsupported/file3.json" && r.Action == repository.FileActionIgnored &&
-			r.Warning != nil && r.Warning.Error() == "resource was not processed because the parent folder could not be created"
+		return r.Path() == "unsupported/file3.json" && r.Action() == repository.FileActionIgnored &&
+			r.Warning() != nil && r.Warning().Error() == "resource was not processed because the parent folder could not be created"
 	})).Return().Once()
 
 	progress.On("HasDirPathFailedCreation", "other/file.json").Return(false).Once()
 	repoResources.On("WriteResourceFromFile", mock.Anything, "other/file.json", "new-ref").
 		Return("test-resource", schema.GroupVersionKind{Kind: "Dashboard"}, nil).Once()
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-		return r.Path == "other/file.json" && r.Action == repository.FileActionCreated && r.Error == nil
+		return r.Path() == "other/file.json" && r.Action() == repository.FileActionCreated && r.Error() == nil
 	})).Return().Once()
 
 	err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
@@ -447,8 +447,8 @@ func TestIncrementalSync_HierarchicalErrorHandling_FailedFileDeletion(t *testing
 		Return("dashboard-1", "folder-uid", schema.GroupVersionKind{Kind: "Dashboard"}, fmt.Errorf("permission denied")).Once()
 
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-		return r.Path == "dashboards/file1.json" && r.Action == repository.FileActionDeleted &&
-			r.Error != nil && r.Error.Error() == "removing resource from file dashboards/file1.json: permission denied"
+		return r.Path() == "dashboards/file1.json" && r.Action() == repository.FileActionDeleted &&
+			r.Error() != nil && r.Error().Error() == "removing resource from file dashboards/file1.json: permission denied"
 	})).Return().Once()
 
 	progress.On("HasDirPathFailedDeletion", "dashboards/").Return(true).Once()
@@ -482,7 +482,7 @@ func TestIncrementalSync_HierarchicalErrorHandling_DeletionNotAffectedByCreation
 		Return("", schema.GroupVersionKind{}, &resources.PathCreationError{Path: "folder1/", Err: fmt.Errorf("permission denied")}).Once()
 
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-		return r.Path == "folder1/file.json" && r.Error != nil
+		return r.Path() == "folder1/file.json" && r.Error() != nil
 	})).Return().Once()
 
 	// Deletion should NOT be skipped (not checking HasDirPathFailedCreation for deletions)
@@ -491,7 +491,7 @@ func TestIncrementalSync_HierarchicalErrorHandling_DeletionNotAffectedByCreation
 		Return("old-resource", "", schema.GroupVersionKind{Kind: "Dashboard"}, nil).Once()
 
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-		return r.Path == "folder1/old.json" && r.Action == repository.FileActionDeleted && r.Error == nil
+		return r.Path() == "folder1/old.json" && r.Action() == repository.FileActionDeleted && r.Error() == nil
 	})).Return().Once()
 
 	err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
@@ -523,19 +523,19 @@ func TestIncrementalSync_HierarchicalErrorHandling_MultiLevelNesting(t *testing.
 	repoResources.On("EnsureFolderPathExist", mock.Anything, "level1/").Return("", folderErr).Once()
 
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-		return r.Path == "level1/file.txt" && r.Action == repository.FileActionIgnored && r.Error != nil
+		return r.Path() == "level1/file.txt" && r.Action() == repository.FileActionIgnored && r.Error() != nil
 	})).Return().Once()
 
 	progress.On("HasDirPathFailedCreation", "level1/level2/file.txt").Return(true).Once()
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-		return r.Path == "level1/level2/file.txt" && r.Action == repository.FileActionIgnored &&
-			r.Warning != nil && r.Warning.Error() == "resource was not processed because the parent folder could not be created"
+		return r.Path() == "level1/level2/file.txt" && r.Action() == repository.FileActionIgnored &&
+			r.Warning() != nil && r.Warning().Error() == "resource was not processed because the parent folder could not be created"
 	})).Return().Once()
 
 	progress.On("HasDirPathFailedCreation", "level1/level2/level3/file.txt").Return(true).Once()
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-		return r.Path == "level1/level2/level3/file.txt" && r.Action == repository.FileActionIgnored &&
-			r.Warning != nil && r.Warning.Error() == "resource was not processed because the parent folder could not be created"
+		return r.Path() == "level1/level2/level3/file.txt" && r.Action() == repository.FileActionIgnored &&
+			r.Warning() != nil && r.Warning().Error() == "resource was not processed because the parent folder could not be created"
 	})).Return().Once()
 
 	err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
@@ -566,27 +566,27 @@ func TestIncrementalSync_HierarchicalErrorHandling_MixedSuccessAndFailure(t *tes
 	repoResources.On("WriteResourceFromFile", mock.Anything, "success/file1.json", "new-ref").
 		Return("resource-1", schema.GroupVersionKind{Kind: "Dashboard"}, nil).Once()
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-		return r.Path == "success/file1.json" && r.Action == repository.FileActionCreated && r.Error == nil
+		return r.Path() == "success/file1.json" && r.Action() == repository.FileActionCreated && r.Error() == nil
 	})).Return().Once()
 
 	progress.On("HasDirPathFailedCreation", "success/nested/file2.json").Return(false).Once()
 	repoResources.On("WriteResourceFromFile", mock.Anything, "success/nested/file2.json", "new-ref").
 		Return("resource-2", schema.GroupVersionKind{Kind: "Dashboard"}, nil).Once()
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-		return r.Path == "success/nested/file2.json" && r.Action == repository.FileActionCreated && r.Error == nil
+		return r.Path() == "success/nested/file2.json" && r.Action() == repository.FileActionCreated && r.Error() == nil
 	})).Return().Once()
 
 	folderErr := &resources.PathCreationError{Path: "failure/", Err: fmt.Errorf("disk full")}
 	progress.On("HasDirPathFailedCreation", "failure/file3.txt").Return(false).Once()
 	repoResources.On("EnsureFolderPathExist", mock.Anything, "failure/").Return("", folderErr).Once()
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-		return r.Path == "failure/file3.txt" && r.Action == repository.FileActionIgnored
+		return r.Path() == "failure/file3.txt" && r.Action() == repository.FileActionIgnored
 	})).Return().Once()
 
 	progress.On("HasDirPathFailedCreation", "failure/nested/file4.txt").Return(true).Once()
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-		return r.Path == "failure/nested/file4.txt" && r.Action == repository.FileActionIgnored &&
-			r.Warning != nil && r.Warning.Error() == "resource was not processed because the parent folder could not be created"
+		return r.Path() == "failure/nested/file4.txt" && r.Action() == repository.FileActionIgnored &&
+			r.Warning() != nil && r.Warning().Error() == "resource was not processed because the parent folder could not be created"
 	})).Return().Once()
 
 	err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
@@ -613,8 +613,8 @@ func TestIncrementalSync_HierarchicalErrorHandling_RenameWithFailedFolderCreatio
 
 	progress.On("HasDirPathFailedCreation", "newfolder/file.json").Return(true).Once()
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-		return r.Path == "newfolder/file.json" && r.Action == repository.FileActionIgnored &&
-			r.Warning != nil && r.Warning.Error() == "resource was not processed because the parent folder could not be created"
+		return r.Path() == "newfolder/file.json" && r.Action() == repository.FileActionIgnored &&
+			r.Warning() != nil && r.Warning().Error() == "resource was not processed because the parent folder could not be created"
 	})).Return().Once()
 
 	err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))


### PR DESCRIPTION
**What is this feature?**

Change how job results are created, from a regular struct instantiation to a factory method (New..).

**Why do we need this feature?**

This change set the base for a better error ownership. With the previous model, each piece of code calling progress.Record needed to handle how a error is represented in the result.

With the new approach, the error/warning logic lives in a single place and using the factory method ensures proper error counting. Also, the factory method has a couple of variation that simplifies it's usage through the code (skipped resources and non-named results).

This PR sets the base for classifying particular errors (e.g. malformed dashboards) as warnings. This classification happens in centralized place, meaning code creating the result doesn't need to take care of the logic of error classification. 

**Who is this feature for?**

Customers of provisioning feature.



**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/git-ui-sync-project/issues/683
