### PR TITLE
Alerting: Fix flaky test in NotificationPreview.test.tsx

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.test.tsx
@@ -108,9 +108,8 @@ const folder: Folder = {
 };
 
 describe('NotificationPreview', () => {
-  jest.retryTimes(2);
-
   it('should render notification preview without alert manager label, when having only one alert manager configured to receive alerts', async () => {
+    mockHasEditPermission(false); // Grant read permissions
     mockOneAlertManager();
     mockPreviewApiResponse(server, [
       mockAlertmanagerAlert({
@@ -136,6 +135,7 @@ describe('NotificationPreview', () => {
   });
 
   it('should render notification preview with alert manager sections, when having more than one alert manager configured to receive alerts', async () => {
+    mockHasEditPermission(false); // Grant read permissions
     // two alert managers configured  to receive alerts
     mockTwoAlertManagers();
     mockPreviewApiResponse(server, [


### PR DESCRIPTION
**Summary**

This PR adds missing permission grants on two tests that needed it to render the notification preview component. The tests were passing on retry because permission state from other tests was leaking, but it was possible to see them failing in the test output.

**Changes**
- Removed jest.retryTimes(2)
- Added mockHasEditPermission(false) to the first two tests to grant necessary read permissions


