### PR TITLE
CommandPalette: Trim leading and trailing whitespace

### DIFF
--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -48,15 +48,19 @@ function CommandPaletteContents() {
   useRegisterRecentDashboardsActions();
   useRegisterRecentScopesActions();
 
+  const trimmedSearchQuery = searchQuery.trim();
   const queryToggle = useCallback(() => query.toggle(), [query]);
-  const { scopesRow } = useRegisterScopesActions(searchQuery, queryToggle, currentRootActionId);
+  const { scopesRow } = useRegisterScopesActions(trimmedSearchQuery, queryToggle, currentRootActionId);
 
   // This searches dashboards and folders it shows only if we are not in some specific category (and there is no
   // dashboards category right now, so if any category is selected, we don't show these).
   // Normally we register actions with kbar, and it knows not to show actions which are under a different parent than is
   // the currentRootActionId. Because these search results are manually added to the list later, they would show every
   // time.
-  const { searchResults, isFetchingSearchResults } = useSearchResults({ searchQuery, show: !currentRootActionId });
+  const { searchResults, isFetchingSearchResults } = useSearchResults({
+    searchQuery: trimmedSearchQuery,
+    show: !currentRootActionId,
+  });
 
   const ref = useRef<HTMLDivElement>(null);
   const { overlayProps } = useOverlay(


### PR DESCRIPTION
**What is this feature?**
Possible leading and trailing whitespaces get removed. They prevent the user from getting a search result.

**Who is this feature for?**
Everyone using the general search 

Relates to #112238
=> The external contributor fixed the bug but abandoned the PR afterwards.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
