### PR TITLE
Apiservers: expand/configure timeout

### DIFF
--- a/pkg/services/apiserver/config.go
+++ b/pkg/services/apiserver/config.go
@@ -40,10 +40,17 @@ func applyGrafanaConfig(cfg *setting.Cfg, features featuremgmt.FeatureToggles, o
 	apiserverCfg := cfg.SectionWithEnvOverrides("grafana-apiserver")
 
 	runtimeConfig := apiserverCfg.Key("runtime_config").String()
+
 	if runtimeConfig != "" {
 		if err := o.APIEnablementOptions.RuntimeConfig.Set(runtimeConfig); err != nil {
 			return fmt.Errorf("failed to set runtime config: %w", err)
 		}
+	}
+
+	// equivalent to --request-timeout flag from k8s apiserver
+	requestTimeout := apiserverCfg.Key("request_timeout").MustDuration(0)
+	if requestTimeout > 0 {
+		o.ExtraOptions.RequestTimeout = requestTimeout
 	}
 
 	o.RecommendedOptions.Etcd.StorageConfig.Transport.ServerList = apiserverCfg.Key("etcd_servers").Strings(",")

--- a/pkg/services/apiserver/options/extra.go
+++ b/pkg/services/apiserver/options/extra.go
@@ -28,7 +28,7 @@ func NewExtraOptions() *ExtraOptions {
 	return &ExtraOptions{
 		DevMode:        false,
 		Verbosity:      0,
-		RequestTimeout: 1 * time.Hour,
+		RequestTimeout: 10 * time.Minute,
 	}
 }
 

--- a/pkg/services/apiserver/options/extra.go
+++ b/pkg/services/apiserver/options/extra.go
@@ -3,6 +3,7 @@ package options
 import (
 	"log/slog"
 	"strconv"
+	"time"
 
 	"github.com/spf13/pflag"
 	genericfeatures "k8s.io/apiserver/pkg/features"
@@ -20,12 +21,14 @@ type ExtraOptions struct {
 	ExternalAddress string
 	APIURL          string
 	Verbosity       int
+	RequestTimeout  time.Duration
 }
 
 func NewExtraOptions() *ExtraOptions {
 	return &ExtraOptions{
-		DevMode:   false,
-		Verbosity: 0,
+		DevMode:        false,
+		Verbosity:      0,
+		RequestTimeout: 1 * time.Hour,
 	}
 }
 

--- a/pkg/services/apiserver/options/options.go
+++ b/pkg/services/apiserver/options/options.go
@@ -117,6 +117,15 @@ func (o *Options) ApplyTo(serverConfig *genericapiserver.RecommendedConfig) erro
 		}
 		serverConfig.SecureServing = nil
 	}
+
+	// serverConfig.RequestTimeout is a k8s setting for all http requests, defaulting to 1 minute
+	// This setting is not removable so we force a long timeout to match existing behavior
+	// (ex: most (all?) sql datasources before apiservers were introduced did not have a global timeout and could run indefinitely)
+	// Normally for apiservers, this is set with a command line flag, --request-timeout, however in st-mode, we set a default in ExtraOptions
+	// and make it potentially configurable as needed by users in custom.ini
+	if o.ExtraOptions.RequestTimeout > 0 {
+		serverConfig.RequestTimeout = o.ExtraOptions.RequestTimeout
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What is this feature?**

- overwrites the default k8s apiserver timeout of 1 minute to 10 minutes. 
- makes that timeout configurable in custom.ini files

k8s apiservers come with a default timeout for requests of 1min. This can be overwritten with the `--request-timeout` flag ([docs](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/?utm_source=chatgpt.com#:~:text=%2D%2Drequest%2Dtimeout%20duration)). 

When we are running these apiservers separately, we can easily configure this timeout per service. However when we run these services as part of one single tenant service, we do not have these command line flags to work with. I did not see an easy way to make this configurable per groupversion here, so I'm proposing we just have one really large timeout (basically equivalent to not having a timeout at all) and for all single tenant apiservers that is configurable in the custom.ini. In mt apiservers, these are configurable per service.  If these apiservers need additional/smaller timeout settings we can create them within the code of the apiservers rather than as a global flag that gets inherited by all services.

**Why do we need this feature?**

When we enabled the new /apis/query.grafana.app endpoint in single tenant mode, we realized users with long running queries were hitting a 1 minute timeout, but existing behavior had no timeout. 

**Who is this feature for?**

No new user-facing functionality really. 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-enterprise/issues/10483

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
