### PR TITLE
Stars: Fix infinite loading with no starred items

### DIFF
--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -1,6 +1,9 @@
 import { isEmpty } from 'lodash';
 
-import { BASE_URL as v0alphaBaseURL } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
+import {
+  API_GROUP as DASHBOARD_API_GROUP,
+  BASE_URL as v0alphaBaseURL,
+} from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
 import { generatedAPI as legacyUserAPI } from '@grafana/api-clients/rtkq/legacy/user';
 import { DataFrame, DataFrameView, getDisplayProcessor, SelectableValue, toDataFrame } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -85,10 +88,11 @@ export class UnifiedSearcher implements GrafanaSearcher {
           fieldSelector: `metadata.name=${name}`,
         })
       );
-      starsIds =
-        result.data.items?.[0].spec.resource.find(
-          (info) => info.group === 'dashboard.grafana.app' && info.kind === 'Dashboard'
-        )?.names || [];
+      const items = result.data.items;
+      starsIds = items?.length
+        ? items[0].spec.resource.find(({ group, kind }) => group === DASHBOARD_API_GROUP && kind === 'Dashboard')
+            ?.names || []
+        : [];
     } else {
       starsIds = await dispatch(legacyUserAPI.endpoints.getStars.initiate()).unwrap();
     }
@@ -331,7 +335,7 @@ export class UnifiedSearcher implements GrafanaSearcher {
     }
 
     if (query.deleted) {
-      uri = `${getAPIBaseURL('dashboard.grafana.app', 'v1beta1')}/dashboards/?labelSelector=grafana.app/get-trash=true`;
+      uri = `${getAPIBaseURL(DASHBOARD_API_GROUP, 'v1beta1')}/dashboards/?labelSelector=grafana.app/get-trash=true`;
     }
     return uri;
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**


  A bug fix that prevents a TypeError when loading the starred dashboards page with no starred items and the `starsFromAPIServer` feature toggle enabled.

**Why do we need this feature?**

  When the starred items API returns an empty array, the code was attempting to access properties on `undefined`, causing an infinite loading indicator instead of showing the empty state.

**Who is this feature for?**

  Users who have the starsFromAPIServer feature toggle enabled and navigate to the starred dashboards page when they have no starred dashboards.

