### PR TITLE
datasources: refactor the request validator api

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -847,7 +847,7 @@ func (hs *HTTPServer) checkDatasourceHealth(c *contextmodel.ReqContext, ds *data
 		Headers:       map[string]string{},
 	}
 
-	err = hs.DataSourceRequestValidator.Validate(ds, c.Req)
+	err = hs.DataSourceRequestValidator.Validate(ds.URL, ds.JsonData, c.Req)
 	if err != nil {
 		return response.Error(http.StatusForbidden, "Access denied", err)
 	}

--- a/pkg/api/ds_query_test.go
+++ b/pkg/api/ds_query_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db/dbtest"
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -40,7 +41,7 @@ type fakeDataSourceRequestValidator struct {
 	err error
 }
 
-func (rv *fakeDataSourceRequestValidator) Validate(ds *datasources.DataSource, req *http.Request) error {
+func (rv *fakeDataSourceRequestValidator) Validate(dsURL string, dsJsonData *simplejson.Json, req *http.Request) error {
 	return rv.err
 }
 

--- a/pkg/api/plugin_resource.go
+++ b/pkg/api/plugin_resource.go
@@ -62,7 +62,7 @@ func (hs *HTTPServer) callPluginResourceWithDataSource(c *contextmodel.ReqContex
 		return
 	}
 
-	err = hs.DataSourceRequestValidator.Validate(ds, c.Req)
+	err = hs.DataSourceRequestValidator.Validate(ds.URL, ds.JsonData, c.Req)
 	if err != nil {
 		c.JsonApiErr(http.StatusForbidden, "Access denied", err)
 		return

--- a/pkg/services/datasourceproxy/datasourceproxy.go
+++ b/pkg/services/datasourceproxy/datasourceproxy.go
@@ -108,7 +108,7 @@ func toAPIError(c *contextmodel.ReqContext, err error) {
 }
 
 func (p *DataSourceProxyService) proxyDatasourceRequest(c *contextmodel.ReqContext, ds *datasources.DataSource) {
-	err := p.DataSourceRequestValidator.Validate(ds, c.Req)
+	err := p.DataSourceRequestValidator.Validate(ds.URL, ds.JsonData, c.Req)
 	if err != nil {
 		c.JsonApiErr(http.StatusForbidden, "Access denied", err)
 		return

--- a/pkg/services/datasourceproxy/datasourceproxy_test.go
+++ b/pkg/services/datasourceproxy/datasourceproxy_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/plugins"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -131,6 +132,6 @@ func TestDatasourceProxy_proxyDatasourceRequest(t *testing.T) {
 
 type fakeDataSourceRequestValidator struct{}
 
-func (rv *fakeDataSourceRequestValidator) Validate(_ *datasources.DataSource, _ *http.Request) error {
+func (rv *fakeDataSourceRequestValidator) Validate(_ string, _ *simplejson.Json, _ *http.Request) error {
 	return nil
 }

--- a/pkg/services/datasources/models.go
+++ b/pkg/services/datasources/models.go
@@ -76,9 +76,13 @@ type DataSource struct {
 	isSecureSocksDSProxyEnabled *bool `xorm:"-"`
 }
 
+func IsSecureSocksDSProxyEnabled(jsonData *simplejson.Json) bool {
+	return jsonData != nil && jsonData.Get("enableSecureSocksProxy").MustBool(false)
+}
+
 func (ds *DataSource) IsSecureSocksDSProxyEnabled() bool {
 	if ds.isSecureSocksDSProxyEnabled == nil {
-		enabled := ds.JsonData != nil && ds.JsonData.Get("enableSecureSocksProxy").MustBool(false)
+		enabled := IsSecureSocksDSProxyEnabled(ds.JsonData)
 		ds.isSecureSocksDSProxyEnabled = &enabled
 	}
 	return *ds.isSecureSocksDSProxyEnabled

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -290,7 +290,7 @@ func (s *ServiceImpl) handleExpressions(ctx context.Context, user identity.Reque
 func (s *ServiceImpl) handleQuerySingleDatasource(ctx context.Context, user identity.Requester, parsedReq *parsedRequest) (*backend.QueryDataResponse, error) {
 	queries := parsedReq.getFlattenedQueries()
 	ds := queries[0].datasource
-	if err := s.dataSourceRequestValidator.Validate(ds, nil); err != nil {
+	if err := s.dataSourceRequestValidator.Validate(ds.URL, ds.JsonData, nil); err != nil {
 		return nil, datasources.ErrDataSourceAccessDenied
 	}
 

--- a/pkg/services/query/query_test.go
+++ b/pkg/services/query/query_test.go
@@ -926,7 +926,7 @@ type fakeDataSourceRequestValidator struct {
 	err error
 }
 
-func (rv *fakeDataSourceRequestValidator) Validate(ds *datasources.DataSource, req *http.Request) error {
+func (rv *fakeDataSourceRequestValidator) Validate(dsURL string, dsJsonData *simplejson.Json, req *http.Request) error {
 	return rv.err
 }
 

--- a/pkg/services/validations/oss.go
+++ b/pkg/services/validations/oss.go
@@ -3,12 +3,12 @@ package validations
 import (
 	"net/http"
 
-	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 )
 
 type OSSDataSourceRequestValidator struct{}
 
-func (*OSSDataSourceRequestValidator) Validate(*datasources.DataSource, *http.Request) error {
+func (*OSSDataSourceRequestValidator) Validate(string, *simplejson.Json, *http.Request) error {
 	return nil
 }
 

--- a/pkg/services/validations/service.go
+++ b/pkg/services/validations/service.go
@@ -3,14 +3,14 @@ package validations
 import (
 	"net/http"
 
-	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 )
 
 type DataSourceRequestValidator interface {
 	// Validate performs a request validation based
 	// on the data source URL and some of the request
 	// attributes (headers, cookies, etc).
-	Validate(ds *datasources.DataSource, req *http.Request) error
+	Validate(dsURL string, dsJsonData *simplejson.Json, req *http.Request) error
 }
 
 type DataSourceRequestURLValidator interface {


### PR DESCRIPTION
we adjust the request-validator API to make it more flexible:
- until now you needed a `datasources.Datasource` instance
- now it is enough to know the datasource-url-attribute and the jsonData