### PR TITLE
Dashboard: Fix Unsaved dashboard sharing flow

### DIFF
--- a/public/app/features/dashboard-scene/scene/new-toolbar/actions/ShareExportDashboardButton.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/actions/ShareExportDashboardButton.tsx
@@ -36,36 +36,34 @@ export const ShareExportDashboardButton = ({
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <ButtonGroup
-      data-testid={groupTestId}
-      onPointerDown={(evt) => {
-        if (dashboard.state.isEditing && dashboard.state.isDirty) {
-          evt.preventDefault();
-          evt.stopPropagation();
-
-          appEvents.publish(
-            new ShowConfirmModalEvent({
-              title: t('dashboard.toolbar.new.share-export.modal.title', 'Save changes to dashboard?'),
-              text: t(
-                'dashboard.toolbar.new.share-export.modal.text',
-                'You have unsaved changes to this dashboard. You need to save them before you can share it.'
-              ),
-              icon: 'exclamation-triangle',
-              noText: t('dashboard.toolbar.new.share-export.modal.noText', 'Discard'),
-              yesText: t('dashboard.toolbar.new.share-export.modal.yesText', 'Save'),
-              yesButtonVariant: 'primary',
-              onConfirm: () => dashboard.openSaveDrawer({}),
-            })
-          );
-        }
-      }}
-    >
+    <ButtonGroup data-testid={groupTestId}>
       <ToolbarButton
         data-testid={buttonTestId}
         tooltip={buttonTooltip}
         variant={variant}
-        onClick={onButtonClick}
         icon="share-alt"
+        onClick={(evt) => {
+          if (dashboard.state.isEditing && dashboard.state.isDirty) {
+            evt.preventDefault();
+            evt.stopPropagation();
+            appEvents.publish(
+              new ShowConfirmModalEvent({
+                title: t('dashboard.toolbar.new.share-export.modal.title', 'Save changes to dashboard?'),
+                text: t(
+                  'dashboard.toolbar.new.share-export.modal.text',
+                  'You have unsaved changes to this dashboard. You need to save them before you can share it.'
+                ),
+                icon: 'exclamation-triangle',
+                noText: t('dashboard.toolbar.new.share-export.modal.noText', 'Discard'),
+                yesText: t('dashboard.toolbar.new.share-export.modal.yesText', 'Save'),
+                yesButtonVariant: 'primary',
+                onConfirm: () => dashboard.openSaveDrawer({ onSaveSuccess: onButtonClick }),
+              })
+            );
+          } else {
+            onButtonClick?.();
+          }
+        }}
       >
         {buttonLabel}
       </ToolbarButton>

--- a/public/app/features/dashboard-scene/sharing/ShareButton/ShareMenu.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareButton/ShareMenu.test.tsx
@@ -1,9 +1,12 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
+import { locationService } from '@grafana/runtime';
 import { SceneTimeRange, VizPanel } from '@grafana/scenes';
+import { appEvents } from 'app/core/app_events';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
+import { ShowConfirmModalEvent } from 'app/types/events';
 
 import { config } from '../../../../core/config';
 import { grantUserPermissions } from '../../../alerting/unified/mocks';
@@ -19,6 +22,14 @@ jest.mock('app/core/utils/shortLinks', () => ({
 }));
 
 const selector = e2eSelectors.pages.Dashboard.DashNav.newShareButton.menu;
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  locationService: {
+    partial: jest.fn(),
+    getLocation: jest.fn().mockReturnValue({ pathname: '/d/dash-1', search: '' }),
+  },
+}));
 
 describe('ShareMenu', () => {
   afterEach(() => {
@@ -79,6 +90,115 @@ describe('ShareMenu', () => {
       expect(screen.queryByTestId(selector.shareSnapshot)).not.toBeInTheDocument();
     });
   });
+
+  describe('Save confirmation modal', () => {
+    beforeEach(() => {
+      jest.spyOn(appEvents, 'publish');
+      jest.spyOn(locationService, 'partial');
+    });
+
+    it('should show save confirmation modal when dashboard is editing and dirty', async () => {
+      Object.defineProperty(contextSrv, 'isSignedIn', {
+        value: true,
+      });
+      grantUserPermissions([AccessControlAction.SnapshotsCreate]);
+
+      setup({ isEditing: true, isDirty: true, meta: { canEdit: true } });
+
+      const shareInternallyButton = await screen.findByTestId(selector.shareInternally);
+      fireEvent.click(shareInternallyButton);
+
+      await waitFor(() => {
+        expect(appEvents.publish).toHaveBeenCalledWith(expect.any(ShowConfirmModalEvent));
+      });
+
+      const modalCall = (appEvents.publish as jest.Mock).mock.calls.find(
+        (call) => call[0] instanceof ShowConfirmModalEvent
+      );
+      expect(modalCall).toBeDefined();
+
+      const modalEvent = modalCall![0] as ShowConfirmModalEvent;
+      expect(modalEvent.payload.title).toBe('Save changes to dashboard?');
+      expect(modalEvent.payload.text).toContain('You have unsaved changes');
+      expect(modalEvent.payload.yesText).toBe('Save');
+      expect(modalEvent.payload.noText).toBe('Discard');
+
+      expect(locationService.partial).not.toHaveBeenCalled();
+    });
+
+    it('should navigate directly when dashboard is not editing', async () => {
+      Object.defineProperty(contextSrv, 'isSignedIn', {
+        value: true,
+      });
+      grantUserPermissions([AccessControlAction.SnapshotsCreate]);
+
+      setup({ isEditing: false, isDirty: false, meta: { canEdit: true } });
+
+      const shareInternallyButton = await screen.findByTestId(selector.shareInternally);
+      fireEvent.click(shareInternallyButton);
+
+      await waitFor(() => {
+        expect(locationService.partial).toHaveBeenCalledWith({ shareView: 'link' });
+      });
+
+      expect(appEvents.publish).not.toHaveBeenCalled();
+    });
+
+    it('should navigate directly when dashboard is editing but not dirty', async () => {
+      Object.defineProperty(contextSrv, 'isSignedIn', {
+        value: true,
+      });
+      grantUserPermissions([AccessControlAction.SnapshotsCreate]);
+
+      setup({ isEditing: true, isDirty: false, meta: { canEdit: true } });
+
+      const shareInternallyButton = await screen.findByTestId(selector.shareInternally);
+      fireEvent.click(shareInternallyButton);
+
+      await waitFor(() => {
+        expect(locationService.partial).toHaveBeenCalledWith({ shareView: 'link' });
+      });
+
+      expect(appEvents.publish).not.toHaveBeenCalled();
+    });
+
+    it('should call onSaveSuccess callback after saving', async () => {
+      Object.defineProperty(contextSrv, 'isSignedIn', {
+        value: true,
+      });
+      grantUserPermissions([AccessControlAction.SnapshotsCreate]);
+
+      const dashboard = setup({ isEditing: true, isDirty: true, meta: { canEdit: true } });
+      const openSaveDrawerSpy = jest.spyOn(dashboard, 'openSaveDrawer').mockImplementation(() => {});
+
+      const shareInternallyButton = await screen.findByTestId(selector.shareInternally);
+      fireEvent.click(shareInternallyButton);
+
+      await waitFor(() => {
+        expect(appEvents.publish).toHaveBeenCalledWith(expect.any(ShowConfirmModalEvent));
+      });
+
+      const modalCall = (appEvents.publish as jest.Mock).mock.calls.find(
+        (call) => call[0] instanceof ShowConfirmModalEvent
+      );
+      const modalEvent = modalCall![0] as ShowConfirmModalEvent;
+
+      // Simulate clicking "Save" button
+      modalEvent.payload.onConfirm?.();
+
+      expect(openSaveDrawerSpy).toHaveBeenCalledWith({
+        onSaveSuccess: expect.any(Function),
+      });
+
+      // Simulate save success callback
+      const onSaveSuccess = openSaveDrawerSpy.mock.calls[0][0].onSaveSuccess;
+      if (onSaveSuccess) {
+        onSaveSuccess();
+      }
+
+      expect(locationService.partial).toHaveBeenCalledWith({ shareView: 'link' });
+    });
+  });
 });
 
 function setup(overrides?: Partial<DashboardSceneState>) {
@@ -97,4 +217,5 @@ function setup(overrides?: Partial<DashboardSceneState>) {
   });
 
   render(<ShareMenu dashboard={dashboard} />);
+  return dashboard;
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR fixes the user experience issue where users had to click the share button twice when trying to share an unsaved dashboard. Previously, after being prompted to save and completing the save flow, users had to manually click the share button again. Now, the share action automatically proceeds after a successful save.

**Why do we need this feature?**


In the existing implementation, when a dashboard has unsaved changes and a user tries to share it:
1. User clicks share button
2. User is prompted to save changes
3. User confirms and goes through the save flow
4. **User has to click the share button again** ← This was the problem


This creates a poor user experience with unnecessary extra clicks and interrupts the user's workflow. Users expect that after saving, the share action should proceed automatically without requiring them to click the share button again.

**Flows in new implementation**
If the dashboard is unsaved
- if user clicks on the save button they immediately go to the save flow and as soon as they save the link is copied to their clipboard.
- if user clicks on the shave dropdown they are first promted with the dropdown menu content and then asked to save, once they save they go the respective share flow based on the item they have selected in the dropdown earlier.

**Which issue(s) does this PR fix?**:

Fixes [#115626](https://github.com/grafana/grafana/issues/115626)
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
