### PR TITLE
Chore: Bump undici

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -33604,9 +33604,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^7.12.0":
-  version: 7.13.0
-  resolution: "undici@npm:7.13.0"
-  checksum: 10/a51ba5c95046159e7def34d67a48605ff913e357e2aab6d51f2201f8ed09f9237f90d5bbe1beb6b3cc890940b500dc0c208527cf597de27d4a964a8c5f721f65
+  version: 7.18.2
+  resolution: "undici@npm:7.18.2"
+  checksum: 10/7d8b921717f5a11fe7e3631dd46ea6dbd80173bdbd454c0115d2c52595352b4a620a3e48c02c40e8f32a416b8bd0028b027cbc8ddebc2d9cdc7a283d50399e3c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps undici to 7.18.2 to mitigate non-exploitable CVE-2026-22036.

This is a transitive dependency from `i18next-parser` and `pa11y-ci` dev tools.