### PR TITLE
Unistore: Prevent deadlock on startup errors

### DIFF
--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -115,6 +115,7 @@ func ProvideUnifiedStorageGrpcService(
 		cfg:                cfg,
 		features:           features,
 		stopCh:             make(chan struct{}),
+		stoppedCh:          make(chan error, 1),
 		authenticator:      authn,
 		tracing:            tracer,
 		db:                 db,


### PR DESCRIPTION
When adding additional integration tests for Zanzana, I ran into a scenario a few times where we'd get into a deadlock and traced it back to the stoppedCh not being initialized, so if anything sent or tried to receive from the channel, it would hang forever since the channel was nil. For example, [if s.handler.Run(ctx) errored](https://github.com/grafana/grafana/blob/105b4076297047890fead0b6c4fc9bfdae860383/pkg/storage/unified/sql/service.go#L343), it would hang forever. 

Extracted from https://github.com/grafana/grafana/pull/115771