### PR TITLE
fix: improve resilience for unified storage and search service grpc clients

### DIFF
--- a/pkg/server/ring.go
+++ b/pkg/server/ring.go
@@ -158,7 +158,7 @@ func newClientPool(clientCfg grpcclient.Config, log log.Logger, reg prometheus.R
 func ringClientRetryInterceptor() grpc.UnaryClientInterceptor {
 	return grpc_retry.UnaryClientInterceptor(
 		grpc_retry.WithMax(3),
-		grpc_retry.WithBackoff(grpc_retry.BackoffExponentialWithJitter(time.Second, 0.5)),
+		grpc_retry.WithBackoff(grpc_retry.BackoffExponentialWithJitter(time.Second, 0.1)),
 		grpc_retry.WithCodes(codes.ResourceExhausted, codes.Unavailable),
 	)
 }

--- a/pkg/server/ring.go
+++ b/pkg/server/ring.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/grafana/dskit/flagext"
@@ -15,11 +16,14 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
+	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
@@ -111,9 +115,18 @@ func newClientPool(clientCfg grpcclient.Config, log log.Logger, reg prometheus.R
 		Help:    "Time spent executing requests to resource server.",
 		Buckets: prometheus.ExponentialBuckets(0.008, 4, 7),
 	}, []string{"operation", "status_code"})
+	factoryRequestRetries := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "resource_server_client_request_retries_total",
+		Help: "Total number of retries for requests to the resource server.",
+	}, []string{"operation"})
 
 	factory := ringclient.PoolInstFunc(func(inst ring.InstanceDesc) (ringclient.PoolClient, error) {
 		unaryInterceptors, streamInterceptors := grpcclient.Instrument(factoryRequestDuration)
+
+		// Add retry interceptors for transient connection issues
+		unaryInterceptors = append(unaryInterceptors, ringClientRetryInterceptor())
+		unaryInterceptors = append(unaryInterceptors, ringClientRetryInstrument(factoryRequestRetries))
+
 		opts, err := clientCfg.DialOption(unaryInterceptors, streamInterceptors, nil)
 		if err != nil {
 			return nil, err
@@ -134,4 +147,27 @@ func newClientPool(clientCfg grpcclient.Config, log log.Logger, reg prometheus.R
 	})
 
 	return ringclient.NewPool(resource.RingName, poolCfg, nil, factory, clientsCount, log)
+}
+
+// ringClientRetryInterceptor creates an interceptor to perform retries for unary methods.
+// It retries on ResourceExhausted and Unavailable codes, which are typical for
+// transient connection issues and rate limiting.
+func ringClientRetryInterceptor() grpc.UnaryClientInterceptor {
+	return grpc_retry.UnaryClientInterceptor(
+		grpc_retry.WithMax(3),
+		grpc_retry.WithBackoff(grpc_retry.BackoffExponentialWithJitter(time.Second, 0.5)),
+		grpc_retry.WithCodes(codes.ResourceExhausted, codes.Unavailable),
+	)
+}
+
+// ringClientRetryInstrument creates an interceptor to count retry attempts for metrics.
+func ringClientRetryInstrument(metric *prometheus.CounterVec) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, resp interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		// We can tell if a call is a retry by checking the retry attempt metadata.
+		attempt, err := strconv.Atoi(metautils.ExtractOutgoing(ctx).Get(grpc_retry.AttemptMetadataKey))
+		if err == nil && attempt > 0 {
+			metric.WithLabelValues(method).Inc()
+		}
+		return invoker(ctx, method, req, resp, cc, opts...)
+	}
 }

