### PR TITLE
Alerting: Fix label value search not filtering results

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
@@ -162,7 +162,7 @@ export function useCombinedLabels(
   // This is called by Combobox when the dropdown menu opens
   const createAsyncValuesLoader = useCallback(
     (key: string): AsyncOptionsLoader => {
-      return async (_inputValue: string): Promise<Array<ComboboxOption<string>>> => {
+      return async (valueQuery: string): Promise<Array<ComboboxOption<string>>> => {
         if (!isKeyAllowed(key) || !key) {
           return [];
         }
@@ -188,7 +188,10 @@ export function useCombinedLabels(
         // Combine: existing values first, then unique ops values (Set preserves first occurrence)
         const combinedValues = [...new Set([...existingValues, ...opsValues])];
 
-        return mapLabelsToOptions(combinedValues);
+        const valueQueryLowerCase = valueQuery.toLowerCase();
+        const filteredValues = combinedValues.filter((value) => value.toLowerCase().includes(valueQueryLowerCase));
+
+        return mapLabelsToOptions(filteredValues);
       };
     },
     [labelsByKeyFromExisingAlerts, labelsPluginInstalled, opsLabelKeysSet, fetchLabelValues]


### PR DESCRIPTION
## What this PR does

Fixes a bug in the alert rule editor where typing in the label value dropdown would not filter the available options. The dropdown would show all values for the selected label key, regardless of what the user typed.

## Changes

- **LabelsField.tsx**: Modified the async values loader to filter label values based on user input (case-insensitive search)
- **LabelsFieldOpsLabels.test.tsx**: Added comprehensive tests to verify:
  - Correct label values are shown for each label key
  - Value filtering works when typing in the combobox
  - Proper test setup with portal container and getBoundingClientRect mock for virtualized lists