### PR TITLE
chore(integration-test): increase Postgres max connections

### DIFF
--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -251,6 +251,7 @@ jobs:
           POSTGRES_USER: grafanatest
           POSTGRES_PASSWORD: grafanatest
           POSTGRES_DB: grafanatest
+        options: -c 'max_connections=200'
         ports:
           - 5432:5432
     steps:

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -244,21 +244,14 @@ jobs:
       GRAFANA_TEST_DB: postgres
       PGPASSWORD: grafanatest
       POSTGRES_HOST: 127.0.0.1
-    services:
-      postgres:
-        image: postgres:17.6
-        env:
-          POSTGRES_USER: grafanatest
-          POSTGRES_PASSWORD: grafanatest
-          POSTGRES_DB: grafanatest
-        options: -c 'max_connections=200'
-        ports:
-          - 5432:5432
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+      - name: Start Postgres via docker compose
+        run: |
+          make devenv sources=postgres_tests
       - name: Setup Go
         uses: actions/setup-go@v6.0.0
         with:
@@ -273,6 +266,10 @@ jobs:
           set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
           CGO_ENABLED=0 go test -p=1 -tags=postgres -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
+      - name: Cleanup Postgres
+        if: always()
+        run: |
+          make devenv-down sources=postgres_tests
 
   #### Enterprise
   sqlite-enterprise:
@@ -496,20 +493,14 @@ jobs:
       GRAFANA_TEST_DB: postgres
       PGPASSWORD: grafanatest
       POSTGRES_HOST: 127.0.0.1
-    services:
-      postgres:
-        image: postgres:17.6
-        env:
-          POSTGRES_USER: grafanatest
-          POSTGRES_PASSWORD: grafanatest
-          POSTGRES_DB: grafanatest
-        ports:
-          - 5432:5432
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+      - name: Start Postgres via docker compose
+        run: |
+          make devenv sources=postgres_tests
       - name: Setup Go
         uses: actions/setup-go@v6.0.0
         with:
@@ -528,6 +519,10 @@ jobs:
           set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
           CGO_ENABLED=0 go test -p=1 -tags=enterprise,postgres -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
+      - name: Cleanup Postgres
+        if: always()
+        run: |
+          make devenv-down sources=postgres_tests
 
   # This is the job that is actually required by rulesets.
   # We want to only require one job instead of all the individual tests and shards.

--- a/devenv/docker/blocks/postgres_tests/Dockerfile
+++ b/devenv/docker/blocks/postgres_tests/Dockerfile
@@ -2,4 +2,4 @@ ARG postgres_version=17.4-alpine3.21
 FROM postgres:${postgres_version}
 ADD setup.sql /docker-entrypoint-initdb.d
 RUN chown -R postgres:postgres /docker-entrypoint-initdb.d/
-CMD ["postgres"]
+CMD ["postgres", "-c", "max_connections=200"]

--- a/devenv/docker/blocks/postgres_tests/docker-compose.yaml
+++ b/devenv/docker/blocks/postgres_tests/docker-compose.yaml
@@ -6,6 +6,7 @@
     environment:
       POSTGRES_USER: grafanatest
       POSTGRES_PASSWORD: grafanatest
+    command: ["postgres", "-c", "max_connections=200"]
     ports:
       - "5432:5432"
     tmpfs: /var/lib/postgresql/data:rw

--- a/pkg/tests/apis/iam/user_teams_search_integration_test.go
+++ b/pkg/tests/apis/iam/user_teams_search_integration_test.go
@@ -31,15 +31,11 @@ type userTeamsResponse struct {
 func TestIntegrationUserTeams(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
-	// TODO: Add rest.Mode3, rest.Mode4, rest.Mode5 when they are supported
-	// Currently modes 3-5 are failing for postgres with the following error:
-	// unable to start dualwrite service due to migration error: unified storage data migration failed: migration failed (id = playlists migration): migration failed for org 1 (Main Org.): pq: sorry, too many clients already
-	modes := []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode2 /*, rest.Mode3, rest.Mode4, rest.Mode5*/}
+	modes := []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode2, rest.Mode3, rest.Mode4, rest.Mode5}
 
 	for _, mode := range modes {
 		t.Run(fmt.Sprintf("With dual writer mode %d", mode), func(t *testing.T) {
 			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
-				EnableLog:            true,
 				AppModeProduction:    false,
 				DisableAnonymous:     true,
 				APIServerStorageType: "unified",


### PR DESCRIPTION
**What is this feature?**

This change increases the max connections for test postgres container to 200.

**Why do we need this feature?**

This is only needed for packages where tests have reached that limit, in production we close the DB via finalizers here:
[grafana/pkg/util/xorm/xorm.go](https://github.com/grafana/grafana/blob/a3975ea1c931e74c66e0de39004ee9e96217682f/pkg/util/xorm/xorm.go#L112)

**Who is this feature for?**

IAM integration tests

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
