### PR TITLE
Plugins: replace usages of `config.apps` in AdvisorRedirectNotice

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1762,16 +1762,6 @@
       "count": 1
     }
   },
-  "public/app/features/connections/components/AdvisorRedirectNotice/AdvisorRedirectNotice.test.tsx": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "public/app/features/connections/components/AdvisorRedirectNotice/AdvisorRedirectNotice.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "public/app/features/connections/tabs/ConnectData/ConnectData.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1

--- a/public/app/features/plugins/admin/pages/Browse.test.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.test.tsx
@@ -13,7 +13,10 @@ import BrowsePage from './Browse';
 
 jest.mock('@grafana/runtime', () => {
   const original = jest.requireActual('@grafana/runtime');
-  const mockedRuntime = { ...original };
+  const mockedRuntime = {
+    ...original,
+    useAppPluginInstalled: jest.fn().mockReturnValue({ loading: false, value: false, error: undefined }),
+  };
 
   mockedRuntime.config.buildInfo.version = 'v8.1.0';
 


### PR DESCRIPTION
**What is this feature?**

This pull request refactors how the `AdvisorRedirectNotice` component checks for the installation of the Advisor app, switching from directly inspecting the `config.apps` object to using the `useAppPluginInstalled` hook. 

**Why do we need this feature?**

Because `config.apps` has been deprecated and will be removed

**Who is this feature for?**

Plugins platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #116472

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
