### PR TITLE
Provisioning: Add README.md support for Git Sync folders

### DIFF
--- a/pkg/registry/apis/provisioning/files_test.go
+++ b/pkg/registry/apis/provisioning/files_test.go
@@ -1,0 +1,234 @@
+package provisioning
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/auth"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
+)
+
+func TestParseRequestOptionsPathValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		method      string
+		path        string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:   "GET json file allowed",
+			method: http.MethodGet,
+			path:   "dashboard.json",
+		},
+		{
+			name:   "GET yaml file allowed",
+			method: http.MethodGet,
+			path:   "dashboard.yaml",
+		},
+		{
+			name:   "GET yml file allowed",
+			method: http.MethodGet,
+			path:   "dashboard.yml",
+		},
+		{
+			name:   "GET markdown file allowed",
+			method: http.MethodGet,
+			path:   "README.md",
+		},
+		{
+			name:   "GET nested markdown file allowed",
+			method: http.MethodGet,
+			path:   "folder/subfolder/README.md",
+		},
+		{
+			name:        "GET txt file not allowed",
+			method:      http.MethodGet,
+			path:        "file.txt",
+			wantErr:     true,
+			errContains: "unsupported file extension",
+		},
+		{
+			name:   "POST json file allowed",
+			method: http.MethodPost,
+			path:   "dashboard.json",
+		},
+		{
+			name:        "POST markdown file not allowed",
+			method:      http.MethodPost,
+			path:        "README.md",
+			wantErr:     true,
+			errContains: "unsupported file extension",
+		},
+		{
+			name:        "PUT markdown file not allowed",
+			method:      http.MethodPut,
+			path:        "README.md",
+			wantErr:     true,
+			errContains: "unsupported file extension",
+		},
+		{
+			name:        "DELETE markdown file not allowed",
+			method:      http.MethodDelete,
+			path:        "README.md",
+			wantErr:     true,
+			errContains: "unsupported file extension",
+		},
+		{
+			name:   "GET directory allowed",
+			method: http.MethodGet,
+			path:   "dashboards/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := repository.NewMockRepository(t)
+			mockRepo.On("Config").Return(&provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Title: "test-repo",
+				},
+			}).Maybe()
+
+			connector := &filesConnector{}
+			r := httptest.NewRequest(tt.method, "/test-repo/files/"+tt.path, nil)
+
+			opts, err := connector.parseRequestOptions(r, "test-repo", mockRepo)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.path, opts.Path)
+			}
+		})
+	}
+}
+
+func TestHandleGetRawFile(t *testing.T) {
+	tests := []struct {
+		name           string
+		path           string
+		fileContent    string
+		readError      error
+		wantErr        bool
+		errContains    string
+		expectedResult string
+	}{
+		{
+			name:           "successful readme read",
+			path:           "README.md",
+			fileContent:    "# Hello World\n\nThis is a test.",
+			expectedResult: "# Hello World\n\nThis is a test.",
+		},
+		{
+			name:           "nested readme read",
+			path:           "folder/README.md",
+			fileContent:    "# Folder Readme",
+			expectedResult: "# Folder Readme",
+		},
+		{
+			name:        "file not found",
+			path:        "README.md",
+			readError:   repository.ErrFileNotFound,
+			wantErr:     true,
+			errContains: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockReadWriter := repository.NewMockReaderWriter(t)
+			mockAccess := auth.NewMockAccessChecker(t)
+
+			// Setup auth mock - always allow
+			mockAccess.EXPECT().Check(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+			// Setup Read mock
+			if tt.readError != nil {
+				mockReadWriter.EXPECT().Read(mock.Anything, tt.path, "").Return(nil, tt.readError)
+			} else {
+				mockReadWriter.EXPECT().Read(mock.Anything, tt.path, "").Return(&repository.FileInfo{
+					Path: tt.path,
+					Data: []byte(tt.fileContent),
+					Ref:  "main",
+					Hash: "abc123",
+				}, nil)
+			}
+
+			connector := &filesConnector{
+				access: mockAccess,
+			}
+
+			opts := resources.DualWriteOptions{
+				Path: tt.path,
+				Ref:  "",
+			}
+
+			result, err := connector.handleGetRawFile(context.Background(), "test-repo", opts, mockReadWriter)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.Equal(t, tt.path, result.Path)
+
+				// Check that content is in the response
+				content, ok := result.Resource.File.Object["content"]
+				require.True(t, ok, "content field should exist")
+				require.Equal(t, tt.expectedResult, content)
+			}
+		})
+	}
+}
+
+func TestIsRawFileIntegration(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "README.md is raw",
+			path:     "README.md",
+			expected: true,
+		},
+		{
+			name:     "nested README.md is raw",
+			path:     "folder/subfolder/README.md",
+			expected: true,
+		},
+		{
+			name:     "dashboard.json is not raw",
+			path:     "dashboard.json",
+			expected: false,
+		},
+		{
+			name:     "dashboard.yaml is not raw",
+			path:     "dashboard.yaml",
+			expected: false,
+		},
+		{
+			name:     "directory is not raw",
+			path:     "folder/",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resources.IsRawFile(tt.path)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/registry/apis/provisioning/resources/filepath.go
+++ b/pkg/registry/apis/provisioning/resources/filepath.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"errors"
 	"path"
+	"strings"
 
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
 )
