### PR TITLE
Dynamic Dashboards: Fix show/hide rules when template variable has "All" selected

### DIFF
--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingVariable.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingVariable.tsx
@@ -2,6 +2,7 @@ import { ReactElement, useEffect, useMemo, useState } from 'react';
 
 import { t } from '@grafana/i18n';
 import {
+  MultiValueVariable,
   SceneComponentProps,
   sceneGraph,
   SceneObjectBase,
@@ -13,6 +14,7 @@ import {
   ConditionalRenderingVariableSpec,
 } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { Box, Combobox, ComboboxOption, Field, Input, Stack } from '@grafana/ui';
+import { ALL_VARIABLE_TEXT } from 'app/features/variables/constants';
 
 import { dashboardEditActions } from '../../edit-pane/shared';
 import { getDashboardSceneFor } from '../../utils/utils';
@@ -97,13 +99,20 @@ export class ConditionalRenderingVariable extends SceneObjectBase<ConditionalRen
     }
 
     const variableValue = variable.getValue() ?? '';
+    const comparisonValue = this.state.value.toString();
+
+    // Check if "All" is selected in a multi-value variable with includeAll option
+    const isAllSelected =
+      variable instanceof MultiValueVariable &&
+      variable.hasAllValue() &&
+      comparisonValue.toLowerCase() === ALL_VARIABLE_TEXT.toLowerCase();
 
     let hit: boolean;
 
     if (this.state.operator === '=' || this.state.operator === '!=') {
       hit = Array.isArray(variableValue)
-        ? variableValue.includes(this.state.value.toString())
-        : variableValue === this.state.value.toString();
+        ? variableValue.includes(comparisonValue) || isAllSelected
+        : variableValue === comparisonValue || isAllSelected;
     } else {
       try {
         const regex = new RegExp(this.state.value);


### PR DESCRIPTION
**What is this feature?**

Fixes an issue where panel show/hide rules based on template variables did not work correctly when the variable had the "Include All option" enabled and "All" was selected.

**Why do we need this feature?**

When configuring show/hide rules for panels using template variables, users expect that setting a rule like `variable = All` would match when "All" is selected in the variable dropdown. However, this didn't work because the scenes library's `getValue()` method returns an array of all individual option values when "All" is selected, not the string "All". This made it impossible to create rules that respond to the "All" selection state.

**Who is this feature for?**

Users who want to conditionally show or hide panels based on whether "All" is selected in a multi-value template variable with "Include All option" enabled.

**Which issue(s) does this PR fix?**

Fixes #116152

**Special notes for your reviewer:**

The fix uses the `hasAllValue()` method from the scenes library to properly detect when "All" is selected, rather than trying to match against the raw value. This is the correct approach because:

- When "All" is selected, `getValue()` returns an array of all option values (e.g., `["Option0", "Option1"]`), not `$__all` or `"All"`
- The `hasAllValue()` method correctly checks the internal state to determine if the special "All" option is active