### PR TITLE
Replace clients with app-sdk-generated versions

### DIFF
--- a/pkg/tests/apis/alerting/notifications/receivers/imported_test.go
+++ b/pkg/tests/apis/alerting/notifications/receivers/imported_test.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/grafana/alerting/notify"
 	"github.com/grafana/alerting/receivers/schema"
+	"github.com/grafana/grafana-app-sdk/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v0alpha1"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -21,7 +21,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/tests/api/alerting"
 	"github.com/grafana/grafana/pkg/tests/apis"
-	test_common "github.com/grafana/grafana/pkg/tests/apis/alerting/notifications/common"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 )
 
@@ -34,7 +33,8 @@ func TestIntegrationReadImported_Snapshot(t *testing.T) {
 		},
 	})
 
-	receiverClient := test_common.NewReceiverClient(t, helper.Org1.Admin)
+	receiverClient, err := v0alpha1.NewReceiverClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
 
 	cliCfg := helper.Org1.Admin.NewRestConfig()
 	alertingApi := alerting.NewAlertingLegacyAPIClient(helper.GetEnv().Server.HTTPServer.Listener.Addr().String(), cliCfg.Username, cliCfg.Password)
@@ -58,9 +58,9 @@ func TestIntegrationReadImported_Snapshot(t *testing.T) {
 	response := alertingApi.ConvertPrometheusPostAlertmanagerConfig(t, amConfig, headers)
 	require.Equal(t, "success", response.Status)
 
-	receiversRaw, err := receiverClient.Client.List(ctx, v1.ListOptions{})
+	receiversRaw, err := receiverClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 	require.NoError(t, err)
-	raw, err := receiversRaw.MarshalJSON()
+	raw, err := json.Marshal(receiversRaw)
 	require.NoError(t, err)
 
 	expectedBytes, err := os.ReadFile(path.Join("test-data", "imported-expected-snapshot.json"))
@@ -74,7 +74,7 @@ func TestIntegrationReadImported_Snapshot(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	receivers, err := receiverClient.List(ctx, v1.ListOptions{})
+	receivers, err := receiverClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 	require.NoError(t, err)
 	t.Run("secure fields should be properly masked", func(t *testing.T) {
 		for _, receiver := range receivers.Items {
@@ -114,14 +114,14 @@ func TestIntegrationReadImported_Snapshot(t *testing.T) {
 		toUpdate := receivers.Items[1]
 		toUpdate.Spec.Title = "another title"
 
-		_, err = receiverClient.Update(ctx, &toUpdate, v1.UpdateOptions{})
+		_, err = receiverClient.Update(ctx, &toUpdate, resource.UpdateOptions{})
 		require.Truef(t, errors.IsBadRequest(err), "Expected BadRequest but got %s", err)
 	})
 
 	t.Run("should not be able to delete", func(t *testing.T) {
 		toDelete := receivers.Items[1]
 
-		err = receiverClient.Delete(ctx, toDelete.Name, v1.DeleteOptions{})
+		err = receiverClient.Delete(ctx, resource.Identifier{Namespace: apis.DefaultNamespace, Name: toDelete.Name}, resource.DeleteOptions{})
 		require.Truef(t, errors.IsBadRequest(err), "Expected BadRequest but got %s", err)
 	})
 }

--- a/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
+++ b/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/grafana/alerting/notify/notifytest"
 	"github.com/grafana/alerting/receivers/line"
 	"github.com/grafana/alerting/receivers/schema"
+	"github.com/grafana/grafana-app-sdk/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/grafana/alerting/notify"
 
@@ -65,7 +65,8 @@ func TestIntegrationResourceIdentifier(t *testing.T) {
 
 	ctx := context.Background()
 	helper := getTestHelper(t)
-	client := test_common.NewReceiverClient(t, helper.Org1.Admin)
+	client, err := v0alpha1.NewReceiverClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
 	newResource := &v0alpha1.Receiver{
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: "default",
@@ -77,42 +78,42 @@ func TestIntegrationResourceIdentifier(t *testing.T) {
 	}
 
 	t.Run("create should fail if object name is specified", func(t *testing.T) {
-		resource := newResource.Copy().(*v0alpha1.Receiver)
-		resource.Name = "new-receiver"
-		_, err := client.Create(ctx, resource, v1.CreateOptions{})
+		receiver := newResource.Copy().(*v0alpha1.Receiver)
+		receiver.Name = "new-receiver"
+		_, err := client.Create(ctx, receiver, resource.CreateOptions{})
 		require.Truef(t, errors.IsBadRequest(err), "Expected BadRequest but got %s", err)
 	})
 
-	var resourceID string
+	var resourceID resource.Identifier
 	t.Run("create should succeed and provide resource name", func(t *testing.T) {
-		actual, err := client.Create(ctx, newResource, v1.CreateOptions{})
+		actual, err := client.Create(ctx, newResource, resource.CreateOptions{})
 		require.NoError(t, err)
 		require.NotEmptyf(t, actual.Name, "Resource name should not be empty")
 		require.NotEmptyf(t, actual.UID, "Resource UID should not be empty")
-		resourceID = actual.Name
+		resourceID = actual.GetStaticMetadata().Identifier()
 	})
 
 	t.Run("resource should be available by the identifier", func(t *testing.T) {
-		actual, err := client.Get(ctx, resourceID, v1.GetOptions{})
+		actual, err := client.Get(ctx, resourceID)
 		require.NoError(t, err)
 		require.NotEmptyf(t, actual.Name, "Resource name should not be empty")
 		require.Equal(t, newResource.Spec, actual.Spec)
 	})
 
 	t.Run("update should rename receiver if name in the specification changes", func(t *testing.T) {
-		existing, err := client.Get(ctx, resourceID, v1.GetOptions{})
+		existing, err := client.Get(ctx, resourceID)
 		require.NoError(t, err)
 
 		updated := existing.Copy().(*v0alpha1.Receiver)
 		updated.Spec.Title = "another-newReceiver"
 
-		actual, err := client.Update(ctx, updated, v1.UpdateOptions{})
+		actual, err := client.Update(ctx, updated, resource.UpdateOptions{})
 		require.NoError(t, err)
 		require.Equal(t, updated.Spec, actual.Spec)
 		require.NotEqualf(t, updated.Name, actual.Name, "Update should change the resource name but it didn't")
 		require.NotEqualf(t, updated.ResourceVersion, actual.ResourceVersion, "Update should change the resource version but it didn't")
 
-		resource, err := client.Get(ctx, actual.Name, v1.GetOptions{})
+		resource, err := client.Get(ctx, actual.GetStaticMetadata().Identifier())
 		require.NoError(t, err)
 		require.Equal(t, actual.Spec, resource.Spec)
 		require.Equal(t, actual.Name, resource.Name)
@@ -140,7 +141,8 @@ func TestIntegrationResourcePermissions(t *testing.T) {
 	admin := org1.Admin
 	viewer := org1.Viewer
 	editor := org1.Editor
-	adminClient := test_common.NewReceiverClient(t, admin)
+	adminClient, err := v0alpha1.NewReceiverClientFromGenerator(admin.GetClientRegistry())
+	require.NoError(t, err)
 
 	writeACMetadata := []string{"canWrite", "canDelete"}
 	allACMetadata := []string{"canWrite", "canDelete", "canReadSecrets", "canAdmin", "canModifyProtected"}
@@ -292,8 +294,10 @@ func TestIntegrationResourcePermissions(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			createClient := test_common.NewReceiverClient(t, tc.creatingUser)
-			client := test_common.NewReceiverClient(t, tc.testUser)
+			createClient, err := v0alpha1.NewReceiverClientFromGenerator(tc.creatingUser.GetClientRegistry())
+			require.NoError(t, err)
+			client, err := v0alpha1.NewReceiverClientFromGenerator(tc.testUser.GetClientRegistry())
+			require.NoError(t, err)
 
 			var created = &v0alpha1.Receiver{
 				ObjectMeta: v1.ObjectMeta{
@@ -308,12 +312,12 @@ func TestIntegrationResourcePermissions(t *testing.T) {
 			require.NoError(t, err)
 
 			// Create receiver with creatingUser
-			created, err = createClient.Create(ctx, created, v1.CreateOptions{})
+			created, err = createClient.Create(ctx, created, resource.CreateOptions{})
 			require.NoErrorf(t, err, "Payload %s", string(d))
 			require.NotNil(t, created)
 
 			defer func() {
-				_ = adminClient.Delete(ctx, created.Name, v1.DeleteOptions{})
+				_ = adminClient.Delete(ctx, created.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
 			}()
 
 			// Assign resource permissions
@@ -338,7 +342,7 @@ func TestIntegrationResourcePermissions(t *testing.T) {
 
 				// Obtain expected responses using admin client as source of truth.
 				expectedGetWithMetadata, expectedListWithMetadata := func() (*v0alpha1.Receiver, *v0alpha1.Receiver) {
-					expectedGet, err := adminClient.Get(ctx, created.Name, v1.GetOptions{})
+					expectedGet, err := adminClient.Get(ctx, created.GetStaticMetadata().Identifier())
 					require.NoError(t, err)
 					require.NotNil(t, expectedGet)
 
@@ -352,7 +356,7 @@ func TestIntegrationResourcePermissions(t *testing.T) {
 						expectedGetWithMetadata.SetAccessControl(ac)
 					}
 
-					expectedList, err := adminClient.List(ctx, v1.ListOptions{})
+					expectedList, err := adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 					require.NoError(t, err)
 					expectedListWithMetadata := extractReceiverFromList(expectedList, created.Name)
 					require.NotNil(t, expectedListWithMetadata)
@@ -368,26 +372,26 @@ func TestIntegrationResourcePermissions(t *testing.T) {
 				}()
 
 				t.Run("should be able to list receivers", func(t *testing.T) {
-					list, err := client.List(ctx, v1.ListOptions{})
+					list, err := client.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 					require.NoError(t, err)
 					listedReceiver := extractReceiverFromList(list, created.Name)
 					assert.Equalf(t, expectedListWithMetadata, listedReceiver, "Expected %v but got %v", expectedListWithMetadata, listedReceiver)
 				})
 
 				t.Run("should be able to read receiver by resource identifier", func(t *testing.T) {
-					got, err := client.Get(ctx, expectedGetWithMetadata.Name, v1.GetOptions{})
+					got, err := client.Get(ctx, expectedGetWithMetadata.GetStaticMetadata().Identifier())
 					require.NoError(t, err)
 					assert.Equalf(t, expectedGetWithMetadata, got, "Expected %v but got %v", expectedGetWithMetadata, got)
 				})
 			} else {
 				t.Run("list receivers should be empty", func(t *testing.T) {
-					list, err := client.List(ctx, v1.ListOptions{})
+					list, err := client.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 					require.NoError(t, err)
 					require.Emptyf(t, list.Items, "Expected no receivers but got %v", list.Items)
 				})
 
 				t.Run("should be forbidden to read receiver by name", func(t *testing.T) {
-					_, err := client.Get(ctx, created.Name, v1.GetOptions{})
+					_, err := client.Get(ctx, created.GetStaticMetadata().Identifier())
 					require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 				})
 			}
@@ -559,10 +563,12 @@ func TestIntegrationAccessControl(t *testing.T) {
 		},
 	}
 
-	adminClient := test_common.NewReceiverClient(t, helper.Org1.Admin)
+	adminClient, err := v0alpha1.NewReceiverClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("user '%s'", tc.user.Identity.GetLogin()), func(t *testing.T) {
-			client := test_common.NewReceiverClient(t, tc.user)
+			client, err := v0alpha1.NewReceiverClientFromGenerator(tc.user.GetClientRegistry())
+			require.NoError(t, err)
 
 			var expected = &v0alpha1.Receiver{
 				ObjectMeta: v1.ObjectMeta{
@@ -580,29 +586,29 @@ func TestIntegrationAccessControl(t *testing.T) {
 			newReceiver.Spec.Title = fmt.Sprintf("receiver-2-%s", tc.user.Identity.GetLogin())
 			if tc.canCreate {
 				t.Run("should be able to create receiver", func(t *testing.T) {
-					actual, err := client.Create(ctx, newReceiver, v1.CreateOptions{})
+					actual, err := client.Create(ctx, newReceiver, resource.CreateOptions{})
 					require.NoErrorf(t, err, "Payload %s", string(d))
 
 					require.Equal(t, newReceiver.Spec, actual.Spec)
 
 					t.Run("should fail if already exists", func(t *testing.T) {
-						_, err := client.Create(ctx, newReceiver, v1.CreateOptions{})
+						_, err := client.Create(ctx, newReceiver, resource.CreateOptions{})
 						require.Truef(t, errors.IsConflict(err), "expected  bad request but got %s", err)
 					})
 
 					// Cleanup.
-					require.NoError(t, adminClient.Delete(ctx, actual.Name, v1.DeleteOptions{}))
+					require.NoError(t, adminClient.Delete(ctx, actual.GetStaticMetadata().Identifier(), resource.DeleteOptions{}))
 				})
 			} else {
 				t.Run("should be forbidden to create", func(t *testing.T) {
-					_, err := client.Create(ctx, newReceiver, v1.CreateOptions{})
+					_, err := client.Create(ctx, newReceiver, resource.CreateOptions{})
 					require.Truef(t, errors.IsForbidden(err), "Payload %s", string(d))
 				})
 			}
 
 			// create resource to proceed with other tests. We don't use the one created above because the user will always
 			// have admin permissions on it.
-			expected, err = adminClient.Create(ctx, expected, v1.CreateOptions{})
+			expected, err = adminClient.Create(ctx, expected, resource.CreateOptions{})
 			require.NoErrorf(t, err, "Payload %s", string(d))
 			require.NotNil(t, expected)
 
@@ -627,34 +633,34 @@ func TestIntegrationAccessControl(t *testing.T) {
 					expectedWithMetadata.SetAccessControl("canAdmin")
 				}
 				t.Run("should be able to list receivers", func(t *testing.T) {
-					list, err := client.List(ctx, v1.ListOptions{})
+					list, err := client.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 					require.NoError(t, err)
 					require.Len(t, list.Items, 2) // default + created
 				})
 
 				t.Run("should be able to read receiver by resource identifier", func(t *testing.T) {
-					got, err := client.Get(ctx, expected.Name, v1.GetOptions{})
+					got, err := client.Get(ctx, expected.GetStaticMetadata().Identifier())
 					require.NoError(t, err)
 					require.Equal(t, expectedWithMetadata, got)
 
 					t.Run("should get NotFound if resource does not exist", func(t *testing.T) {
-						_, err := client.Get(ctx, "Notfound", v1.GetOptions{})
+						_, err := client.Get(ctx, resource.Identifier{Namespace: apis.DefaultNamespace, Name: "Notfound"})
 						require.Truef(t, errors.IsNotFound(err), "Should get NotFound error but got: %s", err)
 					})
 				})
 			} else {
 				t.Run("list receivers should be empty", func(t *testing.T) {
-					list, err := client.List(ctx, v1.ListOptions{})
+					list, err := client.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 					require.NoError(t, err)
 					require.Emptyf(t, list.Items, "Expected no receivers but got %v", list.Items)
 				})
 
 				t.Run("should be forbidden to read receiver by name", func(t *testing.T) {
-					_, err := client.Get(ctx, expected.Name, v1.GetOptions{})
+					_, err := client.Get(ctx, expected.GetStaticMetadata().Identifier())
 					require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 
 					t.Run("should get forbidden even if name does not exist", func(t *testing.T) {
-						_, err := client.Get(ctx, "Notfound", v1.GetOptions{})
+						_, err := client.Get(ctx, resource.Identifier{Namespace: apis.DefaultNamespace, Name: "Notfound"})
 						require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 					})
 				})
@@ -668,7 +674,7 @@ func TestIntegrationAccessControl(t *testing.T) {
 
 			if tc.canUpdate {
 				t.Run("should be able to update receiver", func(t *testing.T) {
-					updated, err := client.Update(ctx, updatedExpected, v1.UpdateOptions{})
+					updated, err := client.Update(ctx, updatedExpected, resource.UpdateOptions{})
 					require.NoErrorf(t, err, "Payload %s", string(d))
 
 					expected = updated
@@ -676,7 +682,7 @@ func TestIntegrationAccessControl(t *testing.T) {
 					t.Run("should get NotFound if name does not exist", func(t *testing.T) {
 						up := updatedExpected.Copy().(*v0alpha1.Receiver)
 						up.Name = "notFound"
-						_, err := client.Update(ctx, up, v1.UpdateOptions{})
+						_, err := client.Update(ctx, up, resource.UpdateOptions{})
 						require.Truef(t, errors.IsNotFound(err), "Should get NotFound error but got: %s", err)
 					})
 				})
@@ -686,7 +692,7 @@ func TestIntegrationAccessControl(t *testing.T) {
 					createIntegration(t, "webhook"),
 				}
 
-				expected, err = adminClient.Update(ctx, updatedExpected, v1.UpdateOptions{})
+				expected, err = adminClient.Update(ctx, updatedExpected, resource.UpdateOptions{})
 				require.NoErrorf(t, err, "Payload %s", string(d))
 				require.NotNil(t, expected)
 
@@ -695,60 +701,62 @@ func TestIntegrationAccessControl(t *testing.T) {
 
 				if tc.canUpdateProtected {
 					t.Run("should be able to update protected fields of the receiver", func(t *testing.T) {
-						updated, err := client.Update(ctx, updatedProtected, v1.UpdateOptions{})
+						updated, err := client.Update(ctx, updatedProtected, resource.UpdateOptions{})
 						require.NoErrorf(t, err, "Payload %s", string(d))
 						require.NotNil(t, updated)
 						expected = updated
 					})
 				} else {
 					t.Run("should be forbidden to edit protected fields of the receiver", func(t *testing.T) {
-						_, err := client.Update(ctx, updatedProtected, v1.UpdateOptions{})
+						_, err := client.Update(ctx, updatedProtected, resource.UpdateOptions{})
 						require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 					})
 				}
 			} else {
 				t.Run("should be forbidden to update receiver", func(t *testing.T) {
-					_, err := client.Update(ctx, updatedExpected, v1.UpdateOptions{})
+					_, err := client.Update(ctx, updatedExpected, resource.UpdateOptions{})
 					require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 
 					t.Run("should get forbidden even if resource does not exist", func(t *testing.T) {
 						up := updatedExpected.Copy().(*v0alpha1.Receiver)
 						up.Name = "notFound"
-						_, err := client.Update(ctx, up, v1.UpdateOptions{})
+						_, err := client.Update(ctx, up, resource.UpdateOptions{
+							ResourceVersion: up.ResourceVersion,
+						})
 						require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 					})
 				})
 				require.Falsef(t, tc.canUpdateProtected, "Invalid combination of assertions. CanUpdateProtected should be false")
 			}
 
-			deleteOptions := v1.DeleteOptions{Preconditions: &v1.Preconditions{ResourceVersion: util.Pointer(expected.ResourceVersion)}}
+			deleteOptions := resource.DeleteOptions{Preconditions: resource.DeleteOptionsPreconditions{ResourceVersion: expected.ResourceVersion}}
 
 			if tc.canDelete {
 				t.Run("should be able to delete receiver", func(t *testing.T) {
-					err := client.Delete(ctx, expected.Name, deleteOptions)
+					err := client.Delete(ctx, expected.GetStaticMetadata().Identifier(), deleteOptions)
 					require.NoError(t, err)
 
 					t.Run("should get NotFound if name does not exist", func(t *testing.T) {
-						err := client.Delete(ctx, "notfound", v1.DeleteOptions{})
+						err := client.Delete(ctx, resource.Identifier{Namespace: apis.DefaultNamespace, Name: "notfound"}, resource.DeleteOptions{})
 						require.Truef(t, errors.IsNotFound(err), "Should get NotFound error but got: %s", err)
 					})
 				})
 			} else {
 				t.Run("should be forbidden to delete receiver", func(t *testing.T) {
-					err := client.Delete(ctx, expected.Name, deleteOptions)
+					err := client.Delete(ctx, expected.GetStaticMetadata().Identifier(), deleteOptions)
 					require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 
 					t.Run("should be forbidden even if resource does not exist", func(t *testing.T) {
-						err := client.Delete(ctx, "notfound", v1.DeleteOptions{})
+						err := client.Delete(ctx, resource.Identifier{Namespace: apis.DefaultNamespace, Name: "notfound"}, resource.DeleteOptions{})
 						require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 					})
 				})
-				require.NoError(t, adminClient.Delete(ctx, expected.Name, v1.DeleteOptions{}))
+				require.NoError(t, adminClient.Delete(ctx, expected.GetStaticMetadata().Identifier(), resource.DeleteOptions{}))
 			}
 
 			if tc.canRead {
 				t.Run("should get empty list if no receivers", func(t *testing.T) {
-					list, err := client.List(ctx, v1.ListOptions{})
+					list, err := client.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 					require.NoError(t, err)
 					require.Len(t, list.Items, 1)
 				})
@@ -766,7 +774,8 @@ func TestIntegrationInUseMetadata(t *testing.T) {
 	cliCfg := helper.Org1.Admin.NewRestConfig()
 	legacyCli := alerting.NewAlertingLegacyAPIClient(helper.GetEnv().Server.HTTPServer.Listener.Addr().String(), cliCfg.Username, cliCfg.Password)
 
-	adminClient := test_common.NewReceiverClient(t, helper.Org1.Admin)
+	adminClient, err := v0alpha1.NewReceiverClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
 	// Prepare environment and create notification policy and rule that use receiver
 	alertmanagerRaw, err := testData.ReadFile(path.Join("test-data", "notification-settings.json"))
 	require.NoError(t, err)
@@ -813,7 +822,7 @@ func TestIntegrationInUseMetadata(t *testing.T) {
 
 	requestReceivers := func(t *testing.T, title string) (v0alpha1.Receiver, v0alpha1.Receiver) {
 		t.Helper()
-		receivers, err := adminClient.List(ctx, v1.ListOptions{})
+		receivers, err := adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 		require.NoError(t, err)
 		require.Len(t, receivers.Items, 2)
 		idx := slices.IndexFunc(receivers.Items, func(interval v0alpha1.Receiver) bool {
@@ -821,7 +830,7 @@ func TestIntegrationInUseMetadata(t *testing.T) {
 		})
 		receiverListed := receivers.Items[idx]
 
-		receiverGet, err := adminClient.Get(ctx, receiverListed.Name, v1.GetOptions{})
+		receiverGet, err := adminClient.Get(ctx, receiverListed.GetStaticMetadata().Identifier())
 		require.NoError(t, err)
 
 		return receiverListed, *receiverGet
@@ -846,7 +855,7 @@ func TestIntegrationInUseMetadata(t *testing.T) {
 	amConfig.AlertmanagerConfig.Route.Routes = amConfig.AlertmanagerConfig.Route.Routes[:1]
 	v1Route, err := routingtree.ConvertToK8sResource(helper.Org1.AdminServiceAccount.OrgId, *amConfig.AlertmanagerConfig.Route, "", func(int64) string { return "default" })
 	require.NoError(t, err)
-	routeAdminClient := test_common.NewRoutingTreeClient(t, helper.Org1.Admin)
+	routeAdminClient := v0alpha1.NewRoutingTreeClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
 	_, err = routeAdminClient.Update(ctx, v1Route, v1.UpdateOptions{})
 	require.NoError(t, err)
 
@@ -892,7 +901,8 @@ func TestIntegrationProvisioning(t *testing.T) {
 	org := helper.Org1
 
 	admin := org.Admin
-	adminClient := test_common.NewReceiverClient(t, helper.Org1.Admin)
+	adminClient, err := v0alpha1.NewReceiverClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
 	env := helper.GetEnv()
 	ac := acimpl.ProvideAccessControl(env.FeatureToggles)
 	db, err := store.ProvideDBStore(env.Cfg, env.FeatureToggles, env.SQLStore, &foldertest.FakeService{}, &dashboards.FakeDashboardService{}, ac, bus.ProvideBus(tracing.InitializeTracerForTest()))
@@ -908,7 +918,7 @@ func TestIntegrationProvisioning(t *testing.T) {
 				createIntegration(t, "email"),
 			},
 		},
-	}, v1.CreateOptions{})
+	}, resource.CreateOptions{})
 	require.NoError(t, err)
 	require.Equal(t, "none", created.GetProvenanceStatus())
 
@@ -917,23 +927,23 @@ func TestIntegrationProvisioning(t *testing.T) {
 			UID: *created.Spec.Integrations[0].Uid,
 		}, admin.Identity.GetOrgID(), "API"))
 
-		got, err := adminClient.Get(ctx, created.Name, v1.GetOptions{})
+		got, err := adminClient.Get(ctx, created.GetStaticMetadata().Identifier())
 		require.NoError(t, err)
 		require.Equal(t, "API", got.GetProvenanceStatus())
 	})
 
 	t.Run("should not let update if provisioned", func(t *testing.T) {
-		got, err := adminClient.Get(ctx, created.Name, v1.GetOptions{})
+		got, err := adminClient.Get(ctx, created.GetStaticMetadata().Identifier())
 		require.NoError(t, err)
 		updated := got.Copy().(*v0alpha1.Receiver)
 		updated.Spec.Integrations = append(updated.Spec.Integrations, createIntegration(t, "email"))
 
-		_, err = adminClient.Update(ctx, updated, v1.UpdateOptions{})
+		_, err = adminClient.Update(ctx, updated, resource.UpdateOptions{})
 		require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 	})
 
 	t.Run("should not let delete if provisioned", func(t *testing.T) {
-		err := adminClient.Delete(ctx, created.Name, v1.DeleteOptions{})
+		err := adminClient.Delete(ctx, created.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
 		require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 	})
 }
@@ -944,7 +954,10 @@ func TestIntegrationOptimisticConcurrency(t *testing.T) {
 	ctx := context.Background()
 	helper := getTestHelper(t)
 
-	adminClient := test_common.NewReceiverClient(t, helper.Org1.Admin)
+	adminClient, err := v0alpha1.NewReceiverClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
+	oldClient := test_common.NewReceiverClient(t, helper.Org1.Admin) // TODO replace with regular client once Delete works
+
 	receiver := v0alpha1.Receiver{
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: "default",
@@ -955,21 +968,22 @@ func TestIntegrationOptimisticConcurrency(t *testing.T) {
 		},
 	}
 
-	created, err := adminClient.Create(ctx, &receiver, v1.CreateOptions{})
+	created, err := adminClient.Create(ctx, &receiver, resource.CreateOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, created)
 	require.NotEmpty(t, created.ResourceVersion)
 
-	t.Run("should forbid if version does not match", func(t *testing.T) {
+	t.Run("should conflict if version does not match", func(t *testing.T) {
 		updated := created.Copy().(*v0alpha1.Receiver)
-		updated.ResourceVersion = "test"
-		_, err := adminClient.Update(ctx, updated, v1.UpdateOptions{})
+		_, err := adminClient.Update(ctx, updated, resource.UpdateOptions{
+			ResourceVersion: "test",
+		})
 		require.Truef(t, errors.IsConflict(err), "should get Forbidden error but got %s", err)
 	})
 	t.Run("should update if version matches", func(t *testing.T) {
 		updated := created.Copy().(*v0alpha1.Receiver)
 		updated.Spec.Integrations = append(updated.Spec.Integrations, createIntegration(t, "email"))
-		actualUpdated, err := adminClient.Update(ctx, updated, v1.UpdateOptions{})
+		actualUpdated, err := adminClient.Update(ctx, updated, resource.UpdateOptions{})
 		require.NoError(t, err)
 		for i, integration := range actualUpdated.Spec.Integrations {
 			updated.Spec.Integrations[i].Uid = integration.Uid
@@ -981,25 +995,25 @@ func TestIntegrationOptimisticConcurrency(t *testing.T) {
 		updated := created.Copy().(*v0alpha1.Receiver)
 		updated.ResourceVersion = ""
 		updated.Spec.Integrations = append(updated.Spec.Integrations, createIntegration(t, "webhook"))
-		_, err := adminClient.Update(ctx, updated, v1.UpdateOptions{})
+		_, err := oldClient.Update(ctx, updated, v1.UpdateOptions{})
 		require.Truef(t, errors.IsConflict(err), "should get Forbidden error but got %s", err) // TODO Change that? K8s returns 400 instead.
 	})
 	t.Run("should fail to delete if version does not match", func(t *testing.T) {
-		actual, err := adminClient.Get(ctx, created.Name, v1.GetOptions{})
+		actual, err := adminClient.Get(ctx, created.GetStaticMetadata().Identifier())
 		require.NoError(t, err)
 
-		err = adminClient.Delete(ctx, actual.Name, v1.DeleteOptions{
+		err = oldClient.Delete(ctx, actual.Name, v1.DeleteOptions{
 			Preconditions: &v1.Preconditions{
 				ResourceVersion: util.Pointer("something"),
 			},
 		})
-		require.Truef(t, errors.IsConflict(err), "should get Forbidden error but got %s", err)
+		require.Truef(t, errors.IsConflict(err), "should get conflict error but got %s", err)
 	})
 	t.Run("should succeed if version matches", func(t *testing.T) {
-		actual, err := adminClient.Get(ctx, created.Name, v1.GetOptions{})
+		actual, err := adminClient.Get(ctx, created.GetStaticMetadata().Identifier())
 		require.NoError(t, err)
 
-		err = adminClient.Delete(ctx, actual.Name, v1.DeleteOptions{
+		err = oldClient.Delete(ctx, actual.Name, v1.DeleteOptions{
 			Preconditions: &v1.Preconditions{
 				ResourceVersion: util.Pointer(actual.ResourceVersion),
 			},
@@ -1007,10 +1021,10 @@ func TestIntegrationOptimisticConcurrency(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("should succeed if version is empty", func(t *testing.T) {
-		actual, err := adminClient.Create(ctx, &receiver, v1.CreateOptions{})
+		actual, err := adminClient.Create(ctx, &receiver, resource.CreateOptions{})
 		require.NoError(t, err)
 
-		err = adminClient.Delete(ctx, actual.Name, v1.DeleteOptions{
+		err = oldClient.Delete(ctx, actual.Name, v1.DeleteOptions{
 			Preconditions: &v1.Preconditions{
 				ResourceVersion: util.Pointer(actual.ResourceVersion),
 			},
@@ -1025,7 +1039,8 @@ func TestIntegrationPatch(t *testing.T) {
 	ctx := context.Background()
 	helper := getTestHelper(t)
 
-	adminClient := test_common.NewReceiverClient(t, helper.Org1.Admin)
+	adminClient, err := v0alpha1.NewReceiverClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
 	receiver := v0alpha1.Receiver{
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: "default",
@@ -1040,40 +1055,40 @@ func TestIntegrationPatch(t *testing.T) {
 		},
 	}
 
-	current, err := adminClient.Create(ctx, &receiver, v1.CreateOptions{})
+	current, err := adminClient.Create(ctx, &receiver, resource.CreateOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, current)
 
 	t.Run("should patch with json patch", func(t *testing.T) {
-		current, err := adminClient.Get(ctx, current.Name, v1.GetOptions{})
+		current, err := adminClient.Get(ctx, current.GetStaticMetadata().Identifier())
 		require.NoError(t, err)
 
 		index := slices.IndexFunc(current.Spec.Integrations, func(t v0alpha1.ReceiverIntegration) bool {
 			return t.Type == "webhook"
 		})
 
-		patch := []map[string]any{
+		patch := []resource.PatchOperation{
 			{
-				"op":   "remove",
-				"path": fmt.Sprintf("/spec/integrations/%d/settings/username", index),
+				Operation: "remove",
+				Path:      fmt.Sprintf("/spec/integrations/%d/settings/username", index),
 			},
 			{
-				"op":   "remove",
-				"path": fmt.Sprintf("/spec/integrations/%d/secureFields/password", index),
+				Operation: "remove",
+				Path:      fmt.Sprintf("/spec/integrations/%d/secureFields/password", index),
 			},
 			{
-				"op":    "replace",
-				"path":  fmt.Sprintf("/spec/integrations/%d/settings/authorization_scheme", index),
-				"value": "bearer",
+				Operation: "replace",
+				Path:      fmt.Sprintf("/spec/integrations/%d/settings/authorization_scheme", index),
+				Value:     "bearer",
 			},
 			{
-				"op":    "add",
-				"path":  fmt.Sprintf("/spec/integrations/%d/settings/authorization_credentials", index),
-				"value": "authz-token",
+				Operation: "add",
+				Path:      fmt.Sprintf("/spec/integrations/%d/settings/authorization_credentials", index),
+				Value:     "authz-token",
 			},
 			{
-				"op":   "remove",
-				"path": fmt.Sprintf("/spec/integrations/%d/secureFields/authorization_credentials", index),
+				Operation: "remove",
+				Path:      fmt.Sprintf("/spec/integrations/%d/secureFields/authorization_credentials", index),
 			},
 		}
 
@@ -1084,10 +1099,7 @@ func TestIntegrationPatch(t *testing.T) {
 		delete(expected.SecureFields, "password")
 		expected.SecureFields["authorization_credentials"] = true
 
-		patchData, err := json.Marshal(patch)
-		require.NoError(t, err)
-
-		result, err := adminClient.Patch(ctx, current.Name, types.JSONPatchType, patchData, v1.PatchOptions{})
+		result, err := adminClient.Patch(ctx, current.GetStaticMetadata().Identifier(), resource.PatchRequest{Operations: patch}, resource.PatchOptions{})
 		require.NoError(t, err)
 
 		require.EqualValues(t, expected, result.Spec.Integrations[index])
@@ -1127,7 +1139,8 @@ func TestIntegrationReferentialIntegrity(t *testing.T) {
 	cliCfg := helper.Org1.Admin.NewRestConfig()
 	legacyCli := alerting.NewAlertingLegacyAPIClient(helper.GetEnv().Server.HTTPServer.Listener.Addr().String(), cliCfg.Username, cliCfg.Password)
 
-	adminClient := test_common.NewReceiverClient(t, helper.Org1.Admin)
+	adminClient, err := v0alpha1.NewReceiverClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
 	// Prepare environment and create notification policy and rule that use time receiver
 	alertmanagerRaw, err := testData.ReadFile(path.Join("test-data", "notification-settings.json"))
 	require.NoError(t, err)
@@ -1146,7 +1159,7 @@ func TestIntegrationReferentialIntegrity(t *testing.T) {
 	_, status, data := legacyCli.PostRulesGroupWithStatus(t, folderUID, &ruleGroup, false)
 	require.Equalf(t, http.StatusAccepted, status, "Failed to post Rule: %s", data)
 
-	receivers, err := adminClient.List(ctx, v1.ListOptions{})
+	receivers, err := adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, receivers.Items, 2)
 	idx := slices.IndexFunc(receivers.Items, func(interval v0alpha1.Receiver) bool {
@@ -1164,7 +1177,7 @@ func TestIntegrationReferentialIntegrity(t *testing.T) {
 			expectedTitle := renamed.Spec.Title + "-new"
 			renamed.Spec.Title = expectedTitle
 
-			actual, err := adminClient.Update(ctx, renamed, v1.UpdateOptions{})
+			actual, err := adminClient.Update(ctx, renamed, resource.UpdateOptions{})
 			require.NoError(t, err)
 
 			updatedRuleGroup, status := legacyCli.GetRulesGroup(t, folderUID, ruleGroup.Name)
@@ -1178,7 +1191,7 @@ func TestIntegrationReferentialIntegrity(t *testing.T) {
 				assert.Equalf(t, expectedTitle, route.Receiver, "time receiver in routes should have been renamed but it did not")
 			}
 
-			actual, err = adminClient.Get(ctx, actual.Name, v1.GetOptions{})
+			actual, err = adminClient.Get(ctx, actual.GetStaticMetadata().Identifier())
 			require.NoError(t, err)
 
 			receiver = *actual
@@ -1194,20 +1207,20 @@ func TestIntegrationReferentialIntegrity(t *testing.T) {
 				t.Cleanup(func() {
 					require.NoError(t, db.DeleteProvenance(ctx, &currentRoute, orgID))
 				})
-				actual, err := adminClient.Update(ctx, renamed, v1.UpdateOptions{})
+				actual, err := adminClient.Update(ctx, renamed, resource.UpdateOptions{})
 				require.Errorf(t, err, "Expected error but got successful result: %v", actual)
 				require.Truef(t, errors.IsConflict(err), "Expected Conflict, got: %s", err)
 			})
 
 			t.Run("provisioned rules", func(t *testing.T) {
 				ruleUid := currentRuleGroup.Rules[0].GrafanaManagedAlert.UID
-				resource := &ngmodels.AlertRule{UID: ruleUid}
-				require.NoError(t, db.SetProvenance(ctx, resource, orgID, "API"))
+				rule := &ngmodels.AlertRule{UID: ruleUid}
+				require.NoError(t, db.SetProvenance(ctx, rule, orgID, "API"))
 				t.Cleanup(func() {
-					require.NoError(t, db.DeleteProvenance(ctx, resource, orgID))
+					require.NoError(t, db.DeleteProvenance(ctx, rule, orgID))
 				})
 
-				actual, err := adminClient.Update(ctx, renamed, v1.UpdateOptions{})
+				actual, err := adminClient.Update(ctx, renamed, resource.UpdateOptions{})
 				require.Errorf(t, err, "Expected error but got successful result: %v", actual)
 				require.Truef(t, errors.IsConflict(err), "Expected Conflict, got: %s", err)
 			})
@@ -1216,7 +1229,7 @@ func TestIntegrationReferentialIntegrity(t *testing.T) {
 
 	t.Run("Delete", func(t *testing.T) {
 		t.Run("should fail to delete if receiver is used in rule and routes", func(t *testing.T) {
-			err := adminClient.Delete(ctx, receiver.Name, v1.DeleteOptions{})
+			err := adminClient.Delete(ctx, receiver.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
 			require.Truef(t, errors.IsConflict(err), "Expected Conflict, got: %s", err)
 		})
 
@@ -1225,7 +1238,7 @@ func TestIntegrationReferentialIntegrity(t *testing.T) {
 			route.Routes[0].Receiver = ""
 			legacyCli.UpdateRoute(t, route, true)
 
-			err = adminClient.Delete(ctx, receiver.Name, v1.DeleteOptions{})
+			err = adminClient.Delete(ctx, receiver.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
 			require.Truef(t, errors.IsConflict(err), "Expected Conflict, got: %s", err)
 		})
 	})
@@ -1237,10 +1250,11 @@ func TestIntegrationCRUD(t *testing.T) {
 	ctx := context.Background()
 	helper := getTestHelper(t)
 
-	adminClient := test_common.NewReceiverClient(t, helper.Org1.Admin)
+	adminClient, err := v0alpha1.NewReceiverClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
 	var defaultReceiver *v0alpha1.Receiver
 	t.Run("should list the default receiver", func(t *testing.T) {
-		items, err := adminClient.List(ctx, v1.ListOptions{})
+		items, err := adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 		require.NoError(t, err)
 		assert.Len(t, items.Items, 1)
 		defaultReceiver = &items.Items[0]
@@ -1249,7 +1263,7 @@ func TestIntegrationCRUD(t *testing.T) {
 		assert.NotEmpty(t, defaultReceiver.Name)
 		assert.NotEmpty(t, defaultReceiver.ResourceVersion)
 
-		defaultReceiver, err = adminClient.Get(ctx, defaultReceiver.Name, v1.GetOptions{})
+		defaultReceiver, err = adminClient.Get(ctx, defaultReceiver.GetStaticMetadata().Identifier())
 		require.NoError(t, err)
 		assert.NotEmpty(t, defaultReceiver.UID)
 		assert.NotEmpty(t, defaultReceiver.Name)
@@ -1262,7 +1276,7 @@ func TestIntegrationCRUD(t *testing.T) {
 		newDefault := defaultReceiver.Copy().(*v0alpha1.Receiver)
 		newDefault.Spec.Integrations = append(newDefault.Spec.Integrations, createIntegration(t, line.Type))
 
-		updatedReceiver, err := adminClient.Update(ctx, newDefault, v1.UpdateOptions{})
+		updatedReceiver, err := adminClient.Update(ctx, newDefault, resource.UpdateOptions{})
 		require.NoError(t, err)
 
 		expected := newDefault.Copy().(*v0alpha1.Receiver)
@@ -1290,12 +1304,12 @@ func TestIntegrationCRUD(t *testing.T) {
 				Integrations: []v0alpha1.ReceiverIntegration{},
 			},
 		}
-		_, err := adminClient.Create(ctx, newReceiver, v1.CreateOptions{})
+		_, err := adminClient.Create(ctx, newReceiver, resource.CreateOptions{})
 		require.Truef(t, errors.IsConflict(err), "Expected Conflict, got: %s", err)
 	})
 
 	t.Run("should not let delete default receiver", func(t *testing.T) {
-		err := adminClient.Delete(ctx, defaultReceiver.Name, v1.DeleteOptions{})
+		err := adminClient.Delete(ctx, defaultReceiver.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
 		require.Truef(t, errors.IsConflict(err), "Expected Conflict, got: %s", err)
 	})
 
@@ -1317,7 +1331,7 @@ func TestIntegrationCRUD(t *testing.T) {
 				Title:        "all-receivers",
 				Integrations: integrations,
 			},
-		}, v1.CreateOptions{})
+		}, resource.CreateOptions{})
 		require.NoError(t, err)
 		require.Len(t, receiver.Spec.Integrations, len(integrations))
 
@@ -1342,7 +1356,7 @@ func TestIntegrationCRUD(t *testing.T) {
 	})
 
 	t.Run("should be able read what it is created", func(t *testing.T) {
-		get, err := adminClient.Get(ctx, receiver.Name, v1.GetOptions{})
+		get, err := adminClient.Get(ctx, receiver.GetStaticMetadata().Identifier())
 		require.NoError(t, err)
 		require.Equal(t, receiver, get)
 		t.Run("should return secrets in secureFields but not settings", func(t *testing.T) {
@@ -1394,7 +1408,7 @@ func TestIntegrationCRUD(t *testing.T) {
 						Title:        fmt.Sprintf("invalid-%s", key),
 						Integrations: []v0alpha1.ReceiverIntegration{integration},
 					},
-				}, v1.CreateOptions{})
+				}, resource.CreateOptions{})
 				require.Errorf(t, err, "Expected error but got successful result: %v", receiver)
 				require.Truef(t, errors.IsBadRequest(err), "Expected BadRequest, got: %s", err)
 			})
@@ -1408,7 +1422,8 @@ func TestIntegrationReceiverListSelector(t *testing.T) {
 	ctx := context.Background()
 	helper := getTestHelper(t)
 
-	adminClient := test_common.NewReceiverClient(t, helper.Org1.Admin)
+	adminClient, err := v0alpha1.NewReceiverClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
 	recv1 := &v0alpha1.Receiver{
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: "default",
@@ -1420,7 +1435,7 @@ func TestIntegrationReceiverListSelector(t *testing.T) {
 			},
 		},
 	}
-	recv1, err := adminClient.Create(ctx, recv1, v1.CreateOptions{})
+	recv1, err = adminClient.Create(ctx, recv1, resource.CreateOptions{})
 	require.NoError(t, err)
 
 	recv2 := &v0alpha1.Receiver{
@@ -1434,7 +1449,7 @@ func TestIntegrationReceiverListSelector(t *testing.T) {
 			},
 		},
 	}
-	recv2, err = adminClient.Create(ctx, recv2, v1.CreateOptions{})
+	recv2, err = adminClient.Create(ctx, recv2, resource.CreateOptions{})
 	require.NoError(t, err)
 
 	env := helper.GetEnv()
@@ -1444,18 +1459,20 @@ func TestIntegrationReceiverListSelector(t *testing.T) {
 	require.NoError(t, db.SetProvenance(ctx, &definitions.EmbeddedContactPoint{
 		UID: *recv2.Spec.Integrations[0].Uid,
 	}, helper.Org1.Admin.Identity.GetOrgID(), "API"))
-	recv2, err = adminClient.Get(ctx, recv2.Name, v1.GetOptions{})
+	recv2, err = adminClient.Get(ctx, recv2.GetStaticMetadata().Identifier())
 
 	require.NoError(t, err)
 
-	receivers, err := adminClient.List(ctx, v1.ListOptions{})
+	receivers, err := adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, receivers.Items, 3) // Includes default.
 
 	t.Run("should filter by receiver name", func(t *testing.T) {
 		t.Skip("disabled until app installer supports it") // TODO revisit when custom field selectors are supported
-		list, err := adminClient.List(ctx, v1.ListOptions{
-			FieldSelector: "spec.title=" + recv1.Spec.Title,
+		list, err := adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{
+			FieldSelectors: []string{
+				"spec.title=" + recv1.Spec.Title,
+			},
 		})
 		require.NoError(t, err)
 		require.Len(t, list.Items, 1)
@@ -1463,8 +1480,10 @@ func TestIntegrationReceiverListSelector(t *testing.T) {
 	})
 
 	t.Run("should filter by metadata name", func(t *testing.T) {
-		list, err := adminClient.List(ctx, v1.ListOptions{
-			FieldSelector: "metadata.name=" + recv2.Name,
+		list, err := adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{
+			FieldSelectors: []string{
+				"metadata.name=" + recv2.Name,
+			},
 		})
 		require.NoError(t, err)
 		require.Len(t, list.Items, 1)
@@ -1473,8 +1492,10 @@ func TestIntegrationReceiverListSelector(t *testing.T) {
 
 	t.Run("should filter by multiple filters", func(t *testing.T) {
 		t.Skip("disabled until app installer supports it") // TODO revisit when custom field selectors are supported
-		list, err := adminClient.List(ctx, v1.ListOptions{
-			FieldSelector: fmt.Sprintf("metadata.name=%s,spec.title=%s", recv2.Name, recv2.Spec.Title),
+		list, err := adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{
+			FieldSelectors: []string{
+				fmt.Sprintf("metadata.name=%s,spec.title=%s", recv2.Name, recv2.Spec.Title),
+			},
 		})
 		require.NoError(t, err)
 		require.Len(t, list.Items, 1)
@@ -1482,8 +1503,10 @@ func TestIntegrationReceiverListSelector(t *testing.T) {
 	})
 
 	t.Run("should be empty when filter does not match", func(t *testing.T) {
-		list, err := adminClient.List(ctx, v1.ListOptions{
-			FieldSelector: fmt.Sprintf("metadata.name=%s", "unknown"),
+		list, err := adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{
+			FieldSelectors: []string{
+				fmt.Sprintf("metadata.name=%s", "unknown"),
+			},
 		})
 		require.NoError(t, err)
 		require.Empty(t, list.Items)
@@ -1497,7 +1520,8 @@ func persistInitialConfig(t *testing.T, amConfig definitions.PostableUserConfig)
 
 	helper := getTestHelper(t)
 
-	receiverClient := test_common.NewReceiverClient(t, helper.Org1.Admin)
+	receiverClient, err := v0alpha1.NewReceiverClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
 	for _, receiver := range amConfig.AlertmanagerConfig.Receivers {
 		if receiver.Name == "grafana-default-email" {
 			continue
@@ -1523,7 +1547,7 @@ func persistInitialConfig(t *testing.T, amConfig definitions.PostableUserConfig)
 			})
 		}
 
-		created, err := receiverClient.Create(ctx, &toCreate, v1.CreateOptions{})
+		created, err := receiverClient.Create(ctx, &toCreate, resource.CreateOptions{})
 		require.NoError(t, err)
 
 		for i, integration := range created.Spec.Integrations {

--- a/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
+++ b/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
@@ -855,8 +855,9 @@ func TestIntegrationInUseMetadata(t *testing.T) {
 	amConfig.AlertmanagerConfig.Route.Routes = amConfig.AlertmanagerConfig.Route.Routes[:1]
 	v1Route, err := routingtree.ConvertToK8sResource(helper.Org1.AdminServiceAccount.OrgId, *amConfig.AlertmanagerConfig.Route, "", func(int64) string { return "default" })
 	require.NoError(t, err)
-	routeAdminClient := v0alpha1.NewRoutingTreeClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
-	_, err = routeAdminClient.Update(ctx, v1Route, v1.UpdateOptions{})
+	routeAdminClient, err := v0alpha1.NewRoutingTreeClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
+	_, err = routeAdminClient.Update(ctx, v1Route, resource.UpdateOptions{})
 	require.NoError(t, err)
 
 	receiverListed, receiverGet = requestReceivers(t, "user-defined")
@@ -877,7 +878,7 @@ func TestIntegrationInUseMetadata(t *testing.T) {
 	amConfig.AlertmanagerConfig.Route.Routes = nil
 	v1route, err := routingtree.ConvertToK8sResource(1, *amConfig.AlertmanagerConfig.Route, "", func(int64) string { return "default" })
 	require.NoError(t, err)
-	_, err = routeAdminClient.Update(ctx, v1route, v1.UpdateOptions{})
+	_, err = routeAdminClient.Update(ctx, v1route, resource.UpdateOptions{})
 	require.NoError(t, err)
 
 	// Remove the remaining rules.
@@ -1557,10 +1558,11 @@ func persistInitialConfig(t *testing.T, amConfig definitions.PostableUserConfig)
 
 	nsMapper := func(_ int64) string { return "default" }
 
-	routeClient := test_common.NewRoutingTreeClient(t, helper.Org1.Admin)
+	routeClient, err := v0alpha1.NewRoutingTreeClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
 	v1route, err := routingtree.ConvertToK8sResource(helper.Org1.AdminServiceAccount.OrgId, *amConfig.AlertmanagerConfig.Route, "", nsMapper)
 	require.NoError(t, err)
-	_, err = routeClient.Update(ctx, v1route, v1.UpdateOptions{})
+	_, err = routeClient.Update(ctx, v1route, resource.UpdateOptions{})
 	require.NoError(t, err)
 }
 

--- a/pkg/tests/apis/alerting/notifications/receivers/test-data/imported-expected-snapshot.json
+++ b/pkg/tests/apis/alerting/notifications/receivers/test-data/imported-expected-snapshot.json
@@ -1,10 +1,14 @@
 {
+  "kind": "ReceiverList",
   "apiVersion": "notifications.alerting.grafana.app/v0alpha1",
+  "metadata": {},
   "items": [
     {
-      "apiVersion": "notifications.alerting.grafana.app/v0alpha1",
-      "kind": "Receiver",
       "metadata": {
+        "name": "Z3JhZmFuYS1kZWZhdWx0LWVtYWls",
+        "namespace": "default",
+        "uid": "zyXFk301pvwNz4HRPrTMKPMFO2934cPB7H1ZXmyM1TUX",
+        "resourceVersion": "a82b34036bdabbc4",
         "annotations": {
           "grafana.com/access/canAdmin": "true",
           "grafana.com/access/canDelete": "true",
@@ -15,53 +19,29 @@
           "grafana.com/inUse/routes": "1",
           "grafana.com/inUse/rules": "0",
           "grafana.com/provenance": "none"
-        },
-        "name": "Z3JhZmFuYS1kZWZhdWx0LWVtYWls",
-        "namespace": "default",
-        "resourceVersion": "a82b34036bdabbc4",
-        "uid": "zyXFk301pvwNz4HRPrTMKPMFO2934cPB7H1ZXmyM1TUX"
+        }
       },
       "spec": {
+        "title": "grafana-default-email",
         "integrations": [
           {
+            "uid": "",
+            "type": "email",
+            "version": "v1",
             "disableResolveMessage": false,
             "settings": {
               "addresses": "\u003cexample@email.com\u003e"
-            },
-            "type": "email",
-            "uid": "",
-            "version": "v1"
+            }
           }
-        ],
-        "title": "grafana-default-email"
+        ]
       }
     },
     {
-      "apiVersion": "notifications.alerting.grafana.app/v0alpha1",
-      "kind": "Receiver",
       "metadata": {
-        "annotations": {
-          "grafana.com/access/canModifyProtected": "true",
-          "grafana.com/access/canReadSecrets": "true",
-          "grafana.com/canUse": "false",
-          "grafana.com/inUse/routes": "0",
-          "grafana.com/inUse/rules": "0",
-          "grafana.com/provenance": "converted_prometheus"
-        },
         "name": "Z3JhZmFuYS1kZWZhdWx0LWVtYWlsdGVzdC1jcmVhdGUtZ2V0LWNvbmZpZw",
         "namespace": "default",
+        "uid": "JzW6DIlcxj4sRN8A2ULcwTXAmm0Vs0Z68aEBqXSvxK0X",
         "resourceVersion": "b2823b50ffa1eff6",
-        "uid": "JzW6DIlcxj4sRN8A2ULcwTXAmm0Vs0Z68aEBqXSvxK0X"
-      },
-      "spec": {
-        "integrations": [],
-        "title": "grafana-default-emailtest-create-get-config"
-      }
-    },
-    {
-      "apiVersion": "notifications.alerting.grafana.app/v0alpha1",
-      "kind": "Receiver",
-      "metadata": {
         "annotations": {
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
@@ -69,19 +49,36 @@
           "grafana.com/inUse/routes": "0",
           "grafana.com/inUse/rules": "0",
           "grafana.com/provenance": "converted_prometheus"
-        },
-        "name": "ZGlzY29yZA",
-        "namespace": "default",
-        "resourceVersion": "06e437697f62ac59",
-        "uid": "8cH8Ql2S6VhPEVUhwlQEKYWyPbRJS7YKj2lEXdrehH8X"
+        }
       },
       "spec": {
+        "title": "grafana-default-emailtest-create-get-config",
+        "integrations": []
+      }
+    },
+    {
+      "metadata": {
+        "name": "ZGlzY29yZA",
+        "namespace": "default",
+        "uid": "8cH8Ql2S6VhPEVUhwlQEKYWyPbRJS7YKj2lEXdrehH8X",
+        "resourceVersion": "06e437697f62ac59",
+        "annotations": {
+          "grafana.com/access/canModifyProtected": "true",
+          "grafana.com/access/canReadSecrets": "true",
+          "grafana.com/canUse": "false",
+          "grafana.com/inUse/routes": "0",
+          "grafana.com/inUse/rules": "0",
+          "grafana.com/provenance": "converted_prometheus"
+        }
+      },
+      "spec": {
+        "title": "discord",
         "integrations": [
           {
+            "uid": "",
+            "type": "discord",
+            "version": "v0mimir1",
             "disableResolveMessage": false,
-            "secureFields": {
-              "webhook_url": true
-            },
             "settings": {
               "http_config": {
                 "enable_http2": true,
@@ -95,18 +92,19 @@
               "send_resolved": true,
               "title": "{{ template \"discord.default.title\" . }}"
             },
-            "type": "discord",
-            "uid": "",
-            "version": "v0mimir1"
+            "secureFields": {
+              "webhook_url": true
+            }
           }
-        ],
-        "title": "discord"
+        ]
       }
     },
     {
-      "apiVersion": "notifications.alerting.grafana.app/v0alpha1",
-      "kind": "Receiver",
       "metadata": {
+        "name": "ZW1haWw",
+        "namespace": "default",
+        "uid": "bhlvlN758xmnwVrHVPX0c5XvFHepenUbOXP0fuE6eUMX",
+        "resourceVersion": "9b3ffed277cee189",
         "annotations": {
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
@@ -114,19 +112,16 @@
           "grafana.com/inUse/routes": "0",
           "grafana.com/inUse/rules": "0",
           "grafana.com/provenance": "converted_prometheus"
-        },
-        "name": "ZW1haWw",
-        "namespace": "default",
-        "resourceVersion": "9b3ffed277cee189",
-        "uid": "bhlvlN758xmnwVrHVPX0c5XvFHepenUbOXP0fuE6eUMX"
+        }
       },
       "spec": {
+        "title": "email",
         "integrations": [
           {
+            "uid": "",
+            "type": "email",
+            "version": "v0mimir1",
             "disableResolveMessage": false,
-            "secureFields": {
-              "auth_password": true
-            },
             "settings": {
               "auth_username": "alertmanager",
               "from": "alertmanager@example.com",
@@ -144,18 +139,19 @@
               },
               "to": "team@example.com"
             },
-            "type": "email",
-            "uid": "",
-            "version": "v0mimir1"
+            "secureFields": {
+              "auth_password": true
+            }
           }
-        ],
-        "title": "email"
+        ]
       }
     },
     {
-      "apiVersion": "notifications.alerting.grafana.app/v0alpha1",
-      "kind": "Receiver",
       "metadata": {
+        "name": "amlyYQ",
+        "namespace": "default",
+        "uid": "7Pu4xcRXbvw4XEX279SoqyO8Ibo8cMl0vAJyYTsJ0NEX",
+        "resourceVersion": "deae9d34f8554205",
         "annotations": {
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
@@ -163,19 +159,16 @@
           "grafana.com/inUse/routes": "0",
           "grafana.com/inUse/rules": "0",
           "grafana.com/provenance": "converted_prometheus"
-        },
-        "name": "amlyYQ",
-        "namespace": "default",
-        "resourceVersion": "deae9d34f8554205",
-        "uid": "7Pu4xcRXbvw4XEX279SoqyO8Ibo8cMl0vAJyYTsJ0NEX"
+        }
       },
       "spec": {
+        "title": "jira",
         "integrations": [
           {
+            "uid": "",
+            "type": "jira",
+            "version": "v0mimir1",
             "disableResolveMessage": false,
-            "secureFields": {
-              "http_config.basic_auth.password": true
-            },
             "settings": {
               "api_url": "http://localhost/jira",
               "custom_fields": {
@@ -203,18 +196,19 @@
               "send_resolved": true,
               "summary": "{{ template \"jira.default.summary\" . }}"
             },
-            "type": "jira",
-            "uid": "",
-            "version": "v0mimir1"
+            "secureFields": {
+              "http_config.basic_auth.password": true
+            }
           }
-        ],
-        "title": "jira"
+        ]
       }
     },
     {
-      "apiVersion": "notifications.alerting.grafana.app/v0alpha1",
-      "kind": "Receiver",
       "metadata": {
+        "name": "bXN0ZWFtcw",
+        "namespace": "default",
+        "uid": "z7xTMDjrk1HAHXPEx78tQb63LXYA6ivXLOtz2Z09ucIX",
+        "resourceVersion": "95c8d082d65466a3",
         "annotations": {
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
@@ -222,19 +216,16 @@
           "grafana.com/inUse/routes": "0",
           "grafana.com/inUse/rules": "0",
           "grafana.com/provenance": "converted_prometheus"
-        },
-        "name": "bXN0ZWFtcw",
-        "namespace": "default",
-        "resourceVersion": "95c8d082d65466a3",
-        "uid": "z7xTMDjrk1HAHXPEx78tQb63LXYA6ivXLOtz2Z09ucIX"
+        }
       },
       "spec": {
+        "title": "msteams",
         "integrations": [
           {
+            "uid": "",
+            "type": "teams",
+            "version": "v0mimir1",
             "disableResolveMessage": false,
-            "secureFields": {
-              "webhook_url": true
-            },
             "settings": {
               "http_config": {
                 "enable_http2": true,
@@ -249,18 +240,19 @@
               "text": "{{ template \"msteams.default.text\" . }}",
               "title": "{{ template \"msteams.default.title\" . }}"
             },
-            "type": "teams",
-            "uid": "",
-            "version": "v0mimir1"
+            "secureFields": {
+              "webhook_url": true
+            }
           }
-        ],
-        "title": "msteams"
+        ]
       }
     },
     {
-      "apiVersion": "notifications.alerting.grafana.app/v0alpha1",
-      "kind": "Receiver",
       "metadata": {
+        "name": "b3BzZ2VuaWU",
+        "namespace": "default",
+        "uid": "XmkZ214Dj030hvynYiwNLq8i6uRCjUYXMXjE5m19OKAX",
+        "resourceVersion": "8ee2957ba150ba16",
         "annotations": {
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
@@ -268,19 +260,16 @@
           "grafana.com/inUse/routes": "0",
           "grafana.com/inUse/rules": "0",
           "grafana.com/provenance": "converted_prometheus"
-        },
-        "name": "b3BzZ2VuaWU",
-        "namespace": "default",
-        "resourceVersion": "8ee2957ba150ba16",
-        "uid": "XmkZ214Dj030hvynYiwNLq8i6uRCjUYXMXjE5m19OKAX"
+        }
       },
       "spec": {
+        "title": "opsgenie",
         "integrations": [
           {
+            "uid": "",
+            "type": "opsgenie",
+            "version": "v0mimir1",
             "disableResolveMessage": false,
-            "secureFields": {
-              "api_key": true
-            },
             "settings": {
               "actions": "test actions",
               "api_url": "http://localhost/opsgenie/",
@@ -311,18 +300,19 @@
               "tags": "test-tags",
               "update_alerts": true
             },
-            "type": "opsgenie",
-            "uid": "",
-            "version": "v0mimir1"
+            "secureFields": {
+              "api_key": true
+            }
           }
-        ],
-        "title": "opsgenie"
+        ]
       }
     },
     {
-      "apiVersion": "notifications.alerting.grafana.app/v0alpha1",
-      "kind": "Receiver",
       "metadata": {
+        "name": "cGFnZXJkdXR5",
+        "namespace": "default",
+        "uid": "QNitkUCkwzrIc7WVCCJGGDyvXLyo9csSUVqfyStyctQX",
+        "resourceVersion": "fe673d5dcd67ccf0",
         "annotations": {
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
@@ -330,20 +320,16 @@
           "grafana.com/inUse/routes": "1",
           "grafana.com/inUse/rules": "0",
           "grafana.com/provenance": "converted_prometheus"
-        },
-        "name": "cGFnZXJkdXR5",
-        "namespace": "default",
-        "resourceVersion": "fe673d5dcd67ccf0",
-        "uid": "QNitkUCkwzrIc7WVCCJGGDyvXLyo9csSUVqfyStyctQX"
+        }
       },
       "spec": {
+        "title": "pagerduty",
         "integrations": [
           {
+            "uid": "",
+            "type": "pagerduty",
+            "version": "v0mimir1",
             "disableResolveMessage": false,
-            "secureFields": {
-              "routing_key": true,
-              "service_key": true
-            },
             "settings": {
               "class": "test class",
               "client": "Alertmanager",
@@ -383,18 +369,20 @@
               "source": "test source",
               "url": "http://localhost/pagerduty"
             },
-            "type": "pagerduty",
-            "uid": "",
-            "version": "v0mimir1"
+            "secureFields": {
+              "routing_key": true,
+              "service_key": true
+            }
           }
-        ],
-        "title": "pagerduty"
+        ]
       }
     },
     {
-      "apiVersion": "notifications.alerting.grafana.app/v0alpha1",
-      "kind": "Receiver",
       "metadata": {
+        "name": "cHVzaG92ZXI",
+        "namespace": "default",
+        "uid": "t2TJSktI6vyGfdbLOKmxH4eBqgcIGsAuW8Qm9m0HRycX",
+        "resourceVersion": "6ae076725ab463e0",
         "annotations": {
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
@@ -402,21 +390,16 @@
           "grafana.com/inUse/routes": "0",
           "grafana.com/inUse/rules": "0",
           "grafana.com/provenance": "converted_prometheus"
-        },
-        "name": "cHVzaG92ZXI",
-        "namespace": "default",
-        "resourceVersion": "6ae076725ab463e0",
-        "uid": "t2TJSktI6vyGfdbLOKmxH4eBqgcIGsAuW8Qm9m0HRycX"
+        }
       },
       "spec": {
+        "title": "pushover",
         "integrations": [
           {
+            "uid": "",
+            "type": "pushover",
+            "version": "v0mimir1",
             "disableResolveMessage": false,
-            "secureFields": {
-              "http_config.authorization.credentials": true,
-              "token": true,
-              "user_key": true
-            },
             "settings": {
               "expire": "1h0m0s",
               "http_config": {
@@ -437,18 +420,21 @@
               "title": "{{ template \"pushover.default.title\" . }}",
               "url": "http://localhost/pushover"
             },
-            "type": "pushover",
-            "uid": "",
-            "version": "v0mimir1"
+            "secureFields": {
+              "http_config.authorization.credentials": true,
+              "token": true,
+              "user_key": true
+            }
           }
-        ],
-        "title": "pushover"
+        ]
       }
     },
     {
-      "apiVersion": "notifications.alerting.grafana.app/v0alpha1",
-      "kind": "Receiver",
       "metadata": {
+        "name": "c2xhY2s",
+        "namespace": "default",
+        "uid": "xSB0hnoc9j1CnLCHR3VgeVGXdVXILM0p2dM64bbHN9oX",
+        "resourceVersion": "ec0e343029ff5d8b",
         "annotations": {
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
@@ -456,19 +442,16 @@
           "grafana.com/inUse/routes": "0",
           "grafana.com/inUse/rules": "0",
           "grafana.com/provenance": "converted_prometheus"
-        },
-        "name": "c2xhY2s",
-        "namespace": "default",
-        "resourceVersion": "ec0e343029ff5d8b",
-        "uid": "xSB0hnoc9j1CnLCHR3VgeVGXdVXILM0p2dM64bbHN9oX"
+        }
       },
       "spec": {
+        "title": "slack",
         "integrations": [
           {
+            "uid": "",
+            "type": "slack",
+            "version": "v0mimir1",
             "disableResolveMessage": false,
-            "secureFields": {
-              "api_url": true
-            },
             "settings": {
               "actions": [
                 {
@@ -522,18 +505,19 @@
               "title_link": "http://localhost",
               "username": "Alerting Team"
             },
-            "type": "slack",
-            "uid": "",
-            "version": "v0mimir1"
+            "secureFields": {
+              "api_url": true
+            }
           }
-        ],
-        "title": "slack"
+        ]
       }
     },
     {
-      "apiVersion": "notifications.alerting.grafana.app/v0alpha1",
-      "kind": "Receiver",
       "metadata": {
+        "name": "c25z",
+        "namespace": "default",
+        "uid": "vSP8NtFr23hnqZqLxRgzUKfr1wOemOvZm1S6MYkfRI4X",
+        "resourceVersion": "77d734ad4c196d36",
         "annotations": {
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
@@ -541,19 +525,16 @@
           "grafana.com/inUse/routes": "0",
           "grafana.com/inUse/rules": "0",
           "grafana.com/provenance": "converted_prometheus"
-        },
-        "name": "c25z",
-        "namespace": "default",
-        "resourceVersion": "77d734ad4c196d36",
-        "uid": "vSP8NtFr23hnqZqLxRgzUKfr1wOemOvZm1S6MYkfRI4X"
+        }
       },
       "spec": {
+        "title": "sns",
         "integrations": [
           {
+            "uid": "",
+            "type": "sns",
+            "version": "v0mimir1",
             "disableResolveMessage": false,
-            "secureFields": {
-              "sigv4.SecretKey": true
-            },
             "settings": {
               "attributes": {
                 "key1": "value1"
@@ -577,18 +558,19 @@
               "subject": "{{ template \"sns.default.subject\" . }}",
               "topic_arn": "arn:aws:sns:us-east-1:123456789012:alerts"
             },
-            "type": "sns",
-            "uid": "",
-            "version": "v0mimir1"
+            "secureFields": {
+              "sigv4.SecretKey": true
+            }
           }
-        ],
-        "title": "sns"
+        ]
       }
     },
     {
-      "apiVersion": "notifications.alerting.grafana.app/v0alpha1",
-      "kind": "Receiver",
       "metadata": {
+        "name": "dGVsZWdyYW0",
+        "namespace": "default",
+        "uid": "XLWjtmYcjP5PiqBCwZXX3YKHV1G8niRtpCakIpcHqoYX",
+        "resourceVersion": "d9850878a33e302e",
         "annotations": {
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
@@ -596,19 +578,16 @@
           "grafana.com/inUse/routes": "0",
           "grafana.com/inUse/rules": "0",
           "grafana.com/provenance": "converted_prometheus"
-        },
-        "name": "dGVsZWdyYW0",
-        "namespace": "default",
-        "resourceVersion": "d9850878a33e302e",
-        "uid": "XLWjtmYcjP5PiqBCwZXX3YKHV1G8niRtpCakIpcHqoYX"
+        }
       },
       "spec": {
+        "title": "telegram",
         "integrations": [
           {
+            "uid": "",
+            "type": "telegram",
+            "version": "v0mimir1",
             "disableResolveMessage": false,
-            "secureFields": {
-              "token": true
-            },
             "settings": {
               "api_url": "http://localhost/telegram-default",
               "chat": -1001234567890,
@@ -624,18 +603,19 @@
               "parse_mode": "MarkdownV2",
               "send_resolved": true
             },
-            "type": "telegram",
-            "uid": "",
-            "version": "v0mimir1"
+            "secureFields": {
+              "token": true
+            }
           }
-        ],
-        "title": "telegram"
+        ]
       }
     },
     {
-      "apiVersion": "notifications.alerting.grafana.app/v0alpha1",
-      "kind": "Receiver",
       "metadata": {
+        "name": "dmljdG9yb3Bz",
+        "namespace": "default",
+        "uid": "EWiwQ6TIW0GpEo46WusW7Nvg0HuD4QAbHf0JZ2OSOhEX",
+        "resourceVersion": "1e6886531440afc2",
         "annotations": {
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
@@ -643,19 +623,16 @@
           "grafana.com/inUse/routes": "0",
           "grafana.com/inUse/rules": "0",
           "grafana.com/provenance": "converted_prometheus"
-        },
-        "name": "dmljdG9yb3Bz",
-        "namespace": "default",
-        "resourceVersion": "1e6886531440afc2",
-        "uid": "EWiwQ6TIW0GpEo46WusW7Nvg0HuD4QAbHf0JZ2OSOhEX"
+        }
       },
       "spec": {
+        "title": "victorops",
         "integrations": [
           {
+            "uid": "",
+            "type": "victorops",
+            "version": "v0mimir1",
             "disableResolveMessage": false,
-            "secureFields": {
-              "api_key": true
-            },
             "settings": {
               "api_url": "http://localhost/victorops-default/",
               "entity_display_name": "{{ template \"victorops.default.entity_display_name\" . }}",
@@ -674,18 +651,19 @@
               "send_resolved": true,
               "state_message": "{{ template \"victorops.default.state_message\" . }}"
             },
-            "type": "victorops",
-            "uid": "",
-            "version": "v0mimir1"
+            "secureFields": {
+              "api_key": true
+            }
           }
-        ],
-        "title": "victorops"
+        ]
       }
     },
     {
-      "apiVersion": "notifications.alerting.grafana.app/v0alpha1",
-      "kind": "Receiver",
       "metadata": {
+        "name": "d2ViZXg",
+        "namespace": "default",
+        "uid": "wDNufI44UXHWq4ERRYenZ7XgXVV3Tjxaokz9IjMRZ54X",
+        "resourceVersion": "08fc955a08dfe9c0",
         "annotations": {
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
@@ -693,19 +671,16 @@
           "grafana.com/inUse/routes": "0",
           "grafana.com/inUse/rules": "0",
           "grafana.com/provenance": "converted_prometheus"
-        },
-        "name": "d2ViZXg",
-        "namespace": "default",
-        "resourceVersion": "08fc955a08dfe9c0",
-        "uid": "wDNufI44UXHWq4ERRYenZ7XgXVV3Tjxaokz9IjMRZ54X"
+        }
       },
       "spec": {
+        "title": "webex",
         "integrations": [
           {
+            "uid": "",
+            "type": "webex",
+            "version": "v0mimir1",
             "disableResolveMessage": false,
-            "secureFields": {
-              "http_config.authorization.credentials": true
-            },
             "settings": {
               "api_url": "http://localhost/webes-default",
               "http_config": {
@@ -723,18 +698,19 @@
               "room_id": "Y2lzY29zcGFyazovL3VzL1JPT00v12345678",
               "send_resolved": true
             },
-            "type": "webex",
-            "uid": "",
-            "version": "v0mimir1"
+            "secureFields": {
+              "http_config.authorization.credentials": true
+            }
           }
-        ],
-        "title": "webex"
+        ]
       }
     },
     {
-      "apiVersion": "notifications.alerting.grafana.app/v0alpha1",
-      "kind": "Receiver",
       "metadata": {
+        "name": "d2ViaG9vaw",
+        "namespace": "default",
+        "uid": "aKzigXATPp6HOh20yTrlTcuF2Y9IrPHridGIcWrJygsX",
+        "resourceVersion": "494392f899a7b410",
         "annotations": {
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
@@ -742,19 +718,16 @@
           "grafana.com/inUse/routes": "1",
           "grafana.com/inUse/rules": "0",
           "grafana.com/provenance": "converted_prometheus"
-        },
-        "name": "d2ViaG9vaw",
-        "namespace": "default",
-        "resourceVersion": "494392f899a7b410",
-        "uid": "aKzigXATPp6HOh20yTrlTcuF2Y9IrPHridGIcWrJygsX"
+        }
       },
       "spec": {
+        "title": "webhook",
         "integrations": [
           {
+            "uid": "",
+            "type": "webhook",
+            "version": "v0mimir1",
             "disableResolveMessage": false,
-            "secureFields": {
-              "url": true
-            },
             "settings": {
               "http_config": {
                 "enable_http2": true,
@@ -769,18 +742,19 @@
               "timeout": "0s",
               "url_file": ""
             },
-            "type": "webhook",
-            "uid": "",
-            "version": "v0mimir1"
+            "secureFields": {
+              "url": true
+            }
           }
-        ],
-        "title": "webhook"
+        ]
       }
     },
     {
-      "apiVersion": "notifications.alerting.grafana.app/v0alpha1",
-      "kind": "Receiver",
       "metadata": {
+        "name": "d2VjaGF0",
+        "namespace": "default",
+        "uid": "jkXCvNrNVw7XX5nmYFyrGiA4ckAvJ282u2scW8KZq7IX",
+        "resourceVersion": "135913515cbc156b",
         "annotations": {
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
@@ -788,19 +762,16 @@
           "grafana.com/inUse/routes": "0",
           "grafana.com/inUse/rules": "0",
           "grafana.com/provenance": "converted_prometheus"
-        },
-        "name": "d2VjaGF0",
-        "namespace": "default",
-        "resourceVersion": "135913515cbc156b",
-        "uid": "jkXCvNrNVw7XX5nmYFyrGiA4ckAvJ282u2scW8KZq7IX"
+        }
       },
       "spec": {
+        "title": "wechat",
         "integrations": [
           {
+            "uid": "",
+            "type": "wechat",
+            "version": "v0mimir1",
             "disableResolveMessage": false,
-            "secureFields": {
-              "api_secret": true
-            },
             "settings": {
               "agent_id": "1000002",
               "api_url": "http://localhost/wechat/",
@@ -820,15 +791,12 @@
               "to_tag": "tag1",
               "to_user": "user1"
             },
-            "type": "wechat",
-            "uid": "",
-            "version": "v0mimir1"
+            "secureFields": {
+              "api_secret": true
+            }
           }
-        ],
-        "title": "wechat"
+        ]
       }
     }
-  ],
-  "kind": "ReceiverList",
-  "metadata": {}
+  ]
 }

--- a/pkg/tests/apis/alerting/notifications/templategroup/templates_group_test.go
+++ b/pkg/tests/apis/alerting/notifications/templategroup/templates_group_test.go
@@ -537,7 +537,6 @@ func TestIntegrationPatch(t *testing.T) {
 	require.NotEmpty(t, current.ResourceVersion)
 
 	t.Run("should patch with merge patch", func(t *testing.T) {
-
 		patch := `{
              "spec": {
                  "content" : "{{ define \"test-another\" }} test {{ end }}"

--- a/pkg/tests/apis/alerting/notifications/templategroup/templates_group_test.go
+++ b/pkg/tests/apis/alerting/notifications/templategroup/templates_group_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/grafana/alerting/templates"
+	"github.com/grafana/grafana-app-sdk/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -45,7 +46,8 @@ func TestIntegrationResourceIdentifier(t *testing.T) {
 
 	ctx := context.Background()
 	helper := getTestHelper(t)
-	client := common.NewTemplateGroupClient(t, helper.Org1.Admin)
+	client, err := v0alpha1.NewTemplateGroupClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
 
 	newTemplate := &v0alpha1.TemplateGroup{
 		ObjectMeta: v1.ObjectMeta{
@@ -61,23 +63,23 @@ func TestIntegrationResourceIdentifier(t *testing.T) {
 	t.Run("create should fail if object name is specified", func(t *testing.T) {
 		template := newTemplate.Copy().(*v0alpha1.TemplateGroup)
 		template.Name = "new-templateGroup"
-		_, err := client.Create(ctx, template, v1.CreateOptions{})
+		_, err := client.Create(ctx, template, resource.CreateOptions{})
 		assert.Error(t, err)
 		require.Truef(t, errors.IsBadRequest(err), "Expected BadRequest but got %s", err)
 	})
 
-	var resourceID string
+	var resourceID resource.Identifier
 	t.Run("create should succeed and provide resource name", func(t *testing.T) {
-		actual, err := client.Create(ctx, newTemplate, v1.CreateOptions{})
+		actual, err := client.Create(ctx, newTemplate, resource.CreateOptions{})
 		require.NoError(t, err)
 		require.NotEmptyf(t, actual.Name, "Resource name should not be empty")
 		require.NotEmptyf(t, actual.UID, "Resource UID should not be empty")
-		resourceID = actual.Name
+		resourceID = actual.GetStaticMetadata().Identifier()
 	})
 
 	var existingTemplateGroup *v0alpha1.TemplateGroup
 	t.Run("resource should be available by the identifier", func(t *testing.T) {
-		actual, err := client.Get(ctx, resourceID, v1.GetOptions{})
+		actual, err := client.Get(ctx, resourceID)
 		require.NoError(t, err)
 		require.NotEmptyf(t, actual.Name, "Resource name should not be empty")
 		require.Equal(t, newTemplate.Spec, actual.Spec)
@@ -90,12 +92,12 @@ func TestIntegrationResourceIdentifier(t *testing.T) {
 		}
 		updated := existingTemplateGroup.Copy().(*v0alpha1.TemplateGroup)
 		updated.Spec.Title = "another-templateGroup"
-		actual, err := client.Update(ctx, updated, v1.UpdateOptions{})
+		actual, err := client.Update(ctx, updated, resource.UpdateOptions{})
 		require.NoError(t, err)
 		require.Equal(t, updated.Spec, actual.Spec)
 		require.NotEqualf(t, updated.Name, actual.Name, "Update should change the resource name but it didn't")
 
-		resource, err := client.Get(ctx, actual.Name, v1.GetOptions{})
+		resource, err := client.Get(ctx, actual.GetStaticMetadata().Identifier())
 		require.NoError(t, err)
 		require.Equal(t, actual, resource)
 
@@ -104,7 +106,7 @@ func TestIntegrationResourceIdentifier(t *testing.T) {
 
 	var defaultTemplateGroup *v0alpha1.TemplateGroup
 	t.Run("default template should be available by the identifier", func(t *testing.T) {
-		actual, err := client.Get(ctx, templates.DefaultTemplateName, v1.GetOptions{})
+		actual, err := client.Get(ctx, resource.Identifier{Namespace: apis.DefaultNamespace, Name: templates.DefaultTemplateName})
 		require.NoError(t, err)
 		require.NotEmptyf(t, actual.Name, "Resource name should not be empty")
 
@@ -122,7 +124,7 @@ func TestIntegrationResourceIdentifier(t *testing.T) {
 	t.Run("create with reserved default title should work", func(t *testing.T) {
 		template := newTemplate.Copy().(*v0alpha1.TemplateGroup)
 		template.Spec.Title = defaultTemplateGroup.Spec.Title
-		actual, err := client.Create(ctx, template, v1.CreateOptions{})
+		actual, err := client.Create(ctx, template, resource.CreateOptions{})
 		require.NoError(t, err)
 		require.NotEmptyf(t, actual.Name, "Resource name should not be empty")
 		require.NotEmptyf(t, actual.UID, "Resource UID should not be empty")
@@ -130,7 +132,7 @@ func TestIntegrationResourceIdentifier(t *testing.T) {
 	})
 
 	t.Run("default template should not be available by calculated UID", func(t *testing.T) {
-		actual, err := client.Get(ctx, newTemplateWithOverlappingName.Name, v1.GetOptions{})
+		actual, err := client.Get(ctx, newTemplateWithOverlappingName.GetStaticMetadata().Identifier())
 		require.NoError(t, err)
 		require.NotEmptyf(t, actual.Name, "Resource name should not be empty")
 
@@ -215,11 +217,13 @@ func TestIntegrationAccessControl(t *testing.T) {
 		},
 	}
 
-	adminClient := common.NewTemplateGroupClient(t, org1.Admin)
+	adminClient, err := v0alpha1.NewTemplateGroupClientFromGenerator(org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("user '%s'", tc.user.Identity.GetLogin()), func(t *testing.T) {
-			client := common.NewTemplateGroupClient(t, tc.user)
+			client, err := v0alpha1.NewTemplateGroupClientFromGenerator(tc.user.GetClientRegistry())
+			require.NoError(t, err)
 
 			var expected = &v0alpha1.TemplateGroup{
 				ObjectMeta: v1.ObjectMeta{
@@ -237,12 +241,12 @@ func TestIntegrationAccessControl(t *testing.T) {
 
 			if tc.canCreate {
 				t.Run("should be able to create template group", func(t *testing.T) {
-					actual, err := client.Create(ctx, expected, v1.CreateOptions{})
+					actual, err := client.Create(ctx, expected, resource.CreateOptions{})
 					require.NoErrorf(t, err, "Payload %s", string(d))
 					require.Equal(t, expected.Spec, actual.Spec)
 
 					t.Run("should fail if already exists", func(t *testing.T) {
-						_, err := client.Create(ctx, actual, v1.CreateOptions{})
+						_, err := client.Create(ctx, actual, resource.CreateOptions{})
 						require.Truef(t, errors.IsBadRequest(err), "expected bad request but got %s", err)
 					})
 
@@ -250,45 +254,45 @@ func TestIntegrationAccessControl(t *testing.T) {
 				})
 			} else {
 				t.Run("should be forbidden to create", func(t *testing.T) {
-					_, err := client.Create(ctx, expected, v1.CreateOptions{})
+					_, err := client.Create(ctx, expected, resource.CreateOptions{})
 					require.Truef(t, errors.IsForbidden(err), "Payload %s", string(d))
 				})
 
 				// create resource to proceed with other tests
-				expected, err = adminClient.Create(ctx, expected, v1.CreateOptions{})
+				expected, err = adminClient.Create(ctx, expected, resource.CreateOptions{})
 				require.NoErrorf(t, err, "Payload %s", string(d))
 				require.NotNil(t, expected)
 			}
 
 			if tc.canRead {
 				t.Run("should be able to list template groups", func(t *testing.T) {
-					list, err := client.List(ctx, v1.ListOptions{})
+					list, err := client.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 					require.NoError(t, err)
 					require.Len(t, list.Items, 2) // Includes default template.
 				})
 
 				t.Run("should be able to read template group by resource identifier", func(t *testing.T) {
-					got, err := client.Get(ctx, expected.Name, v1.GetOptions{})
+					got, err := client.Get(ctx, expected.GetStaticMetadata().Identifier())
 					require.NoError(t, err)
-					require.Equal(t, expected, got)
+					require.Equal(t, expected.Spec, got.Spec)
 
 					t.Run("should get NotFound if resource does not exist", func(t *testing.T) {
-						_, err := client.Get(ctx, "Notfound", v1.GetOptions{})
+						_, err := client.Get(ctx, resource.Identifier{Namespace: apis.DefaultNamespace, Name: "Notfound"})
 						require.Truef(t, errors.IsNotFound(err), "Should get NotFound error but got: %s", err)
 					})
 				})
 			} else {
 				t.Run("should be forbidden to list template groups", func(t *testing.T) {
-					_, err := client.List(ctx, v1.ListOptions{})
+					_, err := client.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 					require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 				})
 
 				t.Run("should be forbidden to read template group by name", func(t *testing.T) {
-					_, err := client.Get(ctx, expected.Name, v1.GetOptions{})
+					_, err := client.Get(ctx, expected.GetStaticMetadata().Identifier())
 					require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 
 					t.Run("should get forbidden even if name does not exist", func(t *testing.T) {
-						_, err := client.Get(ctx, "Notfound", v1.GetOptions{})
+						_, err := client.Get(ctx, resource.Identifier{Namespace: apis.DefaultNamespace, Name: "Notfound"})
 						require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 					})
 				})
@@ -302,7 +306,7 @@ func TestIntegrationAccessControl(t *testing.T) {
 
 			if tc.canUpdate {
 				t.Run("should be able to update template group", func(t *testing.T) {
-					updated, err := client.Update(ctx, updatedExpected, v1.UpdateOptions{})
+					updated, err := client.Update(ctx, updatedExpected, resource.UpdateOptions{})
 					require.NoErrorf(t, err, "Payload %s", string(d))
 
 					expected = updated
@@ -310,52 +314,54 @@ func TestIntegrationAccessControl(t *testing.T) {
 					t.Run("should get NotFound if name does not exist", func(t *testing.T) {
 						up := updatedExpected.Copy().(*v0alpha1.TemplateGroup)
 						up.Name = "notFound"
-						_, err := client.Update(ctx, up, v1.UpdateOptions{})
+						_, err := client.Update(ctx, up, resource.UpdateOptions{})
 						require.Truef(t, errors.IsNotFound(err), "Should get NotFound error but got: %s", err)
 					})
 				})
 			} else {
 				t.Run("should be forbidden to update template group", func(t *testing.T) {
-					_, err := client.Update(ctx, updatedExpected, v1.UpdateOptions{})
+					_, err := client.Update(ctx, updatedExpected, resource.UpdateOptions{})
 					require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 
 					t.Run("should get forbidden even if resource does not exist", func(t *testing.T) {
 						up := updatedExpected.Copy().(*v0alpha1.TemplateGroup)
 						up.Name = "notFound"
-						_, err := client.Update(ctx, up, v1.UpdateOptions{})
+						_, err := client.Update(ctx, up, resource.UpdateOptions{
+							ResourceVersion: up.ResourceVersion,
+						})
 						require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 					})
 				})
 			}
 
 			deleteOptions := v1.DeleteOptions{Preconditions: &v1.Preconditions{ResourceVersion: util.Pointer(expected.ResourceVersion)}}
-
+			oldClient := common.NewTemplateGroupClient(t, tc.user) // TODO replace with normal client once delete is fixed
 			if tc.canDelete {
 				t.Run("should be able to delete template group", func(t *testing.T) {
-					err := client.Delete(ctx, expected.Name, deleteOptions)
+					err := oldClient.Delete(ctx, expected.GetStaticMetadata().Identifier().Name, deleteOptions)
 					require.NoError(t, err)
 
 					t.Run("should get NotFound if name does not exist", func(t *testing.T) {
-						err := client.Delete(ctx, "notfound", v1.DeleteOptions{})
+						err := oldClient.Delete(ctx, "notfound", v1.DeleteOptions{})
 						require.Truef(t, errors.IsNotFound(err), "Should get NotFound error but got: %s", err)
 					})
 				})
 			} else {
 				t.Run("should be forbidden to delete template group", func(t *testing.T) {
-					err := client.Delete(ctx, expected.Name, deleteOptions)
+					err := oldClient.Delete(ctx, expected.GetStaticMetadata().Identifier().Name, deleteOptions)
 					require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 
 					t.Run("should be forbidden even if resource does not exist", func(t *testing.T) {
-						err := client.Delete(ctx, "notfound", v1.DeleteOptions{})
+						err := oldClient.Delete(ctx, "notfound", v1.DeleteOptions{})
 						require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 					})
 				})
-				require.NoError(t, adminClient.Delete(ctx, expected.Name, v1.DeleteOptions{}))
+				require.NoError(t, adminClient.Delete(ctx, expected.GetStaticMetadata().Identifier(), resource.DeleteOptions{}))
 			}
 
 			if tc.canRead {
 				t.Run("should get list with just default template if no template groups", func(t *testing.T) {
-					list, err := client.List(ctx, v1.ListOptions{})
+					list, err := client.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 					require.NoError(t, err)
 					require.Len(t, list.Items, 1)
 					require.Equal(t, templates.DefaultTemplateName, list.Items[0].Name)
@@ -374,7 +380,8 @@ func TestIntegrationProvisioning(t *testing.T) {
 	org := helper.Org1
 
 	admin := org.Admin
-	adminClient := common.NewTemplateGroupClient(t, admin)
+	adminClient, err := v0alpha1.NewTemplateGroupClientFromGenerator(admin.GetClientRegistry())
+	require.NoError(t, err)
 
 	env := helper.GetEnv()
 	ac := acimpl.ProvideAccessControl(env.FeatureToggles)
@@ -390,7 +397,7 @@ func TestIntegrationProvisioning(t *testing.T) {
 			Content: `{{ define "test" }} test {{ end }}`,
 			Kind:    v0alpha1.TemplateGroupTemplateKindGrafana,
 		},
-	}, v1.CreateOptions{})
+	}, resource.CreateOptions{})
 	require.NoError(t, err)
 	require.Equal(t, "none", created.GetProvenanceStatus())
 
@@ -399,7 +406,7 @@ func TestIntegrationProvisioning(t *testing.T) {
 			Name: created.Spec.Title,
 		}, admin.Identity.GetOrgID(), "API"))
 
-		got, err := adminClient.Get(ctx, created.Name, v1.GetOptions{})
+		got, err := adminClient.Get(ctx, created.GetStaticMetadata().Identifier())
 		require.NoError(t, err)
 		require.Equal(t, "API", got.GetProvenanceStatus())
 	})
@@ -407,12 +414,12 @@ func TestIntegrationProvisioning(t *testing.T) {
 		updated := created.Copy().(*v0alpha1.TemplateGroup)
 		updated.Spec.Content = `{{ define "another-test" }} test {{ end }}`
 
-		_, err := adminClient.Update(ctx, updated, v1.UpdateOptions{})
+		_, err := adminClient.Update(ctx, updated, resource.UpdateOptions{})
 		require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 	})
 
 	t.Run("should not let delete if provisioned", func(t *testing.T) {
-		err := adminClient.Delete(ctx, created.Name, v1.DeleteOptions{})
+		err := adminClient.Delete(ctx, created.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
 		require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 	})
 }
@@ -423,8 +430,9 @@ func TestIntegrationOptimisticConcurrency(t *testing.T) {
 	ctx := context.Background()
 	helper := getTestHelper(t)
 
-	adminClient := common.NewTemplateGroupClient(t, helper.Org1.Admin)
-
+	adminClient, err := v0alpha1.NewTemplateGroupClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
+	oldClient := common.NewTemplateGroupClient(t, helper.Org1.Admin)
 	template := v0alpha1.TemplateGroup{
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: "default",
@@ -436,21 +444,22 @@ func TestIntegrationOptimisticConcurrency(t *testing.T) {
 		},
 	}
 
-	created, err := adminClient.Create(ctx, &template, v1.CreateOptions{})
+	created, err := adminClient.Create(ctx, &template, resource.CreateOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, created)
 	require.NotEmpty(t, created.ResourceVersion)
 
 	t.Run("should forbid if version does not match", func(t *testing.T) {
 		updated := created.Copy().(*v0alpha1.TemplateGroup)
-		updated.ResourceVersion = "test"
-		_, err := adminClient.Update(ctx, updated, v1.UpdateOptions{})
+		_, err := adminClient.Update(ctx, updated, resource.UpdateOptions{
+			ResourceVersion: "test",
+		})
 		require.Truef(t, errors.IsConflict(err), "should get Forbidden error but got %s", err)
 	})
 	t.Run("should update if version matches", func(t *testing.T) {
 		updated := created.Copy().(*v0alpha1.TemplateGroup)
 		updated.Spec.Content = `{{ define "test-another" }} test {{ end }}`
-		actualUpdated, err := adminClient.Update(ctx, updated, v1.UpdateOptions{})
+		actualUpdated, err := adminClient.Update(ctx, updated, resource.UpdateOptions{})
 		require.NoError(t, err)
 		require.EqualValues(t, updated.Spec, actualUpdated.Spec)
 		require.NotEqual(t, updated.ResourceVersion, actualUpdated.ResourceVersion)
@@ -460,16 +469,16 @@ func TestIntegrationOptimisticConcurrency(t *testing.T) {
 		updated.ResourceVersion = ""
 		updated.Spec.Content = `{{ define "test-another-2" }} test {{ end }}`
 
-		actualUpdated, err := adminClient.Update(ctx, updated, v1.UpdateOptions{})
+		actualUpdated, err := adminClient.Update(ctx, updated, resource.UpdateOptions{})
 		require.NoError(t, err)
 		require.EqualValues(t, updated.Spec, actualUpdated.Spec)
 		require.NotEqual(t, created.ResourceVersion, actualUpdated.ResourceVersion)
 	})
 	t.Run("should fail to delete if version does not match", func(t *testing.T) {
-		actual, err := adminClient.Get(ctx, created.Name, v1.GetOptions{})
+		actual, err := adminClient.Get(ctx, created.GetStaticMetadata().Identifier())
 		require.NoError(t, err)
 
-		err = adminClient.Delete(ctx, actual.Name, v1.DeleteOptions{
+		err = oldClient.Delete(ctx, actual.GetStaticMetadata().Identifier().Name, v1.DeleteOptions{
 			Preconditions: &v1.Preconditions{
 				ResourceVersion: util.Pointer("something"),
 			},
@@ -477,10 +486,10 @@ func TestIntegrationOptimisticConcurrency(t *testing.T) {
 		require.Truef(t, errors.IsConflict(err), "should get Forbidden error but got %s", err)
 	})
 	t.Run("should succeed if version matches", func(t *testing.T) {
-		actual, err := adminClient.Get(ctx, created.Name, v1.GetOptions{})
+		actual, err := adminClient.Get(ctx, created.GetStaticMetadata().Identifier())
 		require.NoError(t, err)
 
-		err = adminClient.Delete(ctx, actual.Name, v1.DeleteOptions{
+		err = oldClient.Delete(ctx, actual.GetStaticMetadata().Identifier().Name, v1.DeleteOptions{
 			Preconditions: &v1.Preconditions{
 				ResourceVersion: util.Pointer(actual.ResourceVersion),
 			},
@@ -488,10 +497,10 @@ func TestIntegrationOptimisticConcurrency(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("should succeed if version is empty", func(t *testing.T) {
-		actual, err := adminClient.Create(ctx, &template, v1.CreateOptions{})
+		actual, err := adminClient.Create(ctx, &template, resource.CreateOptions{})
 		require.NoError(t, err)
 
-		err = adminClient.Delete(ctx, actual.Name, v1.DeleteOptions{
+		err = oldClient.Delete(ctx, actual.GetStaticMetadata().Identifier().Name, v1.DeleteOptions{
 			Preconditions: &v1.Preconditions{
 				ResourceVersion: util.Pointer(actual.ResourceVersion),
 			},
@@ -506,7 +515,8 @@ func TestIntegrationPatch(t *testing.T) {
 	ctx := context.Background()
 	helper := getTestHelper(t)
 
-	adminClient := common.NewTemplateGroupClient(t, helper.Org1.Admin)
+	adminClient, err := v0alpha1.NewTemplateGroupClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
 
 	template := v0alpha1.TemplateGroup{
 		ObjectMeta: v1.ObjectMeta{
@@ -519,19 +529,22 @@ func TestIntegrationPatch(t *testing.T) {
 		},
 	}
 
-	current, err := adminClient.Create(ctx, &template, v1.CreateOptions{})
+	current, err := adminClient.Create(ctx, &template, resource.CreateOptions{})
 	require.NoError(t, err)
+	oldClient := common.NewTemplateGroupClient(t, helper.Org1.Admin)
+
 	require.NotNil(t, current)
 	require.NotEmpty(t, current.ResourceVersion)
 
 	t.Run("should patch with merge patch", func(t *testing.T) {
+
 		patch := `{
              "spec": {
                  "content" : "{{ define \"test-another\" }} test {{ end }}"
              }
 		 }`
 
-		result, err := adminClient.Patch(ctx, current.Name, types.MergePatchType, []byte(patch), v1.PatchOptions{})
+		result, err := oldClient.Patch(ctx, current.GetStaticMetadata().Identifier().Name, types.MergePatchType, []byte(patch), v1.PatchOptions{})
 		require.NoError(t, err)
 		require.Equal(t, `{{ define "test-another" }} test {{ end }}`, result.Spec.Content)
 		current = result
@@ -540,18 +553,15 @@ func TestIntegrationPatch(t *testing.T) {
 	t.Run("should patch with json patch", func(t *testing.T) {
 		expected := `{{ define "test-json-patch" }} test {{ end }}`
 
-		patch := []map[string]interface{}{
+		patch := []resource.PatchOperation{
 			{
-				"op":    "replace",
-				"path":  "/spec/content",
-				"value": expected,
+				Operation: "replace",
+				Path:      "/spec/content",
+				Value:     expected,
 			},
 		}
 
-		patchData, err := json.Marshal(patch)
-		require.NoError(t, err)
-
-		result, err := adminClient.Patch(ctx, current.Name, types.JSONPatchType, patchData, v1.PatchOptions{})
+		result, err := adminClient.Patch(ctx, current.GetStaticMetadata().Identifier(), resource.PatchRequest{Operations: patch}, resource.PatchOptions{})
 		require.NoError(t, err)
 		expectedSpec := current.Spec
 		expectedSpec.Content = expected
@@ -565,7 +575,8 @@ func TestIntegrationListSelector(t *testing.T) {
 
 	ctx := context.Background()
 	helper := getTestHelper(t)
-	adminClient := common.NewTemplateGroupClient(t, helper.Org1.Admin)
+	adminClient, err := v0alpha1.NewTemplateGroupClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
 
 	template1 := &v0alpha1.TemplateGroup{
 		ObjectMeta: v1.ObjectMeta{
@@ -577,7 +588,7 @@ func TestIntegrationListSelector(t *testing.T) {
 			Kind:    v0alpha1.TemplateGroupTemplateKindGrafana,
 		},
 	}
-	template1, err := adminClient.Create(ctx, template1, v1.CreateOptions{})
+	template1, err = adminClient.Create(ctx, template1, resource.CreateOptions{})
 	require.NoError(t, err)
 
 	template2 := &v0alpha1.TemplateGroup{
@@ -590,7 +601,7 @@ func TestIntegrationListSelector(t *testing.T) {
 			Kind:    v0alpha1.TemplateGroupTemplateKindGrafana,
 		},
 	}
-	template2, err = adminClient.Create(ctx, template2, v1.CreateOptions{})
+	template2, err = adminClient.Create(ctx, template2, resource.CreateOptions{})
 	require.NoError(t, err)
 	env := helper.GetEnv()
 	ac := acimpl.ProvideAccessControl(env.FeatureToggles)
@@ -599,18 +610,18 @@ func TestIntegrationListSelector(t *testing.T) {
 	require.NoError(t, db.SetProvenance(ctx, &definitions.NotificationTemplate{
 		Name: template2.Spec.Title,
 	}, helper.Org1.Admin.Identity.GetOrgID(), "API"))
-	template2, err = adminClient.Get(ctx, template2.Name, v1.GetOptions{})
+	template2, err = adminClient.Get(ctx, template2.GetStaticMetadata().Identifier())
 
 	require.NoError(t, err)
 
-	tmpls, err := adminClient.List(ctx, v1.ListOptions{})
+	tmpls, err := adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, tmpls.Items, 3) // Includes default template.
 
 	t.Run("should filter by template name", func(t *testing.T) {
 		t.Skip("disabled until app installer supports it") // TODO revisit when custom field selectors are supported
-		list, err := adminClient.List(ctx, v1.ListOptions{
-			FieldSelector: "spec.title=" + template1.Spec.Title,
+		list, err := adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{
+			FieldSelectors: []string{"spec.title=" + template1.Spec.Title},
 		})
 		require.NoError(t, err)
 		require.Len(t, list.Items, 1)
@@ -618,8 +629,8 @@ func TestIntegrationListSelector(t *testing.T) {
 	})
 
 	t.Run("should filter by template metadata name", func(t *testing.T) {
-		list, err := adminClient.List(ctx, v1.ListOptions{
-			FieldSelector: "metadata.name=" + template2.Name,
+		list, err := adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{
+			FieldSelectors: []string{"metadata.name=" + template2.Name},
 		})
 		require.NoError(t, err)
 		require.Len(t, list.Items, 1)
@@ -628,8 +639,8 @@ func TestIntegrationListSelector(t *testing.T) {
 
 	t.Run("should filter by multiple filters", func(t *testing.T) {
 		t.Skip("disabled until app installer supports it") // TODO revisit when custom field selectors are supported
-		list, err := adminClient.List(ctx, v1.ListOptions{
-			FieldSelector: fmt.Sprintf("metadata.name=%s,spec.title=%s", template2.Name, template2.Spec.Title),
+		list, err := adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{
+			FieldSelectors: []string{fmt.Sprintf("metadata.name=%s,spec.title=%s", template2.Name, template2.Spec.Title)},
 		})
 		require.NoError(t, err)
 		require.Len(t, list.Items, 1)
@@ -637,8 +648,8 @@ func TestIntegrationListSelector(t *testing.T) {
 	})
 
 	t.Run("should be empty when filter does not match", func(t *testing.T) {
-		list, err := adminClient.List(ctx, v1.ListOptions{
-			FieldSelector: fmt.Sprintf("metadata.name=%s", "unknown"),
+		list, err := adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{
+			FieldSelectors: []string{fmt.Sprintf("metadata.name=%s", "unknown")},
 		})
 		require.NoError(t, err)
 		require.Empty(t, list.Items)
@@ -646,17 +657,17 @@ func TestIntegrationListSelector(t *testing.T) {
 
 	t.Run("should filter by default template name", func(t *testing.T) {
 		t.Skip("disabled until app installer supports it") // TODO revisit when custom field selectors are supported
-		list, err := adminClient.List(ctx, v1.ListOptions{
-			FieldSelector: "spec.title=" + v0alpha1.DefaultTemplateTitle,
+		list, err := adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{
+			FieldSelectors: []string{"spec.title=" + v0alpha1.DefaultTemplateTitle},
 		})
 		require.NoError(t, err)
 		require.Len(t, list.Items, 1)
 		require.Equal(t, templates.DefaultTemplateName, list.Items[0].Name)
 
 		// Now just non-default templates
-		list, err = adminClient.List(ctx, v1.ListOptions{
-			FieldSelector: "spec.title!=" + v0alpha1.DefaultTemplateTitle,
-		})
+		list, err = adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{
+			FieldSelectors: []string{"spec.title!=" + v0alpha1.DefaultTemplateTitle}},
+		)
 		require.NoError(t, err)
 		require.Len(t, list.Items, 2)
 		require.NotEqualf(t, templates.DefaultTemplateName, list.Items[0].Name, "Expected non-default template but got %s", list.Items[0].Name)
@@ -669,7 +680,8 @@ func TestIntegrationKinds(t *testing.T) {
 
 	ctx := context.Background()
 	helper := getTestHelper(t)
-	client := common.NewTemplateGroupClient(t, helper.Org1.Admin)
+	client, err := v0alpha1.NewTemplateGroupClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
 
 	newTemplate := &v0alpha1.TemplateGroup{
 		ObjectMeta: v1.ObjectMeta{
@@ -683,17 +695,17 @@ func TestIntegrationKinds(t *testing.T) {
 	}
 
 	t.Run("should not let create Mimir template", func(t *testing.T) {
-		_, err := client.Create(ctx, newTemplate, v1.CreateOptions{})
+		_, err := client.Create(ctx, newTemplate, resource.CreateOptions{})
 		require.Truef(t, errors.IsBadRequest(err), "expected bad request but got %s", err)
 	})
 
 	t.Run("should not let change kind", func(t *testing.T) {
 		newTemplate.Spec.Kind = v0alpha1.TemplateGroupTemplateKindGrafana
-		created, err := client.Create(ctx, newTemplate, v1.CreateOptions{})
+		created, err := client.Create(ctx, newTemplate, resource.CreateOptions{})
 		require.NoError(t, err)
 
 		created.Spec.Kind = v0alpha1.TemplateGroupTemplateKindMimir
-		_, err = client.Update(ctx, created, v1.UpdateOptions{})
+		_, err = client.Update(ctx, created, resource.UpdateOptions{})
 		require.Truef(t, errors.IsBadRequest(err), "expected bad request but got %s", err)
 	})
 }

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	githubConnection "github.com/grafana/grafana/apps/provisioning/pkg/connection/github"
+	appsdk_k8s "github.com/grafana/grafana-app-sdk/k8s"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -27,6 +27,8 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
+
+	githubConnection "github.com/grafana/grafana/apps/provisioning/pkg/connection/github"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -443,6 +445,11 @@ func (c *User) RESTClient(t *testing.T, gv *schema.GroupVersion) *rest.RESTClien
 	client, err := rest.RESTClientFor(cfg)
 	require.NoError(t, err)
 	return client
+}
+
+func (c *User) GetClientRegistry() *appsdk_k8s.ClientRegistry {
+	restConfig := c.NewRestConfig()
+	return appsdk_k8s.NewClientRegistry(*restConfig, appsdk_k8s.DefaultClientConfig())
 }
 
 type RequestParams struct {

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -59,6 +59,8 @@ import (
 const (
 	Org1 = "Org1"
 	Org2 = "OrgB"
+
+	DefaultNamespace = "default"
 )
 
 var (


### PR DESCRIPTION
---

**What is this feature?**

Replaces manually crafted clients with those generated by the `app-sdk` library. This ensures consistency and maintainability. Additionally, exposes `GetClientRegistry` for use in integration tests, enabling the creation of resource clients.

**Why do we need this feature?**

This change reduces manual client management, leverages code generation for uniformity, and facilitates better testing capabilities by providing access to the client registry.

**Who is this feature for?**

Developers maintaining the codebase and writing integration tests.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.