### PR TITLE
Alerting: Update RuleGroupConfig definitions with missing fields

### DIFF
--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -647,12 +647,6 @@
   },
   "BacktestConfig": {
    "properties": {
-    "annotations": {
-     "additionalProperties": {
-      "type": "string"
-     },
-     "type": "object"
-    },
     "condition": {
      "type": "string"
     },
@@ -662,8 +656,16 @@
      },
      "type": "array"
     },
+    "exec_err_state": {
+     "enum": [
+      "OK",
+      "Alerting",
+      "Error"
+     ],
+     "type": "string"
+    },
     "for": {
-     "$ref": "#/definitions/Duration"
+     "type": "string"
     },
     "from": {
      "format": "date-time",
@@ -672,11 +674,21 @@
     "interval": {
      "$ref": "#/definitions/Duration"
     },
+    "keep_firing_for": {
+     "type": "string"
+    },
     "labels": {
      "additionalProperties": {
       "type": "string"
      },
      "type": "object"
+    },
+    "missing_series_evals_to_resolve": {
+     "format": "int64",
+     "type": "integer"
+    },
+    "namespace_uid": {
+     "type": "string"
     },
     "no_data_state": {
      "enum": [
@@ -686,11 +698,17 @@
      ],
      "type": "string"
     },
+    "rule_group": {
+     "type": "string"
+    },
     "title": {
      "type": "string"
     },
     "to": {
      "format": "date-time",
+     "type": "string"
+    },
+    "uid": {
      "type": "string"
     }
    },
@@ -1813,6 +1831,12 @@
     "interval": {
      "$ref": "#/definitions/Duration"
     },
