### PR TITLE
Histogram: Ensure range exists for log scale on x axis

### DIFF
--- a/public/app/plugins/panel/histogram/Histogram.tsx
+++ b/public/app/plugins/panel/histogram/Histogram.tsx
@@ -112,7 +112,7 @@ const prepConfig = (frame: DataFrame, theme: GrafanaTheme2) => {
     direction: ScaleDirection.Right,
     range: useLogScale
       ? (u, wantedMin, wantedMax) => {
-          return uPlot.rangeLog(wantedMin, wantedMax * bucketFactor, 2, true);
+          return uPlot.rangeLog(wantedMin, (wantedMax ?? 1) * bucketFactor, 2, true);
         }
       : (u, wantedMin, wantedMax) => {
           // these settings will prevent zooming, probably okay?


### PR DESCRIPTION

**What is this feature?**

In some instances, the histogram will attempt to calculate the x axis where the max is returned as undefined. In this case, the x range is not calculated and the data is not displayed. Default to 1 in this case so we can at least show something on the chart.

**Why do we need this feature?**

To provide a sensible default if the max cannot be calculated.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/20245

**Special notes for your reviewer:**

I tested this against https://github.com/grafana/grafana/issues/106861 but that does not fix their issue.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
