### PR TITLE
Dynamic dashboard: do not open sidebar if in home page

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -57,7 +57,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
   const { chrome } = useGrafana();
   const { kioskMode } = chrome.useState();
   const { isPlaying } = playlistSrv.useState();
-  const isNewEmptyDashboard = !dashboard.state.uid;
+  const isEditingNewDashboard = isEditing && !dashboard.state.uid;
 
   /**
    * Adds star button and left side actions to app chrome breadcrumb area
@@ -76,15 +76,15 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
   }, [isEditing, editPane]);
 
   useEffectOnce(() => {
-    if (isNewEmptyDashboard) {
-      editPane.openPane('add');
+    if (isEditingNewDashboard) {
+       editPane.openPane('add'); 
     }
   });
 
   const { selectionContext, openPane } = useSceneObjectState(editPane, { shouldActivateOrKeepAlive: true });
 
   const sidebarContext = useSidebar({
-    hasOpenPane: Boolean(openPane) || isNewEmptyDashboard,
+    hasOpenPane: Boolean(openPane) || isEditingNewDashboard,
     contentMargin: 1,
     position: 'right',
     persistanceKey: 'dashboard',

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -1,6 +1,5 @@
 import { css, cx } from '@emotion/css';
 import React, { useEffect, useLayoutEffect } from 'react';
-import { useEffectOnce } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -75,11 +74,11 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
     }
   }, [isEditing, editPane]);
 
-  useEffectOnce(() => {
+  useEffect(() => {
     if (isEditingNewDashboard) {
-       editPane.openPane('add'); 
+      editPane.openPane('add');
     }
-  });
+  }, [isEditingNewDashboard, editPane]);
 
   const { selectionContext, openPane } = useSceneObjectState(editPane, { shouldActivateOrKeepAlive: true });
 


### PR DESCRIPTION
The home page (for OSS) is also a dashboard but not editable, we shouldn't open the sidebar to the new panel if it isn't in edit mode
Before: 
<img width="500" height="670" alt="image" src="https://github.com/user-attachments/assets/e18a194a-cc7a-4065-8e0b-8d18dd58d01a" />