### PR TITLE
SQL Expressions: Rename backendQueries to nonDashboardQueries

### DIFF
--- a/public/app/features/expressions/components/SqlExpressions/hooks/useSQLSchemas.test.ts
+++ b/public/app/features/expressions/components/SqlExpressions/hooks/useSQLSchemas.test.ts
@@ -11,9 +11,9 @@ describe('isDashboardDatasource', () => {
       { refId: 'C', datasource: { uid: 'mysql-uid', type: 'mysql' } },
     ];
 
-    const backendQueries = queries.filter((q) => !isDashboardDatasource(q));
+    const nonDashboardQueries = queries.filter((q) => !isDashboardDatasource(q));
 
-    expect(backendQueries.map((q) => q.refId)).toEqual(['A', 'C']);
+    expect(nonDashboardQueries.map((q) => q.refId)).toEqual(['A', 'C']);
   });
 
   it('returns true when query has dashboard datasource uid', () => {

--- a/public/app/features/expressions/components/SqlExpressions/hooks/useSQLSchemas.ts
+++ b/public/app/features/expressions/components/SqlExpressions/hooks/useSQLSchemas.ts
@@ -67,9 +67,9 @@ export function useSQLSchemas({ queries, enabled, timeRange }: UseSQLSchemasOpti
 
     try {
       // Filter out Dashboard datasource queries - they are frontend-only and can't be processed by backend
-      const backendQueries = currentQueries.filter((q) => !isDashboardDatasource(q));
+      const nonDashboardQueries = currentQueries.filter((q) => !isDashboardDatasource(q));
 
-      if (backendQueries.length === 0) {
+      if (nonDashboardQueries.length === 0) {
         setSchemas({ kind: 'SQLSchemaResponse', apiVersion: 'query.grafana.app/v0alpha1', sqlSchemas: {} });
         setLoading(false);
         return;
@@ -81,7 +81,7 @@ export function useSQLSchemas({ queries, enabled, timeRange }: UseSQLSchemasOpti
       const response = await getBackendSrv().post<SQLSchemasResponse>(
         `/apis/query.grafana.app/v0alpha1/namespaces/${namespace}/sqlschemas/name`,
         {
-          queries: backendQueries,
+          queries: nonDashboardQueries,
           from: currentTimeRange.from.toISOString(),
           to: currentTimeRange.to.toISOString(),
         }


### PR DESCRIPTION
Renames the `backendQueries` variable to `nonDashboardQueries` to better reflect its purpose.

The variable filters out Dashboard datasource queries specifically, not all frontend datasources. The previous name was misleading as it implied all frontend datasources were filtered out.

This is a code clarity improvement with no functional changes.