### PR TITLE
Plugins: add new loading of app plugins II

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2999,7 +2999,7 @@
   },
   "public/app/features/plugins/extensions/utils.tsx": {
     "no-restricted-syntax": {
-      "count": 7
+      "count": 1
     }
   },
   "public/app/features/plugins/extensions/validators.test.tsx": {

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1263,4 +1263,9 @@ export interface FeatureToggles {
   * Use synchronized dispatch timer to minimize duplicate notifications across alertmanager HA pods
   */
   alertingSyncDispatchTimer?: boolean;
+  /**
+  * Enables new loading of app plugins
+  * @default false
+  */
+  useMTAppsLoading?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2054,6 +2054,7 @@ var (
 			Owner:        grafanaPluginsPlatformSquad,
 			FrontendOnly: true,
 			Expression:   "false",
+			HideFromDocs: true,
 		},
 		{
 			Name:         "multiPropsVariables",
@@ -2091,6 +2092,15 @@ var (
 			Owner:           grafanaAlertingSquad,
 			RequiresRestart: true,
 			HideFromDocs:    true,
+		},
+		{
+			Name:         "useMTAppsLoading",
+			Description:  "Enables new loading of app plugins",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaPluginsPlatformSquad,
+			FrontendOnly: true,
+			Expression:   "false",
+			HideFromDocs: true,
 		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -283,3 +283,4 @@ smoothingTransformation,experimental,@grafana/datapro,false,false,true
 secretsManagementAppPlatformAwsKeeper,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 profilesExemplars,experimental,@grafana/observability-traces-and-profiling,false,false,false
 alertingSyncDispatchTimer,experimental,@grafana/alerting-squad,false,true,false
+useMTAppsLoading,experimental,@grafana/plugins-platform-backend,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3838,15 +3838,34 @@
     },
     {
       "metadata": {
+        "name": "useMTAppsLoading",
+        "resourceVersion": "1768473704313",
+        "creationTimestamp": "2026-01-15T10:41:44Z"
+      },
+      "spec": {
+        "description": "Enables new loading of app plugins",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true,
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "useMTPlugins",
-        "resourceVersion": "1764913709691",
-        "creationTimestamp": "2025-12-05T05:48:29Z"
+        "resourceVersion": "1768473704313",
+        "creationTimestamp": "2025-12-05T05:48:29Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-01-15 10:41:44.313533 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables plugins decoupling from bootdata",
         "stage": "experimental",
         "codeowner": "@grafana/plugins-platform-backend",
         "frontend": true,
+        "hideFromDocs": true,
         "expression": "false"
       }
     },

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -257,8 +257,8 @@ export class GrafanaApp {
       const skipAppPluginsPreload =
         config.featureToggles.rendererDisableAppPluginsPreload && contextSrv.user.authenticatedBy === 'render';
       if (contextSrv.user.orgRole !== '' && !skipAppPluginsPreload) {
-        const appPluginsToAwait = getAppPluginsToAwait();
-        const appPluginsToPreload = getAppPluginsToPreload();
+        const appPluginsToAwait = await getAppPluginsToAwait();
+        const appPluginsToPreload = await getAppPluginsToPreload();
 
         preloadPlugins(appPluginsToPreload);
         await preloadPlugins(appPluginsToAwait);

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -1,5 +1,5 @@
 import { createContext, ReactNode, useCallback, useContext, useEffect, useState, useMemo } from 'react';
-import { useLocalStorage } from 'react-use';
+import { useAsync, useLocalStorage } from 'react-use';
 
 import { PluginExtensionPoints, store } from '@grafana/data';
 import { getAppEvents, reportInteraction, usePluginLinks, locationService } from '@grafana/runtime';
@@ -89,19 +89,28 @@ export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarCo
   // that means, a plugin would need to register both, a link and a component to
   // `grafana/extension-sidebar/v0-alpha` and the link's `configure` method would control
   // whether the component is rendered or not
-  const { links, isLoading } = usePluginLinks({
+  const { links, isLoading: isPluginLinksLoading } = usePluginLinks({
     extensionPointId: PluginExtensionPoints.ExtensionSidebar,
     context: {
       path: currentPath,
     },
   });
 
+  const { loading: isExtensionPointPluginMetaLoading, value: pluginMap } = useAsync(() =>
+    getExtensionPointPluginMeta(PluginExtensionPoints.ExtensionSidebar)
+  );
+
+  const isLoading = useMemo(
+    () => isPluginLinksLoading || isExtensionPointPluginMetaLoading,
+    [isPluginLinksLoading, isExtensionPointPluginMetaLoading]
+  );
+
   // get all components for this extension point, but only for the permitted plugins
   // if the extension sidebar is not enabled, we will return an empty map
   const availableComponents = useMemo(
     () =>
       new Map(
-        Array.from(getExtensionPointPluginMeta(PluginExtensionPoints.ExtensionSidebar).entries()).filter(
+        Array.from(pluginMap?.entries() || []).filter(
           ([pluginId, pluginMeta]) =>
             PERMITTED_EXTENSION_SIDEBAR_PLUGINS.includes(pluginId) &&
             links.some(
@@ -111,7 +120,7 @@ export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarCo
             )
         )
       ),
-    [links]
+    [links, pluginMap]
   );
 
   // check if the stored docked component is still available

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.test.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.test.tsx
@@ -1,18 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useAsync } from 'react-use';
 
 import { EventBusSrv, store } from '@grafana/data';
 import { setAppEvents, usePluginLinks } from '@grafana/runtime';
-import { getExtensionPointPluginMeta } from 'app/features/plugins/extensions/utils';
 
 import { ExtensionSidebarContextProvider, useExtensionSidebarContext } from './ExtensionSidebarProvider';
 import { ExtensionToolbarItem } from './ExtensionToolbarItem';
-
-// Mock the extension point plugin meta
-jest.mock('app/features/plugins/extensions/utils', () => ({
-  ...jest.requireActual('app/features/plugins/extensions/utils'),
-  getExtensionPointPluginMeta: jest.fn(),
-}));
 
 // Mock store
 jest.mock('@grafana/data', () => ({
@@ -35,6 +29,11 @@ jest.mock('@grafana/runtime', () => ({
     ],
     isLoading: false,
   })),
+}));
+
+jest.mock('react-use', () => ({
+  ...jest.requireActual('react-use'),
+  useAsync: jest.fn(),
 }));
 
 const mockComponent = {
@@ -68,9 +67,10 @@ const setup = () => {
 };
 
 describe('ExtensionToolbarItem', () => {
+  const useAsyncMock = jest.mocked(useAsync);
   beforeEach(() => {
     jest.clearAllMocks();
-    (getExtensionPointPluginMeta as jest.Mock).mockReturnValue(new Map([[mockPluginMeta.pluginId, mockPluginMeta]]));
+    useAsyncMock.mockReturnValue({ loading: false, value: new Map([[mockPluginMeta.pluginId, mockPluginMeta]]) });
     (store.get as jest.Mock).mockClear();
     (store.set as jest.Mock).mockClear();
     (store.delete as jest.Mock).mockClear();
@@ -82,7 +82,7 @@ describe('ExtensionToolbarItem', () => {
   });
 
   it('should not render when no components are available', () => {
-    (getExtensionPointPluginMeta as jest.Mock).mockReturnValue(new Map());
+    useAsyncMock.mockReturnValue({ loading: false, value: new Map() });
     setup();
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
@@ -124,9 +124,10 @@ describe('ExtensionToolbarItem', () => {
       isLoading: false,
     });
 
-    (getExtensionPointPluginMeta as jest.Mock).mockReturnValue(
-      new Map([[multipleComponentsMeta.pluginId, multipleComponentsMeta]])
-    );
+    useAsyncMock.mockReturnValue({
+      loading: false,
+      value: new Map([[multipleComponentsMeta.pluginId, multipleComponentsMeta]]),
+    });
 
     setup();
 
@@ -148,9 +149,10 @@ describe('ExtensionToolbarItem', () => {
       ],
     };
 
-    (getExtensionPointPluginMeta as jest.Mock).mockReturnValue(
-      new Map([[multipleComponentsMeta.pluginId, multipleComponentsMeta]])
-    );
+    useAsyncMock.mockReturnValue({
+      loading: false,
+      value: new Map([[multipleComponentsMeta.pluginId, multipleComponentsMeta]]),
+    });
 
     setup();
 
@@ -172,9 +174,10 @@ describe('ExtensionToolbarItem', () => {
       ],
     };
 
-    (getExtensionPointPluginMeta as jest.Mock).mockReturnValue(
-      new Map([[multipleComponentsMeta.pluginId, multipleComponentsMeta]])
-    );
+    useAsyncMock.mockReturnValue({
+      loading: false,
+      value: new Map([[multipleComponentsMeta.pluginId, multipleComponentsMeta]]),
+    });
 
     setup();
 
@@ -199,9 +202,10 @@ describe('ExtensionToolbarItem', () => {
       ],
     };
 
-    (getExtensionPointPluginMeta as jest.Mock).mockReturnValue(
-      new Map([[multipleComponentsMeta.pluginId, multipleComponentsMeta]])
-    );
+    useAsyncMock.mockReturnValue({
+      loading: false,
+      value: new Map([[multipleComponentsMeta.pluginId, multipleComponentsMeta]]),
+    });
 
     setup();
 
@@ -235,12 +239,13 @@ describe('ExtensionToolbarItem', () => {
       isLoading: false,
     });
 
-    (getExtensionPointPluginMeta as jest.Mock).mockReturnValue(
-      new Map([
+    useAsyncMock.mockReturnValue({
+      loading: false,
+      value: new Map([
         [plugin1Meta.pluginId, plugin1Meta],
         [plugin2Meta.pluginId, plugin2Meta],
-      ])
-    );
+      ]),
+    });
 
     setup();
 

--- a/public/app/features/plugins/extensions/useLoadAppPlugins.tsx
+++ b/public/app/features/plugins/extensions/useLoadAppPlugins.tsx
@@ -6,7 +6,7 @@ import { getAppPluginConfigs } from './utils';
 
 export function useLoadAppPlugins(pluginIds: string[] = []): { isLoading: boolean } {
   const { loading: isLoading } = useAsync(async () => {
-    const appConfigs = getAppPluginConfigs(pluginIds);
+    const appConfigs = await getAppPluginConfigs(pluginIds);
 
     if (!appConfigs.length) {
       return;

--- a/public/app/features/plugins/extensions/useLoadAppPluginsWithPredicate.tsx
+++ b/public/app/features/plugins/extensions/useLoadAppPluginsWithPredicate.tsx
@@ -1,0 +1,12 @@
+import { useAsync } from 'react-use';
+
+import { useLoadAppPlugins } from './useLoadAppPlugins';
+
+type Predicate = (pluginId: string) => Promise<string[]>;
+
+export function useLoadAppPluginsWithPredicate(pluginId: string, predicate: Predicate): { isLoading: boolean } {
+  const { loading: isPredicateLoading, value: pluginIds } = useAsync(() => predicate(pluginId), [pluginId, predicate]);
+  const { isLoading } = useLoadAppPlugins(pluginIds);
+
+  return { isLoading: isPredicateLoading || isLoading };
+}

--- a/public/app/features/plugins/extensions/usePluginComponent.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponent.tsx
@@ -6,7 +6,7 @@ import { UsePluginComponentResult } from '@grafana/runtime';
 import * as errors from './errors';
 import { log } from './logs/log';
 import { useExposedComponentRegistrySlice } from './registry/useRegistrySlice';
-import { useLoadAppPlugins } from './useLoadAppPlugins';
+import { useLoadAppPluginsWithPredicate } from './useLoadAppPluginsWithPredicate';
 import { getExposedComponentPluginDependencies, isGrafanaDevMode, wrapWithPluginContext } from './utils';
 import { isExposedComponentDependencyMissing } from './validators';
 
@@ -15,7 +15,7 @@ import { isExposedComponentDependencyMissing } from './validators';
 export function usePluginComponent<Props extends object = {}>(id: string): UsePluginComponentResult<Props> {
   const registryItem = useExposedComponentRegistrySlice<Props>(id);
   const pluginContext = usePluginContext();
-  const { isLoading: isLoadingAppPlugins } = useLoadAppPlugins(getExposedComponentPluginDependencies(id));
+  const { isLoading: isLoadingAppPlugins } = useLoadAppPluginsWithPredicate(id, getExposedComponentPluginDependencies);
 
   return useMemo(() => {
     // For backwards compatibility we don't enable restrictions in production or when the hook is used in core Grafana.

--- a/public/app/features/plugins/extensions/usePluginComponents.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.tsx
@@ -10,7 +10,7 @@ import { UsePluginComponentsOptions, UsePluginComponentsResult } from '@grafana/
 
 import { AddedComponentRegistryItem } from './registry/AddedComponentsRegistry';
 import { useAddedComponentsRegistrySlice } from './registry/useRegistrySlice';
-import { useLoadAppPlugins } from './useLoadAppPlugins';
+import { useLoadAppPluginsWithPredicate } from './useLoadAppPluginsWithPredicate';
 import { generateExtensionId, getExtensionPointPluginDependencies } from './utils';
 import { validateExtensionPoint } from './validateExtensionPoint';
 
@@ -21,7 +21,10 @@ export function usePluginComponents<Props extends object = {}>({
 }: UsePluginComponentsOptions): UsePluginComponentsResult<Props> {
   const registryItems = useAddedComponentsRegistrySlice<Props>(extensionPointId);
   const pluginContext = usePluginContext();
-  const { isLoading: isLoadingAppPlugins } = useLoadAppPlugins(getExtensionPointPluginDependencies(extensionPointId));
+  const { isLoading: isLoadingAppPlugins } = useLoadAppPluginsWithPredicate(
+    extensionPointId,
+    getExtensionPointPluginDependencies
+  );
 
   return useMemo(() => {
     const { result } = validateExtensionPoint({ extensionPointId, pluginContext, isLoadingAppPlugins });

--- a/public/app/features/plugins/extensions/usePluginFunctions.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginFunctions.test.tsx
@@ -20,6 +20,7 @@ import { AddedLinksRegistry } from './registry/AddedLinksRegistry';
 import { ExposedComponentsRegistry } from './registry/ExposedComponentsRegistry';
 import { PluginExtensionRegistries } from './registry/types';
 import { useLoadAppPlugins } from './useLoadAppPlugins';
+import { useLoadAppPluginsWithPredicate } from './useLoadAppPluginsWithPredicate';
 import { usePluginFunctions } from './usePluginFunctions';
 import { isGrafanaDevMode } from './utils';
 
@@ -62,6 +63,7 @@ describe('usePluginFunctions()', () => {
 
   beforeEach(() => {
     jest.mocked(useLoadAppPlugins).mockReturnValue({ isLoading: false });
+    jest.mocked(useLoadAppPluginsWithPredicate).mockReturnValue({ isLoading: false });
     jest.mocked(isGrafanaDevMode).mockReturnValue(false);
     registries = {
       addedComponentsRegistry: new AddedComponentsRegistry(),
@@ -265,6 +267,7 @@ describe('usePluginFunctions()', () => {
   });
 
   it('should return isLoading: true when app plugins are loading', () => {
+    jest.mocked(useLoadAppPluginsWithPredicate).mockReturnValue({ isLoading: true });
     jest.mocked(useLoadAppPlugins).mockReturnValue({ isLoading: true });
 
     const { result } = renderHook(() => usePluginFunctions({ extensionPointId }), { wrapper });

--- a/public/app/features/plugins/extensions/usePluginFunctions.tsx
+++ b/public/app/features/plugins/extensions/usePluginFunctions.tsx
@@ -4,7 +4,7 @@ import { usePluginContext, PluginExtensionFunction, PluginExtensionTypes } from 
 import { UsePluginFunctionsOptions, UsePluginFunctionsResult } from '@grafana/runtime';
 
 import { useAddedFunctionsRegistrySlice } from './registry/useRegistrySlice';
-import { useLoadAppPlugins } from './useLoadAppPlugins';
+import { useLoadAppPluginsWithPredicate } from './useLoadAppPluginsWithPredicate';
 import { generateExtensionId, getExtensionPointPluginDependencies } from './utils';
 import { validateExtensionPoint } from './validateExtensionPoint';
 
@@ -15,8 +15,10 @@ export function usePluginFunctions<Signature>({
 }: UsePluginFunctionsOptions): UsePluginFunctionsResult<Signature> {
   const registryItems = useAddedFunctionsRegistrySlice<Signature>(extensionPointId);
   const pluginContext = usePluginContext();
-  const deps = getExtensionPointPluginDependencies(extensionPointId);
-  const { isLoading: isLoadingAppPlugins } = useLoadAppPlugins(deps);
+  const { isLoading: isLoadingAppPlugins } = useLoadAppPluginsWithPredicate(
+    extensionPointId,
+    getExtensionPointPluginDependencies
+  );
 
   return useMemo(() => {
     const { result } = validateExtensionPoint({ extensionPointId, pluginContext, isLoadingAppPlugins });

--- a/public/app/features/plugins/extensions/usePluginLinks.tsx
+++ b/public/app/features/plugins/extensions/usePluginLinks.tsx
@@ -5,7 +5,7 @@ import { PluginExtensionLink, PluginExtensionTypes, usePluginContext } from '@gr
 import { UsePluginLinksOptions, UsePluginLinksResult } from '@grafana/runtime';
 
 import { useAddedLinksRegistrySlice } from './registry/useRegistrySlice';
-import { useLoadAppPlugins } from './useLoadAppPlugins';
+import { useLoadAppPluginsWithPredicate } from './useLoadAppPluginsWithPredicate';
 import {
   generateExtensionId,
   getExtensionPointPluginDependencies,
@@ -24,7 +24,10 @@ export function usePluginLinks({
 }: UsePluginLinksOptions): UsePluginLinksResult {
   const registryItems = useAddedLinksRegistrySlice(extensionPointId);
   const pluginContext = usePluginContext();
-  const { isLoading: isLoadingAppPlugins } = useLoadAppPlugins(getExtensionPointPluginDependencies(extensionPointId));
+  const { isLoading: isLoadingAppPlugins } = useLoadAppPluginsWithPredicate(
+    extensionPointId,
+    getExtensionPointPluginDependencies
+  );
 
   return useMemo(() => {
     const { result, pointLog } = validateExtensionPoint({

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -1027,7 +1027,7 @@ describe('Plugin Extensions / Utils', () => {
       config.apps = originalApps;
     });
 
-    test('should return the app plugin configs based on the provided plugin ids', () => {
+    test('should return the app plugin configs based on the provided plugin ids', async () => {
       config.apps = {
         'myorg-first-app': {
           ...genereicAppPluginConfig,
@@ -1043,13 +1043,11 @@ describe('Plugin Extensions / Utils', () => {
         },
       };
 
-      expect(getAppPluginConfigs(['myorg-first-app', 'myorg-third-app'])).toEqual([
-        config.apps['myorg-first-app'],
-        config.apps['myorg-third-app'],
-      ]);
+      const appPluginIds = await getAppPluginConfigs(['myorg-first-app', 'myorg-third-app']);
+      expect(appPluginIds).toEqual([config.apps['myorg-first-app'], config.apps['myorg-third-app']]);
     });
 
-    test('should simply ignore the app plugin ids that do not belong to a config', () => {
+    test('should simply ignore the app plugin ids that do not belong to a config', async () => {
       config.apps = {
         'myorg-first-app': {
           ...genereicAppPluginConfig,
@@ -1065,7 +1063,8 @@ describe('Plugin Extensions / Utils', () => {
         },
       };
 
-      expect(getAppPluginConfigs(['myorg-first-app', 'unknown-app-id'])).toEqual([config.apps['myorg-first-app']]);
+      const appPluginIds = await getAppPluginConfigs(['myorg-first-app', 'unknown-app-id']);
+      expect(appPluginIds).toEqual([config.apps['myorg-first-app']]);
     });
   });
 
@@ -1106,7 +1105,7 @@ describe('Plugin Extensions / Utils', () => {
       config.apps = originalApps;
     });
 
-    test('should return the app plugin ids that register extensions to a link extension point', () => {
+    test('should return the app plugin ids that register extensions to a link extension point', async () => {
       const extensionPointId = 'myorg-first-app/link/v1';
 
       config.apps = {
@@ -1137,12 +1136,12 @@ describe('Plugin Extensions / Utils', () => {
         },
       };
 
-      const appPluginIds = getExtensionPointPluginDependencies(extensionPointId);
+      const appPluginIds = await getExtensionPointPluginDependencies(extensionPointId);
 
       expect(appPluginIds).toEqual(['myorg-second-app']);
     });
 
-    test('should return the app plugin ids that register extensions to a component extension point', () => {
+    test('should return the app plugin ids that register extensions to a component extension point', async () => {
       const extensionPointId = 'myorg-first-app/component/v1';
 
       config.apps = {
@@ -1173,12 +1172,12 @@ describe('Plugin Extensions / Utils', () => {
         },
       };
 
-      const appPluginIds = getExtensionPointPluginDependencies(extensionPointId);
+      const appPluginIds = await getExtensionPointPluginDependencies(extensionPointId);
 
       expect(appPluginIds).toEqual(['myorg-third-app']);
     });
 
-    test('should return an empty array if there are no apps that that extend the extension point', () => {
+    test('should return an empty array if there are no apps that that extend the extension point', async () => {
       const extensionPointId = 'myorg-first-app/component/v1';
 
       // None of the apps are extending the extension point
@@ -1197,12 +1196,12 @@ describe('Plugin Extensions / Utils', () => {
         },
       };
 
-      const appPluginIds = getExtensionPointPluginDependencies(extensionPointId);
+      const appPluginIds = await getExtensionPointPluginDependencies(extensionPointId);
 
       expect(appPluginIds).toEqual([]);
     });
 
-    test('should also return (recursively) the app plugin ids that the apps which extend the extension-point depend on', () => {
+    test('should also return (recursively) the app plugin ids that the apps which extend the extension-point depend on', async () => {
       const extensionPointId = 'myorg-first-app/component/v1';
 
       config.apps = {
@@ -1283,7 +1282,7 @@ describe('Plugin Extensions / Utils', () => {
         },
       };
 
-      const appPluginIds = getExtensionPointPluginDependencies(extensionPointId);
+      const appPluginIds = await getExtensionPointPluginDependencies(extensionPointId);
 
       expect(appPluginIds).toEqual(['myorg-second-app', 'myorg-fourth-app', 'myorg-fifth-app']);
     });
@@ -1320,7 +1319,7 @@ describe('Plugin Extensions / Utils', () => {
       config.apps = originalApps;
     });
 
-    test('should only return the app plugin id that exposes the component, if that component does not depend on anything', () => {
+    test('should only return the app plugin id that exposes the component, if that component does not depend on anything', async () => {
       const exposedComponentId = 'myorg-second-app/component/v1';
 
       config.apps = {
@@ -1350,12 +1349,12 @@ describe('Plugin Extensions / Utils', () => {
         },
       };
 
-      const appPluginIds = getExposedComponentPluginDependencies(exposedComponentId);
+      const appPluginIds = await getExposedComponentPluginDependencies(exposedComponentId);
 
       expect(appPluginIds).toEqual(['myorg-second-app']);
     });
 
-    test('should also return the list of app plugin ids that the plugin - which exposes the component - is depending on', () => {
+    test('should also return the list of app plugin ids that the plugin - which exposes the component - is depending on', async () => {
       const exposedComponentId = 'myorg-second-app/component/v1';
 
       config.apps = {
@@ -1429,7 +1428,7 @@ describe('Plugin Extensions / Utils', () => {
         },
       };
 
-      const appPluginIds = getExposedComponentPluginDependencies(exposedComponentId);
+      const appPluginIds = await getExposedComponentPluginDependencies(exposedComponentId);
 
       expect(appPluginIds).toEqual(['myorg-second-app', 'myorg-fourth-app', 'myorg-fifth-app']);
     });
@@ -1466,7 +1465,7 @@ describe('Plugin Extensions / Utils', () => {
       config.apps = originalApps;
     });
 
-    test('should not end up in an infinite loop if there are circular dependencies', () => {
+    test('should not end up in an infinite loop if there are circular dependencies', async () => {
       config.apps = {
         'myorg-first-app': {
           ...genereicAppPluginConfig,
@@ -1494,12 +1493,12 @@ describe('Plugin Extensions / Utils', () => {
         },
       };
 
-      const appPluginIds = getAppPluginDependencies('myorg-second-app');
+      const appPluginIds = await getAppPluginDependencies('myorg-second-app');
 
       expect(appPluginIds).toEqual(['myorg-third-app']);
     });
 
-    test('should not end up in an infinite loop if a plugin depends on itself', () => {
+    test('should not end up in an infinite loop if a plugin depends on itself', async () => {
       config.apps = {
         'myorg-first-app': {
           ...genereicAppPluginConfig,
@@ -1519,7 +1518,7 @@ describe('Plugin Extensions / Utils', () => {
         },
       };
 
-      const appPluginIds = getAppPluginDependencies('myorg-second-app');
+      const appPluginIds = await getAppPluginDependencies('myorg-second-app');
 
       expect(appPluginIds).toEqual([]);
     });
@@ -1588,23 +1587,23 @@ describe('Plugin Extensions / Utils', () => {
       config.apps = originalApps;
     });
 
-    it('should return empty map when no plugins have extensions for the point', () => {
+    it('should return empty map when no plugins have extensions for the point', async () => {
       config.apps = {
         app1: { ...mockApp1, extensions: { ...mockApp1.extensions, addedComponents: [], addedLinks: [] } },
         app2: { ...mockApp2, extensions: { ...mockApp2.extensions, addedComponents: [], addedLinks: [] } },
       };
 
-      const result = getExtensionPointPluginMeta(mockExtensionPointId);
+      const result = await getExtensionPointPluginMeta(mockExtensionPointId);
       expect(result.size).toBe(0);
     });
 
-    it('should return map with plugins that have components for the extension point', () => {
+    it('should return map with plugins that have components for the extension point', async () => {
       config.apps = {
         app1: mockApp1,
         app2: mockApp2,
       };
 
-      const result = getExtensionPointPluginMeta(mockExtensionPointId);
+      const result = await getExtensionPointPluginMeta(mockExtensionPointId);
 
       expect(result.size).toBe(2);
       expect(result.get('app1')).toEqual({
@@ -1617,7 +1616,7 @@ describe('Plugin Extensions / Utils', () => {
       });
     });
 
-    it('should filter out plugins that do not have any extensions for the point', () => {
+    it('should filter out plugins that do not have any extensions for the point', async () => {
       config.apps = {
         app1: mockApp1,
         app2: { ...mockApp2, extensions: { ...mockApp2.extensions, addedComponents: [], addedLinks: [] } },
@@ -1632,7 +1631,7 @@ describe('Plugin Extensions / Utils', () => {
         },
       };
 
-      const result = getExtensionPointPluginMeta(mockExtensionPointId);
+      const result = await getExtensionPointPluginMeta(mockExtensionPointId);
 
       expect(result.size).toBe(1);
       expect(result.get('app1')).toEqual({

--- a/public/test/setupTests.ts
+++ b/public/test/setupTests.ts
@@ -46,6 +46,11 @@ jest.mock('app/features/plugins/extensions/usePluginComponents', () => ({
   usePluginComponents: jest.fn().mockReturnValue({ components: [], isLoading: false }),
 }));
 
+// Mock useLoadAppPluginsWithPredidcate to prevent async state updates in tests
+jest.mock('app/features/plugins/extensions/useLoadAppPluginsWithPredicate', () => ({
+  useLoadAppPluginsWithPredicate: jest.fn().mockReturnValue({ isLoading: false }),
+}));
+
 // our tests are heavy in CI due to parallelisation and monaco and kusto
 // so we increase the default timeout to 2secs to avoid flakiness
 configure({ asyncUtilTimeout: 2000 });


### PR DESCRIPTION
**What is this feature?**

This pull request introduces a new experimental feature toggle, `useMTAppsLoading`, which enables an updated mechanism for loading app plugins in Grafana. There is an existing feature toggle called `useMTPlugins` that toggles where the apps data is fetched from, either `config.apps` or the new Plugins Meta API.
These changes collectively enable a smoother transition to the new app plugin loading mechanism, with a feature flag to control rollout and maintain backward compatibility.

I've tried to keep the changes to existing functions as minimum as possible to avoid any new bugs.

**Why do we need this feature?**

We need to replace usages of `config.apps` as that is deprecated.

**Who is this feature for?**

Plugins platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #116258 

**Special notes for your reviewer:**

Existing usages of `getAppPluginDependencies` function
![getAppPluginDependencies](https://github.com/user-attachments/assets/87b99536-00c2-40b2-8bd4-486d2df90751)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
