### PR TITLE
GitHub: Add tests checkbox to PR template checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,9 +42,11 @@ Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"
 
 Fixes #
 
-**Special notes for your reviewer:**
+**Checklist:**
 
-Please check that:
+Both author and reviewer should ensure the following:
+
 - [ ] It works as expected from a user's perspective.
 - [ ] If this is a pre-GA feature, it is behind a feature toggle.
 - [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
+- [ ] Tests are added and passing, both for new functionality and for any bug fixes.


### PR DESCRIPTION
## Summary

- Adds a new checklist item reminding authors and reviewers to ensure tests are added and passing for new functionality and bug fixes
- Renames the section from "Special notes for your reviewer" to "Checklist" with explicit shared accountability framing ("Both author and reviewer should ensure the following")

## Why

The existing PR template mentions tests in the intro tips but lacks an explicit, checkable reminder in the checklist itself. This change makes the testing expectation more visible and actionable for both internal contributors and the OSS community.

## Checklist

- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
- [x] Tests are added and passing, both for new functionality and for any bug fixes.