### PR TITLE
chore: reduce Explore barrel files

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2610,11 +2610,6 @@
       "count": 2
     }
   },
-  "public/app/features/explore/hooks/useStateSync/index.ts": {
-    "no-barrel-files/no-barrel-files": {
-      "count": 1
-    }
-  },
   "public/app/features/explore/spec/helper/setup.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -73,7 +73,7 @@ import {
   contentOutlineTrackUnpinClicked,
 } from '../ContentOutline/ContentOutlineAnalyticEvents';
 import { useContentOutlineContext } from '../ContentOutline/ContentOutlineContext';
-import { getUrlStateFromPaneState } from '../hooks/useStateSync';
+import { getUrlStateFromPaneState } from '../hooks/useStateSync/external.utils';
 import { changePanelState } from '../state/explorePane';
 import { changeQueries, runQueries } from '../state/query';
 

--- a/public/app/features/explore/Logs/LogsTableActionButtons.tsx
+++ b/public/app/features/explore/Logs/LogsTableActionButtons.tsx
@@ -12,7 +12,7 @@ import {
 import { t } from '@grafana/i18n';
 import { ClipboardButton, CustomCellRendererProps, IconButton, Modal, useTheme2 } from '@grafana/ui';
 import { getLogsPermalinkRange } from 'app/core/utils/shortLinks';
-import { getUrlStateFromPaneState } from 'app/features/explore/hooks/useStateSync';
+import { getUrlStateFromPaneState } from 'app/features/explore/hooks/useStateSync/external.utils';
 import { LogsFrame, DATAPLANE_ID_NAME } from 'app/features/logs/logsFrame';
 import { getState } from 'app/store/store';
 

--- a/public/app/features/explore/hooks/useStateSync/index.ts
+++ b/public/app/features/explore/hooks/useStateSync/index.ts
@@ -12,8 +12,6 @@ import { syncFromURL } from './synchronizer/fromURL';
 import { initializeFromURL } from './synchronizer/init';
 import { syncToURL, syncToURLPredicate } from './synchronizer/toURL';
 
-export { getUrlStateFromPaneState } from './external.utils';
-
 /**
  * Bi-directionally syncs URL changes with Explore's state.
  */

--- a/public/app/features/explore/hooks/useStateSync/synchronizer/fromURL.ts
+++ b/public/app/features/explore/hooks/useStateSync/synchronizer/fromURL.ts
@@ -11,7 +11,7 @@ import { withUniqueRefIds } from 'app/features/explore/utils/queries';
 import { ExploreItemState } from 'app/types/explore';
 import { ThunkDispatch } from 'app/types/store';
 
-import { getUrlStateFromPaneState } from '../index';
+import { getUrlStateFromPaneState } from '../external.utils';
 import { urlDiff } from '../internal.utils';
 import { ExploreURLV1 } from '../migrators/v1';
 

--- a/public/app/features/explore/hooks/useStateSync/synchronizer/init.ts
+++ b/public/app/features/explore/hooks/useStateSync/synchronizer/init.ts
@@ -11,7 +11,7 @@ import { withUniqueRefIds } from 'app/features/explore/utils/queries';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { ThunkDispatch } from 'app/types/store';
 
-import { getUrlStateFromPaneState } from '../index';
+import { getUrlStateFromPaneState } from '../external.utils';
 import {
   getDefaultQuery,
   getPaneDatasource,

--- a/public/app/features/explore/hooks/useStateSync/synchronizer/toURL.ts
+++ b/public/app/features/explore/hooks/useStateSync/synchronizer/toURL.ts
@@ -11,7 +11,7 @@ import { runQueries } from 'app/features/explore/state/query';
 import { changeRangeAction } from 'app/features/explore/state/time';
 import { ExploreState } from 'app/types/explore';
 
-import { getUrlStateFromPaneState } from '../index';
+import { getUrlStateFromPaneState } from '../external.utils';
 import { InitState } from '../internal.utils';
 
 /*

--- a/public/app/features/explore/utils/links.ts
+++ b/public/app/features/explore/utils/links.ts
@@ -30,7 +30,7 @@ import { parseDataplaneLogsFrame } from 'app/features/logs/logsFrame';
 import { ExploreItemState } from 'app/types/explore';
 
 import { getLinkSrv } from '../../panel/panellinks/link_srv';
-import { getUrlStateFromPaneState } from '../hooks/useStateSync';
+import { getUrlStateFromPaneState } from '../hooks/useStateSync/external.utils';
 
 type DataLinkFilter = (link: DataLink, scopedVars: ScopedVars) => boolean;
 

--- a/public/app/features/logs/components/logParser.test.ts
+++ b/public/app/features/logs/components/logParser.test.ts
@@ -1,6 +1,8 @@
 import { DataFrameType, Field, FieldType, LogRowModel, MutableDataFrame } from '@grafana/data';
 import { mockTimeRange } from '@grafana/plugin-ui';
+import { setTemplateSrv } from '@grafana/runtime';
 import { ExploreFieldLinkModel, getFieldLinksForExplore } from 'app/features/explore/utils/links';
+import { TemplateSrv } from 'app/features/templating/template_srv';
 import { GetFieldLinksFn } from 'app/plugins/panel/logs/types';
 
 import { getAllFields, createLogLineLinks, FieldDef, getDataframeFields } from './logParser';
@@ -466,6 +468,10 @@ describe('logParser', () => {
   });
 
   describe('getDataframeFields', () => {
+    beforeEach(() => {
+      setTemplateSrv(new TemplateSrv());
+    });
+
     it('should add row labels as variables for links', () => {
       const row = createLogRow({
         labels: { service_name: 'checkout', service_namespace: 'prod' },

--- a/public/app/features/logs/components/panel/links.test.ts
+++ b/public/app/features/logs/components/panel/links.test.ts
@@ -1,6 +1,8 @@
 import { FieldType, getDefaultTimeRange, LogsSortOrder, toDataFrame } from '@grafana/data';
+import { setTemplateSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getFieldLinksForExplore } from 'app/features/explore/utils/links';
+import { TemplateSrv } from 'app/features/templating/template_srv';
 import { GetFieldLinksFn } from 'app/plugins/panel/logs/types';
 
 import { createLogLine } from '../mocks/logRow';
@@ -70,6 +72,7 @@ describe('getTempoTraceFromLinks', () => {
         wrapLogMessage: true,
       }
     );
+    setTemplateSrv(new TemplateSrv());
   });
 
   test('Gets the trace information from a link', () => {


### PR DESCRIPTION
**What is this feature?**

This pull request refactors how the `getUrlStateFromPaneState` utility is imported throughout the Explore feature. The main goal is to standardize and clarify its import path, ensuring that all usages reference it directly from the `external.utils` file rather than through barrel files or index files. This change improves maintainability and aligns with linting rules that discourage barrel file usage.

**Why do we need this feature?**

Barrel files simplify and centralize imports making it easier to consume modules. However they also cause the following issues:

- Circular Dependencies - if two modules import from each other's barrel files, it can create a cycle that's hard to detect and debug.
- Tree Shaking Issues - barrel files can interfere with tree shaking
- Name Collisions - re-exporting many symbols from different modules come with the risk of name collisions creating confusing errors
- Hidden Dependencies - barrel files obscure where a symbol is originally defined
- Slower Compilation in Large Projects - using many barrel files can slow down TypeScript compilation and type-checking
- Unintentional Exports - makes it really easy to accidentally export internal or private modules

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates: #107611
**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
