### PR TITLE
Plugin Metrics: Improve metrics on long duration queries within grafana

### DIFF
--- a/pkg/services/pluginsintegration/clientmiddleware/metrics_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/metrics_middleware.go
@@ -58,7 +58,7 @@ func newMetricsMiddleware(promRegisterer prometheus.Registerer, pluginRegistry r
 		Namespace: "grafana",
 		Name:      "plugin_request_duration_seconds",
 		Help:      "Plugin request duration in seconds",
-		Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25},
+		Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 60, 120, 300, 600},
 	}, append([]string{"source", "plugin_id", "endpoint", "status", "target", "plugin_version"}, additionalLabels...))
 	pluginRequestConnectionUnavailableCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   "grafana",


### PR DESCRIPTION
**What is this feature?**

This is for internal observation of how plugins are performing in grafana. We currently have a metric we emit that reports the duration of queries, however the highest bucket for it is 25 seconds. This pr adds more buckets for 1 minute, 2 minutes, 3 minutes, 5 minutes and 10 minutes. 

We are doing this to get better insight into long tail performance issues as well as to gain better understanding of current user behavior in datasources where queries may be expected to take a long time to return (ex a sql ds)
 
**Why do we need this feature?**

Internal needs within Grafana Labs

**Who is this feature for?**

grafana devs (and potentially grafana operators for on prem instances) 

**Which issue(s) does this PR fix?**:

relates to https://github.com/grafana/grafana-enterprise/issues/10624

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
