### PR TITLE
Provisioning: Remove connection reference for temporary tokens in /test

### DIFF
--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -168,6 +168,10 @@ func (s *testConnector) Connect(ctx context.Context, name string, _ runtime.Obje
 					}
 
 					cfg.Secure.Token.Create = token.Token
+					// HACK: currently, Repository validator does not allow for Connection and token
+					// to be declared together in a new / temporary Repository.
+					// We are therefore removing it in such cases.
+					cfg.Spec.Connection = nil
 				}
 
 				// Create a temporary repository


### PR DESCRIPTION
**What is this feature?**

In `/test` endpoint, when a temporary `Repository` resource needs to be generated for testing, we're currently facing a validation error as `spec.connection` and `secure.token` are declared together - as a temporary fix for this, we're removing the `spec.connection` reference in the temporary resource.

**Why do we need this feature?**

We need this as a temporary solution to unblock frontend testing, while we work on a proper one.

**Who is this feature for?**

Users of GitSync
