### PR TITLE
Azure: Increase test timeout

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.test.tsx
@@ -92,7 +92,7 @@ describe('LogsQueryEditor', () => {
         }),
       })
     );
-  });
+  }, 10000);
 
   it('should disable other resource types when selecting multiple resources', async () => {
     const mockDatasource = createMockDatasource({ resourcePickerData: createMockResourcePickerData() });


### PR DESCRIPTION
This test has started misbehaving and timing out, most likely due to resource issues on the runners. Bumping the timeout to make it more stable.