### PR TITLE
kvstore: refactor delete operations and NotFound

### DIFF
--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -816,8 +816,7 @@ func testDataStoreDelete(t *testing.T, ctx context.Context, ds *dataStore) {
 		}
 
 		err := ds.Delete(ctx, nonExistentKey)
-		require.Error(t, err)
-		require.Equal(t, ErrNotFound, err)
+		require.NoError(t, err)
 	})
 }
 

--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -237,16 +237,7 @@ func (k *badgerKV) Delete(ctx context.Context, section string, key string) error
 
 	key = section + "/" + key
 
-	// Check if key exists before deleting
-	_, err := txn.Get([]byte(key))
-	if err != nil {
-		if errors.Is(err, badger.ErrKeyNotFound) {
-			return ErrNotFound
-		}
-		return err
-	}
-
-	err = txn.Delete([]byte(key))
+	err := txn.Delete([]byte(key))
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/unified/resource/sqlkv.go
+++ b/pkg/storage/unified/resource/sqlkv.go
@@ -456,21 +456,12 @@ func (w *sqlWriteCloser) Close() error {
 }
 
 func (k *sqlKV) Delete(ctx context.Context, section string, key string) error {
-	res, err := dbutil.Exec(ctx, k.db, sqlKVDelete, sqlKVDeleteRequest{
+	_, err := dbutil.Exec(ctx, k.db, sqlKVDelete, sqlKVDeleteRequest{
 		SQLTemplate:     sqltemplate.New(k.dialect),
 		sqlKVSectionKey: sqlKVSectionKey{sqlKVSection{section}, key},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to delete key: %w", err)
-	}
-
-	rows, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to validate delete: %w", err)
-	}
-
-	if rows == 0 {
-		return ErrNotFound
 	}
 
 	return nil

--- a/pkg/storage/unified/testing/kv.go
+++ b/pkg/storage/unified/testing/kv.go
@@ -276,8 +276,7 @@ func runTestKVDelete(t *testing.T, kv resource.KV, nsPrefix string) {
 
 	t.Run("delete non-existent key", func(t *testing.T) {
 		err := kv.Delete(ctx, testSection, namespacedKey(nsPrefix, "non-existent-delete-key"))
-		assert.Error(t, err)
-		assert.Equal(t, resource.ErrNotFound, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("delete with empty section", func(t *testing.T) {


### PR DESCRIPTION
Make KV Delete method idempotent by removing ErrNotFound when key doesn't exist.
