### PR TITLE
Auth: Move auth proxy session creation to post-auth hook

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -137,19 +137,6 @@ func (hs *HTTPServer) LoginView(c *contextmodel.ReqContext) {
 	}
 
 	if c.IsSignedIn {
-		// Assign login token to auth proxy users if enable_login_token = true
-		// LDAP users authenticated by auth proxy are also assigned login token but their auth module is LDAP
-		if hs.Cfg.AuthProxy.Enabled &&
-			hs.Cfg.AuthProxy.EnableLoginToken &&
-			c.IsAuthenticatedBy(loginservice.AuthProxyAuthModule, loginservice.LDAPAuthModule) {
-			user := &user.User{ID: c.UserID, Email: c.Email, Login: c.Login}
-			err := hs.loginUserWithUser(user, c)
-			if err != nil {
-				c.Handle(hs.Cfg, http.StatusInternalServerError, "Failed to sign in user", err)
-				return
-			}
-		}
-
 		if !c.UseSessionStorageRedirect {
 			c.Redirect(hs.GetRedirectURL(c))
 			return

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -581,18 +581,25 @@ func TestAuthProxyLoginEnableLoginTokenDisabled(t *testing.T) {
 }
 
 func TestAuthProxyLoginWithEnableLoginToken(t *testing.T) {
+	// Session token assignment for auth proxy users is now handled by the
+	// AuthProxySessionSync hook in the authn service, not in the login view.
+	// This test verifies that the login view correctly redirects without
+	// attempting to set a session cookie (that's the hook's responsibility).
 	sc := setupAuthProxyLoginTest(t, true)
 	require.Equal(t, 302, sc.resp.Code)
 
 	location, ok := sc.resp.Header()["Location"]
 	assert.True(t, ok)
 	assert.Equal(t, "/", location[0])
-	setCookie := sc.resp.Header()["Set-Cookie"]
-	require.NotNil(t, setCookie, "Set-Cookie should exist")
-	assert.Equal(t, fmt.Sprintf("%s=; Path=/; Max-Age=0; HttpOnly", loginCookieName), setCookie[0])
+	// The login view no longer sets the session cookie - this is now handled
+	// by the AuthProxySessionSync hook during authentication
+	_, ok = sc.resp.Header()["Set-Cookie"]
+	assert.False(t, ok, "Set-Cookie should not exist - session token is handled by auth service hook")
 }
 
 func TestAuthProxyLoginWithEnableLoginTokenAndEnabledOauthAutoLogin(t *testing.T) {
+	// Session token assignment for auth proxy users is now handled by the
+	// AuthProxySessionSync hook in the authn service, not in the login view.
 	fakeSetIndexViewData(t)
 
 	mock := &mockSocialService{
@@ -642,9 +649,10 @@ func TestAuthProxyLoginWithEnableLoginTokenAndEnabledOauthAutoLogin(t *testing.T
 	location, ok := sc.resp.Header()["Location"]
 	assert.True(t, ok)
 	assert.Equal(t, "/", location[0])
-	setCookie := sc.resp.Header()["Set-Cookie"]
-	require.NotNil(t, setCookie, "Set-Cookie should exist")
-	assert.Equal(t, fmt.Sprintf("%s=; Path=/; Max-Age=0; HttpOnly", loginCookieName), setCookie[0])
+	// The login view no longer sets the session cookie - this is now handled
+	// by the AuthProxySessionSync hook during authentication
+	_, ok = sc.resp.Header()["Set-Cookie"]
+	assert.False(t, ok, "Set-Cookie should not exist - session token is handled by auth service hook")
 }
 
 func setupAuthProxyLoginTest(t *testing.T, enableLoginToken bool) *scenarioContext {

--- a/pkg/services/authn/authnimpl/registration.go
+++ b/pkg/services/authn/authnimpl/registration.go
@@ -141,6 +141,7 @@ func ProvideRegistration(
 	authnSvc.RegisterPostAuthHook(orgSync.SyncOrgRolesHook, 40)
 	authnSvc.RegisterPostAuthHook(userSync.SyncLastSeenHook, 130)
 	authnSvc.RegisterPostAuthHook(sync.ProvideOAuthTokenSync(oauthTokenService, sessionService, socialService, tracer, features).SyncOauthTokenHook, 60)
+	authnSvc.RegisterPostAuthHook(sync.ProvideAuthProxySessionSync(cfg, sessionService, tracer).SyncAuthProxySessionHook, 70)
 	authnSvc.RegisterPostAuthHook(userSync.FetchSyncedUserHook, 100)
 
 	//nolint:staticcheck // not yet migrated to OpenFeature

--- a/pkg/services/authn/authnimpl/sync/auth_proxy_session_sync.go
+++ b/pkg/services/authn/authnimpl/sync/auth_proxy_session_sync.go
@@ -1,0 +1,106 @@
+package sync
+
+import (
+	"context"
+	"net"
+	"strings"
+
+	claims "github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/network"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/login"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+func ProvideAuthProxySessionSync(cfg *setting.Cfg, sessionService auth.UserTokenService, tracer tracing.Tracer) *AuthProxySessionSync {
+	return &AuthProxySessionSync{
+		cfg:            cfg,
+		sessionService: sessionService,
+		log:            log.New("auth_proxy.session.sync"),
+		tracer:         tracer,
+	}
+}
+
+type AuthProxySessionSync struct {
+	cfg            *setting.Cfg
+	sessionService auth.UserTokenService
+	log            log.Logger
+	tracer         tracing.Tracer
+}
+
+// SyncAuthProxySessionHook creates a session token for auth proxy users when enable_login_token is enabled.
+// This hook runs after successful authentication and assigns a session cookie to auth proxy users
+// so they don't need to rely on the proxy header for subsequent requests within the session lifetime.
+func (s *AuthProxySessionSync) SyncAuthProxySessionHook(ctx context.Context, id *authn.Identity, r *authn.Request) error {
+	ctx, span := s.tracer.Start(ctx, "auth_proxy.session.sync.SyncAuthProxySessionHook")
+	defer span.End()
+
+	// Only proceed if auth proxy is enabled and login token is enabled
+	if !s.cfg.AuthProxy.Enabled || !s.cfg.AuthProxy.EnableLoginToken {
+		return nil
+	}
+
+	// Only process user identities
+	if !id.IsIdentityType(claims.TypeUser) {
+		return nil
+	}
+
+	// Only process auth proxy or LDAP authenticated users (LDAP users can be authenticated via auth proxy)
+	authenticatedBy := id.GetAuthenticatedBy()
+	if !isAuthProxyOrLDAP(authenticatedBy) {
+		return nil
+	}
+
+	if id.SessionToken != nil {
+		return nil
+	}
+
+	userID, err := id.GetInternalID()
+	if err != nil {
+		s.log.FromContext(ctx).Warn("Failed to get internal user ID for auth proxy session sync", "error", err)
+		return nil
+	}
+
+	var clientIP net.IP
+	if r.HTTPRequest != nil {
+		addr := web.RemoteAddr(r.HTTPRequest)
+		clientIP, err = network.GetIPFromAddress(addr)
+		if err != nil {
+			s.log.FromContext(ctx).Debug("Failed to parse IP from address", "addr", addr, "error", err)
+		}
+	}
+
+	var userAgent string
+	if r.HTTPRequest != nil {
+		userAgent = r.HTTPRequest.UserAgent()
+	}
+
+	token, err := s.sessionService.CreateToken(ctx, &auth.CreateTokenCommand{
+		User:      &user.User{ID: userID},
+		ClientIP:  clientIP,
+		UserAgent: userAgent,
+	})
+	if err != nil {
+		s.log.FromContext(ctx).Error("Failed to create session token for auth proxy user", "userID", userID, "error", err)
+		return nil
+	}
+
+	id.SessionToken = token
+	s.log.FromContext(ctx).Debug("Created session token for auth proxy user", "userID", userID)
+
+	return nil
+}
+
+// isAuthProxyOrLDAP checks if the authentication module is auth proxy or LDAP.
+// LDAP users authenticated via auth proxy are also included since they may use
+// the auth proxy header for initial authentication but want a session token.
+func isAuthProxyOrLDAP(authModule string) bool {
+	return strings.EqualFold(authModule, login.AuthProxyAuthModule) ||
+		strings.EqualFold(authModule, login.LDAPAuthModule)
+}

--- a/pkg/services/authn/authnimpl/sync/auth_proxy_session_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/auth_proxy_session_sync_test.go
@@ -1,0 +1,207 @@
+package sync
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	claims "github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/models/usertoken"
+	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/auth/authtest"
+	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/login"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestAuthProxySessionSync_SyncAuthProxySessionHook(t *testing.T) {
+	type testCase struct {
+		desc                    string
+		identity                *authn.Identity
+		authProxyEnabled        bool
+		enableLoginToken        bool
+		expectTokenCreated      bool
+		existingSessionToken    *usertoken.UserToken
+		createTokenError        error
+		expectedSessionTokenNil bool
+	}
+
+	tests := []testCase{
+		{
+			desc: "should skip sync when auth proxy is disabled",
+			identity: &authn.Identity{
+				ID:              "1",
+				Type:            claims.TypeUser,
+				AuthenticatedBy: login.AuthProxyAuthModule,
+			},
+			authProxyEnabled:        false,
+			enableLoginToken:        true,
+			expectTokenCreated:      false,
+			expectedSessionTokenNil: true,
+		},
+		{
+			desc: "should skip sync when enable_login_token is disabled",
+			identity: &authn.Identity{
+				ID:              "1",
+				Type:            claims.TypeUser,
+				AuthenticatedBy: login.AuthProxyAuthModule,
+			},
+			authProxyEnabled:        true,
+			enableLoginToken:        false,
+			expectTokenCreated:      false,
+			expectedSessionTokenNil: true,
+		},
+		{
+			desc: "should skip sync when identity is not a user",
+			identity: &authn.Identity{
+				ID:              "1",
+				Type:            claims.TypeServiceAccount,
+				AuthenticatedBy: login.AuthProxyAuthModule,
+			},
+			authProxyEnabled:        true,
+			enableLoginToken:        true,
+			expectTokenCreated:      false,
+			expectedSessionTokenNil: true,
+		},
+		{
+			desc: "should skip sync when authenticated by different method",
+			identity: &authn.Identity{
+				ID:              "1",
+				Type:            claims.TypeUser,
+				AuthenticatedBy: login.GenericOAuthModule,
+			},
+			authProxyEnabled:        true,
+			enableLoginToken:        true,
+			expectTokenCreated:      false,
+			expectedSessionTokenNil: true,
+		},
+		{
+			desc: "should skip sync when session token already exists",
+			identity: &authn.Identity{
+				ID:              "1",
+				Type:            claims.TypeUser,
+				AuthenticatedBy: login.AuthProxyAuthModule,
+				SessionToken:    &usertoken.UserToken{Id: 1},
+			},
+			authProxyEnabled:        true,
+			enableLoginToken:        true,
+			expectTokenCreated:      false,
+			expectedSessionTokenNil: false,
+		},
+		{
+			desc: "should create session token for auth proxy user",
+			identity: &authn.Identity{
+				ID:              "1",
+				Type:            claims.TypeUser,
+				AuthenticatedBy: login.AuthProxyAuthModule,
+			},
+			authProxyEnabled:        true,
+			enableLoginToken:        true,
+			expectTokenCreated:      true,
+			expectedSessionTokenNil: false,
+		},
+		{
+			desc: "should create session token for LDAP user authenticated via auth proxy",
+			identity: &authn.Identity{
+				ID:              "1",
+				Type:            claims.TypeUser,
+				AuthenticatedBy: login.LDAPAuthModule,
+			},
+			authProxyEnabled:        true,
+			enableLoginToken:        true,
+			expectTokenCreated:      true,
+			expectedSessionTokenNil: false,
+		},
+		{
+			desc: "should not fail if token creation fails",
+			identity: &authn.Identity{
+				ID:              "1",
+				Type:            claims.TypeUser,
+				AuthenticatedBy: login.AuthProxyAuthModule,
+			},
+			authProxyEnabled:        true,
+			enableLoginToken:        true,
+			expectTokenCreated:      true,
+			createTokenError:        assert.AnError,
+			expectedSessionTokenNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var tokenCreated bool
+
+			sessionService := &authtest.FakeUserAuthTokenService{
+				CreateTokenProvider: func(_ context.Context, cmd *auth.CreateTokenCommand) (*auth.UserToken, error) {
+					tokenCreated = true
+					if tt.createTokenError != nil {
+						return nil, tt.createTokenError
+					}
+					return &auth.UserToken{
+						Id:            1,
+						UserId:        cmd.User.ID,
+						UnhashedToken: "test-token",
+					}, nil
+				},
+			}
+
+			cfg := setting.NewCfg()
+			cfg.AuthProxy.Enabled = tt.authProxyEnabled
+			cfg.AuthProxy.EnableLoginToken = tt.enableLoginToken
+
+			sync := ProvideAuthProxySessionSync(cfg, sessionService, tracing.InitializeTracerForTest())
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("User-Agent", "test-agent")
+			req.RemoteAddr = "192.168.1.1:1234"
+
+			err := sync.SyncAuthProxySessionHook(context.Background(), tt.identity, &authn.Request{
+				HTTPRequest: req,
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectTokenCreated, tokenCreated)
+
+			if tt.expectedSessionTokenNil {
+				if tt.existingSessionToken != nil {
+					// If there was an existing token, it should still be there
+					assert.NotNil(t, tt.identity.SessionToken)
+				} else if !tt.expectTokenCreated || tt.createTokenError != nil {
+					assert.Nil(t, tt.identity.SessionToken)
+				}
+			} else {
+				assert.NotNil(t, tt.identity.SessionToken)
+			}
+		})
+	}
+}
+
+func TestIsAuthProxyOrLDAP(t *testing.T) {
+	tests := []struct {
+		authModule string
+		expected   bool
+	}{
+		{login.AuthProxyAuthModule, true},
+		{login.LDAPAuthModule, true},
+		{"authproxy", true},
+		{"ldap", true},
+		{"AUTHPROXY", true},
+		{"LDAP", true},
+		{login.GenericOAuthModule, false},
+		{login.AzureADAuthModule, false},
+		{login.SAMLAuthModule, false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.authModule, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isAuthProxyOrLDAP(tt.authModule))
+		})
+	}
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this change?**  
Refactors session token assignment for auth proxy users by moving session creation from the `/login` view handler to a dedicated post-authentication hook in the `authn` service.

**Why is this needed?**
- Ensures session tokens for auth proxy users are created **during authentication**, not only when visiting `/login`
- Improves **separation of concerns** and overall maintainability
- Prevents other auth providers from triggering session assignment via the login view
- Aligns auth proxy behavior with existing authentication hook patterns

**Who is this for?**  
Grafana administrators and users authenticating via an **HTTP auth proxy** who rely on session tokens for seamless navigation.

**What changed?**
- Moved session assignment logic to a **post-authentication hook** in the `authn` service
- Removed session creation for auth proxy users from the `/login` view
- Updated tests to reflect the new authentication flow

**Related issues**  
Fixes #85093

**Notes for reviewers**
- Session assignment is now handled exclusively by a post-auth hook
- Verify auth proxy login and navigation behavior
- Confirm that non–auth proxy providers do **not** create sessions via `/login`
- This PR should be included in the changelog. Please add the 'add to changelog' label.