### PR TITLE
QueryOperationRow: Preserve component state when collapsing query rows

### DIFF
--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -129,7 +129,7 @@ export function QueryOperationRow({
                     expanderMessages={expanderMessages}
                   />
                 </div>
-                {isContentVisible && <div className={styles.content}>{children}</div>}
+                <div className={styles.content} hidden={!isContentVisible}>{children}</div>
               </div>
             </>
           );
@@ -153,7 +153,7 @@ export function QueryOperationRow({
         title={title}
         expanderMessages={expanderMessages}
       />
-      {isContentVisible && <div className={styles.content}>{children}</div>}
+      <div className={styles.content} hidden={!isContentVisible}>{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
**What is this feature?**

Fixes query editor component state being lost when collapsing and expanding query rows. Changes `QueryOperationRow` to use the `hidden` attribute instead of conditional rendering, keeping children mounted but visually hidden when collapsed.

**Why do we need this feature?**

When a user collapses a query row in Explore, the `QueryOperationRow` component unmounts its children, destroying all local React state. When expanded again, the component remounts and rebuilds state from the query object.

For the Loki query builder, this causes disabled operations to disappear because:
- Disabled operations are stored in local component state
- Disabled operations are intentionally not rendered into the `expr` string  
- On remount, the builder parses `expr` to rebuild state, losing the disabled operation info

**Who is this feature for?**

Users working with the Loki query builder (and other datasources) who use the disable operation feature and collapse/expand query rows in Explore.

**Which issue(s) does this PR fix?**

Fixes grafana/grafana-loki-datasource#175

**Special notes for your reviewer:**

- Uses the `hidden` HTML attribute which sets `display: none` - well-supported and semantic
- Children remain mounted preserving all React state (not just `visualQuery`)
- Benefits all datasources automatically, not just Loki
- Minimal change (2 lines) vs complex state persistence alternative

**How to test:**

1. Go to Explore page
2. Select **Loki** datasource in **builder mode**
3. Add a "Line contains" operation
4. Click the **eye icon** to disable the operation
5. **Collapse** the query row (click chevron)
6. **Expand** the query row
7. Verify the disabled operation is still present (previously it would disappear)

**Before**

https://github.com/user-attachments/assets/ab387342-07d0-47d5-a8de-03b7ed73c7a8

**After**

https://github.com/user-attachments/assets/d5544bcd-8b71-42ae-b28b-e5594aa52939
