### PR TITLE
Alerting: Introduce TestIntegration method in Alertmanager

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager_mock/Alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager_mock/Alertmanager.go
@@ -813,6 +813,65 @@ func (_c *AlertmanagerMock_StopAndWait_Call) RunAndReturn(run func()) *Alertmana
 	return _c
 }
 
+// TestIntegration provides a mock function with given fields: ctx, receiverName, integrationConfig, alert
+func (_m *AlertmanagerMock) TestIntegration(ctx context.Context, receiverName string, integrationConfig models.Integration, alert alertingmodels.TestReceiversConfigAlertParams) (alertingmodels.IntegrationStatus, error) {
+	ret := _m.Called(ctx, receiverName, integrationConfig, alert)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TestIntegration")
+	}
+
+	var r0 alertingmodels.IntegrationStatus
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, models.Integration, alertingmodels.TestReceiversConfigAlertParams) (alertingmodels.IntegrationStatus, error)); ok {
+		return rf(ctx, receiverName, integrationConfig, alert)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, models.Integration, alertingmodels.TestReceiversConfigAlertParams) alertingmodels.IntegrationStatus); ok {
+		r0 = rf(ctx, receiverName, integrationConfig, alert)
+	} else {
+		r0 = ret.Get(0).(alertingmodels.IntegrationStatus)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, models.Integration, alertingmodels.TestReceiversConfigAlertParams) error); ok {
+		r1 = rf(ctx, receiverName, integrationConfig, alert)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// AlertmanagerMock_TestIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TestIntegration'
+type AlertmanagerMock_TestIntegration_Call struct {
+	*mock.Call
+}
+
+// TestIntegration is a helper method to define mock.On call
+//   - ctx context.Context
+//   - receiverName string
+//   - integrationConfig models.Integration
+//   - alert alertingmodels.TestReceiversConfigAlertParams
+func (_e *AlertmanagerMock_Expecter) TestIntegration(ctx interface{}, receiverName interface{}, integrationConfig interface{}, alert interface{}) *AlertmanagerMock_TestIntegration_Call {
+	return &AlertmanagerMock_TestIntegration_Call{Call: _e.mock.On("TestIntegration", ctx, receiverName, integrationConfig, alert)}
+}
+
+func (_c *AlertmanagerMock_TestIntegration_Call) Run(run func(ctx context.Context, receiverName string, integrationConfig models.Integration, alert alertingmodels.TestReceiversConfigAlertParams)) *AlertmanagerMock_TestIntegration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(models.Integration), args[3].(alertingmodels.TestReceiversConfigAlertParams))
+	})
+	return _c
+}
+
+func (_c *AlertmanagerMock_TestIntegration_Call) Return(_a0 alertingmodels.IntegrationStatus, _a1 error) *AlertmanagerMock_TestIntegration_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *AlertmanagerMock_TestIntegration_Call) RunAndReturn(run func(context.Context, string, models.Integration, alertingmodels.TestReceiversConfigAlertParams) (alertingmodels.IntegrationStatus, error)) *AlertmanagerMock_TestIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // TestReceivers provides a mock function with given fields: ctx, c
 func (_m *AlertmanagerMock) TestReceivers(ctx context.Context, c definitions.TestReceiversConfigBodyParams) (*notify.TestReceiversResult, int, error) {
 	ret := _m.Called(ctx, c)

--- a/pkg/services/ngalert/notifier/compat.go
+++ b/pkg/services/ngalert/notifier/compat.go
@@ -1,6 +1,9 @@
 package notifier
 
 import (
+	"encoding/json"
+
+	alertingModels "github.com/grafana/alerting/models"
 	alertingNotify "github.com/grafana/alerting/notify"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -30,4 +33,19 @@ func SilenceToPostableSilence(s models.Silence) *alertingNotify.PostableSilence 
 		ID:      id,
 		Silence: s.Silence,
 	}
+}
+
+func IntegrationToIntegrationConfig(i models.Integration) (alertingModels.IntegrationConfig, error) {
+	raw, err := json.Marshal(i.Settings)
+	if err != nil {
+		return alertingModels.IntegrationConfig{}, err
+	}
+	return alertingModels.IntegrationConfig{
+		UID:                   i.UID,
+		Name:                  i.Name,
+		Type:                  string(i.Config.Type()),
+		DisableResolveMessage: i.DisableResolveMessage,
+		Settings:              raw,
+		SecureSettings:        i.SecureSettings,
+	}, nil
 }

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	alertingModels "github.com/grafana/alerting/models"
 	"github.com/grafana/alerting/notify/nfstatus"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -71,6 +72,7 @@ type Alertmanager interface {
 	// Receivers
 	GetReceivers(ctx context.Context) ([]apimodels.Receiver, error)
 	TestReceivers(ctx context.Context, c apimodels.TestReceiversConfigBodyParams) (*alertingNotify.TestReceiversResult, int, error)
+	TestIntegration(ctx context.Context, receiverName string, integrationConfig models.Integration, alert alertingModels.TestReceiversConfigAlertParams) (alertingModels.IntegrationStatus, error)
 	TestTemplate(ctx context.Context, c apimodels.TestTemplatesConfigBodyParams) (*TestTemplatesResults, error)
 
 	// Lifecycle

--- a/pkg/services/ngalert/notifier/testreceivers.go
+++ b/pkg/services/ngalert/notifier/testreceivers.go
@@ -9,6 +9,7 @@ import (
 	v2 "github.com/prometheus/alertmanager/api/v2"
 
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
 func (am *alertmanager) TestReceivers(ctx context.Context, c apimodels.TestReceiversConfigBodyParams) (*alertingNotify.TestReceiversResult, int, error) {
@@ -50,6 +51,14 @@ func (am *alertmanager) TestReceivers(ctx context.Context, c apimodels.TestRecei
 		},
 		Receivers: receivers,
 	})
+}
+
+func (am *alertmanager) TestIntegration(ctx context.Context, receiverName string, integrationConfig ngmodels.Integration, alert models.TestReceiversConfigAlertParams) (models.IntegrationStatus, error) {
+	cfg, err := IntegrationToIntegrationConfig(integrationConfig)
+	if err != nil {
+		return models.IntegrationStatus{}, err
+	}
+	return am.Base.TestIntegration(ctx, receiverName, cfg, alert)
 }
 
 func (am *alertmanager) GetReceivers(_ context.Context) ([]apimodels.Receiver, error) {

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -31,7 +31,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	common_config "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/client_golang/prometheus"
 	common_config "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
 
@@ -1368,6 +1369,47 @@ func TestIntegrationRemoteAlertmanagerTestTemplates(t *testing.T) {
 	require.Len(t, res.Results, 0)
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, notify.ExecutionError, res.Errors[0].Kind)
+}
+
+func TestIntegrationRemoteAlertmanagerTestIntegration(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	amURL, ok := os.LookupEnv("AM_URL")
+	if !ok {
+		t.Skip("No Alertmanager URL provided")
+	}
+
+	tenantID := os.Getenv("AM_TENANT_ID")
+	password := os.Getenv("AM_PASSWORD")
+
+	cfg := AlertmanagerConfig{
+		OrgID:             1,
+		URL:               amURL,
+		TenantID:          tenantID,
+		BasicAuthPassword: password,
+		DefaultConfig:     defaultGrafanaConfig,
+	}
+
+	ctx := context.Background()
+	secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
+	m := metrics.NewRemoteAlertmanagerMetrics(prometheus.NewRegistry())
+	am, err := NewAlertmanager(ctx, cfg, nil, notifier.NewCrypto(secretsService, nil, log.NewNopLogger()), NoopAutogenFn, m, tracing.InitializeTracerForTest())
+	require.NoError(t, err)
+
+	integration := ngmodels.IntegrationGen(ngmodels.IntegrationMuts.WithValidConfig("webhook"))()
+	integration.Settings["url"] = "grafana://noop" // TODO remove later if https://github.com/grafana/alerting/pull/465 merged
+	testAlert := alertingModels.TestReceiversConfigAlertParams{
+		Annotations: model.LabelSet{
+			"annotations_label": "annotations_value",
+		},
+		Labels: model.LabelSet{
+			"alertname": "test",
+			"severity":  "critical",
+		},
+	}
+	result, err := am.TestIntegration(ctx, "test-receiver", integration, testAlert)
+	require.NoError(t, err)
+	require.NotEmpty(t, result.LastNotifyAttemptDuration)
 }
 
 func genAlert(active bool, labels map[string]string) amv2.PostableAlert {

--- a/pkg/services/ngalert/remote/mock/remoteAlertmanager.go
+++ b/pkg/services/ngalert/remote/mock/remoteAlertmanager.go
@@ -964,6 +964,65 @@ func (_c *RemoteAlertmanagerMock_StopAndWait_Call) RunAndReturn(run func()) *Rem
 	return _c
 }
 
