### PR TITLE
Auth: change text to mediumtext for oauth fields in user_auth migration

### DIFF
--- a/pkg/services/sqlstore/migrations/user_auth_mig.go
+++ b/pkg/services/sqlstore/migrations/user_auth_mig.go
@@ -50,4 +50,10 @@ func addUserAuthMigrations(mg *Migrator) {
 	mg.AddMigration("Add user_unique_id to user_auth", NewAddColumnMigration(userAuthV1, &Column{
 		Name: "external_uid", Type: DB_Text, Nullable: true,
 	}))
+
+	// Upgrade OAuth token columns from TEXT to MEDIUMTEXT to support large tokens
+	// TEXT has a limit of 65,535 bytes which can be exceeded by OAuth tokens with many groups/claims
+	mg.AddMigration("Update OAuth token columns to MEDIUMTEXT in user_auth", NewRawSQLMigration("").
+		Mysql("ALTER TABLE user_auth MODIFY COLUMN o_auth_access_token MEDIUMTEXT, MODIFY COLUMN o_auth_refresh_token MEDIUMTEXT, MODIFY COLUMN o_auth_id_token MEDIUMTEXT, MODIFY COLUMN o_auth_token_type MEDIUMTEXT;"),
+	)
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Auth: change text to mediumtext for oauth fields in user_auth migration. For large organizations or if a user is part of multiple email groups, the OAuth Token ID can exceed 64 KB size. 

This will prevent the users to login and throw an error 

```
"logger=user.sync t=2026-01-06T09:45:18.990501768Z level=error msg="Failed to fetch user" error="illegal base64 data at input byte 65532" auth_module=oauth_generic_oauth auth_id="
```

The change handles token sized more than 64 KB (which is limit of text type column in mysql) and it changes it `mediumtext`. This solves the issue.

**Why do we need this feature?**

This should ideally fix https://github.com/grafana/grafana/issues/115866 

**Who is this feature for?**

Everyone as user groups are not subjective to organization size

**Which issue(s) does this PR fix?**:
Fixes: #115866 

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
