### PR TITLE
Stars: Return an error when trying to save non-dashboard stars with legacy storage

### DIFF
--- a/pkg/registry/apis/collections/legacy/stars.go
+++ b/pkg/registry/apis/collections/legacy/stars.go
@@ -170,6 +170,13 @@ func (s *DashboardStarsStorage) write(ctx context.Context, obj *collections.Star
 		return nil, err
 	}
 
+	// Send an error if we try to save a non-dashboard star
+	for _, res := range obj.Spec.Resource {
+		if res.Group != "dashboard.grafana.app" || res.Kind != "Dashboard" {
+			return nil, fmt.Errorf("only dashboard stars are supported until the migration to unified storage is complete")
+		}
+	}
+
 	user, err := s.users.GetByUID(ctx, &user.GetUserByUIDQuery{
 		UID: owner.Identifier,
 	})

--- a/pkg/tests/apis/collections/stars_test.go
+++ b/pkg/tests/apis/collections/stars_test.go
@@ -140,7 +140,8 @@ func TestIntegrationStars(t *testing.T) {
 			}, &raw)
 			require.Equal(t, http.StatusOK, legacyResponse.Response.StatusCode, "removed dashboard star")
 
-			rspObj, err := starsClient.Resource.Get(ctx, "user-"+starsClient.Args.User.Identity.GetIdentifier(), metav1.GetOptions{})
+			adminStarName := "user-" + starsClient.Args.User.Identity.GetIdentifier()
+			rspObj, err := starsClient.Resource.Get(ctx, adminStarName, metav1.GetOptions{})
 			require.NoError(t, err)
 
 			after := typed(t, rspObj, &collections.Stars{})
@@ -154,7 +155,7 @@ func TestIntegrationStars(t *testing.T) {
 			rspObj, err = starsClient.Resource.Update(ctx, &unstructured.Unstructured{
 				Object: map[string]any{
 					"metadata": map[string]any{
-						"name":      "user-" + starsClient.Args.User.Identity.GetIdentifier(),
+						"name":      adminStarName,
 						"namespace": "default",
 					},
 					"spec": map[string]any{
@@ -179,7 +180,15 @@ func TestIntegrationStars(t *testing.T) {
 				[]string{"test-2", "aaa", "bbb"}, // keeps the requested order, removing duplicates
 				resources[0].Names)
 
-			rspObj, err = starsClient.Resource.Get(ctx, "user-"+starsClient.Args.User.Identity.GetIdentifier(), metav1.GetOptions{})
+			// Now add a star with the sub-resource route used by the UI
+			client := helper.Org1.Admin.RESTClient(t, &collections.GroupVersion)
+			res := client.Put().AbsPath("apis", "collections.grafana.app", "v1alpha1",
+				"namespaces", "default",
+				"stars", adminStarName,
+				"update", "dashboard.grafana.app", "Dashboard", "xxx").Do(ctx)
+			require.NoError(t, res.Error())
+
+			rspObj, err = starsClient.Resource.Get(ctx, adminStarName, metav1.GetOptions{})
 			require.NoError(t, err)
 
 			after = typed(t, rspObj, &collections.Stars{})
@@ -197,7 +206,8 @@ func TestIntegrationStars(t *testing.T) {
 							"names": [
 								"aaa",
 								"bbb",
-								"test-2"
+								"test-2",
+								"xxx"
 							]
 						}
 					]
@@ -212,6 +222,17 @@ func TestIntegrationStars(t *testing.T) {
 			rspObj, err = starsClientViewer.Resource.Get(ctx, "user-"+starsClient.Args.User.Identity.GetIdentifier(), metav1.GetOptions{})
 			require.Error(t, err)
 			require.Nil(t, rspObj)
+
+			// Use the API to star a non-dashboard resource
+			res = client.Put().AbsPath("apis", "collections.grafana.app", "v1alpha1",
+				"namespaces", "default",
+				"stars", adminStarName,
+				"update", "servicemodel.ext.grafana.com", "Component", "xxx").Do(ctx)
+			if mode == grafanarest.Mode5 {
+				require.NoError(t, res.Error())
+			} else {
+				require.Error(t, res.Error(), "only dashboard stars are supported until the migration to unified storage is complete")
+			}
 		})
 	}
 }


### PR DESCRIPTION
The stars API will currently accept star requests for non-dashboard resources and then quietly ignore them.

This PR updates thing so we return an error, and adds this scenario to the integration tests