### PR TITLE
Docs: Add show values option

### DIFF
--- a/docs/sources/shared/visualizations/graph-styles-options.md
+++ b/docs/sources/shared/visualizations/graph-styles-options.md
@@ -1,7 +1,7 @@
 ---
 title: Graph styles options
 comments: |
-  This file is used in the following visualizations: time series.
+  This file is used in the following visualizations: time series, trend.
 ---
 
 <!-- prettier-ignore-start -->
@@ -17,6 +17,7 @@ comments: |
 | [Connect null values](#connect-null-values) | Choose how null values, which are gaps in the data, appear on the graph. |
 | [Disconnect values](#disconnect-values)     | Choose whether to set a threshold above which values in the data should be disconnected. |
 | [Show points](#show-points)                 | Set whether to show data points to lines or bars. |
+| Show values                                 | Set whether to show data point values above the lines or bars. |
 | Point size                                  | Set the size of the points, from 1 to 40 pixels in diameter. |
 | [Stack series](#stack-series)               | Set whether Grafana displays series on top of each other. |
 | [Bar alignment](#bar-alignment)             | Set the position of the bar relative to a data point. |


### PR DESCRIPTION
This PR adds the **Show values** switch to the shared `graph-styles-options.md` shared file used in time series and trend viz docs. Related to PR https://github.com/grafana/grafana/pull/108090
