### PR TITLE
Chore: Deprecate the localeFormatPreference feature toggle

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -93,7 +93,6 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `enableSCIM`                      | Enables SCIM support for user and group management                                                     |
 | `alertRuleRestore`                | Enables the alert rule restore feature                                                                 |
 | `azureMonitorLogsBuilderEditor`   | Enables the logs builder mode for the Azure Monitor data source                                        |
-| `localeFormatPreference`          | Specifies the locale so the correct format for numbers and dates can be shown                          |
 | `logsPanelControls`               | Enables a control component for the logs panel in Explore                                              |
 | `interactiveLearning`             | Enables the interactive learning app                                                                   |
 | `newGauge`                        | Enable new gauge visualization                                                                         |

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -991,6 +991,7 @@ export interface FeatureToggles {
   azureMonitorLogsBuilderEditor?: boolean;
   /**
   * Specifies the locale so the correct format for numbers and dates can be shown
+  * @deprecated
   * @default false
   */
   localeFormatPreference?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1551,7 +1551,7 @@ var (
 		{
 			Name:        "localeFormatPreference",
 			Description: "Specifies the locale so the correct format for numbers and dates can be shown",
-			Stage:       FeatureStagePublicPreview,
+			Stage:       FeatureStageDeprecated, // not continuing the work for now, will be removed
 			Owner:       grafanaFrontendPlatformSquad,
 			Expression:  "false",
 		},

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -25,7 +25,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2023-04-12,disableSSEDataplane,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2023-04-03,renderAuthJWT,preview,@grafana/grafana-operator-experience-squad,false,false,false
 2023-06-06,refactorVariablesTimeRange,preview,@grafana/dashboards-squad,false,false,false
-2023-05-04,faroDatasourceSelector,preview,@grafana/app-o11y,false,false,true
+2023-05-05,faroDatasourceSelector,preview,@grafana/app-o11y,false,false,true
 2023-04-24,enableDatagridEditing,preview,@grafana/dataviz-squad,false,false,false
 2023-07-12,logsExploreTableVisualisation,GA,@grafana/observability-logs,false,false,true
 2023-07-06,awsDatasourcesTempCredentials,GA,@grafana/aws-datasources,false,false,false
@@ -148,10 +148,10 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-10-04,pluginsSriChecks,GA,@grafana/plugins-platform-backend,false,false,false
 2024-10-17,unifiedStorageBigObjectsSupport,experimental,@grafana/search-and-storage,false,false,false
 2024-10-22,timeRangeProvider,experimental,@grafana/grafana-frontend-platform,false,false,false
-2025-11-04,timeRangePan,experimental,@grafana/dataviz-squad,false,false,true
+2025-11-05,timeRangePan,experimental,@grafana/dataviz-squad,false,false,true
 2025-11-20,newTimeRangeZoomShortcuts,experimental,@grafana/dataviz-squad,false,false,true
 2024-10-24,azureMonitorDisableLogLimit,GA,@grafana/partner-datasources,false,false,false
-2024-12-19,playlistsReconciler,experimental,@grafana/grafana-app-platform-squad,false,true,false
+2024-12-20,playlistsReconciler,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2024-11-14,passwordlessMagicLinkAuthentication,experimental,@grafana/identity-access-team,false,false,false
 2024-12-18,prometheusSpecialCharsInLabelValues,experimental,@grafana/oss-big-tent,false,false,true
 2024-11-05,enableExtensionsAdminPage,experimental,@grafana/plugins-platform-backend,false,true,false
@@ -193,7 +193,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-03-14,alertingMigrationUI,GA,@grafana/alerting-squad,false,false,true
 2025-05-21,alertingImportYAMLUI,GA,@grafana/alerting-squad,false,false,true
 2025-04-02,azureMonitorLogsBuilderEditor,preview,@grafana/partner-datasources,false,false,false
-2025-03-31,localeFormatPreference,preview,@grafana/grafana-frontend-platform,false,false,false
+2025-03-31,localeFormatPreference,deprecated,@grafana/grafana-frontend-platform,false,false,false
 2025-03-21,unifiedStorageGrpcConnectionPool,experimental,@grafana/search-and-storage,false,false,false
 2025-04-03,alertingRulePermanentlyDelete,GA,@grafana/alerting-squad,false,false,true
 2025-03-27,alertingRuleRecoverDeleted,GA,@grafana/alerting-squad,false,false,false
@@ -230,7 +230,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-06-17,preferLibraryPanelTitle,privatePreview,@grafana/dashboards-squad,false,false,false
 2025-06-24,tabularNumbers,GA,@grafana/grafana-frontend-platform,false,false,false
 2025-06-25,newInfluxDSConfigPageDesign,privatePreview,@grafana/partner-datasources,false,false,false
-2025-06-29,enableAppChromeExtensions,experimental,@grafana/plugins-platform-backend,false,false,true
+2025-06-30,enableAppChromeExtensions,experimental,@grafana/plugins-platform-backend,false,false,true
 2025-10-13,enableDashboardEmptyExtensions,experimental,@grafana/dashboards-squad,false,false,true
 2025-07-03,foldersAppPlatformAPI,experimental,@grafana/grafana-search-navigate-organise,false,false,true
 2025-07-16,otelLogsFormatting,experimental,@grafana/observability-logs,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2672,15 +2672,15 @@
     {
       "metadata": {
         "name": "localeFormatPreference",
-        "resourceVersion": "1768498862515",
+        "resourceVersion": "1769012601213",
         "creationTimestamp": "2025-03-31T13:59:07Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-01-15 17:41:02.515355 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-01-21 16:23:21.21319 +0000 UTC"
         }
       },
       "spec": {
         "description": "Specifies the locale so the correct format for numbers and dates can be shown",
-        "stage": "preview",
+        "stage": "deprecated",
         "codeowner": "@grafana/grafana-frontend-platform",
         "expression": "false"
       }


### PR DESCRIPTION
A while back we decided to not continue the `localeFormatPreference` work is due to implementation difficulties with wanted to preserve ISO8601-ish date formatting as its own option, and low relative value of the effort overall.

We should remove all the feature toggled code, but at least this deprecates the feature toggle so its not documented.