--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -11,10 +11,14 @@ import (
 	"github.com/spf13/pflag"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/options"
 	"k8s.io/client-go/rest"
+
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 
 	apiserverrest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -232,19 +236,16 @@ func (o *StorageOptions) ApplyTo(serverConfig *genericapiserver.RecommendedConfi
 	if o.StorageType != StorageTypeUnifiedGrpc {
 		return nil
 	}
-	conn, err := grpc.NewClient(o.Address,
-		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+
+	grpcOpts := o.buildGrpcDialOptions()
+
+	conn, err := grpc.NewClient(o.Address, grpcOpts...)
 	if err != nil {
 		return err
 	}
 	var indexConn *grpc.ClientConn
 	if o.SearchServerAddress != "" {
-		indexConn, err = grpc.NewClient(o.SearchServerAddress,
-			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-		)
+		indexConn, err = grpc.NewClient(o.SearchServerAddress, grpcOpts...)
 		if err != nil {
 			return err
 		}
@@ -292,4 +293,35 @@ func (o *StorageOptions) ApplyTo(serverConfig *genericapiserver.RecommendedConfi
 	getter := apistore.NewRESTOptionsGetterForClient(unified, o.InlineSecrets, etcdOptions.StorageConfig, o.ConfigProvider)
 	serverConfig.RESTOptionsGetter = getter
 	return nil
+}
+
+// buildGrpcDialOptions creates gRPC dial options with resilience mechanisms:
+// - Round-robin load balancing with client-side health checking
+// - Retry interceptor for transient connection issues
+// - Keepalive for long-lived connections
+func (o *StorageOptions) buildGrpcDialOptions() []grpc.DialOption {
+	// Retry interceptor for transient connection issues (codes.Unavailable includes connection refused)
+	retryInterceptor := grpc_retry.UnaryClientInterceptor(
+		grpc_retry.WithMax(3),
+		grpc_retry.WithBackoff(grpc_retry.BackoffExponentialWithJitter(time.Second, 0.5)),
+		grpc_retry.WithCodes(codes.ResourceExhausted, codes.Unavailable),
+	)
+
+	opts := []grpc.DialOption{
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithChainUnaryInterceptor(retryInterceptor),
+		// Use round_robin with health checking so unhealthy backends are excluded
+		grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin","healthCheckConfig":{"serviceName":""}}`),
+	}
+
+	if o.GrpcClientKeepaliveTime > 0 {
+		opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                o.GrpcClientKeepaliveTime,
+			Timeout:             10 * time.Second,
+			PermitWithoutStream: true,
+		}))
+	}
+
+	return opts
 }

--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -271,7 +271,7 @@ func grpcConn(address string, metrics *clientMetrics, clientKeepaliveTime time.D
 	retryCfg := retryConfig{
 		Max:           3,
 		Backoff:       time.Second,
-		BackoffJitter: 0.5,
+		BackoffJitter: 0.1,
 	}
 	unary = append(unary, unaryRetryInterceptor(retryCfg))
 	unary = append(unary, unaryRetryInstrument(metrics.requestRetries))
@@ -289,7 +289,6 @@ func grpcConn(address string, metrics *clientMetrics, clientKeepaliveTime time.D
 	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
 	// Use round_robin to balance requests more evenly over the available Storage server.
-	// Enable health checking so round_robin excludes unhealthy backends (e.g., terminated pods).
 	opts = append(opts, grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`))
 
 	// Disable looking up service config from TXT DNS records.

--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -290,11 +290,13 @@ func grpcConn(address string, metrics *clientMetrics, clientKeepaliveTime time.D
 
 	// Use round_robin to balance requests more evenly over the available Storage server.
 	// Enable health checking so round_robin excludes unhealthy backends (e.g., terminated pods).
-	opts = append(opts, grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin","healthCheckConfig":{"serviceName":""}}`))
+	opts = append(opts, grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`))
 
 	// Disable looking up service config from TXT DNS records.
 	// This reduces the number of requests made to the DNS servers.
 	opts = append(opts, grpc.WithDisableServiceConfig())
+
+	opts = append(opts, connectionBackoffOptions())
 
 	if clientKeepaliveTime > 0 {
 		opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{

--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -288,8 +288,9 @@ func grpcConn(address string, metrics *clientMetrics, clientKeepaliveTime time.D
 	opts = append(opts, grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
 	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
-	// Use round_robin to balances requests more evenly over the available Storage server.
-	opts = append(opts, grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`))
+	// Use round_robin to balance requests more evenly over the available Storage server.
+	// Enable health checking so round_robin excludes unhealthy backends (e.g., terminated pods).
+	opts = append(opts, grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin","healthCheckConfig":{"serviceName":""}}`))
 
 	// Disable looking up service config from TXT DNS records.
 	// This reduces the number of requests made to the DNS servers.

--- a/pkg/storage/unified/client_retry.go
+++ b/pkg/storage/unified/client_retry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/codes"
 )
 
@@ -43,4 +44,18 @@ func unaryRetryInstrument(metric *prometheus.CounterVec) grpc.UnaryClientInterce
 		}
 		return invoker(ctx, method, req, resp, cc, opts...)
 	}
