### PR TITLE
Dashboards: Fix row panels getting negative IDs when converting v2 to v1

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v15.mimir_rollout_debugging.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v15.mimir_rollout_debugging.v0alpha1.json
@@ -60,7 +60,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 7,
         "title": "Rollout progress",
         "type": "row"
       },
@@ -403,7 +403,7 @@
           "x": 0,
           "y": 19
         },
-        "id": -1,
+        "id": 8,
         "title": "Rollout health",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v15.mimir_rollout_debugging.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v15.mimir_rollout_debugging.v1beta1.json
@@ -60,7 +60,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 7,
         "title": "Rollout progress",
         "type": "row"
       },
@@ -403,7 +403,7 @@
           "x": 0,
           "y": 19
         },
-        "id": -1,
+        "id": 8,
         "title": "Rollout health",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v16.empty-rows-and-panels-array.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v16.empty-rows-and-panels-array.v0alpha1.json
@@ -678,7 +678,7 @@
           "x": 0,
           "y": 32
         },
-        "id": -1,
+        "id": 13,
         "title": "Sample section",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v16.empty-rows-and-panels-array.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v16.empty-rows-and-panels-array.v1beta1.json
@@ -678,7 +678,7 @@
           "x": 0,
           "y": 32
         },
-        "id": -1,
+        "id": 13,
         "title": "Sample section",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v16.grid_layout_upgrade.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v16.grid_layout_upgrade.v0alpha1.json
@@ -34,7 +34,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 12,
         "title": "",
         "type": "row"
       },
@@ -98,7 +98,7 @@
           "x": 0,
           "y": 7
         },
-        "id": -1,
+        "id": 13,
         "panels": [
           {
             "gridPos": {
@@ -154,7 +154,7 @@
           "x": 0,
           "y": 8
         },
-        "id": -1,
+        "id": 14,
         "title": "Visible Row Title",
         "type": "row"
       },
@@ -244,7 +244,7 @@
           "x": 0,
           "y": 14
         },
-        "id": -1,
+        "id": 15,
         "title": "",
         "type": "row"
       },
@@ -308,7 +308,7 @@
           "x": 0,
           "y": 18
         },
-        "id": -1,
+        "id": 16,
         "repeat": "server",
         "title": "",
         "type": "row"

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v16.grid_layout_upgrade.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v16.grid_layout_upgrade.v1beta1.json
@@ -34,7 +34,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 12,
         "title": "",
         "type": "row"
       },
@@ -98,7 +98,7 @@
           "x": 0,
           "y": 7
         },
-        "id": -1,
+        "id": 13,
         "panels": [
           {
             "gridPos": {
@@ -154,7 +154,7 @@
           "x": 0,
           "y": 8
         },
-        "id": -1,
+        "id": 14,
         "title": "Visible Row Title",
         "type": "row"
       },
@@ -244,7 +244,7 @@
           "x": 0,
           "y": 14
         },
-        "id": -1,
+        "id": 15,
         "title": "",
         "type": "row"
       },
@@ -308,7 +308,7 @@
           "x": 0,
           "y": 18
         },
-        "id": -1,
+        "id": 16,
         "repeat": "server",
         "title": "",
         "type": "row"

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v16.span_zero_demo.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v16.span_zero_demo.v0alpha1.json
@@ -77,7 +77,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 23,
         "title": "Application Service",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v16.span_zero_demo.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v16.span_zero_demo.v1beta1.json
@@ -77,7 +77,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 23,
         "title": "Application Service",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v27.repeated_panels_and_constant_variable.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v27.repeated_panels_and_constant_variable.v0alpha1.json
@@ -60,7 +60,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 7,
         "title": "Row with repeated panels",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v27.repeated_panels_and_constant_variable.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v27.repeated_panels_and_constant_variable.v1beta1.json
@@ -60,7 +60,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 7,
         "title": "Row with repeated panels",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v30.value_mappings_and_tooltip_options.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v30.value_mappings_and_tooltip_options.v0alpha1.json
