### PR TITLE
Alerting: Show managed plugin metadata

### DIFF
--- a/public/app/features/alerting/unified/plugins/PluginOriginBadge.tsx
+++ b/public/app/features/alerting/unified/plugins/PluginOriginBadge.tsx
@@ -12,7 +12,7 @@ interface PluginOriginBadgeProps {
 }
 
 export function PluginOriginBadge({ pluginId, size = 'md' }: PluginOriginBadgeProps) {
-  const { value: pluginMeta, loading } = useAsync(() => getPluginSettings(pluginId));
+  const { value: pluginMeta, loading } = useAsync(() => getPluginSettings(pluginId, { showErrorAlert: false }));
 
   if (loading) {
     return null;

--- a/public/app/features/alerting/unified/rule-list/GrafanaRuleListItem.tsx
+++ b/public/app/features/alerting/unified/rule-list/GrafanaRuleListItem.tsx
@@ -4,7 +4,7 @@ import { GrafanaPromRuleDTO, PromRuleType } from 'app/types/unified-alerting-dto
 import { GRAFANA_RULES_SOURCE_NAME, GrafanaRulesSource } from '../utils/datasource';
 import { groups } from '../utils/navigation';
 import { totalFromStats } from '../utils/ruleStats';
-import { prometheusRuleType } from '../utils/rules';
+import { getRulePluginOrigin, prometheusRuleType } from '../utils/rules';
 import { createRelativeUrl } from '../utils/url';
 
 import {
@@ -53,6 +53,7 @@ export function GrafanaRuleListItem({
     application: 'grafana' as const,
     actions: <RuleActionsButtons promRule={rule} groupIdentifier={groupIdentifier} compact />,
     querySourceUIDs: rule?.queriedDatasourceUIDs,
+    origin: getRulePluginOrigin(rule),
   };
 
   if (prometheusRuleType.grafana.alertingRule(rule)) {


### PR DESCRIPTION
**What is this feature?**

Now shows that alert rules are managed by plugins in the list view. This was always supported we just never passed the origin prop apparently.