+    "labels": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "type": "object"
+    },
     "limit": {
      "format": "int64",
      "type": "integer"
@@ -1822,6 +1846,12 @@
     },
     "query_offset": {
      "type": "string"
+    },
+    "remote_write": {
+     "items": {
+      "$ref": "#/definitions/RemoteWriteConfig"
+     },
+     "type": "array"
     },
     "rules": {
      "items": {
@@ -3142,6 +3172,12 @@
     "interval": {
      "$ref": "#/definitions/Duration"
     },
+    "labels": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "type": "object"
+    },
     "limit": {
      "format": "int64",
      "type": "integer"
@@ -3151,6 +3187,12 @@
     },
     "query_offset": {
      "type": "string"
+    },
+    "remote_write": {
+     "items": {
+      "$ref": "#/definitions/RemoteWriteConfig"
+     },
+     "type": "array"
     },
     "rules": {
      "items": {
@@ -3817,6 +3859,14 @@
    },
    "type": "object"
   },
+  "RemoteWriteConfig": {
+   "properties": {
+    "url": {
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
   "ResponseDetails": {
    "properties": {
     "msg": {
@@ -4093,6 +4143,12 @@
     "interval": {
      "$ref": "#/definitions/Duration"
     },
+    "labels": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "type": "object"
+    },
     "limit": {
      "format": "int64",
      "type": "integer"
@@ -4102,6 +4158,12 @@
     },
     "query_offset": {
      "type": "string"
+    },
+    "remote_write": {
+     "items": {
+      "$ref": "#/definitions/RemoteWriteConfig"
+     },
+     "type": "array"
     },
     "rules": {
      "items": {

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -284,11 +284,20 @@ type PostableRuleGroupConfig struct {
 
 	// fields below are used by Mimir/Loki rulers
 
-	SourceTenants                 []string        `yaml:"source_tenants,omitempty" json:"source_tenants,omitempty"`
-	EvaluationDelay               *model.Duration `yaml:"evaluation_delay,omitempty" json:"evaluation_delay,omitempty"`
-	QueryOffset                   *model.Duration `yaml:"query_offset,omitempty" json:"query_offset,omitempty"`
-	AlignEvaluationTimeOnInterval bool            `yaml:"align_evaluation_time_on_interval,omitempty" json:"align_evaluation_time_on_interval,omitempty"`
-	Limit                         int             `yaml:"limit,omitempty" json:"limit,omitempty"`
+	SourceTenants                 []string          `yaml:"source_tenants,omitempty" json:"source_tenants,omitempty"`
+	EvaluationDelay               *model.Duration   `yaml:"evaluation_delay,omitempty" json:"evaluation_delay,omitempty"`
+	QueryOffset                   *model.Duration   `yaml:"query_offset,omitempty" json:"query_offset,omitempty"`
+	AlignEvaluationTimeOnInterval bool              `yaml:"align_evaluation_time_on_interval,omitempty" json:"align_evaluation_time_on_interval,omitempty"`
+	Limit                         int               `yaml:"limit,omitempty" json:"limit,omitempty"`
+	Labels                        map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
+
+	// GEM Ruler.
+
+	RWConfigs []RemoteWriteConfig `yaml:"remote_write,omitempty" json:"remote_write,omitempty"`
+}
+
+type RemoteWriteConfig struct {
+	URL string `yaml:"url,omitempty" json:"url,omitempty"`
 }
 
 func (c *PostableRuleGroupConfig) UnmarshalJSON(b []byte) error {
@@ -328,8 +337,8 @@ func (c *PostableRuleGroupConfig) validate() error {
 		return fmt.Errorf("cannot mix Grafana & Prometheus style rules")
 	}
 
-	if hasGrafRules && (len(c.SourceTenants) > 0 || c.EvaluationDelay != nil || c.QueryOffset != nil || c.AlignEvaluationTimeOnInterval || c.Limit > 0) {
-		return fmt.Errorf("fields source_tenants, evaluation_delay, query_offset, align_evaluation_time_on_interval and limit are not supported for Grafana rules")
+	if hasGrafRules && (len(c.SourceTenants) > 0 || c.EvaluationDelay != nil || c.QueryOffset != nil || c.AlignEvaluationTimeOnInterval || c.Limit > 0 || len(c.Labels) > 0 || len(c.RWConfigs) > 0) {
+		return fmt.Errorf("fields source_tenants, evaluation_delay, query_offset, align_evaluation_time_on_interval, limit, labels, and remote_write are not supported for Grafana rules")
 	}
 	return nil
 }
@@ -345,11 +354,16 @@ type GettableRuleGroupConfig struct {
 
 	// fields below are used by Mimir/Loki rulers
 
-	SourceTenants                 []string        `yaml:"source_tenants,omitempty" json:"source_tenants,omitempty"`
-	EvaluationDelay               *model.Duration `yaml:"evaluation_delay,omitempty" json:"evaluation_delay,omitempty"`
-	QueryOffset                   *model.Duration `yaml:"query_offset,omitempty" json:"query_offset,omitempty"`
-	AlignEvaluationTimeOnInterval bool            `yaml:"align_evaluation_time_on_interval,omitempty" json:"align_evaluation_time_on_interval,omitempty"`
-	Limit                         int             `yaml:"limit,omitempty" json:"limit,omitempty"`
+	SourceTenants                 []string          `yaml:"source_tenants,omitempty" json:"source_tenants,omitempty"`
+	EvaluationDelay               *model.Duration   `yaml:"evaluation_delay,omitempty" json:"evaluation_delay,omitempty"`
+	QueryOffset                   *model.Duration   `yaml:"query_offset,omitempty" json:"query_offset,omitempty"`
+	AlignEvaluationTimeOnInterval bool              `yaml:"align_evaluation_time_on_interval,omitempty" json:"align_evaluation_time_on_interval,omitempty"`
+	Limit                         int               `yaml:"limit,omitempty" json:"limit,omitempty"`
+	Labels                        map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
+
+	// GEM Ruler.
+
+	RWConfigs []RemoteWriteConfig `yaml:"remote_write,omitempty" json:"remote_write,omitempty"`
 }
 
 func (c *GettableRuleGroupConfig) UnmarshalJSON(b []byte) error {

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -647,12 +647,6 @@
   },
   "BacktestConfig": {
    "properties": {
-    "annotations": {
-     "additionalProperties": {
-      "type": "string"
-     },
-     "type": "object"
-    },
     "condition": {
      "type": "string"
     },
@@ -662,8 +656,16 @@
      },
      "type": "array"
     },
+    "exec_err_state": {
+     "enum": [
+      "OK",
+      "Alerting",
+      "Error"
+     ],
+     "type": "string"
+    },
     "for": {
-     "$ref": "#/definitions/Duration"
+     "type": "string"
     },
     "from": {
      "format": "date-time",
@@ -672,11 +674,21 @@
     "interval": {
      "$ref": "#/definitions/Duration"
     },
+    "keep_firing_for": {
+     "type": "string"
+    },
     "labels": {
      "additionalProperties": {
       "type": "string"
      },
      "type": "object"
+    },
+    "missing_series_evals_to_resolve": {
+     "format": "int64",
+     "type": "integer"
+    },
+    "namespace_uid": {
+     "type": "string"
     },
     "no_data_state": {
      "enum": [
@@ -686,11 +698,17 @@
      ],
      "type": "string"
     },
+    "rule_group": {
+     "type": "string"
+    },
     "title": {
      "type": "string"
     },
     "to": {
      "format": "date-time",
+     "type": "string"
+    },
+    "uid": {
      "type": "string"
     }
    },
@@ -1813,6 +1831,12 @@
     "interval": {
      "$ref": "#/definitions/Duration"
     },
+    "labels": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "type": "object"
+    },
     "limit": {
      "format": "int64",
      "type": "integer"
@@ -1822,6 +1846,12 @@
     },
     "query_offset": {
      "type": "string"
+    },
+    "remote_write": {
+     "items": {
+      "$ref": "#/definitions/RemoteWriteConfig"
+     },
+     "type": "array"
     },
     "rules": {
      "items": {
@@ -3142,6 +3172,12 @@
     "interval": {
      "$ref": "#/definitions/Duration"
     },
+    "labels": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "type": "object"
+    },
     "limit": {
      "format": "int64",
      "type": "integer"
@@ -3151,6 +3187,12 @@
     },
     "query_offset": {
      "type": "string"
+    },
+    "remote_write": {
+     "items": {
+      "$ref": "#/definitions/RemoteWriteConfig"
+     },
+     "type": "array"
     },
     "rules": {
      "items": {
@@ -3817,6 +3859,14 @@
    },
    "type": "object"
   },
+  "RemoteWriteConfig": {
+   "properties": {
+    "url": {
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
   "ResponseDetails": {
    "properties": {
     "msg": {
@@ -4093,6 +4143,12 @@
     "interval": {
      "$ref": "#/definitions/Duration"
     },
+    "labels": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "type": "object"
+    },
     "limit": {
      "format": "int64",
      "type": "integer"
@@ -4102,6 +4158,12 @@
     },
     "query_offset": {
      "type": "string"
+    },
+    "remote_write": {
+     "items": {
+      "$ref": "#/definitions/RemoteWriteConfig"
+     },
+     "type": "array"
     },
     "rules": {
      "items": {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -5072,12 +5072,6 @@
     "BacktestConfig": {
       "type": "object",
       "properties": {
-        "annotations": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
         "condition": {
           "type": "string"
         },
@@ -5087,8 +5081,16 @@
             "$ref": "#/definitions/AlertQuery"
           }
         },
+        "exec_err_state": {
+          "type": "string",
+          "enum": [
+            "OK",
+            "Alerting",
+            "Error"
+          ]
+        },
         "for": {
-          "$ref": "#/definitions/Duration"
+          "type": "string"
         },
         "from": {
           "type": "string",
@@ -5097,11 +5099,21 @@
         "interval": {
           "$ref": "#/definitions/Duration"
         },
+        "keep_firing_for": {
+          "type": "string"
+        },
         "labels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "missing_series_evals_to_resolve": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "namespace_uid": {
+          "type": "string"
         },
         "no_data_state": {
           "type": "string",
@@ -5111,12 +5123,18 @@
             "OK"
           ]
         },
+        "rule_group": {
+          "type": "string"
+        },
         "title": {
           "type": "string"
         },
         "to": {
           "type": "string",
           "format": "date-time"
+        },
+        "uid": {
+          "type": "string"
         }
       }
     },
@@ -6239,6 +6257,12 @@
         "interval": {
           "$ref": "#/definitions/Duration"
         },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "limit": {
           "type": "integer",
           "format": "int64"
@@ -6248,6 +6272,12 @@
         },
         "query_offset": {
           "type": "string"
+        },
+        "remote_write": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RemoteWriteConfig"
+          }
         },
         "rules": {
           "type": "array",
@@ -7569,6 +7599,12 @@
         "interval": {
           "$ref": "#/definitions/Duration"
         },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "limit": {
           "type": "integer",
           "format": "int64"
@@ -7578,6 +7614,12 @@
         },
         "query_offset": {
           "type": "string"
+        },
+        "remote_write": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RemoteWriteConfig"
+          }
         },
         "rules": {
           "type": "array",
@@ -8243,6 +8285,14 @@
         }
       }
     },
+    "RemoteWriteConfig": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        }
+      }
+    },
     "ResponseDetails": {
       "type": "object",
       "properties": {
@@ -8520,6 +8570,12 @@
         "interval": {
           "$ref": "#/definitions/Duration"
         },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "limit": {
           "type": "integer",
           "format": "int64"
@@ -8529,6 +8585,12 @@
         },
         "query_offset": {
           "type": "string"
+        },
+        "remote_write": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RemoteWriteConfig"
+          }
         },
         "rules": {
           "type": "array",

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -13829,12 +13829,6 @@
     "BacktestConfig": {
       "type": "object",
       "properties": {
-        "annotations": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
         "condition": {
           "type": "string"
         },
@@ -13844,8 +13838,16 @@
             "$ref": "#/definitions/AlertQuery"
           }
         },
+        "exec_err_state": {
+          "type": "string",
+          "enum": [
+            "OK",
+            "Alerting",
+            "Error"
+          ]
+        },
         "for": {
-          "$ref": "#/definitions/Duration"
+          "type": "string"
         },
         "from": {
           "type": "string",
@@ -13854,11 +13856,21 @@
         "interval": {
           "$ref": "#/definitions/Duration"
         },
+        "keep_firing_for": {
+          "type": "string"
+        },
         "labels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "missing_series_evals_to_resolve": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "namespace_uid": {
+          "type": "string"
         },
         "no_data_state": {
           "type": "string",
@@ -13868,12 +13880,18 @@
             "OK"
           ]
         },
+        "rule_group": {
+          "type": "string"
+        },
         "title": {
           "type": "string"
         },
         "to": {
           "type": "string",
           "format": "date-time"
+        },
+        "uid": {
+          "type": "string"
         }
       }
     },
@@ -16778,6 +16796,12 @@
         "interval": {
           "$ref": "#/definitions/Duration"
         },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "limit": {
           "type": "integer",
           "format": "int64"
@@ -16787,6 +16811,12 @@
         },
         "query_offset": {
           "type": "string"
+        },
+        "remote_write": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RemoteWriteConfig"
+          }
         },
         "rules": {
           "type": "array",
@@ -19263,6 +19293,12 @@
         "interval": {
           "$ref": "#/definitions/Duration"
         },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "limit": {
           "type": "integer",
           "format": "int64"
@@ -19272,6 +19308,12 @@
         },
         "query_offset": {
           "type": "string"
+        },
+        "remote_write": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RemoteWriteConfig"
+          }
         },
         "rules": {
           "type": "array",
@@ -20310,6 +20352,14 @@
         }
       }
     },
