### PR TITLE
Provisioning: Block connection deletion when repositories reference it

### DIFF
--- a/apps/provisioning/pkg/connection/finalizers.go
+++ b/apps/provisioning/pkg/connection/finalizers.go
@@ -1,0 +1,4 @@
+package connection
+
+// BlockDeletionFinalizer prevents deletion of connections while repositories reference them
+const BlockDeletionFinalizer = "block-deletion-while-repositories-exist"

--- a/pkg/registry/apis/provisioning/controller/connection_test.go
+++ b/pkg/registry/apis/provisioning/controller/connection_test.go
@@ -1,13 +1,25 @@
 package controller
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	connectionvalidation "github.com/grafana/grafana/apps/provisioning/pkg/connection"
+	applyconfiguration "github.com/grafana/grafana/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1"
+	client "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
 )
 
 func TestConnectionController_shouldCheckHealth(t *testing.T) {
@@ -284,4 +296,328 @@ func TestConnectionController_processNextWorkItem(t *testing.T) {
 		// This test verifies the structure is correct
 		assert.NotNil(t, cc)
 	})
+}
+
+// mockRepositoryLister is a mock implementation of RepositoryLister for testing
+type mockRepositoryLister struct {
+	mock.Mock
+}
+
+func (m *mockRepositoryLister) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
+	args := m.Called(ctx, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(runtime.Object), args.Error(1)
+}
+
+// mockConnectionInterface is a mock implementation of client.ConnectionInterface for testing
+type mockConnectionInterface struct {
+	mock.Mock
+}
+
+func (m *mockConnectionInterface) Create(ctx context.Context, connection *provisioning.Connection, opts metav1.CreateOptions) (*provisioning.Connection, error) {
+	args := m.Called(ctx, connection, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*provisioning.Connection), args.Error(1)
+}
+
+func (m *mockConnectionInterface) Update(ctx context.Context, connection *provisioning.Connection, opts metav1.UpdateOptions) (*provisioning.Connection, error) {
+	args := m.Called(ctx, connection, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*provisioning.Connection), args.Error(1)
+}
+
+func (m *mockConnectionInterface) UpdateStatus(ctx context.Context, connection *provisioning.Connection, opts metav1.UpdateOptions) (*provisioning.Connection, error) {
+	args := m.Called(ctx, connection, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*provisioning.Connection), args.Error(1)
+}
+
+func (m *mockConnectionInterface) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	args := m.Called(ctx, name, opts)
+	return args.Error(0)
+}
+
+func (m *mockConnectionInterface) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+	args := m.Called(ctx, opts, listOpts)
+	return args.Error(0)
+}
+
+func (m *mockConnectionInterface) Get(ctx context.Context, name string, opts metav1.GetOptions) (*provisioning.Connection, error) {
+	args := m.Called(ctx, name, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*provisioning.Connection), args.Error(1)
+}
+
+func (m *mockConnectionInterface) List(ctx context.Context, opts metav1.ListOptions) (*provisioning.ConnectionList, error) {
+	args := m.Called(ctx, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*provisioning.ConnectionList), args.Error(1)
+}
+
+func (m *mockConnectionInterface) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	args := m.Called(ctx, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(watch.Interface), args.Error(1)
+}
+
+func (m *mockConnectionInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*provisioning.Connection, error) {
+	args := m.Called(ctx, name, pt, data, opts, subresources)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*provisioning.Connection), args.Error(1)
+}
+
+func (m *mockConnectionInterface) Apply(ctx context.Context, connection *applyconfiguration.ConnectionApplyConfiguration, opts metav1.ApplyOptions) (*provisioning.Connection, error) {
+	args := m.Called(ctx, connection, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*provisioning.Connection), args.Error(1)
+}
+
+func (m *mockConnectionInterface) ApplyStatus(ctx context.Context, connection *applyconfiguration.ConnectionApplyConfiguration, opts metav1.ApplyOptions) (*provisioning.Connection, error) {
+	args := m.Called(ctx, connection, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*provisioning.Connection), args.Error(1)
+}
+
+// mockProvisioningV0alpha1InterfaceForConnections is a mock implementation of client.ProvisioningV0alpha1Interface for connection tests
+type mockProvisioningV0alpha1InterfaceForConnections struct {
+	mock.Mock
+	connections *mockConnectionInterface
+}
+
+func (m *mockProvisioningV0alpha1InterfaceForConnections) RESTClient() rest.Interface {
+	panic("not needed for testing")
+}
+
+func (m *mockProvisioningV0alpha1InterfaceForConnections) HistoricJobs(namespace string) client.HistoricJobInterface {
+	panic("not needed for testing")
+}
+
+func (m *mockProvisioningV0alpha1InterfaceForConnections) Jobs(namespace string) client.JobInterface {
+	panic("not needed for testing")
+}
+
+func (m *mockProvisioningV0alpha1InterfaceForConnections) Connections(namespace string) client.ConnectionInterface {
+	return m.connections
+}
+
+func (m *mockProvisioningV0alpha1InterfaceForConnections) Repositories(namespace string) client.RepositoryInterface {
+	panic("not needed for testing")
+}
+
+func TestConnectionController_handleDelete(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name                   string
+		connection             *provisioning.Connection
+		repoListerSetup        func(*mockRepositoryLister)
+		connectionSetup        func(*mockConnectionInterface)
+		expectedError          string
+		expectFinalizerRemoved bool
+	}{
+		{
+			name: "no finalizer present, should return nil",
+			connection: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-conn",
+					Namespace:         "default",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{},
+				},
+			},
+			repoListerSetup:        func(m *mockRepositoryLister) {},
+			connectionSetup:        func(m *mockConnectionInterface) {},
+			expectedError:          "",
+			expectFinalizerRemoved: false,
+		},
+		{
+			name: "finalizer present but repositories exist, should block deletion",
+			connection: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-conn",
+					Namespace:         "default",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{connectionvalidation.BlockDeletionFinalizer},
+				},
+			},
+			repoListerSetup: func(m *mockRepositoryLister) {
+				m.On("List", ctx, mock.MatchedBy(func(opts *internalversion.ListOptions) bool {
+					return opts.FieldSelector != nil && opts.FieldSelector.String() == "spec.connection.name=test-conn"
+				})).Return(&provisioning.RepositoryList{
+					Items: []provisioning.Repository{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "repo-1"},
+							Spec: provisioning.RepositorySpec{
+								Connection: &provisioning.ConnectionInfo{Name: "test-conn"},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "repo-2"},
+							Spec: provisioning.RepositorySpec{
+								Connection: &provisioning.ConnectionInfo{Name: "test-conn"},
+							},
+						},
+					},
+				}, nil)
+			},
+			connectionSetup:        func(m *mockConnectionInterface) {},
+			expectedError:          "cannot delete connection while repositories are using it: repo-1, repo-2",
+			expectFinalizerRemoved: false,
+		},
+		{
+			name: "finalizer present and no repositories, should remove finalizer",
+			connection: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-conn",
+					Namespace:         "default",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{connectionvalidation.BlockDeletionFinalizer},
+				},
+			},
+			repoListerSetup: func(m *mockRepositoryLister) {
+				m.On("List", ctx, mock.MatchedBy(func(opts *internalversion.ListOptions) bool {
+					return opts.FieldSelector != nil && opts.FieldSelector.String() == "spec.connection.name=test-conn"
+				})).Return(&provisioning.RepositoryList{
+					Items: []provisioning.Repository{},
+				}, nil)
+			},
+			connectionSetup: func(m *mockConnectionInterface) {
+				m.On("Patch", ctx, "test-conn", types.JSONPatchType, mock.Anything, metav1.PatchOptions{
+					FieldManager: "provisioning-connection-controller",
+				}, mock.Anything).Return(&provisioning.Connection{}, nil)
+			},
+			expectedError:          "",
+			expectFinalizerRemoved: true,
+		},
+		{
+			name: "error checking repositories, should return error",
+			connection: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-conn",
+					Namespace:         "default",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{connectionvalidation.BlockDeletionFinalizer},
+				},
+			},
+			repoListerSetup: func(m *mockRepositoryLister) {
+				m.On("List", ctx, mock.Anything).Return(nil, errors.New("list error"))
+			},
+			connectionSetup:        func(m *mockConnectionInterface) {},
+			expectedError:          "check for connected repositories: list error",
+			expectFinalizerRemoved: false,
+		},
+		{
+			name: "error removing finalizer, should return error",
+			connection: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-conn",
+					Namespace:         "default",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{connectionvalidation.BlockDeletionFinalizer},
+				},
+			},
+			repoListerSetup: func(m *mockRepositoryLister) {
+				m.On("List", ctx, mock.Anything).Return(&provisioning.RepositoryList{
+					Items: []provisioning.Repository{},
+				}, nil)
+			},
+			connectionSetup: func(m *mockConnectionInterface) {
+				m.On("Patch", ctx, "test-conn", types.JSONPatchType, mock.Anything, metav1.PatchOptions{
+					FieldManager: "provisioning-connection-controller",
+				}, mock.Anything).Return(nil, errors.New("patch error"))
+			},
+			expectedError:          "remove finalizer: patch error",
+			expectFinalizerRemoved: false,
+		},
+		{
+			name: "pagination handled correctly",
+			connection: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-conn",
+					Namespace:         "default",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{connectionvalidation.BlockDeletionFinalizer},
+				},
+			},
+			repoListerSetup: func(m *mockRepositoryLister) {
+				// First call returns empty with continue token (testing pagination even when empty)
+				m.On("List", ctx, mock.MatchedBy(func(opts *internalversion.ListOptions) bool {
+					return opts.Continue == ""
+				})).Return(&provisioning.RepositoryList{
+					Items:    []provisioning.Repository{},
+					ListMeta: metav1.ListMeta{Continue: "continue-token"},
+				}, nil)
+				// Second call returns empty with no continue token
+				m.On("List", ctx, mock.MatchedBy(func(opts *internalversion.ListOptions) bool {
+					return opts.Continue == "continue-token"
+				})).Return(&provisioning.RepositoryList{
+					Items: []provisioning.Repository{},
+				}, nil)
+			},
+			connectionSetup: func(m *mockConnectionInterface) {
+				m.On("Patch", ctx, "test-conn", types.JSONPatchType, mock.Anything, metav1.PatchOptions{
+					FieldManager: "provisioning-connection-controller",
+				}, mock.Anything).Return(&provisioning.Connection{}, nil)
+			},
+			expectedError:          "",
+			expectFinalizerRemoved: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoLister := new(mockRepositoryLister)
+			connInterface := new(mockConnectionInterface)
+			client := &mockProvisioningV0alpha1InterfaceForConnections{connections: connInterface}
+
+			tt.repoListerSetup(repoLister)
+			tt.connectionSetup(connInterface)
+
+			cc := &ConnectionController{
+				client:     client,
+				repoLister: repoLister,
+				logger:     nil, // logger is optional for testing
+			}
+
+			err := cc.handleDelete(ctx, tt.connection)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tt.expectFinalizerRemoved {
+				connInterface.AssertCalled(t, "Patch", ctx, "test-conn", types.JSONPatchType, mock.Anything, metav1.PatchOptions{
+					FieldManager: "provisioning-connection-controller",
+				}, mock.Anything)
+			} else {
+				connInterface.AssertNotCalled(t, "Patch", ctx, "test-conn", types.JSONPatchType, mock.Anything, metav1.PatchOptions{}, mock.Anything)
+			}
+
+			repoLister.AssertExpectations(t)
+			connInterface.AssertExpectations(t)
+		})
+	}
 }

