### PR TITLE
`grafana-iam`: Split `UpdateAPIGroupInfo` in multiple resource specific functions.

### DIFF
--- a/pkg/registry/apis/iam/authorizer/resource_permissions.go
+++ b/pkg/registry/apis/iam/authorizer/resource_permissions.go
@@ -179,19 +179,17 @@ func (r *ResourcePermissionsAuthorizer) FilterList(ctx context.Context, list run
 			canViewFuncs  = map[schema.GroupResource]types.ItemChecker{}
 		)
 		for _, item := range l.Items {
-			gr := schema.GroupResource{
-				Group:    item.Spec.Resource.ApiGroup,
-				Resource: item.Spec.Resource.Resource,
-			}
+			target := item.Spec.Resource
+			targetGR := schema.GroupResource{Group: target.ApiGroup, Resource: target.Resource}
 
 			// Reuse the same canView for items with the same resource
-			canView, found := canViewFuncs[gr]
+			canView, found := canViewFuncs[targetGR]
 
 			if !found {
 				listReq := types.ListRequest{
 					Namespace: item.Namespace,
-					Group:     item.Spec.Resource.ApiGroup,
-					Resource:  item.Spec.Resource.Resource,
+					Group:     target.ApiGroup,
+					Resource:  target.Resource,
 					Verb:      utils.VerbGetPermissions,
 				}
 
@@ -200,11 +198,8 @@ func (r *ResourcePermissionsAuthorizer) FilterList(ctx context.Context, list run
 					return nil, err
 				}
 
-				canViewFuncs[gr] = canView
+				canViewFuncs[targetGR] = canView
 			}
-
-			target := item.Spec.Resource
-			targetGR := schema.GroupResource{Group: target.ApiGroup, Resource: target.Resource}
 
 			parent := ""
 			// Fetch the parent of the resource

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -273,6 +273,7 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 		return err
 	}
 
+	// SSO settings apis
 	if b.ssoLegacyStore != nil {
 		ssoResource := legacyiamv0.SSOSettingResourceInfo
 		storage[ssoResource.StoragePath()] = b.ssoLegacyStore
@@ -297,6 +298,7 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 			return err
 		}
 	}
+
 	//nolint:staticcheck // not yet migrated to OpenFeature
 	if b.features.IsEnabledGlobally(featuremgmt.FlagKubernetesAuthzResourcePermissionApis) {
 		if err := b.UpdateResourcePermissionsAPIGroup(apiGroupInfo, opts, storage, enableZanzanaSync); err != nil {


### PR DESCRIPTION
This PR is just a Noop refactor.
- It splits the iam app `UpdateAPIGroupInfo` in multiple functions to reduce its complexity.
- Also noticed `FilterList` from the `ResourcePermissions` authorizer had duplicated variables and leveraged this PR to change that.