### PR TITLE
Dashboard: Prevent changing layout to tabs when rows contain tabs

### DIFF
--- a/public/app/features/dashboard-scene/scene/layouts-shared/DashboardLayoutSelector.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/DashboardLayoutSelector.test.tsx
@@ -7,10 +7,13 @@ import { SceneGridLayout, VizPanel, SceneVariableSet } from '@grafana/scenes';
 
 import { activateFullSceneTree } from '../../utils/test-utils';
 import { DashboardScene } from '../DashboardScene';
+import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
 import { DashboardGridItem } from '../layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
 import { RowItem } from '../layout-rows/RowItem';
 import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
+import { TabItem } from '../layout-tabs/TabItem';
+import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
 import { LayoutParent } from '../types/LayoutParent';
 
 import { DashboardLayoutSelector } from './DashboardLayoutSelector';
@@ -40,6 +43,27 @@ describe('DashboardLayoutSelector', () => {
     await user.click(confirmButton);
     expect(switchLayoutMock).toHaveBeenCalled();
   });
+
+  it('should disable tabs option when a row contains tabs layout and show correct message', async () => {
+    const scene = buildTestSceneWithNestedTabs();
+    const layoutManager = scene.state.body;
+
+    render(<DashboardLayoutSelector layoutManager={layoutManager} />);
+
+    const tabsOption = screen.getByLabelText('layout-selection-option-Tabs');
+    expect(tabsOption).toBeDisabled();
+    expect(screen.getByTitle('Cannot change to tabs because a row already contains tabs')).toBeInTheDocument();
+  });
+
+  it('should not disable tabs option when rows do not contain tabs', async () => {
+    const scene = buildTestScene();
+    const layoutManager = scene.state.body;
+
+    render(<DashboardLayoutSelector layoutManager={layoutManager} />);
+
+    const tabsOption = screen.getByLabelText('layout-selection-option-Tabs');
+    expect(tabsOption).not.toBeDisabled();
+  });
 });
 
 const buildTestScene = () => {
@@ -61,6 +85,46 @@ const buildTestScene = () => {
                 }),
               ],
             }),
