### PR TITLE
Bugfix: Let API accept content-type declared in OpenAPI schema

### DIFF
--- a/pkg/services/apiserver/builder/request_handler.go
+++ b/pkg/services/apiserver/builder/request_handler.go
@@ -242,6 +242,10 @@ func extractConsumesFromRequestBody(requestBody *spec3.RequestBody) []string {
 	for contentType := range requestBody.Content {
 		result = append(result, contentType)
 	}
+
+	// Counting for missing content-type header
+	result = append(result, "*/*")
+
 	return result
 }
 
@@ -260,6 +264,12 @@ func extractProducesFromResponses(responses *spec3.Responses) []string {
 		}
 	}
 
+	if responses.Default != nil && responses.Default.Content != nil {
+		for contentType := range responses.Default.Content {
+			contentTypes[contentType] = struct{}{}
+		}
+	}
+
 	if len(contentTypes) == 0 {
 		return nil
 	}
@@ -268,6 +278,7 @@ func extractProducesFromResponses(responses *spec3.Responses) []string {
 	for contentType := range contentTypes {
 		result = append(result, contentType)
 	}
+
 	return result
 }
 

--- a/pkg/services/apiserver/builder/request_handler.go
+++ b/pkg/services/apiserver/builder/request_handler.go
@@ -213,6 +213,29 @@ func addRouteFromSpec(ws *restful.WebService, routePath string, pathProps *spec3
 			}
 		}
 
+		// Extract and set content types from OpenAPI spec responses
+		if operation.Responses != nil && operation.Responses.StatusCodeResponses != nil {
+			contentTypes := make(map[string]bool)
+			for _, response := range operation.Responses.StatusCodeResponses {
+				if response != nil && response.Content != nil {
+					for contentType := range response.Content {
+						contentTypes[contentType] = true
+					}
+				}
+			}
+			// Set Produces based on response content types
+			for contentType := range contentTypes {
+				routeBuilder = routeBuilder.Produces(contentType)
+			}
+		}
+
+		// Extract and set content types from OpenAPI spec request body
+		if operation.RequestBody != nil && operation.RequestBody.Content != nil {
+			for contentType := range operation.RequestBody.Content {
+				routeBuilder = routeBuilder.Consumes(contentType)
+			}
+		}
+
 		// Note: Request/response schemas are already defined in the OpenAPI spec from builders
 		// and will be added to the OpenAPI document via addBuilderRoutes in openapi.go.
 		// We don't duplicate that information here since restful uses the route metadata


### PR DESCRIPTION
**What is this feature?**

Let the APIServer's custom route `gorestful` handler accept content types directly from what's declared in the openAPI schema.

Counterpart https://github.com/grafana/grafana-enterprise/pull/10686

**Why do we need this feature?**

Some declared content-types are not automatically accepted by our api server, this PR fixes it. 

**Who is this feature for?**

Users of App Platform. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
