### PR TITLE
MetricsDrilldown: Remove `exploreMetricsRelatedLogs` feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -703,10 +703,6 @@ export interface FeatureToggles {
   */
   passwordlessMagicLinkAuthentication?: boolean;
   /**
-  * Display Related Logs in Grafana Metrics Drilldown
-  */
-  exploreMetricsRelatedLogs?: boolean;
-  /**
   * Adds support for quotes and special characters in label values for Prometheus queries
   */
   prometheusSpecialCharsInLabelValues?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1163,14 +1163,6 @@ var (
 			HideFromDocs: true,
 		},
 		{
-			Name:         "exploreMetricsRelatedLogs",
-			Description:  "Display Related Logs in Grafana Metrics Drilldown",
-			Stage:        FeatureStageExperimental,
-			Owner:        grafanaObservabilityMetricsSquad,
-			FrontendOnly: true,
-			HideFromDocs: false,
-		},
-		{
 			Name:         "prometheusSpecialCharsInLabelValues",
 			Description:  "Adds support for quotes and special characters in label values for Prometheus queries",
 			FrontendOnly: true,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -161,7 +161,6 @@ newTimeRangeZoomShortcuts,experimental,@grafana/dataviz-squad,false,false,true
 azureMonitorDisableLogLimit,GA,@grafana/partner-datasources,false,false,false
 playlistsReconciler,experimental,@grafana/grafana-app-platform-squad,false,true,false
 passwordlessMagicLinkAuthentication,experimental,@grafana/identity-access-team,false,false,false
-exploreMetricsRelatedLogs,experimental,@grafana/observability-metrics,false,false,true
 prometheusSpecialCharsInLabelValues,experimental,@grafana/oss-big-tent,false,false,true
 enableExtensionsAdminPage,experimental,@grafana/plugins-platform-backend,false,true,false
 enableSCIM,preview,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1408,7 +1408,8 @@
       "metadata": {
         "name": "exploreMetricsRelatedLogs",
         "resourceVersion": "1764664939750",
-        "creationTimestamp": "2024-11-05T16:28:43Z"
+        "creationTimestamp": "2024-11-05T16:28:43Z",
+        "deletionTimestamp": "2026-01-09T22:14:53Z"
       },
       "spec": {
         "description": "Display Related Logs in Grafana Metrics Drilldown",


### PR DESCRIPTION
## Motivation

This PR fixes https://github.com/grafana/metrics-drilldown/issues/913.

## What does this PR do?

Removes the `exploreMetricsRelatedLogs` feature toggle, which is no longer used in `grafana/grafana` or by the [Grafana Metrics Drilldown app](https://github.com/grafana/metrics-drilldown).

Steps taken:
1. Removed the feature toggle from `registry.go`
2. Ran `make gen-feature-toggles`