### PR TITLE
unified-storage: implement channel notifier for storage backend

### DIFF
--- a/pkg/storage/unified/resource/notifier_test.go
+++ b/pkg/storage/unified/resource/notifier_test.go
@@ -2,7 +2,9 @@ package resource
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
@@ -496,4 +498,159 @@ func testNotifierWatchMultipleEvents(t *testing.T, ctx context.Context, notifier
 	// Verify the events match and ordered by resource version
 	expectedNames := []string{"test-resource-1", "test-resource-2", "test-resource-3"}
 	assert.ElementsMatch(t, expectedNames, receivedEvents)
+}
+
+func TestChannelNotifier(t *testing.T) {
+	log := &logging.NoOpLogger{}
+	opts := watchOptions{BufferSize: 5}
+
+	var eventCount int64
+	newEvent := func() Event {
+		eventCount++
+		return Event{
+			Namespace:       "default",
+			Group:           "playlists.grafana.app",
+			Resource:        "playlists",
+			Name:            fmt.Sprintf("playlist_%d", eventCount),
+			ResourceVersion: eventCount,
+			Action:          "created",
+		}
+	}
+
+	t.Run("events are received", func(t *testing.T) {
+		notifier := newChannelNotifier(log)
+		watcher := notifier.Watch(t.Context(), opts)
+
+		event := newEvent()
+		notifier.Publish(event)
+		mustReceive(t, watcher, event)
+		mustNotReceive(t, watcher)
+	})
+
+	t.Run("multiple events are received in order", func(t *testing.T) {
+		notifier := newChannelNotifier(log)
+		watcher := notifier.Watch(t.Context(), opts)
+
+		events := []Event{newEvent(), newEvent(), newEvent()}
+		for _, event := range events {
+			notifier.Publish(event)
+		}
+
+		for _, event := range events {
+			mustReceive(t, watcher, event)
+		}
+
+		mustNotReceive(t, watcher)
+	})
+
+	t.Run("multiple watchers and multiple events", func(t *testing.T) {
+		notifier := newChannelNotifier(log)
+
+		watcher1 := notifier.Watch(t.Context(), opts)
+		watcher2 := notifier.Watch(t.Context(), opts)
+		watcher3 := notifier.Watch(t.Context(), opts)
+
+		events := []Event{newEvent(), newEvent(), newEvent()}
+		for _, event := range events {
+			notifier.Publish(event)
+		}
+
+		for _, event := range events {
+			mustReceive(t, watcher1, event)
+			mustReceive(t, watcher2, event)
+			mustReceive(t, watcher3, event)
+		}
+
+		mustNotReceive(t, watcher1)
+		mustNotReceive(t, watcher2)
+		mustNotReceive(t, watcher3)
+	})
+
+	t.Run("continues to receive events", func(t *testing.T) {
+		notifier := newChannelNotifier(log)
+		watcher := notifier.Watch(t.Context(), opts)
+
+		events := []Event{newEvent(), newEvent(), newEvent()}
+		for _, event := range events {
+			notifier.Publish(event)
+		}
+
+		for _, event := range events {
+			mustReceive(t, watcher, event)
+		}
+
+		mustNotReceive(t, watcher)
+
+		nextEvent := newEvent()
+		notifier.Publish(nextEvent)
+		mustReceive(t, watcher, nextEvent)
+		mustNotReceive(t, watcher)
+	})
+
+	t.Run("publishing more than the buffer size", func(t *testing.T) {
+		notifier := newChannelNotifier(log)
+		watcher := notifier.Watch(t.Context(), opts)
+
+		const numEvents = 10
+		events := make([]Event, numEvents)
+		for j := range 10 {
+			events[j] = newEvent()
+		}
+
+		// Most events are dropped since the buffer is full.
+		for _, e := range events {
+			notifier.Publish(e)
+		}
+
+		// Only first 5 (bufferSize) events are received.
+		mustReceive(t, watcher, events[0])
+		mustReceive(t, watcher, events[1])
+		mustReceive(t, watcher, events[2])
+		mustReceive(t, watcher, events[3])
+		mustReceive(t, watcher, events[4])
+		mustNotReceive(t, watcher)
+	})
+
+	t.Run("canceling the context stops event publishing", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			notifier := newChannelNotifier(log)
+
+			ctx, stop := context.WithCancel(t.Context())
+			watcher := notifier.Watch(ctx, opts)
+
+			// Publishing works
+			event := newEvent()
+			notifier.Publish(event)
+			mustReceive(t, watcher, event)
+
+			stop()
+			synctest.Wait() // ensure cancelation is propagated to closing the channel
+
+			notifier.Publish(newEvent())     // shouldn't panic
+			mustReceive(t, watcher, Event{}) // zero value
+
+			_, isOpen := <-watcher
+			require.False(t, isOpen, "channel should be closed after context cancelation")
+		})
+	})
+}
+
+func mustReceive(t *testing.T, watcher <-chan Event, expected Event) {
+	select {
+	case e := <-watcher:
+		require.Equal(t, expected, e)
+
+	default:
+		require.FailNow(t, "should have received published event")
+	}
+}
+
+func mustNotReceive(t *testing.T, watcher <-chan Event) {
+	select {
+	case e := <-watcher:
+		require.FailNow(t, "no new events should have been received", "extra event: %#v", e)
+
+	default:
+		// pass
+	}
 }

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -438,6 +438,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 		Resource:  event.Key.Resource,
 		Name:      event.Key.Name,
 	})
+	k.notifier.Publish(eventData)
 
 	return rv, nil
 }

--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -23,7 +23,6 @@ import (
 	"github.com/grafana/authlib/types"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
-	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	sqldb "github.com/grafana/grafana/pkg/storage/unified/sql/db"
@@ -94,14 +93,9 @@ func RunStorageBackendTest(t *testing.T, newBackend NewBackendFunc, opts *TestOp
 	}
 
 	for _, tc := range cases {
-		if shouldSkip := opts.SkipTests[tc.name]; shouldSkip {
-			t.Logf("Skipping test: %s", tc.name)
-			continue
-		}
-
 		t.Run(tc.name, func(t *testing.T) {
-			if db.IsTestDbSQLite() {
-				t.Skip("Skipping tests on sqlite until channel notifier is implemented")
+			if opts.SkipTests[tc.name] {
+				t.Skip()
 			}
 
 			tc.fn(t, newBackend(context.Background()), opts.NSPrefix)


### PR DESCRIPTION
The existing polling notifier implementation in the storage backend is not compatible with `sqlite`. In #116283, we created a stub for a channel-based notifier, to be used in non-HA environments. A counterpart of this exists currently in the SQL backend.

Resolves: https://github.com/grafana/hyperion-planning/issues/485.