### PR TITLE
Suggestions: Fix legend options for preview

### DIFF
--- a/public/app/features/panel/suggestions/utils.ts
+++ b/public/app/features/panel/suggestions/utils.ts
@@ -5,7 +5,7 @@ import {
   VisualizationSuggestion,
   VisualizationSuggestionScore,
 } from '@grafana/data';
-import { ReduceDataOptions } from '@grafana/schema';
+import { LegendDisplayMode, ReduceDataOptions, VizLegendOptions } from '@grafana/schema';
 
 /**
  * @internal
@@ -62,3 +62,15 @@ export function defaultNumericVizOptions(
 export function hasData(data?: PanelData): boolean {
   return Boolean(data && data.series && data.series.length > 0 && data.series.some((frame) => frame.length > 0));
 }
+
+/**
+ * @internal
+ * Hidden legend config for previewing suggestion cards.
+ * This should only be used in previewModifier.
+ */
+export const SUGGESTIONS_LEGEND_OPTIONS: VizLegendOptions = {
+  calcs: [],
+  displayMode: LegendDisplayMode.Hidden,
+  placement: 'right',
+  showLegend: false,
+};

--- a/public/app/plugins/panel/piechart/suggestions.ts
+++ b/public/app/plugins/panel/piechart/suggestions.ts
@@ -7,8 +7,7 @@ import {
   VisualizationSuggestionsSupplier,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { LegendDisplayMode } from '@grafana/schema';
-import { defaultNumericVizOptions } from 'app/features/panel/suggestions/utils';
+import { defaultNumericVizOptions, SUGGESTIONS_LEGEND_OPTIONS } from 'app/features/panel/suggestions/utils';
 
 import { PieChartLabels, Options, PieChartType } from './panelcfg.gen';
 
@@ -16,12 +15,13 @@ const withDefaults = (suggestion: VisualizationSuggestion<Options>): Visualizati
   defaultsDeep(suggestion, {
     options: {
       displayLabels: [PieChartLabels.Percent],
-      legend: {
-        calcs: [],
-        displayMode: LegendDisplayMode.Hidden,
-        placement: 'right',
-        values: [],
-        showLegend: false,
+    },
+    cardOptions: {
+      previewModifier: (s) => {
+        s.options!.legend = {
+          ...SUGGESTIONS_LEGEND_OPTIONS,
+          values: [],
+        };
       },
     },
   } satisfies VisualizationSuggestion<Options>);

--- a/public/app/plugins/panel/timeseries/suggestions.ts
+++ b/public/app/plugins/panel/timeseries/suggestions.ts
@@ -10,15 +10,9 @@ import {
   VisualizationSuggestionsSupplier,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import {
-  GraphDrawStyle,
-  GraphFieldConfig,
-  GraphGradientMode,
-  LegendDisplayMode,
-  LineInterpolation,
-  StackingMode,
-} from '@grafana/schema';
+import { GraphDrawStyle, GraphFieldConfig, GraphGradientMode, LineInterpolation, StackingMode } from '@grafana/schema';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
+import { SUGGESTIONS_LEGEND_OPTIONS } from 'app/features/panel/suggestions/utils';
 
 import { Options } from './panelcfg.gen';
 
@@ -29,14 +23,6 @@ const withDefaults = (
   suggestion: VisualizationSuggestion<Options, GraphFieldConfig>
 ): VisualizationSuggestion<Options, GraphFieldConfig> =>
   defaultsDeep(suggestion, {
-    options: {
-      legend: {
-        calcs: [],
-        displayMode: LegendDisplayMode.Hidden,
-        placement: 'right',
-        showLegend: false,
-      },
-    },
     fieldConfig: {
       defaults: {
         custom: {},
@@ -46,6 +32,7 @@ const withDefaults = (
     cardOptions: {
       previewModifier: (s) => {
         s.options!.disableKeyboardEvents = true;
+        s.options!.legend = SUGGESTIONS_LEGEND_OPTIONS;
         if (s.fieldConfig?.defaults.custom?.drawStyle !== GraphDrawStyle.Bars) {
           s.fieldConfig!.defaults.custom!.lineWidth = Math.max(s.fieldConfig!.defaults.custom!.lineWidth ?? 1, 2);
         }

--- a/public/app/plugins/panel/trend/module.tsx
+++ b/public/app/plugins/panel/trend/module.tsx
@@ -1,8 +1,9 @@
 import { Field, FieldType, PanelPlugin, VisualizationSuggestionScore } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { GraphDrawStyle } from '@grafana/schema';
-import { commonOptionsBuilder, LegendDisplayMode } from '@grafana/ui';
+import { commonOptionsBuilder } from '@grafana/ui';
 import { optsWithHideZeros } from '@grafana/ui/internal';
+import { SUGGESTIONS_LEGEND_OPTIONS } from 'app/features/panel/suggestions/utils';
 
 import { defaultGraphConfig, getGraphFieldConfig } from '../timeseries/config';
 
@@ -49,14 +50,6 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TrendPanel)
     return [
       {
         score: VisualizationSuggestionScore.Good,
-        options: {
-          legend: {
-            calcs: [],
-            displayMode: LegendDisplayMode.Hidden,
-            placement: 'right',
-            showLegend: false,
-          },
-        },
         fieldConfig: {
           defaults: {
             custom: {},
@@ -65,6 +58,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TrendPanel)
         },
         cardOptions: {
           previewModifier: (s) => {
+            s.options!.legend = SUGGESTIONS_LEGEND_OPTIONS;
             if (s.fieldConfig?.defaults.custom?.drawStyle !== GraphDrawStyle.Bars) {
               s.fieldConfig!.defaults.custom!.lineWidth = Math.max(s.fieldConfig!.defaults.custom!.lineWidth ?? 1, 2);
             }


### PR DESCRIPTION
When `newVizSuggestions` is enabled, panels created from suggestions had `displayMode: 'hidden'` applied to actual panel options. Enabling the legend would set `showLegend: true` but leave `displayMode: 'hidden'`, causing VizLegend to return null and breaking the viz.


Before

https://github.com/user-attachments/assets/39dffd4d-b2a6-4256-9960-7a2316b5d875


After

https://github.com/user-attachments/assets/b08d5d67-f977-49e3-ad16-64cb78eff9bc


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