--- a/pkg/registry/apis/provisioning/repository_fields.go
+++ b/pkg/registry/apis/provisioning/repository_fields.go
@@ -1,0 +1,44 @@
+package provisioning
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/generic"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+// RepositoryToSelectableFields returns a field set that can be used for field selectors.
+// This includes standard metadata fields plus custom fields like spec.connection.name.
+func RepositoryToSelectableFields(obj *provisioning.Repository) fields.Set {
+	objectMetaFields := generic.ObjectMetaFieldsSet(&obj.ObjectMeta, true)
+
+	// Add custom selectable fields
+	specificFields := fields.Set{
+		"spec.connection.name": getConnectionName(obj),
+	}
+
+	return generic.MergeFieldsSets(objectMetaFields, specificFields)
+}
+
+// getConnectionName safely extracts the connection name from a Repository.
+// Returns empty string if no connection is configured.
+func getConnectionName(obj *provisioning.Repository) string {
+	if obj == nil || obj.Spec.Connection == nil {
+		return ""
+	}
+	return obj.Spec.Connection.Name
+}
+
+// RepositoryGetAttrs returns labels and fields of a Repository object.
+// This is used by the storage layer for filtering.
+func RepositoryGetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
+	repo, ok := obj.(*provisioning.Repository)
+	if !ok {
+		return nil, nil, fmt.Errorf("given object is not a Repository")
+	}
+	return labels.Set(repo.Labels), RepositoryToSelectableFields(repo), nil
+}

