### PR TITLE
Dashboard Import: Use k8s POST when importing V1 dashboard

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2802,11 +2802,6 @@
       "count": 1
     }
   },
-  "public/app/features/manage-dashboards/components/ImportDashboardOverview.tsx": {
-    "react-prefer-function-component/react-prefer-function-component": {
-      "count": 1
-    }
-  },
   "public/app/features/manage-dashboards/state/actions.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1

--- a/public/app/features/manage-dashboards/components/ImportDashboardOverview.tsx
+++ b/public/app/features/manage-dashboards/components/ImportDashboardOverview.tsx
@@ -46,6 +46,7 @@ interface State {
   uidReset: boolean;
 }
 
+// disabling this rule, eventually we will migrate to function components and also stop using redux
 // eslint-disable-next-line react-prefer-function-component/react-prefer-function-component
 class ImportDashboardOverviewUnConnected extends PureComponent<Props, State> {
   state: State = {

--- a/public/app/features/manage-dashboards/components/ImportDashboardOverview.tsx
+++ b/public/app/features/manage-dashboards/components/ImportDashboardOverview.tsx
@@ -61,8 +61,7 @@ class ImportDashboardOverviewUnConnected extends PureComponent<Props, State> {
     // when kubernetesDashboard are enabled, we bypass api/dashboard/import
     // and hit the k8s dashboard API directly
     if (config.featureToggles.kubernetesDashboards) {
-      // 1. process datasources so the template placeholder is replaced with the actual value user selected
-
+      // process datasources so the template placeholder is replaced with the actual value user selected
       const annotations = dashboard.annotations.list.map((annotation: AnnotationQuery) => {
         return processAnnotation(annotation, inputs, form);
       });
@@ -116,7 +115,6 @@ class ImportDashboardOverviewUnConnected extends PureComponent<Props, State> {
         },
       };
 
-      // hit v1 API directly
       const result = await getDashboardAPI('v1').saveDashboard(dashboardK8SPayload);
 
       if (result.url) {


### PR DESCRIPTION
When `kubernetesDashboards` are enabled:

- Bypass api/dashboards/import and use v1 API to save an imported dashboard, this ensures that the dashboard is saved as v1beta1
- Since we are bypassing `api/dashboards/import`, we are adding new library panels during import using `api/library-elements` directly



