### PR TITLE
Gauge: Fix endpoint rendering for non-gradient cases

### DIFF
--- a/packages/grafana-ui/src/components/RadialGauge/RadialArcPath.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialArcPath.tsx
@@ -1,8 +1,9 @@
-import { useId, memo, HTMLAttributes, ReactNode, SVGProps } from 'react';
+import { useId, memo, HTMLAttributes, SVGProps } from 'react';
 
 import { FieldDisplay } from '@grafana/data';
 
-import { getBarEndcapColors, getGradientCss, getEndpointMarkerColors, getGuideDotColor } from './colors';
+import { RadialArcPathEndpointMarks } from './RadialArcPathEndpointMarks';
+import { getBarEndcapColors, getGradientCss } from './colors';
 import { RadialShape, RadialGaugeDimensions, GradientStop } from './types';
 import { drawRadialArcPath, toRad } from './utils';
 
@@ -28,11 +29,6 @@ interface RadialArcPathPropsWithGradient extends RadialArcPathPropsBase {
 }
 
 type RadialArcPathProps = RadialArcPathPropsWithColor | RadialArcPathPropsWithGradient;
-
-const ENDPOINT_MARKER_MIN_ANGLE = 10;
-const DOT_OPACITY = 0.5;
-const DOT_RADIUS_FACTOR = 0.4;
-const MAX_DOT_RADIUS = 8;
 
 export const RadialArcPath = memo(
   ({
@@ -87,48 +83,6 @@ export const RadialArcPath = memo(
         : [rest.color, rest.color];
     }
 
-    let endpointMarks: ReactNode = null;
-    switch (endpointMarker) {
-      case 'point': {
-        const [pointColorStart, pointColorEnd] = isGradient
-          ? getEndpointMarkerColors(rest.gradient, fieldDisplay.display.percent)
-          : [getGuideDotColor(rest.color), getGuideDotColor(rest.color)];
-
-        const dotRadius =
-          endpointMarker === 'point' ? Math.min((barWidth / 2) * DOT_RADIUS_FACTOR, MAX_DOT_RADIUS) : barWidth / 2;
-
-        endpointMarks = (
-          <>
-            {arcLengthDeg > ENDPOINT_MARKER_MIN_ANGLE && (
-              <circle cx={xStart} cy={yStart} r={dotRadius} fill={pointColorStart} opacity={DOT_OPACITY} />
-            )}
-            <circle cx={xEnd} cy={yEnd} r={dotRadius} fill={pointColorEnd} opacity={DOT_OPACITY} />
-          </>
-        );
-        break;
-      }
-      case 'glow':
-        const offsetAngle = toRad(ENDPOINT_MARKER_MIN_ANGLE);
-        const xStartMark = centerX + radius * Math.cos(endRadians + offsetAngle);
-        const yStartMark = centerY + radius * Math.sin(endRadians + offsetAngle);
-        if (arcLengthDeg <= ENDPOINT_MARKER_MIN_ANGLE) {
-          break;
-        }
-        endpointMarks = (
-          <path
-            d={['M', xStartMark, yStartMark, 'A', radius, radius, 0, 0, 1, xEnd, yEnd].join(' ')}
-            fill="none"
-            strokeWidth={barWidth}
-            stroke={endpointMarkerGlowFilter}
-            strokeLinecap={roundedBars ? 'round' : 'butt'}
-            filter={glowFilter}
-          />
-        );
-        break;
-      default:
-        break;
-    }
-
     const pathEl = (
       <path d={path} strokeWidth={barWidth} strokeLinecap={roundedBars ? 'round' : 'butt'} {...pathProps} />
     );
@@ -158,7 +112,23 @@ export const RadialArcPath = memo(
           )}
         </g>
 
-        {endpointMarks}
+        {endpointMarker && (
+          <RadialArcPathEndpointMarks
+            startAngle={angle}
+            arcLengthDeg={arcLengthDeg}
+            dimensions={dimensions}
+            endpointMarker={endpointMarker}
+            fieldDisplay={fieldDisplay}
+            xStart={xStart}
+            xEnd={xEnd}
+            yStart={yStart}
+            yEnd={yEnd}
+            roundedBars={roundedBars}
+            endpointMarkerGlowFilter={endpointMarkerGlowFilter}
+            glowFilter={glowFilter}
+            {...rest}
+          />
+        )}
       </>
     );
   }

