### PR TITLE
Plugins: Remove `pkg/infra/fs` dependency from `pkg/plugins`

### DIFF
--- a/pkg/plugins/manager/sources/source_local_disk.go
+++ b/pkg/plugins/manager/sources/source_local_disk.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/grafana/grafana/pkg/infra/fs"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/config"
 	"github.com/grafana/grafana/pkg/plugins/log"
@@ -79,13 +78,12 @@ func (s *LocalSource) Discover(_ context.Context) ([]*plugins.FoundBundle, error
 
 	pluginJSONPaths := make([]string, 0, len(s.paths))
 	for _, path := range s.paths {
-		exists, err := fs.Exists(path)
-		if err != nil {
+		if _, err := os.Stat(path); err != nil {
+			if os.IsNotExist(err) {
+				s.log.Warn("Skipping finding plugins as directory does not exist", "path", path)
+				continue
+			}
 			s.log.Warn("Skipping finding plugins as an error occurred", "path", path, "error", err)
-			continue
-		}
-		if !exists {
-			s.log.Warn("Skipping finding plugins as directory does not exist", "path", path)
 			continue
 		}
 


### PR DESCRIPTION
**Why do we need this feature?**

https://github.com/grafana/grafana/issues/115792

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/115793


