### PR TITLE
Sparkline: Hide axes for real

### DIFF
--- a/packages/grafana-ui/src/components/Sparkline/utils.ts
+++ b/packages/grafana-ui/src/components/Sparkline/utils.ts
@@ -120,7 +120,7 @@ const defaultConfig: GraphFieldConfig = {
   drawStyle: GraphDrawStyle.Line,
   showPoints: VisibilityMode.Auto,
   axisPlacement: AxisPlacement.Hidden,
-  pointSize: 2,
+  pointSize: 0,
 };
 
 export const prepareSeries = (
@@ -204,6 +204,7 @@ export const prepareConfig = (
     scaleKey: 'x',
     theme,
     placement: AxisPlacement.Hidden,
+    show: false,
   });
 
   for (let i = 0; i < dataFrame.fields.length; i++) {
@@ -230,6 +231,7 @@ export const prepareConfig = (
       scaleKey,
       theme,
       placement: AxisPlacement.Hidden,
+      show: false,
     });
 
     const colorMode = getFieldColorModeForField(field);


### PR DESCRIPTION
Discovered in the Gauge bug bash. You have to squint and zoom way in to see this, but it is there and annoying right now.

These screenshots are zoomed in to the far left edge of the sparkline on the new gauge.

### Before
<img width="63" height="77" alt="Screenshot 2026-01-08 at 3 49 23 PM" src="https://github.com/user-attachments/assets/bec82975-347b-46f5-9547-c66ae29d9984" />


### After
<img width="73" height="67" alt="Screenshot 2026-01-08 at 3 47 12 PM" src="https://github.com/user-attachments/assets/2b850eef-13a7-45da-b01c-72c608bcb254" />

