### PR TITLE
Tempo: remove backend migration feature toggle

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -66,7 +66,6 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `sharingDashboardImage`               | Enables image sharing functionality for dashboards                                                                                                            | Yes                |
 | `tabularNumbers`                      | Use fixed-width numbers globally in the UI                                                                                                                    |                    |
 | `azureResourcePickerUpdates`          | Enables the updated Azure Monitor resource picker                                                                                                             | Yes                |
-| `tempoSearchBackendMigration`         | Run search queries through the tempo backend                                                                                                                  |                    |
 | `opentsdbBackendMigration`            | Run queries through the data source backend                                                                                                                   |                    |
 
 ## Public preview feature toggles

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -4103,7 +4103,7 @@
       "count": 1
     },
     "@typescript-eslint/no-explicit-any": {
-      "count": 2
+      "count": 1
     }
   },
   "public/app/plugins/datasource/tempo/resultTransformer.ts": {

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1124,11 +1124,6 @@ export interface FeatureToggles {
   */
   pluginContainers?: boolean;
   /**
-  * Run search queries through the tempo backend
-  * @default false
-  */
-  tempoSearchBackendMigration?: boolean;
-  /**
   * Prioritize loading plugins from the CDN before other sources
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1860,14 +1860,6 @@ var (
 			RequiresRestart: true,
 		},
 		{
-			Name:            "tempoSearchBackendMigration",
-			Description:     "Run search queries through the tempo backend",
-			Stage:           FeatureStageGeneralAvailability,
-			Owner:           grafanaOSSBigTent,
-			Expression:      "false",
-			RequiresRestart: true,
-		},
-		{
 			Name:         "cdnPluginsLoadFirst",
 			Description:  "Prioritize loading plugins from the CDN before other sources",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -253,7 +253,6 @@ graphiteBackendMode,privatePreview,@grafana/partner-datasources,false,false,fals
 azureResourcePickerUpdates,GA,@grafana/partner-datasources,false,false,true
 prometheusTypeMigration,experimental,@grafana/partner-datasources,false,true,false
 pluginContainers,privatePreview,@grafana/plugins-platform-backend,false,true,false
-tempoSearchBackendMigration,GA,@grafana/oss-big-tent,false,true,false
 cdnPluginsLoadFirst,experimental,@grafana/plugins-platform-backend,false,false,false
 cdnPluginsUrls,experimental,@grafana/plugins-platform-backend,false,false,false
 pluginInstallAPISync,experimental,@grafana/plugins-platform-backend,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -730,10 +730,6 @@ const (
 	// Enables running plugins in containers
 	FlagPluginContainers = "pluginContainers"
 
-	// FlagTempoSearchBackendMigration
-	// Run search queries through the tempo backend
-	FlagTempoSearchBackendMigration = "tempoSearchBackendMigration"
-
 	// FlagCdnPluginsLoadFirst
 	// Prioritize loading plugins from the CDN before other sources
 	FlagCdnPluginsLoadFirst = "cdnPluginsLoadFirst"

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -61,7 +61,6 @@ describe('Tempo data source', () => {
 
   describe('runs correctly', () => {
     const handleStreamingQuery = jest.spyOn(TempoDatasource.prototype, 'handleStreamingQuery');
-    const request = jest.spyOn(TempoDatasource.prototype, '_request');
     const templateSrv: TemplateSrv = { replace: (s: string) => s } as unknown as TemplateSrv;
 
     const range = {
@@ -97,7 +96,6 @@ describe('Tempo data source', () => {
       const ds = new TempoDatasource(defaultSettings, templateSrv);
       await lastValueFrom(ds.query(traceqlQuery as DataQueryRequest<TempoQuery>));
       expect(handleStreamingQuery).toHaveBeenCalledTimes(1);
-      expect(request).toHaveBeenCalledTimes(0);
     });
 
     it('for traceqlSearch queries when live is enabled', async () => {
@@ -105,7 +103,6 @@ describe('Tempo data source', () => {
       const ds = new TempoDatasource(defaultSettings, templateSrv);
       await lastValueFrom(ds.query(traceqlSearchQuery as DataQueryRequest<TempoQuery>));
       expect(handleStreamingQuery).toHaveBeenCalledTimes(1);
-      expect(request).toHaveBeenCalledTimes(0);
     });
 
     it('for traceql queries when live is not enabled', async () => {
@@ -113,7 +110,6 @@ describe('Tempo data source', () => {
       const ds = new TempoDatasource(defaultSettings, templateSrv);
       await lastValueFrom(ds.query(traceqlQuery as DataQueryRequest<TempoQuery>));
       expect(handleStreamingQuery).toHaveBeenCalledTimes(1);
-      expect(request).toHaveBeenCalledTimes(1);
     });
 
     it('for traceqlSearch queries when live is not enabled', async () => {
@@ -121,7 +117,6 @@ describe('Tempo data source', () => {
       const ds = new TempoDatasource(defaultSettings, templateSrv);
       await lastValueFrom(ds.query(traceqlSearchQuery as DataQueryRequest<TempoQuery>));
       expect(handleStreamingQuery).toHaveBeenCalledTimes(1);
-      expect(request).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -23,14 +23,11 @@ import {
   SelectableValue,
   TestDataSourceResponse,
   TimeRange,
-  urlUtil,
 } from '@grafana/data';
 import { NodeGraphOptions, SpanBarOptions, TraceToLogsOptions } from '@grafana/o11y-ds-frontend';
 import {
-  BackendSrvRequest,
   config,
   DataSourceWithBackend,
-  getBackendSrv,
   getDataSourceSrv,
   getTemplateSrv,
   reportInteraction,
@@ -59,7 +56,6 @@ import {
 import TempoLanguageProvider from './language_provider';
 import {
   enhanceTraceQlMetricsResponse,
-  formatTraceQLResponse,
   transformFromOTLP as transformFromOTEL,
   transformTrace,
 } from './resultTransformer';
@@ -419,12 +415,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
             if (useStreaming) {
               return this.handleStreamingQuery(options, targets.traceql, queryValue);
             }
-
-            if (config.featureToggles.tempoSearchBackendMigration) {
-              subQueries.push(this.handleTraceQlQuery(options, targets));
-            } else {
-              subQueries.push(this.oldSearchQueryLogic(options, targets, queryValue));
-            }
+            subQueries.push(this.handleTraceQlQuery(options, targets));
           }
         }
       } catch (error) {
@@ -464,11 +455,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
           if (this.isStreamingSearchEnabled()) {
             subQueries.push(this.handleStreamingQuery(options, traceqlSearchTargets, queryFromFilters));
           } else {
-            if (config.featureToggles.tempoSearchBackendMigration) {
-              subQueries.push(this.handleTraceQlQuery(options, targets));
-            } else {
-              subQueries.push(this.oldSearchQueryLogic(options, targets, queryFromFilters));
-            }
+            subQueries.push(this.handleTraceQlQuery(options, targets));
           }
         }
       } catch (error) {
@@ -712,49 +699,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     );
   }
 
-  // this is just a short term function, we will remove once we have rolled
-  // out the backend migration and are happy with the stability of the feature
-  oldSearchQueryLogic = (
-    options: DataQueryRequest<TempoQuery>,
-    targets: { [type: string]: TempoQuery[] },
-    queryValue: string
-  ) => {
-    const startTime = performance.now();
-    const tableType = targets.traceqlSearch?.[0]?.tableType ?? targets.traceql?.[0]?.tableType;
-
-    return this._request('/api/search', {
-      q: queryValue,
-      limit: options.targets[0].limit ?? DEFAULT_LIMIT,
-      spss: options.targets[0].spss ?? DEFAULT_SPSS,
-      start: options.range.from.unix(),
-      end: options.range.to.unix(),
-    }).pipe(
-      map((response) => {
-        reportTempoQueryMetrics('grafana_traces_traceql_response', options, {
-          success: true,
-          streaming: false,
-          latencyMs: Math.round(performance.now() - startTime), // rounded to nearest millisecond
-          query: queryValue ?? '',
-        });
-        return {
-          data: formatTraceQLResponse(response.data.traces, this.instanceSettings, tableType),
-        };
-      }),
-      catchError((err) => {
-        reportTempoQueryMetrics('grafana_traces_traceql_response', options, {
-          success: false,
-          streaming: false,
-          latencyMs: Math.round(performance.now() - startTime), // rounded to nearest millisecond
-          query: queryValue ?? '',
-          error: getErrorMessage(err.message),
-          statusCode: err.status,
-          statusText: err.statusText,
-        });
-        return of({ error: { message: getErrorMessage(err?.data?.message) }, data: [] });
-      })
-    );
-  };
-
   handleTraceQlMetricsQuery(
     options: DataQueryRequest<TempoQuery>,
     targets: TempoQuery[],
@@ -924,13 +868,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
 
     const res = await this.getResource(url, params, { method: 'GET', hideFromInspector: true });
     return res?.data ?? res;
-  }
-
-  _request(apiUrl: string, data?: unknown, options?: Partial<BackendSrvRequest>): Observable<Record<string, any>> {
-    const params = data ? urlUtil.serializeParams(data) : '';
-    const url = `${this.instanceSettings.url}${apiUrl}${params.length ? `?${params}` : ''}`;
-    const req = { ...options, url };
-    return getBackendSrv().fetch(req);
   }
 
   async testDatasource(): Promise<TestDataSourceResponse> {


### PR DESCRIPTION
Remove the `tempoSearchBackendMigration` feature toggle.

This toggle was introduced in September 2025 as a safeguard for the backend migration. The new backend has been live for 3–4 months without any major issues, so we can safely remove the toggle along with the legacy frontend code path.