### PR TITLE
docs: improve RBAC and role creation documentation

### DIFF
--- a/docs/sources/administration/roles-and-permissions/_index.md
+++ b/docs/sources/administration/roles-and-permissions/_index.md
@@ -37,7 +37,7 @@ For Grafana Cloud users, Grafana Support is not authorised to make org role chan
 
 A Grafana server administrator (sometimes referred to as a **Grafana Admin**) manages server-wide settings and access to resources such as organizations, users, and licenses. Grafana includes a default server administrator that you can use to manage all of Grafana, or you can divide that responsibility among other server administrators that you create.
 
-{{< admonition type="note" >}}
+{{< admonition type="caution" >}}
 The server administrator role is distinct from the [organization administrator](#organization-roles) role.
 {{< /admonition >}}
 

--- a/docs/sources/administration/roles-and-permissions/_index.md
+++ b/docs/sources/administration/roles-and-permissions/_index.md
@@ -35,10 +35,10 @@ For Grafana Cloud users, Grafana Support is not authorised to make org role chan
 
 ## Grafana server administrators
 
-A Grafana server administrator manages server-wide settings and access to resources such as organizations, users, and licenses. Grafana includes a default server administrator that you can use to manage all of Grafana, or you can divide that responsibility among other server administrators that you create.
+A Grafana server administrator (sometimes referred to as a **Grafana Admin**) manages server-wide settings and access to resources such as organizations, users, and licenses. Grafana includes a default server administrator that you can use to manage all of Grafana, or you can divide that responsibility among other server administrators that you create.
 
 {{< admonition type="note" >}}
-The server administrator role does not mean that the user is also a Grafana [organization administrator](#organization-roles).
+The server administrator role is distinct from the [organization administrator](#organization-roles) role.
 {{< /admonition >}}
 
 A server administrator can perform the following tasks:
@@ -50,7 +50,7 @@ A server administrator can perform the following tasks:
 - Upgrade the server to Grafana Enterprise.
 
 {{< admonition type="note" >}}
-The server administrator role does not exist in Grafana Cloud.
+The server administrator (Grafana Admin) role does not exist in Grafana Cloud.
 {{< /admonition >}}
 
 To assign or remove server administrator privileges, see [Server user management](../user-management/server-user-management/assign-remove-server-admin-privileges/).

--- a/docs/sources/administration/roles-and-permissions/access-control/manage-rbac-roles/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/manage-rbac-roles/index.md
@@ -173,7 +173,7 @@ Create a custom role when basic roles and fixed roles do not meet your permissio
 The following examples show you how to create a custom role using the Grafana HTTP API. For more information about the HTTP API, refer to [Create a new custom role](ref:api-rbac-create-a-new-custom-role).
 
 {{< admonition type="note" >}}
-You cannot create a custom role with permissions that you do not have. For example, if you only have `users:create` permissions, then you cannot create a role that includes other permissions.
+When you create a custom role you can only give it the same permissions you already have. For example, if you only have `users:create` permissions, then you can't create a role that includes other permissions.
 {{< /admonition >}}
 
 The following example creates a `custom:users:admin` role and assigns the `users:create` action to it.
@@ -258,7 +258,7 @@ For more information, refer to the [`grafana_role`](https://registry.terraform.i
 
 ### Create custom roles using file-based provisioning
 
-[File-based provisioning](ref:rbac-grafana-provisioning) is one method you can use to create custom roles for self-managed instances.
+You can use [file-based provisioning](ref:rbac-grafana-provisioning) to create custom roles for self-managed instances.
 
 1. Open the YAML configuration file and locate the `roles` section.
 

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-grafana-provisioning/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-grafana-provisioning/index.md
@@ -6,7 +6,6 @@ description: Learn about RBAC Grafana provisioning and view an example YAML prov
   file that configures Grafana role assignments.
 labels:
   products:
-    - cloud
     - enterprise
 menuTitle: Provisioning RBAC with Grafana
 title: Provisioning RBAC with Grafana
@@ -52,10 +51,12 @@ refs:
 # Provisioning RBAC with Grafana
 
 {{< admonition type="note" >}}
-Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud).
+Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) for self-managed instances. This feature is not available in Grafana Cloud.
 {{< /admonition >}}
 
 You can create, change or remove [Custom roles](ref:manage-rbac-roles-create-custom-roles-using-provisioning) and create or remove [basic role assignments](ref:assign-rbac-roles-assign-a-fixed-role-to-a-basic-role-using-provisioning), by adding one or more YAML configuration files in the `provisioning/access-control/` directory.
+
+Because this method requires access to the file system where Grafana is running, it's only available for self-managed Grafana instances. To provision RBAC in Grafana Cloud, use [Terraform](ref:rbac-terraform-provisioning) or the [HTTP API](ref:api-rbac-create-and-manage-custom-roles).
 
 Grafana performs provisioning during startup. After you make a change to the configuration file, you can reload it during runtime. You do not need to restart the Grafana server for your changes to take effect.
 


### PR DESCRIPTION
This PR improves the RBAC and role creation documentation:

- Clarifies that file-based RBAC provisioning is for self-managed instances only and requires file system access.
- Explicitly distinguishes between Grafana Admin (Server Admin) and Org Admin, noting that Server Admin doesn't exist in Grafana Cloud.
- Adds a Terraform example for creating a custom folder manager role and assigning it to a team.