### PR TITLE
[release-12.2.4] InspectJsonTab: Force render the layout after change to reflect new gridPos

### DIFF
--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.test.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.test.tsx
@@ -12,7 +12,7 @@ import {
 } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils, setRunRequest } from '@grafana/runtime';
-import { SceneCanvasText, SceneDataTransformer, SceneQueryRunner, VizPanel } from '@grafana/scenes';
+import { SceneCanvasText, SceneDataTransformer, SceneGridLayout, SceneQueryRunner, VizPanel } from '@grafana/scenes';
 import * as libpanels from 'app/features/library-panels/state/api';
 import { getStandardTransformers } from 'app/features/transformers/standardTransformers';
 
@@ -181,6 +181,51 @@ describe('InspectJsonTab', () => {
     expect((panel2.parent as DashboardGridItem).state.width!).toBe(3);
 
     expect(tab.state.onClose).toHaveBeenCalled();
+  });
+
+  it('Can update gridPos and forces layout re-render', async () => {
+    const { tab, panel, scene } = await buildTestScene();
+
+    // Get the layout manager and spy on the grid's forceRender
+    const layoutManager = scene.state.body as DefaultGridLayoutManager;
+    const grid = layoutManager.state.grid as SceneGridLayout;
+    const forceRenderSpy = jest.spyOn(grid, 'forceRender');
+
+    const originalGridItem = panel.parent as DashboardGridItem;
+    expect(originalGridItem.state.x).toBe(0);
+    expect(originalGridItem.state.y).toBe(0);
+    expect(originalGridItem.state.width).toBe(8);
+    expect(originalGridItem.state.height).toBe(10);
+
+    tab.onCodeEditorBlur(`{
+      "id": 12,
+      "type": "table",
+      "title": "Panel A",
+      "gridPos": {
+        "x": 5,
+        "y": 10,
+        "w": 12,
+        "h": 8
+      },
+      "options": {},
+      "fieldConfig": {},
+      "transformations": [],
+      "transparent": false
+    }`);
+
+    tab.onApplyChange();
+
+    const panel2 = findVizPanelByKey(scene, panel.state.key)!;
+    const gridItem = panel2.parent as DashboardGridItem;
+
+    // Verify all gridPos properties are updated
+    expect(gridItem.state.x).toBe(5);
+    expect(gridItem.state.y).toBe(10);
+    expect(gridItem.state.width).toBe(12);
+    expect(gridItem.state.height).toBe(8);
+
+    // Verify forceRender was called on the layout to apply position changes
+    expect(forceRenderSpy).toHaveBeenCalled();
   });
 
   it('Can show panel json for V2 dashboard specification', async () => {

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -9,6 +9,7 @@ import {
   SceneDataTransformer,
   sceneGraph,
   SceneGridItemStateLike,
+  SceneGridLayout,
   SceneObjectBase,
   SceneObjectRef,
   SceneObjectState,
@@ -126,6 +127,12 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
     }
 
     panel.parent.setState(newState);
+
+    // Force the grid layout to re-render with the new positions
+    const layout = sceneGraph.getLayout(panel);
+    if (layout instanceof SceneGridLayout) {
+      layout.forceRender();
+    }
 
     //Report relevant updates
     reportPanelInspectInteraction(InspectTab.JSON, 'apply', {


### PR DESCRIPTION
Backport 0a0f92e85ea6d319c8e7501e435672608e3e3884 from #115688

---

When editing a non V2 panel gridPos through panel JSON inspect tab we do not get an updated panel position due to this logic living in layout component which does not get updated. 

Fix: force rendering layout component to reflect new position.

Fixes: https://github.com/grafana/support-escalations/issues/20048

Steps to reproduce without the fix:
1. open dashboard with `kubernetesDashboards` feature toggle disabled.
2. go into edit mode 
3. go into panel inspect and try to edit gridPos
4. click apply
5. no change is reflected in UI but correctly reflected in save drawer
