### PR TITLE
Loki: Send data plane type instead of preferredVisualisationType

### DIFF
--- a/public/app/plugins/datasource/loki/makeTableFrames.test.ts
+++ b/public/app/plugins/datasource/loki/makeTableFrames.test.ts
@@ -102,7 +102,7 @@ const outputSingle = [
       { config: {}, name: 'Value #A', type: 'number', values: [23] },
     ],
     length: 1,
-    meta: { preferredVisualisationType: 'table' },
+    meta: { type: 'numeric-long' },
     refId: 'A',
   },
 ];
@@ -117,7 +117,7 @@ const outputMulti = [
       { config: {}, name: 'Value #A', type: 'number', values: [23, 45] },
     ],
     length: 2,
-    meta: { preferredVisualisationType: 'table' },
+    meta: { type: 'numeric-long' },
     refId: 'A',
   },
   {
@@ -129,7 +129,7 @@ const outputMulti = [
       { config: {}, name: 'Value #B', type: 'number', values: [72] },
     ],
     length: 1,
-    meta: { preferredVisualisationType: 'table' },
+    meta: { type: 'numeric-long' },
     refId: 'B',
   },
 ];

--- a/public/app/plugins/datasource/loki/makeTableFrames.ts
+++ b/public/app/plugins/datasource/loki/makeTableFrames.ts
@@ -1,6 +1,6 @@
 import { groupBy } from 'lodash';
 
-import { DataFrame, Field, FieldType } from '@grafana/data';
+import { DataFrame, DataFrameType, Field, FieldType } from '@grafana/data';
 
 export function makeTableFrames(instantMetricFrames: DataFrame[]): DataFrame[] {
   // first we remove frames that have no refId
@@ -70,7 +70,7 @@ function makeTableFrame(instantMetricFrames: DataFrame[], refId: string): DataFr
   return {
     fields: [tableTimeField, ...labelFields, tableValueField],
     refId,
-    meta: { preferredVisualisationType: 'table' },
+    meta: { type: DataFrameType.NumericLong },
     length: tableTimeField.values.length,
   };
 }


### PR DESCRIPTION
Opened this after testing Instant queries with new Suggestions.

While a table is the best thing to show in the Explore tab for instant queries, we would prefer to suggest visualizations suited to numeric frames when setting up a dashboard with these queries - stat, gauge, or bar gauge panels are the most applicable. If we sent `preferredVisualizationType` === `table`, we have no choice but to show table as the best option, so I want us to consider not doing that since it really isn't the best option.

In my testing, explore still shows a table even if we make this change.