### PR TITLE
fix: handle graceful shutdown support for storage api

### DIFF
--- a/pkg/services/grpcserver/service.go
+++ b/pkg/services/grpcserver/service.go
@@ -163,11 +163,11 @@ func (s *gPRCServerService) Run(ctx context.Context) error {
 
 	select {
 	case err := <-serveErrCh:
-
 		return err
 	case <-ctx.Done():
 		// Context cancelled, proceed with graceful shutdown
 	}
+
 	s.logger.Info("GRPC server: initiating graceful shutdown")
 	gracefulStopDone := make(chan struct{})
 	go func() {

--- a/pkg/services/grpcserver/service.go
+++ b/pkg/services/grpcserver/service.go
@@ -152,24 +152,23 @@ func (s *gPRCServerService) Run(ctx context.Context) error {
 	s.address = listener.Addr().String()
 	close(s.startedChan)
 
-	serveErr := make(chan error, 1)
+	serveErrCh := make(chan error, 1)
 	go func() {
 		s.logger.Info("GRPC server: starting")
-		err := s.server.Serve(listener)
-		if err != nil {
+		if err := s.server.Serve(listener); err != nil {
 			s.logger.Error("GRPC server: failed to serve", "err", err)
-			serveErr <- err
+			serveErrCh <- err
 		}
 	}()
 
 	select {
-	case err := <-serveErr:
-		s.logger.Error("GRPC server: failed to serve", "err", err)
+	case err := <-serveErrCh:
 		return err
 	case <-ctx.Done():
+		// Context cancelled, proceed with graceful shutdown
 	}
 
-	s.logger.Warn("GRPC server: initiating graceful shutdown")
+	s.logger.Info("GRPC server: initiating graceful shutdown")
 	gracefulStopDone := make(chan struct{})
 	go func() {
 		s.server.GracefulStop()
@@ -183,7 +182,8 @@ func (s *gPRCServerService) Run(ctx context.Context) error {
 		s.logger.Warn("GRPC server: graceful shutdown timed out, forcing stop")
 		s.server.Stop()
 	}
-	return ctx.Err()
+
+	return nil
 }
 
 func (s *gPRCServerService) IsDisabled() bool {

--- a/pkg/services/grpcserver/service.go
+++ b/pkg/services/grpcserver/service.go
@@ -163,11 +163,11 @@ func (s *gPRCServerService) Run(ctx context.Context) error {
 
 	select {
 	case err := <-serveErrCh:
+
 		return err
 	case <-ctx.Done():
 		// Context cancelled, proceed with graceful shutdown
 	}
-
 	s.logger.Info("GRPC server: initiating graceful shutdown")
 	gracefulStopDone := make(chan struct{})
 	go func() {

--- a/pkg/services/grpcserver/service_test.go
+++ b/pkg/services/grpcserver/service_test.go
@@ -1,0 +1,379 @@
+package grpcserver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestGracefulShutdown(t *testing.T) {
+	t.Run("graceful shutdown completes before timeout", func(t *testing.T) {
+		// Setup
+		cfg := &setting.GRPCServerSettings{
+			Network:                 "tcp",
+			Address:                 "127.0.0.1:0", // Use port 0 to get a random available port
+			GracefulShutdownTimeout: 5 * time.Second,
+		}
+
+		service := &gPRCServerService{
+			cfg:         *cfg,
+			logger:      log.NewNopLogger(),
+			enabled:     true,
+			startedChan: make(chan struct{}),
+			server:      grpc.NewServer(),
+		}
+
+		// Register health service to have something to call
+		grpc_health_v1.RegisterHealthServer(service.server, &testHealthServer{})
+
+		// Start the server in a goroutine
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		serverDone := make(chan error, 1)
+		go func() {
+			serverDone <- service.Run(ctx)
+		}()
+
+		// Wait for server to start
+		<-service.startedChan
+
+		// Create a client connection to verify server is running
+		conn, err := grpc.NewClient(
+			service.GetAddress(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		// Make a health check call to ensure server is working
+		healthClient := grpc_health_v1.NewHealthClient(conn)
+		_, err = healthClient.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+		require.NoError(t, err)
+
+		// Trigger shutdown
+		shutdownStart := time.Now()
+		cancel()
+
+		// Wait for shutdown to complete
+		err = <-serverDone
+		shutdownDuration := time.Since(shutdownStart)
+
+		// Assertions
+		assert.NoError(t, err)
+		assert.Less(t, shutdownDuration, cfg.GracefulShutdownTimeout,
+			"Shutdown should complete before timeout")
+		assert.Greater(t, shutdownDuration, time.Duration(0),
+			"Shutdown should take some time")
+
+		// Verify server is actually stopped by attempting another call
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		_, err = healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+		assert.Error(t, err, "Server should not accept new connections after shutdown")
+	})
+
+	t.Run("graceful shutdown times out and forces stop", func(t *testing.T) {
+		// Setup with very short timeout
+		cfg := &setting.GRPCServerSettings{
+			Network:                 "tcp",
+			Address:                 "127.0.0.1:0",
+			GracefulShutdownTimeout: 100 * time.Millisecond, // Very short timeout
+		}
+
+		service := &gPRCServerService{
+			cfg:         *cfg,
+			logger:      log.NewNopLogger(),
+			enabled:     true,
+			startedChan: make(chan struct{}),
+			server:      grpc.NewServer(),
+		}
+
+		grpc_health_v1.RegisterHealthServer(service.server, &testHealthServer{})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		serverDone := make(chan error, 1)
+		go func() {
+			serverDone <- service.Run(ctx)
+		}()
+
+		<-service.startedChan
+
+		// Create a long-running streaming call that won't finish quickly
+		conn, err := grpc.NewClient(
+			service.GetAddress(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		healthClient := grpc_health_v1.NewHealthClient(conn)
+
+		// Start a watch that simulates a hanging connection
+		streamCtx, streamCancel := context.WithCancel(context.Background())
+		defer streamCancel()
+
+		stream, err := healthClient.Watch(streamCtx, &grpc_health_v1.HealthCheckRequest{})
+		require.NoError(t, err)
+
+		// Trigger shutdown while stream is active
+		shutdownStart := time.Now()
+		cancel()
+
+		// Wait for shutdown to complete
+		err = <-serverDone
+		shutdownDuration := time.Since(shutdownStart)
+
+		// Assertions
+		assert.NoError(t, err)
+		// Should timeout and force stop, taking approximately the timeout duration
+		assert.GreaterOrEqual(t, shutdownDuration, cfg.GracefulShutdownTimeout,
+			"Should wait for graceful shutdown timeout")
+		assert.Less(t, shutdownDuration, cfg.GracefulShutdownTimeout+500*time.Millisecond,
+			"Should force stop shortly after timeout")
+
+		// Stream should be terminated (may or may not error depending on timing)
+		_, _ = stream.Recv()
+	})
+
+	t.Run("handles server startup failure", func(t *testing.T) {
+		// Try to bind to an invalid address
+		cfg := &setting.GRPCServerSettings{
+			Network:                 "tcp",
+			Address:                 "999.999.999.999:0", // Invalid address
+			GracefulShutdownTimeout: 5 * time.Second,
+		}
+
+		service := &gPRCServerService{
+			cfg:         *cfg,
+			logger:      log.NewNopLogger(),
+			enabled:     true,
+			startedChan: make(chan struct{}),
+			server:      grpc.NewServer(),
+		}
+
+		ctx := context.Background()
+		err := service.Run(ctx)
+
+		// Should return error immediately without hanging
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to listen")
+	})
+
+	t.Run("context cancellation is respected", func(t *testing.T) {
+		cfg := &setting.GRPCServerSettings{
+			Network:                 "tcp",
+			Address:                 "127.0.0.1:0",
+			GracefulShutdownTimeout: 5 * time.Second,
+		}
+
+		service := &gPRCServerService{
+			cfg:         *cfg,
+			logger:      log.NewNopLogger(),
+			enabled:     true,
+			startedChan: make(chan struct{}),
+			server:      grpc.NewServer(),
+		}
+
+		grpc_health_v1.RegisterHealthServer(service.server, &testHealthServer{})
+
+		// Create a context with timeout
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		serverDone := make(chan error, 1)
+		go func() {
+			serverDone <- service.Run(ctx)
+		}()
+
+		<-service.startedChan
+
+		// Wait for context to expire
+		<-ctx.Done()
+
+		// Server should stop gracefully
+		err := <-serverDone
+		assert.NoError(t, err)
+	})
+
+	t.Run("multiple concurrent clients shutdown cleanly", func(t *testing.T) {
+		cfg := &setting.GRPCServerSettings{
+			Network:                 "tcp",
+			Address:                 "127.0.0.1:0",
+			GracefulShutdownTimeout: 5 * time.Second,
+		}
+
+		service := &gPRCServerService{
+			cfg:         *cfg,
+			logger:      log.NewNopLogger(),
+			enabled:     true,
+			startedChan: make(chan struct{}),
+			server:      grpc.NewServer(),
+		}
+
+		grpc_health_v1.RegisterHealthServer(service.server, &testHealthServer{})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		serverDone := make(chan error, 1)
+		go func() {
+			serverDone <- service.Run(ctx)
+		}()
+
+		<-service.startedChan
+
+		// Create multiple client connections
+		var conns []*grpc.ClientConn
+		for i := 0; i < 5; i++ {
+			conn, err := grpc.NewClient(
+				service.GetAddress(),
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			)
+			require.NoError(t, err)
+			defer conn.Close()
+			conns = append(conns, conn)
+
+			// Make a call to ensure connection is established
+			healthClient := grpc_health_v1.NewHealthClient(conn)
+			_, err = healthClient.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+			require.NoError(t, err)
+		}
+
+		// Trigger shutdown
+		cancel()
+
+		// Should return without error
+		err := <-serverDone
+		assert.NoError(t, err)
+	})
+}
+
+func TestGetAddress(t *testing.T) {
+	t.Run("blocks until server starts", func(t *testing.T) {
+		service := &gPRCServerService{
+			startedChan: make(chan struct{}),
+			address:     "127.0.0.1:9999",
+		}
+
+		// Start a goroutine that gets the address
+		addressChan := make(chan string, 1)
+		go func() {
+			addressChan <- service.GetAddress()
+		}()
+
+		// Should block initially
+		select {
+		case <-addressChan:
+			t.Fatal("GetAddress should block until server starts")
+		case <-time.After(100 * time.Millisecond):
+			// Expected - still blocking
+		}
+
+		// Close the started channel
+		close(service.startedChan)
+
+		// Now should get the address
+		select {
+		case addr := <-addressChan:
+			assert.Equal(t, "127.0.0.1:9999", addr)
+		case <-time.After(1 * time.Second):
+			t.Fatal("GetAddress should return after server starts")
+		}
+	})
+}
+
+func TestIsDisabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+		want    bool
+	}{
+		{
+			name:    "enabled service",
+			enabled: true,
+			want:    false,
+		},
+		{
+			name:    "disabled service",
+			enabled: false,
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &gPRCServerService{
+				enabled: tt.enabled,
+			}
+			assert.Equal(t, tt.want, service.IsDisabled())
+		})
+	}
+}
+
+// testHealthServer implements a simple health check server for testing
+type testHealthServer struct {
+	grpc_health_v1.UnimplementedHealthServer
+}
+
+func (h *testHealthServer) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	return &grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_SERVING,
+	}, nil
+}
+
+func (h *testHealthServer) Watch(req *grpc_health_v1.HealthCheckRequest, stream grpc_health_v1.Health_WatchServer) error {
+	// Send initial status
+	if err := stream.Send(&grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_SERVING,
+	}); err != nil {
+		return err
+	}
+
+	// Block until context is cancelled (simulates long-running stream)
+	<-stream.Context().Done()
+	return stream.Context().Err()
+}
+
+// BenchmarkGracefulShutdown benchmarks the graceful shutdown process
+func BenchmarkGracefulShutdown(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		cfg := &setting.GRPCServerSettings{
+			Network:                 "tcp",
+			Address:                 "127.0.0.1:0",
+			GracefulShutdownTimeout: 5 * time.Second,
+		}
+
+		service := &gPRCServerService{
+			cfg:         *cfg,
+			logger:      log.NewNopLogger(),
+			enabled:     true,
+			startedChan: make(chan struct{}),
+			server:      grpc.NewServer(),
+		}
+
+		grpc_health_v1.RegisterHealthServer(service.server, &testHealthServer{})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		serverDone := make(chan error, 1)
+
+		go func() {
+			serverDone <- service.Run(ctx)
+		}()
+
+		<-service.startedChan
+		cancel()
+		<-serverDone
+	}
+}

--- a/pkg/services/grpcserver/service_test.go
+++ b/pkg/services/grpcserver/service_test.go
@@ -53,7 +53,7 @@ func TestGracefulShutdown(t *testing.T) {
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		)
 		require.NoError(t, err)
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 
 		// Make a health check call to ensure server is working
 		healthClient := grpc_health_v1.NewHealthClient(conn)
@@ -116,7 +116,7 @@ func TestGracefulShutdown(t *testing.T) {
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		)
 		require.NoError(t, err)
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 
 		healthClient := grpc_health_v1.NewHealthClient(conn)
 
@@ -235,15 +235,13 @@ func TestGracefulShutdown(t *testing.T) {
 		<-service.startedChan
 
 		// Create multiple client connections
-		var conns []*grpc.ClientConn
 		for i := 0; i < 5; i++ {
 			conn, err := grpc.NewClient(
 				service.GetAddress(),
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 			)
 			require.NoError(t, err)
-			defer conn.Close()
-			conns = append(conns, conn)
+			defer func() { _ = conn.Close() }()
 
 			// Make a call to ensure connection is established
 			healthClient := grpc_health_v1.NewHealthClient(conn)

--- a/pkg/services/grpcserver/service_test.go
+++ b/pkg/services/grpcserver/service_test.go
@@ -53,7 +53,10 @@ func TestGracefulShutdown(t *testing.T) {
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		)
 		require.NoError(t, err)
-		defer func() { _ = conn.Close() }()
+		defer func() {
+			err := conn.Close()
+			require.NoError(t, err)
+		}()
 
 		// Make a health check call to ensure server is working
 		healthClient := grpc_health_v1.NewHealthClient(conn)
@@ -116,7 +119,10 @@ func TestGracefulShutdown(t *testing.T) {
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		)
 		require.NoError(t, err)
-		defer func() { _ = conn.Close() }()
+		defer func() {
+			err := conn.Close()
+			require.NoError(t, err)
+		}()
 
 		healthClient := grpc_health_v1.NewHealthClient(conn)
 
@@ -241,7 +247,10 @@ func TestGracefulShutdown(t *testing.T) {
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 			)
 			require.NoError(t, err)
-			defer func() { _ = conn.Close() }()
+			defer func() {
+				err := conn.Close()
+				require.NoError(t, err)
+			}()
 
 			// Make a call to ensure connection is established
 			healthClient := grpc_health_v1.NewHealthClient(conn)

--- a/pkg/storage/unified/client_retry.go
+++ b/pkg/storage/unified/client_retry.go
@@ -20,12 +20,6 @@ type retryConfig struct {
 }
 
 // unaryRetryInterceptor creates an interceptor to perform retries for unary methods.
-//
-// Note: Retry codes are the same as the default codes.
-//
-//	From go-grpc-middleware/interceptors/retry/options.go:
-//	`ResourceExhausted` means that the user quota, e.g. per-RPC limits, have been reached.
-//	`Unavailable` means that system is currently unavailable and the client should retry again.
 func unaryRetryInterceptor(cfg retryConfig) grpc.UnaryClientInterceptor {
 	return grpc_retry.UnaryClientInterceptor(
 		grpc_retry.WithMax(cfg.Max),
@@ -51,7 +45,7 @@ func unaryRetryInstrument(metric *prometheus.CounterVec) grpc.UnaryClientInterce
 func connectionBackoffOptions() grpc.DialOption {
 	return grpc.WithConnectParams(grpc.ConnectParams{
 		Backoff: backoff.Config{
-			BaseDelay:  100 * time.Millisecond,
+			BaseDelay:  1 * time.Second,
 			Multiplier: 1.6,
 			Jitter:     0.2,
 			MaxDelay:   10 * time.Second,

--- a/pkg/storage/unified/client_retry.go
+++ b/pkg/storage/unified/client_retry.go
@@ -20,6 +20,12 @@ type retryConfig struct {
 }
 
 // unaryRetryInterceptor creates an interceptor to perform retries for unary methods.
+//
+// Note: Retry codes are the same as the default codes.
+//
+//	From go-grpc-middleware/interceptors/retry/options.go:
+//	`ResourceExhausted` means that the user quota, e.g. per-RPC limits, have been reached.
+//	`Unavailable` means that system is currently unavailable and the client should retry again.
 func unaryRetryInterceptor(cfg retryConfig) grpc.UnaryClientInterceptor {
 	return grpc_retry.UnaryClientInterceptor(
 		grpc_retry.WithMax(cfg.Max),

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -43,6 +43,11 @@ type ResourceServer interface {
 	resourcepb.BlobStoreServer
 	resourcepb.DiagnosticsServer
 	resourcepb.QuotasServer
+	ResourceServerStopper
+}
+
+type ResourceServerStopper interface {
+	Stop(ctx context.Context) error
 }
 
 type ListIterator interface {
@@ -449,7 +454,7 @@ func (s *server) Stop(ctx context.Context) error {
 		err := s.lifecycle.Stop(ctx)
 		if err != nil {
 			stopFailed = true
-			s.initErr = fmt.Errorf("service stopeed with error: %w", err)
+			s.initErr = fmt.Errorf("service stopped with error: %w", err)
 		}
 	}
 

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -367,7 +367,6 @@ func (s *service) running(ctx context.Context) error {
 		}
 
 		// Now wait for the gRPC server to complete graceful shutdown.
-		// Watch streams should already be closed, so this won't timeout.
 		s.log.Info("Waiting for gRPC server to complete graceful shutdown")
 		err := <-serverErrCh
 		if err != nil && !errors.Is(err, context.Canceled) {

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -59,12 +59,11 @@ type service struct {
 	subservicesWatcher *services.FailureWatcher
 	hasSubservices     bool
 
-	backend   resource.StorageBackend
-	cfg       *setting.Cfg
-	features  featuremgmt.FeatureToggles
-	db        infraDB.DB
-	stopCh    chan struct{}
-	stoppedCh chan error
+	backend       resource.StorageBackend
+	serverStopper resource.ResourceServerStopper
+	cfg           *setting.Cfg
+	features      featuremgmt.FeatureToggles
+	db            infraDB.DB
 
 	handler grpcserver.Provider
 
@@ -114,8 +113,6 @@ func ProvideUnifiedStorageGrpcService(
 		backend:            backend,
 		cfg:                cfg,
 		features:           features,
-		stopCh:             make(chan struct{}),
-		stoppedCh:          make(chan error, 1),
 		authenticator:      authn,
 		tracing:            tracer,
 		db:                 db,
@@ -296,6 +293,7 @@ func (s *service) starting(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	s.serverStopper = server
 	s.handler, err = grpcserver.ProvideService(s.cfg, s.features, interceptors.AuthenticatorFunc(s.authenticator), s.tracing, prometheus.DefaultRegisterer)
 	if err != nil {
 		return err
@@ -337,15 +335,6 @@ func (s *service) starting(ctx context.Context) error {
 		s.log.Info("resource server is ACTIVE in the ring")
 	}
 
-	// start the gRPC server
-	go func() {
-		err := s.handler.Run(ctx)
-		if err != nil {
-			s.stoppedCh <- err
-		} else {
-			s.stoppedCh <- nil
-		}
-	}()
 	return nil
 }
 
@@ -355,17 +344,37 @@ func (s *service) GetAddress() string {
 }
 
 func (s *service) running(ctx context.Context) error {
+	serverErrCh := make(chan error, 1)
+	go func() {
+		serverErrCh <- s.handler.Run(ctx)
+	}()
+
 	select {
-	case err := <-s.stoppedCh:
+	case err := <-serverErrCh:
 		if err != nil && !errors.Is(err, context.Canceled) {
 			return err
 		}
+		return nil
 	case err := <-s.subservicesWatcher.Chan():
 		return fmt.Errorf("subservice failure: %w", err)
 	case <-ctx.Done():
-		close(s.stopCh)
+		s.log.Info("Stopping resource server")
+		if s.serverStopper != nil {
+			if err := s.serverStopper.Stop(context.Background()); err != nil {
+				s.log.Warn("Failed to stop resource server", "error", err)
+			}
+			s.log.Info("Resource server stopped")
+		}
+
+		// Now wait for the gRPC server to complete graceful shutdown.
+		// Watch streams should already be closed, so this won't timeout.
+		s.log.Info("Waiting for gRPC server to complete graceful shutdown")
+		err := <-serverErrCh
+		if err != nil && !errors.Is(err, context.Canceled) {
+			return err
+		}
+		return nil
 	}
-	return nil
 }
 
 func (s *service) stopping(_ error) error {


### PR DESCRIPTION
I noticed that the `storage-api` server was still not shutting down gracefully. Further investigation proved it locally too. This was due to the `Watch` stream not being shutdown properly. In this PR, I propagate the context cancellation to the watch stream via explicitly calling the resource server `Stop` method which cancels the server context and enable graceful shutdown. `search-distributor` did [shutdown gracefully](https://ops.grafana-ops.net/goto/cfabq0bjvp1q8e?orgId=stacks-27821) as it does not rely on the watch stream.

Note: Also added unit tests for the grpc server in relation to [the previous](https://github.com/grafana/grafana/pull/116284) graceful shutdown implementation.

Ticket: https://github.com/grafana/support-escalations/issues/20139