### PR TITLE
Docs: Update SCIM provisioning to GA status

### DIFF
--- a/docs/sources/setup-grafana/configure-access/configure-scim-provisioning/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-scim-provisioning/_index.md
@@ -23,19 +23,7 @@ weight: 200
 System for Cross-domain Identity Management (SCIM) is an open standard that allows automated user provisioning and management. With SCIM, you can automate the provisioning of users and groups from your identity provider to Grafana.
 
 {{< admonition type="note" >}}
-Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and select Grafana Cloud plans in [public preview](https://grafana.com/docs/release-life-cycle/).
-Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
-
-This feature is behind the `enableSCIM` feature toggle.
-You can enable feature toggles through configuration file or environment variables.
-
-For more information, refer to the [feature toggles documentation](/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#feature_toggles).
-
-{{< /admonition >}}
-
-{{< admonition type="warning" >}}
-
-**Public Preview:** SCIM provisioning is currently in Public Preview. While functional, the feature is actively being refined and may undergo changes. We recommend thorough testing in non-production environments before deploying to production systems.
+Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud/).
 {{< /admonition >}}
 
 ## Benefits

--- a/docs/sources/setup-grafana/configure-access/configure-scim-provisioning/configure-scim-with-entraid/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-scim-provisioning/configure-scim-with-entraid/_index.md
@@ -27,21 +27,10 @@ weight: 320
 # Configure SCIM with Entra ID
 
 {{< admonition type="note" >}}
-Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and to customers on select Grafana Cloud plans. For pricing information, visit [pricing](https://grafana.com/pricing/) or contact our sales team.
-{{< /admonition >}}
-
-{{< admonition type="warning" >}}
-**Public Preview:** SCIM provisioning is currently in Public Preview. While functional, the feature is actively being refined and may undergo changes. We recommend thorough testing in non-production environments before deploying to production systems.
+Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud/).
 {{< /admonition >}}
 
 This guide explains how to configure SCIM provisioning with Entra ID to automate user and team management in Grafana.
-
-{{< admonition type="note" >}}
-This feature is behind the `enableSCIM` feature toggle.
-You can enable feature toggles through configuration file or environment variables.
-
-For more information, refer to the [feature toggles documentation](/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#feature_toggles).
-{{< /admonition >}}
 
 {{< admonition type="note" >}}
 **Important SAML and SCIM Configuration:**

--- a/docs/sources/setup-grafana/configure-access/configure-scim-provisioning/configure-scim-with-okta/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-scim-provisioning/configure-scim-with-okta/_index.md
@@ -23,21 +23,10 @@ weight: 320
 # Configure SCIM with Okta
 
 {{< admonition type="note" >}}
-Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and to customers on select Grafana Cloud plans. For pricing information, visit [pricing](https://grafana.com/pricing/) or contact our sales team.
-{{< /admonition >}}
-
-{{< admonition type="warning" >}}
-**Public Preview:** SCIM provisioning is currently in Public Preview. While functional, the feature is actively being refined and may undergo changes. We recommend thorough testing in non-production environments before deploying to production systems.
+Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud/).
 {{< /admonition >}}
 
 This guide explains how to configure SCIM provisioning with Okta to automate user and team management in Grafana.
-
-{{< admonition type="note" >}}
-This feature is behind the `enableSCIM` feature toggle.
-You can enable feature toggles through configuration file or environment variables.
-
-For more information, refer to the [feature toggles documentation](/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#feature_toggles).
-{{< /admonition >}}
 
 ## Prerequisites
 

--- a/docs/sources/setup-grafana/configure-access/configure-scim-provisioning/manage-users-teams/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-scim-provisioning/manage-users-teams/_index.md
@@ -21,11 +21,7 @@ weight: 310
 # Manage users and teams with SCIM
 
 {{< admonition type="note" >}}
-Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and to customers on select Grafana Cloud plans. For pricing information, visit [pricing](https://grafana.com/pricing/) or contact our sales team.
-{{< /admonition >}}
-
-{{< admonition type="warning" >}}
-**Public Preview:** SCIM provisioning is currently in Public Preview. While functional, the feature is actively being refined and may undergo changes. We recommend thorough testing in non-production environments before deploying to production systems.
+Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud/).
 {{< /admonition >}}
 
 SCIM streamlines identity management in Grafana by automating user lifecycle and team membership operations. This guide explains how SCIM works with existing Grafana setups, handles user provisioning, and manages team synchronization.


### PR DESCRIPTION
## Summary

- Remove public preview warnings and feature toggle references from SCIM documentation
- SCIM is now generally available in Grafana Cloud and Grafana Enterprise v12.4

## Changes

- Remove public preview admonition boxes from all SCIM docs
- Remove `enableSCIM` feature toggle references (no longer needed for GA)
- Update availability notes to standard GA format: "Available in Grafana Enterprise and Grafana Cloud"

## Files changed

- `docs/sources/setup-grafana/configure-access/configure-scim-provisioning/_index.md`
- `docs/sources/setup-grafana/configure-access/configure-scim-provisioning/configure-scim-with-okta/_index.md`
- `docs/sources/setup-grafana/configure-access/configure-scim-provisioning/configure-scim-with-entraid/_index.md`
- `docs/sources/setup-grafana/configure-access/configure-scim-provisioning/manage-users-teams/_index.md`

🤖 Generated with [Claude Code](https://claude.ai/code)