### PR TITLE
RecentlyViewedDashboards: UI tweaks

### DIFF
--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -123,6 +123,7 @@ const getStyles = (theme: GrafanaTheme2) => {
         color: 'transparent',
         cursor: 'pointer',
       },
+      padding: 0,
     }),
     content: css({
       paddingTop: theme.spacing(0),

--- a/public/app/plugins/panel/dashlist/DashListItem.tsx
+++ b/public/app/plugins/panel/dashlist/DashListItem.tsx
@@ -1,3 +1,5 @@
+import { truncate } from 'lodash';
+
 import { reportInteraction } from '@grafana/runtime';
 import { Box, Card, Icon, Link, Stack, Text, useStyles2 } from '@grafana/ui';
 import { LocationInfo } from 'app/features/search/service/types';
@@ -25,6 +27,7 @@ export function DashListItem({
   onStarChange,
 }: Props) {
   const css = useStyles2(getStyles);
+  const shortTitle = truncate(dashboard.name, { length: 40, omission: '…' });
 
   const onCardLinkClick = () => {
     reportInteraction('grafana_recently_viewed_dashboards_click_card', {
@@ -54,27 +57,35 @@ export function DashListItem({
         </div>
       ) : (
         <Card className={css.dashlistCard} noMargin>
-          <Stack justifyContent="space-between" alignItems="center">
-            <Link href={url} onClick={onCardLinkClick}>
-              {dashboard.name}
-            </Link>
-            <StarToolbarButton
-              title={dashboard.name}
-              group="dashboard.grafana.app"
-              kind="Dashboard"
-              id={dashboard.uid}
-              onStarChange={onStarChange}
-            />
-          </Stack>
-
-          {showFolderNames && locationInfo && (
-            <Stack alignItems="center" direction="row" gap={0}>
-              <Icon name="folder" size="sm" className={css.dashlistCardIcon} aria-hidden="true" />
-              <Text color="secondary" variant="bodySmall" element="p">
-                {locationInfo?.name}
-              </Text>
+          <Stack direction="column" justifyContent="space-between" height="100%">
+            <Stack justifyContent="space-between" alignItems="start">
+              <Link
+                className={css.dashlistCardLink}
+                href={url}
+                aria-label={dashboard.name}
+                title={dashboard.name}
+                onClick={onCardLinkClick}
+              >
+                {shortTitle}
+              </Link>
+              <StarToolbarButton
+                title={dashboard.name}
+                group="dashboard.grafana.app"
+                kind="Dashboard"
+                id={dashboard.uid}
+                onStarChange={onStarChange}
+              />
             </Stack>
-          )}
+
+            {showFolderNames && locationInfo && (
+              <Stack alignItems="start" direction="row" gap={0.5} height="25%">
+                <Icon name="folder" size="sm" className={css.dashlistCardIcon} aria-hidden="true" />
+                <Text color="secondary" variant="bodySmall" element="p">
+                  {locationInfo?.name}
+                </Text>
+              </Stack>
+            )}
+          </Stack>
         </Card>
       )}
     </>

--- a/public/app/plugins/panel/dashlist/styles.ts
+++ b/public/app/plugins/panel/dashlist/styles.ts
@@ -32,6 +32,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
         textDecoration: 'underline',
       },
       height: '100%',
+      paddingTop: theme.spacing(1.5),
 
       '&:hover': {
         backgroundImage: gradient,
@@ -40,6 +41,9 @@ export const getStyles = (theme: GrafanaTheme2) => {
     }),
     dashlistCardIcon: css({
       marginRight: theme.spacing(0.5),
+    }),
+    dashlistCardLink: css({
+      paddingTop: theme.spacing(0.5),
     }),
   };
 };


### PR DESCRIPTION
**What is this feature?**

RecentlyViewedDashboards: Small UI tweaks, mostly around spacing. 
<img width="1438" height="328" alt="image" src="https://github.com/user-attachments/assets/063cb86b-a6dc-4638-9f2b-c73e4ffab3d0" />


**Why do we need this feature?**

Better UI

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/115969

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
