### PR TITLE
Build: Fix running e2e tests for Cypress with Dagger

### DIFF
--- a/pkg/build/e2e/README.md
+++ b/pkg/build/e2e/README.md
@@ -1,0 +1,20 @@
+## Build artifacts
+
+Put the resulting tar in your `grafana` OSS path:
+```sh
+go -C grafana run ./pkg/build/cmd artifacts -a targz:enterprise:linux/amd64 --alpine-base=alpine:3.22 --tag-format='{{ .version }}-{{ .buildID }}-{{ .arch }}' --grafana-dir="${PWD}/grafana" --enterprise-dir="${PWD}/grafana-enterprise"
+```
+
+Also build the e2e test runner:
+```sh
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ./e2e-runner ./e2e/
+```
+
+And then `chmod +x ./e2e-runner`.
+
+## Running tests
+
+Reporting tests with Image Renderer:
+```sh
+go run ./pkg/build/e2e --suite=e2e/extensions/enterprise/smtp-suite --license=e2e/extensions/enterprise/license.jwt --image-renderer
+```

--- a/pkg/build/e2e/main.go
+++ b/pkg/build/e2e/main.go
@@ -138,6 +138,10 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	if code != 0 {
+		if stdout, _ := c.Stdout(ctx); len(stdout) > 0 {
+			log.Printf("e2e test suite stdout:\n%s", stdout)
+		}
+
 		return fmt.Errorf("e2e tests failed with exit code %d", code)
 	}
 

--- a/pkg/build/e2e/run.go
+++ b/pkg/build/e2e/run.go
@@ -8,10 +8,10 @@ import (
 
 func RunSuite(d *dagger.Client, svc *dagger.Service, src *dagger.Directory, cache *dagger.CacheVolume, suite, runnerFlags string) *dagger.Container {
 	command := fmt.Sprintf(
-		"./e2e-runner cypress --start-grafana=false --cypress-video"+
+		"./e2e-runner cypress --browser=electron --start-grafana=false --cypress-video"+
 			" --grafana-base-url http://grafana:3001 --suite %s %s", suite, runnerFlags)
 
-	return WithYarnCache(WithGrafanaFrontend(d.Container().From("cypress/included:13.1.0"), src), cache).
+	return WithYarnCache(WithGrafanaFrontend(d.Container().From("cypress/included:14.3.2"), src), cache).
 		WithWorkdir("/src").
 		WithServiceBinding("grafana", svc).
 		WithExec([]string{"yarn", "install", "--immutable"}).


### PR DESCRIPTION
Some changes to how we can run the Cypress e2e tests with Dagger locally, mainly for the Reporting tests:
- Update Cypress version to match the package.json one
- Use Electron browser as that's included
- Use Image Renderer Docker image
- Print out errors during run