### PR TITLE
ValueFormats: Fix disappearing Y-axis labels for large IEC values

### DIFF
--- a/packages/grafana-data/src/utils/numbers.ts
+++ b/packages/grafana-data/src/utils/numbers.ts
@@ -25,5 +25,31 @@ export function roundDecimals(val: number, dec = 0) {
  * bad  for arbitrary floats:     371.499999999999 -> 12
  */
 export function guessDecimals(num: number) {
-  return (('' + num).split('.')[1] || '').length;
+  if (num === 0 || !Number.isFinite(num)) {
+    return 0;
+  }
+
+  const str = num.toString();
+  const parts = str.split('.');
+  if (parts.length === 1) {
+    if (str.indexOf('e-') !== -1) {
+      return parseInt(str.split('e-')[1], 10);
+    }
+    return 0;
+  }
+
+  const dotPart = parts[1];
+  const exponentIndex = dotPart.indexOf('e');
+  if (exponentIndex === -1) {
+    return dotPart.length;
+  }
+
+  const fraction = dotPart.substring(0, exponentIndex);
+  const exponent = parseInt(dotPart.substring(exponentIndex + 1), 10);
+
+  if (exponent < 0) {
+    return fraction.length + Math.abs(exponent);
+  }
+
+  return Math.max(0, fraction.length - exponent);
 }

--- a/packages/grafana-data/src/valueFormats/valueFormats.test.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.test.ts
@@ -76,6 +76,7 @@ describe('valueFormats', () => {
     ${'dateTimeAsSystem'}              | ${0}         | ${dateTime(new Date(2010, 6, 2)).valueOf()} | ${'2010-07-02 00:00:00'}
     ${'dtdurationms'}                  | ${undefined} | ${100000}                                   | ${'1 minute'}
     ${'dtdurationms'}                  | ${undefined} | ${150000}                                   | ${'2 minutes'}
+    ${'bytes'}                         | ${undefined} | ${23000000000000000}                        | ${'20.4 PiB'}
   `(
     'With format=$format decimals=$decimals and value=$value then result should be = $expected',
     async ({ format, value, decimals, expected }) => {

--- a/packages/grafana-data/src/valueFormats/valueFormats.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.ts
@@ -46,11 +46,11 @@ const index: ValueFormatterIndex = {};
 let hasBuiltIndex = false;
 
 export function toFixed(value: number, decimals?: DecimalCount): string {
-  if (value === null) {
+  if (value === null || value === undefined) {
     return '';
   }
 
-  if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
+  if (!Number.isFinite(value)) {
     return value.toLocaleString();
   }
 
@@ -58,22 +58,25 @@ export function toFixed(value: number, decimals?: DecimalCount): string {
     decimals = getDecimalsForValue(value);
   }
 
+
+  decimals = clamp(decimals, 0, 20);
+
   if (value === 0) {
     return value.toFixed(decimals);
   }
 
-  const factor = decimals ? Math.pow(10, Math.max(0, decimals)) : 1;
+  const factor = Math.pow(10, decimals);
   const formatted = String(Math.round(value * factor) / factor);
 
-  // if exponent return directly
-  if (formatted.indexOf('e') !== -1 || value === 0) {
+  // if exponent return directly or if no decimals needed
+  if (formatted.indexOf('e') !== -1 || decimals === 0) {
     return formatted;
   }
 
   const decimalPos = formatted.indexOf('.');
   const precision = decimalPos === -1 ? 0 : formatted.length - decimalPos - 1;
   if (precision < decimals) {
-    return (precision ? formatted : formatted + '.') + String(factor).slice(1, decimals - precision + 1);
+    return (precision ? formatted : formatted + '.') + '0'.repeat(decimals - precision);
   }
 
   return formatted;


### PR DESCRIPTION
**What is this feature?**

This PR fixes a bug in the value formatting logic in `@grafana/data`.  
It resolves a rendering issue where Y-axis labels disappeared when values exceeded ~22.5 PiB while using IEC units such as `bytes(IEC)`.

**Why do we need this feature?**

When values become very large, JavaScript switches to scientific notation (e.g. `1.125e+21`).  
Two problems caused the axis rendering to break:

- `guessDecimals` incorrectly parsed scientific notation, leading to wrong precision calculations.
- `toFixed` used unsafe string slicing on the scientific exponent, generating invalid numeric strings like `20.4e+21000`, which caused uPlot to fail when computing or rendering axis labels.

**Who is this feature for?**

Users monitoring large-scale systems such as storage platforms, backup solutions, and high-throughput networks where metrics reach PiB/EiB scale.

**Which issue(s) does this PR fix?**

Fixes #115853

**Special notes for your reviewer:**

**Technical changes:**
- Updated `guessDecimals` to robustly handle both positive and negative scientific notation exponents.
- Refactored `toFixed` to use safe zero-padding via `.repeat('0')` instead of string slicing on the exponent factor.
- Added a defensive clamp for decimal precision (max 20).
- Added a regression test in `valueFormats.test.ts` for `23000000000000000` to prevent future breakage.

**Please check that:**
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (N/A - bug fix)
- [x] The docs are updated. (N/A - internal logic fix)
