### PR TITLE
SearchAPI: Return "shared with me" children based on the permission query param

### DIFF
--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -569,9 +569,11 @@ func asResourceKey(ns string, k string) (*resourcepb.ResourceKey, error) {
 	return key, nil
 }
 
+// getDashboardsUIDsSharedWithUser gets dashboards/folders that the user was granted access to, but does not have access
+// to their parent folder. This powers the virtual "Shared with me" folder.
+// With the requestedPermission argument you can define what "access" means. So, for example, you can still get all the
+// folders that user would not be able to get to from the root if they were filtered by edit permissions.
 func (s *SearchHandler) getDashboardsUIDsSharedWithUser(ctx context.Context, user identity.Requester, requestedPermission dashboardaccess.PermissionType) ([]string, error) {
-	// Gets dashboards/folders that the user was granted access to, but does not have access to their parent folder.
-	// This powers the virtual "Shared with me" folder.
 	dashboardAction, folderAction := permissionToActions(requestedPermission)
 	permissions := user.GetPermissions()
 	dashboardPermissions := permissions[dashboardAction]

--- a/pkg/registry/apis/dashboard/search_test.go
+++ b/pkg/registry/apis/dashboard/search_test.go
@@ -1169,7 +1169,7 @@ func TestConvertHttpSearchRequestToResourceSearchRequest(t *testing.T) {
 			queryParams, err := url.ParseQuery(tt.queryString)
 			require.NoError(t, err)
 
-			getDashboardsFunc := func() ([]string, error) {
+			getDashboardsFunc := func(requestedPermission dashboardaccess.PermissionType) ([]string, error) {
 				if tt.sharedDashboardsError != nil {
 					return nil, tt.sharedDashboardsError
 				}


### PR DESCRIPTION
When sharing and browsing folders, it's possible to share a folder but not it's parent. This means that the group of folders user has access to isn't a single tree, but possible multiple trees.

To allow getting to them in the UI we have a "shared with me" folder that should show all the subtrees that aren't connected to the main root when accounted for the permissions.

Problem is the `getDashboardsUIDsSharedWithUser` function in the search API only computed which folders user has access to based on `view` permissions. This didn't work as expected with existing query param `permission` which could be set to `edit/admin`. This is usefull, for example, in a folder picker when saving dashboard, as we don't want to show all folders user can view, but those that user can `edit` and save the dashboard to.

So this PR passes the `permission` param into the `getDashboardsUIDsSharedWithUser` to compute the folder accessibility also based on that param.