### PR TITLE
Alerting: Update logic handling canCreate in integrations version, and handle the new deprecated field in the schema

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.test.tsx
@@ -269,6 +269,7 @@ describe('ChannelSubForm', () => {
 
     const webhookWithVersions: NotifierDTO = {
       ...grafanaAlertNotifiers.webhook,
+      currentVersion: 'v1',
       versions: [
         {
           version: 'v0mimir1',

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
@@ -20,6 +20,7 @@ import {
   canCreateNotifier,
   getLegacyVersionLabel,
   getOptionsForVersion,
+  isDeprecated,
   isLegacyVersion,
 } from '../../../utils/notifier-versions';
 import { OnCallIntegrationType } from '../grafanaAppReceivers/onCall/useOnCallIntegration';
@@ -218,10 +219,14 @@ export function ChannelSubForm<R extends ChannelValues>({
   const isParseModeNone = parse_mode === 'None' || !parse_mode;
   const showTelegramWarning = isTelegram && !isParseModeNone;
 
-  // Check if current integration is a legacy version (canCreate: false)
-  // Legacy integrations are read-only and cannot be edited
   // Read version from existing integration data (stored in receiver config)
   const integrationVersion = initialValues?.version || defaultValues.version;
+
+  // Check if integration is deprecated (will be removed in a future release)
+  const notifierIsDeprecated = notifier ? isDeprecated(notifier.dto, integrationVersion) : false;
+
+  // Check if current integration is a legacy version (old version format, e.g., v0mimir1)
+  // Legacy integrations use an older schema imported from Mimir
   const isLegacy = notifier ? isLegacyVersion(notifier.dto, integrationVersion) : false;
 
   // Get the correct options based on the integration's version
@@ -260,6 +265,17 @@ export function ChannelSubForm<R extends ChannelValues>({
                   />
                 )}
               />
+              {notifierIsDeprecated && (
+                <Badge
+                  text={t('alerting.channel-sub-form.badge-deprecated', 'Deprecated')}
+                  color="orange"
+                  icon="exclamation-triangle"
+                  tooltip={t(
+                    'alerting.channel-sub-form.tooltip-deprecated',
+                    'This integration is deprecated and will be removed in a future release.'
+                  )}
+                />
+              )}
               {isLegacy && integrationVersion && (
                 <Badge
                   text={getLegacyVersionLabel(integrationVersion)}

--- a/public/app/features/alerting/unified/types/alerting.ts
+++ b/public/app/features/alerting/unified/types/alerting.ts
@@ -92,6 +92,8 @@ export interface NotifierVersion {
   options: NotificationChannelOption[];
   /** Whether this version can be used to create new integrations */
   canCreate?: boolean;
+  /** Whether this version is deprecated and will be removed in a future release */
+  deprecated?: boolean;
 }
 
 export interface NotifierDTO<T = NotifierType> {
@@ -119,6 +121,8 @@ export interface NotifierDTO<T = NotifierType> {
    * version information or validate notifier capabilities.
    */
   currentVersion?: string;
+  /** Whether this integration type is deprecated and will be removed in a future release */
+  deprecated?: boolean;
 }
 
 export interface NotificationChannelType {

--- a/public/app/features/alerting/unified/utils/notifier-versions.ts
+++ b/public/app/features/alerting/unified/utils/notifier-versions.ts
@@ -47,6 +47,36 @@ export function isLegacyVersion(notifier: NotifierDTO, version?: string): boolea
 }
 
 /**
+ * Checks if a notifier or a specific version is deprecated.
+ * A notifier is deprecated if either:
+ * - The notifier itself has deprecated: true (top-level)
+ * - The specific version has deprecated: true
+ * - If no version specified, checks the currentVersion
+ *
+ * @param notifier - The notifier DTO to check
+ * @param version - Optional version string to check for version-specific deprecation
+ * @returns True if the notifier or version is deprecated
+ */
+export function isDeprecated(notifier: NotifierDTO, version?: string): boolean {
+  // Check top-level deprecation first
+  if (notifier.deprecated) {
+    return true;
+  }
+
+  // Determine which version to check: provided version, currentVersion, or first version
+  // Use empty string check since version might be '' instead of undefined
+  const versionToCheck = (version && version.length > 0 ? version : null) || notifier.currentVersion;
+
+  // Check if the version is deprecated
+  if (versionToCheck && notifier.versions) {
+    const versionData = notifier.versions.find((v) => v.version === versionToCheck);
+    return versionData?.deprecated === true;
+  }
+
+  return false;
+}
+
+/**
  * Gets the options for a specific version of a notifier.
  * Used to display the correct form fields based on integration version.
  *

--- a/public/app/features/alerting/unified/utils/notifier-versions.ts
+++ b/public/app/features/alerting/unified/utils/notifier-versions.ts
@@ -28,24 +28,22 @@ export function canCreateNotifier(notifier: NotifierDTO): boolean {
 }
 
 /**
- * Checks if a specific version is legacy (cannot be created).
- * A version is legacy if it has canCreate: false in the notifier's versions array.
+ * Checks if a specific version is legacy (an old/deprecated version format).
+ * A version is legacy if it is NOT the current version of the notifier.
+ * For example, 'v0mimir1' is legacy when 'currentVersion' is 'v1'.
  *
- * @param notifier - The notifier DTO containing versions array
+ * @param notifier - The notifier DTO containing versions array and currentVersion
  * @param version - The version string to check (e.g., 'v0mimir1', 'v1')
- * @returns True if the version is legacy (canCreate: false)
+ * @returns True if the version is not the current version
  */
 export function isLegacyVersion(notifier: NotifierDTO, version?: string): boolean {
-  // If no version specified or no versions array, it's not legacy
-  if (!version || !notifier.versions || notifier.versions.length === 0) {
+  // If no version specified or no currentVersion defined, it's not legacy
+  if (!version || !notifier.currentVersion) {
     return false;
   }
 
-  // Find the matching version and check its canCreate property
-  const versionData = notifier.versions.find((v) => v.version === version);
-
-  // A version is legacy if canCreate is explicitly false
-  return versionData?.canCreate === false;
+  // A version is legacy if it's different from the current version
+  return version !== notifier.currentVersion;
 }
 
 /**

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -802,12 +802,14 @@
       }
     },
     "channel-sub-form": {
+      "badge-deprecated": "Deprecated",
       "delete": "Delete",
       "duplicate": "Duplicate",
       "label-integration": "Integration",
       "label-notification-settings": "Notification settings",
       "label-section": "Optional {{name}} settings",
       "test": "Test",
+      "tooltip-deprecated": "This integration is deprecated and will be removed in a future release.",
       "tooltip-legacy-version": "This is a legacy integration (version: {{version}}). It cannot be modified."
     },
     "classic-condition-viewer": {


### PR DESCRIPTION
**What is this feature?**

This PR improves how the contact point form handles canCreate field, and integration versioning, specifically for legacy (imported from Mimir) and deprecated integrations.

### Changes

#### 1. Fix Legacy badge logic
- **Before**: The "Legacy" badge was shown based on `canCreate: false`
- **After**: The "Legacy" badge is now shown only when the integration version differs from the `currentVersion` (e.g., `v0mimir1` when `currentVersion` is `v1`)

#### 2. Show current integration type in dropdown when editing
- When editing an existing contact point, the integration type now appears in the dropdown even if `canCreate: false`
- This allows users to view and edit legacy integrations that can no longer be created as new

#### 3. Hide Duplicate button for non-creatable integrations
- The "Duplicate" button is now hidden for integration types where no version has `canCreate: true`
- This prevents users from attempting to duplicate integrations that cannot be created

#### 4. Add Deprecated badge support
- Added `deprecated` field support to `NotifierDTO` and `NotifierVersion` types
- New `isDeprecated()` function checks both top-level and version-level deprecation
- Shows "Deprecated" badge (orange) when an integration is marked as deprecated
- Works with the new `deprecated` field from [grafana/alerting#469](https://github.com/grafana/alerting/pull/469)

### Visual behavior

| Scenario | Badges shown |
|----------|--------------|
| LINE v1 (deprecated) | "Deprecated" |
| Slack v0mimir1 (legacy version) | "Legacy" |
| WeChat v0mimir1 (deprecated + legacy) | "Deprecated" + "Legacy" |
| Slack v1 (current) | None |

### Testing

- Added unit tests for `isDeprecated()` function
- Updated existing tests for `isLegacyVersion()` to use `currentVersion`
- Updated tests for `hasLegacyIntegrations()`

### Related PRs

- [grafana/alerting#469](https://github.com/grafana/alerting/pull/469) - Adds `deprecated` field to integration schema

**Who is this feature for?**

Alerting users

**Special notes for your reviewer:**

<img width="1396" height="1040" alt="Screenshot 2026-01-22 at 12 28 18" src="https://github.com/user-attachments/assets/6a51adfe-cfde-4a00-ad8d-acd1c398ecc3" />



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
