### PR TITLE
Docs: Clarify silences and active time intervals terminology

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -300,7 +300,7 @@ Complete the following steps to set up notifications.
 
       All notifications for this alert rule are sent to this contact point automatically and notification policies aren't used.
 
-   1. You can also optionally select a mute or active timing as well as groupings and timings to define when not to send notifications.
+   1. You can also optionally select a mute timing or active time interval as well as groupings and timings to define when not to send notifications.
 
    **Use notification policy**
    1. Choose this option to use the [notification policy tree](ref:notification-policies) to handle alert notifications.

--- a/docs/sources/alerting/configure-notifications/_index.md
+++ b/docs/sources/alerting/configure-notifications/_index.md
@@ -81,7 +81,7 @@ By default, Grafana uses its built-in Alertmanager, and Grafana Cloud instances 
 
 {{< figure src="/media/docs/alerting/alerting-choose-alertmanager.png" max-width="750px" alt="A screenshot choosing an Alertmanager in the notification policies UI" >}}
 
-When having multiple Alertmanagers, note that each Alertmanager manages its own independent notification resources, such as contact points, templates, policies, silences, mute timings, and active notifications.
+When having multiple Alertmanagers, note that each Alertmanager manages its own independent notification resources, such as contact points, templates, policies, silences, mute timings, active time intervals, and active notifications.
 
 These notification resources cannot be shared across different Alertmanagers.
 

--- a/docs/sources/alerting/configure-notifications/create-silence.md
+++ b/docs/sources/alerting/configure-notifications/create-silence.md
@@ -68,9 +68,9 @@ Silences stop notifications from being created for a specified time window but d
 Silences are assigned to a [specific Alertmanager](ref:alertmanager-architecture) and only suppress notifications for alerts managed by that Alertmanager.
 {{< /admonition >}}
 
-## Mute and active timings vs silences
+## Mute timings and active time intervals vs silences
 
-[Mute and active timings](ref:shared-mute-timings) and [silences](ref:shared-silences) are distinct methods to suppress notifications. They do not prevent alert rules from being evaluated or stop alert instances from appearing in the user interface; they only prevent notifications from being created.
+[Mute timings and active time intervals](ref:shared-mute-timings) and [silences](ref:shared-silences) are distinct methods to suppress notifications. They do not prevent alert rules from being evaluated or stop alert instances from appearing in the user interface; they only prevent notifications from being created.
 
 The following table highlights the key differences between mute timings and silences.
 

--- a/docs/sources/alerting/configure-notifications/mute-timings.md
+++ b/docs/sources/alerting/configure-notifications/mute-timings.md
@@ -4,7 +4,7 @@ aliases:
   - ../unified-alerting/notifications/mute-timings/ # /docs/grafana/<GRAFANA_VERSION>/alerting/unified-alerting/notifications/mute-timings/
   - ../manage-notifications/mute-timings/ # /docs/grafana/<GRAFANA_VERSION>/alerting/manage-notifications/mute-timings/
 canonical: /docs/grafana/latest/alerting/configure-notifications/mute-timings/
-description: Use mute timings and active intervals to manage notification handling during a specific and reoccurring period of time
+description: Use mute timings and active time intervals to manage notification handling during a specific and reoccurring period of time
 keywords:
   - grafana
   - alerting
@@ -38,23 +38,23 @@ refs:
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/mute-timings/
 ---
 
-# Configure mute timings and active intervals
+# Configure mute timings and active time intervals
 
-Mute timing and active time intervals let you determine how your alert notifications are handled during designated periods of time. After you create a time interval, you can apply it as either a mute or active time interval for your notifications policies.
+Mute timings and active time intervals let you determine how your alert notifications are handled during designated periods of time. After you create a time interval, you can apply it as either a mute timing or active time interval for your notification policies.
 
 A mute timing is a recurring interval that stops notifications for one or multiple notification policies during a specified period. It suppresses notifications but does not interrupt alert evaluation.
 
 Use mute timings to temporarily pause notifications for a specific recurring period, such as a regular maintenance window or weekends.
 