+    "RemoteWriteConfig": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        }
+      }
+    },
     "Report": {
       "type": "object",
       "properties": {
@@ -21009,6 +21059,12 @@
         "interval": {
           "$ref": "#/definitions/Duration"
         },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "limit": {
           "type": "integer",
           "format": "int64"
@@ -21018,6 +21074,12 @@
         },
         "query_offset": {
           "type": "string"
+        },
+        "remote_write": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RemoteWriteConfig"
+          }
         },
         "rules": {
           "type": "array",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -3364,12 +3364,6 @@
       },
       "BacktestConfig": {
         "properties": {
-          "annotations": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "type": "object"
-          },
           "condition": {
             "type": "string"
           },
@@ -3379,8 +3373,16 @@
             },
             "type": "array"
           },
+          "exec_err_state": {
+            "enum": [
+              "OK",
+              "Alerting",
+              "Error"
+            ],
+            "type": "string"
+          },
           "for": {
-            "$ref": "#/components/schemas/Duration"
+            "type": "string"
           },
           "from": {
             "format": "date-time",
@@ -3389,11 +3391,21 @@
           "interval": {
             "$ref": "#/components/schemas/Duration"
           },
+          "keep_firing_for": {
+            "type": "string"
+          },
           "labels": {
             "additionalProperties": {
               "type": "string"
             },
             "type": "object"
+          },
+          "missing_series_evals_to_resolve": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "namespace_uid": {
+            "type": "string"
           },
           "no_data_state": {
             "enum": [
@@ -3403,11 +3415,17 @@
             ],
             "type": "string"
           },
+          "rule_group": {
+            "type": "string"
+          },
           "title": {
             "type": "string"
           },
           "to": {
             "format": "date-time",
+            "type": "string"
+          },
+          "uid": {
             "type": "string"
           }
         },
