### PR TITLE
Entra ID OAuth Docs: Remove "lang" from appRoles in manifest

### DIFF
--- a/docs/sources/setup-grafana/configure-access/configure-authentication/entraid/index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/entraid/index.md
@@ -170,7 +170,6 @@ Every role requires a [Universally Unique Identifier](https://en.wikipedia.org/w
    				"displayName": "Grafana Org Admin",
    				"id": "SOME_UNIQUE_ID",
    				"isEnabled": true,
-   				"lang": null,
    				"origin": "Application",
    				"value": "Admin"
    			},
@@ -182,7 +181,6 @@ Every role requires a [Universally Unique Identifier](https://en.wikipedia.org/w
    				"displayName": "Grafana Viewer",
    				"id": "SOME_UNIQUE_ID",
    				"isEnabled": true,
-   				"lang": null,
    				"origin": "Application",
    				"value": "Viewer"
    			},
@@ -194,7 +192,6 @@ Every role requires a [Universally Unique Identifier](https://en.wikipedia.org/w
    				"displayName": "Grafana Editor",
    				"id": "SOME_UNIQUE_ID",
    				"isEnabled": true,
-   				"lang": null,
    				"origin": "Application",
    				"value": "Editor"
    			}


### PR DESCRIPTION
This is a simple docs change.

The Azure AD Graph format for manifest files does not work with the "lang" field under "appRoles". This format is being phased out for the recommend format, which is the Microsoft Graph format. This does not use the "lang" field.
