### PR TITLE
Tempo: Fix search streaming queries

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -801,7 +801,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     return merge(
       ...targets.map((target) =>
         doTempoMetricsStreaming(
-          { ...target, query: query },
+          { ...target, query: this.applyVariables(target, options.scopedVars).query },
           this, // the datasource
           options
         )

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -755,7 +755,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     return merge(
       ...targets.map((target) =>
         doTempoSearchStreaming(
-          { ...target, query: this.applyVariables(target, options.scopedVars).query },
+          { ...target, query: query },
           this, // the datasource
           options,
           this.instanceSettings
@@ -801,7 +801,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     return merge(
       ...targets.map((target) =>
         doTempoMetricsStreaming(
-          { ...target, query: this.applyVariables(target, options.scopedVars).query },
+          { ...target, query: query },
           this, // the datasource
           options
         )


### PR DESCRIPTION
This PR (https://github.com/grafana/grafana/pull/114360) introduces a changes that breaks some queries.
Most notably, streaming search queries now return the error: `tempo search queries cannot be empty`.
I don’t believe this change is necessary, as the values passed into these functions already have variables applied before execution.

Specifically:

- Variables are applied for search queries here:
https://github.com/grafana/grafana/blob/51dcdd3499dcf676cfed34c9035470eda0492088/public/app/plugins/datasource/tempo/datasource.ts#L441-L445

I have also tested that variables are working as expected with this change reverted.

<img width="1383" height="866" alt="Screenshot 2026-01-13 at 00 41 57" src="https://github.com/user-attachments/assets/4cada04d-3d80-406f-ba87-89649a3aafc7" />
