### PR TITLE
Use subpath in features API URL

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -16,8 +16,11 @@ export async function initOpenFeature() {
    *   to allow for overrides https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/multi-provider
    */
 
+  const subPath = config.appSubUrl || '';
+  const baseUrl = `${subPath}/apis/features.grafana.app/v0alpha1/namespaces/${config.namespace}`;
+
   const ofProvider = new OFREPWebProvider({
-    baseUrl: '/apis/features.grafana.app/v0alpha1/namespaces/' + config.namespace,
+    baseUrl: baseUrl,
     pollInterval: -1, // disable polling
     timeoutMs: 5_000,
   });


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/114213

If grafana is served from subpath, the `/apis` should be under subpath too: 
<img width="624" height="171" alt="Screenshot 2026-01-14 at 14 31 03" src="https://github.com/user-attachments/assets/59918599-58d8-43ef-893c-5d4c09055da6" />

