### PR TITLE
Prometheus: Allow hiding prom type/version and exemplar settings

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -377,11 +377,6 @@
       "count": 1
     }
   },
-  "packages/grafana-prometheus/src/configuration/PromSettings.tsx": {
-    "no-restricted-syntax": {
-      "count": 25
-    }
-  },
   "packages/grafana-prometheus/src/datasource.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1

--- a/packages/grafana-prometheus/src/configuration/PromSettings.tsx
+++ b/packages/grafana-prometheus/src/configuration/PromSettings.tsx
@@ -11,7 +11,7 @@ import {
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { ConfigSubSection } from '@grafana/plugin-ui';
-import { InlineField, Input, Select, Switch, TextLink, useTheme2 } from '@grafana/ui';
+import { Box, InlineField, Input, Select, Stack, Switch, TextLink, useTheme2 } from '@grafana/ui';
 
 import {
   DEFAULT_SERIES_LIMIT,
@@ -107,157 +107,149 @@ export const PromSettings = (props: Props) => {
         title={t('grafana-prometheus.configuration.prom-settings.title-interval-behaviour', 'Interval behaviour')}
         className={styles.container}
       >
-        <div className="gf-form-group">
-          {/* Scrape interval */}
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <InlineField
-                label={t('grafana-prometheus.configuration.prom-settings.label-scrape-interval', 'Scrape interval')}
-                labelWidth={PROM_CONFIG_LABEL_WIDTH}
-                tooltip={
-                  <>
-                    <Trans
-                      i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-scrape-interval"
-                      values={{ default: '15s' }}
-                    >
-                      This interval is how frequently Prometheus scrapes targets. Set this to the typical scrape and
-                      evaluation interval configured in your Prometheus config file. If you set this to a greater value
-                      than your Prometheus config file interval, Grafana will evaluate the data according to this
-                      interval and you will see less data points. Defaults to {'{{default}}'}.
-                    </Trans>{' '}
-                    {docsTip()}
-                  </>
+        <Box marginBottom={5}>
+          <Stack direction="column" gap={0.5}>
+            {/* Scrape interval */}
+            <InlineField
+            label={t('grafana-prometheus.configuration.prom-settings.label-scrape-interval', 'Scrape interval')}
+            labelWidth={PROM_CONFIG_LABEL_WIDTH}
+            tooltip={
+              <>
+                <Trans
+                  i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-scrape-interval"
+                  values={{ default: '15s' }}
+                >
+                  This interval is how frequently Prometheus scrapes targets. Set this to the typical scrape and
+                  evaluation interval configured in your Prometheus config file. If you set this to a greater value than
+                  your Prometheus config file interval, Grafana will evaluate the data according to this interval and
+                  you will see less data points. Defaults to {'{{default}}'}.
+                </Trans>{' '}
+                {docsTip()}
+              </>
+            }
+            interactive={true}
+            disabled={optionsWithDefaults.readOnly}
+          >
+            <>
+              <Input
+                className="width-20"
+                value={optionsWithDefaults.jsonData.timeInterval}
+                spellCheck={false}
+                // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+                placeholder="15s"
+                onChange={onChangeHandler('timeInterval', optionsWithDefaults, onOptionsChange)}
+                onBlur={(e) =>
+                  updateValidDuration({
+                    ...validDuration,
+                    timeInterval: e.currentTarget.value,
+                  })
                 }
-                interactive={true}
-                disabled={optionsWithDefaults.readOnly}
-              >
-                <>
-                  <Input
-                    className="width-20"
-                    value={optionsWithDefaults.jsonData.timeInterval}
-                    spellCheck={false}
-                    // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
-                    placeholder="15s"
-                    onChange={onChangeHandler('timeInterval', optionsWithDefaults, onOptionsChange)}
-                    onBlur={(e) =>
-                      updateValidDuration({
-                        ...validDuration,
-                        timeInterval: e.currentTarget.value,
-                      })
-                    }
-                    data-testid={selectors.components.DataSource.Prometheus.configPage.scrapeInterval}
-                  />
-                  {validateInput(validDuration.timeInterval, DURATION_REGEX, durationError)}
-                </>
-              </InlineField>
-            </div>
-          </div>
+                data-testid={selectors.components.DataSource.Prometheus.configPage.scrapeInterval}
+              />
+              {validateInput(validDuration.timeInterval, DURATION_REGEX, durationError)}
+            </>
+          </InlineField>
           {/* Query Timeout */}
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <InlineField
-                label={t('grafana-prometheus.configuration.prom-settings.label-query-timeout', 'Query timeout')}
-                labelWidth={PROM_CONFIG_LABEL_WIDTH}
-                tooltip={
-                  <>
-                    <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-query-timeout">
-                      Set the Prometheus query timeout.
-                    </Trans>{' '}
-                    {docsTip()}
-                  </>
+          <InlineField
+            label={t('grafana-prometheus.configuration.prom-settings.label-query-timeout', 'Query timeout')}
+            labelWidth={PROM_CONFIG_LABEL_WIDTH}
+            tooltip={
+              <>
+                <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-query-timeout">
+                  Set the Prometheus query timeout.
+                </Trans>{' '}
+                {docsTip()}
+              </>
+            }
+            interactive={true}
+            disabled={optionsWithDefaults.readOnly}
+          >
+            <>
+              <Input
+                className="width-20"
+                value={optionsWithDefaults.jsonData.queryTimeout}
+                onChange={onChangeHandler('queryTimeout', optionsWithDefaults, onOptionsChange)}
+                spellCheck={false}
+                // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+                placeholder="60s"
+                onBlur={(e) =>
+                  updateValidDuration({
+                    ...validDuration,
+                    queryTimeout: e.currentTarget.value,
+                  })
                 }
-                interactive={true}
-                disabled={optionsWithDefaults.readOnly}
-              >
-                <>
-                  <Input
-                    className="width-20"
-                    value={optionsWithDefaults.jsonData.queryTimeout}
-                    onChange={onChangeHandler('queryTimeout', optionsWithDefaults, onOptionsChange)}
-                    spellCheck={false}
-                    // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
-                    placeholder="60s"
-                    onBlur={(e) =>
-                      updateValidDuration({
-                        ...validDuration,
-                        queryTimeout: e.currentTarget.value,
-                      })
-                    }
-                    data-testid={selectors.components.DataSource.Prometheus.configPage.queryTimeout}
-                  />
-                  {validateInput(validDuration.queryTimeout, DURATION_REGEX, durationError)}
-                </>
-              </InlineField>
-            </div>
-          </div>
-        </div>
+                data-testid={selectors.components.DataSource.Prometheus.configPage.queryTimeout}
+              />
+              {validateInput(validDuration.queryTimeout, DURATION_REGEX, durationError)}
+            </>
+            </InlineField>
+          </Stack>
+        </Box>
       </ConfigSubSection>
 
       <ConfigSubSection
         title={t('grafana-prometheus.configuration.prom-settings.title-query-editor', 'Query editor')}
         className={styles.container}
       >
-        <div className="gf-form-group">
-          <div className="gf-form">
+        <Box marginBottom={5}>
+          <Stack direction="column" gap={0.5}>
             <InlineField
               label={t('grafana-prometheus.configuration.prom-settings.label-default-editor', 'Default editor')}
-              labelWidth={PROM_CONFIG_LABEL_WIDTH}
-              tooltip={
-                <>
-                  <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-default-editor">
-                    Set default editor option for all users of this data source.
-                  </Trans>{' '}
-                  {docsTip()}
-                </>
-              }
-              interactive={true}
-              disabled={optionsWithDefaults.readOnly}
-            >
-              <Select
-                aria-label={t(
-                  'grafana-prometheus.configuration.prom-settings.aria-label-default-editor',
-                  'Default Editor (Code or Builder)'
-                )}
-                options={editorOptions}
-                value={
-                  editorOptions.find((o) => o.value === optionsWithDefaults.jsonData.defaultEditor) ??
-                  editorOptions.find((o) => o.value === QueryEditorMode.Builder)
-                }
-                onChange={onChangeHandler('defaultEditor', optionsWithDefaults, onOptionsChange)}
-                width={40}
-                data-testid={selectors.components.DataSource.Prometheus.configPage.defaultEditor}
-              />
-            </InlineField>
-          </div>
-          <div className="gf-form">
-            <InlineField
-              labelWidth={PROM_CONFIG_LABEL_WIDTH}
-              label={t(
-                'grafana-prometheus.configuration.prom-settings.label-disable-metrics-lookup',
-                'Disable metrics lookup'
+            labelWidth={PROM_CONFIG_LABEL_WIDTH}
+            tooltip={
+              <>
+                <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-default-editor">
+                  Set default editor option for all users of this data source.
+                </Trans>{' '}
+                {docsTip()}
+              </>
+            }
+            interactive={true}
+            disabled={optionsWithDefaults.readOnly}
+          >
+            <Select
+              aria-label={t(
+                'grafana-prometheus.configuration.prom-settings.aria-label-default-editor',
+                'Default Editor (Code or Builder)'
               )}
-              tooltip={
-                <>
-                  <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-disable-metrics-lookup">
-                    Checking this option will disable the metrics chooser and metric/label support in the query
-                    field&apos;s autocomplete. This helps if you have performance issues with bigger Prometheus
-                    instances.{' '}
-                  </Trans>
-                  {docsTip()}
-                </>
+              options={editorOptions}
+              value={
+                editorOptions.find((o) => o.value === optionsWithDefaults.jsonData.defaultEditor) ??
+                editorOptions.find((o) => o.value === QueryEditorMode.Builder)
               }
-              interactive={true}
-              disabled={optionsWithDefaults.readOnly}
-              className={styles.switchField}
-            >
-              <Switch
-                value={optionsWithDefaults.jsonData.disableMetricsLookup ?? false}
-                onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'disableMetricsLookup')}
-                id={selectors.components.DataSource.Prometheus.configPage.disableMetricLookup}
-              />
+              onChange={onChangeHandler('defaultEditor', optionsWithDefaults, onOptionsChange)}
+              width={40}
+              data-testid={selectors.components.DataSource.Prometheus.configPage.defaultEditor}
+            />
+          </InlineField>
+          <InlineField
+            labelWidth={PROM_CONFIG_LABEL_WIDTH}
+            label={t(
+              'grafana-prometheus.configuration.prom-settings.label-disable-metrics-lookup',
+              'Disable metrics lookup'
+            )}
+            tooltip={
+              <>
+                <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-disable-metrics-lookup">
+                  Checking this option will disable the metrics chooser and metric/label support in the query
+                  field&apos;s autocomplete. This helps if you have performance issues with bigger Prometheus
+                  instances.{' '}
+                </Trans>
+                {docsTip()}
+              </>
+            }
+            interactive={true}
+            disabled={optionsWithDefaults.readOnly}
+            className={styles.switchField}
+          >
+            <Switch
+              value={optionsWithDefaults.jsonData.disableMetricsLookup ?? false}
+              onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'disableMetricsLookup')}
+              id={selectors.components.DataSource.Prometheus.configPage.disableMetricLookup}
+            />
             </InlineField>
-          </div>
-        </div>
+          </Stack>
+        </Box>
       </ConfigSubSection>
 
       <ConfigSubSection
@@ -279,319 +271,293 @@ export const PromSettings = (props: Props) => {
                   </Trans>
                 </div>
               )}
-            <div className="gf-form-group">
-              <div className="gf-form-inline">
-                <div className="gf-form">
-                  <InlineField
-                    label={t('grafana-prometheus.configuration.prom-settings.label-prometheus-type', 'Prometheus type')}
-                    labelWidth={PROM_CONFIG_LABEL_WIDTH}
-                    tooltip={
-                      <>
-                        {/* , and attempt to detect the version */}
-                        <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-prometheus-type">
-                          Set this to the type of your prometheus database, e.g. Prometheus, Cortex, Mimir or Thanos.
-                          Changing this field will save your current settings. Certain types of Prometheus supports or
-                          does not support various APIs. For example, some types support regex matching for label
-                          queries to improve performance. Some types have an API for metadata. If you set this
-                          incorrectly you may experience odd behavior when querying metrics and labels. Please check
-                          your Prometheus documentation to ensure you enter the correct type.
-                        </Trans>{' '}
-                        {docsTip()}
-                      </>
-                    }
-                    interactive={true}
-                    disabled={optionsWithDefaults.readOnly}
-                  >
-                    <Select
-                      aria-label={t(
-                        'grafana-prometheus.configuration.prom-settings.aria-label-prometheus-type',
-                        'Prometheus type'
-                      )}
-                      options={prometheusFlavorSelectItems}
-                      value={prometheusFlavorSelectItems.find(
-                        (o) => o.value === optionsWithDefaults.jsonData.prometheusType
-                      )}
-                      onChange={onChangeHandler('prometheusType', optionsWithDefaults, onOptionsChange)}
-                      width={40}
-                      data-testid={selectors.components.DataSource.Prometheus.configPage.prometheusType}
-                    />
-                  </InlineField>
-                </div>
-              </div>
-              <div className="gf-form-inline">
-                {optionsWithDefaults.jsonData.prometheusType && (
-                  <div className="gf-form">
-                    <InlineField
-                      label={t(
-                        'grafana-prometheus.configuration.prom-settings.label-prom-type-version',
-                        '{{promType}} version',
-                        {
-                          promType: optionsWithDefaults.jsonData.prometheusType,
-                        }
-                      )}
-                      labelWidth={PROM_CONFIG_LABEL_WIDTH}
-                      tooltip={
-                        <>
-                          <Trans
-                            i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-prom-type-version"
-                            values={{ promType: optionsWithDefaults.jsonData.prometheusType }}
-                          >
-                            Use this to set the version of your {'{{promType}}'} instance if it is not automatically
-                            configured.
-                          </Trans>{' '}
-                          {docsTip()}
-                        </>
-                      }
-                      interactive={true}
-                      disabled={optionsWithDefaults.readOnly}
-                    >
-                      <Select
-                        aria-label={t(
-                          'grafana-prometheus.configuration.prom-settings.aria-label-prom-type-type',
-                          '{{promType}} type',
-                          {
-                            promType: optionsWithDefaults.jsonData.prometheusType,
-                          }
-                        )}
-                        options={PromFlavorVersions[optionsWithDefaults.jsonData.prometheusType]}
-                        value={PromFlavorVersions[optionsWithDefaults.jsonData.prometheusType]?.find(
-                          (o) => o.value === optionsWithDefaults.jsonData.prometheusVersion
-                        )}
-                        onChange={onChangeHandler('prometheusVersion', optionsWithDefaults, onOptionsChange)}
-                        width={40}
-                        data-testid={selectors.components.DataSource.Prometheus.configPage.prometheusVersion}
-                      />
-                    </InlineField>
-                  </div>
-                )}
-              </div>
-            </div>
-          </>
-        )}
-        <div className="gf-form-group">
-          <div className="gf-form-inline">
-            <div className="gf-form max-width-30">
-              <InlineField
-                label={t('grafana-prometheus.configuration.prom-settings.label-cache-level', 'Cache level')}
+            <Box marginBottom={5}>
+              <Stack direction="column" gap={0.5}>
+                <InlineField
+                  label={t('grafana-prometheus.configuration.prom-settings.label-prometheus-type', 'Prometheus type')}
                 labelWidth={PROM_CONFIG_LABEL_WIDTH}
                 tooltip={
                   <>
-                    <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-cache-level">
-                      Sets the browser caching level for editor queries. Higher cache settings are recommended for high
-                      cardinality data sources.
-                    </Trans>
+                    {/* , and attempt to detect the version */}
+                    <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-prometheus-type">
+                      Set this to the type of your prometheus database, e.g. Prometheus, Cortex, Mimir or Thanos.
+                      Changing this field will save your current settings. Certain types of Prometheus supports or does
+                      not support various APIs. For example, some types support regex matching for label queries to
+                      improve performance. Some types have an API for metadata. If you set this incorrectly you may
+                      experience odd behavior when querying metrics and labels. Please check your Prometheus
+                      documentation to ensure you enter the correct type.
+                    </Trans>{' '}
+                    {docsTip()}
                   </>
                 }
                 interactive={true}
                 disabled={optionsWithDefaults.readOnly}
               >
                 <Select
+                  aria-label={t(
+                    'grafana-prometheus.configuration.prom-settings.aria-label-prometheus-type',
+                    'Prometheus type'
+                  )}
+                  options={prometheusFlavorSelectItems}
+                  value={prometheusFlavorSelectItems.find(
+                    (o) => o.value === optionsWithDefaults.jsonData.prometheusType
+                  )}
+                  onChange={onChangeHandler('prometheusType', optionsWithDefaults, onOptionsChange)}
                   width={40}
-                  onChange={onChangeHandler('cacheLevel', optionsWithDefaults, onOptionsChange)}
-                  options={cacheValueOptions}
-                  value={
-                    cacheValueOptions.find((o) => o.value === optionsWithDefaults.jsonData.cacheLevel) ??
-                    PrometheusCacheLevel.Low
+                  data-testid={selectors.components.DataSource.Prometheus.configPage.prometheusType}
+                />
+              </InlineField>
+              {optionsWithDefaults.jsonData.prometheusType && (
+                <InlineField
+                  label={t(
+                    'grafana-prometheus.configuration.prom-settings.label-prom-type-version',
+                    '{{promType}} version',
+                    {
+                      promType: optionsWithDefaults.jsonData.prometheusType,
+                    }
+                  )}
+                  labelWidth={PROM_CONFIG_LABEL_WIDTH}
+                  tooltip={
+                    <>
+                      <Trans
+                        i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-prom-type-version"
+                        values={{ promType: optionsWithDefaults.jsonData.prometheusType }}
+                      >
+                        Use this to set the version of your {'{{promType}}'} instance if it is not automatically
+                        configured.
+                      </Trans>{' '}
+                      {docsTip()}
+                    </>
                   }
-                  data-testid={selectors.components.DataSource.Prometheus.configPage.cacheLevel}
-                />
-              </InlineField>
-            </div>
-          </div>
-
-          <div className="gf-form-inline">
-            <div className="gf-form max-width-30">
-              <InlineField
-                label={t(
-                  'grafana-prometheus.configuration.prom-settings.label-incremental-querying-beta',
-                  'Incremental querying (beta)'
-                )}
-                labelWidth={PROM_CONFIG_LABEL_WIDTH}
-                tooltip={
-                  <>
-                    <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-incremental-querying-beta">
-                      This feature will change the default behavior of relative queries to always request fresh data
-                      from the prometheus instance, instead query results will be cached, and only new records are
-                      requested. Turn this on to decrease database and network load.
-                    </Trans>
-                  </>
-                }
-                interactive={true}
-                className={styles.switchField}
-                disabled={optionsWithDefaults.readOnly}
-              >
-                <Switch
-                  value={optionsWithDefaults.jsonData.incrementalQuerying ?? false}
-                  onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'incrementalQuerying')}
-                  id={selectors.components.DataSource.Prometheus.configPage.incrementalQuerying}
-                />
-              </InlineField>
-            </div>
-          </div>
-
-          <div className="gf-form-inline">
-            {optionsWithDefaults.jsonData.incrementalQuerying && (
-              <InlineField
-                label={t(
-                  'grafana-prometheus.configuration.prom-settings.label-query-overlap-window',
-                  'Query overlap window'
-                )}
-                labelWidth={PROM_CONFIG_LABEL_WIDTH}
-                tooltip={
-                  <>
-                    <Trans
-                      i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-query-overlap-window"
-                      values={{
-                        example1: '10m',
-                        example2: '120s',
-                        example3: '0s',
-                        default: '10m',
-                      }}
-                    >
-                      Set a duration like {'{{example1}}'} or {'{{example2}}'} or {'{{example3}}'}. Default of{' '}
-                      {'{{default}}'}. This duration will be added to the duration of each incremental request.
-                    </Trans>
-                  </>
-                }
-                interactive={true}
-                disabled={optionsWithDefaults.readOnly}
-              >
-                <>
-                  <Input
-                    onBlur={(e) =>
-                      updateValidDuration({
-                        ...validDuration,
-                        incrementalQueryOverlapWindow: e.currentTarget.value,
-                      })
-                    }
-                    className="width-20"
-                    value={
-                      optionsWithDefaults.jsonData.incrementalQueryOverlapWindow ?? defaultPrometheusQueryOverlapWindow
-                    }
-                    onChange={onChangeHandler('incrementalQueryOverlapWindow', optionsWithDefaults, onOptionsChange)}
-                    spellCheck={false}
-                    data-testid={selectors.components.DataSource.Prometheus.configPage.queryOverlapWindow}
+                  interactive={true}
+                  disabled={optionsWithDefaults.readOnly}
+                >
+                  <Select
+                    aria-label={t(
+                      'grafana-prometheus.configuration.prom-settings.aria-label-prom-type-type',
+                      '{{promType}} type',
+                      {
+                        promType: optionsWithDefaults.jsonData.prometheusType,
+                      }
+                    )}
+                    options={PromFlavorVersions[optionsWithDefaults.jsonData.prometheusType]}
+                    value={PromFlavorVersions[optionsWithDefaults.jsonData.prometheusType]?.find(
+                      (o) => o.value === optionsWithDefaults.jsonData.prometheusVersion
+                    )}
+                    onChange={onChangeHandler('prometheusVersion', optionsWithDefaults, onOptionsChange)}
+                    width={40}
+                    data-testid={selectors.components.DataSource.Prometheus.configPage.prometheusVersion}
                   />
-                  {validateInput(validDuration.incrementalQueryOverlapWindow, MULTIPLE_DURATION_REGEX, durationError)}
-                </>
-              </InlineField>
-            )}
-          </div>
-
-          <div className="gf-form-inline">
-            <div className="gf-form max-width-30">
-              <InlineField
-                label={t(
-                  'grafana-prometheus.configuration.prom-settings.label-disable-recording-rules-beta',
-                  'Disable recording rules (beta)'
+                </InlineField>
                 )}
-                labelWidth={PROM_CONFIG_LABEL_WIDTH}
-                tooltip={
-                  <>
-                    <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-disable-recording-rules-beta">
-                      This feature will disable recording rules. Turn this on to improve dashboard performance
-                    </Trans>
-                  </>
-                }
-                interactive={true}
-                className={styles.switchField}
-                disabled={optionsWithDefaults.readOnly}
-              >
-                <Switch
-                  value={optionsWithDefaults.jsonData.disableRecordingRules ?? false}
-                  onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'disableRecordingRules')}
-                  id={selectors.components.DataSource.Prometheus.configPage.disableRecordingRules}
+              </Stack>
+            </Box>
+          </>
+        )}
+        <Box marginBottom={5}>
+          <Stack direction="column" gap={0.5}>
+            <InlineField
+              label={t('grafana-prometheus.configuration.prom-settings.label-cache-level', 'Cache level')}
+            labelWidth={PROM_CONFIG_LABEL_WIDTH}
+            tooltip={
+              <>
+                <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-cache-level">
+                  Sets the browser caching level for editor queries. Higher cache settings are recommended for high
+                  cardinality data sources.
+                </Trans>
+              </>
+            }
+            interactive={true}
+            disabled={optionsWithDefaults.readOnly}
+          >
+            <Select
+              width={40}
+              onChange={onChangeHandler('cacheLevel', optionsWithDefaults, onOptionsChange)}
+              options={cacheValueOptions}
+              value={
+                cacheValueOptions.find((o) => o.value === optionsWithDefaults.jsonData.cacheLevel) ??
+                PrometheusCacheLevel.Low
+              }
+              data-testid={selectors.components.DataSource.Prometheus.configPage.cacheLevel}
+            />
+          </InlineField>
+
+          <InlineField
+            label={t(
+              'grafana-prometheus.configuration.prom-settings.label-incremental-querying-beta',
+              'Incremental querying (beta)'
+            )}
+            labelWidth={PROM_CONFIG_LABEL_WIDTH}
+            tooltip={
+              <>
+                <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-incremental-querying-beta">
+                  This feature will change the default behavior of relative queries to always request fresh data from
+                  the prometheus instance, instead query results will be cached, and only new records are requested.
+                  Turn this on to decrease database and network load.
+                </Trans>
+              </>
+            }
+            interactive={true}
+            className={styles.switchField}
+            disabled={optionsWithDefaults.readOnly}
+          >
+            <Switch
+              value={optionsWithDefaults.jsonData.incrementalQuerying ?? false}
+              onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'incrementalQuerying')}
+              id={selectors.components.DataSource.Prometheus.configPage.incrementalQuerying}
+            />
+          </InlineField>
+
+          {optionsWithDefaults.jsonData.incrementalQuerying && (
+            <InlineField
+              label={t(
+                'grafana-prometheus.configuration.prom-settings.label-query-overlap-window',
+                'Query overlap window'
+              )}
+              labelWidth={PROM_CONFIG_LABEL_WIDTH}
+              tooltip={
+                <>
+                  <Trans
+                    i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-query-overlap-window"
+                    values={{
+                      example1: '10m',
+                      example2: '120s',
+                      example3: '0s',
+                      default: '10m',
+                    }}
+                  >
+                    Set a duration like {'{{example1}}'} or {'{{example2}}'} or {'{{example3}}'}. Default of{' '}
+                    {'{{default}}'}. This duration will be added to the duration of each incremental request.
+                  </Trans>
+                </>
+              }
+              interactive={true}
+              disabled={optionsWithDefaults.readOnly}
+            >
+              <>
+                <Input
+                  onBlur={(e) =>
+                    updateValidDuration({
+                      ...validDuration,
+                      incrementalQueryOverlapWindow: e.currentTarget.value,
+                    })
+                  }
+                  className="width-20"
+                  value={
+                    optionsWithDefaults.jsonData.incrementalQueryOverlapWindow ?? defaultPrometheusQueryOverlapWindow
+                  }
+                  onChange={onChangeHandler('incrementalQueryOverlapWindow', optionsWithDefaults, onOptionsChange)}
+                  spellCheck={false}
+                  data-testid={selectors.components.DataSource.Prometheus.configPage.queryOverlapWindow}
                 />
-              </InlineField>
-            </div>
-          </div>
-        </div>
+                {validateInput(validDuration.incrementalQueryOverlapWindow, MULTIPLE_DURATION_REGEX, durationError)}
+              </>
+            </InlineField>
+          )}
+
+          <InlineField
+            label={t(
+              'grafana-prometheus.configuration.prom-settings.label-disable-recording-rules-beta',
+              'Disable recording rules (beta)'
+            )}
+            labelWidth={PROM_CONFIG_LABEL_WIDTH}
+            tooltip={
+              <>
+                <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-disable-recording-rules-beta">
+                  This feature will disable recording rules. Turn this on to improve dashboard performance
+                </Trans>
+              </>
+            }
+            interactive={true}
+            className={styles.switchField}
+            disabled={optionsWithDefaults.readOnly}
+          >
+            <Switch
+              value={optionsWithDefaults.jsonData.disableRecordingRules ?? false}
+              onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'disableRecordingRules')}
+              id={selectors.components.DataSource.Prometheus.configPage.disableRecordingRules}
+            />
+            </InlineField>
+          </Stack>
+        </Box>
       </ConfigSubSection>
 
       <ConfigSubSection
         title={t('grafana-prometheus.configuration.prom-settings.title-other', 'Other')}
         className={styles.container}
       >
