### PR TITLE
OpenFeature: Add OFREP provider type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,6 +146,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5 // @grafana/grafana-backend-group
 	github.com/open-feature/go-sdk v1.16.0 // @grafana/grafana-backend-group
 	github.com/open-feature/go-sdk-contrib/providers/go-feature-flag v0.2.6 // @grafana/grafana-backend-group
+	github.com/open-feature/go-sdk-contrib/providers/ofrep v0.1.6 // @grafana/grafana-backend-group
 	github.com/openfga/api/proto v0.0.0-20250909172242-b4b2a12f5c67 // @grafana/identity-access-team
 	github.com/openfga/language/pkg/go v0.2.0-beta.2.0.20251027165255-0f8f255e5f6c // @grafana/identity-access-team
 	github.com/openfga/openfga v1.11.1 // @grafana/identity-access-team
@@ -543,7 +544,6 @@ require (
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
-	github.com/open-feature/go-sdk-contrib/providers/ofrep v0.1.6 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.124.1 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils v0.124.1 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.124.1 // indirect

--- a/pkg/registry/apis/ofrep/register.go
+++ b/pkg/registry/apis/ofrep/register.go
@@ -276,7 +276,7 @@ func (b *APIBuilder) oneFlagHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if b.providerType == setting.GOFFProviderType {
+	if b.providerType == setting.GOFFProviderType || b.providerType == setting.OFREPProviderType {
 		b.proxyFlagReq(ctx, flagKey, isAuthedReq, w, r)
 		return
 	}
@@ -304,7 +304,7 @@ func (b *APIBuilder) allFlagsHandler(w http.ResponseWriter, r *http.Request) {
 	isAuthedReq := b.isAuthenticatedRequest(r)
 	span.SetAttributes(attribute.Bool("authenticated", isAuthedReq))
 
-	if b.providerType == setting.GOFFProviderType {
+	if b.providerType == setting.GOFFProviderType || b.providerType == setting.OFREPProviderType {
 		b.proxyAllFlagReq(ctx, isAuthedReq, w, r)
 		return
 	}

--- a/pkg/services/featuremgmt/ofrep_provider.go
+++ b/pkg/services/featuremgmt/ofrep_provider.go
@@ -1,0 +1,17 @@
+package featuremgmt
+
+import (
+	"net/http"
+
+	ofrep "github.com/open-feature/go-sdk-contrib/providers/ofrep"
+	"github.com/open-feature/go-sdk/openfeature"
+)
+
+func newOFREPProvider(url string, client *http.Client) (openfeature.FeatureProvider, error) {
+	options := []ofrep.Option{}
+	if client != nil {
+		options = append(options, ofrep.WithClient(client))
+	}
+
+	return ofrep.NewProvider(url, options...), nil
+}

--- a/pkg/setting/setting_openfeature.go
+++ b/pkg/setting/setting_openfeature.go
@@ -8,6 +8,7 @@ import (
 const (
 	StaticProviderType = "static"
 	GOFFProviderType   = "goff"
+	OFREPProviderType  = "ofrep"
 )
 
 type OpenFeatureSettings struct {
@@ -33,7 +34,7 @@ func (cfg *Cfg) readOpenFeatureSettings() error {
 
 	cfg.OpenFeature.TargetingKey = config.Key("targetingKey").MustString(defaultTargetingKey)
 
-	if strURL != "" && cfg.OpenFeature.ProviderType == GOFFProviderType {
+	if strURL != "" && (cfg.OpenFeature.ProviderType == GOFFProviderType || cfg.OpenFeature.ProviderType == OFREPProviderType) {
 		u, err := url.Parse(strURL)
 		if err != nil {
 			return fmt.Errorf("invalid feature provider url: %w", err)


### PR DESCRIPTION
**What is this feature?**

Adds a new OFREP provider option for Grafana's OpenFeature support, allowing for any OFREP-compatible service to be used.

**Why do we need this feature?**

Allows for other OpenFeature OFREP-compatible services to be used with Grafana.

This will be especially helpful for local development, where we currently use the GOFF provider, which requires stubbed gRPC token exchange information, causing retry loops on every OpenFeature request, as we can switch to the OFREP provider type instead (while still using GOFF as the service URL). cc https://github.com/grafana/grafana-setupguide-app/pull/722 (🔐)

**Who is this feature for?**

Operators of Grafana instances.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.