### PR TITLE
Prometheus: Optimize regex pattern for multi-value label matchers

### DIFF
--- a/packages/grafana-prometheus/src/components/metrics-browser/selectorBuilder.test.ts
+++ b/packages/grafana-prometheus/src/components/metrics-browser/selectorBuilder.test.ts
@@ -31,12 +31,12 @@ describe('selectorBuilder', () => {
     });
 
     it('handles multiple values for a label using regex matcher', () => {
-      expect(buildSelector('', { multi: ['val1', 'val2', 'val3'] })).toEqual('{multi=~"val1|val2|val3"}');
+      expect(buildSelector('', { multi: ['val1', 'val2', 'val3'] })).toEqual('{multi=~"(val1|val2|val3)"}');
     });
 
     it('properly escapes special characters in regex values', () => {
       expect(buildSelector('', { special: ['val*', 'val.', 'val+'] })).toEqual(
-        '{special=~"val\\\\*|val\\\\.|val\\\\+"}'
+        '{special=~"(val\\\\*|val\\\\.|val\\\\+)"}'
       );
     });
 
@@ -64,7 +64,7 @@ describe('selectorBuilder', () => {
           single: ['value'],
           multi: ['val1', 'val2'],
         })
-      ).toEqual('{single="value",multi=~"val1|val2"}');
+      ).toEqual('{single="value",multi=~"(val1|val2)"}');
     });
 
     describe('utf8 support', () => {
@@ -99,7 +99,7 @@ describe('selectorBuilder', () => {
       });
 
       it('handles utf8 characters in label values', () => {
-        expect(buildSelector('', { label: ['值', '😀', '你好'] })).toEqual('{label=~"值|😀|你好"}');
+        expect(buildSelector('', { label: ['值', '😀', '你好'] })).toEqual('{label=~"(值|😀|你好)"}');
       });
     });
   });

--- a/packages/grafana-prometheus/src/components/metrics-browser/selectorBuilder.ts
+++ b/packages/grafana-prometheus/src/components/metrics-browser/selectorBuilder.ts
@@ -25,7 +25,8 @@ export function buildSelector(selectedMetric: string, selectedLabelValues: Recor
 
     // Use regex matcher for multiple values
     if (values.length > 1) {
-      selectorParts.push(`${utf8Support(key)}=~"${values.map(escapeLabelValueInRegexSelector).join('|')}"`);
+      // Wrap alternation in parentheses for better regex performance: (val1|val2|val3) instead of val1|val2|val3
+      selectorParts.push(`${utf8Support(key)}=~"(${values.map(escapeLabelValueInRegexSelector).join('|')})"`);
     } else {
       // Use exact matcher for single value
       selectorParts.push(`${utf8Support(key)}="${escapeLabelValueInExactSelector(values[0])}"`);


### PR DESCRIPTION
Wrap alternation patterns in parentheses for better regex performance when multiple label values are selected. Changes pattern from `label=~"val1|val2|val3"` to `label=~"(val1|val2|val3)"`.

Fixes #107097

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Optimizes the regex pattern generated for Prometheus label matchers when multiple values are selected. The change wraps alternation patterns in parentheses, changing from label=~"val1|val2|val3" to label=~"(val1|val2|val3)".

**Why do we need this feature?**

The current pattern generates redundant regex structures when multiple label values are combined. By wrapping the alternation in parentheses, the regex engine can process the pattern more efficiently. This consolidates multiple alternation branches into a grouped pattern, providing performance benefits for Prometheus queries with multi-value label selectors.

**Who is this feature for?**

Users who use the Prometheus query builder with multi-value label filters, particularly those with dashboards that select multiple label values simultaneously.

**Which issue(s) does this PR fix?**:

Fixes #107097
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #107097"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
