### PR TITLE
Auditing: Move sinkable/logger interfaces and add global default logger implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/crewjam/saml v0.4.14 // @grafana/identity-access-team
 	github.com/dgraph-io/badger/v4 v4.7.0 // @grafana/grafana-search-and-storage
 	github.com/dlmiddlecote/sqlstats v1.0.2 // @grafana/grafana-backend-group
-	github.com/docker/go-connections v0.6.0 // indirect; @grafana/grafana-app-platform-squad
+	github.com/docker/go-connections v0.6.0 // @grafana/grafana-app-platform-squad
 	github.com/dolthub/go-mysql-server v0.19.1-0.20250410182021-5632d67cd46e // @grafana/grafana-datasources-core-services
 	github.com/dolthub/vitess v0.0.0-20250930230441-70c2c6a98e33 // @grafana/grafana-datasources-core-services
 	github.com/dustin/go-humanize v1.0.1 // @grafana/observability-traces-and-profiling

--- a/pkg/apiserver/auditing/logger.go
+++ b/pkg/apiserver/auditing/logger.go
@@ -1,6 +1,7 @@
 package auditing
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 )
@@ -17,4 +18,38 @@ type Logger interface {
 	Log(entry Sinkable) error
 	Close() error
 	Type() string
+}
+
+// Implementation inspired by https://github.com/grafana/grafana-app-sdk/blob/main/logging/logger.go
+type loggerContextKey struct{}
+
+var (
+	// DefaultLogger is the default Logger if one hasn't been provided in the context.
+	// You may use this to add arbitrary audit logging outside of an API request lifecycle.
+	DefaultLogger Logger = &NoopLogger{}
+
+	contextKey = loggerContextKey{}
+)
+
+// FromContext returns the Logger set in the context with Context(), or the DefaultLogger if no Logger is set in the context.
+// If DefaultLogger is nil, it returns a *NoopLogger so that the return is always valid to call methods on without nil-checking.
+// You may use this to add arbitrary audit logging outside of an API request lifecycle.
+func FromContext(ctx context.Context) Logger {
+	if l := ctx.Value(contextKey); l != nil {
+		if logger, ok := l.(Logger); ok {
+			return logger
+		}
+	}
+
+	if DefaultLogger != nil {
+		return DefaultLogger
+	}
+
+	return &NoopLogger{}
+}
+
+// Context returns a new context built from the provided context with the provided logger in it.
+// The Logger added with Context() can be retrieved with FromContext()
+func Context(ctx context.Context, logger Logger) context.Context {
+	return context.WithValue(ctx, contextKey, logger)
 }

--- a/pkg/apiserver/auditing/logger.go
+++ b/pkg/apiserver/auditing/logger.go
@@ -1,0 +1,20 @@
+package auditing
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Sinkable is a log entry abstraction that can be sent to an audit log sink through the different implementing methods.
+type Sinkable interface {
+	json.Marshaler
+	KVPairs() []any
+	Time() time.Time
+}
+
+// Logger specifies the contract for a specific audit logger.
+type Logger interface {
+	Log(entry Sinkable) error
+	Close() error
+	Type() string
+}

--- a/pkg/apiserver/auditing/noop.go
+++ b/pkg/apiserver/auditing/noop.go
@@ -11,9 +11,9 @@ type NoopBackend struct{}
 
 func ProvideNoopBackend() audit.Backend { return &NoopBackend{} }
 
-func (b *NoopBackend) ProcessEvents(k8sEvents ...*auditinternal.Event) bool { return false }
+func (NoopBackend) ProcessEvents(...*auditinternal.Event) bool { return false }
 
-func (NoopBackend) Run(stopCh <-chan struct{}) error { return nil }
+func (NoopBackend) Run(<-chan struct{}) error { return nil }
 
 func (NoopBackend) Shutdown() {}
 
@@ -34,3 +34,14 @@ type NoopPolicyRuleEvaluator struct{}
 func (NoopPolicyRuleEvaluator) EvaluatePolicyRule(authorizer.Attributes) audit.RequestAuditConfig {
 	return audit.RequestAuditConfig{Level: auditinternal.LevelNone}
 }
+
+// NoopLogger is a no-op implementation of Logger
+type NoopLogger struct{}
+
+func ProvideNoopLogger() Logger { return &NoopLogger{} }
+
+func (NoopLogger) Type() string { return "noop" }
+
+func (NoopLogger) Log(Sinkable) error { return nil }
+
+func (NoopLogger) Close() error { return nil }

--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/blugelabs/bluge"
 	_ "github.com/blugelabs/bluge_segment_api"
 	_ "github.com/crewjam/saml"
+	_ "github.com/docker/go-connections/nat"
 	_ "github.com/go-jose/go-jose/v4"
 	_ "github.com/gobwas/glob"
 	_ "github.com/googleapis/gax-go/v2"
@@ -30,6 +31,7 @@ import (
 	_ "github.com/spf13/cobra" // used by the standalone apiserver cli
 	_ "github.com/spyzhov/ajson"
 	_ "github.com/stretchr/testify/require"
+	_ "github.com/testcontainers/testcontainers-go"
 	_ "gocloud.dev/secrets/awskms"
 	_ "gocloud.dev/secrets/azurekeyvault"
 	_ "gocloud.dev/secrets/gcpkms"
@@ -54,9 +56,7 @@ import (
 	_ "github.com/grafana/e2e"
 	_ "github.com/grafana/gofpdf"
 	_ "github.com/grafana/gomemcache/memcache"
-	_ "github.com/grafana/tempo/pkg/traceql"
-
 	_ "github.com/grafana/grafana/apps/alerting/alertenrichment/pkg/apis/alertenrichment/v1beta1"
 	_ "github.com/grafana/grafana/apps/scope/pkg/apis/scope/v0alpha1"
-	_ "github.com/testcontainers/testcontainers-go"
+	_ "github.com/grafana/tempo/pkg/traceql"
 )


### PR DESCRIPTION
Moves the audit logging interfaces to `pkg/apiserver/auditing` so that we can provide a global audit logger `DefaultLogger` similar to what is done by the Grafana App SDK Logging package.

The intent here is to allow clients to create audit logging events outside of an HTTP request, which is covered by the k8s audit backend.

Example: audit events for secure value decryption.

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1642