### PR TITLE
GrpcServer: add basic auth interceptor

### DIFF
--- a/pkg/services/grpcserver/interceptors/basic_auth.go
+++ b/pkg/services/grpcserver/interceptors/basic_auth.go
@@ -1,0 +1,65 @@
+package interceptors
+
+import (
+	"context"
+	"crypto/subtle"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+// basicAuthenticator implements basic authentication for gRPC requests.
+type basicAuthenticator struct {
+	username string
+	password string
+	logger   log.Logger
+}
+
+// NewBasicAuthenticator creates a new basic auth authenticator with the provided credentials.
+func NewBasicAuthenticator(username, password string) Authenticator {
+	return &basicAuthenticator{
+		username: username,
+		password: password,
+		logger:   log.New("grpc-basic-authenticator"),
+	}
+}
+
+const basicPrefix = "Basic "
+
+// Authenticate validates basic auth credentials from the gRPC request metadata.
+func (a *basicAuthenticator) Authenticate(ctx context.Context) (context.Context, error) {
+	auth, err := extractAuthorization(ctx)
+	if err != nil {
+		return ctx, err
+	}
+
+	if !strings.HasPrefix(auth, basicPrefix) {
+		return ctx, status.Error(codes.Unauthenticated, `missing "Basic " prefix in "authorization" value`)
+	}
+
+	// Decode credentials (DecodeBasicAuthHeader expects the full "Basic <credentials>" string)
+	username, password, err := util.DecodeBasicAuthHeader(auth)
+	if err != nil {
+		a.logger.Warn("failed to decode basic auth header", "error", err)
+		return ctx, status.Error(codes.Unauthenticated, "invalid basic auth credentials")
+	}
+
+	// Use constant-time comparison to prevent timing attacks
+	validUsername := subtle.ConstantTimeCompare([]byte(username), []byte(a.username)) == 1
+	validPassword := subtle.ConstantTimeCompare([]byte(password), []byte(a.password)) == 1
+
+	if !validUsername || !validPassword {
+		a.logger.Warn("invalid credentials provided", "username", username)
+		return ctx, status.Error(codes.Unauthenticated, "invalid username or password")
+	}
+
+	// Remove authorization header from context
+	newCtx := purgeHeader(ctx, "authorization")
+
+	a.logger.Debug("successfully authenticated request", "username", username)
+	return newCtx, nil
+}

--- a/pkg/services/grpcserver/interceptors/basic_auth.go
+++ b/pkg/services/grpcserver/interceptors/basic_auth.go
@@ -53,7 +53,7 @@ func (a *basicAuthenticator) Authenticate(ctx context.Context) (context.Context,
 	validPassword := subtle.ConstantTimeCompare([]byte(password), []byte(a.password)) == 1
 
 	if !validUsername || !validPassword {
-		a.logger.Warn("invalid credentials provided", "username", username)
+		a.logger.Warn("invalid credentials provided")
 		return ctx, status.Error(codes.Unauthenticated, "invalid username or password")
 	}
 

--- a/pkg/services/grpcserver/interceptors/basic_auth_test.go
+++ b/pkg/services/grpcserver/interceptors/basic_auth_test.go
@@ -1,0 +1,94 @@
+package interceptors
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func TestBasicAuthenticator_Authenticate(t *testing.T) {
+	username := "admin"
+	password := "secret"
+
+	t.Run("accepts valid credentials", func(t *testing.T) {
+		auth := NewBasicAuthenticator(username, password)
+		ctx := setupBasicAuthContext(username, password)
+		_, err := auth.Authenticate(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects invalid username", func(t *testing.T) {
+		auth := NewBasicAuthenticator(username, password)
+		ctx := setupBasicAuthContext("wrong", password)
+		_, err := auth.Authenticate(ctx)
+		require.Error(t, err)
+		require.Equal(t, codes.Unauthenticated, status.Code(err))
+	})
+
+	t.Run("rejects invalid password", func(t *testing.T) {
+		auth := NewBasicAuthenticator(username, password)
+		ctx := setupBasicAuthContext(username, "wrong")
+		_, err := auth.Authenticate(ctx)
+		require.Error(t, err)
+		require.Equal(t, codes.Unauthenticated, status.Code(err))
+	})
+
+	t.Run("rejects missing authorization header", func(t *testing.T) {
+		auth := NewBasicAuthenticator(username, password)
+		ctx := context.Background()
+		md := metadata.New(map[string]string{})
+		ctx = metadata.NewIncomingContext(ctx, md)
+		_, err := auth.Authenticate(ctx)
+		require.Error(t, err)
+		require.Equal(t, codes.Unauthenticated, status.Code(err))
+	})
+
+	t.Run("rejects malformed authorization header", func(t *testing.T) {
+		auth := NewBasicAuthenticator(username, password)
+		ctx := context.Background()
+		md := metadata.New(map[string]string{})
+		md["authorization"] = []string{"Bearer token"}
+		ctx = metadata.NewIncomingContext(ctx, md)
+		_, err := auth.Authenticate(ctx)
+		require.Error(t, err)
+		require.Equal(t, codes.Unauthenticated, status.Code(err))
+	})
+
+	t.Run("rejects invalid base64 encoding", func(t *testing.T) {
+		auth := NewBasicAuthenticator(username, password)
+		ctx := context.Background()
+		md := metadata.New(map[string]string{})
+		md["authorization"] = []string{"Basic invalid!!!base64"}
+		ctx = metadata.NewIncomingContext(ctx, md)
+		_, err := auth.Authenticate(ctx)
+		require.Error(t, err)
+		require.Equal(t, codes.Unauthenticated, status.Code(err))
+	})
+
+	t.Run("removes auth header from context", func(t *testing.T) {
+		auth := NewBasicAuthenticator(username, password)
+		ctx := setupBasicAuthContext(username, password)
+		md, ok := metadata.FromIncomingContext(ctx)
+		require.True(t, ok)
+		require.NotEmpty(t, md["authorization"])
+
+		ctx, err := auth.Authenticate(ctx)
+		require.NoError(t, err)
+		md, ok = metadata.FromIncomingContext(ctx)
+		require.True(t, ok)
+		require.Empty(t, md["authorization"])
+	})
+}
+
+func setupBasicAuthContext(username, password string) context.Context {
+	ctx := context.Background()
+	credentials := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+	md := metadata.New(map[string]string{})
+	md["authorization"] = []string{"Basic " + credentials}
+	return metadata.NewIncomingContext(ctx, md)
+}

--- a/pkg/services/grpcserver/interceptors/basic_auth_test.go
+++ b/pkg/services/grpcserver/interceptors/basic_auth_test.go
@@ -17,14 +17,14 @@ func TestBasicAuthenticator_Authenticate(t *testing.T) {
 
 	t.Run("accepts valid credentials", func(t *testing.T) {
 		auth := NewBasicAuthenticator(username, password)
-		ctx := setupBasicAuthContext(username, password)
+		ctx := newBasicAuthContext(username, password)
 		_, err := auth.Authenticate(ctx)
 		require.NoError(t, err)
 	})
 
 	t.Run("rejects invalid username", func(t *testing.T) {
 		auth := NewBasicAuthenticator(username, password)
-		ctx := setupBasicAuthContext("wrong", password)
+		ctx := newBasicAuthContext("wrong", password)
 		_, err := auth.Authenticate(ctx)
 		require.Error(t, err)
 		require.Equal(t, codes.Unauthenticated, status.Code(err))
@@ -32,7 +32,7 @@ func TestBasicAuthenticator_Authenticate(t *testing.T) {
 
 	t.Run("rejects invalid password", func(t *testing.T) {
 		auth := NewBasicAuthenticator(username, password)
-		ctx := setupBasicAuthContext(username, "wrong")
+		ctx := newBasicAuthContext(username, "wrong")
 		_, err := auth.Authenticate(ctx)
 		require.Error(t, err)
 		require.Equal(t, codes.Unauthenticated, status.Code(err))
@@ -72,7 +72,7 @@ func TestBasicAuthenticator_Authenticate(t *testing.T) {
 
 	t.Run("removes auth header from context", func(t *testing.T) {
 		auth := NewBasicAuthenticator(username, password)
-		ctx := setupBasicAuthContext(username, password)
+		ctx := newBasicAuthContext(username, password)
 		md, ok := metadata.FromIncomingContext(ctx)
 		require.True(t, ok)
 		require.NotEmpty(t, md["authorization"])
@@ -85,7 +85,7 @@ func TestBasicAuthenticator_Authenticate(t *testing.T) {
 	})
 }
 
-func setupBasicAuthContext(username, password string) context.Context {
+func newBasicAuthContext(username, password string) context.Context {
 	ctx := context.Background()
 	credentials := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
 	md := metadata.New(map[string]string{})


### PR DESCRIPTION
This PR adds a basic authentication interceptor for gRPC server requests, providing an alternative authentication mechanism to the existing Bearer token authentication. The implementation validates username and password credentials from HTTP Basic Auth headers and uses constant-time comparison to prevent timing attacks.

Changes:

Added NewBasicAuthenticator function that creates a basic auth authenticator implementing the Authenticator interface
Implemented credential validation using constant-time comparison for security
Added comprehensive test coverage for various authentication scenarios

Required for https://github.com/grafana/grafana-enterprise/pull/10602