+}
+
+// connectionBackoffOptions configures connection backoff parameters for faster recovery from
+// transient connection failures (e.g., during pod restarts).
+func connectionBackoffOptions() grpc.DialOption {
+	return grpc.WithConnectParams(grpc.ConnectParams{
+		Backoff: backoff.Config{
+			BaseDelay:  100 * time.Millisecond,
+			Multiplier: 1.6,
+			Jitter:     0.2,
+			MaxDelay:   10 * time.Second,
+		},
+		MinConnectTimeout: 5 * time.Second,
+	})
 }

--- a/pkg/storage/unified/resource/search_server_distributor.go
+++ b/pkg/storage/unified/resource/search_server_distributor.go
@@ -79,7 +79,7 @@ func (c *RingClient) RemoteAddress() string {
 
 const RingKey = "search-server-ring"
 const RingName = "search_server_ring"
-const RingHeartbeatTimeout = 30 * time.Second
+const RingHeartbeatTimeout = time.Minute
 const RingNumTokens = 128
 
 type distributorServer struct {
@@ -99,19 +99,23 @@ var (
 func (ds *distributorServer) Search(ctx context.Context, r *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {
 	ctx, span := ds.tracing.Start(ctx, "distributor.Search")
 	defer span.End()
+	ctx, client, err := ds.getClientToDistributeRequest(ctx, r.Options.Key.Namespace, "Search")
+	if err != nil {
+		return nil, err
+	}
 
-	return distributeRequest(ctx, ds, r.Options.Key.Namespace, "Search", func(ctx context.Context, client ResourceClient) (*resourcepb.ResourceSearchResponse, error) {
-		return client.Search(ctx, r)
-	})
+	return client.Search(ctx, r)
 }
 
 func (ds *distributorServer) GetStats(ctx context.Context, r *resourcepb.ResourceStatsRequest) (*resourcepb.ResourceStatsResponse, error) {
 	ctx, span := ds.tracing.Start(ctx, "distributor.GetStats")
 	defer span.End()
+	ctx, client, err := ds.getClientToDistributeRequest(ctx, r.Namespace, "GetStats")
+	if err != nil {
+		return nil, err
+	}
 
-	return distributeRequest(ctx, ds, r.Namespace, "GetStats", func(ctx context.Context, client ResourceClient) (*resourcepb.ResourceStatsResponse, error) {
-		return client.GetStats(ctx, r)
-	})
+	return client.GetStats(ctx, r)
 }
 
 func (ds *distributorServer) RebuildIndexes(ctx context.Context, r *resourcepb.RebuildIndexesRequest) (*resourcepb.RebuildIndexesResponse, error) {
@@ -211,80 +215,58 @@ func (ds *distributorServer) RebuildIndexes(ctx context.Context, r *resourcepb.R
 func (ds *distributorServer) CountManagedObjects(ctx context.Context, r *resourcepb.CountManagedObjectsRequest) (*resourcepb.CountManagedObjectsResponse, error) {
 	ctx, span := ds.tracing.Start(ctx, "distributor.CountManagedObjects")
 	defer span.End()
+	ctx, client, err := ds.getClientToDistributeRequest(ctx, r.Namespace, "CountManagedObjects")
+	if err != nil {
+		return nil, err
+	}
 
-	return distributeRequest(ctx, ds, r.Namespace, "CountManagedObjects", func(ctx context.Context, client ResourceClient) (*resourcepb.CountManagedObjectsResponse, error) {
-		return client.CountManagedObjects(ctx, r)
-	})
+	return client.CountManagedObjects(ctx, r)
 }
 
 func (ds *distributorServer) ListManagedObjects(ctx context.Context, r *resourcepb.ListManagedObjectsRequest) (*resourcepb.ListManagedObjectsResponse, error) {
 	ctx, span := ds.tracing.Start(ctx, "distributor.ListManagedObjects")
 	defer span.End()
+	ctx, client, err := ds.getClientToDistributeRequest(ctx, r.Namespace, "ListManagedObjects")
+	if err != nil {
+		return nil, err
+	}
 
-	return distributeRequest(ctx, ds, r.Namespace, "ListManagedObjects", func(ctx context.Context, client ResourceClient) (*resourcepb.ListManagedObjectsResponse, error) {
-		return client.ListManagedObjects(ctx, r)
-	})
+	return client.ListManagedObjects(ctx, r)
 }
 
-// distributeRequest handles request distribution with failover across instances in the replication set.
-// It tries each instance in shuffled order until one succeeds, handling both pool-level and RPC-level errors.
-func distributeRequest[T any](ctx context.Context, ds *distributorServer, namespace string, methodName string, rpcCall func(context.Context, ResourceClient) (T, error)) (T, error) {
-	var zero T
-
+func (ds *distributorServer) getClientToDistributeRequest(ctx context.Context, namespace string, methodName string) (context.Context, ResourceClient, error) {
 	ringHasher := fnv.New32a()
 	_, err := ringHasher.Write([]byte(namespace))
 	if err != nil {
 		ds.log.Debug("error hashing namespace", "err", err, "namespace", namespace)
-		return zero, err
+		return ctx, nil, err
 	}
 
 	rs, err := ds.ring.GetWithOptions(ringHasher.Sum32(), searchRingRead, ring.WithReplicationFactor(ds.ring.ReplicationFactor()))
 	if err != nil {
 		ds.log.Debug("error getting replication set from ring", "err", err, "namespace", namespace)
-		return zero, err
+		return ctx, nil, err
 	}
 
-	// Shuffle instances for load balancing while enabling failover
-	instances := make([]ring.InstanceDesc, len(rs.Instances))
-	copy(instances, rs.Instances)
-	rand.Shuffle(len(instances), func(i, j int) {
-		instances[i], instances[j] = instances[j], instances[i]
-	})
-
-	// Try each instance in the shuffled order until one succeeds
-	var lastErr error
-	for i, inst := range instances {
-		client, err := ds.clientPool.GetClientForInstance(inst)
-		if err != nil {
-			ds.log.Debug("error getting instance client from pool, trying next instance", "err", err, "namespace", namespace, "searchApiInstanceId", inst.Id, "remainingInstances", len(instances)-i-1)
-			lastErr = err
-			continue
-		}
-
-		md, ok := metadata.FromIncomingContext(ctx)
-		if !ok {
-			md = make(metadata.MD)
-		}
-
-		err = grpc.SetHeader(ctx, metadata.Pairs("proxied-instance-id", inst.Id))
-		if err != nil {
-			ds.log.Debug("error setting grpc header", "err", err)
-		}
-
-		rpcCtx := userutils.InjectOrgID(metadata.NewOutgoingContext(ctx, md), namespace)
-
-		result, err := rpcCall(rpcCtx, client.(*RingClient).Client)
-		if err != nil {
-			ds.log.Debug("RPC call failed, trying next instance", "err", err, "namespace", namespace, "searchApiInstanceId", inst.Id, "method", methodName, "remainingInstances", len(instances)-i-1)
-			lastErr = err
-			continue
-		}
-
-		return result, nil
+	// Randomly select an instance for primitive load balancing
+	inst := rs.Instances[rand.Intn(len(rs.Instances))]
+	client, err := ds.clientPool.GetClientForInstance(inst)
+	if err != nil {
+		ds.log.Debug("error getting instance client from pool", "err", err, "namespace", namespace, "searchApiInstanceId", inst.Id)
+		return ctx, nil, err
 	}
 
-	// All instances in the replication set failed
-	return zero, fmt.Errorf("all %d instances in replication set unavailable for namespace %s: %w", len(instances), namespace, lastErr)
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		md = make(metadata.MD)
+	}
+
+	err = grpc.SetHeader(ctx, metadata.Pairs("proxied-instance-id", inst.Id))
+	if err != nil {
+		ds.log.Debug("error setting grpc header", "err", err)
+	}
+
+	return userutils.InjectOrgID(metadata.NewOutgoingContext(ctx, md), namespace), client.(*RingClient).Client, nil
 }
 
 func (ds *distributorServer) IsHealthy(ctx context.Context, r *resourcepb.HealthCheckRequest) (*resourcepb.HealthCheckResponse, error) {


### PR DESCRIPTION
In this PR, I try to improve the reliability for the unified storage services in relation with the below escalation. I noticed multiple `connect: connection refused` errors with both `search-distributor` and `storage-api` k8s services. Adding here connection backoff for the grpc clients targeting both servers.

Query: https://ops.grafana-ops.net/goto/df9y0y1lvcpogd?orgId=stacks-27821

Escalation: https://github.com/grafana/support-escalations/issues/20139