+// TestIntegration provides a mock function with given fields: ctx, receiverName, integrationConfig, alert
+func (_m *RemoteAlertmanagerMock) TestIntegration(ctx context.Context, receiverName string, integrationConfig models.Integration, alert alertingmodels.TestReceiversConfigAlertParams) (alertingmodels.IntegrationStatus, error) {
+	ret := _m.Called(ctx, receiverName, integrationConfig, alert)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TestIntegration")
+	}
+
+	var r0 alertingmodels.IntegrationStatus
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, models.Integration, alertingmodels.TestReceiversConfigAlertParams) (alertingmodels.IntegrationStatus, error)); ok {
+		return rf(ctx, receiverName, integrationConfig, alert)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, models.Integration, alertingmodels.TestReceiversConfigAlertParams) alertingmodels.IntegrationStatus); ok {
+		r0 = rf(ctx, receiverName, integrationConfig, alert)
+	} else {
+		r0 = ret.Get(0).(alertingmodels.IntegrationStatus)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, models.Integration, alertingmodels.TestReceiversConfigAlertParams) error); ok {
+		r1 = rf(ctx, receiverName, integrationConfig, alert)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// RemoteAlertmanagerMock_TestIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TestIntegration'
+type RemoteAlertmanagerMock_TestIntegration_Call struct {
+	*mock.Call
+}
+
+// TestIntegration is a helper method to define mock.On call
+//   - ctx context.Context
+//   - receiverName string
+//   - integrationConfig models.Integration
+//   - alert alertingmodels.TestReceiversConfigAlertParams
+func (_e *RemoteAlertmanagerMock_Expecter) TestIntegration(ctx interface{}, receiverName interface{}, integrationConfig interface{}, alert interface{}) *RemoteAlertmanagerMock_TestIntegration_Call {
+	return &RemoteAlertmanagerMock_TestIntegration_Call{Call: _e.mock.On("TestIntegration", ctx, receiverName, integrationConfig, alert)}
+}
+
+func (_c *RemoteAlertmanagerMock_TestIntegration_Call) Run(run func(ctx context.Context, receiverName string, integrationConfig models.Integration, alert alertingmodels.TestReceiversConfigAlertParams)) *RemoteAlertmanagerMock_TestIntegration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(models.Integration), args[3].(alertingmodels.TestReceiversConfigAlertParams))
+	})
+	return _c
+}
+
+func (_c *RemoteAlertmanagerMock_TestIntegration_Call) Return(_a0 alertingmodels.IntegrationStatus, _a1 error) *RemoteAlertmanagerMock_TestIntegration_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *RemoteAlertmanagerMock_TestIntegration_Call) RunAndReturn(run func(context.Context, string, models.Integration, alertingmodels.TestReceiversConfigAlertParams) (alertingmodels.IntegrationStatus, error)) *RemoteAlertmanagerMock_TestIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // TestReceivers provides a mock function with given fields: ctx, c
 func (_m *RemoteAlertmanagerMock) TestReceivers(ctx context.Context, c definitions.TestReceiversConfigBodyParams) (*notify.TestReceiversResult, int, error) {
 	ret := _m.Called(ctx, c)

--- a/pkg/services/ngalert/remote/remote_primary_forked_alertmanager.go
+++ b/pkg/services/ngalert/remote/remote_primary_forked_alertmanager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	alertingModels "github.com/grafana/alerting/models"
 	alertingNotify "github.com/grafana/alerting/notify"
 
 	"github.com/grafana/grafana/pkg/infra/kvstore"
@@ -171,6 +172,10 @@ func (fam *RemotePrimaryForkedAlertmanager) GetReceivers(ctx context.Context) ([
 
 func (fam *RemotePrimaryForkedAlertmanager) TestReceivers(ctx context.Context, c apimodels.TestReceiversConfigBodyParams) (*alertingNotify.TestReceiversResult, int, error) {
 	return fam.remote.TestReceivers(ctx, c)
+}
+
+func (fam *RemotePrimaryForkedAlertmanager) TestIntegration(ctx context.Context, receiverName string, integrationConfig models.Integration, alert alertingModels.TestReceiversConfigAlertParams) (alertingModels.IntegrationStatus, error) {
+	return fam.remote.TestIntegration(ctx, receiverName, integrationConfig, alert)
 }
 
 func (fam *RemotePrimaryForkedAlertmanager) TestTemplate(ctx context.Context, c apimodels.TestTemplatesConfigBodyParams) (*notifier.TestTemplatesResults, error) {

--- a/pkg/services/ngalert/remote/remote_secondary_forked_alertmanager.go
+++ b/pkg/services/ngalert/remote/remote_secondary_forked_alertmanager.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	alertingModels "github.com/grafana/alerting/models"
 	alertingNotify "github.com/grafana/alerting/notify"
 
 	"github.com/grafana/grafana/pkg/infra/kvstore"
@@ -232,6 +233,10 @@ func (fam *RemoteSecondaryForkedAlertmanager) GetReceivers(ctx context.Context) 
 
 func (fam *RemoteSecondaryForkedAlertmanager) TestReceivers(ctx context.Context, c apimodels.TestReceiversConfigBodyParams) (*alertingNotify.TestReceiversResult, int, error) {
 	return fam.internal.TestReceivers(ctx, c)
+}
+
+func (fam *RemoteSecondaryForkedAlertmanager) TestIntegration(ctx context.Context, receiverName string, integrationConfig models.Integration, alert alertingModels.TestReceiversConfigAlertParams) (alertingModels.IntegrationStatus, error) {
+	return fam.internal.TestIntegration(ctx, receiverName, integrationConfig, alert)
 }
 
 func (fam *RemoteSecondaryForkedAlertmanager) TestTemplate(ctx context.Context, c apimodels.TestTemplatesConfigBodyParams) (*notifier.TestTemplatesResults, error) {


### PR DESCRIPTION
**What is this feature?**
Exposes a new method added in https://github.com/grafana/alerting/pull/406. For remote alert manager it uses the legacy method for now. 

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/pull/111338