### PR TITLE
Tests: Bootstrapping for CI workflow to compare PR test coverage with main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1056,6 +1056,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /scripts/clean-git-or-error.sh @grafana/grafana-as-code
 /scripts/grafana-server/ @grafana/grafana-frontend-platform
 /scripts/check-frontend-dev.sh @grafana/grafana-frontend-platform
+/scripts/compare-coverage-by-codeowner.js @grafana/dataviz-squad
 /scripts/helpers/ @grafana/grafana-developer-enablement-squad
 /scripts/import_many_dashboards.sh @torkelo
 /scripts/mixin-check.sh @bergquist
@@ -1292,6 +1293,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/cleanup-branches.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/publish-artifact.yml @grafana/grafana-developer-enablement-squad
 /.github/actions/changelog @zserge
+/.github/workflows/check-frontend-test-coverage.yml @grafana/dataviz-squad
 /.github/workflows/swagger-gen.yml @grafana/grafana-backend-group
 /.github/workflows/pr-frontend-unit-tests.yml @grafana/grafana-frontend-platform
 /.github/workflows/frontend-lint.yml @grafana/grafana-frontend-platform

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -1,0 +1,49 @@
+name: Check Fronted Test Coverage
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '**/*.js'
+      - '**/*.jsx'
+      - '**/*.ts'
+      - '**/*.tsx'
+      - 'package.json'
+      - '.github/CODEOWNERS'
+
+permissions: {}
+
+jobs:
+  generate-slugs:
+    name: Generate slug for ${{ matrix.codeowner }}
+    runs-on: ubuntu-x64-small
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # NOTE: Only checks test coverage for opted-in codeowners.
+        #       Please add the GitHub user/team or email used in
+        #       CODEOWNERS to the list below to opt-in.
+        codeowner: &codeowners
+          - '@grafana/datapro'
+          - '@grafana/dataviz-squad'
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Generate slug for ${{ matrix.codeowner }}
+        run: |
+          SLUG=$(node -e "
+            const { createCodeownerSlug } = require('./scripts/codeowners-manifest/utils.js');
+            console.log(createCodeownerSlug('${{ matrix.codeowner }}'));
+          ")
+
+          echo "=== Codeowner Slug Generated ==="
+          echo "Codeowner: ${{ matrix.codeowner }}"
+          echo "Slug: $SLUG"
+          echo "================================"

--- a/jest.config.codeowner.js
+++ b/jest.config.codeowner.js
@@ -3,6 +3,7 @@ const open = require('open').default;
 const path = require('path');
 
 const baseConfig = require('./jest.config.js');
+const { CODEOWNER_KIND, getCodeownerKind, createCodeownerSlug } = require('./scripts/codeowners-manifest/utils.js');
 
 const CODEOWNERS_MANIFEST_FILENAMES_BY_TEAM_PATH = 'codeowners-manifest/filenames-by-team.json';
 
@@ -12,7 +13,8 @@ if (!codeownerName) {
   process.exit(1);
 }
 
-const outputDir = `./coverage/by-team/${createOwnerDirectory(codeownerName)}`;
+const outputDir = `./coverage/by-team/${createCodeownerDirectory(codeownerName)}`;
+const COVERAGE_SUMMARY_OUTPUT_PATH = './coverage-summary.json';
 
 const codeownersFilePath = path.join(__dirname, CODEOWNERS_MANIFEST_FILENAMES_BY_TEAM_PATH);
 
@@ -100,6 +102,8 @@ module.exports = {
             openCoverageReport(reportURL);
           }
 
+          writeCoverageSummaryArtifact(coverageResults);
+
           // TODO: Emit coverage metrics https://github.com/grafana/grafana/issues/111208
         },
       },
@@ -112,28 +116,73 @@ module.exports = {
 };
 
 /**
- * Create a filesystem-safe directory structure for different owner types
- * @param {string} owner - CODEOWNERS owner (username, team, or email)
- * @returns {string} Directory path relative to coverage/by-team/
+ * @typedef {Object} CoverageMetric
+ * @property {number} pct - Percentage value
  */
