### PR TITLE
feat: enhance InviteUserButton to support upgrade functionality

### DIFF
--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -236,6 +236,7 @@ export interface GrafanaConfig {
   externalUserMngInfo: string;
   externalUserMngAnalytics: boolean;
   externalUserMngAnalyticsParams: string;
+  externalUserUpgradeLinkUrl: string;
   allowOrgCreate: boolean;
   disableLoginForm: boolean;
   defaultDatasource: string;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -105,6 +105,7 @@ export class GrafanaBootConfig {
   externalUserMngInfo = '';
   externalUserMngAnalytics = false;
   externalUserMngAnalyticsParams = '';
+  externalUserUpgradeLinkUrl = '';
   allowOrgCreate = false;
   feedbackLinksEnabled = true;
   disableLoginForm = false;

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -222,6 +222,7 @@ type FrontendSettingsDTO struct {
 	ExternalUserMngLinkName              string              `json:"externalUserMngLinkName"`
 	ExternalUserMngAnalytics             bool                `json:"externalUserMngAnalytics"`
 	ExternalUserMngAnalyticsParams       string              `json:"externalUserMngAnalyticsParams"`
+	ExternalUserUpgradeLinkUrl           string              `json:"externalUserUpgradeLinkUrl"`
 	ViewersCanEdit                       bool                `json:"viewersCanEdit"`
 	DisableSanitizeHtml                  bool                `json:"disableSanitizeHtml"`
 	TrustedTypesDefaultPolicyEnabled     bool                `json:"trustedTypesDefaultPolicyEnabled"`

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -248,6 +248,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		ExternalUserMngLinkName:              hs.Cfg.ExternalUserMngLinkName,
 		ExternalUserMngAnalytics:             hs.Cfg.ExternalUserMngAnalytics,
 		ExternalUserMngAnalyticsParams:       hs.Cfg.ExternalUserMngAnalyticsParams,
+		ExternalUserUpgradeLinkUrl:           hs.Cfg.ExternalUserUpgradeLinkUrl,
 		//nolint:staticcheck // ViewersCanEdit is deprecated but still used for backward compatibility
 		ViewersCanEdit:                   hs.Cfg.ViewersCanEdit,
 		DisableSanitizeHtml:              hs.Cfg.DisableSanitizeHtml,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -448,6 +448,7 @@ type Cfg struct {
 	ExternalUserMngInfo            string
 	ExternalUserMngAnalytics       bool
 	ExternalUserMngAnalyticsParams string
+	ExternalUserUpgradeLinkUrl     string
 	AutoAssignOrg                  bool
 	AutoAssignOrgId                int
 	AutoAssignOrgRole              string
@@ -1847,6 +1848,7 @@ func readUserSettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.ExternalUserMngInfo = valueAsString(users, "external_manage_info", "")
 	cfg.ExternalUserMngAnalytics = users.Key("external_manage_analytics").MustBool(false)
 	cfg.ExternalUserMngAnalyticsParams = valueAsString(users, "external_manage_analytics_params", "")
+	cfg.ExternalUserUpgradeLinkUrl = valueAsString(users, "external_upgrade_link_url", "")
 
 	//nolint:staticcheck
 	cfg.ViewersCanEdit = users.Key("viewers_can_edit").MustBool(false)

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButton.test.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButton.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { render } from 'test/test-utils';
 
 import { config, reportInteraction } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -7,18 +8,30 @@ import { getExternalUserMngLinkUrl } from 'app/features/users/utils';
 
 import { InviteUserButton } from './InviteUserButton';
 
-// Mock dependencies
+// Mock the API hook
+const mockUseGetCurrentOrgQuotaQuery = jest.fn(() => ({ data: undefined }));
+
+jest.mock('app/api/clients/legacy', () => {
+  const actual = jest.requireActual('app/api/clients/legacy');
+  return {
+    ...actual,
+    useGetCurrentOrgQuotaQuery: () => mockUseGetCurrentOrgQuotaQuery(),
+  };
+});
+
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
-  config: {
-    externalUserMngLinkUrl: 'https://example.com/invite',
-  },
   reportInteraction: jest.fn(),
 }));
 
 jest.mock('app/core/services/context_srv', () => ({
   contextSrv: {
     hasPermission: jest.fn(),
+    user: {
+      orgId: 1,
+      timezone: 'browser',
+      weekStart: '',
+    },
   },
 }));
 
@@ -27,7 +40,6 @@ jest.mock('app/features/users/utils', () => ({
 }));
 
 const mockContextSrv = jest.mocked(contextSrv);
-const mockConfig = jest.mocked(config);
 const mockReportInteraction = jest.mocked(reportInteraction);
 const mockGetExternalUserMngLinkUrl = jest.mocked(getExternalUserMngLinkUrl);
 
@@ -56,11 +68,14 @@ describe('InviteUserButton', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetExternalUserMngLinkUrl.mockReturnValue(mockInviteUrl);
+    config.externalUserMngLinkUrl = 'https://example.com/invite';
+    config.externalUserUpgradeLinkUrl = '';
+    config.namespace = 'org-1';
   });
 
   describe('Business Logic - When button should appear', () => {
     it('should not render when user lacks permission', () => {
-      mockConfig.externalUserMngLinkUrl = 'https://example.com/invite';
+      config.externalUserMngLinkUrl = 'https://example.com/invite';
       mockContextSrv.hasPermission.mockReturnValue(false);
       mockMatchMedia(true);
 
@@ -70,7 +85,8 @@ describe('InviteUserButton', () => {
     });
 
     it('should not render when external user management URL is not configured', () => {
-      mockConfig.externalUserMngLinkUrl = '';
+      config.externalUserMngLinkUrl = '';
+      config.externalUserUpgradeLinkUrl = '';
       mockContextSrv.hasPermission.mockReturnValue(true);
       mockMatchMedia(true);
 
@@ -82,7 +98,7 @@ describe('InviteUserButton', () => {
 
   describe('User Experience - Responsive behavior', () => {
     beforeEach(() => {
-      mockConfig.externalUserMngLinkUrl = 'https://example.com/invite';
+      config.externalUserMngLinkUrl = 'https://example.com/invite';
       mockContextSrv.hasPermission.mockReturnValue(true);
     });
 
@@ -107,7 +123,7 @@ describe('InviteUserButton', () => {
 
   describe('Core Functionality - Click behavior', () => {
     beforeEach(() => {
-      mockConfig.externalUserMngLinkUrl = 'https://example.com/invite';
+      config.externalUserMngLinkUrl = 'https://example.com/invite';
       mockContextSrv.hasPermission.mockReturnValue(true);
       mockMatchMedia(true);
     });
@@ -130,7 +146,7 @@ describe('InviteUserButton', () => {
 
   describe('Error Handling - Preventing crashes', () => {
     beforeEach(() => {
-      mockConfig.externalUserMngLinkUrl = 'https://example.com/invite';
+      config.externalUserMngLinkUrl = 'https://example.com/invite';
       mockContextSrv.hasPermission.mockReturnValue(true);
       mockMatchMedia(true);
     });
@@ -148,7 +164,7 @@ describe('InviteUserButton', () => {
       // Should not crash when URL generation fails
       await user.click(screen.getByRole('button', { name: /invite user/i }));
 
-      expect(consoleSpy).toHaveBeenCalledWith('Failed to handle invite user click:', expect.any(Error));
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to handle invite/upgrade user click:', expect.any(Error));
 
       consoleSpy.mockRestore();
     });
@@ -166,7 +182,7 @@ describe('InviteUserButton', () => {
       // Should not crash when popup is blocked
       await user.click(screen.getByRole('button', { name: /invite user/i }));
 
-      expect(consoleSpy).toHaveBeenCalledWith('Failed to handle invite user click:', expect.any(Error));
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to handle invite/upgrade user click:', expect.any(Error));
 
       consoleSpy.mockRestore();
     });

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
@@ -1,33 +1,65 @@
+import { skipToken } from '@reduxjs/toolkit/query';
+
 import { t } from '@grafana/i18n';
 import { ToolbarButton } from '@grafana/ui';
+import { useGetCurrentOrgQuotaQuery } from 'app/api/clients/legacy';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 
 import { NavToolbarSeparator } from '../NavToolbar/NavToolbarSeparator';
 
-import { performInviteUserClick, shouldRenderInviteUserButton } from './InviteUserButtonUtils';
+import {
+  performInviteUserClick,
+  performUpgradeUserClick,
+  shouldRenderInviteUserButton,
+  shouldRenderUpgradeUserButton,
+} from './InviteUserButtonUtils';
 
 export function InviteUserButton() {
   const isLargeScreen = useMediaQueryMinWidth('lg');
+  const shouldRender = shouldRenderInviteUserButton();
+  const shouldCheckQuota = shouldRenderUpgradeUserButton();
+
+  // Only fetch quotas when we should check quota (Cloud instance with upgrade URL configured)
+  const { data: quotas } = useGetCurrentOrgQuotaQuery(!shouldCheckQuota ? skipToken : undefined);
+
+  // Check if org_user quota is reached
+  const userQuota = quotas?.find((quota) => quota.target === 'org_user');
+  const isQuotaReached =
+    userQuota != null && userQuota.used != null && userQuota.limit != null && userQuota.used >= userQuota.limit;
+
+  // Show upgrade button if: should check quota (Cloud + upgrade URL configured) AND quota is reached
+  const showUpgrade = shouldCheckQuota && isQuotaReached;
 
   const handleClick = () => {
     try {
-      performInviteUserClick('top_bar_right', 'invite-user-top-bar');
+      if (showUpgrade) {
+        performUpgradeUserClick('top_bar_right');
+      } else {
+        performInviteUserClick('top_bar_right', 'invite-user-top-bar');
+      }
     } catch (error) {
-      console.error('Failed to handle invite user click:', error);
+      console.error('Failed to handle invite/upgrade user click:', error);
     }
   };
 
+  const buttonText = showUpgrade
+    ? t('navigation.invite-user.upgrade-button', 'Upgrade')
+    : t('navigation.invite-user.invite-button', 'Invite');
+  const tooltipText = showUpgrade
+    ? t('navigation.invite-user.upgrade-tooltip', 'Upgrade to add more users')
+    : t('navigation.invite-user.invite-tooltip', 'Invite user');
+
   return (
-    shouldRenderInviteUserButton() && (
+    shouldRender && (
       <>
         <ToolbarButton
           icon="add-user"
           iconOnly={!isLargeScreen}
           onClick={handleClick}
-          tooltip={t('navigation.invite-user.invite-tooltip', 'Invite user')}
-          aria-label={t('navigation.invite-user.invite-tooltip', 'Invite user')}
+          tooltip={tooltipText}
+          aria-label={tooltipText}
         >
-          {isLargeScreen ? t('navigation.invite-user.invite-button', 'Invite') : undefined}
+          {isLargeScreen ? buttonText : undefined}
         </ToolbarButton>
         <NavToolbarSeparator />
       </>

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButtonUtils.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButtonUtils.tsx
@@ -1,10 +1,15 @@
 import { reportInteraction, config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
+import { isOnPrem } from 'app/features/provisioning/utils/isOnPrem';
 import { getExternalUserMngLinkUrl } from 'app/features/users/utils';
 import { AccessControlAction } from 'app/types/accessControl';
 
 export const shouldRenderInviteUserButton = () =>
-  config.externalUserMngLinkUrl && contextSrv.hasPermission(AccessControlAction.OrgUsersAdd);
+  (config.externalUserMngLinkUrl || config.externalUserUpgradeLinkUrl) &&
+  contextSrv.hasPermission(AccessControlAction.OrgUsersAdd);
+
+export const shouldRenderUpgradeUserButton = () =>
+  config.externalUserUpgradeLinkUrl && !isOnPrem() && contextSrv.hasPermission(AccessControlAction.OrgUsersAdd);
 
 export const performInviteUserClick = (placement: string, cnt: string) => {
   reportInteraction('invite_user_button_clicked', {
@@ -13,4 +18,12 @@ export const performInviteUserClick = (placement: string, cnt: string) => {
 
   const url = getExternalUserMngLinkUrl(cnt);
   window.open(url.toString(), '_blank');
+};
+
+export const performUpgradeUserClick = (placement: string) => {
+  reportInteraction('upgrade_user_button_clicked', {
+    placement,
+  });
+
+  window.open(config.externalUserUpgradeLinkUrl, '_blank');
 };

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10925,7 +10925,9 @@
     "invite-user": {
       "invite-button": "Invite",
       "invite-new-user-button": "Invite new user",
-      "invite-tooltip": "Invite user"
+      "invite-tooltip": "Invite user",
+      "upgrade-button": "Upgrade",
+      "upgrade-tooltip": "Upgrade to add more users"
     },
     "item": {
       "add-bookmark": "Add to Bookmarks",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Replaces the "Invite" button in the top navigation bar with an "Upgrade" button when a Grafana Cloud organization reaches its `org_user` quota limit. Clicking the Upgrade button opens the organization's Manage Plan page at `https://grafana.com/orgs/<org-name>/my-account/manage-plan`

Supersedes https://github.com/grafana/grafana/pull/114452 (previous PR closed as stale).

<img width="3100" height="1704" alt="localhost_3000__orgId=1 from=now-6h to=now timezone=browser" src="https://github.com/user-attachments/assets/fa409ce7-d445-4c6d-bfe2-37ca19f86cb7" />

**Why do we need this feature?**

When free or trial organizations reach their user limit (e.g., 3 users) and click "Invite," they currently hit a dead end—being redirected to the Members page with an error message saying they've reached their limit. This creates friction and confusion, requiring users to search for upgrade options elsewhere. Reaching the user limit signals the org is growing and ready for more collaboration. The "Upgrade" button provides a clear, frictionless path forward at the exact moment users need it, preventing frustration and improving conversion for orgs ready to expand.

**Who is this feature for?**

Free and trial Grafana Cloud organizations that have reached their `org_user` quota limit. Organizations actively growing their teams who hit the seat limit and need to upgrade to add more users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Addresses https://github.com/grafana/OGPM/issues/352

**Special notes for your reviewer:**
- Set `stack_id = 12345` in `conf/custom.ini` to simulate Grafana Cloud
- Set `[quota] org_user = 1` to simulate reaching the limit
- Set `external_upgrade_link_url = https://your-upgrade-url.com` to simulate upgrade url
- Verify button changes to "Upgrade"
- Click button and verify it opens: `https://your-upgrade-url.com`
- Test on-prem mode (no `stack_id`) shows "Invite" without quota checks

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
