### PR TITLE
SQL Expressions: Filter Dashboard datasource queries from schema fetching

### DIFF
--- a/public/app/features/expressions/components/SqlExpressions/hooks/useSQLSchemas.test.ts
+++ b/public/app/features/expressions/components/SqlExpressions/hooks/useSQLSchemas.test.ts
@@ -15,4 +15,12 @@ describe('isDashboardDatasource', () => {
 
     expect(backendQueries.map((q) => q.refId)).toEqual(['A', 'C']);
   });
+
+  it('returns true when query has dashboard datasource uid', () => {
+    const query: DataQuery = {
+      refId: 'A',
+      datasource: { uid: SHARED_DASHBOARD_QUERY, type: 'datasource' },
+    };
+    expect(isDashboardDatasource(query)).toBe(true);
+  });
 });

--- a/public/app/features/expressions/components/SqlExpressions/hooks/useSQLSchemas.test.ts
+++ b/public/app/features/expressions/components/SqlExpressions/hooks/useSQLSchemas.test.ts
@@ -1,0 +1,18 @@
+import { DataQuery } from '@grafana/schema';
+import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constants';
+
+import { isDashboardDatasource } from './useSQLSchemas';
+
+describe('isDashboardDatasource', () => {
+  it('identifies Dashboard datasource queries in a mixed set', () => {
+    const queries: DataQuery[] = [
+      { refId: 'A', datasource: { uid: 'prometheus-uid', type: 'prometheus' } },
+      { refId: 'B', datasource: { uid: SHARED_DASHBOARD_QUERY, type: 'datasource' } },
+      { refId: 'C', datasource: { uid: 'mysql-uid', type: 'mysql' } },
+    ];
+
+    const backendQueries = queries.filter((q) => !isDashboardDatasource(q));
+
+    expect(backendQueries.map((q) => q.refId)).toEqual(['A', 'C']);
+  });
+});


### PR DESCRIPTION
## What

Filter out Dashboard datasource queries before sending schema requests to the backend.

## Why

Dashboard datasource is frontend-only and cannot be processed by the backend SQL expression schema endpoint. When a panel uses Mixed datasource with both backend datasources and Dashboard datasource, the schema fetching would fail with "Failed to fetch SQL schemas" errors.

<img width="2844" height="1714" alt="image" src="https://github.com/user-attachments/assets/9eac185e-dcda-4d12-90c3-887005eab154" />
