### PR TITLE
Geomap: Variable support in the XYZ Tile layer

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/geomap/index.md
@@ -513,6 +513,7 @@ The XYZ Tile layer is a map from a generic tile layer.
 - **URL template** - Set a valid tile server url, with {z}/{x}/{y} for example: https://tile.openstreetmap.org/{z}/{x}/{y}.png
 - **Attribution** sets the reference string for the layer if displayed in [map controls](#show-attribution)
 - **Opacity** from 0 (transparent) to 1 (opaque)
+- **Dashboard variables** - You can use dashboard variables in both the **URL template** and **Attribution** fields. This allows you to dynamically switch map sources or versions. Example: `https://example.com/maps/${version}/{z}/{x}/{y}.png`.
 
 ##### More information
 

--- a/public/app/plugins/panel/geomap/layers/basemaps/generic.test.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/generic.test.ts
@@ -6,7 +6,15 @@ import { EventBus, GrafanaTheme2, MapLayerOptions } from '@grafana/data';
 
 import { xyzTiles, XYZConfig } from './generic';
 
-describe('XYZ tile layer noRepeat functionality', () => {
+const replaceMock = jest.fn((text: string) => text);
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getTemplateSrv: () => ({
+    replace: replaceMock,
+  }),
+}));
+
+describe('XYZ tile layer', () => {
   let mockMap: OpenLayersMap;
   let mockEventBus: EventBus;
   let mockTheme: GrafanaTheme2;
@@ -15,6 +23,41 @@ describe('XYZ tile layer noRepeat functionality', () => {
     mockMap = {} as OpenLayersMap;
     mockEventBus = {} as EventBus;
     mockTheme = {} as GrafanaTheme2;
+    replaceMock.mockClear();
+  });
+
+  it('should interpolate variables in URL and attribution', async () => {
+    const rawUrl = 'https://example.com/$version/{z}/{x}/{y}.png';
+    const interpolatedUrl = 'https://example.com/v1/{z}/{x}/{y}.png';
+    const rawAttr = 'Map version $version';
+    const interpolatedAttr = 'Map version v1';
+
+    replaceMock.mockImplementation((text) => {
+      if (text === rawUrl) {
+        return interpolatedUrl;
+      }
+      if (text === rawAttr) {
+        return interpolatedAttr;
+      }
+      return text;
+    });
+
+    const options: MapLayerOptions<XYZConfig> = {
+      name: 'Test Layer',
+      type: 'xyz',
+      config: {
+        url: rawUrl,
+        attribution: rawAttr,
+      },
+    };
+
+    const result = await xyzTiles.create(mockMap, options, mockEventBus, mockTheme);
+    const layer = result.init();
+    const source = (layer as TileLayer<XYZ>).getSource() as XYZ;
+
+    expect(replaceMock).toHaveBeenCalledWith(rawUrl);
+    expect(replaceMock).toHaveBeenCalledWith(rawAttr);
+    expect(source.getUrls()).toContain(interpolatedUrl);
   });
 
   it('should set wrapX to false when noRepeat is true', async () => {

--- a/public/app/plugins/panel/geomap/layers/basemaps/generic.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/generic.ts
@@ -3,6 +3,7 @@ import TileLayer from 'ol/layer/Tile';
 import XYZ from 'ol/source/XYZ';
 
 import { MapLayerRegistryItem, MapLayerOptions, GrafanaTheme2, EventBus } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
 
 export interface XYZConfig {
   url: string;
@@ -36,11 +37,13 @@ export const xyzTiles: MapLayerRegistryItem<XYZConfig> = {
         cfg.attribution = cfg.attribution ?? defaultXYZConfig.attribution;
       }
       const noRepeat = options.noRepeat ?? false;
+      const interpolatedUrl = getTemplateSrv().replace(cfg.url);
+      const interpolatedAttribution = getTemplateSrv().replace(cfg.attribution);
 
       return new TileLayer({
         source: new XYZ({
-          url: cfg.url,
-          attributions: cfg.attribution, // singular?
+          url: interpolatedUrl,
+          attributions: interpolatedAttribution,
           wrapX: !noRepeat,
         }),
         minZoom: cfg.minZoom,
@@ -52,7 +55,7 @@ export const xyzTiles: MapLayerRegistryItem<XYZConfig> = {
         .addTextInput({
           path: 'config.url',
           name: 'URL template',
-          description: 'Must include {x}, {y} or {-y}, and {z} placeholders',
+          description: 'Must include {x}, {y} or {-y}, and {z} placeholders. Dashboard variables are supported.',
           settings: {
             placeholder: defaultXYZConfig.url,
           },


### PR DESCRIPTION
**What is this feature?**

This adds support for dashboard variables in the **XYZ Tile Layer** settings. Now you can use variables inside the URL template and Attribution fields.

https://github.com/user-attachments/assets/296dcaf6-e6a2-4137-93ec-39bae1bdfb27

**Why do we need this feature?**

I ran into a use case where I needed to switch between different map versions dynamically using a dashboard dropdown.
Currently, the XYZ layer URL is static, so the only way to change the map source is to edit the panel. This change makes the map source dynamic based on user selection.

**Who is this feature for?**

Anyone using custom tile servers who wants to switch between map styles, versions, or sources directly from the dashboard.

**Which issue(s) does this PR fix?**:

#58482

**Special notes for your reviewer:**

Added unit tests, documentation, checked everything and recorded a video demonstration of the work.

> [!NOTE]
> Reopen of #114371

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.