### PR TITLE
Auditing: Set default policy rule level for create to req+resp

### DIFF
--- a/pkg/apiserver/auditing/policy.go
+++ b/pkg/apiserver/auditing/policy.go
@@ -46,14 +46,23 @@ func (defaultGrafanaPolicyRuleEvaluator) EvaluatePolicyRule(attrs authorizer.Att
 		}
 	}
 
+	// Logging the response object allows us to get the resource name for create requests.
+	level := auditinternal.LevelMetadata
+	if attrs.GetVerb() == utils.VerbCreate {
+		level = auditinternal.LevelRequestResponse
+	}
+
 	return audit.RequestAuditConfig{
-		Level: auditinternal.LevelMetadata,
+		Level: level,
+
+		// Only log on StageResponseComplete, to avoid noisy logs.
 		OmitStages: []auditinternal.Stage{
-			// Only log on StageResponseComplete
 			auditinternal.StageRequestReceived,
 			auditinternal.StageResponseStarted,
 			auditinternal.StagePanic,
 		},
-		OmitManagedFields: false, // Setting it to true causes extra copying/unmarshalling.
+
+		// Setting it to true causes extra copying/unmarshalling.
+		OmitManagedFields: false,
 	}
 }

--- a/pkg/apiserver/auditing/policy_test.go
+++ b/pkg/apiserver/auditing/policy_test.go
@@ -55,12 +55,28 @@ func TestDefaultGrafanaPolicyRuleEvaluator(t *testing.T) {
 		require.Equal(t, auditinternal.LevelNone, config.Level)
 	})
 
-	t.Run("return audit level metadata for other resource requests", func(t *testing.T) {
+	t.Run("return audit level request+response for create requests", func(t *testing.T) {
 		t.Parallel()
 
 		attrs := authorizer.AttributesRecord{
 			ResourceRequest: true,
 			Verb:            utils.VerbCreate,
+			User: &user.DefaultInfo{
+				Name:   "test-user",
+				Groups: []string{"test-group"},
+			},
+		}
+
+		config := evaluator.EvaluatePolicyRule(attrs)
+		require.Equal(t, auditinternal.LevelRequestResponse, config.Level)
+	})
+
+	t.Run("return audit level metadata for other resource requests", func(t *testing.T) {
+		t.Parallel()
+
+		attrs := authorizer.AttributesRecord{
+			ResourceRequest: true,
+			Verb:            utils.VerbGet,
 			User: &user.DefaultInfo{
 				Name:   "test-user",
 				Groups: []string{"test-group"},


### PR DESCRIPTION
Change the default policy rule evaluator logging level to request + response, so we can grab the resource name from the response payload on create requests.

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1642