--- a/pkg/registry/apis/provisioning/repository_fields_test.go
+++ b/pkg/registry/apis/provisioning/repository_fields_test.go
@@ -1,0 +1,184 @@
+package provisioning
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+func TestGetConnectionName(t *testing.T) {
+	tests := []struct {
+		name     string
+		repo     *provisioning.Repository
+		expected string
+	}{
+		{
+			name:     "nil repository returns empty string",
+			repo:     nil,
+			expected: "",
+		},
+		{
+			name: "repository without connection returns empty string",
+			repo: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Title: "test-repo",
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "repository with connection returns connection name",
+			repo: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Title: "test-repo",
+					Connection: &provisioning.ConnectionInfo{
+						Name: "my-connection",
+					},
+				},
+			},
+			expected: "my-connection",
+		},
+		{
+			name: "repository with empty connection name returns empty string",
+			repo: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Title: "test-repo",
+					Connection: &provisioning.ConnectionInfo{
+						Name: "",
+					},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getConnectionName(tt.repo)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRepositoryToSelectableFields(t *testing.T) {
+	tests := []struct {
+		name           string
+		repo           *provisioning.Repository
+		expectedFields map[string]string
+	}{
+		{
+			name: "includes metadata.name and metadata.namespace",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Title: "Test Repository",
+				},
+			},
+			expectedFields: map[string]string{
+				"metadata.name":        "test-repo",
+				"metadata.namespace":   "default",
+				"spec.connection.name": "",
+			},
+		},
+		{
+			name: "includes spec.connection.name when set",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "repo-with-connection",
+					Namespace: "org-1",
+				},
+				Spec: provisioning.RepositorySpec{
+					Title: "Repo With Connection",
+					Connection: &provisioning.ConnectionInfo{
+						Name: "github-connection",
+					},
+				},
+			},
+			expectedFields: map[string]string{
+				"metadata.name":        "repo-with-connection",
+				"metadata.namespace":   "org-1",
+				"spec.connection.name": "github-connection",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields := RepositoryToSelectableFields(tt.repo)
+
+			for key, expectedValue := range tt.expectedFields {
+				actualValue, exists := fields[key]
+				assert.True(t, exists, "field %s should exist", key)
+				assert.Equal(t, expectedValue, actualValue, "field %s should have correct value", key)
+			}
+		})
+	}
+}
+
+func TestRepositoryGetAttrs(t *testing.T) {
+	t.Run("returns error for non-Repository object", func(t *testing.T) {
+		// Pass a different runtime.Object type instead of a Repository
+		connection := &provisioning.Connection{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "not-a-repository",
+			},
+		}
+		_, _, err := RepositoryGetAttrs(connection)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a Repository")
+	})
+
+	t.Run("returns labels and fields for valid Repository", func(t *testing.T) {
+		repo := &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-repo",
+				Namespace: "default",
+				Labels: map[string]string{
+					"app": "grafana",
+					"env": "test",
+				},
+			},
+			Spec: provisioning.RepositorySpec{
+				Title: "Test Repository",
+				Connection: &provisioning.ConnectionInfo{
+					Name: "my-connection",
+				},
+			},
+		}
+
+		labels, fields, err := RepositoryGetAttrs(repo)
+		require.NoError(t, err)
+
+		// Check labels
+		assert.Equal(t, "grafana", labels["app"])
+		assert.Equal(t, "test", labels["env"])
+
+		// Check fields
+		assert.Equal(t, "test-repo", fields["metadata.name"])
+		assert.Equal(t, "default", fields["metadata.namespace"])
+		assert.Equal(t, "my-connection", fields["spec.connection.name"])
+	})
+
+	t.Run("returns empty connection name when not set", func(t *testing.T) {
+		repo := &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-repo",
+				Namespace: "default",
+			},
+			Spec: provisioning.RepositorySpec{
+				Title: "Test Repository",
+			},
+		}
+
+		_, fields, err := RepositoryGetAttrs(repo)
+		require.NoError(t, err)
+		assert.Equal(t, "", fields["spec.connection.name"])
+	})
+}

