### PR TITLE
Prometheus: Introduce failsafe PromQueryFormat unmarshalling

### DIFF
--- a/pkg/promlib/models/query.go
+++ b/pkg/promlib/models/query.go
@@ -40,7 +40,14 @@ func (f *PromQueryFormat) UnmarshalJSON(data []byte) error {
 	// Try to unmarshal as string first (the expected type)
 	var s string
 	if err := json.Unmarshal(data, &s); err == nil {
-		*f = PromQueryFormat(s)
+		// Validate that the string is one of the valid enum values
+		switch s {
+		case string(PromQueryFormatTimeSeries), string(PromQueryFormatTable), string(PromQueryFormatHeatmap):
+			*f = PromQueryFormat(s)
+		default:
+			// Invalid string value, fall back to default
+			*f = PromQueryFormatTimeSeries
+		}
 		return nil
 	}
 

--- a/pkg/promlib/models/query.go
+++ b/pkg/promlib/models/query.go
@@ -53,7 +53,7 @@ func (f *PromQueryFormat) UnmarshalJSON(data []byte) error {
 
 	// If that fails, try as number and convert to the default format
 	// This handles cases where clients incorrectly send numeric values
-	var n float64
+	var n uint32
 	if err := json.Unmarshal(data, &n); err == nil {
 		// Map numbers to format strings for backwards compatibility
 		switch int(n) {


### PR DESCRIPTION
**What is this feature?**

We observed high error rates in Prometheus data source with given log:

```
json: cannot unmarshal number into Go struct field internalQueryModel.PrometheusQueryProperties.format of type models.PromQueryFormat 
```                                                                                                                                                                                                           
This occurs when clients incorrectly send numeric values (e.g., "format": 0) instead of strings (e.g., "format": "time_series") for the format field.

So with this PR we introduced a custom UnmarshalJSON method to the PromQueryFormat type that provides failsafe handling.

**Why do we need this feature?**

To prevent accidental unmarshalling issues 

Fixes: https://github.com/grafana/grafana/issues/112002

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
