### PR TITLE
ImportDashboardOverview: Display datasource name instead of plugin id

### DIFF
--- a/public/app/features/dashboard-scene/v2schema/ImportDashboardFormV2.tsx
+++ b/public/app/features/dashboard-scene/v2schema/ImportDashboardFormV2.tsx
@@ -95,7 +95,7 @@ export const ImportDashboardFormV2 = ({
 
           return (
             <Field
-              label={input.pluginId}
+              label={input.name}
               description={input.description}
               key={input.pluginId}
               invalid={!!errors[dataSourceOption]}

--- a/public/app/features/manage-dashboards/components/ImportDashboardForm.tsx
+++ b/public/app/features/manage-dashboards/components/ImportDashboardForm.tsx
@@ -121,7 +121,7 @@ export const ImportDashboardForm = ({
           const current = watchDataSources ?? [];
           return (
             <Field
-              label={input.pluginId}
+              label={input.name}
               description={input.description}
               key={dataSourceOption}
               invalid={errors.dataSources && !!errors.dataSources[index]}


### PR DESCRIPTION
part of the solution for https://github.com/grafana/support-escalations/issues/20101

