### PR TITLE
Dynamic Dashboards: Fix scopes variables showing up in edit mode

### DIFF
--- a/public/app/features/dashboard-scene/scene/VariableControls.test.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.test.tsx
@@ -22,7 +22,7 @@ jest.mock('@grafana/runtime', () => {
 
 describe('VariableControls', () => {
   it('should not render scopes variable', () => {
-    const variables = [new ScopesVariable({})];
+    const variables = [new ScopesVariable({ hide: VariableHide.hideVariable, name: '__scopes' })];
     const dashboard = buildScene(variables);
     dashboard.activate();
 
@@ -68,6 +68,16 @@ describe('VariableControls', () => {
     render(<VariableControls dashboard={dashboard} />);
 
     expect(screen.queryByText('TextVarControls')).not.toBeInTheDocument();
+  });
+
+  it('should render visible variables in edit mode', async () => {
+    const dashboard = buildScene([new TextBoxVariable({ name: 'TextVarVisible', hide: VariableHide.dontHide })]);
+    dashboard.activate();
+
+    dashboard.setState({ isEditing: true });
+    render(<VariableControls dashboard={dashboard} />);
+
+    expect(await screen.findByText('TextVarVisible')).toBeInTheDocument();
   });
 });
 

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -34,16 +34,18 @@ export function VariableControls({ dashboard }: { dashboard: DashboardScene }) {
     (v) => v.state.name !== adHocVar?.state.name && v.state.name !== groupByVar?.state.name
   );
 
-  // Variables to render (exclude adhoc/groupby when drilldown controls are shown in top row)
+  //  Variables to render (exclude adhoc/groupby when drilldown controls are shown in top row)
   const variablesToRender = hasDrilldownControls
     ? restVariables.filter((v) => v.state.hide !== VariableHide.inControlsMenu)
-    : variables.filter(
-        (v) =>
-          // used for scopes variables, should always be hidden
-          // if we're editing in dynamic dashboards, still shows hidden variable but greyed out
-          (!v.UNSAFE_renderAsHidden && isEditingNewLayouts && v.state.hide === VariableHide.hideVariable) ||
-          v.state.hide !== VariableHide.inControlsMenu
-      );
+    : isEditingNewLayouts
+      ? variables.filter(
+          (v) =>
+            v.state.hide !== VariableHide.inControlsMenu &&
+            // UNSAFE_renderAsHidden used for scopes variables, should always be hidden
+            // if we're editing in dynamic dashboards, still shows hidden variable but greyed out
+            (v.state.hide !== VariableHide.hideVariable || !v.UNSAFE_renderAsHidden)
+        )
+      : variables.filter((v) => v.state.hide !== VariableHide.inControlsMenu);
 
   return (
     <>


### PR DESCRIPTION
The previous condition set in [this PR](https://github.com/grafana/grafana/pull/116132) was wrong because it checked for ` || v.state.hide !== VariableHide.inControlsMenu` and scopes variables have the V`ariableHide.hidden`, so it still showed the variable in edit mode. Tested it locally with scopes enabled: 
<img width="600" height="171" alt="Screenshot 2026-01-15 at 13 19 01" src="https://github.com/user-attachments/assets/032efa4a-6925-46e3-abe7-9a144e0628f3" />
