### PR TITLE
Dashboard Conversions: Include staticOptions when converting v1 to v2

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/testdata/input/v1beta1.variable-conversions.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/input/v1beta1.variable-conversions.json
@@ -338,6 +338,17 @@
           "regex": "/host[0-9]+/",
           "regexApplyTo": "value",
           "skipUrlSync": false,
+          "staticOptions": [
+            {
+              "text": "All",
+              "value": "$__all"
+            },
+            {
+              "text": "host1",
+              "value": "host1"
+            }
+          ],
+          "staticOptionsOrder": "before",
           "refresh": 1,
           "sort": 2,
           "tagValuesQuery": "",

--- a/apps/dashboard/pkg/migration/conversion/testdata/input/v2beta1.complete.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/input/v2beta1.complete.json
@@ -304,7 +304,18 @@
           "options": null,
           "multi": true,
           "includeAll": true,
-          "allowCustomValue": false
+          "allowCustomValue": false,
+          "staticOptions": [
+            {
+              "text": "All",
+              "value": "$__all"
+            },
+            {
+              "text": "host1",
+              "value": "host1"
+            }
+          ],
+          "staticOptionsOrder": "before"
         }
       },
       {

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.variable-conversions.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.variable-conversions.v0alpha1.json
@@ -366,6 +366,17 @@
           "regexApplyTo": "value",
           "skipUrlSync": false,
           "sort": 2,
+          "staticOptions": [
+            {
+              "text": "All",
+              "value": "$__all"
+            },
+            {
+              "text": "host1",
+              "value": "host1"
+            }
+          ],
+          "staticOptionsOrder": "before",
           "tagValuesQuery": "",
           "tagsQuery": "",
           "type": "query",

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.variable-conversions.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.variable-conversions.v2alpha1.json
@@ -409,7 +409,20 @@
           "multi": true,
           "includeAll": true,
           "allValue": "*",
-          "allowCustomValue": true
+          "allowCustomValue": true,
+          "staticOptions": [
+            {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            {
+              "selected": false,
+              "text": "host1",
+              "value": "host1"
+            }
+          ],
+          "staticOptionsOrder": "before"
         }
       }
     ]

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.variable-conversions.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.variable-conversions.v2beta1.json
@@ -412,7 +412,20 @@
           "multi": true,
           "includeAll": true,
           "allValue": "*",
-          "allowCustomValue": true
+          "allowCustomValue": true,
+          "staticOptions": [
+            {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            {
+              "selected": false,
+              "text": "host1",
+              "value": "host1"
+            }
+          ],
+          "staticOptionsOrder": "before"
         }
       }
     ]

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.complete.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.complete.v0alpha1.json
@@ -208,6 +208,17 @@
           "regex": "",
           "skipUrlSync": false,
           "sort": 0,
+          "staticOptions": [
+            {
+              "text": "All",
+              "value": "$__all"
+            },
+            {
+              "text": "host1",
+              "value": "host1"
+            }
+          ],
+          "staticOptionsOrder": "before",
           "type": "query"
         },
         {

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.complete.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.complete.v1beta1.json
@@ -208,6 +208,17 @@
           "regex": "",
           "skipUrlSync": false,
           "sort": 0,
+          "staticOptions": [
+            {
+              "text": "All",
+              "value": "$__all"
+            },
+            {
+              "text": "host1",
+              "value": "host1"
+            }
+          ],
+          "staticOptionsOrder": "before",
           "type": "query"
         },
         {

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.complete.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.complete.v2alpha1.json
@@ -299,7 +299,18 @@
           "options": null,
           "multi": true,
           "includeAll": true,
-          "allowCustomValue": false
+          "allowCustomValue": false,
+          "staticOptions": [
+            {
+              "text": "All",
+              "value": "$__all"
+            },
+            {
+              "text": "host1",
+              "value": "host1"
+            }
+          ],
+          "staticOptionsOrder": "before"
         }
       },
       {

--- a/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
@@ -961,6 +961,30 @@ func transformVariableSortToEnum(sort interface{}) dashv2alpha1.DashboardVariabl
 	}
 }
 
