### PR TITLE
User Storage: Revamp based on global cache

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -501,11 +501,6 @@
       "count": 1
     }
   },
-  "packages/grafana-runtime/src/utils/userStorage.tsx": {
-    "no-restricted-syntax": {
-      "count": 12
-    }
-  },
   "packages/grafana-schema/src/veneer/common.types.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1

--- a/packages/grafana-runtime/src/utils/userStorage.test.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.test.tsx
@@ -4,7 +4,7 @@ import { of } from 'rxjs';
 import { config } from '../config';
 import { BackendSrvRequest, FetchError, FetchResponse, BackendSrv } from '../services';
 
-import { usePluginUserStorage } from './userStorage';
+import { usePluginUserStorage, clearStorageCache } from './userStorage';
 
 const request = jest.fn<Promise<FetchResponse | FetchError>, BackendSrvRequest[]>();
 
@@ -19,27 +19,38 @@ jest.mock('../services', () => ({
   getBackendSrv: () => backendSrv,
 }));
 
-jest.mock('@grafana/data', () => ({
-  ...jest.requireActual('@grafana/data'),
-  usePluginContext: jest.fn().mockReturnValue({ meta: { id: 'plugin-id' } }),
-}));
+jest.mock('@grafana/data', () => {
+  const storeMocks = {
+    get: jest.fn(),
+    set: jest.fn(),
+  };
+  return {
+    ...jest.requireActual('@grafana/data'),
+    usePluginContext: jest.fn().mockReturnValue({ meta: { id: 'plugin-id' } }),
+    store: storeMocks,
+  };
+});
+
+// Get reference to the mocked store for use in tests
+const getStoreMocks = () => {
+  const { store } = require('@grafana/data');
+  return store;
+};
 
 describe('userStorage', () => {
-  const originalGetItem = Storage.prototype.getItem;
-  const originalSetItem = Storage.prototype.setItem;
   const originalConfig = cloneDeep(config);
 
   beforeEach(() => {
     config.bootData.user.isSignedIn = true;
     config.bootData.user.uid = 'abc';
     request.mockReset();
-    Storage.prototype.setItem = jest.fn();
-    Storage.prototype.getItem = jest.fn();
+    const store = getStoreMocks();
+    store.get.mockReset();
+    store.set.mockReset();
+    clearStorageCache();
   });
 
   afterEach(() => {
-    Storage.prototype.setItem = originalSetItem;
-    Storage.prototype.getItem = originalGetItem;
     config.featureToggles = originalConfig.featureToggles;
     config.bootData = originalConfig.bootData;
   });
@@ -49,14 +60,14 @@ describe('userStorage', () => {
       config.bootData.user.isSignedIn = false;
       const storage = usePluginUserStorage();
       await storage.getItem('key');
-      expect(localStorage.getItem).toHaveBeenCalledWith('plugin-id:abc:key');
+      expect(getStoreMocks().get).toHaveBeenCalledWith('plugin-id:abc:key');
     });
 
     it('use localStorage if the user storage is not found', async () => {
       request.mockReturnValue(Promise.reject({ status: 404 } as FetchError));
       const storage = usePluginUserStorage();
       await storage.getItem('key');
-      expect(localStorage.getItem).toHaveBeenCalledWith('plugin-id:abc:key');
+      expect(getStoreMocks().get).toHaveBeenCalledWith('plugin-id:abc:key');
     });
 
     it('returns the value from the user storage', async () => {
@@ -74,7 +85,7 @@ describe('userStorage', () => {
       config.bootData.user.isSignedIn = false;
       const storage = usePluginUserStorage();
       await storage.setItem('key', 'value');
-      expect(localStorage.setItem).toHaveBeenCalledWith('plugin-id:abc:key', 'value');
+      expect(getStoreMocks().set).toHaveBeenCalledWith('plugin-id:abc:key', 'value');
     });
 
     it('creates a new user storage if it does not exist', async () => {
@@ -101,7 +112,7 @@ describe('userStorage', () => {
           },
         })
       );
-      expect(localStorage.setItem).not.toHaveBeenCalled();
+      expect(getStoreMocks().set).not.toHaveBeenCalled();
     });
 
     it('falls back to localStorage if the user storage fails to be created', async () => {
@@ -111,7 +122,7 @@ describe('userStorage', () => {
       request.mockReturnValueOnce(Promise.reject({ status: 403 } as FetchError));
       const storage = usePluginUserStorage();
       await storage.setItem('key', 'value');
-      expect(localStorage.setItem).toHaveBeenCalledWith('plugin-id:abc:key', 'value');
+      expect(getStoreMocks().set).toHaveBeenCalledWith('plugin-id:abc:key', 'value');
     });
 
     it('updates the user storage if it exists', async () => {
@@ -141,6 +152,165 @@ describe('userStorage', () => {
           },
         })
       );
+    });
+  });
+
+  describe('Cache behavior', () => {
+    it('multiple instances share the same network request', async () => {
+      request.mockReturnValue(
+        Promise.resolve({ status: 200, data: { spec: { data: { key: 'value' } } } } as FetchResponse)
+      );
+      const storage1 = usePluginUserStorage();
+      const storage2 = usePluginUserStorage();
+
+      // Both should call getItem concurrently
+      const [value1, value2] = await Promise.all([storage1.getItem('key'), storage2.getItem('key')]);
+
+      // Should only make one network request
+      expect(request).toHaveBeenCalledTimes(1);
+      expect(value1).toBe('value');
+      expect(value2).toBe('value');
+    });
+
+    it('caches 404 responses to avoid multiple requests', async () => {
+      request.mockReturnValue(Promise.reject({ status: 404 } as FetchError));
+      const storage1 = usePluginUserStorage();
+      const storage2 = usePluginUserStorage();
+
+      // Both should call getItem concurrently
+      await Promise.all([storage1.getItem('key'), storage2.getItem('key')]);
+
+      // Should only make one network request despite multiple instances
+      expect(request).toHaveBeenCalledTimes(1);
+    });
+
+    it('updates cache after creating new storage', async () => {
+      // First call: 404, then create
+      request.mockReturnValueOnce(Promise.reject({ status: 404 } as FetchError));
+      request.mockReturnValueOnce(Promise.resolve({ status: 200 } as FetchResponse));
+
+      const storage1 = usePluginUserStorage();
+      await storage1.setItem('key1', 'value1');
+
+      // Second instance should use cached data without network request
+      request.mockReset();
+      const storage2 = usePluginUserStorage();
+      const value = await storage2.getItem('key1');
+
+      // Should not make a GET request because cache has the data
+      expect(request).not.toHaveBeenCalled();
+      expect(value).toBe('value1');
+    });
+
+    it('updates cache after modifying existing storage', async () => {
+      // Initial GET returns existing data
+      request.mockReturnValueOnce(
+        Promise.resolve({
+          status: 200,
+          data: { spec: { data: { key1: 'value1' } } },
+        } as FetchResponse)
+      );
+      // PATCH updates the storage
+      request.mockReturnValueOnce(Promise.resolve({ status: 200 } as FetchResponse));
+
+      const storage1 = usePluginUserStorage();
+      await storage1.setItem('key1', 'new-value1');
+
+      // Second instance should get updated value from cache
+      request.mockReset();
+      const storage2 = usePluginUserStorage();
+      const value = await storage2.getItem('key1');
+
+      // Should not make a GET request because cache has the updated data
+      expect(request).not.toHaveBeenCalled();
+      expect(value).toBe('new-value1');
+    });
+
+    it('concurrent initialization requests share the same promise', async () => {
+      let resolvePromise: (value: FetchResponse | FetchError) => void;
+      const promise = new Promise<FetchResponse | FetchError>((resolve) => {
+        resolvePromise = resolve;
+      });
+
+      request.mockReturnValue(promise);
+
+      const storage1 = usePluginUserStorage();
+      const storage2 = usePluginUserStorage();
+
+      // Start both getItem calls concurrently
+      const promise1 = storage1.getItem('key');
+      const promise2 = storage2.getItem('key');
+
+      // Should only make one network request
+      expect(request).toHaveBeenCalledTimes(1);
+
+      // Resolve the request
+      resolvePromise!({ status: 200, data: { spec: { data: { key: 'value' } } } } as FetchResponse);
+
+      const [value1, value2] = await Promise.all([promise1, promise2]);
+
+      expect(value1).toBe('value');
+      expect(value2).toBe('value');
+    });
+
+    it('serializes concurrent setItem operations to prevent race conditions', async () => {
+      // Initial GET returns existing data
+      request.mockReturnValueOnce(
+        Promise.resolve({
+          status: 200,
+          data: { spec: { data: { key1: 'initial' } } },
+        } as FetchResponse)
+      );
+      // Two PATCH requests for concurrent setItem calls
+      request.mockReturnValueOnce(Promise.resolve({ status: 200 } as FetchResponse));
+      request.mockReturnValueOnce(Promise.resolve({ status: 200 } as FetchResponse));
+
+      const storage1 = usePluginUserStorage();
+      const storage2 = usePluginUserStorage();
+
+      // Call setItem concurrently on different keys
+      await Promise.all([
+        storage1.setItem('key1', 'value1'),
+        storage2.setItem('key2', 'value2'),
+      ]);
+
+      // Both operations should complete successfully
+      // Verify both values are in cache
+      const value1 = await storage1.getItem('key1');
+      const value2 = await storage2.getItem('key2');
+
+      expect(value1).toBe('value1');
+      expect(value2).toBe('value2');
+      // Should have made 1 GET and 2 PATCH requests
+      expect(request).toHaveBeenCalledTimes(3);
+    });
+
+    it('handles concurrent setItem on the same key correctly', async () => {
+      // Initial GET returns existing data
+      request.mockReturnValueOnce(
+        Promise.resolve({
+          status: 200,
+          data: { spec: { data: { key1: 'initial' } } },
+        } as FetchResponse)
+      );
+      // Two PATCH requests for concurrent setItem calls on same key
+      request.mockReturnValueOnce(Promise.resolve({ status: 200 } as FetchResponse));
+      request.mockReturnValueOnce(Promise.resolve({ status: 200 } as FetchResponse));
+
+      const storage1 = usePluginUserStorage();
+      const storage2 = usePluginUserStorage();
+
+      // Call setItem concurrently on the same key
+      await Promise.all([
+        storage1.setItem('key1', 'value1'),
+        storage2.setItem('key1', 'value2'),
+      ]);
+
+      // Both operations should complete (last one wins)
+      const finalValue = await storage1.getItem('key1');
+      expect(finalValue).toBe('value2'); // Last write wins
+      // Should have made 1 GET and 2 PATCH requests
+      expect(request).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/packages/grafana-runtime/src/utils/userStorage.test.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.test.tsx
@@ -269,10 +269,7 @@ describe('userStorage', () => {
       const storage2 = usePluginUserStorage();
 
       // Call setItem concurrently on different keys
-      await Promise.all([
-        storage1.setItem('key1', 'value1'),
-        storage2.setItem('key2', 'value2'),
-      ]);
+      await Promise.all([storage1.setItem('key1', 'value1'), storage2.setItem('key2', 'value2')]);
 
       // Both operations should complete successfully
       // Verify both values are in cache
@@ -301,10 +298,7 @@ describe('userStorage', () => {
       const storage2 = usePluginUserStorage();
 
       // Call setItem concurrently on the same key
-      await Promise.all([
-        storage1.setItem('key1', 'value1'),
-        storage2.setItem('key1', 'value2'),
-      ]);
+      await Promise.all([storage1.setItem('key1', 'value1'), storage2.setItem('key1', 'value2')]);
 
       // Both operations should complete (last one wins)
       const finalValue = await storage1.getItem('key1');

--- a/packages/grafana-runtime/src/utils/userStorage.test.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.test.tsx
@@ -4,7 +4,7 @@ import { of } from 'rxjs';
 import { config } from '../config';
 import { BackendSrvRequest, FetchError, FetchResponse, BackendSrv } from '../services';
 
-import { usePluginUserStorage, clearStorageCache } from './userStorage';
+import { usePluginUserStorage, _clearStorageCache } from './userStorage';
 
 const request = jest.fn<Promise<FetchResponse | FetchError>, BackendSrvRequest[]>();
 
@@ -47,7 +47,7 @@ describe('userStorage', () => {
     const store = getStoreMocks();
     store.get.mockReset();
     store.set.mockReset();
-    clearStorageCache();
+    _clearStorageCache();
   });
 
   afterEach(() => {

--- a/packages/grafana-runtime/src/utils/userStorage.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.tsx
@@ -1,12 +1,31 @@
 import { get } from 'lodash';
 import { lastValueFrom } from 'rxjs';
 
-import { usePluginContext, type UserStorage as UserStorageType } from '@grafana/data';
+import { usePluginContext, type UserStorage as UserStorageType, store } from '@grafana/data';
 
 import { config } from '../config';
 import { BackendSrvRequest, getBackendSrv } from '../services';
 
 const baseURL = `/apis/userstorage.grafana.app/v0alpha1/namespaces/${config.namespace}/user-storage`;
+
+// Global cache for user storage initialization requests
+// Cache key: resourceName (e.g., "plugin-id:user-uid")
+// Cache value: Promise<UserStorageSpec | null> | UserStorageSpec | null
+const storageCache = new Map<string, Promise<UserStorageSpec | null> | UserStorageSpec | null>();
+
+// Lock map to serialize setItem operations per resourceName
+// Cache key: resourceName
+// Cache value: Promise that resolves when the lock is available
+const setItemLocks = new Map<string, Promise<void>>();
+
+/**
+ * Clears the global storage cache. Used for testing purposes.
+ * @internal
+ */
+export function clearStorageCache() {
+  storageCache.clear();
+  setItemLocks.clear();
+}
 
 interface RequestOptions extends BackendSrvRequest {
   manageError?: (err: unknown) => { error: unknown };
@@ -45,7 +64,6 @@ export class UserStorage implements UserStorageType {
   private resourceName: string;
   private userUID: string;
   private canUseUserStorage: boolean;
-  private storageSpec: UserStorageSpec | null | undefined;
 
   constructor(service: string) {
     this.service = service;
@@ -54,95 +72,193 @@ export class UserStorage implements UserStorageType {
     this.canUseUserStorage = config.bootData.user.isSignedIn;
   }
 
-  private async init() {
-    if (this.storageSpec !== undefined) {
+  private async init(): Promise<unknown> {
+    // Check global cache first
+    const cached = storageCache.get(this.resourceName);
+    if (cached !== undefined) {
+      if (cached instanceof Promise) {
+        // Cache has a promise, await it
+        try {
+          await cached;
+          return;
+        } catch (error) {
+          // Promise rejected, return error to match original behavior
+          return error;
+        }
+      } else {
+        // Cache has a resolved result, already initialized
+        return;
+      }
+    }
+
+    // No cache entry, create the request promise and cache it atomically
+    // Use a double-check pattern to handle race conditions
+    let requestPromise = storageCache.get(this.resourceName);
+    if (requestPromise instanceof Promise) {
+      // Another instance created the promise between our check and now, use it
+      try {
+        await requestPromise;
+        return;
+      } catch (error) {
+        return error;
+      }
+    }
+
+    // Create new promise
+    requestPromise = (async (): Promise<UserStorageSpec | null> => {
+      const userStorage = await apiRequest<{ spec: UserStorageSpec }>({
+        url: `/${this.resourceName}`,
+        method: 'GET',
+        manageError: (error) => {
+          if (get(error, 'status') === 404) {
+            return { error: null };
+          }
+          return { error };
+        },
+      });
+      if ('error' in userStorage) {
+        if (userStorage.error === null) {
+          // 404 - storage doesn't exist
+          return null;
+        }
+        // Other error, throw so it can be caught and returned
+        throw userStorage.error;
+      }
+      return userStorage.data.spec;
+    })();
+
+    // Atomically set the promise only if cache is still empty
+    const existing = storageCache.get(this.resourceName);
+    if (existing === undefined) {
+      storageCache.set(this.resourceName, requestPromise);
+    } else if (existing instanceof Promise) {
+      // Another instance set a promise, use it instead
+      requestPromise = existing;
+    } else {
+      // Another instance already resolved, we're done
       return;
     }
-    const userStorage = await apiRequest<{ spec: UserStorageSpec }>({
-      url: `/${this.resourceName}`,
-      method: 'GET',
-      manageError: (error) => {
-        if (get(error, 'status') === 404) {
-          this.storageSpec = null;
-          return { error: null };
-        }
-        return { error };
-      },
-    });
-    if ('error' in userStorage) {
-      return userStorage.error;
+
+    try {
+      const result = await requestPromise;
+      // Replace promise with resolved result in cache
+      storageCache.set(this.resourceName, result);
+    } catch (error) {
+      // Remove failed promise from cache so it can be retried
+      storageCache.delete(this.resourceName);
+      return error;
     }
-    this.storageSpec = userStorage.data.spec;
     return;
   }
 
   async getItem(key: string): Promise<string | null> {
     if (!this.canUseUserStorage) {
       // Fallback to localStorage
-      return localStorage.getItem(`${this.resourceName}:${key}`);
+      return store.get(`${this.resourceName}:${key}`) ?? null;
     }
-    // Ensure this.storageSpec is initialized
+    // Ensure storage is initialized
     await this.init();
-    if (!this.storageSpec) {
-      // Also, fallback to localStorage for backward compatibility
-      return localStorage.getItem(`${this.resourceName}:${key}`);
+    const storageSpec = storageCache.get(this.resourceName);
+    if (!storageSpec || storageSpec instanceof Promise) {
+      // Storage doesn't exist or still loading, fallback to localStorage
+      return store.get(`${this.resourceName}:${key}`) ?? null;
     }
-    return this.storageSpec.data[key];
+    return storageSpec.data[key];
   }
 
   async setItem(key: string, value: string): Promise<void> {
     if (!this.canUseUserStorage) {
       // Fallback to localStorage
-      localStorage.setItem(`${this.resourceName}:${key}`, value);
+      store.set(`${this.resourceName}:${key}`, value);
       return;
     }
 
-    const newData = { data: { [key]: value } };
-    // Ensure this.storageSpec is initialized
-    const error = await this.init();
-    if (error) {
-      // Fallback to localStorage
-      localStorage.setItem(`${this.resourceName}:${key}`, value);
-      return;
+    // Acquire lock for this resourceName to serialize setItem operations
+    let lockPromise = setItemLocks.get(this.resourceName);
+    if (lockPromise) {
+      await lockPromise;
     }
 
-    if (!this.storageSpec) {
-      // No user storage found, create a new one
-      await apiRequest<UserStorageSpec>({
-        url: `/`,
-        method: 'POST',
-        body: {
-          metadata: { name: this.resourceName, labels: { user: this.userUID, service: this.service } },
-          spec: newData,
-        },
+    // Create a new lock promise that will be resolved when this operation completes
+    let resolveLock: (() => void) | undefined;
+    const newLockPromise = new Promise<void>((resolve) => {
+      resolveLock = resolve;
+    });
+    setItemLocks.set(this.resourceName, newLockPromise);
+
+    try {
+      const newData = { data: { [key]: value } };
+      // Ensure storage is initialized
+      const error = await this.init();
+      if (error) {
+        // Fallback to localStorage
+        store.set(`${this.resourceName}:${key}`, value);
+        return;
+      }
+
+      const storageSpec = storageCache.get(this.resourceName);
+      if (!storageSpec || storageSpec instanceof Promise) {
+        // No user storage found, create a new one
+        const createResult = await apiRequest<UserStorageSpec>({
+          url: `/`,
+          method: 'POST',
+          body: {
+            metadata: { name: this.resourceName, labels: { user: this.userUID, service: this.service } },
+            spec: newData,
+          },
+          manageError: (error) => {
+            // Fallback to localStorage
+            store.set(`${this.resourceName}:${key}`, value);
+            return { error };
+          },
+        });
+        if ('error' in createResult && createResult.error) {
+          // Error occurred, fallback already handled in manageError
+          return;
+        }
+        // Update global cache with the new storage
+        storageCache.set(this.resourceName, newData);
+        return;
+      }
+
+      // Clone the storage spec to avoid mutating the cached object directly
+      // This prevents race conditions where multiple setItem calls modify the same object
+      const updatedSpec: UserStorageSpec = {
+        data: { ...storageSpec.data, [key]: value },
+      };
+
+      const updateResult = await apiRequest<UserStorageSpec>({
+        headers: { 'Content-Type': 'application/merge-patch+json' },
+        url: `/${this.resourceName}`,
+        method: 'PATCH',
+        body: { spec: newData },
         manageError: (error) => {
           // Fallback to localStorage
-          localStorage.setItem(`${this.resourceName}:${key}`, value);
+          store.set(`${this.resourceName}:${key}`, value);
           return { error };
         },
       });
-      this.storageSpec = newData;
-      return;
+      if ('error' in updateResult && updateResult.error) {
+        // Error occurred, fallback already handled in manageError
+        return;
+      }
+      // Update global cache with the modified storage (using cloned object)
+      storageCache.set(this.resourceName, updatedSpec);
+    } finally {
+      // Release the lock
+      if (resolveLock) {
+        resolveLock();
+      }
+      // Remove lock if it's still the current one (in case another operation started)
+      if (setItemLocks.get(this.resourceName) === newLockPromise) {
+        setItemLocks.delete(this.resourceName);
+      }
     }
-
-    // Update existing user storage
-    this.storageSpec.data[key] = value;
-    await apiRequest<UserStorageSpec>({
-      headers: { 'Content-Type': 'application/merge-patch+json' },
-      url: `/${this.resourceName}`,
-      method: 'PATCH',
-      body: { spec: newData },
-      manageError: (error) => {
-        // Fallback to localStorage
-        localStorage.setItem(`${this.resourceName}:${key}`, value);
-        return { error };
-      },
-    });
   }
 }
 
 // This is a type alias to avoid breaking changes
-export interface PluginUserStorage extends UserStorageType {}
+export interface PluginUserStorage extends UserStorageType { }
 
 /**
  * A hook for interacting with the backend user storage (or local storage if not enabled).

--- a/packages/grafana-runtime/src/utils/userStorage.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.tsx
@@ -22,7 +22,10 @@ const operationLocks = new Map<string, Promise<void>>();
  * Clears the global storage cache. Used for testing purposes.
  * @internal
  */
-export function clearStorageCache() {
+export function _clearStorageCache() {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error('clearStorageCache() function can only be called from tests.');
+  }
   storageCache.clear();
   operationLocks.clear();
 }

--- a/packages/grafana-runtime/src/utils/userStorage.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.tsx
@@ -258,7 +258,7 @@ export class UserStorage implements UserStorageType {
 }
 
 // This is a type alias to avoid breaking changes
-export interface PluginUserStorage extends UserStorageType { }
+export interface PluginUserStorage extends UserStorageType {}
 
 /**
  * A hook for interacting with the backend user storage (or local storage if not enabled).


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR moves the cache of the userStorage data from a class property to a global variable. The benefit for this is that multiple parts of the code can create multiple instances of the userStorage instance but it will only make the strictly necessary network calls.

I have also added a locking system so concurrent calls using different instances don't overwrite each other.

Finally, unrelated but I have removed the usage of `localStorage` in favor `store` provided by grafana/data.

**Why do we need this feature?**

Avoid multiple unnecessary network calls.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/116414

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