+          }),
+        }),
+      ],
+    }),
+  });
+
+  activateFullSceneTree(scene);
+  return scene;
+};
+
+const buildTestSceneWithNestedTabs = () => {
+  const scene = new DashboardScene({
+    title: 'testScene',
+    editable: true,
+    $variables: new SceneVariableSet({
+      variables: [],
+    }),
+    body: new RowsLayoutManager({
+      rows: [
+        new RowItem({
+          title: 'Row 1',
+          layout: new DefaultGridLayoutManager({
+            grid: new SceneGridLayout({
+              children: [
+                new DashboardGridItem({
+                  body: new VizPanel({ key: 'panel-1', pluginId: 'text' }),
+                }),
+              ],
+            }),
+          }),
+        }),
+        new RowItem({
+          title: 'Row with Tabs',
+          layout: new TabsLayoutManager({
+            tabs: [
+              new TabItem({
+                title: 'Tab 1',
+                layout: AutoGridLayoutManager.createEmpty(),
+              }),
+            ],
           }),
         }),
       ],

--- a/public/app/features/dashboard-scene/scene/layouts-shared/findAllGridTypes.test.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/findAllGridTypes.test.ts
@@ -1,0 +1,93 @@
+import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
+import { RowItem } from '../layout-rows/RowItem';
+import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
+import { TabItem } from '../layout-tabs/TabItem';
+import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
+
+import { containsTabsLayout, findAllGridTypes } from './findAllGridTypes';
+
+describe('findAllGridTypes', () => {
+  it('should return grid type for a grid layout', () => {
+    const layout = AutoGridLayoutManager.createEmpty();
+    expect(findAllGridTypes(layout)).toEqual([AutoGridLayoutManager.descriptor.id]);
+  });
+
+  it('should return grid types from tabs', () => {
+    const layout = new TabsLayoutManager({
+      tabs: [
+        new TabItem({ layout: AutoGridLayoutManager.createEmpty() }),
+        new TabItem({ layout: AutoGridLayoutManager.createEmpty() }),
+      ],
+    });
+    expect(findAllGridTypes(layout)).toEqual([
+      AutoGridLayoutManager.descriptor.id,
+      AutoGridLayoutManager.descriptor.id,
+    ]);
+  });
+
+  it('should return grid types from rows', () => {
+    const layout = new RowsLayoutManager({
+      rows: [
+        new RowItem({ layout: AutoGridLayoutManager.createEmpty() }),
+        new RowItem({ layout: AutoGridLayoutManager.createEmpty() }),
+      ],
+    });
+    expect(findAllGridTypes(layout)).toEqual([
+      AutoGridLayoutManager.descriptor.id,
+      AutoGridLayoutManager.descriptor.id,
+    ]);
+  });
+});
+
+describe('containsTabsLayout', () => {
+  it('should return true when layout is TabsLayoutManager', () => {
+    const layout = new TabsLayoutManager({
+      tabs: [new TabItem({ layout: AutoGridLayoutManager.createEmpty() })],
+    });
+    expect(containsTabsLayout(layout)).toBe(true);
+  });
+
+  it('should return false when layout is a grid layout', () => {
+    const layout = AutoGridLayoutManager.createEmpty();
+    expect(containsTabsLayout(layout)).toBe(false);
+  });
+
+  it('should return false when layout is RowsLayoutManager with no tabs in rows', () => {
+    const layout = new RowsLayoutManager({
+      rows: [
+        new RowItem({ layout: AutoGridLayoutManager.createEmpty() }),
+        new RowItem({ layout: AutoGridLayoutManager.createEmpty() }),
+      ],
+    });
+    expect(containsTabsLayout(layout)).toBe(false);
+  });
+
+  it('should return true when RowsLayoutManager contains a row with tabs layout', () => {
+    const layout = new RowsLayoutManager({
+      rows: [
+        new RowItem({ layout: AutoGridLayoutManager.createEmpty() }),
+        new RowItem({
+          layout: new TabsLayoutManager({
+            tabs: [new TabItem({ layout: AutoGridLayoutManager.createEmpty() })],
+          }),
+        }),
+      ],
+    });
+    expect(containsTabsLayout(layout)).toBe(true);
+  });
+
+  it('should return true when any row contains tabs layout', () => {
+    const layout = new RowsLayoutManager({
+      rows: [
+        new RowItem({
+          layout: new TabsLayoutManager({
+            tabs: [new TabItem({ layout: AutoGridLayoutManager.createEmpty() })],
+          }),
+        }),
+        new RowItem({ layout: AutoGridLayoutManager.createEmpty() }),
+        new RowItem({ layout: AutoGridLayoutManager.createEmpty() }),
+      ],
+    });
+    expect(containsTabsLayout(layout)).toBe(true);
+  });
+});

--- a/public/app/features/dashboard-scene/scene/layouts-shared/findAllGridTypes.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/findAllGridTypes.ts
@@ -15,3 +15,15 @@ export function findAllGridTypes(layout: DashboardLayoutManager): string[] {
 
   return [];
 }
+
+export function containsTabsLayout(layout: DashboardLayoutManager): boolean {
+  if (layout instanceof TabsLayoutManager) {
+    return true;
+  }
+
+  if (layout instanceof RowsLayoutManager) {
+    return layout.state.rows.some((row) => containsTabsLayout(row.getLayout()));
+  }
+
+  return false;
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4614,6 +4614,7 @@
     },
     "canvas-actions": {
       "add-panel": "Add panel",
+      "disabled-child-contains-tabs": "Cannot change to tabs because a row already contains tabs",
       "disabled-nested-grouping": "Grouping is limited to 2 levels",
       "disabled-nested-tabs": "Tabs cannot be nested inside other tabs",
       "group-into-row": "Group into row",


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Disables changing a rows layout to a tabs layout if a row contains tabs. Otherwise the user will end up in a scenario with tabs nested in tabs, which is something we try to prevent.

<img width="420" height="358" alt="image" src="https://github.com/user-attachments/assets/be5d12ca-4d28-4a62-a9b7-4aa636fddeb2" />


- Add containsTabsLayout helper function to check if child layouts contain tabs
- Update DashboardLayoutSelector to disable tabs option when children contain tabs
- Show different tooltip message for parent vs child tabs nesting scenarios
- Add tests for the new functionality

Fixes #115906