### PR TITLE
FS: Fix oauth login error not displaying

### DIFF
--- a/pkg/services/frontend/frontend_service_test.go
+++ b/pkg/services/frontend/frontend_service_test.go
@@ -187,6 +187,112 @@ func TestFrontendService_Middleware(t *testing.T) {
 	})
 }
 
+func TestFrontendService_LoginErrorCookie(t *testing.T) {
+	publicDir := setupTestWebAssets(t)
+	cfg := &setting.Cfg{
+		HTTPPort:               "3000",
+		StaticRootPath:         publicDir,
+		BuildVersion:           "10.3.0",
+		OAuthLoginErrorMessage: "oauth.login.error",
+		CookieSecure:           false,
+		CookieSameSiteDisabled: false,
+		CookieSameSiteMode:     http.SameSiteLaxMode,
+	}
+
+	t.Run("should detect login_error cookie and set generic error message", func(t *testing.T) {
+		service := createTestService(t, cfg)
+
+		mux := web.New()
+		service.addMiddlewares(mux)
+		service.registerRoutes(mux)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		// Set the login_error cookie (with some encrypted-looking value)
+		req.AddCookie(&http.Cookie{
+			Name:  "login_error",
+			Value: "abc123encryptedvalue",
+		})
+		recorder := httptest.NewRecorder()
+
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 200, recorder.Code)
+		body := recorder.Body.String()
+
+		// Check that the generic error message is in the response
+		assert.Contains(t, body, "loginError", "Should contain loginError when cookie is present")
+		assert.Contains(t, body, "oauth.login.error", "Should contain the generic OAuth error message")
+
+		// Check that the cookie was deleted (MaxAge=-1)
+		cookies := recorder.Result().Cookies()
+		var foundDeletedCookie bool
+		for _, cookie := range cookies {
+			if cookie.Name == "login_error" {
+				assert.Equal(t, -1, cookie.MaxAge, "Cookie should be deleted (MaxAge=-1)")
+				assert.Equal(t, "", cookie.Value, "Cookie value should be empty")
+				foundDeletedCookie = true
+				break
+			}
+		}
+		assert.True(t, foundDeletedCookie, "Should have set a cookie deletion header")
+	})
+
+	t.Run("should not set error when login_error cookie is absent", func(t *testing.T) {
+		service := createTestService(t, cfg)
+
+		mux := web.New()
+		service.addMiddlewares(mux)
+		service.registerRoutes(mux)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		// No login_error cookie
+		recorder := httptest.NewRecorder()
+
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 200, recorder.Code)
+		body := recorder.Body.String()
+
+		// The page should render but without the login error
+		assert.Contains(t, body, "window.grafanaBootData")
+		// Check that loginError is not set (or is empty/omitted in JSON)
+		// Since it's omitempty, it shouldn't appear at all
+		assert.NotContains(t, body, "loginError", "Should not contain loginError when cookie is absent")
+	})
+
+	t.Run("should handle custom OAuth error message from config", func(t *testing.T) {
+		customCfg := &setting.Cfg{
+			HTTPPort:               "3000",
+			StaticRootPath:         publicDir,
+			BuildVersion:           "10.3.0",
+			OAuthLoginErrorMessage: "Oh no a boo-boo happened!",
+			CookieSecure:           false,
+			CookieSameSiteDisabled: false,
+			CookieSameSiteMode:     http.SameSiteLaxMode,
+		}
+		service := createTestService(t, customCfg)
+
+		mux := web.New()
+		service.addMiddlewares(mux)
+		service.registerRoutes(mux)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req.AddCookie(&http.Cookie{
+			Name:  "login_error",
+			Value: "abc123encryptedvalue",
+		})
+		recorder := httptest.NewRecorder()
+
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 200, recorder.Code)
+		body := recorder.Body.String()
+
+		// Check that the custom error message is used
+		assert.Contains(t, body, "Oh no a boo-boo happened!", "Should use custom OAuth error message from config")
+	})
+}
+
 func TestFrontendService_IndexHooks(t *testing.T) {
 	publicDir := setupTestWebAssets(t)
 	cfg := &setting.Cfg{

--- a/pkg/services/frontend/frontend_settings.go
+++ b/pkg/services/frontend/frontend_settings.go
@@ -47,4 +47,6 @@ type FSFrontendSettings struct {
 	CSPReportOnlyEnabled             bool              `json:"cspReportOnlyEnabled,omitempty"`
 	Http2Enabled                     bool              `json:"http2Enabled,omitempty"`
 	ReportingStaticContext           map[string]string `json:"reportingStaticContext,omitempty"`
+
+	LoginError string `json:"loginError,omitempty"`
 }


### PR DESCRIPTION
Fixes an issue with the frontend service where error message from oauth login (such as not being granted access) is not shown in the UI.

Problem:
- When oauth fails, the backend sets an encrypted `login_error` cookie and issues a 302 redirect to `/login`
- In the old ST backend, the `LoginView` handler would decrypt the cookie and display it to the user
- This no longer works because the frontend service backend doesn’t read the cookie, and the login error cookie value is not returned by the /bootdata API endpoint
- The frontend service is not able to decrypt the cookie value because it doesn’t have access to those secrets, but it can check that its present

This is a quick fix to just show a generic error message in the UI while we work on a longer term solution, which might require changes in both the ST backend and frontend service.

To test this, check out https://github.com/grafana/grafana/pull/116271 instead has these changes, plus a way to run oauth locally. You can't log in with oauth in it yet, but it fails enough to generate an error message!

Fixes https://github.com/grafana/grafana/issues/116272

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #116322 
- <kbd>&nbsp;1&nbsp;</kbd> #116269 👈 
<!-- GitButler Footer Boundary Bottom -->

