### PR TITLE
Alerting: Fix alert instances count to include error state

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
@@ -176,6 +176,54 @@ describe('RuleDetailsMatchingInstances', () => {
       expect(ui.showAllInstances.query()).not.toBeInTheDocument();
     });
   });
+
+  describe('Total count', () => {
+    it('should include error instances in total count', () => {
+      const rule = mockCombinedRule({
+        promRule: mockPromAlertingRule({
+          alerts: [
+            mockPromAlert({ state: GrafanaAlertState.Normal }),
+            mockPromAlert({ state: GrafanaAlertState.Error }),
+          ],
+        }),
+        instanceTotals: {
+          inactive: 1,
+          error: 1,
+        },
+      });
+
+      render(<RuleDetailsMatchingInstances rule={rule} itemsDisplayLimit={1} />);
+
+      expect(ui.showAllInstances.get()).toHaveTextContent('Show all 2 alert instances');
+    });
+
+    it('should include all states in total count', () => {
+      const rule = mockCombinedRule({
+        promRule: mockPromAlertingRule({
+          alerts: [
+            mockPromAlert({ state: GrafanaAlertState.Normal }),
+            mockPromAlert({ state: GrafanaAlertState.Alerting }),
+            mockPromAlert({ state: GrafanaAlertState.Pending }),
+            mockPromAlert({ state: GrafanaAlertState.Recovering }),
+            mockPromAlert({ state: GrafanaAlertState.NoData }),
+            mockPromAlert({ state: GrafanaAlertState.Error }),
+          ],
+        }),
+        instanceTotals: {
+          inactive: 1,
+          alerting: 1,
+          pending: 1,
+          recovering: 1,
+          nodata: 1,
+          error: 1,
+        },
+      });
+
+      render(<RuleDetailsMatchingInstances rule={rule} itemsDisplayLimit={1} />);
+
+      expect(ui.showAllInstances.get()).toHaveTextContent('Show all 6 alert instances');
+    });
+  });
 });
 
 function mockPromNamespace(): CombinedRuleNamespace {

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
@@ -115,15 +115,7 @@ export function RuleDetailsMatchingInstances(props: Props) {
   // Count All By State is used only when filtering is enabled and we have access to all instances
   const countAllByState = countBy(promRule.alerts, (alert) => mapStateWithReasonToBaseState(alert.state));
 
-  // error state is not a separate state
-  const totalInstancesCount = sum([
-    instanceTotals.alerting,
-    instanceTotals.inactive,
-    instanceTotals.pending,
-    instanceTotals.recovering,
-    instanceTotals.nodata,
-  ]);
-  const hiddenInstancesCount = totalInstancesCount - visibleInstances.length;
+  const totalInstancesCount = sum(Object.values(instanceTotals));
 
   const stats: ShowMoreStats = {
     totalItemsCount: totalInstancesCount,
@@ -141,15 +133,16 @@ export function RuleDetailsMatchingInstances(props: Props) {
 
   const resetFilter = () => setAlertState(undefined);
 
-  const footerRow = hiddenInstancesCount ? (
-    <ShowMoreInstances
-      stats={stats}
-      onClick={enableFiltering ? resetFilter : undefined}
-      href={!enableFiltering ? ruleViewPageLink : undefined}
-      enableFiltering={enableFiltering}
-      alertState={alertState}
-    />
-  ) : undefined;
+  const footerRow =
+    totalInstancesCount > visibleInstances.length ? (
+      <ShowMoreInstances
+        stats={stats}
+        onClick={enableFiltering ? resetFilter : undefined}
+        href={!enableFiltering ? ruleViewPageLink : undefined}
+        enableFiltering={enableFiltering}
+        alertState={alertState}
+      />
+    ) : undefined;
 
   return (
     <>


### PR DESCRIPTION
**What is this feature?**

Fixes the alert instances count to include instances in the Error state. Previously, the "Showing X out of Y instances" message excluded error instances from the total count. This leads to confusing messages like "Showing 2 out of 1 instances":

<img width="981" height="314" alt="image" src="https://github.com/user-attachments/assets/c960b2b9-5852-454b-8e80-5846178ef8a9" />


**Who is this feature for?**

Users of Grafana Alerting.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
