### PR TITLE
Dashboard: Fix mobile navigation when using dynamic dashboards

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -197,6 +197,14 @@ function getStyles(theme: GrafanaTheme2, headerHeight: number) {
       position: 'relative',
       flex: '1 1 0',
       overflow: 'hidden',
+
+      [theme.breakpoints.down('sm')]: {
+        flex: 1,
+
+        '> div:nth-child(2)': {
+          zIndex: theme.zIndex.activePanel,
+        },
+      },
     }),
     bodyWrapperKiosk: css({
       padding: theme.spacing(0, 2, 2, 2),


### PR DESCRIPTION
**What is this feature?**

Set `flex` and `z-index` to the sidebar on mobile devices.

**Why do we need this feature?**

Allow the entire dashboard to be scrolled on mobile devices.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

- contributes to: https://github.com/grafana/grafana/issues/115336

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