--- a/packages/grafana-ui/src/components/RadialGauge/RadialArcPathEndpointMarks.test.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialArcPathEndpointMarks.test.tsx
@@ -1,0 +1,143 @@
+import { render, RenderResult } from '@testing-library/react';
+
+import { FieldDisplay } from '@grafana/data';
+
+import { RadialArcPathEndpointMarks, RadialArcPathEndpointMarksProps } from './RadialArcPathEndpointMarks';
+import { RadialGaugeDimensions } from './types';
+
+const ser = new XMLSerializer();
+
+const expectHTML = (result: RenderResult, expected: string) => {
+  let actual = ser.serializeToString(result.asFragment()).replace(/xmlns=".*?" /g, '');
+  expect(actual).toEqual(expected.replace(/^\s*|\n/gm, ''));
+};
+
+describe('RadialArcPathEndpointMarks', () => {
+  const defaultDimensions = Object.freeze({
+    centerX: 100,
+    centerY: 100,
+    radius: 80,
+    barWidth: 20,
+    vizWidth: 200,
+    vizHeight: 200,
+    margin: 10,
+    barIndex: 0,
+    thresholdsBarRadius: 0,
+    thresholdsBarWidth: 0,
+    thresholdsBarSpacing: 0,
+    scaleLabelsFontSize: 0,
+    scaleLabelsSpacing: 0,
+    scaleLabelsRadius: 0,
+    gaugeBottomY: 0,
+  }) satisfies RadialGaugeDimensions;
+
+  const defaultFieldDisplay = Object.freeze({
+    name: 'Test',
+    field: {},
+    display: { text: '50', numeric: 50, color: '#FF0000' },
+    hasLinks: false,
+  }) satisfies FieldDisplay;
+
+  const defaultProps = Object.freeze({
+    arcLengthDeg: 90,
+    dimensions: defaultDimensions,
+    fieldDisplay: defaultFieldDisplay,
+    startAngle: 0,
+    xStart: 100,
+    xEnd: 150,
+    yStart: 100,
+    yEnd: 50,
+  }) satisfies Omit<RadialArcPathEndpointMarksProps, 'color' | 'gradient' | 'endpointMarker'>;
+
+  it('renders the expected marks when endpointMarker is "point" w/ a static color', () => {
+    expectHTML(
+      render(
+        <svg role="img">
+          <RadialArcPathEndpointMarks {...defaultProps} endpointMarker="point" color="#FF0000" />
+        </svg>
+      ),
+      '<svg role=\"img\"><circle cx=\"100\" cy=\"100\" r=\"4\" fill=\"#111217\" opacity=\"0.5\"/><circle cx=\"150\" cy=\"50\" r=\"4\" fill=\"#111217\" opacity=\"0.5\"/></svg>'
+    );
+  });
+
+  it('renders the expected marks when endpointMarker is "point" w/ a gradient color', () => {
+    expectHTML(
+      render(
+        <svg role="img">
+          <RadialArcPathEndpointMarks
+            {...defaultProps}
+            endpointMarker="point"
+            gradient={[
+              { color: '#00FF00', percent: 0 },
+              { color: '#0000FF', percent: 1 },
+            ]}
+          />
+        </svg>
+      ),
+      '<svg role=\"img\"><circle cx=\"100\" cy=\"100\" r=\"4\" fill=\"#111217\" opacity=\"0.5\"/><circle cx=\"150\" cy=\"50\" r=\"4\" fill=\"#fbfbfb\" opacity=\"0.5\"/></svg>'
+    );
+  });
+
+  it('renders the expected marks when endpointMarker is "glow" w/ a static color', () => {
+    expectHTML(
+      render(
+        <svg role="img">
+          <RadialArcPathEndpointMarks {...defaultProps} endpointMarker="glow" color="#FF0000" />
+        </svg>
+      ),
+      '<svg role=\"img\"><path d=\"M 113.89185421335443 21.215379759023364 A 80 80 0 0 1 150 50\" fill=\"none\" stroke-width=\"20\" stroke-linecap=\"butt\"/></svg>'
+    );
+  });
+
+  it('renders the expected marks when endpointMarker is "glow" w/ a gradient color', () => {
+    expectHTML(
+      render(
+        <svg role="img">
+          <RadialArcPathEndpointMarks
+            {...defaultProps}
+            endpointMarker="glow"
+            gradient={[
+              { color: '#00FF00', percent: 0 },
+              { color: '#0000FF', percent: 1 },
+            ]}
+          />
+        </svg>
+      ),
+      '<svg role=\"img\"><path d=\"M 113.89185421335443 21.215379759023364 A 80 80 0 0 1 150 50\" fill=\"none\" stroke-width=\"20\" stroke-linecap=\"butt\"/></svg>'
+    );
+  });
+
+  it('does not render the start mark when arcLengthDeg is less than the minimum angle for "point" endpointMarker', () => {
+    expectHTML(
+      render(
+        <svg role="img">
+          <RadialArcPathEndpointMarks {...defaultProps} arcLengthDeg={5} endpointMarker="point" color="#FF0000" />
+        </svg>
+      ),
+      '<svg role=\"img\"><circle cx=\"150\" cy=\"50\" r=\"4\" fill=\"#111217\" opacity=\"0.5\"/></svg>'
+    );
+  });
+
+  it('does not render anything when arcLengthDeg is less than the minimum angle for "glow" endpointMarker', () => {
+    expectHTML(
+      render(
+        <svg role="img">
+          <RadialArcPathEndpointMarks {...defaultProps} arcLengthDeg={5} endpointMarker="glow" color="#FF0000" />
+        </svg>
+      ),
+      '<svg role=\"img\"/>'
+    );
+  });
+
+  it('does not render anything if endpointMarker is some other value', () => {
+    expectHTML(
+      render(
+        <svg role="img">
+          {/* @ts-ignore: confirming the component doesn't throw */}
+          <RadialArcPathEndpointMarks {...defaultProps} endpointMarker="foo" />
+        </svg>
+      ),
+      '<svg role=\"img\"/>'
+    );
+  });
+});

