### PR TITLE
Dashboards V2: Check that variable is not null when initializing DS ref

### DIFF
--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
@@ -345,10 +345,12 @@ export class V2DashboardSerializer
     // initialize autossigned variable ds references map
     if (saveModel?.variables) {
       for (const variable of saveModel.variables) {
-        // for query variables that dont have a ds defined add them to the list
-        if (variable.kind === 'QueryVariable' && !variable.spec.query.datasource?.name) {
-          const datasourceType = variable.spec.query.group || undefined;
-          this.defaultDsReferencesMap.variables.set(variable.spec.name, datasourceType);
+        if (variable) {
+          // for query variables that dont have a ds defined add them to the list
+          if (variable.kind === 'QueryVariable' && !variable.spec.query.datasource?.name) {
+            const datasourceType = variable.spec.query.group || undefined;
+            this.defaultDsReferencesMap.variables.set(variable.spec.name, datasourceType);
+          }
         }
       }
     }

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
@@ -23,7 +23,7 @@ import { getVariablesCompatibility } from '../utils/getVariablesCompatibility';
 import { getVizPanelKeyForPanelId } from '../utils/utils';
 
 import { transformSceneToSaveModel } from './transformSceneToSaveModel';
-import { transformSceneToSaveModelSchemaV2 } from './transformSceneToSaveModelSchemaV2'; 
+import { transformSceneToSaveModelSchemaV2 } from './transformSceneToSaveModelSchemaV2';
 
 /**
  * T is the type of the save model

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
@@ -1,3 +1,4 @@
+import { logWarning } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
 import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { AnnoKeyDashboardSnapshotOriginalUrl, ObjectMeta } from 'app/features/apiserver/types';
@@ -22,7 +23,7 @@ import { getVariablesCompatibility } from '../utils/getVariablesCompatibility';
 import { getVizPanelKeyForPanelId } from '../utils/utils';
 
 import { transformSceneToSaveModel } from './transformSceneToSaveModel';
-import { transformSceneToSaveModelSchemaV2 } from './transformSceneToSaveModelSchemaV2';
+import { transformSceneToSaveModelSchemaV2 } from './transformSceneToSaveModelSchemaV2'; 
 
 /**
  * T is the type of the save model
@@ -351,6 +352,10 @@ export class V2DashboardSerializer
             const datasourceType = variable.spec.query.group || undefined;
             this.defaultDsReferencesMap.variables.set(variable.spec.name, datasourceType);
           }
+        } else {
+          const warningMsg = 'Dashboard serializer: Undefined variable found in dashboard save model, ignoring it';
+          console.warn(warningMsg);
+          logWarning(warningMsg);
         }
       }
     }


### PR DESCRIPTION
I'm not sure how it happened, but one of the variables in my dashboard was null, so the dashboard broke in the serializer and failed to load :

<img width="589" height="224" alt="Screenshot 2025-12-31 at 09 59 17" src="https://github.com/user-attachments/assets/9a7ec616-7a91-419c-ba11-9320c037966d" />

I guess it would be better to track down why it was null, than to fix the symptom, but I don't think that's possible nor do I remember how I made the dashboard 😭 