### PR TITLE
Plugins: replace `config.apps` from sandbox

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2972,11 +2972,6 @@
       "count": 4
     }
   },
-  "public/app/features/plugins/sandbox/codeLoader.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "public/app/features/plugins/sandbox/distortions.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1

--- a/public/app/features/plugins/sandbox/codeLoader.ts
+++ b/public/app/features/plugins/sandbox/codeLoader.ts
@@ -1,5 +1,6 @@
 import { PluginType, patchArrayVectorProrotypeMethods } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { getAppPluginMetas } from '@grafana/runtime/internal';
 
 import { transformPluginSourceForCDN } from '../cdn/utils';
 import { resolvePluginUrlWithCache } from '../loader/pluginInfoCache';
@@ -121,7 +122,7 @@ export function patchSandboxEnvironmentPrototype(sandboxEnvironment: SandboxEnvi
   );
 }
 
-export function getPluginLoadData(pluginId: string): SandboxPluginMeta {
+export async function getPluginLoadData(pluginId: string): Promise<SandboxPluginMeta> {
   // find it in datasources
   for (const datasource of Object.values(config.datasources)) {
     if (datasource.type === pluginId) {
@@ -138,7 +139,8 @@ export function getPluginLoadData(pluginId: string): SandboxPluginMeta {
 
   //find it in apps
   //the information inside the apps object is more limited
-  for (const app of Object.values(config.apps)) {
+  const apps = await getAppPluginMetas();
+  for (const app of apps) {
     if (app.id === pluginId) {
       return {
         id: pluginId,

--- a/public/app/features/plugins/sandbox/sandboxPluginLoader.ts
+++ b/public/app/features/plugins/sandbox/sandboxPluginLoader.ts
@@ -31,7 +31,7 @@ const pluginLogCache: Record<string, boolean> = {};
 export async function importPluginModuleInSandbox({ pluginId }: { pluginId: string }): Promise<System.Module> {
   patchWebAPIs();
   try {
-    const pluginMeta = getPluginLoadData(pluginId);
+    const pluginMeta = await getPluginLoadData(pluginId);
     if (!pluginImportCache.has(pluginId)) {
       pluginImportCache.set(pluginId, doImportPluginModuleInSandbox(pluginMeta));
     }


### PR DESCRIPTION
**What is this feature?**

This pull request refactors the way plugin metadata is retrieved in the sandbox plugin loader, making the process asynchronous and using the new plugin meta apis replacing `config.apps` usages. 

**Why do we need this feature?**

We need to replace usages of config.apps as that is deprecated.

**Who is this feature for?**

Grafana maintainers and plugins platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
