### PR TITLE
Dashboard Conversion: Fix type assertion mismatch in data loss detection

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/conversion_data_loss_detection.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion_data_loss_detection.go
@@ -180,12 +180,15 @@ func countAnnotationsV0V1(spec map[string]interface{}) int {
 		return 0
 	}
 
-	annotationList, ok := annotations["list"].([]interface{})
-	if !ok {
-		return 0
+	// Handle both []interface{} (from JSON unmarshaling) and []map[string]interface{} (from programmatic creation)
+	if annotationList, ok := annotations["list"].([]interface{}); ok {
+		return len(annotationList)
+	}
+	if annotationList, ok := annotations["list"].([]map[string]interface{}); ok {
+		return len(annotationList)
 	}
 
-	return len(annotationList)
+	return 0
 }
 
 // countLinksV0V1 counts dashboard links in v0alpha1 or v1beta1 dashboard spec
@@ -194,12 +197,15 @@ func countLinksV0V1(spec map[string]interface{}) int {
 		return 0
 	}
 
-	links, ok := spec["links"].([]interface{})
-	if !ok {
-		return 0
+	// Handle both []interface{} (from JSON unmarshaling) and []map[string]interface{} (from programmatic creation)
+	if links, ok := spec["links"].([]interface{}); ok {
+		return len(links)
+	}
+	if links, ok := spec["links"].([]map[string]interface{}); ok {
+		return len(links)
 	}
 
-	return len(links)
+	return 0
 }
 
 // countVariablesV0V1 counts template variables in v0alpha1 or v1beta1 dashboard spec
@@ -213,12 +219,15 @@ func countVariablesV0V1(spec map[string]interface{}) int {
 		return 0
 	}
 
-	variableList, ok := templating["list"].([]interface{})
-	if !ok {
-		return 0
+	// Handle both []interface{} (from JSON unmarshaling) and []map[string]interface{} (from programmatic creation)
+	if variableList, ok := templating["list"].([]interface{}); ok {
+		return len(variableList)
+	}
+	if variableList, ok := templating["list"].([]map[string]interface{}); ok {
+		return len(variableList)
 	}
 
-	return len(variableList)
+	return 0
 }
 
 // collectStatsV0V1 collects statistics from v0alpha1 or v1beta1 dashboard


### PR DESCRIPTION
Fixes a false positive bug in the dashboard conversion data loss detection system that incorrectly reported data loss when converting v2beta1 dashboards to v0alpha1.

### Symptoms
When loading a v2beta1 dashboard through v0alpha1 endpoint, the following error appeared in logs even though no actual data was lost:

```
ERROR[12-30|07:51:37] Dashboard conversion failed
  caller=logger.go:234
  logger=dashboard.conversion
  sourceVersionAPI=dashboard.grafana.app/v2beta1
  targetVersionAPI=dashboard.grafana.app/v0alpha1
  erroredConversionFunc=V2beta1_to_V0
  dashboardUID=t40yQAX2TX3nBetcCVqwItEZdOWXcESDqDtcLa90utgX
  panelsLost=0
  queriesLost=0
  annotationsLost=1
  linksLost=0
  variablesLost=1
  errorType=conversion_data_loss_error
  error="data loss detected in V2beta1_to_V0..."
```

### Root Cause

The issue was a **Go type assertion mismatch** in the data loss detection code, not in the actual conversion logic.

### The Problem

1. When dashboards are loaded from JSON storage, Go's JSON unmarshaler creates `[]interface{}` for arrays
2. When dashboards are converted programmatically (e.g., v2beta1 → v1beta1 → v0), the conversion functions create `[]map[string]interface{}` for annotations, variables, and links
3. The data loss detection counting functions were only checking for `[]interface{}`
4. In Go, `[]map[string]interface{}` cannot be type-asserted as `[]interface{}` - they are different types at runtime

### Reproducing bug locally (on main)
1. Load a v2 dashboard through v0 endpoint
2. In terminal, you should see logger reporting loss detection, although no annotations or variables are lost

Fixes https://github.com/grafana/grafana/issues/115316

Please check that:
- [ ] It works as expected from a user's perspective.

