### PR TITLE
Documentation: Remove Cloud product label from RBAC YAML Provisioning

### DIFF
--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-grafana-provisioning/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-grafana-provisioning/index.md
@@ -6,7 +6,6 @@ description: Learn about RBAC Grafana provisioning and view an example YAML prov
   file that configures Grafana role assignments.
 labels:
   products:
-    - cloud
     - enterprise
 menuTitle: Provisioning RBAC with Grafana
 title: Provisioning RBAC with Grafana


### PR DESCRIPTION
--Minor documentation fix--

RBAC YAML provisioning currently only exists for self-hosted Enterprise users. Removing the cloud product tag to align with current offerings.

Internal slack ref: https://raintank-corp.slack.com/archives/C05JDQ100NS/p1767626847587599