### PR TITLE
Zanzana: Add metric for last reconciliation

### DIFF
--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -847,7 +847,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	if err != nil {
 		return nil, err
 	}
-	zanzanaReconciler := dualwrite2.ProvideZanzanaReconciler(cfg, featureToggles, zanzanaClient, sqlStore, serverLockService, folderimplService)
+	zanzanaReconciler := dualwrite2.ProvideZanzanaReconciler(cfg, featureToggles, zanzanaClient, sqlStore, serverLockService, folderimplService, registerer)
 	investigationsAppProvider := investigations.RegisterApp(cfg)
 	appregistryService, err := appregistry.ProvideBuilderRunners(apiserverService, eventualRestConfigProvider, featureToggles, investigationsAppProvider, cfg)
 	if err != nil {
@@ -1509,7 +1509,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	if err != nil {
 		return nil, err
 	}
-	zanzanaReconciler := dualwrite2.ProvideZanzanaReconciler(cfg, featureToggles, zanzanaClient, sqlStore, serverLockService, folderimplService)
+	zanzanaReconciler := dualwrite2.ProvideZanzanaReconciler(cfg, featureToggles, zanzanaClient, sqlStore, serverLockService, folderimplService, registerer)
 	investigationsAppProvider := investigations.RegisterApp(cfg)
 	appregistryService, err := appregistry.ProvideBuilderRunners(apiserverService, eventualRestConfigProvider, featureToggles, investigationsAppProvider, cfg)
 	if err != nil {

--- a/pkg/services/accesscontrol/dualwrite/reconciler.go
+++ b/pkg/services/accesscontrol/dualwrite/reconciler.go
@@ -177,7 +177,7 @@ func (r *ZanzanaReconciler) hasBasicRolePermissions(ctx context.Context) bool {
 func (r *ZanzanaReconciler) waitForBasicRolesSeeded(ctx context.Context) {
 	// Best-effort: don't block forever. If we can't observe basic roles, proceed anyway.
 	const (
-		maxWait  = 30 * time.Second
+		maxWait  = 15 * time.Second
 		interval = 1 * time.Second
 	)
 

--- a/pkg/tests/apis/folder/folder_tree_test.go
+++ b/pkg/tests/apis/folder/folder_tree_test.go
@@ -102,6 +102,8 @@ func runIntegrationFolderTree(t *testing.T, opts testinfra.GrafanaOpts) {
 	helper := apis.NewK8sTestHelper(t, opts)
 	defer helper.Shutdown()
 
+	apis.AwaitZanzanaReconcileNext(t, helper)
+
 	tests := []struct {
 		Name       string
 		Definition FolderDefinition
@@ -154,6 +156,8 @@ func runIntegrationFolderTree(t *testing.T, opts testinfra.GrafanaOpts) {
 			tt.Definition.RequireUniqueName(t, make(map[string]bool))
 
 			tt.Definition.CreateWithLegacyAPI(t, helper, "")
+
+			apis.AwaitZanzanaReconcileNext(t, helper)
 
 			for _, expect := range tt.Expected {
 				unstructured, client := getFolderClients(t, expect.User)

--- a/pkg/tests/apis/folder/folder_tree_test.go
+++ b/pkg/tests/apis/folder/folder_tree_test.go
@@ -249,6 +249,8 @@ func (f *FolderDefinition) CreateWithLegacyAPI(t *testing.T, h *apis.K8sTestHelp
 		})
 		require.NoError(t, err)
 
+		apis.AwaitZanzanaReconcileNext(t, h)
+
 		var statusCode int
 		result := client.Post().AbsPath("api", "folders").
 			Body(body).
@@ -258,8 +260,6 @@ func (f *FolderDefinition) CreateWithLegacyAPI(t *testing.T, h *apis.K8sTestHelp
 		require.NoError(t, result.Error(), f.Name)
 		require.Equal(t, int(http.StatusOK), statusCode, f.Name)
 		parent = f.Name
-
-		apis.AwaitZanzanaReconcileNext(t, h)
 
 		if len(f.Permissions) > 0 {
 			for _, def := range f.Permissions {
@@ -278,7 +278,6 @@ func (f *FolderDefinition) CreateWithLegacyAPI(t *testing.T, h *apis.K8sTestHelp
 					require.Equal(t, int(http.StatusOK), statusCode, f.Name)
 				}
 			}
-			apis.AwaitZanzanaReconcileNext(t, h)
 		}
 	}
 

--- a/pkg/tests/apis/folder/folder_tree_test.go
+++ b/pkg/tests/apis/folder/folder_tree_test.go
@@ -157,8 +157,6 @@ func runIntegrationFolderTree(t *testing.T, opts testinfra.GrafanaOpts) {
 
 			tt.Definition.CreateWithLegacyAPI(t, helper, "")
 
-			apis.AwaitZanzanaReconcileNext(t, helper)
-
 			for _, expect := range tt.Expected {
 				unstructured, client := getFolderClients(t, expect.User)
 				t.Run(fmt.Sprintf("query as %s", expect.User.Identity.GetLogin()), func(t *testing.T) {
@@ -261,6 +259,8 @@ func (f *FolderDefinition) CreateWithLegacyAPI(t *testing.T, h *apis.K8sTestHelp
 		require.Equal(t, int(http.StatusOK), statusCode, f.Name)
 		parent = f.Name
 
+		apis.AwaitZanzanaReconcileNext(t, h)
+
 		if len(f.Permissions) > 0 {
 			for _, def := range f.Permissions {
 				// http://localhost:3000/api/access-control/folders/feyx0ezuwqwowb/users/aeyx0jzgix9fkd
@@ -278,6 +278,7 @@ func (f *FolderDefinition) CreateWithLegacyAPI(t *testing.T, h *apis.K8sTestHelp
 					require.Equal(t, int(http.StatusOK), statusCode, f.Name)
 				}
 			}
+			apis.AwaitZanzanaReconcileNext(t, h)
 		}
 	}
 

--- a/pkg/tests/apis/zanzana_reconcile.go
+++ b/pkg/tests/apis/zanzana_reconcile.go
@@ -2,6 +2,7 @@ package apis
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -22,7 +23,11 @@ const zanzanaReconcileLastSuccessMetric = "grafana_zanzana_reconcile_last_succes
 func AwaitZanzanaReconcileNext(t *testing.T, helper *K8sTestHelper) {
 	t.Helper()
 
-	if helper == nil || !helper.GetEnv().FeatureToggles.IsEnabledGlobally(featuremgmt.FlagZanzana) {
+	enabled := false
+	if helper != nil {
+		enabled = helper.GetEnv().FeatureToggles.GetEnabled(context.Background())[featuremgmt.FlagZanzana]
+	}
+	if helper == nil || !enabled {
 		return
 	}
 
@@ -38,7 +43,7 @@ func AwaitZanzanaReconcileNext(t *testing.T, helper *K8sTestHelper) {
 			return
 		}
 		assert.Greater(c, ts, prev, "expected %s (%v) > %v", zanzanaReconcileLastSuccessMetric, ts, prev)
-	}, 5*time.Second, 50*time.Millisecond)
+	}, 10*time.Second, 50*time.Millisecond)
 }
 
 func getZanzanaReconcileLastSuccessTimestampSeconds(t *testing.T, helper *K8sTestHelper) (float64, bool) {

--- a/pkg/tests/apis/zanzana_reconcile.go
+++ b/pkg/tests/apis/zanzana_reconcile.go
@@ -1,0 +1,82 @@
+package apis
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+const zanzanaReconcileLastSuccessMetric = "grafana_zanzana_reconcile_last_success_timestamp_seconds"
+
+// AwaitZanzanaReconcileNext waits for the next Zanzana reconciliation cycle to complete.
+// It is a no-op unless the `zanzana` feature toggle is enabled for the running test env.
+func AwaitZanzanaReconcileNext(t *testing.T, helper *K8sTestHelper) {
+	t.Helper()
+
+	if helper == nil || !helper.GetEnv().FeatureToggles.IsEnabledGlobally(featuremgmt.FlagZanzana) {
+		return
+	}
+
+	prev, ok := getZanzanaReconcileLastSuccessTimestampSeconds(t, helper)
+	if !ok {
+		prev = 0
+	}
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		ts, ok := getZanzanaReconcileLastSuccessTimestampSeconds(t, helper)
+		assert.True(c, ok, "expected to find %s in /metrics", zanzanaReconcileLastSuccessMetric)
+		if !ok {
+			return
+		}
+		assert.Greater(c, ts, prev, "expected %s (%v) > %v", zanzanaReconcileLastSuccessMetric, ts, prev)
+	}, 5*time.Second, 50*time.Millisecond)
+}
+
+func getZanzanaReconcileLastSuccessTimestampSeconds(t *testing.T, helper *K8sTestHelper) (float64, bool) {
+	t.Helper()
+
+	rsp := DoRequest(helper, RequestParams{
+		User:   helper.Org1.Admin,
+		Path:   "/metrics",
+		Accept: "text/plain",
+	}, &struct{}{})
+	if rsp.Response == nil || rsp.Response.StatusCode != http.StatusOK {
+		return 0, false
+	}
+
+	parser := expfmt.NewTextParser(model.UTF8Validation)
+	metrics, err := parser.TextToMetricFamilies(bytes.NewReader(rsp.Body))
+	if err != nil {
+		return 0, false
+	}
+
+	metric := metrics[zanzanaReconcileLastSuccessMetric]
+	if metric == nil || len(metric.Metric) == 0 {
+		return 0, false
+	}
+
+	m := metric.Metric[0]
+	switch metric.GetType() {
+	case dto.MetricType_GAUGE:
+		if m.Gauge == nil {
+			return 0, false
+		}
+		return m.Gauge.GetValue(), true
+	case dto.MetricType_UNTYPED:
+		if m.Untyped == nil {
+			return 0, false
+		}
+		return m.Untyped.GetValue(), true
+	default:
+		return 0, false
+	}
+}

--- a/pkg/tests/apis/zanzana_reconcile.go
+++ b/pkg/tests/apis/zanzana_reconcile.go
@@ -43,7 +43,7 @@ func AwaitZanzanaReconcileNext(t *testing.T, helper *K8sTestHelper) {
 			return
 		}
 		assert.Greater(c, ts, prev, "expected %s (%v) > %v", zanzanaReconcileLastSuccessMetric, ts, prev)
-	}, 10*time.Second, 50*time.Millisecond)
+	}, 30*time.Second, 50*time.Millisecond)
 }
 
 func getZanzanaReconcileLastSuccessTimestampSeconds(t *testing.T, helper *K8sTestHelper) (float64, bool) {


### PR DESCRIPTION
Adds a metric for last zanzana reconciliation time and uses that to ensure the integration test isnt flaky (but this will be helpful regardless to make sure things are running)