-        <div className="gf-form-group">
-          <div className="gf-form-inline">
-            <div className="gf-form max-width-30">
-              <InlineField
-                label={t(
-                  'grafana-prometheus.configuration.prom-settings.label-custom-query-parameters',
-                  'Custom query parameters'
-                )}
-                labelWidth={PROM_CONFIG_LABEL_WIDTH}
-                tooltip={
-                  <>
-                    <Trans
-                      i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-custom-query-parameters"
-                      values={{
-                        example1: 'timeout',
-                        example2: 'partial_response',
-                        example3: 'dedup',
-                        example4: 'max_source_resolution',
-                        concatenationChar: '‘&’',
-                      }}
-                    >
-                      Add custom parameters to the Prometheus query URL. For example {'{{example1}}'}, {'{{example2}}'},{' '}
-                      {'{{example3}}'}, or
-                      {'{{example4}}'}. Multiple parameters should be concatenated together with{' '}
-                      {'{{concatenationChar}}'}.
-                    </Trans>{' '}
-                    {docsTip()}
-                  </>
-                }
-                interactive={true}
-                disabled={optionsWithDefaults.readOnly}
-              >
-                <Input
-                  className="width-20"
-                  value={optionsWithDefaults.jsonData.customQueryParameters}
-                  onChange={onChangeHandler('customQueryParameters', optionsWithDefaults, onOptionsChange)}
-                  spellCheck={false}
-                  placeholder={t(
-                    'grafana-prometheus.configuration.prom-settings.placeholder-example-maxsourceresolutionmtimeout',
-                    'Example: {{example}}',
-                    { example: 'max_source_resolution=5m&timeout=10' }
-                  )}
-                  data-testid={selectors.components.DataSource.Prometheus.configPage.customQueryParameters}
-                />
-              </InlineField>
-            </div>
-          </div>
-          <div className="gf-form-inline">
-            {/* HTTP Method */}
-            <div className="gf-form">
-              <InlineField
-                labelWidth={PROM_CONFIG_LABEL_WIDTH}
-                tooltip={
-                  <>
-                    <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-http-method">
-                      You can use either POST or GET HTTP method to query your Prometheus data source. POST is the
-                      recommended method as it allows bigger queries. Change this to GET if you have a Prometheus
-                      version older than 2.1 or if POST requests are restricted in your network.
-                    </Trans>{' '}
-                    {docsTip()}
-                  </>
-                }
-                interactive={true}
-                label={t('grafana-prometheus.configuration.prom-settings.label-http-method', 'HTTP method')}
-                disabled={optionsWithDefaults.readOnly}
-              >
-                <Select
-                  width={40}
-                  aria-label={t(
-                    'grafana-prometheus.configuration.prom-settings.aria-label-select-http-method',
-                    'Select HTTP method'
-                  )}
-                  options={httpOptions}
-                  value={httpOptions.find((o) => o.value === optionsWithDefaults.jsonData.httpMethod)}
-                  onChange={onChangeHandler('httpMethod', optionsWithDefaults, onOptionsChange)}
-                  data-testid={selectors.components.DataSource.Prometheus.configPage.httpMethod}
-                />
-              </InlineField>
-            </div>
-          </div>
+        <Box marginBottom={5}>
+          <Stack direction="column" gap={0.5}>
+            <InlineField
+              label={t(
+                'grafana-prometheus.configuration.prom-settings.label-custom-query-parameters',
+                'Custom query parameters'
+              )}
+            labelWidth={PROM_CONFIG_LABEL_WIDTH}
+            tooltip={
+              <>
+                <Trans
+                  i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-custom-query-parameters"
+                  values={{
+                    example1: 'timeout',
+                    example2: 'partial_response',
+                    example3: 'dedup',
+                    example4: 'max_source_resolution',
+                    concatenationChar: '‘&’',
+                  }}
+                >
+                  Add custom parameters to the Prometheus query URL. For example {'{{example1}}'}, {'{{example2}}'},{' '}
+                  {'{{example3}}'}, or
+                  {'{{example4}}'}. Multiple parameters should be concatenated together with {'{{concatenationChar}}'}.
+                </Trans>{' '}
+                {docsTip()}
+              </>
+            }
+            interactive={true}
+            disabled={optionsWithDefaults.readOnly}
+          >
+            <Input
+              className="width-20"
+              value={optionsWithDefaults.jsonData.customQueryParameters}
+              onChange={onChangeHandler('customQueryParameters', optionsWithDefaults, onOptionsChange)}
+              spellCheck={false}
+              placeholder={t(
+                'grafana-prometheus.configuration.prom-settings.placeholder-example-maxsourceresolutionmtimeout',
+                'Example: {{example}}',
+                { example: 'max_source_resolution=5m&timeout=10' }
+              )}
+              data-testid={selectors.components.DataSource.Prometheus.configPage.customQueryParameters}
+            />
+          </InlineField>
+          {/* HTTP Method */}
+          <InlineField
+            labelWidth={PROM_CONFIG_LABEL_WIDTH}
+            tooltip={
+              <>
+                <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-http-method">
+                  You can use either POST or GET HTTP method to query your Prometheus data source. POST is the
+                  recommended method as it allows bigger queries. Change this to GET if you have a Prometheus version
+                  older than 2.1 or if POST requests are restricted in your network.
+                </Trans>{' '}
+                {docsTip()}
+              </>
+            }
+            interactive={true}
+            label={t('grafana-prometheus.configuration.prom-settings.label-http-method', 'HTTP method')}
+            disabled={optionsWithDefaults.readOnly}
+          >
+            <Select
+              width={40}
+              aria-label={t(
+                'grafana-prometheus.configuration.prom-settings.aria-label-select-http-method',
+                'Select HTTP method'
+              )}
+              options={httpOptions}
+              value={httpOptions.find((o) => o.value === optionsWithDefaults.jsonData.httpMethod)}
+              onChange={onChangeHandler('httpMethod', optionsWithDefaults, onOptionsChange)}
+              data-testid={selectors.components.DataSource.Prometheus.configPage.httpMethod}
+            />
+          </InlineField>
           <InlineField
             labelWidth={PROM_CONFIG_LABEL_WIDTH}
             label={t('grafana-prometheus.configuration.prom-settings.label-series-limit', 'Series limit')}
