### PR TITLE
FieldConfig: Fix multiple value mappings in field overrides being overwritten

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -9,6 +9,7 @@ import { FieldColorModeId } from '../types/fieldColor';
 import { FieldConfigPropertyItem, FieldConfigSource } from '../types/fieldOverrides';
 import { InterpolateFunction } from '../types/panel';
 import { ThresholdsMode } from '../types/thresholds';
+import { MappingType } from '../types/valueMapping';
 import { Registry } from '../utils/Registry';
 import { locationUtil } from '../utils/location';
 import { mockStandardProperties } from '../utils/tests/mockStandardProperties';
@@ -998,6 +999,45 @@ describe('setDynamicConfigValue', () => {
 
     expect(config.custom.property3).toEqual({});
     expect(config.displayName).toBeUndefined();
+  });
+
+  it('works correctly with multiple value mappings in the same override', () => {
+    const config: FieldConfig = {
+      mappings: [{ type: MappingType.ValueToText, options: { existing: { text: 'existing' } } }],
+    };
+
+    setDynamicConfigValue(
+      config,
+      {
+        id: 'mappings',
+        value: [{ type: MappingType.ValueToText, options: { first: { text: 'first' } } }],
+      },
+      {
+        fieldConfigRegistry: customFieldRegistry,
+        data: [],
+        field: { type: FieldType.number } as Field,
+        dataFrameIndex: 0,
+      }
+    );
+
+    setDynamicConfigValue(
+      config,
+      {
+        id: 'mappings',
+        value: [{ type: MappingType.ValueToText, options: { second: { text: 'second' } } }],
+      },
+      {
+        fieldConfigRegistry: customFieldRegistry,
+        data: [],
+        field: { type: FieldType.number } as Field,
+        dataFrameIndex: 0,
+      }
+    );
+
+    expect(config.mappings).toHaveLength(3);
+    expect(config.mappings![0]).toEqual({ type: MappingType.ValueToText, options: { existing: { text: 'existing' } } });
+    expect(config.mappings![1]).toEqual({ type: MappingType.ValueToText, options: { first: { text: 'first' } } });
+    expect(config.mappings![2]).toEqual({ type: MappingType.ValueToText, options: { second: { text: 'second' } } });
   });
 });
 

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -352,6 +352,7 @@ export function setDynamicConfigValue(config: FieldConfig, value: DynamicConfigV
       unset(config, item.path);
     }
   } else {
+    // Merge arrays (e.g. mappings) when multiple overrides target the same field
     if (Array.isArray(val)) {
       const existingValue = item.isCustom ? get(config.custom, item.path) : get(config, item.path);
 

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -356,7 +356,7 @@ export function setDynamicConfigValue(config: FieldConfig, value: DynamicConfigV
     if (Array.isArray(val)) {
       const existingValue = item.isCustom ? get(config.custom, item.path) : get(config, item.path);
 
-      if (Array.isArray(existingValue) && existingValue.length > 0) {
+      if (Array.isArray(existingValue)) {
         val = [...existingValue, ...val];
       }
     }

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -341,7 +341,7 @@ export function setDynamicConfigValue(config: FieldConfig, value: DynamicConfigV
     return;
   }
 
-  const val = item.process(value.value, context, item.settings);
+  let val = item.process(value.value, context, item.settings);
 
   const remove = val === undefined || val === null;
 
@@ -352,6 +352,14 @@ export function setDynamicConfigValue(config: FieldConfig, value: DynamicConfigV
       unset(config, item.path);
     }
   } else {
+    if (Array.isArray(val)) {
+      const existingValue = item.isCustom ? get(config.custom, item.path) : get(config, item.path);
+
+      if (Array.isArray(existingValue) && existingValue.length > 0) {
+        val = [...existingValue, ...val];
+      }
+    }
+
     if (item.isCustom) {
       if (!config.custom) {
         config.custom = {};


### PR DESCRIPTION
**What is this feature?**

When applying field overrides, array-type properties (like `mappings`) are now merged instead of overwritten when multiple override properties target the same path.

**Why do we need this feature?**

Previously, if an override had multiple `mappings` properties, only the last one would be applied. The others were silently overwritten.

**Who is this feature for?**

Dashboard users who configure multiple value mapping override properties for a single field.

ex:
<img width="681" height="448" alt="image" src="https://github.com/user-attachments/assets/90d82ed8-f2b6-4218-8f94-3c8ada349057" />


