### PR TITLE
Tests: Check frontend test coverage CI workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1056,6 +1056,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /scripts/clean-git-or-error.sh @grafana/grafana-as-code
 /scripts/grafana-server/ @grafana/grafana-frontend-platform
 /scripts/check-frontend-dev.sh @grafana/grafana-frontend-platform
+/scripts/check-codeowner-affected.js @grafana/dataviz-squad
 /scripts/compare-coverage-by-codeowner.js @grafana/dataviz-squad
 /scripts/helpers/ @grafana/grafana-developer-enablement-squad
 /scripts/import_many_dashboards.sh @torkelo

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -58,29 +58,62 @@ jobs:
   cleanup-on-skip:
     name: Cleanup coverage comments
     needs: setup
-    if: contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage')
+    if: contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage') && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-x64-small
     permissions:
       pull-requests: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
         codeowner: ${{ fromJSON(needs.setup.outputs.opted-in-teams) }}
     steps:
+      - name: Get Vault secrets
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            GITHUB_APP_ID=grafana_pr_automation_app:app_id
+            GITHUB_APP_PRIVATE_KEY=grafana_pr_automation_app:app_pem
+
+      - name: Generate GitHub App token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+
       - name: Delete coverage comment for ${{ matrix.codeowner }}
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: coverage-report-${{ matrix.codeowner }}
           delete: true
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
   post-skip-warning:
     name: Post skip warning
     needs: [setup, cleanup-on-skip]
-    if: contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage')
+    if: contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage') && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-x64-small
     permissions:
       pull-requests: write
+      id-token: write
     steps:
+      - name: Get Vault secrets
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            GITHUB_APP_ID=grafana_pr_automation_app:app_id
+            GITHUB_APP_PRIVATE_KEY=grafana_pr_automation_app:app_pem
+
+      - name: Generate GitHub App token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+
       - name: Generate skip message
         id: skip-message
         run: |
