### PR TITLE
Azure Monitor: Hide the time-range toggle for builder queries

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/TimeManagement.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/TimeManagement.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import FakeSchemaData from '../../azure_log_analytics/mocks/schema';
+import { LogsEditorMode } from '../../dataquery.gen';
 import createMockDatasource from '../../mocks/datasource';
 import createMockQuery from '../../mocks/query';
 
@@ -206,5 +207,24 @@ describe('LogsQueryEditor.TimeManagement', () => {
 
     expect(screen.getByLabelText('Query')).toBeDisabled();
     expect(screen.getByLabelText('Dashboard')).toBeChecked();
+  });
+
+  it('should hide time-range toggle for builder queries', async () => {
+    const mockDatasource = createMockDatasource();
+    const query = createMockQuery({ azureLogAnalytics: { mode: LogsEditorMode.Builder } });
+    const onChange = jest.fn();
+
+    render(
+      <TimeManagement
+        query={query}
+        datasource={mockDatasource}
+        variableOptionGroup={variableOptionGroup}
+        onQueryChange={onChange}
+        setError={() => {}}
+        schema={FakeSchemaData.getLogAnalyticsFakeEngineSchema()}
+      />
+    );
+
+    expect(screen.queryByText('Time-range')).not.toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/TimeManagement.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/TimeManagement.tsx
@@ -88,34 +88,32 @@ export function TimeManagement({ query, onQueryChange: onChange, schema }: Azure
 
   return (
     <>
-      <InlineField
-        label={t('components.time-management.label-time-range', 'Time-range')}
-        tooltip={
-          <Trans i18nKey="components.time-management.tooltip-time-range">
-            <span>
-              Specifies the time-range used to query. The <code>Query</code> option will only use time-ranges specified
-              in the query. <code>Dashboard</code> will only use the Grafana time-range. In Logs Builder mode, only
-              Dashboard time will be used.
-            </span>
-          </Trans>
-        }
-      >
-        <RadioButtonGroup
-          options={[
-            { label: 'Query', value: 'query', disabled: query.azureLogAnalytics?.mode === 'builder' },
-            { label: 'Dashboard', value: 'dashboard' },
-          ]}
-          value={
-            query.azureLogAnalytics?.dashboardTime || query.azureLogAnalytics?.mode === 'builder'
-              ? 'dashboard'
-              : 'query'
+      {query.azureLogAnalytics?.mode !== 'builder' && (
+        <InlineField
+          label={t('components.time-management.label-time-range', 'Time-range')}
+          tooltip={
+            <Trans i18nKey="components.time-management.tooltip-time-range">
+              <span>
+                Specifies the time-range used to query. The <code>Query</code> option will only use time-ranges
+                specified in the query. <code>Dashboard</code> will only use the Grafana time-range. In Logs Builder
+                mode, only Dashboard time will be used.
+              </span>
+            </Trans>
           }
-          size={'md'}
-          onChange={(val) => onChange(setDashboardTime(query, val))}
-          disabled={disabledTimePicker}
-          disabledOptions={disabledTimePicker ? ['query'] : []}
-        />
-      </InlineField>
+        >
+          <RadioButtonGroup
+            options={[
+              { label: 'Query', value: 'query' },
+              { label: 'Dashboard', value: 'dashboard' },
+            ]}
+            value={query.azureLogAnalytics?.dashboardTime ? 'dashboard' : 'query'}
+            size={'md'}
+            onChange={(val) => onChange(setDashboardTime(query, val))}
+            disabled={disabledTimePicker}
+            disabledOptions={disabledTimePicker ? ['query'] : []}
+          />
+        </InlineField>
+      )}
       {(query.azureLogAnalytics?.dashboardTime || query.azureLogAnalytics?.mode === 'builder') && (
         <InlineField
           label={t('components.time-management.label-time-column', 'Time Column')}

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/TimeManagement.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/TimeManagement.tsx
@@ -95,8 +95,7 @@ export function TimeManagement({ query, onQueryChange: onChange, schema }: Azure
             <Trans i18nKey="components.time-management.tooltip-time-range">
               <span>
                 Specifies the time-range used to query. The <code>Query</code> option will only use time-ranges
-                specified in the query. <code>Dashboard</code> will only use the Grafana time-range. In Logs Builder
-                mode, only Dashboard time will be used.
+                specified in the query. <code>Dashboard</code> will only use the Grafana time-range.
               </span>
             </Trans>
           }

--- a/public/app/plugins/datasource/azuremonitor/locales/en-US/grafana-azure-monitor-datasource.json
+++ b/public/app/plugins/datasource/azuremonitor/locales/en-US/grafana-azure-monitor-datasource.json
@@ -274,7 +274,7 @@
       "label-time-column": "Time Column",
       "label-time-range": "Time-range",
       "tooltip-time-column": "<0>Specifies the time column used for filtering. Defaults to the first tables <1>timeSpan</1> column, the first <3>datetime</3> column found or <5>TimeGenerated</5>.</0>",
-      "tooltip-time-range": "<0>Specifies the time-range used to query. The <1>Query</1> option will only use time-ranges specified in the query. <3>Dashboard</3> will only use the Grafana time-range. In Logs Builder mode, only Dashboard time will be used.</0>"
+      "tooltip-time-range": "<0>Specifies the time-range used to query. The <1>Query</1> option will only use time-ranges specified in the query. <3>Dashboard</3> will only use the Grafana time-range.</0>"
     },
     "top-field": {
       "label-top": "Top"


### PR DESCRIPTION
Currently, the time-range toggle is displayed for builder queries. However, the user cannot actually modify the time-range from dashboard.

This change will hide the toggle when builder mode is used to reduce confusion. 

TBD on if we actually want to implement this or not.

Fixes #115433