### PR TITLE
Alerting: Support imported time intervals

### DIFF
--- a/apps/alerting/notifications/pkg/apis/alertingnotifications/v0alpha1/timeinterval_ext.go
+++ b/apps/alerting/notifications/pkg/apis/alertingnotifications/v0alpha1/timeinterval_ext.go
@@ -1,6 +1,8 @@
 package v0alpha1
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apiserver/pkg/registry/generic"
 )
@@ -24,6 +26,13 @@ func (o *TimeInterval) SetProvenanceStatus(status string) {
 		status = ProvenanceStatusNone
 	}
 	o.Annotations[ProvenanceStatusAnnotationKey] = status
+}
+
+func (o *TimeInterval) SetCanUse(canUse bool) {
+	if o.Annotations == nil {
+		o.Annotations = make(map[string]string, 1)
+	}
+	o.Annotations[CanUseAnnotationKey] = fmt.Sprintf("%v", canUse)
 }
 
 func TimeIntervalSelectableFields(obj *TimeInterval) fields.Set {

--- a/pkg/registry/apps/alerting/notifications/register.go
+++ b/pkg/registry/apps/alerting/notifications/register.go
@@ -97,7 +97,12 @@ func (a AppInstaller) GetLegacyStorage(gvr schema.GroupVersionResource) grafanar
 	if gvr == receiver.ResourceInfo.GroupVersionResource() {
 		return receiver.NewStorage(api.ReceiverService, namespacer, api.ReceiverService)
 	} else if gvr == timeinterval.ResourceInfo.GroupVersionResource() {
-		return timeinterval.NewStorage(api.MuteTimings, namespacer)
+		srv := api.MuteTimings
+		//nolint:staticcheck // not yet migrated to OpenFeature
+		if a.ng.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertingImportAlertmanagerAPI) {
+			srv = srv.WithIncludeImported()
+		}
+		return timeinterval.NewStorage(srv, namespacer)
 	} else if gvr == templategroup.ResourceInfo.GroupVersionResource() {
 		srv := api.Templates
 		//nolint:staticcheck // not yet migrated to OpenFeature

--- a/pkg/registry/apps/alerting/notifications/timeinterval/conversions.go
+++ b/pkg/registry/apps/alerting/notifications/timeinterval/conversions.go
@@ -66,6 +66,9 @@ func buildTimeInterval(orgID int64, interval definitions.MuteTimeInterval, spec 
 	}
 	i.SetProvenanceStatus(string(interval.Provenance))
 	i.UID = gapiutil.CalculateClusterWideUID(&i)
+
+	i.SetCanUse(ngmodels.Provenance(interval.Provenance) != ngmodels.ProvenanceConvertedPrometheus)
+
 	return i
 }
 

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -62,7 +62,7 @@ type NotificationPolicyService interface {
 
 type MuteTimingService interface {
 	GetMuteTimings(ctx context.Context, orgID int64) ([]definitions.MuteTimeInterval, error)
-	GetMuteTiming(ctx context.Context, name string, orgID int64) (definitions.MuteTimeInterval, error)
+	GetMuteTimingByName(ctx context.Context, name string, orgID int64) (definitions.MuteTimeInterval, error)
 	CreateMuteTiming(ctx context.Context, mt definitions.MuteTimeInterval, orgID int64) (definitions.MuteTimeInterval, error)
 	UpdateMuteTiming(ctx context.Context, mt definitions.MuteTimeInterval, orgID int64) (definitions.MuteTimeInterval, error)
 	DeleteMuteTiming(ctx context.Context, name string, orgID int64, provenance definitions.Provenance, version string) error
@@ -245,7 +245,7 @@ func (srv *ProvisioningSrv) RouteDeleteTemplate(c *contextmodel.ReqContext, name
 }
 
 func (srv *ProvisioningSrv) RouteGetMuteTiming(c *contextmodel.ReqContext, name string) response.Response {
-	timing, err := srv.muteTimings.GetMuteTiming(c.Req.Context(), name, c.GetOrgID())
+	timing, err := srv.muteTimings.GetMuteTimingByName(c.Req.Context(), name, c.GetOrgID())
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to get mute timing by name", err)
 	}

--- a/pkg/services/ngalert/notifier/legacy_storage/imported.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 
 	"github.com/grafana/alerting/definition"
+	"github.com/prometheus/alertmanager/config"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -66,6 +67,53 @@ func (e ImportedConfigRevision) GetReceivers(uids []string) ([]*models.Receiver,
 		}
 		result = append(result, recv)
 	}
+	return result, nil
+}
+
+func (e ImportedConfigRevision) GetMuteTimeIntervals() ([]config.MuteTimeInterval, error) {
+	if e.importedConfig == nil {
+		return nil, nil
+	}
+
+	// Get original imported intervals (before deduplication)
+	importedMute := e.importedConfig.GetMuteTimeIntervals()
+	importedTime := e.importedConfig.GetTimeIntervals()
+
+	if len(importedMute) == 0 && len(importedTime) == 0 {
+		return nil, nil
+	}
+
+	// Get Grafana time intervals for merge
+	grafanaMute := e.rev.Config.AlertmanagerConfig.MuteTimeIntervals
+	grafanaTime := e.rev.Config.AlertmanagerConfig.TimeIntervals
+
+	// Merge to get the renames map (only renamed if name collision occurs)
+	_, renames := definition.MergeTimeIntervals(
+		grafanaMute,
+		grafanaTime,
+		importedMute,
+		importedTime,
+		e.opts.DedupSuffix,
+	)
+
+	// Apply renames to imported intervals
+	result := make([]config.MuteTimeInterval, 0, len(importedTime)+len(importedMute))
+
+	pushRenamed := func(mt config.MuteTimeInterval) {
+		if newName, renamed := renames[mt.Name]; renamed {
+			mt.Name = newName
+		}
+		result = append(result, mt)
+	}
+
+	for _, ti := range importedTime {
+		pushRenamed(config.MuteTimeInterval(ti))
+	}
+
+	for _, mti := range importedMute {
+		pushRenamed(mti)
+	}
+
 	return result, nil
 }
 

