### PR TITLE
unified-storage: pass a concrete logger to the storage backend

### DIFF
--- a/pkg/storage/unified/apistore/restoptions.go
+++ b/pkg/storage/unified/apistore/restoptions.go
@@ -17,6 +17,7 @@ import (
 	flowcontrolrequest "k8s.io/apiserver/pkg/util/flowcontrol/request"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	secret "github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
@@ -66,6 +67,7 @@ func NewRESTOptionsGetterMemory(originalStorageConfig storagebackend.Config, sec
 	backend, err := resource.NewKVStorageBackend(resource.KVBackendOptions{
 		KvStore:                      kv,
 		WithExperimentalClusterScope: true,
+		Log:                          log.New(),
 	})
 	if err != nil {
 		return nil, err
@@ -105,6 +107,7 @@ func NewRESTOptionsGetterForFileXX(path string,
 	kv := resource.NewBadgerKV(db)
 	backend, err := resource.NewKVStorageBackend(resource.KVBackendOptions{
 		KvStore: kv,
+		Log:     log.New(),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/dskit/services"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	infraDB "github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	secrets "github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/services/apiserver/options"
@@ -121,6 +122,7 @@ func newClient(opts options.StorageOptions,
 		kv := resource.NewBadgerKV(db)
 		backend, err := resource.NewKVStorageBackend(resource.KVBackendOptions{
 			KvStore: kv,
+			Log:     log.New(),
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/storage/unified/resource/notifier_test.go
+++ b/pkg/storage/unified/resource/notifier_test.go
@@ -7,8 +7,8 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
 	"github.com/grafana/grafana/pkg/util/testutil"
@@ -24,7 +24,7 @@ func setupTestNotifier(t *testing.T) (*pollingNotifier, *eventStore) {
 	})
 	kv := NewBadgerKV(db)
 	eventStore := newEventStore(kv)
-	notifier := newNotifier(eventStore, notifierOptions{log: &logging.NoOpLogger{}})
+	notifier := newNotifier(eventStore, notifierOptions{log: log.NewNopLogger()})
 	return notifier.(*pollingNotifier), eventStore
 }
 
@@ -35,7 +35,7 @@ func setupTestNotifierSqlKv(t *testing.T) (*pollingNotifier, *eventStore) {
 	kv, err := NewSQLKV(eDB)
 	require.NoError(t, err)
 	eventStore := newEventStore(kv)
-	notifier := newNotifier(eventStore, notifierOptions{log: &logging.NoOpLogger{}})
+	notifier := newNotifier(eventStore, notifierOptions{log: log.NewNopLogger()})
 	return notifier.(*pollingNotifier), eventStore
 }
 
@@ -501,7 +501,7 @@ func testNotifierWatchMultipleEvents(t *testing.T, ctx context.Context, notifier
 }
 
 func TestChannelNotifier(t *testing.T) {
-	log := &logging.NoOpLogger{}
+	log := log.NewNopLogger()
 	opts := watchOptions{BufferSize: 5}
 
 	var eventCount int64

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/dskit/services"
 
 	infraDB "github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/log"
 	secrets "github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	inlinesecurevalue "github.com/grafana/grafana/pkg/registry/apis/secret/inline"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -113,6 +114,7 @@ func NewResourceServer(opts ServerOptions) (resource.ResourceServer, error) {
 				Tracer:             opts.Tracer,
 				Reg:                opts.Reg,
 				UseChannelNotifier: !isHA,
+				Log:                log.New("storage-backend"),
 			}
 
 			ctx := context.Background()


### PR DESCRIPTION
The storage backend and notifier now use `pkg/infra/log` instead of the `logging` package in grafana-app-sdk. In addition, a concrete logger is passed when initializing the storage backend instead of using a no-op logger.