### PR TITLE
Icons: Add brain icon

### DIFF
--- a/packages/grafana-data/src/types/icon.ts
+++ b/packages/grafana-data/src/types/icon.ts
@@ -52,7 +52,7 @@ export const availableIconsIndex = {
   bookmark: true,
   'book-open': true,
   'brackets-curly': true,
-  'brain': true,
+  brain: true,
   'browser-alt': true,
   bug: true,
   building: true,

--- a/packages/grafana-data/src/types/icon.ts
+++ b/packages/grafana-data/src/types/icon.ts
@@ -52,6 +52,7 @@ export const availableIconsIndex = {
   bookmark: true,
   'book-open': true,
   'brackets-curly': true,
+  'brain': true,
   'browser-alt': true,
   bug: true,
   building: true,

--- a/public/app/core/icons/cached.json
+++ b/public/app/core/icons/cached.json
@@ -29,6 +29,7 @@
   "unicons/bookmark",
   "unicons/book-open",
   "unicons/brackets-curly",
+  "unicons/brain",
   "unicons/bug",
   "unicons/building",
   "unicons/calculator-alt",


### PR DESCRIPTION
Makes brain icon available https://iconscout.com/unicons/free-line-icon/brain

<img width="900" height="842" alt="image" src="https://github.com/user-attachments/assets/a34140a6-27fe-459d-9e92-1c069cc467c6" />