-The active time interval provide the opposite functionality, where alerts handled by a notification policy are suppressed unless the notification happens at a time that matches the time interval. Use active time intervals for periods where you want to reduce alert noise. Mute timings take precedence over active time intervals when they overlap.
+Active time intervals provide the opposite functionality, where alerts handled by a notification policy are suppressed unless the notification happens at a time that matches the time interval. Use active time intervals for periods where you want to reduce alert noise. Mute timings take precedence over active time intervals when they overlap.
 
 {{< admonition type="note" >}}
 Mute timings and active time intervals are assigned to a [specific Alertmanager](ref:alertmanager-architecture) and only suppress notifications for alerts managed by that Alertmanager.
 {{< /admonition >}}
 
-## Mute and active timings vs silences
+## Mute timings and active time intervals vs silences
 
-[Mute and active timings](ref:shared-mute-timings) and [silences](ref:shared-silences) are distinct methods to suppress notifications. They do not prevent alert rules from being evaluated or stop alert instances from appearing in the user interface; they only prevent notifications from being created.
+[Mute timings and active time intervals](ref:shared-mute-timings) and [silences](ref:shared-silences) are distinct methods to suppress notifications. They do not prevent alert rules from being evaluated or stop alert instances from appearing in the user interface; they only prevent notifications from being created.
 
 The following table highlights the key differences between mute timings and silences.
 
@@ -71,7 +71,7 @@ The following table highlights the key differences between mute timings and sile
 1. Click **Notification policies** and then the **Time intervals** tab.
 1. From the **Alertmanager** dropdown, select an external Alertmanager. By default, the **Grafana Alertmanager** is selected.
 1. Click **+ Add time interval**.
-1. Fill out the form to create a [time interval](#time-intervals) to match against for your mute or active timing.
+1. Fill out the form to create a [time interval](#time-intervals) to match against for your mute timing or active time interval.
 1. Save your changes.
 
 ## Assign a time interval to a notification policy
@@ -79,14 +79,14 @@ The following table highlights the key differences between mute timings and sile
 1. In the left-side menu, click **Alerts & IRM**, and then **Alerting**.
 1. Click **Notification policies** and make sure you are on the **Notification Policies** tab.
 1. Find the notification policy you would like to add the time intervals to and click **...** -> **Edit**.
-1. From either the **Mute timings** or **Active timings** dropdowns, choose the notification timings you would like to add to the policy.
+1. From either the **Mute timings** or **Active time intervals** dropdowns, choose the time intervals you would like to add to the policy.
 1. Save your changes.
 
 ## Time intervals
 
 A time interval is a specific duration during which alerts are suppressed. The duration typically consists of a specific time range and the days of the week, month, or year.
 
-A mute or active timing can contain multiple time intervals.
+A mute timing or active time interval can contain multiple time intervals.
 
 Supported time interval options are:
 


### PR DESCRIPTION
Fixes #116226

The alerting documentation was using inconsistent terminology for "active time intervals" - sometimes called "active timing", "active timings", or "active intervals". This caused confusion especially since a "what's new" post stated "Mute Timings have been renamed to Active Time Intervals."

This change standardizes the terminology across all alerting documentation:
- Use "active time intervals" consistently (not "active timing" or "active timings")
- Use "mute timings" consistently
- Fix grammar issues (e.g., "Active time intervals provide" instead of "The active time interval provide")
- Update section headings to "Mute timings and active time intervals vs silences"
- Update UI dropdown references to match actual UI labels
- Add "active time intervals" to the list of Alertmanager resources

Test Plan: Verified documentation renders correctly and terminology is consistent across all modified files.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This update standardizes the terminology used in Grafana Alerting documentation for notification suppression features. It clarifies the distinction between "mute timings," "active time intervals," and "silences," ensuring consistent language across all alerting docs. The update fixes inconsistent usage where "active timing," "active timings," and "active intervals" were used interchangeably, and corrects grammar issues in the documentation.

**Why do we need this feature?**

The alerting documentation was causing confusion due to inconsistent terminology. A "what's new" post stated "Mute Timings have been renamed to Active Time Intervals," but the docs used various terms interchangeably ("active timing," "active timings," "active intervals"). This inconsistency made it difficult for users to understand the relationship between these features and how they differ from silences. Clear, consistent documentation helps users correctly configure their alerting notification suppression.

**Who is this feature for?**

This documentation improvement is for all Grafana users who configure alerting notifications, including:

Platform engineers and SREs setting up alerting systems
DevOps teams managing notification policies and maintenance windows
New Grafana users learning about notification suppression options
Anyone referencing the alerting documentation to understand the difference between mute timings, active time intervals, and silences

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #116226"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
