### PR TITLE
Provisioning: add dryRun runtime validation for Connection resources

### DIFF
--- a/apps/provisioning/pkg/connection/validator.go
+++ b/apps/provisioning/pkg/connection/validator.go
@@ -3,8 +3,10 @@ package connection
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -60,6 +62,69 @@ func (v *AdmissionValidator) Validate(ctx context.Context, a admission.Attribute
 		return apierrors.NewInvalid(
 			provisioning.ConnectionResourceInfo.GroupVersionKind().GroupKind(),
 			c.GetName(), list)
+	}
+
+	// If dryRun, also run runtime validation (external systems, internal state)
+	// This allows full validation without persisting the resource
+	if a.IsDryRun() {
+		if err := v.validateRuntime(ctx, c); err != nil {
+			return err // Return errors immediately - resource won't be created
+		}
+	}
+
+	return nil
+}
+
+// validateRuntime performs runtime validation by building the connection and testing it
+// This checks external systems (e.g., GitHub API) to validate appID and installationID
+func (v *AdmissionValidator) validateRuntime(ctx context.Context, conn *provisioning.Connection) error {
+	// Build the connection to get a Connection interface
+	connection, err := v.factory.Build(ctx, conn)
+	if err != nil {
+		// If build fails, return an error (this might happen if secrets are invalid)
+		return apierrors.NewInvalid(
+			provisioning.ConnectionResourceInfo.GroupVersionKind().GroupKind(),
+			conn.GetName(),
+			field.ErrorList{
+				field.Invalid(
+					field.NewPath(""),
+					"",
+					fmt.Sprintf("failed to build connection: %v", err),
+				),
+			},
+		)
+	}
+
+	// Run runtime validation via Test() method
+	testResults, err := connection.Test(ctx)
+	if err != nil {
+		return apierrors.NewInternalError(fmt.Errorf("failed to test connection: %w", err))
+	}
+
+	// If test failed, convert TestResults.Errors to field.ErrorList
+	if !testResults.Success && len(testResults.Errors) > 0 {
+		var list field.ErrorList
+		for _, testError := range testResults.Errors {
+			fieldPath := field.NewPath("")
+			if testError.Field != "" {
+				// Convert dot-separated path to field.Path
+				parts := strings.Split(testError.Field, ".")
+				fieldPath = field.NewPath(parts[0])
+				for _, part := range parts[1:] {
+					fieldPath = fieldPath.Child(part)
+				}
+			}
+			list = append(list, field.Invalid(
+				fieldPath,
+				"",
+				testError.Detail,
+			))
+		}
+		return apierrors.NewInvalid(
+			provisioning.ConnectionResourceInfo.GroupVersionKind().GroupKind(),
+			conn.GetName(),
+			list,
+		)
 	}
 
 	return nil

--- a/apps/provisioning/pkg/connection/validator.go
+++ b/apps/provisioning/pkg/connection/validator.go
@@ -34,6 +34,11 @@ func NewAdmissionValidator(factory Factory) *AdmissionValidator {
 
 // Validate validates Connection resources during admission
 func (v *AdmissionValidator) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+	// AdmissionValidator is only for CREATE and UPDATE operations
+	if a.GetOperation() == admission.Delete {
+		return nil
+	}
+
 	obj := a.GetObject()
 	if obj == nil {
 		return nil

--- a/apps/provisioning/pkg/connection/validator.go
+++ b/apps/provisioning/pkg/connection/validator.go
@@ -67,9 +67,7 @@ func (v *AdmissionValidator) Validate(ctx context.Context, a admission.Attribute
 	// If dryRun, also run runtime validation (external systems, internal state)
 	// This allows full validation without persisting the resource
 	if a.IsDryRun() {
-		if err := v.validateRuntime(ctx, c); err != nil {
-			return err // Return errors immediately - resource won't be created
-		}
+		return v.validateRuntime(ctx, c) // Return errors immediately - resource won't be created
 	}
 
 	return nil

--- a/apps/provisioning/pkg/connection/validator_test.go
+++ b/apps/provisioning/pkg/connection/validator_test.go
@@ -93,6 +93,15 @@ func TestAdmissionValidator_Validate(t *testing.T) {
 			wantErrContains: "expected connection configuration",
 		},
 		{
+			name: "skips validation for DELETE operations",
+			obj: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec:       provisioning.ConnectionSpec{Type: provisioning.GithubConnectionType},
+			},
+			operation: admission.Delete,
+			wantErr:   false,
+		},
+		{
 			name: "skips validation for objects being deleted",
 			obj: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{

--- a/apps/provisioning/pkg/repository/validator.go
+++ b/apps/provisioning/pkg/repository/validator.go
@@ -181,6 +181,11 @@ func NewAdmissionValidator(allowedTargets []provisioning.SyncTargetType, validat
 // The returned error is an apierrors.StatusError containing field.ErrorList when
 // validation fails. Callers can use apierrors.StatusError to extract the field errors.
 func (v *AdmissionValidator) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+	// AdmissionValidator is only for CREATE and UPDATE operations
+	if a.GetOperation() == admission.Delete {
+		return nil
+	}
+
 	obj := a.GetObject()
 	if obj == nil {
 		return nil

--- a/apps/provisioning/pkg/repository/validator_test.go
+++ b/apps/provisioning/pkg/repository/validator_test.go
@@ -348,7 +348,7 @@ func TestAdmissionValidator_Validate(t *testing.T) {
 			name: "skips validation for DELETE operations",
 			obj: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
-				Spec: provisioning.RepositorySpec{
+				Spec:       provisioning.RepositorySpec{
 					// Invalid - missing title
 				},
 			},

--- a/apps/provisioning/pkg/repository/validator_test.go
+++ b/apps/provisioning/pkg/repository/validator_test.go
@@ -345,6 +345,17 @@ func TestAdmissionValidator_Validate(t *testing.T) {
 			wantErrContains: "expected repository configuration",
 		},
 		{
+			name: "skips validation for DELETE operations",
+			obj: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: provisioning.RepositorySpec{
+					// Invalid - missing title
+				},
+			},
+			operation: admission.Delete,
+			wantErr:   false,
+		},
+		{
 			name: "skips validation for objects being deleted",
 			obj: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/tests/apis/provisioning/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection_test.go
@@ -1198,10 +1198,10 @@ func TestIntegrationConnectionController_DryRunValidation(t *testing.T) {
 		require.Error(t, err, "dryRun create should fail with invalid installation ID")
 
 		// Verify it's an Invalid error with field error details
-		statusErr, ok := err.(*k8serrors.StatusError)
-		require.True(t, ok, "error should be StatusError")
+		var statusErr *k8serrors.StatusError
+		require.True(t, errors.As(err, &statusErr), "error should be StatusError")
 		// Check if it's an Invalid error (could be Invalid or BadRequest depending on how errors are returned)
-		require.True(t, statusErr.Status().Reason == metav1.StatusReasonInvalid || statusErr.Status().Code == 422, 
+		require.True(t, statusErr.Status().Reason == metav1.StatusReasonInvalid || statusErr.Status().Code == 422,
 			"error reason should be Invalid or status code should be 422")
 
 		// Verify the error message contains information about invalid installation ID
@@ -1264,8 +1264,8 @@ func TestIntegrationConnectionController_DryRunValidation(t *testing.T) {
 		require.Error(t, err, "dryRun create should fail with invalid app ID")
 
 		// Verify it's an Invalid error
-		statusErr, ok := err.(*k8serrors.StatusError)
-		require.True(t, ok, "error should be StatusError")
+		var statusErr *k8serrors.StatusError
+		require.True(t, errors.As(err, &statusErr), "error should be StatusError")
 		// Check if it's an Invalid error (could be Invalid or BadRequest depending on how errors are returned)
 		require.True(t, statusErr.Status().Reason == metav1.StatusReasonInvalid || statusErr.Status().Code == 422,
 			"error reason should be Invalid or status code should be 422")
@@ -1329,8 +1329,8 @@ func TestIntegrationConnectionController_DryRunValidation(t *testing.T) {
 		require.Error(t, err, "dryRun create should fail with invalid token")
 
 		// Verify it's an Invalid error
-		statusErr, ok := err.(*k8serrors.StatusError)
-		require.True(t, ok, "error should be StatusError")
+		var statusErr *k8serrors.StatusError
+		require.True(t, errors.As(err, &statusErr), "error should be StatusError")
 		// Check if it's an Invalid error (could be Invalid or BadRequest depending on how errors are returned)
 		require.True(t, statusErr.Status().Reason == metav1.StatusReasonInvalid || statusErr.Status().Code == 422,
 			"error reason should be Invalid or status code should be 422")
@@ -1372,8 +1372,8 @@ func TestIntegrationConnectionController_DryRunValidation(t *testing.T) {
 		require.Error(t, err, "dryRun create should fail with structural validation error")
 
 		// Verify it's an Invalid error
-		statusErr, ok := err.(*k8serrors.StatusError)
-		require.True(t, ok, "error should be StatusError")
+		var statusErr *k8serrors.StatusError
+		require.True(t, errors.As(err, &statusErr), "error should be StatusError")
 		require.Equal(t, metav1.StatusReasonInvalid, statusErr.Status().Reason, "error reason should be Invalid")
 
 		// Verify the error message contains information about missing github config


### PR DESCRIPTION
## Summary

This PR implements `dryRun` behavior for Connection resources, enabling full runtime validation (including external system checks) during admission without persisting the resource.

## Changes

- **Admission Validator**: Added runtime validation when `dryRun=true` is set on CREATE/UPDATE requests
- **Runtime Validation**: Validates connections against external systems (GitHub API) to check appID and installationID
- **Error Handling**: Converts runtime validation errors to admission errors with field-level details
- **Unit Tests**: Added comprehensive unit tests for dryRun validation scenarios
- **Integration Tests**: Added integration tests verifying dryRun behavior end-to-end

## How It Works

When `dryRun=true` is set on a CREATE or UPDATE request:
1. Structural validation runs first (format, required fields)
2. If structural validation passes, runtime validation runs:
   - Builds the connection (decrypts secrets)
   - Tests the connection against external systems (GitHub API)
   - Returns admission errors if validation fails
3. Resource is not persisted (standard Kubernetes `dryRun` behavior)

When `dryRun=false` (normal operation):
- Only structural validation runs
- Runtime validation happens later during controller reconciliation
- Errors appear in `status.fieldErrors` (as per previous PR)

## Benefits

- **Prevents Invalid Resources**: Clients can validate connections before creation
- **Immediate Feedback**: Validation errors are returned synchronously
- **Works with Any Client**: Frontend, kubectl, and API calls can all use `dryRun=true`
- **No Side Effects**: Resources are not persisted during dryRun

## Testing

- ✅ Unit tests for all dryRun scenarios
- ✅ Integration tests verifying end-to-end behavior
- ✅ Tests verify resources are not persisted after dryRun
- ✅ Tests verify proper error messages and types

## Related

This complements the `fieldErrors` in status work by providing pre-creation validation, while `fieldErrors` handles post-creation validation during reconciliation.