### PR TITLE
Alerting: Add inhibition rules alert

### DIFF
--- a/public/app/features/alerting/unified/AlertGroups.tsx
+++ b/public/app/features/alerting/unified/AlertGroups.tsx
@@ -9,6 +9,7 @@ import { AlertmanagerChoice } from '../../../plugins/datasource/alertmanager/typ
 
 import { alertmanagerApi } from './api/alertmanagerApi';
 import { AlertmanagerPageWrapper } from './components/AlertingPageWrapper';
+import { InhibitionRulesAlert } from './components/InhibitionRulesAlert';
 import { AlertGroup } from './components/alert-groups/AlertGroup';
 import { AlertGroupFilter } from './components/alert-groups/AlertGroupFilter';
 import { useFilteredAmGroups } from './hooks/useFilteredAmGroups';
@@ -81,6 +82,8 @@ const AlertGroups = () => {
           </Trans>
         </Alert>
       )}
+
+      {selectedAlertmanager && <InhibitionRulesAlert alertmanagerSourceName={selectedAlertmanager} />}
 
       {results &&
         filteredAlertGroups.map((group, index) => {

--- a/public/app/features/alerting/unified/NotificationPoliciesPage.tsx
+++ b/public/app/features/alerting/unified/NotificationPoliciesPage.tsx
@@ -11,6 +11,7 @@ import { AlertmanagerAction, useAlertmanagerAbility } from 'app/features/alertin
 
 import { AlertmanagerPageWrapper } from './components/AlertingPageWrapper';
 import { GrafanaAlertmanagerWarning } from './components/GrafanaAlertmanagerWarning';
+import { InhibitionRulesAlert } from './components/InhibitionRulesAlert';
 import { TimeIntervalsTable } from './components/mute-timings/MuteTimingsTable';
 import { useAlertmanager } from './state/AlertmanagerContext';
 import { withPageErrorBoundary } from './withPageErrorBoundary';
@@ -49,6 +50,7 @@ const NotificationPoliciesTabs = () => {
   return (
     <>
       <GrafanaAlertmanagerWarning currentAlertmanager={selectedAlertmanager} />
+      <InhibitionRulesAlert alertmanagerSourceName={selectedAlertmanager} />
       <TabsBar>
         {policiesSupported && canSeePoliciesTab && (
           <Tab

--- a/public/app/features/alerting/unified/components/InhibitionRulesAlert.test.tsx
+++ b/public/app/features/alerting/unified/components/InhibitionRulesAlert.test.tsx
@@ -2,6 +2,7 @@ import { produce } from 'immer';
 import { render, screen, waitFor } from 'test/test-utils';
 
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
+import { makeAllAlertmanagerConfigFetchFail } from 'app/features/alerting/unified/mocks/server/configure';
 import {
   getAlertmanagerConfig,
   setAlertmanagerConfig,
@@ -75,6 +76,16 @@ describe('InhibitionRulesAlert', () => {
 
   it('should not render when alertmanagerSourceName is empty', async () => {
     const { container } = render(<InhibitionRulesAlert alertmanagerSourceName="" />);
+
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  it('should not render when fetching config fails', async () => {
+    makeAllAlertmanagerConfigFetchFail();
+
+    const { container } = render(<InhibitionRulesAlert alertmanagerSourceName={GRAFANA_RULES_SOURCE_NAME} />);
 
     await waitFor(() => {
       expect(container).toBeEmptyDOMElement();

--- a/public/app/features/alerting/unified/components/InhibitionRulesAlert.test.tsx
+++ b/public/app/features/alerting/unified/components/InhibitionRulesAlert.test.tsx
@@ -46,7 +46,7 @@ describe('InhibitionRulesAlert', () => {
 
     render(<InhibitionRulesAlert alertmanagerSourceName={GRAFANA_RULES_SOURCE_NAME} />);
 
-    expect(await screen.findByRole('status')).toBeInTheDocument();
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
     expect(screen.getByText('Inhibition rules are in effect')).toBeInTheDocument();
     expect(screen.getByText(/This Alertmanager has inhibition rules configured/i)).toBeInTheDocument();
   });

--- a/public/app/features/alerting/unified/components/InhibitionRulesAlert.test.tsx
+++ b/public/app/features/alerting/unified/components/InhibitionRulesAlert.test.tsx
@@ -1,0 +1,83 @@
+import { produce } from 'immer';
+import { render, screen, waitFor } from 'test/test-utils';
+
+import { setupMswServer } from 'app/features/alerting/unified/mockApi';
+import {
+  getAlertmanagerConfig,
+  setAlertmanagerConfig,
+} from 'app/features/alerting/unified/mocks/server/entities/alertmanagers';
+import { GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
+
+import { InhibitionRulesAlert } from './InhibitionRulesAlert';
+
+setupMswServer();
+
+describe('InhibitionRulesAlert', () => {
+  beforeEach(() => {
+    // Reset to a config without inhibition rules by default
+    const config = getAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);
+    const configWithoutInhibitRules = produce(config, (draft) => {
+      draft.alertmanager_config.inhibit_rules = [];
+    });
+    setAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME, configWithoutInhibitRules);
+  });
+
+  it('should not render when there are no inhibition rules', async () => {
+    const { container } = render(<InhibitionRulesAlert alertmanagerSourceName={GRAFANA_RULES_SOURCE_NAME} />);
+
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  it('should render alert when inhibition rules are configured', async () => {
+    const config = getAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);
+    const configWithInhibitRules = produce(config, (draft) => {
+      draft.alertmanager_config.inhibit_rules = [
+        {
+          source_match: { severity: 'critical' },
+          target_match: { severity: 'warning' },
+          equal: ['alertname'],
+        },
+      ];
+    });
+    setAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME, configWithInhibitRules);
+
+    render(<InhibitionRulesAlert alertmanagerSourceName={GRAFANA_RULES_SOURCE_NAME} />);
+
+    expect(await screen.findByRole('status')).toBeInTheDocument();
+    expect(screen.getByText('Inhibition rules are in effect')).toBeInTheDocument();
+    expect(screen.getByText(/This Alertmanager has inhibition rules configured/i)).toBeInTheDocument();
+  });
+
+  it('should include a link to documentation', async () => {
+    const config = getAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);
+    const configWithInhibitRules = produce(config, (draft) => {
+      draft.alertmanager_config.inhibit_rules = [
+        {
+          source_match: { severity: 'critical' },
+          target_match: { severity: 'warning' },
+          equal: ['alertname'],
+        },
+      ];
+    });
+    setAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME, configWithInhibitRules);
+
+    render(<InhibitionRulesAlert alertmanagerSourceName={GRAFANA_RULES_SOURCE_NAME} />);
+
+    const link = await screen.findByRole('link', { name: /Learn more about inhibition rules/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute(
+      'href',
+      'https://grafana.com/docs/grafana/latest/alerting/configure-notifications/create-silence/#inhibition-rules'
+    );
+  });
+
+  it('should not render when alertmanagerSourceName is empty', async () => {
+    const { container } = render(<InhibitionRulesAlert alertmanagerSourceName="" />);
+
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/public/app/features/alerting/unified/components/InhibitionRulesAlert.tsx
+++ b/public/app/features/alerting/unified/components/InhibitionRulesAlert.tsx
@@ -22,7 +22,7 @@ export function InhibitionRulesAlert({ alertmanagerSourceName, ...rest }: Inhibi
   }
 
   return (
-    <Alert title={t('alerting.inhibition-rules.title', 'Inhibition rules are in effect')} severity="info" {...rest}>
+    <Alert title={t('alerting.inhibition-rules.title', 'Inhibition rules are in effect')} severity="warning" {...rest}>
       <Trans i18nKey="alerting.inhibition-rules.body">
         This Alertmanager has inhibition rules configured. Some alerts may be suppressed when matching alerts are
         firing.

--- a/public/app/features/alerting/unified/components/InhibitionRulesAlert.tsx
+++ b/public/app/features/alerting/unified/components/InhibitionRulesAlert.tsx
@@ -5,11 +5,9 @@ import { Alert, TextLink } from '@grafana/ui';
 
 import { useHasInhibitionRules } from '../hooks/useHasInhibitionRules';
 
-// Documentation URL for inhibition rules
 const INHIBITION_RULES_DOCS_URL =
   'https://grafana.com/docs/grafana/latest/alerting/configure-notifications/create-silence/#inhibition-rules';
 
-// we'll omit the props we don't want consumers to overwrite and forward the others to the alert component
 type ExtraAlertProps = Omit<ComponentPropsWithoutRef<typeof Alert>, 'title' | 'severity'>;
 
 interface InhibitionRulesAlertProps extends ExtraAlertProps {

--- a/public/app/features/alerting/unified/components/InhibitionRulesAlert.tsx
+++ b/public/app/features/alerting/unified/components/InhibitionRulesAlert.tsx
@@ -1,0 +1,37 @@
+import { ComponentPropsWithoutRef } from 'react';
+
+import { Trans, t } from '@grafana/i18n';
+import { Alert, TextLink } from '@grafana/ui';
+
+import { useHasInhibitionRules } from '../hooks/useHasInhibitionRules';
+
+// Documentation URL for inhibition rules
+const INHIBITION_RULES_DOCS_URL =
+  'https://grafana.com/docs/grafana/latest/alerting/configure-notifications/create-silence/#inhibition-rules';
+
+// we'll omit the props we don't want consumers to overwrite and forward the others to the alert component
+type ExtraAlertProps = Omit<ComponentPropsWithoutRef<typeof Alert>, 'title' | 'severity'>;
+
+interface InhibitionRulesAlertProps extends ExtraAlertProps {
+  alertmanagerSourceName: string;
+}
+
+export function InhibitionRulesAlert({ alertmanagerSourceName, ...rest }: InhibitionRulesAlertProps) {
+  const { hasInhibitionRules, isLoading } = useHasInhibitionRules(alertmanagerSourceName);
+
+  if (isLoading || !hasInhibitionRules) {
+    return null;
+  }
+
+  return (
+    <Alert title={t('alerting.inhibition-rules.title', 'Inhibition rules are in effect')} severity="info" {...rest}>
+      <Trans i18nKey="alerting.inhibition-rules.body">
+        This Alertmanager has inhibition rules configured. Some alerts may be suppressed when matching alerts are
+        firing.
+      </Trans>{' '}
+      <TextLink href={INHIBITION_RULES_DOCS_URL} external>
+        <Trans i18nKey="alerting.inhibition-rules.learn-more">Learn more about inhibition rules</Trans>
+      </TextLink>
+    </Alert>
+  );
+}

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -43,7 +43,12 @@ import { useReturnTo } from '../../hooks/useReturnTo';
 import { PluginOriginBadge } from '../../plugins/PluginOriginBadge';
 import { normalizeHealth, normalizeState } from '../../rule-list/components/util';
 import { Annotation } from '../../utils/constants';
-import { getRulesSourceUid, ruleIdentifierToRuleSourceIdentifier } from '../../utils/datasource';
+import {
+  GRAFANA_RULES_SOURCE_NAME,
+  getRulesSourceUid,
+  isGrafanaRulesSource,
+  ruleIdentifierToRuleSourceIdentifier,
+} from '../../utils/datasource';
 import { labelsSize } from '../../utils/labels';
 import { makeDashboardLink, makePanelLink, stringifyErrorLike } from '../../utils/misc';
 import { createListFilterLink, groups } from '../../utils/navigation';
@@ -57,6 +62,7 @@ import {
   rulerRuleType,
 } from '../../utils/rules';
 import { AlertingPageWrapper } from '../AlertingPageWrapper';
+import { InhibitionRulesAlert } from '../InhibitionRulesAlert';
 import { ProvisionedResource, ProvisioningAlert } from '../Provisioning';
 import { WithReturnButton } from '../WithReturnButton';
 import { decodeGrafanaNamespace } from '../expressions/util';
@@ -101,7 +107,12 @@ const RuleViewer = () => {
   // of duplicating provisioned alert rules
   const [duplicateRuleIdentifier, setDuplicateRuleIdentifier] = useState<RuleIdentifier>();
   const { returnTo } = useReturnTo('/alerting/list');
-  const { annotations, promRule, rulerRule } = rule;
+  const { annotations, promRule, rulerRule, namespace } = rule;
+
+  // For Grafana-managed rules, use the Grafana Alertmanager. For external rules, use the data source name.
+  const alertmanagerSourceName = isGrafanaRulesSource(namespace.rulesSource)
+    ? GRAFANA_RULES_SOURCE_NAME
+    : namespace.rulesSource.name;
 
   const hasError = isErrorHealth(promRule?.health);
 
@@ -161,6 +172,7 @@ const RuleViewer = () => {
       }
     >
       {shouldUseConsistencyCheck && <PrometheusConsistencyCheck ruleIdentifier={identifier} />}
+      <InhibitionRulesAlert alertmanagerSourceName={alertmanagerSourceName} />
       <Stack direction="column" gap={2}>
         {/* tabs and tab content */}
         <TabContent>

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -109,11 +109,6 @@ const RuleViewer = () => {
   const { returnTo } = useReturnTo('/alerting/list');
   const { annotations, promRule, rulerRule, namespace } = rule;
 
-  // For Grafana-managed rules, use the Grafana Alertmanager. For external rules, use the data source name.
-  const alertmanagerSourceName = isGrafanaRulesSource(namespace.rulesSource)
-    ? GRAFANA_RULES_SOURCE_NAME
-    : namespace.rulesSource.name;
-
   const hasError = isErrorHealth(promRule?.health);
 
   const isFederatedRule = isFederatedRuleGroup(rule.group);
@@ -172,7 +167,10 @@ const RuleViewer = () => {
       }
     >
       {shouldUseConsistencyCheck && <PrometheusConsistencyCheck ruleIdentifier={identifier} />}
-      <InhibitionRulesAlert alertmanagerSourceName={alertmanagerSourceName} />
+      {/* Show inhibition rules alert only for Grafana-managed rules */}
+      {isGrafanaRulesSource(namespace.rulesSource) && (
+        <InhibitionRulesAlert alertmanagerSourceName={GRAFANA_RULES_SOURCE_NAME} />
+      )}
       <Stack direction="column" gap={2}>
         {/* tabs and tab content */}
         <TabContent>

--- a/public/app/features/alerting/unified/components/settings/AlertmanagerConfig.tsx
+++ b/public/app/features/alerting/unified/components/settings/AlertmanagerConfig.tsx
@@ -11,6 +11,7 @@ import { reportFormErrors } from '../../Analytics';
 import { useAlertmanagerConfig } from '../../hooks/useAlertmanagerConfig';
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { GRAFANA_RULES_SOURCE_NAME, isVanillaPrometheusAlertManagerDataSource } from '../../utils/datasource';
+import { InhibitionRulesAlert } from '../InhibitionRulesAlert';
 import { Spacer } from '../Spacer';
 
 export interface FormValues {
@@ -153,6 +154,7 @@ export default function AlertmanagerConfig({ alertmanagerName, onDismiss, onSave
           </Trans>
         </Alert>
       )}
+      <InhibitionRulesAlert alertmanagerSourceName={alertmanagerName} />
       {/* form error state */}
       {errors.configJSON && (
         <Alert

--- a/public/app/features/alerting/unified/hooks/useHasInhibitionRules.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useHasInhibitionRules.test.tsx
@@ -1,0 +1,89 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { produce } from 'immer';
+import { getWrapper } from 'test/test-utils';
+
+import { setupMswServer } from 'app/features/alerting/unified/mockApi';
+import {
+  getAlertmanagerConfig,
+  setAlertmanagerConfig,
+} from 'app/features/alerting/unified/mocks/server/entities/alertmanagers';
+import { GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
+
+import { useHasInhibitionRules } from './useHasInhibitionRules';
+
+setupMswServer();
+
+const wrapper = () => getWrapper({ renderWithRouter: true });
+
+describe('useHasInhibitionRules', () => {
+  it('should return false when no inhibition rules are configured', async () => {
+    const config = getAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);
+    const configWithoutInhibitRules = produce(config, (draft) => {
+      draft.alertmanager_config.inhibit_rules = [];
+    });
+    setAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME, configWithoutInhibitRules);
+
+    const { result } = renderHook(() => useHasInhibitionRules(GRAFANA_RULES_SOURCE_NAME), { wrapper: wrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.hasInhibitionRules).toBe(false);
+  });
+
+  it('should return false when inhibit_rules is undefined', async () => {
+    const config = getAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);
+    const configWithUndefinedInhibitRules = produce(config, (draft) => {
+      delete (draft.alertmanager_config as Record<string, unknown>).inhibit_rules;
+    });
+    setAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME, configWithUndefinedInhibitRules);
+
+    const { result } = renderHook(() => useHasInhibitionRules(GRAFANA_RULES_SOURCE_NAME), { wrapper: wrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.hasInhibitionRules).toBe(false);
+  });
+
+  it('should return true when inhibition rules are configured', async () => {
+    const config = getAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);
+    const configWithInhibitRules = produce(config, (draft) => {
+      draft.alertmanager_config.inhibit_rules = [
+        {
+          source_match: { severity: 'critical' },
+          target_match: { severity: 'warning' },
+          equal: ['alertname'],
+        },
+      ];
+    });
+    setAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME, configWithInhibitRules);
+
+    const { result } = renderHook(() => useHasInhibitionRules(GRAFANA_RULES_SOURCE_NAME), { wrapper: wrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.hasInhibitionRules).toBe(true);
+  });
+
+  it('should return isLoading true while loading', async () => {
+    const { result } = renderHook(() => useHasInhibitionRules(GRAFANA_RULES_SOURCE_NAME), { wrapper: wrapper() });
+
+    // Initially should be loading
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  it('should return false when alertmanagerSourceName is undefined', async () => {
+    const { result } = renderHook(() => useHasInhibitionRules(undefined), { wrapper: wrapper() });
+
+    expect(result.current.hasInhibitionRules).toBe(false);
+  });
+});

--- a/public/app/features/alerting/unified/hooks/useHasInhibitionRules.ts
+++ b/public/app/features/alerting/unified/hooks/useHasInhibitionRules.ts
@@ -1,0 +1,19 @@
+import { useMemo } from 'react';
+
+import { useAlertmanagerConfig } from './useAlertmanagerConfig';
+
+/**
+ * Hook to detect if the selected Alertmanager has inhibition rules configured.
+ * @param alertmanagerSourceName - The name of the Alertmanager datasource
+ * @returns An object with `hasInhibitionRules` boolean and `isLoading` state
+ */
+export function useHasInhibitionRules(alertmanagerSourceName: string | undefined) {
+  const { data: config, isLoading } = useAlertmanagerConfig(alertmanagerSourceName);
+
+  const hasInhibitionRules = useMemo(() => {
+    const rules = config?.alertmanager_config?.inhibit_rules;
+    return Array.isArray(rules) && rules.length > 0;
+  }, [config]);
+
+  return { hasInhibitionRules, isLoading };
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1643,6 +1643,11 @@
       },
       "yaml-error": "Failed to parse YAML file: {{error}}"
     },
+    "inhibition-rules": {
+      "body": "This Alertmanager has inhibition rules configured. Some alerts may be suppressed when matching alerts are firing.",
+      "learn-more": "Learn more about inhibition rules",
+      "title": "Inhibition rules are in effect"
+    },
     "insights": {
       "monitor-status-of-system": "Monitor the status of your system",
       "monitor-status-system-tooltip": "Alerting insights provides pre-built dashboards to monitor your alerting data.",


### PR DESCRIPTION
**What is this feature?**

This PR adds an alert on the following pages when the selected alert manager has inhibition rules in place:
  - Alert rule detail page
  - Alertmanager config page
  - Active notifications page
  - Notification policies page


https://github.com/user-attachments/assets/a819d053-7920-4406-a371-9838d324a8b0



**Why do we need this feature?**

We don't currently support inhibition rules in the UI at this point (only through API), so need some warning to show to the user that inhibition rules are in effect.

**Who is this feature for?**

Alerting users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1342

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
