### PR TITLE
Dashboards: Use ISO 8601 format for panel time range state

### DIFF
--- a/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
@@ -70,8 +70,8 @@ export class PanelTimeRange extends SceneTimeRangeTransformerBase<PanelTimeRange
     // set initial values on activate
     this.setState({
       value: timeRange,
-      from: timeRange.raw.from.toString(),
-      to: timeRange.raw.to.toString(),
+      from: typeof timeRange.raw.from === 'string' ? timeRange.raw.from : timeRange.raw.from.toISOString(),
+      to: typeof timeRange.raw.to === 'string' ? timeRange.raw.to : timeRange.raw.to.toISOString(),
     });
   }
 


### PR DESCRIPTION
**What is this feature?**

Converts DateTime objects to ISO format instead of js date string when storing `from`/`to` in `PanelTimeRange` state.

**Why do we need this feature?**

with .toString() for historical time range it would produce a string that `dateMath.toDateTime()` would not be able to parse

`dateMath.toDateTime()` requires ISO format:

https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/datetime/datemath.ts#L112-L113



