### PR TITLE
 Alerting: Add alertingNavigationV2 feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -531,6 +531,10 @@ export interface FeatureToggles {
   */
   alertingListViewV2?: boolean;
   /**
+  * Enables the new Alerting navigation structure with improved menu grouping
+  */
+  alertingNavigationV2?: boolean;
+  /**
   * Enables saved searches for alert rules list
   */
   alertingSavedSearches?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -880,6 +880,13 @@ var (
 			FrontendOnly: true,
 		},
 		{
+			Name:         "alertingNavigationV2",
+			Description:  "Enables the new Alerting navigation structure with improved menu grouping",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaAlertingSquad,
+			FrontendOnly: false,
+		},
+		{
 			Name:         "alertingSavedSearches",
 			Description:  "Enables saved searches for alert rules list",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -121,6 +121,7 @@ dashboardLibrary,experimental,@grafana/sharing-squad,false,false,false
 suggestedDashboards,experimental,@grafana/sharing-squad,false,false,false
 dashboardTemplates,preview,@grafana/sharing-squad,false,false,false
 alertingListViewV2,privatePreview,@grafana/alerting-squad,false,false,true
+alertingNavigationV2,experimental,@grafana/alerting-squad,false,false,false
 alertingSavedSearches,experimental,@grafana/alerting-squad,false,false,true
 alertingDisableSendAlertsExternal,experimental,@grafana/alerting-squad,false,false,false
 preserveDashboardStateWhenNavigating,experimental,@grafana/dashboards-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -371,6 +371,10 @@ const (
 	// Enables a flow to get started with a new dashboard from a template
 	FlagDashboardTemplates = "dashboardTemplates"
 
+	// FlagAlertingNavigationV2
+	// Enables the new Alerting navigation structure with improved menu grouping
+	FlagAlertingNavigationV2 = "alertingNavigationV2"
+
 	// FlagAlertingDisableSendAlertsExternal
 	// Disables the ability to send alerts to an external Alertmanager datasource.
 	FlagAlertingDisableSendAlertsExternal = "alertingDisableSendAlertsExternal"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -350,6 +350,18 @@
     },
     {
       "metadata": {
+        "name": "alertingNavigationV2",
+        "resourceVersion": "1768320918269",
+        "creationTimestamp": "2026-01-13T16:15:18Z"
+      },
+      "spec": {
+        "description": "Enables the new Alerting navigation structure with improved menu grouping",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingNotificationHistory",
         "resourceVersion": "1764664939750",
         "creationTimestamp": "2025-07-17T13:26:26Z"


### PR DESCRIPTION
## What this PR does

  Introduces a new feature toggle `alertingNavigationV2` that will enable the improved Alerting navigation structure with
  grouped menu items. This toggle is a prerequisite for implementing the new navigation design.

  ## Why we need it

  We're planning to improve the Alerting menu structure by grouping related functionality into logical parent items with nested
  tabs. Before implementing any navigation changes, we need a feature toggle to:

  - Enable safe incremental rollout of changes
  - Allow quick rollback if issues arise
  - Handle backend/frontend deployment timing differences (BE and FE deploy at different phases)
  - Provide a clear migration path for eventual removal of old navigation code

  ## How it works

  This PR only adds the feature toggle definition - no functional changes are included:

  - **Toggle name**: `alertingNavigationV2`
  - **Stage**: Experimental
  - **Owner**: @grafana/alerting-squad
  - **Default state**: Disabled (false)
  - **Scope**: Both backend and frontend (affects navtree generation and navigation hooks)

  ### Files changed:
  - `pkg/services/featuremgmt/registry.go` - Feature toggle definition
  - `pkg/services/featuremgmt/toggles_gen.*` - Auto-generated Go code and metadata
  - `packages/grafana-data/src/types/featureToggles.gen.ts` - Auto-generated TypeScript types

  ## Next steps

  Follow-up PRs will implement the actual navigation changes behind this toggle:
  1. Backend: Conditional navtree structure generation in `navtree.go`
  2. Frontend: Conditional navigation hooks and page components
  3. Testing: Verify both toggle states work correctly
  4. Eventual cleanup: Remove old navigation code after successful rollout

  ## Checklist

  - [x] Feature toggle added to registry
  - [x] Code generated with `make gen-feature-toggles`
  - [x] Pre-commit hooks passed
  - [x] No functional changes - toggle infrastructure only