-function createOwnerDirectory(owner) {
-  if (owner.includes('@') && owner.includes('/')) {
-    // Example: @grafana/dataviz-squad
-    const [org, team] = owner.substring(1).split('/');
-    return `teams/${org}/${team}`;
-  } else if (owner.startsWith('@')) {
-    // Example: @jesdavpet
-    return `users/${owner.substring(1)}`;
-  } else {
-    // Example: user@domain.tld
-    const [user, domain] = owner.split('@');
-    return `emails/${user}-at-${domain}`;
+
+/**
+ * @typedef {Object} CoverageSummary
+ * @property {CoverageMetric} lines
+ * @property {CoverageMetric} statements
+ * @property {CoverageMetric} functions
+ * @property {CoverageMetric} branches
+ */
+
+/**
+ * @typedef {Object} CoverageResults
+ * @property {CoverageSummary} summary
+ */
+
+/**
+ * Writes coverage summary artifact for CI/CD consumption
+ * @param {CoverageResults} coverageResults - Coverage results from jest-monocart-coverage
+ */
+function writeCoverageSummaryArtifact(coverageResults) {
+  if (!coverageResults || !coverageResults.summary) {
+    return;
+  }
+
+  const summary = {
+    team: codeownerName,
+    commit: process.env.GITHUB_SHA || 'unknown',
+    timestamp: new Date().toISOString(),
+    summary: {
+      lines: { pct: coverageResults.summary.lines.pct },
+      statements: { pct: coverageResults.summary.statements.pct },
+      functions: { pct: coverageResults.summary.functions.pct },
+      branches: { pct: coverageResults.summary.branches.pct },
+    },
+  };
+
+  try {
+    fs.writeFileSync(COVERAGE_SUMMARY_OUTPUT_PATH, JSON.stringify(summary, null, 2));
+    console.log(`📊 Coverage summary written to ${COVERAGE_SUMMARY_OUTPUT_PATH}`);
+  } catch (err) {
+    console.error(`Failed to write coverage summary: ${err}`);
   }
 }
 
 /**
- * Open the given file URL in the default browser safely, without shell injection risk.
- * @param {string} reportURL
+ * Creates a directory path for coverage reports grouped by codeowner kind
+ * @param {string} codeowner - CODEOWNERS codeowner
+ * @returns {string} Directory path relative to coverage/by-team/
+ */
+function createCodeownerDirectory(codeowner) {
+  const kind = getCodeownerKind(codeowner);
+
+  if (kind === CODEOWNER_KIND.UNKNOWN) {
+    throw new Error(
+      `Invalid codeowner format: "${codeowner}". Must be a GitHub team (@org/team), user (@username), or email (email@domain.tld)`
+    );
+  }
+
+  const slug = createCodeownerSlug(codeowner);
+  return `${kind}s/${slug}`;
+}
+
+/**
+ * Opens the coverage report in the default browser
+ * @param {string} reportURL - File URL to the coverage report HTML
  */
 async function openCoverageReport(reportURL) {
   try {

--- a/scripts/codeowners-manifest/utils.js
+++ b/scripts/codeowners-manifest/utils.js
@@ -4,11 +4,72 @@ const { CODEOWNERS_JSON_PATH: CODEOWNERS_MANIFEST_CODEOWNERS_PATH } = require('.
 
 let _codeownersCache = null;
 
+/**
+ * @enum {string}
+ */
+const CODEOWNER_KIND = {
+  TEAM: 'team',
+  USER: 'user',
+  EMAIL: 'email',
+  UNKNOWN: 'unknown',
+};
+
+/**
+ * Determines the kind of codeowner
+ * @param {string} codeowner - CODEOWNERS codeowner
+ * @returns {CODEOWNER_KIND} Codeowner kind
+ */
+function getCodeownerKind(codeowner) {
+  if (codeowner.includes('@') && codeowner.includes('/')) {
+    return CODEOWNER_KIND.TEAM;
+  } else if (codeowner.startsWith('@')) {
+    return CODEOWNER_KIND.USER;
+  } else if (codeowner.includes('@')) {
+    return CODEOWNER_KIND.EMAIL;
+  } else {
+    return CODEOWNER_KIND.UNKNOWN;
+  }
+}
+
+/**
+ * Creates a dasherized slug for codeowner
+ * @param {string} codeowner - CODEOWNERS codeowner
+ * @returns {string} Dasherized slug with kind prefix
+ */
+function createCodeownerSlug(codeowner) {
+  const kind = getCodeownerKind(codeowner);
+
+  switch (kind) {
+    case CODEOWNER_KIND.TEAM: {
+      const [org, team] = codeowner.substring(1).split('/');
+      return ['team', org, team].join('-');
+    }
+    case CODEOWNER_KIND.USER: {
+      return ['user', codeowner.substring(1)].join('-');
+    }
+    case CODEOWNER_KIND.EMAIL: {
+      const [user, domain] = codeowner.split('@');
+      const sanitizedUser = user.replace(/[+.]/g, '-');
+      const sanitizedDomain = domain.replace(/\./g, '-');
+      return ['email', `${sanitizedUser}-at-${sanitizedDomain}`].join('-');
+    }
+    case CODEOWNER_KIND.UNKNOWN:
+    default: {
+      const sanitized = codeowner.replace(/[^a-zA-Z0-9]/g, '-');
+      return `unknown-${sanitized}`;
+    }
+  }
+}
+
 module.exports = {
+  CODEOWNER_KIND,
+  getCodeownerKind,
+  createCodeownerSlug,
+
   /**
-   * import the contents of the codeowners manifest JSON file, with caching
-   * @param {boolean} clearCache - if true, clear the cached data and reload the codeowners manifest
-   * @returns {Promise<Array<string>>} - list of codeowners which own at least one file in the project
+   * Imports codeowners manifest with caching
+   * @param {boolean} clearCache - Clear cached data and reload
+   * @returns {Promise<Array<string>>} List of codeowners
    */
   async getCodeowners(clearCache = false) {
     if (clearCache) {

--- a/scripts/compare-coverage-by-codeowner.js
+++ b/scripts/compare-coverage-by-codeowner.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+
+const COVERAGE_MAIN_PATH = './coverage-main/coverage-summary.json';
+const COVERAGE_PR_PATH = './coverage-pr/coverage-summary.json';
+const COMPARISON_OUTPUT_PATH = './coverage-comparison.md';
+
+/**
+ * Reads and parses a coverage summary JSON file
+ * @param {string} filePath - Path to coverage summary file
+ * @returns {Object} Parsed coverage data
+ */
+function readCoverageFile(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(content);
+  } catch (err) {
+    console.error(`Error reading coverage file ${filePath}: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Formats a number as a percentage string
+ * @param {number} value - Percentage value
+ * @returns {string} Formatted percentage (e.g., "85.3%")
+ */
+function formatPercentage(value) {
+  return `${value.toFixed(1)}%`;
+}
+
+/**
+ * Returns status icon based on coverage comparison
+ * @param {number} mainValue - Main branch coverage percentage
+ * @param {number} prValue - PR branch coverage percentage
+ * @returns {string} Status icon and text
+ */
+function getStatusIcon(mainValue, prValue) {
+  if (prValue >= mainValue) {
+    return '✅ Pass';
+  }
+  return '❌ Fail';
+}
+
+/**
+ * Determines overall pass/fail status for all coverage metrics
+ * @param {Object} mainSummary - Main branch coverage summary
+ * @param {Object} prSummary - PR branch coverage summary
+ * @returns {boolean} True if all metrics maintained or improved
+ */
+function getOverallStatus(mainSummary, prSummary) {
+  const metrics = ['lines', 'statements', 'functions', 'branches'];
+  const allPass = metrics.every((metric) => prSummary[metric].pct >= mainSummary[metric].pct);
+  return allPass;
+}
+
+/**
+ * Generates markdown report comparing main and PR coverage
+ * @param {Object} mainCoverage - Main branch coverage data
+ * @param {Object} prCoverage - PR branch coverage data
+ * @returns {string} Markdown formatted report
+ */
+function generateMarkdown(mainCoverage, prCoverage) {
+  const teamName = prCoverage.team;
+  const mainSummary = mainCoverage.summary;
+  const prSummary = prCoverage.summary;
+
+  const overallPass = getOverallStatus(mainSummary, prSummary);
+
+  const rows = [
+    {
+      metric: 'Lines',
+      main: mainSummary.lines.pct,
+      pr: prSummary.lines.pct,
+    },
+    {
+      metric: 'Statements',
+      main: mainSummary.statements.pct,
+      pr: prSummary.statements.pct,
+    },
+    {
+      metric: 'Functions',
+      main: mainSummary.functions.pct,
+      pr: prSummary.functions.pct,
+    },
+    {
+      metric: 'Branches',
+      main: mainSummary.branches.pct,
+      pr: prSummary.branches.pct,
+    },
+  ];
+
+  const tableRows = rows
+    .map((row) => {
+      const status = getStatusIcon(row.main, row.pr);
+      return `| ${row.metric} | ${formatPercentage(row.main)} | ${formatPercentage(row.pr)} | ${status} |`;
+    })
+    .join('\n');
+
+  const overallStatus = overallPass ? '✅ Pass' : '❌ Fail';
+  const overallMessage = overallPass ? 'Coverage maintained or improved' : 'Coverage decreased in one or more metrics';
+
+  return `## Test Coverage Report - ${teamName}
+
+| Metric | Main Branch | PR Branch | Status |
+|--------|-------------|-----------|--------|
+${tableRows}
+
+**Overall: ${overallStatus}** - ${overallMessage}
+
+<details>
+<summary>Coverage Details</summary>
+
+- **PR Branch**: \`${prCoverage.commit.substring(0, 7)}\` (${prCoverage.timestamp})
+- **Main Branch**: \`${mainCoverage.commit.substring(0, 7)}\` (${mainCoverage.timestamp})
+
+</details>
+`;
+}
+
+/**
+ * Compares coverage between main and PR branches and generates a markdown report
+ * @param {string} mainPath - Path to main branch coverage summary JSON
+ * @param {string} prPath - Path to PR branch coverage summary JSON
+ * @param {string} outputPath - Path to write comparison markdown
+ */
+function compareCoverageByCodeowner(
+  mainPath = COVERAGE_MAIN_PATH,
+  prPath = COVERAGE_PR_PATH,
+  outputPath = COMPARISON_OUTPUT_PATH
+) {
+  const mainCoverage = readCoverageFile(mainPath);
+  const prCoverage = readCoverageFile(prPath);
+
+  if (!mainCoverage.summary || !prCoverage.summary) {
+    console.error('Error: Coverage summary data is missing or invalid');
+    process.exit(1);
+  }
+
+  const markdown = generateMarkdown(mainCoverage, prCoverage);
+
+  try {
+    fs.writeFileSync(outputPath, markdown, 'utf8');
+    console.log(`✅ Coverage comparison written to ${outputPath}`);
+  } catch (err) {
+    console.error(`Error writing output file: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  compareCoverageByCodeowner();
+}
+
+module.exports = { compareCoverageByCodeowner, generateMarkdown, getOverallStatus };


### PR DESCRIPTION
**What is this feature?**

This feature adds a simple script for code coverage comparison between `main` and a PR branch.

**Why do we need this feature?**

Because we will be checking out the `main` branch in one fork of the GHA matrix there's a "bootstrapping problem" until these scripts exist on `main` to be run.

**Who is this feature for?**

🤖 Grafana frontend engineers will need this for CI/CD workflows in the future.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/116453

**Special notes for your reviewer:**

If CI runs and shows a slug-ified codeowner name, then we're good.

Please check that:
- [x] It works as expected from a user's perspective.
- `N/A` ~If this is a pre-GA feature, it is behind a feature toggle.~
- `N/A` ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
