### PR TITLE
UI: Use computed z-index for UsersIndicator to fix tab order

### DIFF
--- a/packages/grafana-ui/src/components/UsersIndicator/UserIcon.tsx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UserIcon.tsx
@@ -16,6 +16,8 @@ export interface UserIconProps {
   showTooltip?: boolean;
   /** An optional class name to be added to the icon element */
   className?: string;
+  /** An optional z-index for when multiple users are stacked */
+  zIndex?: number;
   /** onClick handler to be called when the icon is clicked */
   onClick?: () => void;
 }
@@ -59,6 +61,7 @@ const getUserInitials = (name?: string) => {
 export const UserIcon = ({
   userView,
   className,
+  zIndex,
   children,
   onClick,
   showTooltip = true,
@@ -74,6 +77,7 @@ export const UserIcon = ({
       onClick={onClick}
       className={cx(styles.container, onClick && styles.pointer, className)}
       aria-label={t('grafana-ui.user-icon.label', '{{name}} icon', { name: user.name })}
+      style={zIndex !== undefined ? { zIndex } : undefined}
     >
       {children ? (
         <div className={cx(styles.content, styles.textContent)}>{children}</div>

--- a/packages/grafana-ui/src/components/UsersIndicator/UserIcon.tsx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UserIcon.tsx
@@ -16,8 +16,6 @@ export interface UserIconProps {
   showTooltip?: boolean;
   /** An optional class name to be added to the icon element */
   className?: string;
-  /** An optional z-index for when multiple users are stacked */
-  zIndex?: number;
   /** onClick handler to be called when the icon is clicked */
   onClick?: () => void;
 }
@@ -61,7 +59,6 @@ const getUserInitials = (name?: string) => {
 export const UserIcon = ({
   userView,
   className,
-  zIndex,
   children,
   onClick,
   showTooltip = true,
@@ -77,7 +74,6 @@ export const UserIcon = ({
       onClick={onClick}
       className={cx(styles.container, onClick && styles.pointer, className)}
       aria-label={t('grafana-ui.user-icon.label', '{{name}} icon', { name: user.name })}
-      style={zIndex !== undefined ? { zIndex } : undefined}
     >
       {children ? (
         <div className={cx(styles.content, styles.textContent)}>{children}</div>

--- a/packages/grafana-ui/src/components/UsersIndicator/UsersIndicator.tsx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UsersIndicator.tsx
@@ -39,6 +39,9 @@ export const UsersIndicator = ({ users, onClick, limit = 4 }: UsersIndicatorProp
       className={styles.container}
       aria-label={t('grafana-ui.users-indicator.container-label', 'Users indicator container')}
     >
+      {users.slice(0, limitReached ? limit : limit + 1).map((userView, idx, arr) => (
+        <UserIcon key={userView.user.name} userView={userView} zIndex={arr.length - idx} />
+      ))}
       {limitReached && (
         <UserIcon onClick={onClick} userView={{ user: { name: 'Extra users' } }} showTooltip={false}>
           {tooManyUsers
@@ -47,12 +50,6 @@ export const UsersIndicator = ({ users, onClick, limit = 4 }: UsersIndicatorProp
             : `+${extraUsers}`}
         </UserIcon>
       )}
-      {users
-        .slice(0, limitReached ? limit : limit + 1)
-        .reverse()
-        .map((userView) => (
-          <UserIcon key={userView.user.name} userView={userView} />
-        ))}
     </div>
   );
 };
@@ -62,8 +59,8 @@ const getStyles = (theme: GrafanaTheme2) => {
     container: css({
       display: 'flex',
       justifyContent: 'center',
-      flexDirection: 'row-reverse',
       marginLeft: theme.spacing(1),
+      isolation: 'isolate',
 
       '& > button': {
         marginLeft: theme.spacing(-1), // Overlay the elements a bit on top of each other

--- a/packages/grafana-ui/src/components/UsersIndicator/UsersIndicator.tsx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UsersIndicator.tsx
@@ -23,7 +23,7 @@ export interface UsersIndicatorProps {
  * https://developers.grafana.com/ui/latest/index.html?path=/docs/iconography-usersindicator--docs
  */
 export const UsersIndicator = ({ users, onClick, limit = 4 }: UsersIndicatorProps) => {
-  const styles = useStyles2(getStyles);
+  const styles = useStyles2(getStyles, limit);
   if (!users.length) {
     return null;
   }
@@ -40,7 +40,7 @@ export const UsersIndicator = ({ users, onClick, limit = 4 }: UsersIndicatorProp
       aria-label={t('grafana-ui.users-indicator.container-label', 'Users indicator container')}
     >
       {users.slice(0, limitReached ? limit : limit + 1).map((userView, idx, arr) => (
-        <UserIcon key={userView.user.name} userView={userView} zIndex={arr.length - idx} />
+        <UserIcon key={userView.user.name} userView={userView} />
       ))}
       {limitReached && (
         <UserIcon onClick={onClick} userView={{ user: { name: 'Extra users' } }} showTooltip={false}>
@@ -54,7 +54,7 @@ export const UsersIndicator = ({ users, onClick, limit = 4 }: UsersIndicatorProp
   );
 };
 
-const getStyles = (theme: GrafanaTheme2) => {
+const getStyles = (theme: GrafanaTheme2, limit: number) => {
   return {
     container: css({
       display: 'flex',
@@ -64,6 +64,16 @@ const getStyles = (theme: GrafanaTheme2) => {
 
       '& > button': {
         marginLeft: theme.spacing(-1), // Overlay the elements a bit on top of each other
+
+        // Ensure overlaying user icons are stacked correctly with z-index on each element
+        ...Object.fromEntries(
+          Array.from({ length: limit }).map((_, idx) => [
+            `&:nth-of-type(${idx + 1})`,
+            {
+              zIndex: limit - idx,
+            },
+          ])
+        ),
       },
     }),
     dots: css({


### PR DESCRIPTION
**What is this feature?**

Related to #115887, when you have multiple users displayed in `UsersIndicator`, due to it previously rendering via `row-reverse`, the tab order of the items would also be flipped (you'd tab right-to-left). Instead, we can use computed z-index values to stack the items in an isolated container, preserving the visual overlap and allowing for the correct tab order.

**Why do we need this feature?**

Preserves the correct tab order of users in `UsersIndictor`.

**Who is this feature for?**

All Grafana users, especially those who use keyboard navigation.