### PR TITLE
Dashboard Tags: Validate max length

### DIFF
--- a/docs/sources/as-code/observability-as-code/schema-v2/_index.md
+++ b/docs/sources/as-code/observability-as-code/schema-v2/_index.md
@@ -186,7 +186,7 @@ For the JSON and field usage notes, refer to the [links schema documentation](ht
 
 ### `tags`
 
-The tags associated with the dashboard:
+Tags associated with the dashboard. Each tag can be up to 50 characters long.
 
 ` [...string]`
 

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
@@ -107,9 +107,7 @@ export const TagsInput = forwardRef<HTMLInputElement, Props>(
               size="md"
               disabled={newTagName.length <= 0 || isTagTooLong}
               title={
-                isTagTooLong
-                  ? t('grafana-ui.tags-input.tag-too-long', 'Tag too long, max 50 characters')
-                  : undefined
+                isTagTooLong ? t('grafana-ui.tags-input.tag-too-long', 'Tag too long, max 50 characters') : undefined
               }
             >
               <Trans i18nKey="grafana-ui.tags-input.add">Add</Trans>

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
@@ -54,6 +54,7 @@ export const TagsInput = forwardRef<HTMLInputElement, Props>(
     const [newTagName, setNewTagName] = useState('');
     const styles = useStyles2(getStyles);
     const theme = useTheme2();
+    const isTagTooLong = newTagName.length > 50;
 
     const onNameChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
       setNewTagName(event.target.value);
@@ -65,6 +66,9 @@ export const TagsInput = forwardRef<HTMLInputElement, Props>(
 
     const onAdd = (event?: React.MouseEvent | React.KeyboardEvent) => {
       event?.preventDefault();
+      if (newTagName.length > 50) {
+        return;
+      }
       if (!tags.includes(newTagName)) {
         onChange(tags.concat(newTagName));
       }
@@ -94,14 +98,19 @@ export const TagsInput = forwardRef<HTMLInputElement, Props>(
           value={newTagName}
           onKeyDown={onKeyboardAdd}
           onBlur={onBlur}
-          invalid={invalid}
+          invalid={invalid || isTagTooLong}
           suffix={
             <Button
               fill="text"
               className={styles.addButtonStyle}
               onClick={onAdd}
               size="md"
-              disabled={newTagName.length <= 0}
+              disabled={newTagName.length <= 0 || isTagTooLong}
+              title={
+                isTagTooLong
+                  ? t('grafana-ui.tags-input.tag-too-long', 'Tag too long, max 50 characters')
+                  : undefined
+              }
             >
               <Trans i18nKey="grafana-ui.tags-input.add">Add</Trans>
             </Button>

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -389,6 +389,11 @@ func (b *DashboardsAPIBuilder) validateCreate(ctx context.Context, a admission.A
 		return apierrors.NewBadRequest(err.Error())
 	}
 
+	// Validate tags
+	if err := validateDashboardTags(dashObj); err != nil {
+		return apierrors.NewBadRequest(err.Error())
+	}
+
 	id, err := identity.GetRequester(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting requester: %w", err)
@@ -456,6 +461,11 @@ func (b *DashboardsAPIBuilder) validateUpdate(ctx context.Context, a admission.A
 
 	// Basic validations
 	if err := b.dashboardService.ValidateBasicDashboardProperties(title, newAccessor.GetName(), newAccessor.GetMessage()); err != nil {
+		return apierrors.NewBadRequest(err.Error())
+	}
+
+	// Validate tags
+	if err := validateDashboardTags(newDashObj); err != nil {
 		return apierrors.NewBadRequest(err.Error())
 	}
 
@@ -554,6 +564,32 @@ func getDashboardProperties(obj runtime.Object) (string, string, error) {
 	}
 
 	return title, refresh, nil
+}
+
+// validateDashboardTags validates that all dashboard tags are within the maximum length
+func validateDashboardTags(obj runtime.Object) error {
+	var tags []string
+
+	switch d := obj.(type) {
+	case *dashv0.Dashboard:
+		tags = d.Spec.GetNestedStringSlice("tags")
+	case *dashv1.Dashboard:
+		tags = d.Spec.GetNestedStringSlice("tags")
+	case *dashv2alpha1.Dashboard:
+		tags = d.Spec.Tags
+	case *dashv2beta1.Dashboard:
+		tags = d.Spec.Tags
+	default:
+		return fmt.Errorf("unsupported dashboard version: %T", obj)
+	}
+
+	for _, tag := range tags {
+		if len(tag) > 50 {
+			return dashboards.ErrDashboardTagTooLong
+		}
+	}
+
+	return nil
 }
 
 func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupInfo, opts builder.APIGroupOptions) error {

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -542,6 +542,9 @@ func (d *dashboardStore) saveDashboard(ctx context.Context, sess *db.Session, cm
 	tags := dash.GetTags()
 	if len(tags) > 0 {
 		for _, tag := range tags {
+			if len(tag) > 50 {
+				return nil, dashboards.ErrDashboardTagTooLong
+			}
 			if _, err := sess.Insert(dashboardTag{DashboardId: dash.ID, Term: tag, OrgID: dash.OrgID, DashboardUID: dash.UID}); err != nil {
 				return nil, err
 			}

--- a/pkg/services/dashboards/errors.go
+++ b/pkg/services/dashboards/errors.go
@@ -79,6 +79,11 @@ var (
 		Reason:     "message too long, max 500 characters",
 		StatusCode: 400,
 	}
+	ErrDashboardTagTooLong = dashboardaccess.DashboardErr{
+		Reason:     "dashboard tag too long, max 50 characters",
+		StatusCode: 400,
+		Status:     "tag-too-long",
+	}
 	ErrDashboardCannotSaveProvisionedDashboard = dashboardaccess.DashboardErr{
 		Reason:     "Cannot save provisioned dashboard",
 		StatusCode: 400,

--- a/public/app/features/manage-dashboards/utils/validation.ts
+++ b/public/app/features/manage-dashboards/utils/validation.ts
@@ -18,6 +18,10 @@ export const validateDashboardJson = (json: string) => {
       if (hasInvalidTag) {
         return t('dashboard.validation.tags-expected-strings', 'tags expected array of strings');
       }
+      const hasTooLongTag = dashboard.tags.some((tag: string) => tag.length > 50);
+      if (hasTooLongTag) {
+        return t('dashboard.validation.tag-too-long', 'Dashboard tag too long, max 50 characters');
+      }
     } else {
       return t('dashboard.validation.tags-expected-array', 'tags expected array');
     }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5695,6 +5695,7 @@
     "validation": {
       "invalid-dashboard-id": "Could not find a valid Grafana.com ID",
       "invalid-json": "Not valid JSON",
+      "tag-too-long": "Dashboard tag too long, max 50 characters",
       "tags-expected-array": "tags expected array",
       "tags-expected-strings": "tags expected array of strings"
     },
@@ -9253,7 +9254,8 @@
     "tags-input": {
       "add": "Add",
       "placeholder-new-tag": "New tag (enter key to add)",
-      "remove": "Remove tag: {{name}}"
+      "remove": "Remove tag: {{name}}",
+      "tag-too-long": "Tag too long, max 50 characters"
     },
     "time-sync-button": {
       "aria-label-sync": "Sync times",


### PR DESCRIPTION
**What is this feature?**

This PR adds validation for the length of the dashboard tags, as they are a max of 50 characters in the db. Otherwise, it results in an internal server error

Example api response now:
<img width="776" height="415" alt="Screenshot 2026-01-08 at 5 48 00 PM" src="https://github.com/user-attachments/assets/31be75ad-c6b4-45c6-9cf5-4fc0f204376d" />

UI validation now:
https://github.com/user-attachments/assets/c24d9938-f3da-44a0-b5b0-7103a1d46b34

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/110848
