### PR TITLE
Plugins: add new loading of app plugins

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1259,4 +1259,9 @@ export interface FeatureToggles {
   * Use synchronized dispatch timer to minimize duplicate notifications across alertmanager HA pods
   */
   alertingSyncDispatchTimer?: boolean;
+  /**
+  * Enables new loading of app plugins
+  * @default false
+  */
+  useMTAppsLoading?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2047,6 +2047,7 @@ var (
 			Owner:        grafanaPluginsPlatformSquad,
 			FrontendOnly: true,
 			Expression:   "false",
+			HideFromDocs: true,
 		},
 		{
 			Name:         "multiPropsVariables",
@@ -2084,6 +2085,15 @@ var (
 			Owner:           grafanaAlertingSquad,
 			RequiresRestart: true,
 			HideFromDocs:    true,
+		},
+		{
+			Name:         "useMTAppsLoading",
+			Description:  "Enables new loading of app plugins",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaPluginsPlatformSquad,
+			FrontendOnly: true,
+			Expression:   "false",
+			HideFromDocs: true,
 		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -282,3 +282,4 @@ smoothingTransformation,experimental,@grafana/datapro,false,false,true
 secretsManagementAppPlatformAwsKeeper,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 profilesExemplars,experimental,@grafana/observability-traces-and-profiling,false,false,false
 alertingSyncDispatchTimer,experimental,@grafana/alerting-squad,false,true,false
+useMTAppsLoading,experimental,@grafana/plugins-platform-backend,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3825,15 +3825,37 @@
     },
     {
       "metadata": {
+        "name": "useMTAppsLoading",
+        "resourceVersion": "1768461562946",
+        "creationTimestamp": "2026-01-14T08:24:03Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-01-15 07:19:22.94622 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enables new loading of app plugins",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true,
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "useMTPlugins",
-        "resourceVersion": "1764913709691",
-        "creationTimestamp": "2025-12-05T05:48:29Z"
+        "resourceVersion": "1768461562946",
+        "creationTimestamp": "2025-12-05T05:48:29Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-01-15 07:19:22.94622 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables plugins decoupling from bootdata",
         "stage": "experimental",
         "codeowner": "@grafana/plugins-platform-backend",
         "frontend": true,
+        "hideFromDocs": true,
         "expression": "false"
       }
     },

--- a/public/app/features/plugins/extensions/appUtils.test.ts
+++ b/public/app/features/plugins/extensions/appUtils.test.ts
@@ -1,0 +1,7 @@
+import { getAppPluginConfigs } from './appUtils';
+
+describe('getAppPluginConfigs', () => {
+  it('should return an empty array when no arguments are supplied', () => {
+    expect(getAppPluginConfigs()).toEqual([]);
+  });
+});

--- a/public/app/features/plugins/extensions/appUtils.ts
+++ b/public/app/features/plugins/extensions/appUtils.ts
@@ -1,0 +1,141 @@
+import type { AppPluginConfig } from '@grafana/data';
+
+import { ExtensionPointPluginMeta, getAppPluginIdFromExposedComponentId } from './utils';
+
+/**
+ * Returns a list of app plugin configs that match the given plugin ids.
+ * @param pluginIds - The list of plugin ids to filter by.
+ * @param apps - The app plugin configs.
+ * @returns A list of app plugin configs that match the given plugin ids.
+ */
+export function getAppPluginConfigs(pluginIds: string[] = [], apps: AppPluginConfig[] = []): AppPluginConfig[] {
+  return apps.filter((app) => pluginIds.includes(app.id));
+}
+
+/**
+ * Returns a list of app plugin ids that are registering extensions to this extension point.
+ * (These plugins are necessary to be loaded to use the extension point.)
+ * (The function also returns the plugin ids that the plugins - that extend the extension point - depend on.)
+ * @param extensionPointId - The id of the extension point.
+ * @param apps - The app plugin configs.
+ * @returns A list of app plugin ids that are registering extensions to this extension point.
+ */
+
+export function getExtensionPointPluginDependencies(extensionPointId: string, apps: AppPluginConfig[] = []): string[] {
+  return apps
+    .filter(
+      (app) =>
+        app.extensions.addedLinks.some((link) => link.targets.includes(extensionPointId)) ||
+        app.extensions.addedComponents.some((component) => component.targets.includes(extensionPointId))
+    )
+    .map((app) => app.id)
+    .reduce((acc: string[], id: string) => {
+      return [...acc, id, ...getAppPluginDependencies(id, undefined, apps)];
+    }, []);
+}
+
+/**
+ * Returns a map of plugin ids and their addedComponents and addedLinks to the extension point.
+ * @param extensionPointId - The id of the extension point.
+ * @param apps - The app plugin configs.
+ * @returns A map of plugin ids and their addedComponents and addedLinks to the extension point.
+ */
+export function getExtensionPointPluginMeta(
+  extensionPointId: string,
+  apps: AppPluginConfig[] = []
+): ExtensionPointPluginMeta {
+  return new Map(
+    getExtensionPointPluginDependencies(extensionPointId, apps)
+      .map((pluginId) => {
+        const app = apps.find((app) => app.id === pluginId);
+        // if the plugin does not exist or does not expose any components or links to the extension point, return undefined
+        if (
+          !app ||
+          (!app.extensions.addedComponents.some((component) => component.targets.includes(extensionPointId)) &&
+            !app.extensions.addedLinks.some((link) => link.targets.includes(extensionPointId)))
+        ) {
+          return undefined;
+        }
+        return [
+          pluginId,
+          {
+            addedComponents: app.extensions.addedComponents.filter((component) =>
+              component.targets.includes(extensionPointId)
+            ),
+            addedLinks: app.extensions.addedLinks.filter((link) => link.targets.includes(extensionPointId)),
+          },
+        ] as const;
+      })
+      .filter((c): c is NonNullable<typeof c> => c !== undefined)
+  );
+}
+
+/**
+ * Returns a list of app plugin ids that are necessary to be loaded to use the exposed component.
+ * @param apps - The app plugin configs.
+ * @param exposedComponentId - The id of the exposed component.
+ * @returns A list of app plugin ids that are necessary to be loaded to use the exposed component.
+ */
+
+export function getExposedComponentPluginDependencies(
+  exposedComponentId: string,
+  apps: AppPluginConfig[] = []
+): string[] {
+  const pluginId = getAppPluginIdFromExposedComponentId(exposedComponentId);
+
+  return [pluginId].reduce((acc: string[], pluginId: string) => {
+    return [...acc, pluginId, ...getAppPluginDependencies(pluginId, undefined, apps)];
+  }, []);
+}
+
+/**
+ * Returns a list of app plugin ids that are necessary to be loaded, based on the `dependencies.extensions`
+ * metadata field. (For example the plugins that expose components that the app depends on.)
+ * Heads up! This is a recursive function.
+ * @param pluginId - The id of the plugin.
+ * @param visited - The list of plugin ids that have already been visited.
+ * @param apps - The app plugin configs.
+ * @returns A list of app plugin ids that are necessary to be loaded, based on the `dependencies.extensions`
+ */
+export function getAppPluginDependencies(
+  pluginId: string,
+  visited: string[] = [],
+  apps: AppPluginConfig[] = []
+): string[] {
+  const plugin = apps.find((app) => app.id === pluginId);
+  if (!plugin) {
+    return [];
+  }
+
+  // Prevent infinite recursion (it would happen if there is a circular dependency between app plugins)
+  if (visited.includes(pluginId)) {
+    return [];
+  }
+
+  const pluginIdDependencies = plugin.dependencies.extensions.exposedComponents.map(
+    getAppPluginIdFromExposedComponentId
+  );
+
+  return (
+    pluginIdDependencies
+      .reduce((acc, _pluginId) => {
+        return [...acc, ...getAppPluginDependencies(_pluginId, [...visited, pluginId], apps)];
+      }, pluginIdDependencies)
+      // We don't want the plugin to "depend on itself"
+      .filter((id) => id !== pluginId)
+  );
+}
+
+/**
+ * Returns a list of app plugins that has to be loaded before core Grafana could finish the initialization.
+ * @param apps - The app plugin configs.
+ * @returns A list of app plugins that has to be loaded before core Grafana could finish the initialization.
+ */
+export function getAppPluginsToAwait(apps: AppPluginConfig[]) {
+  const pluginIds = [
+    // The "cloud-home-app" is registering banners once it's loaded, and this can cause a rerender in the AppChrome if it's loaded after the Grafana app init.
+    'cloud-home-app',
+  ];
+
+  return apps.filter((app) => pluginIds.includes(app.id));
+}

--- a/public/app/features/plugins/extensions/useLoadAppPluginsWithPredicate.tsx
+++ b/public/app/features/plugins/extensions/useLoadAppPluginsWithPredicate.tsx
@@ -1,0 +1,27 @@
+import { useAsync } from 'react-use';
+
+import { AppPluginConfig } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { evaluateBooleanFlag, getAppPluginMetas } from '@grafana/runtime/internal';
+
+import { useLoadAppPlugins } from './useLoadAppPlugins';
+
+type LoadAppPluginsWithPredidcate = (pluginId: string, apps?: AppPluginConfig[]) => string[];
+
+export function useLoadAppPluginsWithPredicate(
+  pluginId: string,
+  predicate: LoadAppPluginsWithPredidcate
+): { isLoading: boolean } {
+  const { loading: isLoadingAppPluginMetas, value: apps } = useAsync(async () => {
+    if (!evaluateBooleanFlag('useMTAppsLoading', false)) {
+      // this will go away as soon as the useMTAppsLoading feature is rolled out 100% to prod
+      // eslint-disable-next-line no-restricted-syntax
+      return Object.values(config.apps);
+    }
+
+    return getAppPluginMetas();
+  });
+  const { isLoading } = useLoadAppPlugins(predicate(pluginId, apps));
+
+  return { isLoading: isLoadingAppPluginMetas || isLoading };
+}

--- a/public/app/features/plugins/extensions/usePluginFunctions.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginFunctions.test.tsx
@@ -20,6 +20,7 @@ import { AddedLinksRegistry } from './registry/AddedLinksRegistry';
 import { ExposedComponentsRegistry } from './registry/ExposedComponentsRegistry';
 import { PluginExtensionRegistries } from './registry/types';
 import { useLoadAppPlugins } from './useLoadAppPlugins';
+import { useLoadAppPluginsWithPredicate } from './useLoadAppPluginsWithPredicate';
 import { usePluginFunctions } from './usePluginFunctions';
 import { isGrafanaDevMode } from './utils';
 
@@ -62,6 +63,7 @@ describe('usePluginFunctions()', () => {
 
   beforeEach(() => {
     jest.mocked(useLoadAppPlugins).mockReturnValue({ isLoading: false });
+    jest.mocked(useLoadAppPluginsWithPredicate).mockReturnValue({ isLoading: false });
     jest.mocked(isGrafanaDevMode).mockReturnValue(false);
     registries = {
       addedComponentsRegistry: new AddedComponentsRegistry(),
@@ -265,6 +267,7 @@ describe('usePluginFunctions()', () => {
   });
 
   it('should return isLoading: true when app plugins are loading', () => {
+    jest.mocked(useLoadAppPluginsWithPredicate).mockReturnValue({ isLoading: true });
     jest.mocked(useLoadAppPlugins).mockReturnValue({ isLoading: true });
 
     const { result } = renderHook(() => usePluginFunctions({ extensionPointId }), { wrapper });

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { useAsync } from 'react-use';
 
 import {
+  type AppPluginConfig,
   type PluginExtensionEventHelpers,
   type PluginExtensionOpenModalOptions,
   isDateTime,
@@ -16,7 +17,7 @@ import {
   PluginExtensionPoints,
   ExtensionInfo,
 } from '@grafana/data';
-import { reportInteraction, config, AppPluginConfig } from '@grafana/runtime';
+import { reportInteraction, config } from '@grafana/runtime';
 import { Modal } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
 import { getPluginSettings } from 'app/features/plugins/pluginSettings';
@@ -30,6 +31,14 @@ import {
 import { RestrictedGrafanaApisProvider } from '../components/restrictedGrafanaApis/RestrictedGrafanaApisProvider';
 
 import { ExtensionErrorBoundary } from './ExtensionErrorBoundary';
+import {
+  getAppPluginConfigs as getAppPluginConfigsFromApps,
+  getAppPluginDependencies as getAppPluginDependenciesFromApps,
+  getAppPluginsToAwait as getAppPluginsToAwaitFromApps,
+  getExposedComponentPluginDependencies as getExposedComponentPluginDependenciesFromApps,
+  getExtensionPointPluginDependencies as getExtensionPointPluginDependenciesFromApps,
+  getExtensionPointPluginMeta as getExtensionPointPluginMetaFromApps,
+} from './appUtils';
 import { ExtensionsLog, log as baseLog } from './logs/log';
 import { AddedLinkRegistryItem } from './registry/AddedLinksRegistry';
 import { assertIsNotPromise, assertStringProps, isPromise } from './validators';
@@ -612,7 +621,7 @@ export function getLinkExtensionPathWithTracking(pluginId: string, path: string,
 export const isGrafanaDevMode = () => config.buildInfo.env === 'development';
 
 export const getAppPluginConfigs = (pluginIds: string[] = []) =>
-  Object.values(config.apps).filter((app) => pluginIds.includes(app.id));
+  getAppPluginConfigsFromApps(pluginIds, Object.values(config.apps));
 
 export const getAppPluginIdFromExposedComponentId = (exposedComponentId: string) => {
   return exposedComponentId.split('/')[0];
@@ -622,24 +631,12 @@ export const getAppPluginIdFromExposedComponentId = (exposedComponentId: string)
 // (These plugins are necessary to be loaded to use the extension point.)
 // (The function also returns the plugin ids that the plugins - that extend the extension point - depend on.)
 export const getExtensionPointPluginDependencies = (extensionPointId: string): string[] => {
-  return Object.values(config.apps)
-    .filter(
-      (app) =>
-        app.extensions.addedLinks.some((link) => link.targets.includes(extensionPointId)) ||
-        app.extensions.addedComponents.some((component) => component.targets.includes(extensionPointId))
-    )
-    .map((app) => app.id)
-    .reduce((acc: string[], id: string) => {
-      return [...acc, id, ...getAppPluginDependencies(id)];
-    }, []);
+  return getExtensionPointPluginDependenciesFromApps(extensionPointId, Object.values(config.apps));
 };
 
 export type ExtensionPointPluginMeta = Map<
   string,
-  {
-    readonly addedComponents: ExtensionInfo[];
-    readonly addedLinks: ExtensionInfo[];
-  }
+  { readonly addedComponents: ExtensionInfo[]; readonly addedLinks: ExtensionInfo[] }
 >;
 
 /**
@@ -648,77 +645,25 @@ export type ExtensionPointPluginMeta = Map<
  * @returns A map of plugin ids and their addedComponents and addedLinks to the extension point.
  */
 export const getExtensionPointPluginMeta = (extensionPointId: string): ExtensionPointPluginMeta => {
-  return new Map(
-    getExtensionPointPluginDependencies(extensionPointId)
-      .map((pluginId) => {
-        const app = config.apps[pluginId];
-        // if the plugin does not exist or does not expose any components or links to the extension point, return undefined
-        if (
-          !app ||
-          (!app.extensions.addedComponents.some((component) => component.targets.includes(extensionPointId)) &&
-            !app.extensions.addedLinks.some((link) => link.targets.includes(extensionPointId)))
-        ) {
-          return undefined;
-        }
-        return [
-          pluginId,
-          {
-            addedComponents: app.extensions.addedComponents.filter((component) =>
-              component.targets.includes(extensionPointId)
-            ),
-            addedLinks: app.extensions.addedLinks.filter((link) => link.targets.includes(extensionPointId)),
-          },
-        ] as const;
-      })
-      .filter((c): c is NonNullable<typeof c> => c !== undefined)
-  );
+  return getExtensionPointPluginMetaFromApps(extensionPointId, Object.values(config.apps));
 };
 
 // Returns a list of app plugin ids that are necessary to be loaded to use the exposed component.
 // (It is first the plugin that exposes the component, and then the ones that it depends on.)
 export const getExposedComponentPluginDependencies = (exposedComponentId: string) => {
-  const pluginId = getAppPluginIdFromExposedComponentId(exposedComponentId);
-
-  return [pluginId].reduce((acc: string[], pluginId: string) => {
-    return [...acc, pluginId, ...getAppPluginDependencies(pluginId)];
-  }, []);
+  return getExposedComponentPluginDependenciesFromApps(exposedComponentId, Object.values(config.apps));
 };
 
 // Returns a list of app plugin ids that are necessary to be loaded, based on the `dependencies.extensions`
 // metadata field. (For example the plugins that expose components that the app depends on.)
 // Heads up! This is a recursive function.
 export const getAppPluginDependencies = (pluginId: string, visited: string[] = []): string[] => {
-  if (!config.apps[pluginId]) {
-    return [];
-  }
-
-  // Prevent infinite recursion (it would happen if there is a circular dependency between app plugins)
-  if (visited.includes(pluginId)) {
-    return [];
-  }
-
-  const pluginIdDependencies = config.apps[pluginId].dependencies.extensions.exposedComponents.map(
-    getAppPluginIdFromExposedComponentId
-  );
-
-  return (
-    pluginIdDependencies
-      .reduce((acc, _pluginId) => {
-        return [...acc, ...getAppPluginDependencies(_pluginId, [...visited, pluginId])];
-      }, pluginIdDependencies)
-      // We don't want the plugin to "depend on itself"
-      .filter((id) => id !== pluginId)
-  );
+  return getAppPluginDependenciesFromApps(pluginId, visited, Object.values(config.apps));
 };
 
 // Returns a list of app plugins that has to be loaded before core Grafana could finish the initialization.
 export const getAppPluginsToAwait = () => {
-  const pluginIds = [
-    // The "cloud-home-app" is registering banners once it's loaded, and this can cause a rerender in the AppChrome if it's loaded after the Grafana app init.
-    'cloud-home-app',
-  ];
-
-  return Object.values(config.apps).filter((app) => pluginIds.includes(app.id));
+  return getAppPluginsToAwaitFromApps(Object.values(config.apps));
 };
 
 // Returns a list of app plugins that has to be preloaded in parallel with the core Grafana initialization.

--- a/public/app/features/plugins/pluginPreloader.ts
+++ b/public/app/features/plugins/pluginPreloader.ts
@@ -1,12 +1,15 @@
-import type {
-  AppPluginConfig,
-  PluginExtensionAddedLinkConfig,
-  PluginExtensionExposedComponentConfig,
-  PluginExtensionAddedComponentConfig,
+import {
+  type AppPluginConfig,
+  type PluginExtensionAddedLinkConfig,
+  type PluginExtensionExposedComponentConfig,
+  type PluginExtensionAddedComponentConfig,
+  PluginExtensionPoints,
 } from '@grafana/data';
+import { getAppPluginMetas } from '@grafana/runtime/internal';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getPluginSettings } from 'app/features/plugins/pluginSettings';
 
+import { getAppPluginsToAwait, getExtensionPointPluginDependencies } from './extensions/appUtils';
 import { pluginImporter } from './importer/pluginImporter';
 
 export type PluginPreloadResult = {
@@ -22,6 +25,29 @@ const preloadPromises = new Map<string, Promise<void>>();
 export const clearPreloadedPluginsCache = () => {
   preloadPromises.clear();
 };
+
+export async function preloadAppPluginsToAwait() {
+  const apps = await getAppPluginMetas();
+  const appsToAwait = getAppPluginsToAwait(apps);
+
+  return preloadPlugins(appsToAwait);
+}
+
+export async function preloadAppPluginsToPreload() {
+  const apps = await getAppPluginMetas();
+  // The DashboardPanelMenu extension point is using the `getPluginExtensions()` API in scenes at the moment, which means that it cannot yet benefit from dynamic plugin loading.
+  const dashboardPanelMenuPluginIds = getExtensionPointPluginDependencies(
+    PluginExtensionPoints.DashboardPanelMenu,
+    apps
+  );
+  const awaitedPluginIds = getAppPluginsToAwait(apps).map((app) => app.id);
+  const isNotAwaited = (app: AppPluginConfig) => !awaitedPluginIds.includes(app.id);
+  const appPluginsToPreload = apps.filter(
+    (app) => isNotAwaited(app) && (app.preload || dashboardPanelMenuPluginIds.includes(app.id))
+  );
+
+  return preloadPlugins(appPluginsToPreload);
+}
 
 export async function preloadPlugins(apps: AppPluginConfig[] = []) {
   // Create preload promises for each app, reusing existing promises if already loading

--- a/public/test/setupTests.ts
+++ b/public/test/setupTests.ts
@@ -46,6 +46,11 @@ jest.mock('app/features/plugins/extensions/usePluginComponents', () => ({
   usePluginComponents: jest.fn().mockReturnValue({ components: [], isLoading: false }),
 }));
 
+// Mock useLoadAppPluginsWithPredidcate to prevent async state updates in tests
+jest.mock('app/features/plugins/extensions/useLoadAppPluginsWithPredicate', () => ({
+  useLoadAppPluginsWithPredicate: jest.fn().mockReturnValue({ isLoading: false }),
+}));
+
 // our tests are heavy in CI due to parallelisation and monaco and kusto
 // so we increase the default timeout to 2secs to avoid flakiness
 configure({ asyncUtilTimeout: 2000 });


### PR DESCRIPTION
**What is this feature?**

This pull request introduces a new experimental feature toggle, `useMTAppsLoading`, which enables an updated mechanism for loading app plugins in Grafana. There is an existing feature toggle called `useMTPlugins` that toggles where the apps data is fetched from, either `config.apps` or the new Plugins Meta API.
These changes collectively enable a smoother transition to the new app plugin loading mechanism, with a feature flag to control rollout and maintain backward compatibility.

I've tried to keep the changes to existing functions as minimum as possible to avoid any new bugs.

**Why do we need this feature?**

We need to replace usages of `config.apps` as that is deprecated.

**Who is this feature for?**

Plugins platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #116258 

**Special notes for your reviewer:**

Existing usages of `getAppPluginDependencies` function
![getAppPluginDependencies](https://github.com/user-attachments/assets/87b99536-00c2-40b2-8bd4-486d2df90751)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