--- a/pkg/services/ngalert/provisioning/errors.go
+++ b/pkg/services/ngalert/provisioning/errors.go
@@ -22,6 +22,10 @@ var (
 		"Time interval cannot be renamed because it is used by provisioned {{ if .Public.UsedByRules }}alert rules{{ end }}{{ if .Public.UsedByRoutes }}{{ if .Public.UsedByRules }} and {{ end }}notification policies{{ end }}",
 		errutil.WithPublic(`Time interval cannot be renamed because it is used by provisioned {{ if .Public.UsedByRules }}alert rules{{ end }}{{ if .Public.UsedByRoutes }}{{ if .Public.UsedByRules }} and {{ end }}notification policies{{ end }}. You must update those resources first using the original provision method.`),
 	)
+	ErrTimeIntervalOrigin = errutil.BadRequest("alerting.notifications.time-intervals.originInvalid").MustTemplate(
+		"Time interval '{{ .Public.Name }}' cannot be {{ .Public.Action }}d because it belongs to an imported configuration.",
+		errutil.WithPublic("Time interval '{{ .Public.Name }}' cannot be {{ .Public.Action }}d because it belongs to an imported configuration. Finish the import of the configuration first."),
+	)
 
 	ErrTemplateNotFound = errutil.NotFound("alerting.notifications.templates.notFound")
 	ErrTemplateInvalid  = errutil.BadRequest("alerting.notifications.templates.invalidFormat").MustTemplate("Invalid format of the submitted template", errutil.WithPublic("Template is in invalid format. Correct the payload and try again."))
