### PR TITLE
Provisioning: Add fieldSelector for Repository by spec.connection.name

### DIFF
--- a/pkg/apiserver/registry/generic/storage.go
+++ b/pkg/apiserver/registry/generic/storage.go
@@ -33,18 +33,15 @@ func NewRegistryStoreWithSelectableFields(scheme *runtime.Scheme, resourceInfo u
 	}
 
 	// Use custom GetAttrs if provided, otherwise use default
-	attrFunc := GetAttrs
-	predicateFunc := Matcher
+	var attrFunc storage.AttrFunc
+	var predicateFunc func(label labels.Selector, field fields.Selector) storage.SelectionPredicate
 	if fieldOpts.GetAttrs != nil {
 		attrFunc = fieldOpts.GetAttrs
-		// Create a matcher that uses the custom GetAttrs
-		predicateFunc = func(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
-			return storage.SelectionPredicate{
-				Label:    label,
-				Field:    field,
-				GetAttrs: attrFunc,
-			}
-		}
+		// Pass nil predicateFunc to use default behavior with custom attrFunc
+		predicateFunc = nil
+	} else {
+		attrFunc = GetAttrs
+		predicateFunc = Matcher
 	}
 
 	store := &registry.Store{

--- a/pkg/registry/apis/provisioning/repository_fields.go
+++ b/pkg/registry/apis/provisioning/repository_fields.go
@@ -1,0 +1,44 @@
+package provisioning
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/generic"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+// RepositoryToSelectableFields returns a field set that can be used for field selectors.
+// This includes standard metadata fields plus custom fields like spec.connection.name.
+func RepositoryToSelectableFields(obj *provisioning.Repository) fields.Set {
+	objectMetaFields := generic.ObjectMetaFieldsSet(&obj.ObjectMeta, true)
+
+	// Add custom selectable fields
+	specificFields := fields.Set{
+		"spec.connection.name": getConnectionName(obj),
+	}
+
+	return generic.MergeFieldsSets(objectMetaFields, specificFields)
+}
+
+// getConnectionName safely extracts the connection name from a Repository.
+// Returns empty string if no connection is configured.
+func getConnectionName(obj *provisioning.Repository) string {
+	if obj == nil || obj.Spec.Connection == nil {
+		return ""
+	}
+	return obj.Spec.Connection.Name
+}
+
+// RepositoryGetAttrs returns labels and fields of a Repository object.
+// This is used by the storage layer for filtering.
+func RepositoryGetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
+	repo, ok := obj.(*provisioning.Repository)
+	if !ok {
+		return nil, nil, fmt.Errorf("given object is not a Repository")
+	}
+	return labels.Set(repo.Labels), RepositoryToSelectableFields(repo), nil
+}

