### PR TITLE
fix(DashListItem): Improve click targets for dashboard list/card items

### DIFF
--- a/public/app/plugins/panel/dashlist/DashListItem.tsx
+++ b/public/app/plugins/panel/dashlist/DashListItem.tsx
@@ -1,5 +1,5 @@
 import { reportInteraction } from '@grafana/runtime';
-import { Box, Card, Icon, Link, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Card, Icon, Link, Stack, Text, useStyles2 } from '@grafana/ui';
 import { LocationInfo } from 'app/features/search/service/types';
 import { StarToolbarButton } from 'app/features/stars/StarToolbarButton';
 
@@ -59,43 +59,42 @@ export function DashListItem({
         </div>
       ) : (
         <Card noMargin className={css.dashlistCardContainer}>
-          <div className={css.dashlistCard}>
-            <Stack justifyContent="space-between" alignItems="start">
-              <Link
-                className={css.dashlistCardLink}
-                href={url}
-                aria-label={dashboard.name}
-                title={dashboard.name}
-                onClick={onCardLinkClick}
-              >
-                {dashboard.name}
-              </Link>
-              <StarToolbarButton
-                title={dashboard.name}
-                group="dashboard.grafana.app"
-                kind="Dashboard"
-                id={dashboard.uid}
-                onStarChange={onStarChange}
-              />
-            </Stack>
+          <Stack justifyContent="space-between" alignItems="start">
+            <Link
+              className={css.dashlistCard}
+              href={url}
+              aria-label={dashboard.name}
+              title={dashboard.name}
+              onClick={onCardLinkClick}
+            >
+              <div className={css.dashlistCardLink}>{dashboard.name}</div>
 
-            {showFolderNames && locationInfo && (
-              <Stack alignItems="start" direction="row" gap={0.5}>
-                <Icon name="folder" size="sm" className={css.dashlistCardIcon} aria-hidden="true" />
-                <div className={css.dashlistCardFolder}>
-                  <Text
-                    color="secondary"
-                    variant="bodySmall"
-                    element="p"
-                    aria-label={locationInfo?.name}
-                    title={locationInfo?.name}
-                  >
-                    {locationInfo?.name}
-                  </Text>
-                </div>
-              </Stack>
-            )}
-          </div>
+              {showFolderNames && locationInfo && (
+                <Stack alignItems="start" direction="row" gap={0.5}>
+                  <Icon name="folder" size="sm" className={css.dashlistCardIcon} aria-hidden="true" />
+                  <div className={css.dashlistCardFolder}>
+                    <Text
+                      color="secondary"
+                      variant="bodySmall"
+                      element="p"
+                      aria-label={locationInfo?.name}
+                      title={locationInfo?.name}
+                    >
+                      {locationInfo?.name}
+                    </Text>
+                  </div>
+                </Stack>
+              )}
+            </Link>
+
+            <StarToolbarButton
+              title={dashboard.name}
+              group="dashboard.grafana.app"
+              kind="Dashboard"
+              id={dashboard.uid}
+              onStarChange={onStarChange}
+            />
+          </Stack>
         </Card>
       )}
     </>

--- a/public/app/plugins/panel/dashlist/DashListItem.tsx
+++ b/public/app/plugins/panel/dashlist/DashListItem.tsx
@@ -41,14 +41,14 @@ export function DashListItem({
     <>
       {layoutMode === 'list' ? (
         <div className={css.dashlistLink}>
-          <Box flex={1}>
-            <Link href={url}>{dashboard.name}</Link>
+          <Link href={url}>
+            <Text element="p">{dashboard.name}</Text>
             {showFolderNames && locationInfo && (
               <Text color="secondary" variant="bodySmall" element="p">
                 {locationInfo?.name}
               </Text>
             )}
-          </Box>
+          </Link>
           <StarToolbarButton
             title={dashboard.name}
             group="dashboard.grafana.app"

--- a/public/app/plugins/panel/dashlist/styles.ts
+++ b/public/app/plugins/panel/dashlist/styles.ts
@@ -33,8 +33,8 @@ export const getStyles = (theme: GrafanaTheme2) => {
     dashlistCardContainer: css({
       display: 'block',
       height: '100%',
-      paddingBottom: theme.spacing(0.5),
-      '&:hover': {
+
+      '&:has(a:hover)': {
         backgroundImage: gradient,
         color: theme.colors.text.primary,
       },
@@ -44,12 +44,17 @@ export const getStyles = (theme: GrafanaTheme2) => {
       gridTemplateRows: '1fr 1fr',
       gap: theme.spacing(2),
       flexDirection: 'column',
-      '&:hover a': {
-        color: theme.colors.text.link,
-        textDecoration: 'underline',
-      },
       height: '100%',
       width: '100%',
+
+      '&:hover': {
+        '> div': {
+          '&:first-child': {
+            color: theme.colors.text.link,
+            textDecoration: 'underline',
+          },
+        },
+      },
     }),
     dashlistCardIcon: css({
       marginRight: theme.spacing(0.25),

--- a/public/app/plugins/panel/dashlist/styles.ts
+++ b/public/app/plugins/panel/dashlist/styles.ts
@@ -12,16 +12,21 @@ export const getStyles = (theme: GrafanaTheme2) => {
   return {
     dashlistLink: css({
       display: 'flex',
-      cursor: 'pointer',
       borderBottom: `1px solid ${theme.colors.border.weak}`,
       margin: theme.spacing(1),
       padding: theme.spacing(1),
       alignItems: 'center',
 
-      '&:hover': {
-        a: {
-          color: theme.colors.text.link,
-          textDecoration: 'underline',
+      a: {
+        flex: 1,
+
+        '&:hover': {
+          '> p': {
+            '&:first-child': {
+              color: theme.colors.text.link,
+              textDecoration: 'underline',
+            },
+          },
         },
       },
     }),


### PR DESCRIPTION
**What is this feature?**

This changes the `DashListItem` component to have a larger `a` click target, while also ensuring the hover styling only provides visual feedback when the user is actually hovering on the click target.

| Before | After |
|-|-|
| <img width="1905" height="437" alt="image" src="https://github.com/user-attachments/assets/d65e63e7-472c-4219-bb68-2b822529abd8" /> | <img width="1905" height="437" alt="image" src="https://github.com/user-attachments/assets/72e496c7-bf5b-4f71-9dcf-a7ef182e8238" /> |
| <img width="1905" height="437" alt="image" src="https://github.com/user-attachments/assets/67bc742d-c8d0-4774-8e22-39c6275e6c2f" /> | <img width="1905" height="437" alt="image" src="https://github.com/user-attachments/assets/d5aaa624-2a32-4204-a4f3-30c69aca7923" /> |

**Why do we need this feature?**

`DashListItem` applied hover styling to the outer container, while the actual `a` click target was a much smaller portion of the component, leading to visual feedback that the user could click when they couldn't. As an example, you could hover over the folder name in both views, which would show styling for the component as if you were hovering over the link, but clicking did nothing -- this now works with this PR.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes #115929

Fixes #114289

Closes #116257

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
