### PR TITLE
Gauge: Mark grafana/ui export as deprecated

### DIFF
--- a/packages/grafana-ui/src/components/Gauge/Gauge.tsx
+++ b/packages/grafana-ui/src/components/Gauge/Gauge.tsx
@@ -34,6 +34,10 @@ export interface Props {
   orientation?: VizOrientation;
 }
 
+/**
+ * @deprecated
+ * The Gauge component is deprecated and will be removed in Grafana 13.0.
+ */
 export class Gauge extends PureComponent<Props> {
   canvasElement: HTMLDivElement | null = null;
 


### PR DESCRIPTION
We are deprecating the flot-based Gauge and replacing it with the new RadialGauge. We did not expose RadialGauge from `@grafana/ui` with the hope that we don't actually need to _(it's `@grafana/ui/internal` right now)_.

- [A broad search of GitHub](https://github.com/search?q=import+Gauge+from+%27%40grafana%2Fui%27+-is%3Afork&type=code&p=1) only revealed [one project](https://github.com/syamsitaufik/react-plugin-examples/blob/80f4deea2970cc81a09d3945f240d0aa09aee3fe/combo-panel/src/components/Graph/BigGraphLayout.tsx#L2) that I saw which actually imports Gauge from `@grafana/ui` - that project hasn't had an update in 7 years, either.
- [A deep search of the grafana GitHub org](https://github.com/search?q=import+Gauge+from+%27%40grafana%2Fui%27+-is%3Afork+org%3Agrafana&type=code) reveals that no one in the org uses the export other than the GaugePanel itself, which means from an internal perspective it is certainly safe to deprecate this quickly.

Given this, I think we can mark Gauge in `@grafana/ui` deprecated for 12.4 and delete the component in 13.0 as part of GA-ing the new Gauge panel, _without_ exposing RadialGauge externally in `@grafana/ui`.