### PR TITLE
Alerting: Fix hyphen escaping in rule labels filter

### DIFF
--- a/pkg/services/ngalert/store/alert_rule_labels_test.go
+++ b/pkg/services/ngalert/store/alert_rule_labels_test.go
@@ -73,21 +73,21 @@ func TestBuildLabelMatcherJSON(t *testing.T) {
 			name:     "MySQL MatchEqual with non-empty value",
 			dialect:  migrator.NewMysqlDialect(),
 			matcher:  &labels.Matcher{Type: labels.MatchEqual, Name: "team", Value: "alerting"},
-			wantSQL:  "JSON_UNQUOTE(JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$.', ?))) = ?",
+			wantSQL:  `JSON_UNQUOTE(JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$."', ?, '"'))) = ?`,
 			wantArgs: []any{"team", "alerting"},
 		},
 		{
 			name:     "MySQL MatchEqual with empty value",
 			dialect:  migrator.NewMysqlDialect(),
 			matcher:  &labels.Matcher{Type: labels.MatchEqual, Name: "team", Value: ""},
-			wantSQL:  "(JSON_UNQUOTE(JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$.', ?))) = ? OR JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$.', ?)) IS NULL)",
+			wantSQL:  `(JSON_UNQUOTE(JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$."', ?, '"'))) = ? OR JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$."', ?, '"')) IS NULL)`,
 			wantArgs: []any{"team", "", "team"},
 		},
 		{
 			name:     "MySQL MatchNotEqual",
 			dialect:  migrator.NewMysqlDialect(),
 			matcher:  &labels.Matcher{Type: labels.MatchNotEqual, Name: "team", Value: "alerting"},
-			wantSQL:  "(JSON_UNQUOTE(JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$.', ?))) IS NULL OR JSON_UNQUOTE(JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$.', ?))) != ?)",
+			wantSQL:  `(JSON_UNQUOTE(JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$."', ?, '"'))) IS NULL OR JSON_UNQUOTE(JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$."', ?, '"'))) != ?)`,
 			wantArgs: []any{"team", "team", "alerting"},
 		},
 		{
@@ -149,7 +149,7 @@ func TestBuildLabelKeyExistsCondition(t *testing.T) {
 			dialect:  migrator.NewMysqlDialect(),
 			column:   "labels",
 			key:      "__grafana_origin",
-			wantSQL:  "JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$.', ?)) IS NOT NULL",
+			wantSQL:  `JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$."', ?, '"')) IS NOT NULL`,
 			wantArgs: []any{"__grafana_origin"},
 		},
 		{
@@ -194,7 +194,7 @@ func TestBuildLabelKeyMissingCondition(t *testing.T) {
 			dialect:  migrator.NewMysqlDialect(),
 			column:   "labels",
 			key:      "__grafana_origin",
-			wantSQL:  "JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$.', ?)) IS NULL",
+			wantSQL:  `JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$."', ?, '"')) IS NULL`,
 			wantArgs: []any{"__grafana_origin"},
 		},
 		{

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -2454,7 +2454,7 @@ func TestIntegration_ListAlertRules(t *testing.T) {
 			ruleGen.WithLabels(map[string]string{"glob": "*[?]"}),
 			ruleGen.WithTitle("rule_glob")))
 		ruleSpecialChars := createRule(t, store, ruleGen.With(
-			ruleGen.WithLabels(map[string]string{"json": "line1\nline2\\end\"quote"}),
+			ruleGen.WithLabels(map[string]string{"label-with-hyphen": "line1\nline2\\end\"quote"}),
 			ruleGen.WithTitle("rule_special_chars")))
 		ruleEmpty := createRule(t, store, ruleGen.With(
 			ruleGen.WithLabels(map[string]string{"empty": ""}),
@@ -2531,7 +2531,7 @@ func TestIntegration_ListAlertRules(t *testing.T) {
 				name: "JSON escape characters are handled correctly",
 				labelMatchers: labels.Matchers{
 					func() *labels.Matcher {
-						m, _ := labels.NewMatcher(labels.MatchEqual, "json", "line1\nline2\\end\"quote")
+						m, _ := labels.NewMatcher(labels.MatchEqual, "label-with-hyphen", "line1\nline2\\end\"quote")
 						return m
 					}(),
 				},

--- a/pkg/services/ngalert/store/json.go
+++ b/pkg/services/ngalert/store/json.go
@@ -13,7 +13,7 @@ import (
 func jsonEquals(dialect migrator.Dialect, column, key, value string) (string, []any) {
 	switch dialect.DriverName() {
 	case migrator.MySQL:
-		return fmt.Sprintf("JSON_UNQUOTE(JSON_EXTRACT(NULLIF(%s, ''), CONCAT('$.', ?))) = ?", column), []any{key, value}
+		return fmt.Sprintf(`JSON_UNQUOTE(JSON_EXTRACT(NULLIF(%s, ''), CONCAT('$."', ?, '"'))) = ?`, column), []any{key, value}
 	case migrator.Postgres:
 		return fmt.Sprintf("jsonb_extract_path_text(NULLIF(%s, '')::jsonb, ?) = ?", column), []any{key, value}
 	default:
@@ -25,7 +25,7 @@ func jsonNotEquals(dialect migrator.Dialect, column, key, value string) (string,
 	var jx string
 	switch dialect.DriverName() {
 	case migrator.MySQL:
-		jx = fmt.Sprintf("JSON_UNQUOTE(JSON_EXTRACT(NULLIF(%s, ''), CONCAT('$.', ?)))", column)
+		jx = fmt.Sprintf(`JSON_UNQUOTE(JSON_EXTRACT(NULLIF(%s, ''), CONCAT('$."', ?, '"')))`, column)
 	case migrator.Postgres:
 		jx = fmt.Sprintf("jsonb_extract_path_text(NULLIF(%s, '')::jsonb, ?)", column)
 	default:
@@ -49,7 +49,7 @@ func jsonKeyCondition(dialect migrator.Dialect, column, key string, exists bool)
 	}
 	switch dialect.DriverName() {
 	case migrator.MySQL:
-		return fmt.Sprintf("JSON_EXTRACT(NULLIF(%s, ''), CONCAT('$.', ?)) %s", column, nullCheck), []any{key}, nil
+		return fmt.Sprintf(`JSON_EXTRACT(NULLIF(%s, ''), CONCAT('$."', ?, '"')) %s`, column, nullCheck), []any{key}, nil
 	case migrator.Postgres:
 		return fmt.Sprintf("jsonb_extract_path_text(NULLIF(%s, '')::jsonb, ?) %s", column, nullCheck), []any{key}, nil
 	default:

--- a/pkg/services/ngalert/store/json_test.go
+++ b/pkg/services/ngalert/store/json_test.go
@@ -23,7 +23,7 @@ func TestJsonEquals(t *testing.T) {
 			column:   "labels",
 			key:      "team",
 			value:    "alerting",
-			wantSQL:  "JSON_UNQUOTE(JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$.', ?))) = ?",
+			wantSQL:  `JSON_UNQUOTE(JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$."', ?, '"'))) = ?`,
 			wantArgs: []any{"team", "alerting"},
 		},
 		{
@@ -62,7 +62,7 @@ func TestJsonNotEquals(t *testing.T) {
 			column:   "labels",
 			key:      "team",
 			value:    "alerting",
-			wantSQL:  "(JSON_UNQUOTE(JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$.', ?))) IS NULL OR JSON_UNQUOTE(JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$.', ?))) != ?)",
+			wantSQL:  `(JSON_UNQUOTE(JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$."', ?, '"'))) IS NULL OR JSON_UNQUOTE(JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$."', ?, '"'))) != ?)`,
 			wantArgs: []any{"team", "team", "alerting"},
 		},
 		{
@@ -99,7 +99,7 @@ func TestJsonKeyMissing(t *testing.T) {
 			dialect:  migrator.NewMysqlDialect(),
 			column:   "labels",
 			key:      "team",
-			wantSQL:  "JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$.', ?)) IS NULL",
+			wantSQL:  `JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$."', ?, '"')) IS NULL`,
 			wantArgs: []any{"team"},
 		},
 		{
@@ -136,7 +136,7 @@ func TestJsonKeyExists(t *testing.T) {
 			dialect:  migrator.NewMysqlDialect(),
 			column:   "labels",
 			key:      "__grafana_origin",
-			wantSQL:  "JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$.', ?)) IS NOT NULL",
+			wantSQL:  `JSON_EXTRACT(NULLIF(labels, ''), CONCAT('$."', ?, '"')) IS NOT NULL`,
 			wantArgs: []any{"__grafana_origin"},
 		},
 		{


### PR DESCRIPTION
**What is this feature?**

Fixes backend filtering alert rules by labels that have hyphens in the label key name when using MySQL.

All MySQL JSON paths now use `CONCAT('$."', ?, '"')` instead of `CONCAT('$.', ?)` which makes the JSON keys be `$."label-1"` instead of `$.label-1` to be properly parsed by MySQL when they have hyphens.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/alerting-squad/issues/1275

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
