### PR TITLE
Table: fix hidden fields from being displayed

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
@@ -97,6 +97,12 @@ const createNestedDataFrame = (): DataFrame => {
     name: 'NestedData',
     fields: [
       {
+        name: 'Nested hidden',
+        type: FieldType.string,
+        values: ['secret1', 'secret2'],
+        config: { custom: { hidden: true } },
+      },
+      {
         name: 'Nested A',
         type: FieldType.string,
         values: ['N1', 'N2'],
@@ -412,6 +418,10 @@ describe('TableNG', () => {
         expectedExpandedContent.forEach((text) => {
           expect(screen.getByText(text)).toBeInTheDocument();
         });
+
+        // Hidden nested fields should stay hidden
+        expect(screen.queryByText('Nested hidden')).not.toBeInTheDocument();
+        expect(screen.queryByText('secret1')).not.toBeInTheDocument();
 
         // Check if the expanded row has the aria-expanded attribute
         const expandedRow = container.querySelector('[aria-expanded="true"]');

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
@@ -100,7 +100,7 @@ const createNestedDataFrame = (): DataFrame => {
         name: 'Nested hidden',
         type: FieldType.string,
         values: ['secret1', 'secret2'],
-        config: { custom: { hidden: true } },
+        config: { custom: { hideFrom: { viz: true } } },
       },
       {
         name: 'Nested A',

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -745,7 +745,11 @@ export function TableNG(props: TableNGProps) {
     () => (hasNestedFrames ? rows.find((r) => r.data)?.data : undefined),
     [hasNestedFrames, rows]
   );
-  const [nestedFieldWidths] = useColWidths(firstRowNestedData?.fields ?? [], availableWidth);
+  const nestedVisibleFields = useMemo(
+    () => (firstRowNestedData ? getVisibleFields(firstRowNestedData.fields) : []),
+    [firstRowNestedData]
+  );
+  const [nestedFieldWidths] = useColWidths(nestedVisibleFields, availableWidth);
 
   const { columns, cellRootRenderers } = useMemo(() => {
     const result = fromFields(visibleFields, widths);
@@ -759,7 +763,7 @@ export function TableNG(props: TableNGProps) {
     const hasNestedHeaders = firstRowNestedData.meta?.custom?.noHeader !== true;
     const renderRow = renderRowFactory(firstRowNestedData.fields, panelContext, expandedRows, enableSharedCrosshair);
     const { columns: nestedColumns, cellRootRenderers: nestedCellRootRenderers } = fromFields(
-      firstRowNestedData.fields,
+      nestedVisibleFields,
       nestedFieldWidths
     );
 
@@ -782,6 +786,7 @@ export function TableNG(props: TableNGProps) {
     firstRowNestedData,
     fromFields,
     nestedFieldWidths,
+    nestedVisibleFields,
     panelContext,
     visibleFields,
     widths,


### PR DESCRIPTION
Since PRs https://github.com/grafana/grafana/pull/111463 and https://github.com/grafana/grafana/pull/115117 were merged, a regression was introduced in Tempo table response rendering. Fields in nested data frames that are marked as hidden are no longer respected.

Specifically, fields such as `traceIdHidden` and `name` include `config: { custom: { hidden: true } }` in the data frame, which correctly hid them prior to these changes. After these PRs, those fields are now visible when they appear in nested frames.

This PR restores the previous behavior so that `config.custom.hidden = true` is honored for nested data frames as well.

**Before the fix / After the fix:**
<div>
<img width="49%" height="1162" alt="Screenshot 2026-01-20 at 16 17 49" src="https://github.com/user-attachments/assets/ebf73f1b-fd28-48dd-9472-3f9ed82d14a7" />
<img width="49%" height="1162" alt="Screenshot 2026-01-20 at 16 08 54" src="https://github.com/user-attachments/assets/e450edc1-43f3-4da4-8a31-817e0dd44a9e" />
</div>

