### PR TITLE
Gauge: Update migration gdev to test that neutral worked

### DIFF
--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-gauge/gauge_tests_old_to_new.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-gauge/gauge_tests_old_to_new.v42.json
@@ -995,7 +995,7 @@
       },
       "id": 5,
       "panels": [],
-      "title": "Neutral value (not sure we will implement it yet)",
+      "title": "Neutral value",
       "type": "row"
     },
     {
@@ -1047,6 +1047,7 @@
       "options": {
         "minVizHeight": 75,
         "minVizWidth": 75,
+        "neutral": 0,
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -1119,6 +1120,7 @@
       "options": {
         "minVizHeight": 75,
         "minVizWidth": 75,
+        "neutral": 47,
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [

--- a/devenv/dev-dashboards/panel-gauge/gauge_tests_old_to_new.json
+++ b/devenv/dev-dashboards/panel-gauge/gauge_tests_old_to_new.json
@@ -971,7 +971,7 @@
       },
       "id": 5,
       "panels": [],
-      "title": "Neutral value (not sure we will implement it yet)",
+      "title": "Neutral value",
       "type": "row"
     },
     {
@@ -1023,6 +1023,7 @@
       "options": {
         "minVizHeight": 75,
         "minVizWidth": 75,
+        "neutral": 0,
         "orientation": "auto",
         "reduceOptions": {
           "calcs": ["lastNotNull"],
@@ -1093,6 +1094,7 @@
       "options": {
         "minVizHeight": 75,
         "minVizWidth": 75,
+        "neutral": 47,
         "orientation": "auto",
         "reduceOptions": {
           "calcs": ["lastNotNull"],


### PR DESCRIPTION
I didn't notice these panels when working through #115966, so now I'm coming through to make sure they are configured correctly. When tested manually, they prove that the neutral option migrates over seamlessly (since we didn't change the name or anything about it)