### PR TITLE
unified-storage: fix event persistence when sqlkv is enabled

### DIFF
--- a/pkg/storage/unified/resource/sqlkv.go
+++ b/pkg/storage/unified/resource/sqlkv.go
@@ -437,7 +437,7 @@ func (w *sqlWriteCloser) Close() error {
 
 	_, err = dbutil.Exec(w.ctx, tx, sqlKVInsertLegacyResourceHistory, sqlKVSaveRequest{
 		SQLTemplate:     sqltemplate.New(w.kv.dialect),
-		sqlKVSectionKey: w.sectionKey,
+		sqlKVSectionKey: w.sectionKey, // unused: key_path is set by rvmanager
 		Value:           value,
 		GUID:            dataKey.GUID,
 		Group:           dataKey.Group,

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -346,7 +346,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 			return 0, fmt.Errorf("failed to write data: %w", err)
 		}
 
-		dataKey.ResourceVersion = rv
+		dataKey.ResourceVersion = rvmanager.SnowflakeFromRv(rv)
 	} else {
 		err := k.dataStore.Save(ctx, dataKey, bytes.NewReader(event.Value))
 		if err != nil {
@@ -372,22 +372,14 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 		}
 
 		// Check if the RV we just wrote is the latest. If not, a concurrent write with higher RV happened
-		if !rvmanager.IsRvEqual(latestKey.ResourceVersion, rv) {
+		if latestKey.ResourceVersion != dataKey.ResourceVersion {
 			// Delete the data we just wrote since it's not the latest
-			// if we're running with rvManager, convert the ResourceVersion back to snowflake to delete
-			if k.rvManager != nil {
-				dataKey.ResourceVersion = rvmanager.SnowflakeFromRv(dataKey.ResourceVersion)
-			}
 			_ = k.dataStore.Delete(ctx, dataKey)
 			return 0, fmt.Errorf("optimistic locking failed: concurrent modification detected")
 		}
 
 		if !rvmanager.IsRvEqual(prevKey.ResourceVersion, event.PreviousRV) {
 			// Another concurrent write happened between our read and write
-			// if we're running with rvManager, convert the ResourceVersion back to snowflake to delete
-			if k.rvManager != nil {
-				dataKey.ResourceVersion = rvmanager.SnowflakeFromRv(dataKey.ResourceVersion)
-			}
 			_ = k.dataStore.Delete(ctx, dataKey)
 			return 0, fmt.Errorf("optimistic locking failed: resource was modified concurrently (expected previous RV %d, found %d)", event.PreviousRV, prevKey.ResourceVersion)
 		}
@@ -406,12 +398,8 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 		}
 
 		// Check if the RV we just wrote is the latest. If not, a concurrent create with higher RV happened
-		if !rvmanager.IsRvEqual(latestKey.ResourceVersion, rv) {
+		if latestKey.ResourceVersion != dataKey.ResourceVersion {
 			// Delete the data we just wrote since it's not the latest
-			// if we're running with rvManager, convert the ResourceVersion back to snowflake to delete
-			if k.rvManager != nil {
-				dataKey.ResourceVersion = rvmanager.SnowflakeFromRv(dataKey.ResourceVersion)
-			}
 			_ = k.dataStore.Delete(ctx, dataKey)
 			return 0, fmt.Errorf("optimistic locking failed: concurrent create detected")
 		}
@@ -419,10 +407,6 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 		// Verify that the immediate predecessor is not a create
 		if prevKey.Action == DataActionCreated {
 			// Another concurrent create happened - delete our write and return error
-			// if we're running with rvManager, convert the ResourceVersion back to snowflake to delete
-			if k.rvManager != nil {
-				dataKey.ResourceVersion = rvmanager.SnowflakeFromRv(dataKey.ResourceVersion)
-			}
 			_ = k.dataStore.Delete(ctx, dataKey)
 			return 0, fmt.Errorf("optimistic locking failed: concurrent create detected")
 		}
@@ -434,7 +418,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 		Group:           event.Key.Group,
 		Resource:        event.Key.Resource,
 		Name:            event.Key.Name,
-		ResourceVersion: rv,
+		ResourceVersion: dataKey.ResourceVersion,
 		Action:          action,
 		Folder:          obj.GetFolder(),
 		PreviousRV:      event.PreviousRV,


### PR DESCRIPTION
This PR fixes the resource version used when generating the `key_path` for the event store (`resource_events`) when sqlkv is enabled. Previously, the old resource version (microsecond timestamp) was being used, instead of the expected snowflake ID. As a consequence, search was not working as `ListModifiedSince` was unable to fetch any data.

Related to https://github.com/grafana/hyperion-planning/issues/463.