### PR TITLE
DashListItem: use grafana_browse_dashboards_page_click_list_item rudderstack event

### DIFF
--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -95,6 +95,7 @@ export function RecentlyViewedDashboards() {
                   showFolderNames={true}
                   locationInfo={foldersByUid[dash.location]}
                   layoutMode="card"
+                  source="browseDashboardsPage_RecentlyViewedCard"
                 />
               </li>
             ))}

--- a/public/app/plugins/panel/dashlist/DashList.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.tsx
@@ -192,6 +192,7 @@ export function DashList(props: PanelProps<Options>) {
               locationInfo={locationInfo}
               layoutMode="list"
               onStarChange={handleStarChange}
+              source="browseDashboardsPage_DashListView"
             />
           </li>
         );

--- a/public/app/plugins/panel/dashlist/DashList.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.tsx
@@ -192,7 +192,7 @@ export function DashList(props: PanelProps<Options>) {
               locationInfo={locationInfo}
               layoutMode="list"
               onStarChange={handleStarChange}
-              source="browseDashboardsPage_DashListView"
+              source="dashListView"
             />
           </li>
         );

--- a/public/app/plugins/panel/dashlist/DashListItem.tsx
+++ b/public/app/plugins/panel/dashlist/DashListItem.tsx
@@ -32,7 +32,7 @@ export function DashListItem({
   const onCardLinkClick = () => {
     reportInteraction('grafana_browse_dashboards_page_click_list_item', {
       itemKind: dashboard.kind,
-      source: 'browseDashboardsPage_BrowseView',
+      source: 'browseDashboardsPage_RecentlyViewed',
       uid: dashboard.uid,
       cardOrder: order,
     });

--- a/public/app/plugins/panel/dashlist/DashListItem.tsx
+++ b/public/app/plugins/panel/dashlist/DashListItem.tsx
@@ -14,9 +14,9 @@ interface Props {
   showFolderNames: boolean;
   locationInfo?: LocationInfo;
   layoutMode: 'list' | 'card';
+  source: string; // for rudderstack analytics to track which page DashListItem click from
   order?: number; // for rudderstack analytics to track position in cards
   onStarChange?: (id: string, isStarred: boolean) => void;
-  source?: string; // for rudderstack analytics to track which page DashListItem click from
 }
 export function DashListItem({
   dashboard,

--- a/public/app/plugins/panel/dashlist/DashListItem.tsx
+++ b/public/app/plugins/panel/dashlist/DashListItem.tsx
@@ -14,8 +14,9 @@ interface Props {
   showFolderNames: boolean;
   locationInfo?: LocationInfo;
   layoutMode: 'list' | 'card';
-  order?: number; // for rudderstack analytics to track position in card list
+  order?: number; // for rudderstack analytics to track position in cards
   onStarChange?: (id: string, isStarred: boolean) => void;
+  source?: string; // for rudderstack analytics to track which page DashListItem click from
 }
 export function DashListItem({
   dashboard,
@@ -25,6 +26,7 @@ export function DashListItem({
   layoutMode,
   order,
   onStarChange,
+  source,
 }: Props) {
   const css = useStyles2(getStyles);
   const shortTitle = truncate(dashboard.name, { length: 40, omission: '…' });
@@ -32,7 +34,7 @@ export function DashListItem({
   const onCardLinkClick = () => {
     reportInteraction('grafana_browse_dashboards_page_click_list_item', {
       itemKind: dashboard.kind,
-      source: 'browseDashboardsPage_RecentlyViewed',
+      source,
       uid: dashboard.uid,
       cardOrder: order,
     });

--- a/public/app/plugins/panel/dashlist/DashListItem.tsx
+++ b/public/app/plugins/panel/dashlist/DashListItem.tsx
@@ -30,7 +30,10 @@ export function DashListItem({
   const shortTitle = truncate(dashboard.name, { length: 40, omission: '…' });
 
   const onCardLinkClick = () => {
-    reportInteraction('grafana_recently_viewed_dashboards_click_card', {
+    reportInteraction('grafana_browse_dashboards_page_click_list_item', {
+      itemKind: dashboard.kind,
+      source: 'browseDashboardsPage_BrowseView',
+      uid: dashboard.uid,
       cardOrder: order,
     });
   };


### PR DESCRIPTION
**What is this feature?**

`DashListItem`: Replace `grafana_recently_viewed_dashboards_click_card` with `grafana_browse_dashboards_page_click_list_item` 

**Why do we need this feature?**

Easier to query

**Who is this feature for?**

Internal

**Which issue(s) does this PR fix?**:

Fixes N/A

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
