### PR TITLE
`grafana-iam`: Skeleton of the GlobalRole api setup

### DIFF
--- a/apps/iam/kinds/role.cue
+++ b/apps/iam/kinds/role.cue
@@ -25,6 +25,7 @@ coreroleKind: {
 globalroleKind: {
 	kind:       "GlobalRole"
 	pluralName: "GlobalRoles"
+	scope:      "Cluster"
 	codegen: {
 		ts: { enabled: false }
 		go: { enabled: true }

--- a/apps/iam/pkg/apis/iam/v0alpha1/globalrole_schema_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/globalrole_schema_gen.go
@@ -11,7 +11,7 @@ import (
 // schema is unexported to prevent accidental overwrites
 var (
 	schemaGlobalRole = resource.NewSimpleSchema("iam.grafana.app", "v0alpha1", NewGlobalRole(), &GlobalRoleList{}, resource.WithKind("GlobalRole"),
-		resource.WithPlural("globalroles"), resource.WithScope(resource.NamespacedScope))
+		resource.WithPlural("globalroles"), resource.WithScope(resource.ClusterScope))
 	kindGlobalRole = resource.Kind{
 		Schema: schemaGlobalRole,
 		Codecs: map[resource.KindEncoding]resource.Codec{

--- a/apps/iam/pkg/apis/iam/v0alpha1/register.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/register.go
@@ -74,6 +74,33 @@ var RoleInfo = utils.NewResourceInfo(GROUP, VERSION,
 	},
 )
 
+var GlobalRoleInfo = globalRoleInfo.WithClusterScope()
+var globalRoleInfo = utils.NewResourceInfo(GROUP, VERSION,
+	"globalroles", "globalrole", "GlobalRole",
+	func() runtime.Object { return &GlobalRole{} },
+	func() runtime.Object { return &GlobalRoleList{} },
+	utils.TableColumns{
+		Definition: []metav1.TableColumnDefinition{
+			{Name: "Name", Type: "string", Format: "name"},
+			{Name: "Group", Type: "string", Format: "group", Description: "Role group"},
+			{Name: "Title", Type: "string", Format: "string", Description: "Role name"},
+			{Name: "Created At", Type: "date"},
+		},
+		Reader: func(obj any) ([]interface{}, error) {
+			globalRole, ok := obj.(*GlobalRole)
+			if ok {
+				return []interface{}{
+					globalRole.Name,
+					globalRole.Spec.Group,
+					globalRole.Spec.Title,
+					globalRole.CreationTimestamp.UTC().Format(time.RFC3339),
+				}, nil
+			}
+			return nil, fmt.Errorf("expected global role")
+		},
+	},
+)
+
 var ResourcePermissionInfo = utils.NewResourceInfo(GROUP, VERSION,
 	"resourcepermissions", "resourcepermission", "ResourcePermission",
 	func() runtime.Object { return &ResourcePermission{} },
@@ -304,6 +331,14 @@ func AddResourcePermissionKnownTypes(scheme *runtime.Scheme, version schema.Grou
 		// What is this about?
 		&metav1.PartialObjectMetadata{},
 		&metav1.PartialObjectMetadataList{},
+	)
+	return nil
+}
+
+func AddGlobalRoleKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&GlobalRole{},
+		&GlobalRoleList{},
 	)
 	return nil
 }

--- a/apps/iam/pkg/apis/iam_manifest.go
+++ b/apps/iam/pkg/apis/iam_manifest.go
@@ -18,6 +18,8 @@ import (
 	v0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 )
 
+var ()
+
 var appManifestData = app.ManifestData{
 	AppName:          "iam",
 	Group:            "iam.grafana.app",
@@ -30,7 +32,7 @@ var appManifestData = app.ManifestData{
 				{
 					Kind:       "GlobalRole",
 					Plural:     "GlobalRoles",
-					Scope:      "Namespaced",
+					Scope:      "Cluster",
 					Conversion: false,
 				},
 

--- a/apps/iam/pkg/apis/iam_manifest.go
+++ b/apps/iam/pkg/apis/iam_manifest.go
@@ -18,8 +18,6 @@ import (
 	v0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 )
 
-var ()
-
 var appManifestData = app.ManifestData{
 	AppName:          "iam",
 	Group:            "iam.grafana.app",

--- a/pkg/registry/apis/iam/api_installer.go
+++ b/pkg/registry/apis/iam/api_installer.go
@@ -39,6 +39,9 @@ type ApiInstaller[T runtime.Object] interface {
 // while keeping the core IAM registration logic in OSS.
 type RoleApiInstaller ApiInstaller[*iamv0.Role]
 
+// GlobalRoleApiInstaller provides GlobalRole-specific API registration and validation.
+type GlobalRoleApiInstaller ApiInstaller[*iamv0.GlobalRole]
+
 // NoopApiInstaller is a no-op implementation for when roles are not available (OSS).
 type NoopApiInstaller[T runtime.Object] struct {
 	ResourceInfo utils.ResourceInfo
@@ -75,5 +78,12 @@ func (n *NoopApiInstaller[T]) ValidateOnDelete(ctx context.Context, obj T) error
 func ProvideNoopRoleApiInstaller() RoleApiInstaller {
 	return &NoopApiInstaller[*iamv0.Role]{
 		ResourceInfo: iamv0.RoleInfo,
+	}
+}
+
+// ProvideNoopGlobalRoleApiInstaller provides a no-op global role installer specifically for GlobalRole types.
+func ProvideNoopGlobalRoleApiInstaller() GlobalRoleApiInstaller {
+	return &NoopApiInstaller[*iamv0.GlobalRole]{
+		ResourceInfo: iamv0.GlobalRoleInfo,
 	}
 }

--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -23,6 +23,7 @@ func newIAMAuthorizer(
 	accessClient authlib.AccessClient,
 	legacyAccessClient authlib.AccessClient,
 	roleApiInstaller RoleApiInstaller,
+	globalRoleApiInstaller GlobalRoleApiInstaller,
 ) authorizer.Authorizer {
 	resourceAuthorizer := make(map[string]authorizer.Authorizer)
 
@@ -57,6 +58,8 @@ func newIAMAuthorizer(
 	resourceAuthorizer[iamv0.TeamBindingResourceInfo.GetName()] = allowAuthorizer
 	resourceAuthorizer["searchUsers"] = serviceAuthorizer
 	resourceAuthorizer["searchTeams"] = serviceAuthorizer
+
+	resourceAuthorizer[iamv0.GlobalRoleInfo.GetName()] = globalRoleApiInstaller.GetAuthorizer()
 
 	return &iamAuthorizer{resourceAuthorizer: resourceAuthorizer}
 }

--- a/pkg/registry/apis/iam/models.go
+++ b/pkg/registry/apis/iam/models.go
@@ -57,6 +57,7 @@ type IdentityAccessManagementAPIBuilder struct {
 	ssoLegacyStore              *sso.LegacyStore
 	coreRolesStorage            CoreRoleStorageBackend
 	roleApiInstaller            RoleApiInstaller
+	globalRoleApiInstaller      GlobalRoleApiInstaller
 	resourcePermissionsStorage  resource.StorageBackend
 	roleBindingsStorage         RoleBindingStorageBackend
 	externalGroupMappingStorage ExternalGroupMappingStorageBackend

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -75,6 +75,7 @@ func RegisterAPIService(
 	reg prometheus.Registerer,
 	coreRolesStorage CoreRoleStorageBackend,
 	roleApiInstaller RoleApiInstaller,
+	globalRoleApiInstaller GlobalRoleApiInstaller,
 	tracing *tracing.TracingService,
 	roleBindingsStorage RoleBindingStorageBackend,
 	externalGroupMappingStorageBackend ExternalGroupMappingStorageBackend,
@@ -89,7 +90,7 @@ func RegisterAPIService(
 	dbProvider := legacysql.NewDatabaseProvider(sql)
 	store := legacy.NewLegacySQLStores(dbProvider)
 	legacyAccessClient := newLegacyAccessClient(ac, store)
-	authorizer := newIAMAuthorizer(accessClient, legacyAccessClient, roleApiInstaller)
+	authorizer := newIAMAuthorizer(accessClient, legacyAccessClient, roleApiInstaller, globalRoleApiInstaller)
 	registerMetrics(reg)
 
 	//nolint:staticcheck // not yet migrated to OpenFeature
@@ -109,6 +110,7 @@ func RegisterAPIService(
 		ssoLegacyStore:              sso.NewLegacyStore(ssoService, tracing),
 		coreRolesStorage:            coreRolesStorage,
 		roleApiInstaller:            roleApiInstaller,
+		globalRoleApiInstaller:      globalRoleApiInstaller,
 		resourcePermissionsStorage:  resourcepermission.ProvideStorageBackend(dbProvider),
 		roleBindingsStorage:         roleBindingsStorage,
 		externalGroupMappingStorage: externalGroupMappingStorageBackend,
@@ -174,6 +176,7 @@ func NewAPIService(
 		zTickets:                   make(chan bool, MaxConcurrentZanzanaWrites),
 		reg:                        reg,
 		roleApiInstaller:           roleApiInstaller,
+		globalRoleApiInstaller:     ProvideNoopGlobalRoleApiInstaller(), // TODO: add a proper global role installer
 		authorizer: authorizer.AuthorizerFunc(
 			func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
 				user, ok := types.AuthInfoFrom(ctx)
@@ -219,12 +222,20 @@ func (b *IdentityAccessManagementAPIBuilder) InstallSchema(scheme *runtime.Schem
 	enableCoreRolesApi := client.Boolean(ctx, featuremgmt.FlagKubernetesAuthzCoreRolesApi, false, openfeature.TransactionContext(ctx))
 	enableRolesApi := client.Boolean(ctx, featuremgmt.FlagKubernetesAuthzRolesApi, false, openfeature.TransactionContext(ctx))
 	enableRoleBindingsApi := client.Boolean(ctx, featuremgmt.FlagKubernetesAuthzRoleBindingsApi, false, openfeature.TransactionContext(ctx))
+	enableGlobalRolesApi := client.Boolean(ctx, featuremgmt.FlagKubernetesAuthzGlobalRolesApi, false, openfeature.TransactionContext(ctx))
 
 	if enableCoreRolesApi || enableRolesApi || enableRoleBindingsApi {
 		if err := iamv0.AddAuthZKnownTypes(scheme); err != nil {
 			return err
 		}
 	}
+
+	if enableGlobalRolesApi {
+		if err := iamv0.AddGlobalRoleKnownTypes(scheme); err != nil {
+			return err
+		}
+	}
+
 	//nolint:staticcheck // not yet migrated to OpenFeature
 	if b.features.IsEnabledGlobally(featuremgmt.FlagKubernetesAuthzResourcePermissionApis) {
 		if err := iamv0.AddResourcePermissionKnownTypes(scheme, iamv0.SchemeGroupVersion); err != nil {
@@ -264,6 +275,7 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 	enableCoreRolesApi := client.Boolean(ctx, featuremgmt.FlagKubernetesAuthzCoreRolesApi, false, openfeature.TransactionContext(ctx))
 	enableRolesApi := client.Boolean(ctx, featuremgmt.FlagKubernetesAuthzRolesApi, false, openfeature.TransactionContext(ctx))
 	enableRoleBindingsApi := client.Boolean(ctx, featuremgmt.FlagKubernetesAuthzRoleBindingsApi, false, openfeature.TransactionContext(ctx))
+	enableGlobalRolesApi := client.Boolean(ctx, featuremgmt.FlagKubernetesAuthzGlobalRolesApi, false, openfeature.TransactionContext(ctx))
 
 	// teams + users must have shorter names because they are often used as part of another name
 	opts.StorageOptsRegister(iamv0.TeamResourceInfo.GroupResource(), apistore.StorageOptions{
@@ -309,6 +321,12 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 	if enableRolesApi {
 		// Role registration is delegated to the RoleApiInstaller
 		if err := b.roleApiInstaller.RegisterStorage(apiGroupInfo, &opts, storage); err != nil {
+			return err
+		}
+	}
+
+	if enableGlobalRolesApi {
+		if err := b.globalRoleApiInstaller.RegisterStorage(apiGroupInfo, &opts, storage); err != nil {
 			return err
 		}
 	}
@@ -664,6 +682,8 @@ func (b *IdentityAccessManagementAPIBuilder) Validate(ctx context.Context, a adm
 			return externalgroupmapping.ValidateOnCreate(typedObj)
 		case *iamv0.Role:
 			return b.roleApiInstaller.ValidateOnCreate(ctx, typedObj)
+		case *iamv0.GlobalRole:
+			return b.globalRoleApiInstaller.ValidateOnCreate(ctx, typedObj)
 		}
 		return nil
 	case admission.Update:
@@ -694,12 +714,20 @@ func (b *IdentityAccessManagementAPIBuilder) Validate(ctx context.Context, a adm
 				return fmt.Errorf("expected old object to be a Role, got %T", oldRoleObj)
 			}
 			return b.roleApiInstaller.ValidateOnUpdate(ctx, oldRoleObj, typedObj)
+		case *iamv0.GlobalRole:
+			oldGlobalRoleObj, ok := a.GetOldObject().(*iamv0.GlobalRole)
+			if !ok {
+				return fmt.Errorf("expected old object to be a GlobalRole, got %T", oldGlobalRoleObj)
+			}
+			return b.globalRoleApiInstaller.ValidateOnUpdate(ctx, oldGlobalRoleObj, typedObj)
 		}
 		return nil
 	case admission.Delete:
-		switch oldRoleObj := a.GetOldObject().(type) {
+		switch oldObj := a.GetOldObject().(type) {
 		case *iamv0.Role:
-			return b.roleApiInstaller.ValidateOnDelete(ctx, oldRoleObj)
+			return b.roleApiInstaller.ValidateOnDelete(ctx, oldObj)
+		case *iamv0.GlobalRole:
+			return b.globalRoleApiInstaller.ValidateOnDelete(ctx, oldObj)
 		}
 		return nil
 	case admission.Connect:

--- a/pkg/registry/apis/wireset.go
+++ b/pkg/registry/apis/wireset.go
@@ -29,6 +29,7 @@ var WireSetExts = wire.NewSet(
 	noopstorage.ProvideStorageBackend,
 	wire.Bind(new(iam.CoreRoleStorageBackend), new(*noopstorage.StorageBackendImpl)),
 	iam.ProvideNoopRoleApiInstaller,
+	iam.ProvideNoopGlobalRoleApiInstaller,
 	wire.Bind(new(iam.RoleBindingStorageBackend), new(*noopstorage.StorageBackendImpl)),
 	wire.Bind(new(iam.ExternalGroupMappingStorageBackend), new(*noopstorage.StorageBackendImpl)),
 

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -882,8 +882,9 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	folderAPIBuilder := folders.RegisterAPIService(cfg, featureToggles, apiserverService, folderimplService, folderPermissionsService, accessControl, acimplService, accessClient, registerer, resourceClient, zanzanaClient)
 	storageBackendImpl := noopstorage.ProvideStorageBackend()
 	roleApiInstaller := iam.ProvideNoopRoleApiInstaller()
+	globalRoleApiInstaller := iam.ProvideNoopGlobalRoleApiInstaller()
 	noopTeamGroupsREST := externalgroupmapping.ProvideNoopTeamGroupsREST()
-	identityAccessManagementAPIBuilder, err := iam.RegisterAPIService(cfg, featureToggles, apiserverService, ssosettingsimplService, sqlStore, accessControl, accessClient, zanzanaClient, registerer, storageBackendImpl, roleApiInstaller, tracingService, storageBackendImpl, storageBackendImpl, noopTeamGroupsREST, dualwriteService, resourceClient, orgService, userService, teamService, eventualRestConfigProvider)
+	identityAccessManagementAPIBuilder, err := iam.RegisterAPIService(cfg, featureToggles, apiserverService, ssosettingsimplService, sqlStore, accessControl, accessClient, zanzanaClient, registerer, storageBackendImpl, roleApiInstaller, globalRoleApiInstaller, tracingService, storageBackendImpl, storageBackendImpl, noopTeamGroupsREST, dualwriteService, resourceClient, orgService, userService, teamService, eventualRestConfigProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -1550,8 +1551,9 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	folderAPIBuilder := folders.RegisterAPIService(cfg, featureToggles, apiserverService, folderimplService, folderPermissionsService, accessControl, acimplService, accessClient, registerer, resourceClient, zanzanaClient)
 	storageBackendImpl := noopstorage.ProvideStorageBackend()
 	roleApiInstaller := iam.ProvideNoopRoleApiInstaller()
+	globalRoleApiInstaller := iam.ProvideNoopGlobalRoleApiInstaller()
 	noopTeamGroupsREST := externalgroupmapping.ProvideNoopTeamGroupsREST()
-	identityAccessManagementAPIBuilder, err := iam.RegisterAPIService(cfg, featureToggles, apiserverService, ssosettingsimplService, sqlStore, accessControl, accessClient, zanzanaClient, registerer, storageBackendImpl, roleApiInstaller, tracingService, storageBackendImpl, storageBackendImpl, noopTeamGroupsREST, dualwriteService, resourceClient, orgService, userService, teamService, eventualRestConfigProvider)
+	identityAccessManagementAPIBuilder, err := iam.RegisterAPIService(cfg, featureToggles, apiserverService, ssosettingsimplService, sqlStore, accessControl, accessClient, zanzanaClient, registerer, storageBackendImpl, roleApiInstaller, globalRoleApiInstaller, tracingService, storageBackendImpl, storageBackendImpl, noopTeamGroupsREST, dualwriteService, resourceClient, orgService, userService, teamService, eventualRestConfigProvider)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds the boilerplate code to install the GlobalRole apis in the `grafana-iam` app.
Currently uses a `NoopApiInstaller` which means access is denied and backend returns not implemented.

```
kubectl --kubeconfig local.kubeconfig get globalroles
Error from server (Forbidden): globalroles.iam.grafana.app is forbidden: User "admin" cannot list resource "globalroles" in API group "iam.grafana.app" in the namespace "default": Unavailable functionality
```