### PR TITLE
unified-storage: dont use polling notifier with sqlite in sqlkv

### DIFF
--- a/pkg/storage/unified/resource/notifier.go
+++ b/pkg/storage/unified/resource/notifier.go
@@ -61,7 +61,7 @@ func newNotifier(eventStore *eventStore, opts notifierOptions) notifier {
 	return &pollingNotifier{eventStore: eventStore, log: opts.log}
 }
 
-type channelNotifier struct {}
+type channelNotifier struct{}
 
 func (cn *channelNotifier) Watch(ctx context.Context, opts watchOptions) <-chan Event {
 	return nil

--- a/pkg/storage/unified/resource/notifier.go
+++ b/pkg/storage/unified/resource/notifier.go
@@ -19,7 +19,11 @@ const (
 	defaultBufferSize     = 10000
 )
 
-type notifier struct {
+type notifier interface {
+	Watch(context.Context, watchOptions) <-chan Event
+}
+
+type pollingNotifier struct {
 	eventStore *eventStore
 	log        logging.Logger
 }
@@ -45,21 +49,26 @@ func defaultWatchOptions() watchOptions {
 	}
 }
 
-func newNotifier(eventStore *eventStore, opts notifierOptions) *notifier {
+func newNotifier(eventStore *eventStore, opts notifierOptions) notifier {
 	if opts.log == nil {
 		opts.log = &logging.NoOpLogger{}
 	}
 
 	if opts.useChannelNotifier {
-		// TODO
-		return nil
+		return &channelNotifier{}
 	}
 
-	return &notifier{eventStore: eventStore, log: opts.log}
+	return &pollingNotifier{eventStore: eventStore, log: opts.log}
+}
+
+type channelNotifier struct {}
+
+func (cn *channelNotifier) Watch(ctx context.Context, opts watchOptions) <-chan Event {
+	return nil
 }
 
 // Return the last resource version from the event store
-func (n *notifier) lastEventResourceVersion(ctx context.Context) (int64, error) {
+func (n *pollingNotifier) lastEventResourceVersion(ctx context.Context) (int64, error) {
 	e, err := n.eventStore.LastEventKey(ctx)
 	if err != nil {
 		return 0, err
@@ -67,11 +76,11 @@ func (n *notifier) lastEventResourceVersion(ctx context.Context) (int64, error) 
 	return e.ResourceVersion, nil
 }
 
-func (n *notifier) cacheKey(evt Event) string {
+func (n *pollingNotifier) cacheKey(evt Event) string {
 	return fmt.Sprintf("%s~%s~%s~%s~%d", evt.Namespace, evt.Group, evt.Resource, evt.Name, evt.ResourceVersion)
 }
 
-func (n *notifier) Watch(ctx context.Context, opts watchOptions) <-chan Event {
+func (n *pollingNotifier) Watch(ctx context.Context, opts watchOptions) <-chan Event {
 	if opts.MinBackoff <= 0 {
 		opts.MinBackoff = defaultMinBackoff
 	}

--- a/pkg/storage/unified/resource/notifier.go
+++ b/pkg/storage/unified/resource/notifier.go
@@ -25,7 +25,8 @@ type notifier struct {
 }
 
 type notifierOptions struct {
-	log logging.Logger
+	log                logging.Logger
+	useChannelNotifier bool
 }
 
 type watchOptions struct {
@@ -48,6 +49,12 @@ func newNotifier(eventStore *eventStore, opts notifierOptions) *notifier {
 	if opts.log == nil {
 		opts.log = &logging.NoOpLogger{}
 	}
+
+	if opts.useChannelNotifier {
+		// TODO
+		return nil
+	}
+
 	return &notifier{eventStore: eventStore, log: opts.log}
 }
 

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -61,7 +61,7 @@ type kvStorageBackend struct {
 	bulkLock                     *BulkLock
 	dataStore                    *dataStore
 	eventStore                   *eventStore
-	notifier                     *notifier
+	notifier                     notifier
 	builder                      DocumentBuilder
 	log                          logging.Logger
 	withPruner                   bool

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -91,6 +91,7 @@ type KVBackendOptions struct {
 	Tracer                       trace.Tracer          // TODO add tracing
 	Reg                          prometheus.Registerer // TODO add metrics
 
+	UseChannelNotifier bool
 	// Adding RvManager overrides the RV generated with snowflake in order to keep backwards compatibility with
 	// unified/sql
 	RvManager *rvmanager.ResourceVersionManager
@@ -121,7 +122,7 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 		bulkLock:                     NewBulkLock(),
 		dataStore:                    newDataStore(kv),
 		eventStore:                   eventStore,
-		notifier:                     newNotifier(eventStore, notifierOptions{}),
+		notifier:                     newNotifier(eventStore, notifierOptions{useChannelNotifier: opts.UseChannelNotifier}),
 		snowflake:                    s,
 		builder:                      StandardDocumentBuilder(), // For now we use the standard document builder.
 		log:                          &logging.NoOpLogger{},     // Make this configurable

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -109,9 +109,9 @@ func NewResourceServer(opts ServerOptions) (resource.ResourceServer, error) {
 			}
 
 			kvBackendOpts := resource.KVBackendOptions{
-				KvStore: sqlkv,
-				Tracer:  opts.Tracer,
-				Reg:     opts.Reg,
+				KvStore:            sqlkv,
+				Tracer:             opts.Tracer,
+				Reg:                opts.Reg,
 				UseChannelNotifier: !isHA,
 			}
 

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -112,6 +112,7 @@ func NewResourceServer(opts ServerOptions) (resource.ResourceServer, error) {
 				KvStore: sqlkv,
 				Tracer:  opts.Tracer,
 				Reg:     opts.Reg,
+				UseChannelNotifier: !isHA,
 			}
 
 			ctx := context.Background()
@@ -135,7 +136,6 @@ func NewResourceServer(opts ServerOptions) (resource.ResourceServer, error) {
 
 			// TODO add config to decide whether to pass RvManager or not
 			kvBackendOpts.RvManager = rvManager
-			kvBackendOpts.UseChannelNotifier = isHA
 			kvBackend, err := resource.NewKVStorageBackend(kvBackendOpts)
 			if err != nil {
 				return nil, fmt.Errorf("error creating kv backend: %s", err)


### PR DESCRIPTION
The polling notifier is not compatible with sqlite, we will need to use a channel based one. related https://github.com/grafana/hyperion-planning/issues/485