--- a/pkg/registry/apis/provisioning/validation_test.go
+++ b/pkg/registry/apis/provisioning/validation_test.go
@@ -1,0 +1,200 @@
+package provisioning
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+// mockRepositoryLister is a mock implementation of RepositoryLister for testing
+type mockRepositoryLister struct {
+	repositories []provisioning.Repository
+	listErr      error
+	// Track the field selector used in List calls
+	lastFieldSelector fields.Selector
+}
+
+func (m *mockRepositoryLister) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+
+	// Store the field selector for verification
+	m.lastFieldSelector = options.FieldSelector
+
+	// Filter repositories based on field selector if present
+	filteredRepos := m.repositories
+	if options.FieldSelector != nil && !options.FieldSelector.Empty() {
+		filteredRepos = make([]provisioning.Repository, 0)
+		for _, repo := range m.repositories {
+			// Simulate field selector matching for spec.connection.name
+			repoFields := fields.Set{
+				"spec.connection.name": getRepoConnectionName(&repo),
+			}
+			if options.FieldSelector.Matches(repoFields) {
+				filteredRepos = append(filteredRepos, repo)
+			}
+		}
+	}
+
+	return &provisioning.RepositoryList{
+		Items: filteredRepos,
+	}, nil
+}
+
+func getRepoConnectionName(repo *provisioning.Repository) string {
+	if repo.Spec.Connection == nil {
+		return ""
+	}
+	return repo.Spec.Connection.Name
+}
+
+func TestGetRepositoriesByConnection(t *testing.T) {
+	tests := []struct {
+		name           string
+		repositories   []provisioning.Repository
+		connectionName string
+		expectedCount  int
+		expectedNames  []string
+		expectedErr    bool
+	}{
+		{
+			name:           "empty repository list returns empty",
+			repositories:   []provisioning.Repository{},
+			connectionName: "test-conn",
+			expectedCount:  0,
+			expectedNames:  []string{},
+		},
+		{
+			name: "finds single matching repository",
+			repositories: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "repo-1"},
+					Spec: provisioning.RepositorySpec{
+						Connection: &provisioning.ConnectionInfo{Name: "conn-a"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "repo-2"},
+					Spec: provisioning.RepositorySpec{
+						Connection: &provisioning.ConnectionInfo{Name: "conn-b"},
+					},
+				},
+			},
+			connectionName: "conn-a",
+			expectedCount:  1,
+			expectedNames:  []string{"repo-1"},
+		},
+		{
+			name: "finds multiple matching repositories",
+			repositories: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "repo-1"},
+					Spec: provisioning.RepositorySpec{
+						Connection: &provisioning.ConnectionInfo{Name: "shared-conn"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "repo-2"},
+					Spec: provisioning.RepositorySpec{
+						Connection: &provisioning.ConnectionInfo{Name: "shared-conn"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "repo-3"},
+					Spec: provisioning.RepositorySpec{
+						Connection: &provisioning.ConnectionInfo{Name: "different-conn"},
+					},
+				},
+			},
+			connectionName: "shared-conn",
+			expectedCount:  2,
+			expectedNames:  []string{"repo-1", "repo-2"},
+		},
+		{
+			name: "no matches returns empty list",
+			repositories: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "repo-1"},
+					Spec: provisioning.RepositorySpec{
+						Connection: &provisioning.ConnectionInfo{Name: "conn-a"},
+					},
+				},
+			},
+			connectionName: "non-existent",
+			expectedCount:  0,
+			expectedNames:  []string{},
+		},
+		{
+			name: "empty connection name matches repos without connection",
+			repositories: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "repo-with-conn"},
+					Spec: provisioning.RepositorySpec{
+						Connection: &provisioning.ConnectionInfo{Name: "some-conn"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "repo-without-conn"},
+					Spec: provisioning.RepositorySpec{
+						Connection: nil,
+					},
+				},
+			},
+			connectionName: "",
+			expectedCount:  1,
+			expectedNames:  []string{"repo-without-conn"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockRepositoryLister{repositories: tt.repositories}
+			ctx := context.Background()
+
+			repos, err := GetRepositoriesByConnection(ctx, mock, tt.connectionName)
+
+			if tt.expectedErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, repos, tt.expectedCount)
+
+			// Verify the field selector was used
+			require.NotNil(t, mock.lastFieldSelector, "field selector should have been set")
+			expectedSelector := fields.OneTermEqualSelector("spec.connection.name", tt.connectionName)
+			assert.Equal(t, expectedSelector.String(), mock.lastFieldSelector.String())
+
+			// Verify the correct repositories were returned
+			actualNames := make([]string, len(repos))
+			for i, repo := range repos {
+				actualNames[i] = repo.Name
+			}
+			for _, expectedName := range tt.expectedNames {
+				assert.Contains(t, actualNames, expectedName)
+			}
+		})
+	}
+}
+
+func TestGetRepositoriesByConnection_ListError(t *testing.T) {
+	mock := &mockRepositoryLister{
+		listErr: assert.AnError,
+	}
+	ctx := context.Background()
+
+	repos, err := GetRepositoriesByConnection(ctx, mock, "any-conn")
+
+	require.Error(t, err)
+	assert.Nil(t, repos)
+}


