### PR TITLE
Node Graph: Use first numeric field as fallback for main stat

### DIFF
--- a/public/app/plugins/panel/nodeGraph/utils.ts
+++ b/public/app/plugins/panel/nodeGraph/utils.ts
@@ -71,7 +71,9 @@ export function getNodeFields(nodes: DataFrame): NodeFields {
     id: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.id.toLowerCase()),
     title: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.title.toLowerCase()),
     subTitle: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.subTitle.toLowerCase()),
-    mainStat: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.mainStat.toLowerCase()),
+    mainStat:
+      fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.mainStat.toLowerCase()) ||
+      fieldsCache.getFirstFieldOfType(FieldType.number),
     secondaryStat: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.secondaryStat.toLowerCase()),
     arc: findFieldsByPrefix(nodes, NodeGraphDataFrameFieldNames.arc),
     details: findFieldsByPrefix(nodes, NodeGraphDataFrameFieldNames.detail),
@@ -111,7 +113,9 @@ export function getEdgeFields(edges: DataFrame): EdgeFields {
     id: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.id.toLowerCase()),
     source: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.source.toLowerCase()),
     target: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.target.toLowerCase()),
-    mainStat: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.mainStat.toLowerCase()),
+    mainStat:
+      fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.mainStat.toLowerCase()) ||
+      fieldsCache.getFirstFieldOfType(FieldType.number),
     secondaryStat: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.secondaryStat.toLowerCase()),
     details: findFieldsByPrefix(edges, NodeGraphDataFrameFieldNames.detail.toLowerCase()),
     // @deprecated -- for edges use color instead


### PR DESCRIPTION
Fixes #116525

https://github.com/user-attachments/assets/5c835160-6820-4381-bec4-37f299e5c3ed

Use following dashboard model for testing with gdev-prometheus:

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 0,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "prometheus",
        "uid": "gdev-prometheus"
      },
      "fieldConfig": {
        "defaults": {},
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "edges": {},
        "layoutAlgorithm": "layered",
        "nodes": {},
        "zoomMode": "cooperative"
      },
      "pluginVersion": "12.4.0-pre",
      "targets": [
        {
          "datasource": {
            "type": "prometheus",
            "uid": "gdev-prometheus"
          },
          "editorMode": "code",
          "exemplar": false,
          "expr": "label_replace(\n    label_replace(\n      label_replace(\n        label_replace(\n          sum(rate(grafana_http_request_duration_seconds_sum{status_source=\"server\"}[$__range])),\n          \"id\", \"server\", \"\", \"\"\n        ),\n        \"title\", \"Server\", \"\", \"\"\n      ),\n      \"icon\", \"cloud\", \"\", \"\"\n    ),\n    \"service_name\", \"server\", \"\", \"\"\n  )\n\nor\n  label_replace(\n    label_replace(\n      label_replace(\n        label_replace(\n          sum(rate(grafana_http_request_duration_seconds_sum{status_source=\"downstream\"}[$__range])),\n          \"id\", \"downstream\", \"\", \"\"\n        ),\n        \"title\", \"Downstream\", \"\", \"\"\n      ),\n      \"icon\", \"cloud\", \"\", \"\"\n    ),\n    \"service_name\", \"downstream\", \"\", \"\"\n  )",
          "format": "table",
          "instant": true,
          "legendFormat": "__auto",
          "range": false,
          "refId": "A"
        },
        {
          "datasource": {
            "type": "prometheus",
            "uid": "gdev-prometheus"
          },
          "editorMode": "code",
          "exemplar": false,
          "expr": "label_join(\n  label_replace(\n    label_replace(\n      sum(rate(grafana_http_request_duration_seconds_sum{status_source=\"server\"}[$__range])),\n      \"source\", \"server\", \"\", \"\"\n    ),\n    \"target\", \"downstream\", \"\", \"\"\n  ),\n  \"id\", \"-\", \"source\", \"target\"\n)",
          "format": "table",
          "instant": true,
          "legendFormat": "__auto",
          "range": false,
          "refId": "B"
        }
      ],
      "title": "New panel",
      "type": "nodeGraph"
    }
  ],
  "preload": false,
  "schemaVersion": 42,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-5m",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "Prometheus and Node Graph",
  "uid": "adcxvz7",
  "version": 5,
  "weekStart": ""
}
```