### PR TITLE
PluginExtensions: Added support for providing custom icons in the panel menu

### DIFF
--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -188,7 +188,11 @@ export interface PanelOptionsEditorConfig<TOptions, TSettings = any, TValue = an
 export interface PanelMenuItem {
   type?: 'submenu' | 'divider' | 'group';
   text: string;
-  prefix?: React.ReactElement;
+  /** A React element or IconName that will be displayed before the title */
+  prefix?: React.ReactElement | IconName;
+  /**
+   * @deprecated Use `prefix` instead. This property will be removed in a future release.
+   */
   iconClassName?: IconName;
   onClick?: (event: React.MouseEvent) => void;
   shortcut?: string;

--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -188,6 +188,7 @@ export interface PanelOptionsEditorConfig<TOptions, TSettings = any, TValue = an
 export interface PanelMenuItem {
   type?: 'submenu' | 'divider' | 'group';
   text: string;
+  prefix?: React.ReactElement;
   iconClassName?: IconName;
   onClick?: (event: React.MouseEvent) => void;
   shortcut?: string;

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -28,7 +28,9 @@ export type PluginExtensionLink = PluginExtensionBase & {
   type: PluginExtensionTypes.link;
   path?: string;
   onClick?: (event?: React.MouseEvent) => void;
-  icon?: IconName | React.ReactNode;
+  icon?: IconName;
+  suffix?: React.ReactElement;
+  prefix?: React.ReactElement;
   category?: string;
   openInNewTab?: boolean;
 };
@@ -106,7 +108,9 @@ export type PluginAddedLinksConfigureFunc<Context extends object> = (context: Re
       description: string;
       path: string;
       onClick: (event: React.MouseEvent | undefined, helpers: PluginExtensionEventHelpers<Context>) => void;
-      icon: IconName | React.ReactNode;
+      icon: IconName;
+      suffix: React.ReactElement;
+      prefix: React.ReactElement;
       category: string;
       openInNewTab: boolean;
     }>
@@ -136,7 +140,7 @@ export type PluginExtensionAddedLinkConfig<Context extends object = object> = Pl
   configure?: PluginAddedLinksConfigureFunc<Context>;
 
   // (Optional) A icon that can be displayed in the ui for the extension option.
-  icon?: IconName | React.ReactNode;
+  icon?: IconName;
 
   // (Optional) A category to be used when grouping the options in the ui
   category?: string;
@@ -144,6 +148,12 @@ export type PluginExtensionAddedLinkConfig<Context extends object = object> = Pl
   // (Optional) If true, opens the link in a new tab (renders with target="_blank")
   // (Important: this is not guaranteed, depends on the extension point if it implements it.)
   openInNewTab?: boolean;
+
+  // (Optional) A React element that will be displayed after the title
+  suffix?: React.ReactElement;
+
+  // (Optional) A React element that will be displayed before the title
+  prefix?: React.ReactElement;
 };
 
 export type PluginExtensionExposedComponentConfig<Props = {}> = PluginExtensionConfigBase & {

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -28,9 +28,12 @@ export type PluginExtensionLink = PluginExtensionBase & {
   type: PluginExtensionTypes.link;
   path?: string;
   onClick?: (event?: React.MouseEvent) => void;
+  /**
+   * @deprecated Use `prefix` instead. This property will be removed in a future release.
+   */
   icon?: IconName;
-  suffix?: React.ReactElement;
-  prefix?: React.ReactElement;
+  /** A React element or IconName that will be displayed before the title */
+  prefix?: React.ReactElement | IconName;
   category?: string;
   openInNewTab?: boolean;
 };
@@ -108,9 +111,12 @@ export type PluginAddedLinksConfigureFunc<Context extends object> = (context: Re
       description: string;
       path: string;
       onClick: (event: React.MouseEvent | undefined, helpers: PluginExtensionEventHelpers<Context>) => void;
+      /**
+       * @deprecated Use `prefix` instead. This property will be removed in a future release.
+       */
       icon: IconName;
-      suffix: React.ReactElement;
-      prefix: React.ReactElement;
+      /** A React element or IconName that will be displayed before the title */
+      prefix: React.ReactElement | IconName;
       category: string;
       openInNewTab: boolean;
     }>
@@ -139,7 +145,9 @@ export type PluginExtensionAddedLinkConfig<Context extends object = object> = Pl
   // (Optional) A function that can be used to configure the extension dynamically based on the extension point's context
   configure?: PluginAddedLinksConfigureFunc<Context>;
 
-  // (Optional) A icon that can be displayed in the ui for the extension option.
+  /**
+   * @deprecated Use `prefix` instead. This property will be removed in a future release.
+   */
   icon?: IconName;
 
   // (Optional) A category to be used when grouping the options in the ui
@@ -149,11 +157,8 @@ export type PluginExtensionAddedLinkConfig<Context extends object = object> = Pl
   // (Important: this is not guaranteed, depends on the extension point if it implements it.)
   openInNewTab?: boolean;
 
-  // (Optional) A React element that will be displayed after the title
-  suffix?: React.ReactElement;
-
-  // (Optional) A React element that will be displayed before the title
-  prefix?: React.ReactElement;
+  // (Optional) A React element or IconName that will be displayed before the title
+  prefix?: React.ReactElement | IconName;
 };
 
 export type PluginExtensionExposedComponentConfig<Props = {}> = PluginExtensionConfigBase & {

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -28,7 +28,7 @@ export type PluginExtensionLink = PluginExtensionBase & {
   type: PluginExtensionTypes.link;
   path?: string;
   onClick?: (event?: React.MouseEvent) => void;
-  icon?: IconName;
+  icon?: IconName | React.ReactNode;
   category?: string;
   openInNewTab?: boolean;
 };
@@ -106,7 +106,7 @@ export type PluginAddedLinksConfigureFunc<Context extends object> = (context: Re
       description: string;
       path: string;
       onClick: (event: React.MouseEvent | undefined, helpers: PluginExtensionEventHelpers<Context>) => void;
-      icon: IconName;
+      icon: IconName | React.ReactNode;
       category: string;
       openInNewTab: boolean;
     }>
@@ -136,7 +136,7 @@ export type PluginExtensionAddedLinkConfig<Context extends object = object> = Pl
   configure?: PluginAddedLinksConfigureFunc<Context>;
 
   // (Optional) A icon that can be displayed in the ui for the extension option.
-  icon?: IconName;
+  icon?: IconName | React.ReactNode;
 
   // (Optional) A category to be used when grouping the options in the ui
   category?: string;

--- a/packages/grafana-ui/src/components/Menu/MenuItem.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItem.tsx
@@ -2,12 +2,11 @@ import { css, cx } from '@emotion/css';
 import { ReactElement, useCallback, useState, useRef, useImperativeHandle, CSSProperties, AriaRole } from 'react';
 import * as React from 'react';
 
-import { GrafanaTheme2, LinkTarget } from '@grafana/data';
+import { GrafanaTheme2, IconName, isIconName, LinkTarget } from '@grafana/data';
 import { t } from '@grafana/i18n';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { getFocusStyles, getInternalRadius } from '../../themes/mixins';
-import { IconName } from '../../types/icon';
 import { Icon } from '../Icon/Icon';
 import { Stack } from '../Layout/Stack/Stack';
 
@@ -29,10 +28,12 @@ export interface MenuItemProps<T = unknown> {
   ariaChecked?: boolean;
   /** Target of the menu item (i.e. new window)  */
   target?: LinkTarget;
-  /** Icon of the menu item */
+  /**
+   * @deprecated Use `prefix` instead. This property will be removed in a future release.
+   */
   icon?: IconName;
-  /** Prefix of the menu item if icon is specified prefix will be ignored */
-  prefix?: React.ReactElement;
+  /** A React element or IconName that will be displayed before the title */
+  prefix?: React.ReactElement | IconName;
   /** Role of the menu item */
   role?: AriaRole;
   /** Url of the menu item */
@@ -180,7 +181,7 @@ export const MenuItem = React.memo(
         {...disabledProps}
       >
         <Stack direction="row" justifyContent="flex-start" alignItems="center">
-          <MenuItemPrefix icon={icon} prefix={prefix} />
+          <MenuItemPrefix prefix={isIconName(icon) ? icon : prefix} />
           <span className={cx(styles.ellipsis, styles.label)}>{label}</span>
           <div className={cx(styles.rightWrapper, { [styles.withShortcut]: hasShortcut })}>
             {hasShortcut && (

--- a/packages/grafana-ui/src/components/Menu/MenuItem.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItem.tsx
@@ -11,6 +11,7 @@ import { IconName } from '../../types/icon';
 import { Icon } from '../Icon/Icon';
 import { Stack } from '../Layout/Stack/Stack';
 
+import { MenuItemPrefix } from './MenuItemPrefix';
 import { SubMenu } from './SubMenu';
 
 /** @internal */
@@ -30,6 +31,8 @@ export interface MenuItemProps<T = unknown> {
   target?: LinkTarget;
   /** Icon of the menu item */
   icon?: IconName;
+  /** Prefix of the menu item if icon is specified prefix will be ignored */
+  prefix?: React.ReactElement;
   /** Role of the menu item */
   role?: AriaRole;
   /** Url of the menu item */
@@ -79,6 +82,7 @@ export const MenuItem = React.memo(
       customSubMenuContainerStyles,
       shortcut,
       testId,
+      prefix,
     } = props;
     const styles = useStyles2(getStyles);
     const [isActive, setIsActive] = useState(active);
@@ -176,7 +180,7 @@ export const MenuItem = React.memo(
         {...disabledProps}
       >
         <Stack direction="row" justifyContent="flex-start" alignItems="center">
-          {icon && <Icon name={icon} className={styles.icon} aria-hidden />}
+          <MenuItemPrefix icon={icon} prefix={prefix} />
           <span className={cx(styles.ellipsis, styles.label)}>{label}</span>
           <div className={cx(styles.rightWrapper, { [styles.withShortcut]: hasShortcut })}>
             {hasShortcut && (
@@ -271,9 +275,6 @@ const getStyles = (theme: GrafanaTheme2) => {
         background: 'none',
         color: theme.colors.action.disabledText,
       },
-    }),
-    icon: css({
-      opacity: 0.7,
     }),
     rightWrapper: css({
       display: 'flex',

--- a/packages/grafana-ui/src/components/Menu/MenuItemPrefix.test.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItemPrefix.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+
+import { MenuItemPrefix } from './MenuItemPrefix';
+
+describe('MenuItemPrefix', () => {
+  it('renders nothing when prefix is not provided', () => {
+    const { container } = render(<MenuItemPrefix />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders icon when prefix is an IconName string', () => {
+    const { container } = render(<MenuItemPrefix prefix="history" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('renders custom element when prefix is a React element', () => {
+    render(<MenuItemPrefix prefix={<span data-testid="custom-icon">Custom</span>} />);
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+  });
+
+  it('wraps React element prefix in a div with aria-hidden', () => {
+    render(<MenuItemPrefix prefix={<span data-testid="custom-icon">Custom</span>} />);
+    const wrapper = screen.getByTestId('custom-icon').parentElement;
+    expect(wrapper).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('renders nothing when prefix is an invalid value', () => {
+    // @ts-expect-error - testing invalid input
+    const { container } = render(<MenuItemPrefix prefix="not-a-valid-icon-name" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when prefix is null', () => {
+    // @ts-expect-error - testing null input
+    const { container } = render(<MenuItemPrefix prefix={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/grafana-ui/src/components/Menu/MenuItemPrefix.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItemPrefix.tsx
@@ -1,0 +1,48 @@
+import { css } from '@emotion/css';
+
+import { IconName } from '@grafana/data';
+
+import { useStyles2 } from '../../themes/ThemeContext';
+import { Icon } from '../Icon/Icon';
+import { getSvgSize } from '../Icon/utils';
+
+type MenuItemPrefixProps = {
+  prefix?: React.ReactElement;
+  icon?: IconName;
+};
+
+/** @internal */
+export function MenuItemPrefix({ prefix, icon }: MenuItemPrefixProps): React.ReactNode {
+  const styles = useStyles2(getStyles);
+
+  if (!icon && !prefix) {
+    return null;
+  }
+
+  if (icon) {
+    return <Icon name={icon} className={styles.icon} aria-hidden />;
+  }
+
+  return (
+    <div className={styles.prefix} aria-hidden>
+      {prefix}
+    </div>
+  );
+}
+
+function getStyles() {
+  const prefixSize = getSvgSize('md');
+
+  return {
+    icon: css({
+      opacity: 0.7,
+    }),
+    prefix: css({
+      display: 'inline-block',
+      verticalAlign: 'middle',
+      width: prefixSize,
+      height: prefixSize,
+      overflow: 'hidden',
+    }),
+  };
+}

--- a/packages/grafana-ui/src/components/Menu/MenuItemPrefix.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItemPrefix.tsx
@@ -1,26 +1,30 @@
 import { css } from '@emotion/css';
+import { isValidElement } from 'react';
 
-import { IconName } from '@grafana/data';
+import { IconName, isIconName } from '@grafana/data';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { Icon } from '../Icon/Icon';
 import { getSvgSize } from '../Icon/utils';
 
 type MenuItemPrefixProps = {
-  prefix?: React.ReactElement;
-  icon?: IconName;
+  prefix?: React.ReactElement | IconName;
 };
 
 /** @internal */
-export function MenuItemPrefix({ prefix, icon }: MenuItemPrefixProps): React.ReactNode {
+export function MenuItemPrefix({ prefix }: MenuItemPrefixProps): React.ReactNode {
   const styles = useStyles2(getStyles);
 
-  if (!icon && !prefix) {
+  if (!prefix) {
     return null;
   }
 
-  if (icon) {
-    return <Icon name={icon} className={styles.icon} aria-hidden />;
+  if (isIconName(prefix)) {
+    return <Icon name={prefix} className={styles.icon} aria-hidden />;
+  }
+
+  if (!isValidElement(prefix)) {
+    return null;
   }
 
   return (

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderMenu.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderMenu.tsx
@@ -29,6 +29,7 @@ export function PanelHeaderMenu({ items }: Props) {
               key={item.text}
               label={item.text}
               icon={item.iconClassName}
+              prefix={item.prefix}
               childItems={item.subMenu ? renderItems(item.subMenu) : undefined}
               url={item.href}
               onClick={item.onClick}

--- a/public/app/features/plugins/extensions/getPluginExtensions.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.ts
@@ -142,6 +142,7 @@ export const getPluginExtensions: GetExtensions = ({
         path: isString(path) ? getLinkExtensionPathWithTracking(pluginId, path, extensionPointId) : undefined,
         category: overrides?.category || addedLink.category,
         openInNewTab: overrides?.openInNewTab ?? addedLink.openInNewTab,
+        prefix: overrides?.prefix || addedLink.prefix || overrides?.icon || addedLink.icon,
       };
 
       extensions.push(extension);

--- a/public/app/features/plugins/extensions/registry/AddedLinksRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/AddedLinksRegistry.ts
@@ -19,9 +19,12 @@ export type AddedLinkRegistryItem<Context extends object = object> = {
   path?: string;
   onClick?: (event: React.MouseEvent | undefined, helpers: PluginExtensionEventHelpers<Context>) => void;
   configure?: PluginAddedLinksConfigureFunc<Context>;
+  /**
+   * @deprecated Use `prefix` instead. This property will be removed in a future release.
+   */
   icon?: IconName;
-  suffix?: React.ReactElement;
-  prefix?: React.ReactElement;
+  /** A React element or IconName that will be displayed before the title */
+  prefix?: React.ReactElement | IconName;
   category?: string;
   openInNewTab?: boolean;
 };

--- a/public/app/features/plugins/extensions/registry/AddedLinksRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/AddedLinksRegistry.ts
@@ -20,6 +20,8 @@ export type AddedLinkRegistryItem<Context extends object = object> = {
   onClick?: (event: React.MouseEvent | undefined, helpers: PluginExtensionEventHelpers<Context>) => void;
   configure?: PluginAddedLinksConfigureFunc<Context>;
   icon?: IconName;
+  suffix?: React.ReactElement;
+  prefix?: React.ReactElement;
   category?: string;
   openInNewTab?: boolean;
 };

--- a/public/app/features/plugins/extensions/usePluginLinks.tsx
+++ b/public/app/features/plugins/extensions/usePluginLinks.tsx
@@ -86,6 +86,8 @@ export function usePluginLinks({
         path: isString(path) ? getLinkExtensionPathWithTracking(pluginId, path, extensionPointId) : undefined,
         category: overrides?.category || addedLink.category,
         openInNewTab: overrides?.openInNewTab ?? addedLink.openInNewTab,
+        suffix: overrides?.suffix || addedLink.suffix,
+        prefix: overrides?.prefix || addedLink.prefix,
       };
 
       extensions.push(extension);

--- a/public/app/features/plugins/extensions/usePluginLinks.tsx
+++ b/public/app/features/plugins/extensions/usePluginLinks.tsx
@@ -73,8 +73,7 @@ export function usePluginLinks({
       }
 
       const path = overrides?.path || addedLink.path;
-      // For backwards compatibility: if prefix is not set, fall back to icon
-      const prefix = overrides?.prefix || addedLink.prefix || overrides?.icon || addedLink.icon;
+
       const extension: PluginExtensionLink = {
         id: generateExtensionId(pluginId, extensionPointId, addedLink.title),
         type: PluginExtensionTypes.link,
@@ -88,7 +87,7 @@ export function usePluginLinks({
         path: isString(path) ? getLinkExtensionPathWithTracking(pluginId, path, extensionPointId) : undefined,
         category: overrides?.category || addedLink.category,
         openInNewTab: overrides?.openInNewTab ?? addedLink.openInNewTab,
-        prefix,
+        prefix: overrides?.prefix || addedLink.prefix || overrides?.icon || addedLink.icon,
       };
 
       extensions.push(extension);

--- a/public/app/features/plugins/extensions/usePluginLinks.tsx
+++ b/public/app/features/plugins/extensions/usePluginLinks.tsx
@@ -73,6 +73,8 @@ export function usePluginLinks({
       }
 
       const path = overrides?.path || addedLink.path;
+      // For backwards compatibility: if prefix is not set, fall back to icon
+      const prefix = overrides?.prefix || addedLink.prefix || overrides?.icon || addedLink.icon;
       const extension: PluginExtensionLink = {
         id: generateExtensionId(pluginId, extensionPointId, addedLink.title),
         type: PluginExtensionTypes.link,
@@ -86,8 +88,7 @@ export function usePluginLinks({
         path: isString(path) ? getLinkExtensionPathWithTracking(pluginId, path, extensionPointId) : undefined,
         category: overrides?.category || addedLink.category,
         openInNewTab: overrides?.openInNewTab ?? addedLink.openInNewTab,
-        suffix: overrides?.suffix || addedLink.suffix,
-        prefix: overrides?.prefix || addedLink.prefix,
+        prefix,
       };
 
       extensions.push(extension);

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -486,7 +486,6 @@ export function getLinkExtensionOverrides(
       icon = config.icon,
       category = config.category,
       openInNewTab = config.openInNewTab,
-      suffix = config.suffix,
       prefix = config.prefix,
       ...rest
     } = overrides;
@@ -513,7 +512,6 @@ export function getLinkExtensionOverrides(
       icon,
       category,
       openInNewTab,
-      suffix,
       prefix,
     };
   } catch (error) {

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -421,6 +421,7 @@ export function createExtensionSubMenu(extensions: PluginExtensionLink[]): Panel
         onClick: extension.onClick,
         iconClassName: extension.icon,
         target: extension.openInNewTab ? '_blank' : undefined,
+        prefix: extension.prefix,
       });
       continue;
     }
@@ -435,6 +436,7 @@ export function createExtensionSubMenu(extensions: PluginExtensionLink[]): Panel
       onClick: extension.onClick,
       iconClassName: extension.icon,
       target: extension.openInNewTab ? '_blank' : undefined,
+      prefix: extension.prefix,
     });
   }
 
@@ -484,6 +486,8 @@ export function getLinkExtensionOverrides(
       icon = config.icon,
       category = config.category,
       openInNewTab = config.openInNewTab,
+      suffix = config.suffix,
+      prefix = config.prefix,
       ...rest
     } = overrides;
 
@@ -509,6 +513,8 @@ export function getLinkExtensionOverrides(
       icon,
       category,
       openInNewTab,
+      suffix,
+      prefix,
     };
   } catch (error) {
     if (error instanceof Error) {


### PR DESCRIPTION
**What is this feature?**

This PR adds support for custom prefixes in plugin extension links, allowing plugins to display custom React elements (like brand icons or SVGs) instead of being limited to Grafana's built-in icon set. By doing so I will also open up the `PanelMenu` component to do the same.

The newly introduced prefix property accepts either an IconName string or a React.ReactElement, giving plugin developers more flexibility in how their extensions appear in e.g. the dashboard panel menu.

**Why do we need this feature?**

Currently, plugin extension links can only use icons from Grafana's predefined icon set via the icon property. This limitation prevents plugins from displaying their own brand icons or custom visuals in the panel menu, making it harder for users to quickly identify which plugin an extension belongs to.

**Who is this feature for?**

Plugin developers who want to provide a better user experience by displaying recognizable custom icons for their extension links in the dashboard panel menu.


**Usage:**

```ts
     1 │// Using an IconName (same as before, but with prefix)
     2 │.addLink({
     3 │  title: 'My Extension',
     4 │  targets: PluginExtensionPoints.DashboardPanelMenu,
     5 │  prefix: 'cloud',
     6 │  path: '/a/my-plugin/',
     7 │})
     8 │
     9 │// Using a custom React element
    10 │.addLink({
    11 │  title: 'My Extension', 
    12 │  targets: PluginExtensionPoints.DashboardPanelMenu,
    13 │  prefix: <img src="/public/plugins/my-plugin/img/logo.svg" alt="" width={16} height={16} />,
    14 │  path: '/a/my-plugin/',
    15 │})
```

**Work to be done in follow up PRs:**
If this PR gets merged I will open additional PRs to complete the tasks below.

- Migrate extensions points within the grafana code base to use the `prefix` property instead of `icon`.
- Update stories and documentation for the `PanelMenu` component to use `prefix` instead of `icon`.
- Introduce a utility function that will return `IconName | undefined` that can be used on places where `ReactElement` isn't applicable.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