@@ -15,9 +16,65 @@ var (
 
 const maxPathDepth = 8
 
-// IsPathSupported checks if the file path is supported by the provisioning API.
-// it also validates if the path is safe and if the file extension is supported.
+// resourceExtensions are file extensions that contain k8s resources and can be parsed
+var resourceExtensions = map[string]bool{
+	".yml":  true,
+	".yaml": true,
+	".json": true,
+}
+
+// readOnlyExtensions are file extensions that can be read as raw content (read-only)
+var readOnlyExtensions = map[string]bool{
+	".md": true,
+}
+
+// IsPathSupported checks if the file path is supported by the provisioning API for write operations.
+// It validates if the path is safe and if the file extension is a resource type (yml, yaml, json).
 func IsPathSupported(filePath string) error {
+	if err := validatePathBasics(filePath); err != nil {
+		return err
+	}
+
+	// Only check file extension if it's not a folder path
+	if !safepath.IsDir(filePath) {
+		ext := path.Ext(filePath)
+		if !resourceExtensions[ext] {
+			return ErrUnsupportedFileExtension
+		}
+	}
+
+	return nil
+}
+
+// IsReadablePath checks if the file path is supported for read operations.
+// This includes resource files (yml, yaml, json) and read-only files (md).
+func IsReadablePath(filePath string) error {
+	if err := validatePathBasics(filePath); err != nil {
+		return err
+	}
+
+	// Only check file extension if it's not a folder path
+	if !safepath.IsDir(filePath) {
+		ext := path.Ext(filePath)
+		if !resourceExtensions[ext] && !readOnlyExtensions[ext] {
+			return ErrUnsupportedFileExtension
+		}
+	}
+
+	return nil
+}
+
+// IsRawFile checks if the file path is a read-only raw file (not a k8s resource).
+func IsRawFile(filePath string) bool {
+	if safepath.IsDir(filePath) {
+		return false
+	}
+	ext := strings.ToLower(path.Ext(filePath))
+	return readOnlyExtensions[ext]
+}
+
+// validatePathBasics performs common path validation checks.
+func validatePathBasics(filePath string) error {
 	// Validate the path for any traversal attempts first
 	if err := safepath.IsSafe(filePath); err != nil {
 		return err
@@ -29,13 +86,6 @@ func IsPathSupported(filePath string) error {
 
 	if safepath.IsAbs(filePath) {
 		return ErrNotRelative
-	}
-
-	// Only check file extension if it's not a folder path
-	if !safepath.IsDir(filePath) {
-		if ext := path.Ext(filePath); ext != ".yml" && ext != ".yaml" && ext != ".json" {
-			return ErrUnsupportedFileExtension
-		}
 	}
 
 	return nil

--- a/pkg/registry/apis/provisioning/resources/filepath_test.go
+++ b/pkg/registry/apis/provisioning/resources/filepath_test.go
@@ -39,6 +39,11 @@ func TestIsPathSupported(t *testing.T) {
 			expectedErr: ErrUnsupportedFileExtension,
 		},
 		{
+			name:        "markdown file not supported for write",
+			path:        "dashboards/README.md",
+			expectedErr: ErrUnsupportedFileExtension,
+		},
+		{
 			name:        "path traversal attempt",
 			path:        "../dashboards/my-dashboard.yaml",
 			expectedErr: safepath.ErrPathTraversalAttempt,
@@ -67,6 +72,130 @@ func TestIsPathSupported(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestIsReadablePath(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		expectedErr error
+	}{
+		{
+			name: "valid yaml file",
+			path: "dashboards/my-dashboard.yaml",
+		},
+		{
+			name: "valid yml file",
+			path: "dashboards/my-dashboard.yml",
+		},
+		{
+			name: "valid json file",
+			path: "dashboards/my-dashboard.json",
+		},
+		{
+			name: "valid markdown file",
+			path: "dashboards/README.md",
+		},
+		{
+			name: "markdown file in nested path",
+			path: "dashboards/folder1/folder2/README.md",
+		},
+		{
+			name: "valid directory path",
+			path: "dashboards/folder1/",
+		},
+		{
+			name:        "unsupported file extension",
+			path:        "dashboards/my-dashboard.txt",
+			expectedErr: ErrUnsupportedFileExtension,
+		},
+		{
+			name:        "path traversal attempt",
+			path:        "../dashboards/README.md",
+			expectedErr: safepath.ErrPathTraversalAttempt,
+		},
+		{
+			name:        "path too deep",
+			path:        "level1/level2/level3/level4/level5/level6/level7/level8/level9/README.md",
+			expectedErr: ErrPathTooDeep,
+		},
+		{
+			name:        "absolute path",
+			path:        "/etc/dashboards/README.md",
+			expectedErr: ErrNotRelative,
+		},
+		{
+			name: "empty directory path",
+			path: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := IsReadablePath(tt.path)
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestIsRawFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "markdown file is raw",
+			path:     "README.md",
+			expected: true,
+		},
+		{
+			name:     "nested markdown file is raw",
+			path:     "dashboards/folder/README.md",
+			expected: true,
+		},
+		{
+			name:     "uppercase MD extension",
+			path:     "README.MD",
+			expected: true,
+		},
+		{
+			name:     "yaml file is not raw",
+			path:     "dashboard.yaml",
+			expected: false,
+		},
+		{
+			name:     "json file is not raw",
+			path:     "dashboard.json",
+			expected: false,
+		},
+		{
+			name:     "yml file is not raw",
+			path:     "dashboard.yml",
+			expected: false,
+		},
+		{
+			name:     "directory is not raw",
+			path:     "dashboards/",
+			expected: false,
+		},
+		{
+			name:     "empty path is not raw",
+			path:     "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsRawFile(tt.path)
+			require.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/tests/apis/provisioning/helper_test.go
+++ b/pkg/tests/apis/provisioning/helper_test.go
@@ -389,6 +389,17 @@ func (h *provisioningTestHelper) CopyToProvisioningPath(t *testing.T, from, to s
 	require.NoError(t, err, "failed to write file to provisioning path")
 }
 
+// WriteToProvisioningPath writes content directly to a file in the provisioning path.
+func (h *provisioningTestHelper) WriteToProvisioningPath(t *testing.T, to string, content []byte) {
+	fullPath := path.Join(h.ProvisioningPath, to)
+	t.Logf("Writing to provisioning path '%s'", fullPath)
+	err := os.MkdirAll(path.Dir(fullPath), 0o750)
+	require.NoError(t, err, "failed to create directories for provisioning path")
+
+	err = os.WriteFile(fullPath, content, 0o600)
+	require.NoError(t, err, "failed to write file to provisioning path")
+}
+
 // DebugState logs the current state of filesystem, repository, and Grafana resources for debugging
 func (h *provisioningTestHelper) DebugState(t *testing.T, repo string, label string) {
 	t.Helper()

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -17,7 +17,6 @@ import { contextSrv } from '../../core/services/context_srv';
 import { ManagerKind } from '../apiserver/types';
 import { TemplateDashboardModal } from '../dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal';
 import { buildNavModel, getDashboardsTabID } from '../folders/state/navModel';
-import { FolderReadme } from '../provisioning/components/Folders/FolderReadme';
 import { ProvisionedFolderPreviewBanner } from '../provisioning/components/Folders/ProvisionedFolderPreviewBanner';
 import { useGetResourceRepositoryView } from '../provisioning/hooks/useGetResourceRepositoryView';
 import { useSearchStateManager } from '../search/state/SearchStateManager';
@@ -180,7 +179,6 @@ const BrowseDashboardsPage = memo(({ queryParams }: { queryParams: Record<string
     >
       <Page.Contents className={styles.pageContents}>
         <ProvisionedFolderPreviewBanner queryParams={queryParams} />
-        {folderUID && <FolderReadme folderUID={folderUID} />}
         {/* only show recently viewed dashboards when in root */}
         {!folderUID && <RecentlyViewedDashboards />}
         <div>

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -17,6 +17,7 @@ import { contextSrv } from '../../core/services/context_srv';
 import { ManagerKind } from '../apiserver/types';
 import { TemplateDashboardModal } from '../dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal';
 import { buildNavModel, getDashboardsTabID } from '../folders/state/navModel';
+import { FolderReadme } from '../provisioning/components/Folders/FolderReadme';
 import { ProvisionedFolderPreviewBanner } from '../provisioning/components/Folders/ProvisionedFolderPreviewBanner';
 import { useGetResourceRepositoryView } from '../provisioning/hooks/useGetResourceRepositoryView';
 import { useSearchStateManager } from '../search/state/SearchStateManager';
@@ -179,6 +180,7 @@ const BrowseDashboardsPage = memo(({ queryParams }: { queryParams: Record<string
     >
       <Page.Contents className={styles.pageContents}>
         <ProvisionedFolderPreviewBanner queryParams={queryParams} />
+        {folderUID && <FolderReadme folderUID={folderUID} />}
         {/* only show recently viewed dashboards when in root */}
         {!folderUID && <RecentlyViewedDashboards />}
         <div>

--- a/public/app/features/browse-dashboards/BrowseFolderReadmePage.tsx
+++ b/public/app/features/browse-dashboards/BrowseFolderReadmePage.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from 'react';
+import { useParams } from 'react-router-dom-v5-compat';
+
+import { useGetFolderQueryFacade, useUpdateFolder } from 'app/api/clients/folder/v1beta1/hooks';
+import { Page } from 'app/core/components/Page/Page';
+
+import { GrafanaRouteComponentProps } from '../../core/navigation/types';
+import { ManagerKind } from '../apiserver/types';
+import { FolderActionsButton } from '../browse-dashboards/components/FolderActionsButton';
+import { buildNavModel, getReadmeTabID } from '../folders/state/navModel';
+import { FolderReadmeContent } from '../provisioning/components/Folders/FolderReadmeContent';
+import { useGetResourceRepositoryView } from '../provisioning/hooks/useGetResourceRepositoryView';
+
+export interface OwnProps extends GrafanaRouteComponentProps<{ uid: string }> {}
+
+export function BrowseFolderReadmePage() {
+  const { uid: folderUID = '' } = useParams();
+  const { data: folderDTO } = useGetFolderQueryFacade(folderUID);
+  const [saveFolder] = useUpdateFolder();
+  const { repoType, isReadOnlyRepo } = useGetResourceRepositoryView({ folderName: folderUID });
+
+  const navModel = useMemo(() => {
+    if (!folderDTO) {
+      return undefined;
+    }
+    const model = buildNavModel(folderDTO);
+
+    // Set the "README" tab to active
+    const readmeTabID = getReadmeTabID(folderDTO.uid);
+    const readmeTab = model.children?.find((child) => child.id === readmeTabID);
+    if (readmeTab) {
+      readmeTab.active = true;
+    }
+    return model;
+  }, [folderDTO]);
+
+  const isProvisionedFolder = folderDTO?.managedBy === ManagerKind.Repo;
+
+  const onEditTitle =
+    folderUID && !isProvisionedFolder
+      ? async (newValue: string) => {
+          if (folderDTO) {
+            const result = await saveFolder({
+              ...folderDTO,
+              title: newValue,
+            });
+            if ('error' in result) {
+              throw result.error;
+            }
+          }
+        }
+      : undefined;
+
+  return (
+    <Page
+      navId="dashboards/browse"
+      pageNav={navModel}
+      onEditTitle={onEditTitle}
+      actions={<>{folderDTO && <FolderActionsButton folder={folderDTO} repoType={repoType} isReadOnlyRepo={isReadOnlyRepo} />}</>}
+    >
+      <Page.Contents>
+        <FolderReadmeContent folderUID={folderUID} />
+      </Page.Contents>
+    </Page>
+  );
+}
+
+export default BrowseFolderReadmePage;

--- a/public/app/features/browse-dashboards/BrowseFolderReadmePage.tsx
+++ b/public/app/features/browse-dashboards/BrowseFolderReadmePage.tsx
@@ -8,7 +8,7 @@ import { GrafanaRouteComponentProps } from '../../core/navigation/types';
 import { ManagerKind } from '../apiserver/types';
 import { FolderActionsButton } from '../browse-dashboards/components/FolderActionsButton';
 import { buildNavModel, getReadmeTabID } from '../folders/state/navModel';
-import { FolderReadmeContent } from '../provisioning/components/Folders/FolderReadmeContent';
+import { FolderReadmeContent } from '../provisioning/components/Folders/FolderReadme';
 import { useGetResourceRepositoryView } from '../provisioning/hooks/useGetResourceRepositoryView';
 
 export interface OwnProps extends GrafanaRouteComponentProps<{ uid: string }> {}

--- a/public/app/features/folders/state/navModel.ts
+++ b/public/app/features/folders/state/navModel.ts
@@ -9,6 +9,7 @@ import { FolderDTO, FolderParent } from 'app/types/folders';
 
 export const FOLDER_ID = 'manage-folder';
 
+export const getReadmeTabID = (folderUID: string) => `folder-readme-${folderUID}`;
 export const getDashboardsTabID = (folderUID: string) => `folder-dashboards-${folderUID}`;
 export const getLibraryPanelsTabID = (folderUID: string) => `folder-library-panels-${folderUID}`;
 export const getAlertingTabID = (folderUID: string) => `folder-alerting-${folderUID}`;
@@ -19,21 +20,35 @@ export function buildNavModel(folder: FolderDTO | FolderParent, parentsArg?: Fol
   const parents = parentsArg ?? ('parents' in folder ? folder.parents : undefined);
   const isProvisioned = 'managedBy' in folder ? folder.managedBy === ManagerKind.Repo : false;
 
+  const children: NavModelItem[] = [];
+
+  // Add README tab first for provisioned folders
+  if (isProvisioned && config.featureToggles.provisioning) {
+    children.push({
+      active: false,
+      icon: 'document-info',
+      id: getReadmeTabID(folder.uid),
+      text: t('browse-dashboards.manage-folder-nav.readme', 'README'),
+      url: `${folder.url}/readme`,
+    });
+  }
+
+  // Dashboards tab
+  children.push({
+    active: false,
+    icon: 'apps',
+    id: getDashboardsTabID(folder.uid),
+    text: t('browse-dashboards.manage-folder-nav.dashboards', 'Dashboards'),
+    url: folder.url,
+  });
+
   const model: NavModelItem = {
     icon: 'folder',
     id: FOLDER_ID,
     subTitle: getNavSubTitle('manage-folder'),
     url: folder.url,
     text: folder.title,
-    children: [
-      {
-        active: false,
-        icon: 'apps',
-        id: getDashboardsTabID(folder.uid),
-        text: t('browse-dashboards.manage-folder-nav.dashboards', 'Dashboards'),
-        url: folder.url,
-      },
-    ],
+    children,
   };
 
   if (parents && parents.length > 0) {

--- a/public/app/features/provisioning/components/Folders/FolderReadme.test.tsx
+++ b/public/app/features/provisioning/components/Folders/FolderReadme.test.tsx
@@ -1,0 +1,330 @@
+import { render, screen } from '@testing-library/react';
+
+import { config } from '@grafana/runtime';
+import { useGetRepositoryFilesWithPathQuery, RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
+
+import { useGetResourceRepositoryView } from '../../hooks/useGetResourceRepositoryView';
+
+import { FolderReadme } from './FolderReadme';
+
+// Mock dependencies
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  config: {
+    featureToggles: {
+      provisioning: true,
+    },
+  },
+}));
+
+jest.mock('app/api/clients/provisioning/v0alpha1', () => ({
+  useGetRepositoryFilesWithPathQuery: jest.fn(),
+}));
+
+jest.mock('../../hooks/useGetResourceRepositoryView');
+
+const mockUseGetRepositoryFilesWithPathQuery = useGetRepositoryFilesWithPathQuery as jest.MockedFunction<
+  typeof useGetRepositoryFilesWithPathQuery
+>;
+
+const mockUseGetResourceRepositoryView = useGetResourceRepositoryView as jest.MockedFunction<
+  typeof useGetResourceRepositoryView
+>;
+
+const mockRepository: RepositoryView = {
+  name: 'test-repo',
+  target: 'folder' as const,
+  title: 'Test Repository',
+  type: 'git' as const,
+  workflows: [],
+};
+
+const mockFolder = {
+  metadata: {
+    name: 'test-folder',
+    annotations: {
+      'grafana.app/sourcePath': 'dashboards/team-a',
+    },
+  },
+  spec: {
+    title: 'Test Folder',
+  },
+  status: {},
+};
+
+describe('FolderReadme', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (config.featureToggles as Record<string, boolean>).provisioning = true;
+  });
+
+  describe('when provisioning is disabled', () => {
+    it('should not render anything', () => {
+      (config.featureToggles as Record<string, boolean>).provisioning = false;
+
+      mockUseGetResourceRepositoryView.mockReturnValue({
+        repository: mockRepository,
+        folder: mockFolder,
+        isLoading: false,
+        isInstanceManaged: false,
+        isReadOnlyRepo: false,
+      });
+
+      const { container } = render(<FolderReadme folderUID="test-folder" />);
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('when folder is not provisioned', () => {
+    it('should not render anything when repository is undefined', () => {
+      mockUseGetResourceRepositoryView.mockReturnValue({
+        repository: undefined,
+        folder: undefined,
+        isLoading: false,
+        isInstanceManaged: false,
+        isReadOnlyRepo: false,
+      });
+
+      const { container } = render(<FolderReadme folderUID="test-folder" />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('should not render anything when folderUID is undefined', () => {
+      mockUseGetResourceRepositoryView.mockReturnValue({
+        repository: mockRepository,
+        folder: mockFolder,
+        isLoading: false,
+        isInstanceManaged: false,
+        isReadOnlyRepo: false,
+      });
+
+      const { container } = render(<FolderReadme folderUID={undefined} />);
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('when loading', () => {
+    it('should not render anything while loading repository info', () => {
+      mockUseGetResourceRepositoryView.mockReturnValue({
+        repository: mockRepository,
+        folder: mockFolder,
+        isLoading: true,
+        isInstanceManaged: false,
+        isReadOnlyRepo: false,
+      });
+
+      const { container } = render(<FolderReadme folderUID="test-folder" />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('should show loading spinner while fetching README', () => {
+      mockUseGetResourceRepositoryView.mockReturnValue({
+        repository: mockRepository,
+        folder: mockFolder,
+        isLoading: false,
+        isInstanceManaged: false,
+        isReadOnlyRepo: false,
+      });
+
+      mockUseGetRepositoryFilesWithPathQuery.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+        error: undefined,
+        refetch: jest.fn(),
+      });
+
+      render(<FolderReadme folderUID="test-folder" />);
+      // Check for spinner by looking for the role or a common class
+      expect(screen.getByTestId('Spinner')).toBeInTheDocument();
+    });
+  });
+
+  describe('when README fetch fails', () => {
+    it('should not render anything on error', () => {
+      mockUseGetResourceRepositoryView.mockReturnValue({
+        repository: mockRepository,
+        folder: mockFolder,
+        isLoading: false,
+        isInstanceManaged: false,
+        isReadOnlyRepo: false,
+      });
+
+      mockUseGetRepositoryFilesWithPathQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: { status: 404, data: 'Not found' },
+        refetch: jest.fn(),
+      });
+
+      const { container } = render(<FolderReadme folderUID="test-folder" />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('should not render anything when file data is empty', () => {
+      mockUseGetResourceRepositoryView.mockReturnValue({
+        repository: mockRepository,
+        folder: mockFolder,
+        isLoading: false,
+        isInstanceManaged: false,
+        isReadOnlyRepo: false,
+      });
+
+      mockUseGetRepositoryFilesWithPathQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: false,
+        error: undefined,
+        refetch: jest.fn(),
+      });
+
+      const { container } = render(<FolderReadme folderUID="test-folder" />);
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('when README is successfully fetched', () => {
+    it('should render markdown content', () => {
+      mockUseGetResourceRepositoryView.mockReturnValue({
+        repository: mockRepository,
+        folder: mockFolder,
+        isLoading: false,
+        isInstanceManaged: false,
+        isReadOnlyRepo: false,
+      });
+
+      mockUseGetRepositoryFilesWithPathQuery.mockReturnValue({
+        data: {
+          resource: {
+            file: {
+              content: '# Hello World\n\nThis is a test README.',
+            },
+          },
+        },
+        isLoading: false,
+        isError: false,
+        error: undefined,
+        refetch: jest.fn(),
+      });
+
+      render(<FolderReadme folderUID="test-folder" />);
+
+      // The markdown should be rendered as HTML
+      expect(screen.getByText('Hello World')).toBeInTheDocument();
+      expect(screen.getByText('This is a test README.')).toBeInTheDocument();
+    });
+
+    it('should handle string content directly', () => {
+      mockUseGetResourceRepositoryView.mockReturnValue({
+        repository: mockRepository,
+        folder: mockFolder,
+        isLoading: false,
+        isInstanceManaged: false,
+        isReadOnlyRepo: false,
+      });
+
+      mockUseGetRepositoryFilesWithPathQuery.mockReturnValue({
+        data: {
+          resource: {
+            file: '# Direct String Content',
+          },
+        },
+        isLoading: false,
+        isError: false,
+        error: undefined,
+        refetch: jest.fn(),
+      });
+
+      render(<FolderReadme folderUID="test-folder" />);
+      expect(screen.getByText('Direct String Content')).toBeInTheDocument();
+    });
+
+    it('should not render when file content cannot be extracted', () => {
+      mockUseGetResourceRepositoryView.mockReturnValue({
+        repository: mockRepository,
+        folder: mockFolder,
+        isLoading: false,
+        isInstanceManaged: false,
+        isReadOnlyRepo: false,
+      });
+
+      mockUseGetRepositoryFilesWithPathQuery.mockReturnValue({
+        data: {
+          resource: {
+            file: { someUnexpectedFormat: true },
+          },
+        },
+        isLoading: false,
+        isError: false,
+        error: undefined,
+        refetch: jest.fn(),
+      });
+
+      const { container } = render(<FolderReadme folderUID="test-folder" />);
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('README path construction', () => {
+    it('should use source path from folder annotations', () => {
+      mockUseGetResourceRepositoryView.mockReturnValue({
+        repository: mockRepository,
+        folder: mockFolder,
+        isLoading: false,
+        isInstanceManaged: false,
+        isReadOnlyRepo: false,
+      });
+
+      mockUseGetRepositoryFilesWithPathQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: false,
+        error: undefined,
+        refetch: jest.fn(),
+      });
+
+      render(<FolderReadme folderUID="test-folder" />);
+
+      // Verify the query was called with the correct path
+      expect(mockUseGetRepositoryFilesWithPathQuery).toHaveBeenCalledWith({
+        name: 'test-repo',
+        path: 'dashboards/team-a/README.md',
+      });
+    });
+
+    it('should use root README.md when no source path is set', () => {
+      const folderWithoutPath = {
+        metadata: {
+          name: 'test-folder',
+          annotations: {},
+        },
+        spec: { title: 'Test Folder' },
+        status: {},
+      };
+
+      mockUseGetResourceRepositoryView.mockReturnValue({
+        repository: mockRepository,
+        folder: folderWithoutPath,
+        isLoading: false,
+        isInstanceManaged: false,
+        isReadOnlyRepo: false,
+      });
+
+      mockUseGetRepositoryFilesWithPathQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: false,
+        error: undefined,
+        refetch: jest.fn(),
+      });
+
+      render(<FolderReadme folderUID="test-folder" />);
+
+      expect(mockUseGetRepositoryFilesWithPathQuery).toHaveBeenCalledWith({
+        name: 'test-repo',
+        path: 'README.md',
+      });
+    });
+  });
+});

--- a/public/app/features/provisioning/components/Folders/FolderReadme.tsx
+++ b/public/app/features/provisioning/components/Folders/FolderReadme.tsx
@@ -1,0 +1,131 @@
+import { css } from '@emotion/css';
+import { skipToken } from '@reduxjs/toolkit/query/react';
+
+import { GrafanaTheme2, renderMarkdown } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { Card, Spinner, useStyles2 } from '@grafana/ui';
+import { useGetRepositoryFilesWithPathQuery } from 'app/api/clients/provisioning/v0alpha1';
+import { AnnoKeySourcePath } from 'app/features/apiserver/types';
+
+import { useGetResourceRepositoryView } from '../../hooks/useGetResourceRepositoryView';
+
+interface FolderReadmeProps {
+  folderUID: string | undefined;
+}
+
+/**
+ * FolderReadme fetches and renders a README.md file from a Git Sync provisioned folder.
+ * It only renders when:
+ * - The provisioning feature is enabled
+ * - The folder is managed by a repository
+ * - The README.md file exists and can be fetched
+ */
+export function FolderReadme({ folderUID }: FolderReadmeProps) {
+  const styles = useStyles2(getStyles);
+  const provisioningEnabled = config.featureToggles.provisioning;
+
+  // Get repository info for the folder
+  const { repository, folder, isLoading: isRepoLoading } = useGetResourceRepositoryView({
+    folderName: folderUID,
+  });
+
+  // Construct the README path based on the folder's source path annotation
+  const sourcePath = folder?.metadata?.annotations?.[AnnoKeySourcePath] || '';
+  const readmePath = sourcePath ? `${sourcePath}/README.md` : 'README.md';
+
+  // Determine if we should fetch the README
+  const shouldFetch = provisioningEnabled && !!repository && !!folderUID && !isRepoLoading;
+
+  // Fetch the README.md file from the repository
+  const {
+    data: fileData,
+    isLoading: isFileLoading,
+    isError,
+  } = useGetRepositoryFilesWithPathQuery(
+    shouldFetch
+      ? {
+          name: repository.name,
+          path: readmePath,
+        }
+      : skipToken
+  );
+
+  // Don't render if provisioning is disabled or folder is not managed
+  if (!provisioningEnabled || !folderUID || !repository) {
+    return null;
+  }
+
+  // Show loading spinner while fetching repository info
+  if (isRepoLoading) {
+    return null;
+  }
+
+  // Show loading spinner while fetching README
+  if (isFileLoading) {
+    return (
+      <Card className={styles.card}>
+        <div className={styles.loadingContainer}>
+          <Spinner size="sm" />
+        </div>
+      </Card>
+    );
+  }
+
+  // Don't render if there was an error (README doesn't exist or unsupported)
+  if (isError || !fileData) {
+    return null;
+  }
+
+  // Extract the raw content from the file data
+  // The API returns a ResourceWrapper with resource.file containing the file data
+  const fileContent = fileData.resource?.file;
+  if (!fileContent) {
+    return null;
+  }
+
+  // For markdown files, the content might be in different formats depending on how the API returns it
+  // Try to get the content as a string
+  let markdownContent: string | undefined;
+
+  if (typeof fileContent === 'string') {
+    markdownContent = fileContent;
+  } else if (typeof fileContent === 'object') {
+    // If it's an object, try common property names
+    markdownContent =
+      (fileContent as Record<string, unknown>).content as string | undefined ||
+      (fileContent as Record<string, unknown>).data as string | undefined ||
+      (fileContent as Record<string, unknown>).spec as string | undefined;
+
+    // If still not found, try to get raw text if available
+    if (!markdownContent && (fileContent as Record<string, unknown>).raw) {
+      markdownContent = (fileContent as Record<string, unknown>).raw as string;
+    }
+  }
+
+  // Don't render if we couldn't extract the content
+  if (!markdownContent || typeof markdownContent !== 'string') {
+    return null;
+  }
+
+  // Render the markdown content
+  const renderedHtml = renderMarkdown(markdownContent);
+
+  return (
+    <Card className={styles.card}>
+      <div className="markdown-html" dangerouslySetInnerHTML={{ __html: renderedHtml }} />
+    </Card>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  card: css({
+    marginBottom: theme.spacing(2),
+    padding: theme.spacing(2),
+  }),
+  loadingContainer: css({
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: theme.spacing(2),
+  }),
+});

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -485,6 +485,15 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
+      path: '/dashboards/f/:uid/:slug/readme',
+      component: SafeDynamicImport(
+        () =>
+          import(
+            /* webpackChunkName: "FolderReadmePage"*/ 'app/features/browse-dashboards/BrowseFolderReadmePage'
+          )
+      ),
+    },
+    {
       path: '/dashboards/f/:uid/:slug/library-panels',
       component: SafeDynamicImport(
         () =>


### PR DESCRIPTION
## Summary

- Enables fetching and rendering README.md files from Git Sync provisioned folders in the UI
- Adds a **README tab** as the first tab for provisioned folders (before Dashboards tab)
- Backend supports read-only access to .md files through the `/files` API

## Changes

### Backend
- Added `IsReadablePath()` function to allow `.md` files for read-only operations
- Added `IsRawFile()` function to detect raw content files (not k8s resources)
- Added `handleGetRawFile()` to return raw file content without parsing as k8s resources
- Raw file content is returned in `resource.file.content` field

### Frontend
- Added README tab to folder navigation model (`getReadmeTabID`)
- Created `BrowseFolderReadmePage` component for the README tab
- Added `/dashboards/f/:uid/:slug/readme` route
- Created `FolderReadmeContent` component with proper empty states:
  - Loading spinner while fetching
  - "Not managed by Git repository" message for non-provisioned folders
  - "No README.md file found" message with helpful hint

## Screenshots

The README tab appears first in the folder navigation for provisioned folders:
- README tab (active when viewing README content)
- Dashboards tab (existing functionality)

## Test plan

- [ ] Unit tests pass for path validation (`filepath_test.go`)
- [ ] Unit tests pass for raw file reading (`files_test.go`)
- [ ] Integration tests pass for README.md API operations
- [ ] Frontend tests pass for FolderReadmeContent component
- [ ] Manual testing: 
  - [ ] Open a Git Sync provisioned folder and verify README tab appears first
  - [ ] Verify README content renders correctly as markdown
  - [ ] Verify Dashboards tab still works as expected
  - [ ] Verify non-provisioned folders don't show README tab