@@ -656,8 +622,9 @@ export const PromSettings = (props: Props) => {
               value={optionsWithDefaults.jsonData.seriesEndpoint ?? false}
               onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'seriesEndpoint')}
             />
-          </InlineField>
-        </div>
+            </InlineField>
+          </Stack>
+        </Box>
       </ConfigSubSection>
 
       {!hideExemplars && (

--- a/packages/grafana-prometheus/src/configuration/PromSettings.tsx
+++ b/packages/grafana-prometheus/src/configuration/PromSettings.tsx
@@ -256,23 +256,24 @@ export const PromSettings = (props: Props) => {
         title={t('grafana-prometheus.configuration.prom-settings.title-performance', 'Performance')}
         className={styles.container}
       >
-        {!hidePrometheusTypeVersion && (
-          <>
-            {!optionsWithDefaults.jsonData.prometheusType &&
-              !optionsWithDefaults.jsonData.prometheusVersion &&
-              optionsWithDefaults.readOnly && (
-                <div className={styles.versionMargin}>
-                  <Trans i18nKey="grafana-prometheus.configuration.prom-settings.more-info">
-                    For more information on configuring prometheus type and version in data sources, see the{' '}
-                    <TextLink external href="https://grafana.com/docs/grafana/latest/administration/provisioning/">
-                      provisioning documentation
-                    </TextLink>
-                    .
-                  </Trans>
-                </div>
-              )}
-            <Box marginBottom={5}>
-              <Stack direction="column" gap={0.5}>
+        {!hidePrometheusTypeVersion &&
+          !optionsWithDefaults.jsonData.prometheusType &&
+          !optionsWithDefaults.jsonData.prometheusVersion &&
+          optionsWithDefaults.readOnly && (
+            <div className={styles.versionMargin}>
+              <Trans i18nKey="grafana-prometheus.configuration.prom-settings.more-info">
+                For more information on configuring prometheus type and version in data sources, see the{' '}
+                <TextLink external href="https://grafana.com/docs/grafana/latest/administration/provisioning/">
+                  provisioning documentation
+                </TextLink>
+                .
+              </Trans>
+            </div>
+          )}
+        <Box marginBottom={5}>
+          <Stack direction="column" gap={0.5}>
+            {!hidePrometheusTypeVersion && (
+              <>
                 <InlineField
                   label={t('grafana-prometheus.configuration.prom-settings.label-prometheus-type', 'Prometheus type')}
                   labelWidth={PROM_CONFIG_LABEL_WIDTH}
@@ -350,12 +351,8 @@ export const PromSettings = (props: Props) => {
                     />
                   </InlineField>
                 )}
-              </Stack>
-            </Box>
-          </>
-        )}
-        <Box marginBottom={5}>
-          <Stack direction="column" gap={0.5}>
+              </>
+            )}
             <InlineField
               label={t('grafana-prometheus.configuration.prom-settings.label-cache-level', 'Cache level')}
               labelWidth={PROM_CONFIG_LABEL_WIDTH}

--- a/packages/grafana-prometheus/src/configuration/PromSettings.tsx
+++ b/packages/grafana-prometheus/src/configuration/PromSettings.tsx
@@ -30,7 +30,12 @@ import { ExemplarsSettings } from './ExemplarsSettings';
 import { PromFlavorVersions } from './PromFlavorVersions';
 import { docsTip, overhaulStyles, validateInput } from './shared/utils';
 
-type Props = Pick<DataSourcePluginOptionsEditorProps<PromOptions>, 'options' | 'onOptionsChange'>;
+type Props = Pick<DataSourcePluginOptionsEditorProps<PromOptions>, 'options' | 'onOptionsChange'> & {
+  /** Hide the Prometheus type and version dropdowns */
+  hidePrometheusTypeVersion?: boolean;
+  /** Hide the Exemplars settings section */
+  hideExemplars?: boolean;
+};
 
 const httpOptions = [
   { value: 'POST', label: 'POST' },
@@ -72,7 +77,7 @@ const getOptionsWithDefaults = (options: DataSourceSettings<PromOptions>) => {
 export const PromSettings = (props: Props) => {
   const theme = useTheme2();
   const styles = overhaulStyles(theme);
-  const { onOptionsChange } = props;
+  const { onOptionsChange, hidePrometheusTypeVersion, hideExemplars } = props;
 
   const editorOptions = [
     {
@@ -259,106 +264,111 @@ export const PromSettings = (props: Props) => {
         title={t('grafana-prometheus.configuration.prom-settings.title-performance', 'Performance')}
         className={styles.container}
       >
-        {!optionsWithDefaults.jsonData.prometheusType &&
-          !optionsWithDefaults.jsonData.prometheusVersion &&
-          optionsWithDefaults.readOnly && (
-            <div className={styles.versionMargin}>
-              <Trans i18nKey="grafana-prometheus.configuration.prom-settings.more-info">
-                For more information on configuring prometheus type and version in data sources, see the{' '}
-                <TextLink external href="https://grafana.com/docs/grafana/latest/administration/provisioning/">
-                  provisioning documentation
-                </TextLink>
-                .
-              </Trans>
-            </div>
-          )}
-        <div className="gf-form-group">
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <InlineField
-                label={t('grafana-prometheus.configuration.prom-settings.label-prometheus-type', 'Prometheus type')}
-                labelWidth={PROM_CONFIG_LABEL_WIDTH}
-                tooltip={
-                  <>
-                    {/* , and attempt to detect the version */}
-                    <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-prometheus-type">
-                      Set this to the type of your prometheus database, e.g. Prometheus, Cortex, Mimir or Thanos.
-                      Changing this field will save your current settings. Certain types of Prometheus supports or does
-                      not support various APIs. For example, some types support regex matching for label queries to
-                      improve performance. Some types have an API for metadata. If you set this incorrectly you may
-                      experience odd behavior when querying metrics and labels. Please check your Prometheus
-                      documentation to ensure you enter the correct type.
-                    </Trans>{' '}
-                    {docsTip()}
-                  </>
-                }
-                interactive={true}
-                disabled={optionsWithDefaults.readOnly}
-              >
-                <Select
-                  aria-label={t(
-                    'grafana-prometheus.configuration.prom-settings.aria-label-prometheus-type',
-                    'Prometheus type'
-                  )}
-                  options={prometheusFlavorSelectItems}
-                  value={prometheusFlavorSelectItems.find(
-                    (o) => o.value === optionsWithDefaults.jsonData.prometheusType
-                  )}
-                  onChange={onChangeHandler('prometheusType', optionsWithDefaults, onOptionsChange)}
-                  width={40}
-                  data-testid={selectors.components.DataSource.Prometheus.configPage.prometheusType}
-                />
-              </InlineField>
-            </div>
-          </div>
-          <div className="gf-form-inline">
-            {optionsWithDefaults.jsonData.prometheusType && (
-              <div className="gf-form">
-                <InlineField
-                  label={t(
-                    'grafana-prometheus.configuration.prom-settings.label-prom-type-version',
-                    '{{promType}} version',
-                    {
-                      promType: optionsWithDefaults.jsonData.prometheusType,
+        {!hidePrometheusTypeVersion && (
+          <>
+            {!optionsWithDefaults.jsonData.prometheusType &&
+              !optionsWithDefaults.jsonData.prometheusVersion &&
+              optionsWithDefaults.readOnly && (
+                <div className={styles.versionMargin}>
+                  <Trans i18nKey="grafana-prometheus.configuration.prom-settings.more-info">
+                    For more information on configuring prometheus type and version in data sources, see the{' '}
+                    <TextLink external href="https://grafana.com/docs/grafana/latest/administration/provisioning/">
+                      provisioning documentation
+                    </TextLink>
+                    .
+                  </Trans>
+                </div>
+              )}
+            <div className="gf-form-group">
+              <div className="gf-form-inline">
+                <div className="gf-form">
+                  <InlineField
+                    label={t('grafana-prometheus.configuration.prom-settings.label-prometheus-type', 'Prometheus type')}
+                    labelWidth={PROM_CONFIG_LABEL_WIDTH}
+                    tooltip={
+                      <>
+                        {/* , and attempt to detect the version */}
+                        <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-prometheus-type">
+                          Set this to the type of your prometheus database, e.g. Prometheus, Cortex, Mimir or Thanos.
+                          Changing this field will save your current settings. Certain types of Prometheus supports or
+                          does not support various APIs. For example, some types support regex matching for label
+                          queries to improve performance. Some types have an API for metadata. If you set this
+                          incorrectly you may experience odd behavior when querying metrics and labels. Please check
+                          your Prometheus documentation to ensure you enter the correct type.
+                        </Trans>{' '}
+                        {docsTip()}
+                      </>
                     }
-                  )}
-                  labelWidth={PROM_CONFIG_LABEL_WIDTH}
-                  tooltip={
-                    <>
-                      <Trans
-                        i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-prom-type-version"
-                        values={{ promType: optionsWithDefaults.jsonData.prometheusType }}
-                      >
-                        Use this to set the version of your {'{{promType}}'} instance if it is not automatically
-                        configured.
-                      </Trans>{' '}
-                      {docsTip()}
-                    </>
-                  }
-                  interactive={true}
-                  disabled={optionsWithDefaults.readOnly}
-                >
-                  <Select
-                    aria-label={t(
-                      'grafana-prometheus.configuration.prom-settings.aria-label-prom-type-type',
-                      '{{promType}} type',
-                      {
-                        promType: optionsWithDefaults.jsonData.prometheusType,
-                      }
-                    )}
-                    options={PromFlavorVersions[optionsWithDefaults.jsonData.prometheusType]}
-                    value={PromFlavorVersions[optionsWithDefaults.jsonData.prometheusType]?.find(
-                      (o) => o.value === optionsWithDefaults.jsonData.prometheusVersion
-                    )}
-                    onChange={onChangeHandler('prometheusVersion', optionsWithDefaults, onOptionsChange)}
-                    width={40}
-                    data-testid={selectors.components.DataSource.Prometheus.configPage.prometheusVersion}
-                  />
-                </InlineField>
+                    interactive={true}
+                    disabled={optionsWithDefaults.readOnly}
+                  >
+                    <Select
+                      aria-label={t(
+                        'grafana-prometheus.configuration.prom-settings.aria-label-prometheus-type',
+                        'Prometheus type'
+                      )}
+                      options={prometheusFlavorSelectItems}
+                      value={prometheusFlavorSelectItems.find(
+                        (o) => o.value === optionsWithDefaults.jsonData.prometheusType
+                      )}
+                      onChange={onChangeHandler('prometheusType', optionsWithDefaults, onOptionsChange)}
+                      width={40}
+                      data-testid={selectors.components.DataSource.Prometheus.configPage.prometheusType}
+                    />
+                  </InlineField>
+                </div>
               </div>
-            )}
-          </div>
-
+              <div className="gf-form-inline">
+                {optionsWithDefaults.jsonData.prometheusType && (
+                  <div className="gf-form">
+                    <InlineField
+                      label={t(
+                        'grafana-prometheus.configuration.prom-settings.label-prom-type-version',
+                        '{{promType}} version',
+                        {
+                          promType: optionsWithDefaults.jsonData.prometheusType,
+                        }
+                      )}
+                      labelWidth={PROM_CONFIG_LABEL_WIDTH}
+                      tooltip={
+                        <>
+                          <Trans
+                            i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-prom-type-version"
+                            values={{ promType: optionsWithDefaults.jsonData.prometheusType }}
+                          >
+                            Use this to set the version of your {'{{promType}}'} instance if it is not automatically
+                            configured.
+                          </Trans>{' '}
+                          {docsTip()}
+                        </>
+                      }
+                      interactive={true}
+                      disabled={optionsWithDefaults.readOnly}
+                    >
+                      <Select
+                        aria-label={t(
+                          'grafana-prometheus.configuration.prom-settings.aria-label-prom-type-type',
+                          '{{promType}} type',
+                          {
+                            promType: optionsWithDefaults.jsonData.prometheusType,
+                          }
+                        )}
+                        options={PromFlavorVersions[optionsWithDefaults.jsonData.prometheusType]}
+                        value={PromFlavorVersions[optionsWithDefaults.jsonData.prometheusType]?.find(
+                          (o) => o.value === optionsWithDefaults.jsonData.prometheusVersion
+                        )}
+                        onChange={onChangeHandler('prometheusVersion', optionsWithDefaults, onOptionsChange)}
+                        width={40}
+                        data-testid={selectors.components.DataSource.Prometheus.configPage.prometheusVersion}
+                      />
+                    </InlineField>
+                  </div>
+                )}
+              </div>
+            </div>
+          </>
+        )}
+        <div className="gf-form-group">
           <div className="gf-form-inline">
             <div className="gf-form max-width-30">
               <InlineField
@@ -650,17 +660,19 @@ export const PromSettings = (props: Props) => {
         </div>
       </ConfigSubSection>
 
-      <ExemplarsSettings
-        options={optionsWithDefaults.jsonData.exemplarTraceIdDestinations}
-        onChange={(exemplarOptions) =>
-          updateDatasourcePluginJsonDataOption(
-            { onOptionsChange, options: optionsWithDefaults },
-            'exemplarTraceIdDestinations',
-            exemplarOptions
-          )
-        }
-        disabled={optionsWithDefaults.readOnly}
-      />
+      {!hideExemplars && (
+        <ExemplarsSettings
+          options={optionsWithDefaults.jsonData.exemplarTraceIdDestinations}
+          onChange={(exemplarOptions) =>
+            updateDatasourcePluginJsonDataOption(
+              { onOptionsChange, options: optionsWithDefaults },
+              'exemplarTraceIdDestinations',
+              exemplarOptions
+            )
+          }
+          disabled={optionsWithDefaults.readOnly}
+        />
+      )}
     </>
   );
 };

--- a/packages/grafana-prometheus/src/configuration/PromSettings.tsx
+++ b/packages/grafana-prometheus/src/configuration/PromSettings.tsx
@@ -111,77 +111,77 @@ export const PromSettings = (props: Props) => {
           <Stack direction="column" gap={0.5}>
             {/* Scrape interval */}
             <InlineField
-            label={t('grafana-prometheus.configuration.prom-settings.label-scrape-interval', 'Scrape interval')}
-            labelWidth={PROM_CONFIG_LABEL_WIDTH}
-            tooltip={
+              label={t('grafana-prometheus.configuration.prom-settings.label-scrape-interval', 'Scrape interval')}
+              labelWidth={PROM_CONFIG_LABEL_WIDTH}
+              tooltip={
+                <>
+                  <Trans
+                    i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-scrape-interval"
+                    values={{ default: '15s' }}
+                  >
+                    This interval is how frequently Prometheus scrapes targets. Set this to the typical scrape and
+                    evaluation interval configured in your Prometheus config file. If you set this to a greater value
+                    than your Prometheus config file interval, Grafana will evaluate the data according to this interval
+                    and you will see less data points. Defaults to {'{{default}}'}.
+                  </Trans>{' '}
+                  {docsTip()}
+                </>
+              }
+              interactive={true}
+              disabled={optionsWithDefaults.readOnly}
+            >
               <>
-                <Trans
-                  i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-scrape-interval"
-                  values={{ default: '15s' }}
-                >
-                  This interval is how frequently Prometheus scrapes targets. Set this to the typical scrape and
-                  evaluation interval configured in your Prometheus config file. If you set this to a greater value than
-                  your Prometheus config file interval, Grafana will evaluate the data according to this interval and
-                  you will see less data points. Defaults to {'{{default}}'}.
-                </Trans>{' '}
-                {docsTip()}
+                <Input
+                  className="width-20"
+                  value={optionsWithDefaults.jsonData.timeInterval}
+                  spellCheck={false}
+                  // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+                  placeholder="15s"
+                  onChange={onChangeHandler('timeInterval', optionsWithDefaults, onOptionsChange)}
+                  onBlur={(e) =>
+                    updateValidDuration({
+                      ...validDuration,
+                      timeInterval: e.currentTarget.value,
+                    })
+                  }
+                  data-testid={selectors.components.DataSource.Prometheus.configPage.scrapeInterval}
+                />
+                {validateInput(validDuration.timeInterval, DURATION_REGEX, durationError)}
               </>
-            }
-            interactive={true}
-            disabled={optionsWithDefaults.readOnly}
-          >
-            <>
-              <Input
-                className="width-20"
-                value={optionsWithDefaults.jsonData.timeInterval}
-                spellCheck={false}
-                // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
-                placeholder="15s"
-                onChange={onChangeHandler('timeInterval', optionsWithDefaults, onOptionsChange)}
-                onBlur={(e) =>
-                  updateValidDuration({
-                    ...validDuration,
-                    timeInterval: e.currentTarget.value,
-                  })
-                }
-                data-testid={selectors.components.DataSource.Prometheus.configPage.scrapeInterval}
-              />
-              {validateInput(validDuration.timeInterval, DURATION_REGEX, durationError)}
-            </>
-          </InlineField>
-          {/* Query Timeout */}
-          <InlineField
-            label={t('grafana-prometheus.configuration.prom-settings.label-query-timeout', 'Query timeout')}
-            labelWidth={PROM_CONFIG_LABEL_WIDTH}
-            tooltip={
+            </InlineField>
+            {/* Query Timeout */}
+            <InlineField
+              label={t('grafana-prometheus.configuration.prom-settings.label-query-timeout', 'Query timeout')}
+              labelWidth={PROM_CONFIG_LABEL_WIDTH}
+              tooltip={
+                <>
+                  <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-query-timeout">
+                    Set the Prometheus query timeout.
+                  </Trans>{' '}
+                  {docsTip()}
+                </>
+              }
+              interactive={true}
+              disabled={optionsWithDefaults.readOnly}
+            >
               <>
-                <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-query-timeout">
-                  Set the Prometheus query timeout.
-                </Trans>{' '}
-                {docsTip()}
+                <Input
+                  className="width-20"
+                  value={optionsWithDefaults.jsonData.queryTimeout}
+                  onChange={onChangeHandler('queryTimeout', optionsWithDefaults, onOptionsChange)}
+                  spellCheck={false}
+                  // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+                  placeholder="60s"
+                  onBlur={(e) =>
+                    updateValidDuration({
+                      ...validDuration,
+                      queryTimeout: e.currentTarget.value,
+                    })
+                  }
+                  data-testid={selectors.components.DataSource.Prometheus.configPage.queryTimeout}
+                />
+                {validateInput(validDuration.queryTimeout, DURATION_REGEX, durationError)}
               </>
-            }
-            interactive={true}
-            disabled={optionsWithDefaults.readOnly}
-          >
-            <>
-              <Input
-                className="width-20"
-                value={optionsWithDefaults.jsonData.queryTimeout}
-                onChange={onChangeHandler('queryTimeout', optionsWithDefaults, onOptionsChange)}
-                spellCheck={false}
-                // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
-                placeholder="60s"
-                onBlur={(e) =>
-                  updateValidDuration({
-                    ...validDuration,
-                    queryTimeout: e.currentTarget.value,
-                  })
-                }
-                data-testid={selectors.components.DataSource.Prometheus.configPage.queryTimeout}
-              />
-              {validateInput(validDuration.queryTimeout, DURATION_REGEX, durationError)}
-            </>
             </InlineField>
           </Stack>
         </Box>
@@ -195,58 +195,58 @@ export const PromSettings = (props: Props) => {
           <Stack direction="column" gap={0.5}>
             <InlineField
               label={t('grafana-prometheus.configuration.prom-settings.label-default-editor', 'Default editor')}
-            labelWidth={PROM_CONFIG_LABEL_WIDTH}
-            tooltip={
-              <>
-                <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-default-editor">
-                  Set default editor option for all users of this data source.
-                </Trans>{' '}
-                {docsTip()}
-              </>
-            }
-            interactive={true}
-            disabled={optionsWithDefaults.readOnly}
-          >
-            <Select
-              aria-label={t(
-                'grafana-prometheus.configuration.prom-settings.aria-label-default-editor',
-                'Default Editor (Code or Builder)'
-              )}
-              options={editorOptions}
-              value={
-                editorOptions.find((o) => o.value === optionsWithDefaults.jsonData.defaultEditor) ??
-                editorOptions.find((o) => o.value === QueryEditorMode.Builder)
+              labelWidth={PROM_CONFIG_LABEL_WIDTH}
+              tooltip={
+                <>
+                  <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-default-editor">
+                    Set default editor option for all users of this data source.
+                  </Trans>{' '}
+                  {docsTip()}
+                </>
               }
-              onChange={onChangeHandler('defaultEditor', optionsWithDefaults, onOptionsChange)}
-              width={40}
-              data-testid={selectors.components.DataSource.Prometheus.configPage.defaultEditor}
-            />
-          </InlineField>
-          <InlineField
-            labelWidth={PROM_CONFIG_LABEL_WIDTH}
-            label={t(
-              'grafana-prometheus.configuration.prom-settings.label-disable-metrics-lookup',
-              'Disable metrics lookup'
-            )}
-            tooltip={
-              <>
-                <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-disable-metrics-lookup">
-                  Checking this option will disable the metrics chooser and metric/label support in the query
-                  field&apos;s autocomplete. This helps if you have performance issues with bigger Prometheus
-                  instances.{' '}
-                </Trans>
-                {docsTip()}
-              </>
-            }
-            interactive={true}
-            disabled={optionsWithDefaults.readOnly}
-            className={styles.switchField}
-          >
-            <Switch
-              value={optionsWithDefaults.jsonData.disableMetricsLookup ?? false}
-              onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'disableMetricsLookup')}
-              id={selectors.components.DataSource.Prometheus.configPage.disableMetricLookup}
-            />
+              interactive={true}
+              disabled={optionsWithDefaults.readOnly}
+            >
+              <Select
+                aria-label={t(
+                  'grafana-prometheus.configuration.prom-settings.aria-label-default-editor',
+                  'Default Editor (Code or Builder)'
+                )}
+                options={editorOptions}
+                value={
+                  editorOptions.find((o) => o.value === optionsWithDefaults.jsonData.defaultEditor) ??
+                  editorOptions.find((o) => o.value === QueryEditorMode.Builder)
+                }
+                onChange={onChangeHandler('defaultEditor', optionsWithDefaults, onOptionsChange)}
+                width={40}
+                data-testid={selectors.components.DataSource.Prometheus.configPage.defaultEditor}
+              />
+            </InlineField>
+            <InlineField
+              labelWidth={PROM_CONFIG_LABEL_WIDTH}
+              label={t(
+                'grafana-prometheus.configuration.prom-settings.label-disable-metrics-lookup',
+                'Disable metrics lookup'
+              )}
+              tooltip={
+                <>
+                  <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-disable-metrics-lookup">
+                    Checking this option will disable the metrics chooser and metric/label support in the query
+                    field&apos;s autocomplete. This helps if you have performance issues with bigger Prometheus
+                    instances.{' '}
+                  </Trans>
+                  {docsTip()}
+                </>
+              }
+              interactive={true}
+              disabled={optionsWithDefaults.readOnly}
+              className={styles.switchField}
+            >
+              <Switch
+                value={optionsWithDefaults.jsonData.disableMetricsLookup ?? false}
+                onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'disableMetricsLookup')}
+                id={selectors.components.DataSource.Prometheus.configPage.disableMetricLookup}
+              />
             </InlineField>
           </Stack>
         </Box>
@@ -275,56 +275,17 @@ export const PromSettings = (props: Props) => {
               <Stack direction="column" gap={0.5}>
                 <InlineField
                   label={t('grafana-prometheus.configuration.prom-settings.label-prometheus-type', 'Prometheus type')}
-                labelWidth={PROM_CONFIG_LABEL_WIDTH}
-                tooltip={
-                  <>
-                    {/* , and attempt to detect the version */}
-                    <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-prometheus-type">
-                      Set this to the type of your prometheus database, e.g. Prometheus, Cortex, Mimir or Thanos.
-                      Changing this field will save your current settings. Certain types of Prometheus supports or does
-                      not support various APIs. For example, some types support regex matching for label queries to
-                      improve performance. Some types have an API for metadata. If you set this incorrectly you may
-                      experience odd behavior when querying metrics and labels. Please check your Prometheus
-                      documentation to ensure you enter the correct type.
-                    </Trans>{' '}
-                    {docsTip()}
-                  </>
-                }
-                interactive={true}
-                disabled={optionsWithDefaults.readOnly}
-              >
-                <Select
-                  aria-label={t(
-                    'grafana-prometheus.configuration.prom-settings.aria-label-prometheus-type',
-                    'Prometheus type'
-                  )}
-                  options={prometheusFlavorSelectItems}
-                  value={prometheusFlavorSelectItems.find(
-                    (o) => o.value === optionsWithDefaults.jsonData.prometheusType
-                  )}
-                  onChange={onChangeHandler('prometheusType', optionsWithDefaults, onOptionsChange)}
-                  width={40}
-                  data-testid={selectors.components.DataSource.Prometheus.configPage.prometheusType}
-                />
-              </InlineField>
-              {optionsWithDefaults.jsonData.prometheusType && (
-                <InlineField
-                  label={t(
-                    'grafana-prometheus.configuration.prom-settings.label-prom-type-version',
-                    '{{promType}} version',
-                    {
-                      promType: optionsWithDefaults.jsonData.prometheusType,
-                    }
-                  )}
                   labelWidth={PROM_CONFIG_LABEL_WIDTH}
                   tooltip={
                     <>
-                      <Trans
-                        i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-prom-type-version"
-                        values={{ promType: optionsWithDefaults.jsonData.prometheusType }}
-                      >
-                        Use this to set the version of your {'{{promType}}'} instance if it is not automatically
-                        configured.
+                      {/* , and attempt to detect the version */}
+                      <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-prometheus-type">
+                        Set this to the type of your prometheus database, e.g. Prometheus, Cortex, Mimir or Thanos.
+                        Changing this field will save your current settings. Certain types of Prometheus supports or
+                        does not support various APIs. For example, some types support regex matching for label queries
+                        to improve performance. Some types have an API for metadata. If you set this incorrectly you may
+                        experience odd behavior when querying metrics and labels. Please check your Prometheus
+                        documentation to ensure you enter the correct type.
                       </Trans>{' '}
                       {docsTip()}
                     </>
@@ -334,21 +295,60 @@ export const PromSettings = (props: Props) => {
                 >
                   <Select
                     aria-label={t(
-                      'grafana-prometheus.configuration.prom-settings.aria-label-prom-type-type',
-                      '{{promType}} type',
+                      'grafana-prometheus.configuration.prom-settings.aria-label-prometheus-type',
+                      'Prometheus type'
+                    )}
+                    options={prometheusFlavorSelectItems}
+                    value={prometheusFlavorSelectItems.find(
+                      (o) => o.value === optionsWithDefaults.jsonData.prometheusType
+                    )}
+                    onChange={onChangeHandler('prometheusType', optionsWithDefaults, onOptionsChange)}
+                    width={40}
+                    data-testid={selectors.components.DataSource.Prometheus.configPage.prometheusType}
+                  />
+                </InlineField>
+                {optionsWithDefaults.jsonData.prometheusType && (
+                  <InlineField
+                    label={t(
+                      'grafana-prometheus.configuration.prom-settings.label-prom-type-version',
+                      '{{promType}} version',
                       {
                         promType: optionsWithDefaults.jsonData.prometheusType,
                       }
                     )}
-                    options={PromFlavorVersions[optionsWithDefaults.jsonData.prometheusType]}
-                    value={PromFlavorVersions[optionsWithDefaults.jsonData.prometheusType]?.find(
-                      (o) => o.value === optionsWithDefaults.jsonData.prometheusVersion
-                    )}
-                    onChange={onChangeHandler('prometheusVersion', optionsWithDefaults, onOptionsChange)}
-                    width={40}
-                    data-testid={selectors.components.DataSource.Prometheus.configPage.prometheusVersion}
-                  />
-                </InlineField>
+                    labelWidth={PROM_CONFIG_LABEL_WIDTH}
+                    tooltip={
+                      <>
+                        <Trans
+                          i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-prom-type-version"
+                          values={{ promType: optionsWithDefaults.jsonData.prometheusType }}
+                        >
+                          Use this to set the version of your {'{{promType}}'} instance if it is not automatically
+                          configured.
+                        </Trans>{' '}
+                        {docsTip()}
+                      </>
+                    }
+                    interactive={true}
+                    disabled={optionsWithDefaults.readOnly}
+                  >
+                    <Select
+                      aria-label={t(
+                        'grafana-prometheus.configuration.prom-settings.aria-label-prom-type-type',
+                        '{{promType}} type',
+                        {
+                          promType: optionsWithDefaults.jsonData.prometheusType,
+                        }
+                      )}
+                      options={PromFlavorVersions[optionsWithDefaults.jsonData.prometheusType]}
+                      value={PromFlavorVersions[optionsWithDefaults.jsonData.prometheusType]?.find(
+                        (o) => o.value === optionsWithDefaults.jsonData.prometheusVersion
+                      )}
+                      onChange={onChangeHandler('prometheusVersion', optionsWithDefaults, onOptionsChange)}
+                      width={40}
+                      data-testid={selectors.components.DataSource.Prometheus.configPage.prometheusVersion}
+                    />
+                  </InlineField>
                 )}
               </Stack>
             </Box>
@@ -358,125 +358,125 @@ export const PromSettings = (props: Props) => {
           <Stack direction="column" gap={0.5}>
             <InlineField
               label={t('grafana-prometheus.configuration.prom-settings.label-cache-level', 'Cache level')}
-            labelWidth={PROM_CONFIG_LABEL_WIDTH}
-            tooltip={
-              <>
-                <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-cache-level">
-                  Sets the browser caching level for editor queries. Higher cache settings are recommended for high
-                  cardinality data sources.
-                </Trans>
-              </>
-            }
-            interactive={true}
-            disabled={optionsWithDefaults.readOnly}
-          >
-            <Select
-              width={40}
-              onChange={onChangeHandler('cacheLevel', optionsWithDefaults, onOptionsChange)}
-              options={cacheValueOptions}
-              value={
-                cacheValueOptions.find((o) => o.value === optionsWithDefaults.jsonData.cacheLevel) ??
-                PrometheusCacheLevel.Low
-              }
-              data-testid={selectors.components.DataSource.Prometheus.configPage.cacheLevel}
-            />
-          </InlineField>
-
-          <InlineField
-            label={t(
-              'grafana-prometheus.configuration.prom-settings.label-incremental-querying-beta',
-              'Incremental querying (beta)'
-            )}
-            labelWidth={PROM_CONFIG_LABEL_WIDTH}
-            tooltip={
-              <>
-                <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-incremental-querying-beta">
-                  This feature will change the default behavior of relative queries to always request fresh data from
-                  the prometheus instance, instead query results will be cached, and only new records are requested.
-                  Turn this on to decrease database and network load.
-                </Trans>
-              </>
-            }
-            interactive={true}
-            className={styles.switchField}
-            disabled={optionsWithDefaults.readOnly}
-          >
-            <Switch
-              value={optionsWithDefaults.jsonData.incrementalQuerying ?? false}
-              onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'incrementalQuerying')}
-              id={selectors.components.DataSource.Prometheus.configPage.incrementalQuerying}
-            />
-          </InlineField>
-
-          {optionsWithDefaults.jsonData.incrementalQuerying && (
-            <InlineField
-              label={t(
-                'grafana-prometheus.configuration.prom-settings.label-query-overlap-window',
-                'Query overlap window'
-              )}
               labelWidth={PROM_CONFIG_LABEL_WIDTH}
               tooltip={
                 <>
-                  <Trans
-                    i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-query-overlap-window"
-                    values={{
-                      example1: '10m',
-                      example2: '120s',
-                      example3: '0s',
-                      default: '10m',
-                    }}
-                  >
-                    Set a duration like {'{{example1}}'} or {'{{example2}}'} or {'{{example3}}'}. Default of{' '}
-                    {'{{default}}'}. This duration will be added to the duration of each incremental request.
+                  <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-cache-level">
+                    Sets the browser caching level for editor queries. Higher cache settings are recommended for high
+                    cardinality data sources.
                   </Trans>
                 </>
               }
               interactive={true}
               disabled={optionsWithDefaults.readOnly}
             >
-              <>
-                <Input
-                  onBlur={(e) =>
-                    updateValidDuration({
-                      ...validDuration,
-                      incrementalQueryOverlapWindow: e.currentTarget.value,
-                    })
-                  }
-                  className="width-20"
-                  value={
-                    optionsWithDefaults.jsonData.incrementalQueryOverlapWindow ?? defaultPrometheusQueryOverlapWindow
-                  }
-                  onChange={onChangeHandler('incrementalQueryOverlapWindow', optionsWithDefaults, onOptionsChange)}
-                  spellCheck={false}
-                  data-testid={selectors.components.DataSource.Prometheus.configPage.queryOverlapWindow}
-                />
-                {validateInput(validDuration.incrementalQueryOverlapWindow, MULTIPLE_DURATION_REGEX, durationError)}
-              </>
+              <Select
+                width={40}
+                onChange={onChangeHandler('cacheLevel', optionsWithDefaults, onOptionsChange)}
+                options={cacheValueOptions}
+                value={
+                  cacheValueOptions.find((o) => o.value === optionsWithDefaults.jsonData.cacheLevel) ??
+                  PrometheusCacheLevel.Low
+                }
+                data-testid={selectors.components.DataSource.Prometheus.configPage.cacheLevel}
+              />
             </InlineField>
-          )}
 
-          <InlineField
-            label={t(
-              'grafana-prometheus.configuration.prom-settings.label-disable-recording-rules-beta',
-              'Disable recording rules (beta)'
+            <InlineField
+              label={t(
+                'grafana-prometheus.configuration.prom-settings.label-incremental-querying-beta',
+                'Incremental querying (beta)'
+              )}
+              labelWidth={PROM_CONFIG_LABEL_WIDTH}
+              tooltip={
+                <>
+                  <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-incremental-querying-beta">
+                    This feature will change the default behavior of relative queries to always request fresh data from
+                    the prometheus instance, instead query results will be cached, and only new records are requested.
+                    Turn this on to decrease database and network load.
+                  </Trans>
+                </>
+              }
+              interactive={true}
+              className={styles.switchField}
+              disabled={optionsWithDefaults.readOnly}
+            >
+              <Switch
+                value={optionsWithDefaults.jsonData.incrementalQuerying ?? false}
+                onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'incrementalQuerying')}
+                id={selectors.components.DataSource.Prometheus.configPage.incrementalQuerying}
+              />
+            </InlineField>
+
+            {optionsWithDefaults.jsonData.incrementalQuerying && (
+              <InlineField
+                label={t(
+                  'grafana-prometheus.configuration.prom-settings.label-query-overlap-window',
+                  'Query overlap window'
+                )}
+                labelWidth={PROM_CONFIG_LABEL_WIDTH}
+                tooltip={
+                  <>
+                    <Trans
+                      i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-query-overlap-window"
+                      values={{
+                        example1: '10m',
+                        example2: '120s',
+                        example3: '0s',
+                        default: '10m',
+                      }}
+                    >
+                      Set a duration like {'{{example1}}'} or {'{{example2}}'} or {'{{example3}}'}. Default of{' '}
+                      {'{{default}}'}. This duration will be added to the duration of each incremental request.
+                    </Trans>
+                  </>
+                }
+                interactive={true}
+                disabled={optionsWithDefaults.readOnly}
+              >
+                <>
+                  <Input
+                    onBlur={(e) =>
+                      updateValidDuration({
+                        ...validDuration,
+                        incrementalQueryOverlapWindow: e.currentTarget.value,
+                      })
+                    }
+                    className="width-20"
+                    value={
+                      optionsWithDefaults.jsonData.incrementalQueryOverlapWindow ?? defaultPrometheusQueryOverlapWindow
+                    }
+                    onChange={onChangeHandler('incrementalQueryOverlapWindow', optionsWithDefaults, onOptionsChange)}
+                    spellCheck={false}
+                    data-testid={selectors.components.DataSource.Prometheus.configPage.queryOverlapWindow}
+                  />
+                  {validateInput(validDuration.incrementalQueryOverlapWindow, MULTIPLE_DURATION_REGEX, durationError)}
+                </>
+              </InlineField>
             )}
-            labelWidth={PROM_CONFIG_LABEL_WIDTH}
-            tooltip={
-              <>
-                <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-disable-recording-rules-beta">
-                  This feature will disable recording rules. Turn this on to improve dashboard performance
-                </Trans>
-              </>
-            }
-            interactive={true}
-            className={styles.switchField}
-            disabled={optionsWithDefaults.readOnly}
-          >
-            <Switch
-              value={optionsWithDefaults.jsonData.disableRecordingRules ?? false}
-              onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'disableRecordingRules')}
-              id={selectors.components.DataSource.Prometheus.configPage.disableRecordingRules}
-            />
+
+            <InlineField
+              label={t(
+                'grafana-prometheus.configuration.prom-settings.label-disable-recording-rules-beta',
+                'Disable recording rules (beta)'
+              )}
+              labelWidth={PROM_CONFIG_LABEL_WIDTH}
+              tooltip={
+                <>
+                  <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-disable-recording-rules-beta">
+                    This feature will disable recording rules. Turn this on to improve dashboard performance
+                  </Trans>
+                </>
+              }
+              interactive={true}
+              className={styles.switchField}
+              disabled={optionsWithDefaults.readOnly}
+            >
+              <Switch
+                value={optionsWithDefaults.jsonData.disableRecordingRules ?? false}
+                onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'disableRecordingRules')}
+                id={selectors.components.DataSource.Prometheus.configPage.disableRecordingRules}
+              />
             </InlineField>
           </Stack>
         </Box>
@@ -493,135 +493,139 @@ export const PromSettings = (props: Props) => {
                 'grafana-prometheus.configuration.prom-settings.label-custom-query-parameters',
                 'Custom query parameters'
               )}
-            labelWidth={PROM_CONFIG_LABEL_WIDTH}
-            tooltip={
-              <>
-                <Trans
-                  i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-custom-query-parameters"
-                  values={{
-                    example1: 'timeout',
-                    example2: 'partial_response',
-                    example3: 'dedup',
-                    example4: 'max_source_resolution',
-                    concatenationChar: '‘&’',
-                  }}
-                >
-                  Add custom parameters to the Prometheus query URL. For example {'{{example1}}'}, {'{{example2}}'},{' '}
-                  {'{{example3}}'}, or
-                  {'{{example4}}'}. Multiple parameters should be concatenated together with {'{{concatenationChar}}'}.
-                </Trans>{' '}
-                {docsTip()}
-              </>
-            }
-            interactive={true}
-            disabled={optionsWithDefaults.readOnly}
-          >
-            <Input
-              className="width-20"
-              value={optionsWithDefaults.jsonData.customQueryParameters}
-              onChange={onChangeHandler('customQueryParameters', optionsWithDefaults, onOptionsChange)}
-              spellCheck={false}
-              placeholder={t(
-                'grafana-prometheus.configuration.prom-settings.placeholder-example-maxsourceresolutionmtimeout',
-                'Example: {{example}}',
-                { example: 'max_source_resolution=5m&timeout=10' }
-              )}
-              data-testid={selectors.components.DataSource.Prometheus.configPage.customQueryParameters}
-            />
-          </InlineField>
-          {/* HTTP Method */}
-          <InlineField
-            labelWidth={PROM_CONFIG_LABEL_WIDTH}
-            tooltip={
-              <>
-                <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-http-method">
-                  You can use either POST or GET HTTP method to query your Prometheus data source. POST is the
-                  recommended method as it allows bigger queries. Change this to GET if you have a Prometheus version
-                  older than 2.1 or if POST requests are restricted in your network.
-                </Trans>{' '}
-                {docsTip()}
-              </>
-            }
-            interactive={true}
-            label={t('grafana-prometheus.configuration.prom-settings.label-http-method', 'HTTP method')}
-            disabled={optionsWithDefaults.readOnly}
-          >
-            <Select
-              width={40}
-              aria-label={t(
-                'grafana-prometheus.configuration.prom-settings.aria-label-select-http-method',
-                'Select HTTP method'
-              )}
-              options={httpOptions}
-              value={httpOptions.find((o) => o.value === optionsWithDefaults.jsonData.httpMethod)}
-              onChange={onChangeHandler('httpMethod', optionsWithDefaults, onOptionsChange)}
-              data-testid={selectors.components.DataSource.Prometheus.configPage.httpMethod}
-            />
-          </InlineField>
-          <InlineField
-            labelWidth={PROM_CONFIG_LABEL_WIDTH}
-            label={t('grafana-prometheus.configuration.prom-settings.label-series-limit', 'Series limit')}
-            tooltip={
-              <>
-                <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-series-limit">
-                  The limit applies to all resources (metrics, labels, and values) for both endpoints (series and
-                  labels). Leave the field empty to use the default limit (40000). Set to 0 to disable the limit and
-                  fetch everything — this may cause performance issues. Default limit is 40000.
-                </Trans>
-                {docsTip()}
-              </>
-            }
-            interactive={true}
-            disabled={optionsWithDefaults.readOnly}
-          >
-            <>
+              labelWidth={PROM_CONFIG_LABEL_WIDTH}
+              tooltip={
+                <>
+                  <Trans
+                    i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-custom-query-parameters"
+                    values={{
+                      example1: 'timeout',
+                      example2: 'partial_response',
+                      example3: 'dedup',
+                      example4: 'max_source_resolution',
+                      concatenationChar: '‘&’',
+                    }}
+                  >
+                    Add custom parameters to the Prometheus query URL. For example {'{{example1}}'}, {'{{example2}}'},{' '}
+                    {'{{example3}}'}, or
+                    {'{{example4}}'}. Multiple parameters should be concatenated together with {'{{concatenationChar}}'}
+                    .
+                  </Trans>{' '}
+                  {docsTip()}
+                </>
+              }
+              interactive={true}
+              disabled={optionsWithDefaults.readOnly}
+            >
               <Input
                 className="width-20"
-                value={seriesLimit}
+                value={optionsWithDefaults.jsonData.customQueryParameters}
+                onChange={onChangeHandler('customQueryParameters', optionsWithDefaults, onOptionsChange)}
                 spellCheck={false}
-                // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
-                placeholder="40000"
-                onChange={(event: { currentTarget: { value: string } }) => {
-                  setSeriesLimit(event.currentTarget.value);
-                  onOptionsChange({
-                    ...optionsWithDefaults,
-                    jsonData: {
-                      ...optionsWithDefaults.jsonData,
-                      seriesLimit: parseInt(event.currentTarget.value, 10),
-                    },
-                  });
-                }}
-                onBlur={(e) => validateInput(e.currentTarget.value, NON_NEGATIVE_INTEGER_REGEX, seriesLimitError)}
-                data-testid={selectors.components.DataSource.Prometheus.configPage.seriesLimit}
+                placeholder={t(
+                  'grafana-prometheus.configuration.prom-settings.placeholder-example-maxsourceresolutionmtimeout',
+                  'Example: {{example}}',
+                  { example: 'max_source_resolution=5m&timeout=10' }
+                )}
+                data-testid={selectors.components.DataSource.Prometheus.configPage.customQueryParameters}
               />
-              {validateInput(seriesLimit, NON_NEGATIVE_INTEGER_REGEX, seriesLimitError)}
-            </>
-          </InlineField>
-          <InlineField
-            labelWidth={PROM_CONFIG_LABEL_WIDTH}
-            label={t('grafana-prometheus.configuration.prom-settings.label-use-series-endpoint', 'Use series endpoint')}
-            tooltip={
+            </InlineField>
+            {/* HTTP Method */}
+            <InlineField
+              labelWidth={PROM_CONFIG_LABEL_WIDTH}
+              tooltip={
+                <>
+                  <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-http-method">
+                    You can use either POST or GET HTTP method to query your Prometheus data source. POST is the
+                    recommended method as it allows bigger queries. Change this to GET if you have a Prometheus version
+                    older than 2.1 or if POST requests are restricted in your network.
+                  </Trans>{' '}
+                  {docsTip()}
+                </>
+              }
+              interactive={true}
+              label={t('grafana-prometheus.configuration.prom-settings.label-http-method', 'HTTP method')}
+              disabled={optionsWithDefaults.readOnly}
+            >
+              <Select
+                width={40}
+                aria-label={t(
+                  'grafana-prometheus.configuration.prom-settings.aria-label-select-http-method',
+                  'Select HTTP method'
+                )}
+                options={httpOptions}
+                value={httpOptions.find((o) => o.value === optionsWithDefaults.jsonData.httpMethod)}
+                onChange={onChangeHandler('httpMethod', optionsWithDefaults, onOptionsChange)}
+                data-testid={selectors.components.DataSource.Prometheus.configPage.httpMethod}
+              />
+            </InlineField>
+            <InlineField
+              labelWidth={PROM_CONFIG_LABEL_WIDTH}
+              label={t('grafana-prometheus.configuration.prom-settings.label-series-limit', 'Series limit')}
+              tooltip={
+                <>
+                  <Trans i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-series-limit">
+                    The limit applies to all resources (metrics, labels, and values) for both endpoints (series and
+                    labels). Leave the field empty to use the default limit (40000). Set to 0 to disable the limit and
+                    fetch everything — this may cause performance issues. Default limit is 40000.
+                  </Trans>
+                  {docsTip()}
+                </>
+              }
+              interactive={true}
+              disabled={optionsWithDefaults.readOnly}
+            >
               <>
-                <Trans
-                  i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-use-series-endpoint"
-                  values={{ exampleParameter: 'match[]' }}
-                >
-                  Checking this option will favor the series endpoint with {'{{exampleParameter}}'} parameter over the
-                  label values endpoint with {'{{exampleParameter}}'} parameter. While the label values endpoint is
-                  considered more performant, some users may prefer the series because it has a POST method while the
-                  label values endpoint only has a GET method.
-                </Trans>{' '}
-                {docsTip()}
+                <Input
+                  className="width-20"
+                  value={seriesLimit}
+                  spellCheck={false}
+                  // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+                  placeholder="40000"
+                  onChange={(event: { currentTarget: { value: string } }) => {
+                    setSeriesLimit(event.currentTarget.value);
+                    onOptionsChange({
+                      ...optionsWithDefaults,
+                      jsonData: {
+                        ...optionsWithDefaults.jsonData,
+                        seriesLimit: parseInt(event.currentTarget.value, 10),
+                      },
+                    });
+                  }}
+                  onBlur={(e) => validateInput(e.currentTarget.value, NON_NEGATIVE_INTEGER_REGEX, seriesLimitError)}
+                  data-testid={selectors.components.DataSource.Prometheus.configPage.seriesLimit}
+                />
+                {validateInput(seriesLimit, NON_NEGATIVE_INTEGER_REGEX, seriesLimitError)}
               </>
-            }
-            interactive={true}
-            disabled={optionsWithDefaults.readOnly}
-            className={styles.switchField}
-          >
-            <Switch
-              value={optionsWithDefaults.jsonData.seriesEndpoint ?? false}
-              onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'seriesEndpoint')}
-            />
+            </InlineField>
+            <InlineField
+              labelWidth={PROM_CONFIG_LABEL_WIDTH}
+              label={t(
+                'grafana-prometheus.configuration.prom-settings.label-use-series-endpoint',
+                'Use series endpoint'
+              )}
+              tooltip={
+                <>
+                  <Trans
+                    i18nKey="grafana-prometheus.configuration.prom-settings.tooltip-use-series-endpoint"
+                    values={{ exampleParameter: 'match[]' }}
+                  >
+                    Checking this option will favor the series endpoint with {'{{exampleParameter}}'} parameter over the
+                    label values endpoint with {'{{exampleParameter}}'} parameter. While the label values endpoint is
+                    considered more performant, some users may prefer the series because it has a POST method while the
+                    label values endpoint only has a GET method.
+                  </Trans>{' '}
+                  {docsTip()}
+                </>
+              }
+              interactive={true}
+              disabled={optionsWithDefaults.readOnly}
+              className={styles.switchField}
+            >
+              <Switch
+                value={optionsWithDefaults.jsonData.seriesEndpoint ?? false}
+                onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'seriesEndpoint')}
+              />
             </InlineField>
           </Stack>
         </Box>

--- a/packages/grafana-prometheus/src/index.ts
+++ b/packages/grafana-prometheus/src/index.ts
@@ -67,7 +67,7 @@ export { transformV2, transformDFToTable, parseSampleValue, sortSeriesByLabel } 
 export {
   type PromQuery,
   type PrometheusCacheLevel,
-  type PromApplication,
+  PromApplication,
   type PromOptions,
   type ExemplarTraceIdDestination,
   type PromQueryRequest,

--- a/packages/grafana-prometheus/src/index.ts
+++ b/packages/grafana-prometheus/src/index.ts
@@ -66,7 +66,7 @@ export { getQueryHints, getInitHints } from './query_hints';
 export { transformV2, transformDFToTable, parseSampleValue, sortSeriesByLabel } from './result_transformer';
 export {
   type PromQuery,
-  type PrometheusCacheLevel,
+  PrometheusCacheLevel,
   PromApplication,
   type PromOptions,
   type ExemplarTraceIdDestination,
@@ -76,8 +76,8 @@ export {
   type PromValue,
   type PromMetric,
   type PromBuildInfoResponse,
-  type LegendFormatMode,
-  type PromVariableQueryType,
+  LegendFormatMode,
+  PromVariableQueryType,
   type PromVariableQuery,
   type StandardPromVariableQuery,
 } from './types';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- Adds `hidePrometheusTypeVersion` and `hideExemplars` to hide settings that do not apply to other flavours of the prometheus data source.
- Exports the `PromApplication` enum so it can be used as a value instead of just as a type.

**Why do we need this feature?**

This is required for https://github.com/grafana/grafana-amazonprometheus-datasource/pull/600. The Amazon Managed Service for Prometheus data source automatically sets the prom type/version so shouldn't require the user to manually set them. It also doesn't support exemplars at the moment so the setting can be hidden. The `PromApplication` enum is used as a value by the AMP data source to set the prom type so it needs to be exported as a value instead of just as a type.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

I recommend viewing the PR with `Hide whitespace` enabled.

I also removed deprecated css classes from `PromSettings.tsx` because the frontend lint was failing in CI. Here's the before and after screenshots:

Before (with existing deprecated classes)
---
<img width="607" height="727" alt="before" src="https://github.com/user-attachments/assets/1168fda2-27ef-4c03-ab90-0a703ad6d942" />


After (with deprecated classes removed)
---
<img width="607" height="727" alt="after" src="https://github.com/user-attachments/assets/1fc698e5-289c-4b96-81b6-71bf7eb9522e" />


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
