### PR TITLE
unified-storage: lift `name` requirement in storage backend `ListHistory`

### DIFF
--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -689,9 +689,6 @@ func validateListHistoryRequest(req *resourcepb.ListRequest) error {
 	if key.Namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
-	if key.Name == "" {
-		return fmt.Errorf("name is required")
-	}
 	return nil
 }
 


### PR DESCRIPTION
The SQL backend does not have this requirement. Without this PR, the dashboard cleanup process that runs in the background fails consistently with the error:

```
ERROR[01-14|11:32:47] failed to fetch initial list             logger=dashboards-k8s-client error="name is required"
ERROR[01-14|11:32:47] Failed to cleanup k8s dashboard resources logger=dashboard-service error="org 1: failed to list resources: name is required"
```