### PR TITLE
Alerting: Hide DMA options when no manageAlerts datasources exist

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -36,7 +36,11 @@ import {
   isExpressionQueryInAlert,
 } from '../../../rule-editor/formProcessing';
 import { RuleFormType, RuleFormValues } from '../../../types/rule-form';
-import { GRAFANA_RULES_SOURCE_NAME, getDefaultOrFirstCompatibleDataSource } from '../../../utils/datasource';
+import {
+  GRAFANA_RULES_SOURCE_NAME,
+  getDefaultOrFirstCompatibleDataSource,
+  getRulesDataSources,
+} from '../../../utils/datasource';
 import { PromOrLokiQuery, isPromOrLokiQuery } from '../../../utils/rule-form';
 import {
   isCloudAlertingRuleByType,
@@ -417,7 +421,9 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
   ]);
 
   const { sectionTitle, helpLabel, helpContent, helpLink } = DESCRIPTIONS[type ?? RuleFormType.grafana];
-
+  // Only show the data source managed option if there are data sources with manageAlerts enabled
+  const hasAlertEnabledDataSources = useMemo(() => getRulesDataSources().length > 0, []);
+  const canSelectDataSourceManaged = onlyOneDSInQueries(queries) && hasAlertEnabledDataSources;
   if (!type) {
     return null;
   }
@@ -436,8 +442,6 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
           },
         }
       : undefined;
-
-  const canSelectDataSourceManaged = onlyOneDSInQueries(queries);
 
   return (
     <>
@@ -506,7 +510,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
                 }}
               />
             </Field>
-            {mode === 'edit' && (
+            {mode === 'edit' && hasAlertEnabledDataSources && (
               <>
                 <Divider />
                 <SmartAlertTypeDetector

--- a/public/app/features/alerting/unified/rule-editor/RuleEditorGrafanaRules.test.tsx
+++ b/public/app/features/alerting/unified/rule-editor/RuleEditorGrafanaRules.test.tsx
@@ -194,4 +194,53 @@ describe('RuleEditor grafana managed rules', () => {
       ]),
     });
   });
+
+  it('should not show rule type switch when no data sources have manageAlerts enabled', async () => {
+    // Setup data source with manageAlerts explicitly disabled
+    setupDataSources(
+      mockDataSource(
+        {
+          type: 'prometheus',
+          name: 'Prom-disabled',
+          uid: 'prometheus-disabled',
+          isDefault: true,
+          jsonData: { manageAlerts: false },
+        },
+        { alerting: true, module: 'core:plugin/prometheus' }
+      )
+    );
+
+    renderRuleEditor();
+
+    // Wait for the form to load
+    await screen.findByRole('textbox', { name: 'name' });
+
+    // The rule type switch should NOT be visible
+    expect(screen.queryByText('Rule type')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('rule-type-radio-group')).not.toBeInTheDocument();
+  });
+
+  it('should show rule type switch when data sources have manageAlerts enabled', async () => {
+    // Setup data source with manageAlerts enabled
+    setupDataSources(
+      mockDataSource(
+        {
+          type: 'prometheus',
+          name: 'Prom-enabled',
+          uid: 'prometheus-enabled',
+          isDefault: true,
+          jsonData: { manageAlerts: true },
+        },
+        { alerting: true, module: 'core:plugin/prometheus' }
+      )
+    );
+
+    renderRuleEditor();
+
+    // Wait for the form to load
+    await screen.findByRole('textbox', { name: 'name' });
+
+    // The rule type section should be visible
+    expect(await screen.findByText('Rule type')).toBeInTheDocument();
+  });
 });

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
@@ -13,6 +13,7 @@ import { useListViewMode } from '../components/rules/Filter/RulesViewModeSelecto
 import { AIAlertRuleButtonComponent } from '../enterprise-components/AI/AIGenAlertRuleButton/addAIAlertRuleButton';
 import { AlertingAction, useAlertingAbility } from '../hooks/useAbilities';
 import { useRulesFilter } from '../hooks/useFilteredRules';
+import { getRulesDataSources } from '../utils/datasource';
 
 import { FilterView } from './FilterView';
 import { GroupedView } from './GroupedView';
@@ -41,8 +42,11 @@ export function RuleListActions() {
   const [createCloudRuleSupported, createCloudRuleAllowed] = useAlertingAbility(AlertingAction.CreateExternalAlertRule);
   const [exportRulesSupported, exportRulesAllowed] = useAlertingAbility(AlertingAction.ExportGrafanaManagedRules);
 
+  // Check if there are any data sources with manageAlerts enabled
+  const hasAlertEnabledDataSources = useMemo(() => getRulesDataSources().length > 0, []);
+
   const canCreateGrafanaRules = createGrafanaRuleSupported && createGrafanaRuleAllowed;
-  const canCreateCloudRules = createCloudRuleSupported && createCloudRuleAllowed;
+  const canCreateCloudRules = createCloudRuleSupported && createCloudRuleAllowed && hasAlertEnabledDataSources;
   const canExportRules = exportRulesSupported && exportRulesAllowed;
 
   const canCreateRules = canCreateGrafanaRules || canCreateCloudRules;


### PR DESCRIPTION
**What is this feature?**

This PR updates the UI to dynamically hide data source-managed rules options when there are no data sources with `manageAlerts` enabled.

#### Changes

##### Rule List Page (`RuleList.v2.tsx`)
- Added check for `hasAlertEnabledDataSources` using `getRulesDataSources()`
- The "New Data source recording rule" option in the "More" dropdown menu is now hidden when no data sources have `manageAlerts` enabled

##### Rule Editor (`QueryAndExpressionsStep.tsx`)
- Added `hasAlertEnabledDataSources` check to control visibility of the `SmartAlertTypeDetector` component
- The "Rule type" switch (Grafana-managed vs Data source-managed) is now hidden when no data sources have `manageAlerts` enabled

**Why do we need this feature?**

We want to force new stacks to use single alert type (Grafana)

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1347

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
