### PR TITLE
[DOC] Changed so max_spans_per_span_set can't be changed in Cloud Traces

### DIFF
--- a/docs/sources/shared/datasources/tempo-editor-traceql.md
+++ b/docs/sources/shared/datasources/tempo-editor-traceql.md
@@ -135,8 +135,11 @@ You can use the **Span Limit** field in **Options** section of the TraceQL query
 This field sets the maximum number of spans to return for each span set.
 By default, the maximum value that you can set for the **Span Limit** value (or the spss query) is 100.
 In Tempo configuration, this value is controlled by the `max_spans_per_span_set` parameter and can be modified by your Tempo administrator.
-Grafana Cloud users can contact Grafana Support to request a change.
 Entering a value higher than the default results in an error.
+
+{{< admonition type="note" >}}
+Changing the value of `max_spans_per_span_set` isn't supported in Grafana Cloud.
+{{< /admonition >}}
 
 ### Focus on traces or spans
 


### PR DESCRIPTION
Updates the TraceQL query editor doc to note that modifiying `max_spans_per_span_set` isn't supported in Cloud Traces. 

**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/support-escalations/issues/19820

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
