### PR TITLE
Navigation: Conditionally load grafana-servicecenter-app 

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -212,7 +212,7 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 
 	s.addPluginToSection(c, treeRoot, plugin, appLink)
 
-	if plugin.ID == "grafana-slo-app" {
+	if s.loadServiceCenterInSlo(c, plugin) {
 		// Add Service Center as a standalone nav item under Alerts & IRM
 		if alertsSection := treeRoot.FindById(navtree.NavIDAlertsAndIncidents); alertsSection != nil {
 			serviceLink := &navtree.NavLink{
@@ -386,6 +386,7 @@ func (s *ServiceImpl) readNavigationSettings() {
 		"grafana-assistant-app":            {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightAssistant, Text: "Assistant", SubTitle: "AI-powered assistant for Grafana", Icon: "ai-sparkle", IsNew: true},
 		"grafana-ml-app":                   {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightAIAndML, Text: "Machine Learning", SubTitle: "Explore AI and machine learning features", Icon: "gf-ml-alt"},
 		"grafana-slo-app":                  {SectionID: navtree.NavIDAlertsAndIncidents, SortWeight: 7},
+		"grafana-servicecenter-app":        {SectionID: navtree.NavIDAlertsAndIncidents, SortWeight: 1, Text: "Service center", IsNew: true},
 		"grafana-cloud-link-app":           {SectionID: navtree.NavIDCfgPlugins, SortWeight: 3},
 		"grafana-adaptive-metrics-app":     {SectionID: navtree.NavIDAdaptiveTelemetry, SortWeight: 1},
 		"grafana-adaptivelogs-app":         {SectionID: navtree.NavIDAdaptiveTelemetry, SortWeight: 2},
@@ -455,4 +456,16 @@ func (s *ServiceImpl) readNavigationSettings() {
 
 		s.navigationAppPathConfig[url] = *appCfg
 	}
+}
+
+// loadServiceCenterInSlo returns true if Service Center should be loaded via the SLO plugin
+// This only happens when processing grafana-slo-app AND the grafana-servicecenter-app does not exist.
+func (s *ServiceImpl) loadServiceCenterInSlo(c *contextmodel.ReqContext, plugin pluginstore.Plugin) bool {
+	if plugin.ID != "grafana-slo-app" {
+		return false
+	}
+
+	// Only load Service Center via SLO plugin if grafana-servicecenter-app doesn't exist
+	_, exists := s.pluginStore.Plugin(c.Req.Context(), "grafana-servicecenter-app")
+	return !exists
 }


### PR DESCRIPTION
**What is this feature?**
This feature ensures that we load the `grafana-servicecenter-app` from the correct location, once the `grafana-servicecenter-app` is released. Currently, it is being loaded from within the `grafana-slo-app`. The `grafana-servicecenter-app` is not yet released in `ops` or in `prod`. We will be releasing the `grafana-servicecenter-app` likely next week, and we want to ensure that once released, users can only access the "Service Center" via one access point in the NavTree.

This change ensures that if:
- there is NO `grafana-servicecenter-app`, then we load Service Center from within the SLO app
- there IS a `grafana-servicecenter-app` plugin, then we correctly load Service Center fthrough the `grafana-servicecenter-app`

We will remove the loading of the Service Center through the SLO app once the transition is complete. 

**Why do we need this feature?**
Feature is needed to ensure that Grafana Cloud users only see one access point to the `grafana-servicecenter-app` in the NavTree. 

**Who is this feature for?**
All Grafana Cloud Users.

**Which issue(s) does this PR fix?**:
Usage: Fixes [118](https://github.com/grafana/service-model/issues/118)

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective - _Please see testing images below_
<img width="1049" height="586" alt="current-state" src="https://github.com/user-attachments/assets/3212063a-542c-42f8-9303-146aaeaee5d5" />
<img width="2890" height="1171" alt="service-center-separate-exists" src="https://github.com/user-attachments/assets/9b479223-d878-4fab-ae02-2332936d7421" />

