### PR TITLE
Docs: Add note about Builder/Code mode parity limitations

### DIFF
--- a/docs/sources/datasources/prometheus/query-editor/_index.md
+++ b/docs/sources/datasources/prometheus/query-editor/_index.md
@@ -63,6 +63,10 @@ The Prometheus query editor has two modes:
 
 Grafana synchronizes both modes, allowing you to switch between them. Grafana also displays a warning message if it detects an issue with the query while switching modes.
 
+{{< admonition type="note" >}}
+While Builder mode and Code mode are synchronized in most cases, there are edge cases where full parity is not guaranteed. Complex queries, new PromQL features, certain operations, or specific parsing scenarios may not translate perfectly between modes. If you encounter issues when switching modes, you may need to manually adjust your query.
+{{< /admonition >}}
+
 You can configure Prometheus-specific options in the query editor by setting several options regardless of mode.
 
 {{< figure src="/static/img/docs/prometheus/options.png" max-width="500px" class="docs-image--no-shadow" caption="Options" >}}


### PR DESCRIPTION
## What this PR does / why we need it

This PR addresses issue grafana/grafana-prometheus-datasource#147 by adding clear documentation about the parity limitations between Builder mode and Code mode in the Prometheus query editor.

## Changes made

- Added a note in the Prometheus query editor documentation explaining that Builder mode and Code mode don't always have full parity
- The note sets proper expectations for users about edge cases with:
  - Complex queries
  - New PromQL features
  - Certain operations
  - Specific parsing scenarios
- Warns users that manual query adjustments may be needed when switching modes

## Why is this important?

The current documentation states that users can "jump between Code, Builder, and Explain mode anytime while keeping your query intact," which can be misleading. This change manages user expectations and reduces confusion when encountering parity issues.

## Related issue

Closes grafana/grafana-prometheus-datasource#147

## Testing

- [x] Documentation builds successfully
- [x] Language is clear and concise
- [x] Follows existing documentation style