### PR TITLE
Prometheus: Add variable job and replaced hardcoded values in prometheus 2.0 stats dashboard

### DIFF
--- a/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
+++ b/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
@@ -531,7 +531,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(process_open_fds{job=\"prometheus\"})",
+          "expr": "sum(process_open_fds{job=\"${job}\"})",
           "format": "time_series",
           "legendFormat": "open_fds",
           "refId": "B"

--- a/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
+++ b/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
@@ -945,7 +945,7 @@
           "expr": "histogram_quantile(0.99, sum(rate(prometheus_tsdb_compaction_duration_bucket{job=\"${job}\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "hide": false,
-          "legendFormat": "duration-{{p99}}",
+          "legendFormat": "duration-p99",
           "refId": "A"
         },
         {
@@ -1336,7 +1336,7 @@
   "tags": ["prometheus"],
   "templating": {
     "list": [
-       {
+      {
         "name": "job",
         "type": "query",
         "label": "Prometheus Job",

--- a/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
+++ b/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
@@ -144,7 +144,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "{instance=\"localhost:9090\",job=\"prometheus\"}"
+              "options": "{instance=\"localhost:9090\",job=\"${job}\"}"
             },
             "properties": [
               {
@@ -179,7 +179,7 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "sum(irate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus\"}[$__rate_interval]))",
+          "expr": "sum(irate(prometheus_tsdb_head_samples_appended_total{job=\"${job}\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "legendFormat": "samples",
@@ -356,14 +356,14 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "sum(process_resident_memory_bytes{job=\"prometheus\"})",
+          "expr": "sum(process_resident_memory_bytes{job=\"${job}\"})",
           "format": "time_series",
           "hide": false,
           "legendFormat": "p8s process resident memory",
           "refId": "D"
         },
         {
-          "expr": "process_virtual_memory_bytes{job=\"prometheus\"}",
+          "expr": "process_virtual_memory_bytes{job=\"${job}\"}",
           "format": "time_series",
           "hide": false,
           "legendFormat": "virtual memory",
@@ -440,7 +440,7 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "prometheus_tsdb_wal_corruptions_total{job=\"prometheus\"}",
+          "expr": "prometheus_tsdb_wal_corruptions_total{job=\"${job}\"}",
           "format": "time_series",
           "legendFormat": "",
           "refId": "A"
@@ -524,7 +524,7 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "sum(prometheus_tsdb_head_active_appenders{job=\"prometheus\"})",
+          "expr": "sum(prometheus_tsdb_head_active_appenders{job=\"${job}\"})",
           "format": "time_series",
           "legendFormat": "active_appenders",
           "metric": "",
@@ -613,7 +613,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "{instance=\"localhost:9090\",interval=\"5s\",job=\"prometheus\"}"
+              "options": "{instance=\"localhost:9090\",interval=\"5s\",job=\"${job}\"}"
             },
             "properties": [
               {
@@ -648,7 +648,7 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "prometheus_tsdb_blocks_loaded{job=\"prometheus\"}",
+          "expr": "prometheus_tsdb_blocks_loaded{job=\"${job}\"}",
           "format": "time_series",
           "legendFormat": "blocks",
           "refId": "A"
@@ -735,7 +735,7 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "prometheus_tsdb_head_chunks{job=\"prometheus\"}",
+          "expr": "prometheus_tsdb_head_chunks{job=\"${job}\"}",
           "format": "time_series",
           "legendFormat": "chunks",
           "refId": "A"
@@ -835,13 +835,13 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "prometheus_tsdb_head_gc_duration_seconds{job=\"prometheus\",quantile=\"0.99\"}",
+          "expr": "prometheus_tsdb_head_gc_duration_seconds{job=\"${job}\",quantile=\"0.99\"}",
           "format": "time_series",
           "legendFormat": "duration-p99",
           "refId": "A"
         },
         {
-          "expr": "irate(prometheus_tsdb_head_gc_duration_seconds_count{job=\"prometheus\"}[$__rate_interval])",
+          "expr": "irate(prometheus_tsdb_head_gc_duration_seconds_count{job=\"${job}\"}[$__rate_interval])",
           "format": "time_series",
           "legendFormat": "collections",
           "refId": "B"
@@ -942,26 +942,26 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(prometheus_tsdb_compaction_duration_bucket{job=\"prometheus\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(prometheus_tsdb_compaction_duration_bucket{job=\"${job}\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "hide": false,
           "legendFormat": "duration-{{p99}}",
           "refId": "A"
         },
         {
-          "expr": "irate(prometheus_tsdb_compactions_total{job=\"prometheus\"}[$__rate_interval])",
+          "expr": "irate(prometheus_tsdb_compactions_total{job=\"${job}\"}[$__rate_interval])",
           "format": "time_series",
           "legendFormat": "compactions",
           "refId": "B"
         },
         {
-          "expr": "irate(prometheus_tsdb_compactions_failed_total{job=\"prometheus\"}[$__rate_interval])",
+          "expr": "irate(prometheus_tsdb_compactions_failed_total{job=\"${job}\"}[$__rate_interval])",
           "format": "time_series",
           "legendFormat": "failed",
           "refId": "C"
         },
         {
-          "expr": "irate(prometheus_tsdb_compactions_triggered_total{job=\"prometheus\"}[$__rate_interval])",
+          "expr": "irate(prometheus_tsdb_compactions_triggered_total{job=\"${job}\"}[$__rate_interval])",
           "format": "time_series",
           "legendFormat": "triggered",
           "refId": "D"
@@ -1047,13 +1047,13 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "rate(prometheus_tsdb_reloads_total{job=\"prometheus\"}[$__rate_interval])",
+          "expr": "rate(prometheus_tsdb_reloads_total{job=\"${job}\"}[$__rate_interval])",
           "format": "time_series",
           "legendFormat": "reloads",
           "refId": "A"
         },
         {
-          "expr": "rate(prometheus_tsdb_reloads_failures_total{job=\"prometheus\"}[$__rate_interval])",
+          "expr": "rate(prometheus_tsdb_reloads_failures_total{job=\"${job}\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "legendFormat": "failures",
@@ -1140,7 +1140,7 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "prometheus_engine_query_duration_seconds{job=\"prometheus\", quantile=\"0.99\"}",
+          "expr": "prometheus_engine_query_duration_seconds{job=\"${job}\", quantile=\"0.99\"}",
           "format": "time_series",
           "legendFormat": "{{slice}}_p99",
           "refId": "A"
@@ -1226,7 +1226,7 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "max(prometheus_rule_group_duration_seconds{job=\"prometheus\"}) by (quantile)",
+          "expr": "max(prometheus_rule_group_duration_seconds{job=\"${job}\"}) by (quantile)",
           "format": "time_series",
           "legendFormat": "{{quantile}}",
           "refId": "A"
@@ -1312,13 +1312,13 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "rate(prometheus_rule_group_iterations_missed_total{job=\"prometheus\"}[$__rate_interval])",
+          "expr": "rate(prometheus_rule_group_iterations_missed_total{job=\"${job}\"}[$__rate_interval])",
           "format": "time_series",
           "legendFormat": "missed",
           "refId": "B"
         },
         {
-          "expr": "rate(prometheus_rule_group_iterations_total{job=\"prometheus\"}[$__rate_interval])",
+          "expr": "rate(prometheus_rule_group_iterations_total{job=\"${job}\"}[$__rate_interval])",
           "format": "time_series",
           "legendFormat": "iterations",
           "refId": "A"
@@ -1335,7 +1335,23 @@
   "schemaVersion": 30,
   "tags": ["prometheus"],
   "templating": {
-    "list": []
+    "list": [
+       {
+        "name": "job",
+        "type": "query",
+        "label": "Prometheus Job",
+        "datasource": "${DS_GDEV-PROMETHEUS}",
+        "refresh": 1,
+        "query": {
+          "query": "label_values(prometheus_build_info, job)",
+          "refId": "Prometheus-job"
+        },
+        "current": {
+          "text": "prometheus",
+          "value": "prometheus"
+        }
+      }
+    ]
   },
   "time": {
     "from": "now-1h",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR updates the built-in Prometheus 2.0 Stats dashboard so it’s more flexible.
Instead of being fixed to one Prometheus job, users can now choose the `job.`
This makes it easy to use the same dashboard to monitor multiple Prometheus instances without creating separate dashboards.

**Why do we need this feature?**
Right now, the dashboard is fixed to {job="prometheus"}, so it works with only one Prometheus instance.


**Who is this feature for?**

This feature is for the  Prometheus 2.0 Stats Dashboard 

**Which issue(s) does this PR fix?**:

Fixes #115892 

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #", or "Fixes #1158922"

-->


**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