### PR DESCRIPTION
## What is this pull request about?

This PR prevents deletion of Connections when any Repository references them via `spec.connection.name`. This uses the field selector feature to efficiently query repositories and adds a finalizer-based approach to prevent race conditions.

**Closes:** https://github.com/grafana/git-ui-sync-project/issues/730

## Changes

### Modified files
- `pkg/registry/apis/provisioning/validation.go` - Add `GetRepositoriesByConnection` function
- `pkg/registry/apis/provisioning/register.go` - Add `validateDelete` method and finalizer handling
- `pkg/registry/apis/provisioning/controller/connection.go` - Add deletion handling with finalizer support
- `pkg/tests/apis/provisioning/connection_test.go` - Add integration tests

### New files
- `apps/provisioning/pkg/connection/finalizers.go` - Finalizer constant for connections
- `pkg/registry/apis/provisioning/validation_test.go` - Unit tests for GetRepositoriesByConnection
- `pkg/registry/apis/provisioning/controller/connection_test.go` - Unit tests for finalizer handling

## How does it work?

The implementation uses a two-layer approach:

1. **Admission Webhook** (`validateDelete`): Provides immediate feedback when deletion is attempted
2. **Finalizer + Controller**: Handles race conditions and ensures proper cleanup

When a Connection deletion is attempted:
1. The admission webhook checks for repositories using the `spec.connection.name` field selector
2. If allowed, `DeletionTimestamp` is set and the connection enters deletion state
3. The controller processes the deletion:
   - Checks for repositories using field selector (handles pagination)
   - If repositories exist: keeps finalizer (prevents actual deletion)
   - If no repositories: removes finalizer (allows deletion to complete)

This prevents race conditions where a repository might be created while a connection deletion is in progress.

## Testing

```bash
# Unit tests
go test -v -run 'TestGetRepositoriesByConnection' ./pkg/registry/apis/provisioning/...
go test -v -run 'TestConnectionController_handleDelete' ./pkg/registry/apis/provisioning/controller/...

# Integration tests
go test -v -run 'TestIntegrationProvisioning_ConnectionDeletionBlocking' ./pkg/tests/apis/provisioning/...
```

## Example error message

```
connections.provisioning.grafana.app "my-connection" is forbidden: cannot delete connection while repositories are using it: repo-1, repo-2
```

## Related PRs

This PR includes the field selector feature from the previous work, which enables efficient querying of repositories by connection name.