### PR TITLE
Fix: Make plugin.json routes[].path field required

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -370,11 +370,12 @@
       "items": {
         "type": "object",
         "description": "For data source plugins. Proxy routes used for plugin authentication and adding headers to HTTP requests made by the plugin. For more information, refer to [Authentication for data source plugins](https://grafana.com/developers/plugin-tools/how-to-guides/data-source-plugins/add-authentication-for-data-source-plugins).",
+        "required": ["path"],
         "additionalProperties": false,
         "properties": {
           "path": {
             "type": "string",
-            "description": "For data source plugins. The route path that is replaced by the route URL field when proxying the call."
+            "description": "For data source plugins. The route path that is replaced by the route URL field when proxying the call. **Warning**: Don't use an empty string (\"\")."
           },
           "method": {
             "type": "string",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Plugins data proxy route

**Why do we need this feature?**

Make sure plugin developers explicitly define the path in route entry

**Who is this feature for?**

Plugin authors

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-community-team/issues/715

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

# Release notice breaking change

Plugin.json `routes[].path` must be declared for all proxy routes. Routes without `path` field won't be proxied and will return 502 from Grafana core.
