### PR TITLE
Dashboard Save: Don't pass v1 shape to v2 endpoint

### DIFF
--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
@@ -45,7 +45,7 @@ describe('browseDashboardsAPI saveDashboard', () => {
   });
 
   const createMockDashboardAPI = (saveDashboard: jest.Mock) =>
-    ({ saveDashboard } as unknown as ReturnType<typeof getDashboardAPI>);
+    ({ saveDashboard }) as unknown as ReturnType<typeof getDashboardAPI>;
 
   it('uses v1 dashboard API for v1 dashboards', async () => {
     const saveDashboardV1 = jest.fn().mockResolvedValue({ uid: 'test-uid-v1' });

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
@@ -1,0 +1,104 @@
+import { configureStore } from '@reduxjs/toolkit';
+
+import { Dashboard } from '@grafana/schema';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
+import { SaveDashboardCommand } from 'app/features/dashboard/components/SaveDashboard/types';
+
+import { browseDashboardsAPI } from './browseDashboardsAPI';
+
+const mockGet = jest.fn().mockResolvedValue({});
+const mockPut = jest.fn().mockResolvedValue({});
+const mockPost = jest.fn().mockResolvedValue({});
+
+jest.mock('app/features/dashboard/api/dashboard_api', () => ({
+  getDashboardAPI: jest.fn(),
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: () => ({
+    get: mockGet,
+    put: mockPut,
+    post: mockPost,
+  }),
+  config: {
+    ...jest.requireActual('@grafana/runtime').config,
+    buildInfo: {
+      version: '11.5.0-test-version-string',
+    },
+  },
+}));
+
+describe('browseDashboardsAPI saveDashboard', () => {
+  const getDashboardAPIMock = jest.mocked(getDashboardAPI);
+  const createTestStore = () =>
+    configureStore({
+      reducer: {
+        [browseDashboardsAPI.reducerPath]: browseDashboardsAPI.reducer,
+      },
+      middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(browseDashboardsAPI.middleware),
+    });
+
+  beforeEach(() => {
+    getDashboardAPIMock.mockReset();
+  });
+
+  const createMockDashboardAPI = (saveDashboard: jest.Mock) =>
+    ({ saveDashboard } as unknown as ReturnType<typeof getDashboardAPI>);
+
+  it('uses v1 dashboard API for v1 dashboards', async () => {
+    const saveDashboardV1 = jest.fn().mockResolvedValue({ uid: 'test-uid-v1' });
+    const saveDashboardV2 = jest.fn().mockResolvedValue({ uid: 'test-uid-v2' });
+
+    getDashboardAPIMock.mockImplementation((version?: 'v1' | 'v2') => {
+      if (version === 'v1') {
+        return createMockDashboardAPI(saveDashboardV1);
+      }
+      if (version === 'v2') {
+        return createMockDashboardAPI(saveDashboardV2);
+      }
+      return createMockDashboardAPI(jest.fn());
+    });
+
+    const cmd: SaveDashboardCommand<Dashboard> = {
+      dashboard: { title: 'V1', panels: [], schemaVersion: 1 } as unknown as Dashboard,
+      folderUid: 'folder-1',
+    };
+
+    const store = createTestStore();
+    await store.dispatch(browseDashboardsAPI.endpoints.saveDashboard.initiate(cmd));
+
+    expect(getDashboardAPIMock).toHaveBeenCalledWith('v1');
+    expect(saveDashboardV1).toHaveBeenCalledWith(cmd);
+    expect(saveDashboardV2).not.toHaveBeenCalled();
+  });
+
+  it('uses v2 dashboard API for v2 dashboards', async () => {
+    const saveDashboardV1 = jest.fn().mockResolvedValue({ uid: 'test-uid-v1' });
+    const saveDashboardV2 = jest.fn().mockResolvedValue({ uid: 'test-uid-v2' });
+
+    getDashboardAPIMock.mockImplementation((version?: 'v1' | 'v2') => {
+      if (version === 'v1') {
+        return createMockDashboardAPI(saveDashboardV1);
+      }
+      if (version === 'v2') {
+        return createMockDashboardAPI(saveDashboardV2);
+      }
+      return createMockDashboardAPI(jest.fn());
+    });
+
+    const v2Dashboard: DashboardV2Spec = { title: 'V2', elements: [] } as unknown as DashboardV2Spec;
+    const cmd: SaveDashboardCommand<DashboardV2Spec> = {
+      dashboard: v2Dashboard,
+      folderUid: 'folder-2',
+    };
+
+    const store = createTestStore();
+    await store.dispatch(browseDashboardsAPI.endpoints.saveDashboard.initiate(cmd));
+
+    expect(getDashboardAPIMock).toHaveBeenCalledWith('v2');
+    expect(saveDashboardV2).toHaveBeenCalledWith(cmd);
+    expect(saveDashboardV1).not.toHaveBeenCalled();
+  });
+});

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -416,7 +416,7 @@ export const browseDashboardsAPI = createApi({
           }
 
           if (isV1DashboardCommand(cmd)) {
-            const rsp = await getDashboardAPI().saveDashboard(cmd);
+            const rsp = await getDashboardAPI('v1').saveDashboard(cmd);
             return { data: rsp };
           }
           throw new Error('Invalid dashboard version');


### PR DESCRIPTION
Fixes the issue of not being able to save the dashboard template with dynamic dashboards enabled.

This was happening because dashboard templates are in v1 shape, but when dynamic dashboards are enabled we were hitting v2 endpoint, which will cause an error because v2 endpoint can't accept v1 shape. 

Please check that:
- [ ] It works as expected from a user's perspective.
