### PR TITLE
FS: Allow anonymous access to user invite page

### DIFF
--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -395,6 +395,7 @@ export function getAppRoutes(): RouteDescriptor[] {
     },
     {
       path: '/invite/:code',
+      allowAnonymous: true,
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "SignupInvited" */ 'app/features/invites/SignupInvited')
       ),


### PR DESCRIPTION
By policy, the `/invite/:code` is typically not able to be used with Frontend Service (in Grafana Cloud). However, during testing sometimes we have this enabled.

This PR enables the page to work when Grafana is accessed through Frontend Service./