### PR TITLE
Dashboards: Allow editing provisioned dashboards if AllowUIUpdates is set

### DIFF
--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -294,6 +294,9 @@ type DashboardProvisioning struct {
 	ExternalID  string `xorm:"external_id"`
 	CheckSum    string
 	Updated     int64
+
+	// note: only used when writing metadata to unified storage resources - not saved in legacy table.
+	AllowUIUpdates bool `xorm:"-"`
 }
 
 type DeleteDashboardCommand struct {

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1942,6 +1942,7 @@ func (dr *DashboardServiceImpl) saveProvisionedDashboardThroughK8s(ctx context.C
 		// HOWEVER, maybe OK to leave this for now and "fix" it by using file provisioning for mode 4
 		m.Kind = utils.ManagerKindClassicFP // nolint:staticcheck
 		m.Identity = provisioning.Name
+		m.AllowsEdits = provisioning.AllowUIUpdates
 		s.Path = provisioning.ExternalID
 		s.Checksum = provisioning.CheckSum
 		s.TimestampMillis = time.Unix(provisioning.Updated, 0).UnixMilli()

--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -358,6 +358,8 @@ func (fr *FileReader) saveDashboard(ctx context.Context, path string, folderID i
 			Name:       fr.Cfg.Name,
 			Updated:    resolvedFileInfo.ModTime().Unix(),
 			CheckSum:   jsonFile.checkSum,
+			// adds `grafana.app/managerAllowsEdits` to the provisioned dashboards in unified storage. not used if in legacy.
+			AllowUIUpdates: fr.Cfg.AllowUIUpdates,
 		}
 		_, err := fr.dashboardProvisioningService.SaveProvisionedDashboard(ctx, dash, dp)
 		if err != nil {

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -164,7 +164,11 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
       const managerKind = annotations[AnnoKeyManagerKind];
 
       if (managerKind) {
-        result.meta.provisioned = annotations[AnnoKeyManagerAllowsEdits] === 'true' || managerKind === ManagerKind.Repo;
+        // `meta.provisioned` is used by the save/delete UI to decide if a dashboard is locked
+        // (i.e. it can't be saved from the UI). This should match the legacy behavior where
+        // `allowUiUpdates: true` keeps the dashboard editable/savable.
+        const allowsEdits = annotations[AnnoKeyManagerAllowsEdits] === 'true';
+        result.meta.provisioned = !allowsEdits && managerKind !== ManagerKind.Repo;
         result.meta.provisionedExternalId = annotations[AnnoKeySourcePath];
       }
 


### PR DESCRIPTION
**What is this feature?**

This PR fixes a bug in Grafana, where we were not allowing saving provisioned dashboards in the UI, even if the provider specified  AllowUIUpdates is true.

There were two bugs:
1) (What OSS users were experiencing): The check in the frontend was incorrect, so we were not allowing edits even when the dashboard dto returned the annotation that it was managed.
2) (What we would've run into later): If backed by unified storage, we were not saving the annotation for if the manager allowed edits or not.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/111525