### PR TITLE
Plugins: Add plugin.isFullyInstalled to usePluginConfig hook

### DIFF
--- a/public/app/features/plugins/admin/hooks/usePluginConfig.tsx
+++ b/public/app/features/plugins/admin/hooks/usePluginConfig.tsx
@@ -17,5 +17,5 @@ export const usePluginConfig = (plugin?: CatalogPlugin) => {
       return loadPlugin(plugin.id);
     }
     return null;
-  }, [plugin?.id, plugin?.isInstalled, plugin?.isDisabled]);
+  }, [plugin?.id, plugin?.isInstalled, plugin?.isDisabled, plugin?.isFullyInstalled]);
 };


### PR DESCRIPTION
**What is this feature?**

Added `plugin?.isFullyInstalled` to the useAsync dependency array.

**Why do we need this feature?**

The hook uses plugin.isFullyInstalled to decide if a plugin is installed, but the dependency array didn't include it. Without this dependency, the hook won't re-run when isFullyInstalled changes. This is causing the UI to render incorrectly in some instances - for example when navigating directly to [plugin configuration pages/tabs](https://ops.grafana-ops.net/plugins/grafana-lokiexplore-app?page=configuration):

Before:

<img width="1308" height="1227" alt="image" src="https://github.com/user-attachments/assets/d8185c1d-35db-476e-b8df-fb3c15b8c56e" />

After:

<img width="1325" height="1267" alt="image" src="https://github.com/user-attachments/assets/736a2ccb-60dc-4cd8-a3b1-9d44ee4fe4f4" />


Try it out for yourself [here](https://ephemeral15111821115898wbrown.grafana-dev.net/plugins/grafana-lokiexplore-app?page=configuration).
