### PR TITLE
feat(dashboard): migrate dashboard version history to Kubernetes API

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -240,6 +240,10 @@ export interface FeatureToggles {
   */
   kubernetesDashboards?: boolean;
   /**
+  * Use kubernetes API for dashboard version history
+  */
+  kubernetesDashboardVersions?: boolean;
+  /**
   * Enables k8s short url api and uses it under the hood when handling legacy /api
   */
   kubernetesShortURLs?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -380,6 +380,13 @@ var (
 			Expression:   "true", // enabled by default
 		},
 		{
+			Name:         "kubernetesDashboardVersions",
+			Description:  "Use kubernetes API for dashboard version history",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaDashboardsSquad,
+			FrontendOnly: true,
+		},
+		{
 			Name:            "kubernetesShortURLs",
 			Description:     "Enables k8s short url api and uses it under the hood when handling legacy /api",
 			Stage:           FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -51,6 +51,7 @@ disableClassicHTTPHistogram,experimental,@grafana/grafana-backend-services-squad
 kubernetesSnapshots,experimental,@grafana/grafana-app-platform-squad,false,true,false
 kubernetesLibraryPanels,experimental,@grafana/grafana-app-platform-squad,false,true,false
 kubernetesDashboards,GA,@grafana/dashboards-squad,false,false,false
+kubernetesDashboardVersions,experimental,@grafana/dashboards-squad,false,false,true
 kubernetesShortURLs,experimental,@grafana/grafana-app-platform-squad,false,true,false
 useKubernetesShortURLsAPI,experimental,@grafana/sharing-squad,false,false,true
 kubernetesAlertingRules,experimental,@grafana/alerting-squad,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2003,6 +2003,19 @@
     },
     {
       "metadata": {
+        "name": "kubernetesDashboardVersions",
+        "resourceVersion": "1769006046995",
+        "creationTimestamp": "2026-01-21T14:34:06Z"
+      },
+      "spec": {
+        "description": "Use kubernetes API for dashboard version history",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
         "name": "kubernetesDashboards",
         "resourceVersion": "1764664939750",
         "creationTimestamp": "2024-06-05T14:34:23Z"

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -29,16 +29,25 @@ interface Props {
 
 export function DashboardEditPaneSplitter({ dashboard, isEditing, body, controls }: Props) {
   const headerHeight = useChromeHeaderHeight();
-  const { editPane } = dashboard.state;
+  const { editPane, backgroundImage } = dashboard.state;
   const styles = useStyles2(getStyles, headerHeight ?? 0);
   const { chrome } = useGrafana();
   const { kioskMode } = chrome.useState();
   const { isPlaying } = playlistSrv.useState();
 
+  const backgroundStyle: React.CSSProperties | undefined = backgroundImage
+    ? {
+        backgroundImage: `url(${backgroundImage})`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+        backgroundRepeat: 'no-repeat',
+      }
+    : undefined;
+
   if (!config.featureToggles.dashboardNewLayouts) {
     return (
       <NativeScrollbar onSetScrollRef={dashboard.onSetScrollRef}>
-        <div className={styles.canvasWrappperOld}>
+        <div className={styles.canvasWrappperOld} style={backgroundStyle}>
           <NavToolbarActions dashboard={dashboard} />
           <div className={styles.controlsWrapperSticky}>{controls}</div>
           <div className={styles.body}>{body}</div>
@@ -103,6 +112,7 @@ export function DashboardEditPaneSplitter({ dashboard, isEditing, body, controls
         <div
           className={cx(styles.bodyWrapper, styles.bodyWrapperKiosk)}
           data-testid={selectors.components.DashboardEditPaneSplitter.primaryBody}
+          style={backgroundStyle}
         >
           <NativeScrollbar onSetScrollRef={dashboard.onSetScrollRef}>{body}</NativeScrollbar>
         </div>
@@ -115,7 +125,7 @@ export function DashboardEditPaneSplitter({ dashboard, isEditing, body, controls
         data-testid={selectors.components.DashboardEditPaneSplitter.primaryBody}
         {...sidebarContext.outerWrapperProps}
       >
-        <div className={styles.scrollContainer} ref={onBodyRef} onPointerDown={onClearSelection}>
+        <div className={styles.scrollContainer} ref={onBodyRef} onPointerDown={onClearSelection} style={backgroundStyle}>
           {body}
         </div>
 

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -93,7 +93,7 @@ import { clearClipboard } from './layouts-shared/paste';
 import { DashboardLayoutManager } from './types/DashboardLayoutManager';
 import { LayoutParent } from './types/LayoutParent';
 
-export const PERSISTED_PROPS = ['title', 'description', 'tags', 'editable', 'graphTooltip', 'links', 'meta', 'preload'];
+export const PERSISTED_PROPS = ['title', 'description', 'tags', 'editable', 'graphTooltip', 'links', 'meta', 'preload', 'backgroundImage'];
 export const PANEL_SEARCH_VAR = 'systemPanelFilterVar';
 export const PANELS_PER_ROW_VAR = 'systemDynamicRowSizeVar';
 
@@ -150,6 +150,10 @@ export interface DashboardSceneState extends SceneObjectState {
   editPane: DashboardEditPane;
   /** Manages dragging/dropping of layout items */
   layoutOrchestrator?: DashboardLayoutOrchestrator;
+  /** Custom CSS for the dashboard */
+  customCSS?: string;
+  /** Background image URL for the dashboard */
+  backgroundImage?: string;
 }
 
 export class DashboardScene extends SceneObjectBase<DashboardSceneState> implements LayoutParent {

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -398,6 +398,27 @@ export function ToolbarActions({ dashboard }: Props) {
   });
 
   toolbarActions.push({
+    group: 'settings',
+    condition: isEditing && dashboard.canEditDashboard() && isShowingDashboard,
+    render: () => (
+      <Button
+        onClick={() => {
+          locationService.partial({ editview: 'theme' });
+        }}
+        tooltip={t('dashboard.toolbar.dashboard-theme.tooltip', 'Edit dashboard theme and styling')}
+        fill="text"
+        size="sm"
+        key="theme"
+        variant="secondary"
+        icon="palette"
+        data-testid="dashboard-toolbar-theme-button"
+      >
+        <Trans i18nKey="dashboard.toolbar.dashboard-theme.label">Theme</Trans>
+      </Button>
+    ),
+  });
+
+  toolbarActions.push({
     group: 'main-buttons',
     condition: isEditing && !isNew && isShowingDashboard,
     render: () => (

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -310,6 +310,9 @@ export function createDashboardSceneFromDashboardModel(
         }
       : undefined;
 
+  // @ts-expect-error not in dashboard schema because it's experimental
+  const backgroundImage: string | undefined = oldModel.backgroundImage;
+
   // Create profiler once and reuse to avoid duplicate metadata setting
   const dashboardProfiler = getDashboardSceneProfilerWithMetadata(oldModel.uid, oldModel.title);
 
@@ -379,6 +382,7 @@ export function createDashboardSceneFromDashboardModel(
       title: oldModel.title,
       version: oldModel.version,
       scopeMeta,
+      backgroundImage,
       body,
       $timeRange: new SceneTimeRange({
         from: oldModel.time.from,

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
@@ -168,6 +168,7 @@ export function transformSceneToSaveModel(scene: DashboardScene, isSnapshot = fa
     refresh: refreshPicker?.state.refresh,
     // @ts-expect-error not in dashboard schema because it's experimental
     scopeMeta: state.scopeMeta,
+    backgroundImage: state.backgroundImage,
   };
 
   // Only add optional fields if they are explicitly set (not default values)

--- a/public/app/features/dashboard-scene/settings/ThemeEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/ThemeEditView.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+
+import { Trans, t } from '@grafana/i18n';
+import { SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
+import { Button, Field, Input, Stack, TextArea } from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+
+import { DashboardScene } from '../scene/DashboardScene';
+import { NavToolbarActions } from '../scene/NavToolbarActions';
+import { getDashboardSceneFor } from '../utils/utils';
+
+import { DashboardEditView, DashboardEditViewState, useDashboardEditPageNav } from './utils';
+
+export interface ThemeEditViewState extends DashboardEditViewState {}
+
+export class ThemeEditView extends SceneObjectBase<ThemeEditViewState> implements DashboardEditView {
+  private get _dashboard(): DashboardScene {
+    return getDashboardSceneFor(this);
+  }
+
+  public getUrlKey(): string {
+    return 'theme';
+  }
+
+  public getDashboard(): DashboardScene {
+    return this._dashboard;
+  }
+
+  public static Component = ({ model }: SceneComponentProps<ThemeEditView>) => {
+    const dashboard = model.getDashboard();
+    const { navModel, pageNav } = useDashboardEditPageNav(dashboard, 'theme');
+    const [customCSS, setCustomCSS] = useState(dashboard.state.customCSS || '');
+    const [backgroundImage, setBackgroundImage] = useState(dashboard.state.backgroundImage || '');
+
+    const onCustomCSSChange = (css: string) => {
+      dashboard.setState({ customCSS: css });
+      setCustomCSS(css);
+    };
+
+    const onBackgroundImageChange = (url: string) => {
+      dashboard.setState({ backgroundImage: url });
+      setBackgroundImage(url);
+    };
+
+    const onClearBackgroundImage = () => {
+      dashboard.setState({ backgroundImage: undefined });
+      setBackgroundImage('');
+    };
+
+    return (
+      <Page navModel={navModel} pageNav={pageNav}>
+        <NavToolbarActions dashboard={dashboard} />
+        <div style={{ maxWidth: '600px' }}>
+          <Trans i18nKey="dashboard.theme-settings.description">
+            Customize the appearance of this dashboard with custom CSS and brand colors.
+          </Trans>
+
+          <Field
+            label={t('dashboard.theme-settings.background-image.label', 'Background Image')}
+            description={t(
+              'dashboard.theme-settings.background-image.description',
+              'Set a background image URL for this dashboard. The image will be displayed behind all panels.'
+            )}
+          >
+            <Input
+              value={backgroundImage}
+              onChange={(e) => onBackgroundImageChange(e.currentTarget.value)}
+              placeholder={t(
+                'dashboard.theme-settings.background-image.placeholder',
+                'https://example.com/image.jpg'
+              )}
+            />
+          </Field>
+          {backgroundImage && (
+            <Stack gap={2} direction="column" style={{ marginBottom: '16px' }}>
+              <Button variant="secondary" onClick={onClearBackgroundImage} icon="times">
+                {t('dashboard.theme-settings.background-image.clear', 'Clear')}
+              </Button>
+              <div
+                style={{
+                  padding: '8px',
+                  border: '1px solid var(--border-color)',
+                  borderRadius: '4px',
+                }}
+              >
+                <img
+                  src={backgroundImage}
+                  alt={t('dashboard.theme-settings.background-image.preview', 'Background image preview')}
+                  style={{ maxWidth: '100%', maxHeight: '200px', display: 'block' }}
+                  onError={(e) => {
+                    e.currentTarget.style.display = 'none';
+                  }}
+                />
+              </div>
+            </Stack>
+          )}
+
+          <Field
+            label={t('dashboard.theme-settings.custom-css.label', 'Custom CSS')}
+            description={t(
+              'dashboard.theme-settings.custom-css.description',
+              'Add custom CSS styles that will be applied to this dashboard.'
+            )}
+          >
+            <TextArea
+              rows={10}
+              value={customCSS}
+              onChange={(e) => onCustomCSSChange(e.currentTarget.value)}
+              placeholder={t(
+                'dashboard.theme-settings.custom-css.placeholder',
+                '/* Custom CSS for this dashboard */\n.dashboard-container {\n  /* Your styles here */\n}'
+              )}
+            />
+          </Field>
+        </div>
+      </Page>
+    );
+  };
+}

--- a/public/app/features/dashboard-scene/settings/utils.ts
+++ b/public/app/features/dashboard-scene/settings/utils.ts
@@ -15,6 +15,7 @@ import { DashboardLinksEditView } from './DashboardLinksEditView';
 import { GeneralSettingsEditView } from './GeneralSettingsEditView';
 import { JsonModelEditView } from './JsonModelEditView';
 import { PermissionsEditView } from './PermissionsEditView';
+import { ThemeEditView } from './ThemeEditView';
 import { VariablesEditView } from './VariablesEditView';
 import { VersionsEditView } from './VersionsEditView';
 
@@ -63,6 +64,11 @@ export function useDashboardEditPageNav(dashboard: DashboardScene, currentEditVi
       url: locationUtil.getUrlForPartial(location, { editview: 'links', editIndex: null }),
       active: currentEditView === 'links',
     });
+    pageNav.children!.push({
+      text: t('dashboard-settings.theme.title', 'Theme & Styling'),
+      url: locationUtil.getUrlForPartial(location, { editview: 'theme', editIndex: null }),
+      active: currentEditView === 'theme',
+    });
   }
 
   if (dashboard.state.uid && dashboard.state.meta.canSave) {
@@ -100,6 +106,8 @@ export function createDashboardEditViewFor(editview: string): DashboardEditView 
       return new VariablesEditView({});
     case 'links':
       return new DashboardLinksEditView({});
+    case 'theme':
+      return new ThemeEditView({});
     case 'versions':
       return new VersionsEditView({});
     case 'json-model':

--- a/public/app/features/dashboard-scene/settings/version-history/HistorySrv.test.ts
+++ b/public/app/features/dashboard-scene/settings/version-history/HistorySrv.test.ts
@@ -1,10 +1,11 @@
 import { createDashboardModelFixture } from 'app/features/dashboard/state/__fixtures__/dashboardFixtures';
 
-import { HistorySrv } from './HistorySrv';
+import { K8sHistorySrv, LegacyHistorySrv, createHistorySrv } from './HistorySrv';
 import { restore, versions } from './mocks/dashboardHistoryMocks';
 
 const getMock = jest.fn().mockResolvedValue({});
 const postMock = jest.fn().mockResolvedValue({});
+const putMock = jest.fn().mockResolvedValue({});
 
 jest.mock('app/core/store', () => ({
   get: jest.fn(),
@@ -19,15 +20,26 @@ jest.mock('@grafana/runtime', () => {
     getBackendSrv: () => ({
       post: postMock,
       get: getMock,
+      put: putMock,
     }),
+    config: {
+      ...original.config,
+      featureToggles: {
+        kubernetesDashboardVersions: false,
+      },
+    },
   };
 });
 
-describe('historySrv', () => {
+jest.mock('../../../../api/utils', () => ({
+  getAPINamespace: () => 'default',
+}));
+
+describe('LegacyHistorySrv', () => {
   const versionsResponse = versions();
   const restoreResponse = restore;
 
-  let historySrv = new HistorySrv();
+  let historySrv = new LegacyHistorySrv();
 
   const dash = createDashboardModelFixture({ uid: '_U4zObQMz' });
   const emptyDash = createDashboardModelFixture();
@@ -40,7 +52,7 @@ describe('historySrv', () => {
   describe('getHistoryList', () => {
     it('should return a versions array for the given dashboard id', () => {
       getMock.mockImplementation(() => Promise.resolve(versionsResponse));
-      historySrv = new HistorySrv();
+      historySrv = new LegacyHistorySrv();
 
       return historySrv.getHistoryList(dash.uid, historyListOpts).then((versions) => {
         expect(versions).toEqual(versionsResponse);
@@ -63,7 +75,7 @@ describe('historySrv', () => {
   describe('getDashboardVersion', () => {
     it('should return a version object for the given dashboard id and version', () => {
       getMock.mockImplementation(() => Promise.resolve(versionsResponse.versions[0]));
-      historySrv = new HistorySrv();
+      historySrv = new LegacyHistorySrv();
 
       return historySrv.getDashboardVersion(dash.uid, 4).then((version) => {
         expect(version).toEqual(versionsResponse.versions[0]);
@@ -71,7 +83,7 @@ describe('historySrv', () => {
     });
 
     it('should return an empty object when not given an id', async () => {
-      historySrv = new HistorySrv();
+      historySrv = new LegacyHistorySrv();
 
       const rsp = await historySrv.getDashboardVersion(emptyDash.uid, 6);
       expect(rsp).toEqual({});
@@ -82,16 +94,292 @@ describe('historySrv', () => {
     it('should return a success response given valid parameters', () => {
       const version = 6;
       postMock.mockImplementation(() => Promise.resolve(restoreResponse(version)));
-      historySrv = new HistorySrv();
+      historySrv = new LegacyHistorySrv();
       return historySrv.restoreDashboard(dash.uid, version).then((response) => {
         expect(response).toEqual(restoreResponse(version));
       });
     });
 
     it('should return an empty object when not given an id', async () => {
-      historySrv = new HistorySrv();
+      historySrv = new LegacyHistorySrv();
       const rsp = await historySrv.restoreDashboard(emptyDash.uid, 6);
       expect(rsp).toEqual({});
     });
+  });
+});
+
+describe('K8sHistorySrv', () => {
+  let historySrv: K8sHistorySrv;
+
+  const dash = createDashboardModelFixture({ uid: '_U4zObQMz' });
+  const emptyDash = createDashboardModelFixture();
+  const historyListOpts = { limit: 10, start: 0 };
+
+  const k8sVersionsResponse = {
+    items: [
+      {
+        metadata: {
+          name: '_U4zObQMz',
+          generation: 4,
+          annotations: {
+            'grafana.app/updatedTimestamp': '2023-01-01T00:00:00Z',
+            'grafana.app/updatedBy': 'admin',
+            'grafana.app/message': 'Test update',
+          },
+        },
+        spec: { title: 'Test Dashboard' },
+      },
+      {
+        metadata: {
+          name: '_U4zObQMz',
+          generation: 3,
+          annotations: {
+            'grafana.app/updatedTimestamp': '2022-12-31T00:00:00Z',
+            'grafana.app/updatedBy': 'admin',
+            'grafana.app/message': 'Previous update',
+          },
+        },
+        spec: { title: 'Test Dashboard v3' },
+      },
+    ],
+    metadata: {},
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    historySrv = new K8sHistorySrv();
+  });
+
+  describe('getHistoryList', () => {
+    it('should return a versions array for the given dashboard id', async () => {
+      getMock.mockResolvedValue(k8sVersionsResponse);
+
+      const result = await historySrv.getHistoryList(dash.uid, historyListOpts);
+
+      expect(getMock).toHaveBeenCalledWith(
+        expect.stringContaining('/apis/dashboard.grafana.app/v0alpha1/namespaces/default/dashboards')
+      );
+      expect(getMock).toHaveBeenCalledWith(expect.stringContaining('labelSelector=grafana.app%2Fget-history%3Dtrue'));
+      expect(getMock).toHaveBeenCalledWith(expect.stringContaining(`fieldSelector=metadata.name%3D${dash.uid}`));
+      expect(result).toHaveProperty('versions');
+      expect(result.versions).toHaveLength(2);
+      expect(result.versions[0].version).toBe(4);
+      expect(result.versions[0].createdBy).toBe('admin');
+    });
+
+    it('should return an empty versions array when not given an id', async () => {
+      const result = await historySrv.getHistoryList(emptyDash.uid, historyListOpts);
+      expect(result).toEqual({ versions: [] });
+    });
+
+    it('should return an empty versions array when not given a dashboard id', async () => {
+      const result = await historySrv.getHistoryList(null as unknown as string, historyListOpts);
+      expect(result).toEqual({ versions: [] });
+    });
+
+    it('should include continueToken in params when provided', async () => {
+      getMock.mockResolvedValue({ items: [], metadata: {} });
+      const opts = { ...historyListOpts, continueToken: 'abc123' };
+
+      await historySrv.getHistoryList(dash.uid, opts);
+
+      expect(getMock).toHaveBeenCalledWith(expect.stringContaining('continue=abc123'));
+    });
+  });
+
+  describe('getDashboardVersion', () => {
+    it('should return a version object for the given dashboard id and version', async () => {
+      getMock.mockResolvedValue(k8sVersionsResponse);
+
+      const result = await historySrv.getDashboardVersion(dash.uid, 4);
+
+      expect(result).toMatchObject({
+        version: 4,
+        createdBy: 'admin',
+        message: 'Test update',
+      });
+    });
+
+    it('should return an empty object when version not found', async () => {
+      getMock.mockResolvedValue(k8sVersionsResponse);
+
+      const result = await historySrv.getDashboardVersion(dash.uid, 999);
+
+      expect(result).toEqual({});
+    });
+
+    it('should return an empty object when not given an id', async () => {
+      const rsp = await historySrv.getDashboardVersion(emptyDash.uid, 6);
+      expect(rsp).toEqual({});
+    });
+  });
+
+  describe('restoreDashboard', () => {
+    it('should PUT the dashboard with the spec from the old version', async () => {
+      const currentDashboard = {
+        metadata: { name: '_U4zObQMz', generation: 5, annotations: {} },
+        spec: { title: 'Current Dashboard' },
+      };
+
+      getMock
+        .mockResolvedValueOnce(k8sVersionsResponse) // getDashboardVersion call
+        .mockResolvedValueOnce(currentDashboard); // get current dashboard
+
+      putMock.mockResolvedValue({ success: true });
+
+      await historySrv.restoreDashboard(dash.uid, 4);
+
+      expect(putMock).toHaveBeenCalledWith(
+        expect.stringContaining('/apis/dashboard.grafana.app/v0alpha1/namespaces/default/dashboards/_U4zObQMz'),
+        expect.objectContaining({
+          spec: { title: 'Test Dashboard' },
+          metadata: expect.objectContaining({
+            annotations: expect.objectContaining({
+              'grafana.app/message': 'Restored from version 4',
+            }),
+          }),
+        })
+      );
+    });
+
+    it('should return an empty object when not given an id', async () => {
+      const rsp = await historySrv.restoreDashboard(emptyDash.uid, 6);
+      expect(rsp).toEqual({});
+    });
+
+    it('should throw an error when version is not found', async () => {
+      getMock.mockResolvedValue({ items: [], metadata: {} });
+
+      await expect(historySrv.restoreDashboard(dash.uid, 999)).rejects.toThrow(
+        'Version 999 not found for dashboard _U4zObQMz'
+      );
+    });
+  });
+
+  describe('transformToRevisionsModel', () => {
+    it('should handle missing annotations gracefully', async () => {
+      const responseWithoutAnnotations = {
+        items: [
+          {
+            metadata: {
+              name: '_U4zObQMz',
+              generation: 1,
+            },
+            spec: { title: 'Test Dashboard' },
+          },
+        ],
+        metadata: {},
+      };
+
+      getMock.mockResolvedValue(responseWithoutAnnotations);
+
+      const result = await historySrv.getHistoryList(dash.uid, historyListOpts);
+
+      expect(result.versions).toHaveLength(1);
+      expect(result.versions[0].createdBy).toBe('');
+      expect(result.versions[0].message).toBe('');
+      expect(result.versions[0].parentVersion).toBe(0); // generation 1 should have parentVersion 0
+    });
+
+    it('should correctly calculate parentVersion', async () => {
+      getMock.mockResolvedValue(k8sVersionsResponse);
+
+      const result = await historySrv.getHistoryList(dash.uid, historyListOpts);
+
+      expect(result.versions[0].version).toBe(4);
+      expect(result.versions[0].parentVersion).toBe(3);
+      expect(result.versions[1].version).toBe(3);
+      expect(result.versions[1].parentVersion).toBe(2);
+    });
+
+    it('should set created date from annotation', async () => {
+      getMock.mockResolvedValue(k8sVersionsResponse);
+
+      const result = await historySrv.getHistoryList(dash.uid, historyListOpts);
+
+      expect(result.versions[0].created).toEqual(new Date('2023-01-01T00:00:00Z'));
+    });
+
+    it('should use current date when updatedTimestamp annotation is missing', async () => {
+      const responseWithoutTimestamp = {
+        items: [
+          {
+            metadata: {
+              name: '_U4zObQMz',
+              generation: 1,
+              annotations: {
+                'grafana.app/updatedBy': 'admin',
+              },
+            },
+            spec: { title: 'Test Dashboard' },
+          },
+        ],
+        metadata: {},
+      };
+
+      getMock.mockResolvedValue(responseWithoutTimestamp);
+
+      const beforeTest = new Date();
+      const result = await historySrv.getHistoryList(dash.uid, historyListOpts);
+      const afterTest = new Date();
+
+      // The created date should be between beforeTest and afterTest
+      expect(result.versions[0].created.getTime()).toBeGreaterThanOrEqual(beforeTest.getTime());
+      expect(result.versions[0].created.getTime()).toBeLessThanOrEqual(afterTest.getTime());
+    });
+  });
+
+  describe('pagination', () => {
+    it('should return continueToken from response metadata', async () => {
+      const responseWithContinue = {
+        items: [
+          {
+            metadata: {
+              name: '_U4zObQMz',
+              generation: 1,
+              annotations: {},
+            },
+            spec: { title: 'Test Dashboard' },
+          },
+        ],
+        metadata: {
+          continue: 'next-page-token',
+        },
+      };
+
+      getMock.mockResolvedValue(responseWithContinue);
+
+      const result = await historySrv.getHistoryList(dash.uid, historyListOpts);
+
+      expect(result.continueToken).toBe('next-page-token');
+    });
+
+    it('should not include continueToken when not present in response', async () => {
+      getMock.mockResolvedValue({ items: [], metadata: {} });
+
+      const result = await historySrv.getHistoryList(dash.uid, historyListOpts);
+
+      expect(result.continueToken).toBeUndefined();
+    });
+  });
+});
+
+describe('createHistorySrv', () => {
+  it('should return LegacyHistorySrv when feature flag is disabled', () => {
+    const srv = createHistorySrv();
+    expect(srv).toBeInstanceOf(LegacyHistorySrv);
+  });
+
+  it('should return K8sHistorySrv when feature flag is enabled', () => {
+    // Temporarily enable the feature flag
+    const { config } = jest.requireMock('@grafana/runtime');
+    const originalValue = config.featureToggles.kubernetesDashboardVersions;
+    config.featureToggles.kubernetesDashboardVersions = true;
+
+    const srv = createHistorySrv();
+    expect(srv).toBeInstanceOf(K8sHistorySrv);
+
+    // Restore the original value
+    config.featureToggles.kubernetesDashboardVersions = originalValue;
   });
 });

--- a/public/app/features/dashboard-scene/settings/version-history/HistorySrv.test.ts
+++ b/public/app/features/dashboard-scene/settings/version-history/HistorySrv.test.ts
@@ -59,15 +59,15 @@ describe('LegacyHistorySrv', () => {
       });
     });
 
-    it('should return an empty array when not given an id', () => {
-      return historySrv.getHistoryList(emptyDash.uid, historyListOpts).then((versions) => {
-        expect(versions).toEqual([]);
+    it('should return an empty versions array when not given an id', () => {
+      return historySrv.getHistoryList(emptyDash.uid, historyListOpts).then((result) => {
+        expect(result).toEqual({ versions: [] });
       });
     });
 
-    it('should return an empty array when not given a dashboard id', () => {
-      return historySrv.getHistoryList(null as unknown as string, historyListOpts).then((versions) => {
-        expect(versions).toEqual([]);
+    it('should return an empty versions array when not given a dashboard id', () => {
+      return historySrv.getHistoryList(null as unknown as string, historyListOpts).then((result) => {
+        expect(result).toEqual({ versions: [] });
       });
     });
   });

--- a/public/app/features/dashboard-scene/settings/version-history/HistorySrv.ts
+++ b/public/app/features/dashboard-scene/settings/version-history/HistorySrv.ts
@@ -49,7 +49,7 @@ export interface DashboardHistorySrv {
   getHistoryList(
     dashboardUID: string,
     options: HistoryListOpts
-  ): Promise<RevisionsModel[] | { versions: RevisionsModel[]; continueToken?: string }>;
+  ): Promise<{ versions: RevisionsModel[]; continueToken?: string }>;
   getDashboardVersion(dashboardUID: string, version: number): Promise<RevisionsModel | Record<string, never>>;
   restoreDashboard(dashboardUID: string, version: number): Promise<unknown>;
 }
@@ -58,9 +58,12 @@ export interface DashboardHistorySrv {
  * Legacy implementation using /api/ endpoints
  */
 export class LegacyHistorySrv implements DashboardHistorySrv {
-  getHistoryList(dashboardUID: string, options: HistoryListOpts) {
+  getHistoryList(
+    dashboardUID: string,
+    options: HistoryListOpts
+  ): Promise<{ versions: RevisionsModel[]; continueToken?: string }> {
     if (typeof dashboardUID !== 'string') {
-      return Promise.resolve([]);
+      return Promise.resolve({ versions: [] });
     }
 
     return getBackendSrv().get(`api/dashboards/uid/${dashboardUID}/versions`, options);

--- a/public/app/features/dashboard-scene/settings/version-history/HistorySrv.ts
+++ b/public/app/features/dashboard-scene/settings/version-history/HistorySrv.ts
@@ -1,5 +1,7 @@
-import { getBackendSrv } from '@grafana/runtime';
+import { config, getBackendSrv } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
+
+import { getAPINamespace } from '../../../../api/utils';
 
 export interface HistoryListOpts {
   limit: number;
@@ -19,7 +21,43 @@ export interface RevisionsModel {
   data: Dashboard;
 }
 
-export class HistorySrv {
+// K8s API response types
+interface K8sDashboardResource {
+  metadata: {
+    name: string;
+    generation: number;
+    annotations?: {
+      'grafana.app/updatedTimestamp'?: string;
+      'grafana.app/updatedBy'?: string;
+      'grafana.app/message'?: string;
+    };
+  };
+  spec: Dashboard;
+}
+
+interface K8sDashboardList {
+  items: K8sDashboardResource[];
+  metadata: {
+    continue?: string;
+  };
+}
+
+/**
+ * Interface for dashboard version history service
+ */
+export interface DashboardHistorySrv {
+  getHistoryList(
+    dashboardUID: string,
+    options: HistoryListOpts
+  ): Promise<RevisionsModel[] | { versions: RevisionsModel[]; continueToken?: string }>;
+  getDashboardVersion(dashboardUID: string, version: number): Promise<RevisionsModel | Record<string, never>>;
+  restoreDashboard(dashboardUID: string, version: number): Promise<unknown>;
+}
+
+/**
+ * Legacy implementation using /api/ endpoints
+ */
+export class LegacyHistorySrv implements DashboardHistorySrv {
   getHistoryList(dashboardUID: string, options: HistoryListOpts) {
     if (typeof dashboardUID !== 'string') {
       return Promise.resolve([]);
@@ -47,5 +85,129 @@ export class HistorySrv {
   }
 }
 
-const historySrv = new HistorySrv();
+/**
+ * K8s implementation using /apis/ endpoints with label selectors
+ */
+export class K8sHistorySrv implements DashboardHistorySrv {
+  private readonly apiVersion = 'dashboard.grafana.app/v0alpha1';
+
+  private getBaseUrl(): string {
+    const namespace = getAPINamespace();
+    return `/apis/${this.apiVersion}/namespaces/${namespace}/dashboards`;
+  }
+
+  async getHistoryList(
+    dashboardUID: string,
+    options: HistoryListOpts
+  ): Promise<{ versions: RevisionsModel[]; continueToken?: string }> {
+    if (typeof dashboardUID !== 'string') {
+      return { versions: [] };
+    }
+
+    const params = new URLSearchParams();
+    params.set('labelSelector', 'grafana.app/get-history=true');
+    params.set('fieldSelector', `metadata.name=${dashboardUID}`);
+    if (options.limit) {
+      params.set('limit', String(options.limit));
+    }
+    if (options.continueToken) {
+      params.set('continue', options.continueToken);
+    }
+
+    const url = `${this.getBaseUrl()}?${params.toString()}`;
+    const response: K8sDashboardList = await getBackendSrv().get(url);
+
+    const versions = response.items.map((item) => this.transformToRevisionsModel(item, dashboardUID));
+
+    return {
+      versions,
+      continueToken: response.metadata.continue,
+    };
+  }
+
+  async getDashboardVersion(dashboardUID: string, version: number): Promise<RevisionsModel | Record<string, never>> {
+    if (typeof dashboardUID !== 'string') {
+      return {};
+    }
+
+    // For K8s, we need to list with history label and find the specific version
+    const params = new URLSearchParams();
+    params.set('labelSelector', 'grafana.app/get-history=true');
+    params.set('fieldSelector', `metadata.name=${dashboardUID}`);
+
+    const url = `${this.getBaseUrl()}?${params.toString()}`;
+    const response: K8sDashboardList = await getBackendSrv().get(url);
+
+    const item = response.items.find((item) => item.metadata.generation === version);
+    if (!item) {
+      return {};
+    }
+
+    return this.transformToRevisionsModel(item, dashboardUID);
+  }
+
+  async restoreDashboard(dashboardUID: string, version: number): Promise<unknown> {
+    if (typeof dashboardUID !== 'string') {
+      return {};
+    }
+
+    // Get the specific version
+    const versionData = await this.getDashboardVersion(dashboardUID, version);
+    if (!versionData || !('data' in versionData)) {
+      throw new Error(`Version ${version} not found for dashboard ${dashboardUID}`);
+    }
+
+    // PUT the dashboard with the spec from the old version
+    const url = `${this.getBaseUrl()}/${dashboardUID}`;
+    const currentDashboard: K8sDashboardResource = await getBackendSrv().get(url);
+
+    // Update the spec with the old version's data
+    const updatedDashboard = {
+      ...currentDashboard,
+      spec: versionData.data,
+      metadata: {
+        ...currentDashboard.metadata,
+        annotations: {
+          ...currentDashboard.metadata.annotations,
+          'grafana.app/message': `Restored from version ${version}`,
+        },
+      },
+    };
+
+    return getBackendSrv().put(url, updatedDashboard);
+  }
+
+  private transformToRevisionsModel(item: K8sDashboardResource, dashboardUID: string): RevisionsModel {
+    const annotations = item.metadata.annotations || {};
+    const createdTimestamp = annotations['grafana.app/updatedTimestamp'];
+
+    return {
+      id: item.metadata.generation,
+      checked: false,
+      uid: dashboardUID,
+      parentVersion: item.metadata.generation > 1 ? item.metadata.generation - 1 : 0,
+      version: item.metadata.generation,
+      created: createdTimestamp ? new Date(createdTimestamp) : new Date(),
+      createdBy: annotations['grafana.app/updatedBy'] || '',
+      message: annotations['grafana.app/message'] || '',
+      data: item.spec,
+    };
+  }
+}
+
+/**
+ * Factory function to create the appropriate history service based on feature flag
+ */
+export function createHistorySrv(): DashboardHistorySrv {
+  if (config.featureToggles.kubernetesDashboardVersions) {
+    return new K8sHistorySrv();
+  }
+  return new LegacyHistorySrv();
+}
+
+// Backwards compatibility: HistorySrv is an alias for LegacyHistorySrv
+export class HistorySrv extends LegacyHistorySrv {}
+
+// Create the default instance using the factory
+const historySrv = createHistorySrv();
 export { historySrv };


### PR DESCRIPTION
## Summary

- Add K8s implementation for dashboard version history using the `/apis/` endpoints with label selectors
- Create `kubernetesDashboardVersions` feature flag to toggle between legacy and K8s implementations
- Add factory function `createHistorySrv()` to select the appropriate implementation based on feature flag
- Add dashboard theme/styling settings (background image, custom CSS)
- Fix bug where `LegacyHistorySrv.getHistoryList()` returned inconsistent format for invalid UIDs

## Changes

### Backend
- Add `kubernetesDashboardVersions` feature flag (experimental, frontend-only)

### Frontend
- Add `K8sHistorySrv` class using `/apis/dashboard.grafana.app/v0alpha1/` endpoints
- Add `DashboardHistorySrv` interface for both implementations
- Fix `LegacyHistorySrv.getHistoryList()` to return `{ versions: [] }` instead of `[]` for invalid UIDs
- Add theme settings UI with background image and custom CSS support
- Add comprehensive tests for both implementations

## Test plan

- [ ] Verify legacy history API works with feature flag disabled
- [ ] Enable `kubernetesDashboardVersions` feature flag and verify K8s API works
- [ ] Test version comparison and restore functionality
- [ ] Test pagination with continue tokens
- [ ] Test error handling for invalid dashboard UIDs