### PR TITLE
Chore: remove deprecated, internal getDataSourceById function

### DIFF
--- a/public/app/features/datasources/api.test.ts
+++ b/public/app/features/datasources/api.test.ts
@@ -3,7 +3,7 @@ import { of } from 'rxjs';
 import { BackendSrvRequest, FetchResponse } from '@grafana/runtime';
 import { getBackendSrv } from 'app/core/services/backend_srv';
 
-import { getDataSourceByIdOrUid } from './api';
+import { getDataSourceByUid } from './api';
 
 jest.mock('app/core/services/backend_srv');
 jest.mock('@grafana/runtime', () => ({
@@ -20,7 +20,7 @@ const mockResponse = (response: Partial<FetchResponse>) => {
 };
 
 describe('Datasources / API', () => {
-  describe('getDataSourceByIdOrUid()', () => {
+  describe('getDataSourceByUid()', () => {
     it('should resolve to the datasource object in case it is fetched using a UID', async () => {
       const response = {
         ok: true,
@@ -31,7 +31,7 @@ describe('Datasources / API', () => {
       };
       mockResponse(response);
 
-      expect(await getDataSourceByIdOrUid(response.data.uid)).toBe(response.data);
+      expect(await getDataSourceByUid(response.data.uid)).toBe(response.data);
     });
   });
 });

--- a/public/app/features/datasources/api.ts
+++ b/public/app/features/datasources/api.ts
@@ -8,26 +8,6 @@ export const getDataSources = async (): Promise<DataSourceSettings[]> => {
   return await getBackendSrv().get('/api/datasources');
 };
 
-/**
- * @deprecated Use `getDataSourceByUid` instead.
- */
-export const getDataSourceById = async (id: string) => {
-  const response = await lastValueFrom(
-    getBackendSrv().fetch<DataSourceSettings>({
-      method: 'GET',
-      url: `/api/datasources/${id}`,
-      params: accessControlQueryParam(),
-      showErrorAlert: false,
-    })
-  );
-
-  if (response.ok) {
-    return response.data;
-  }
-
-  throw Error(`Could not find data source by ID: "${id}"`);
-};
-
 export const getDataSourceByUid = async (uid: string) => {
   const response = await lastValueFrom(
     getBackendSrv().fetch<DataSourceSettings>({
@@ -45,22 +25,11 @@ export const getDataSourceByUid = async (uid: string) => {
   throw Error(`Could not find data source by UID: "${uid}"`);
 };
 
+/**
+ * @deprecated Use `getDataSourceByUid` instead.
+ */
 export const getDataSourceByIdOrUid = async (idOrUid: string) => {
-  // Try with UID first, as we are trying to migrate to that
-  try {
-    return await getDataSourceByUid(idOrUid);
-  } catch (err) {
-    console.log(`Failed to lookup data source using UID "${idOrUid}"`);
-  }
-
-  // Try using ID
-  try {
-    return await getDataSourceById(idOrUid);
-  } catch (err) {
-    console.log(`Failed to lookup data source using ID "${idOrUid}"`);
-  }
-
-  throw Error('Could not find data source');
+  return getDataSourceByUid(idOrUid);
 };
 
 export const createDataSource = (dataSource: Partial<DataSourceSettings>) =>

--- a/public/app/features/datasources/api.ts
+++ b/public/app/features/datasources/api.ts
@@ -25,13 +25,6 @@ export const getDataSourceByUid = async (uid: string) => {
   throw Error(`Could not find data source by UID: "${uid}"`);
 };
 
-/**
- * @deprecated Use `getDataSourceByUid` instead.
- */
-export const getDataSourceByIdOrUid = async (idOrUid: string) => {
-  return getDataSourceByUid(idOrUid);
-};
-
 export const createDataSource = (dataSource: Partial<DataSourceSettings>) =>
   getBackendSrv().post('/api/datasources', dataSource);
 

--- a/public/app/features/datasources/state/actions.test.ts
+++ b/public/app/features/datasources/state/actions.test.ts
@@ -89,7 +89,7 @@ describe('loadDataSource()', () => {
     const dispatch = jest.fn();
     const getState = jest.fn();
 
-    (api.getDataSourceByIdOrUid as jest.Mock).mockResolvedValueOnce(dataSourceMock);
+    (api.getDataSourceByUid as jest.Mock).mockResolvedValueOnce(dataSourceMock);
 
     const dataSource = await loadDataSource(dataSourceMock.uid)(dispatch, getState, undefined);
 
@@ -110,7 +110,7 @@ describe('loadDataSource()', () => {
     delete win.location;
     win.location = {} as Location;
 
-    (api.getDataSourceByIdOrUid as jest.Mock).mockResolvedValueOnce(dataSourceMock);
+    (api.getDataSourceByUid as jest.Mock).mockResolvedValueOnce(dataSourceMock);
 
     // Fetch the datasource by ID
     const dataSource = await loadDataSource(id.toString())(dispatch, getState, undefined);
@@ -132,7 +132,7 @@ describe('loadDataSource()', () => {
     delete win.location;
     win.location = {} as Location;
 
-    (api.getDataSourceByIdOrUid as jest.Mock).mockResolvedValueOnce(dataSourceMock);
+    (api.getDataSourceByUid as jest.Mock).mockResolvedValueOnce(dataSourceMock);
 
     // Fetch the datasource by ID
     await loadDataSource(id.toString())(dispatch, getState, undefined);

--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -200,7 +200,7 @@ export function loadDataSources(): ThunkResult<Promise<void>> {
 
 export function loadDataSource(uid: string): ThunkResult<Promise<DataSourceSettings>> {
   return async (dispatch) => {
-    let dataSource = await api.getDataSourceByIdOrUid(uid);
+    let dataSource = await api.getDataSourceByUid(uid);
 
     // Reload route to use UID instead
     // -------------------------------


### PR DESCRIPTION
`getDataSourceById` has been deprecated for 4 years

