### PR TITLE
Alerting: Hide alertmanager picker when no external data sources can manage alerts

### DIFF
--- a/public/app/features/alerting/unified/components/AlertingPageWrapper.test.tsx
+++ b/public/app/features/alerting/unified/components/AlertingPageWrapper.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from 'test/test-utils';
 
 import { NavModelItem } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { AlertManagerDataSourceJsonData } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction } from 'app/types/accessControl';
 
@@ -85,12 +86,14 @@ describe('AlertmanagerPageWrapper', () => {
       expect(screen.getByTestId('alertmanager-picker')).toBeInTheDocument();
     });
 
-    it('should show AlertManagerPicker when external data sources have manageAlerts=undefined (defaults to true)', () => {
+    it('should show AlertManagerPicker when external data sources have manageAlerts=undefined and config default is true', () => {
+      config.defaultDatasourceManageAlertsUiToggle = true;
+
       const dataSourceDefaultManageAlerts = mockDataSource({
         name: 'prometheus-default',
         uid: 'prometheus-default-uid',
         type: 'prometheus',
-        jsonData: {}, // manageAlerts defaults to true when undefined
+        jsonData: {}, // manageAlerts uses config.defaultDatasourceManageAlertsUiToggle when undefined
       });
       setupDataSources(dataSourceDefaultManageAlerts);
 
@@ -102,6 +105,27 @@ describe('AlertmanagerPageWrapper', () => {
       renderTestComponent();
 
       expect(screen.getByTestId('alertmanager-picker')).toBeInTheDocument();
+    });
+
+    it('should hide AlertManagerPicker when external data sources have manageAlerts=undefined and config default is false', () => {
+      config.defaultDatasourceManageAlertsUiToggle = false;
+
+      const dataSourceDefaultManageAlerts = mockDataSource({
+        name: 'prometheus-default',
+        uid: 'prometheus-default-uid',
+        type: 'prometheus',
+        jsonData: {}, // manageAlerts uses config.defaultDatasourceManageAlertsUiToggle when undefined
+      });
+      setupDataSources(dataSourceDefaultManageAlerts);
+
+      grantUserPermissions([
+        AccessControlAction.AlertingNotificationsRead,
+        AccessControlAction.AlertingRuleExternalRead,
+      ]);
+
+      renderTestComponent();
+
+      expect(screen.queryByTestId('alertmanager-picker')).not.toBeInTheDocument();
     });
 
     it('should show AlertManagerPicker when multiple external data sources exist with at least one managing alerts', () => {

--- a/public/app/features/alerting/unified/components/AlertingPageWrapper.test.tsx
+++ b/public/app/features/alerting/unified/components/AlertingPageWrapper.test.tsx
@@ -1,0 +1,192 @@
+import { render, screen } from 'test/test-utils';
+
+import { NavModelItem } from '@grafana/data';
+import { AlertManagerDataSourceJsonData } from 'app/plugins/datasource/alertmanager/types';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { setupMswServer } from '../mockApi';
+import { grantUserPermissions, mockDataSource } from '../mocks';
+import { setupDataSources } from '../testSetup/datasources';
+
+import { AlertmanagerPageWrapper } from './AlertingPageWrapper';
+
+// Minimal pageNav required for PageHeader to render (which renders the actions prop including AlertManagerPicker)
+const testPageNav: NavModelItem = {
+  text: 'Alerting',
+  url: '/alerting',
+};
+
+setupMswServer();
+
+describe('AlertmanagerPageWrapper', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderTestComponent = () => {
+    return render(
+      <AlertmanagerPageWrapper accessType="notification" pageNav={testPageNav}>
+        <div>Test content</div>
+      </AlertmanagerPageWrapper>
+    );
+  };
+
+  describe('AlertManagerPicker visibility', () => {
+    it('should hide AlertManagerPicker when no external data sources are configured', () => {
+      grantUserPermissions([
+        AccessControlAction.AlertingNotificationsRead,
+        AccessControlAction.AlertingRuleExternalRead,
+      ]);
+
+      renderTestComponent();
+
+      expect(screen.queryByTestId('alertmanager-picker')).not.toBeInTheDocument();
+    });
+
+    it('should hide AlertManagerPicker when external data sources have manageAlerts=false', () => {
+      const dataSourceWithoutManageAlerts = mockDataSource<AlertManagerDataSourceJsonData>({
+        name: 'prometheus-no-manage',
+        uid: 'prometheus-no-manage-uid',
+        type: 'prometheus',
+        jsonData: {
+          manageAlerts: false,
+        },
+      });
+      setupDataSources(dataSourceWithoutManageAlerts);
+
+      grantUserPermissions([
+        AccessControlAction.AlertingNotificationsRead,
+        AccessControlAction.AlertingRuleExternalRead,
+      ]);
+
+      renderTestComponent();
+
+      expect(screen.queryByTestId('alertmanager-picker')).not.toBeInTheDocument();
+    });
+
+    it('should show AlertManagerPicker when external data sources have manageAlerts=true', () => {
+      const dataSourceWithManageAlerts = mockDataSource({
+        name: 'prometheus-managed',
+        uid: 'prometheus-managed-uid',
+        type: 'prometheus',
+        jsonData: {
+          manageAlerts: true,
+        },
+      });
+      setupDataSources(dataSourceWithManageAlerts);
+
+      grantUserPermissions([
+        AccessControlAction.AlertingNotificationsRead,
+        AccessControlAction.AlertingRuleExternalRead,
+      ]);
+
+      renderTestComponent();
+
+      expect(screen.getByTestId('alertmanager-picker')).toBeInTheDocument();
+    });
+
+    it('should show AlertManagerPicker when external data sources have manageAlerts=undefined (defaults to true)', () => {
+      const dataSourceDefaultManageAlerts = mockDataSource({
+        name: 'prometheus-default',
+        uid: 'prometheus-default-uid',
+        type: 'prometheus',
+        jsonData: {}, // manageAlerts defaults to true when undefined
+      });
+      setupDataSources(dataSourceDefaultManageAlerts);
+
+      grantUserPermissions([
+        AccessControlAction.AlertingNotificationsRead,
+        AccessControlAction.AlertingRuleExternalRead,
+      ]);
+
+      renderTestComponent();
+
+      expect(screen.getByTestId('alertmanager-picker')).toBeInTheDocument();
+    });
+
+    it('should show AlertManagerPicker when multiple external data sources exist with at least one managing alerts', () => {
+      const dsWithManageAlerts = mockDataSource({
+        name: 'prometheus-1',
+        uid: 'prometheus-1-uid',
+        type: 'prometheus',
+        jsonData: {
+          manageAlerts: true,
+        },
+      });
+
+      const dsWithoutManageAlerts = mockDataSource({
+        name: 'prometheus-2',
+        uid: 'prometheus-2-uid',
+        type: 'prometheus',
+        jsonData: {
+          manageAlerts: false,
+        },
+      });
+
+      setupDataSources(dsWithManageAlerts, dsWithoutManageAlerts);
+
+      grantUserPermissions([
+        AccessControlAction.AlertingNotificationsRead,
+        AccessControlAction.AlertingRuleExternalRead,
+      ]);
+
+      renderTestComponent();
+
+      expect(screen.getByTestId('alertmanager-picker')).toBeInTheDocument();
+    });
+
+    it('should work correctly when only Grafana built-in alertmanager is available (no external datasources)', () => {
+      grantUserPermissions([
+        AccessControlAction.AlertingNotificationsRead,
+        AccessControlAction.AlertingNotificationsWrite,
+      ]);
+
+      render(
+        <AlertmanagerPageWrapper accessType="notification" pageNav={testPageNav}>
+          <div>Built-in alertmanager content</div>
+        </AlertmanagerPageWrapper>
+      );
+
+      expect(screen.queryByTestId('alertmanager-picker')).not.toBeInTheDocument();
+    });
+
+    it('should show AlertManagerPicker for supported external data source types (Loki)', () => {
+      const lokiDataSource = mockDataSource({
+        name: 'loki-managed',
+        uid: 'loki-managed-uid',
+        type: 'loki',
+        jsonData: {
+          manageAlerts: true,
+        },
+      });
+      setupDataSources(lokiDataSource);
+
+      grantUserPermissions([
+        AccessControlAction.AlertingNotificationsRead,
+        AccessControlAction.AlertingRuleExternalRead,
+      ]);
+
+      renderTestComponent();
+
+      expect(screen.getByTestId('alertmanager-picker')).toBeInTheDocument();
+    });
+
+    it('should hide AlertManagerPicker when user lacks permissions even if external data sources exist', () => {
+      const dataSourceWithManageAlerts = mockDataSource({
+        name: 'prometheus-managed',
+        uid: 'prometheus-managed-uid',
+        type: 'prometheus',
+        jsonData: {
+          manageAlerts: true,
+        },
+      });
+      setupDataSources(dataSourceWithManageAlerts);
+
+      grantUserPermissions([AccessControlAction.AlertingNotificationsRead]);
+
+      renderTestComponent();
+
+      expect(screen.queryByTestId('alertmanager-picker')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/alerting/unified/components/AlertingPageWrapper.tsx
+++ b/public/app/features/alerting/unified/components/AlertingPageWrapper.tsx
@@ -1,10 +1,11 @@
-import { PropsWithChildren, ReactNode } from 'react';
+import { PropsWithChildren, ReactNode, useMemo } from 'react';
 import { useLocation } from 'react-use';
 
 import { Page } from 'app/core/components/Page/Page';
 import { PageProps } from 'app/core/components/Page/types';
 
 import { AlertmanagerProvider, useAlertmanager } from '../state/AlertmanagerContext';
+import { getRulesDataSources } from '../utils/datasource';
 
 import { AlertManagerPicker } from './AlertManagerPicker';
 import { NoAlertManagerWarning } from './NoAlertManagerWarning';
@@ -34,10 +35,16 @@ interface AlertmanagerPageWrapperProps extends AlertingPageWrapperProps {
 }
 export const AlertmanagerPageWrapper = ({ children, accessType, ...props }: AlertmanagerPageWrapperProps) => {
   const disableAlertmanager = useIsDisabledAlertmanagerSelection();
+  // Check if there are any external data sources that can manage alerts
+  // If so, show the AlertManagerPicker so users can configure their alertmanagers
+  const hasExternalManagedAlerts = useMemo(() => getRulesDataSources().length > 0, []);
 
   return (
     <AlertmanagerProvider accessType={accessType}>
-      <AlertingPageWrapper {...props} actions={<AlertManagerPicker disabled={disableAlertmanager} />}>
+      <AlertingPageWrapper
+        {...props}
+        actions={hasExternalManagedAlerts && <AlertManagerPicker disabled={disableAlertmanager} />}
+      >
         <AlertManagerPagePermissionsCheck>{children}</AlertManagerPagePermissionsCheck>
       </AlertingPageWrapper>
     </AlertmanagerProvider>

--- a/public/app/features/alerting/unified/utils/datasource.test.ts
+++ b/public/app/features/alerting/unified/utils/datasource.test.ts
@@ -1,3 +1,5 @@
+import { config } from '@grafana/runtime';
+
 import { mockDataSource } from '../mocks';
 
 import {
@@ -19,27 +21,43 @@ describe('isDataSourceManagingAlerts', () => {
     ).toBe(true);
   });
 
-  it('should return true when the prop is undefined', () => {
+  it('should return false when the prop is set as false', () => {
     expect(
       isDataSourceManagingAlerts(
         mockDataSource({
-          jsonData: {},
+          jsonData: {
+            manageAlerts: false,
+          },
         })
       )
-    ).toBe(true);
+    ).toBe(false);
   });
-});
 
-it('should return false when the prop is set as false', () => {
-  expect(
-    isDataSourceManagingAlerts(
-      mockDataSource({
-        jsonData: {
-          manageAlerts: false,
-        },
-      })
-    )
-  ).toBe(false);
+  describe('when manageAlerts is undefined', () => {
+    it('should use the config default when true', () => {
+      config.defaultDatasourceManageAlertsUiToggle = true;
+
+      expect(
+        isDataSourceManagingAlerts(
+          mockDataSource({
+            jsonData: {},
+          })
+        )
+      ).toBe(true);
+    });
+
+    it('should use the config default when false', () => {
+      config.defaultDatasourceManageAlertsUiToggle = false;
+
+      expect(
+        isDataSourceManagingAlerts(
+          mockDataSource({
+            jsonData: {},
+          })
+        )
+      ).toBe(false);
+    });
+  });
 });
 
 describe('isValidRecordingRulesTarget', () => {

--- a/public/app/features/alerting/unified/utils/datasource.ts
+++ b/public/app/features/alerting/unified/utils/datasource.ts
@@ -1,5 +1,5 @@
 import { DataSourceInstanceSettings, DataSourceJsonData, DataSourceSettings } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { config, getDataSourceSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { PERMISSIONS_TIME_INTERVALS } from 'app/features/alerting/unified/components/mute-timings/permissions';
 import { PERMISSIONS_NOTIFICATION_POLICIES } from 'app/features/alerting/unified/components/notification-policies/permissions';
@@ -342,7 +342,7 @@ export function getDefaultOrFirstCompatibleDataSource(): DataSourceInstanceSetti
 }
 
 export function isDataSourceManagingAlerts(ds: DataSourceInstanceSettings<DataSourceJsonData>) {
-  return ds.jsonData.manageAlerts !== false; //if this prop is undefined it defaults to true
+  return ds.jsonData.manageAlerts ?? config.defaultDatasourceManageAlertsUiToggle;
 }
 
 export function isDataSourceAllowedAsRecordingRulesTarget(ds: DataSourceInstanceSettings<DataSourceJsonData>) {


### PR DESCRIPTION
**What is this feature?**

This PR adds changes to hide the alertmanager selector when there are no data sources with manageAlerts enabled

**No datasources with manageAlerts enabled**
<img width="1840" height="1196" alt="Screenshot 2026-01-19 at 2 39 30 PM" src="https://github.com/user-attachments/assets/fa8a92f9-9466-4a4f-87af-b1296ec234a8" />
 
**With datasources with manageAlerts enabled**
<img width="1840" height="1196" alt="Screenshot 2026-01-19 at 2 42 08 PM" src="https://github.com/user-attachments/assets/4069d2a1-688e-4784-b75f-79b9d547ecd6" />


**Why do we need this feature?**

The user doesn't need to select a different alertmanager when there are no data sources with manageAlerts enabled

**Who is this feature for?**

Alerting users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1362

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
