### PR TITLE
Alerting: Update GOPS labels API calls to v2alpha1

### DIFF
--- a/public/app/features/alerting/unified/api/labelsApi.ts
+++ b/public/app/features/alerting/unified/api/labelsApi.ts
@@ -17,13 +17,13 @@ export const labelsApi = alertingApi.injectEndpoints({
   endpoints: (build) => ({
     getLabels: build.query<LabelItem[], void>({
       query: () => ({
-        url: `/api/plugins/${SupportedPlugin.Labels}/resources/v1/labels/keys`,
+        url: `/api/plugins/${SupportedPlugin.Labels}/resources/v2alpha1/labels/keys`,
       }),
       providesTags: ['GrafanaLabels'],
     }),
     getLabelValues: build.query<LabelKeyAndValues, { key: string }>({
       query: ({ key }) => ({
-        url: `/api/plugins/${SupportedPlugin.Labels}/resources/v1/labels/name/${key}`,
+        url: `/api/plugins/${SupportedPlugin.Labels}/resources/v2alpha1/labels/name/${key}`,
       }),
       providesTags: ['GrafanaLabels'],
     }),

--- a/public/app/features/alerting/unified/mocks/server/handlers/plugins/grafana-labels-app.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/plugins/grafana-labels-app.ts
@@ -46,16 +46,16 @@ export function getMockOpsLabels(
 }
 
 /**
- * Handler for GET /api/plugins/grafana-labels-app/resources/v1/labels/keys
+ * Handler for GET /api/plugins/grafana-labels-app/resources/v2alpha1/labels/keys
  * Returns all available label keys
  */
 export const getLabelsKeysHandler = (labelKeys: LabelItem[] = defaultLabelKeys) =>
-  http.get(`${BASE_URL}/v1/labels/keys`, () => {
+  http.get(`${BASE_URL}/v2alpha1/labels/keys`, () => {
     return HttpResponse.json(labelKeys);
   });
 
 /**
- * Handler for GET /api/plugins/grafana-labels-app/resources/v1/labels/name/:key
+ * Handler for GET /api/plugins/grafana-labels-app/resources/v2alpha1/labels/name/:key
  * Returns values for a specific label key.
  * @param labelValues - Custom label values map (defaults to defaultLabelValues)
  * @param onKeyRequested - Optional callback to spy on which keys are requested (useful for testing)
@@ -64,7 +64,7 @@ export const getLabelValuesHandler = (
   labelValues: Record<string, LabelItem[]> = defaultLabelValues,
   onKeyRequested?: (key: string) => void
 ) =>
-  http.get<{ key: string }>(`${BASE_URL}/v1/labels/name/:key`, ({ params }) => {
+  http.get<{ key: string }>(`${BASE_URL}/v2alpha1/labels/name/:key`, ({ params }) => {
     const key = params.key;
     onKeyRequested?.(key);
     const values = labelValues[key] || [];


### PR DESCRIPTION
**What is this feature?**

This PR updates GOPS labels API calls to the new v2alpha1.
See more context [here](https://raintank-corp.slack.com/archives/C04LG9N6R4J/p1765992928288979?thread_ts=1765984367.899539&cid=C04LG9N6R4J)

You can test it in https://ephemeral15111821116327soniaa.grafana-dev.net/ 

**Why do we need this feature?**

We should use the new v2alpha1  endpoints.

Fixes https://github.com/grafana/alerting-squad/issues/1349

**Special notes for your reviewer:**

<img width="1062" height="780" alt="Screenshot 2026-01-15 at 09 51 02" src="https://github.com/user-attachments/assets/008e5a24-4c86-4a24-935c-d15a339d2dcd" />

<img width="1741" height="1019" alt="Screenshot 2026-01-15 at 12 14 56" src="https://github.com/user-attachments/assets/06f57f24-bdfc-4813-81cd-c317ee5286ec" />

<img width="1464" height="320" alt="Screenshot 2026-01-15 at 12 17 24" src="https://github.com/user-attachments/assets/3daa31d5-40fe-4827-a187-f8cb682ff2b2" />



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
