### PR TITLE
docs(alerting): add tracking params to Grafana Play links

### DIFF
--- a/docs/sources/alerting/examples/dynamic-labels.md
+++ b/docs/sources/alerting/examples/dynamic-labels.md
@@ -283,7 +283,11 @@ This setup reproduces label flapping and shows how dynamic label values affect a
 
    {{< figure src="/media/docs/alerting/example-dynamic-labels-alert-history-page.png" max-width="750px" caption="You can find multiple transitions over time as the label value fluctuates." >}}
 
-   {{< docs/play title="this alert example" url="https://play.grafana.org/alerting/grafana/eep7oslk5u680e/view" >}}
+   {{< admonition type="tip" >}}
+   You can explore this **[alerting example in Grafana Play](https://play.grafana.org/alerting/grafana/eep7oslk5u680e/view?tech=docs&pg=alerting-examples&plcmt=callout-tip&cta=alert-dynamic-labels)**.
+
+   Open the example to view alert evaluation results, generated alert instances, the alert history timeline, and alert rule details.
+   {{< /admonition >}}
 
 ## Considerations
 

--- a/docs/sources/alerting/examples/dynamic-thresholds.md
+++ b/docs/sources/alerting/examples/dynamic-thresholds.md
@@ -198,7 +198,11 @@ You can use the [TestData data source](ref:testdata-data-source) to replicate th
 
    {{< figure src="/media/docs/alerting/example-dynamic-thresholds-preview-v3.png" max-width="750px" caption="Alert preview evaluating multiple series with distinct threshold values" >}}
 
-   {{< docs/play title="this alert example" url="https://play.grafana.org/alerting/grafana/aep7osljvuku8e/view" >}}
+   {{< admonition type="tip" >}}
+   You can explore this **[alerting example in Grafana Play](https://play.grafana.org/alerting/grafana/aep7osljvuku8e/view?tech=docs&pg=alerting-examples&plcmt=callout-tip&cta=alert-dynamic-thresholds)**.
+
+   Open the example to view alert evaluation results, generated alert instances, the alert history timeline, and alert rule details.
+   {{< /admonition >}}
 
 ## Other use cases
 

--- a/docs/sources/alerting/examples/multi-dimensional-alerts.md
+++ b/docs/sources/alerting/examples/multi-dimensional-alerts.md
@@ -148,7 +148,11 @@ For demo purposes, this example uses the **Advanced mode** with a **Reduce** exp
 
    {{< figure src="/media/docs/alerting/using-expressions-with-multiple-series.png" max-width="750px" caption="The alert condition evaluates the reduced value for each alert instance and shows whether each instance is Firing or Normal." alt="Alert preview using a Reduce expression and a threshold condition" >}}
 
-   {{< docs/play title="this alert example" url="https://play.grafana.org/alerting/grafana/dep7osljedaf4a/view" >}}
+   {{< admonition type="tip" >}}
+   You can explore this **[alerting example in Grafana Play](https://play.grafana.org/alerting/grafana/dep7osljedaf4a/view?tech=docs&pg=alerting-examples&plcmt=callout-tip&cta=alert-dynamic-thresholds)**.
+
+   Open the example to view alert evaluation results, generated alert instances, the alert history timeline, and alert rule details.
+   {{< /admonition >}}
 
 ## Learn more
 

--- a/docs/sources/alerting/examples/table-data.md
+++ b/docs/sources/alerting/examples/table-data.md
@@ -120,7 +120,11 @@ To test this quickly, you can simulate the table using the [**TestData** data so
 
    {{< figure src="/media/docs/alerting/example-table-data-preview.png" max-width="750px" alt="Alert preview with tabular data using the TestData data source" >}}
 
-   {{< docs/play title="this alert example" url="https://play.grafana.org/alerting/grafana/eep7osljocvswa/view" >}}
+   {{< admonition type="tip" >}}
+   You can explore this **[alerting example in Grafana Play](https://play.grafana.org/alerting/grafana/eep7osljocvswa/view?tech=docs&pg=alerting-examples&plcmt=callout-tip&cta=alert-tabular-data)**.
+
+   Open the example to view alert evaluation results, generated alert instances, the alert history timeline, and alert rule details.
+   {{< /admonition >}}
 
 ## CSV data with Infinity
 

--- a/docs/sources/alerting/monitor-status/view-alert-state.md
+++ b/docs/sources/alerting/monitor-status/view-alert-state.md
@@ -128,4 +128,4 @@ Additionally, Grafana provides an [alert list panel](ref:alert-list-panel) that 
 
 You can configure the alert list panel with various visualization options and filters to control how alerts are displayed. For more details, refer to the [Alert list documentation](ref:alert-list-panel).
 
-{{< docs/play title="this demo dashboard with alert list panels and linked alert rules" url="https://play.grafana.org/d/000000074/" >}}
+{{< docs/play title="this demo dashboard with alert list panels and linked alert rules" url="https://play.grafana.org/d/000000074/alerting?tech=docs&pg=alerting-demo&plcmt=callout-play&cta=alert-demo-dashboard" >}}


### PR DESCRIPTION
Adds tracking parameters to Grafana Play links in the alerting docs to help distinguish where examples are accessed from.