### PR TITLE
Secrets: Dont update createdBy when updating a secure value

### DIFF
--- a/pkg/storage/secret/metadata/data/secure_value_get_latest_version_and_created_at.sql
+++ b/pkg/storage/secret/metadata/data/secure_value_get_latest_version_and_created_at.sql
@@ -1,12 +1,13 @@
 SELECT
   {{ .Ident "created" }},
+  {{ .Ident "created_by" }},
   {{ .Ident "version" }},
   {{ .Ident "active" }},
   {{ .Ident "namespace" }},
   {{ .Ident "name" }}
 FROM
   {{ .Ident "secret_secure_value" }}
-WHERE 
+WHERE
   {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "name" }} = {{ .Arg .Name }}
 ORDER BY {{ .Ident "version" }} DESC

--- a/pkg/storage/secret/metadata/secure_value_model.go
+++ b/pkg/storage/secret/metadata/secure_value_model.go
@@ -122,7 +122,7 @@ func (sv *secureValueDB) toKubernetes() (*secretv1beta1.SecureValue, error) {
 }
 
 // toCreateRow maps a Kubernetes resource into a DB row for new resources being created/inserted.
-func toCreateRow(createdAt, updatedAt int64, keeper string, sv *secretv1beta1.SecureValue, actorUID string) (*secureValueDB, error) {
+func toCreateRow(createdAt, updatedAt int64, keeper string, sv *secretv1beta1.SecureValue, createdBy, updatedBy string) (*secureValueDB, error) {
 	row, err := toRow(keeper, sv, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert SecureValue to secureValueDB: %w", err)
@@ -130,9 +130,9 @@ func toCreateRow(createdAt, updatedAt int64, keeper string, sv *secretv1beta1.Se
 
 	row.GUID = uuid.New().String()
 	row.Created = createdAt
-	row.CreatedBy = actorUID
+	row.CreatedBy = createdBy
 	row.Updated = updatedAt
-	row.UpdatedBy = actorUID
+	row.UpdatedBy = updatedBy
 
 	return row, nil
 }

--- a/pkg/storage/secret/metadata/testdata/mysql--secure_value_get_latest_version_and_created_at-get latest secure value version.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--secure_value_get_latest_version_and_created_at-get latest secure value version.sql
@@ -1,12 +1,13 @@
 SELECT
   `created`,
+  `created_by`,
   `version`,
   `active`,
   `namespace`,
   `name`
 FROM
   `secret_secure_value`
-WHERE 
+WHERE
   `namespace` = 'ns' AND
   `name` = 'name'
 ORDER BY `version` DESC

--- a/pkg/storage/secret/metadata/testdata/postgres--secure_value_get_latest_version_and_created_at-get latest secure value version.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--secure_value_get_latest_version_and_created_at-get latest secure value version.sql
@@ -1,12 +1,13 @@
 SELECT
   "created",
+  "created_by",
   "version",
   "active",
   "namespace",
   "name"
 FROM
   "secret_secure_value"
-WHERE 
+WHERE
   "namespace" = 'ns' AND
   "name" = 'name'
 ORDER BY "version" DESC

--- a/pkg/storage/secret/metadata/testdata/sqlite--secure_value_get_latest_version_and_created_at-get latest secure value version.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--secure_value_get_latest_version_and_created_at-get latest secure value version.sql
@@ -1,12 +1,13 @@
 SELECT
   "created",
+  "created_by",
   "version",
   "active",
   "namespace",
   "name"
 FROM
   "secret_secure_value"
-WHERE 
+WHERE
   "namespace" = 'ns' AND
   "name" = 'name'
 ORDER BY "version" DESC


### PR DESCRIPTION
When updating an existing Secure Value, the `createdBy` annotation was not preserved, but shouldn't be modified like the `createdAt`.