### PR TITLE
auth: Protect from empty session token panic

### DIFF
--- a/pkg/services/auth/auth.go
+++ b/pkg/services/auth/auth.go
@@ -20,9 +20,10 @@ const (
 
 // Typed errors
 var (
-	ErrUserTokenNotFound       = errors.New("user token not found")
-	ErrInvalidSessionToken     = usertoken.ErrInvalidSessionToken
-	ErrExternalSessionNotFound = errors.New("external session not found")
+	ErrUserTokenNotFound            = errors.New("user token not found")
+	ErrInvalidSessionToken          = usertoken.ErrInvalidSessionToken
+	ErrExternalSessionNotFound      = errors.New("external session not found")
+	ErrExternalSessionTokenNotFound = errors.New("session token was nil")
 )
 
 type (

--- a/pkg/services/oauthtoken/oauth_token.go
+++ b/pkg/services/oauthtoken/oauth_token.go
@@ -660,6 +660,10 @@ func (o *Service) getExternalSession(ctx context.Context, usr identity.Requester
 		return externalSessions[0], nil
 	}
 
+	if sessionToken == nil {
+		return nil, auth.ErrExternalSessionNotFound
+	}
+
 	// For regular users, we use the session token ID to fetch the external session
 	return o.sessionService.GetExternalSession(ctx, sessionToken.ExternalSessionId)
 }

--- a/pkg/services/oauthtoken/oauth_token.go
+++ b/pkg/services/oauthtoken/oauth_token.go
@@ -661,7 +661,7 @@ func (o *Service) getExternalSession(ctx context.Context, usr identity.Requester
 	}
 
 	if sessionToken == nil {
-		return nil, auth.ErrExternalSessionNotFound
+		return nil, auth.ErrExternalSessionTokenNotFound
 	}
 
 	// For regular users, we use the session token ID to fetch the external session


### PR DESCRIPTION
**What is this feature?**

This PR protects from a panic generated when the session token was not found.

**Why do we need this feature?**

We have received reports that a panic is generated on when the session token is missing.

**Who is this feature for?**

IAM / OAuth users

**Which issue(s) does this PR fix?**:

Fixes #
