### PR TITLE
fix: AWS Cloudwatch Bedrock Service include cache metrics

### DIFF
--- a/pkg/tsdb/cloudwatch/services/metrics_extensions.go
+++ b/pkg/tsdb/cloudwatch/services/metrics_extensions.go
@@ -1,0 +1,45 @@
+package services
+
+import (
+	"github.com/grafana/grafana-aws-sdk/pkg/cloudWatchConsts"
+)
+
+// init extends the SDK's NamespaceMetricsMap with additional metrics
+// that may not be available in the current SDK version.
+// This allows Grafana to support new CloudWatch metrics without waiting
+// for SDK releases.
+func init() {
+	extendBedrockMetrics()
+}
+
+// extendBedrockMetrics adds additional AWS/Bedrock metrics that are not
+// yet available in the grafana-aws-sdk package.
+func extendBedrockMetrics() {
+	bedrockMetrics := cloudWatchConsts.NamespaceMetricsMap["AWS/Bedrock"]
+	if bedrockMetrics == nil {
+		return
+	}
+
+	additionalMetrics := []string{
+		"CacheWriteInputTokenCount",
+		"CacheWriteOutputTokenCount",
+	}
+
+	for _, metric := range additionalMetrics {
+		if !containsMetric(bedrockMetrics, metric) {
+			cloudWatchConsts.NamespaceMetricsMap["AWS/Bedrock"] = append(
+				cloudWatchConsts.NamespaceMetricsMap["AWS/Bedrock"],
+				metric,
+			)
+		}
+	}
+}
+
+func containsMetric(metrics []string, metric string) bool {
+	for _, m := range metrics {
+		if m == metric {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/tsdb/cloudwatch/services/metrics_extensions_test.go
+++ b/pkg/tsdb/cloudwatch/services/metrics_extensions_test.go
@@ -1,0 +1,55 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-aws-sdk/pkg/cloudWatchConsts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBedrockCacheMetrics(t *testing.T) {
+	t.Run("AWS/Bedrock namespace should include CacheWriteInputTokenCount metric", func(t *testing.T) {
+		metrics := cloudWatchConsts.NamespaceMetricsMap["AWS/Bedrock"]
+		assert.Contains(t, metrics, "CacheWriteInputTokenCount")
+	})
+
+	t.Run("AWS/Bedrock namespace should include CacheWriteOutputTokenCount metric", func(t *testing.T) {
+		metrics := cloudWatchConsts.NamespaceMetricsMap["AWS/Bedrock"]
+		assert.Contains(t, metrics, "CacheWriteOutputTokenCount")
+	})
+
+	t.Run("GetHardCodedMetricsByNamespace should return Bedrock cache metrics", func(t *testing.T) {
+		resp, err := GetHardCodedMetricsByNamespace("AWS/Bedrock")
+		assert.NoError(t, err)
+
+		var foundCacheWriteInput, foundCacheWriteOutput bool
+		for _, metric := range resp {
+			if metric.Value.Name == "CacheWriteInputTokenCount" {
+				foundCacheWriteInput = true
+			}
+			if metric.Value.Name == "CacheWriteOutputTokenCount" {
+				foundCacheWriteOutput = true
+			}
+		}
+
+		assert.True(t, foundCacheWriteInput, "CacheWriteInputTokenCount metric should be returned")
+		assert.True(t, foundCacheWriteOutput, "CacheWriteOutputTokenCount metric should be returned")
+	})
+}
+
+func TestContainsMetric(t *testing.T) {
+	t.Run("should return true if metric exists", func(t *testing.T) {
+		metrics := []string{"MetricA", "MetricB", "MetricC"}
+		assert.True(t, containsMetric(metrics, "MetricB"))
+	})
+
+	t.Run("should return false if metric does not exist", func(t *testing.T) {
+		metrics := []string{"MetricA", "MetricB", "MetricC"}
+		assert.False(t, containsMetric(metrics, "MetricD"))
+	})
+
+	t.Run("should return false for empty slice", func(t *testing.T) {
+		metrics := []string{}
+		assert.False(t, containsMetric(metrics, "MetricA"))
+	})
+}


### PR DESCRIPTION
Fixes #114945

## Changes
- Add `CacheWriteInputTokenCount` and `CacheWriteOutputTokenCount` metrics to AWS/Bedrock namespace in CloudWatch datasource
- Extend the SDK's NamespaceMetricsMap via init() to support new metrics without waiting for SDK releases
- Add tests to verify the metrics are correctly added