### PR TITLE
Dashboard Templates: Add FF tracking property when a dashboard is saved

### DIFF
--- a/public/app/features/dashboard-scene/utils/tracking.ts
+++ b/public/app/features/dashboard-scene/utils/tracking.ts
@@ -74,9 +74,7 @@ export function trackDashboardSceneCreatedOrSaved(
     config.featureToggles.dashboardTemplates ||
     config.featureToggles.suggestedDashboards
       ? {
-          isDashboardLibraryEnabled: config.featureToggles.dashboardLibrary,
-          isSuggestedDashboardsEnabled: config.featureToggles.suggestedDashboards,
-          isDashboardTemplatesEnabled: config.featureToggles.dashboardTemplates,
+          isDashboardTemplatesEnabled: config.featureToggles.dashboardTemplates ?? false,
           datasourceTypes,
           sourceEntryPoint,
           libraryItemId,

--- a/public/app/features/dashboard-scene/utils/tracking.ts
+++ b/public/app/features/dashboard-scene/utils/tracking.ts
@@ -74,6 +74,9 @@ export function trackDashboardSceneCreatedOrSaved(
     config.featureToggles.dashboardTemplates ||
     config.featureToggles.suggestedDashboards
       ? {
+          isDashboardLibraryEnabled: config.featureToggles.dashboardLibrary,
+          isSuggestedDashboardsEnabled: config.featureToggles.suggestedDashboards,
+          isDashboardTemplatesEnabled: config.featureToggles.dashboardTemplates,
           datasourceTypes,
           sourceEntryPoint,
           libraryItemId,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Improves tracking events to understand more about the number of dashboards that are saved (from-scratch or template dashboards) while the dashboard library feature is enabled

**Why do we need this feature?**

To improve analytics

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/116629

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
