### PR TITLE
Test: Opt-in test coverage CI check by codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1057,6 +1057,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /scripts/clean-git-or-error.sh @grafana/grafana-as-code
 /scripts/grafana-server/ @grafana/grafana-frontend-platform
 /scripts/check-frontend-dev.sh @grafana/grafana-frontend-platform
+/scripts/compare-coverage-by-codeowner.js @grafana/dataviz-squad
 /scripts/helpers/ @grafana/grafana-developer-enablement-squad
 /scripts/import_many_dashboards.sh @torkelo
 /scripts/mixin-check.sh @bergquist
@@ -1296,6 +1297,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/swagger-gen.yml @grafana/grafana-backend-group
 /.github/workflows/pr-frontend-unit-tests.yml @grafana/grafana-frontend-platform
 /.github/workflows/frontend-lint.yml @grafana/grafana-frontend-platform
+/.github/workflows/pr-coverage-by-team.yml @grafana/dataviz-squad
 /.github/workflows/analytics-events-report.yml @grafana/grafana-frontend-platform
 /.github/workflows/pr-e2e-tests.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/skye-add-to-project.yml @grafana/grafana-frontend-platform

--- a/.github/workflows/pr-coverage-by-team.yml
+++ b/.github/workflows/pr-coverage-by-team.yml
@@ -1,0 +1,207 @@
+name: PR Coverage by Team
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '**/*.js'
+      - '**/*.jsx'
+      - '**/*.ts'
+      - '**/*.tsx'
+      - 'package.json'
+      - '.github/CODEOWNERS'
+
+permissions: {}
+
+jobs:
+  setup:
+    name: Generate team slugs
+    runs-on: ubuntu-x64-small
+    permissions:
+      contents: read
+    outputs:
+      team-slugs: ${{ steps.generate-slugs.outputs.team-slugs }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Generate team slugs
+        id: generate-slugs
+        run: |
+          # Generate slugs using pure bash (no Node.js dependencies)
+          # Transform: @grafana/dataviz-squad -> team-grafana-dataviz-squad
+          TEAMS=("@grafana/dataviz-squad" "@grafana/datapro")
+          
+          JSON="{"
+          for TEAM in "${TEAMS[@]}"; do
+            # Remove @ and replace / with -
+            SLUG="${TEAM/@/team-}"
+            SLUG="${SLUG//\//-}"
+            JSON+="\"$TEAM\":\"$SLUG\","
+          done
+          JSON="${JSON%,}}"
+          
+          echo "team-slugs=$JSON" >> "$GITHUB_OUTPUT"
+
+  coverage:
+    name: Coverage ${{ matrix.branch }} - ${{ matrix.team }}
+    needs: [setup]
+    runs-on: ubuntu-x64-large
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # Opted-in teams for coverage tracking
+        team: &teams
+          - '@grafana/dataviz-squad'
+        branch: [pr, main]
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ matrix.branch == 'main' && 'main' || github.ref }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Install dependencies
+        run: yarn install --immutable
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
+          CYPRESS_INSTALL_BINARY: 0
+
+      - name: Get team slug
+        id: team-slug
+        run: |
+          TEAM_SLUG=$(node -e '
+            const slugs = JSON.parse(${{ toJSON(needs.setup.outputs.team-slugs) }});
+            const team = "${{ matrix.team }}";
+            const result = slugs[team];
+            if (!result) {
+              console.error("ERROR: Team not found in slugs!");
+              process.exit(1);
+            }
+            process.stdout.write(result);
+          ')
+          echo "team-slug=$TEAM_SLUG" >> "$GITHUB_OUTPUT"
+
+      - name: Run coverage for ${{ matrix.team }}
+        run: yarn test:coverage:by-codeowner ${{ matrix.team }}
+        env:
+          SHOULD_OPEN_COVERAGE_REPORT: 'false'
+          CI: 'true'
+
+      - name: Create fallback coverage summary (bootstrapping)
+        if: matrix.branch == 'main'
+        run: |
+          cat > coverage-summary.json <<'EOF'
+          {
+            "team": "${{ matrix.team }}",
+            "commit": "${{ github.event.pull_request.base.sha }}",
+            "timestamp": "${{ github.event.pull_request.updated_at }}",
+            "summary": {
+              "lines": { "pct": 99 },
+              "statements": { "pct": 99 },
+              "functions": { "pct": 99 },
+              "branches": { "pct": 99 }
+            }
+          }
+          EOF
+          echo "⚠️ Created fallback coverage summary with 99% coverage (bootstrapping mode)"
+
+      - name: Upload coverage summary
+        uses: actions/upload-artifact@v5
+        with:
+          name: coverage-${{ matrix.branch }}-${{ steps.team-slug.outputs.team-slug }}
+          path: coverage-summary.json
+          retention-days: 1
+
+  compare-and-report:
+    name: Compare & Report - ${{ matrix.team }}
+    needs: [setup, coverage]
+    runs-on: ubuntu-x64-small
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        team: *teams
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Get team slug
+        id: team-slug
+        run: |
+          TEAM_SLUG=$(node -e '
+            const slugs = JSON.parse(${{ toJSON(needs.setup.outputs.team-slugs) }});
+            const team = "${{ matrix.team }}";
+            const result = slugs[team];
+            if (!result) {
+              console.error("ERROR: Team not found in slugs!");
+              process.exit(1);
+            }
+            process.stdout.write(result);
+          ')
+          echo "team-slug=$TEAM_SLUG" >> "$GITHUB_OUTPUT"
+
+      - name: Download PR coverage
+        uses: actions/download-artifact@v6
+        with:
+          name: coverage-pr-${{ steps.team-slug.outputs.team-slug }}
+          path: ./coverage-pr
+
+      - name: Download Main coverage
+        uses: actions/download-artifact@v6
+        with:
+          name: coverage-main-${{ steps.team-slug.outputs.team-slug }}
+          path: ./coverage-main
+
+      - name: Install dependencies for comparison script
+        run: yarn install --immutable
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
+          CYPRESS_INSTALL_BINARY: 0
+
+      - name: Compare coverage
+        id: compare
+        run: |
+          node scripts/compare-coverage-by-codeowner.js
+          {
+            echo "markdown<<EOF"
+            cat ./coverage-comparison.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Get Vault secrets
+        id: get-secrets
+        if: github.event.pull_request.head.repo.fork == false
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            GITHUB_APP_ID=grafana_pr_automation_app:app_id
+            GITHUB_APP_PRIVATE_KEY=grafana_pr_automation_app:app_pem
+
+      - name: Generate GitHub App token
+        id: generate_token
+        if: github.event.pull_request.head.repo.fork == false
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Post PR comment
+        if: github.event.pull_request.head.repo.fork == false
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: coverage-report-${{ matrix.team }}
+          message: ${{ steps.compare.outputs.markdown }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/scripts/codeowners-manifest/utils.js
+++ b/scripts/codeowners-manifest/utils.js
@@ -4,9 +4,65 @@ const { CODEOWNERS_JSON_PATH: CODEOWNERS_MANIFEST_CODEOWNERS_PATH } = require('.
 
 let _codeownersCache = null;
 
+const CODEOWNER_KIND = {
+  TEAM: 'team',
+  USER: 'user',
+  EMAIL: 'email',
+};
+
+/**
+ * Determine the kind of codeowner
+ * @param {string} codeowner - CODEOWNERS codeowner (username, team, or email)
+ * @returns {string} One of CODEOWNER_KIND values
+ *
+ * @example
+ * getCodeownerKind('@grafana/dataviz-squad') => 'team'
+ * getCodeownerKind('@jesdavpet') => 'user'
+ * getCodeownerKind('john@example.com') => 'email'
+ */
+function getCodeownerKind(codeowner) {
+  if (codeowner.includes('@') && codeowner.includes('/')) {
+    return CODEOWNER_KIND.TEAM;
+  } else if (codeowner.startsWith('@')) {
+    return CODEOWNER_KIND.USER;
+  } else {
+    return CODEOWNER_KIND.EMAIL;
+  }
+}
+
+/**
+ * Creates a dasherized slug for any codeowner
+ * @param {string} codeowner - CODEOWNERS codeowner (username, team, or email)
+ * @returns {string} Dasherized slug with singular prefix
+ *
+ * @example
+ * createCodeownerSlug('@grafana/dataviz-squad') => 'team-grafana-dataviz-squad'
+ * createCodeownerSlug('@jesdavpet') => 'user-jesdavpet'
+ * createCodeownerSlug('john+doe@example.com') => 'email-john-doe-at-example-com'
+ */
+function createCodeownerSlug(codeowner) {
+  const kind = getCodeownerKind(codeowner);
+
+  if (kind === CODEOWNER_KIND.TEAM) {
+    const [org, team] = codeowner.substring(1).split('/');
+    return ['team', org, team].join('-');
+  } else if (kind === CODEOWNER_KIND.USER) {
+    return ['user', codeowner.substring(1)].join('-');
+  } else {
+    const [user, domain] = codeowner.split('@');
+    const sanitizedUser = user.replace(/[+.]/g, '-');
+    const sanitizedDomain = domain.replace(/\./g, '-');
+    return ['email', `${sanitizedUser}-at-${sanitizedDomain}`].join('-');
+  }
+}
+
 module.exports = {
+  CODEOWNER_KIND,
+  getCodeownerKind,
+  createCodeownerSlug,
+
   /**
-   * import the contents of the codeowners manifest JSON file, with caching
+   * Imports the contents of the codeowners manifest JSON file, with caching
    * @param {boolean} clearCache - if true, clear the cached data and reload the codeowners manifest
    * @returns {Promise<Array<string>>} - list of codeowners which own at least one file in the project
    */

--- a/scripts/compare-coverage-by-codeowner.js
+++ b/scripts/compare-coverage-by-codeowner.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+
+const COVERAGE_PR_PATH = './coverage-pr/coverage-summary.json';
+const COVERAGE_MAIN_PATH = './coverage-main/coverage-summary.json';
+const COMPARISON_OUTPUT_PATH = './coverage-comparison.md';
+
+function readCoverageFile(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(content);
+  } catch (err) {
+    console.error(`Error reading coverage file ${filePath}: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+function formatPercentage(value) {
+  return `${value.toFixed(1)}%`;
+}
+
+function getStatusIcon(prValue, mainValue) {
+  if (prValue >= mainValue) {
+    return '✅ Pass';
+  }
+  return '❌ Fail';
+}
+
+function getOverallStatus(prSummary, mainSummary) {
+  const metrics = ['lines', 'statements', 'functions', 'branches'];
+  const allPass = metrics.every((metric) => prSummary[metric].pct >= mainSummary[metric].pct);
+  return allPass;
+}
+
+function generateMarkdown(prCoverage, mainCoverage) {
+  const teamName = prCoverage.team;
+  const prSum = prCoverage.summary;
+  const mainSum = mainCoverage.summary;
+
+  const overallPass = getOverallStatus(prSum, mainSum);
+
+  const rows = [
+    {
+      metric: 'Lines',
+      main: mainSum.lines.pct,
+      pr: prSum.lines.pct,
+    },
+    {
+      metric: 'Statements',
+      main: mainSum.statements.pct,
+      pr: prSum.statements.pct,
+    },
+    {
+      metric: 'Functions',
+      main: mainSum.functions.pct,
+      pr: prSum.functions.pct,
+    },
+    {
+      metric: 'Branches',
+      main: mainSum.branches.pct,
+      pr: prSum.branches.pct,
+    },
+  ];
+
+  const tableRows = rows
+    .map((row) => {
+      const status = getStatusIcon(row.pr, row.main);
+      return `| ${row.metric} | ${formatPercentage(row.main)} | ${formatPercentage(row.pr)} | ${status} |`;
+    })
+    .join('\n');
+
+  const overallStatus = overallPass ? '✅ Pass' : '❌ Fail';
+  const overallMessage = overallPass ? 'Coverage maintained or improved' : 'Coverage decreased in one or more metrics';
+
+  return `## Test Coverage Report - ${teamName}
+
+| Metric | Main Branch | PR Branch | Status |
+|--------|-------------|-----------|--------|
+${tableRows}
+
+**Overall: ${overallStatus}** - ${overallMessage}
+
+<details>
+<summary>Coverage Details</summary>
+
+- **PR Branch**: \`${prCoverage.commit.substring(0, 7)}\` (${prCoverage.timestamp})
+- **Main Branch**: \`${mainCoverage.commit.substring(0, 7)}\` (${mainCoverage.timestamp})
+
+</details>
+`;
+}
+
+function main() {
+  const prCoverage = readCoverageFile(COVERAGE_PR_PATH);
+  const mainCoverage = readCoverageFile(COVERAGE_MAIN_PATH);
+
+  if (!prCoverage.summary || !mainCoverage.summary) {
+    console.error('Error: Coverage summary data is missing or invalid');
+    process.exit(1);
+  }
+
+  const markdown = generateMarkdown(prCoverage, mainCoverage);
+
+  try {
+    fs.writeFileSync(COMPARISON_OUTPUT_PATH, markdown, 'utf8');
+    console.log(`✅ Coverage comparison written to ${COMPARISON_OUTPUT_PATH}`);
+  } catch (err) {
+    console.error(`Error writing output file: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { generateMarkdown, getOverallStatus };

--- a/scripts/test-coverage-by-codeowner.js
+++ b/scripts/test-coverage-by-codeowner.js
@@ -2,6 +2,7 @@
 
 const { AutoComplete } = require('enquirer');
 const cp = require('node:child_process');
+const path = require('node:path');
 const { hideBin } = require('yargs/helpers');
 const yargs = require('yargs/yargs');
 
@@ -35,9 +36,9 @@ async function runTestCoverageByCodeowner(codeownerName, noOpen = process.env.CI
   process.env.SHOULD_OPEN_COVERAGE_REPORT = String(!noOpen);
 
   return new Promise((resolve, reject) => {
-    const child = cp.spawn('jest', [`--config=${JEST_CONFIG_PATH}`], {
+    const jestBin = path.join(__dirname, '..', 'node_modules', '.bin', 'jest');
+    const child = cp.spawn(jestBin, [`--config=${JEST_CONFIG_PATH}`], {
       stdio: 'inherit',
-      shell: true,
     });
 
     child.on('error', (error) => {


### PR DESCRIPTION
# 🚧 WIP - Not ready for review yet! 🚧 

**What is this feature?**

This change adds an opt-in CI workflow to compare the test coverage of an incoming PR to that of the `main` branch. If the coverage is degraded by the PR the workflow check will fail. Test coverage is reported in a PR comment.

> [!IMPORTANT]
> Only code owned by codeowners who have opted in will be checked -- not all code, and not all codeowners.

**Why do we need this feature?**

To automate checks that tests coverage is at least being maintained if not improved when code changes.

**Who is this feature for?**

Contributors to the Grafana monorepo, and maintainers of Grafana code.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/116310

**Special notes for your reviewer:**

🚫 👀 Look away, this is hideous -- and not ready for review _(yet)_.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
