### PR TITLE
Alerting: Add EvaluationCoordinator to skip rule evaluation on non-primary nodes

### DIFF
--- a/pkg/services/ngalert/cluster/evaluation_coordinator.go
+++ b/pkg/services/ngalert/cluster/evaluation_coordinator.go
@@ -1,0 +1,23 @@
+package cluster
+
+type ClusterPositionProvider interface {
+	Position() int
+}
+
+// EvaluationCoordinator determines whether alert rule evaluation should occur
+// based on cluster position. Only the node with position 0 evaluates rules.
+type EvaluationCoordinator struct {
+	cluster ClusterPositionProvider
+}
+
+func NewEvaluationCoordinator(cluster ClusterPositionProvider) *EvaluationCoordinator {
+	return &EvaluationCoordinator{cluster: cluster}
+}
+
+// ShouldEvaluate returns true if this node should evaluate alert rules.
+func (c *EvaluationCoordinator) ShouldEvaluate() bool {
+	if c.cluster == nil {
+		return true
+	}
+	return c.cluster.Position() == 0
+}

--- a/pkg/services/ngalert/cluster/evaluation_coordinator_test.go
+++ b/pkg/services/ngalert/cluster/evaluation_coordinator_test.go
@@ -1,0 +1,64 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockPositionProvider struct {
+	position int
+}
+
+func (m *mockPositionProvider) Position() int {
+	return m.position
+}
+
+func TestEvaluationCoordinator_ShouldEvaluate(t *testing.T) {
+	testCases := []struct {
+		name             string
+		provider         ClusterPositionProvider
+		expectedEvaluate bool
+	}{
+		{
+			name:             "nil cluster should evaluate",
+			provider:         nil,
+			expectedEvaluate: true,
+		},
+		{
+			name:             "position 0 should evaluate",
+			provider:         &mockPositionProvider{position: 0},
+			expectedEvaluate: true,
+		},
+		{
+			name:             "position 1 should not evaluate",
+			provider:         &mockPositionProvider{position: 1},
+			expectedEvaluate: false,
+		},
+		{
+			name:             "position 2 should not evaluate",
+			provider:         &mockPositionProvider{position: 2},
+			expectedEvaluate: false,
+		},
+		{
+			name:             "position 10 should not evaluate",
+			provider:         &mockPositionProvider{position: 10},
+			expectedEvaluate: false,
+		},
+		{
+			name:             "negative position should not evaluate",
+			provider:         &mockPositionProvider{position: -1},
+			expectedEvaluate: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			coordinator := NewEvaluationCoordinator(tc.provider)
+
+			result := coordinator.ShouldEvaluate()
+
+			require.Equal(t, tc.expectedEvaluate, result)
+		})
+	}
+}

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -35,6 +35,7 @@ import (
 	ac "github.com/grafana/grafana/pkg/services/ngalert/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/ngalert/api"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/cluster"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/image"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
@@ -351,6 +352,10 @@ func (ng *AlertNG) init() error {
 		Log:                  log.New("ngalert.scheduler"),
 		RecordingWriter:      ng.RecordingWriter,
 		FeatureToggles:       ng.FeatureToggles,
+	}
+
+	if ng.Cfg.UnifiedAlerting.HASingleNodeEvaluation {
+		schedCfg.EvaluationCoordinator = cluster.NewEvaluationCoordinator(ng.MultiOrgAlertmanager.Peer())
 	}
 
 	history, err := configureHistorianBackend(

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -421,6 +421,12 @@ func (moa *MultiOrgAlertmanager) StopAndWait() {
 	}
 }
 
+// Peer returns the cluster peer for this Alertmanager.
+// Returns nil if clustering is not configured.
+func (moa *MultiOrgAlertmanager) Peer() alertingNotify.ClusterPeer {
+	return moa.peer
+}
+
 // AlertmanagerFor returns the Alertmanager instance for the organization provided.
 // When the organization does not have an active Alertmanager, it returns a ErrNoAlertmanagerForOrg.
 // When the Alertmanager of the organization is not ready, it returns a ErrAlertmanagerNotReady.

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -48,6 +48,11 @@ type RecordingWriter interface {
 	WriteDatasource(ctx context.Context, dsUID string, name string, t time.Time, frames data.Frames, orgID int64, extraLabels map[string]string) error
 }
 
+// EvaluationCoordinator determines whether alert rule evaluation should occur
+type EvaluationCoordinator interface {
+	ShouldEvaluate() bool
+}
+
 // AlertRuleStopReasonProvider is an interface for determining the reason why an alert rule was stopped.
 type AlertRuleStopReasonProvider interface {
 	// FindReason returns two values:
@@ -104,9 +109,10 @@ type schedule struct {
 	// last evaluated.
 	schedulableAlertRules alertRulesRegistry
 
-	tracer          tracing.Tracer
-	featureToggles  featuremgmt.FeatureToggles
-	recordingWriter RecordingWriter
+	tracer                tracing.Tracer
+	featureToggles        featuremgmt.FeatureToggles
+	recordingWriter       RecordingWriter
+	evaluationCoordinator EvaluationCoordinator
 }
 
 // RetryConfig configures the exponential backoff for alert rule and recording rule evaluations.
@@ -136,6 +142,7 @@ type SchedulerCfg struct {
 	RecordingWriter        RecordingWriter
 	RuleStopReasonProvider AlertRuleStopReasonProvider
 	FeatureToggles         featuremgmt.FeatureToggles
+	EvaluationCoordinator  EvaluationCoordinator
 }
 
 // NewScheduler returns a new scheduler.
@@ -167,6 +174,7 @@ func NewScheduler(cfg SchedulerCfg, stateManager *state.Manager) *schedule {
 		recordingWriter:        cfg.RecordingWriter,
 		ruleStopReasonProvider: cfg.RuleStopReasonProvider,
 		featureToggles:         cfg.FeatureToggles,
+		evaluationCoordinator:  cfg.EvaluationCoordinator,
 	}
 
 	return &sch
@@ -274,6 +282,11 @@ type readyToRunItem struct {
 // TODO refactor to accept a callback for tests that will be called with things that are returned currently, and return nothing.
 // Returns a slice of rules that were scheduled for evaluation, map of stopped rules, and a slice of updated rules
 func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.Group, tick time.Time) ([]readyToRunItem, map[ngmodels.AlertRuleKey]struct{}, []ngmodels.AlertRuleKeyWithVersion) {
+	if sch.evaluationCoordinator != nil && !sch.evaluationCoordinator.ShouldEvaluate() {
+		sch.log.Debug("Skipping rule evaluation on non-primary node")
+		return nil, nil, nil
+	}
+
 	tickNum := tick.Unix() / int64(sch.baseInterval.Seconds())
 
 	// update the local registry. If there was a difference between the previous state and the current new state, rulesDiff will contains keys of rules that were updated.

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -99,6 +99,7 @@ type UnifiedAlertingSettings struct {
 	HARedisMaxConns                 int
 	HARedisTLSEnabled               bool
 	HARedisTLSConfig                dstls.ClientConfig
+	HASingleNodeEvaluation          bool
 	InitializationTimeout           time.Duration
 	MaxAttempts                     int64
 	InitialRetryDelay               time.Duration
@@ -340,6 +341,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	uaCfg.HARedisTLSConfig.InsecureSkipVerify = ua.Key("ha_redis_tls_insecure_skip_verify").MustBool(false)
 	uaCfg.HARedisTLSConfig.CipherSuites = ua.Key("ha_redis_tls_cipher_suites").MustString("")
 	uaCfg.HARedisTLSConfig.MinVersion = ua.Key("ha_redis_tls_min_version").MustString("")
+	uaCfg.HASingleNodeEvaluation = ua.Key("ha_single_node_evaluation").MustBool(false)
 
 	// TODO load from ini file
 	uaCfg.DefaultConfiguration = alertmanagerDefaultConfiguration


### PR DESCRIPTION
**What is this feature?**

- Adds configurable `EvaluationCoordinator` interface to the scheduler, to allow evaluating alerts based on what it retuens in its `ShouldEvaluate()` function.
- Adds implementation of `EvaluationCoordinator` based on the embedded Alertmanager, which knows its position in the cluster and can be used as evaluation coordinator when Grafana is running in the [HA mode](https://grafana.com/docs/grafana/latest/alerting/set-up/configure-high-availability/).

**Why do we need this feature?**

Part of https://github.com/grafana/grafana/issues/116545

This allows to configure alert rule evaluation based on dynamic conditions, for example instance position in the cluster.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
