### PR TITLE
Team Folders: Update hooks to allow creating folders with owner references

### DIFF
--- a/public/app/api/clients/folder/v1beta1/hooks.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.ts
@@ -4,7 +4,13 @@ import { useEffect, useMemo } from 'react';
 import { AppEvents } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getAppEvents } from '@grafana/runtime';
-import { DisplayList, iamAPIv0alpha1, useLazyGetDisplayMappingQuery } from 'app/api/clients/iam/v0alpha1';
+import {
+  API_GROUP as IAM_API_GROUP,
+  API_VERSION as IAM_API_VERSION,
+  DisplayList,
+  iamAPIv0alpha1,
+  useLazyGetDisplayMappingQuery,
+} from 'app/api/clients/iam/v0alpha1';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import {
   useDeleteFolderMutation as useDeleteFolderMutationLegacy,
@@ -56,6 +62,8 @@ import {
   ReplaceFolderApiArg,
   useGetAffectedItemsQuery,
   FolderInfo,
+  ObjectMeta,
+  OwnerReference,
 } from './index';
 
 function getFolderUrl(uid: string, title: string): string {
@@ -66,6 +74,15 @@ function getFolderUrl(uid: string, title: string): string {
   return `${config.appSubUrl}/dashboards/f/${uid}/${slug}`;
 }
 
+/**
+ * FolderDTO with optional ownerReferences
+ *
+ * (owner references will only be populated with app platform API + team folders functionality)
+ */
+type CombinedFolder = FolderDTO & {
+  ownerReferences?: OwnerReference[];
+};
+
 const combineFolderResponses = (
   folder: Folder,
   legacyFolder: FolderDTO,
@@ -75,7 +92,7 @@ const combineFolderResponses = (
   const updatedBy = folder.metadata.annotations?.[AnnoKeyUpdatedBy];
   const createdBy = folder.metadata.annotations?.[AnnoKeyCreatedBy];
 
-  const newData: FolderDTO = {
+  const newData: CombinedFolder = {
     canAdmin: legacyFolder.canAdmin,
     canDelete: legacyFolder.canDelete,
     canEdit: legacyFolder.canEdit,
@@ -84,6 +101,7 @@ const combineFolderResponses = (
     createdBy: (createdBy && userDisplay?.display[userDisplay?.keys.indexOf(createdBy)]?.displayName) || 'Anonymous',
     updatedBy: (updatedBy && userDisplay?.display[userDisplay?.keys.indexOf(updatedBy)]?.displayName) || 'Anonymous',
     ...appPlatformFolderToLegacyFolder(folder),
+    ownerReferences: folder.metadata.ownerReferences || [],
   };
 
   if (parents.length) {
@@ -101,7 +119,7 @@ const combineFolderResponses = (
   return newData;
 };
 
-export async function getFolderByUidFacade(uid: string): Promise<FolderDTO> {
+export async function getFolderByUidFacade(uid: string) {
   const isVirtualFolder = uid && [GENERAL_FOLDER_UID, config.sharedWithMeFolderUID].includes(uid);
   const shouldUseAppPlatformAPI = Boolean(config.featureToggles.foldersAppPlatformAPI);
 
@@ -216,7 +234,7 @@ export function useGetFolderQueryFacade(uid?: string) {
 
   // Stitch together the responses to create a single FolderDTO object so on the outside this behaves as the legacy
   // api client.
-  let newData: FolderDTO | undefined = undefined;
+  let newData: CombinedFolder | undefined = undefined;
   if (
     resultFolder.data &&
     resultParents.data &&
@@ -359,13 +377,44 @@ export function useCreateFolder() {
     return legacyHook;
   }
 
-  const createFolderAppPlatform = async (folder: NewFolder) => {
-    const payload: CreateFolderApiArg = {
+  const createFolderAppPlatform = async (
+    payload: NewFolder & {
+      /**
+       * UIDs of teams to add as owner references to the new folder
+       */
+      teamOwnerReferences?: Array<{ uid: string; name: string }>;
+    }
+  ) => {
+    const { teamOwnerReferences: teamOwnerReferenceUids, ...folder } = payload;
+
+    /**
+     * Additional metadata to use for the folder
+     *
+     * If team details are included, add them as owner references to the folder
+     */
+    const partialMetadata: ObjectMeta =
+      teamOwnerReferenceUids && teamOwnerReferenceUids.length > 0
+        ? {
+          ownerReferences: [
+            ...teamOwnerReferenceUids.map(({ uid, name }) => ({
+              apiVersion: `${IAM_API_GROUP}/${IAM_API_VERSION}`,
+              kind: 'Team',
+              name,
+              uid,
+              controller: true,
+              blockOwnerDeletion: false,
+            })),
+          ],
+        }
+        : {};
+
+    const apiPayload: CreateFolderApiArg = {
       folder: {
         spec: {
           title: folder.title,
         },
         metadata: {
+          ...partialMetadata,
           generateName: 'f',
           annotations: {
             ...(folder.parentUid && { [AnnoKeyFolder]: folder.parentUid }),
@@ -374,7 +423,7 @@ export function useCreateFolder() {
       },
     };
 
-    const result = await createFolder(payload);
+    const result = await createFolder(apiPayload);
     refresh({ childrenOf: folder.parentUid });
     deletedDashboardsCache.clear();
 

--- a/public/app/api/clients/folder/v1beta1/hooks.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.ts
@@ -395,17 +395,17 @@ export function useCreateFolder() {
     const partialMetadata: ObjectMeta =
       teamOwnerReferenceUids && teamOwnerReferenceUids.length > 0
         ? {
-          ownerReferences: [
-            ...teamOwnerReferenceUids.map(({ uid, name }) => ({
-              apiVersion: `${IAM_API_GROUP}/${IAM_API_VERSION}`,
-              kind: 'Team',
-              name,
-              uid,
-              controller: true,
-              blockOwnerDeletion: false,
-            })),
-          ],
-        }
+            ownerReferences: [
+              ...teamOwnerReferenceUids.map(({ uid, name }) => ({
+                apiVersion: `${IAM_API_GROUP}/${IAM_API_VERSION}`,
+                kind: 'Team',
+                name,
+                uid,
+                controller: true,
+                blockOwnerDeletion: false,
+              })),
+            ],
+          }
         : {};
 
     const apiPayload: CreateFolderApiArg = {

--- a/public/app/features/teams/hooks.ts
+++ b/public/app/features/teams/hooks.ts
@@ -1,6 +1,7 @@
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useEffect, useMemo } from 'react';
 
+import { useCreateFolder } from 'app/api/clients/folder/v1beta1/hooks';
 import {
   useSearchTeamsQuery as useLegacySearchTeamsQuery,
   useCreateTeamMutation,
@@ -127,14 +128,16 @@ export const useDeleteTeam = () => {
 export const useCreateTeam = () => {
   const [createTeam, response] = useCreateTeamMutation();
   const [setTeamRoles] = useSetTeamRolesMutation();
+  const [createFolder] = useCreateFolder();
 
-  const trigger = async (team: CreateTeamCommand, pendingRoles?: Role[]) => {
+  const trigger = async (team: CreateTeamCommand, pendingRoles?: Role[], createTeamFolder?: boolean) => {
     const mutationResult = await createTeam({
       createTeamCommand: team,
     });
 
     const { data } = mutationResult;
 
+    // Add any pending roles to the team
     if (data && data.teamId && pendingRoles && pendingRoles.length) {
       await contextSrv.fetchUserPermissions();
       if (contextSrv.licensedAccessControlEnabled() && canUpdateRoles()) {
@@ -145,6 +148,13 @@ export const useCreateTeam = () => {
           },
         });
       }
+    }
+
+    if (data && data.uid && createTeamFolder) {
+      await createFolder({
+        title: team.name,
+        teamOwnerReferences: [{ uid: data.uid, name: team.name }],
+      });
     }
 
     return mutationResult;


### PR DESCRIPTION
**What is this feature?**
Changes hooks so a folder can be created with ownerReferences (at this time, just team references)

**Why do we need this feature?**
To support team folders functionality/folder ownership in the UI

**Who is this feature for?**
Devs at this time