+func transformVariableStaticOptionsOrderToEnum(order interface{}) *dashv2alpha1.DashboardQueryVariableSpecStaticOptionsOrder {
+	if order == nil {
+		return nil
+	}
+
+	switch v := order.(type) {
+	case string:
+		var value dashv2alpha1.DashboardQueryVariableSpecStaticOptionsOrder
+		switch v {
+		case "before":
+			value = dashv2alpha1.DashboardQueryVariableSpecStaticOptionsOrderBefore
+		case "after":
+			value = dashv2alpha1.DashboardQueryVariableSpecStaticOptionsOrderAfter
+		case "sorted":
+			value = dashv2alpha1.DashboardQueryVariableSpecStaticOptionsOrderSorted
+		default:
+			return nil
+		}
+		return &value
+	default:
+		return nil
+	}
+}
+
 func transformVariables(ctx context.Context, dashboard map[string]interface{}, dsIndexProvider schemaversion.DataSourceIndexProvider) ([]dashv2alpha1.DashboardVariableKind, error) {
 	templating, ok := dashboard["templating"].(map[string]interface{})
 	if !ok {
@@ -1262,6 +1286,8 @@ func buildQueryVariable(ctx context.Context, varMap map[string]interface{}, comm
 
 	// Always set options (matching frontend behavior)
 	queryVar.Spec.Options = buildVariableOptions(varMap["options"])
+	queryVar.Spec.StaticOptions = buildVariableOptions(varMap["staticOptions"])
+	queryVar.Spec.StaticOptionsOrder = transformVariableStaticOptionsOrderToEnum(varMap["staticOptionsOrder"])
 
 	if allValue := schemaversion.GetStringValue(varMap, "allValue"); allValue != "" {
 		queryVar.Spec.AllValue = &allValue

--- a/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1.go
+++ b/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1.go
@@ -1375,6 +1375,12 @@ func convertQueryVariableToV1(variable *dashv2alpha1.DashboardQueryVariableKind)
 		varMap["regexApplyTo"] = string(*spec.RegexApplyTo)
 	}
 	varMap["allowCustomValue"] = spec.AllowCustomValue
+	if len(spec.StaticOptions) > 0 {
+		varMap["staticOptions"] = convertVariableOptionsToV1(spec.StaticOptions)
+	}
+	if spec.StaticOptionsOrder != nil {
+		varMap["staticOptionsOrder"] = string(*spec.StaticOptionsOrder)
+	}
 
 	// Convert query - handle LEGACY_STRING_VALUE_KEY
 	querySpec := spec.Query.Spec

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -378,6 +378,15 @@ function createSceneVariableFromVariableModel(variable: TypedVariableModelV2): S
       hide: transformVariableHideToEnumV1(variable.spec.hide),
       definition: variable.spec.definition,
       ...(variable.spec.allowCustomValue !== undefined && { allowCustomValue: variable.spec.allowCustomValue }),
+      ...(variable.spec.staticOptions?.length
+        ? {
+            staticOptions: variable.spec.staticOptions.map((option) => ({
+              label: String(option.text),
+              value: String(option.value),
+            })),
+          }
+        : {}),
+      ...(variable.spec.staticOptionsOrder !== undefined && { staticOptionsOrder: variable.spec.staticOptionsOrder }),
     });
   } else if (variable.kind === defaultDatasourceVariableKind().kind) {
     return new DataSourceVariable({


### PR DESCRIPTION
Adding missing `staticOptions` and `staticOptionsOrder` when converting v1 and v2. Also, staticOptions were missed during runtime in V2 when creating a scene. 

Please check that:
- [ ] It works as expected from a user's perspective.

