### PR TITLE
Prometheus: Hide common labels when the legendFormat is set as `auto`

### DIFF
--- a/packages/grafana-data/src/field/fieldState.test.ts
+++ b/packages/grafana-data/src/field/fieldState.test.ts
@@ -54,6 +54,32 @@ describe('getFieldDisplayName', () => {
     expect(getFieldDisplayName(frame.fields[2], frame)).toBe('ServerB (comparison)');
     expect(getFieldDisplayName(frame.fields[3], frame)).toBe('Value 3 (comparison)');
   });
+
+  it('Should remove common labels', () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: TIME_SERIES_TIME_FIELD_NAME, values: [1, 2, 3], type: FieldType.time },
+        {
+          name: 'Value 1',
+          values: [1, 2, 3],
+          type: FieldType.number,
+          labels: { __name__: 'up', varying: '1', common: 'common' },
+        },
+        {
+          name: 'Value 2',
+          values: [1, 2, 3],
+          type: FieldType.number,
+          labels: { __name__: 'up', varying: '2', common: 'common' },
+        },
+      ],
+    });
+    expect(getFieldDisplayName(frame.fields[1], frame, [frame], { __name__: 'up', common: 'common' })).toBe(
+      'Value 1 {varying="1"}'
+    );
+    expect(getFieldDisplayName(frame.fields[2], frame, [frame], { __name__: 'up', common: 'common' })).toBe(
+      'Value 2 {varying="2"}'
+    );
+  });
 });
 
 describe('getFrameDisplayName', () => {

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -1,4 +1,5 @@
 import { getFieldMatcher } from '../transformations/matchers';
+import { Labels } from '../types/data';
 import {
   DataFrame,
   FieldType,
@@ -7,7 +8,7 @@ import {
   TIME_SERIES_VALUE_FIELD_NAME,
 } from '../types/dataFrame';
 import { FieldConfigSource } from '../types/fieldOverrides';
-import { formatLabels } from '../utils/labels';
+import { findUniqueLabels, formatLabels } from '../utils/labels';
 
 /**
  * Get an appropriate display title
@@ -107,7 +108,12 @@ export function decoupleHideFromState(frames: DataFrame[], fieldConfig: FieldCon
   });
 }
 
-export function getFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: DataFrame[]): string {
+export function getFieldDisplayName(
+  field: Field,
+  frame?: DataFrame,
+  allFrames?: DataFrame[],
+  commonLabels?: Labels
+): string {
   const existingTitle = field.state?.displayName;
   const multipleFrames = Boolean(allFrames && allFrames.length > 1);
 
@@ -115,7 +121,7 @@ export function getFieldDisplayName(field: Field, frame?: DataFrame, allFrames?:
     return existingTitle;
   }
 
-  const displayName = calculateFieldDisplayName(field, frame, allFrames);
+  const displayName = calculateFieldDisplayName(field, frame, allFrames, commonLabels);
   field.state = field.state || {};
   field.state.displayName = displayName;
   field.state.multipleFrames = multipleFrames;
@@ -126,7 +132,12 @@ export function getFieldDisplayName(field: Field, frame?: DataFrame, allFrames?:
 /**
  * Get an appropriate display name. If the 'displayName' field config is set, use that.
  */
-export function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: DataFrame[]): string {
+export function calculateFieldDisplayName(
+  field: Field,
+  frame?: DataFrame,
+  allFrames?: DataFrame[],
+  commonLabels?: Labels
+): string {
   const hasConfigTitle = field.config?.displayName && field.config?.displayName.length;
   const isComparisonSeries = Boolean(frame?.meta?.timeCompare?.isTimeShiftQuery);
   let displayName = hasConfigTitle ? field.config!.displayName! : field.name;
@@ -175,7 +186,7 @@ export function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFr
     let singleLabelName = getSingleLabelName(allFrames ?? [frame]);
 
     if (!singleLabelName) {
-      let allLabels = formatLabels(field.labels);
+      let allLabels = formatLabels(commonLabels ? findUniqueLabels(field.labels, commonLabels) : field.labels);
       if (allLabels) {
         parts.push(allLabels);
         labelsAdded = true;

--- a/packages/grafana-prometheus/src/result_transformer.test.ts
+++ b/packages/grafana-prometheus/src/result_transformer.test.ts
@@ -211,6 +211,119 @@ describe('Prometheus Result Transformer', () => {
       });
     });
 
+    it('legendFormat auto removes common labels', () => {
+      const request = {
+        targets: [
+          {
+            format: 'time_series',
+            refId: 'A',
+            legendFormat: '__auto',
+          },
+        ],
+      } as unknown as DataQueryRequest<PromQuery>;
+      const response = {
+        state: 'Done',
+        data: [
+          {
+            fields: [
+              {
+                name: 'Time',
+                type: 'time',
+                values: [1],
+                typeInfo: { frame: 'time.Time' },
+              },
+              {
+                name: 'up',
+                labels: { __name__: 'up', varying: 'A', common: 'common' },
+                config: {},
+                values: [1],
+              },
+            ],
+            length: 1,
+            refId: 'A',
+            meta: {
+              type: 'timeseries-multi',
+              typeVersion: [0, 1],
+            },
+          },
+          {
+            fields: [
+              {
+                name: 'Time',
+                type: 'time',
+                values: [1],
+                typeInfo: { frame: 'time.Time' },
+              },
+              {
+                name: 'up',
+                labels: { __name__: 'up', varying: 'B', common: 'common' },
+                config: {},
+                values: [1],
+              },
+            ],
+            length: 1,
+            refId: 'A',
+            meta: {
+              type: 'timeseries-multi',
+              typeVersion: [0, 1],
+            },
+          },
+        ],
+      } as unknown as DataQueryResponse;
+      const series = transformV2(response, request, {});
+      expect(series).toEqual({
+        data: [
+          {
+            fields: [
+              {
+                name: 'Time',
+                type: 'time',
+                values: [1],
+                typeInfo: { frame: 'time.Time' },
+              },
+              {
+                config: { displayNameFromDS: '{varying="A"}' },
+                labels: { __name__: 'up', varying: 'A', common: 'common' },
+                name: 'up',
+                values: [1],
+              },
+            ],
+            length: 1,
+            meta: {
+              type: 'timeseries-multi',
+              typeVersion: [0, 1],
+              preferredVisualisationType: 'graph',
+            },
+            refId: 'A',
+          },
+          {
+            fields: [
+              {
+                name: 'Time',
+                type: 'time',
+                values: [1],
+                typeInfo: { frame: 'time.Time' },
+              },
+              {
+                config: { displayNameFromDS: '{varying="B"}' },
+                labels: { __name__: 'up', varying: 'B', common: 'common' },
+                name: 'up',
+                values: [1],
+              },
+            ],
+            length: 1,
+            meta: {
+              type: 'timeseries-multi',
+              typeVersion: [0, 1],
+              preferredVisualisationType: 'graph',
+            },
+            refId: 'A',
+          },
+        ],
+        state: 'Done',
+      });
+    });
+
     it('results with table format should be transformed to table dataFrames', () => {
       const request = {
         targets: [


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

As described in #82870 the auto legend behavior is broken since it was introduced. Instead it behaves like the `verbose` option.

**Who is this feature for?**

Grafana users who want to query prometheus. It increases readability of the default legend by suppressing noise from common labels.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #82870

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
