### PR TITLE
Refactor: Remove jQuery from AppWrapper

### DIFF
--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -57,7 +57,7 @@ export class AppWrapper extends Component<AppWrapperProps, AppWrapperState> {
 
   async componentDidMount() {
     this.setState({ ready: true });
-    $('.preloader').remove();
+    this.removePreloader();
 
     // clear any old icon caches
     const cacheKeys = (await window.caches?.keys()) ?? [];
@@ -65,6 +65,15 @@ export class AppWrapper extends Component<AppWrapperProps, AppWrapperState> {
       if (key.startsWith('grafana-icon-cache') && key !== this.iconCacheID) {
         window.caches.delete(key);
       }
+    }
+  }
+
+  removePreloader() {
+    const preloader = document.querySelector('.preloader');
+    if (preloader) {
+      preloader.remove();
+    } else {
+      console.warn('Preloader element not found');
     }
   }
 


### PR DESCRIPTION
AppWrapper had a usage of jQuery (`$`) to remove the page loading element. jQuery isn’t needed here, so this replaces the usage with native DOM APIs.