### PR TITLE
Table: fix hidden fields from being displayed

### DIFF
--- a/public/app/features/explore/Table/TableContainer.test.tsx
+++ b/public/app/features/explore/Table/TableContainer.test.tsx
@@ -72,6 +72,35 @@ describe('TableContainerWithTheme', () => {
       render(<TableContainerWithTheme {...tableProps} />);
       expect(screen.getByText('Table - metric{label="value"}')).toBeInTheDocument();
     });
+
+    it('preserves datasource hidden fields while applying Explore column limiting', () => {
+      const df = toDataFrame({
+        name: 'A',
+        fields: [
+          {
+            name: 'traceIdHidden',
+            type: FieldType.string,
+            values: ['t1'],
+            config: {
+              custom: {
+                hideFrom: { viz: true },
+              },
+            },
+          },
+
+          {
+            name: 'spanId',
+            type: FieldType.string,
+            values: ['s1'],
+            config: {},
+          },
+        ],
+      });
+
+      render(<TableContainerWithTheme {...defaultProps} tableResult={[df]} />);
+      expect(df.fields[0].config.custom?.hideFrom?.viz).toBe(true);
+      expect(df.fields[1].config.custom?.hideFrom?.viz).toBe(false);
+    });
   });
 
   describe('With multiple main frames', () => {

--- a/public/app/features/explore/Table/TableContainer.tsx
+++ b/public/app/features/explore/Table/TableContainer.tsx
@@ -103,9 +103,22 @@ export class TableContainer extends PureComponent<Props, State> {
     if (dataFrames?.length) {
       dataFrames = dataFrames.map((frame) => {
         frame.fields.forEach((field, index) => {
-          const hidden = showAll ? false : index >= MAX_NUMBER_OF_COLUMNS;
-          field.config.custom = { hidden };
-          dataLimited = dataLimited || hidden;
+          const custom = field.config.custom ?? {};
+
+          const hiddenByColumnLimit = showAll ? false : index >= MAX_NUMBER_OF_COLUMNS;
+          dataLimited = dataLimited || hiddenByColumnLimit;
+
+          const hiddenByDatasource = custom.hideFrom?.viz === true || custom.hidden === true;
+          const hidden = hiddenByDatasource || hiddenByColumnLimit;
+
+          field.config.custom = {
+            ...custom,
+            hidden,
+            hideFrom: {
+              ...custom.hideFrom,
+              viz: hidden,
+            },
+          };
         });
         return frame;
       });


### PR DESCRIPTION
Similar to https://github.com/grafana/grafana/pull/116552, this extends the hidden-field fix to top-level Table panels. The previous change addressed the issue for nested tables, but hidden fields were still being applied incorrectly at the top level. This aligns the behavior so hidden fields are consistently respected across all table contexts.

**Before the fix / After the fix:**
<div>
<img width="49%" height="621" alt="Screenshot 2026-01-21 at 11 50 42" src="https://github.com/user-attachments/assets/f970b2be-4df2-4e4e-a08b-d68856cc8f79" />
<img width="49%" height="620" alt="Screenshot 2026-01-21 at 11 28 08" src="https://github.com/user-attachments/assets/6445a842-daf7-4da3-b8c6-283af6744821" />
</div>