@@ -104,19 +137,37 @@ jobs:
         with:
           header: coverage-skip-warning
           message: ${{ steps.skip-message.outputs.message }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
   clear-skip-warning:
     name: Clear skip warning
-    if: "!contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage')"
+    if: "!contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage') && github.event.pull_request.head.repo.fork == false"
     runs-on: ubuntu-x64-small
     permissions:
       pull-requests: write
+      id-token: write
     steps:
+      - name: Get Vault secrets
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            GITHUB_APP_ID=grafana_pr_automation_app:app_id
+            GITHUB_APP_PRIVATE_KEY=grafana_pr_automation_app:app_pem
+
+      - name: Generate GitHub App token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+
       - name: Delete skip warning comment
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: coverage-skip-warning
           delete: true
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
   coverage:
     name: Coverage ${{ matrix.branch }} - ${{ matrix.codeowner }}

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -183,18 +183,13 @@ jobs:
           ")
           echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
 
-      - name: Get current commit SHA
-        if: steps.check-affected.outputs.affected == 'true'
-        id: get-sha
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
       - name: Run coverage for ${{ matrix.codeowner }}
         if: steps.check-affected.outputs.affected == 'true'
         run: yarn test:coverage:by-codeowner "${{ matrix.codeowner }}" --maxWorkers=1
         env:
           SHOULD_OPEN_COVERAGE_REPORT: 'false'
           CI: 'true'
-          GITHUB_SHA: ${{ steps.get-sha.outputs.sha }}
+          GITHUB_SHA: ${{ matrix.branch == 'main' && github.event.pull_request.base.sha || github.event.pull_request.head.sha }}
 
       - name: Upload coverage summary
         if: steps.check-affected.outputs.affected == 'true'

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -30,6 +30,31 @@ jobs:
       - name: Define opted-in teams
         run: echo "Opted-in teams defined in job outputs"
 
+  detect-changes:
+    name: Detect changed files
+    runs-on: ubuntu-x64-small
+    permissions:
+      contents: read
+    outputs:
+      changed-files: ${{ steps.changed-files.outputs.all_changed_files }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: true
+          fetch-depth: 2
+
+      - name: Detect changed files
+        id: changed-files
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
+        with:
+          separator: ' '
+
+      - name: Display changed files
+        run: |
+          echo "=== Changed Files Detected ==="
+          echo "${{ steps.changed-files.outputs.all_changed_files }}"
+          echo "=============================="
+
   cleanup-on-skip:
     name: Cleanup coverage comments
     needs: setup

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -73,33 +73,82 @@ jobs:
           header: coverage-report-${{ matrix.codeowner }}
           delete: true
 
-  generate-slugs:
-    name: Generate slug for ${{ matrix.codeowner }}
-    needs: setup
+  coverage:
+    name: Coverage ${{ matrix.branch }} - ${{ matrix.codeowner }}
+    needs: [setup, detect-changes]
     if: "!contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage')"
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-x64-large
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
         codeowner: ${{ fromJSON(needs.setup.outputs.opted-in-teams) }}
+        branch: [pr, main]
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout PR branch to access script
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
-      - name: Setup Node.js
+      - name: Setup Node.js for manifest generation
         uses: ./.github/actions/setup-node
 
-      - name: Generate slug for ${{ matrix.codeowner }}
+      - name: Install dependencies for manifest generation
+        run: yarn install --immutable
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
+          CYPRESS_INSTALL_BINARY: 0
+
+      - name: Generate codeowners manifest
+        run: yarn codeowners-manifest
+
+      - name: Check if codeowner affected by changes
+        id: check-affected
+        run: |
+          AFFECTED=$(node scripts/check-codeowner-affected.js "${{ matrix.codeowner }}" ${{ needs.detect-changes.outputs.changed-files }})
+          echo "affected=$AFFECTED" >> $GITHUB_OUTPUT
+          echo "Codeowner ${{ matrix.codeowner }} affected: $AFFECTED"
+
+      - name: Checkout target branch
+        if: steps.check-affected.outputs.affected == 'true'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ matrix.branch == 'main' && 'main' || github.ref }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        if: steps.check-affected.outputs.affected == 'true'
+        uses: ./.github/actions/setup-node
+
+      - name: Install dependencies
+        if: steps.check-affected.outputs.affected == 'true'
+        run: yarn install --immutable
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
+          CYPRESS_INSTALL_BINARY: 0
+
+      - name: Get codeowner slug
+        if: steps.check-affected.outputs.affected == 'true'
+        id: codeowner-slug
         run: |
           SLUG=$(node -e "
             const { createCodeownerSlug } = require('./scripts/codeowners-manifest/utils.js');
             console.log(createCodeownerSlug('${{ matrix.codeowner }}'));
           ")
+          echo "slug=$SLUG" >> $GITHUB_OUTPUT
 
-          echo "=== Codeowner Slug Generated ==="
-          echo "Codeowner: ${{ matrix.codeowner }}"
-          echo "Slug: $SLUG"
-          echo "================================"
+      - name: Run coverage for ${{ matrix.codeowner }}
+        if: steps.check-affected.outputs.affected == 'true'
+        run: yarn test:coverage:by-codeowner ${{ matrix.codeowner }}
+        env:
+          SHOULD_OPEN_COVERAGE_REPORT: 'false'
+          CI: 'true'
+
+      - name: Upload coverage summary
+        if: steps.check-affected.outputs.affected == 'true'
+        uses: actions/upload-artifact@v5
+        with:
+          name: coverage-${{ matrix.branch }}-${{ steps.codeowner-slug.outputs.slug }}
+          path: coverage-summary.json
+          retention-days: 1

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -152,3 +152,107 @@ jobs:
           name: coverage-${{ matrix.branch }}-${{ steps.codeowner-slug.outputs.slug }}
           path: coverage-summary.json
           retention-days: 1
+
+  compare-and-report:
+    name: Compare & Report - ${{ matrix.codeowner }}
+    needs: [setup, detect-changes, coverage]
+    if: "!contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage')"
+    runs-on: ubuntu-x64-small
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        codeowner: ${{ fromJSON(needs.setup.outputs.opted-in-teams) }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Install dependencies for manifest and comparison
+        run: yarn install --immutable
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
+          CYPRESS_INSTALL_BINARY: 0
+
+      - name: Generate codeowners manifest
+        run: yarn codeowners-manifest
+
+      - name: Check if codeowner affected by changes
+        id: check-affected
+        run: |
+          AFFECTED=$(node scripts/check-codeowner-affected.js "${{ matrix.codeowner }}" ${{ needs.detect-changes.outputs.changed-files }})
+          echo "affected=$AFFECTED" >> $GITHUB_OUTPUT
+          echo "Codeowner ${{ matrix.codeowner }} affected: $AFFECTED"
+
+      - name: Delete old coverage comment if not affected
+        if: steps.check-affected.outputs.affected == 'false'
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: coverage-report-${{ matrix.codeowner }}
+          delete: true
+
+      - name: Get codeowner slug
+        if: steps.check-affected.outputs.affected == 'true'
+        id: codeowner-slug
+        run: |
+          SLUG=$(node -e "
+            const { createCodeownerSlug } = require('./scripts/codeowners-manifest/utils.js');
+            console.log(createCodeownerSlug('${{ matrix.codeowner }}'));
+          ")
+          echo "slug=$SLUG" >> $GITHUB_OUTPUT
+
+      - name: Download PR coverage
+        if: steps.check-affected.outputs.affected == 'true'
+        uses: actions/download-artifact@v6
+        with:
+          name: coverage-pr-${{ steps.codeowner-slug.outputs.slug }}
+          path: ./coverage-pr
+
+      - name: Download main coverage
+        if: steps.check-affected.outputs.affected == 'true'
+        uses: actions/download-artifact@v6
+        with:
+          name: coverage-main-${{ steps.codeowner-slug.outputs.slug }}
+          path: ./coverage-main
+
+      - name: Compare coverage
+        if: steps.check-affected.outputs.affected == 'true'
+        id: compare
+        run: |
+          node scripts/compare-coverage-by-codeowner.js
+          {
+            echo "markdown<<EOF"
+            cat ./coverage-comparison.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Get Vault secrets
+        if: steps.check-affected.outputs.affected == 'true' && github.event.pull_request.head.repo.fork == false
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            GITHUB_APP_ID=grafana_pr_automation_app:app_id
+            GITHUB_APP_PRIVATE_KEY=grafana_pr_automation_app:app_pem
+
+      - name: Generate GitHub App token
+        if: steps.check-affected.outputs.affected == 'true' && github.event.pull_request.head.repo.fork == false
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Post PR comment
+        if: steps.check-affected.outputs.affected == 'true' && github.event.pull_request.head.repo.fork == false
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: coverage-report-${{ matrix.codeowner }}
+          message: ${{ steps.compare.outputs.markdown }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -90,11 +90,11 @@ jobs:
           {
             echo "message<<EOF"
             echo "## ⚠️ Frontend Test Coverage Checks Skipped"
-            echo ""
+            echo
             echo "Coverage checks have been skipped for the following codeowners:"
-            echo ""
+            echo
             echo "$TEAM_LIST"
-            echo ""
+            echo
             echo "Remove the \`no-check-frontend-test-coverage\` label to re-enable coverage checks."
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
@@ -131,7 +131,7 @@ jobs:
         codeowner: ${{ fromJSON(needs.setup.outputs.opted-in-teams) }}
         branch: [pr, main]
     steps:
-      - name: Checkout PR branch to access script
+      - name: Checkout PR branch
         uses: actions/checkout@v5
         with:
           persist-credentials: false
@@ -151,8 +151,8 @@ jobs:
       - name: Check if codeowner affected by changes
         id: check-affected
         run: |
-          AFFECTED=$(node scripts/check-codeowner-affected.js "${{ matrix.codeowner }}" ${{ needs.detect-changes.outputs.changed-files }})
-          echo "affected=$AFFECTED" >> $GITHUB_OUTPUT
+          AFFECTED=$(node scripts/check-codeowner-affected.js "${{ matrix.codeowner }}" "${{ needs.detect-changes.outputs.changed-files }}")
+          echo "affected=$AFFECTED" >> "$GITHUB_OUTPUT"
           echo "Codeowner ${{ matrix.codeowner }} affected: $AFFECTED"
 
       - name: Checkout target branch
@@ -181,11 +181,11 @@ jobs:
             const { createCodeownerSlug } = require('./scripts/codeowners-manifest/utils.js');
             console.log(createCodeownerSlug('${{ matrix.codeowner }}'));
           ")
-          echo "slug=$SLUG" >> $GITHUB_OUTPUT
+          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
 
       - name: Run coverage for ${{ matrix.codeowner }}
         if: steps.check-affected.outputs.affected == 'true'
-        run: yarn test:coverage:by-codeowner ${{ matrix.codeowner }}
+        run: yarn test:coverage:by-codeowner "${{ matrix.codeowner }}"
         env:
           SHOULD_OPEN_COVERAGE_REPORT: 'false'
           CI: 'true'
@@ -231,8 +231,8 @@ jobs:
       - name: Check if codeowner affected by changes
         id: check-affected
         run: |
-          AFFECTED=$(node scripts/check-codeowner-affected.js "${{ matrix.codeowner }}" ${{ needs.detect-changes.outputs.changed-files }})
-          echo "affected=$AFFECTED" >> $GITHUB_OUTPUT
+          AFFECTED=$(node scripts/check-codeowner-affected.js "${{ matrix.codeowner }}" "${{ needs.detect-changes.outputs.changed-files }}")
+          echo "affected=$AFFECTED" >> "$GITHUB_OUTPUT"
           echo "Codeowner ${{ matrix.codeowner }} affected: $AFFECTED"
 
       - name: Delete old coverage comment if not affected
@@ -250,7 +250,7 @@ jobs:
             const { createCodeownerSlug } = require('./scripts/codeowners-manifest/utils.js');
             console.log(createCodeownerSlug('${{ matrix.codeowner }}'));
           ")
-          echo "slug=$SLUG" >> $GITHUB_OUTPUT
+          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
 
       - name: Download PR coverage
         if: steps.check-affected.outputs.affected == 'true'

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -2,7 +2,7 @@ name: Check Fronted Test Coverage
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - '**/*.js'
       - '**/*.jsx'
@@ -14,20 +14,51 @@ on:
 permissions: {}
 
 jobs:
+  setup:
+    name: Setup opted-in teams
+    runs-on: ubuntu-x64-small
+    outputs:
+      # NOTE: Only checks test coverage for opted-in codeowners.
+      #       Please add the GitHub user/team or email used in
+      #       CODEOWNERS to the list below to opt-in.
+      opted-in-teams: >-
+        [
+          "@grafana/datapro",
+          "@grafana/dataviz-squad"
+        ]
+    steps:
+      - name: Define opted-in teams
+        run: echo "Opted-in teams defined in job outputs"
+
+  cleanup-on-skip:
+    name: Cleanup coverage comments
+    needs: setup
+    if: contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage')
+    runs-on: ubuntu-x64-small
+    permissions:
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        codeowner: ${{ fromJSON(needs.setup.outputs.opted-in-teams) }}
+    steps:
+      - name: Delete coverage comment for ${{ matrix.codeowner }}
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: coverage-report-${{ matrix.codeowner }}
+          delete: true
+
   generate-slugs:
     name: Generate slug for ${{ matrix.codeowner }}
+    needs: setup
+    if: "!contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage')"
     runs-on: ubuntu-x64-small
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        # NOTE: Only checks test coverage for opted-in codeowners.
-        #       Please add the GitHub user/team or email used in
-        #       CODEOWNERS to the list below to opt-in.
-        codeowner: &codeowners
-          - '@grafana/datapro'
-          - '@grafana/dataviz-squad'
+        codeowner: ${{ fromJSON(needs.setup.outputs.opted-in-teams) }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -336,4 +336,8 @@ jobs:
       - name: Verify all checks passed
         if: steps.check-skip.outputs.skipped == 'false'
         run: |
-          echo "If this step succeeds, all coverage metrics were maintained or improved."
+          if [[ "${{ needs.compare-and-report.result }}" != "success" ]]; then
+            echo "❌ Coverage checks failed for one or more teams"
+            exit 1
+          fi
+          echo "✅ All coverage metrics were maintained or improved."

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -301,3 +301,25 @@ jobs:
           header: coverage-report-${{ matrix.codeowner }}
           message: ${{ steps.compare.outputs.markdown }}
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+  all-coverage-checks-pass:
+    name: All coverage checks pass
+    needs: [setup, compare-and-report]
+    if: always()
+    runs-on: ubuntu-x64-small
+    steps:
+      - name: Check if skipped
+        id: check-skip
+        run: |
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage') }}" == "true" ]]; then
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "✅ Coverage checks skipped due to 'no-check-frontend-test-coverage' label"
+          else
+            echo "skipped=false" >> "$GITHUB_OUTPUT"
+            echo "All opted-in teams' coverage checks have completed."
+          fi
+
+      - name: Verify all checks passed
+        if: steps.check-skip.outputs.skipped == 'false'
+        run: |
+          echo "If this step succeeds, all coverage metrics were maintained or improved."

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -73,6 +73,51 @@ jobs:
           header: coverage-report-${{ matrix.codeowner }}
           delete: true
 
+  post-skip-warning:
+    name: Post skip warning
+    needs: [setup, cleanup-on-skip]
+    if: contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage')
+    runs-on: ubuntu-x64-small
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Generate skip message
+        id: skip-message
+        run: |
+          TEAMS='${{ needs.setup.outputs.opted-in-teams }}'
+          TEAM_LIST=$(echo "$TEAMS" | jq -r '.[] | "- `" + . + "`"' | tr '\n' '\n')
+          
+          {
+            echo "message<<EOF"
+            echo "## ⚠️ Frontend Test Coverage Checks Skipped"
+            echo ""
+            echo "Coverage checks have been skipped for the following codeowners:"
+            echo ""
+            echo "$TEAM_LIST"
+            echo ""
+            echo "Remove the \`no-check-frontend-test-coverage\` label to re-enable coverage checks."
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post skip warning comment
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: coverage-skip-warning
+          message: ${{ steps.skip-message.outputs.message }}
+
+  clear-skip-warning:
+    name: Clear skip warning
+    if: "!contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage')"
+    runs-on: ubuntu-x64-small
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Delete skip warning comment
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: coverage-skip-warning
+          delete: true
+
   coverage:
     name: Coverage ${{ matrix.branch }} - ${{ matrix.codeowner }}
     needs: [setup, detect-changes]

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -159,7 +159,7 @@ jobs:
         if: steps.check-affected.outputs.affected == 'true'
         uses: actions/checkout@v5
         with:
-          ref: ${{ matrix.branch == 'main' && github.event.pull_request.base.ref || github.event.pull_request.head.sha }}
+          ref: ${{ matrix.branch == 'main' && github.event.pull_request.base.sha || github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Setup Node.js

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -159,7 +159,7 @@ jobs:
         if: steps.check-affected.outputs.affected == 'true'
         uses: actions/checkout@v5
         with:
-          ref: ${{ matrix.branch == 'main' && 'main' || github.ref }}
+          ref: ${{ matrix.branch == 'main' && github.event.pull_request.base.ref || github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -183,12 +183,18 @@ jobs:
           ")
           echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
 
+      - name: Get current commit SHA
+        if: steps.check-affected.outputs.affected == 'true'
+        id: get-sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Run coverage for ${{ matrix.codeowner }}
         if: steps.check-affected.outputs.affected == 'true'
         run: yarn test:coverage:by-codeowner "${{ matrix.codeowner }}"
         env:
           SHOULD_OPEN_COVERAGE_REPORT: 'false'
           CI: 'true'
+          GITHUB_SHA: ${{ steps.get-sha.outputs.sha }}
 
       - name: Upload coverage summary
         if: steps.check-affected.outputs.affected == 'true'

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -190,7 +190,7 @@ jobs:
 
       - name: Run coverage for ${{ matrix.codeowner }}
         if: steps.check-affected.outputs.affected == 'true'
-        run: yarn test:coverage:by-codeowner "${{ matrix.codeowner }}"
+        run: yarn test:coverage:by-codeowner "${{ matrix.codeowner }}" --maxWorkers=1
         env:
           SHOULD_OPEN_COVERAGE_REPORT: 'false'
           CI: 'true'

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -1,4 +1,4 @@
-name: Check Fronted Test Coverage
+name: Check Frontend Test Coverage
 
 on:
   pull_request:
@@ -276,7 +276,14 @@ jobs:
         if: steps.check-affected.outputs.affected == 'true'
         id: compare
         run: |
-          node scripts/compare-coverage-by-codeowner.js
+          # Run comparison and capture exit code
+          if node scripts/compare-coverage-by-codeowner.js; then
+            echo "passed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "passed=false" >> "$GITHUB_OUTPUT"
+          fi
+          
+          # Always capture the markdown output
           {
             echo "markdown<<EOF"
             cat ./coverage-comparison.md
@@ -307,6 +314,12 @@ jobs:
           header: coverage-report-${{ matrix.codeowner }}
           message: ${{ steps.compare.outputs.markdown }}
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      - name: Fail if coverage decreased
+        if: steps.check-affected.outputs.affected == 'true' && steps.compare.outputs.passed == 'false'
+        run: |
+          echo "❌ Coverage check failed for ${{ matrix.codeowner }}"
+          exit 1
 
   all-coverage-checks-pass:
     name: All coverage checks pass

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -280,6 +280,23 @@ jobs:
       - name: Generate codeowners manifest
         run: yarn codeowners-manifest
 
+      - name: Get Vault secrets
+        if: github.event.pull_request.head.repo.fork == false
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            GITHUB_APP_ID=grafana_pr_automation_app:app_id
+            GITHUB_APP_PRIVATE_KEY=grafana_pr_automation_app:app_pem
+
+      - name: Generate GitHub App token
+        if: github.event.pull_request.head.repo.fork == false
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+
       - name: Check if codeowner affected by changes
         id: check-affected
         run: |
@@ -288,11 +305,12 @@ jobs:
           echo "Codeowner ${{ matrix.codeowner }} affected: $AFFECTED"
 
       - name: Delete old coverage comment if not affected
-        if: steps.check-affected.outputs.affected == 'false'
+        if: steps.check-affected.outputs.affected == 'false' && github.event.pull_request.head.repo.fork == false
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: coverage-report-${{ matrix.codeowner }}
           delete: true
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       - name: Get codeowner slug
         if: steps.check-affected.outputs.affected == 'true'
@@ -335,23 +353,6 @@ jobs:
             cat ./coverage-comparison.md
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
-
-      - name: Get Vault secrets
-        if: steps.check-affected.outputs.affected == 'true' && github.event.pull_request.head.repo.fork == false
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
-        with:
-          repo_secrets: |
-            GITHUB_APP_ID=grafana_pr_automation_app:app_id
-            GITHUB_APP_PRIVATE_KEY=grafana_pr_automation_app:app_pem
-
-      - name: Generate GitHub App token
-        if: steps.check-affected.outputs.affected == 'true' && github.event.pull_request.head.repo.fork == false
-        id: generate_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
 
       - name: Post PR comment
         if: steps.check-affected.outputs.affected == 'true' && github.event.pull_request.head.repo.fork == false

--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,5 @@ public/mockServiceWorker.js
 
 # Ignore grafana/hippocampus local cache folder
 .hippo
+
+coverage-summary.json

--- a/jest.config.codeowner.js
+++ b/jest.config.codeowner.js
@@ -50,7 +50,11 @@ const sourceFiles = teamFiles.filter((file) => {
     !file.includes('.d.ts') &&
     !file.endsWith('/types.ts') &&
     // and anything in graveyard
-    !path.matchesGlob(file, '**/graveyard/**/*')
+    !path.matchesGlob(file, '**/graveyard/**/*') &&
+    // and scripts directory
+    !file.startsWith('scripts/') &&
+    // and jest config files
+    !path.matchesGlob(file, '**/jest.config*.js')
   );
 });
 

--- a/scripts/check-codeowner-affected.js
+++ b/scripts/check-codeowner-affected.js
@@ -24,20 +24,23 @@ function isCodeownerAffected(codeowner, changedFiles, manifestPath = CODEOWNERS_
 /**
  * Runs the codeowner affected check from command line
  * @param {string} codeowner - Codeowner name from CLI args
- * @param {string[]} changedFiles - Changed file paths from CLI args
+ * @param {string|string[]} changedFiles - Changed file paths (space-separated string or array)
  */
 function checkCodeownerAffected(codeowner, changedFiles) {
   if (!codeowner) {
-    console.error('Usage: node check-codeowner-affected.js <codeowner> <file1> <file2> ...');
+    console.error('Usage: node check-codeowner-affected.js <codeowner> <space-separated-files>');
+    console.error('   or: node check-codeowner-affected.js <codeowner> <file1> <file2> ...');
     process.exit(1);
   }
 
-  const isAffected = isCodeownerAffected(codeowner, changedFiles);
+  const filesArray = typeof changedFiles === 'string' ? changedFiles.split(/\s+/).filter(Boolean) : changedFiles;
+  const isAffected = isCodeownerAffected(codeowner, filesArray);
   console.log(isAffected ? 'true' : 'false');
 }
 
 if (require.main === module) {
-  const [codeowner, ...changedFiles] = process.argv.slice(2);
+  const [codeowner, ...rest] = process.argv.slice(2);
+  const changedFiles = rest.length === 1 ? rest[0] : rest;
   checkCodeownerAffected(codeowner, changedFiles);
 }
 

--- a/scripts/check-codeowner-affected.js
+++ b/scripts/check-codeowner-affected.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+const CODEOWNERS_MANIFEST_PATH = '../codeowners-manifest/filenames-by-team.json';
+
+/**
+ * Checks if any files owned by a codeowner are in the list of changed files
+ * @param {string} codeowner - Codeowner name (e.g., '@grafana/dataviz-squad')
+ * @param {string[]} changedFiles - Array of changed file paths
+ * @param {string} manifestPath - Path to codeowners manifest JSON file
+ * @returns {boolean} True if any team files are in the changed files list
+ */
+function isCodeownerAffected(codeowner, changedFiles, manifestPath = CODEOWNERS_MANIFEST_PATH) {
+  const manifest = require(manifestPath);
+  const teamFiles = manifest[codeowner] || [];
+
+  if (teamFiles.length === 0) {
+    console.warn(`Warning: No files found for codeowner "${codeowner}"`);
+    return false;
+  }
+
+  return teamFiles.some((file) => changedFiles.includes(file));
+}
+
+/**
+ * Runs the codeowner affected check from command line
+ * @param {string} codeowner - Codeowner name from CLI args
+ * @param {string[]} changedFiles - Changed file paths from CLI args
+ */
+function checkCodeownerAffected(codeowner, changedFiles) {
+  if (!codeowner) {
+    console.error('Usage: node check-codeowner-affected.js <codeowner> <file1> <file2> ...');
+    process.exit(1);
+  }
+
+  const isAffected = isCodeownerAffected(codeowner, changedFiles);
+  console.log(isAffected ? 'true' : 'false');
+}
+
+if (require.main === module) {
+  const [codeowner, ...changedFiles] = process.argv.slice(2);
+  checkCodeownerAffected(codeowner, changedFiles);
+}
+
+module.exports = { isCodeownerAffected, checkCodeownerAffected };

--- a/scripts/compare-coverage-by-codeowner.js
+++ b/scripts/compare-coverage-by-codeowner.js
@@ -56,6 +56,22 @@ function getOverallStatus(mainSummary, prSummary) {
 }
 
 /**
+ * Calculates the difference between PR and main coverage
+ * @param {number} prValue - PR coverage percentage
+ * @param {number} mainValue - Main coverage percentage
+ * @returns {string} Formatted delta (e.g., "+1.2%" or "-0.5%")
+ */
+function formatDelta(prValue, mainValue) {
+  const delta = prValue - mainValue;
+  if (delta > 0) {
+    return `+${delta.toFixed(1)}%`;
+  } else if (delta < 0) {
+    return `${delta.toFixed(1)}%`;
+  }
+  return '—';
+}
+
+/**
  * Generates markdown report comparing main and PR coverage
  * @param {Object} mainCoverage - Main branch coverage data
  * @param {Object} prCoverage - PR branch coverage data
@@ -94,28 +110,28 @@ function generateMarkdown(mainCoverage, prCoverage) {
   const tableRows = rows
     .map((row) => {
       const status = getStatusIcon(row.main, row.pr);
-      return `| ${row.metric} | ${formatPercentage(row.main)} | ${formatPercentage(row.pr)} | ${status} |`;
+      const delta = formatDelta(row.pr, row.main);
+      return `| ${row.metric} | ${formatPercentage(row.main)} | ${formatPercentage(row.pr)} | ${delta} | ${status} |`;
     })
     .join('\n');
 
   const overallStatus = overallPass ? '✅ Pass' : '❌ Fail';
-  const overallMessage = overallPass ? 'Coverage maintained or improved' : 'Coverage decreased in one or more metrics';
 
-  return `## Test Coverage Report - ${teamName}
+  return `## Test Coverage Checks ${overallStatus} for ${teamName}
 
-| Metric | Main Branch | PR Branch | Status |
-|--------|-------------|-----------|--------|
+| Metric | Main | PR | Change | Status |
+|--------|------|----|----|--------|
 ${tableRows}
 
-**Overall: ${overallStatus}** - ${overallMessage}
+**Run locally:** 💻 \`yarn test:coverage:by-codeowner ${teamName}\`
 
-<details>
-<summary>Coverage Details</summary>
+**Break glass:** 🚨 In case of emergency, adding the \`no-check-frontend-test-coverage\` label to this PR will skip checks.
 
-- **PR Branch**: \`${prCoverage.commit.substring(0, 7)}\` (${prCoverage.timestamp})
-- **Main Branch**: \`${mainCoverage.commit.substring(0, 7)}\` (${mainCoverage.timestamp})
+**Compared:**
 
-</details>
+- PR: \`${prCoverage.commit.substring(0, 7)}\` (${prCoverage.timestamp})
+- Main: \`${mainCoverage.commit.substring(0, 7)}\` (${mainCoverage.timestamp})
+
 `;
 }
 

--- a/scripts/compare-coverage-by-codeowner.js
+++ b/scripts/compare-coverage-by-codeowner.js
@@ -149,6 +149,7 @@ ${tableRows}
  * @param {string} mainPath - Path to main branch coverage summary JSON
  * @param {string} prPath - Path to PR branch coverage summary JSON
  * @param {string} outputPath - Path to write comparison markdown
+ * @returns {boolean} True if coverage check passed
  */
 function compareCoverageByCodeowner(
   mainPath = COVERAGE_MAIN_PATH,
@@ -164,6 +165,7 @@ function compareCoverageByCodeowner(
   }
 
   const markdown = generateMarkdown(mainCoverage, prCoverage);
+  const overallPass = getOverallStatus(mainCoverage.summary, prCoverage.summary);
 
   try {
     fs.writeFileSync(outputPath, markdown, 'utf8');
@@ -172,10 +174,17 @@ function compareCoverageByCodeowner(
     console.error(`Error writing output file: ${err.message}`);
     process.exit(1);
   }
+
+  return overallPass;
 }
 
 if (require.main === module) {
-  compareCoverageByCodeowner();
+  const passed = compareCoverageByCodeowner();
+  if (!passed) {
+    console.error('❌ Coverage check failed: One or more metrics decreased');
+    process.exit(1);
+  }
+  console.log('✅ Coverage check passed: All metrics maintained or improved');
 }
 
 module.exports = { compareCoverageByCodeowner, generateMarkdown, getOverallStatus };

--- a/scripts/compare-coverage-by-codeowner.js
+++ b/scripts/compare-coverage-by-codeowner.js
@@ -37,7 +37,11 @@ function formatPercentage(value) {
  * @returns {string} Status icon and text
  */
 function getStatusIcon(mainValue, prValue) {
-  if (prValue >= mainValue) {
+  // Round to 1 decimal place for comparison to match display precision
+  const prPct = Math.round(prValue * 10) / 10;
+  const mainPct = Math.round(mainValue * 10) / 10;
+
+  if (prPct >= mainPct) {
     return '✅ Pass';
   }
   return '❌ Fail';
@@ -51,7 +55,12 @@ function getStatusIcon(mainValue, prValue) {
  */
 function getOverallStatus(mainSummary, prSummary) {
   const metrics = ['lines', 'statements', 'functions', 'branches'];
-  const allPass = metrics.every((metric) => prSummary[metric].pct >= mainSummary[metric].pct);
+  const allPass = metrics.every((metric) => {
+    // Round to 1 decimal place for comparison to match display precision
+    const prPct = Math.round(prSummary[metric].pct * 10) / 10;
+    const mainPct = Math.round(mainSummary[metric].pct * 10) / 10;
+    return prPct >= mainPct;
+  });
   return allPass;
 }
 

--- a/scripts/compare-coverage-by-codeowner.js
+++ b/scripts/compare-coverage-by-codeowner.js
@@ -124,7 +124,7 @@ function generateMarkdown(mainCoverage, prCoverage) {
     })
     .join('\n');
 
-  const overallStatus = overallPass ? '✅ Pass' : '❌ Fail';
+  const overallStatus = overallPass ? '✅ Passed' : '❌ Failed';
 
   return `## Test Coverage Checks ${overallStatus} for ${teamName}
 
@@ -135,12 +135,6 @@ ${tableRows}
 **Run locally:** 💻 \`yarn test:coverage:by-codeowner ${teamName}\`
 
 **Break glass:** 🚨 In case of emergency, adding the \`no-check-frontend-test-coverage\` label to this PR will skip checks.
-
-**Compared:**
-
-- PR: \`${prCoverage.commit.substring(0, 7)}\` (${prCoverage.timestamp})
-- Main: \`${mainCoverage.commit.substring(0, 7)}\` (${mainCoverage.timestamp})
-
 `;
 }
 

--- a/scripts/compare-coverage-by-codeowner.js
+++ b/scripts/compare-coverage-by-codeowner.js
@@ -24,10 +24,10 @@ function readCoverageFile(filePath) {
 /**
  * Formats a number as a percentage string
  * @param {number} value - Percentage value
- * @returns {string} Formatted percentage (e.g., "85.3%")
+ * @returns {string} Formatted percentage (e.g., "85.34%")
  */
 function formatPercentage(value) {
-  return `${value.toFixed(1)}%`;
+  return `${value.toFixed(2)}%`;
 }
 
 /**
@@ -37,9 +37,9 @@ function formatPercentage(value) {
  * @returns {string} Status icon and text
  */
 function getStatusIcon(mainValue, prValue) {
-  // Round to 1 decimal place for comparison to match display precision
-  const prPct = Math.round(prValue * 10) / 10;
-  const mainPct = Math.round(mainValue * 10) / 10;
+  // Round to 2 decimal places for comparison to match display precision
+  const prPct = Math.round(prValue * 100) / 100;
+  const mainPct = Math.round(mainValue * 100) / 100;
 
   if (prPct >= mainPct) {
     return '✅ Pass';
@@ -56,9 +56,9 @@ function getStatusIcon(mainValue, prValue) {
 function getOverallStatus(mainSummary, prSummary) {
   const metrics = ['lines', 'statements', 'functions', 'branches'];
   const allPass = metrics.every((metric) => {
-    // Round to 1 decimal place for comparison to match display precision
-    const prPct = Math.round(prSummary[metric].pct * 10) / 10;
-    const mainPct = Math.round(mainSummary[metric].pct * 10) / 10;
+    // Round to 2 decimal places for comparison to match display precision
+    const prPct = Math.round(prSummary[metric].pct * 100) / 100;
+    const mainPct = Math.round(mainSummary[metric].pct * 100) / 100;
     return prPct >= mainPct;
   });
   return allPass;
@@ -73,9 +73,9 @@ function getOverallStatus(mainSummary, prSummary) {
 function formatDelta(prValue, mainValue) {
   const delta = prValue - mainValue;
   if (delta > 0) {
-    return `+${delta.toFixed(1)}%`;
+    return `+${delta.toFixed(2)}%`;
   } else if (delta < 0) {
-    return `${delta.toFixed(1)}%`;
+    return `${delta.toFixed(2)}%`;
   }
   return '—';
 }


### PR DESCRIPTION
**What is this feature?**

This change introduces a new opt-in GitHub Actions CI workflow to verify test coverage of incoming PRs for opted in CODEOWNERS to a tolerance of ~0.01%

> [!NOTE]
> _As of this PR only @grafana/dataviz-squad and @grafana/datapro are opted in._
> _🙋 Your team is totally welcome to opt in as well, if you'd like._


## Use-cases

### Incoming PR test coverage is checked ✅ pass

https://github.com/grafana/grafana/actions/runs/21224388650 _(this PR)_

<img width="1911" height="810" alt="Screenshot 2026-01-21 at 16 30 25" src="https://github.com/user-attachments/assets/26222c71-f21f-427f-86a9-31145b5f8a09" />

Because none of the files changed in this PR were owned by @grafana/datapro, change-detection optimization skipped running their test suite entirely, and no comment is posted.

However, @grafana/dataviz-squad owns some files changed in this PR, their test suite was run and passed.
Results of the check are contained in a comment posted on the PR.

<img width="938" height="540" alt="Screenshot 2026-01-21 at 16 29 44" src="https://github.com/user-attachments/assets/f486c69c-24cf-43d8-9c69-1c94828b0242" />

### Incoming PR test coverage is _not_ checked ⚠️ warning

https://github.com/grafana/grafana/actions/runs/21221994998 _(this PR)_

<img width="1897" height="803" alt="Screenshot 2026-01-21 at 15 00 24" src="https://github.com/user-attachments/assets/2cb60c39-1229-4a1e-aeaa-ada7504264ab" />

Because 🏷️ `no-check-frontend-test-coverage` was applied to this PR, all coverage checks were skipped.
A warning mentioning that coverage checks were skipped is posted on the PR for auditing later.

<img width="935" height="321" alt="Screenshot 2026-01-21 at 14 59 41" src="https://github.com/user-attachments/assets/233dba24-1c85-4f0f-bce0-62f1eac4143b" />



### Incoming PR test coverage is checked ❌ fail

https://github.com/grafana/grafana/actions/runs/21224773881 _(PR https://github.com/grafana/grafana/pull/116635)_

<img width="1897" height="765" alt="Screenshot 2026-01-21 at 16 51 14" src="https://github.com/user-attachments/assets/9a0fdb99-1c8e-40cf-bf7b-c51075d024ba" />

Some of the tests owned by @grafana/datapro were skipped to demonstrate failure, their test suite was run and all tests passed, but the coverage dropped which failed the job.

Results of the check are contained in a comment posted on the PR.

Also @grafana/dataviz-squad owns some files changed in this PR, their test suite was run and passed.

<img width="925" height="542" alt="Screenshot 2026-01-21 at 16 50 40" src="https://github.com/user-attachments/assets/f43d2c35-e9c1-483e-a6f6-e6a537c19629" />

----

**Why do we need this feature?**

Automated checks will help us to avoid the dilution of test coverage over time, by bringing awareness to PRs that are insufficiently tested.

**Who is this feature for?**

Both Grafanistas on teams who own frontend code, and contributors to the Grafana monorepo alike.

**Which issue(s) does this PR fix?**:



Fixes https://github.com/grafana/grafana/issues/116310

**Special notes for your reviewer:**

You can run this by basing a new branch off this one and pushing it to remote, and checking CI runs in GHA if you have another use-case you'd like to try out.

Please check that:
- [x] It works as expected from a user's perspective.
- `N/A` ~If this is a pre-GA feature, it is behind a feature toggle.~
- `N/A` ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
