### PR TITLE
Datagrid: Deprecate panel

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/visualizations/datagrid/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/datagrid/index.md
@@ -31,7 +31,7 @@ refs:
 # Datagrid
 
 {{< admonition type="caution" >}}
-Starting with 12.3, Datagrid is deprecated. It will be removed in 13.0.
+Starting with Grafana 12.4, Datagrid is deprecated. It will be removed in version 13.0.
 {{< /admonition >}}
 
 Datagrids offer you the ability to create, edit, and fine-tune data within Grafana. As such, this panel can act as a data source for other panels

--- a/docs/sources/visualizations/panels-visualizations/visualizations/datagrid/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/datagrid/index.md
@@ -30,7 +30,9 @@ refs:
 
 # Datagrid
 
-{{< docs/experimental product="The datagrid visualization" featureFlag="`enableDatagridEditing`" >}}
+{{< admonition type="caution" >}}
+Starting with 12.3, Datagrid is deprecated. It will be removed in 13.0.
+{{< /admonition >}}
 
 Datagrids offer you the ability to create, edit, and fine-tune data within Grafana. As such, this panel can act as a data source for other panels
 inside a dashboard.

--- a/public/app/plugins/panel/datagrid/plugin.json
+++ b/public/app/plugins/panel/datagrid/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Datagrid",
   "id": "datagrid",
-  "state": "beta",
+  "state": "deprecated",
 
   "info": {
     "author": {


### PR DESCRIPTION
# Deprecation notice

As of 12.4.0 the Datagrid panel is deprecated. It will be removed in 13.0.0