### PR TITLE
UI: Use react-table column header types in InteractiveTable with story and tests

### DIFF
--- a/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.mdx
+++ b/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.mdx
@@ -128,7 +128,15 @@ const columns: Array<Column<TableData>> = [
   // React element header
   {
     id: 'checkbox',
-    header: <Checkbox />,
+    header: (
+      <>
+        <label htmlFor="select-all" className="sr-only">
+          Select all rows
+        </label>
+        <Checkbox id="select-all" />
+      </>
+    ),
+    cell: () => <Checkbox aria-label="Select row" />,
   },
 
   // Function renderer header

--- a/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.mdx
+++ b/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.mdx
@@ -117,6 +117,36 @@ export const MyComponent = () => {
 };
 ```
 
+### Custom Header Rendering
+
+Column headers can be customized using strings, React elements, or renderer functions. The `header` property accepts any value that matches React Table's `Renderer` type.
+
+**Important:** When using custom header content, prefer inline elements (like `<span>`) over block elements (like `<div>`) to avoid layout issues. Block-level elements can cause extra spacing and alignment problems in table headers because they disrupt the table's inline flow. Use `display: inline-flex` or `display: inline-block` when you need flexbox or block-like behavior.
+
+```tsx
+const columns: Array<Column<TableData>> = [
+  // React element header
+  {
+    id: 'checkbox',
+    header: <Checkbox />,
+  },
+
+  // Function renderer header
+  {
+    id: 'firstName',
+    header: () => (
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
+        <Icon name="user" size="sm" />
+        <span>First Name</span>
+      </span>
+    ),
+  },
+
+  // String header
+  { id: 'lastName', header: 'Last name' },
+];
+```
+
 ### Custom Cell Rendering
 
 Individual cells can be rendered using custom content dy defining a `cell` property on the column definition.

--- a/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.story.tsx
+++ b/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.story.tsx
@@ -5,9 +5,11 @@ import { CellProps } from 'react-table';
 import { LinkButton } from '../Button/Button';
 import { Field } from '../Forms/Field';
 import { Input } from '../Input/Input';
+import { Checkbox } from '../Forms/Checkbox';
 
 import { FetchDataArgs, InteractiveTable, InteractiveTableHeaderTooltip } from './InteractiveTable';
 import mdx from './InteractiveTable.mdx';
+import { Icon } from '../Icon/Icon';
 
 const EXCLUDED_PROPS = ['className', 'renderExpandedRow', 'getRowId', 'fetchData'];
 
@@ -297,4 +299,33 @@ export const WithControlledSort: StoryFn<typeof InteractiveTable> = (args) => {
   return <InteractiveTable {...args} data={data} pageSize={15} fetchData={fetchData} />;
 };
 
+export const WithCustomHeader: TableStoryObj = {
+  args: {
+    columns: [
+      // React element header
+      {
+        id: 'checkbox',
+        header: <Checkbox />,
+        cell: () => <Checkbox />,
+      },
+      // Function renderer header
+      {
+        id: 'firstName',
+        header: () => (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
+            <Icon name="user" size="sm" />
+            <span>First Name</span>
+          </span>
+        ),
+        sortType: 'string',
+      },
+      // String header
+      { id: 'lastName', header: 'Last name', sortType: 'string' },
+      { id: 'car', header: 'Car', sortType: 'string' },
+      { id: 'age', header: 'Age', sortType: 'number' },
+    ],
+    data: pageableData.slice(0, 10),
+    getRowId: (r) => r.id,
+  },
+};
 export default meta;

--- a/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.story.tsx
+++ b/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.story.tsx
@@ -3,13 +3,14 @@ import { useCallback, useMemo, useState } from 'react';
 import { CellProps } from 'react-table';
 
 import { LinkButton } from '../Button/Button';
-import { Field } from '../Forms/Field';
-import { Input } from '../Input/Input';
 import { Checkbox } from '../Forms/Checkbox';
+import { Field } from '../Forms/Field';
+import { Icon } from '../Icon/Icon';
+import { Input } from '../Input/Input';
+import { Text } from '../Text/Text';
 
 import { FetchDataArgs, InteractiveTable, InteractiveTableHeaderTooltip } from './InteractiveTable';
 import mdx from './InteractiveTable.mdx';
-import { Icon } from '../Icon/Icon';
 
 const EXCLUDED_PROPS = ['className', 'renderExpandedRow', 'getRowId', 'fetchData'];
 
@@ -305,8 +306,15 @@ export const WithCustomHeader: TableStoryObj = {
       // React element header
       {
         id: 'checkbox',
-        header: <Checkbox />,
-        cell: () => <Checkbox />,
+        header: (
+          <>
+            <label htmlFor="select-all" className="sr-only">
+              Select all rows
+            </label>
+            <Checkbox id="select-all" />
+          </>
+        ),
+        cell: () => <Checkbox aria-label="Select row" />,
       },
       // Function renderer header
       {
@@ -314,7 +322,7 @@ export const WithCustomHeader: TableStoryObj = {
         header: () => (
           <span style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
             <Icon name="user" size="sm" />
-            <span>First Name</span>
+            <Text element="span">First Name</Text>
           </span>
         ),
         sortType: 'string',

--- a/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.test.tsx
+++ b/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.test.tsx
@@ -2,6 +2,9 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
+import { Checkbox } from '../Forms/Checkbox';
+import { Icon } from '../Icon/Icon';
+
 import { InteractiveTable } from './InteractiveTable';
 import { Column } from './types';
 
@@ -245,6 +248,89 @@ describe('InteractiveTable', () => {
       await userEvent.click(valueColumnHeader);
 
       expect(fetchData).toHaveBeenCalledWith({ sortBy: [{ id: 'id', desc: false }] });
+    });
+  });
+
+  describe('custom header rendering', () => {
+    it('should render string headers', () => {
+      const columns: Array<Column<TableData>> = [{ id: 'id', header: 'ID' }];
+      const data: TableData[] = [{ id: '1', value: '1', country: 'Sweden' }];
+      render(<InteractiveTable columns={columns} data={data} getRowId={getRowId} />);
+
+      expect(screen.getByRole('columnheader', { name: 'ID' })).toBeInTheDocument();
+    });
+
+    it('should render React element headers', () => {
+      const columns: Array<Column<TableData>> = [
+        {
+          id: 'checkbox',
+          header: <Checkbox data-testid="header-checkbox" />,
+          cell: () => <Checkbox data-testid="cell-checkbox" />,
+        },
+      ];
+      const data: TableData[] = [{ id: '1', value: '1', country: 'Sweden' }];
+      render(<InteractiveTable columns={columns} data={data} getRowId={getRowId} />);
+
+      expect(screen.getByTestId('header-checkbox')).toBeInTheDocument();
+      expect(screen.getByTestId('cell-checkbox')).toBeInTheDocument();
+    });
+
+    it('should render function renderer headers', () => {
+      const columns: Array<Column<TableData>> = [
+        {
+          id: 'firstName',
+          header: () => (
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
+              <Icon name="user" size="sm" data-testid="header-icon" />
+              <span>First Name</span>
+            </span>
+          ),
+          sortType: 'string',
+        },
+      ];
+      const data: TableData[] = [{ id: '1', value: '1', country: 'Sweden' }];
+      render(<InteractiveTable columns={columns} data={data} getRowId={getRowId} />);
+
+      expect(screen.getByTestId('header-icon')).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: /first name/i })).toBeInTheDocument();
+    });
+
+    it('should render all header types together', () => {
+      const columns: Array<Column<TableData>> = [
+        {
+          id: 'checkbox',
+          header: <Checkbox data-testid="header-checkbox" />,
+          cell: () => <Checkbox />,
+        },
+        {
+          id: 'id',
+          header: () => (
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
+              <Icon name="user" size="sm" data-testid="header-icon" />
+              <span>ID</span>
+            </span>
+          ),
+          sortType: 'string',
+        },
+        { id: 'country', header: 'Country', sortType: 'string' },
+        { id: 'value', header: 'Value' },
+      ];
+      const data: TableData[] = [
+        { id: '1', value: 'Value 1', country: 'Sweden' },
+        { id: '2', value: 'Value 2', country: 'Norway' },
+      ];
+      render(<InteractiveTable columns={columns} data={data} getRowId={getRowId} />);
+
+      expect(screen.getByTestId('header-checkbox')).toBeInTheDocument();
+      expect(screen.getByTestId('header-icon')).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Country' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Value' })).toBeInTheDocument();
+
+      // Verify data is rendered
+      expect(screen.getByText('Sweden')).toBeInTheDocument();
+      expect(screen.getByText('Norway')).toBeInTheDocument();
+      expect(screen.getByText('Value 1')).toBeInTheDocument();
+      expect(screen.getByText('Value 2')).toBeInTheDocument();
     });
   });
 });

--- a/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.test.tsx
+++ b/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.test.tsx
@@ -264,8 +264,15 @@ describe('InteractiveTable', () => {
       const columns: Array<Column<TableData>> = [
         {
           id: 'checkbox',
-          header: <Checkbox data-testid="header-checkbox" />,
-          cell: () => <Checkbox data-testid="cell-checkbox" />,
+          header: (
+            <>
+              <label htmlFor="select-all" className="sr-only">
+                Select all rows
+              </label>
+              <Checkbox id="select-all" data-testid="header-checkbox" />
+            </>
+          ),
+          cell: () => <Checkbox data-testid="cell-checkbox" aria-label="Select row" />,
         },
       ];
       const data: TableData[] = [{ id: '1', value: '1', country: 'Sweden' }];
@@ -273,6 +280,9 @@ describe('InteractiveTable', () => {
 
       expect(screen.getByTestId('header-checkbox')).toBeInTheDocument();
       expect(screen.getByTestId('cell-checkbox')).toBeInTheDocument();
+      expect(screen.getByLabelText('Select all rows')).toBeInTheDocument();
+      expect(screen.getByLabelText('Select row')).toBeInTheDocument();
+      expect(screen.getByText('Select all rows')).toBeInTheDocument();
     });
 
     it('should render function renderer headers', () => {
@@ -299,8 +309,15 @@ describe('InteractiveTable', () => {
       const columns: Array<Column<TableData>> = [
         {
           id: 'checkbox',
-          header: <Checkbox data-testid="header-checkbox" />,
-          cell: () => <Checkbox />,
+          header: (
+            <>
+              <label htmlFor="select-all" className="sr-only">
+                Select all rows
+              </label>
+              <Checkbox id="select-all" data-testid="header-checkbox" />
+            </>
+          ),
+          cell: () => <Checkbox aria-label="Select row" />,
         },
         {
           id: 'id',

--- a/packages/grafana-ui/src/components/InteractiveTable/types.ts
+++ b/packages/grafana-ui/src/components/InteractiveTable/types.ts
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { CellProps, DefaultSortTypes, IdType, SortByFn } from 'react-table';
+import { CellProps, DefaultSortTypes, HeaderProps, IdType, Renderer, SortByFn } from 'react-table';
 
 export interface Column<TableData extends object> {
   /**
@@ -11,9 +11,9 @@ export interface Column<TableData extends object> {
    */
   cell?: (props: CellProps<TableData>) => ReactNode;
   /**
-   * Header name. if `undefined` the header will be empty. Useful for action columns.
+   * Header name. Can be a string, renderer function, or undefined. If `undefined` the header will be empty. Useful for action columns.
    */
-  header?: string;
+  header?: Renderer<HeaderProps<TableData>>;
   /**
    * Column sort type. If `undefined` the column will not be sortable.
    * */


### PR DESCRIPTION
### What is this feature?

Extends the InteractiveTable component's `header` property to support React elements and renderer functions in addition to strings. This change extends the underlying React Table library's `Renderer<HeaderProps<TableData>>` type, allowing headers to be:
- String values (existing behavior)
- React elements (e.g., `<Checkbox />`, `<Icon />`)
- Renderer functions that receive `HeaderProps` for dynamic content

### Why do we need this feature?

Previously, the `header` property only accepted strings, limiting customization. Users needed more flexibility to:
- Add icons or other UI components to headers
- Create interactive headers (e.g., checkboxes for bulk selection)
- Dynamically render headers based on table state or column properties
- Match React Table's native header rendering capabilities

**Specific use case:** For use within IRM, we need to use the underlying React Table type for a custom checkbox header to implement "select all" functionality for bulk actions.

### Who is this feature for?

Developers using the InteractiveTable component who need custom header rendering beyond simple text labels. This is particularly useful for:
- Administrative interfaces requiring bulk action checkboxes (e.g., IRM's select all functionality)
- Tables needing visual indicators or icons in headers
- Dynamic headers that change based on table state

### Which issue(s) does this PR fix?

N/A

### Special notes for your reviewer

Please check that:

- It works as expected from a user's perspective.
- The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

**Questions for reviewers:**
- Does this change require a feature toggle/flag? (InteractiveTable is already marked as `@alpha`)
- Do we need any additional documentation beyond what's been added to the MDX file?

**Additional notes:**
- This is a backward-compatible change - existing string headers continue to work without modification
- The `header` property type has been extended from `string | undefined` to `Renderer<HeaderProps<TableData>> | undefined`, which aligns with React Table's native type system
- Documentation includes best practices about using inline elements (like `<span>`) instead of block elements (like `<div>`) in headers to avoid layout issues
- Tests have been added to verify all three header types (string, React element, function renderer) work correctly
- Storybook example demonstrates the new functionality