### PR TITLE
Plugins: Sync validator plugin.json schema copy edits back to source of truth

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -369,7 +369,7 @@
       "description": "For data source plugins. Proxy routes used for plugin authentication and adding headers to HTTP requests made by the plugin. For more information, refer to [Authentication for data source plugins](https://grafana.com/developers/plugin-tools/how-to-guides/data-source-plugins/add-authentication-for-data-source-plugins).",
       "items": {
         "type": "object",
-        "description": "",
+        "description": "For data source plugins. Proxy routes used for plugin authentication and adding headers to HTTP requests made by the plugin. For more information, refer to [Authentication for data source plugins](https://grafana.com/developers/plugin-tools/how-to-guides/data-source-plugins/add-authentication-for-data-source-plugins).",
         "additionalProperties": false,
         "properties": {
           "path": {


### PR DESCRIPTION
**What is this feature?**

Updates the plugin.json schema to be up to date with changes that were only reflected in the copy (which exists in https://github.com/grafana/plugin-validator). 

**Why do we need this feature?**

Due to a new sync process (via GHA) we have recently introduced, this will overwrite changes that should exist in the source of truth.

Context: https://github.com/grafana/plugin-validator/pull/475/files#r2593350395


