### PR TITLE
chore: remove app/core/config barrel files

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1161,11 +1161,6 @@
       "count": 2
     }
   },
-  "public/app/core/config.ts": {
-    "no-barrel-files/no-barrel-files": {
-      "count": 2
-    }
-  },
   "public/app/core/navigation/types.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1

--- a/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
+++ b/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
@@ -4,8 +4,8 @@ import * as React from 'react';
 import SplitPane, { Split } from 'react-split-pane';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { getDragStyles } from '@grafana/ui';
-import { config } from 'app/core/config';
 
 interface Props {
   splitOrientation?: Split;

--- a/public/app/core/config.ts
+++ b/public/app/core/config.ts
@@ -1,6 +1,5 @@
 import { PluginState } from '@grafana/data';
 import { config, GrafanaBootConfig } from '@grafana/runtime';
-export { config, type GrafanaBootConfig as Settings };
 
 let grafanaConfig: GrafanaBootConfig = config;
 

--- a/public/app/core/internationalization/dates.ts
+++ b/public/app/core/internationalization/dates.ts
@@ -2,7 +2,7 @@ import deepEqual from 'fast-deep-equal';
 import memoize from 'micro-memoize';
 
 import { getLanguage } from '@grafana/i18n/internal';
-import { config } from 'app/core/config';
+import { config } from '@grafana/runtime';
 
 const deepMemoize: typeof memoize = (fn) => memoize(fn, { isEqual: deepEqual });
 

--- a/public/app/core/services/theme.ts
+++ b/public/app/core/services/theme.ts
@@ -1,8 +1,7 @@
 import { getThemeById } from '@grafana/data/internal';
-import { ThemeChangedEvent } from '@grafana/runtime';
+import { config, ThemeChangedEvent } from '@grafana/runtime';
 
 import { appEvents } from '../app_events';
-import { config } from '../config';
 import { contextSrv } from '../services/context_srv';
 
 import { PreferencesService } from './PreferencesService';

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -1,7 +1,7 @@
 import { Navigate } from 'react-router-dom-v5-compat';
 
+import { config } from '@grafana/runtime';
 import { SafeDynamicImport } from 'app/core/components/DynamicImports/SafeDynamicImport';
-import { config } from 'app/core/config';
 import { GrafanaRouteComponent, RouteDescriptor } from 'app/core/navigation/types';
 import { AccessControlAction } from 'app/types/accessControl';
 

--- a/public/app/features/alerting/state/ThresholdMapper.ts
+++ b/public/app/features/alerting/state/ThresholdMapper.ts
@@ -1,4 +1,4 @@
-import { config } from 'app/core/config';
+import { config } from '@grafana/runtime';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 
 export const hiddenReducerTypes = ['percent_diff', 'percent_diff_abs'];

--- a/public/app/features/alerting/unified/components/rule-editor/util.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.ts
@@ -8,8 +8,8 @@ import {
   ThresholdsMode,
   isTimeSeriesFrames,
 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { GraphThresholdsStyleMode } from '@grafana/schema';
-import { config } from 'app/core/config';
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
 import { isExpressionQuery } from 'app/features/expressions/guards';
 import { ClassicCondition, ExpressionQueryType } from 'app/features/expressions/types';

--- a/public/app/features/annotations/standardAnnotationSupport.ts
+++ b/public/app/features/annotations/standardAnnotationSupport.ts
@@ -18,7 +18,7 @@ import {
   standardTransformers,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config } from 'app/core/config';
+import { config } from '@grafana/runtime';
 
 export const standardAnnotationSupport: AnnotationSupport = {
   /**

--- a/public/app/features/auth-config/AuthProvidersListPage.tsx
+++ b/public/app/features/auth-config/AuthProvidersListPage.tsx
@@ -3,10 +3,9 @@ import { connect, ConnectedProps } from 'react-redux';
 
 import { GrafanaEdition } from '@grafana/data/internal';
 import { Trans } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { Grid, TextLink, ToolbarButton } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
-import { config } from 'app/core/config';
 import { StoreState } from 'app/types/store';
 
 import { isOpenSourceBuildOrUnlicenced } from '../admin/EnterpriseAuthFeaturesCard';

--- a/public/app/features/canvas/element.ts
+++ b/public/app/features/canvas/element.ts
@@ -2,8 +2,8 @@ import { ComponentType } from 'react';
 
 import { DataLink, RegistryItem, Action } from '@grafana/data';
 import { PanelOptionsSupplier } from '@grafana/data/internal';
+import { config } from '@grafana/runtime';
 import { ColorDimensionConfig, ScaleDimensionConfig, DirectionDimensionConfig } from '@grafana/schema';
-import { config } from 'app/core/config';
 import { BackgroundConfig, Constraint, LineConfig, Placement } from 'app/plugins/panel/canvas/panelcfg.gen';
 
 import { LineStyleConfig } from '../../plugins/panel/canvas/editor/LineStyleEditor';

--- a/public/app/features/canvas/elements/cloud.tsx
+++ b/public/app/features/canvas/elements/cloud.tsx
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config } from 'app/core/config';
+import { config } from '@grafana/runtime';
 import { DimensionContext } from 'app/features/dimensions/context';
 import { ColorDimensionEditor } from 'app/features/dimensions/editors/ColorDimensionEditor';
 import { TextDimensionEditor } from 'app/features/dimensions/editors/TextDimensionEditor';

--- a/public/app/features/canvas/elements/ellipse.tsx
+++ b/public/app/features/canvas/elements/ellipse.tsx
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config } from 'app/core/config';
+import { config } from '@grafana/runtime';
 import { DimensionContext } from 'app/features/dimensions/context';
 import { ColorDimensionEditor } from 'app/features/dimensions/editors/ColorDimensionEditor';
 import { TextDimensionEditor } from 'app/features/dimensions/editors/TextDimensionEditor';

--- a/public/app/features/canvas/elements/parallelogram.tsx
+++ b/public/app/features/canvas/elements/parallelogram.tsx
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config } from 'app/core/config';
+import { config } from '@grafana/runtime';
 import { DimensionContext } from 'app/features/dimensions/context';
 import { ColorDimensionEditor } from 'app/features/dimensions/editors/ColorDimensionEditor';
 import { TextDimensionEditor } from 'app/features/dimensions/editors/TextDimensionEditor';

--- a/public/app/features/canvas/elements/triangle.tsx
+++ b/public/app/features/canvas/elements/triangle.tsx
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config } from 'app/core/config';
+import { config } from '@grafana/runtime';
 import { DimensionContext } from 'app/features/dimensions/context';
 import { ColorDimensionEditor } from 'app/features/dimensions/editors/ColorDimensionEditor';
 import { TextDimensionEditor } from 'app/features/dimensions/editors/TextDimensionEditor';

--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -14,10 +14,10 @@ import {
   ActionType,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { TooltipDisplayMode } from '@grafana/schema';
 import { ConfirmModal, VariablesInputModal } from '@grafana/ui';
 import { LayerElement } from 'app/core/components/Layers/types';
-import { config } from 'app/core/config';
 import { notFoundItem } from 'app/features/canvas/elements/notFound';
 import { DimensionContext } from 'app/features/dimensions/context';
 import {

--- a/public/app/features/canvas/runtime/scene.tsx
+++ b/public/app/features/canvas/runtime/scene.tsx
@@ -6,7 +6,7 @@ import { BehaviorSubject, ReplaySubject, Subject, Subscription } from 'rxjs';
 import Selecto from 'selecto';
 
 import { AppEvents, PanelData, OneClickMode, ActionType } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import {
   ColorDimensionConfig,
   ResourceDimensionConfig,
@@ -17,7 +17,6 @@ import {
   DirectionDimensionConfig,
 } from '@grafana/schema';
 import { Portal } from '@grafana/ui';
-import { config } from 'app/core/config';
 import { DimensionContext } from 'app/features/dimensions/context';
 import {
   getColorDimensionFromData,

--- a/public/app/features/canvas/runtime/sceneAbleManagement.ts
+++ b/public/app/features/canvas/runtime/sceneAbleManagement.ts
@@ -2,7 +2,7 @@ import InfiniteViewer from 'infinite-viewer';
 import Moveable from 'moveable';
 import Selecto from 'selecto';
 
-import { config } from 'app/core/config';
+import { config } from '@grafana/runtime';
 import { CONNECTION_ANCHOR_DIV_ID } from 'app/plugins/panel/canvas/components/connections/ConnectionAnchors';
 import {
   CONNECTION_VERTEX_ID,

--- a/public/app/features/dashboard-scene/sharing/ShareButton/ShareMenu.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareButton/ShareMenu.test.tsx
@@ -1,11 +1,11 @@
 import { render, screen } from '@testing-library/react';
 
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
+import { config } from '@grafana/runtime';
 import { SceneTimeRange, VizPanel } from '@grafana/scenes';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 
-import { config } from '../../../../core/config';
 import { grantUserPermissions } from '../../../alerting/unified/mocks';
 import { DashboardScene, DashboardSceneState } from '../../scene/DashboardScene';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';

--- a/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { Modal, ModalTabsHeader, TabContent, Themeable2, withTheme2 } from '@grafana/ui';
-import { config } from 'app/core/config';
 import { contextSrv } from 'app/core/services/context_srv';
 import { SharePublicDashboard } from 'app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard';
 import { isPublicDashboardsEnabled } from 'app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils';

--- a/public/app/features/dashboard/dashgrid/PanelLoadTimeMonitor.test.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelLoadTimeMonitor.test.tsx
@@ -4,7 +4,7 @@ const mockPushMeasurement = jest.fn();
 
 import { PanelLoadTimeMonitor } from './PanelLoadTimeMonitor';
 
-jest.mock('app/core/config', () => ({
+jest.mock('@grafana/runtime', () => ({
   config: {
     grafanaJavascriptAgent: {
       enabled: true,

--- a/public/app/features/dashboard/dashgrid/PanelLoadTimeMonitor.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelLoadTimeMonitor.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { faro } from '@grafana/faro-web-sdk';
-import { config } from 'app/core/config';
+import { config } from '@grafana/runtime';
 import { PanelLogEvents } from 'app/core/log_events';
 
 interface Props {

--- a/public/app/features/dashboard/dashgrid/panelOptionsLogger.test.ts
+++ b/public/app/features/dashboard/dashgrid/panelOptionsLogger.test.ts
@@ -12,7 +12,7 @@ jest.mock('@grafana/faro-web-sdk', () => ({
   },
 }));
 
-jest.mock('app/core/config', () => ({
+jest.mock('@grafana/runtime', () => ({
   config: {
     grafanaJavascriptAgent: {
       enabled: true,

--- a/public/app/features/dashboard/dashgrid/panelOptionsLogger.ts
+++ b/public/app/features/dashboard/dashgrid/panelOptionsLogger.ts
@@ -1,6 +1,6 @@
 import { FieldConfigSource } from '@grafana/data';
 import { faro } from '@grafana/faro-web-sdk';
-import { config } from 'app/core/config';
+import { config } from '@grafana/runtime';
 import { FIELD_CONFIG_CUSTOM_KEY, FIELD_CONFIG_OVERRIDES_KEY, PanelLogEvents } from 'app/core/log_events';
 
 interface PanelLogInfo {

--- a/public/app/features/dashboard/routes.ts
+++ b/public/app/features/dashboard/routes.ts
@@ -1,7 +1,7 @@
+import { config } from '@grafana/runtime';
 import { DashboardRoutes } from 'app/types/dashboard';
 
 import { SafeDynamicImport } from '../../core/components/DynamicImports/SafeDynamicImport';
-import { config } from '../../core/config';
 import { RouteDescriptor } from '../../core/navigation/types';
 
 export const getPublicDashboardRoutes = (): RouteDescriptor[] => {

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -13,10 +13,9 @@ import {
   dateTimeForTimeZone,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { locationService } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import { sceneGraph } from '@grafana/scenes';
 import { appEvents } from 'app/core/app_events';
-import { config } from 'app/core/config';
 import { AutoRefreshInterval, contextSrv, ContextSrv } from 'app/core/services/context_srv';
 import {
   getCopiedTimeRange,

--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -2,8 +2,8 @@ import { each, map } from 'lodash';
 
 import { DataLinkBuiltInVars, MappingType, VariableHide } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
+import { config } from '@grafana/runtime';
 import { FieldConfigSource } from '@grafana/schema';
-import { config } from 'app/core/config';
 import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN } from 'app/core/constants';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';

--- a/public/app/features/dashboard/utils/loadSnapshotData.ts
+++ b/public/app/features/dashboard/utils/loadSnapshotData.ts
@@ -6,7 +6,7 @@ import {
   LoadingState,
   PanelData,
 } from '@grafana/data';
-import { config } from 'app/core/config';
+import { config } from '@grafana/runtime';
 
 import { SnapshotWorker } from '../../query/state/DashboardQueryRunner/SnapshotWorker';
 import { getTimeSrv } from '../services/TimeSrv';

--- a/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
+++ b/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
@@ -6,9 +6,8 @@ import { useRef, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { getBackendSrv } from '@grafana/runtime';
+import { config, getBackendSrv } from '@grafana/runtime';
 import { Button, useStyles2 } from '@grafana/ui';
-import { config } from 'app/core/config';
 
 import { MediaType, PickerTabType, ResourceFolderName } from '../types';
 

--- a/public/app/features/explore/RawPrometheus/RawPrometheusContainer.tsx
+++ b/public/app/features/explore/RawPrometheus/RawPrometheusContainer.tsx
@@ -3,10 +3,9 @@ import { memo, useState } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { applyFieldOverrides, DataFrame, SelectableValue, SplitOpen } from '@grafana/data';
-import { getTemplateSrv, reportInteraction } from '@grafana/runtime';
+import { config, getTemplateSrv, reportInteraction } from '@grafana/runtime';
 import { TimeZone } from '@grafana/schema';
 import { RadioButtonGroup, Table, AdHocFilterItem, PanelChrome } from '@grafana/ui';
-import { config } from 'app/core/config';
 import { PANEL_BORDER } from 'app/core/constants';
 import { ExploreItemState, TABLE_RESULTS_STYLE, TABLE_RESULTS_STYLES, TableResultsStyle } from 'app/types/explore';
 import { StoreState } from 'app/types/store';

--- a/public/app/features/explore/Table/TableContainer.tsx
+++ b/public/app/features/explore/Table/TableContainer.tsx
@@ -13,10 +13,9 @@ import {
   EventBusSrv,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { getTemplateSrv, PanelRenderer } from '@grafana/runtime';
+import { config, getTemplateSrv, PanelRenderer } from '@grafana/runtime';
 import { TimeZone } from '@grafana/schema';
 import { AdHocFilterItem, PanelChrome, withTheme2, Themeable2, PanelContextProvider } from '@grafana/ui';
-import { config } from 'app/core/config';
 import {
   hasDeprecatedParentRowIndex,
   migrateFromParentRowIndexToNestedFrames,

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.test.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.test.tsx
@@ -22,7 +22,7 @@ import {
   PluginExtensionPoints,
   PluginExtensionTypes,
 } from '@grafana/data';
-import { usePluginLinks, usePluginComponents } from '@grafana/runtime';
+import { usePluginLinks, usePluginComponents, config } from '@grafana/runtime';
 import { DEFAULT_SPAN_FILTERS } from 'app/features/explore/state/constants';
 
 import { TraceViewPluginExtensionContext } from '../types/trace';
@@ -45,13 +45,6 @@ jest.mock('app/core/copy/appNotification', () => ({
     warning: jest.fn(),
     error: jest.fn(),
   })),
-}));
-
-// Mock config
-jest.mock('../../../../../core/config', () => ({
-  config: {
-    feedbackLinksEnabled: false, // Default to false to avoid interference with tests
-  },
 }));
 
 // Mock navigator.clipboard
@@ -127,6 +120,7 @@ describe('TracePageHeader test', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockWindowOpen.mockClear();
+    config.feedbackLinksEnabled = false; // Default to false to avoid interference with tests
   });
 
   it('should render the new trace header', () => {
@@ -438,9 +432,7 @@ describe('TracePageHeader test', () => {
     });
 
     it('should render feedback button when feedbackLinksEnabled is true', () => {
-      // Mock config with feedbackLinksEnabled = true
-      const mockConfig = require('../../../../../core/config');
-      mockConfig.config.feedbackLinksEnabled = true;
+      config.feedbackLinksEnabled = true;
 
       setup();
 
@@ -453,9 +445,7 @@ describe('TracePageHeader test', () => {
     it('should display tooltip for feedback button', async () => {
       const user = userEvent.setup();
 
-      // Mock config with feedbackLinksEnabled = true
-      const mockConfig = require('../../../../../core/config');
-      mockConfig.config.feedbackLinksEnabled = true;
+      config.feedbackLinksEnabled = true;
 
       setup();
 
@@ -469,9 +459,7 @@ describe('TracePageHeader test', () => {
     });
 
     it('should render feedback button with correct styling and icon', () => {
-      // Mock config with feedbackLinksEnabled = true
-      const mockConfig = require('../../../../../core/config');
-      mockConfig.config.feedbackLinksEnabled = true;
+      config.feedbackLinksEnabled = true;
 
       setup();
 

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
@@ -26,7 +26,13 @@ import {
   PluginExtensionPoints,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { reportInteraction, renderLimitedComponents, usePluginComponents, usePluginLinks } from '@grafana/runtime';
+import {
+  reportInteraction,
+  renderLimitedComponents,
+  usePluginComponents,
+  usePluginLinks,
+  config,
+} from '@grafana/runtime';
 import { AdHocFiltersComboboxRenderer } from '@grafana/scenes';
 import { TimeZone } from '@grafana/schema';
 import {
@@ -46,7 +52,6 @@ import {
 } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
 
-import { config } from '../../../../../core/config';
 import { downloadTraceAsJson } from '../../../../inspector/utils/download';
 import { ViewRangeTimeUpdate, TUpdateViewRangeTimeFunction, ViewRange } from '../TraceTimelineViewer/types';
 import { getHeaderTags, getTraceName } from '../model/trace-viewer';

--- a/public/app/features/expressions/types.ts
+++ b/public/app/features/expressions/types.ts
@@ -1,5 +1,5 @@
 import { DataQuery, ReducerID, SelectableValue } from '@grafana/data';
-import { config } from 'app/core/config';
+import { config } from '@grafana/runtime';
 
 import { EvalFunction } from '../alerting/state/alertDef';
 

--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -15,9 +15,8 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { getTemplateSrv, reportInteraction } from '@grafana/runtime';
+import { config, getTemplateSrv, reportInteraction } from '@grafana/runtime';
 import { Button, Spinner, Table } from '@grafana/ui';
-import { config } from 'app/core/config';
 import { GetDataOptions } from 'app/features/query/state/PanelQueryRunner';
 
 import { dataFrameToLogsModel } from '../logs/logsModel';

--- a/public/app/features/inspector/styles.ts
+++ b/public/app/features/inspector/styles.ts
@@ -1,8 +1,8 @@
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { stylesFactory } from '@grafana/ui';
-import { config } from 'app/core/config';
 
 /** @deprecated */
 export const getPanelInspectorStyles = stylesFactory(() => {

--- a/public/app/features/panel/state/util.ts
+++ b/public/app/features/panel/state/util.ts
@@ -1,5 +1,5 @@
 import { PanelPluginMeta, PluginState, unEscapeStringFromRegex } from '@grafana/data';
-import { config } from 'app/core/config';
+import { config } from '@grafana/runtime';
 
 export function getAllPanelPluginMeta(): PanelPluginMeta[] {
   const allPanels = config.panels;

--- a/public/app/features/panel/suggestions/getAllSuggestions.test.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.test.ts
@@ -11,6 +11,7 @@ import {
   toDataFrame,
   VisualizationSuggestionScore,
 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import {
   BarGaugeDisplayMode,
   BigValueColorMode,
@@ -20,7 +21,6 @@ import {
   VizOrientation,
 } from '@grafana/schema';
 import { appEvents } from 'app/core/app_events';
-import { config } from 'app/core/config';
 import { clearPanelPluginCache } from 'app/features/plugins/importPanelPlugin';
 import { pluginImporter } from 'app/features/plugins/importer/pluginImporter';
 

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -3,7 +3,6 @@ import { from, forkJoin, timeout, lastValueFrom, catchError, of } from 'rxjs';
 
 import { PanelPlugin, PluginError } from '@grafana/data';
 import { config, getBackendSrv, isFetchError } from '@grafana/runtime';
-import { Settings } from 'app/core/config';
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
 import { StoreState, ThunkResult } from 'app/types/store';
 
@@ -301,7 +300,7 @@ export const loadPanelPlugin = (id: string): ThunkResult<Promise<PanelPlugin>> =
 function updatePanels() {
   return getBackendSrv()
     .get('/api/frontend/settings')
-    .then((settings: Settings) => {
+    .then((settings) => {
       config.panels = settings.panels;
     });
 }

--- a/public/app/features/profile/routes.tsx
+++ b/public/app/features/profile/routes.tsx
@@ -1,7 +1,7 @@
 import { uniq } from 'lodash';
 
+import { config } from '@grafana/runtime';
 import { SafeDynamicImport } from 'app/core/components/DynamicImports/SafeDynamicImport';
-import { config } from 'app/core/config';
 import { RouteDescriptor } from 'app/core/navigation/types';
 
 const profileRoutes: RouteDescriptor[] = [

--- a/public/app/features/users/UsersActionBar.test.tsx
+++ b/public/app/features/users/UsersActionBar.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { mockToolkitActionCreator } from 'test/core/redux/mocks';
 
-import { config } from 'app/core/config';
+import { config } from '@grafana/runtime';
 
 import { Props, UsersActionBarUnconnected } from './UsersActionBar';
 import { searchQueryChanged } from './state/reducers';

--- a/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
@@ -4,8 +4,8 @@ import { Link } from 'react-router-dom-v5-compat';
 
 import { SIGV4ConnectionConfig } from '@grafana/aws-sdk';
 import { DataSourcePluginOptionsEditorProps, SelectableValue } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { Box, DataSourceHttpSettings, InlineField, InlineSwitch, Select, Text } from '@grafana/ui';
-import { config } from 'app/core/config';
 
 import { AlertManagerDataSourceJsonData, AlertManagerImplementation } from './types';
 

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -5,7 +5,7 @@ import { useEffectOnce, useToggle } from 'react-use';
 
 import { GrafanaTheme2, PanelProps } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { TimeRangeUpdatedEvent } from '@grafana/runtime';
+import { config, TimeRangeUpdatedEvent } from '@grafana/runtime';
 import {
   Alert,
   BigValue,
@@ -17,7 +17,6 @@ import {
   ScrollContainer,
   useStyles2,
 } from '@grafana/ui';
-import { config } from 'app/core/config';
 import alertDef from 'app/features/alerting/state/alertDef';
 import { alertRuleApi } from 'app/features/alerting/unified/api/alertRuleApi';
 import { INSTANCES_DISPLAY_LIMIT } from 'app/features/alerting/unified/components/rules/RuleDetails';

--- a/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
+++ b/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
@@ -12,10 +12,10 @@ import {
   PanelProps,
   VizOrientation,
 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { BarGaugeSizing } from '@grafana/schema';
 import { BarGauge, DataLinksContextMenu, VizLayout, VizRepeater, VizRepeaterRenderValueProps } from '@grafana/ui';
 import { DataLinksContextMenuApi } from '@grafana/ui/internal';
-import { config } from 'app/core/config';
 
 import { BarGaugeLegend } from './BarGaugeLegend';
 import { defaultOptions, Options } from './panelcfg.gen';

--- a/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
+++ b/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
@@ -5,7 +5,7 @@ import { useMemo, useState } from 'react';
 import uPlot from 'uplot';
 
 import { Field, getDisplayProcessor, PanelProps, useDataLinksContext } from '@grafana/data';
-import { PanelDataErrorView } from '@grafana/runtime';
+import { config, PanelDataErrorView } from '@grafana/runtime';
 import { DashboardCursorSync, TooltipDisplayMode } from '@grafana/schema';
 import {
   EventBusPlugin,
@@ -18,7 +18,6 @@ import {
 } from '@grafana/ui';
 import { AxisProps, ScaleProps, TimeRange2, TooltipHoverMode } from '@grafana/ui/internal';
 import { TimeSeries } from 'app/core/components/TimeSeries/TimeSeries';
-import { config } from 'app/core/config';
 
 import { TimeSeriesTooltip } from '../timeseries/TimeSeriesTooltip';
 import { AnnotationsPlugin2 } from '../timeseries/plugins/AnnotationsPlugin2';

--- a/public/app/plugins/panel/canvas/components/CanvasContextMenu.tsx
+++ b/public/app/plugins/panel/canvas/components/CanvasContextMenu.tsx
@@ -5,8 +5,8 @@ import { first } from 'rxjs/operators';
 
 import { SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { ContextMenu, MenuItem, MenuItemProps } from '@grafana/ui';
-import { config } from 'app/core/config';
 import { ElementState } from 'app/features/canvas/runtime/element';
 import { FrameState } from 'app/features/canvas/runtime/frame';
 import { Scene } from 'app/features/canvas/runtime/scene';

--- a/public/app/plugins/panel/canvas/components/connections/ConnectionSVG.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/ConnectionSVG.tsx
@@ -2,9 +2,9 @@ import { css } from '@emotion/css';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { DirectionDimensionConfig, DirectionDimensionMode, ConnectionDirection } from '@grafana/schema';
 import { useStyles2 } from '@grafana/ui';
-import { config } from 'app/core/config';
 import { Scene } from 'app/features/canvas/runtime/scene';
 
 import { ConnectionCoordinates } from '../../panelcfg.gen';

--- a/public/app/plugins/panel/canvas/components/connections/ConnectionSVG2.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/ConnectionSVG2.tsx
@@ -2,9 +2,9 @@ import { css } from '@emotion/css';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { DirectionDimensionConfig, DirectionDimensionMode, ConnectionDirection } from '@grafana/schema';
 import { useStyles2 } from '@grafana/ui';
-import { config } from 'app/core/config';
 import { Scene } from 'app/features/canvas/runtime/scene';
 
 import { ConnectionCoordinates } from '../../panelcfg.gen';

--- a/public/app/plugins/panel/canvas/utils.ts
+++ b/public/app/plugins/panel/canvas/utils.ts
@@ -1,9 +1,10 @@
 import { isNumber, isString } from 'lodash';
 
 import { DataFrame, Field, AppEvents, getFieldDisplayName, PluginState, SelectableValue } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { ConnectionDirection } from '@grafana/schema';
 import { appEvents } from 'app/core/app_events';
-import { hasAlphaPanels, config } from 'app/core/config';
+import { hasAlphaPanels } from 'app/core/config';
 import { CanvasConnection, CanvasElementItem, CanvasElementOptions } from 'app/features/canvas/element';
 import { notFoundItem } from 'app/features/canvas/elements/notFound';
 import { advancedElementItems, canvasElementRegistry, defaultElementItems } from 'app/features/canvas/registry';

--- a/public/app/plugins/panel/gauge/GaugePanel.tsx
+++ b/public/app/plugins/panel/gauge/GaugePanel.tsx
@@ -1,10 +1,10 @@
 import { PureComponent, type JSX } from 'react';
 
 import { FieldDisplay, getDisplayProcessor, getFieldDisplayValues, PanelProps } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { BarGaugeSizing, VizOrientation } from '@grafana/schema';
 import { DataLinksContextMenu, Gauge, VizRepeater, VizRepeaterRenderValueProps } from '@grafana/ui';
 import { DataLinksContextMenuApi } from '@grafana/ui/internal';
-import { config } from 'app/core/config';
 
 import { clearNameForSingleSeries } from '../bargauge/BarGaugePanel';
 

--- a/public/app/plugins/panel/geomap/components/DebugOverlay.tsx
+++ b/public/app/plugins/panel/geomap/components/DebugOverlay.tsx
@@ -8,7 +8,7 @@ import tinycolor from 'tinycolor2';
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans } from '@grafana/i18n';
-import { config } from 'app/core/config';
+import { config } from '@grafana/runtime';
 
 interface Props {
   map: Map;

--- a/public/app/plugins/panel/geomap/components/MarkersLegend.tsx
+++ b/public/app/plugins/panel/geomap/components/MarkersLegend.tsx
@@ -12,11 +12,11 @@ import {
   GrafanaTheme2,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { useStyles2, VizLegendItem } from '@grafana/ui';
 import { ColorScale } from 'app/core/components/ColorScale/ColorScale';
 import { SanitizedSVG } from 'app/core/components/SVG/SanitizedSVG';
 import { getThresholdItems } from 'app/core/components/TimelineChart/utils';
-import { config } from 'app/core/config';
 import { DimensionSupplier } from 'app/features/dimensions/types';
 
 import { StyleConfigState } from '../style/types';

--- a/public/app/plugins/panel/geomap/components/MeasureOverlay.tsx
+++ b/public/app/plugins/panel/geomap/components/MeasureOverlay.tsx
@@ -5,8 +5,8 @@ import { useMemo, useRef, useState } from 'react';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { Button, IconButton, RadioButtonGroup, Select } from '@grafana/ui';
-import { config } from 'app/core/config';
 
 import { MapMeasure, MapMeasureOptions, measures } from '../utils/measure';
 

--- a/public/app/plugins/panel/geomap/layers/registry.ts
+++ b/public/app/plugins/panel/geomap/layers/registry.ts
@@ -9,7 +9,8 @@ import {
   SelectableValue,
   PluginState,
 } from '@grafana/data';
-import { config, hasAlphaPanels } from 'app/core/config';
+import { config } from '@grafana/runtime';
+import { hasAlphaPanels } from 'app/core/config';
 
 import { basemapLayers } from './basemaps';
 import { carto } from './basemaps/carto';

--- a/public/app/plugins/panel/live/LiveChannelEditor.tsx
+++ b/public/app/plugins/panel/live/LiveChannelEditor.tsx
@@ -10,8 +10,8 @@ import {
   parseLiveChannelAddress,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { Select, Alert, Label, stylesFactory, Combobox } from '@grafana/ui';
-import { config } from 'app/core/config';
 import { discoveryResources, getAPIGroupDiscoveryList, GroupDiscoveryResource } from 'app/features/apiserver/discovery';
 import { getManagedChannelInfo } from 'app/features/live/info';
 

--- a/public/app/plugins/panel/radialbar/RadialBarPanel.tsx
+++ b/public/app/plugins/panel/radialbar/RadialBarPanel.tsx
@@ -7,10 +7,9 @@ import {
   getFieldDisplayValues,
   PanelProps,
 } from '@grafana/data';
-import { PanelDataErrorView } from '@grafana/runtime';
+import { config, PanelDataErrorView } from '@grafana/runtime';
 import { DataLinksContextMenu, Stack, VizRepeater, VizRepeaterRenderValueProps } from '@grafana/ui';
 import { DataLinksContextMenuApi, RadialGauge } from '@grafana/ui/internal';
-import { config } from 'app/core/config';
 
 import { Options } from './panelcfg.gen';
 

--- a/public/app/plugins/panel/table/suggestions.ts
+++ b/public/app/plugins/panel/table/suggestions.ts
@@ -1,5 +1,5 @@
 import { PanelDataSummary, VisualizationSuggestionScore, VisualizationSuggestionsSupplier } from '@grafana/data';
-import { config } from 'app/core/config';
+import { config } from '@grafana/runtime';
 import icnTablePanelSvg from 'app/plugins/panel/table/img/icn-table-panel.svg';
 
 import { Options, FieldConfig } from './panelcfg.gen';

--- a/public/app/plugins/panel/text/module.tsx
+++ b/public/app/plugins/panel/text/module.tsx
@@ -1,6 +1,6 @@
 import { PanelPlugin } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config } from 'app/core/config';
+import { config } from '@grafana/runtime';
 
 import { TextPanel } from './TextPanel';
 import { TextPanelEditor } from './TextPanelEditor';

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -10,7 +10,7 @@ import {
   useDataLinksContext,
   FieldType,
 } from '@grafana/data';
-import { PanelDataErrorView } from '@grafana/runtime';
+import { config, PanelDataErrorView } from '@grafana/runtime';
 import { TooltipDisplayMode, VizOrientation } from '@grafana/schema';
 import {
   EventBusPlugin,
@@ -21,7 +21,6 @@ import {
 } from '@grafana/ui';
 import { FILTER_OUT_OPERATOR, TimeRange2, TooltipHoverMode } from '@grafana/ui/internal';
 import { TimeSeries } from 'app/core/components/TimeSeries/TimeSeries';
-import { config } from 'app/core/config';
 
 import { TimeSeriesTooltip } from './TimeSeriesTooltip';
 import { Options } from './panelcfg.gen';


### PR DESCRIPTION

> [!NOTE]  
> There is an Enterprise PR here: https://github.com/grafana/grafana-enterprise/pull/10609


**What is this feature?**

This pull request primarily refactors the way the `config` object is imported throughout the codebase, standardizing its import source to `@grafana/runtime` instead of local or relative paths. 

**Why do we need this feature?**

Barrel files simplify and centralize imports making it easier to consume modules. However they also cause the following issues:

- Circular Dependencies - if two modules import from each other's barrel files, it can create a cycle that's hard to detect and debug.
- Tree Shaking Issues - barrel files can interfere with tree shaking
- Name Collisions - re-exporting many symbols from different modules come with the risk of name collisions creating confusing errors
- Hidden Dependencies - barrel files obscure where a symbol is originally defined
- Slower Compilation in Large Projects - using many barrel files can slow down TypeScript compilation and type-checking
- Unintentional Exports - makes it really easy to accidentally export internal or private modules

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates: #107611
**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
