### PR TITLE
Logs: escape special characters in log labels in the `generateLogGrammar` function

### DIFF
--- a/public/app/features/logs/components/panel/grammar.test.ts
+++ b/public/app/features/logs/components/panel/grammar.test.ts
@@ -5,8 +5,8 @@ import { createLogLine } from '../mocks/logRow';
 import { generateLogGrammar, generateTextMatchGrammar } from './grammar';
 
 describe('generateLogGrammar', () => {
-  function generateScenario(entry: string) {
-    const log = createLogLine({ labels: { place: 'luna', source: 'logs' }, entry });
+  function generateScenario(entry: string, labels: Record<string, string> = { place: 'luna', source: 'logs' }) {
+    const log = createLogLine({ labels, entry });
     // Access body getter to trigger LogLineModel internals
     expect(log.body).toBeDefined();
     const grammar = generateLogGrammar(log);
@@ -86,6 +86,15 @@ describe('generateLogGrammar', () => {
       expect.assertions(3);
     }
   );
+
+  test('Identifies labels with special regexp characters', () => {
+    const { tokens } = generateScenario('place(*)=luna', { 'place(*)': 'luna', source: 'logs' });
+    if (tokens[0] instanceof Token) {
+      expect(tokens[0].content).toBe('place(*)=');
+      expect(tokens[0].type).toBe('log-token-label');
+    }
+    expect.assertions(3);
+  });
 });
 
 describe('generateTextMatchGrammar', () => {

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -33,7 +33,9 @@ const jsonGrammar: Grammar = {
 };
 
 export const generateLogGrammar = (log: LogListModel) => {
-  const labels = Object.keys(log.labels).concat(log.fields.map((field) => field.keys[0]));
+  const labels = Object.keys(log.labels)
+    .concat(log.fields.map((field) => field.keys[0]))
+    .map((label) => escapeRegex(label));
   const labelGrammar: Grammar = {
     'log-token-label': new RegExp(`\\b(${labels.join('|')})(?:[=:]{1})\\b`, 'g'),
   };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This is a fix for the logs page, where some labels that contain special characters break the page if highlighting is enabled. 
Special characters in labels break the page during the grammar generation. Need to escape special characters via `escapeRegex` function.

**Which issue(s) does this PR fix?**:
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #114967 

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
