### PR TITLE
Alerting: Add alert broadcasting for HA single-node evaluation

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -313,7 +313,8 @@ func (ng *AlertNG) init() error {
 	clk := clock.New()
 
 	alertsRouter := sender.NewAlertsRouter(ng.MultiOrgAlertmanager, ng.store, clk, appUrl, ng.Cfg.UnifiedAlerting.DisabledOrgs,
-		ng.Cfg.UnifiedAlerting.AdminConfigPollInterval, ng.DataSourceService, ng.SecretsService, ng.FeatureToggles)
+		ng.Cfg.UnifiedAlerting.AdminConfigPollInterval, ng.DataSourceService, ng.SecretsService, ng.FeatureToggles,
+		ng.Cfg.UnifiedAlerting.HASingleNodeEvaluation)
 
 	// Make sure we sync at least once as Grafana starts to get the router up and running before we start sending any alerts.
 	if err := alertsRouter.SyncAndApplyConfigFromDatabase(initCtx); err != nil {

--- a/pkg/services/ngalert/notifier/alert_broadcast.go
+++ b/pkg/services/ngalert/notifier/alert_broadcast.go
@@ -1,0 +1,65 @@
+package notifier
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+)
+
+const alertBroadcastKey = "alerts:broadcast"
+
+type AlertBroadcastPayload struct {
+	OrgID  int64                    `json:"orgId"`
+	Alerts apimodels.PostableAlerts `json:"alerts"`
+}
+
+type alertBroadcast struct {
+	logger log.Logger
+	moa    *MultiOrgAlertmanager
+}
+
+func newAlertBroadcastState(logger log.Logger, moa *MultiOrgAlertmanager) *alertBroadcast {
+	return &alertBroadcast{
+		logger: logger,
+		moa:    moa,
+	}
+}
+
+func (s *alertBroadcast) MarshalBinary() ([]byte, error) {
+	return nil, nil
+}
+
+func (s *alertBroadcast) Merge(b []byte) error {
+	if len(b) == 0 {
+		return nil
+	}
+
+	var payload AlertBroadcastPayload
+	if err := json.Unmarshal(b, &payload); err != nil {
+		s.logger.Warn("Failed to decode broadcast alerts payload", "error", err)
+		return nil
+	}
+	if len(payload.Alerts.PostableAlerts) == 0 {
+		return nil
+	}
+
+	am, err := s.moa.AlertmanagerFor(payload.OrgID)
+	if err != nil {
+		if errors.Is(err, ErrNoAlertmanagerForOrg) || errors.Is(err, ErrAlertmanagerNotReady) {
+			s.logger.Debug("Skipping receiving of broadcasted alerts, alertmanager unavailable", "orgID", payload.OrgID, "error", err)
+			return nil
+		}
+		s.logger.Warn("Failed to resolve alertmanager for broadcast alerts", "orgID", payload.OrgID, "error", err)
+		return nil
+	}
+
+	if err := am.PutAlerts(context.Background(), payload.Alerts); err != nil {
+		s.logger.Warn("Failed to accept received broadcast alerts", "orgID", payload.OrgID, "alerts", len(payload.Alerts.PostableAlerts), "error", err)
+	} else {
+		s.logger.Debug("Received broadcast alerts from peer", "orgID", payload.OrgID, "alerts", len(payload.Alerts.PostableAlerts))
+	}
+	return nil
+}

