### PR TITLE
Prometheus: Introduce filtering /series endpoint for prometheus versions that don't support match[] parameter

### DIFF
--- a/packages/grafana-prometheus/src/resource_clients.test.ts
+++ b/packages/grafana-prometheus/src/resource_clients.test.ts
@@ -821,6 +821,32 @@ describe('processSeries', () => {
     const result = processSeries(series, 'non_existent_label');
     expect(result.labelValues).toEqual([]);
   });
+
+  it("should return a filtered result for a datasource that doesn't have match api support", () => {
+    const series = [
+      {
+        __name__: 'up',
+        instance: 'node_exporter:9101',
+        job: 'node_exporter',
+      },
+      {
+        __name__: 'up',
+        instance: 'fake-prometheus-data:9091',
+        job: 'fake-data-gen',
+      },
+    ];
+    const hasMatchApiSupport = false;
+    const matchSelector = `{instance="fake-prometheus-data:9091",__name__="up"}`;
+    const findValuesForKey = 'job';
+    const expectedResult = {
+      metrics: [],
+      labelKeys: [],
+      labelValues: ['fake-data-gen'],
+    };
+
+    const result = processSeries(series, findValuesForKey, hasMatchApiSupport, matchSelector);
+    expect(result.labelValues).toEqual(expectedResult.labelValues);
+  });
 });
 
 describe('BaseResourceClient', () => {

--- a/packages/grafana-prometheus/src/resource_clients.test.ts
+++ b/packages/grafana-prometheus/src/resource_clients.test.ts
@@ -1151,7 +1151,7 @@ describe('processSeries', () => {
         { __name__: 'metric1', instance: 'host1', job: 'api' },
         { __name__: 'metric1', instance: 'host2' }, // Missing 'job' label
         { __name__: 'metric1', instance: 'host3', job: 'worker' },
-      ];
+      ] as Array<{ [key: string]: string }>;
       const hasMatchApiSupport = false;
       const matchSelector = `{job!="api"}`;
 
@@ -1167,7 +1167,7 @@ describe('processSeries', () => {
         { __name__: 'metric1', instance: 'host1', env: 'production' },
         { __name__: 'metric1', instance: 'host2' }, // Missing 'env' label
         { __name__: 'metric1', instance: 'host3', env: 'development' },
-      ];
+      ] as Array<{ [key: string]: string }>;
       const hasMatchApiSupport = false;
       const matchSelector = `{env!~"prod.*"}`;
 
@@ -1183,7 +1183,7 @@ describe('processSeries', () => {
         { __name__: 'metric1', instance: 'host1', job: 'api' },
         { __name__: 'metric1', instance: 'host2' }, // Missing 'job' label
         { __name__: 'metric1', instance: 'host3', job: 'api' },
-      ];
+      ] as Array<{ [key: string]: string }>;
       const hasMatchApiSupport = false;
       const matchSelector = `{job="api"}`;
 
@@ -1199,7 +1199,7 @@ describe('processSeries', () => {
         { __name__: 'metric1', instance: 'host1', env: 'production' },
         { __name__: 'metric1', instance: 'host2' }, // Missing 'env' label
         { __name__: 'metric1', instance: 'host3', env: 'prod-eu' },
-      ];
+      ] as Array<{ [key: string]: string }>;
       const hasMatchApiSupport = false;
       const matchSelector = `{env=~"prod.*"}`;
 

--- a/packages/grafana-prometheus/src/resource_clients.ts
+++ b/packages/grafana-prometheus/src/resource_clients.ts
@@ -379,7 +379,6 @@ export function processSeries(
   const labelKeys: Set<string> = new Set();
   const labelValues: Set<string> = new Set();
 
-  // Filter series if the datasource doesn't have match[] API support
   let filteredSeries = series;
   if (!hasLabelsMatchAPISupport) {
     // The datasource doesn't have match[] parameter support.

--- a/packages/grafana-prometheus/src/resource_clients.ts
+++ b/packages/grafana-prometheus/src/resource_clients.ts
@@ -198,7 +198,7 @@ export class SeriesApiClient extends BaseResourceClient implements ResourceApiCl
 
   public queryMetrics = async (timeRange: TimeRange): Promise<{ metrics: string[]; histogramMetrics: string[] }> => {
     const series = await this.querySeries(timeRange, undefined, DEFAULT_SERIES_LIMIT);
-    const { metrics, labelKeys } = processSeries(series, METRIC_LABEL);
+    const { metrics, labelKeys } = processSeries(series, METRIC_LABEL, this.datasource.hasLabelsMatchAPISupport());
     this.metrics = metrics;
     this.histogramMetrics = processHistogramMetrics(this.metrics);
     this.labelKeys = labelKeys;
@@ -216,7 +216,7 @@ export class SeriesApiClient extends BaseResourceClient implements ResourceApiCl
     }
 
     const series = await this.querySeries(timeRange, effectiveMatch, effectiveLimit);
-    const { labelKeys } = processSeries(series);
+    const { labelKeys } = processSeries(series, undefined, this.datasource.hasLabelsMatchAPISupport(), effectiveMatch);
     this._cache.setLabelKeys(timeRange, effectiveMatch, effectiveLimit, labelKeys);
     return labelKeys;
   };
@@ -252,7 +252,12 @@ export class SeriesApiClient extends BaseResourceClient implements ResourceApiCl
     }
 
     const series = await this.querySeries(timeRange, effectiveMatch, effectiveLimit);
-    const { labelValues } = processSeries(series, removeQuotesIfExist(labelKey));
+    const { labelValues } = processSeries(
+      series,
+      removeQuotesIfExist(labelKey),
+      this.datasource.hasLabelsMatchAPISupport(),
+      effectiveMatch
+    );
     this._cache.setLabelValues(timeRange, effectiveMatch, effectiveLimit, labelValues);
     return labelValues;
   };


### PR DESCRIPTION
**What is this feature?**

Older Prometheus versions (< 2.24.0) or custom build prometheus flavors don't support the match[] parameter in series APIs. When querying these datasources, unfiltered results are returned, which can include unwanted metrics and cause performance issues.

As a solution and backward compatibility, this PR introcuded client-side filtering in the processSeries function to manually filter series based on label matchers.

- Added support for all Prometheus label matching operators: `=`, `!=`, `=~`, `!~`
- Handles edge cases like missing labels and invalid regex patterns
- Refactored `processSeries` to eliminate code duplication and this code path only executes when there is no `match[]` support.

**Why do we need this feature?**

To be able to extend backward compatibility to older or custom prometheus versions/flavors.

**Who is this feature for?**

Prometheus users who have an old or custom version that has no `match[]` support for series. 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/109275

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
