### PR TITLE
Saved queries: Expose component for plugins

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -245,7 +245,7 @@ export enum PluginExtensionPointPatterns {
 export enum PluginExtensionExposedComponents {
   CentralAlertHistorySceneV1 = 'grafana/central-alert-history-scene/v1',
   AddToDashboardFormV1 = 'grafana/add-to-dashboard-form/v1',
-  QueryLibraryContextV1 = 'grafana/query-library-context/v1',
+  OpenQueryLibraryV1 = 'grafana/query-library-context/v1',
 }
 
 export type PluginExtensionPanelContext = {

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -245,6 +245,7 @@ export enum PluginExtensionPointPatterns {
 export enum PluginExtensionExposedComponents {
   CentralAlertHistorySceneV1 = 'grafana/central-alert-history-scene/v1',
   AddToDashboardFormV1 = 'grafana/add-to-dashboard-form/v1',
+  QueryLibraryContextV1 = 'grafana/query-library-context/v1',
 }
 
 export type PluginExtensionPanelContext = {

--- a/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.test.tsx
+++ b/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { DataQuery } from '@grafana/schema';
+
+import { OpenQueryLibraryExposedComponent } from './OpenQueryLibraryExposedComponent';
+import { QueryLibraryContextType, useQueryLibraryContext } from './QueryLibraryContext';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
+
+jest.mock('./QueryLibraryContext', () => ({
+  useQueryLibraryContext: jest.fn(),
+}));
+
+const mockUseQueryLibraryContext = useQueryLibraryContext as jest.MockedFunction<typeof useQueryLibraryContext>;
+
+describe('OpenQueryLibraryExposedComponent', () => {
+  const mockOpenDrawer = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseQueryLibraryContext.mockReturnValue({
+      openDrawer: mockOpenDrawer,
+      queryLibraryEnabled: true,
+    } as unknown as QueryLibraryContextType);
+  });
+
+  it('renders a toolbar button when query library is enabled', () => {
+    render(<OpenQueryLibraryExposedComponent />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('returns null and logs warning when query library is disabled', () => {
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    mockUseQueryLibraryContext.mockReturnValue({
+      openDrawer: mockOpenDrawer,
+      queryLibraryEnabled: false,
+    } as unknown as QueryLibraryContextType);
+
+    const { container } = render(<OpenQueryLibraryExposedComponent />);
+    expect(container.firstChild).toBeNull();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      '[OpenQueryLibraryExposedComponent]: Attempted to use unsupported exposed component. Query library is not enabled.'
+    );
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('renders button with custom icon prop', () => {
+    render(<OpenQueryLibraryExposedComponent icon="folder-open" />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('renders button with default icon prop', () => {
+    render(<OpenQueryLibraryExposedComponent />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('renders with custom tooltip', () => {
+    render(<OpenQueryLibraryExposedComponent tooltip="Custom tooltip" />);
+    expect(screen.getByLabelText('Custom tooltip')).toBeInTheDocument();
+  });
+
+  it('calls openDrawer to save a query', async () => {
+    const mockQuery: DataQuery = { refId: 'A' };
+    const mockDatasourceFilters = ['loki'];
+
+    render(
+      <OpenQueryLibraryExposedComponent
+        query={mockQuery}
+        datasourceFilters={mockDatasourceFilters}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(mockOpenDrawer).toHaveBeenCalledWith({
+      datasourceFilters: mockDatasourceFilters,
+      onSelectQuery: undefined,
+      query: mockQuery,
+    });
+  });
+
+  it('calls openDrawer to load a query', async () => {
+    const mockDatasourceFilters = ['loki'];
+    const mockOnSelectQuery = jest.fn();
+
+    render(
+      <OpenQueryLibraryExposedComponent
+        datasourceFilters={mockDatasourceFilters}
+        onSelectQuery={mockOnSelectQuery}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(mockOpenDrawer).toHaveBeenCalledWith({
+      datasourceFilters: mockDatasourceFilters,
+      onSelectQuery: mockOnSelectQuery,
+      query: undefined,
+    });
+  });
+
+  it('opens the drawer when no arguments are provided', async () => {
+    render(<OpenQueryLibraryExposedComponent />);
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(mockOpenDrawer).toHaveBeenCalledWith({
+      datasourceFilters: undefined,
+      onSelectQuery: undefined,
+      query: undefined,
+    });
+  });
+});

--- a/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.test.tsx
+++ b/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.test.tsx
@@ -68,12 +68,7 @@ describe('OpenQueryLibraryExposedComponent', () => {
     const mockQuery: DataQuery = { refId: 'A' };
     const mockDatasourceFilters = ['loki'];
 
-    render(
-      <OpenQueryLibraryExposedComponent
-        query={mockQuery}
-        datasourceFilters={mockDatasourceFilters}
-      />
-    );
+    render(<OpenQueryLibraryExposedComponent query={mockQuery} datasourceFilters={mockDatasourceFilters} />);
 
     await userEvent.click(screen.getByRole('button'));
 
@@ -89,10 +84,7 @@ describe('OpenQueryLibraryExposedComponent', () => {
     const mockOnSelectQuery = jest.fn();
 
     render(
-      <OpenQueryLibraryExposedComponent
-        datasourceFilters={mockDatasourceFilters}
-        onSelectQuery={mockOnSelectQuery}
-      />
+      <OpenQueryLibraryExposedComponent datasourceFilters={mockDatasourceFilters} onSelectQuery={mockOnSelectQuery} />
     );
 
     await userEvent.click(screen.getByRole('button'));

--- a/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
+++ b/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
@@ -9,12 +9,58 @@ import { useQueryLibraryContext } from './QueryLibraryContext';
 
 interface Props {
   datasourceFilters?: string[];
+  // Query to save
   query?: DataQuery;
   icon?: string;
+  // Callback to load
   onSelectQuery?(query: DataQuery): void;
   tooltip?: string;
 }
 
+/**
+ * EXPOSED COMPONENT (stable): grafana/open-query-library/v1
+ *
+ * This component is exposed to plugins via the Plugin Extensions system.
+ * Treat its props and user-visible behavior as a stable contract. Do not make
+ * breaking changes in-place. If you need to change the API or behavior in a
+ * breaking way, create a new versioned component (e.g. v2) and register it
+ * under a new ID: "grafana/open-query-library/v2".
+ *
+ * This component is designed for use by plugins, like Drilldown apps, to add
+ * support to save generated queries or load saved queries from the plugin itself
+ * or from Explore.
+ *
+ * Usage from a plugin:
+ * ```tsx
+ * import { usePluginComponent } from '@grafana/runtime';
+ *
+ * const { component: OpenQueryLibraryComponent, isLoading } = usePluginComponent(
+ *   'grafana/open-query-library/v1'
+ * );
+ *
+ * // Open Query Library to save a query
+ * 
+ * <OpenQueryLibraryComponent
+ *   // Data source filter
+ *   datasourceFilters={['data-source-name']}
+ *   // Query to save
+ *   query={query}
+ *   icon="save"
+ *   tooltip={'Save in Saved Queries'}
+ * />
+ * 
+ * // Open Query Library to load a query
+ * 
+ * <OpenQueryLibraryComponent
+ *   // Data source filter
+ *   datasourceFilters={['data-source-name']}
+ *   icon="folder-open"
+ *   // Callback to receive the selected query to load
+ *   onSelectQuery={onSelectQuery}
+ *   tooltip={'Load saved query'}
+ * />
+ * ```
+ */
 export const OpenQueryLibraryExposedComponent = ({
   datasourceFilters,
   icon = 'save',

--- a/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
+++ b/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 
 import { t } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { ToolbarButton } from '@grafana/ui';
 
@@ -25,6 +26,7 @@ export const OpenQueryLibraryExposedComponent = ({
 
   const handleClick = useCallback(() => {
     openDrawer({ datasourceFilters, onSelectQuery, query });
+    reportInteraction(`exposed_query_library-${onSelectQuery ? 'load-queries-open' : 'save-queries-open'}`);
   }, [datasourceFilters, onSelectQuery, openDrawer, query]);
 
   if (!queryLibraryEnabled) {

--- a/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
+++ b/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+
+import { t } from '@grafana/i18n';
+import { DataQuery } from '@grafana/schema';
+import { ToolbarButton } from '@grafana/ui';
+
+import { useQueryLibraryContext } from './QueryLibraryContext';
+
+interface Props {
+  datasourceFilters?: string[];
+  query?: DataQuery;
+  icon?: string;
+  onSelectQuery?(query: DataQuery): void;
+  tooltip?: string;
+}
+
+export const OpenQueryLibraryExposedComponent = ({
+  datasourceFilters,
+  icon = 'save',
+  query,
+  onSelectQuery,
+  tooltip = t('query-operation.header.save-to-query-library', 'Save query'),
+}: Props) => {
+  const { openDrawer, queryLibraryEnabled } = useQueryLibraryContext();
+
+  const handleClick = useCallback(() => {
+    openDrawer({ datasourceFilters, onSelectQuery, query });
+  }, [datasourceFilters, onSelectQuery, openDrawer, query]);
+
+  if (!queryLibraryEnabled) {
+    console.warn(
+      '[OpenQueryLibraryExposedComponent]: Attempted to use unsupported exposed component. Query library is not enabled.'
+    );
+    return null;
+  }
+
+  return <ToolbarButton variant="canvas" icon={icon} onClick={handleClick} tooltip={tooltip} />;
+};

--- a/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
+++ b/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
@@ -66,7 +66,7 @@ export const OpenQueryLibraryExposedComponent = ({
   icon = 'save',
   query,
   onSelectQuery,
-  tooltip = t('query-operation.header.save-to-query-library', 'Save query'),
+  tooltip = t('query-library.exposed-compoment.tooltip', 'Open Query Library'),
 }: Props) => {
   const { openDrawer, queryLibraryEnabled } = useQueryLibraryContext();
 

--- a/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
+++ b/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
@@ -39,7 +39,7 @@ interface Props {
  * );
  *
  * // Open Query Library to save a query
- * 
+ *
  * <OpenQueryLibraryComponent
  *   // Data source filter
  *   datasourceFilters={['data-source-name']}
@@ -48,9 +48,9 @@ interface Props {
  *   icon="save"
  *   tooltip={'Save in Saved Queries'}
  * />
- * 
+ *
  * // Open Query Library to load a query
- * 
+ *
  * <OpenQueryLibraryComponent
  *   // Data source filter
  *   datasourceFilters={['data-source-name']}

--- a/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
+++ b/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
@@ -8,6 +8,7 @@ import { ToolbarButton } from '@grafana/ui';
 import { useQueryLibraryContext } from './QueryLibraryContext';
 
 interface Props {
+  className?: string;
   datasourceFilters?: string[];
   // Query to save
   query?: DataQuery;
@@ -62,6 +63,7 @@ interface Props {
  * ```
  */
 export const OpenQueryLibraryExposedComponent = ({
+  className,
   datasourceFilters,
   icon = 'save',
   query,
@@ -82,5 +84,5 @@ export const OpenQueryLibraryExposedComponent = ({
     return null;
   }
 
-  return <ToolbarButton variant="canvas" icon={icon} onClick={handleClick} tooltip={tooltip} />;
+  return <ToolbarButton className={className} variant="canvas" icon={icon} onClick={handleClick} tooltip={tooltip} />;
 };

--- a/public/app/features/plugins/extensions/registry/setup.ts
+++ b/public/app/features/plugins/extensions/registry/setup.ts
@@ -1,6 +1,7 @@
 import { PluginExtensionExposedComponents } from '@grafana/data';
 import CentralAlertHistorySceneExposedComponent from 'app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistorySceneExposedComponent';
 import { AddToDashboardFormExposedComponent } from 'app/features/dashboard-scene/addToDashboard/AddToDashboardFormExposedComponent';
+import { OpenQueryLibraryExposedComponent } from 'app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent';
 
 import { getCoreExtensionConfigurations } from '../getCoreExtensionConfigurations';
 
@@ -42,6 +43,12 @@ exposedComponentsRegistry.register({
       title: 'Add to dashboard form',
       description: 'Add to dashboard form',
       component: AddToDashboardFormExposedComponent,
+    },
+    {
+      id: PluginExtensionExposedComponents.QueryLibraryContextV1,
+      title: 'Access to the Query Library',
+      description: 'Access to the Query Library',
+      component: OpenQueryLibraryExposedComponent,
     },
   ],
 });

--- a/public/app/features/plugins/extensions/registry/setup.ts
+++ b/public/app/features/plugins/extensions/registry/setup.ts
@@ -45,7 +45,7 @@ exposedComponentsRegistry.register({
       component: AddToDashboardFormExposedComponent,
     },
     {
-      id: PluginExtensionExposedComponents.QueryLibraryContextV1,
+      id: PluginExtensionExposedComponents.OpenQueryLibraryV1,
       title: 'Access to the Query Library',
       description: 'Access to the Query Library',
       component: OpenQueryLibraryExposedComponent,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12598,6 +12598,7 @@
       "other-queries": "Other queries",
       "query-with-assistant": "Query with Assistant",
       "remove-query": "Remove query",
+      "save-to-query-library": "Save query",
       "selected-datasource-label": "Selected data source:",
       "show-response": "Show response"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12578,6 +12578,11 @@
       "title-data-source-help": "Data source help"
     }
   },
+  "query-library": {
+    "exposed-compoment": {
+      "tooltip": "Open Query Library"
+    }
+  },
   "query-operation": {
     "header": {
       "app-dashboard": "Dashboard",
@@ -12598,7 +12603,6 @@
       "other-queries": "Other queries",
       "query-with-assistant": "Query with Assistant",
       "remove-query": "Remove query",
-      "save-to-query-library": "Save query",
       "selected-datasource-label": "Selected data source:",
       "show-response": "Show response"
     },


### PR DESCRIPTION
Analog to PRs like https://github.com/grafana/grafana/pull/116439, part of https://github.com/grafana/logs-drilldown/issues/1693, this PR adds an exposed component to access Saved Queries from plugins Logs Drilldown.

### Analytic events

- exposed_query_library-load-queries-open
- exposed_query_library-save-queries-open

### How to test

- Pre-requisites: have local Grafana, Grafana Enterprise, and Logs Drilldown
- Logs Drilldown branch: https://github.com/grafana/logs-drilldown/pull/1702
- Make sure the `queryLibrary` feature flag is enabled.

Browse Logs Drilldown, and you should see icons to save and load from Saved Queries.

### Demo

https://github.com/user-attachments/assets/17867189-36f5-4e79-aa4c-71d787f60ae9
