### PR TITLE
Grafana Monitoring: Enable native HTTP histograms by default, make classic histograms configurable 

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1771,6 +1771,9 @@ interval_seconds = 10
 disable_total_stats = false
 # The interval at which the total stats collector will update the stats. Default is 1800 seconds.
 total_stats_collector_interval_seconds = 1800
+# Enable classic HTTP histogram buckets alongside native histograms
+# Set to false to only expose native histogram format (reduces cardinality)
+classic_http_histogram_enabled = true
 
 #If both are set, basic auth will be required for the metrics endpoints.
 basic_auth_username =

--- a/docs/sources/setup-grafana/set-up-grafana-monitoring.md
+++ b/docs/sources/setup-grafana/set-up-grafana-monitoring.md
@@ -43,6 +43,19 @@ When enabled, Grafana exposes a number of metrics, including:
 - Grafana active alerts
 - Grafana performance
 
+#### Native histogram format
+
+Grafana exposes HTTP request metrics using native histograms for a more accurate representation of metric distributions. By default, both native histograms and classic histogram buckets are exposed for compatibility.
+
+To reduce metric cardinality, you can disable classic histogram buckets and expose only native histograms by setting the following option in your configuration file:
+
+```
+[metrics]
+# Enable classic HTTP histogram buckets alongside native histograms
+# Set to false to only expose native histogram format (reduces cardinality)
+classic_http_histogram_enabled = false
+```
+
 ### Pull metrics from Grafana into Prometheus
 
 These instructions assume you have already added Prometheus as a data source in Grafana.

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -244,11 +244,6 @@ export interface FeatureToggles {
   */
   externalServiceAccounts?: boolean;
   /**
-  * Enables native HTTP Histograms
-  * @default false
-  */
-  enableNativeHTTPHistogram?: boolean;
-  /**
   * Disables classic HTTP Histogram (use with enableNativeHTTPHistogram)
   * @default false
   */

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -244,11 +244,6 @@ export interface FeatureToggles {
   */
   externalServiceAccounts?: boolean;
   /**
-  * Disables classic HTTP Histogram (use with enableNativeHTTPHistogram)
-  * @default false
-  */
-  disableClassicHTTPHistogram?: boolean;
-  /**
   * Routes snapshot requests from /api to the /apis endpoint
   * @default false
   */

--- a/pkg/middleware/request_metrics.go
+++ b/pkg/middleware/request_metrics.go
@@ -55,27 +55,25 @@ func RequestMetrics(features featuremgmt.FeatureToggles, cfg *setting.Cfg, promR
 	}
 
 	//nolint:staticcheck // not yet migrated to OpenFeature
-	if features.IsEnabledGlobally(featuremgmt.FlagEnableNativeHTTPHistogram) {
-		// the recommended default value from the prom_client
-		// https://github.com/prometheus/client_golang/blob/main/prometheus/histogram.go#L411
-		// Giving this variable a value means the client will expose a native
-		// histogram.
-		reqDurationOptions.NativeHistogramBucketFactor = 1.1
-		reqSizeOptions.NativeHistogramBucketFactor = 1.1
-		// The default value in OTel. It probably good enough for us as well.
-		reqDurationOptions.NativeHistogramMaxBucketNumber = 160
-		reqSizeOptions.NativeHistogramMaxBucketNumber = 160
-		reqDurationOptions.NativeHistogramMinResetDuration = time.Hour
-		reqSizeOptions.NativeHistogramMinResetDuration = time.Hour
+	// the recommended default value from the prom_client
+	// https://github.com/prometheus/client_golang/blob/main/prometheus/histogram.go#L411
+	// Giving this variable a value means the client will expose a native
+	// histogram.
+	reqDurationOptions.NativeHistogramBucketFactor = 1.1
+	reqSizeOptions.NativeHistogramBucketFactor = 1.1
+	// The default value in OTel. It probably good enough for us as well.
+	reqDurationOptions.NativeHistogramMaxBucketNumber = 160
+	reqSizeOptions.NativeHistogramMaxBucketNumber = 160
+	reqDurationOptions.NativeHistogramMinResetDuration = time.Hour
+	reqSizeOptions.NativeHistogramMinResetDuration = time.Hour
 
-		//nolint:staticcheck // not yet migrated to OpenFeature
-		if features.IsEnabledGlobally(featuremgmt.FlagDisableClassicHTTPHistogram) {
-			// setting Buckets to nil with native options set means the classic
-			// histogram will no longer be exposed - this can be a good way to
-			// reduce cardinality in the exposed metrics
-			reqDurationOptions.Buckets = nil
-			reqSizeOptions.Buckets = nil
-		}
+	//nolint:staticcheck // not yet migrated to OpenFeature
+	if features.IsEnabledGlobally(featuremgmt.FlagDisableClassicHTTPHistogram) {
+		// setting Buckets to nil with native options set means the classic
+		// histogram will no longer be exposed - this can be a good way to
+		// reduce cardinality in the exposed metrics
+		reqDurationOptions.Buckets = nil
+		reqSizeOptions.Buckets = nil
 	}
 
 	httpRequestDurationHistogram := prometheus.NewHistogramVec(

--- a/pkg/middleware/request_metrics.go
+++ b/pkg/middleware/request_metrics.go
@@ -67,8 +67,7 @@ func RequestMetrics(features featuremgmt.FeatureToggles, cfg *setting.Cfg, promR
 	reqDurationOptions.NativeHistogramMinResetDuration = time.Hour
 	reqSizeOptions.NativeHistogramMinResetDuration = time.Hour
 
-	//nolint:staticcheck // not yet migrated to OpenFeature
-	if features.IsEnabledGlobally(featuremgmt.FlagDisableClassicHTTPHistogram) {
+	if !cfg.ClassicHTTPHistogramEnabled {
 		// setting Buckets to nil with native options set means the classic
 		// histogram will no longer be exposed - this can be a good way to
 		// reduce cardinality in the exposed metrics

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -366,15 +366,6 @@ var (
 			Expression:  "false",
 		},
 		{
-			Name:            "enableNativeHTTPHistogram",
-			Description:     "Enables native HTTP Histograms",
-			Stage:           FeatureStageExperimental,
-			FrontendOnly:    false,
-			Owner:           grafanaBackendServicesSquad,
-			RequiresRestart: true,
-			Expression:      "false",
-		},
-		{
 			Name:            "disableClassicHTTPHistogram",
 			Description:     "Disables classic HTTP Histogram (use with enableNativeHTTPHistogram)",
 			Stage:           FeatureStageExperimental,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -366,15 +366,6 @@ var (
 			Expression:  "false",
 		},
 		{
-			Name:            "disableClassicHTTPHistogram",
-			Description:     "Disables classic HTTP Histogram (use with enableNativeHTTPHistogram)",
-			Stage:           FeatureStageExperimental,
-			FrontendOnly:    false,
-			Owner:           grafanaBackendServicesSquad,
-			RequiresRestart: true,
-			Expression:      "false",
-		},
-		{
 			Name:            "kubernetesSnapshots",
 			Description:     "Routes snapshot requests from /api to the /apis endpoint",
 			Stage:           FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -44,7 +44,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2023-09-07,sseGroupByDatasource,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2023-09-19,lokiRunQueriesInParallel,privatePreview,@grafana/oss-big-tent,false,false,false
 2023-09-28,externalServiceAccounts,preview,@grafana/identity-access-team,false,false,false
-2024-06-18,disableClassicHTTPHistogram,experimental,@grafana/grafana-backend-services-squad,false,true,false
 2023-12-05,kubernetesSnapshots,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2025-06-26,kubernetesLibraryPanels,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2024-06-05,kubernetesDashboards,GA,@grafana/dashboards-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -44,7 +44,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2023-09-07,sseGroupByDatasource,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2023-09-19,lokiRunQueriesInParallel,privatePreview,@grafana/oss-big-tent,false,false,false
 2023-09-28,externalServiceAccounts,preview,@grafana/identity-access-team,false,false,false
-2023-10-03,enableNativeHTTPHistogram,experimental,@grafana/grafana-backend-services-squad,false,true,false
 2024-06-18,disableClassicHTTPHistogram,experimental,@grafana/grafana-backend-services-squad,false,true,false
 2023-12-05,kubernetesSnapshots,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2025-06-26,kubernetesLibraryPanels,experimental,@grafana/grafana-app-platform-squad,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -143,10 +143,6 @@ const (
 	// Automatic service account and token setup for plugins
 	FlagExternalServiceAccounts = "externalServiceAccounts"
 
-	// FlagEnableNativeHTTPHistogram
-	// Enables native HTTP Histograms
-	FlagEnableNativeHTTPHistogram = "enableNativeHTTPHistogram"
-
 	// FlagDisableClassicHTTPHistogram
 	// Disables classic HTTP Histogram (use with enableNativeHTTPHistogram)
 	FlagDisableClassicHTTPHistogram = "disableClassicHTTPHistogram"

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -143,10 +143,6 @@ const (
 	// Automatic service account and token setup for plugins
 	FlagExternalServiceAccounts = "externalServiceAccounts"
 
-	// FlagDisableClassicHTTPHistogram
-	// Disables classic HTTP Histogram (use with enableNativeHTTPHistogram)
-	FlagDisableClassicHTTPHistogram = "disableClassicHTTPHistogram"
-
 	// FlagKubernetesSnapshots
 	// Routes snapshot requests from /api to the /apis endpoint
 	FlagKubernetesSnapshots = "kubernetesSnapshots"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1374,6 +1374,7 @@
         "name": "disableClassicHTTPHistogram",
         "resourceVersion": "1768498862515",
         "creationTimestamp": "2024-06-18T19:37:44Z",
+        "deletionTimestamp": "2026-01-20T11:46:10Z",
         "annotations": {
           "grafana.app/updatedTimestamp": "2026-01-15 17:41:02.515355 +0000 UTC"
         }

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1559,6 +1559,7 @@
         "name": "enableNativeHTTPHistogram",
         "resourceVersion": "1768498862515",
         "creationTimestamp": "2023-10-03T18:23:55Z",
+        "deletionTimestamp": "2026-01-20T11:37:01Z",
         "annotations": {
           "grafana.app/updatedTimestamp": "2026-01-15 17:41:02.515355 +0000 UTC"
         }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -245,6 +245,7 @@ type Cfg struct {
 	// use this setting.
 	MetricsIncludeTeamLabel          bool
 	MetricsTotalStatsIntervalSeconds int
+	ClassicHTTPHistogramEnabled      bool
 	MetricsGrafanaEnvironmentInfo    map[string]string
 
 	// Dashboards
@@ -1271,6 +1272,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	cfg.MetricsEndpointDisableTotalStats = iniFile.Section("metrics").Key("disable_total_stats").MustBool(false)
 	cfg.MetricsIncludeTeamLabel = iniFile.Section("metrics").Key("include_team_label").MustBool(false)
 	cfg.MetricsTotalStatsIntervalSeconds = iniFile.Section("metrics").Key("total_stats_collector_interval_seconds").MustInt(1800)
+	cfg.ClassicHTTPHistogramEnabled = iniFile.Section("metrics").Key("classic_http_histogram_enabled").MustBool(true)
 
 	analytics := iniFile.Section("analytics")
 	cfg.CheckForGrafanaUpdates = analytics.Key("check_for_updates").MustBool(true)


### PR DESCRIPTION
- Remove `enableNativeHTTPHistogram` flag: native histograms are now always enabled for `grafana_http_request_duration_seconds` and `grafana_http_response_size_bytes` metrics                                
- Replace `disableClassicHTTPHistogram` feature flag with `[metrics].classic_http_histogram_enabled` configuration setting