### PR TITLE
Gauge: Improve suggestions

### DIFF
--- a/packages/grafana-ui/src/components/RadialGauge/RadialArcPath.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialArcPath.tsx
@@ -1,3 +1,4 @@
+import { omit } from 'lodash';
 import { useId, memo, HTMLAttributes, SVGProps } from 'react';
 
 import { FieldDisplay } from '@grafana/data';
@@ -7,7 +8,7 @@ import { getBarEndcapColors, getGradientCss } from './colors';
 import { RadialShape, RadialGaugeDimensions, GradientStop } from './types';
 import { drawRadialArcPath, toRad } from './utils';
 
-export interface RadialArcPathPropsBase {
+export interface RadialArcPathPropsBase extends SVGProps<SVGGElement> {
   arcLengthDeg: number;
   barEndcaps?: boolean;
   dimensions: RadialGaugeDimensions;
@@ -98,7 +99,7 @@ export const RadialArcPath = memo(
           </defs>
         )}
 
-        <g filter={glowFilter}>
+        <g filter={glowFilter} {...omit(rest, 'color', 'gradient')}>
           {isGradient ? (
             <foreignObject x={0} y={0} width={vizWidth} height={vizHeight} mask={`url(#${id})`}>
               <div style={bgDivStyle} />

--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.test.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.test.tsx
@@ -27,7 +27,7 @@ describe('RadialGauge', () => {
     }
   );
 
-  describe('threshold labels', () => {
+  describe('labels', () => {
     it('should render labels', () => {
       render(<RadialGaugeExample showScaleLabels />);
 
@@ -77,6 +77,70 @@ describe('RadialGauge', () => {
       expect(screen.getByRole('img')).toBeInTheDocument();
       expect(screen.getByLabelText('Threshold 85')).toBeInTheDocument();
       expect(screen.queryByLabelText('Neutral 85')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('thresholds bar', () => {
+    it('should render thresholds bar if some thresholds are in range', () => {
+      render(
+        <RadialGaugeExample
+          thresholdsBar
+          min={50}
+          max={150}
+          thresholds={{
+            mode: ThresholdsMode.Absolute,
+            steps: [
+              { value: 0, color: 'green' },
+              { value: 65, color: 'orange' },
+              { value: 200, color: 'red' },
+            ],
+          }}
+        />
+      );
+
+      expect(screen.getByRole('img')).toBeInTheDocument();
+      expect(screen.getAllByTestId('radial-gauge-thresholds-bar')).toHaveLength(2);
+    });
+
+    it('should not render thresholds bar if min === max', () => {
+      render(
+        <RadialGaugeExample
+          thresholdsBar
+          min={1}
+          max={1}
+          thresholds={{
+            mode: ThresholdsMode.Absolute,
+            steps: [
+              { value: 1, color: 'green' },
+              { value: 65, color: 'orange' },
+              { value: 200, color: 'red' },
+            ],
+          }}
+        />
+      );
+
+      expect(screen.getByRole('img')).toBeInTheDocument();
+      expect(screen.queryByTestId('radial-gauge-thresholds-bar')).not.toBeInTheDocument();
+    });
+
+    it.skip('should not render thresholds bar the prop is not set', () => {
+      render(
+        <RadialGaugeExample
+          min={50}
+          max={150}
+          thresholds={{
+            mode: ThresholdsMode.Absolute,
+            steps: [
+              { value: 0, color: 'green' },
+              { value: 65, color: 'orange' },
+              { value: 200, color: 'red' },
+            ],
+          }}
+        />
+      );
+
+      expect(screen.getByRole('img')).toBeInTheDocument();
+      expect(screen.queryByTestId('radial-gauge-thresholds-bar')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
@@ -94,7 +94,7 @@ export function RadialGauge(props: RadialGaugeProps) {
     segmentCount = 0,
     segmentSpacing = 0.1,
     roundedBars = true,
-    thresholdsBar = false,
+    thresholdsBar: rawThresholdsBar = false,
     showScaleLabels = false,
     neutral,
     endpointMarker,
@@ -119,6 +119,8 @@ export function RadialGauge(props: RadialGaugeProps) {
 
   for (let barIndex = 0; barIndex < values.length; barIndex++) {
     const displayValue = values[barIndex];
+    // if min === max, the min and max thresholds will also be equal, which causes visual bugs.
+    const thresholdsBar = rawThresholdsBar && displayValue.field.min !== displayValue.field.max;
     const { startValueAngle, endValueAngle, angleRange } = getValueAngleForValue(
       displayValue,
       startAngle,

--- a/packages/grafana-ui/src/components/RadialGauge/ThresholdsBar.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/ThresholdsBar.tsx
@@ -63,6 +63,7 @@ export function ThresholdsBar({
         roundedBars={roundedBars}
         shape={shape}
         startAngle={currentStart}
+        data-testid="radial-gauge-thresholds-bar"
         {...colorProps}
       />
     );

--- a/public/app/features/panel/suggestions/utils.ts
+++ b/public/app/features/panel/suggestions/utils.ts
@@ -26,11 +26,11 @@ export function showDefaultSuggestion(fn: (panelDataSummary: PanelDataSummary) =
  * @param shouldUseRawValues if true, reduceOptions will be set to use raw values,
  *   otherwise a calcs will be used with the default value of `lastNotNull`.
  */
-export function defaultNumericVizOptions(
-  suggestion: VisualizationSuggestion<{ reduceOptions?: ReduceDataOptions }>,
+export function defaultNumericVizOptions<S extends VisualizationSuggestion<{ reduceOptions?: ReduceDataOptions }>>(
+  suggestion: S,
   panelDataSummary: PanelDataSummary,
   shouldUseRawValues: boolean
-): VisualizationSuggestion {
+): S {
   suggestion.score =
     (suggestion.score ??
     (panelDataSummary.hasDataFrameType(DataFrameType.NumericLong) ||

--- a/public/app/plugins/panel/radialbar/suggestions.test.ts
+++ b/public/app/plugins/panel/radialbar/suggestions.test.ts
@@ -152,16 +152,26 @@ describe('RadialBarPanel Suggestions', () => {
   it('figures out a suitable min and max for gauges', () => {
     const suggestions = radialBarSuggestionsSupplier(
       getPanelDataSummary([
-        createDataFrame({
-          fields: [{ name: 'value', type: FieldType.number, values: [40, 50, 60, 70, 80, 90] }],
-        }),
+        {
+          length: 1,
+          fields: [
+            {
+              name: 'value',
+              type: FieldType.number,
+              config: {},
+              values: [40, 50, 60, 70, 80, 90],
+              state: { calcs: { min: 40, max: 90 } },
+            },
+          ],
+        },
       ])
     );
-    if (Array.isArray(suggestions)) {
-      for (const suggestion of suggestions) {
-        expect(suggestion.fieldConfig?.defaults?.min).toBe(35);
-        expect(suggestion.fieldConfig?.defaults?.max).toBe(95);
-      }
+    if (!Array.isArray(suggestions)) {
+      throw new Error('expected suggestions to be an array');
+    }
+    for (const suggestion of suggestions) {
+      expect(suggestion.fieldConfig?.defaults?.min).toBe(35);
+      expect(suggestion.fieldConfig?.defaults?.max).toBe(95);
     }
   });
 });

--- a/public/app/plugins/panel/radialbar/suggestions.test.ts
+++ b/public/app/plugins/panel/radialbar/suggestions.test.ts
@@ -148,4 +148,20 @@ describe('RadialBarPanel Suggestions', () => {
       }
     });
   });
+
+  it('figures out a suitable min and max for gauges', () => {
+    const suggestions = radialBarSuggestionsSupplier(
+      getPanelDataSummary([
+        createDataFrame({
+          fields: [{ name: 'value', type: FieldType.number, values: [40, 50, 60, 70, 80, 90] }],
+        }),
+      ])
+    );
+    if (Array.isArray(suggestions)) {
+      for (const suggestion of suggestions) {
+        expect(suggestion.fieldConfig?.defaults?.min).toBe(35);
+        expect(suggestion.fieldConfig?.defaults?.max).toBe(95);
+      }
+    }
+  });
 });

--- a/public/app/plugins/panel/radialbar/suggestions.ts
+++ b/public/app/plugins/panel/radialbar/suggestions.ts
@@ -49,11 +49,10 @@ export const radialBarSuggestionsSupplier: VisualizationSuggestionsSupplier<Opti
       let newMin = min;
       let newMax = max;
       for (const f of frame.fields) {
-        if (f.type !== FieldType.number) {
-          continue;
+        if (f.type === FieldType.number) {
+          newMin = Math.min(newMin, f.state?.calcs?.min ?? Infinity);
+          newMax = Math.max(newMax, f.state?.calcs?.max ?? -Infinity);
         }
-        newMin = Math.min(newMin, f.state?.calcs?.min ?? Infinity);
-        newMax = Math.max(newMax, f.state?.calcs?.max ?? -Infinity);
       }
       return [newMin, newMax];
     },

--- a/public/app/plugins/panel/radialbar/suggestions.ts
+++ b/public/app/plugins/panel/radialbar/suggestions.ts
@@ -52,14 +52,8 @@ export const radialBarSuggestionsSupplier: VisualizationSuggestionsSupplier<Opti
         if (f.type !== FieldType.number) {
           continue;
         }
-        newMin = Math.min(
-          newMin,
-          f.state?.calcs?.min ?? f.values.reduce((accum, curr) => Math.min(accum, curr), Infinity)
-        );
-        newMax = Math.max(
-          newMax,
-          f.state?.calcs?.max ?? f.values.reduce((accum, curr) => Math.max(accum, curr), -Infinity)
-        );
+        newMin = Math.min(newMin, f.state?.calcs?.min ?? Infinity);
+        newMax = Math.max(newMax, f.state?.calcs?.max ?? -Infinity);
       }
       return [newMin, newMax];
     },
@@ -67,7 +61,7 @@ export const radialBarSuggestionsSupplier: VisualizationSuggestionsSupplier<Opti
   );
 
   let fieldConfig: FieldConfigSource<Partial<GraphFieldConfig>> | undefined = undefined;
-  if (suggestedRange) {
+  if (suggestedRange && suggestedRange.every(isFinite)) {
     const delta = suggestedRange[1] - suggestedRange[0];
     fieldConfig = {
       defaults: {

--- a/public/app/plugins/panel/radialbar/suggestions.ts
+++ b/public/app/plugins/panel/radialbar/suggestions.ts
@@ -1,6 +1,12 @@
 import { defaultsDeep } from 'lodash';
 
-import { FieldColorModeId, FieldType, VisualizationSuggestion, VisualizationSuggestionsSupplier } from '@grafana/data';
+import {
+  FieldColorModeId,
+  FieldConfigSource,
+  FieldType,
+  VisualizationSuggestion,
+  VisualizationSuggestionsSupplier,
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { GraphFieldConfig } from '@grafana/ui';
 import { defaultNumericVizOptions } from 'app/features/panel/suggestions/utils';
@@ -11,6 +17,10 @@ const withDefaults = (
   suggestion: VisualizationSuggestion<Options, GraphFieldConfig>
 ): VisualizationSuggestion<Options, GraphFieldConfig> =>
   defaultsDeep(suggestion, {
+    options: {
+      barWidthFactor: 0.3,
+      showThresholdMarkers: false,
+    },
     cardOptions: {
       previewModifier: (s) => {
         if (s.options?.reduceOptions) {
@@ -34,15 +44,50 @@ export const radialBarSuggestionsSupplier: VisualizationSuggestionsSupplier<Opti
     return;
   }
 
+  const suggestedRange = dataSummary.rawFrames?.reduce(
+    ([min, max], frame) => {
+      let newMin = min;
+      let newMax = max;
+      for (const f of frame.fields) {
+        if (f.type !== FieldType.number) {
+          continue;
+        }
+        newMin = Math.min(
+          newMin,
+          f.state?.calcs?.min ?? f.values.reduce((accum, curr) => Math.min(accum, curr), Infinity)
+        );
+        newMax = Math.max(
+          newMax,
+          f.state?.calcs?.max ?? f.values.reduce((accum, curr) => Math.max(accum, curr), -Infinity)
+        );
+      }
+      return [newMin, newMax];
+    },
+    [Infinity, -Infinity]
+  );
+
+  let fieldConfig: FieldConfigSource<Partial<GraphFieldConfig>> | undefined = undefined;
+  if (suggestedRange) {
+    const delta = suggestedRange[1] - suggestedRange[0];
+    fieldConfig = {
+      defaults: {
+        min: Math.floor(suggestedRange[0] - delta * 0.1),
+        max: Math.ceil(suggestedRange[1] + delta * 0.1),
+      },
+      overrides: [],
+    };
+  }
+
   const suggestions: Array<VisualizationSuggestion<Options, GraphFieldConfig>> = [
-    { name: t('gauge.suggestions.arc', 'Gauge') },
+    {
+      name: t('gauge.suggestions.arc', 'Gauge'),
+      fieldConfig,
+      options: { shape: 'gauge' },
+    },
     {
       name: t('gauge.suggestions.circular', 'Circular gauge'),
-      options: {
-        shape: 'circle',
-        showThresholdMarkers: false,
-        barWidthFactor: 0.3,
-      },
+      fieldConfig,
+      options: { shape: 'circle' },
     },
   ];
 
@@ -51,8 +96,13 @@ export const radialBarSuggestionsSupplier: VisualizationSuggestionsSupplier<Opti
     dataSummary.frameCount === 1 &&
     dataSummary.rowCountTotal <= MAX_GAUGES;
 
+  const showSparkline = dataSummary.rowCountTotal > 1 && dataSummary.hasFieldType(FieldType.time);
+
   return suggestions.map((s) => {
     const suggestion = defaultNumericVizOptions(withDefaults(s), dataSummary, shouldUseRawValues);
+
+    suggestion.options = suggestion.options ?? {};
+    suggestion.options.sparkline = showSparkline;
 
     if (shouldUseRawValues) {
       suggestion.fieldConfig = suggestion.fieldConfig ?? {
@@ -60,7 +110,7 @@ export const radialBarSuggestionsSupplier: VisualizationSuggestionsSupplier<Opti
         overrides: [],
       };
       suggestion.fieldConfig.defaults.color = suggestion.fieldConfig.defaults.color ?? {
-        mode: FieldColorModeId.PaletteClassic,
+        mode: dataSummary.rowCountTotal > 1 ? FieldColorModeId.PaletteClassic : FieldColorModeId.Thresholds,
       };
     }
 

--- a/public/app/plugins/panel/radialbar/suggestions.ts
+++ b/public/app/plugins/panel/radialbar/suggestions.ts
@@ -96,7 +96,8 @@ export const radialBarSuggestionsSupplier: VisualizationSuggestionsSupplier<Opti
     dataSummary.frameCount === 1 &&
     dataSummary.rowCountTotal <= MAX_GAUGES;
 
-  const showSparkline = dataSummary.rowCountTotal > 1 && dataSummary.hasFieldType(FieldType.time);
+  const showSparkline =
+    !shouldUseRawValues && dataSummary.rowCountTotal > 1 && dataSummary.hasFieldType(FieldType.time);
 
   return suggestions.map((s) => {
     const suggestion = defaultNumericVizOptions(withDefaults(s), dataSummary, shouldUseRawValues);
@@ -110,7 +111,7 @@ export const radialBarSuggestionsSupplier: VisualizationSuggestionsSupplier<Opti
         overrides: [],
       };
       suggestion.fieldConfig.defaults.color = suggestion.fieldConfig.defaults.color ?? {
-        mode: dataSummary.rowCountTotal > 1 ? FieldColorModeId.PaletteClassic : FieldColorModeId.Thresholds,
+        mode: FieldColorModeId.PaletteClassic,
       };
     }
 


### PR DESCRIPTION
While testing Suggestions for the new Gauge panel, discovered a handful of things that could use improvement.

- **we should never suggest threshold bars by default**. If a user opts to set up thresholds, then they can turn on the bars.
- since gauge isn't very helpful without mins and maxes, **suggestions ought to propose and set a min and max** based on the values that they get back.
  - the automatically assigned min and max gives a small affordance less than the min and greater than the max across all numeric fields in the frame.
  - this is probably the most controversial change in here, but I think it just gives the user a slightly better starting point in an average case.
- **we should suggest sparkline to be enabled by default if we detect multiple rows and a time field**.

I want to figure out some way to suggest different color schemes for different scenarios, but I think that I may follow up with that later.

Finally, I also fixed a bug:
- if the min === max for a gauge, the value inside `thresholds` will have the min and max equal, which leads to a rendering bug. we will just refuse to render threshold bars in that situation.