### PR TITLE
Users:  Fix "Last active" displaying incorrect value instead of "Never"

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
@@ -5334,6 +5334,7 @@ export type OrgUserDto = {
   };
   authLabels?: string[];
   avatarUrl?: string;
+  created?: string;
   email?: string;
   isDisabled?: boolean;
   isExternallySynced?: boolean;
@@ -6111,6 +6112,7 @@ export type ChangeUserPasswordCommand = {
 export type UserSearchHitDto = {
   authLabels?: string[];
   avatarUrl?: string;
+  created?: string;
   email?: string;
   id?: number;
   isAdmin?: boolean;

--- a/pkg/services/org/model.go
+++ b/pkg/services/org/model.go
@@ -151,7 +151,7 @@ type OrgUserDTO struct {
 	Role               string          `json:"role"`
 	LastSeenAt         time.Time       `json:"lastSeenAt"`
 	Updated            time.Time       `json:"-"`
-	Created            time.Time       `json:"-"`
+	Created            time.Time       `json:"created"`
 	LastSeenAtAge      string          `json:"lastSeenAtAge"`
 	AccessControl      map[string]bool `json:"accessControl,omitempty"`
 	IsDisabled         bool            `json:"isDisabled"`

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -146,6 +146,7 @@ type UserSearchHitDTO struct {
 	LastSeenAtAge string               `json:"lastSeenAtAge"`
 	AuthLabels    []string             `json:"authLabels"`
 	AuthModule    AuthModuleConversion `json:"-"`
+	Created       time.Time            `json:"created" xorm:"created"`
 }
 
 type GetUserProfileQuery struct {

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -541,7 +541,7 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 			sess.Limit(query.Limit, offset)
 		}
 
-		sess.Cols("u.id", "u.uid", "u.email", "u.name", "u.login", "u.is_admin", "u.is_disabled", "u.last_seen_at", "user_auth.auth_module", "u.is_provisioned")
+		sess.Cols("u.id", "u.uid", "u.email", "u.name", "u.login", "u.is_admin", "u.is_disabled", "u.last_seen_at", "user_auth.auth_module", "u.is_provisioned", "u.created")
 
 		if len(query.SortOpts) > 0 {
 			for i := range query.SortOpts {

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -6002,6 +6002,10 @@
         "avatarUrl": {
           "type": "string"
         },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
         "email": {
           "type": "string"
         },
@@ -8905,6 +8909,10 @@
         },
         "avatarUrl": {
           "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
         },
         "email": {
           "type": "string"

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -18453,6 +18453,10 @@
         "avatarUrl": {
           "type": "string"
         },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
         "email": {
           "type": "string"
         },
@@ -23344,6 +23348,10 @@
         },
         "avatarUrl": {
           "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
         },
         "email": {
           "type": "string"

--- a/public/app/features/admin/Users/OrgUsersTable.tsx
+++ b/public/app/features/admin/Users/OrgUsersTable.tsx
@@ -115,12 +115,15 @@ export const OrgUsersTable = ({
       {
         id: 'lastSeenAtAge',
         header: 'Last active',
-        cell: ({ cell: { value } }: Cell<'lastSeenAtAge'>) => {
+        cell: ({ cell: { value }, row: { original } }: Cell<'lastSeenAtAge'>) => {
+          // If lastSeenAt is before created, user has never logged in
+          const neverLoggedIn =
+            original.lastSeenAt && original.created && new Date(original.lastSeenAt) < new Date(original.created);
           return (
             <>
               {value && (
                 <>
-                  {value === '10 years' ? (
+                  {neverLoggedIn ? (
                     <Text color={'disabled'}>
                       <Trans i18nKey="admin.org-uers.last-seen-never">Never</Trans>
                     </Text>

--- a/public/app/features/admin/Users/UsersTable.tsx
+++ b/public/app/features/admin/Users/UsersTable.tsx
@@ -135,12 +135,19 @@ export const UsersTable = ({
           content: 'Time since user was seen using Grafana',
           iconName: 'question-circle',
         },
-        cell: ({ cell: { value } }: Cell<'lastSeenAtAge'>) => {
+        cell: ({
+          cell: { value },
+          row: {
+            original: { lastSeenAt, created },
+          },
+        }: Cell<'lastSeenAtAge'>) => {
+          // The user has never logged in if lastSeenAt is before its creation date.
+          const neverLoggedIn = lastSeenAt && created && new Date(lastSeenAt) < new Date(created);
           return (
             <>
               {value && (
                 <>
-                  {value === '10 years' ? (
+                  {neverLoggedIn ? (
                     <Text color={'disabled'}>
                       <Trans i18nKey="admin.users-table.last-seen-never">Never</Trans>
                     </Text>

--- a/public/app/types/user.ts
+++ b/public/app/types/user.ts
@@ -5,6 +5,7 @@ import { Role } from './accessControl';
 export interface OrgUser extends WithAccessControlMetadata {
   avatarUrl: string;
   email: string;
+  created?: string;
   lastSeenAt: string;
   lastSeenAtAge: string;
   login: string;
@@ -49,6 +50,7 @@ export interface UserDTO extends WithAccessControlMetadata {
   theme?: string;
   avatarUrl?: string;
   orgId?: number;
+  created?: string;
   lastSeenAt?: string;
   lastSeenAtAge?: string;
   licensedRole?: string;

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -7988,6 +7988,10 @@
           "avatarUrl": {
             "type": "string"
           },
+          "created": {
+            "format": "date-time",
+            "type": "string"
+          },
           "email": {
             "type": "string"
           },
@@ -12877,6 +12881,10 @@
             "type": "array"
           },
           "avatarUrl": {
+            "type": "string"
+          },
+          "created": {
+            "format": "date-time",
             "type": "string"
           },
           "email": {


### PR DESCRIPTION
**What is this feature?**

This PR fixes the "Last active" column in the Users admin pages to correctly display "Never" for users who have never logged in.

**Why do we need this feature?**

When a user is created, their `lastSeenAt` is set to 10 years before their creation date as a sentinel value to indicate they've never logged in. The frontend previously checked if `lastSeenAtAge === "10 years"` to display "Never". However, as time passes, this value becomes "11 years", "12 years", etc., causing the UI to display the raw age string instead of "Never".

This fix exposes the user's `created` timestamp in the API response and updates the frontend to compare `lastSeenAt < created` to reliably determine if a user has never logged in, regardless of how long ago they were created.

**Who is this feature for?**

Grafana administrators viewing user lists in the admin UI.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/support-escalations/issues/20070.

**Note to reviewers**:

This solution involves returning `created` in two endpoints. Alternatively, we could make this change in terms of `lastSeenAtAge`, by performing the date comparison in the backend and having it return `never` instead. If you feel strongly about not including `created` in these endpoints, do let me know and we can look into the alternative. 

cc @mgyongyosi 