### PR TITLE
RecentlyViewedDashboards: Hide entire section when there is no recently view item

### DIFF
--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -39,7 +39,7 @@ export function RecentlyViewedDashboards() {
     retry();
   };
 
-  if (!evaluateBooleanFlag('recentlyViewedDashboards', false)) {
+  if (!evaluateBooleanFlag('recentlyViewedDashboards', false) || recentDashboards.length === 0) {
     return null;
   }
 
@@ -76,10 +76,6 @@ export function RecentlyViewedDashboards() {
         </>
       )}
       {loading && <Spinner />}
-      {/* TODO: Better empty state https://github.com/grafana/grafana/issues/114804 */}
-      {!loading && recentDashboards.length === 0 && (
-        <Text>{t('browse-dashboards.recently-viewed.empty', 'Nothing viewed yet')}</Text>
-      )}
 
       {!loading && recentDashboards.length > 0 && (
         <ul className={styles.list}>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3759,7 +3759,6 @@
     },
     "recently-viewed": {
       "clear": "Clear history",
-      "empty": "Nothing viewed yet",
       "error": "Recently viewed dashboards couldn’t be loaded.",
       "retry": "Retry",
       "title": "Recently viewed"


### PR DESCRIPTION
**What is this feature?**

RecentlyViewedDashboards: Hide entire section when there is no recently view item

**Why do we need this feature?**

Better UX

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/114804

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
