### PR TITLE
Auth: Cleanup duplicate isGroupMember methods from OAuth connectors

### DIFF
--- a/pkg/login/social/connectors/generic_oauth.go
+++ b/pkg/login/social/connectors/generic_oauth.go
@@ -162,23 +162,6 @@ func (s *SocialGenericOAuth) Reload(ctx context.Context, settings ssoModels.SSOS
 	return nil
 }
 
-// TODOD: remove this in the next PR and use the isGroupMember from social.go
-func (s *SocialGenericOAuth) isGroupMember(groups []string) bool {
-	if len(s.info.AllowedGroups) == 0 {
-		return true
-	}
-
-	for _, allowedGroup := range s.info.AllowedGroups {
-		for _, group := range groups {
-			if group == allowedGroup {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
 func (s *SocialGenericOAuth) isTeamMember(ctx context.Context, client *http.Client) bool {
 	if len(s.teamIds) == 0 {
 		return true

--- a/pkg/login/social/connectors/okta_oauth.go
+++ b/pkg/login/social/connectors/okta_oauth.go
@@ -205,20 +205,3 @@ func (s *SocialOkta) getGroups(data *OktaUserInfoJson) []string {
 	}
 	return groups
 }
-
-// TODO: remove this in a separate PR and use the isGroupMember from the social.go
-func (s *SocialOkta) isGroupMember(groups []string) bool {
-	if len(s.info.AllowedGroups) == 0 {
-		return true
-	}
-
-	for _, allowedGroup := range s.info.AllowedGroups {
-		for _, group := range groups {
-			if group == allowedGroup {
-				return true
-			}
-		}
-	}
-
-	return false
-}


### PR DESCRIPTION
Both SocialGenericOAuth and SocialOkta structs embed SocialBase, which already provides the isGroupMember method. 

**What is this feature?**

Removed duplicate `isGroupMember` methods from `SocialGenericOAuth` and `SocialOkta` connectors that shadowed the inherited method from `SocialBase`.

**Why do we need this feature?**

was written in todo

**Who is this feature for?**

oauth

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

- No functional changes 
- already promoted methods