### PR TITLE
Dashboard Conversion: Preserve repeat property when converting tabs to rows

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tabs-and-rows-repeated.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tabs-and-rows-repeated.v0alpha1.json
@@ -611,8 +611,11 @@
           "y": 22
         },
         "id": 6,
+        "maxPerRow": 3,
         "options": {},
         "pluginVersion": "12.4.0-19736337744",
+        "repeat": "custom_var_panel",
+        "repeatDirection": "h",
         "targets": [
           {
             "refId": "A"

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tabs-and-rows-repeated.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tabs-and-rows-repeated.v0alpha1.json
@@ -586,6 +586,7 @@
         },
         "id": -1,
         "panels": [],
+        "repeat": "custom_var_tab",
         "title": "Repeated Tab by \"$custom_var_tab\"",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tabs-and-rows-repeated.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tabs-and-rows-repeated.v1beta1.json
@@ -611,8 +611,11 @@
           "y": 22
         },
         "id": 6,
+        "maxPerRow": 3,
         "options": {},
         "pluginVersion": "12.4.0-19736337744",
+        "repeat": "custom_var_panel",
+        "repeatDirection": "h",
         "targets": [
           {
             "refId": "A"

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tabs-and-rows-repeated.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tabs-and-rows-repeated.v1beta1.json
@@ -586,6 +586,7 @@
         },
         "id": -1,
         "panels": [],
+        "repeat": "custom_var_tab",
         "title": "Repeated Tab by \"$custom_var_tab\"",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1.go
+++ b/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1.go
@@ -467,6 +467,11 @@ func processTabItem(elements map[string]dashv2alpha1.DashboardElement, tab *dash
 		rowPanel["title"] = *tab.Spec.Title
 	}
 
+	if tab.Spec.Repeat != nil && tab.Spec.Repeat.Value != "" {
+		// We only use value here as V1 doesn't support mode
+		rowPanel["repeat"] = tab.Spec.Repeat.Value
+	}
+
 	rowPanel["gridPos"] = map[string]interface{}{
 		"x": 0,
 		"y": currentY,

--- a/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1.go
+++ b/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1.go
@@ -852,6 +852,21 @@ func convertAutoGridLayoutToPanelsWithOffset(elements map[string]dashv2alpha1.Da
 			},
 		}
 
+		// Convert AutoGridRepeatOptions to RepeatOptions if present
+		// AutoGridRepeatOptions only has mode and value; infer direction and maxPerRow from AutoGrid settings:
+		// - direction: always "h" (AutoGrid flows horizontally, left-to-right then wraps)
+		// - maxPerRow: from AutoGrid's maxColumnCount
+		if item.Spec.Repeat != nil {
+			directionH := dashv2alpha1.DashboardRepeatOptionsDirectionH
+			maxPerRow := int64(maxColumnCount)
+			gridItem.Spec.Repeat = &dashv2alpha1.DashboardRepeatOptions{
+				Mode:      item.Spec.Repeat.Mode,
+				Value:     item.Spec.Repeat.Value,
+				Direction: &directionH,
+				MaxPerRow: &maxPerRow,
+			}
+		}
+
 		panel, err := convertPanelFromElement(&element, &gridItem)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert panel %s: %w", item.Spec.Element.Name, err)

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
@@ -781,6 +781,10 @@ export function tabItemToSaveModel(
     panels: [],
   };
 
+  if (tab.state.repeatByVariable) {
+    rowPanel.repeat = tab.state.repeatByVariable;
+  }
+
   panelsArray.push(rowPanel);
 
   // The base Y position for panels in this tab (after the row panel)

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
@@ -916,6 +916,15 @@ function autoGridLayoutToPanels(layout: AutoGridLayoutManager, isSnapshot = fals
         },
         isSnapshot
       );
+
+      // Handle repeat properties for AutoGridItem
+      // AutoGrid always uses horizontal direction, and maxPerRow is derived from maxColumnCount
+      if (item.state.variableName) {
+        panel.repeat = item.state.variableName;
+        panel.repeatDirection = 'h';
+        panel.maxPerRow = maxColumnCount;
+      }
+
       panels.push(panel);
 
       // Move to next position


### PR DESCRIPTION
When converting from V2 to V1, we convert tabs to rows, and in this case we were not preserving repeat property. This PR fixes that. 

@Sergej-Vlasov in the issue you reported, you also mentioned that repeated auto grid panels lose repeats when converting to custom grid panels. I've tested this and it's working now. Probably got fixed at some point. 

Fixes https://github.com/grafana/grafana/issues/114924

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
