### PR TITLE
Scopes: Eliminate prop drilling in ScopesSelector via hooks

### DIFF
--- a/public/app/features/scopes/selector/ScopesSelector.tsx
+++ b/public/app/features/scopes/selector/ScopesSelector.tsx
@@ -45,28 +45,10 @@ export const ScopesSelector = () => {
     return null;
   }
 
-  const {
-    nodes,
-    loadingNodeName,
-    opened,
-    selectedScopes,
-    appliedScopes,
-    tree,
-    scopes: scopesMap,
-  } = selectorServiceState;
+  const { nodes, opened, appliedScopes, tree, scopes: scopesMap } = selectorServiceState;
   const { scopesService, scopesSelectorService } = services;
   const { readOnly, loading } = scopes.state;
-  const {
-    open,
-    removeAllScopes,
-    closeAndApply,
-    closeAndReset,
-    filterNode,
-    selectScope,
-    deselectScope,
-    getRecentScopes,
-    toggleExpandedNode,
-  } = scopesSelectorService;
+  const { open, removeAllScopes, closeAndApply, closeAndReset, getRecentScopes } = scopesSelectorService;
 
   const recentScopes = getRecentScopes();
 
@@ -108,14 +90,7 @@ export const ScopesSelector = () => {
                       <>
                         <ScopesTree
                           tree={tree}
-                          loadingNodeName={loadingNodeName}
-                          filterNode={filterNode}
                           recentScopes={recentScopes}
-                          selectedScopes={selectedScopes}
-                          scopeNodes={nodes}
-                          selectScope={selectScope}
-                          deselectScope={deselectScope}
-                          toggleExpandedNode={toggleExpandedNode}
                           onRecentScopesSelect={(scopeIds: string[], parentNodeId?: string, scopeNodeId?: string) => {
                             scopesSelectorService.changeScopes(scopeIds, parentNodeId, scopeNodeId);
                             scopesSelectorService.closeAndReset();

--- a/public/app/features/scopes/selector/ScopesTree.test.tsx
+++ b/public/app/features/scopes/selector/ScopesTree.test.tsx
@@ -132,10 +132,11 @@ describe('ScopesTree', () => {
     });
 
     it('should not show selectedNodesToShow when first scope has no scopeNodeId', () => {
-      const selectedScopes: SelectedScope[] = [
+      // Set mock selected scopes
+      mockSelectedScopes.push(
         { scopeId: 'scope-1', scopeNodeId: undefined }, // No scopeNodeId
-        { scopeId: 'scope-2', scopeNodeId: 'child-2' },
-      ];
+        { scopeId: 'scope-2', scopeNodeId: 'child-2' }
+      );
 
       // Tree with no children to make it obvious if selectedNodesToShow is populated
       const tree: TreeNode = {
@@ -146,17 +147,18 @@ describe('ScopesTree', () => {
         childrenLoaded: true,
       };
 
-      render(<ScopesTree {...defaultProps} tree={tree} selectedScopes={selectedScopes} />);
+      render(<ScopesTree {...defaultProps} tree={tree} />);
 
       // child-2 should NOT appear because only first scope is considered and it has no scopeNodeId
       expect(screen.queryByText('Title child-2')).not.toBeInTheDocument();
     });
 
     it('should not show selectedNodesToShow when first scope node is not in scopeNodes cache', () => {
-      const selectedScopes: SelectedScope[] = [
+      // Set mock selected scopes
+      mockSelectedScopes.push(
         { scopeId: 'scope-1', scopeNodeId: 'missing-node' }, // Node not in scopeNodes
-        { scopeId: 'scope-2', scopeNodeId: 'child-2' },
-      ];
+        { scopeId: 'scope-2', scopeNodeId: 'child-2' }
+      );
 
       // Tree with no children
       const tree: TreeNode = {
@@ -167,7 +169,7 @@ describe('ScopesTree', () => {
         childrenLoaded: true,
       };
 
-      render(<ScopesTree {...defaultProps} tree={tree} selectedScopes={selectedScopes} />);
+      render(<ScopesTree {...defaultProps} tree={tree} />);
 
       // Neither should appear since first scope's node is missing from cache
       expect(screen.queryByText('Title missing-node')).not.toBeInTheDocument();
@@ -175,9 +177,8 @@ describe('ScopesTree', () => {
     });
 
     it('should not show selectedNodesToShow when tree scopeNodeId does not match first scope parent', () => {
-      const selectedScopes: SelectedScope[] = [
-        { scopeId: 'scope-1', scopeNodeId: 'child-1' }, // child-1's parent is 'parent-container'
-      ];
+      // Set mock selected scopes
+      mockSelectedScopes.push({ scopeId: 'scope-1', scopeNodeId: 'child-1' }); // child-1's parent is 'parent-container'
 
       // Tree with different scopeNodeId
       const tree: TreeNode = {
@@ -196,14 +197,18 @@ describe('ScopesTree', () => {
         },
       };
 
-      render(<ScopesTree {...defaultProps} tree={tree} scopeNodes={scopeNodes} selectedScopes={selectedScopes} />);
+      // Update mock scope nodes
+      Object.assign(mockScopeNodes, scopeNodes);
+
+      render(<ScopesTree {...defaultProps} tree={tree} />);
 
       // child-1 should NOT appear since tree's scopeNodeId doesn't match child-1's parent
       expect(screen.queryByText('Title child-1')).not.toBeInTheDocument();
     });
 
     it('should not duplicate scope in selectedNodesToShow if already in children', () => {
-      const selectedScopes: SelectedScope[] = [{ scopeId: 'scope-1', scopeNodeId: 'child-1' }];
+      // Set mock selected scopes
+      mockSelectedScopes.push({ scopeId: 'scope-1', scopeNodeId: 'child-1' });
 
       // Tree already has child-1 in children
       const tree: TreeNode = {
@@ -217,7 +222,7 @@ describe('ScopesTree', () => {
         childrenLoaded: true,
       };
 
-      render(<ScopesTree {...defaultProps} tree={tree} selectedScopes={selectedScopes} />);
+      render(<ScopesTree {...defaultProps} tree={tree} />);
 
       // child-1 should appear exactly once (in regular children, not duplicated)
       const child1Elements = screen.getAllByText('Title child-1');

--- a/public/app/features/scopes/selector/ScopesTreeHeadline.tsx
+++ b/public/app/features/scopes/selector/ScopesTreeHeadline.tsx
@@ -5,15 +5,16 @@ import { Trans } from '@grafana/i18n';
 import { useStyles2 } from '@grafana/ui';
 
 import { NodesMap, TreeNode } from './types';
+import { useScopesTree } from './useScopesTree';
 
 export interface ScopesTreeHeadlineProps {
   anyChildExpanded: boolean;
   query: string;
   resultsNodes: TreeNode[];
-  scopeNodes: NodesMap;
 }
 
-export function ScopesTreeHeadline({ anyChildExpanded, query, resultsNodes, scopeNodes }: ScopesTreeHeadlineProps) {
+export function ScopesTreeHeadline({ anyChildExpanded, query, resultsNodes }: ScopesTreeHeadlineProps) {
+  const scopeNodes: NodesMap = useScopesTree();
   const styles = useStyles2(getStyles);
 
   if (

--- a/public/app/features/scopes/selector/ScopesTreeItemList.tsx
+++ b/public/app/features/scopes/selector/ScopesTreeItemList.tsx
@@ -4,40 +4,18 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { ScrollContainer, useStyles2 } from '@grafana/ui';
 
 import { ScopesTreeItem } from './ScopesTreeItem';
-import { isNodeSelectable } from './scopesTreeUtils';
-import { NodesMap, SelectedScope, TreeNode } from './types';
+import { TreeNode } from './types';
 
 type Props = {
   anyChildExpanded: boolean;
   lastExpandedNode: boolean;
-  loadingNodeName: string | undefined;
   items: TreeNode[];
   maxHeight: string;
-  selectedScopes: SelectedScope[];
-  scopeNodes: NodesMap;
-  filterNode: (scopeNodeId: string, query: string) => void;
-  selectScope: (scopeNodeId: string) => void;
-  deselectScope: (scopeNodeId: string) => void;
   highlightedId: string | undefined;
   id: string;
-  toggleExpandedNode: (scopeNodeId: string) => void;
 };
 
-export function ScopesTreeItemList({
-  items,
-  anyChildExpanded,
-  lastExpandedNode,
-  maxHeight,
-  selectedScopes,
-  scopeNodes,
-  loadingNodeName,
-  filterNode,
-  selectScope,
-  deselectScope,
-  highlightedId,
-  id,
-  toggleExpandedNode,
-}: Props) {
+export function ScopesTreeItemList({ items, anyChildExpanded, lastExpandedNode, maxHeight, highlightedId, id }: Props) {
   const styles = useStyles2(getStyles);
 
   if (items.length === 0) {
@@ -46,40 +24,14 @@ export function ScopesTreeItemList({
 
   const children = (
     <div role="tree" id={id} className={anyChildExpanded ? styles.expandedContainer : undefined}>
-      {items.map((childNode) => {
-        const node = scopeNodes[childNode.scopeNodeId];
-        // Skip rendering if node data isn't available
-        if (!node) {
-          return null;
-        }
-        const selected =
-          isNodeSelectable(node) &&
-          selectedScopes.some((s) => {
-            if (s.scopeNodeId) {
-              // If we have scopeNodeId we only match based on that so even if the actual scope is the same we don't
-              // mark different scopeNode as selected.
-              return s.scopeNodeId === childNode.scopeNodeId;
-            } else {
-              return s.scopeId === node.spec.linkId;
-            }
-          });
-        return (
-          <ScopesTreeItem
-            key={childNode.scopeNodeId}
-            treeNode={childNode}
-            selected={selected}
-            selectedScopes={selectedScopes}
-            scopeNodes={scopeNodes}
-            loadingNodeName={loadingNodeName}
-            anyChildExpanded={anyChildExpanded}
-            filterNode={filterNode}
-            selectScope={selectScope}
-            deselectScope={deselectScope}
-            highlighted={childNode.scopeNodeId === highlightedId}
-            toggleExpandedNode={toggleExpandedNode}
-          />
-        );
-      })}
+      {items.map((childNode) => (
+        <ScopesTreeItem
+          key={childNode.scopeNodeId}
+          treeNode={childNode}
+          anyChildExpanded={anyChildExpanded}
+          highlighted={childNode.scopeNodeId === highlightedId}
+        />
+      ))}
     </div>
   );
 

--- a/public/app/features/scopes/selector/ScopesTreeSearch.tsx
+++ b/public/app/features/scopes/selector/ScopesTreeSearch.tsx
@@ -7,12 +7,12 @@ import { t } from '@grafana/i18n';
 import { FilterInput, useStyles2 } from '@grafana/ui';
 
 import { TreeNode } from './types';
+import { useScopeActions } from './useScopeActions';
 
 export interface ScopesTreeSearchProps {
   anyChildExpanded: boolean;
   searchArea: string;
   treeNode: TreeNode;
-  filterNode: (scopeNodeId: string, query: string) => void;
   onFocus: () => void;
   onBlur: () => void;
   'aria-controls': string;
@@ -22,13 +22,13 @@ export interface ScopesTreeSearchProps {
 export function ScopesTreeSearch({
   anyChildExpanded,
   treeNode,
-  filterNode,
   searchArea,
   onFocus,
   onBlur,
   'aria-controls': ariaControls,
   'aria-activedescendant': ariaActivedescendant,
 }: ScopesTreeSearchProps) {
+  const { filterNode } = useScopeActions();
   const styles = useStyles2(getStyles);
 
   const [inputState, setInputState] = useState<{ value: string; dirty: boolean }>({

--- a/public/app/features/scopes/selector/useScopeActions.ts
+++ b/public/app/features/scopes/selector/useScopeActions.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+
+import { useScopesServices } from '../ScopesContextProvider';
+
+/**
+ * Hook that provides stable references to scope action methods.
+ * These methods never change, so they won't cause re-renders when passed as props.
+ *
+ * This eliminates the need to drill these action methods through multiple component layers.
+ */
+export function useScopeActions() {
+  const services = useScopesServices();
+  const selector = services?.scopesSelectorService;
+
+  return useMemo(
+    () => ({
+      selectScope: selector?.selectScope ?? (() => {}),
+      deselectScope: selector?.deselectScope ?? (() => {}),
+      filterNode: selector?.filterNode ?? (() => {}),
+      toggleExpandedNode: selector?.toggleExpandedNode ?? (() => {}),
+    }),
+    [selector]
+  );
+}

--- a/public/app/features/scopes/selector/useScopeNode.ts
+++ b/public/app/features/scopes/selector/useScopeNode.ts
@@ -1,25 +1,55 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useObservable } from 'react-use';
+import { Observable } from 'rxjs';
+import { distinctUntilChanged, map } from 'rxjs/operators';
 
 import { ScopeNode } from '@grafana/data';
 
 import { useScopesServices } from '../ScopesContextProvider';
 
-// Light wrapper around the scopesSelectorService.getScopeNode to make it easier to use in the UI.
+/**
+ * Hook that provides a specific scope node with fine-grained reactivity.
+ *
+ * This hook:
+ * 1. Subscribes to the RxJS state for the specific node (fine-grained updates)
+ * 2. Automatically fetches the node if it's not in the cache
+ * 3. Returns the node and loading state
+ *
+ * Components using this hook will only re-render when this specific node changes,
+ * not when any other node in the tree changes.
+ */
 export function useScopeNode(scopeNodeId?: string) {
-  const [node, setNode] = useState<ScopeNode | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(false);
-  const scopesSelectorService = useScopesServices()?.scopesSelectorService;
+  const services = useScopesServices();
+  const selector = services?.scopesSelectorService;
 
+  // Subscribe to the specific node in state for fine-grained reactivity
+  const node = useObservable(
+    useMemo(
+      () =>
+        selector
+          ? selector.stateObservable.pipe(
+              map((state) => (scopeNodeId ? state.nodes[scopeNodeId] : undefined)),
+              distinctUntilChanged()
+            )
+          : // Return an observable that emits undefined if selector is not available
+            new Observable<ScopeNode | undefined>((subscriber) => {
+              subscriber.next(undefined);
+            }),
+      [selector, scopeNodeId]
+    ),
+    undefined
+  );
+
+  // Fetch node if not in cache (preserve existing behavior)
   useEffect(() => {
     const loadNode = async () => {
-      if (!scopeNodeId || !scopesSelectorService) {
-        setNode(undefined);
+      if (!scopeNodeId || !selector || node) {
         return;
       }
       setIsLoading(true);
       try {
-        const node = await scopesSelectorService.getScopeNode(scopeNodeId);
-        setNode(node);
+        await selector.getScopeNode(scopeNodeId);
       } catch (error) {
         console.error('Failed to load node', error);
       } finally {
@@ -27,7 +57,7 @@ export function useScopeNode(scopeNodeId?: string) {
       }
     };
     loadNode();
-  }, [scopeNodeId, scopesSelectorService]);
+  }, [scopeNodeId, selector, node]);
 
   return { node, isLoading };
 }

--- a/public/app/features/scopes/selector/useScopesTree.ts
+++ b/public/app/features/scopes/selector/useScopesTree.ts
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import { useObservable } from 'react-use';
+import { Observable } from 'rxjs';
+import { distinctUntilChanged, map } from 'rxjs/operators';
+
+import { useScopesServices } from '../ScopesContextProvider';
+
+import { NodesMap } from './types';
+
+/**
+ * Hook that provides the full scopeNodes map for components that need to render multiple nodes.
+ * Uses RxJS distinctUntilChanged with shallow comparison to only re-render when the map reference changes.
+ *
+ * This eliminates the need to drill scopeNodes through multiple component layers.
+ */
+export function useScopesTree(): NodesMap {
+  const services = useScopesServices();
+  const selector = services?.scopesSelectorService;
+
+  const scopeNodes = useObservable(
+    useMemo(
+      () =>
+        selector
+          ? selector.stateObservable.pipe(
+              map((state) => state.nodes),
+              distinctUntilChanged() // Shallow comparison on the map reference
+            )
+          : // Return an observable that emits an empty map if selector is not available
+            new Observable<NodesMap>((subscriber) => {
+              subscriber.next({});
+            }),
+      [selector]
+    ),
+    {} // Default value
+  );
+
+  return scopeNodes ?? {};
+}


### PR DESCRIPTION
**What is this feature?**

Refactors ScopesSelector components to use a three-hook pattern that eliminates prop drilling while preserving the existing RxJS/services architecture.

**Why do we need this feature?**

The current implementation drills 7+ props through multiple component layers (ScopesSelector → ScopesTree → ScopesTreeItemList → ScopesTreeItem), creating maintenance challenges and tight coupling. This refactor:

- Reduces props by ~70% in most components (e.g., ScopesTreeItem: 10 → 3 props)
- Enables fine-grained reactivity using RxJS subscriptions
- Separates stable action methods from reactive state to prevent unnecessary re-renders
- Improves component reusability and maintainability

**Implementation details:**

Creates three new hooks:
- `useScopeActions()` - Provides stable action method references
- `useScopesTree()` - Exposes full scopeNodes map with RxJS fine-grained reactivity
- `useScopeNode()` - Enhanced to use RxJS subscriptions for single-node access

**Changes:**
- 2 new hook files, 9 modified component/test files
- All tests updated with proper mocks

**Who is this feature for?**

Scopes feature developers - improves codebase maintainability and component architecture.

**Special notes for your reviewer:**

- [x] No changes to service layer or state management
- [x] No visual or functional changes expected
- [x] Tests updated and passing
- [x] Follows design doc: "[ScopesSelector Prop Drilling Refactor](https://docs.google.com/document/d/1TazknDfT-92yOhbReu51m5HTllTVw7pUSVyiSS0p4Lk/edit?tab=t.0)" (Proposal 4)