### PR TITLE
CloudWatch: Fix template variable intepolation for metrics queries

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3640,11 +3640,6 @@
       "count": 1
     }
   },
-  "public/app/plugins/datasource/cloudwatch/datasource.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
   "public/app/plugins/datasource/cloudwatch/guards.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -157,21 +157,23 @@ export class CloudWatchDatasource
     return merge(...dataQueryResponses);
   }
 
-  interpolateVariablesInQueries(queries: CloudWatchQuery[], scopedVars: ScopedVars): CloudWatchQuery[] {
-    if (!queries.length) {
-      return queries;
+  applyTemplateVariables(query: CloudWatchQuery, scopedVars: ScopedVars): CloudWatchQuery {
+    if (isCloudWatchMetricsQuery(query)) {
+      return this.metricsQueryRunner.interpolateMetricsQueryVariables(query, scopedVars);
     }
 
-    return queries.map((query) => ({
+    if (isCloudWatchLogsQuery(query)) {
+      return {
+        ...query,
+        region: this.templateSrv.replace(this.getActualRegion(query.region), scopedVars),
+        ...this.logsQueryRunner.interpolateLogsQueryVariables(query, scopedVars),
+      };
+    }
+
+    return {
       ...query,
-      region: this.metricsQueryRunner.replaceVariableAndDisplayWarningIfMulti(
-        this.getActualRegion(query.region),
-        scopedVars
-      ),
-      ...(isCloudWatchMetricsQuery(query) &&
-        this.metricsQueryRunner.interpolateMetricsQueryVariables(query, scopedVars)),
-      ...(isCloudWatchLogsQuery(query) && this.logsQueryRunner.interpolateLogsQueryVariables(query, scopedVars)),
-    }));
+      region: this.templateSrv.replace(this.getActualRegion(query.region), scopedVars),
+    };
   }
 
   /**
@@ -183,14 +185,14 @@ export class CloudWatchDatasource
   }
 
   targetContainsTemplate(target: any) {
-    return (
+      return (
       this.templateSrv.containsTemplate(target.region) ||
-      this.templateSrv.containsTemplate(target.namespace) ||
-      this.templateSrv.containsTemplate(target.metricName) ||
+        this.templateSrv.containsTemplate(target.namespace) ||
+        this.templateSrv.containsTemplate(target.metricName) ||
       this.templateSrv.containsTemplate(target.expression!) ||
       target.logGroupNames?.some((logGroup: string) => this.templateSrv.containsTemplate(logGroup)) ||
       find(target.dimensions, (v, k) => this.templateSrv.containsTemplate(k) || this.templateSrv.containsTemplate(v))
-    );
+      );
   }
 
   getQueryDisplayText(query: CloudWatchQuery) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When using CloudWatch with cross-account observability, the accountId template variable was not being interpolated when math expressions were added to a panel.

Reason for is is because we had two separate code paths for template variable interpolation:

1. Normal query execution used replaceMetricQueryVars() which included accountId
2. Expression-based queries used interpolateMetricsQueryVariables() which was missing accountId

When expressions are present, the expression datasource calls interpolateVariablesInQueries() → applyTemplateVariables() → interpolateMetricsQueryVariables(), and since accountId wasn't in that method, it was never interpolated.

This PR consolidates the two interpolation methods into a single interpolateMetricsQueryVariables() method that so metric queries only have one interpolation path. This is similar to what was done for [CloudWatch Logs queries](https://github.com/grafana/grafana/pull/104041).

Note that in `datasource.ts` we now only have `applyTemplateVariables`. I removed `interpolateVariablesInQueries` from `datasource.ts` because there's already a default implementation from [DataSourceWithBackend.ts](https://github.com/grafana/grafana/blob/d2de4f95dc8cab2d95f629f26f7fd5f4b038733a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts#L282) that is called when generating a link to link.

There was also a type error from the `targetContainsTemplate` using `any` so I fixed that up too.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #116181

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
