### PR TITLE
feat(sharing): add invite team callout to ShareMenu

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ShareButton/ShareMenu.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareButton/ShareMenu.tsx
@@ -3,10 +3,11 @@ import * as React from 'react';
 
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { config, locationService } from '@grafana/runtime';
+import { config, locationService, reportInteraction } from '@grafana/runtime';
 import { VizPanel } from '@grafana/scenes';
-import { IconName, Menu, ModalsContext } from '@grafana/ui';
+import { Alert, IconName, LinkButton, Menu, ModalsContext } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
+import { getExternalUserMngLinkUrl } from 'app/features/users/utils';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { isPublicDashboardsEnabled } from '../../../dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils';
@@ -119,8 +120,38 @@ export default function ShareMenu({ dashboard, panel }: { dashboard: DashboardSc
     }));
   }, [menuItems, onClick]);
 
+  const canInviteUsers = config.externalUserMngLinkUrl && contextSrv.hasPermission(AccessControlAction.OrgUsersAdd);
+
+  const inviteUrl = canInviteUsers ? getExternalUserMngLinkUrl('share_menu') : '';
+
   return (
     <Menu data-testid={newShareButtonSelector.container}>
+      {canInviteUsers && (
+        <div style={{ padding: '8px', maxWidth: '300px' }}>
+          <Alert
+            title={t('share-dashboard.menu.invite-team-title', 'Invite your team')}
+            severity="info"
+            bottomSpacing={0}
+          >
+            {t('share-dashboard.menu.invite-team-description', 'Share this dashboard with collaborators')}
+            <div style={{ marginTop: '8px' }}>
+              <LinkButton
+                fullWidth
+                size="sm"
+                href={inviteUrl}
+                target="_blank"
+                onClick={() =>
+                  reportInteraction('invite_user_button_clicked', {
+                    placement: 'share_menu',
+                  })
+                }
+              >
+                {t('share-dashboard.menu.invite-team-button', 'Invite team')}
+              </LinkButton>
+            </div>
+          </Alert>
+        </div>
+      )}
       {menuItemsWithHandlers.map((item) => (
         <React.Fragment key={item.shareId}>
           {item.renderDividerAbove && <Menu.Divider />}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12938,6 +12938,9 @@
     "menu": {
       "export-image-title": "Export as image",
       "export-json-title": "Export as JSON",
+      "invite-team-button": "Invite team",
+      "invite-team-description": "Share this dashboard with collaborators",
+      "invite-team-title": "Invite your team",
       "share-externally-title": "Share externally",
       "share-internally-title": "Share internally",
       "share-snapshot-title": "Share snapshot"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds an "Invite your team" callout to the share menu. This feature allows users with the appropriate permissions to easily invite collaborators via an external user management link. 
<img width="3100" height="1704" alt="localhost_3000_d_adktjb7_new-dashboard_orgId=1 from=now-6h to=now timezone=browser" src="https://github.com/user-attachments/assets/e3fae438-d1b1-4ef0-b5c4-276ddb56b756" />

**Why do we need this feature?**

This feature improves user onboarding and dashboard collaboration by proactively surfacing the ability to invite team members directly within the share workflow. When users are actively trying to share a dashboard, it's the ideal moment to remind them they can invite collaborators to their organization.

**Who is this feature for?**

This feature is primarily for org admins and users with invite permissions who are actively sharing dashboards and want to bring more collaborators into their Grafana organization.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/OGPM/issues/386

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.