### PR TITLE
Docs: Dashboards and folders: Add annotation and label restriction

### DIFF
--- a/docs/sources/developer-resources/api-reference/http-api/dashboard.md
+++ b/docs/sources/developer-resources/api-reference/http-api/dashboard.md
@@ -231,6 +231,11 @@ JSON Body schema:
 - **metadata.annotations.grafana.app/folder** - Optional field, the unique identifier of the folder under which the dashboard should be created.
 - **spec** – The dashboard json.
 
+{{< admonition type="note" >}}
+Custom labels and annotations in the metadata field are not currently supported and are ignored during dashboard creates. 
+Support will be added in a future release.
+{{< /admonition >}}
+
 **Example Response**:
 
 ```http
@@ -520,6 +525,11 @@ JSON Body schema:
 - **metadata.annotations.grafana.app/folder** - Optional field, the unique identifier of the folder under which the dashboard should be created.
 - **metadata.annotations.grafana.app/message** - Optional field, to set a commit message for the version history.
 - **spec** – The dashboard json.
+
+{{< admonition type="note" >}}
+Custom labels and annotations in the metadata field are not currently supported and are ignored during dashboard updates. 
+Support will be added in a future release.
+{{< /admonition >}}
 
 **Example Response**:
 

--- a/docs/sources/developer-resources/api-reference/http-api/dashboard.md
+++ b/docs/sources/developer-resources/api-reference/http-api/dashboard.md
@@ -232,7 +232,7 @@ JSON Body schema:
 - **spec** – The dashboard json.
 
 {{< admonition type="note" >}}
-Custom labels and annotations in the metadata field are supported on some instances, with full support planned for all instances when these APIs reach general availability. If they are not yet available on your instance, they will be ignored.
+Custom labels and annotations in the metadata field are supported on some instances, with full support planned for all instances when these APIs reach general availability. If they are not yet supported on your instance, they will be ignored.
 {{< /admonition >}}
 
 **Example Response**:
@@ -526,7 +526,7 @@ JSON Body schema:
 - **spec** – The dashboard json.
 
 {{< admonition type="note" >}}
-Custom labels and annotations in the metadata field are supported on some instances, with full support planned for all instances when these APIs reach general availability. If they are not yet available on your instance, they will be ignored.
+Custom labels and annotations in the metadata field are supported on some instances, with full support planned for all instances when these APIs reach general availability. If they are not yet supported on your instance, they will be ignored.
 {{< /admonition >}}
 
 **Example Response**:

--- a/docs/sources/developer-resources/api-reference/http-api/dashboard.md
+++ b/docs/sources/developer-resources/api-reference/http-api/dashboard.md
@@ -232,8 +232,7 @@ JSON Body schema:
 - **spec** – The dashboard json.
 
 {{< admonition type="note" >}}
-Custom labels and annotations in the metadata field are not currently supported and are ignored during dashboard creates. 
-Support will be added in a future release.
+Custom labels and annotations in the metadata field are supported on some instances, with full support planned for all instances when these APIs reach general availability. If they are not yet available on your instance, they will be ignored.
 {{< /admonition >}}
 
 **Example Response**:
@@ -527,8 +526,7 @@ JSON Body schema:
 - **spec** – The dashboard json.
 
 {{< admonition type="note" >}}
-Custom labels and annotations in the metadata field are not currently supported and are ignored during dashboard updates. 
-Support will be added in a future release.
+Custom labels and annotations in the metadata field are supported on some instances, with full support planned for all instances when these APIs reach general availability. If they are not yet available on your instance, they will be ignored.
 {{< /admonition >}}
 
 **Example Response**:

--- a/docs/sources/developer-resources/api-reference/http-api/folder.md
+++ b/docs/sources/developer-resources/api-reference/http-api/folder.md
@@ -259,6 +259,11 @@ JSON Body schema:
 - **metadata.annotations.grafana.app/folder** - Optional field, the unique identifier of the parent folder under which the folder should be created. Requires nested folders to be enabled.
 - **spec.title** – The title of the folder.
 
+{{< admonition type="note" >}}
+Custom labels and annotations in the metadata field are not currently supported and are ignored during folder creates. 
+Support will be added in a future release.
+{{< /admonition >}}
+
 **Example Response**:
 
 ```http
@@ -336,6 +341,11 @@ JSON Body schema:
 - **metadata.name** – The [unique identifier]({{< ref "#identifier-id-vs-unique-identifier-uid" >}}) of the folder.
 - **metadata.annotations.grafana.app/folder** - Optional field, the unique identifier of the parent folder under which the folder should be - update this to move the folder under a different parent folder. Requires nested folders to be enabled.
 - **spec.title** – The title of the folder.
+
+{{< admonition type="note" >}}
+Custom labels and annotations in the metadata field are not currently supported and are ignored during folder updates. 
+Support will be added in a future release.
+{{< /admonition >}}
 
 **Example Response**:
 

--- a/docs/sources/developer-resources/api-reference/http-api/folder.md
+++ b/docs/sources/developer-resources/api-reference/http-api/folder.md
@@ -260,7 +260,7 @@ JSON Body schema:
 - **spec.title** – The title of the folder.
 
 {{< admonition type="note" >}}
-Custom labels and annotations in the metadata field are supported on some instances, with full support planned for all instances when these APIs reach general availability. If they are not yet available on your instance, they will be ignored.
+Custom labels and annotations in the metadata field are supported on some instances, with full support planned for all instances when these APIs reach general availability. If they are not yet supported on your instance, they will be ignored.
 {{< /admonition >}}
 
 **Example Response**:
@@ -342,7 +342,7 @@ JSON Body schema:
 - **spec.title** – The title of the folder.
 
 {{< admonition type="note" >}}
-Custom labels and annotations in the metadata field are supported on some instances, with full support planned for all instances when these APIs reach general availability. If they are not yet available on your instance, they will be ignored.
+Custom labels and annotations in the metadata field are supported on some instances, with full support planned for all instances when these APIs reach general availability. If they are not yet supported on your instance, they will be ignored.
 {{< /admonition >}}
 
 **Example Response**:

--- a/docs/sources/developer-resources/api-reference/http-api/folder.md
+++ b/docs/sources/developer-resources/api-reference/http-api/folder.md
@@ -260,8 +260,7 @@ JSON Body schema:
 - **spec.title** – The title of the folder.
 
 {{< admonition type="note" >}}
-Custom labels and annotations in the metadata field are not currently supported and are ignored during folder creates. 
-Support will be added in a future release.
+Custom labels and annotations in the metadata field are supported on some instances, with full support planned for all instances when these APIs reach general availability. If they are not yet available on your instance, they will be ignored.
 {{< /admonition >}}
 
 **Example Response**:
@@ -343,8 +342,7 @@ JSON Body schema:
 - **spec.title** – The title of the folder.
 
 {{< admonition type="note" >}}
-Custom labels and annotations in the metadata field are not currently supported and are ignored during folder updates. 
-Support will be added in a future release.
+Custom labels and annotations in the metadata field are supported on some instances, with full support planned for all instances when these APIs reach general availability. If they are not yet available on your instance, they will be ignored.
 {{< /admonition >}}
 
 **Example Response**:


### PR DESCRIPTION
**What is this feature?**

Adds to the documentation the current restriction on custom labels and annotations in folders and dashboards

**Why do we need this feature?**

Until folders & dashboards are backed by unified storage by default for all instances (which is when we will mark dashboards and folders as GA), this will remain true.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/112186