@@ -137,4 +141,10 @@ func MakeErrContactPointUidExists(uid, name string) error {
 
 func makeErrTemplateOrigin(t definitions.NotificationTemplate, action string) error {
 	return ErrTemplateOrigin.Build(errutil.TemplateData{Public: map[string]interface{}{"Action": action, "Name": t.Name}})
+}
+
+func makeErrMuteTimeIntervalOrigin(mt definitions.MuteTimeInterval, action string) error {
+	return ErrTimeIntervalOrigin.Build(errutil.TemplateData{
+		Public: map[string]interface{}{"Action": action, "Name": mt.Name},
+	})
 }

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -135,10 +135,16 @@ func (svc *MuteTimingService) CreateMuteTiming(ctx context.Context, mt definitio
 		return definitions.MuteTimeInterval{}, err
 	}
 
-	_, found := getMuteTimingByName(revision, mt.Name)
-	if found {
+	grafanaIntervals := getGrafanaTimeIntervals(revision)
+	if idx := slices.IndexFunc(grafanaIntervals, findByName(mt.Name)); idx != -1 {
 		return definitions.MuteTimeInterval{}, ErrTimeIntervalExists.Errorf("")
 	}
+
+	importedIntervals := svc.getImportedTimeIntervals(revision)
+	if idx := slices.IndexFunc(importedIntervals, findByName(mt.Name)); idx != -1 {
+		return definitions.MuteTimeInterval{}, ErrTimeIntervalExists.Errorf("")
+	}
+
 	revision.Config.AlertmanagerConfig.TimeIntervals = append(revision.Config.AlertmanagerConfig.TimeIntervals, config.TimeInterval(mt.MuteTimeInterval))
 
 	err = svc.xact.InTransaction(ctx, func(ctx context.Context) error {
@@ -150,12 +156,8 @@ func (svc *MuteTimingService) CreateMuteTiming(ctx context.Context, mt definitio
 	if err != nil {
 		return definitions.MuteTimeInterval{}, err
 	}
-	return definitions.MuteTimeInterval{
-		UID:              legacy_storage.NameToUid(mt.Name),
-		MuteTimeInterval: mt.MuteTimeInterval,
-		Version:          calculateMuteTimeIntervalFingerprint(mt.MuteTimeInterval),
-		Provenance:       mt.Provenance,
-	}, nil
+
+	return newMuteTimingInterval(mt.MuteTimeInterval, mt.Provenance), nil
 }
 
 // UpdateMuteTiming replaces an existing mute timing within the specified org. The replaced mute timing is returned. If the mute timing does not exist, ErrMuteTimingsNotFound is returned.

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -140,11 +140,6 @@ func (svc *MuteTimingService) CreateMuteTiming(ctx context.Context, mt definitio
 		return definitions.MuteTimeInterval{}, ErrTimeIntervalExists.Errorf("")
 	}
 
-	importedIntervals := svc.getImportedTimeIntervals(revision)
-	if idx := slices.IndexFunc(importedIntervals, findByName(mt.Name)); idx != -1 {
-		return definitions.MuteTimeInterval{}, ErrTimeIntervalExists.Errorf("")
-	}
-
 	revision.Config.AlertmanagerConfig.TimeIntervals = append(revision.Config.AlertmanagerConfig.TimeIntervals, config.TimeInterval(mt.MuteTimeInterval))
 
 	err = svc.xact.InTransaction(ctx, func(ctx context.Context) error {

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -3,6 +3,7 @@ package provisioning
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"slices"
@@ -309,18 +310,71 @@ func isTimeIntervalInUseInRoutes(name string, route *definitions.Route) bool {
 	return false
 }
 
-func getMuteTimingByName(rev *legacy_storage.ConfigRevision, name string) (config.MuteTimeInterval, bool) {
-	intervals := getTimeIntervals(rev)
-	idx := slices.IndexFunc(intervals, func(interval config.MuteTimeInterval) bool {
-		return interval.Name == name
-	})
-	if idx == -1 {
-		return config.MuteTimeInterval{}, false
-	}
-	return intervals[idx], true
+func (svc *MuteTimingService) getMuteTimingByName(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, name string) (definitions.MuteTimeInterval, bool, error) {
+	return svc.getMuteTimingBy(ctx, revision, orgID, findByName(name))
 }
 
-func getTimeIntervals(rev *legacy_storage.ConfigRevision) []config.MuteTimeInterval {
+func (svc *MuteTimingService) getMuteTimingByUID(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, uid string) (definitions.MuteTimeInterval, bool, error) {
+	return svc.getMuteTimingBy(ctx, revision, orgID, findByUID(uid))
+}
+
+func (svc *MuteTimingService) getMuteTimingBy(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, find func(config.MuteTimeInterval) bool) (definitions.MuteTimeInterval, bool, error) {
+	grafanaIntervals := getGrafanaTimeIntervals(revision)
+	if idx := slices.IndexFunc(grafanaIntervals, find); idx != -1 {
+		interval := grafanaIntervals[idx]
+
+		prov, err := svc.provenanceStore.GetProvenance(ctx, &definitions.MuteTimeInterval{UID: legacy_storage.NameToUid(interval.Name), MuteTimeInterval: interval}, orgID)
+		if err != nil {
+			return definitions.MuteTimeInterval{}, false, err
+		}
+
+		return newMuteTimingInterval(interval, definitions.Provenance(prov)), true, nil
+	}
+
+	if importedIntervals := svc.getImportedTimeIntervals(revision); len(importedIntervals) > 0 {
+		if idx := slices.IndexFunc(importedIntervals, find); idx != -1 {
+			interval := importedIntervals[idx]
+
+			return newMuteTimingInterval(interval, definitions.Provenance(models.ProvenanceConvertedPrometheus)), true, nil
+		}
+	}
+
+	return definitions.MuteTimeInterval{}, false, nil
+}
+
+func (svc *MuteTimingService) getImportedTimeIntervals(rev *legacy_storage.ConfigRevision) []config.MuteTimeInterval {
+	if !svc.includeImported {
+		return nil
+	}
+
+	imported, err := rev.Imported()
+	if err != nil {
+		svc.log.Warn("failed to get imported config revision for mute time intervals", "error", err)
+		return nil
+	}
+
+	intervals, err := imported.GetMuteTimeIntervals()
+	if err != nil {
+		svc.log.Warn("failed to get imported mute time intervals", "error", err)
+		return nil
+	}
+
+	return intervals
+}
+
+func findByName(name string) func(config.MuteTimeInterval) bool {
+	return func(interval config.MuteTimeInterval) bool {
+		return interval.Name == name
+	}
+}
+
+func findByUID(uid string) func(config.MuteTimeInterval) bool {
+	return func(interval config.MuteTimeInterval) bool {
+		return legacy_storage.NameToUid(interval.Name) == uid
+	}
+}
+
+func getGrafanaTimeIntervals(rev *legacy_storage.ConfigRevision) []config.MuteTimeInterval {
 	result := make([]config.MuteTimeInterval, 0, len(rev.Config.AlertmanagerConfig.TimeIntervals)+len(rev.Config.AlertmanagerConfig.MuteTimeIntervals))
 	for _, interval := range rev.Config.AlertmanagerConfig.TimeIntervals {
 		result = append(result, config.MuteTimeInterval(interval))
@@ -344,9 +398,7 @@ func updateTimeInterval(rev *legacy_storage.ConfigRevision, interval config.Mute
 }
 
 func deleteTimeInterval(rev *legacy_storage.ConfigRevision, interval config.MuteTimeInterval) {
-	rev.Config.AlertmanagerConfig.MuteTimeIntervals = slices.DeleteFunc(rev.Config.AlertmanagerConfig.MuteTimeIntervals, func(i config.MuteTimeInterval) bool {
-		return i.Name == interval.Name
-	})
+	rev.Config.AlertmanagerConfig.MuteTimeIntervals = slices.DeleteFunc(rev.Config.AlertmanagerConfig.MuteTimeIntervals, findByName(interval.Name))
 	rev.Config.AlertmanagerConfig.TimeIntervals = slices.DeleteFunc(rev.Config.AlertmanagerConfig.TimeIntervals, func(i config.TimeInterval) bool {
 		return i.Name == interval.Name
 	})
@@ -469,4 +521,13 @@ func replaceMuteTiming(route *definitions.Route, oldName, newName string) int {
 		updated += replaceMuteTiming(route, oldName, newName)
 	}
 	return updated
+}
+
+func newMuteTimingInterval(interval config.MuteTimeInterval, provenance definitions.Provenance) definitions.MuteTimeInterval {
+	return definitions.MuteTimeInterval{
+		UID:              legacy_storage.NameToUid(interval.Name),
+		MuteTimeInterval: interval,
+		Version:          calculateMuteTimeIntervalFingerprint(interval),
+		Provenance:       provenance,
+	}
 }

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -27,6 +27,7 @@ type MuteTimingService struct {
 	log                    log.Logger
 	validator              validation.ProvenanceStatusTransitionValidator
 	ruleNotificationsStore AlertRuleNotificationSettingsStore
+	includeImported        bool
 }
 
 func NewMuteTimingService(config alertmanagerConfigStore, prov ProvisioningStore, xact TransactionManager, log log.Logger, ns AlertRuleNotificationSettingsStore) *MuteTimingService {
@@ -37,6 +38,19 @@ func NewMuteTimingService(config alertmanagerConfigStore, prov ProvisioningStore
 		log:                    log,
 		validator:              validation.ValidateProvenanceRelaxed,
 		ruleNotificationsStore: ns,
+		includeImported:        false,
+	}
+}
+
+func (svc *MuteTimingService) WithIncludeImported() *MuteTimingService {
+	return &MuteTimingService{
+		configStore:            svc.configStore,
+		provenanceStore:        svc.provenanceStore,
+		xact:                   svc.xact,
+		log:                    svc.log,
+		validator:              svc.validator,
+		ruleNotificationsStore: svc.ruleNotificationsStore,
+		includeImported:        true,
 	}
 }
 

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -171,48 +171,48 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt definitio
 		return definitions.MuteTimeInterval{}, err
 	}
 
-	var old config.MuteTimeInterval
-	found := false
+	var found bool
+	var existing definitions.MuteTimeInterval
 	if mt.UID != "" {
-		name, err := legacy_storage.UidToName(mt.UID)
-		if err == nil {
-			old, found = getMuteTimingByName(revision, name)
-		}
+		existing, found, err = svc.getMuteTimingByUID(ctx, revision, orgID, mt.UID)
 	} else {
-		old, found = getMuteTimingByName(revision, mt.Name)
+		existing, found, err = svc.getMuteTimingByName(ctx, revision, orgID, mt.Name)
 	}
-	if !found {
+	if err != nil {
+		return definitions.MuteTimeInterval{}, err
+	} else if !found {
 		return definitions.MuteTimeInterval{}, ErrTimeIntervalNotFound.Errorf("")
 	}
 
-	// check optimistic concurrency
-	err = svc.checkOptimisticConcurrency(old, models.Provenance(mt.Provenance), mt.Version, "update")
-	if err != nil {
-		return definitions.MuteTimeInterval{}, err
+	if existing.Provenance == definitions.Provenance(models.ProvenanceConvertedPrometheus) {
+		return definitions.MuteTimeInterval{}, makeErrMuteTimeIntervalOrigin(existing, "update")
 	}
 
 	// check that provenance is not changed in an invalid way
-	storedProvenance, err := svc.provenanceStore.GetProvenance(ctx, &definitions.MuteTimeInterval{MuteTimeInterval: old}, orgID)
-	if err != nil {
+	if err := svc.validator(models.Provenance(existing.Provenance), models.Provenance(mt.Provenance)); err != nil {
 		return definitions.MuteTimeInterval{}, err
 	}
-	if err := svc.validator(storedProvenance, models.Provenance(mt.Provenance)); err != nil {
+
+	existingInterval := existing.MuteTimeInterval
+
+	// check optimistic concurrency
+	if err = svc.checkOptimisticConcurrency(existingInterval, models.Provenance(mt.Provenance), mt.Version, "update"); err != nil {
 		return definitions.MuteTimeInterval{}, err
 	}
 
 	// TODO add diff and noop detection
 	err = svc.xact.InTransaction(ctx, func(ctx context.Context) error {
 		// if the name of the time interval changed
-		if old.Name != mt.Name {
-			deleteTimeInterval(revision, old)
+		if existingInterval.Name != mt.Name {
+			deleteTimeInterval(revision, existingInterval)
 			revision.Config.AlertmanagerConfig.TimeIntervals = append(revision.Config.AlertmanagerConfig.TimeIntervals, config.TimeInterval(mt.MuteTimeInterval))
 
-			err = svc.renameTimeIntervalInDependentResources(ctx, orgID, revision.Config.AlertmanagerConfig.Route, old.Name, mt.Name, models.Provenance(mt.Provenance))
+			err = svc.renameTimeIntervalInDependentResources(ctx, orgID, revision.Config.AlertmanagerConfig.Route, existingInterval.Name, mt.Name, models.Provenance(mt.Provenance))
 			if err != nil {
 				return err
 			}
 
-			err = svc.provenanceStore.DeleteProvenance(ctx, &definitions.MuteTimeInterval{MuteTimeInterval: old}, orgID)
+			err = svc.provenanceStore.DeleteProvenance(ctx, &existing, orgID)
 			if err != nil {
 				return err
 			}
@@ -227,12 +227,8 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt definitio
 	if err != nil {
 		return definitions.MuteTimeInterval{}, err
 	}
-	return definitions.MuteTimeInterval{
-		UID:              legacy_storage.NameToUid(mt.Name),
-		MuteTimeInterval: mt.MuteTimeInterval,
-		Version:          calculateMuteTimeIntervalFingerprint(mt.MuteTimeInterval),
-		Provenance:       mt.Provenance,
-	}, err
+
+	return newMuteTimingInterval(mt.MuteTimeInterval, mt.Provenance), nil
 }
 
 // DeleteMuteTiming deletes the mute timing with the given name in the given org. If the mute timing does not exist, no error is returned.

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -639,6 +639,37 @@ func TestUpdateMuteTimings(t *testing.T) {
 		require.ErrorIs(t, err, expectedErr)
 	})
 
+	t.Run("rejects mute timings if new name already exists", func(t *testing.T) {
+		sut, store, prov := createMuteTimingSvcSut()
+		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
+			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
+		}
+		sut.validator = func(from, to models.Provenance) error {
+			return nil
+		}
+		timing := definitions.MuteTimeInterval{
+			UID: legacy_storage.NameToUid("Test2"),
+			MuteTimeInterval: config.MuteTimeInterval{
+				Name: "Test",
+				TimeIntervals: []timeinterval.TimeInterval{
+					{
+						Times: []timeinterval.TimeRange{
+							{
+								StartMinute: 10, EndMinute: 60,
+							},
+						},
+					},
+				},
+			},
+			Provenance: definitions.Provenance(expectedProvenance),
+		}
+
+		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(expectedProvenance, nil)
+
+		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
+		require.ErrorIs(t, err, ErrTimeIntervalExists)
+	})
+
 	t.Run("returns ErrVersionConflict if storage version does not match", func(t *testing.T) {
 		sut, store, prov := createMuteTimingSvcSut()
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -123,6 +124,92 @@ func TestGetMuteTimings(t *testing.T) {
 			require.ErrorIs(t, err, expected)
 		})
 	})
+
+	t.Run("with imported intervals", func(t *testing.T) {
+		grafanaIntervals := []config.MuteTimeInterval{
+			{Name: "grafana-interval"},
+		}
+		importedIntervals := []config.MuteTimeInterval{
+			{Name: "imported-interval"},
+		}
+		revision := createConfigWithImportedIntervals(grafanaIntervals, importedIntervals)
+
+		provenances := map[string]models.Provenance{
+			"grafana-interval": models.ProvenanceAPI,
+		}
+
+		t.Run("returns only Grafana intervals without WithIncludeImported", func(t *testing.T) {
+			sut, store, prov := createMuteTimingSvcSut()
+			store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
+				return revision, nil
+			}
+			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(provenances, nil)
+
+			result, err := sut.GetMuteTimings(context.Background(), orgID)
+
+			require.NoError(t, err)
+			require.Len(t, result, 1)
+			require.Equal(t, "grafana-interval", result[0].Name)
+			require.EqualValues(t, models.ProvenanceAPI, result[0].Provenance)
+		})
+
+		t.Run("returns both Grafana and imported intervals with WithIncludeImported", func(t *testing.T) {
+			sut, store, prov := createMuteTimingSvcSut()
+			sut = sut.WithIncludeImported()
+
+			store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
+				return revision, nil
+			}
+			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(provenances, nil)
+
+			result, err := sut.GetMuteTimings(context.Background(), orgID)
+
+			require.NoError(t, err)
+			require.Len(t, result, 2)
+
+			// Find Grafana interval
+			var grafanaInterval *definitions.MuteTimeInterval
+			var importedInterval *definitions.MuteTimeInterval
+			for i := range result {
+				switch name := result[i].Name; name {
+				case "grafana-interval":
+					grafanaInterval = &result[i]
+				case "imported-interval":
+					importedInterval = &result[i]
+				}
+			}
+
+			require.NotNil(t, grafanaInterval, "Grafana interval not found")
+			require.NotNil(t, importedInterval, "Imported interval not found")
+
+			// Verify Grafana interval
+			require.Equal(t, "grafana-interval", grafanaInterval.Name)
+			require.EqualValues(t, models.ProvenanceAPI, grafanaInterval.Provenance)
+			require.Equal(t, legacy_storage.NameToUid(grafanaInterval.Name), grafanaInterval.UID)
+
+			// Verify imported interval
+			require.Equal(t, "imported-interval", importedInterval.Name)
+			require.EqualValues(t, models.ProvenanceConvertedPrometheus, importedInterval.Provenance)
+			require.Equal(t, legacy_storage.NameToUid(importedInterval.Name), importedInterval.UID)
+		})
+
+		t.Run("handles empty ExtraConfigs", func(t *testing.T) {
+			sut, store, prov := createMuteTimingSvcSut()
+			sut = sut.WithIncludeImported()
+
+			emptyRevision := createConfigWithImportedIntervals(grafanaIntervals, nil)
+			store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
+				return emptyRevision, nil
+			}
+			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(provenances, nil)
+
+			result, err := sut.GetMuteTimings(context.Background(), orgID)
+
+			require.NoError(t, err)
+			require.Len(t, result, 1)
+			require.Equal(t, "grafana-interval", result[0].Name)
+		})
+	})
 }
 
 func TestGetMuteTiming(t *testing.T) {
@@ -168,7 +255,9 @@ func TestGetMuteTiming(t *testing.T) {
 		require.Equal(t, "Get", store.Calls[0].Method)
 		require.Equal(t, orgID, store.Calls[0].Args[1])
 
-		prov.AssertCalled(t, "GetProvenance", mock.Anything, &result, orgID)
+		prov.AssertCalled(t, "GetProvenance", mock.Anything, mock.MatchedBy(func(mt *definitions.MuteTimeInterval) bool {
+			return mt.Name == result.Name
+		}), orgID)
 
 		t.Run("and by UID", func(t *testing.T) {
 			result2, err := sut.GetMuteTiming(context.Background(), result.UID, orgID)
@@ -199,7 +288,9 @@ func TestGetMuteTiming(t *testing.T) {
 		require.Equal(t, "Get", store.Calls[0].Method)
 		require.Equal(t, orgID, store.Calls[0].Args[1])
 
-		prov.AssertCalled(t, "GetProvenance", mock.Anything, &result, orgID)
+		prov.AssertCalled(t, "GetProvenance", mock.Anything, mock.MatchedBy(func(mt *definitions.MuteTimeInterval) bool {
+			return mt.Name == result.Name
+		}), orgID)
 
 		t.Run("and by UID", func(t *testing.T) {
 			result2, err := sut.GetMuteTiming(context.Background(), result.UID, orgID)
@@ -317,10 +408,11 @@ func TestCreateMuteTimings(t *testing.T) {
 	})
 
 	t.Run("returns ErrTimeIntervalExists if mute timing with the name exists", func(t *testing.T) {
-		sut, store, _ := createMuteTimingSvcSut()
+		sut, store, prov := createMuteTimingSvcSut()
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 		}
+		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 
 		existing := initialConfig().AlertmanagerConfig.MuteTimeIntervals[0]
 		timing := definitions.MuteTimeInterval{
@@ -1261,4 +1353,75 @@ func createMuteTimingSvcSut() (*MuteTimingService, *legacy_storage.AlertmanagerC
 		},
 		ruleNotificationsStore: &fakeAlertRuleNotificationStore{},
 	}, store, prov
+}
+
+// buildMimirAMConfigWithTimeIntervals creates a Mimir alertmanager config YAML string
+// containing the provided time intervals for use in ExtraConfigs.
+// This generates a minimal but valid Prometheus alertmanager config with a route and receiver.
+func buildMimirAMConfigWithTimeIntervals(intervals []config.MuteTimeInterval) string {
+	if len(intervals) == 0 {
+		return ""
+	}
+
+	// Start with required route and receivers
+	yaml := "route:\n"
+	yaml += "  receiver: test-receiver\n"
+	yaml += "receivers:\n"
+	yaml += "  - name: test-receiver\n"
+
+	// Add time intervals
+	yaml += "time_intervals:\n"
+	for _, interval := range intervals {
+		yaml += fmt.Sprintf("  - name: %s\n", interval.Name)
+		if len(interval.TimeIntervals) > 0 {
+			yaml += "    time_intervals:\n"
+			for _, ti := range interval.TimeIntervals {
+				yaml += "      -\n"
+				if len(ti.Times) > 0 {
+					yaml += "        times:\n"
+					for _, tr := range ti.Times {
+						yaml += fmt.Sprintf("          - start_time: '%02d:%02d'\n", tr.StartMinute/60, tr.StartMinute%60)
+						yaml += fmt.Sprintf("            end_time: '%02d:%02d'\n", tr.EndMinute/60, tr.EndMinute%60)
+					}
+				}
+				if len(ti.Weekdays) > 0 {
+					yaml += "        weekdays:\n"
+					for _, wd := range ti.Weekdays {
+						// WeekdayRange uses InclusiveRange with Begin/End
+						if wd.Begin == wd.End {
+							yaml += fmt.Sprintf("          - %d\n", wd.Begin)
+						} else {
+							yaml += fmt.Sprintf("          - %d:%d\n", wd.Begin, wd.End)
+						}
+					}
+				}
+			}
+		}
+	}
+	return yaml
+}
+
+// createConfigWithImportedIntervals creates a ConfigRevision with both Grafana and imported
+// Mimir time intervals for testing.
+func createConfigWithImportedIntervals(grafanaIntervals []config.MuteTimeInterval, importedIntervals []config.MuteTimeInterval) *legacy_storage.ConfigRevision {
+	cfg := &definitions.PostableUserConfig{
+		AlertmanagerConfig: definitions.PostableApiAlertingConfig{
+			Config: definitions.Config{
+				MuteTimeIntervals: grafanaIntervals,
+			},
+		},
+	}
+
+	if len(importedIntervals) > 0 {
+		mimirConfig := buildMimirAMConfigWithTimeIntervals(importedIntervals)
+		cfg.ExtraConfigs = []definitions.ExtraConfiguration{
+			{
+				Identifier:         "test-mimir",
+				MergeMatchers:      config.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "__imported", Value: "test"}},
+				AlertmanagerConfig: mimirConfig,
+			},
+		}
+	}
+
+	return &legacy_storage.ConfigRevision{Config: cfg}
 }

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -296,9 +296,7 @@ func TestGetMuteTimingByName(t *testing.T) {
 				require.ErrorIs(t, err, expected)
 			})
 		})
-
 	})
-
 }
 
 func TestGetMuteTimingByUID(t *testing.T) {

--- a/pkg/tests/apis/alerting/notifications/timeinterval/imported_test.go
+++ b/pkg/tests/apis/alerting/notifications/timeinterval/imported_test.go
@@ -1,0 +1,125 @@
+package timeinterval
+
+import (
+	"context"
+	"path"
+	"testing"
+
+	"github.com/grafana/grafana-app-sdk/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/tests/api/alerting"
+	"github.com/grafana/grafana/pkg/tests/apis"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+func TestIntegrationImportedTimeIntervals(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+		EnableFeatureToggles: []string{
+			featuremgmt.FlagAlertingImportAlertmanagerAPI,
+		},
+	})
+
+	client, err := v0alpha1.NewTimeIntervalClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
+
+	cliCfg := helper.Org1.Admin.NewRestConfig()
+	alertingApi := alerting.NewAlertingLegacyAPIClient(helper.GetEnv().Server.HTTPServer.Listener.Addr().String(), cliCfg.Username, cliCfg.Password)
+
+	configYaml, err := testData.ReadFile(path.Join("test-data", "imported.yaml"))
+	require.NoError(t, err)
+
+	identifier := "test-imported-time-intervals"
+	mergeMatchers := "_imported=true"
+
+	headers := map[string]string{
+		"Content-Type":                         "application/yaml",
+		"X-Grafana-Alerting-Config-Identifier": identifier,
+		"X-Grafana-Alerting-Merge-Matchers":    mergeMatchers,
+	}
+	var amConfig apimodels.AlertmanagerUserConfig
+	require.NoError(t, yaml.Unmarshal(configYaml, &amConfig))
+
+	response := alertingApi.ConvertPrometheusPostAlertmanagerConfig(t, amConfig, headers)
+	require.Equal(t, "success", response.Status)
+
+	timeIntervals, err := client.List(context.Background(), apis.DefaultNamespace, resource.ListOptions{})
+
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(timeIntervals.Items), 2, "should have at least 2 imported time intervals")
+
+	// Find our imported intervals
+	var businessHours, weekends *v0alpha1.TimeInterval
+	for i := range timeIntervals.Items {
+		switch name := timeIntervals.Items[i].Spec.Name; name {
+		case "business-hours":
+			businessHours = &timeIntervals.Items[i]
+		case "weekends":
+			weekends = &timeIntervals.Items[i]
+		}
+	}
+
+	require.NotNil(t, businessHours, "business-hours interval not found")
+	require.NotNil(t, weekends, "weekends interval not found")
+
+	t.Run("should be provisioned with converted prometheus provenance", func(t *testing.T) {
+		assert.EqualValues(t, models.ProvenanceConvertedPrometheus, businessHours.GetProvenanceStatus())
+		assert.EqualValues(t, models.ProvenanceConvertedPrometheus, weekends.GetProvenanceStatus())
+	})
+
+	t.Run("should have correct canUse annotation", func(t *testing.T) {
+		assert.Equal(t, "false", businessHours.Annotations[v0alpha1.CanUseAnnotationKey])
+		assert.Equal(t, "false", weekends.Annotations[v0alpha1.CanUseAnnotationKey])
+	})
+
+	t.Run("should not be able to update", func(t *testing.T) {
+		interval := *businessHours
+		if len(interval.Spec.TimeIntervals) > 0 && len(interval.Spec.TimeIntervals[0].Times) > 0 {
+			interval.Spec.TimeIntervals[0].Times[0].StartTime = "08:00"
+		}
+
+		_, err := client.Update(context.Background(), &interval, resource.UpdateOptions{})
+		require.Truef(t, errors.IsBadRequest(err), "expected bad request but got %s", err)
+	})
+
+	t.Run("should not be able to delete", func(t *testing.T) {
+		err := client.Delete(context.Background(), businessHours.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
+		require.Truef(t, errors.IsBadRequest(err), "expected bad request but got %s", err)
+	})
+
+	t.Run("should prevent duplicate names across Grafana and imported intervals", func(t *testing.T) {
+		// Create a Grafana time interval with the same name as an imported one
+		interval := v0alpha1.TimeInterval{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+			},
+			Spec: v0alpha1.TimeIntervalSpec{
+				Name: "business-hours",
+				TimeIntervals: []v0alpha1.TimeIntervalInterval{
+					{
+						Times: []v0alpha1.TimeIntervalTimeRange{
+							{
+								StartTime: "10:00",
+								EndTime:   "16:00",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := client.Create(context.Background(), &interval, resource.CreateOptions{})
+		require.Truef(t, errors.IsBadRequest(err), "expected bad request but got %s", err)
+	})
+}

--- a/pkg/tests/apis/alerting/notifications/timeinterval/test-data/imported.yaml
+++ b/pkg/tests/apis/alerting/notifications/timeinterval/test-data/imported.yaml
@@ -1,0 +1,17 @@
+alertmanager_config: |
+  route:
+    receiver: sinkhole
+    group_by:
+      - alertname
+  receivers:
+    - name: sinkhole
+  time_intervals:
+    - name: business-hours
+      time_intervals:
+        - times:
+          - start_time: '09:00'
+            end_time: '17:00'
+          weekdays: ['monday:friday']
+    - name: weekends
+      time_intervals:
+        - weekdays: ['saturday', 'sunday']


### PR DESCRIPTION
## Summary

Refactors mute timing service CRUD operations to properly support imported Mimir/Prometheus time intervals. Improves code organization with helper methods and ensures correct handling of imported intervals across all operations.

## Changes

### New Helper Methods

- `getImportedTimeIntervals`: Encapsulates extraction logic from `ExtraConfigs[0]`, respects `includeImported` flag
- `getMuteTiming`: DRY helper for name/UID lookup across Grafana and imported intervals

### Refactored CRUD Operations

**GetMuteTimings/GetMuteTiming:**
- Uses new helpers for cleaner separation between Grafana and imported intervals
- Sets provenance correctly (`ProvenanceConvertedPrometheus` for imported)

**CreateMuteTiming:**
- Blocks creation when name exists in imported configs (prevents UID collisions)

**UpdateMuteTiming/DeleteMuteTiming:**
- Explicit provenance checks block mutations on imported intervals
- Consistent error handling with `makeErrMuteTimeIntervalOrigin`

### Feature Toggle Integration

- Wires up `.WithIncludeImported()` when `alertingAlertmanagerRemoteSecondary` feature toggle is enabled
- `includeImported=false` for file provisioning (manages only Grafana resources)
- `includeImported=true` for API provisioning (visibility of all intervals)

## Design Notes

**Symmetric vs Asymmetric Design:**
Unlike templates which use Kind-aware UIDs (`"grafana|name"` vs `"mimir|name"`), mute timings lack a Kind field. Same names generate identical UIDs, requiring symmetric lookups where both `getMuteTimingByName` and `getMuteTimingByUID` respect the `includeImported` flag to prevent collisions.