@@ -6313,6 +6331,12 @@
           "interval": {
             "$ref": "#/components/schemas/Duration"
           },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "limit": {
             "format": "int64",
             "type": "integer"
@@ -6322,6 +6346,12 @@
           },
           "query_offset": {
             "type": "string"
+          },
+          "remote_write": {
+            "items": {
+              "$ref": "#/components/schemas/RemoteWriteConfig"
+            },
+            "type": "array"
           },
           "rules": {
             "items": {
@@ -8798,6 +8828,12 @@
           "interval": {
             "$ref": "#/components/schemas/Duration"
           },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "limit": {
             "format": "int64",
             "type": "integer"
@@ -8807,6 +8843,12 @@
           },
           "query_offset": {
             "type": "string"
+          },
+          "remote_write": {
+            "items": {
+              "$ref": "#/components/schemas/RemoteWriteConfig"
+            },
+            "type": "array"
           },
           "rules": {
             "items": {
@@ -9846,6 +9888,14 @@
         },
         "type": "object"
       },
+      "RemoteWriteConfig": {
+        "properties": {
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "Report": {
         "properties": {
           "created": {
@@ -10544,6 +10594,12 @@
           "interval": {
             "$ref": "#/components/schemas/Duration"
           },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "limit": {
             "format": "int64",
             "type": "integer"
@@ -10553,6 +10609,12 @@
           },
           "query_offset": {
             "type": "string"
+          },
+          "remote_write": {
+            "items": {
+              "$ref": "#/components/schemas/RemoteWriteConfig"
+            },
+            "type": "array"
           },
           "rules": {
             "items": {


### PR DESCRIPTION
This update adds previously missing fields to the `RuleGroupConfig` structs to
ensure compatibility with external Prometheus-like rulers.

Includes:
- `labels`: per https://github.com/prometheus/prometheus/pull/11474
- `remote_write`: per [rulefmt.go](https://github.com/grafana/mimir/blob/56f33fed6254fee5a53bde1eab36c604863e3d5f/pkg/mimirtool/rules/rwrulefmt/rulefmt.go#L16)

Note: This does not add full support in Grafana; it only allows these fields to
pass through the alerting proxy without causing unmarshal errors when using
external rulers.