--- a/pkg/registry/apis/provisioning/repository_fields_test.go
+++ b/pkg/registry/apis/provisioning/repository_fields_test.go
@@ -1,0 +1,184 @@
+package provisioning
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+func TestGetConnectionName(t *testing.T) {
+	tests := []struct {
+		name     string
+		repo     *provisioning.Repository
+		expected string
+	}{
+		{
+			name:     "nil repository returns empty string",
+			repo:     nil,
+			expected: "",
+		},
+		{
+			name: "repository without connection returns empty string",
+			repo: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Title: "test-repo",
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "repository with connection returns connection name",
+			repo: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Title: "test-repo",
+					Connection: &provisioning.ConnectionInfo{
+						Name: "my-connection",
+					},
+				},
+			},
+			expected: "my-connection",
+		},
+		{
+			name: "repository with empty connection name returns empty string",
+			repo: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Title: "test-repo",
+					Connection: &provisioning.ConnectionInfo{
+						Name: "",
+					},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getConnectionName(tt.repo)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRepositoryToSelectableFields(t *testing.T) {
+	tests := []struct {
+		name           string
+		repo           *provisioning.Repository
+		expectedFields map[string]string
+	}{
+		{
+			name: "includes metadata.name and metadata.namespace",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Title: "Test Repository",
+				},
+			},
+			expectedFields: map[string]string{
+				"metadata.name":        "test-repo",
+				"metadata.namespace":   "default",
+				"spec.connection.name": "",
+			},
+		},
+		{
+			name: "includes spec.connection.name when set",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "repo-with-connection",
+					Namespace: "org-1",
+				},
+				Spec: provisioning.RepositorySpec{
+					Title: "Repo With Connection",
+					Connection: &provisioning.ConnectionInfo{
+						Name: "github-connection",
+					},
+				},
+			},
+			expectedFields: map[string]string{
+				"metadata.name":        "repo-with-connection",
+				"metadata.namespace":   "org-1",
+				"spec.connection.name": "github-connection",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields := RepositoryToSelectableFields(tt.repo)
+
+			for key, expectedValue := range tt.expectedFields {
+				actualValue, exists := fields[key]
+				assert.True(t, exists, "field %s should exist", key)
+				assert.Equal(t, expectedValue, actualValue, "field %s should have correct value", key)
+			}
+		})
+	}
+}
+
+func TestRepositoryGetAttrs(t *testing.T) {
+	t.Run("returns error for non-Repository object", func(t *testing.T) {
+		// Pass a different runtime.Object type instead of a Repository
+		connection := &provisioning.Connection{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "not-a-repository",
+			},
+		}
+		_, _, err := RepositoryGetAttrs(connection)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a Repository")
+	})
+
+	t.Run("returns labels and fields for valid Repository", func(t *testing.T) {
+		repo := &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-repo",
+				Namespace: "default",
+				Labels: map[string]string{
+					"app": "grafana",
+					"env": "test",
+				},
+			},
+			Spec: provisioning.RepositorySpec{
+				Title: "Test Repository",
+				Connection: &provisioning.ConnectionInfo{
+					Name: "my-connection",
+				},
+			},
+		}
+
+		labels, fields, err := RepositoryGetAttrs(repo)
+		require.NoError(t, err)
+
+		// Check labels
+		assert.Equal(t, "grafana", labels["app"])
+		assert.Equal(t, "test", labels["env"])
+
+		// Check fields
+		assert.Equal(t, "test-repo", fields["metadata.name"])
+		assert.Equal(t, "default", fields["metadata.namespace"])
+		assert.Equal(t, "my-connection", fields["spec.connection.name"])
+	})
+
+	t.Run("returns empty connection name when not set", func(t *testing.T) {
+		repo := &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-repo",
+				Namespace: "default",
+			},
+			Spec: provisioning.RepositorySpec{
+				Title: "Test Repository",
+			},
+		}
+
+		_, fields, err := RepositoryGetAttrs(repo)
+		require.NoError(t, err)
+		assert.Equal(t, "", fields["spec.connection.name"])
+	})
+}


### PR DESCRIPTION
## What is this pull request about?

This PR adds the ability to filter repositories by their connection name using Kubernetes field selectors.

### Usage

```bash
# Filter repositories by connection name
kubectl get repositories --field-selector spec.connection.name=my-connection

# Filter repositories without a connection
kubectl get repositories --field-selector spec.connection.name=
```


<img width="1545" height="811" alt="image" src="https://github.com/user-attachments/assets/3586d2a7-17bc-4977-83d0-5f6f84ed92c8" />

## Changes

### New files
- `pkg/registry/apis/provisioning/repository_fields.go` - Helper functions for Repository field selection
- `pkg/registry/apis/provisioning/repository_fields_test.go` - Unit tests

### Modified files
- `pkg/apiserver/registry/generic/storage.go` - Extended with `NewRegistryStoreWithSelectableFields` to support custom field selectors
- `pkg/registry/apis/provisioning/register.go` - Register field label conversion and use custom storage
- `pkg/tests/apis/provisioning/connection_test.go` - Integration tests for field selector

## Implementation Notes

Two parts are required for custom field selectors:
1. **Storage-level filtering**: Custom `GetAttrs` function to extract `spec.connection.name` for in-memory predicate matching
2. **Schema-level validation**: `AddFieldLabelConversionFunc()` to register `spec.connection.name` as a valid field selector (without this, Kubernetes rejects the field as "not a known field selector")

## How to test

```bash
go test -v -run TestIntegrationProvisioning_RepositoryFieldSelectorByConnection ./pkg/tests/apis/provisioning/...
go test -v -run "TestGetConnectionName|TestRepositoryToSelectableFields|TestRepositoryGetAttrs" ./pkg/registry/apis/provisioning/...
```


# Related

Fixes https://github.com/grafana/git-ui-sync-project/issues/717
