### PR TITLE
PieChart: Fix right-oriented legends

### DIFF
--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-piechart/panel_test_piechart.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-piechart/panel_test_piechart.v42.json
@@ -290,7 +290,7 @@
         ],
         "legend": {
           "displayMode": "table",
-          "placement": "bottom",
+          "placement": "right",
           "showLegend": true,
           "values": [
             "percent"
@@ -304,7 +304,7 @@
           "fields": "",
           "values": false
         },
-        "showLegend": false,
+        "showLegend": true,
         "strokeWidth": 1,
         "text": {}
       },
@@ -323,6 +323,15 @@
         }
       ],
       "title": "Percent",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "^Backend-(.*)$",
+            "renamePattern": "b-$1"
+          }
+        }
+      ],
       "type": "piechart"
     },
     {
@@ -366,7 +375,7 @@
         ],
         "legend": {
           "displayMode": "table",
-          "placement": "bottom",
+          "placement": "right",
           "showLegend": true,
           "values": [
             "value"
@@ -380,7 +389,7 @@
           "fields": "",
           "values": false
         },
-        "showLegend": false,
+        "showLegend": true,
         "strokeWidth": 1,
         "text": {}
       },
@@ -399,6 +408,15 @@
         }
       ],
       "title": "Value",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "(.*)",
+            "renamePattern": "$1-how-much-wood-could-a-woodchuck-chuck-if-a-woodchuck-could-chuck-wood"
+          }
+        }
+      ],
       "type": "piechart"
     },
     {

--- a/devenv/dev-dashboards/panel-piechart/panel_test_piechart.json
+++ b/devenv/dev-dashboards/panel-piechart/panel_test_piechart.json
@@ -248,7 +248,7 @@
         "legend": {
           "values": ["percent"],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "right"
         },
         "pieType": "pie",
         "reduceOptions": {
@@ -256,7 +256,7 @@
           "fields": "",
           "values": false
         },
-        "showLegend": false,
+        "showLegend": true,
         "strokeWidth": 1,
         "text": {}
       },
@@ -272,6 +272,15 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "Percent",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "^Backend-(.*)$",
+            "renamePattern": "b-$1"
+          }
+        }
+      ],
       "type": "piechart"
     },
     {
@@ -311,7 +320,7 @@
         "legend": {
           "values": ["value"],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "right"
         },
         "pieType": "pie",
         "reduceOptions": {
@@ -319,7 +328,7 @@
           "fields": "",
           "values": false
         },
-        "showLegend": false,
+        "showLegend": true,
         "strokeWidth": 1,
         "text": {}
       },
@@ -335,6 +344,15 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "Value",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "(.*)",
+            "renamePattern": "$1-how-much-wood-could-a-woodchuck-chuck-if-a-woodchuck-could-chuck-wood"
+          }
+        }
+      ],
       "type": "piechart"
     },
     {

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
@@ -119,6 +119,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   table: css({
     width: '100%',
     'th:first-child': {
+      width: '100%',
       borderBottom: `1px solid ${theme.colors.border.weak}`,
     },
   }),

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.tsx
@@ -134,6 +134,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       label: 'LegendLabelCell',
       maxWidth: 0,
       width: '100%',
+      minWidth: theme.spacing(16),
     }),
     labelCellInner: css({
       label: 'LegendLabelCellInner',


### PR DESCRIPTION
**What is this feature?**

Tweaks minimum widths so that right-oriented legends in table mode don't get squished in Piechart etc.

### ❌ Before ...

<img width="1267" height="497" alt="Screenshot 2026-01-09 at 14 01 37" src="https://github.com/user-attachments/assets/5395f69a-ee6b-4d70-b1e6-a0a94d9e09eb" />

<img width="497" height="350" alt="Screenshot 2026-01-09 at 14 21 18" src="https://github.com/user-attachments/assets/9cb1b0f2-e3b0-4d81-be61-e036a17d9efa" />


### ✅ After!

https://github.com/user-attachments/assets/b979726a-3baf-4a90-ae1f-6c95b02aec3b

<img width="506" height="361" alt="Screenshot 2026-01-09 at 14 22 04" src="https://github.com/user-attachments/assets/d3b07451-81fa-467b-8256-9119b33fa402" />

### ♻️  Regression check

Here's the panel we used to verify the original fix that caused this regression, also looks fine.

<img width="1497" height="801" alt="Screenshot 2026-01-09 at 14 09 00" src="https://github.com/user-attachments/assets/f40bd86a-5949-4a80-8432-eec22c5065c9" />




**Why do we need this feature?**

Fixes a CSS layout bug that was introduced by https://github.com/grafana/grafana/pull/115647.

**Who is this feature for?**

All users of Grafana who have a right-oriented, table view, legend on a Piechart panel in Grafana v12.4

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/83015 https://github.com/grafana/grafana/issues/115277

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- `N/A` ~If this is a pre-GA feature, it is behind a feature toggle.~
- `N/A` ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
