### PR TITLE
Tooltips: Prevent dismissing with keyboard shortcuts

### DIFF
--- a/e2e-playwright/panels-suite/state-timeline.spec.ts
+++ b/e2e-playwright/panels-suite/state-timeline.spec.ts
@@ -78,6 +78,16 @@ test.describe('Panels test: StateTimeine', { tag: ['@panels', '@state-timeline']
     await dashboardPage.getByGrafanaSelector(selectors.components.Portal.container).getByLabel('Close').click();
     await expect(tooltip, 'tooltip closed on "x" click').toBeHidden();
 
+    // test that CMD/CTRL+C doesn't dismiss the tooltip
+    await stateTimelineUplot.click({ position: { x: 100, y: 50 } });
+    await expect(tooltip, 'tooltip appears on click').toBeVisible();
+    await page.keyboard.press('Meta+C');
+    await expect(tooltip, 'tooltip persists after CMD/CTRL+C').toBeVisible();
+
+    // test that Escape key dismisses the tooltip
+    await page.keyboard.press('Escape');
+    await expect(tooltip, 'tooltip closed on Escape key').toBeHidden();
+
     // disable tooltips
     await dashboardPage
       .getByGrafanaSelector(selectors.components.PanelEditor.OptionsPane.fieldLabel('Tooltip Tooltip mode'))

--- a/e2e-playwright/panels-suite/status-history.spec.ts
+++ b/e2e-playwright/panels-suite/status-history.spec.ts
@@ -76,6 +76,16 @@ test.describe('Panels test: StatusHistory', { tag: ['@panels', '@status-history'
     await dashboardPage.getByGrafanaSelector(selectors.components.Portal.container).getByLabel('Close').click();
     await expect(tooltip, 'tooltip closed on "x" click').toBeHidden();
 
+    // test that CMD/CTRL+C doesn't dismiss the tooltip
+    await statusHistoryUplot.click({ position: { x: 100, y: 50 } });
+    await expect(tooltip, 'tooltip appears on click').toBeVisible();
+    await page.keyboard.press('Meta+C');
+    await expect(tooltip, 'tooltip persists after CMD/CTRL+C').toBeVisible();
+
+    // test that Escape key dismisses the tooltip
+    await page.keyboard.press('Escape');
+    await expect(tooltip, 'tooltip closed on Escape key').toBeHidden();
+
     // disable tooltips
     await dashboardPage
       .getByGrafanaSelector(selectors.components.PanelEditor.OptionsPane.fieldLabel('Tooltip Tooltip mode'))

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -240,6 +240,15 @@ export const TooltipPlugin2 = ({
 
     // in some ways this is similar to ClickOutsideWrapper.tsx
     const downEventOutside = (e: Event) => {
+      if (e instanceof KeyboardEvent) {
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          e.stopPropagation();
+          dismiss();
+        }
+        return;
+      }
+
       // this tooltip is Portaled, but actions inside it create forms in Modals
       const isModalOrPortaled = '[role="dialog"], #grafana-portal-container';
 


### PR DESCRIPTION
Only dismiss tooltips on Esc key, not on all keyboard events.

https://github.com/user-attachments/assets/4c1364f5-18db-4b6d-9e36-fe62b756aa31



Fixes #96065
Fixes https://github.com/grafana/support-escalations/issues/20071


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
