### PR TITLE
Alerting: Always show the latest evaluation duration of a rule

### DIFF
--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -631,9 +631,8 @@ func StatesToRuleStatus(states []*State) ngModels.RuleStatus {
 	for _, state := range states {
 		if state.LastEvaluationTime.After(status.EvaluationTimestamp) {
 			status.EvaluationTimestamp = state.LastEvaluationTime
+			status.EvaluationDuration = state.EvaluationDuration
 		}
-
-		status.EvaluationDuration = state.EvaluationDuration
 
 		switch state.State {
 		case eval.Normal:

--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -5595,3 +5595,32 @@ func setCacheID(s *State) *State {
 
 	return s
 }
+
+func TestStatesToRuleStatus(t *testing.T) {
+	t.Run("should pick EvaluationDuration from state with newest LastEvaluationTime", func(t *testing.T) {
+		now := time.Now()
+		newerTime := now.Add(2 * time.Minute)
+		olderTime := now.Add(1 * time.Minute)
+		newerDuration := 5 * time.Second
+		olderDuration := 10 * time.Second
+
+		// State with newer evaluation time added first, older added last.
+		states := []*State{
+			{
+				LastEvaluationTime: newerTime,
+				EvaluationDuration: newerDuration,
+				State:              eval.Normal,
+			},
+			{
+				LastEvaluationTime: olderTime,
+				EvaluationDuration: olderDuration,
+				State:              eval.Normal,
+			},
+		}
+
+		status := StatesToRuleStatus(states)
+
+		require.Equal(t, newerTime, status.EvaluationTimestamp, "EvaluationTimestamp should be from the newest state")
+		require.Equal(t, newerDuration, status.EvaluationDuration, "EvaluationDuration should be from the state with newest LastEvaluationTime")
+	})
+}


### PR DESCRIPTION
**What is this feature?**

Fix `StatesToRuleStatus` to pick `EvaluationDuration` from the state with the newest `LastEvaluationTime`, not from the last iterated state.

**Why do we need this feature?**

The `StatesToRuleStatus` function correctly picks `EvaluationTimestamp` from the state with the newest evaluation time, but it incorrectly assigns `EvaluationDuration` from whichever state happens to be iterated last. This causes the API to return mismatched evaluation metadata with the timestamp from one state and the duration from another.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
