### PR TITLE
Fix provisioning of top-level folders.

### DIFF
--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -14,6 +14,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
 	folderv1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -282,6 +283,10 @@ func (s *Service) getFolderByIDFromApiServer(ctx context.Context, id int64, orgI
 		return nil, err
 	}
 
+	return returnFirstFolderSearchResult(ctx, hits, s, orgID)
+}
+
+func returnFirstFolderSearchResult(ctx context.Context, hits v0alpha1.SearchResults, s *Service, orgID int64) (*folder.Folder, error) {
 	if len(hits.Hits) == 0 {
 		return nil, dashboards.ErrFolderNotFound
 	}
@@ -347,22 +352,12 @@ func (s *Service) getFolderByTitleFromApiServer(ctx context.Context, orgID int64
 		return nil, err
 	}
 
-	if len(hits.Hits) == 0 {
-		return nil, dashboards.ErrFolderNotFound
+	// If we're searching for top-level folders (parentUID == nil), and the first result is not in the root folder, remove it from the results.
+	for parentUID == nil && len(hits.Hits) > 0 && hits.Hits[0].Folder != "" {
+		hits.Hits = hits.Hits[1:]
 	}
 
-	uid := hits.Hits[0].Name
-	user, err := identity.GetRequester(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	f, err := s.Get(ctx, &folder.GetFolderQuery{UID: &uid, SignedInUser: user, OrgID: orgID})
-	if err != nil {
-		return nil, err
-	}
-
-	return f, nil
+	return returnFirstFolderSearchResult(ctx, hits, s, orgID)
 }
 
 func (s *Service) getChildrenFromApiServer(ctx context.Context, q *folder.GetChildrenQuery) ([]*folder.FolderReference, error) {

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -283,10 +283,10 @@ func (s *Service) getFolderByIDFromApiServer(ctx context.Context, id int64, orgI
 		return nil, err
 	}
 
-	return returnFirstFolderSearchResult(ctx, hits, s, orgID)
+	return s.returnFirstFolderSearchResult(ctx, orgID, hits)
 }
 
-func returnFirstFolderSearchResult(ctx context.Context, hits v0alpha1.SearchResults, s *Service, orgID int64) (*folder.Folder, error) {
+func (s *Service) returnFirstFolderSearchResult(ctx context.Context, orgID int64, hits v0alpha1.SearchResults) (*folder.Folder, error) {
 	if len(hits.Hits) == 0 {
 		return nil, dashboards.ErrFolderNotFound
 	}
@@ -357,7 +357,7 @@ func (s *Service) getFolderByTitleFromApiServer(ctx context.Context, orgID int64
 		hits.Hits = hits.Hits[1:]
 	}
 
-	return returnFirstFolderSearchResult(ctx, hits, s, orgID)
+	return s.returnFirstFolderSearchResult(ctx, orgID, hits)
 }
 
 func (s *Service) getChildrenFromApiServer(ctx context.Context, q *folder.GetChildrenQuery) ([]*folder.FolderReference, error) {

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -97,7 +97,7 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 	}
 
 	notFooFolder := &folder.Folder{
-		ID:        fooFolder.ID + 123456,
+		ID:        543,
 		Title:     "Foo Folder",
 		OrgID:     orgID,
 		UID:       "not-foo",

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -96,6 +96,17 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 		UpdatedBy: 1,
 	}
 
+	notFooFolder := &folder.Folder{
+		ID:        fooFolder.ID + 123456,
+		Title:     "Foo Folder",
+		OrgID:     orgID,
+		UID:       "not-foo",
+		URL:       "/dashboards/f/not-foo/foo-folder",
+		CreatedBy: 1,
+		UpdatedBy: 1,
+		ParentUID: "test",
+	}
+
 	updateFolder := &folder.Folder{
 		Title: "Folder",
 		OrgID: orgID,
@@ -122,6 +133,15 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 		result, err := internalfolders.LegacyFolderToUnstructured(fooFolder, namespacer)
 		require.NoError(t, err)
 
+		err = json.NewEncoder(w).Encode(result)
+		require.NoError(t, err)
+	})
+
+	mux.HandleFunc("GET /apis/folder.grafana.app/v1beta1/namespaces/default/folders/not-foo", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		namespacer := func(_ int64) string { return "1" }
+		result, err := internalfolders.LegacyFolderToUnstructured(notFooFolder, namespacer)
+		require.NoError(t, err)
 		err = json.NewEncoder(w).Encode(result)
 		require.NoError(t, err)
 	})
@@ -468,8 +488,14 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 				require.ErrorIs(t, err, dashboards.ErrFolderNotFound)
 			})
 
