### PR TITLE
Custom Variable: Use includeAll instead of onAllValueChange

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/components/CustomVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/CustomVariableForm.tsx
@@ -54,7 +54,7 @@ export function CustomVariableForm({
         allowCustomValue={allowCustomValue}
         onQueryChange={onQueryChange}
         onMultiChange={onMultiChange}
-        onIncludeAllChange={onAllValueChange}
+        onIncludeAllChange={onIncludeAllChange}
         onAllValueChange={onAllValueChange}
         onAllowCustomValueChange={onAllowCustomValueChange}
       />


### PR DESCRIPTION
Caused this: https://github.com/grafana/support-escalations/issues/20322 for instances where multiValueVariable toggle is disabled