--- a/packages/grafana-ui/src/components/RadialGauge/RadialArcPathEndpointMarks.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialArcPathEndpointMarks.tsx
@@ -1,0 +1,98 @@
+import { FieldDisplay } from '@grafana/data';
+
+import { getEndpointMarkerColors, getGuideDotColor } from './colors';
+import { GradientStop, RadialGaugeDimensions } from './types';
+import { toRad } from './utils';
+
+interface RadialArcPathEndpointMarksPropsBase {
+  arcLengthDeg: number;
+  dimensions: RadialGaugeDimensions;
+  fieldDisplay: FieldDisplay;
+  endpointMarker: 'point' | 'glow';
+  roundedBars?: boolean;
+  startAngle: number;
+  glowFilter?: string;
+  endpointMarkerGlowFilter?: string;
+  xStart: number;
+  xEnd: number;
+  yStart: number;
+  yEnd: number;
+}
+
+interface RadialArcPathEndpointMarksPropsWithColor extends RadialArcPathEndpointMarksPropsBase {
+  color: string;
+}
+
+interface RadialArcPathEndpointMarksPropsWithGradient extends RadialArcPathEndpointMarksPropsBase {
+  gradient: GradientStop[];
+}
+
+export type RadialArcPathEndpointMarksProps =
+  | RadialArcPathEndpointMarksPropsWithColor
+  | RadialArcPathEndpointMarksPropsWithGradient;
+
+const ENDPOINT_MARKER_MIN_ANGLE = 10;
+const DOT_OPACITY = 0.5;
+const DOT_RADIUS_FACTOR = 0.4;
+const MAX_DOT_RADIUS = 8;
+
+export function RadialArcPathEndpointMarks({
+  startAngle: angle,
+  arcLengthDeg,
+  dimensions,
+  endpointMarker,
+  fieldDisplay,
+  xStart,
+  xEnd,
+  yStart,
+  yEnd,
+  roundedBars,
+  endpointMarkerGlowFilter,
+  glowFilter,
+  ...rest
+}: RadialArcPathEndpointMarksProps) {
+  const isGradient = 'gradient' in rest;
+  const { radius, centerX, centerY, barWidth } = dimensions;
+  const endRadians = toRad(angle + arcLengthDeg);
+
+  switch (endpointMarker) {
+    case 'point': {
+      const [pointColorStart, pointColorEnd] = isGradient
+        ? getEndpointMarkerColors(rest.gradient, fieldDisplay.display.percent)
+        : [getGuideDotColor(rest.color), getGuideDotColor(rest.color)];
+
+      const dotRadius =
+        endpointMarker === 'point' ? Math.min((barWidth / 2) * DOT_RADIUS_FACTOR, MAX_DOT_RADIUS) : barWidth / 2;
+
+      return (
+        <>
+          {arcLengthDeg > ENDPOINT_MARKER_MIN_ANGLE && (
+            <circle cx={xStart} cy={yStart} r={dotRadius} fill={pointColorStart} opacity={DOT_OPACITY} />
+          )}
+          <circle cx={xEnd} cy={yEnd} r={dotRadius} fill={pointColorEnd} opacity={DOT_OPACITY} />
+        </>
+      );
+    }
+    case 'glow':
+      const offsetAngle = toRad(ENDPOINT_MARKER_MIN_ANGLE);
+      const xStartMark = centerX + radius * Math.cos(endRadians + offsetAngle);
+      const yStartMark = centerY + radius * Math.sin(endRadians + offsetAngle);
+      if (arcLengthDeg <= ENDPOINT_MARKER_MIN_ANGLE) {
+        break;
+      }
+      return (
+        <path
+          d={['M', xStartMark, yStartMark, 'A', radius, radius, 0, 0, 1, xEnd, yEnd].join(' ')}
+          fill="none"
+          strokeWidth={barWidth}
+          stroke={endpointMarkerGlowFilter}
+          strokeLinecap={roundedBars ? 'round' : 'butt'}
+          filter={glowFilter}
+        />
+      );
+    default:
+      break;
+  }
+
+  return null;
+}

--- a/packages/grafana-ui/src/components/RadialGauge/colors.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/colors.ts
@@ -175,7 +175,7 @@ export function getGradientCss(gradientStops: GradientStop[], shape: RadialShape
 const GRAY_05 = '#111217';
 const GRAY_90 = '#fbfbfb';
 const CONTRAST_THRESHOLD_MAX = 4.5;
-const getGuideDotColor = (color: string): string => {
+export const getGuideDotColor = (color: string): string => {
   const darkColor = GRAY_05;
   const lightColor = GRAY_90;
   return colorManipulator.getContrastRatio(darkColor, color) >= CONTRAST_THRESHOLD_MAX ? darkColor : lightColor;


### PR DESCRIPTION
After doing https://github.com/grafana/grafana/pull/115756, I realized that there were a few purely visual issues introduced by https://github.com/grafana/grafana/pull/115756/commits/c063d3478effa1f83229361c59f54de4310478ae that I didn't catch. (My kingdom for viz regression testing!)

This brings a little bit more order to the chaos of some nested conditionals in that component by de-nesting them and reordering what order they happen in.