### PR TITLE
UI: Allow lastActiveAt to be optional for UserIcon UserView

### DIFF
--- a/packages/grafana-ui/src/components/UsersIndicator/UserIcon.mdx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UserIcon.mdx
@@ -66,6 +66,6 @@ export interface UserView {
     avatarUrl?: string;
   };
   /** Datetime string when the user was last active */
-  lastActiveAt: DateTimeInput;
+  lastActiveAt?: DateTimeInput;
 }
 ```

--- a/packages/grafana-ui/src/components/UsersIndicator/UserIcon.tsx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UserIcon.tsx
@@ -10,7 +10,7 @@ import { Tooltip } from '../Tooltip/Tooltip';
 import { UserView } from './types';
 
 export interface UserIconProps {
-  /** An object that contains the user's details and 'lastActiveAt' status */
+  /** An object that contains the user's details and an optional 'lastActiveAt' status */
   userView: UserView;
   /** A boolean value that determines whether the tooltip should be shown or not */
   showTooltip?: boolean;
@@ -64,7 +64,8 @@ export const UserIcon = ({
   showTooltip = true,
 }: PropsWithChildren<UserIconProps>) => {
   const { user, lastActiveAt } = userView;
-  const isActive = dateTime(lastActiveAt).diff(dateTime(), 'minutes', true) >= -15;
+  const hasActive = lastActiveAt !== undefined && lastActiveAt !== null;
+  const isActive = hasActive && dateTime(lastActiveAt).diff(dateTime(), 'minutes', true) >= -15;
   const theme = useTheme2();
   const styles = useMemo(() => getStyles(theme, isActive), [theme, isActive]);
   const content = (
@@ -88,18 +89,20 @@ export const UserIcon = ({
     const tooltip = (
       <div className={styles.tooltipContainer}>
         <div className={styles.tooltipName}>{user.name}</div>
-        <div className={styles.tooltipDate}>
-          {isActive ? (
-            <div className={styles.dotContainer}>
-              <span>
-                <Trans i18nKey="grafana-ui.user-icon.active-text">Active last 15m</Trans>
-              </span>
-              <span className={styles.dot}></span>
-            </div>
-          ) : (
-            formatViewed(lastActiveAt)
-          )}
-        </div>
+        {hasActive && (
+          <div className={styles.tooltipDate}>
+            {isActive ? (
+              <div className={styles.dotContainer}>
+                <span>
+                  <Trans i18nKey="grafana-ui.user-icon.active-text">Active last 15m</Trans>
+                </span>
+                <span className={styles.dot}></span>
+              </div>
+            ) : (
+              formatViewed(lastActiveAt)
+            )}
+          </div>
+        )}
       </div>
     );
 

--- a/packages/grafana-ui/src/components/UsersIndicator/UsersIndicator.mdx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UsersIndicator.mdx
@@ -60,6 +60,6 @@ export interface UserView {
     avatarUrl?: string;
   };
   /** Datetime string when the user was last active */
-  lastActiveAt: DateTimeInput;
+  lastActiveAt?: DateTimeInput;
 }
 ```

--- a/packages/grafana-ui/src/components/UsersIndicator/UsersIndicator.tsx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UsersIndicator.tsx
@@ -9,7 +9,7 @@ import { UserIcon } from './UserIcon';
 import { UserView } from './types';
 
 export interface UsersIndicatorProps {
-  /** An object that contains the user's details and 'lastActiveAt' status */
+  /** An object that contains the user's details and an optional 'lastActiveAt' status */
   users: UserView[];
   /** A limit of how many user icons to show before collapsing them and showing a number of users instead */
   limit?: number;
@@ -40,7 +40,7 @@ export const UsersIndicator = ({ users, onClick, limit = 4 }: UsersIndicatorProp
       aria-label={t('grafana-ui.users-indicator.container-label', 'Users indicator container')}
     >
       {limitReached && (
-        <UserIcon onClick={onClick} userView={{ user: { name: 'Extra users' }, lastActiveAt: '' }} showTooltip={false}>
+        <UserIcon onClick={onClick} userView={{ user: { name: 'Extra users' } }} showTooltip={false}>
           {tooManyUsers
             ? // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
               '...'

--- a/packages/grafana-ui/src/components/UsersIndicator/types.ts
+++ b/packages/grafana-ui/src/components/UsersIndicator/types.ts
@@ -8,5 +8,5 @@ export interface UserView {
     avatarUrl?: string;
   };
   /** Datetime string when the user was last active */
-  lastActiveAt: DateTimeInput;
+  lastActiveAt?: DateTimeInput;
 }


### PR DESCRIPTION
**What is this feature?**

Allows for `UserIcon` (and `UsersIndicator`) to be used to display a user without requiring that a timestamp is passed + shown, while still allowing the tooltip to be displayed with the user's name.

**Why do we need this feature?**

I've ended up implementing a custom version of this component for https://github.com/grafana/grafana-setupguide-app/pull/712 (🔐) currently, as we want to show all users in the Grafana instance as part of onboarding and encouraging the user to invite additional users, but don't want to show the "active" tooltip messaging.

**Who is this feature for?**

Grafana developers.