### PR TITLE
Dynamic Dashboards: Fix Content outline not being scrollable

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
@@ -5,7 +5,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { SceneObject } from '@grafana/scenes';
-import { Box, Icon, Sidebar, Text, useElementSelection, useStyles2 } from '@grafana/ui';
+import { Box, Icon, ScrollContainer, Sidebar, Text, useElementSelection, useStyles2 } from '@grafana/ui';
 
 import { isRepeatCloneOrChildOf } from '../utils/clone';
 import { DashboardInteractions } from '../utils/interactions';
@@ -24,12 +24,14 @@ export function DashboardOutline({ editPane, isEditing }: Props) {
   const dashboard = getDashboardSceneFor(editPane);
 
   return (
-    <>
+    <Box display="flex" direction="column" flex={1} height="100%">
       <Sidebar.PaneHeader title={t('dashboard.outline.pane-header', 'Content outline')} />
-      <Box padding={1} gap={0} display="flex" direction="column" element="ul" role="tree" position="relative">
-        <DashboardOutlineNode sceneObject={dashboard} isEditing={isEditing} editPane={editPane} depth={0} index={0} />
-      </Box>
-    </>
+      <ScrollContainer showScrollIndicators={true}>
+        <Box padding={1} gap={0} display="flex" direction="column" element="ul" role="tree" position="relative">
+          <DashboardOutlineNode sceneObject={dashboard} isEditing={isEditing} editPane={editPane} depth={0} index={0} />
+        </Box>
+      </ScrollContainer>
+    </Box>
   );
 }
 


### PR DESCRIPTION
**What is this feature?**

Fixes the Content outline pane to be scrollable when its content exceeds the available vertical space.

**Why do we need this feature?**

In Dynamic Dashboards, the Content outline pane doesn't support scrolling. When the outline has many items (panels, rows, nested sections) or the browser window is short, the last items are cut off and unreachable.

**Who is this feature for?**

Users working with Dynamic Dashboards who have dashboards with many panels/sections and use the Content outline for navigation.

**Which issue(s) does this PR fix?**

Fixes #115814

**Special notes for your reviewer:**

- The fix follows the same pattern used by `ElementEditPane` - wrapping content in `ScrollContainer`
- Uses `Box` component with flex props instead of custom CSS for consistency with the codebase
- `showScrollIndicators={true}` provides visual feedback when more content exists above/below

**How to test:**
1. Enable `dashboardNewLayouts` feature toggle
2. Create/open a dashboard with many panels
3. Enter edit mode and open the **Content outline** (sidebar icon)
4. Resize browser window to be short, or expand sections
5. Verify you can now scroll to reach all items


https://github.com/user-attachments/assets/19278816-c1c2-432c-86b9-79c53994352a


