### PR TITLE
Zanzana: Add reconcilation verbs

### DIFF
--- a/pkg/services/authz/zanzana/zanzana.go
+++ b/pkg/services/authz/zanzana/zanzana.go
@@ -45,8 +45,16 @@ const (
 )
 
 var (
-	RelationsFolder      = common.RelationsTyped
-	RelationsResouce     = common.RelationsResource
+	// RelationsFolder is used by reconciliation to list tuples for folder objects.
+	// It must include both verb relations (get/update/delete/...) and the permission-set relations (view/edit/admin)
+	RelationsFolder = append(append([]string{}, common.RelationsTyped...),
+		common.RelationSetView, common.RelationSetEdit, common.RelationSetAdmin,
+	)
+	// RelationsResouce is used by reconciliation to list tuples for resource objects.
+	// Include permission-set relations for the same reason as RelationsFolder.
+	RelationsResouce = append(append([]string{}, common.RelationsResource...),
+		common.RelationSetView, common.RelationSetEdit, common.RelationSetAdmin,
+	)
 	RelationsSubresource = common.RelationsSubresource
 )
 


### PR DESCRIPTION
Extracted from https://github.com/grafana/grafana/pull/115771, since this is a functional change. Fixes [this](https://github.com/grafana/grafana/blob/2b27b7a7dcc9d266a960038c94c0169811c6f4e3/pkg/tests/apis/dashboard/integration/api_validation_test.go#L1537)

The Zanzana reconciler lists existing tuples that were of the type [RelationsTyped](https://github.com/grafana/grafana/blob/521670981add82ce8368b416fdc590b4f7ef9095/pkg/services/authz/zanzana/common/tuple.go#L110) and [RelationsResource](https://github.com/grafana/grafana/blob/521670981add82ce8368b416fdc590b4f7ef9095/pkg/services/authz/zanzana/common/tuple.go#L100), not permission-set relations ([view](https://github.com/grafana/grafana/blob/521670981add82ce8368b416fdc590b4f7ef9095/pkg/services/authz/zanzana/common/tuple.go#L49)/edit/admin), so the tuples can go stale.