@@ -287,7 +287,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 10,
         "panels": [
           {
             "fieldConfig": {

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v30.value_mappings_and_tooltip_options.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v30.value_mappings_and_tooltip_options.v1beta1.json
@@ -287,7 +287,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 10,
         "panels": [
           {
             "fieldConfig": {

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v31.labels_to_fields_merge.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v31.labels_to_fields_merge.v0alpha1.json
@@ -230,7 +230,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 10,
         "title": "Row with nested panels",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v31.labels_to_fields_merge.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v31.labels_to_fields_merge.v1beta1.json
@@ -230,7 +230,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 10,
         "title": "Row with nested panels",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v32.no_op_migration.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v32.no_op_migration.v0alpha1.json
@@ -108,7 +108,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 5,
         "title": "Row with nested panels",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v32.no_op_migration.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v32.no_op_migration.v1beta1.json
@@ -108,7 +108,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 5,
         "title": "Row with nested panels",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v33.panel_ds_name_to_ref.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v33.panel_ds_name_to_ref.v0alpha1.json
@@ -296,7 +296,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 11,
         "panels": [
           {
             "datasource": {

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v33.panel_ds_name_to_ref.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v33.panel_ds_name_to_ref.v1beta1.json
@@ -296,7 +296,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 11,
         "panels": [
           {
             "datasource": {

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v34.multiple_stats_cloudwatch.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v34.multiple_stats_cloudwatch.v0alpha1.json
@@ -643,7 +643,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 16,
         "panels": [
           {
             "datasource": {

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v34.multiple_stats_cloudwatch.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v34.multiple_stats_cloudwatch.v1beta1.json
@@ -643,7 +643,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 16,
         "panels": [
           {
             "datasource": {

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v36.ds_name_to_ref.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v36.ds_name_to_ref.v0alpha1.json
@@ -362,7 +362,7 @@
       },
       {
         "collapsed": false,
-        "id": -1,
+        "id": 15,
         "title": "Simple Row Panel",
         "type": "row"
       },
@@ -374,7 +374,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 16,
         "panels": [
           {
             "datasource": {

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v36.ds_name_to_ref.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v36.ds_name_to_ref.v1beta1.json
@@ -362,7 +362,7 @@
       },
       {
         "collapsed": false,
-        "id": -1,
+        "id": 15,
         "title": "Simple Row Panel",
         "type": "row"
       },
@@ -374,7 +374,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 16,
         "panels": [
           {
             "datasource": {

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v37.legend_normalization.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v37.legend_normalization.v0alpha1.json
@@ -190,7 +190,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 14,
         "title": "Row with Nested Panels Having Various Legend Configs",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v37.legend_normalization.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v37.legend_normalization.v1beta1.json
@@ -190,7 +190,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 14,
         "title": "Row with Nested Panels Having Various Legend Configs",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v38.table_displaymode_comprehensive.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v38.table_displaymode_comprehensive.v0alpha1.json
@@ -268,7 +268,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 13,
         "title": "Row with Nested Table Panels",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v38.table_displaymode_comprehensive.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v38.table_displaymode_comprehensive.v1beta1.json
@@ -268,7 +268,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 13,
         "title": "Row with Nested Table Panels",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v38.timeseries_table_display_mode.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v38.timeseries_table_display_mode.v0alpha1.json
@@ -268,7 +268,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 13,
         "title": "Row with Nested Table Panels",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v38.timeseries_table_display_mode.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v38.timeseries_table_display_mode.v1beta1.json
@@ -268,7 +268,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 13,
         "title": "Row with Nested Table Panels",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v39.transform_timeseries_table.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v39.transform_timeseries_table.v0alpha1.json
@@ -233,7 +233,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 11,
         "title": "Row with Nested Panels Having TimeSeriesTable Transformations",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v39.transform_timeseries_table.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v39.transform_timeseries_table.v1beta1.json
@@ -233,7 +233,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 11,
         "title": "Row with Nested Panels Having TimeSeriesTable Transformations",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v42.hidefrom_tooltip.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v42.hidefrom_tooltip.v0alpha1.json
@@ -125,7 +125,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 8,
         "panels": [
           {
             "fieldConfig": {

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v42.hidefrom_tooltip.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dashboards_from_v0_to_v2/v2beta1.v42.hidefrom_tooltip.v1beta1.json
@@ -125,7 +125,7 @@
           "x": 0,
           "y": 3
         },
-        "id": -1,
+        "id": 8,
         "panels": [
           {
             "fieldConfig": {

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2alpha1.complete.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2alpha1.complete.v0alpha1.json
@@ -61,7 +61,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 2,
         "title": "Conditional Row",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2alpha1.complete.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2alpha1.complete.v1beta1.json
@@ -61,7 +61,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 2,
         "title": "Conditional Row",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.complete.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.complete.v0alpha1.json
@@ -61,7 +61,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 2,
         "title": "Conditional Row",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.complete.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.complete.v1beta1.json
@@ -61,7 +61,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 2,
         "title": "Conditional Row",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.rows-with-nested-tabs.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.rows-with-nested-tabs.v0alpha1.json
@@ -48,7 +48,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 4,
         "panels": [],
         "title": "Row with tabs",
         "type": "row"
@@ -61,7 +61,7 @@
           "x": 0,
           "y": 1
         },
-        "id": -1,
+        "id": 5,
         "panels": [],
         "title": "Tab with panels",
         "type": "row"
@@ -168,7 +168,7 @@
           "x": 0,
           "y": 10
         },
-        "id": -1,
+        "id": 6,
         "panels": [],
         "title": "Empty tab",
         "type": "row"
@@ -181,7 +181,7 @@
           "x": 0,
           "y": 11
         },
-        "id": -1,
+        "id": 7,
         "title": "Empty row",
         "type": "row"
       },
@@ -193,7 +193,7 @@
           "x": 0,
           "y": 11
         },
-        "id": -1,
+        "id": 8,
         "panels": [],
         "title": "Row with rows",
         "type": "row"
@@ -206,7 +206,7 @@
           "x": 0,
           "y": 12
         },
-        "id": -1,
+        "id": 9,
         "title": "Empty nested row",
         "type": "row"
       },
@@ -218,7 +218,7 @@
           "x": 0,
           "y": 12
         },
-        "id": -1,
+        "id": 10,
         "title": "Row with panels filling screen",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.rows-with-nested-tabs.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.rows-with-nested-tabs.v1beta1.json
@@ -48,7 +48,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 4,
         "panels": [],
         "title": "Row with tabs",
         "type": "row"
@@ -61,7 +61,7 @@
           "x": 0,
           "y": 1
         },
-        "id": -1,
+        "id": 5,
         "panels": [],
         "title": "Tab with panels",
         "type": "row"
@@ -168,7 +168,7 @@
           "x": 0,
           "y": 10
         },
-        "id": -1,
+        "id": 6,
         "panels": [],
         "title": "Empty tab",
         "type": "row"
@@ -181,7 +181,7 @@
           "x": 0,
           "y": 11
         },
-        "id": -1,
+        "id": 7,
         "title": "Empty row",
         "type": "row"
       },
@@ -193,7 +193,7 @@
           "x": 0,
           "y": 11
         },
-        "id": -1,
+        "id": 8,
         "panels": [],
         "title": "Row with rows",
         "type": "row"
@@ -206,7 +206,7 @@
           "x": 0,
           "y": 12
         },
-        "id": -1,
+        "id": 9,
         "title": "Empty nested row",
         "type": "row"
       },
@@ -218,7 +218,7 @@
           "x": 0,
           "y": 12
         },
-        "id": -1,
+        "id": 10,
         "title": "Row with panels filling screen",
         "type": "row"
       },

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tab-with-multiple-panels.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tab-with-multiple-panels.v0alpha1.json
@@ -48,7 +48,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 6,
         "panels": [],
         "title": "Tab1",
         "type": "row"

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tab-with-multiple-panels.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tab-with-multiple-panels.v1beta1.json
@@ -48,7 +48,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 6,
         "panels": [],
         "title": "Tab1",
         "type": "row"

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tabs-and-rows-repeated.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tabs-and-rows-repeated.v0alpha1.json
@@ -48,7 +48,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 7,
         "panels": [],
         "title": "Tab without rows",
         "type": "row"
@@ -155,7 +155,7 @@
           "x": 0,
           "y": 9
         },
-        "id": -1,
+        "id": 8,
         "panels": [],
         "title": "Tab With Rows",
         "type": "row"
@@ -168,7 +168,7 @@
           "x": 0,
           "y": 10
         },
-        "id": -1,
+        "id": 9,
         "panels": [
           {
             "datasource": {
@@ -276,7 +276,7 @@
           "x": 0,
           "y": 11
         },
-        "id": -1,
+        "id": 10,
         "panels": [
           {
             "datasource": {
@@ -478,7 +478,7 @@
           "x": 0,
           "y": 12
         },
-        "id": -1,
+        "id": 11,
         "title": "Empty row",
         "type": "row"
       },
@@ -584,7 +584,7 @@
           "x": 0,
           "y": 21
         },
-        "id": -1,
+        "id": 12,
         "panels": [],
         "repeat": "custom_var_tab",
         "title": "Repeated Tab by \"$custom_var_tab\"",
@@ -598,7 +598,7 @@
           "x": 0,
           "y": 22
         },
-        "id": -1,
+        "id": 13,
         "repeat": "custom_var_row",
         "title": "Repeated by \"$custom_var_row\"",
         "type": "row"

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tabs-and-rows-repeated.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tabs-and-rows-repeated.v1beta1.json
@@ -48,7 +48,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 7,
         "panels": [],
         "title": "Tab without rows",
         "type": "row"
@@ -155,7 +155,7 @@
           "x": 0,
           "y": 9
         },
-        "id": -1,
+        "id": 8,
         "panels": [],
         "title": "Tab With Rows",
         "type": "row"
@@ -168,7 +168,7 @@
           "x": 0,
           "y": 10
         },
-        "id": -1,
+        "id": 9,
         "panels": [
           {
             "datasource": {
@@ -276,7 +276,7 @@
           "x": 0,
           "y": 11
         },
-        "id": -1,
+        "id": 10,
         "panels": [
           {
             "datasource": {
@@ -478,7 +478,7 @@
           "x": 0,
           "y": 12
         },
-        "id": -1,
+        "id": 11,
         "title": "Empty row",
         "type": "row"
       },
@@ -584,7 +584,7 @@
           "x": 0,
           "y": 21
         },
-        "id": -1,
+        "id": 12,
         "panels": [],
         "repeat": "custom_var_tab",
         "title": "Repeated Tab by \"$custom_var_tab\"",
@@ -598,7 +598,7 @@
           "x": 0,
           "y": 22
         },
-        "id": -1,
+        "id": 13,
         "repeat": "custom_var_row",
         "title": "Repeated by \"$custom_var_row\"",
         "type": "row"

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tabs-with-nested-rows.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tabs-with-nested-rows.v0alpha1.json
@@ -48,7 +48,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 5,
         "panels": [],
         "title": "Tab without rows",
         "type": "row"
@@ -155,7 +155,7 @@
           "x": 0,
           "y": 9
         },
-        "id": -1,
+        "id": 6,
         "panels": [],
         "title": "Tab With Rows",
         "type": "row"
@@ -168,7 +168,7 @@
           "x": 0,
           "y": 10
         },
-        "id": -1,
+        "id": 7,
         "panels": [
           {
             "datasource": {
@@ -276,7 +276,7 @@
           "x": 0,
           "y": 11
         },
-        "id": -1,
+        "id": 8,
         "panels": [
           {
             "datasource": {
@@ -478,7 +478,7 @@
           "x": 0,
           "y": 12
         },
-        "id": -1,
+        "id": 9,
         "title": "Empty row",
         "type": "row"
       }

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tabs-with-nested-rows.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.tabs-with-nested-rows.v1beta1.json
@@ -48,7 +48,7 @@
           "x": 0,
           "y": 0
         },
-        "id": -1,
+        "id": 5,
         "panels": [],
         "title": "Tab without rows",
         "type": "row"
@@ -155,7 +155,7 @@
           "x": 0,
           "y": 9
         },
-        "id": -1,
+        "id": 6,
         "panels": [],
         "title": "Tab With Rows",
         "type": "row"
@@ -168,7 +168,7 @@
           "x": 0,
           "y": 10
         },
-        "id": -1,
+        "id": 7,
         "panels": [
           {
             "datasource": {
@@ -276,7 +276,7 @@
           "x": 0,
           "y": 11
         },
-        "id": -1,
+        "id": 8,
         "panels": [
           {
             "datasource": {
@@ -478,7 +478,7 @@
           "x": 0,
           "y": 12
         },
-        "id": -1,
+        "id": 9,
         "title": "Empty row",
         "type": "row"
       }

--- a/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1.go
+++ b/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1.go
@@ -202,7 +202,6 @@ func convertLinksToV1(links []dashv2alpha1.DashboardDashboardLink) []map[string]
 //   - TabsLayout: Tabs become expanded row panels; content is flattened
 func convertPanelsFromElementsAndLayout(elements map[string]dashv2alpha1.DashboardElement, layout dashv2alpha1.DashboardGridLayoutKindOrRowsLayoutKindOrAutoGridLayoutKindOrTabsLayoutKind) ([]interface{}, error) {
 	// Find the maximum panel ID from all elements to use for row panel IDs.
-	// Row panels in V1 need unique IDs, but V2 layouts don't have row IDs.
 	nextRowID := getMaxPanelIDFromElements(elements) + 1
 
 	if layout.GridLayoutKind != nil {

--- a/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1_test.go
+++ b/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1_test.go
@@ -477,14 +477,11 @@ func TestV2alpha1ToV1beta1LayoutErrors(t *testing.T) {
 		assert.Equal(t, int64(12), getIntValue(gridPos["w"]), "Panel width should be preserved")
 		assert.Equal(t, int64(3), getIntValue(gridPos["h"]), "Panel height should be preserved")
 
-		// Verify row panel has a unique positive ID that doesn't conflict with panel IDs
+		// Verify panel IDs: panel1 has Id:1, row panel should get Id:2 (maxPanelID + 1)
 		rowID := getIntValue(rowPanel["id"])
 		panelID := getIntValue(panel["id"])
-		assert.Greater(t, rowID, int64(0), "Row panel ID should be positive")
-		assert.Greater(t, panelID, int64(0), "Panel ID should be positive")
-		assert.NotEqual(t, rowID, panelID, "Row panel ID should not conflict with panel ID")
-		// Row ID should be greater than max panel ID (which is 1)
-		assert.Greater(t, rowID, int64(1), "Row panel ID should be greater than max panel ID")
+		assert.Equal(t, int64(1), panelID, "Panel ID should be 1")
+		assert.Equal(t, int64(2), rowID, "Row panel ID should be 2 (maxPanelID + 1)")
 	})
 }
 

--- a/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1_test.go
+++ b/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1_test.go
@@ -476,6 +476,15 @@ func TestV2alpha1ToV1beta1LayoutErrors(t *testing.T) {
 		assert.Equal(t, int64(1), getIntValue(gridPos["y"]), "Panel should be at y=1 (after row)")
 		assert.Equal(t, int64(12), getIntValue(gridPos["w"]), "Panel width should be preserved")
 		assert.Equal(t, int64(3), getIntValue(gridPos["h"]), "Panel height should be preserved")
+
+		// Verify row panel has a unique positive ID that doesn't conflict with panel IDs
+		rowID := getIntValue(rowPanel["id"])
+		panelID := getIntValue(panel["id"])
+		assert.Greater(t, rowID, int64(0), "Row panel ID should be positive")
+		assert.Greater(t, panelID, int64(0), "Panel ID should be positive")
+		assert.NotEqual(t, rowID, panelID, "Row panel ID should not conflict with panel ID")
+		// Row ID should be greater than max panel ID (which is 1)
+		assert.Greater(t, rowID, int64(1), "Row panel ID should be greater than max panel ID")
 	})
 }
 


### PR DESCRIPTION
**What is this feature?**

Row panels now get unique positive IDs instead of -1 when converting v2 dashboards to v1.

**Why do we need this feature?**

Row panels were all assigned id: -1, causing invalid/duplicate IDs in v1 dashboards.

**Special notes for your reviewer:**
In order to reproduce the issue just create a dashboard in v2 with at least 2 rows and open it in v1. You'll see that all rows get `id: -1` assigned

Fixes #116492