### PR TITLE
query service: handle request-validator better

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/dsquerierclient"
+	"github.com/grafana/grafana/pkg/services/validations"
 	"github.com/grafana/grafana/pkg/setting"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -340,8 +341,8 @@ func prepareQuery(
 	}, nil
 }
 
-func handlePreparedQuery(ctx context.Context, pq *preparedQuery, concurrentQueryLimit int) (*backend.QueryDataResponse, error) {
-	resp, err := service.QueryData(ctx, pq.logger, pq.cache, pq.exprSvc, pq.mReq, pq.builder, pq.headers, concurrentQueryLimit)
+func handlePreparedQuery(ctx context.Context, pq *preparedQuery, concurrentQueryLimit int, validator validations.DataSourceRequestValidator) (*backend.QueryDataResponse, error) {
+	resp, err := service.QueryData(ctx, pq.logger, pq.cache, pq.exprSvc, pq.mReq, pq.builder, pq.headers, concurrentQueryLimit, validator)
 	pq.reportMetrics()
 	return resp, err
 }
@@ -359,7 +360,7 @@ func handleQuery(
 		responder.Error(err)
 		return nil, err
 	}
-	return handlePreparedQuery(ctx, pq, b.concurrentQueryLimit)
+	return handlePreparedQuery(ctx, pq, b.concurrentQueryLimit, b.dataSourceRequestValidator)
 }
 
 type responderWrapper struct {

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/query/clientapi"
+	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -176,9 +177,10 @@ func TestQueryAPI(t *testing.T) {
 				instanceProvider: mockClient{
 					stubbedFrame: tc.stubbedFrame,
 				},
-				tracer:                 tracing.InitializeTracerForTest(),
-				log:                    log.New("test"),
-				legacyDatasourceLookup: &mockLegacyDataSourceLookup{},
+				tracer:                     tracing.InitializeTracerForTest(),
+				log:                        log.New("test"),
+				legacyDatasourceLookup:     &mockLegacyDataSourceLookup{},
+				dataSourceRequestValidator: &NoOpTestRequestValidator{},
 			}
 
 			reqCtx := claims.WithAuthInfo(identity.WithRequester(context.Background(), mockUser{}), &mockAuthInfo{})
@@ -446,5 +448,11 @@ type mockAuthInfo struct {
 }
 
 func (main mockAuthInfo) GetExtra() map[string][]string {
+	return nil
+}
+
+type NoOpTestRequestValidator struct{}
+
+func (*NoOpTestRequestValidator) Validate(*datasources.DataSource, *http.Request) error {
 	return nil
 }

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -890,7 +890,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 		return nil, err
 	}
 	legacyDataSourceLookup := service9.ProvideLegacyDataSourceLookup(service15)
-	queryAPIBuilder, err := query2.RegisterAPIService(cfg, featureToggles, apiserverService, service15, pluginstoreService, accessControl, middlewareHandler, plugincontextProvider, registerer, tracingService, legacyDataSourceLookup, exprService)
+	queryAPIBuilder, err := query2.RegisterAPIService(cfg, featureToggles, apiserverService, service15, pluginstoreService, accessControl, middlewareHandler, plugincontextProvider, registerer, tracingService, legacyDataSourceLookup, exprService, ossDataSourceRequestValidator)
 	if err != nil {
 		return nil, err
 	}
@@ -1560,7 +1560,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 		return nil, err
 	}
 	legacyDataSourceLookup := service9.ProvideLegacyDataSourceLookup(service15)
-	queryAPIBuilder, err := query2.RegisterAPIService(cfg, featureToggles, apiserverService, service15, pluginstoreService, accessControl, middlewareHandler, plugincontextProvider, registerer, tracingService, legacyDataSourceLookup, exprService)
+	queryAPIBuilder, err := query2.RegisterAPIService(cfg, featureToggles, apiserverService, service15, pluginstoreService, accessControl, middlewareHandler, plugincontextProvider, registerer, tracingService, legacyDataSourceLookup, exprService, ossDataSourceRequestValidator)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -226,12 +226,12 @@ func buildErrorResponses(err error, queries []*simplejson.Json) splitResponse {
 	return splitResponse{er, http.Header{}}
 }
 
-func QueryData(ctx context.Context, log log.Logger, dscache datasources.CacheService, exprService *expr.Service, reqDTO dtos.MetricRequest, qsDatasourceClientBuilder dsquerierclient.QSDatasourceClientBuilder, headers map[string]string, concurrentQueryLimit int) (*backend.QueryDataResponse, error) {
+func QueryData(ctx context.Context, log log.Logger, dscache datasources.CacheService, exprService *expr.Service, reqDTO dtos.MetricRequest, qsDatasourceClientBuilder dsquerierclient.QSDatasourceClientBuilder, headers map[string]string, concurrentQueryLimit int, validator validations.DataSourceRequestValidator) (*backend.QueryDataResponse, error) {
 	s := &ServiceImpl{
 		log:                        log,
 		dataSourceCache:            dscache,
 		expressionService:          exprService,
-		dataSourceRequestValidator: validations.ProvideValidator(),
+		dataSourceRequestValidator: validator,
 		qsDatasourceClientBuilder:  qsDatasourceClientBuilder,
 		headers:                    headers,
 		concurrentQueryLimit:       concurrentQueryLimit,


### PR DESCRIPTION
when the `/api/ds/query` endpoint uses a request-validator, it is injected by `wire`.
when the `/apis/query.grafana.app` does it, it uses a hardcoded one. this PR changes it so that it is also injected by `wire`.