### PR TITLE
Data Source: Proxy fallback routes must match all inputs

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -313,6 +313,9 @@ func (proxy *DataSourceProxy) validateRequest() error {
 		// issues/116273: When we have an empty input route (or input that becomes relative to "."), we do not want it
 		//   to be ".". This is because the `CleanRelativePath` function will never return "./" prefixes, and as such,
 		//   the common prefix we need is an empty string.
+		if r1 == "." && proxy.proxyPath != "." {
+			r1 = ""
+		}
 		if r2 == "." && route.Path != "." {
 			r2 = ""
 		}

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -673,6 +673,42 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 			runDatasourceAuthTest(t, secretsService, secretsStore, cfg, test)
 		}
 	})
+
+	t.Run("Regression of 116273: Fallback routes should apply fallback route roles", func(t *testing.T) {
+		ds := &datasources.DataSource{
+			UID:      "dsUID",
+			JsonData: simplejson.New(),
+		}
+		routes := []*plugins.Route{
+			{
+				ReqRole: org.RoleAdmin,
+				Method:  "GET",
+			},
+			{
+				ReqRole: org.RoleAdmin,
+				Method:  "POST",
+			},
+			{
+				ReqRole: org.RoleAdmin,
+				Method:  "PUT",
+			},
+			{
+				ReqRole: org.RoleAdmin,
+				Method:  "DELETE",
+			},
+		}
+
+		req, err := http.NewRequestWithContext(t.Context(), "GET", "http://localhost/unit-test", nil)
+		require.NoError(t, err, "failed to create HTTP request")
+		ctx := &contextmodel.ReqContext{
+			Context:      &web.Context{Req: req},
+			SignedInUser: &user.SignedInUser{OrgRole: org.RoleViewer},
+		}
+		proxy, err := setupDSProxyTest(t, ctx, ds, routes, "api/v2/leak-ur-secrets")
+		require.NoError(t, err, "failed to setup proxy test")
+		err = proxy.validateRequest()
+		require.ErrorIs(t, err, errPluginProxyRouteAccessDenied, "request was not denied due to access denied?")
+	})
 }
 
 // test DataSourceProxy request handling.

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -675,39 +675,91 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 	})
 
 	t.Run("Regression of 116273: Fallback routes should apply fallback route roles", func(t *testing.T) {
-		ds := &datasources.DataSource{
-			UID:      "dsUID",
-			JsonData: simplejson.New(),
-		}
-		routes := []*plugins.Route{
+		for _, tc := range []struct {
+			InputPath         string
+			ConfigurationPath string
+			ExpectError       bool
+		}{
 			{
-				ReqRole: org.RoleAdmin,
-				Method:  "GET",
+				InputPath:         "api/v2/leak-ur-secrets",
+				ConfigurationPath: "",
+				ExpectError:       true,
 			},
 			{
-				ReqRole: org.RoleAdmin,
-				Method:  "POST",
+				InputPath:         "",
+				ConfigurationPath: "",
+				ExpectError:       true,
 			},
 			{
-				ReqRole: org.RoleAdmin,
-				Method:  "PUT",
+				InputPath:         ".",
+				ConfigurationPath: ".",
+				ExpectError:       true,
 			},
 			{
-				ReqRole: org.RoleAdmin,
-				Method:  "DELETE",
+				InputPath:         "",
+				ConfigurationPath: ".",
+				ExpectError:       false,
 			},
-		}
+			{
+				InputPath:         "api",
+				ConfigurationPath: ".",
+				ExpectError:       false,
+			},
+		} {
+			orEmptyStr := func(s string) string {
+				if s == "" {
+					return "<empty>"
+				}
+				return s
+			}
+			t.Run(
+				fmt.Sprintf("with inputPath=%s, configurationPath=%s, expectError=%v",
+					orEmptyStr(tc.InputPath), orEmptyStr(tc.ConfigurationPath), tc.ExpectError),
+				func(t *testing.T) {
+					ds := &datasources.DataSource{
+						UID:      "dsUID",
+						JsonData: simplejson.New(),
+					}
+					routes := []*plugins.Route{
+						{
+							Path:    tc.ConfigurationPath,
+							ReqRole: org.RoleAdmin,
+							Method:  "GET",
+						},
+						{
+							Path:    tc.ConfigurationPath,
+							ReqRole: org.RoleAdmin,
+							Method:  "POST",
+						},
+						{
+							Path:    tc.ConfigurationPath,
+							ReqRole: org.RoleAdmin,
+							Method:  "PUT",
+						},
+						{
+							Path:    tc.ConfigurationPath,
+							ReqRole: org.RoleAdmin,
+							Method:  "DELETE",
+						},
+					}
 
-		req, err := http.NewRequestWithContext(t.Context(), "GET", "http://localhost/unit-test", nil)
-		require.NoError(t, err, "failed to create HTTP request")
-		ctx := &contextmodel.ReqContext{
-			Context:      &web.Context{Req: req},
-			SignedInUser: &user.SignedInUser{OrgRole: org.RoleViewer},
+					req, err := http.NewRequestWithContext(t.Context(), "GET", "http://localhost/"+tc.InputPath, nil)
+					require.NoError(t, err, "failed to create HTTP request")
+					ctx := &contextmodel.ReqContext{
+						Context:      &web.Context{Req: req},
+						SignedInUser: &user.SignedInUser{OrgRole: org.RoleViewer},
+					}
+					proxy, err := setupDSProxyTest(t, ctx, ds, routes, tc.InputPath)
+					require.NoError(t, err, "failed to setup proxy test")
+					err = proxy.validateRequest()
+					if tc.ExpectError {
+						require.ErrorIs(t, err, errPluginProxyRouteAccessDenied, "request was not denied due to access denied?")
+					} else {
+						require.NoError(t, err, "request was unexpectedly denied access")
+					}
+				},
+			)
 		}
-		proxy, err := setupDSProxyTest(t, ctx, ds, routes, "api/v2/leak-ur-secrets")
-		require.NoError(t, err, "failed to setup proxy test")
-		err = proxy.validateRequest()
-		require.ErrorIs(t, err, errPluginProxyRouteAccessDenied, "request was not denied due to access denied?")
 	})
 }
 


### PR DESCRIPTION
When we are given a route configuration like `{ReqRole: org.RoleAdmin, Method: "GET"}`, we should match _all_ `GET` requests and require `RoleAdmin` on them.

What we see today, is that we do not match these on e.g. `/example`, because the route configuration's path gets normalised to `.` which is notably not a prefix of `/example`. To solve this, we'll make all relative-to-here results (so long as you don't actually _want_ `.`) be empty, and match to everything.

We do not want to perform this fix in the `plugins.CleanRelativePath` function, because _there_ it is intended behaviour to do this (as also shown by its absolute first test case). Therefore, this is the best spot, as far as I can tell.

Fixes: #116273