### PR TITLE
Fix: Ensure clone handles functions properly

### DIFF
--- a/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
@@ -1,3 +1,5 @@
+import { AppPluginConfig } from '@grafana/data';
+
 import { evaluateBooleanFlag } from '../../internal/openFeature';
 
 import {
@@ -217,7 +219,11 @@ describe('immutability', () => {
 
     // mutate deep props
     mutatedApps[0].dependencies.grafanaDependency = '';
-    mutatedApps[0].extensions.addedLinks.push({ targets: [], title: '', description: '' });
+    mutatedApps[0].extensions.addedLinks.push({
+      targets: [],
+      title: '',
+      description: '',
+    });
 
     // assert we have mutated props
     expect(mutatedApps[0].dependencies.grafanaDependency).toEqual('');
@@ -229,6 +235,19 @@ describe('immutability', () => {
     // assert that we have not mutated the source
     expect(apps[0].dependencies.grafanaDependency).toEqual('>=10.4.0');
     expect(apps[0].extensions.addedLinks).toHaveLength(0);
+  });
+
+  it('getAppPluginMetas should return a deep clone including functions', async () => {
+    setAppPluginMetas({
+      'myorg-someplugin-app': {
+        ...app,
+        extensions: {
+          ...app.extensions,
+          addedFunctions: [{ targets: [], title: '', description: '', onClick: () => {} }],
+        },
+      } as unknown as AppPluginConfig,
+    });
+    expect(async () => await getAppPluginMetas()).not.toThrow();
   });
 
   it('getAppPluginMeta should return a deep clone', async () => {

--- a/packages/grafana-runtime/src/services/pluginMeta/apps.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/apps.ts
@@ -1,3 +1,5 @@
+import { cloneDeep } from 'lodash';
+
 import type { AppPluginConfig } from '@grafana/data';
 
 import { config } from '../../config';
@@ -30,7 +32,7 @@ export async function getAppPluginMetas(): Promise<AppPluginConfig[]> {
     await initAppPluginMetas();
   }
 
-  return Object.values(structuredClone(apps));
+  return Object.values(cloneDeep(apps));
 }
 
 export async function getAppPluginMeta(pluginId: string): Promise<AppPluginConfig | null> {
@@ -39,7 +41,7 @@ export async function getAppPluginMeta(pluginId: string): Promise<AppPluginConfi
   }
 
   const app = apps[pluginId];
-  return app ? structuredClone(app) : null;
+  return app ? cloneDeep(app) : null;
 }
 
 /**
@@ -67,5 +69,5 @@ export function setAppPluginMetas(override: AppPluginMetas): void {
     throw new Error('setAppPluginMetas() function can only be called from tests.');
   }
 
-  apps = structuredClone(override);
+  apps = cloneDeep(override);
 }


### PR DESCRIPTION
**What is this feature?**

This PR replaces usage of `structuredClone` with lodash's `deepClone`. 

**Why do we need this feature?**

This is necessary as structuredClone doesn't handle functions in the clones object, and extensions may include functions such as `onClick` and `configure`. 

**Who is this feature for?**

Plugin devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
