### PR TITLE
Dashlist: limit clickable area to dashboard title

### DIFF
--- a/public/app/plugins/panel/dashlist/styles.ts
+++ b/public/app/plugins/panel/dashlist/styles.ts
@@ -10,13 +10,9 @@ export const getStyles = (theme: GrafanaTheme2) => {
   )`;
   return {
     dashlistLink: css({
-      display: 'flex',
-      cursor: 'pointer',
+      display: 'inline-flex',
       borderBottom: `1px solid ${theme.colors.border.weak}`,
-      margin: theme.spacing(1),
-      padding: theme.spacing(1),
       alignItems: 'center',
-
       '&:hover': {
         a: {
           color: theme.colors.text.link,
@@ -27,6 +23,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
     dashlistCard: css({
       display: 'flex',
       flexDirection: 'column',
+      padding:theme.spacing(1),
       '&:hover a': {
         color: theme.colors.text.link,
         textDecoration: 'underline',


### PR DESCRIPTION
Fixes #115929 

The dashboard list panel previously made the entire row clickable,
including empty space beyond the visible dashboard title.

This change limits the clickable area to the link text only, while
preserving row hover styling for better UX.

Tested locally.
