### PR TITLE
InfluxDB: Proxy using UID rather than internal ID

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.test.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.test.tsx
@@ -23,7 +23,7 @@ describe('UrlAndAuthenticationSection', () => {
 
   const defaultProps = createTestProps({
     options: {
-      id: 1234,
+      uid: `abc`,
       jsonData: {
         url: 'http://localhost:8086',
         product: '',
@@ -55,7 +55,7 @@ describe('UrlAndAuthenticationSection', () => {
             return null;
           },
         },
-        url: '/api/datasources/proxy/1234/ping',
+        url: '/api/datasources/proxy/uid/abc/ping',
       })
     );
   };

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
@@ -74,8 +74,8 @@ export const UrlAndAuthenticationSection = (props: Props) => {
   };
 
   const pingInfluxForProductDetection = async (urlValue: string) => {
-    const dsId = options.id;
-    if (!dsId) {
+    const dsUID = options.uid;
+    if (!dsUID) {
       return;
     }
 
@@ -83,7 +83,7 @@ export const UrlAndAuthenticationSection = (props: Props) => {
       const res = await firstValueFrom(
         getBackendSrv().fetch({
           method: 'GET',
-          url: `/api/datasources/proxy/${dsId}/ping`,
+          url: `/api/datasources/proxy/uid/${dsUID}/ping`,
           headers: { Accept: 'application/json' },
           responseType: 'text',
           showErrorAlert: false,


### PR DESCRIPTION
We should avoid calling the deprecated proxy API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/data_source/#data-source-proxy-calls-by-id and use the supported UID flavor instead