### PR TITLE
Fix: Add ActionAlertingProvisioningSetStatus to FolderEditActions

### DIFF
--- a/pkg/services/accesscontrol/ossaccesscontrol/folder.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/folder.go
@@ -38,6 +38,7 @@ var FolderEditActions = append(FolderViewActions, []string{
 	accesscontrol.ActionAlertingRuleDelete,
 	accesscontrol.ActionAlertingSilencesCreate,
 	accesscontrol.ActionAlertingSilencesWrite,
+	accesscontrol.ActionAlertingProvisioningSetStatus,
 	libraryelements.ActionLibraryPanelsCreate,
 	libraryelements.ActionLibraryPanelsWrite,
 	libraryelements.ActionLibraryPanelsDelete,


### PR DESCRIPTION
Fixes #92763

  Service accounts with folder Edit permissions cannot create alert rules via the Provisioning API (used by Terraform), even though they can create alerts via the Ruler API and can create dashboards.

  Root cause: The Provisioning API requires both alert.rules:create AND alert.provisioning.provenance:write permissions. FolderEditActions included alert.rules:create but was missing ActionAlertingProvisioningSetStatus (alert.provisioning.provenance:write).

  This change adds ActionAlertingProvisioningSetStatus to FolderEditActions, enabling service accounts with folder Edit permissions to:
  - Use Terraform Grafana Provider for alert management
  - Use the Provisioning API (/api/v1/provisioning/alert-rules)
  - Set provenance status on alerts they have access to

  This brings folder-level permissions in line with global Editor role behavior, which already has this permission.

  ---

  **What is this feature?**

  This change adds the `ActionAlertingProvisioningSetStatus` permission to the `FolderEditActions` permission set, allowing users and service accounts with folder Edit permissions to use the Provisioning API for alert management.

  **Why do we need this feature?**

  Currently, service accounts with folder-level Edit permissions can create dashboards and can create alerts via the Ruler API, but they receive 403 Forbidden errors when attempting to create alerts via the Provisioning API (used by Terraform and other infrastructure-as-code tools). This creates an inconsistent permission model and prevents automation workflows that rely on folder-scoped permissions.

  The Provisioning API requires both `alert.rules:create` AND `alert.provisioning.provenance:write` permissions. While `alert.rules:create` is included in FolderEditActions, `alert.provisioning.provenance:write` (ActionAlertingProvisioningSetStatus) was missing, causing the authorization check to fail.

  **Who is this feature for?**

  This fix is for:
  - Teams using service accounts with folder-scoped permissions for alert automation
  - Users managing alerts via Terraform Grafana Provider with non-admin service accounts
  - Organizations implementing least-privilege security models with folder-level access control
  - DevOps teams using the Provisioning API for infrastructure-as-code workflows

  **Which issue(s) does this PR fix?**:

  Fixes #92763

  **Special notes for your reviewer:**

  Please check that:
  - [x] It works as expected from a user's perspective.
  - [x] If this is a pre-GA feature, it is behind a feature toggle. *(N/A - this is a bug fix for existing functionality)*
  - [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc. *(Note: This may warrant a mention in release notes as it enables Terraform workflows with folder-scoped service accounts)*

  **Testing performed:**
- [x] Verified service account with folder Edit permission can create alerts via Provisioning API
- [x] Verified service account with folder Edit permission can create alerts via Terraform
- [x] Verified permission enforcement still works (403 for folders without access)
- [x] Verified existing Ruler API functionality remains unchanged

  **Changes:**
  - Modified: `pkg/services/accesscontrol/ossaccesscontrol/folder.go` (added 1 line)
  - One-line change adding `accesscontrol.ActionAlertingProvisioningSetStatus` to the FolderEditActions array

  **Impact:**
  This is a minimal, low-risk change that:
  - Grants organization-scoped provenance permission to users with folder Edit access
  - Aligns folder permissions with global Editor role behavior (which already has this permission)
  - Does not affect existing dashboard or Ruler API workflows
  - Users still require folder-specific CRUD permissions to actually modify alerts