### PR TITLE
`openapi`: List cluster scope routes

### DIFF
--- a/pkg/services/apiserver/builder/openapi.go
+++ b/pkg/services/apiserver/builder/openapi.go
@@ -125,6 +125,24 @@ func addBuilderRoutes(
 	return openAPISpec, nil
 }
 
+// Checks if the path is a "for all namespaces" endpoint
+// If the path is a cluster-scoped resource, return false
+func isAllRoute(prefix, path string, paths map[string]*spec3.Path) bool {
+	if strings.HasPrefix(path, prefix+"namespaces/") {
+		return false
+	}
+
+	// Extract the resource path after the group/version prefix
+	resourcePath := strings.TrimPrefix(path, prefix)
+	// Build the potential namespaced path to check
+	namespacedPath := prefix + "namespaces/{namespace}/" + resourcePath
+	// Check if the namespaced path exists
+	_, hasNamespacedPath := paths[namespacedPath]
+	// If the namespaced path exists, this is a "for all namespaces" endpoint - remove it
+	// Otherwise, it's a cluster-scoped resource - keep it
+	return hasNamespacedPath
+}
+
 // Modify the OpenAPI spec to include the additional routes.
 // nolint:gocyclo
 func getOpenAPIPostProcessor(version string, builders []APIGroupBuilder, gvs []schema.GroupVersion, apiResourceConfig *serverstorage.ResourceConfig) func(*spec3.OpenAPI) (*spec3.OpenAPI, error) {
@@ -162,7 +180,8 @@ func getOpenAPIPostProcessor(version string, builders []APIGroupBuilder, gvs []s
 					}
 
 					// Remove the "for all namespaces" global routes from OpenAPI (v3)
-					if !strings.HasPrefix(k, prefix+"namespaces/") {
+					// Except for cluster-scoped resources
+					if isAllRoute(prefix, k, copy.Paths.Paths) {
 						delete(copy.Paths.Paths, k)
 						continue
 					}


### PR DESCRIPTION
I was working on GlobalRoles and could not see them in the openapi UI.

It seems we are a bit too drastic on filtering out the "for all namespaces" routes which also removes cluster-scoped routes.

This PR intends to fix this 🙏 

<img width="1526" height="514" alt="image" src="https://github.com/user-attachments/assets/4bfbb1f9-5651-4a78-bd64-e1241cf8d5cd" />