-			t.Run("When get folder by Title should return folder", func(t *testing.T) {
+			t.Run("When get folder by Title and nil parentID should return top-level folder", func(t *testing.T) {
 				dashboardStore.On("FindDashboards", mock.Anything, mock.Anything).Return([]dashboards.DashboardSearchProjection{
+					{ // This result will be ignored, because it has FolderUID set, but we're searching for nil parentID.
+						IsFolder:  true,
+						ID:        notFooFolder.ID, // nolint:staticcheck
+						UID:       notFooFolder.UID,
+						FolderUID: notFooFolder.ParentUID,
+					},
 					{
 						IsFolder: true,
 						ID:       fooFolder.ID, // nolint:staticcheck
@@ -486,6 +512,29 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 				actual, err := folderService.Get(context.Background(), query)
 				require.NoError(t, err)
 				compareFoldersNormalizeTime(t, fooFolder, actual)
+			})
+
+			t.Run("When get folder by Title and non-nil parentID should return inner folder", func(t *testing.T) {
+				dashboardStore.On("FindDashboards", mock.Anything, mock.Anything).Return([]dashboards.DashboardSearchProjection{
+					{ // Not ignored this time, compared to previous test.
+						IsFolder:  true,
+						ID:        notFooFolder.ID, // nolint:staticcheck
+						UID:       notFooFolder.UID,
+						FolderUID: notFooFolder.ParentUID,
+					},
+				}, nil).Twice() // Called twice due to total count call
+				title := "foo"
+				parentUID := "test"
+				query := &folder.GetFolderQuery{
+					Title:        &title,
+					OrgID:        1,
+					SignedInUser: usr,
+					ParentUID:    &parentUID,
+				}
+
+				actual, err := folderService.Get(context.Background(), query)
+				require.NoError(t, err)
+				compareFoldersNormalizeTime(t, notFooFolder, actual)
 			})
 
 			t.Run("When get folder by non existing Title should return not found error", func(t *testing.T) {
@@ -791,7 +840,7 @@ func TestGetFoldersFromApiServer(t *testing.T) {
 		Resource:  folderv1.FolderResourceInfo.GroupVersionResource().Resource,
 	}
 
-	t.Run("Get folder by title", func(t *testing.T) {
+	t.Run("Get folder by title with nil parent ID", func(t *testing.T) {
 		// the search here will return a parent, this will be the parent folder returned when we query for it to add to the hit info
 		fakeFolderStore := folder.NewFakeStore()
 		fakeFolderStore.ExpectedFolder = &folder.Folder{
@@ -806,45 +855,92 @@ func TestGetFoldersFromApiServer(t *testing.T) {
 		fakeK8sClient.On("Search", mock.Anything, int64(1), &resourcepb.ResourceSearchRequest{
 			Options: &resourcepb.ListOptions{
 				Key: folderkey,
-				Fields: []*resourcepb.Requirement{
-					{
-						Key:      resource.SEARCH_FIELD_TITLE_PHRASE, // nolint:staticcheck
-						Operator: string(selection.Equals),
-						Values:   []string{"foo title"},
-					},
-				},
+				Fields: []*resourcepb.Requirement{{
+					Key:      resource.SEARCH_FIELD_TITLE_PHRASE, // nolint:staticcheck
+					Operator: string(selection.Equals),
+					Values:   []string{"foo title"},
+				}},
 				Labels: []*resourcepb.Requirement{},
 			},
 			Limit: folderSearchLimit}).
 			Return(&resourcepb.ResourceSearchResponse{
 				Results: &resourcepb.ResourceTable{
-					Columns: []*resourcepb.ResourceTableColumnDefinition{
-						{
-							Name: "title",
-							Type: resourcepb.ResourceTableColumnDefinition_STRING,
-						},
-						{
-							Name: "folder",
-							Type: resourcepb.ResourceTableColumnDefinition_STRING,
-						},
-					},
-					Rows: []*resourcepb.ResourceTableRow{
-						{
-							Key: &resourcepb.ResourceKey{
-								Name:     "uid",
-								Resource: "folder",
-							},
-							Cells: [][]byte{
-								[]byte("foouid"),
-								[]byte("parentuid"),
-							},
-						},
+					Columns: []*resourcepb.ResourceTableColumnDefinition{{
+						Name: "title",
+						Type: resourcepb.ResourceTableColumnDefinition_STRING,
+					}, {
+						Name: "folder",
+						Type: resourcepb.ResourceTableColumnDefinition_STRING,
+					}},
+					Rows: []*resourcepb.ResourceTableRow{{
+						Key: &resourcepb.ResourceKey{Name: "uid", Resource: "folder"},
+						Cells: [][]byte{
+							[]byte("foouid"),
+							[]byte("parentuid"),
+						}},
 					},
 				},
 				TotalHits: 1,
 			}, nil).Once()
 
-		result, err := service.getFolderByTitleFromApiServer(ctx, 1, "foo title", nil)
+		_, err := service.getFolderByTitleFromApiServer(ctx, 1, "foo title", nil)
+		// Since parentUID=nil and there's no top-level folder with the name, we return folder not found error.
+		require.Error(t, err, dashboards.ErrFolderNotFound)
+		fakeK8sClient.AssertExpectations(t)
+	})
+
+	t.Run("Get folder by title with parentID", func(t *testing.T) {
+		// the search here will return a parent, this will be the parent folder returned when we query for it to add to the hit info
+		fakeFolderStore := folder.NewFakeStore()
+		fakeFolderStore.ExpectedFolder = &folder.Folder{
+			UID:       "foouid",
+			ParentUID: "parentuid",
+			ID:        2,
+			OrgID:     1,
+			Title:     "foo title",
+			URL:       "/dashboards/f/foouid/foo-title",
+		}
+		service.unifiedStore = fakeFolderStore
+		fakeK8sClient.On("Search", mock.Anything, int64(1), &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{
+				Key: folderkey,
+				Fields: []*resourcepb.Requirement{{
+					Key:      resource.SEARCH_FIELD_TITLE_PHRASE, // nolint:staticcheck
+					Operator: string(selection.Equals),
+					Values:   []string{"foo title"},
+				}, {
+					Key:      resource.SEARCH_FIELD_FOLDER,
+					Operator: string(selection.In),
+					Values:   []string{"parentuid"},
+				}},
+				Labels: []*resourcepb.Requirement{},
+			},
+			Limit: folderSearchLimit}).
+			Return(&resourcepb.ResourceSearchResponse{
+				Results: &resourcepb.ResourceTable{
+					Columns: []*resourcepb.ResourceTableColumnDefinition{{
+						Name: "title",
+						Type: resourcepb.ResourceTableColumnDefinition_STRING,
+					}, {
+						Name: "folder",
+						Type: resourcepb.ResourceTableColumnDefinition_STRING,
+					}},
+					Rows: []*resourcepb.ResourceTableRow{{
+						Key: &resourcepb.ResourceKey{
+							Name:     "uid",
+							Resource: "folder",
+						},
+						Cells: [][]byte{
+							[]byte("foouid"),
+							[]byte("parentuid"),
+						}},
+					},
+				},
+				TotalHits: 1,
+			}, nil).Once()
+
+		parentid := "parentuid"
+		result, err := service.getFolderByTitleFromApiServer(ctx, 1, "foo title", &parentid)
 		require.NoError(t, err)
 
 		expectedResult := &folder.Folder{


### PR DESCRIPTION
When looking for folder by title with `parentUID=nil`, in [legacy this meant top-level folder](https://github.com/grafana/grafana/blob/7c95d3c8a97f2b77a60c67b79e3f8bc1b695d4d5/pkg/services/folder/folderimpl/dashboard_folder_store.go#L115-L120). But in unified storage we used search without any filter and simply returned the first matched folder.

In this PR I'm adding a filter -- when we're looking for folder with `parentUID=nil`, we filter out matching folders that have parent folder set.

(Ideally we would be able to use search query indicating search for top-level folder. That would require that we index some special value for empty parent folder).