### PR TITLE
Dynamic Dashboards: Fix legend click opening panel edit sidebar

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
@@ -239,11 +239,7 @@ it('does not select the panel when clicking interactive content', async () => {
         onClear: jest.fn(),
       }}
     >
-      <PanelChrome
-        width={100}
-        height={100}
-        selectionId="panel-1"
-      >
+      <PanelChrome width={100} height={100} selectionId="panel-1">
         {() => (
           <div>
             <button type="button">Legend item</button>

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
@@ -5,6 +5,8 @@ import { useToggle } from 'react-use';
 import { LoadingState } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 
+import { ElementSelectionContext } from '../ElementSelectionContext/ElementSelectionContext';
+
 import { PanelChrome, PanelChromeProps } from './PanelChrome';
 
 const setup = (propOverrides?: Partial<PanelChromeProps>) => {
@@ -222,4 +224,39 @@ it('does not render sub-header content when panel is collapsed', () => {
   });
 
   expect(screen.queryByText('This should be a sub-header node')).not.toBeInTheDocument();
+});
+
+it('does not select the panel when clicking interactive content', async () => {
+  const onSelect = jest.fn();
+  const user = userEvent.setup();
+
+  render(
+    <ElementSelectionContext.Provider
+      value={{
+        enabled: true,
+        selected: [],
+        onSelect,
+        onClear: jest.fn(),
+      }}
+    >
+      <PanelChrome
+        width={100}
+        height={100}
+        selectionId="panel-1"
+      >
+        {() => (
+          <div>
+            <button type="button">Legend item</button>
+            <div>Non-interactive</div>
+          </div>
+        )}
+      </PanelChrome>
+    </ElementSelectionContext.Provider>
+  );
+
+  await user.pointer({ keys: '[MouseLeft>]', target: screen.getByRole('button', { name: 'Legend item' }) });
+  expect(onSelect).not.toHaveBeenCalled();
+
+  await user.pointer({ keys: '[MouseLeft>]', target: screen.getByText('Non-interactive') });
+  expect(onSelect).toHaveBeenCalledTimes(1);
 });

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -248,10 +248,14 @@ export function PanelChrome({
 
   const onContentPointerDown = React.useCallback(
     (evt: React.PointerEvent) => {
-      // When selected, ignore clicks inside buttons, links, canvas and svg elments
-      // This does prevent a clicks inside a graphs from selecting panel as there is normal div above the canvas element that intercepts the click
-      if (isSelected && evt.target instanceof Element && evt.target.closest('button,a,canvas,svg')) {
-        // Stop propagation otherwise row config editor will get selected
+      // Always ignore interactive controls so their clicks don't select the panel.
+      // This prevents legend item clicks from selecting the panel and opening the edit sidebar.
+      if (evt.target instanceof Element && evt.target.closest('button,a')) {
+        return;
+      }
+
+      // When selected, ignore clicks inside canvas/svg to avoid selecting row config editor.
+      if (isSelected && evt.target instanceof Element && evt.target.closest('canvas,svg')) {
         evt.stopPropagation();
         return;
       }

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -251,6 +251,7 @@ export function PanelChrome({
       // Always ignore interactive controls so their clicks don't select the panel.
       // This prevents legend item clicks from selecting the panel and opening the edit sidebar.
       if (evt.target instanceof Element && evt.target.closest('button,a')) {
+        evt.stopPropagation();
         return;
       }
 


### PR DESCRIPTION
**What is this feature?**

Fixes an issue where clicking legend items in timeseries panels incorrectly triggered panel selection and opened the edit sidebar, preventing users from toggling series visibility.

**Why do we need this feature?**

In Dynamic Dashboards, clicking on legend items in timeseries panels should toggle the visibility of that series (show/hide the line in the graph). However, clicking a legend item currently selects the panel and opens the panel edit sidebar on the right, completely breaking the expected legend interaction.

**Who is this feature for?**

Users working with timeseries panels who need to toggle series visibility using legend items. This affects any dashboard with timeseries visualizations that have multiple series.

**Which issue(s) does this PR fix?**:

Fixes #116082

**Special notes for your reviewer:**

The root cause was that `PanelChrome` only ignored interactive element clicks (buttons, links) when the panel was already selected. Legend items are rendered as `<button>` elements, so clicking them on an unselected panel would trigger panel selection.

This change moves the interactive element check to apply regardless of selection state, allowing legend button clicks to work as intended while preserving the ability to select panels by clicking non-interactive content.

**Changes:**
- Modified `PanelChrome.onContentPointerDown` to always ignore button/link clicks
- Preserved existing canvas/svg click behavior for already-selected panels (prevents row config editor selection)
- Added unit test `does not select the panel when clicking interactive content`

**How to test:**
1. Navigate to a dashboard with a timeseries panel
2. Create a query that returns multiple time series (so the legend appears with multiple items)
3. Click on any legend item
4. The series should toggle visibility without selecting the panel or opening the edit sidebar