### PR TITLE
Dashboards: Fix liveNow not working for panels with time shift

### DIFF
--- a/packages/grafana-data/src/datetime/datemath.test.ts
+++ b/packages/grafana-data/src/datetime/datemath.test.ts
@@ -165,9 +165,17 @@ describe('DateMath', () => {
       expect(date!.valueOf()).toEqual(dateTime([2014, 1, 3]).valueOf());
     });
 
-    it('should handle multiple math expressions', () => {
-      const date = dateMath.parseDateMath('-2d-6h', dateTime([2014, 1, 5]));
-      expect(date!.valueOf()).toEqual(dateTime([2014, 1, 2, 18]).valueOf());
+    it.each([
+      ['-2d-6h', [2014, 1, 5], [2014, 1, 2, 18]],
+      ['-30m-2d', [2014, 1, 5], [2014, 1, 2, 23, 30]],
+      ['-2d-1d', [2014, 1, 5], [2014, 1, 2]],
+      ['-1h-30m', [2014, 1, 5, 12, 0], [2014, 1, 5, 10, 30]],
+      ['-1d-1h-30m', [2014, 1, 5, 12, 0], [2014, 1, 4, 10, 30]],
+      ['+1d-6h', [2014, 1, 5], [2014, 1, 5, 18]],
+      ['-1w-1d', [2014, 1, 14], [2014, 1, 6]],
+    ])('should handle multiple math expressions: %s', (expression, inputDate, expectedDate) => {
+      const date = dateMath.parseDateMath(expression, dateTime(inputDate));
+      expect(date!.valueOf()).toEqual(dateTime(expectedDate).valueOf());
     });
 
     it('should return false when invalid expression', () => {

--- a/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.test.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.test.tsx
@@ -128,7 +128,7 @@ describe('PanelTimeRange', () => {
     expect(panelTime.state.value.to.format('Z')).toBe('+00:00'); // UTC
   });
 
-  it('should handle invalid time reference in timeShift', () => {
+  it('should handle invalid time reference in timeShift with relative time range', () => {
     const panelTime = new PanelTimeRange({ timeShift: 'now-1d' });
 
     buildAndActivateSceneFor(panelTime);
@@ -137,6 +137,22 @@ describe('PanelTimeRange', () => {
     // Should not be affected by invalid timeShift
     expect(panelTime.state.from).toBe('now-6h');
     expect(panelTime.state.to).toBe('now');
+  });
+
+  it('should handle invalid time reference in timeShift with absolute time range', () => {
+    const panelTime = new PanelTimeRange({ timeShift: 'now-1d' });
+    const panel = new SceneCanvasText({ text: 'Hello', $timeRange: panelTime });
+    const absoluteFrom = '2019-02-11T10:00:00.000Z';
+    const absoluteTo = '2019-02-11T16:00:00.000Z';
+    const scene = new SceneFlexLayout({
+      $timeRange: new SceneTimeRange({ from: absoluteFrom, to: absoluteTo }),
+      children: [new SceneFlexItem({ body: panel })],
+    });
+    activateFullSceneTree(scene);
+
+    expect(panelTime.state.timeInfo).toBe('invalid timeshift');
+    expect(panelTime.state.from).toBe(absoluteFrom);
+    expect(panelTime.state.to).toBe(absoluteTo);
   });
 
   it('should handle invalid time reference in timeShift combined with timeFrom', () => {

--- a/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
@@ -211,11 +211,6 @@ export class PanelTimeRange extends SceneTimeRangeTransformerBase<PanelTimeRange
         const from = dateMath.parseDateMath(shift, newTimeData.timeRange.from, false)!;
         const to = dateMath.parseDateMath(shift, newTimeData.timeRange.to, true)!;
 
-        if (!from || !to) {
-          newTimeData.timeInfo = 'invalid timeshift';
-          return newTimeData;
-        }
-
         newTimeData.timeRange = { from, to, raw: { from, to } };
       }
     }

--- a/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
@@ -81,7 +81,19 @@ export class PanelTimeRange extends SceneTimeRangeTransformerBase<PanelTimeRange
     }
 
     const overrideResult = this.getTimeOverride(timeRange.value);
-    this.setState({ value: overrideResult.timeRange, timeInfo: overrideResult.timeInfo });
+    const { timeRange: overrideTimeRange } = overrideResult;
+    this.setState({
+      value: overrideTimeRange,
+      timeInfo: overrideResult.timeInfo,
+      from:
+        typeof overrideTimeRange.raw.from === 'string'
+          ? overrideTimeRange.raw.from
+          : overrideTimeRange.raw.from.toISOString(),
+      to:
+        typeof overrideTimeRange.raw.to === 'string'
+          ? overrideTimeRange.raw.to
+          : overrideTimeRange.raw.to.toISOString(),
+    });
   }
 
   // Get a time shifted request to compare with the primary request.
@@ -153,10 +165,10 @@ export class PanelTimeRange extends SceneTimeRangeTransformerBase<PanelTimeRange
 
       // Only evaluate if the timeFrom if parent time is relative
       if (rangeUtil.isRelativeTimeRange(parentTimeRange.raw)) {
-        const timeZone = this.getTimeZone();
+        const timezone = this.getTimeZone();
         newTimeData.timeRange = {
-          from: dateMath.parse(timeFromInfo.from, undefined, timeZone)!,
-          to: dateMath.parse(timeFromInfo.to, undefined, timeZone)!,
+          from: dateMath.toDateTime(timeFromInfo.from, { timezone })!,
+          to: dateMath.toDateTime(timeFromInfo.to, { timezone })!,
           raw: { from: timeFromInfo.from, to: timeFromInfo.to },
         };
         infoBlocks.push(timeFromInfo.display);
@@ -172,18 +184,40 @@ export class PanelTimeRange extends SceneTimeRangeTransformerBase<PanelTimeRange
         return newTimeData;
       }
 
-      const timeShift = '-' + timeShiftInterpolated;
-      infoBlocks.push('timeshift ' + timeShift);
+      const shift = '-' + timeShiftInterpolated;
+      infoBlocks.push('timeshift ' + shift);
 
-      const from = dateMath.parseDateMath(timeShift, newTimeData.timeRange.from, false)!;
-      const to = dateMath.parseDateMath(timeShift, newTimeData.timeRange.to, true)!;
+      if (rangeUtil.isRelativeTimeRange(newTimeData.timeRange.raw)) {
+        const timezone = this.getTimeZone();
 
-      if (!from || !to) {
-        newTimeData.timeInfo = 'invalid timeshift';
-        return newTimeData;
+        const rawFromShifted = `${newTimeData.timeRange.raw.from}${shift}`;
+        const rawToShifted = `${newTimeData.timeRange.raw.to}${shift}`;
+
+        const from = dateMath.toDateTime(rawFromShifted, { timezone });
+        const to = dateMath.toDateTime(rawToShifted, { timezone });
+
+        if (!from || !to) {
+          newTimeData.timeInfo = 'invalid timeshift';
+          return newTimeData;
+        }
+
+        newTimeData.timeRange = {
+          from,
+          to,
+          raw: { from: rawFromShifted, to: rawToShifted },
+        };
+      } else {
+        // For absolute time ranges, use parseDateMath to shift DateTime objects
+        const from = dateMath.parseDateMath(shift, newTimeData.timeRange.from, false)!;
+        const to = dateMath.parseDateMath(shift, newTimeData.timeRange.to, true)!;
+
+        if (!from || !to) {
+          newTimeData.timeInfo = 'invalid timeshift';
+          return newTimeData;
+        }
+
+        newTimeData.timeRange = { from, to, raw: { from, to } };
       }
-
-      newTimeData.timeRange = { from, to, raw: { from, to } };
     }
 
     if (compareWith) {

--- a/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
@@ -207,9 +207,13 @@ export class PanelTimeRange extends SceneTimeRangeTransformerBase<PanelTimeRange
           raw: { from: rawFromShifted, to: rawToShifted },
         };
       } else {
-        // For absolute time ranges, use parseDateMath to shift DateTime objects
-        const from = dateMath.parseDateMath(shift, newTimeData.timeRange.from, false)!;
-        const to = dateMath.parseDateMath(shift, newTimeData.timeRange.to, true)!;
+        const from = dateMath.parseDateMath(shift, newTimeData.timeRange.from, false);
+        const to = dateMath.parseDateMath(shift, newTimeData.timeRange.to, true);
+
+        if (!from || !to) {
+          newTimeData.timeInfo = 'invalid timeshift';
+          return newTimeData;
+        }
 
         newTimeData.timeRange = { from, to, raw: { from, to } };
       }


### PR DESCRIPTION
**What is this feature?**

Fixes live refresh feature for panels with time shift configured.

**Why do we need this feature?**

When `liveNow` is enabled, panels with a time shift were not updating because:

1. `ancestorTimeRangeChanged()` was not updating `from`/`to` state when the dashboard time range changed
2. For relative time ranges with timeShift, absolute DateTime objects were stored in `raw` instead of relative strings

**Which issue(s) does this PR fix?**:

Fixes #114346

