### PR TITLE
ci: avoid frontend performance tests being run on forks

### DIFF
--- a/.github/workflows/frontend-perf-tests.yaml
+++ b/.github/workflows/frontend-perf-tests.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   performance-tests:
+    if: github.event.repository.fork == false
     permissions:
       contents: read
       id-token: write
@@ -34,7 +35,7 @@ jobs:
         uses: grafana/shared-workflows/actions/login-to-gar@main
         id: login-to-gar
         with:
-          registry: 'us-docker.pkg.dev'
+          registry: "us-docker.pkg.dev"
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This update adds a repository fork check to the frontend performance tests workflow to prevent it from running on forked repositories. The workflow now includes `if: github.event.repository.fork == false` at the job level.

**Why do we need this feature?**

The frontend performance tests workflow accesses sensitive credentials (Vault secrets, private Docker registries) and shouldn't be accessible to the forks. 