### PR TITLE
Explore: Traces query that will work with either logs drilldown or explore

### DIFF
--- a/public/app/features/explore/TraceView/createSpanLink.test.ts
+++ b/public/app/features/explore/TraceView/createSpanLink.test.ts
@@ -200,7 +200,7 @@ describe('createSpanLinkFactory', () => {
             datasource: 'loki1_uid',
             queries: [
               {
-                expr: '{cluster="cluster1", hostname="hostname1", service_namespace="namespace1"} | label_format log_line_contains_trace_id=`{{ contains "7946b05c2e2e4e5a" __line__  }}` | log_line_contains_trace_id="true" or trace_id="7946b05c2e2e4e5a" | label_format log_line_contains_span_id=`{{ contains "6605c7b08e715d6c" __line__  }}` | log_line_contains_span_id="true" or span_id="6605c7b08e715d6c"',
+                expr: '{cluster="cluster1", hostname="hostname1", service_namespace="namespace1"} | logfmt | json | drop __error__, __error_details__ | trace_id="7946b05c2e2e4e5a" | span_id="6605c7b08e715d6c"',
                 refId: '',
                 datasource: { uid: 'loki1_uid' },
               },

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -447,8 +447,10 @@ function getQueryForLoki(
   let expr = '{${__tags}}';
   if (filterByTraceID && span.traceID) {
     expr += ' | logfmt | json | drop __error__, __error_details__ | trace_id="${__span.traceId}"';
-  }
-  if (filterBySpanID && span.spanID) {
+    if (filterBySpanID && span.spanID) {
+      expr += ' | span_id="${__span.spanId}"';
+    }
+  } else if (filterBySpanID && span.spanID) {
     expr += ' | logfmt | json | drop __error__, __error_details__ | span_id="${__span.spanId}"';
   }
 

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -446,12 +446,10 @@ function getQueryForLoki(
 
   let expr = '{${__tags}}';
   if (filterByTraceID && span.traceID) {
-    expr +=
-      ' | label_format log_line_contains_trace_id=`{{ contains "${__span.traceId}" __line__  }}` | log_line_contains_trace_id="true" or trace_id="${__span.traceId}"';
+    expr += ' | logfmt | json | drop __error__, __error_details__ | trace_id="${__span.traceId}"';
   }
   if (filterBySpanID && span.spanID) {
-    expr +=
-      ' | label_format log_line_contains_span_id=`{{ contains "${__span.spanId}" __line__  }}` | log_line_contains_span_id="true" or span_id="${__span.spanId}"';
+    expr += ' | logfmt | json | drop __error__, __error_details__ | span_id="${__span.spanId}"';
   }
 
   return {


### PR DESCRIPTION
**What is this feature?**

Adding a query that will work with either logs drilldown or explore

**Why do we need this feature?**

To fix queries generated by traces to logs feature

**Who is this feature for?**

Users of trace to logs feature

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/115836

**Special notes for your reviewer:**
Ideally we would know in the traces-to-logs configuration if the traces/span field is structured metadata, and then we could build the more performant query without any parsers, but I don't think there's a good way to do this since Tempo doesn't have these concepts. It might be possible to look at the log datasource's derived fields, but many Loki datasources set up multiple derived fields so trace_id works either as metadata or as a parsed field, so it's probably best to roll out a generic solution like proposed in this PR, and allow folks to write an optimized custom query in the traces-to-logs config if the Loki instance is exclusively using trace_id as structured metadata.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
