### PR TITLE
Use data attribute on Drawer to set portal roots of children portal users, like Toggletip

### DIFF
--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -131,6 +131,7 @@ export function Drawer({
     >
       <FocusScope restoreFocus contain autoFocus>
         <div
+          data-grafana-portal-container
           aria-label={
             typeof title === 'string'
               ? selectors.components.Drawer.General.title(title)

--- a/packages/grafana-ui/src/components/Toggletip/Toggletip.mdx
+++ b/packages/grafana-ui/src/components/Toggletip/Toggletip.mdx
@@ -78,22 +78,22 @@ return (
 
 ### Usage inside Drawer
 
-When using Toggletip inside a Drawer or other focus-trapped container, pass the container element as `portalRoot` to ensure focus management works correctly. This renders the Toggletip content inside the Drawer's DOM tree instead of the default portal container.
-
-Use a state-based ref pattern to ensure the container is available before rendering the Toggletip:
+Toggletip automatically detects when it's inside a Drawer (or other focus-trapped container with the `data-grafana-portal-container` attribute) and adjusts its behavior accordingly. No additional configuration is needed:
 
 ```tsx
-const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
-
 <Drawer title="Settings" onClose={onClose}>
-  <div ref={setContainerEl}>
-    {containerEl && (
-      <Toggletip content={<Input placeholder="Type here..." />} portalRoot={containerEl}>
-        <Button>Open Toggletip</Button>
-      </Toggletip>
-    )}
-  </div>
-</Drawer>;
+  <Toggletip content={<Input placeholder="Type here..." />}>
+    <Button>Open Toggletip</Button>
+  </Toggletip>
+</Drawer>
 ```
+
+When auto-detected inside a focus-trapped container:
+
+- The Toggletip content renders inside the Drawer's DOM tree
+- Focus management defers to the parent container's focus trap
+- Interactive elements like inputs work correctly
+
+If you need to override auto-detection or specify a custom container, use the `portalRoot` prop.
 
 <ArgTypes of={Toggletip} />

--- a/packages/grafana-ui/src/components/Toggletip/Toggletip.mdx
+++ b/packages/grafana-ui/src/components/Toggletip/Toggletip.mdx
@@ -76,4 +76,24 @@ return (
 );
 ```
 
+### Usage inside Drawer
+
+When using Toggletip inside a Drawer or other focus-trapped container, pass the container element as `portalRoot` to ensure focus management works correctly. This renders the Toggletip content inside the Drawer's DOM tree instead of the default portal container.
+
+Use a state-based ref pattern to ensure the container is available before rendering the Toggletip:
+
+```tsx
+const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
+
+<Drawer title="Settings" onClose={onClose}>
+  <div ref={setContainerEl}>
+    {containerEl && (
+      <Toggletip content={<Input placeholder="Type here..." />} portalRoot={containerEl}>
+        <Button>Open Toggletip</Button>
+      </Toggletip>
+    )}
+  </div>
+</Drawer>;
+```
+
 <ArgTypes of={Toggletip} />

--- a/packages/grafana-ui/src/components/Toggletip/Toggletip.story.tsx
+++ b/packages/grafana-ui/src/components/Toggletip/Toggletip.story.tsx
@@ -1,6 +1,10 @@
 import { Meta, StoryFn } from '@storybook/react';
+import { useState } from 'react';
 
 import { Button } from '../Button/Button';
+import { Drawer } from '../Drawer/Drawer';
+import { Field } from '../Forms/Field';
+import { Input } from '../Input/Input';
 import { ScrollContainer } from '../ScrollContainer/ScrollContainer';
 import mdx from '../Toggletip/Toggletip.mdx';
 
@@ -130,6 +134,56 @@ LongContent.parameters = {
   controls: {
     hideNoControlsWarning: true,
     exclude: ['title', 'content', 'children'],
+  },
+};
+
+export const InsideDrawer: StoryFn<typeof Toggletip> = () => {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  // Use state instead of ref to trigger re-render when container is available
+  const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
+
+  return (
+    <>
+      <Button onClick={() => setIsDrawerOpen(true)}>Open Drawer</Button>
+      {isDrawerOpen && (
+        <Drawer title="Drawer with Toggletip" onClose={() => setIsDrawerOpen(false)}>
+          <div ref={setContainerEl}>
+            <p style={{ marginBottom: '16px' }}>
+              This demonstrates using Toggletip inside a Drawer. The <code>portalRoot</code> prop is used to render the
+              Toggletip content inside the Drawer&apos;s DOM, allowing focus to work correctly with the Drawer&apos;s
+              focus trap.
+            </p>
+            {containerEl && (
+              <Toggletip
+                title="Interactive Form"
+                content={
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                    <Field label="Name">
+                      <Input placeholder="Enter your name" />
+                    </Field>
+                    <Button variant="primary" size="sm">
+                      Submit
+                    </Button>
+                  </div>
+                }
+                footer="Focus should work correctly within this Toggletip"
+                placement="bottom-start"
+                portalRoot={containerEl}
+              >
+                <Button>Click to show Toggletip</Button>
+              </Toggletip>
+            )}
+          </div>
+        </Drawer>
+      )}
+    </>
+  );
+};
+
+InsideDrawer.parameters = {
+  controls: {
+    hideNoControlsWarning: true,
+    exclude: ['title', 'content', 'footer', 'children', 'placement', 'theme', 'closeButton', 'portalRoot'],
   },
 };
 

--- a/packages/grafana-ui/src/components/Toggletip/Toggletip.story.tsx
+++ b/packages/grafana-ui/src/components/Toggletip/Toggletip.story.tsx
@@ -139,41 +139,33 @@ LongContent.parameters = {
 
 export const InsideDrawer: StoryFn<typeof Toggletip> = () => {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  // Use state instead of ref to trigger re-render when container is available
-  const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
 
   return (
     <>
       <Button onClick={() => setIsDrawerOpen(true)}>Open Drawer</Button>
       {isDrawerOpen && (
         <Drawer title="Drawer with Toggletip" onClose={() => setIsDrawerOpen(false)}>
-          <div ref={setContainerEl}>
-            <p style={{ marginBottom: '16px' }}>
-              This demonstrates using Toggletip inside a Drawer. The <code>portalRoot</code> prop is used to render the
-              Toggletip content inside the Drawer&apos;s DOM, allowing focus to work correctly with the Drawer&apos;s
-              focus trap.
-            </p>
-            {containerEl && (
-              <Toggletip
-                title="Interactive Form"
-                content={
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-                    <Field label="Name">
-                      <Input placeholder="Enter your name" />
-                    </Field>
-                    <Button variant="primary" size="sm">
-                      Submit
-                    </Button>
-                  </div>
-                }
-                footer="Focus should work correctly within this Toggletip"
-                placement="bottom-start"
-                portalRoot={containerEl}
-              >
-                <Button>Click to show Toggletip</Button>
-              </Toggletip>
-            )}
-          </div>
+          <p style={{ marginBottom: '16px' }}>
+            Toggletip automatically detects when it&apos;s inside a Drawer and renders its content within the
+            Drawer&apos;s DOM, allowing focus to work correctly. No manual configuration needed!
+          </p>
+          <Toggletip
+            title="Interactive Form"
+            content={
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                <Field label="Name">
+                  <Input placeholder="Enter your name" />
+                </Field>
+                <Button variant="primary" size="sm">
+                  Submit
+                </Button>
+              </div>
+            }
+            footer="Focus works correctly - auto-detected!"
+            placement="bottom-start"
+          >
+            <Button>Click to show Toggletip</Button>
+          </Toggletip>
         </Drawer>
       )}
     </>

--- a/packages/grafana-ui/src/components/Toggletip/Toggletip.tsx
+++ b/packages/grafana-ui/src/components/Toggletip/Toggletip.tsx
@@ -47,6 +47,10 @@ export interface ToggletipProps {
   show?: boolean;
   /** Callback function to be called when the toggletip is opened */
   onOpen?: () => void;
+  /** Optional root element for the portal. Use when Toggletip is inside a focus-trapped container like Drawer.
+   *  When provided, the Toggletip will render inside this element and disable its own modal focus trap,
+   *  deferring focus management to the parent container. */
+  portalRoot?: HTMLElement;
 }
 
 /**
@@ -67,6 +71,7 @@ export const Toggletip = memo(
     fitContent = false,
     onOpen,
     show,
+    portalRoot,
   }: ToggletipProps) => {
     const arrowRef = useRef(null);
     const grafanaTheme = useTheme2();
@@ -119,7 +124,7 @@ export const Toggletip = memo(
           ...getReferenceProps(),
         })}
         {isOpen && (
-          <Portal>
+          <Portal root={portalRoot}>
             <FloatingFocusManager context={context} modal={true}>
               <div
                 data-testid="toggletip-content"


### PR DESCRIPTION
Alternative option to https://github.com/grafana/grafana/pull/115737

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This has Drawer setting a data attribute, so that Toggletip can automatically set Portal root and fix input focus if rendered inside a Drawer.

This removes the burden from our consumer, but requires potentially fragile dependencies between Drawer and Toggletip based on this custom data attribute.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
