### PR TITLE
Alerting: Read rule state from the database in single-node evaluation mode

### DIFF
--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -65,7 +65,7 @@ type API struct {
 	DataProxy            *datasourceproxy.DataSourceProxyService
 	MultiOrgAlertmanager *notifier.MultiOrgAlertmanager
 	StateManager         state.AlertInstanceManager
-	Scheduler            apiprometheus.StatusReader
+	RuleStatusReader     apiprometheus.StatusReader
 	AccessControl        ac.AccessControl
 	Policies             *provisioning.NotificationPolicyService
 	ReceiverService      *notifier.ReceiverService
@@ -132,7 +132,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 	api.RegisterPrometheusApiEndpoints(NewForkingProm(
 		api.DatasourceCache,
 		NewLotexProm(proxy, logger),
-		apiprometheus.NewPrometheusSrv(logger, api.StateManager, api.Scheduler, api.RuleStore, ruleAuthzService, api.ProvenanceStore),
+		apiprometheus.NewPrometheusSrv(logger, api.StateManager, api.RuleStatusReader, api.RuleStore, ruleAuthzService, api.ProvenanceStore),
 	), m)
 	// Register endpoints for proxying to Cortex Ruler-compatible backends.
 	api.RegisterRulerApiEndpoints(NewForkingRuler(

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -34,6 +34,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder"
 	ac "github.com/grafana/grafana/pkg/services/ngalert/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/ngalert/api"
+	apiprometheus "github.com/grafana/grafana/pkg/services/ngalert/api/prometheus"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/cluster"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
@@ -409,6 +410,17 @@ func (ng *AlertNG) init() error {
 	ng.stateManager = stateManager
 	ng.schedule = scheduler
 
+	// For HA single-node evaluation mode, use StoreStateReader for API calls.
+	// This ensures Grafana instances read alert rule state from DB instead of memory,
+	// which has no data on non-primary nodes.
+	apiStateManager, apiStatusReader := initAPIStateReaders(
+		ng.Cfg.UnifiedAlerting.HASingleNodeEvaluation,
+		stateManager,
+		scheduler,
+		ng.InstanceStore,
+		ng.Log,
+	)
+
 	configStore := legacy_storage.NewAlertmanagerConfigStore(ng.store, notifier.NewExtraConfigsCrypto(ng.SecretsService))
 	receiverService := notifier.NewReceiverService(
 		ac.NewReceiverAccess[*models.Receiver](ng.accesscontrol, false),
@@ -460,8 +472,8 @@ func (ng *AlertNG) init() error {
 		AdminConfigStore:     ng.store,
 		ProvenanceStore:      ng.store,
 		MultiOrgAlertmanager: ng.MultiOrgAlertmanager,
-		StateManager:         ng.stateManager,
-		Scheduler:            scheduler,
+		StateManager:         apiStateManager,
+		RuleStatusReader:     apiStatusReader,
 		AccessControl:        ng.accesscontrol,
 		Policies:             policyService,
 		ReceiverService:      receiverService,
@@ -525,6 +537,24 @@ func initInstanceStore(sqlStore db.DB, logger log.Logger, featureToggles feature
 	}
 
 	return instanceStore, state.NewMultiInstanceReader(logger, protoInstanceStore, simpleInstanceStore)
+}
+
+// initAPIStateReaders returns the appropriate state manager and status reader for the API.
+// When HASingleNodeEvaluation is enabled, it returns a StoreStateReader that reads from the database,
+// ensuring non-primary instances can serve correct data even though they don't evaluate rules.
+// Otherwise, it returns the in-memory state manager and scheduler.
+func initAPIStateReaders(
+	haSingleNodeEvaluation bool,
+	stateManager *state.Manager,
+	scheduler apiprometheus.StatusReader,
+	instanceStore state.InstanceReader,
+	logger log.Logger,
+) (state.AlertInstanceManager, apiprometheus.StatusReader) {
+	if haSingleNodeEvaluation {
+		storeStateReader := state.NewStoreStateReader(instanceStore, logger)
+		return storeStateReader, storeStateReader
+	}
+	return stateManager, scheduler
 }
 
 func initStatePersister(uaCfg setting.UnifiedAlertingSettings, cfg state.ManagerCfg, featureToggles featuremgmt.FeatureToggles) state.StatePersister {

--- a/pkg/services/ngalert/ngalert_test.go
+++ b/pkg/services/ngalert/ngalert_test.go
@@ -481,3 +481,49 @@ func TestInitStatePersister(t *testing.T) {
 		})
 	}
 }
+
+func TestInitAPIStateReaders(t *testing.T) {
+	logger := log.NewNopLogger()
+	stateManager := &state.Manager{}
+	mockScheduler := &mockStatusReader{}
+	mockInstanceStore := &mockInstanceReader{}
+
+	t.Run("returns in-memory readers when HA single node evaluation disabled", func(t *testing.T) {
+		apiStateManager, apiStatusReader := initAPIStateReaders(
+			false,
+			stateManager,
+			mockScheduler,
+			mockInstanceStore,
+			logger,
+		)
+
+		assert.Equal(t, stateManager, apiStateManager, "should return the in-memory state manager")
+		assert.Equal(t, mockScheduler, apiStatusReader, "should return the scheduler as status reader")
+	})
+
+	t.Run("returns StoreStateReader when HA single node evaluation enabled", func(t *testing.T) {
+		apiStateManager, apiStatusReader := initAPIStateReaders(
+			true,
+			stateManager,
+			mockScheduler,
+			mockInstanceStore,
+			logger,
+		)
+
+		assert.IsType(t, &state.StoreStateReader{}, apiStateManager, "should return StoreStateReader as state manager")
+		assert.IsType(t, &state.StoreStateReader{}, apiStatusReader, "should return StoreStateReader as status reader")
+		assert.Equal(t, apiStateManager, apiStatusReader, "both should be the same StoreStateReader instance")
+	})
+}
+
+type mockStatusReader struct{}
+
+func (m *mockStatusReader) Status(_ context.Context, _ models.AlertRuleKey) (models.RuleStatus, bool) {
+	return models.RuleStatus{}, false
+}
+
+type mockInstanceReader struct{}
+
+func (m *mockInstanceReader) ListAlertInstances(_ context.Context, _ *models.ListAlertInstancesQuery) ([]*models.AlertInstance, error) {
+	return nil, nil
+}


### PR DESCRIPTION
**What is this feature?**

When single-node evaluation mode is enabled, read alert state from the database. This is needed because not all nodes evaluate rules, so not all nodes have state in memory.

**Why do we need this feature?**

Part of https://github.com/grafana/grafana/issues/116545

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
