### PR TITLE
Loki: LogsTable fix - ad hoc filters getting added as wrong type on sparse fields

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -823,7 +823,7 @@ export class LokiDatasource
    */
   toggleQueryFilter(query: LokiQuery, filter: ToggleFilterAction): LokiQuery {
     let expression = query.expr ?? '';
-    const labelType = getLabelTypeFromFrame(filter.options.key, filter.frame, 0);
+    const labelType = getLabelTypeFromFrame(filter.options.key, filter.frame, null);
     switch (filter.type) {
       case 'FILTER_FOR': {
         if (filter.options?.key && filter.options?.value) {
@@ -881,7 +881,7 @@ export class LokiDatasource
     switch (action.type) {
       case 'ADD_FILTER': {
         if (action.options?.key && action.options?.value) {
-          const labelType = getLabelTypeFromFrame(action.options.key, action.frame, 0);
+          const labelType = getLabelTypeFromFrame(action.options.key, action.frame, null);
           const value = escapeLabelValueInSelector(action.options.value);
           expression = addLabelToQuery(expression, action.options.key, '=', value, labelType);
         }
@@ -889,7 +889,7 @@ export class LokiDatasource
       }
       case 'ADD_FILTER_OUT': {
         if (action.options?.key && action.options?.value) {
-          const labelType = getLabelTypeFromFrame(action.options.key, action.frame, 0);
+          const labelType = getLabelTypeFromFrame(action.options.key, action.frame, null);
           const value = escapeLabelValueInSelector(action.options.value);
           expression = addLabelToQuery(expression, action.options.key, '!=', value, labelType);
         }

--- a/public/app/plugins/datasource/loki/languageUtils.test.ts
+++ b/public/app/plugins/datasource/loki/languageUtils.test.ts
@@ -56,40 +56,67 @@ describe('unescapeLabelValueInExactSelector', () => {
 describe('getLabelTypeFromFrame', () => {
   const frameWithTypes = toDataFrame({
     fields: [
-      { name: 'Time', type: FieldType.time, values: [0] },
+      { name: 'Time', type: FieldType.time, values: [0, 1] },
       {
         name: 'Line',
         type: FieldType.string,
-        values: ['line1'],
+        values: ['line1', 'line2'],
       },
-      { name: 'labelTypes', type: FieldType.other, values: [{ indexed: 'I', parsed: 'P', structured: 'S' }] },
+      {
+        name: 'labelTypes',
+        type: FieldType.other,
+        values: [
+          { indexed: 'I', parsed: 'P', structured: 'S' },
+          {
+            /* Empty, the second value has no label types */
+          },
+        ],
+      },
     ],
   });
   const frameWithoutTypes = toDataFrame({
     fields: [
-      { name: 'Time', type: FieldType.time, values: [0] },
+      { name: 'Time', type: FieldType.time, values: [0, 1] },
       {
         name: 'Line',
         type: FieldType.string,
-        values: ['line1'],
+        values: ['line1', 'line2'],
       },
       { name: 'labels', type: FieldType.other, values: [{ job: 'test' }] },
     ],
   });
-  it('returns structuredMetadata', () => {
+  it('returns structuredMetadata if given correct index', () => {
     expect(getLabelTypeFromFrame('structured', frameWithTypes, 0)).toBe(LabelType.StructuredMetadata);
+  });
+  it('returns null if given index to value without label', () => {
+    expect(getLabelTypeFromFrame('structured', frameWithTypes, 1)).toBe(null);
+  });
+  it('returns structuredMetadata if index arg is null, searches through all labels to find a match', () => {
+    expect(getLabelTypeFromFrame('structured', frameWithTypes, null)).toBe(LabelType.StructuredMetadata);
   });
   it('returns indexed', () => {
     expect(getLabelTypeFromFrame('indexed', frameWithTypes, 0)).toBe(LabelType.Indexed);
   });
+  it('returns indexed if null', () => {
+    expect(getLabelTypeFromFrame('indexed', frameWithTypes, null)).toBe(LabelType.Indexed);
+  });
   it('returns parsed', () => {
     expect(getLabelTypeFromFrame('parsed', frameWithTypes, 0)).toBe(LabelType.Parsed);
+  });
+  it('returns parsed if null', () => {
+    expect(getLabelTypeFromFrame('parsed', frameWithTypes, null)).toBe(LabelType.Parsed);
   });
   it('returns null for unknown field', () => {
     expect(getLabelTypeFromFrame('unknown', frameWithTypes, 0)).toBe(null);
   });
-  it('returns null for frame without types', () => {
+  it('returns null for unknown field and unknown index', () => {
+    expect(getLabelTypeFromFrame('unknown', frameWithTypes, null)).toBe(null);
+  });
+  it('returns null for frame value without types', () => {
     expect(getLabelTypeFromFrame('job', frameWithoutTypes, 0)).toBe(null);
+  });
+  it('returns null for frame without types', () => {
+    expect(getLabelTypeFromFrame('job', frameWithoutTypes, null)).toBe(null);
   });
 });
 

--- a/public/app/plugins/datasource/loki/languageUtils.ts
+++ b/public/app/plugins/datasource/loki/languageUtils.ts
@@ -93,16 +93,36 @@ export function isBytesString(string: string) {
   return !!match;
 }
 
-export function getLabelTypeFromFrame(labelKey: string, frame?: DataFrame, index?: number): null | LabelType {
-  if (!frame || index === undefined) {
+/**
+ * Gets the label type from the data frame if present
+ * @param labelKey
+ * @param frame
+ * @param index - if null, will check every value in the data frame for a match.
+ */
+export function getLabelTypeFromFrame(
+  labelKey: string,
+  frame: DataFrame | undefined,
+  index: number | null
+): null | LabelType {
+  if (!frame) {
     return null;
   }
 
-  const typeField = frame.fields.find((field) => field.name === 'labelTypes')?.values[index];
+  const typeField = frame.fields.find((field) => field.name === 'labelTypes');
+
   if (!typeField) {
     return null;
   }
-  switch (typeField[labelKey]) {
+
+  if (index === null) {
+    index = typeField.values.findIndex((typeFieldValue) => typeFieldValue[labelKey]);
+  }
+
+  const valueTypes = typeField?.values[index];
+  if (!typeField) {
+    return null;
+  }
+  switch (valueTypes?.[labelKey]) {
     case 'I':
       return LabelType.Indexed;
     case 'S':

--- a/public/app/plugins/datasource/loki/languageUtils.ts
+++ b/public/app/plugins/datasource/loki/languageUtils.ts
@@ -119,9 +119,6 @@ export function getLabelTypeFromFrame(
   }
 
   const valueTypes = typeField?.values[index];
-  if (!typeField) {
-    return null;
-  }
   switch (valueTypes?.[labelKey]) {
     case 'I':
       return LabelType.Indexed;


### PR DESCRIPTION
**What is this feature?**
Fixes unexpected behavior in ad-hoc filters in table in Explore which cause fields to get added as the wrong type.

**Why do we need this feature?**
To stop breaking queries when adding ad hoc filters on a sparse field.

**Who is this feature for?**
Loki users of the Table in Explore.

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/116564

**Special notes for your reviewer:**
Ideally the `ToggleFilterAction` would contain the data frame value index so we don't need to iterate through the entire frame to find a value, but I only updated the instances of this method that are called on ad-hoc action, so any performance impact should be negligible.
This _shouldn't_ cause problems in explore since the table requires picking a single data frame and there isn't the ability to merge/transform frames by the user, but it's theoretically possible that a data frame defines multiple types for a single field and us grabbing the first label type for a particular label results in the wrong one getting grabbed, but since that still wouldn't work in the prior implementation either I think this PR is safe for merge as this PR will only decrease the likelihood of getting an invalid label type.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
