### PR TITLE
Accessibility: Add keyboard focus indicator to data source list items

### DIFF
--- a/public/app/features/datasources/components/picker/DataSourceCard.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceCard.tsx
@@ -2,6 +2,7 @@ import { css, cx } from '@emotion/css';
 
 import { DataSourceInstanceSettings, GrafanaTheme2 } from '@grafana/data';
 import { Card, Icon, TagList, useTheme2 } from '@grafana/ui';
+import { getFocusStyles } from '@grafana/ui/internal';
 
 interface DataSourceCardProps {
   ds: DataSourceInstanceSettings;
@@ -71,6 +72,8 @@ function getStyles(theme: GrafanaTheme2, builtIn = false) {
       '&:hover': {
         backgroundColor: theme.colors.action.hover,
       },
+
+      '&:focus-visible': getFocusStyles(theme),
     }),
     heading: css({
       width: '100%',


### PR DESCRIPTION
## Summary

This PR adds a visible keyboard focus indicator to data source list items in the DataSourcePicker component, addressing WCAG 2.4.7 (Focus Visible) compliance.

**Changes:**
- Added `&:focus-visible` styling to `DataSourceCard` component using Grafana's standard `getFocusStyles` utility
- When users navigate the data source list using keyboard (Tab key), focused items now display a visible focus ring

## Why

Keyboard-only users currently cannot see which data source is focused when navigating the list, making it difficult or impossible to select the correct data source.

## Test plan

1. Open Grafana dashboard settings
2. Navigate to Annotations tab
3. Click "New query" to open data source picker
4. Use Tab key to navigate through data source list items
5. Verify that a visible focus indicator (box-shadow ring) appears around the focused item

Fixes #116512