### PR TITLE
Add secret.grafana.app/v1beta1 to OpenAPI test groups

### DIFF
--- a/pkg/tests/apis/openapi_test.go
+++ b/pkg/tests/apis/openapi_test.go
@@ -130,6 +130,9 @@ func TestIntegrationOpenAPIs(t *testing.T) {
 	}, {
 		Group:   "logsdrilldown.grafana.app",
 		Version: "v1beta1",
+	}, {
+		Group:   "secret.grafana.app",
+		Version: "v1beta1",
 	}}
 	for _, gv := range groups {
 		VerifyOpenAPISnapshots(t, dir, gv, h)


### PR DESCRIPTION
## Problem

The OpenAPI integration test for `secret.grafana.app/v1beta1` was failing because it wasn't included in the test groups list.

## Solution

Added `secret.grafana.app/v1beta1` to the groups list in `pkg/tests/apis/openapi_test.go` to ensure the OpenAPI snapshot is tested and updated when the spec changes.

## Related

This is related to making discovery endpoints public. When OpenAPI endpoints become public, their specs may change (e.g., security requirements), requiring snapshot updates.

Related PR: grafana-enterprise PR for discovery endpoints authentication fix