### PR TITLE
processing: support duplicated keys when parsing json logs

### DIFF
--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -190,6 +190,22 @@ describe('preProcessLogs', () => {
       expect(logListModel.body).not.toBe(entry);
     });
 
+    test('Prettifies JSON with duplicate keys', () => {
+      const entry = '{"key": "value", "key": "otherValue"}';
+      const logListModel = createLogLine(
+        { entry },
+        {
+          escape: false,
+          order: LogsSortOrder.Descending,
+          timeZone: 'browser',
+          wrapLogMessage: true, // wrapped
+          prettifyJSON: true,
+        }
+      );
+      expect(logListModel.entry).toBe(entry);
+      expect(logListModel.body).not.toBe(entry);
+    });
+
     test('Prettifies and escapes wrapped JSON', () => {
       const entry = '{"key": "value", "otherKey": "other\\nValue"}';
       const logListModel = createLogLine(

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -136,7 +136,7 @@ export class LogListModel implements LogRowModel {
     if (this._body === undefined) {
       try {
         const parsed = parse(this.raw, undefined, {
-          onDuplicateKey: ({ newValue }) => newValue
+          onDuplicateKey: ({ newValue }) => newValue,
         });
         if (typeof parsed === 'object' && parsed !== null && !(parsed instanceof LosslessNumber)) {
           this._json = true;

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -135,7 +135,9 @@ export class LogListModel implements LogRowModel {
   get body(): string {
     if (this._body === undefined) {
       try {
-        const parsed = parse(this.raw);
+        const parsed = parse(this.raw, undefined, {
+          onDuplicateKey: ({ newValue }) => newValue
+        });
         if (typeof parsed === 'object' && parsed !== null && !(parsed instanceof LosslessNumber)) {
           this._json = true;
         }


### PR DESCRIPTION
Fixes https://github.com/grafana/logs-drilldown/pull/1702

Using lossless-json, duplicated keys would trigger an error. We now pass a callback to handle the error and allow prettifying of incorrect JSON, with the same behavior as the native JSON.parse function.

<img width="305" height="92" alt="imagen" src="https://github.com/user-attachments/assets/f1daaeaf-889a-4e2b-b81c-515ee4c04f8c" />

Regression test

<img width="690" height="252" alt="imagen" src="https://github.com/user-attachments/assets/a5fdf700-2cc4-490b-b54d-61df778300e9" />