--- a/pkg/services/ngalert/notifier/alert_broadcast_test.go
+++ b/pkg/services/ngalert/notifier/alert_broadcast_test.go
@@ -1,0 +1,329 @@
+package notifier
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	amv2 "github.com/prometheus/alertmanager/api/v2/models"
+
+	alertingNotify "github.com/grafana/alerting/notify"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/alertmanager_mock"
+)
+
+func TestBroadcastAlerts(t *testing.T) {
+	testCases := []struct {
+		name          string
+		orgID         int64
+		alerts        apimodels.PostableAlerts
+		channelExists bool
+		expected      *AlertBroadcastPayload
+	}{
+		{
+			name:  "broadcasts alerts when channel exists",
+			orgID: 1,
+			alerts: apimodels.PostableAlerts{
+				PostableAlerts: []amv2.PostableAlert{
+					{Annotations: amv2.LabelSet{"summary": "test alert"}},
+				},
+			},
+			channelExists: true,
+			expected: &AlertBroadcastPayload{
+				OrgID: 1,
+				Alerts: apimodels.PostableAlerts{
+					PostableAlerts: []amv2.PostableAlert{
+						{Annotations: amv2.LabelSet{"summary": "test alert"}},
+					},
+				},
+			},
+		},
+		{
+			name:  "does not broadcast when channel is nil",
+			orgID: 1,
+			alerts: apimodels.PostableAlerts{
+				PostableAlerts: []amv2.PostableAlert{
+					{Annotations: amv2.LabelSet{"summary": "test alert"}},
+				},
+			},
+			channelExists: false,
+			expected:      nil,
+		},
+		{
+			name:          "does not broadcast empty alerts",
+			orgID:         1,
+			alerts:        apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{}},
+			channelExists: true,
+			expected:      nil,
+		},
+		{
+			name:          "does not broadcast nil alerts",
+			orgID:         1,
+			alerts:        apimodels.PostableAlerts{},
+			channelExists: true,
+			expected:      nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockChannel := &MockBroadcastChannel{}
+
+			moa := &MultiOrgAlertmanager{
+				logger: log.NewNopLogger(),
+			}
+
+			if tc.channelExists {
+				moa.alertsBroadcastChannel = mockChannel
+			}
+
+			moa.BroadcastAlerts(tc.orgID, tc.alerts)
+
+			if tc.expected == nil {
+				require.Empty(t, mockChannel.Broadcasts())
+			} else {
+				require.Len(t, mockChannel.Broadcasts(), 1)
+				var decoded AlertBroadcastPayload
+				err := json.Unmarshal(mockChannel.Broadcasts()[0], &decoded)
+				require.NoError(t, err)
+				require.Equal(t, *tc.expected, decoded)
+			}
+		})
+	}
+}
+
+func TestAlertBroadcast_MarshalBinary(t *testing.T) {
+	state := newAlertBroadcastState(log.NewNopLogger(), nil)
+
+	data, err := state.MarshalBinary()
+
+	require.NoError(t, err)
+	require.Nil(t, data, "MarshalBinary should return nil for alert broadcast state (no full state sync)")
+}
+
+func TestAlertBroadcast_Merge(t *testing.T) {
+	t.Run("empty payload returns nil", func(t *testing.T) {
+		moa := &MultiOrgAlertmanager{
+			logger:        log.NewNopLogger(),
+			alertmanagers: make(map[int64]Alertmanager),
+		}
+		state := newAlertBroadcastState(log.NewNopLogger(), moa)
+
+		err := state.Merge([]byte{})
+		require.NoError(t, err)
+	})
+
+	t.Run("nil payload returns nil", func(t *testing.T) {
+		moa := &MultiOrgAlertmanager{
+			logger:        log.NewNopLogger(),
+			alertmanagers: make(map[int64]Alertmanager),
+		}
+		state := newAlertBroadcastState(log.NewNopLogger(), moa)
+
+		err := state.Merge(nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid JSON returns nil", func(t *testing.T) {
+		moa := &MultiOrgAlertmanager{
+			logger:        log.NewNopLogger(),
+			alertmanagers: make(map[int64]Alertmanager),
+		}
+		state := newAlertBroadcastState(log.NewNopLogger(), moa)
+
+		err := state.Merge([]byte("not valid json"))
+		require.NoError(t, err)
+	})
+
+	t.Run("empty alerts in payload returns nil", func(t *testing.T) {
+		moa := &MultiOrgAlertmanager{
+			logger:        log.NewNopLogger(),
+			alertmanagers: make(map[int64]Alertmanager),
+		}
+		state := newAlertBroadcastState(log.NewNopLogger(), moa)
+
+		payload, err := json.Marshal(AlertBroadcastPayload{
+			OrgID:  1,
+			Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{}},
+		})
+		require.NoError(t, err)
+
+		err = state.Merge(payload)
+		require.NoError(t, err)
+	})
+
+	t.Run("delivers alerts to alertmanager", func(t *testing.T) {
+		mockAM := alertmanager_mock.NewAlertmanagerMock(t)
+		mockAM.On("Ready").Return(true)
+		mockAM.On("PutAlerts", mock.Anything, mock.MatchedBy(func(alerts apimodels.PostableAlerts) bool {
+			if len(alerts.PostableAlerts) != 3 {
+				return false
+			}
+			expected := []string{"alert 1", "alert 2", "alert 3"}
+			for i, alert := range alerts.PostableAlerts {
+				if alert.Annotations["summary"] != expected[i] {
+					return false
+				}
+			}
+			return true
+		})).Return(nil)
+
+		moa := &MultiOrgAlertmanager{
+			logger:        log.NewNopLogger(),
+			alertmanagers: map[int64]Alertmanager{1: mockAM},
+		}
+		state := newAlertBroadcastState(log.NewNopLogger(), moa)
+
+		payload, err := json.Marshal(AlertBroadcastPayload{
+			OrgID: 1,
+			Alerts: apimodels.PostableAlerts{
+				PostableAlerts: []amv2.PostableAlert{
+					{Annotations: amv2.LabelSet{"summary": "alert 1"}},
+					{Annotations: amv2.LabelSet{"summary": "alert 2"}},
+					{Annotations: amv2.LabelSet{"summary": "alert 3"}},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		err = state.Merge(payload)
+		require.NoError(t, err)
+		mockAM.AssertExpectations(t)
+	})
+
+	t.Run("skips when alertmanager not found", func(t *testing.T) {
+		moa := &MultiOrgAlertmanager{
+			logger:        log.NewNopLogger(),
+			alertmanagers: make(map[int64]Alertmanager),
+		}
+		state := newAlertBroadcastState(log.NewNopLogger(), moa)
+
+		payload, err := json.Marshal(AlertBroadcastPayload{
+			OrgID: 999,
+			Alerts: apimodels.PostableAlerts{
+				PostableAlerts: []amv2.PostableAlert{
+					{Annotations: amv2.LabelSet{"summary": "test"}},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		err = state.Merge(payload)
+		require.NoError(t, err)
+	})
+
+	t.Run("skips when alertmanager not ready", func(t *testing.T) {
+		mockAM := alertmanager_mock.NewAlertmanagerMock(t)
+		mockAM.On("Ready").Return(false)
+
+		moa := &MultiOrgAlertmanager{
+			logger:        log.NewNopLogger(),
+			alertmanagers: map[int64]Alertmanager{1: mockAM},
+		}
+		state := newAlertBroadcastState(log.NewNopLogger(), moa)
+
+		payload, err := json.Marshal(AlertBroadcastPayload{
+			OrgID: 1,
+			Alerts: apimodels.PostableAlerts{
+				PostableAlerts: []amv2.PostableAlert{
+					{Annotations: amv2.LabelSet{"summary": "test"}},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		err = state.Merge(payload)
+		require.NoError(t, err)
+		mockAM.AssertNotCalled(t, "PutAlerts", mock.Anything, mock.Anything)
+	})
+
+	t.Run("does not return error when PutAlerts fails", func(t *testing.T) {
+		mockAM := alertmanager_mock.NewAlertmanagerMock(t)
+		mockAM.On("Ready").Return(true)
+		mockAM.On("PutAlerts", mock.Anything, mock.Anything).Return(errors.New("test error"))
+
+		moa := &MultiOrgAlertmanager{
+			logger:        log.NewNopLogger(),
+			alertmanagers: map[int64]Alertmanager{1: mockAM},
+		}
+		state := newAlertBroadcastState(log.NewNopLogger(), moa)
+
+		payload, err := json.Marshal(AlertBroadcastPayload{
+			OrgID: 1,
+			Alerts: apimodels.PostableAlerts{
+				PostableAlerts: []amv2.PostableAlert{
+					{Annotations: amv2.LabelSet{"summary": "test"}},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		err = state.Merge(payload)
+		require.NoError(t, err)
+		mockAM.AssertExpectations(t)
+	})
+}
+
+func TestInitAlertBroadcast(t *testing.T) {
+	testCases := []struct {
+		name          string
+		setupPeer     func() (alertingNotify.ClusterPeer, *MockBroadcastChannel)
+		expectChannel bool
+		needsMetrics  bool
+	}{
+		{
+			name: "does not initialize when peer is nil",
+			setupPeer: func() (alertingNotify.ClusterPeer, *MockBroadcastChannel) {
+				return nil, nil
+			},
+			expectChannel: false,
+		},
+		{
+			name: "does not initialize when peer is NilPeer",
+			setupPeer: func() (alertingNotify.ClusterPeer, *MockBroadcastChannel) {
+				return &NilPeer{}, nil
+			},
+			expectChannel: false,
+		},
+		{
+			name: "initializes when peer is not NilPeer",
+			setupPeer: func() (alertingNotify.ClusterPeer, *MockBroadcastChannel) {
+				ch := &MockBroadcastChannel{}
+				return &MockClusterPeer{Channel: ch}, ch
+			},
+			expectChannel: true,
+			needsMetrics:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			peer, expectedChannel := tc.setupPeer()
+			moa := &MultiOrgAlertmanager{
+				logger: log.NewNopLogger(),
+				peer:   peer,
+			}
+			if tc.needsMetrics {
+				reg := prometheus.NewRegistry()
+				m := metrics.NewNGAlert(reg)
+				moa.metrics = m.GetMultiOrgAlertmanagerMetrics()
+			}
+
+			moa.initAlertBroadcast()
+
+			if tc.expectChannel {
+				require.NotNil(t, moa.alertsBroadcastChannel)
+				require.Equal(t, expectedChannel, moa.alertsBroadcastChannel)
+			} else {
+				require.Nil(t, moa.alertsBroadcastChannel)
+			}
+		})
+	}
+}

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -2,6 +2,7 @@ package notifier
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -104,8 +105,9 @@ type MultiOrgAlertmanager struct {
 	logger         log.Logger
 
 	// clusterPeer represents the clustering peers of Alertmanagers between Grafana instances.
-	peer         alertingNotify.ClusterPeer
-	settleCancel context.CancelFunc
+	peer                   alertingNotify.ClusterPeer
+	alertsBroadcastChannel alertingCluster.ClusterChannel
+	settleCancel           context.CancelFunc
 
 	configStore AlertingStore
 	orgStore    store.OrgStore
@@ -167,6 +169,8 @@ func NewMultiOrgAlertmanager(
 	if err := moa.setupClustering(cfg); err != nil {
 		return nil, err
 	}
+
+	moa.initAlertBroadcast()
 
 	// Set up the default per tenant Alertmanager factory.
 	moa.factory = func(ctx context.Context, orgID int64) (Alertmanager, error) {
@@ -250,6 +254,42 @@ func (moa *MultiOrgAlertmanager) setupClustering(cfg *setting.Cfg) error {
 		return nil
 	}
 	return nil
+}
+
+// initAlertBroadcast initializes the alert broadcast channel for HA mode.
+// When enabled, alerts evaluated on the primary instance are broadcast to all peers.
+func (moa *MultiOrgAlertmanager) initAlertBroadcast() {
+	if moa.peer == nil {
+		return
+	}
+	if _, ok := moa.peer.(*NilPeer); ok {
+		return
+	}
+	state := newAlertBroadcastState(moa.logger.New("component", "alert-broadcast"), moa)
+	moa.alertsBroadcastChannel = moa.peer.AddState(alertBroadcastKey, state, moa.metrics.Registerer)
+}
+
+// BroadcastAlerts sends alerts to all peers via the cluster channel.
+// This is used in HA single-node evaluation mode to propagate alerts from the
+// primary evaluator to all other instances.
+func (moa *MultiOrgAlertmanager) BroadcastAlerts(orgID int64, alerts apimodels.PostableAlerts) {
+	if moa.alertsBroadcastChannel == nil {
+		return
+	}
+	if len(alerts.PostableAlerts) == 0 {
+		return
+	}
+	payload := AlertBroadcastPayload{
+		OrgID:  orgID,
+		Alerts: alerts,
+	}
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		moa.logger.Warn("Failed to encode broadcast alerts payload", "error", err)
+		return
+	}
+	moa.alertsBroadcastChannel.Broadcast(buf)
+	moa.logger.Debug("Broadcast alerts to peers", "orgID", orgID, "alerts", len(alerts.PostableAlerts))
 }
 
 func (moa *MultiOrgAlertmanager) Run(ctx context.Context) error {

--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -18,6 +18,9 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
+	alertingCluster "github.com/grafana/alerting/cluster"
+	alertingImages "github.com/grafana/alerting/images"
+	alertingNotify "github.com/grafana/alerting/notify"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -28,8 +31,6 @@ import (
 	fake_secrets "github.com/grafana/grafana/pkg/services/secrets/fakes"
 	secretsManager "github.com/grafana/grafana/pkg/services/secrets/manager"
 	"github.com/grafana/grafana/pkg/setting"
-
-	alertingImages "github.com/grafana/alerting/images"
 )
 
 type fakeConfigStore struct {
@@ -461,11 +462,54 @@ func (f *fakeAlertRuleNotificationStore) ListNotificationSettings(ctx context.Co
 	return nil, nil
 }
 
+// MockBroadcastChannel captures broadcast messages for testing.
+type MockBroadcastChannel struct {
+	broadcasts [][]byte
+}
+
+func withPeer(peer alertingNotify.ClusterPeer) Option {
+	return func(moa *MultiOrgAlertmanager) {
+		moa.peer = peer
+		moa.initAlertBroadcast()
+	}
+}
+
+// Broadcast implements alertingCluster.ClusterChannel.
+func (m *MockBroadcastChannel) Broadcast(b []byte) {
+	m.broadcasts = append(m.broadcasts, b)
+}
+
+// Broadcasts returns all captured broadcast messages.
+func (m *MockBroadcastChannel) Broadcasts() [][]byte {
+	return m.broadcasts
+}
+
+// MockClusterPeer implements alertingNotify.ClusterPeer for testing.
+type MockClusterPeer struct {
+	Channel *MockBroadcastChannel
+}
+
+// Position implements alertingNotify.ClusterPeer.
+func (m *MockClusterPeer) Position() int {
+	return 0
+}
+
+// WaitReady implements alertingNotify.ClusterPeer.
+func (m *MockClusterPeer) WaitReady(context.Context) error {
+	return nil
+}
+
+// AddState implements alertingNotify.ClusterPeer.
+func (m *MockClusterPeer) AddState(_ string, _ alertingCluster.State, _ prometheus.Registerer) alertingCluster.ClusterChannel {
+	return m.Channel
+}
+
 type TestMultiOrgAlertmanagerOptions struct {
 	orgs           []int64
 	configs        map[int64]*models.AlertConfiguration
 	disabledOrgs   map[int64]struct{}
 	featureToggles featuremgmt.FeatureToggles
+	peer           alertingNotify.ClusterPeer
 	waitReady      bool
 }
 
@@ -492,6 +536,12 @@ func WithDisabledOrgs(disabledOrgs map[int64]struct{}) TestMultiOrgAlertmanagerO
 func WithFeatureToggles(ft featuremgmt.FeatureToggles) TestMultiOrgAlertmanagerOption {
 	return func(opts *TestMultiOrgAlertmanagerOptions) {
 		opts.featureToggles = ft
+	}
+}
+
+func WithPeer(peer alertingNotify.ClusterPeer) TestMultiOrgAlertmanagerOption {
+	return func(opts *TestMultiOrgAlertmanagerOptions) {
+		opts.peer = peer
 	}
 }
 
@@ -533,6 +583,11 @@ func NewTestMultiOrgAlertmanager(t *testing.T, opts ...TestMultiOrgAlertmanagerO
 		},
 	}
 
+	var moaOpts []Option
+	if options.peer != nil {
+		moaOpts = append(moaOpts, withPeer(options.peer))
+	}
+
 	moa, err := NewMultiOrgAlertmanager(
 		cfg,
 		cfgStore,
@@ -547,6 +602,7 @@ func NewTestMultiOrgAlertmanager(t *testing.T, opts ...TestMultiOrgAlertmanagerO
 		secretsService,
 		options.featureToggles,
 		nil,
+		moaOpts...,
 	)
 	require.NoError(t, err)
 	require.NoError(t, moa.LoadAndSyncAlertmanagersForOrgs(context.Background()))


### PR DESCRIPTION
**What is this feature?**

Broadcast alerts to all peers in cluster when HA single-node evaluation mode is enabled. 

**Why do we need this feature?**

Part of https://github.com/grafana/grafana/issues/116545

When running Grafana in HA mode with single-node evaluation (`[unified_alerting] ha_single_node_evaluation = true`), only the primary instance (position 0) evaluates alert rules. This PR ensures that evaluated alerts are broadcast to all peer instances via the memberlist cluster channel, so every instance's local Alertmanager can process and send notifications and serve the APIs that require alert state to be in Alertmanagers memory.

**Special notes for your reviewer:**

* There are no metrics yet for the broadcast (sent, received, errors)
* The channel queue size is hardcoded to 200, I'll check separately if we need to make it configurable or can leave as is for now.
* When Memberlist is configured with Gossip by default UDP is used for small messages (< 700 bytes). Alerts are mostly larger than that, but I'll check how we can force TCP: [draft PR](https://github.com/grafana/prometheus-alertmanager/pull/144).
* Unlike gossip, Redis-based pub/sub delivers messages to the originating instance too. I will work on that separately.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
