### PR TITLE
Alerting: Add alert list sorting feature

### DIFF
--- a/public/app/features/alerting/unified/components/rules/Filter/RulesFilter.v1.tsx
+++ b/public/app/features/alerting/unified/components/rules/Filter/RulesFilter.v1.tsx
@@ -19,6 +19,7 @@ import { RuleHealth, getSearchFilterFromQuery } from '../../../search/rulesSearc
 import { alertStateToReadable } from '../../../utils/rules';
 import { PopupCard } from '../../HoverCard';
 import { MultipleDataSourcePicker } from '../MultipleDataSourcePicker';
+import { RulesSortingSelector, useRulesSorting } from '../RulesSortingSelector';
 
 import { RulesViewModeSelector } from './RulesViewModeSelector';
 
@@ -46,6 +47,7 @@ const RulesFilter = ({ onClear = () => undefined, viewMode, onViewModeChange }: 
   const styles = useStyles2(getStyles);
   const { pluginsFilterEnabled } = usePluginsFilterStatus();
   const { filterState, hasActiveFilters, searchQuery, setSearchQuery, updateFilters } = useRulesFilter();
+  const { sortOrder, setSortOrder } = useRulesSorting();
 
   // This key is used to force a rerender on the inputs when the filters are cleared
   const [filterKey, setFilterKey] = useState<number>(Math.floor(Math.random() * 100));
@@ -99,6 +101,7 @@ const RulesFilter = ({ onClear = () => undefined, viewMode, onViewModeChange }: 
 
   const handleClearFiltersClick = () => {
     setSearchQuery(undefined);
+    setSortOrder(undefined);
     onClear();
 
     setTimeout(() => setFilterKey(filterKey + 1), 100);
@@ -304,6 +307,12 @@ const RulesFilter = ({ onClear = () => undefined, viewMode, onViewModeChange }: 
             </Field>
             <input type="submit" hidden />
           </form>
+          <div>
+            <Label>
+              <Trans i18nKey="alerting.rules-filter.sort-by">Sort by</Trans>
+            </Label>
+            <RulesSortingSelector sortOrder={sortOrder} onSortOrderChange={setSortOrder} />
+          </div>
           <div>
             <Label>
               <Trans i18nKey="alerting.rules-filter.view-as">View as</Trans>

--- a/public/app/features/alerting/unified/components/rules/RuleListGroupView.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListGroupView.tsx
@@ -5,17 +5,34 @@ import { CombinedRuleNamespace } from 'app/types/unified-alerting';
 import { LogMessages, logInfo } from '../../Analytics';
 import { AlertingAction } from '../../hooks/useAbilities';
 import { isCloudRulesSource, isGrafanaRulesSource } from '../../utils/datasource';
+import { sortRules } from '../../utils/rulesSorting';
 import { Authorize } from '../Authorize';
 
 import { CloudRules } from './CloudRules';
 import { GrafanaRules } from './GrafanaRules';
+import { RuleSortOrder, useRulesSorting } from './RulesSortingSelector';
 
 interface Props {
   namespaces: CombinedRuleNamespace[];
   expandAll: boolean;
 }
 
+function applySortingToNamespaces(
+  namespaces: CombinedRuleNamespace[],
+  sortOrder: RuleSortOrder | undefined
+): CombinedRuleNamespace[] {
+  return namespaces.map((namespace) => ({
+    ...namespace,
+    groups: namespace.groups.map((group) => ({
+      ...group,
+      rules: sortRules(group.rules, sortOrder),
+    })),
+  }));
+}
+
 export const RuleListGroupView = ({ namespaces, expandAll }: Props) => {
+  const { sortOrder } = useRulesSorting();
+
   const [grafanaNamespaces, cloudNamespaces] = useMemo(() => {
     const sorted = namespaces
       .map((namespace) => ({
@@ -23,11 +40,14 @@ export const RuleListGroupView = ({ namespaces, expandAll }: Props) => {
         groups: namespace.groups.sort((a, b) => a.name.localeCompare(b.name)),
       }))
       .sort((a, b) => a.name.localeCompare(b.name));
+
+    const sortedWithRules = applySortingToNamespaces(sorted, sortOrder);
+
     return [
-      sorted.filter((ns) => isGrafanaRulesSource(ns.rulesSource)),
-      sorted.filter((ns) => isCloudRulesSource(ns.rulesSource)),
+      sortedWithRules.filter((ns) => isGrafanaRulesSource(ns.rulesSource)),
+      sortedWithRules.filter((ns) => isCloudRulesSource(ns.rulesSource)),
     ];
-  }, [namespaces]);
+  }, [namespaces, sortOrder]);
 
   useEffect(() => {
     logInfo(LogMessages.loadedList);

--- a/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
@@ -15,9 +15,11 @@ import { createViewLink } from '../../utils/misc';
 import { isAsyncRequestStatePending } from '../../utils/redux';
 import { hashRule } from '../../utils/rule-id';
 import { getRulePluginOrigin, isProvisionedRule, prometheusRuleType } from '../../utils/rules';
+import { sortRules } from '../../utils/rulesSorting';
 import { calculateTotalInstances } from '../rule-viewer/RuleViewer';
 
 import { RuleActionsButtons } from './RuleActionsButtons';
+import { useRulesSorting } from './RulesSortingSelector';
 
 interface Props {
   namespaces: CombinedRuleNamespace[];
@@ -29,6 +31,7 @@ export const RuleListStateView = ({ namespaces }: Props) => {
   const [ref, { width }] = useMeasure<HTMLUListElement>();
 
   const isLoading = useDataSourcesLoadingState();
+  const { sortOrder } = useRulesSorting();
 
   const groupedRules = useMemo(() => {
     const result: GroupedRules = new Map([
@@ -52,10 +55,14 @@ export const RuleListStateView = ({ namespaces }: Props) => {
       )
     );
 
-    result.forEach((rules) => rules.sort((a, b) => a.name.localeCompare(b.name)));
+    // Apply user sorting preference or default to alphabetical
+    result.forEach((rules, state) => {
+      const sortedRules = sortOrder ? sortRules(rules, sortOrder) : rules.sort((a, b) => a.name.localeCompare(b.name));
+      result.set(state, sortedRules);
+    });
 
     return result;
-  }, [namespaces]);
+  }, [namespaces, sortOrder]);
 
   const entries = groupedRules.entries();
 

--- a/public/app/features/alerting/unified/components/rules/RulesSortingSelector.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesSortingSelector.tsx
@@ -1,0 +1,70 @@
+import { useCallback } from 'react';
+
+import { SelectableValue } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Select } from '@grafana/ui';
+
+import { useURLSearchParams } from '../../hooks/useURLSearchParams';
+
+export enum RuleSortOrder {
+  AlphaAsc = 'alpha-asc',
+  AlphaDesc = 'alpha-desc',
+  StateAsc = 'state-asc',
+  StateDesc = 'state-desc',
+  CreatedAsc = 'created-asc',
+  CreatedDesc = 'created-desc',
+  UpdatedAsc = 'updated-asc',
+  UpdatedDesc = 'updated-desc',
+}
+
+const SORT_OPTIONS: Array<SelectableValue<RuleSortOrder>> = [
+  { label: 'Alphabetically (A-Z)', value: RuleSortOrder.AlphaAsc },
+  { label: 'Alphabetically (Z-A)', value: RuleSortOrder.AlphaDesc },
+  { label: 'State (Firing first)', value: RuleSortOrder.StateAsc },
+  { label: 'State (Normal first)', value: RuleSortOrder.StateDesc },
+  { label: 'Created (Newest first)', value: RuleSortOrder.CreatedDesc },
+  { label: 'Created (Oldest first)', value: RuleSortOrder.CreatedAsc },
+  { label: 'Updated (Newest first)', value: RuleSortOrder.UpdatedDesc },
+  { label: 'Updated (Oldest first)', value: RuleSortOrder.UpdatedAsc },
+];
+
+export function useRulesSorting() {
+  const [queryParams, updateQueryParams] = useURLSearchParams();
+
+  const sortOrder = parseRuleSortOrder(queryParams.get('sort'));
+
+  const setSortOrder = useCallback(
+    (order: RuleSortOrder | undefined) => {
+      updateQueryParams({ sort: order });
+    },
+    [updateQueryParams]
+  );
+
+  return { sortOrder, setSortOrder };
+}
+
+function parseRuleSortOrder(value: string | null): RuleSortOrder | undefined {
+  if (value && Object.values(RuleSortOrder).includes(value as RuleSortOrder)) {
+    return value as RuleSortOrder;
+  }
+  return undefined;
+}
+
+interface RulesSortingSelectorProps {
+  sortOrder: RuleSortOrder | undefined;
+  onSortOrderChange: (sortOrder: RuleSortOrder | undefined) => void;
+}
+
+export function RulesSortingSelector({ sortOrder, onSortOrderChange }: RulesSortingSelectorProps) {
+  return (
+    <Select
+      aria-label={t('alerting.rules-sorting-selector.aria-label', 'Sort alert rules')}
+      options={SORT_OPTIONS}
+      value={sortOrder}
+      onChange={(option) => onSortOrderChange(option?.value)}
+      placeholder={t('alerting.rules-sorting-selector.placeholder', 'Sort by...')}
+      isClearable
+      width={24}
+    />
+  );
+}

--- a/public/app/features/alerting/unified/utils/rulesSorting.test.ts
+++ b/public/app/features/alerting/unified/utils/rulesSorting.test.ts
@@ -1,0 +1,237 @@
+import { CombinedRule } from 'app/types/unified-alerting';
+import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
+
+import { RuleSortOrder } from '../components/rules/RulesSortingSelector';
+
+import { sortRules } from './rulesSorting';
+
+function createMockRule(overrides: Partial<CombinedRule> & { name: string }): CombinedRule {
+  return {
+    name: overrides.name,
+    query: '',
+    labels: {},
+    annotations: {},
+    group: { name: 'test-group', rules: [], totals: {} },
+    namespace: { name: 'test-namespace', groups: [], rulesSource: 'grafana' },
+    instanceTotals: {},
+    filteredInstanceTotals: {},
+    ...overrides,
+  };
+}
+
+function createAlertingRule(
+  name: string,
+  state: PromAlertingRuleState,
+  lastEvaluation?: string
+): CombinedRule {
+  return createMockRule({
+    name,
+    promRule: {
+      name,
+      type: 'alerting',
+      state,
+      query: '',
+      labels: {},
+      annotations: {},
+      health: 'ok',
+      lastEvaluation,
+      evaluationTime: 0,
+      alerts: [],
+    },
+  });
+}
+
+function createGrafanaRule(
+  name: string,
+  state: PromAlertingRuleState,
+  updated?: string
+): CombinedRule {
+  const rule = createAlertingRule(name, state);
+  rule.rulerRule = {
+    grafana_alert: {
+      id: 1,
+      orgId: 1,
+      title: name,
+      condition: 'A',
+      data: [],
+      updated: updated || '2024-01-01T00:00:00Z',
+      namespace_uid: 'test-folder',
+      rule_group: 'test-group',
+      no_data_state: 'NoData',
+      exec_err_state: 'Alerting',
+      uid: `rule-${name}`,
+    },
+    for: '5m',
+    labels: {},
+    annotations: {},
+  };
+  return rule;
+}
+
+describe('sortRules', () => {
+  describe('when sortOrder is undefined', () => {
+    it('should return rules unchanged', () => {
+      const rules = [
+        createMockRule({ name: 'Charlie' }),
+        createMockRule({ name: 'Alpha' }),
+        createMockRule({ name: 'Bravo' }),
+      ];
+
+      const result = sortRules(rules, undefined);
+
+      expect(result.map((r) => r.name)).toEqual(['Charlie', 'Alpha', 'Bravo']);
+    });
+  });
+
+  describe('alphabetical sorting', () => {
+    it('should sort A-Z correctly', () => {
+      const rules = [
+        createMockRule({ name: 'Charlie' }),
+        createMockRule({ name: 'Alpha' }),
+        createMockRule({ name: 'Bravo' }),
+      ];
+
+      const result = sortRules(rules, RuleSortOrder.AlphaAsc);
+
+      expect(result.map((r) => r.name)).toEqual(['Alpha', 'Bravo', 'Charlie']);
+    });
+
+    it('should sort Z-A correctly', () => {
+      const rules = [
+        createMockRule({ name: 'Alpha' }),
+        createMockRule({ name: 'Charlie' }),
+        createMockRule({ name: 'Bravo' }),
+      ];
+
+      const result = sortRules(rules, RuleSortOrder.AlphaDesc);
+
+      expect(result.map((r) => r.name)).toEqual(['Charlie', 'Bravo', 'Alpha']);
+    });
+
+    it('should be case insensitive', () => {
+      const rules = [
+        createMockRule({ name: 'charlie' }),
+        createMockRule({ name: 'ALPHA' }),
+        createMockRule({ name: 'Bravo' }),
+      ];
+
+      const result = sortRules(rules, RuleSortOrder.AlphaAsc);
+
+      expect(result.map((r) => r.name)).toEqual(['ALPHA', 'Bravo', 'charlie']);
+    });
+  });
+
+  describe('state sorting', () => {
+    it('should sort by state with firing first', () => {
+      const rules = [
+        createAlertingRule('normal-rule', PromAlertingRuleState.Inactive),
+        createAlertingRule('firing-rule', PromAlertingRuleState.Firing),
+        createAlertingRule('pending-rule', PromAlertingRuleState.Pending),
+      ];
+
+      const result = sortRules(rules, RuleSortOrder.StateAsc);
+
+      expect(result.map((r) => r.name)).toEqual(['firing-rule', 'pending-rule', 'normal-rule']);
+    });
+
+    it('should sort by state with normal first', () => {
+      const rules = [
+        createAlertingRule('firing-rule', PromAlertingRuleState.Firing),
+        createAlertingRule('normal-rule', PromAlertingRuleState.Inactive),
+        createAlertingRule('pending-rule', PromAlertingRuleState.Pending),
+      ];
+
+      const result = sortRules(rules, RuleSortOrder.StateDesc);
+
+      expect(result.map((r) => r.name)).toEqual(['normal-rule', 'pending-rule', 'firing-rule']);
+    });
+
+    it('should use name as tiebreaker for same state', () => {
+      const rules = [
+        createAlertingRule('charlie-firing', PromAlertingRuleState.Firing),
+        createAlertingRule('alpha-firing', PromAlertingRuleState.Firing),
+        createAlertingRule('bravo-firing', PromAlertingRuleState.Firing),
+      ];
+
+      const result = sortRules(rules, RuleSortOrder.StateAsc);
+
+      expect(result.map((r) => r.name)).toEqual(['alpha-firing', 'bravo-firing', 'charlie-firing']);
+    });
+  });
+
+  describe('updated time sorting', () => {
+    it('should sort by updated time with newest first', () => {
+      const rules = [
+        createGrafanaRule('old-rule', PromAlertingRuleState.Inactive, '2024-01-01T00:00:00Z'),
+        createGrafanaRule('new-rule', PromAlertingRuleState.Inactive, '2024-03-01T00:00:00Z'),
+        createGrafanaRule('mid-rule', PromAlertingRuleState.Inactive, '2024-02-01T00:00:00Z'),
+      ];
+
+      const result = sortRules(rules, RuleSortOrder.UpdatedDesc);
+
+      expect(result.map((r) => r.name)).toEqual(['new-rule', 'mid-rule', 'old-rule']);
+    });
+
+    it('should sort by updated time with oldest first', () => {
+      const rules = [
+        createGrafanaRule('old-rule', PromAlertingRuleState.Inactive, '2024-01-01T00:00:00Z'),
+        createGrafanaRule('new-rule', PromAlertingRuleState.Inactive, '2024-03-01T00:00:00Z'),
+        createGrafanaRule('mid-rule', PromAlertingRuleState.Inactive, '2024-02-01T00:00:00Z'),
+      ];
+
+      const result = sortRules(rules, RuleSortOrder.UpdatedAsc);
+
+      expect(result.map((r) => r.name)).toEqual(['old-rule', 'mid-rule', 'new-rule']);
+    });
+  });
+
+  describe('created time sorting', () => {
+    it('should sort by created time with newest first', () => {
+      const rules = [
+        createGrafanaRule('old-rule', PromAlertingRuleState.Inactive, '2024-01-01T00:00:00Z'),
+        createGrafanaRule('new-rule', PromAlertingRuleState.Inactive, '2024-03-01T00:00:00Z'),
+        createGrafanaRule('mid-rule', PromAlertingRuleState.Inactive, '2024-02-01T00:00:00Z'),
+      ];
+
+      const result = sortRules(rules, RuleSortOrder.CreatedDesc);
+
+      expect(result.map((r) => r.name)).toEqual(['new-rule', 'mid-rule', 'old-rule']);
+    });
+
+    it('should sort by created time with oldest first', () => {
+      const rules = [
+        createGrafanaRule('old-rule', PromAlertingRuleState.Inactive, '2024-01-01T00:00:00Z'),
+        createGrafanaRule('new-rule', PromAlertingRuleState.Inactive, '2024-03-01T00:00:00Z'),
+        createGrafanaRule('mid-rule', PromAlertingRuleState.Inactive, '2024-02-01T00:00:00Z'),
+      ];
+
+      const result = sortRules(rules, RuleSortOrder.CreatedAsc);
+
+      expect(result.map((r) => r.name)).toEqual(['old-rule', 'mid-rule', 'new-rule']);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty array', () => {
+      const result = sortRules([], RuleSortOrder.AlphaAsc);
+      expect(result).toEqual([]);
+    });
+
+    it('should handle single item array', () => {
+      const rules = [createMockRule({ name: 'only-rule' })];
+      const result = sortRules(rules, RuleSortOrder.AlphaAsc);
+      expect(result.map((r) => r.name)).toEqual(['only-rule']);
+    });
+
+    it('should handle rules without promRule for state sorting', () => {
+      const rules = [
+        createMockRule({ name: 'no-prom-rule' }),
+        createAlertingRule('firing-rule', PromAlertingRuleState.Firing),
+      ];
+
+      const result = sortRules(rules, RuleSortOrder.StateAsc);
+
+      expect(result.map((r) => r.name)).toEqual(['firing-rule', 'no-prom-rule']);
+    });
+  });
+});

--- a/public/app/features/alerting/unified/utils/rulesSorting.ts
+++ b/public/app/features/alerting/unified/utils/rulesSorting.ts
@@ -1,0 +1,114 @@
+import { sortBy } from 'lodash';
+
+import { CombinedRule } from 'app/types/unified-alerting';
+import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
+
+import { RuleSortOrder } from '../components/rules/RulesSortingSelector';
+
+import { prometheusRuleType, rulerRuleType } from './rules';
+
+const STATE_PRIORITY: Record<string, number> = {
+  [PromAlertingRuleState.Firing]: 1,
+  [PromAlertingRuleState.Pending]: 2,
+  [PromAlertingRuleState.Recovering]: 3,
+  [PromAlertingRuleState.Inactive]: 4,
+  unknown: 5,
+};
+
+function getRuleState(rule: CombinedRule): string {
+  if (prometheusRuleType.alertingRule(rule.promRule)) {
+    return rule.promRule.state;
+  }
+  return 'unknown';
+}
+
+function getRuleStatePriority(rule: CombinedRule): number {
+  const state = getRuleState(rule);
+  return STATE_PRIORITY[state] ?? STATE_PRIORITY.unknown;
+}
+
+function getRuleCreatedTime(rule: CombinedRule): number {
+  const rulerRule = rule.rulerRule;
+
+  if (rulerRuleType.grafana.rule(rulerRule)) {
+    const updatedAt = rulerRule.grafana_alert.updated;
+    if (updatedAt) {
+      return new Date(updatedAt).getTime();
+    }
+  }
+
+  return 0;
+}
+
+function getRuleUpdatedTime(rule: CombinedRule): number {
+  const rulerRule = rule.rulerRule;
+
+  if (rulerRuleType.grafana.rule(rulerRule)) {
+    const updatedAt = rulerRule.grafana_alert.updated;
+    if (updatedAt) {
+      return new Date(updatedAt).getTime();
+    }
+  }
+
+  if (prometheusRuleType.alertingRule(rule.promRule)) {
+    const lastEval = rule.promRule.lastEvaluation;
+    if (lastEval) {
+      return new Date(lastEval).getTime();
+    }
+  }
+
+  return 0;
+}
+
+export function sortRules(rules: CombinedRule[], sortOrder: RuleSortOrder | undefined): CombinedRule[] {
+  if (!sortOrder) {
+    return rules;
+  }
+
+  switch (sortOrder) {
+    case RuleSortOrder.AlphaAsc:
+      return sortBy(rules, [(rule) => rule.name.toLowerCase()]);
+
+    case RuleSortOrder.AlphaDesc:
+      return sortBy(rules, [(rule) => rule.name.toLowerCase()]).reverse();
+
+    case RuleSortOrder.StateAsc:
+      return sortBy(rules, [
+        (rule) => getRuleStatePriority(rule),
+        (rule) => rule.name.toLowerCase(),
+      ]);
+
+    case RuleSortOrder.StateDesc:
+      return sortBy(rules, [
+        (rule) => -getRuleStatePriority(rule),
+        (rule) => rule.name.toLowerCase(),
+      ]);
+
+    case RuleSortOrder.CreatedAsc:
+      return sortBy(rules, [
+        (rule) => getRuleCreatedTime(rule),
+        (rule) => rule.name.toLowerCase(),
+      ]);
+
+    case RuleSortOrder.CreatedDesc:
+      return sortBy(rules, [
+        (rule) => -getRuleCreatedTime(rule),
+        (rule) => rule.name.toLowerCase(),
+      ]);
+
+    case RuleSortOrder.UpdatedAsc:
+      return sortBy(rules, [
+        (rule) => getRuleUpdatedTime(rule),
+        (rule) => rule.name.toLowerCase(),
+      ]);
+
+    case RuleSortOrder.UpdatedDesc:
+      return sortBy(rules, [
+        (rule) => -getRuleUpdatedTime(rule),
+        (rule) => rule.name.toLowerCase(),
+      ]);
+
+    default:
+      return rules;
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds sorting capabilities to the alert rules list, addressing user feedback that alert lists become disorganized as they grow.

### New sorting options:
- **Alphabetical** (A-Z / Z-A)
- **Alert State** (Firing first / Normal first)
- **Created Time** (Newest / Oldest first)
- **Updated Time** (Newest / Oldest first)

### Implementation details:
- Sort preference is stored in URL query params (`?sort=alpha-asc`, etc.) making it shareable and bookmarkable
- Works in both **Grouped** and **State** view modes
- Clears when "Clear filters" is clicked
- Client-side sorting (can be extended to server-side if needed for performance)

## Test plan

- [ ] Verify sorting dropdown appears in the alert rules filter bar
- [ ] Test each sorting option works correctly
- [ ] Verify sorting persists in URL and survives page refresh
- [ ] Test sorting works in both Grouped and State view modes
- [ ] Verify "Clear filters" also clears the sort selection
- [ ] Run unit tests: `yarn test rulesSorting`

## Screenshots

The sorting dropdown is added next to the "View as" selector in the filter bar.

Closes #116229