### PR TITLE
Dynamic dashboards:  Do not show edit actions in embedded dashboard

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
@@ -31,6 +31,7 @@ export function DashboardEditPaneRenderer({ editPane, dashboard, isDocked }: Pro
   const { selection, openPane } = useSceneObjectState(editPane, { shouldActivateOrKeepAlive: true });
   const { isEditing, meta, uid } = dashboard.useState();
   const hasUid = Boolean(uid);
+  const isEmbedded = meta.isEmbedded;
   const selectedObject = selection?.getFirstObject();
   const isNewElement = selection?.isNewElement() ?? false;
 
@@ -103,7 +104,7 @@ export function DashboardEditPaneRenderer({ editPane, dashboard, isDocked }: Pro
             />
           </>
         )}
-        {hasUid && <ShareExportDashboardButton dashboard={dashboard} />}
+        {hasUid && !isEmbedded && <ShareExportDashboardButton dashboard={dashboard} />}
         <Sidebar.Button
           icon="list-ui-alt"
           onClick={() => editPane.openPane('outline')}

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -256,8 +256,9 @@ function DashboardControlActions({ dashboard }: { dashboard: DashboardScene }) {
   const canEditDashboard = dashboard.canEditDashboard();
   const hasUid = Boolean(uid);
   const isSnapshot = Boolean(meta.isSnapshot);
+  const isEmbedded = meta.isEmbedded;
   const isEditable = Boolean(editable);
-  const showShareButton = hasUid && !isSnapshot && !isPlaying;
+  const showShareButton = hasUid && !isSnapshot && !isEmbedded && !isPlaying;
 
   return (
     <>

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -753,8 +753,9 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
 
   canEditDashboard() {
     const { meta } = this.state;
-
-    return !meta.isSnapshot && Boolean(meta.canEdit || meta.canMakeEditable || config.viewersCanEdit);
+    return (
+      !meta.isSnapshot && !meta.isEmbedded && Boolean(meta.canEdit || meta.canMakeEditable || config.viewersCanEdit)
+    );
   }
 
   public getInitialSaveModel() {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -752,10 +752,10 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
   }
 
   canEditDashboard() {
-    const { meta } = this.state;
-    return (
-      !meta.isSnapshot && !meta.isEmbedded && Boolean(meta.canEdit || meta.canMakeEditable || config.viewersCanEdit)
-    );
+    const {
+      meta: { isSnapshot, isEmbedded, canEdit, canMakeEditable },
+    } = this.state;
+    return !isSnapshot && !isEmbedded && Boolean(canEdit || canMakeEditable || config.viewersCanEdit);
   }
 
   public getInitialSaveModel() {

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -152,7 +152,7 @@ export function ToolbarActions({ dashboard }: Props) {
 
   toolbarActions.push({
     group: 'icon-actions',
-    condition: meta.isSnapshot && !isEditing,
+    condition: meta.isSnapshot && !isEditing && !meta.isEmbedded,
     render: () => <GoToSnapshotOriginButton key="go-to-snapshot-origin" originalURL={dashboard.getSnapshotUrl()} />,
   });
 
@@ -315,7 +315,7 @@ export function ToolbarActions({ dashboard }: Props) {
     ),
   });
 
-  const showShareButton = uid && !isEditing && !meta.isSnapshot && !isPlaying;
+  const showShareButton = uid && !isEditing && !meta.isSnapshot && !isPlaying && !meta.isEmbedded;
 
   toolbarActions.push({
     group: 'main-buttons',

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -66,8 +66,18 @@ NavToolbarActions.displayName = 'NavToolbarActions';
  * This part is split into a separate component to help test this
  */
 export function ToolbarActions({ dashboard }: Props) {
-  const { isEditing, viewPanel, isDirty, uid, meta, editview, editPanel, editable, title } = dashboard.useState();
-
+  const {
+    isEditing,
+    viewPanel,
+    isDirty,
+    uid,
+    meta,
+    editview,
+    editPanel,
+    editable,
+    title,
+    meta: { isEmbedded, isSnapshot, canEdit, canMakeEditable, canStar, canSave, folderUid },
+  } = dashboard.useState();
   const { isPlaying } = playlistSrv.useState();
   const [isAddPanelMenuOpen, setIsAddPanelMenuOpen] = useState(false);
 
@@ -85,11 +95,11 @@ export function ToolbarActions({ dashboard }: Props) {
   // Means we are not in settings view, fullscreen panel or edit panel
   const isShowingDashboard = !editview && !isViewingPanel && !isEditingPanel;
   const isEditingAndShowingDashboard = isEditing && isShowingDashboard;
-  const folderRepo = useSelector((state) => selectFolderRepository()(state, meta.folderUid));
+  const folderRepo = useSelector((state) => selectFolderRepository()(state, folderUid));
   const isManaged = Boolean(dashboard.isManagedRepository() || folderRepo);
   // Get the repository for the dashboard's folder
   const { isReadOnlyRepo, repoType } = useGetResourceRepositoryView({
-    folderName: meta.folderUid,
+    folderName: folderUid,
   });
 
   if (!isEditingPanel) {
@@ -99,7 +109,7 @@ export function ToolbarActions({ dashboard }: Props) {
 
   toolbarActions.push({
     group: 'icon-actions',
-    condition: uid && Boolean(meta.canStar) && isShowingDashboard && !isEditing,
+    condition: uid && Boolean(canStar) && isShowingDashboard && !isEditing,
     render: () => {
       if (!uid) {
         return null;
@@ -118,7 +128,7 @@ export function ToolbarActions({ dashboard }: Props) {
 
   toolbarActions.push({
     group: 'icon-actions',
-    condition: uid && Boolean(meta.canStar) && isShowingDashboard && !isEditing,
+    condition: uid && Boolean(canStar) && isShowingDashboard && !isEditing,
     render: () => {
       return <PublicDashboardBadge key="public-dashboard-badge" dashboard={dashboard} />;
     },
@@ -140,7 +150,7 @@ export function ToolbarActions({ dashboard }: Props) {
     });
   }
 
-  if (dashboard.isManaged() && meta.canEdit) {
+  if (dashboard.isManaged() && canEdit) {
     toolbarActions.push({
       group: 'icon-actions',
       condition: true,
@@ -152,7 +162,7 @@ export function ToolbarActions({ dashboard }: Props) {
 
   toolbarActions.push({
     group: 'icon-actions',
-    condition: meta.isSnapshot && !isEditing && !meta.isEmbedded,
+    condition: isSnapshot && !isEditing && !isEmbedded,
     render: () => <GoToSnapshotOriginButton key="go-to-snapshot-origin" originalURL={dashboard.getSnapshotUrl()} />,
   });
 
@@ -315,7 +325,7 @@ export function ToolbarActions({ dashboard }: Props) {
     ),
   });
 
-  const showShareButton = uid && !isEditing && !meta.isSnapshot && !isPlaying && !meta.isEmbedded;
+  const showShareButton = uid && !isEditing && !isSnapshot && !isPlaying && !isEmbedded;
 
   toolbarActions.push({
     group: 'main-buttons',
@@ -501,7 +511,7 @@ export function ToolbarActions({ dashboard }: Props) {
 
   toolbarActions.push({
     group: 'main-buttons',
-    condition: isEditing && !isEditingLibraryPanel && (meta.canSave || canSaveAs),
+    condition: isEditing && !isEditingLibraryPanel && (canSave || canSaveAs),
     render: () => {
       // if we  only can save
       if (isNew) {
@@ -523,7 +533,7 @@ export function ToolbarActions({ dashboard }: Props) {
       }
 
       // If we only can save as copy
-      if (canSaveAs && !meta.canSave && !meta.canMakeEditable && !isManaged) {
+      if (canSaveAs && !canSave && !canMakeEditable && !isManaged) {
         return (
           <Button
             onClick={() => {

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutRenderer.tsx
@@ -17,7 +17,11 @@ import { AutoGridLayoutManager } from './AutoGridLayoutManager';
 export function AutoGridLayoutRenderer({ model }: SceneComponentProps<AutoGridLayout>) {
   const { children, isHidden } = model.useState();
   const styles = useStyles2(getStyles, model.state);
-  const { layoutOrchestrator, isEditing } = useDashboardState(model);
+  const {
+    layoutOrchestrator,
+    isEditing,
+    meta: { isEmbedded },
+  } = useDashboardState(model);
   const layoutManager = sceneGraph.getAncestor(model, AutoGridLayoutManager);
   const { fillScreen, dropPosition } = layoutManager.useState();
   const soloPanelContext = useSoloPanelContext();
@@ -26,7 +30,7 @@ export function AutoGridLayoutRenderer({ model }: SceneComponentProps<AutoGridLa
     return null;
   }
 
-  const showCanvasActions = !isRepeatCloneOrChildOf(model) && isEditing;
+  const showCanvasActions = !isEmbedded && !isRepeatCloneOrChildOf(model) && isEditing;
 
   if (soloPanelContext) {
     return children.map((item) => <item.Component key={item.state.key} model={item} />);

--- a/public/app/features/dashboard-scene/scene/new-toolbar/LeftActions.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/LeftActions.tsx
@@ -48,7 +48,7 @@ export const LeftActions = ({ dashboard }: { dashboard: DashboardScene }) => {
         key: 'open-snapshot-origin-button',
         component: OpenSnapshotOriginButton,
         group: 'actions',
-        condition: isSnapshot && !isEditingDashboard,
+        condition: isSnapshot && !isEditingDashboard && !meta.isEmbedded,
       },
     ],
     dashboard

--- a/public/app/features/dashboard-scene/scene/new-toolbar/LeftActions.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/LeftActions.tsx
@@ -20,6 +20,7 @@ export const LeftActions = ({ dashboard }: { dashboard: DashboardScene }) => {
   const canEdit = Boolean(meta.canEdit);
   const canStar = Boolean(meta.canStar);
   const isSnapshot = Boolean(meta.isSnapshot);
+  const isEmbedded = Boolean(meta.isEmbedded);
   const isShowingDashboard = !hasEditView && !isViewingPanel && !isEditingPanel;
 
   const elements = renderActionElements(
@@ -48,7 +49,7 @@ export const LeftActions = ({ dashboard }: { dashboard: DashboardScene }) => {
         key: 'open-snapshot-origin-button',
         component: OpenSnapshotOriginButton,
         group: 'actions',
-        condition: isSnapshot && !isEditingDashboard && !meta.isEmbedded,
+        condition: isSnapshot && !isEditingDashboard && !isEmbedded,
       },
     ],
     dashboard

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -268,7 +268,7 @@ export const DashNav = memo<Props>((props) => {
 
   const renderRightActions = () => {
     const { dashboard, isFullscreen, hideTimePicker } = props;
-    const { canSave, canEdit, showSettings, canShare } = dashboard.meta;
+    const { canSave, canEdit, showSettings, canShare, isEmbedded } = dashboard.meta;
     const { snapshot } = dashboard;
     const snapshotUrl = snapshot && snapshot.originalUrl;
     const buttons: ReactNode[] = [];
@@ -329,8 +329,7 @@ export const DashNav = memo<Props>((props) => {
         />
       );
     }
-
-    if (canShare) {
+    if (canShare && !isEmbedded) {
       buttons.push(<ShareButton key="button-share" dashboard={dashboard} />);
     }
 


### PR DESCRIPTION
Reported in https://raintank-corp.slack.com/archives/CHKLEJ668/p1768833017132559

In the old layout, embedded dashboards didn't show any sharing or editing buttons. This does the same for new layouts:
 
<img width="600" height="1374" alt="image (1)" src="https://github.com/user-attachments/assets/afa50f01-5229-4115-aa69-415aa8e05f70" />

<img width="600" height="1470" alt="image (3)" src="https://github.com/user-attachments/assets/6ed1f398-1724-404e-b17e-ecad0d1e6881" />
