### PR TITLE
Docs: Fix unclear slack webhook setup instructions

### DIFF
--- a/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-slack.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-slack.md
@@ -63,7 +63,11 @@ If you are using a Slack API Token, complete the following steps.
 
 ### Webhook URL
 
-If you are using a Webhook URL, follow steps 1 and 5 in the [Slack API Quickstart](https://api.slack.com/start/quickstart), and copy the Slack app Webhook URL. You need this when setting up your contact point integration in Grafana Alerting.
+If you are using a Webhook URL, complete the following steps.
+
+1. Follow the [Creating an app](https://docs.slack.dev/app-management/quickstart-app-settings/#creating) section of the Slack API Quickstart to create the app.
+1. Follow the [Create an incoming webhook](https://api.slack.com/messaging/webhooks#create_a_webhook) section of the Slack Incoming Webhooks guide to enable incoming webhooks for your app and create a webhook for your workspace.
+1. Copy the **Webhook URL** that starts with `https://hooks.slack.com/services/`. You need this when setting up your contact point integration in Grafana Alerting.
 
 ## Procedure
 


### PR DESCRIPTION
**What is this feature?**

This PR updates the slack webhook configuration documentation to provide clear, self-contained setup instructions with direct links to specific Slack API documentation sections. This PR addresses the concern raised in #115921 partially. The other segment of #115921 has already been addressed by another PR which is already merged  (Fixed as per #116042).

**Why do we need this feature?**

The previous documentation referenced "steps 1 and 5" in the Slack API Quickstart, but those step numbers no longer exist in Slack's documentation (Fixed as per #116042). This made the instructions unclear and unusable for users trying to configure Slack webhooks.

**Who is this feature for?**

Users configuring Slack webhook notifications in Grafana Alerting.

**Which issue(s) does this PR fix?**:

Fixes #115921

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. *(N/A - documentation only)*
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. *(Not a notable improvement - minor fix)*

**Doc updated after these changes**

<img width="1507" height="883" alt="Screenshot 2026-01-21 at 9 14 09 PM" src="https://github.com/user-attachments/assets/988ff3c7-7b6a-4679-a166-92c37e274783" />

---

**Additional context:**

The Webhook URL section now follows the same pattern as the Slack API Token section, using descriptive link text with direct anchors to the relevant Slack documentation:
- [Creating an app](https://docs.slack.dev/app-management/quickstart-app-settings/#creating)
- [Create an incoming webhook](https://api.slack.com/messaging/webhooks#create_a_webhook)