### PR TITLE
Dashboards: Never show scopes variables

### DIFF
--- a/public/app/features/dashboard-scene/scene/VairableControls.test.tsx
+++ b/public/app/features/dashboard-scene/scene/VairableControls.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+
+import { VariableHide } from '@grafana/data';
+import { SceneGridLayout, SceneVariable, SceneVariableSet, ScopesVariable, TextBoxVariable } from '@grafana/scenes';
+
+import { DashboardScene } from './DashboardScene';
+import { VariableControls } from './VariableControls';
+import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
+
+jest.mock('@grafana/runtime', () => {
+  const runtime = jest.requireActual('@grafana/runtime');
+  return {
+    ...runtime,
+    config: {
+      ...runtime.config,
+      featureToggles: {
+        dashboardNewLayouts: true,
+      },
+    },
+  };
+});
+
+describe('VariableControls', () => {
+  it('should not render scopes variable', () => {
+    const variables = [new ScopesVariable({})];
+    const dashboard = buildScene(variables);
+    dashboard.activate();
+
+    render(<VariableControls dashboard={dashboard} />);
+
+    expect(screen.queryByText('__scopes')).not.toBeInTheDocument();
+  });
+  
+  it('should not render regular hidden variables', () => {
+    const hiddenVariable = new TextBoxVariable({
+      name: 'HiddenVar',
+      hide: VariableHide.hideVariable,
+    });
+    const variables = [hiddenVariable];
+    const dashboard = buildScene(variables);
+    dashboard.activate();
+
+    render(<VariableControls dashboard={dashboard} />);
+
+    expect(screen.queryByText('HiddenVar')).not.toBeInTheDocument();
+  });
+
+  it('should render regular hidden variables in edit mode', async () => {
+    const hiddenVariable = new TextBoxVariable({
+      name: 'HiddenVar',
+      hide: VariableHide.hideVariable,
+    });
+    const variables = [hiddenVariable];
+    const dashboard = buildScene(variables);
+    dashboard.activate();
+
+    dashboard.setState({ isEditing: true });
+    render(<VariableControls dashboard={dashboard} />);
+
+    expect(await screen.findByText('HiddenVar')).toBeInTheDocument();
+  });
+
+  it('should not render variables hidden in controls menu in edit mode', async () => {
+    const dashboard = buildScene([new TextBoxVariable({ name: 'TextVarControls', hide: VariableHide.inControlsMenu })]);
+    dashboard.activate();
+
+    dashboard.setState({ isEditing: true });
+    render(<VariableControls dashboard={dashboard} />);
+
+    expect(screen.queryByText('TextVarControls')).not.toBeInTheDocument();
+  });
+});
+
+function buildScene(variables: SceneVariable[] = []) {
+  const dashboard = new DashboardScene({
+    $variables: new SceneVariableSet({ variables }),
+    body: new DefaultGridLayoutManager({
+      grid: new SceneGridLayout({
+        children: [],
+      }),
+    }),
+  });
+  return dashboard;
+}

--- a/public/app/features/dashboard-scene/scene/VariableControls.test.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.test.tsx
@@ -30,7 +30,7 @@ describe('VariableControls', () => {
 
     expect(screen.queryByText('__scopes')).not.toBeInTheDocument();
   });
-  
+
   it('should not render regular hidden variables', () => {
     const hiddenVariable = new TextBoxVariable({
       name: 'HiddenVar',

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -39,7 +39,7 @@ export function VariableControls({ dashboard }: { dashboard: DashboardScene }) {
     ? restVariables.filter((v) => v.state.hide !== VariableHide.inControlsMenu)
     : variables.filter(
         (v) =>
-          v.state.name !== '__scopes' && // always hide scopes variable
+          !v.UNSAFE_renderAsHidden && // used for scopes variables, should always be hidden
           // if we're editing in dynamic dashboards, still shows hidden variable but greyed out
           ((isEditingNewLayouts && v.state.hide === VariableHide.hideVariable) ||
             v.state.hide !== VariableHide.inControlsMenu)

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -39,9 +39,10 @@ export function VariableControls({ dashboard }: { dashboard: DashboardScene }) {
     ? restVariables.filter((v) => v.state.hide !== VariableHide.inControlsMenu)
     : variables.filter(
         (v) =>
+          v.state.name !== '__scopes' && // always hide scopes variable
           // if we're editing in dynamic dashboards, still shows hidden variable but greyed out
-          (isEditingNewLayouts && v.state.hide === VariableHide.hideVariable) ||
-          v.state.hide !== VariableHide.inControlsMenu
+          ((isEditingNewLayouts && v.state.hide === VariableHide.hideVariable) ||
+            v.state.hide !== VariableHide.inControlsMenu)
       );
 
   return (

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -39,10 +39,10 @@ export function VariableControls({ dashboard }: { dashboard: DashboardScene }) {
     ? restVariables.filter((v) => v.state.hide !== VariableHide.inControlsMenu)
     : variables.filter(
         (v) =>
-          !v.UNSAFE_renderAsHidden && // used for scopes variables, should always be hidden
+          // used for scopes variables, should always be hidden
           // if we're editing in dynamic dashboards, still shows hidden variable but greyed out
-          ((isEditingNewLayouts && v.state.hide === VariableHide.hideVariable) ||
-            v.state.hide !== VariableHide.inControlsMenu)
+          (!v.UNSAFE_renderAsHidden && isEditingNewLayouts && v.state.hide === VariableHide.hideVariable) ||
+          v.state.hide !== VariableHide.inControlsMenu
       );
 
   return (


### PR DESCRIPTION
Bug introduced in https://github.com/grafana/grafana/pull/115723

scopes variables is being shown now in Dynamic dashboards, this adds a check for the default name of scopes variables