### PR TITLE
Elasticsearch: Clear code editor query when switching query types

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/state.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/state.test.ts
@@ -1,6 +1,7 @@
 import { ElasticsearchDataQuery } from '../../dataquery.gen';
 import { reducerTester } from '../reducerTester';
 
+import { changeMetricType } from './MetricAggregationsEditor/state/actions';
 import {
   aliasPatternReducer,
   changeAliasPattern,
@@ -102,5 +103,34 @@ describe('Raw DSL Query Reducer', () => {
       .givenReducer(rawDSLQueryReducer, initialRawQuery)
       .whenActionIsDispatched(changeEditorTypeAndResetQuery('builder'))
       .thenStateShouldEqual('');
+  });
+
+  describe('When switching query types', () => {
+    it('Should clear raw DSL query when switching from metrics to logs', () => {
+      const initialRawQuery: ElasticsearchDataQuery['rawDSLQuery'] = '{"aggs": {"1": {"avg": {"field": "bytes"}}}}';
+
+      reducerTester<ElasticsearchDataQuery['rawDSLQuery']>()
+        .givenReducer(rawDSLQueryReducer, initialRawQuery)
+        .whenActionIsDispatched(changeMetricType({ id: '1', type: 'logs' }))
+        .thenStateShouldEqual('');
+    });
+
+    it('Should clear raw DSL query when switching from logs to metrics', () => {
+      const initialRawQuery: ElasticsearchDataQuery['rawDSLQuery'] = '{"query": {"match_all": {}}}';
+
+      reducerTester<ElasticsearchDataQuery['rawDSLQuery']>()
+        .givenReducer(rawDSLQueryReducer, initialRawQuery)
+        .whenActionIsDispatched(changeMetricType({ id: '1', type: 'avg' }))
+        .thenStateShouldEqual('');
+    });
+
+    it('Should clear raw DSL query when switching to raw_data', () => {
+      const initialRawQuery: ElasticsearchDataQuery['rawDSLQuery'] = '{"aggs": {"1": {"avg": {"field": "bytes"}}}}';
+
+      reducerTester<ElasticsearchDataQuery['rawDSLQuery']>()
+        .givenReducer(rawDSLQueryReducer, initialRawQuery)
+        .whenActionIsDispatched(changeMetricType({ id: '1', type: 'raw_data' }))
+        .thenStateShouldEqual('');
+    });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/state.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/state.ts
@@ -3,6 +3,8 @@ import { Action, createAction } from '@reduxjs/toolkit';
 import { ElasticsearchDataQuery } from '../../dataquery.gen';
 import { QueryType } from '../../types';
 
+import { changeMetricType } from './MetricAggregationsEditor/state/actions';
+
 /**
  * When the `initQuery` Action is dispatched, the query gets populated with default values where values are not present.
  * This means it won't override any existing value in place, but just ensure the query is in a "runnable" state.
@@ -43,6 +45,12 @@ export const rawDSLQueryReducer = (prevRawDSLQuery: ElasticsearchDataQuery['rawD
   }
 
   if (changeEditorTypeAndResetQuery.match(action)) {
+    return '';
+  }
+
+  // Clear raw DSL query when switching query types while using the code editor.
+  // Metric queries and log queries are not the same, so the code editor should be cleared.
+  if (changeMetricType.match(action)) {
     return '';
   }
 


### PR DESCRIPTION
## Summary

- Clears the raw DSL query in the code editor when switching between query types (metrics, logs, raw_data)
- Prevents user confusion since metric queries and log queries have different DSL structures
- Adds tests to verify the clearing behavior

## Test plan

- [ ] Switch from a metric query type to logs while in code editor mode - query should clear
- [ ] Switch from logs to a metric query type while in code editor mode - query should clear
- [ ] Switch to raw_data query type while in code editor mode - query should clear
- [ ] Existing editor type switching behavior remains unchanged
- [ ] Unit tests pass

Fixes #116312