### PR TITLE
Preferences: Add API validation and update documentation

### DIFF
--- a/docs/sources/developer-resources/api-reference/http-api/preferences.md
+++ b/docs/sources/developer-resources/api-reference/http-api/preferences.md
@@ -25,7 +25,7 @@ Keys:
 - **theme** - One of: `light`, `dark`, or an empty string for the default theme
 - **homeDashboardId** - Deprecated. Use `homeDashboardUID` instead.
 - **homeDashboardUID**: The `:uid` of a dashboard
-- **timezone** - One of: `utc`, `browser`, or an empty string for the default
+- **timezone** - Any valid IANA timezone string (e.g., `America/New_York`, `Europe/London`), `utc`, `browser`, or an empty string for the default.
 
 Omitting a key will cause the current value to be replaced with the
 system default value.

--- a/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
@@ -5312,7 +5312,8 @@ export type PatchPrefsCmd = {
   queryHistory?: QueryHistoryPreference;
   regionalFormat?: string;
   theme?: 'light' | 'dark';
-  timezone?: 'utc' | 'browser';
+  /** Any IANA timezone string (e.g. America/New_York), 'utc', 'browser', or empty string */
+  timezone?: string;
   weekStart?: string;
 };
 export type UpdatePrefsCmd = {
@@ -5325,7 +5326,8 @@ export type UpdatePrefsCmd = {
   queryHistory?: QueryHistoryPreference;
   regionalFormat?: string;
   theme?: 'light' | 'dark' | 'system';
-  timezone?: 'utc' | 'browser';
+  /** Any IANA timezone string (e.g. America/New_York), 'utc', 'browser', or empty string */
+  timezone?: string;
   weekStart?: string;
 };
 export type OrgUserDto = {

--- a/packages/grafana-api-clients/src/clients/rtkq/preferences/user/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/preferences/user/endpoints.gen.ts
@@ -86,7 +86,8 @@ export type PatchPrefsCmd = {
   queryHistory?: QueryHistoryPreference;
   regionalFormat?: string;
   theme?: 'light' | 'dark';
-  timezone?: 'utc' | 'browser';
+  /** Any IANA timezone string (e.g. America/New_York), 'utc', 'browser', or empty string */
+  timezone?: string;
   weekStart?: string;
 };
 export type UpdatePrefsCmd = {
@@ -99,7 +100,8 @@ export type UpdatePrefsCmd = {
   queryHistory?: QueryHistoryPreference;
   regionalFormat?: string;
   theme?: 'light' | 'dark' | 'system';
-  timezone?: 'utc' | 'browser';
+  /** Any IANA timezone string (e.g. America/New_York), 'utc', 'browser', or empty string */
+  timezone?: string;
   weekStart?: string;
 };
 export const {

--- a/pkg/api/dtos/prefs.go
+++ b/pkg/api/dtos/prefs.go
@@ -13,7 +13,7 @@ type UpdatePrefsCmd struct {
 	// Deprecated: Use HomeDashboardUID instead
 	HomeDashboardID  int64   `json:"homeDashboardId"`
 	HomeDashboardUID *string `json:"homeDashboardUID,omitempty"`
-	// Enum: utc,browser
+	// Any IANA timezone string (e.g. America/New_York), 'utc', 'browser', or empty string
 	Timezone       string                       `json:"timezone"`
 	WeekStart      string                       `json:"weekStart"`
 	QueryHistory   *pref.QueryHistoryPreference `json:"queryHistory,omitempty"`
@@ -31,7 +31,7 @@ type PatchPrefsCmd struct {
 	// Default:0
 	// Deprecated: Use HomeDashboardUID instead
 	HomeDashboardID *int64 `json:"homeDashboardId,omitempty"`
-	// Enum: utc,browser
+	// Any IANA timezone string (e.g. America/New_York), 'utc', 'browser', or empty string
 	Timezone         *string                      `json:"timezone,omitempty"`
 	WeekStart        *string                      `json:"weekStart,omitempty"`
 	Language         *string                      `json:"language,omitempty"`

--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -134,6 +134,10 @@ func (hs *HTTPServer) patchPreferencesFor(ctx context.Context, orgID, userID, te
 		return response.Error(http.StatusBadRequest, "Invalid theme", nil)
 	}
 
+	if dtoCmd.Timezone != nil && !pref.IsValidTimezone(*dtoCmd.Timezone) {
+		return response.Error(http.StatusBadRequest, "Invalid timezone. Must be a valid IANA timezone (e.g., America/New_York), 'utc', 'browser', or empty string", nil)
+	}
+
 	// convert dashboard UID to ID in order to store internally if it exists in the query, otherwise take the id from query
 	// nolint:staticcheck
 	dashboardID := dtoCmd.HomeDashboardID

--- a/pkg/registry/apis/preferences/legacy/preferences.go
+++ b/pkg/registry/apis/preferences/legacy/preferences.go
@@ -208,6 +208,11 @@ func (s *preferenceStorage) save(ctx context.Context, obj runtime.Object) (runti
 
 // Create implements rest.Creater.
 func (s *preferenceStorage) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	if createValidation != nil {
+		if err := createValidation(ctx, obj); err != nil {
+			return nil, err
+		}
+	}
 	return s.save(ctx, obj)
 }
 
@@ -221,6 +226,12 @@ func (s *preferenceStorage) Update(ctx context.Context, name string, objInfo res
 	obj, err := objInfo.UpdatedObject(ctx, old)
 	if err != nil {
 		return nil, false, err
+	}
+
+	if updateValidation != nil {
+		if err := updateValidation(ctx, obj, old); err != nil {
+			return nil, false, err
+		}
 	}
 
 	obj, err = s.save(ctx, obj)

--- a/pkg/services/preference/prefapi/api.go
+++ b/pkg/services/preference/prefapi/api.go
@@ -20,6 +20,10 @@ func UpdatePreferencesFor(ctx context.Context,
 		return response.Error(http.StatusBadRequest, "Invalid theme", nil)
 	}
 
+	if !pref.IsValidTimezone(dtoCmd.Timezone) {
+		return response.Error(http.StatusBadRequest, "Invalid timezone. Must be a valid IANA timezone (e.g., America/New_York), 'utc', 'browser', or empty string", nil)
+	}
+
 	// convert dashboard UID to ID in order to store internally if it exists in the query, otherwise take the id from query
 	// nolint:staticcheck
 	dashboardID := dtoCmd.HomeDashboardID

--- a/pkg/services/preference/timezone.go
+++ b/pkg/services/preference/timezone.go
@@ -1,0 +1,21 @@
+package pref
+
+import (
+	"time"
+)
+
+// IsValidTimezone checks if the timezone string is valid.
+// It accepts:
+// - "" - uses default
+// - "utc"
+// - "browser"
+// - Any valid IANA timezone (e.g., "America/New_York", "Europe/London")
+func IsValidTimezone(timezone string) bool {
+	if timezone == "" || timezone == "utc" || timezone == "browser" {
+		return true
+	}
+
+	// try to load as IANA timezone
+	_, err := time.LoadLocation(timezone)
+	return err == nil
+}

--- a/pkg/services/preference/timezone_test.go
+++ b/pkg/services/preference/timezone_test.go
@@ -1,0 +1,38 @@
+package pref
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValidTimezone(t *testing.T) {
+	tests := []struct {
+		timezone string
+		valid    bool
+	}{
+		{
+			timezone: "utc",
+			valid:    true,
+		},
+		{
+			timezone: "browser",
+			valid:    true,
+		},
+		{
+			timezone: "Europe/London",
+			valid:    true,
+		},
+		{
+			timezone: "invalid",
+			valid:    false,
+		},
+		{
+			timezone: "",
+			valid:    true,
+		},
+	}
+	for _, test := range tests {
+		assert.Equal(t, test.valid, IsValidTimezone(test.timezone))
+	}
+}

--- a/pkg/tests/apis/preferences/preferences_test.go
+++ b/pkg/tests/apis/preferences/preferences_test.go
@@ -67,7 +67,7 @@ func TestIntegrationPreferences(t *testing.T) {
 			Path:   fmt.Sprintf("/api/teams/%d/preferences", helper.Org1.Staff.ID),
 			Body: []byte(`{
 				"weekStart": "sunday",
-				"timezone": "africa"
+				"timezone": "Africa/Johannesburg"
 			}`),
 		}, &raw)
 		require.Equal(t, http.StatusOK, legacyResponse.Response.StatusCode, "create preference for user")
@@ -79,7 +79,7 @@ func TestIntegrationPreferences(t *testing.T) {
 			Path:   "/api/org/preferences",
 			Body: []byte(`{
 				"weekStart": "sunday",
-				"timezone": "africa",
+				"timezone": "Africa/Accra",
 				"theme": "dark"
 			}`),
 		}, &raw)
@@ -144,7 +144,7 @@ func TestIntegrationPreferences(t *testing.T) {
 
 		jj, _ = json.Marshal(bootdata.Result.User)
 		require.JSONEq(t, `{
-			"timezone":"africa",
+			"timezone":"Africa/Johannesburg",
 			"weekStart":"saturday",
 			"theme":"dark",
 			"language":"en-US", `+ // FROM global default!
@@ -157,10 +157,10 @@ func TestIntegrationPreferences(t *testing.T) {
 			Path:   "/apis/preferences.grafana.app/v1alpha1/namespaces/default/preferences/merged",
 		}, &preferences.Preferences{})
 		require.Equal(t, http.StatusOK, merged.Response.StatusCode, "get merged preferences")
-		require.Equal(t, "saturday", *merged.Result.Spec.WeekStart)        // from user
-		require.Equal(t, "africa", *merged.Result.Spec.Timezone)           // from team
-		require.Equal(t, "dark", *merged.Result.Spec.Theme)                // from org
-		require.Equal(t, "en-US", *merged.Result.Spec.Language)            // settings.ini
-		require.Equal(t, "dd/mm/yyyy", *merged.Result.Spec.RegionalFormat) // from user update
+		require.Equal(t, "saturday", *merged.Result.Spec.WeekStart)           // from user
+		require.Equal(t, "Africa/Johannesburg", *merged.Result.Spec.Timezone) // from team
+		require.Equal(t, "dark", *merged.Result.Spec.Theme)                   // from org
+		require.Equal(t, "en-US", *merged.Result.Spec.Language)               // settings.ini
+		require.Equal(t, "dd/mm/yyyy", *merged.Result.Spec.RegionalFormat)    // from user update
 	})
 }

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -6152,11 +6152,8 @@
           ]
         },
         "timezone": {
-          "type": "string",
-          "enum": [
-            "utc",
-            "browser"
-          ]
+          "description": "Any IANA timezone string (e.g. America/New_York), 'utc', 'browser', or empty string",
+          "type": "string"
         },
         "weekStart": {
           "type": "string"
@@ -8657,11 +8654,8 @@
           ]
         },
         "timezone": {
-          "type": "string",
-          "enum": [
-            "utc",
-            "browser"
-          ]
+          "description": "Any IANA timezone string (e.g. America/New_York), 'utc', 'browser', or empty string",
+          "type": "string"
         },
         "weekStart": {
           "type": "string"

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -18729,11 +18729,8 @@
           ]
         },
         "timezone": {
-          "type": "string",
-          "enum": [
-            "utc",
-            "browser"
-          ]
+          "description": "Any IANA timezone string (e.g. America/New_York), 'utc', 'browser', or empty string",
+          "type": "string"
         },
         "weekStart": {
           "type": "string"
@@ -23120,11 +23117,8 @@
           ]
         },
         "timezone": {
-          "type": "string",
-          "enum": [
-            "utc",
-            "browser"
-          ]
+          "description": "Any IANA timezone string (e.g. America/New_York), 'utc', 'browser', or empty string",
+          "type": "string"
         },
         "weekStart": {
           "type": "string"

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -8264,10 +8264,7 @@
             "type": "string"
           },
           "timezone": {
-            "enum": [
-              "utc",
-              "browser"
-            ],
+            "description": "Any IANA timezone string (e.g. America/New_York), 'utc', 'browser', or empty string",
             "type": "string"
           },
           "weekStart": {
@@ -12654,10 +12651,7 @@
             "type": "string"
           },
           "timezone": {
-            "enum": [
-              "utc",
-              "browser"
-            ],
+            "description": "Any IANA timezone string (e.g. America/New_York), 'utc', 'browser', or empty string",
             "type": "string"
           },
           "weekStart": {


### PR DESCRIPTION
**What is this feature?**

This PR adds validation for timezones in the preferences api, and updates the [preferences documentation](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/preferences/) to reflect what timezones are accepted, as you can now do more than the original 3 listed.

<img width="626" height="556" alt="Screenshot 2026-01-08 at 4 24 10 PM" src="https://github.com/user-attachments/assets/fb67914c-9c0f-4093-a744-e24091916104" />

**Why do we need this feature?**

Without rejecting the request to the api, the UI will fallback to "default" instead of the invalid timezone, which is confusing:
<img width="977" height="480" alt="Screenshot 2026-01-08 at 4 29 32 PM" src="https://github.com/user-attachments/assets/9ed46b50-d15b-4101-8b4e-b45eb25fa5cd" />

Fixes https://github.com/grafana/grafana/issues/115080