### PR TITLE
Library Elements: Deprecate folderFilter query param; update docs for folderFilterUIDs

### DIFF
--- a/docs/sources/developer-resources/api-reference/http-api/library_element.md
+++ b/docs/sources/developer-resources/api-reference/http-api/library_element.md
@@ -41,7 +41,8 @@ Query parameters:
 - `sortDirection`: Sort order of elements. Use `alpha-asc` for ascending and `alpha-desc` for descending sort order.
 - `typeFilter`: A comma separated list of types to filter the elements by.
 - `excludeUid`: Element UID to exclude from search results.
-- `folderFilter`: A comma separated list of folder IDs to filter the elements by.
+- `folderFilter`: **Deprecated.** A comma separated list of folder IDs to filter the elements by. Use `folderFilterUIDs` instead.
+- `folderFilterUIDs`: A comma separated list of folder UIDs to filter the elements by.
 - `perPage`: The number of results per page; default is 100.
 - `page`: The page for a set of records, given that only `perPage` records are returned at a time. Numbering starts at `1`.
 

--- a/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
@@ -1021,7 +1021,7 @@ const injectedRtkApi = api
             typeFilter: queryArg.typeFilter,
             excludeUid: queryArg.excludeUid,
             folderFilter: queryArg.folderFilter,
-            folderFilterUIDs: queryArg.folderFilterUIDs,
+            folderFilterUIDs: queryArg.folderFilterUiDs,
             perPage: queryArg.perPage,
             page: queryArg.page,
           },
@@ -2916,10 +2916,11 @@ export type GetLibraryElementsApiArg = {
   typeFilter?: string;
   /** Element UID to exclude from search results. */
   excludeUid?: string;
-  /** A comma separated list of folder ID(s) to filter the elements by. */
+  /** A comma separated list of folder ID(s) to filter the elements by.
+    Deprecated: Use FolderFilterUIDs instead. */
   folderFilter?: string;
   /** A comma separated list of folder UID(s) to filter the elements by. */
-  folderFilterUIDs?: string;
+  folderFilterUiDs?: string;
   /** The number of results per page. */
   perPage?: number;
   /** The page for a set of records, given that only perPage records are returned at a time. Numbering starts at 1. */

--- a/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
@@ -1021,6 +1021,7 @@ const injectedRtkApi = api
             typeFilter: queryArg.typeFilter,
             excludeUid: queryArg.excludeUid,
             folderFilter: queryArg.folderFilter,
+            folderFilterUIDs: queryArg.folderFilterUIDs,
             perPage: queryArg.perPage,
             page: queryArg.page,
           },
@@ -2917,6 +2918,8 @@ export type GetLibraryElementsApiArg = {
   excludeUid?: string;
   /** A comma separated list of folder ID(s) to filter the elements by. */
   folderFilter?: string;
+  /** A comma separated list of folder UID(s) to filter the elements by. */
+  folderFilterUIDs?: string;
   /** The number of results per page. */
   perPage?: number;
   /** The page for a set of records, given that only perPage records are returned at a time. Numbering starts at 1. */

--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -501,9 +501,15 @@ type GetLibraryElementsParams struct {
 	// required:false
 	ExcludeUID string `json:"excludeUid"`
 	// A comma separated list of folder ID(s) to filter the elements by.
+	// Deprecated: Use FolderFilterUIDs instead.
 	// in:query
 	// required:false
+	// deprecated:true
 	FolderFilter string `json:"folderFilter"`
+	// A comma separated list of folder UID(s) to filter the elements by.
+	// in:query
+	// required:false
+	FolderFilterUIDs string `json:"folderFilterUIDs"`
 	// The number of results per page.
 	// in:query
 	// required:false

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -6167,8 +6167,14 @@
           },
           {
             "type": "string",
-            "description": "A comma separated list of folder ID(s) to filter the elements by.",
+            "description": "A comma separated list of folder ID(s) to filter the elements by.\nDeprecated: Use FolderFilterUIDs instead.",
             "name": "folderFilter",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "A comma separated list of folder UID(s) to filter the elements by.",
+            "name": "folderFilterUIDs",
             "in": "query"
           },
           {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -20727,9 +20727,17 @@
             }
           },
           {
-            "description": "A comma separated list of folder ID(s) to filter the elements by.",
+            "description": "A comma separated list of folder ID(s) to filter the elements by.\nDeprecated: Use FolderFilterUIDs instead.",
             "in": "query",
             "name": "folderFilter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A comma separated list of folder UID(s) to filter the elements by.",
+            "in": "query",
+            "name": "folderFilterUIDs",
             "schema": {
               "type": "string"
             }


### PR DESCRIPTION
**What is this feature?**

This PR marks the query parameter `folderFilter` as deprecated and documents the `folderFilterUIDs` query parameter instead as the one to use, as we are moving away from ids and towards uids.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/113171