### PR TITLE
RadialGauge: Fix issue with min = max

### DIFF
--- a/packages/grafana-ui/src/components/RadialGauge/utils.test.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.test.ts
@@ -89,6 +89,22 @@ describe('RadialGauge utils', () => {
       expect(min).toBe(0);
       expect(max).toBe(100);
     });
+
+    it('should prevent min and max from being equal', () => {
+      const fieldDisplay: FieldDisplay = {
+        display: { numeric: 50, text: '50', color: 'blue' },
+        field: { min: 10, max: 10 },
+        view: undefined,
+        colIndex: 0,
+        rowIndex: 0,
+        name: 'test',
+        getLinks: () => [],
+        hasLinks: false,
+      };
+
+      const [min, max] = getFieldConfigMinMax(fieldDisplay);
+      expect(min).not.toBe(max);
+    });
   });
 
   describe('calculateDimensions', () => {

--- a/packages/grafana-ui/src/components/RadialGauge/utils.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.ts
@@ -14,8 +14,16 @@ export function getFieldDisplayProcessor(displayValue: FieldDisplay) {
 }
 
 export function getFieldConfigMinMax(fieldDisplay: FieldDisplay) {
-  const min = fieldDisplay.field.min ?? 0;
-  const max = fieldDisplay.field.max ?? 100;
+  let min = fieldDisplay.field.min ?? 0;
+  let max = fieldDisplay.field.max ?? 100;
+
+  // If min and max are equal (can happen for single value fields or if all values are the same)
+  // Then we need to adjust them a bit to avoid division by zero
+  if (min === max) {
+    min -= min * 0.1;
+    max += max * 0.1;
+  }
+
   return [min, max];
 }
 


### PR DESCRIPTION
Fixes the issue with the new gauge would not render any svg paths due to min=max  (resulted in invalid path). 

Not sure what the best fix is, or of it's better just show an error here as the resulting viz is kind of meaningless. 