### PR TITLE
CloudWatch: Fix error source for some query errors

### DIFF
--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -33,11 +33,11 @@ func (ds *DataSource) parseResponse(ctx context.Context, metricDataOutputs []*cl
 		dataRes := backend.DataResponse{}
 
 		if response.HasArithmeticError {
-			dataRes.Error = fmt.Errorf("ArithmeticError in query %q: %s", queryRow.RefId, response.ArithmeticErrorMessage)
+			dataRes.Error = backend.DownstreamErrorf("ArithmeticError in query %q: %s", queryRow.RefId, response.ArithmeticErrorMessage)
 		}
 
 		if response.HasPermissionError {
-			dataRes.Error = fmt.Errorf("PermissionError in query %q: %s", queryRow.RefId, response.PermissionErrorMessage)
+			dataRes.Error = backend.DownstreamErrorf("PermissionError in query %q: %s", queryRow.RefId, response.PermissionErrorMessage)
 		}
 
 		var err error


### PR DESCRIPTION
**What is this feature?**

This adds the correct "downstream" error source for some query error responses from AWS. Ported from https://github.com/grafana/grafana-cloudwatch-datasource/pull/331.
