### PR TITLE
BrowseDashboards: Fix nested folder's parent folder dropped after rename folder title

### DIFF
--- a/public/app/api/clients/folder/v1beta1/hooks.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.ts
@@ -403,6 +403,9 @@ export function useUpdateFolder() {
         spec: { title: folder.title },
         metadata: {
           name: folder.uid,
+          annotations: {
+            ...(folder.parentUid && { [AnnoKeyFolder]: folder.parentUid }),
+          },
         },
       },
     };


### PR DESCRIPTION
**What is this feature?**

Bug fix: `updateFolderAppPlatform` is missing parentUid, which causing when renaming folder title it lost relationship with parent folder.  

After changes recording: 

https://github.com/user-attachments/assets/3765dc0c-876b-4b4d-bebb-5ddca1ddeeb6

 


**Why do we need this feature?**

Allow user edit folder title correctly

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/116218

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
