### PR TITLE
Dashboards: Fix datasource replacement during v2 dashboard import

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2007,7 +2007,7 @@
   },
   "public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
-      "count": 10
+      "count": 3
     }
   },
   "public/app/features/dashboard/api/ResponseTransformers.ts": {

--- a/public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx
+++ b/public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx
@@ -30,7 +30,6 @@ export function ImportDashboardOverviewV2() {
   async function onSubmit(form: FormData) {
     reportInteraction(IMPORT_FINISHED_EVENT_NAME);
 
-    // Build datasource mappings from form
     const mappings: DatasourceMappings = {};
     for (const key of Object.keys(form)) {
       if (key.startsWith('datasource-')) {

--- a/public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx
+++ b/public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx
@@ -1,10 +1,6 @@
 import { locationUtil } from '@grafana/data';
 import { locationService, reportInteraction } from '@grafana/runtime';
-import {
-  AnnotationQueryKind,
-  Spec as DashboardV2Spec,
-  defaultDataQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import { AnnotationQueryKind, Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { Form } from 'app/core/components/Form/Form';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { SaveDashboardCommand } from 'app/features/dashboard/components/SaveDashboard/types';
@@ -37,7 +33,7 @@ export function ImportDashboardOverviewV2() {
       ...dashboard,
       title: form.dashboard.title,
       annotations: dashboard.annotations?.map((annotation: AnnotationQueryKind) => {
-        const dsType = annotation.spec.query?.spec.group;
+        const dsType = annotation.spec.query?.group;
         if (dsType) {
           if (form[`datasource-${dsType}` as keyof typeof form]) {
             const ds = form[`datasource-${dsType}` as keyof typeof form] as { uid: string; type: string };
@@ -46,13 +42,8 @@ export function ImportDashboardOverviewV2() {
               spec: {
                 ...annotation.spec,
                 query: {
-                  kind: 'DataQuery',
-                  group: dsType,
-                  version: defaultDataQueryKind().version,
+                  ...annotation.spec.query,
                   datasource: { name: ds.uid },
-                  spec: {
-                    ...annotation.spec.query?.spec,
-                  },
                 },
               },
             };
@@ -62,7 +53,7 @@ export function ImportDashboardOverviewV2() {
       }),
       variables: dashboard.variables?.map((variable) => {
         if (variable.kind === 'QueryVariable') {
-          const dsType = variable.spec.query?.spec.group;
+          const dsType = variable.spec.query?.group;
           if (dsType) {
             if (form[`datasource-${dsType}` as keyof typeof form]) {
               const ds = form[`datasource-${dsType}` as keyof typeof form] as { uid: string; type: string };
@@ -72,12 +63,8 @@ export function ImportDashboardOverviewV2() {
                   ...variable.spec,
                   query: {
                     ...variable.spec.query,
-                    spec: {
-                      ...variable.spec.query.spec,
-                      group: ds.type,
-                      datasource: {
-                        name: ds.uid,
-                      },
+                    datasource: {
+                      name: ds.uid,
                     },
                   },
                   options: [],
@@ -119,17 +106,19 @@ export function ImportDashboardOverviewV2() {
             if (panel.data?.kind === 'QueryGroup') {
               const newQueries = panel.data.spec.queries.map((query) => {
                 if (query.kind === 'PanelQuery') {
-                  const queryType = query.spec.query?.kind;
-                  // Match datasource by query kind
+                  const queryType = query.spec.query?.group;
+                  // Match datasource by query group
                   if (queryType && form[`datasource-${queryType}` as keyof typeof form]) {
                     const ds = form[`datasource-${queryType}` as keyof typeof form] as { uid: string; type: string };
                     return {
                       ...query,
                       spec: {
                         ...query.spec,
-                        datasource: {
-                          uid: ds.uid,
-                          type: ds.type,
+                        query: {
+                          ...query.spec.query,
+                          datasource: {
+                            name: ds.uid,
+                          },
                         },
                       },
                     };

--- a/public/app/features/dashboard-scene/v2schema/importDatasourceReplacer.test.ts
+++ b/public/app/features/dashboard-scene/v2schema/importDatasourceReplacer.test.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { isVariableRef, replaceDatasourcesInDashboard, DatasourceMappings } from './importDatasourceReplacer';

--- a/public/app/features/dashboard-scene/v2schema/importDatasourceReplacer.test.ts
+++ b/public/app/features/dashboard-scene/v2schema/importDatasourceReplacer.test.ts
@@ -1,27 +1,16 @@
-// @ts-nocheck
 import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { isVariableRef, replaceDatasourcesInDashboard, DatasourceMappings } from './importDatasourceReplacer';
 
 describe('isVariableRef', () => {
-  it('returns true for ${ds} format', () => {
-    expect(isVariableRef('${ds}')).toBe(true);
-  });
-
-  it('returns true for $ds format', () => {
-    expect(isVariableRef('$ds')).toBe(true);
-  });
-
-  it('returns false for hardcoded uid', () => {
-    expect(isVariableRef('abc123')).toBe(false);
-  });
-
-  it('returns false for undefined', () => {
-    expect(isVariableRef(undefined)).toBe(false);
-  });
-
-  it('returns false for empty string', () => {
-    expect(isVariableRef('')).toBe(false);
+  it.each([
+    { input: '${ds}', expected: true },
+    { input: '$ds', expected: true },
+    { input: 'abc123', expected: false },
+    { input: undefined, expected: false },
+    { input: '', expected: false },
+  ])('returns $expected for $input', ({ input, expected }) => {
+    expect(isVariableRef(input)).toBe(expected);
   });
 });
 
@@ -54,487 +43,280 @@ describe('replaceDatasourcesInDashboard', () => {
     prometheus: { uid: 'new-prom-uid', type: 'prometheus', name: 'New Prometheus' },
   };
 
+  const createPanelWithQuery = (group: string, datasourceName: string) => ({
+    kind: 'Panel' as const,
+    spec: {
+      id: 1,
+      title: 'Test Panel',
+      description: '',
+      links: [],
+      vizConfig: {
+        kind: 'VizConfig' as const,
+        group: 'timeseries',
+        version: 'v0',
+        spec: { options: {}, fieldConfig: { defaults: {}, overrides: [] } },
+      },
+      data: {
+        kind: 'QueryGroup' as const,
+        spec: {
+          queries: [
+            {
+              kind: 'PanelQuery' as const,
+              spec: {
+                refId: 'A',
+                hidden: false,
+                query: {
+                  kind: 'DataQuery' as const,
+                  group,
+                  version: 'v0',
+                  datasource: { name: datasourceName },
+                  spec: {},
+                },
+              },
+            },
+          ],
+          queryOptions: {},
+          transformations: [],
+        },
+      },
+    },
+  });
+
+  const getPanelQueryDatasourceName = (result: DashboardV2Spec, panelKey = 'panel-1') => {
+    const panel = result.elements[panelKey];
+    if (panel.kind === 'Panel' && panel.spec.data?.kind === 'QueryGroup') {
+      return panel.spec.data.spec.queries[0].spec.query?.datasource?.name;
+    }
+    return undefined;
+  };
+
+  const getQueryVariable = (result: DashboardV2Spec, index = 0) => {
+    const variable = result.variables?.[index];
+    return variable?.kind === 'QueryVariable' ? variable : undefined;
+  };
+
+  const getDatasourceVariable = (result: DashboardV2Spec, index = 0) => {
+    const variable = result.variables?.[index];
+    return variable?.kind === 'DatasourceVariable' ? variable : undefined;
+  };
+
+  const getAdhocVariable = (result: DashboardV2Spec, index = 0) => {
+    const variable = result.variables?.[index];
+    return variable?.kind === 'AdhocVariable' ? variable : undefined;
+  };
+
+  const getGroupByVariable = (result: DashboardV2Spec, index = 0) => {
+    const variable = result.variables?.[index];
+    return variable?.kind === 'GroupByVariable' ? variable : undefined;
+  };
+
   describe('panel queries', () => {
-    it('replaces hardcoded datasource in panel queries', () => {
+    it.each([
+      { group: 'loki', inputDs: 'old-loki-uid', expectedDs: 'new-loki-uid', desc: 'replaces hardcoded datasource' },
+      { group: 'prometheus', inputDs: '${ds}', expectedDs: '${ds}', desc: 'preserves ${ds} variable reference' },
+      { group: 'prometheus', inputDs: '$ds', expectedDs: '$ds', desc: 'preserves $ds variable reference' },
+      {
+        group: 'elasticsearch',
+        inputDs: 'es-uid',
+        expectedDs: 'es-uid',
+        desc: 'keeps original when no mapping exists',
+      },
+    ])('$desc', ({ group, inputDs, expectedDs }) => {
       const dashboard: DashboardV2Spec = {
         ...baseDashboard,
-        elements: {
-          'panel-1': {
-            kind: 'Panel',
-            spec: {
-              id: 1,
-              title: 'Test Panel',
-              vizConfig: { kind: 'VizConfig', group: 'timeseries', spec: {} },
-              data: {
-                kind: 'QueryGroup',
-                spec: {
-                  queries: [
-                    {
-                      kind: 'PanelQuery',
-                      spec: {
-                        refId: 'A',
-                        hidden: false,
-                        query: {
-                          kind: 'DataQuery',
-                          group: 'loki',
-                          version: 'v0',
-                          datasource: { name: 'old-loki-uid' },
-                          spec: {},
-                        },
-                      },
-                    },
-                  ],
-                  queryOptions: {},
-                  transformations: [],
-                },
-              },
-            },
-          },
-        },
+        elements: { 'panel-1': createPanelWithQuery(group, inputDs) },
       };
 
       const result = replaceDatasourcesInDashboard(dashboard, mappings);
 
-      const panel = result.elements['panel-1'];
-      expect(panel.kind).toBe('Panel');
-      if (panel.kind === 'Panel' && panel.spec.data?.kind === 'QueryGroup') {
-        expect(panel.spec.data.spec.queries[0].spec.query?.datasource?.name).toBe('new-loki-uid');
-      }
-    });
-
-    it('preserves variable reference ${ds} in panel queries', () => {
-      const dashboard: DashboardV2Spec = {
-        ...baseDashboard,
-        elements: {
-          'panel-1': {
-            kind: 'Panel',
-            spec: {
-              id: 1,
-              title: 'Test Panel',
-              vizConfig: { kind: 'VizConfig', group: 'timeseries', spec: {} },
-              data: {
-                kind: 'QueryGroup',
-                spec: {
-                  queries: [
-                    {
-                      kind: 'PanelQuery',
-                      spec: {
-                        refId: 'A',
-                        hidden: false,
-                        query: {
-                          kind: 'DataQuery',
-                          group: 'prometheus',
-                          version: 'v0',
-                          datasource: { name: '${ds}' },
-                          spec: {},
-                        },
-                      },
-                    },
-                  ],
-                  queryOptions: {},
-                  transformations: [],
-                },
-              },
-            },
-          },
-        },
-      };
-
-      const result = replaceDatasourcesInDashboard(dashboard, mappings);
-
-      const panel = result.elements['panel-1'];
-      if (panel.kind === 'Panel' && panel.spec.data?.kind === 'QueryGroup') {
-        expect(panel.spec.data.spec.queries[0].spec.query?.datasource?.name).toBe('${ds}');
-      }
-    });
-
-    it('preserves variable reference $ds in panel queries', () => {
-      const dashboard: DashboardV2Spec = {
-        ...baseDashboard,
-        elements: {
-          'panel-1': {
-            kind: 'Panel',
-            spec: {
-              id: 1,
-              title: 'Test Panel',
-              vizConfig: { kind: 'VizConfig', group: 'timeseries', spec: {} },
-              data: {
-                kind: 'QueryGroup',
-                spec: {
-                  queries: [
-                    {
-                      kind: 'PanelQuery',
-                      spec: {
-                        refId: 'A',
-                        hidden: false,
-                        query: {
-                          kind: 'DataQuery',
-                          group: 'prometheus',
-                          version: 'v0',
-                          datasource: { name: '$ds' },
-                          spec: {},
-                        },
-                      },
-                    },
-                  ],
-                  queryOptions: {},
-                  transformations: [],
-                },
-              },
-            },
-          },
-        },
-      };
-
-      const result = replaceDatasourcesInDashboard(dashboard, mappings);
-
-      const panel = result.elements['panel-1'];
-      if (panel.kind === 'Panel' && panel.spec.data?.kind === 'QueryGroup') {
-        expect(panel.spec.data.spec.queries[0].spec.query?.datasource?.name).toBe('$ds');
-      }
-    });
-
-    it('does not replace when no mapping exists for datasource type', () => {
-      const dashboard: DashboardV2Spec = {
-        ...baseDashboard,
-        elements: {
-          'panel-1': {
-            kind: 'Panel',
-            spec: {
-              id: 1,
-              title: 'Test Panel',
-              vizConfig: { kind: 'VizConfig', group: 'timeseries', spec: {} },
-              data: {
-                kind: 'QueryGroup',
-                spec: {
-                  queries: [
-                    {
-                      kind: 'PanelQuery',
-                      spec: {
-                        refId: 'A',
-                        hidden: false,
-                        query: {
-                          kind: 'DataQuery',
-                          group: 'elasticsearch',
-                          version: 'v0',
-                          datasource: { name: 'es-uid' },
-                          spec: {},
-                        },
-                      },
-                    },
-                  ],
-                  queryOptions: {},
-                  transformations: [],
-                },
-              },
-            },
-          },
-        },
-      };
-
-      const result = replaceDatasourcesInDashboard(dashboard, mappings);
-
-      const panel = result.elements['panel-1'];
-      if (panel.kind === 'Panel' && panel.spec.data?.kind === 'QueryGroup') {
-        expect(panel.spec.data.spec.queries[0].spec.query?.datasource?.name).toBe('es-uid');
-      }
+      expect(getPanelQueryDatasourceName(result)).toBe(expectedDs);
     });
   });
 
   describe('annotations', () => {
-    it('replaces hardcoded datasource in annotations', () => {
-      const dashboard: DashboardV2Spec = {
-        ...baseDashboard,
-        annotations: [
-          {
-            kind: 'AnnotationQuery',
-            spec: {
-              name: 'Test Annotation',
-              enable: true,
-              hide: false,
-              iconColor: 'red',
-              query: {
-                kind: 'DataQuery',
-                group: 'prometheus',
-                version: 'v0',
-                datasource: { name: 'old-prom-uid' },
-                spec: {},
-              },
-            },
-          },
-        ],
-      };
-
-      const result = replaceDatasourcesInDashboard(dashboard, mappings);
-
-      expect(result.annotations?.[0].spec.query?.datasource?.name).toBe('new-prom-uid');
+    const createAnnotation = (group: string, datasourceName: string) => ({
+      kind: 'AnnotationQuery' as const,
+      spec: {
+        name: 'Test Annotation',
+        enable: true,
+        hide: false,
+        iconColor: 'red',
+        query: {
+          kind: 'DataQuery' as const,
+          group,
+          version: 'v0',
+          datasource: { name: datasourceName },
+          spec: {},
+        },
+      },
     });
 
-    it('preserves variable reference in annotations', () => {
+    it.each([
+      { inputDs: 'old-prom-uid', expectedDs: 'new-prom-uid', desc: 'replaces hardcoded datasource' },
+      { inputDs: '${ds}', expectedDs: '${ds}', desc: 'preserves variable reference' },
+    ])('$desc', ({ inputDs, expectedDs }) => {
       const dashboard: DashboardV2Spec = {
         ...baseDashboard,
-        annotations: [
-          {
-            kind: 'AnnotationQuery',
-            spec: {
-              name: 'Test Annotation',
-              enable: true,
-              hide: false,
-              iconColor: 'red',
-              query: {
-                kind: 'DataQuery',
-                group: 'prometheus',
-                version: 'v0',
-                datasource: { name: '${ds}' },
-                spec: {},
-              },
-            },
-          },
-        ],
+        annotations: [createAnnotation('prometheus', inputDs)],
       };
 
       const result = replaceDatasourcesInDashboard(dashboard, mappings);
 
-      expect(result.annotations?.[0].spec.query?.datasource?.name).toBe('${ds}');
+      expect(result.annotations?.[0].spec.query?.datasource?.name).toBe(expectedDs);
     });
   });
 
-  describe('QueryVariable', () => {
-    it('replaces hardcoded datasource in QueryVariable', () => {
-      const dashboard: DashboardV2Spec = {
-        ...baseDashboard,
-        variables: [
-          {
-            kind: 'QueryVariable',
-            spec: {
-              name: 'test_var',
-              current: { text: 'All', value: '$__all' },
-              options: [{ text: 'All', value: '$__all' }],
-              hide: 'dontHide',
-              skipUrlSync: false,
-              multi: false,
-              includeAll: true,
-              allowCustomValue: false,
-              refresh: 'onDashboardLoad',
-              regex: '',
-              sort: 'disabled',
-              query: {
-                kind: 'DataQuery',
-                group: 'prometheus',
-                version: 'v0',
-                datasource: { name: 'old-prom-uid' },
-                spec: {},
-              },
-            },
-          },
-        ],
-      };
-
-      const result = replaceDatasourcesInDashboard(dashboard, mappings);
-
-      const variable = result.variables?.[0];
-      expect(variable?.kind).toBe('QueryVariable');
-      if (variable?.kind === 'QueryVariable') {
-        expect(variable.spec.query?.datasource?.name).toBe('new-prom-uid');
-        expect(variable.spec.options).toEqual([]);
-        expect(variable.spec.current).toEqual({ text: '', value: '' });
-        expect(variable.spec.refresh).toBe('onDashboardLoad');
-      }
+  describe('query variable', () => {
+    const createQueryVariable = (group: string, datasourceName: string) => ({
+      kind: 'QueryVariable' as const,
+      spec: {
+        name: 'test_var',
+        current: { text: 'All', value: '$__all' },
+        options: [{ text: 'All', value: '$__all' }],
+        hide: 'dontHide' as const,
+        skipUrlSync: false,
+        multi: false,
+        includeAll: true,
+        allowCustomValue: false,
+        refresh: 'onDashboardLoad' as const,
+        regex: '',
+        sort: 'disabled' as const,
+        query: {
+          kind: 'DataQuery' as const,
+          group,
+          version: 'v0',
+          datasource: { name: datasourceName },
+          spec: {},
+        },
+      },
     });
 
-    it('preserves variable reference in QueryVariable', () => {
+    it('replaces hardcoded datasource and resets options/current', () => {
       const dashboard: DashboardV2Spec = {
         ...baseDashboard,
-        variables: [
-          {
-            kind: 'QueryVariable',
-            spec: {
-              name: 'test_var',
-              current: { text: 'All', value: '$__all' },
-              options: [{ text: 'All', value: '$__all' }],
-              hide: 'dontHide',
-              skipUrlSync: false,
-              multi: false,
-              includeAll: true,
-              allowCustomValue: false,
-              refresh: 'onDashboardLoad',
-              regex: '',
-              sort: 'disabled',
-              query: {
-                kind: 'DataQuery',
-                group: 'prometheus',
-                version: 'v0',
-                datasource: { name: '${ds}' },
-                spec: {},
-              },
-            },
-          },
-        ],
+        variables: [createQueryVariable('prometheus', 'old-prom-uid')],
       };
 
       const result = replaceDatasourcesInDashboard(dashboard, mappings);
+      const variable = getQueryVariable(result);
 
-      const variable = result.variables?.[0];
-      if (variable?.kind === 'QueryVariable') {
-        expect(variable.spec.query?.datasource?.name).toBe('${ds}');
-        // Options should NOT be reset when preserving variable
-        expect(variable.spec.options).toEqual([{ text: 'All', value: '$__all' }]);
-      }
+      expect(variable).toBeDefined();
+      expect(variable?.spec.query?.datasource?.name).toBe('new-prom-uid');
+      expect(variable?.spec.options).toEqual([]);
+      expect(variable?.spec.current).toEqual({ text: '', value: '' });
+      expect(variable?.spec.refresh).toBe('onDashboardLoad');
+    });
+
+    it('preserves variable reference and keeps options intact', () => {
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        variables: [createQueryVariable('prometheus', '${ds}')],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+      const variable = getQueryVariable(result);
+
+      expect(variable?.spec.query?.datasource?.name).toBe('${ds}');
+      expect(variable?.spec.options).toEqual([{ text: 'All', value: '$__all' }]);
     });
   });
 
-  describe('DatasourceVariable', () => {
+  describe('datasource varia', () => {
+    const createDatasourceVariable = (pluginId: string, currentValue: string, currentText: string) => ({
+      kind: 'DatasourceVariable' as const,
+      spec: {
+        name: 'ds',
+        pluginId,
+        current: { text: currentText, value: currentValue },
+        options: [],
+        hide: 'dontHide' as const,
+        skipUrlSync: false,
+        multi: false,
+        includeAll: false,
+        allowCustomValue: false,
+        refresh: 'onDashboardLoad' as const,
+        regex: '',
+      },
+    });
+
     it('replaces current value in DatasourceVariable', () => {
       const dashboard: DashboardV2Spec = {
         ...baseDashboard,
-        variables: [
-          {
-            kind: 'DatasourceVariable',
-            spec: {
-              name: 'ds',
-              pluginId: 'prometheus',
-              current: { text: 'Old Prometheus', value: 'old-prom-uid' },
-              options: [],
-              hide: 'dontHide',
-              skipUrlSync: false,
-              multi: false,
-              includeAll: false,
-              allowCustomValue: false,
-              refresh: 'onDashboardLoad',
-              regex: '',
-            },
-          },
-        ],
+        variables: [createDatasourceVariable('prometheus', 'old-prom-uid', 'Old Prometheus')],
       };
 
       const result = replaceDatasourcesInDashboard(dashboard, mappings);
+      const variable = getDatasourceVariable(result);
 
-      const variable = result.variables?.[0];
-      expect(variable?.kind).toBe('DatasourceVariable');
-      if (variable?.kind === 'DatasourceVariable') {
-        expect(variable.spec.current?.value).toBe('new-prom-uid');
-        expect(variable.spec.current?.text).toBe('New Prometheus');
-      }
+      expect(variable).toBeDefined();
+      expect(variable?.spec.current?.value).toBe('new-prom-uid');
+      expect(variable?.spec.current?.text).toBe('New Prometheus');
     });
   });
 
   describe('AdhocVariable', () => {
-    it('replaces hardcoded datasource in AdhocVariable', () => {
-      const dashboard: DashboardV2Spec = {
-        ...baseDashboard,
-        variables: [
-          {
-            kind: 'AdhocVariable',
-            group: 'loki',
-            datasource: { name: 'old-loki-uid' },
-            spec: {
-              name: 'Filters',
-              hide: 'dontHide',
-              skipUrlSync: false,
-              allowCustomValue: true,
-              defaultKeys: [],
-              filters: [],
-              baseFilters: [],
-            },
-          },
-        ],
-      };
-
-      const result = replaceDatasourcesInDashboard(dashboard, mappings);
-
-      const variable = result.variables?.[0];
-      expect(variable?.kind).toBe('AdhocVariable');
-      if (variable?.kind === 'AdhocVariable') {
-        expect(variable.datasource?.name).toBe('new-loki-uid');
-      }
+    const createAdhocVariable = (group: string, datasourceName: string) => ({
+      kind: 'AdhocVariable' as const,
+      group,
+      datasource: { name: datasourceName },
+      spec: {
+        name: 'Filters',
+        hide: 'dontHide' as const,
+        skipUrlSync: false,
+        allowCustomValue: true,
+        defaultKeys: [],
+        filters: [],
+        baseFilters: [],
+      },
     });
 
-    it('preserves variable reference in AdhocVariable', () => {
+    it.each([
+      { inputDs: 'old-loki-uid', expectedDs: 'new-loki-uid', desc: 'replaces hardcoded datasource' },
+      { inputDs: '${ds}', expectedDs: '${ds}', desc: 'preserves variable reference' },
+    ])('$desc', ({ inputDs, expectedDs }) => {
       const dashboard: DashboardV2Spec = {
         ...baseDashboard,
-        variables: [
-          {
-            kind: 'AdhocVariable',
-            group: 'loki',
-            datasource: { name: '${ds}' },
-            spec: {
-              name: 'Filters',
-              hide: 'dontHide',
-              skipUrlSync: false,
-              allowCustomValue: true,
-              defaultKeys: [],
-              filters: [],
-              baseFilters: [],
-            },
-          },
-        ],
+        variables: [createAdhocVariable('loki', inputDs)],
       };
 
       const result = replaceDatasourcesInDashboard(dashboard, mappings);
+      const variable = getAdhocVariable(result);
 
-      const variable = result.variables?.[0];
-      if (variable?.kind === 'AdhocVariable') {
-        expect(variable.datasource?.name).toBe('${ds}');
-      }
+      expect(variable).toBeDefined();
+      expect(variable?.datasource?.name).toBe(expectedDs);
     });
   });
 
-  describe('GroupByVariable', () => {
-    it('replaces hardcoded datasource in GroupByVariable', () => {
-      const dashboard: DashboardV2Spec = {
-        ...baseDashboard,
-        variables: [
-          {
-            kind: 'GroupByVariable',
-            group: 'prometheus',
-            datasource: { name: 'old-prom-uid' },
-            spec: {
-              name: 'groupby',
-              hide: 'dontHide',
-              skipUrlSync: false,
-              allowCustomValue: false,
-              options: [],
-              current: { text: '', value: '' },
-            },
-          },
-        ],
-      };
-
-      const result = replaceDatasourcesInDashboard(dashboard, mappings);
-
-      const variable = result.variables?.[0];
-      expect(variable?.kind).toBe('GroupByVariable');
-      if (variable?.kind === 'GroupByVariable') {
-        expect(variable.datasource?.name).toBe('new-prom-uid');
-      }
+  describe('GroupBy variable', () => {
+    const createGroupByVariable = (group: string, datasourceName: string) => ({
+      kind: 'GroupByVariable' as const,
+      group,
+      datasource: { name: datasourceName },
+      spec: {
+        name: 'groupby',
+        hide: 'dontHide' as const,
+        skipUrlSync: false,
+        allowCustomValue: false,
+        multi: false,
+        options: [],
+        current: { text: '', value: '' },
+      },
     });
 
-    it('preserves variable reference in GroupByVariable', () => {
+    it.each([
+      { inputDs: 'old-prom-uid', expectedDs: 'new-prom-uid', desc: 'replaces hardcoded datasource' },
+      { inputDs: '${ds}', expectedDs: '${ds}', desc: 'preserves variable reference' },
+    ])('$desc', ({ inputDs, expectedDs }) => {
       const dashboard: DashboardV2Spec = {
         ...baseDashboard,
-        variables: [
-          {
-            kind: 'GroupByVariable',
-            group: 'prometheus',
-            datasource: { name: '${ds}' },
-            spec: {
-              name: 'groupby',
-              hide: 'dontHide',
-              skipUrlSync: false,
-              allowCustomValue: false,
-              options: [],
-              current: { text: '', value: '' },
-            },
-          },
-        ],
+        variables: [createGroupByVariable('prometheus', inputDs)],
       };
 
       const result = replaceDatasourcesInDashboard(dashboard, mappings);
+      const variable = getGroupByVariable(result);
 
-      const variable = result.variables?.[0];
-      if (variable?.kind === 'GroupByVariable') {
-        expect(variable.datasource?.name).toBe('${ds}');
-      }
+      expect(variable).toBeDefined();
+      expect(variable?.datasource?.name).toBe(expectedDs);
     });
   });
 
@@ -543,83 +325,15 @@ describe('replaceDatasourcesInDashboard', () => {
       const dashboard: DashboardV2Spec = {
         ...baseDashboard,
         elements: {
-          'panel-variable': {
-            kind: 'Panel',
-            spec: {
-              id: 1,
-              title: 'Variable DS Panel',
-              vizConfig: { kind: 'VizConfig', group: 'timeseries', spec: {} },
-              data: {
-                kind: 'QueryGroup',
-                spec: {
-                  queries: [
-                    {
-                      kind: 'PanelQuery',
-                      spec: {
-                        refId: 'A',
-                        hidden: false,
-                        query: {
-                          kind: 'DataQuery',
-                          group: 'prometheus',
-                          version: 'v0',
-                          datasource: { name: '${ds}' },
-                          spec: {},
-                        },
-                      },
-                    },
-                  ],
-                  queryOptions: {},
-                  transformations: [],
-                },
-              },
-            },
-          },
-          'panel-hardcoded': {
-            kind: 'Panel',
-            spec: {
-              id: 2,
-              title: 'Hardcoded DS Panel',
-              vizConfig: { kind: 'VizConfig', group: 'logs', spec: {} },
-              data: {
-                kind: 'QueryGroup',
-                spec: {
-                  queries: [
-                    {
-                      kind: 'PanelQuery',
-                      spec: {
-                        refId: 'A',
-                        hidden: false,
-                        query: {
-                          kind: 'DataQuery',
-                          group: 'loki',
-                          version: 'v0',
-                          datasource: { name: 'old-loki-uid' },
-                          spec: {},
-                        },
-                      },
-                    },
-                  ],
-                  queryOptions: {},
-                  transformations: [],
-                },
-              },
-            },
-          },
+          'panel-variable': createPanelWithQuery('prometheus', '${ds}'),
+          'panel-hardcoded': createPanelWithQuery('loki', 'old-loki-uid'),
         },
       };
 
       const result = replaceDatasourcesInDashboard(dashboard, mappings);
 
-      const varPanel = result.elements['panel-variable'];
-      const hardcodedPanel = result.elements['panel-hardcoded'];
-
-      if (varPanel.kind === 'Panel' && varPanel.spec.data?.kind === 'QueryGroup') {
-        expect(varPanel.spec.data.spec.queries[0].spec.query?.datasource?.name).toBe('${ds}');
-      }
-
-      if (hardcodedPanel.kind === 'Panel' && hardcodedPanel.spec.data?.kind === 'QueryGroup') {
-        expect(hardcodedPanel.spec.data.spec.queries[0].spec.query?.datasource?.name).toBe('new-loki-uid');
-      }
+      expect(getPanelQueryDatasourceName(result, 'panel-variable')).toBe('${ds}');
+      expect(getPanelQueryDatasourceName(result, 'panel-hardcoded')).toBe('new-loki-uid');
     });
   });
 });

--- a/public/app/features/dashboard-scene/v2schema/importDatasourceReplacer.test.ts
+++ b/public/app/features/dashboard-scene/v2schema/importDatasourceReplacer.test.ts
@@ -1,0 +1,565 @@
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+
+import { isVariableRef, replaceDatasourcesInDashboard, DatasourceMappings } from './importDatasourceReplacer';
+
+describe('isVariableRef', () => {
+  it('returns true for ${ds} format', () => {
+    expect(isVariableRef('${ds}')).toBe(true);
+  });
+
+  it('returns true for $ds format', () => {
+    expect(isVariableRef('$ds')).toBe(true);
+  });
+
+  it('returns false for hardcoded uid', () => {
+    expect(isVariableRef('abc123')).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isVariableRef(undefined)).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isVariableRef('')).toBe(false);
+  });
+});
+
+describe('replaceDatasourcesInDashboard', () => {
+  const baseDashboard: DashboardV2Spec = {
+    title: 'Test Dashboard',
+    annotations: [],
+    variables: [],
+    elements: {},
+    layout: { kind: 'GridLayout', spec: { items: [] } },
+    cursorSync: 'Off',
+    liveNow: false,
+    editable: true,
+    preload: false,
+    links: [],
+    tags: [],
+    timeSettings: {
+      timezone: 'utc',
+      from: 'now-6h',
+      to: 'now',
+      autoRefresh: '',
+      autoRefreshIntervals: [],
+      hideTimepicker: false,
+      fiscalYearStartMonth: 0,
+    },
+  };
+
+  const mappings: DatasourceMappings = {
+    loki: { uid: 'new-loki-uid', type: 'loki', name: 'New Loki' },
+    prometheus: { uid: 'new-prom-uid', type: 'prometheus', name: 'New Prometheus' },
+  };
+
+  describe('panel queries', () => {
+    it('replaces hardcoded datasource in panel queries', () => {
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        elements: {
+          'panel-1': {
+            kind: 'Panel',
+            spec: {
+              id: 1,
+              title: 'Test Panel',
+              vizConfig: { kind: 'VizConfig', group: 'timeseries', spec: {} },
+              data: {
+                kind: 'QueryGroup',
+                spec: {
+                  queries: [
+                    {
+                      kind: 'PanelQuery',
+                      spec: {
+                        refId: 'A',
+                        hidden: false,
+                        query: {
+                          kind: 'DataQuery',
+                          group: 'loki',
+                          version: 'v0',
+                          datasource: { name: 'old-loki-uid' },
+                          spec: {},
+                        },
+                      },
+                    },
+                  ],
+                  queryOptions: {},
+                  transformations: [],
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+
+      const panel = result.elements['panel-1'];
+      expect(panel.kind).toBe('Panel');
+      if (panel.kind === 'Panel' && panel.spec.data?.kind === 'QueryGroup') {
+        expect(panel.spec.data.spec.queries[0].spec.query?.datasource?.name).toBe('new-loki-uid');
+      }
+    });
+
+    it('preserves variable reference ${ds} in panel queries', () => {
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        elements: {
+          'panel-1': {
+            kind: 'Panel',
+            spec: {
+              id: 1,
+              title: 'Test Panel',
+              vizConfig: { kind: 'VizConfig', group: 'timeseries', spec: {} },
+              data: {
+                kind: 'QueryGroup',
+                spec: {
+                  queries: [
+                    {
+                      kind: 'PanelQuery',
+                      spec: {
+                        refId: 'A',
+                        hidden: false,
+                        query: {
+                          kind: 'DataQuery',
+                          group: 'prometheus',
+                          version: 'v0',
+                          datasource: { name: '${ds}' },
+                          spec: {},
+                        },
+                      },
+                    },
+                  ],
+                  queryOptions: {},
+                  transformations: [],
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+
+      const panel = result.elements['panel-1'];
+      if (panel.kind === 'Panel' && panel.spec.data?.kind === 'QueryGroup') {
+        expect(panel.spec.data.spec.queries[0].spec.query?.datasource?.name).toBe('${ds}');
+      }
+    });
+
+    it('preserves variable reference $ds in panel queries', () => {
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        elements: {
+          'panel-1': {
+            kind: 'Panel',
+            spec: {
+              id: 1,
+              title: 'Test Panel',
+              vizConfig: { kind: 'VizConfig', group: 'timeseries', spec: {} },
+              data: {
+                kind: 'QueryGroup',
+                spec: {
+                  queries: [
+                    {
+                      kind: 'PanelQuery',
+                      spec: {
+                        refId: 'A',
+                        hidden: false,
+                        query: {
+                          kind: 'DataQuery',
+                          group: 'prometheus',
+                          version: 'v0',
+                          datasource: { name: '$ds' },
+                          spec: {},
+                        },
+                      },
+                    },
+                  ],
+                  queryOptions: {},
+                  transformations: [],
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+
+      const panel = result.elements['panel-1'];
+      if (panel.kind === 'Panel' && panel.spec.data?.kind === 'QueryGroup') {
+        expect(panel.spec.data.spec.queries[0].spec.query?.datasource?.name).toBe('$ds');
+      }
+    });
+
+    it('does not replace when no mapping exists for datasource type', () => {
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        elements: {
+          'panel-1': {
+            kind: 'Panel',
+            spec: {
+              id: 1,
+              title: 'Test Panel',
+              vizConfig: { kind: 'VizConfig', group: 'timeseries', spec: {} },
+              data: {
+                kind: 'QueryGroup',
+                spec: {
+                  queries: [
+                    {
+                      kind: 'PanelQuery',
+                      spec: {
+                        refId: 'A',
+                        hidden: false,
+                        query: {
+                          kind: 'DataQuery',
+                          group: 'elasticsearch',
+                          version: 'v0',
+                          datasource: { name: 'es-uid' },
+                          spec: {},
+                        },
+                      },
+                    },
+                  ],
+                  queryOptions: {},
+                  transformations: [],
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+
+      const panel = result.elements['panel-1'];
+      if (panel.kind === 'Panel' && panel.spec.data?.kind === 'QueryGroup') {
+        expect(panel.spec.data.spec.queries[0].spec.query?.datasource?.name).toBe('es-uid');
+      }
+    });
+  });
+
+  describe('annotations', () => {
+    it('replaces hardcoded datasource in annotations', () => {
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        annotations: [
+          {
+            kind: 'AnnotationQuery',
+            spec: {
+              name: 'Test Annotation',
+              enable: true,
+              hide: false,
+              iconColor: 'red',
+              query: {
+                kind: 'DataQuery',
+                group: 'prometheus',
+                version: 'v0',
+                datasource: { name: 'old-prom-uid' },
+                spec: {},
+              },
+            },
+          },
+        ],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+
+      expect(result.annotations?.[0].spec.query?.datasource?.name).toBe('new-prom-uid');
+    });
+
+    it('preserves variable reference in annotations', () => {
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        annotations: [
+          {
+            kind: 'AnnotationQuery',
+            spec: {
+              name: 'Test Annotation',
+              enable: true,
+              hide: false,
+              iconColor: 'red',
+              query: {
+                kind: 'DataQuery',
+                group: 'prometheus',
+                version: 'v0',
+                datasource: { name: '${ds}' },
+                spec: {},
+              },
+            },
+          },
+        ],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+
+      expect(result.annotations?.[0].spec.query?.datasource?.name).toBe('${ds}');
+    });
+  });
+
+  describe('QueryVariable', () => {
+    it('replaces hardcoded datasource in QueryVariable', () => {
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        variables: [
+          {
+            kind: 'QueryVariable',
+            spec: {
+              name: 'test_var',
+              current: { text: 'All', value: '$__all' },
+              options: [{ text: 'All', value: '$__all' }],
+              hide: 'dontHide',
+              skipUrlSync: false,
+              multi: false,
+              includeAll: true,
+              allowCustomValue: false,
+              refresh: 'onDashboardLoad',
+              regex: '',
+              sort: 'disabled',
+              query: {
+                kind: 'DataQuery',
+                group: 'prometheus',
+                version: 'v0',
+                datasource: { name: 'old-prom-uid' },
+                spec: {},
+              },
+            },
+          },
+        ],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+
+      const variable = result.variables?.[0];
+      expect(variable?.kind).toBe('QueryVariable');
+      if (variable?.kind === 'QueryVariable') {
+        expect(variable.spec.query?.datasource?.name).toBe('new-prom-uid');
+        expect(variable.spec.options).toEqual([]);
+        expect(variable.spec.current).toEqual({ text: '', value: '' });
+        expect(variable.spec.refresh).toBe('onDashboardLoad');
+      }
+    });
+
+    it('preserves variable reference in QueryVariable', () => {
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        variables: [
+          {
+            kind: 'QueryVariable',
+            spec: {
+              name: 'test_var',
+              current: { text: 'All', value: '$__all' },
+              options: [{ text: 'All', value: '$__all' }],
+              hide: 'dontHide',
+              skipUrlSync: false,
+              multi: false,
+              includeAll: true,
+              allowCustomValue: false,
+              refresh: 'onDashboardLoad',
+              regex: '',
+              sort: 'disabled',
+              query: {
+                kind: 'DataQuery',
+                group: 'prometheus',
+                version: 'v0',
+                datasource: { name: '${ds}' },
+                spec: {},
+              },
+            },
+          },
+        ],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+
+      const variable = result.variables?.[0];
+      if (variable?.kind === 'QueryVariable') {
+        expect(variable.spec.query?.datasource?.name).toBe('${ds}');
+        // Options should NOT be reset when preserving variable
+        expect(variable.spec.options).toEqual([{ text: 'All', value: '$__all' }]);
+      }
+    });
+  });
+
+  describe('DatasourceVariable', () => {
+    it('replaces current value in DatasourceVariable', () => {
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        variables: [
+          {
+            kind: 'DatasourceVariable',
+            spec: {
+              name: 'ds',
+              pluginId: 'prometheus',
+              current: { text: 'Old Prometheus', value: 'old-prom-uid' },
+              options: [],
+              hide: 'dontHide',
+              skipUrlSync: false,
+              multi: false,
+              includeAll: false,
+              allowCustomValue: false,
+              refresh: 'onDashboardLoad',
+              regex: '',
+            },
+          },
+        ],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+
+      const variable = result.variables?.[0];
+      expect(variable?.kind).toBe('DatasourceVariable');
+      if (variable?.kind === 'DatasourceVariable') {
+        expect(variable.spec.current?.value).toBe('new-prom-uid');
+        expect(variable.spec.current?.text).toBe('New Prometheus');
+      }
+    });
+  });
+
+  describe('AdhocVariable', () => {
+    it('replaces hardcoded datasource in AdhocVariable', () => {
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        variables: [
+          {
+            kind: 'AdhocVariable',
+            group: 'loki',
+            datasource: { name: 'old-loki-uid' },
+            spec: {
+              name: 'Filters',
+              hide: 'dontHide',
+              skipUrlSync: false,
+              allowCustomValue: true,
+              defaultKeys: [],
+              filters: [],
+              baseFilters: [],
+            },
+          },
+        ],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+
+      const variable = result.variables?.[0];
+      expect(variable?.kind).toBe('AdhocVariable');
+      if (variable?.kind === 'AdhocVariable') {
+        expect(variable.datasource?.name).toBe('new-loki-uid');
+      }
+    });
+
+    it('preserves variable reference in AdhocVariable', () => {
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        variables: [
+          {
+            kind: 'AdhocVariable',
+            group: 'loki',
+            datasource: { name: '${ds}' },
+            spec: {
+              name: 'Filters',
+              hide: 'dontHide',
+              skipUrlSync: false,
+              allowCustomValue: true,
+              defaultKeys: [],
+              filters: [],
+              baseFilters: [],
+            },
+          },
+        ],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+
+      const variable = result.variables?.[0];
+      if (variable?.kind === 'AdhocVariable') {
+        expect(variable.datasource?.name).toBe('${ds}');
+      }
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles mixed variable and hardcoded datasources', () => {
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        elements: {
+          'panel-variable': {
+            kind: 'Panel',
+            spec: {
+              id: 1,
+              title: 'Variable DS Panel',
+              vizConfig: { kind: 'VizConfig', group: 'timeseries', spec: {} },
+              data: {
+                kind: 'QueryGroup',
+                spec: {
+                  queries: [
+                    {
+                      kind: 'PanelQuery',
+                      spec: {
+                        refId: 'A',
+                        hidden: false,
+                        query: {
+                          kind: 'DataQuery',
+                          group: 'prometheus',
+                          version: 'v0',
+                          datasource: { name: '${ds}' },
+                          spec: {},
+                        },
+                      },
+                    },
+                  ],
+                  queryOptions: {},
+                  transformations: [],
+                },
+              },
+            },
+          },
+          'panel-hardcoded': {
+            kind: 'Panel',
+            spec: {
+              id: 2,
+              title: 'Hardcoded DS Panel',
+              vizConfig: { kind: 'VizConfig', group: 'logs', spec: {} },
+              data: {
+                kind: 'QueryGroup',
+                spec: {
+                  queries: [
+                    {
+                      kind: 'PanelQuery',
+                      spec: {
+                        refId: 'A',
+                        hidden: false,
+                        query: {
+                          kind: 'DataQuery',
+                          group: 'loki',
+                          version: 'v0',
+                          datasource: { name: 'old-loki-uid' },
+                          spec: {},
+                        },
+                      },
+                    },
+                  ],
+                  queryOptions: {},
+                  transformations: [],
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+
+      const varPanel = result.elements['panel-variable'];
+      const hardcodedPanel = result.elements['panel-hardcoded'];
+
+      if (varPanel.kind === 'Panel' && varPanel.spec.data?.kind === 'QueryGroup') {
+        expect(varPanel.spec.data.spec.queries[0].spec.query?.datasource?.name).toBe('${ds}');
+      }
+
+      if (hardcodedPanel.kind === 'Panel' && hardcodedPanel.spec.data?.kind === 'QueryGroup') {
+        expect(hardcodedPanel.spec.data.spec.queries[0].spec.query?.datasource?.name).toBe('new-loki-uid');
+      }
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/v2schema/importDatasourceReplacer.test.ts
+++ b/public/app/features/dashboard-scene/v2schema/importDatasourceReplacer.test.ts
@@ -478,6 +478,65 @@ describe('replaceDatasourcesInDashboard', () => {
     });
   });
 
+  describe('GroupByVariable', () => {
+    it('replaces hardcoded datasource in GroupByVariable', () => {
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        variables: [
+          {
+            kind: 'GroupByVariable',
+            group: 'prometheus',
+            datasource: { name: 'old-prom-uid' },
+            spec: {
+              name: 'groupby',
+              hide: 'dontHide',
+              skipUrlSync: false,
+              allowCustomValue: false,
+              options: [],
+              current: { text: '', value: '' },
+            },
+          },
+        ],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+
+      const variable = result.variables?.[0];
+      expect(variable?.kind).toBe('GroupByVariable');
+      if (variable?.kind === 'GroupByVariable') {
+        expect(variable.datasource?.name).toBe('new-prom-uid');
+      }
+    });
+
+    it('preserves variable reference in GroupByVariable', () => {
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        variables: [
+          {
+            kind: 'GroupByVariable',
+            group: 'prometheus',
+            datasource: { name: '${ds}' },
+            spec: {
+              name: 'groupby',
+              hide: 'dontHide',
+              skipUrlSync: false,
+              allowCustomValue: false,
+              options: [],
+              current: { text: '', value: '' },
+            },
+          },
+        ],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+
+      const variable = result.variables?.[0];
+      if (variable?.kind === 'GroupByVariable') {
+        expect(variable.datasource?.name).toBe('${ds}');
+      }
+    });
+  });
+
   describe('edge cases', () => {
     it('handles mixed variable and hardcoded datasources', () => {
       const dashboard: DashboardV2Spec = {

--- a/public/app/features/dashboard-scene/v2schema/importDatasourceReplacer.ts
+++ b/public/app/features/dashboard-scene/v2schema/importDatasourceReplacer.ts
@@ -1,22 +1,19 @@
 import { AnnotationQueryKind, Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
-export interface DatasourceRef {
+export interface SelectedDatasource {
   uid: string;
   type: string;
   name?: string;
 }
 
-export type DatasourceMappings = Record<string, DatasourceRef>;
+/** Maps datasource type (e.g. "prometheus", "loki") to user-selected datasource
+ * from the import form */
+export type DatasourceMappings = Record<string, SelectedDatasource>;
 
-/** Check if datasource name is a variable reference (e.g., ${ds}, $ds) */
 export function isVariableRef(dsName: string | undefined): boolean {
   return dsName?.startsWith('$') ?? false;
 }
 
-/**
- * Replace datasource references in a dashboard spec with mapped datasources.
- * Preserves variable references (e.g., ${ds}, $ds).
- */
 export function replaceDatasourcesInDashboard(
   dashboard: DashboardV2Spec,
   mappings: DatasourceMappings

--- a/public/app/features/dashboard-scene/v2schema/importDatasourceReplacer.ts
+++ b/public/app/features/dashboard-scene/v2schema/importDatasourceReplacer.ts
@@ -6,8 +6,7 @@ export interface SelectedDatasource {
   name?: string;
 }
 
-/** Maps datasource type (e.g. "prometheus", "loki") to user-selected datasource
- * from the import form */
+/** Maps datasource type (e.g. "prometheus", "loki") to user-selected datasource from the import form */
 export type DatasourceMappings = Record<string, SelectedDatasource>;
 
 export function isVariableRef(dsName: string | undefined): boolean {

--- a/public/app/features/dashboard-scene/v2schema/importDatasourceReplacer.ts
+++ b/public/app/features/dashboard-scene/v2schema/importDatasourceReplacer.ts
@@ -104,7 +104,7 @@ function replaceVariableDatasources(
       };
     }
 
-    if (variable.kind === 'AdhocVariable') {
+    if (variable.kind === 'AdhocVariable' || variable.kind === 'GroupByVariable') {
       const dsType = variable.group;
       const currentDsName = variable.datasource?.name;
       const ds = dsType ? mappings[dsType] : undefined;

--- a/public/app/features/dashboard-scene/v2schema/importDatasourceReplacer.ts
+++ b/public/app/features/dashboard-scene/v2schema/importDatasourceReplacer.ts
@@ -1,0 +1,172 @@
+import { AnnotationQueryKind, Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+
+export interface DatasourceRef {
+  uid: string;
+  type: string;
+  name?: string;
+}
+
+export type DatasourceMappings = Record<string, DatasourceRef>;
+
+/** Check if datasource name is a variable reference (e.g., ${ds}, $ds) */
+export function isVariableRef(dsName: string | undefined): boolean {
+  return dsName?.startsWith('$') ?? false;
+}
+
+/**
+ * Replace datasource references in a dashboard spec with mapped datasources.
+ * Preserves variable references (e.g., ${ds}, $ds).
+ */
+export function replaceDatasourcesInDashboard(
+  dashboard: DashboardV2Spec,
+  mappings: DatasourceMappings
+): DashboardV2Spec {
+  return {
+    ...dashboard,
+    annotations: replaceAnnotationDatasources(dashboard.annotations, mappings),
+    variables: replaceVariableDatasources(dashboard.variables, mappings),
+    elements: replaceElementDatasources(dashboard.elements, mappings),
+  };
+}
+
+function replaceAnnotationDatasources(
+  annotations: DashboardV2Spec['annotations'],
+  mappings: DatasourceMappings
+): DashboardV2Spec['annotations'] {
+  return annotations?.map((annotation: AnnotationQueryKind) => {
+    const dsType = annotation.spec.query?.group;
+    const currentDsName = annotation.spec.query?.datasource?.name;
+    const ds = dsType ? mappings[dsType] : undefined;
+
+    if (isVariableRef(currentDsName) || !dsType || !ds) {
+      return annotation;
+    }
+
+    return {
+      ...annotation,
+      spec: {
+        ...annotation.spec,
+        query: {
+          ...annotation.spec.query,
+          datasource: { name: ds.uid },
+        },
+      },
+    };
+  });
+}
+
+function replaceVariableDatasources(
+  variables: DashboardV2Spec['variables'],
+  mappings: DatasourceMappings
+): DashboardV2Spec['variables'] {
+  return variables?.map((variable) => {
+    if (variable.kind === 'QueryVariable') {
+      const dsType = variable.spec.query?.group;
+      const currentDsName = variable.spec.query?.datasource?.name;
+      const ds = dsType ? mappings[dsType] : undefined;
+
+      if (isVariableRef(currentDsName) || !dsType || !ds) {
+        return variable;
+      }
+
+      return {
+        ...variable,
+        spec: {
+          ...variable.spec,
+          query: {
+            ...variable.spec.query,
+            datasource: { name: ds.uid },
+          },
+          options: [],
+          current: { text: '', value: '' },
+          refresh: 'onDashboardLoad' as const,
+        },
+      };
+    }
+
+    if (variable.kind === 'DatasourceVariable') {
+      const dsType = variable.spec.pluginId;
+      const ds = dsType ? mappings[dsType] : undefined;
+
+      if (!dsType || !ds) {
+        return variable;
+      }
+
+      return {
+        ...variable,
+        spec: {
+          ...variable.spec,
+          current: {
+            text: ds.name ?? ds.uid,
+            value: ds.uid,
+          },
+        },
+      };
+    }
+
+    if (variable.kind === 'AdhocVariable') {
+      const dsType = variable.group;
+      const currentDsName = variable.datasource?.name;
+      const ds = dsType ? mappings[dsType] : undefined;
+
+      if (isVariableRef(currentDsName) || !dsType || !ds) {
+        return variable;
+      }
+
+      return {
+        ...variable,
+        datasource: { name: ds.uid },
+      };
+    }
+
+    return variable;
+  });
+}
+
+function replaceElementDatasources(
+  elements: DashboardV2Spec['elements'],
+  mappings: DatasourceMappings
+): DashboardV2Spec['elements'] {
+  return Object.fromEntries(
+    Object.entries(elements).map(([key, element]) => {
+      if (element.kind === 'Panel') {
+        const panel = { ...element.spec };
+        if (panel.data?.kind === 'QueryGroup') {
+          const newQueries = panel.data.spec.queries.map((query) => {
+            if (query.kind !== 'PanelQuery') {
+              return query;
+            }
+
+            const queryType = query.spec.query?.group;
+            const currentDsName = query.spec.query?.datasource?.name;
+            const ds = queryType ? mappings[queryType] : undefined;
+
+            if (isVariableRef(currentDsName) || !queryType || !ds) {
+              return query;
+            }
+
+            return {
+              ...query,
+              spec: {
+                ...query.spec,
+                query: {
+                  ...query.spec.query,
+                  datasource: { name: ds.uid },
+                },
+              },
+            };
+          });
+          panel.data = {
+            ...panel.data,
+            spec: {
+              ...panel.data.spec,
+              queries: newQueries,
+            },
+          };
+        }
+        return [key, { kind: element.kind, spec: panel }];
+      }
+      return [key, element];
+    })
+  );
+}


### PR DESCRIPTION
**What is this feature?**

Fix datasource replacement during v2 dashboard import. Selected datasources are now correctly applied to panels, variables, and annotations.

**Why do we need this feature?**

When importing a v2 dashboard, the import UI prompts users to select replacement datasources, but the selections were not being applied. The original hardcoded datasource UIDs remained in the imported dashboard.

Fixes #116610