### PR TITLE
Plugins: replace usage of `config.apps` in GenAI/utils

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2091,11 +2091,6 @@
       "count": 1
     }
   },
-  "public/app/features/dashboard/components/GenAI/utils.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "public/app/features/dashboard/components/HelpWizard/HelpWizard.tsx": {
     "no-restricted-syntax": {
       "count": 3

--- a/public/app/features/dashboard/components/GenAI/utils.test.ts
+++ b/public/app/features/dashboard/components/GenAI/utils.test.ts
@@ -1,4 +1,6 @@
+import { AppPluginConfig } from '@grafana/data';
 import { llm } from '@grafana/llm';
+import { setAppPluginMetas } from '@grafana/runtime/internal';
 
 import { DASHBOARD_SCHEMA_VERSION } from '../../state/DashboardMigrator';
 import { createDashboardModelFixture, createPanelSaveModel } from '../../state/__fixtures__/dashboardFixtures';
@@ -14,16 +16,6 @@ jest.mock('@grafana/llm', () => ({
     accumulateContent: jest.fn(),
     health: jest.fn(),
     Model: { LARGE: 'large' },
-  },
-}));
-
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  config: {
-    ...jest.requireActual('@grafana/runtime').config,
-    apps: {
-      'grafana-llm-app': true,
-    },
   },
 }));
 
@@ -99,6 +91,10 @@ describe('getDashboardChanges', () => {
 });
 
 describe('isLLMPluginEnabled', () => {
+  beforeEach(() => {
+    setAppPluginMetas({ 'grafana-llm-app': {} as AppPluginConfig });
+  });
+
   it('should return false if LLM plugin is not enabled', async () => {
     // Mock llm.health to return false
     jest.mocked(llm.health).mockResolvedValue({ ok: false, configured: false });

--- a/public/app/features/dashboard/components/GenAI/utils.ts
+++ b/public/app/features/dashboard/components/GenAI/utils.ts
@@ -1,7 +1,7 @@
 import { pick } from 'lodash';
 
 import { llm } from '@grafana/llm';
-import { config } from '@grafana/runtime';
+import { isAppPluginInstalled } from '@grafana/runtime';
 import { Panel } from '@grafana/schema';
 
 import { DashboardModel } from '../../state/DashboardModel';
@@ -70,7 +70,8 @@ let llmHealthCheck: Promise<boolean> | undefined;
  * @returns true if the LLM plugin is enabled.
  */
 export async function isLLMPluginEnabled(): Promise<boolean> {
-  if (!config.apps['grafana-llm-app']) {
+  const isLLMAppInstalled = await isAppPluginInstalled('grafana-llm-app');
+  if (!isLLMAppInstalled) {
     return false;
   }
 


### PR DESCRIPTION
**What is this feature?**

This pull request refactors the GenAI utilities to replace the deprecated `config.apps` API with the new async `isAppPluginInstalled` function for checking if the `grafana-llm-app` plugin is installed.

**Why do we need this feature?**

We need to replace usages of config.apps as that is deprecated.

**Who is this feature for?**

Grafana maintainers and plugins platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #116517

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
