### PR TITLE
chore: remove exploreLogsAggregatedMetrics feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -618,10 +618,6 @@ export interface FeatureToggles {
   */
   exploreLogsShardSplitting?: boolean;
   /**
-  * Used in Logs Drilldown to query by aggregated metrics
-  */
-  exploreLogsAggregatedMetrics?: boolean;
-  /**
   * Used in Logs Drilldown to limit the time range
   */
   exploreLogsLimitedTimeRange?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1025,13 +1025,6 @@ var (
 			Owner:        grafanaObservabilityLogsSquad,
 		},
 		{
-			Name:         "exploreLogsAggregatedMetrics",
-			Description:  "Used in Logs Drilldown to query by aggregated metrics",
-			Stage:        FeatureStageExperimental,
-			FrontendOnly: true,
-			Owner:        grafanaObservabilityLogsSquad,
-		},
-		{
 			Name:         "exploreLogsLimitedTimeRange",
 			Description:  "Used in Logs Drilldown to limit the time range",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -141,7 +141,6 @@ newFiltersUI,GA,@grafana/dashboards-squad,false,false,false
 vizActionsAuth,preview,@grafana/dataviz-squad,false,false,true
 alertingPrometheusRulesPrimary,experimental,@grafana/alerting-squad,false,false,true
 exploreLogsShardSplitting,experimental,@grafana/observability-logs,false,false,true
-exploreLogsAggregatedMetrics,experimental,@grafana/observability-logs,false,false,true
 exploreLogsLimitedTimeRange,experimental,@grafana/observability-logs,false,false,true
 appPlatformGrpcClientAuth,experimental,@grafana/identity-access-team,false,false,false
 groupAttributeSync,privatePreview,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1369,7 +1369,8 @@
       "metadata": {
         "name": "exploreLogsAggregatedMetrics",
         "resourceVersion": "1764664939750",
-        "creationTimestamp": "2024-08-29T13:55:59Z"
+        "creationTimestamp": "2024-08-29T13:55:59Z",
+        "deletionTimestamp": "2026-01-12T21:45:49Z"
       },
       "spec": {
         "description": "Used in Logs Drilldown to query by aggregated metrics",


### PR DESCRIPTION
**What is this feature?**

Remove exploreLogsAggregatedMetrics feature flag (promote to GA)

**Special notes for your reviewer:**
Requires https://github.com/grafana/logs-drilldown/pull/1709

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
