### PR TITLE
OpenFeature: Rename provider from `goff` to `features-service`

### DIFF
--- a/pkg/registry/apis/ofrep/register.go
+++ b/pkg/registry/apis/ofrep/register.go
@@ -276,7 +276,7 @@ func (b *APIBuilder) oneFlagHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if b.providerType == setting.GOFFProviderType || b.providerType == setting.OFREPProviderType {
+	if b.providerType == setting.FeaturesServiceProviderType || b.providerType == setting.OFREPProviderType {
 		b.proxyFlagReq(ctx, flagKey, isAuthedReq, w, r)
 		return
 	}
@@ -304,7 +304,7 @@ func (b *APIBuilder) allFlagsHandler(w http.ResponseWriter, r *http.Request) {
 	isAuthedReq := b.isAuthenticatedRequest(r)
 	span.SetAttributes(attribute.Bool("authenticated", isAuthedReq))
 
-	if b.providerType == setting.GOFFProviderType || b.providerType == setting.OFREPProviderType {
+	if b.providerType == setting.FeaturesServiceProviderType || b.providerType == setting.OFREPProviderType {
 		b.proxyAllFlagReq(ctx, isAuthedReq, w, r)
 		return
 	}

--- a/pkg/services/featuremgmt/features_service_provider.go
+++ b/pkg/services/featuremgmt/features_service_provider.go
@@ -7,7 +7,7 @@ import (
 	"github.com/open-feature/go-sdk/openfeature"
 )
 
-func newGOFFProvider(url string, client *http.Client) (openfeature.FeatureProvider, error) {
+func newFeaturesServiceProvider(url string, client *http.Client) (openfeature.FeatureProvider, error) {
 	options := gofeatureflag.ProviderOptions{
 		Endpoint: url,
 		// consider using github.com/grafana/grafana/pkg/infra/httpclient/provider.go

--- a/pkg/services/featuremgmt/openfeature.go
+++ b/pkg/services/featuremgmt/openfeature.go
@@ -21,7 +21,7 @@ const (
 type OpenFeatureConfig struct {
 	// ProviderType is either "static", "features-service", or "ofrep"
 	ProviderType string
-	// URL is the features-service or OFREP service URL (required for features-service + OFREP providers)
+	// URL is the remote provider's URL (required for features-service + OFREP providers)
 	URL *url.URL
 	// HTTPClient is a pre-configured HTTP client (optional, used for features-service + OFREP providers)
 	HTTPClient *http.Client

--- a/pkg/services/featuremgmt/openfeature.go
+++ b/pkg/services/featuremgmt/openfeature.go
@@ -35,7 +35,7 @@ type OpenFeatureConfig struct {
 
 // InitOpenFeature initializes OpenFeature with the provided configuration
 func InitOpenFeature(config OpenFeatureConfig) error {
-	// For features-service + OFREP providers, ensure we have a URL
+	// For remote providers, ensure we have a URL
 	if (config.ProviderType == setting.FeaturesServiceProviderType || config.ProviderType == setting.OFREPProviderType) && (config.URL == nil || config.URL.String() == "") {
 		return fmt.Errorf("URL is required for features-service + OFREP providers")
 	}

--- a/pkg/services/featuremgmt/openfeature.go
+++ b/pkg/services/featuremgmt/openfeature.go
@@ -23,7 +23,7 @@ type OpenFeatureConfig struct {
 	ProviderType string
 	// URL is the remote provider's URL (required for features-service + OFREP providers)
 	URL *url.URL
-	// HTTPClient is a pre-configured HTTP client (optional, used for features-service + OFREP providers)
+	// HTTPClient is a pre-configured HTTP client (optional, used by features-service + OFREP providers)
 	HTTPClient *http.Client
 	// StaticFlags are the feature flags to use with static provider
 	StaticFlags map[string]bool

--- a/pkg/services/featuremgmt/openfeature.go
+++ b/pkg/services/featuremgmt/openfeature.go
@@ -19,11 +19,11 @@ const (
 
 // OpenFeatureConfig holds configuration for initializing OpenFeature
 type OpenFeatureConfig struct {
-	// ProviderType is either "static", "goff", or "ofrep"
+	// ProviderType is either "static", "features-service", or "ofrep"
 	ProviderType string
-	// URL is the GOFF or OFREP service URL (required for GOFF + OFREP providers)
+	// URL is the features-service or OFREP service URL (required for features-service + OFREP providers)
 	URL *url.URL
-	// HTTPClient is a pre-configured HTTP client (optional, used for GOFF + OFREP providers)
+	// HTTPClient is a pre-configured HTTP client (optional, used for features-service + OFREP providers)
 	HTTPClient *http.Client
 	// StaticFlags are the feature flags to use with static provider
 	StaticFlags map[string]bool
@@ -35,9 +35,9 @@ type OpenFeatureConfig struct {
 
 // InitOpenFeature initializes OpenFeature with the provided configuration
 func InitOpenFeature(config OpenFeatureConfig) error {
-	// For GOFF + OFREP providers, ensure we have a URL
+	// For features-service + OFREP providers, ensure we have a URL
 	if (config.ProviderType == setting.FeaturesServiceProviderType || config.ProviderType == setting.OFREPProviderType) && (config.URL == nil || config.URL.String() == "") {
-		return fmt.Errorf("URL is required for GOFF + OFREP providers")
+		return fmt.Errorf("URL is required for features-service + OFREP providers")
 	}
 
 	p, err := createProvider(config.ProviderType, config.URL, config.StaticFlags, config.HTTPClient)
@@ -109,7 +109,7 @@ func createProvider(
 		}
 
 		if providerType == setting.FeaturesServiceProviderType {
-			return newGOFFProvider(u.String(), httpClient)
+			return newFeaturesServiceProvider(u.String(), httpClient)
 		}
 
 		if providerType == setting.OFREPProviderType {

--- a/pkg/services/featuremgmt/openfeature.go
+++ b/pkg/services/featuremgmt/openfeature.go
@@ -36,7 +36,7 @@ type OpenFeatureConfig struct {
 // InitOpenFeature initializes OpenFeature with the provided configuration
 func InitOpenFeature(config OpenFeatureConfig) error {
 	// For GOFF + OFREP providers, ensure we have a URL
-	if (config.ProviderType == setting.GOFFProviderType || config.ProviderType == setting.OFREPProviderType) && (config.URL == nil || config.URL.String() == "") {
+	if (config.ProviderType == setting.FeaturesServiceProviderType || config.ProviderType == setting.OFREPProviderType) && (config.URL == nil || config.URL.String() == "") {
 		return fmt.Errorf("URL is required for GOFF + OFREP providers")
 	}
 
@@ -66,10 +66,10 @@ func InitOpenFeatureWithCfg(cfg *setting.Cfg) error {
 	}
 
 	var httpcli *http.Client
-	if cfg.OpenFeature.ProviderType == setting.GOFFProviderType || cfg.OpenFeature.ProviderType == setting.OFREPProviderType {
+	if cfg.OpenFeature.ProviderType == setting.FeaturesServiceProviderType || cfg.OpenFeature.ProviderType == setting.OFREPProviderType {
 		var m *clientauthmiddleware.TokenExchangeMiddleware
 
-		if cfg.OpenFeature.ProviderType == setting.GOFFProviderType {
+		if cfg.OpenFeature.ProviderType == setting.FeaturesServiceProviderType {
 			m, err = clientauthmiddleware.NewTokenExchangeMiddleware(cfg)
 			if err != nil {
 				return fmt.Errorf("failed to create token exchange middleware: %w", err)
@@ -103,12 +103,12 @@ func createProvider(
 	staticFlags map[string]bool,
 	httpClient *http.Client,
 ) (openfeature.FeatureProvider, error) {
-	if providerType == setting.GOFFProviderType || providerType == setting.OFREPProviderType {
+	if providerType == setting.FeaturesServiceProviderType || providerType == setting.OFREPProviderType {
 		if u == nil || u.String() == "" {
-			return nil, fmt.Errorf("feature provider url is required for GOFFProviderType + OFREPProviderType")
+			return nil, fmt.Errorf("feature provider url is required for FeaturesServiceProviderType + OFREPProviderType")
 		}
 
-		if providerType == setting.GOFFProviderType {
+		if providerType == setting.FeaturesServiceProviderType {
 			return newGOFFProvider(u.String(), httpClient)
 		}
 

--- a/pkg/services/featuremgmt/openfeature.go
+++ b/pkg/services/featuremgmt/openfeature.go
@@ -37,7 +37,7 @@ type OpenFeatureConfig struct {
 func InitOpenFeature(config OpenFeatureConfig) error {
 	// For remote providers, ensure we have a URL
 	if (config.ProviderType == setting.FeaturesServiceProviderType || config.ProviderType == setting.OFREPProviderType) && (config.URL == nil || config.URL.String() == "") {
-		return fmt.Errorf("URL is required for features-service + OFREP providers")
+		return fmt.Errorf("URL is required for remote providers")
 	}
 
 	p, err := createProvider(config.ProviderType, config.URL, config.StaticFlags, config.HTTPClient)

--- a/pkg/services/featuremgmt/openfeature_test.go
+++ b/pkg/services/featuremgmt/openfeature_test.go
@@ -35,7 +35,7 @@ func TestCreateProvider(t *testing.T) {
 			expectedProvider: setting.StaticProviderType,
 		},
 		{
-			name: "goff provider",
+			name: "features-service provider",
 			cfg: setting.OpenFeatureSettings{
 				ProviderType: setting.FeaturesServiceProviderType,
 				URL:          u,
@@ -48,7 +48,7 @@ func TestCreateProvider(t *testing.T) {
 			expectedProvider: setting.FeaturesServiceProviderType,
 		},
 		{
-			name: "goff provider with failing token exchange",
+			name: "features-service provider with failing token exchange",
 			cfg: setting.OpenFeatureSettings{
 				ProviderType: setting.FeaturesServiceProviderType,
 				URL:          u,
@@ -107,7 +107,7 @@ func TestCreateProvider(t *testing.T) {
 
 			tokenExchangeMiddleware := middleware.TestingTokenExchangeMiddleware(tokenExchangeClient)
 			httpClient, err := createHTTPClient(tokenExchangeMiddleware)
-			require.NoError(t, err, "failed to create goff http client")
+			require.NoError(t, err, "failed to create features-service http client")
 			provider, err := createProvider(tc.cfg.ProviderType, tc.cfg.URL, nil, httpClient)
 			require.NoError(t, err)
 
@@ -141,10 +141,10 @@ func testGoFFProvider(t *testing.T, failSigning bool) {
 	_, err := openfeature.NewDefaultClient().BooleanValueDetails(ctx, "test", false, openfeature.NewEvaluationContext("test", map[string]interface{}{"test": "test"}))
 
 	// Error related to the token exchange should be returned if signing fails
-	// otherwise, it should return a connection refused error since the goff URL is not set
+	// otherwise, it should return a connection refused error since the features-service URL is not set
 	if failSigning {
 		assert.ErrorContains(t, err, "failed to exchange token: error signing token", "should return an error when signing fails")
 	} else {
-		assert.ErrorContains(t, err, "connect: connection refused", "should return an error when goff url is not set")
+		assert.ErrorContains(t, err, "connect: connection refused", "should return an error when features-service url is not set")
 	}
 }

--- a/pkg/services/featuremgmt/openfeature_test.go
+++ b/pkg/services/featuremgmt/openfeature_test.go
@@ -37,7 +37,7 @@ func TestCreateProvider(t *testing.T) {
 		{
 			name: "goff provider",
 			cfg: setting.OpenFeatureSettings{
-				ProviderType: setting.GOFFProviderType,
+				ProviderType: setting.FeaturesServiceProviderType,
 				URL:          u,
 				TargetingKey: "grafana",
 			},
@@ -45,12 +45,12 @@ func TestCreateProvider(t *testing.T) {
 				Namespace: "*",
 				Audiences: []string{"features.grafana.app"},
 			},
-			expectedProvider: setting.GOFFProviderType,
+			expectedProvider: setting.FeaturesServiceProviderType,
 		},
 		{
 			name: "goff provider with failing token exchange",
 			cfg: setting.OpenFeatureSettings{
-				ProviderType: setting.GOFFProviderType,
+				ProviderType: setting.FeaturesServiceProviderType,
 				URL:          u,
 				TargetingKey: "grafana",
 			},
@@ -58,7 +58,7 @@ func TestCreateProvider(t *testing.T) {
 				Namespace: "*",
 				Audiences: []string{"features.grafana.app"},
 			},
-			expectedProvider: setting.GOFFProviderType,
+			expectedProvider: setting.FeaturesServiceProviderType,
 			failSigning:      true,
 		},
 		{
@@ -115,7 +115,7 @@ func TestCreateProvider(t *testing.T) {
 			require.NoError(t, err, "failed to set provider")
 
 			switch tc.expectedProvider {
-			case setting.GOFFProviderType:
+			case setting.FeaturesServiceProviderType:
 				_, ok := provider.(*gofeatureflag.Provider)
 				assert.True(t, ok, "expected provider to be of type goff.Provider")
 

--- a/pkg/setting/setting_openfeature.go
+++ b/pkg/setting/setting_openfeature.go
@@ -6,9 +6,9 @@ import (
 )
 
 const (
-	StaticProviderType = "static"
-	GOFFProviderType   = "goff"
-	OFREPProviderType  = "ofrep"
+	StaticProviderType          = "static"
+	FeaturesServiceProviderType = "features-service"
+	OFREPProviderType           = "ofrep"
 )
 
 type OpenFeatureSettings struct {
@@ -34,7 +34,7 @@ func (cfg *Cfg) readOpenFeatureSettings() error {
 
 	cfg.OpenFeature.TargetingKey = config.Key("targetingKey").MustString(defaultTargetingKey)
 
-	if strURL != "" && (cfg.OpenFeature.ProviderType == GOFFProviderType || cfg.OpenFeature.ProviderType == OFREPProviderType) {
+	if strURL != "" && (cfg.OpenFeature.ProviderType == FeaturesServiceProviderType || cfg.OpenFeature.ProviderType == OFREPProviderType) {
 		u, err := url.Parse(strURL)
 		if err != nil {
 			return fmt.Errorf("invalid feature provider url: %w", err)

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -321,7 +321,7 @@ func CreateGrafDir(t *testing.T, opts GrafanaOpts) (string, string) {
 	_, err = openFeatureSect.NewKey("enable_api", strconv.FormatBool(opts.OpenFeatureAPIEnabled))
 	require.NoError(t, err)
 	if !opts.OpenFeatureAPIEnabled {
-		_, err = openFeatureSect.NewKey("provider", "static") // in practice, APIEnabled being false goes with goff type, but trying to make tests work
+		_, err = openFeatureSect.NewKey("provider", "static") // in practice, APIEnabled being false goes with features-service type, but trying to make tests work
 		require.NoError(t, err)
 		_, err = openFeatureSect.NewKey("targetingKey", "grafana")
 		require.NoError(t, err)


### PR DESCRIPTION
As a follow-up to https://github.com/grafana/grafana/pull/115857, it was decided to rename the provider type to clarify its meaning.