### PR TITLE
Provisioning: bound Repo and Connection token update to controller resync interval

### DIFF
--- a/apps/provisioning/pkg/connection/connection.go
+++ b/apps/provisioning/pkg/connection/connection.go
@@ -38,6 +38,8 @@ type Connection interface {
 //
 //go:generate mockery --name TokenConnection --structname MockTokenConnection --inpackage --filename connection_token_mock.go --with-expecter
 type TokenConnection interface {
+	// TokenCreationTime returns when the underlying token has been created.
+	TokenCreationTime(ctx context.Context) (time.Time, error)
 	// TokenExpiration returns the underlying token expiration.
 	TokenExpiration(ctx context.Context) (time.Time, error)
 	// GenerateConnectionToken generates a connection-level token.

--- a/apps/provisioning/pkg/connection/connection_mock.go
+++ b/apps/provisioning/pkg/connection/connection_mock.go
@@ -22,64 +22,6 @@ func (_m *MockConnection) EXPECT() *MockConnection_Expecter {
 	return &MockConnection_Expecter{mock: &_m.Mock}
 }
 
-// ListRepositories provides a mock function with given fields: ctx
-func (_m *MockConnection) ListRepositories(ctx context.Context) ([]v0alpha1.ExternalRepository, error) {
-	ret := _m.Called(ctx)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ListRepositories")
-	}
-
-	var r0 []v0alpha1.ExternalRepository
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context) ([]v0alpha1.ExternalRepository, error)); ok {
-		return rf(ctx)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context) []v0alpha1.ExternalRepository); ok {
-		r0 = rf(ctx)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]v0alpha1.ExternalRepository)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockConnection_ListRepositories_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListRepositories'
-type MockConnection_ListRepositories_Call struct {
-	*mock.Call
-}
-
-// ListRepositories is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *MockConnection_Expecter) ListRepositories(ctx interface{}) *MockConnection_ListRepositories_Call {
-	return &MockConnection_ListRepositories_Call{Call: _e.mock.On("ListRepositories", ctx)}
-}
-
-func (_c *MockConnection_ListRepositories_Call) Run(run func(ctx context.Context)) *MockConnection_ListRepositories_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
-	})
-	return _c
-}
-
-func (_c *MockConnection_ListRepositories_Call) Return(_a0 []v0alpha1.ExternalRepository, _a1 error) *MockConnection_ListRepositories_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockConnection_ListRepositories_Call) RunAndReturn(run func(context.Context) ([]v0alpha1.ExternalRepository, error)) *MockConnection_ListRepositories_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GenerateRepositoryToken provides a mock function with given fields: ctx, repo
 func (_m *MockConnection) GenerateRepositoryToken(ctx context.Context, repo *v0alpha1.Repository) (*ExpirableSecureValue, error) {
 	ret := _m.Called(ctx, repo)
@@ -135,6 +77,64 @@ func (_c *MockConnection_GenerateRepositoryToken_Call) Return(_a0 *ExpirableSecu
 }
 
 func (_c *MockConnection_GenerateRepositoryToken_Call) RunAndReturn(run func(context.Context, *v0alpha1.Repository) (*ExpirableSecureValue, error)) *MockConnection_GenerateRepositoryToken_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListRepositories provides a mock function with given fields: ctx
+func (_m *MockConnection) ListRepositories(ctx context.Context) ([]v0alpha1.ExternalRepository, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListRepositories")
+	}
+
+	var r0 []v0alpha1.ExternalRepository
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) ([]v0alpha1.ExternalRepository, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) []v0alpha1.ExternalRepository); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]v0alpha1.ExternalRepository)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockConnection_ListRepositories_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListRepositories'
+type MockConnection_ListRepositories_Call struct {
+	*mock.Call
+}
+
+// ListRepositories is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockConnection_Expecter) ListRepositories(ctx interface{}) *MockConnection_ListRepositories_Call {
+	return &MockConnection_ListRepositories_Call{Call: _e.mock.On("ListRepositories", ctx)}
+}
+
+func (_c *MockConnection_ListRepositories_Call) Run(run func(ctx context.Context)) *MockConnection_ListRepositories_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockConnection_ListRepositories_Call) Return(_a0 []v0alpha1.ExternalRepository, _a1 error) *MockConnection_ListRepositories_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockConnection_ListRepositories_Call) RunAndReturn(run func(context.Context) ([]v0alpha1.ExternalRepository, error)) *MockConnection_ListRepositories_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/apps/provisioning/pkg/connection/connection_token_mock.go
+++ b/apps/provisioning/pkg/connection/connection_token_mock.go
@@ -80,6 +80,62 @@ func (_c *MockTokenConnection_GenerateConnectionToken_Call) RunAndReturn(run fun
 	return _c
 }
 
+// TokenCreationTime provides a mock function with given fields: ctx
+func (_m *MockTokenConnection) TokenCreationTime(ctx context.Context) (time.Time, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TokenCreationTime")
+	}
+
+	var r0 time.Time
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (time.Time, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) time.Time); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(time.Time)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockTokenConnection_TokenCreationTime_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TokenCreationTime'
+type MockTokenConnection_TokenCreationTime_Call struct {
+	*mock.Call
+}
+
+// TokenCreationTime is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockTokenConnection_Expecter) TokenCreationTime(ctx interface{}) *MockTokenConnection_TokenCreationTime_Call {
+	return &MockTokenConnection_TokenCreationTime_Call{Call: _e.mock.On("TokenCreationTime", ctx)}
+}
+
+func (_c *MockTokenConnection_TokenCreationTime_Call) Run(run func(ctx context.Context)) *MockTokenConnection_TokenCreationTime_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockTokenConnection_TokenCreationTime_Call) Return(_a0 time.Time, _a1 error) *MockTokenConnection_TokenCreationTime_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockTokenConnection_TokenCreationTime_Call) RunAndReturn(run func(context.Context) (time.Time, error)) *MockTokenConnection_TokenCreationTime_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // TokenExpiration provides a mock function with given fields: ctx
 func (_m *MockTokenConnection) TokenExpiration(ctx context.Context) (time.Time, error) {
 	ret := _m.Called(ctx)

--- a/apps/provisioning/pkg/connection/github/connection.go
+++ b/apps/provisioning/pkg/connection/github/connection.go
@@ -221,9 +221,19 @@ func (c *Connection) GenerateConnectionToken(_ context.Context) (common.RawSecur
 	return GenerateJWTToken(c.obj.Spec.GitHub.AppID, c.secrets.PrivateKey)
 }
 
+// TokenCreationTime returns when the underlying token has been created.
+func (c *Connection) TokenCreationTime(_ context.Context) (time.Time, error) {
+	issuingTime, _, err := getIssuingAndExpirationTimeFromToken(c.secrets.Token, c.secrets.PrivateKey)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return issuingTime, nil
+}
+
 // TokenExpiration returns the underlying token expiration.
 func (c *Connection) TokenExpiration(_ context.Context) (time.Time, error) {
-	expiration, err := getExpirationFromToken(c.secrets.Token, c.secrets.PrivateKey)
+	_, expiration, err := getIssuingAndExpirationTimeFromToken(c.secrets.Token, c.secrets.PrivateKey)
 	if err != nil {
 		return time.Time{}, err
 	}

--- a/apps/provisioning/pkg/connection/github/token.go
+++ b/apps/provisioning/pkg/connection/github/token.go
@@ -50,15 +50,15 @@ func GenerateJWTToken(appID string, privateKey common.RawSecureValue) (common.Ra
 	return common.RawSecureValue(signedToken), nil
 }
 
-func getExpirationFromToken(token, privateKey common.RawSecureValue) (time.Time, error) {
+func getIssuingAndExpirationTimeFromToken(token, privateKey common.RawSecureValue) (time.Time, time.Time, error) {
 	privateKeyPEM, err := base64.StdEncoding.DecodeString(string(privateKey))
 	if err != nil {
-		return time.Time{}, fmt.Errorf("failed to decode base64 private key: %w", err)
+		return time.Time{}, time.Time{}, fmt.Errorf("failed to decode base64 private key: %w", err)
 	}
 
 	key, err := jwt.ParseRSAPrivateKeyFromPEM(privateKeyPEM)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("failed to parse private key: %w", err)
+		return time.Time{}, time.Time{}, fmt.Errorf("failed to parse private key: %w", err)
 	}
 
 	parser := jwt.NewParser(
@@ -69,13 +69,13 @@ func getExpirationFromToken(token, privateKey common.RawSecureValue) (time.Time,
 		return &key.PublicKey, nil
 	})
 	if err != nil {
-		return time.Time{}, fmt.Errorf("failed to parse token: %w", err)
+		return time.Time{}, time.Time{}, fmt.Errorf("failed to parse token: %w", err)
 	}
 
 	claims, ok := parsedToken.Claims.(*jwt.RegisteredClaims)
 	if !ok {
-		return time.Time{}, fmt.Errorf("unexpected token claims")
+		return time.Time{}, time.Time{}, fmt.Errorf("unexpected token claims")
 	}
 
-	return claims.ExpiresAt.Time, nil
+	return claims.IssuedAt.Time, claims.ExpiresAt.Time, nil
 }

--- a/apps/provisioning/pkg/connection/github/validator_test.go
+++ b/apps/provisioning/pkg/connection/github/validator_test.go
@@ -1,9 +1,10 @@
-package github
+package github_test
 
 import (
 	"context"
 	"testing"
 
+	"github.com/grafana/grafana/apps/provisioning/pkg/connection/github"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -190,7 +191,7 @@ func TestValidate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			list := Validate(context.Background(), tt.obj)
+			list := github.Validate(context.Background(), tt.obj)
 			if tt.expectedError {
 				assert.NotEmpty(t, list)
 				if len(tt.errorContains) > 0 {

--- a/pkg/operators/provisioning/connection_operator.go
+++ b/pkg/operators/provisioning/connection_operator.go
@@ -73,6 +73,7 @@ func RunConnectionController(deps server.OperatorDependencies) error {
 		statusPatcher,
 		healthChecker,
 		connectionFactory,
+		controllerCfg.resyncInterval,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create connection controller: %w", err)

--- a/pkg/operators/provisioning/repo_operator.go
+++ b/pkg/operators/provisioning/repo_operator.go
@@ -92,6 +92,7 @@ func RunRepoController(deps server.OperatorDependencies) error {
 		deps.Registerer,
 		tracer,
 		controllerCfg.parallelOperations,
+		controllerCfg.resyncInterval,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create repository controller: %w", err)

--- a/pkg/registry/apis/provisioning/controller/connection.go
+++ b/pkg/registry/apis/provisioning/controller/connection.go
@@ -220,20 +220,20 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 
 	tokenConn, ok := c.(connection.TokenConnection)
 	if ok {
-		expiration, err := tokenConn.TokenExpiration(ctx)
+		refresh, err := cc.shouldRefreshToken(ctx, tokenConn)
 		if err != nil {
-			logger.Error("failed to check if token expired", "error", err)
+			logger.Error("failed to check if token needs to be refreshed", "error", err)
 			return err
 		}
-
-		if cc.shouldRefreshToken(expiration) {
+		if refresh {
 			logger.Info("regenerating connection token")
 
 			token, tokenOps, err := cc.generateConnectionToken(ctx, tokenConn)
 			if err != nil {
-				// Log error but continue - health check will surface the issue
 				logger.Error("failed to generate connection token", "error", err)
-			} else if len(tokenOps) > 0 {
+				return err
+			}
+			if len(tokenOps) > 0 {
 				patchOperations = append(patchOperations, tokenOps...)
 			}
 			// Substituting generated token for healthcheck
@@ -286,8 +286,22 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 	return nil
 }
 
-func (cc *ConnectionController) shouldRefreshToken(expiration time.Time) bool {
-	return shouldRefreshBeforeExpiration(expiration, cc.resyncInterval)
+func (cc *ConnectionController) shouldRefreshToken(ctx context.Context, c connection.TokenConnection) (bool, error) {
+	issuingTime, err := c.TokenCreationTime(ctx)
+	if err != nil {
+		return false, err
+	}
+	// If the token has been recently created, we should not refresh it.
+	if tokenRecentlyCreated(issuingTime) {
+		return false, nil
+	}
+
+	expiration, err := c.TokenExpiration(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	return shouldRefreshBeforeExpiration(expiration, cc.resyncInterval), nil
 }
 
 // generateConnectionToken regenerates the connection token if the connection supports it.

--- a/pkg/registry/apis/provisioning/controller/connection.go
+++ b/pkg/registry/apis/provisioning/controller/connection.go
@@ -287,8 +287,7 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 }
 
 func (cc *ConnectionController) shouldRefreshToken(expiration time.Time) bool {
-	// If the expiration is before the next resync, we should refresh the token.
-	return expiration.Before(time.Now().Add(cc.resyncInterval))
+	return shouldRefreshBeforeExpiration(expiration, cc.resyncInterval)
 }
 
 // generateConnectionToken regenerates the connection token if the connection supports it.

--- a/pkg/registry/apis/provisioning/controller/connection_test.go
+++ b/pkg/registry/apis/provisioning/controller/connection_test.go
@@ -23,56 +23,22 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/controller/mocks"
 )
 
-// mockConnectionWithToken is a test helper that implements both Connection and TokenConnection
 type mockConnectionWithToken struct {
-	mock.Mock
-}
-
-func (m *mockConnectionWithToken) TokenExpiration(ctx context.Context) (time.Time, error) {
-	args := m.Called(ctx)
-	return args.Get(0).(time.Time), args.Error(1)
-}
-
-func (m *mockConnectionWithToken) GenerateConnectionToken(ctx context.Context) (common.RawSecureValue, error) {
-	args := m.Called(ctx)
-	return args.Get(0).(common.RawSecureValue), args.Error(1)
-}
-
-func (m *mockConnectionWithToken) GenerateRepositoryToken(ctx context.Context, repo *provisioning.Repository) (*connection.ExpirableSecureValue, error) {
-	args := m.Called(ctx, repo)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*connection.ExpirableSecureValue), args.Error(1)
-}
-
-func (m *mockConnectionWithToken) ListRepositories(ctx context.Context) ([]provisioning.ExternalRepository, error) {
-	args := m.Called(ctx)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).([]provisioning.ExternalRepository), args.Error(1)
-}
-
-func (m *mockConnectionWithToken) Test(ctx context.Context) (*provisioning.TestResults, error) {
-	args := m.Called(ctx)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*provisioning.TestResults), args.Error(1)
+	connection.Connection
+	connection.TokenConnection
 }
 
 func TestConnectionController_process(t *testing.T) {
 	testCases := []struct {
 		name          string
-		setupMocks    func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory, interface{})
+		setupMocks    func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory)
 		conn          *provisioning.Connection
 		expectError   bool
 		errorContains string
 	}{
 		{
 			name: "deletion timestamp - skip without error",
-			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory, interface{}) {
+			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory) {
 				mockLister := &mockConnectionLister{
 					conn: &provisioning.Connection{
 						ObjectMeta: metav1.ObjectMeta{
@@ -82,7 +48,7 @@ func TestConnectionController_process(t *testing.T) {
 						},
 					},
 				}
-				return mockLister, nil, nil, nil, nil
+				return mockLister, nil, nil, nil
 			},
 			conn: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{
@@ -95,7 +61,7 @@ func TestConnectionController_process(t *testing.T) {
 		},
 		{
 			name: "no reconcile needed",
-			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory, interface{}) {
+			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory) {
 				mockLister := &mockConnectionLister{
 					conn: &provisioning.Connection{
 						ObjectMeta: metav1.ObjectMeta{
@@ -114,7 +80,7 @@ func TestConnectionController_process(t *testing.T) {
 				}
 				mockHealthChecker := NewMockConnectionHealthChecker(t)
 				mockHealthChecker.EXPECT().ShouldCheckHealth(mock.IsType(&provisioning.Connection{})).Return(false)
-				return mockLister, mockHealthChecker, nil, nil, nil
+				return mockLister, mockHealthChecker, nil, nil
 			},
 			conn: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{
@@ -134,7 +100,7 @@ func TestConnectionController_process(t *testing.T) {
 		},
 		{
 			name: "spec changed - full reconciliation",
-			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory, interface{}) {
+			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory) {
 				mockLister := &mockConnectionLister{
 					conn: &provisioning.Connection{
 						ObjectMeta: metav1.ObjectMeta{
@@ -182,7 +148,7 @@ func TestConnectionController_process(t *testing.T) {
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 				).Return(nil)
 
-				return mockLister, mockHealthChecker, mockStatusPatcher, mockFactory, mockConnection
+				return mockLister, mockHealthChecker, mockStatusPatcher, mockFactory
 			},
 			conn: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{
@@ -209,7 +175,7 @@ func TestConnectionController_process(t *testing.T) {
 		},
 		{
 			name: "unhealthy with token regeneration",
-			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory, interface{}) {
+			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory) {
 				mockLister := &mockConnectionLister{
 					conn: &provisioning.Connection{
 						ObjectMeta: metav1.ObjectMeta{
@@ -237,7 +203,12 @@ func TestConnectionController_process(t *testing.T) {
 				mockHealthChecker := NewMockConnectionHealthChecker(t)
 				mockStatusPatcher := NewMockConnectionStatusPatcher(t)
 				mockFactory := connection.NewMockFactory(t)
-				mockConnWithToken := &mockConnectionWithToken{}
+				mockConnection := connection.NewMockConnection(t)
+				mockTokenConnection := connection.NewMockTokenConnection(t)
+				mockConnWithToken := &mockConnectionWithToken{
+					Connection:      mockConnection,
+					TokenConnection: mockTokenConnection,
+				}
 
 				testResults := &provisioning.TestResults{
 					Success: false,
@@ -253,10 +224,11 @@ func TestConnectionController_process(t *testing.T) {
 
 				mockHealthChecker.EXPECT().ShouldCheckHealth(mock.Anything).Return(true)
 				mockFactory.EXPECT().Build(mock.Anything, mock.Anything).Return(mockConnWithToken, nil)
-				// Token expires in 2 minutes - should trigger regeneration (within 5-minute window)
-				mockConnWithToken.On("TokenExpiration", mock.Anything).Return(time.Now().Add(2*time.Minute), nil)
-				mockConnWithToken.On("GenerateConnectionToken", mock.Anything).
-					Return(common.RawSecureValue("new-token"), nil)
+				// 'old' token - created more than 10 seconds ago
+				mockTokenConnection.EXPECT().TokenCreationTime(mock.Anything).Return(time.Now().Add(-15*time.Second), nil)
+				// Token expires in 2 minutes - should trigger regeneration
+				mockTokenConnection.EXPECT().TokenExpiration(mock.Anything).Return(time.Now().Add(2*time.Minute), nil)
+				mockTokenConnection.EXPECT().GenerateConnectionToken(mock.Anything).Return(common.RawSecureValue("new-token"), nil)
 				mockHealthChecker.EXPECT().RefreshHealthWithPatchOps(mock.Anything, mock.Anything).
 					Return(testResults, healthStatus, []map[string]interface{}{
 						{"op": "replace", "path": "/status/health", "value": healthStatus},
@@ -265,7 +237,7 @@ func TestConnectionController_process(t *testing.T) {
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 				).Return(nil)
 
-				return mockLister, mockHealthChecker, mockStatusPatcher, mockFactory, mockConnWithToken
+				return mockLister, mockHealthChecker, mockStatusPatcher, mockFactory
 			},
 			conn: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{
@@ -292,8 +264,8 @@ func TestConnectionController_process(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "token not expired and not regenerated",
-			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory, interface{}) {
+			name: "token not expired and not regenerated as it's new",
+			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory) {
 				mockLister := &mockConnectionLister{
 					conn: &provisioning.Connection{
 						ObjectMeta: metav1.ObjectMeta{
@@ -316,7 +288,12 @@ func TestConnectionController_process(t *testing.T) {
 				mockHealthChecker := NewMockConnectionHealthChecker(t)
 				mockStatusPatcher := NewMockConnectionStatusPatcher(t)
 				mockFactory := connection.NewMockFactory(t)
-				mockConnWithToken := &mockConnectionWithToken{}
+				mockConnection := connection.NewMockConnection(t)
+				mockTokenConnection := connection.NewMockTokenConnection(t)
+				mockConnWithToken := &mockConnectionWithToken{
+					Connection:      mockConnection,
+					TokenConnection: mockTokenConnection,
+				}
 
 				testResults := &provisioning.TestResults{
 					Success: true,
@@ -329,8 +306,7 @@ func TestConnectionController_process(t *testing.T) {
 
 				mockHealthChecker.EXPECT().ShouldCheckHealth(mock.Anything).Return(true)
 				mockFactory.EXPECT().Build(mock.Anything, mock.Anything).Return(mockConnWithToken, nil)
-				// Token expires in 15 minutes - with buffer of 10m10s (2*5m + 10s), this will NOT trigger regeneration
-				mockConnWithToken.On("TokenExpiration", mock.Anything).Return(time.Now().Add(15*time.Minute), nil)
+				mockTokenConnection.EXPECT().TokenCreationTime(mock.Anything).Return(time.Now().Add(-8*time.Second), nil)
 				mockHealthChecker.EXPECT().RefreshHealthWithPatchOps(mock.Anything, mock.Anything).
 					Return(testResults, healthStatus, []map[string]interface{}{
 						{"op": "replace", "path": "/status/health", "value": healthStatus},
@@ -351,7 +327,94 @@ func TestConnectionController_process(t *testing.T) {
 					},
 				).Return(nil)
 
-				return mockLister, mockHealthChecker, mockStatusPatcher, mockFactory, mockConnWithToken
+				return mockLister, mockHealthChecker, mockStatusPatcher, mockFactory
+			},
+			conn: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-conn",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Status: provisioning.ConnectionStatus{
+					ObservedGeneration: 1,
+					Health: provisioning.HealthStatus{
+						Healthy: true,
+						Checked: time.Now().Add(-10 * time.Minute).UnixMilli(),
+					},
+				},
+				Spec: provisioning.ConnectionSpec{
+					Type: provisioning.GithubConnectionType,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "token not expired and not regenerated",
+			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory) {
+				mockLister := &mockConnectionLister{
+					conn: &provisioning.Connection{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:       "test-conn",
+							Namespace:  "default",
+							Generation: 1,
+						},
+						Status: provisioning.ConnectionStatus{
+							ObservedGeneration: 1,
+							Health: provisioning.HealthStatus{
+								Healthy: true,
+								Checked: time.Now().Add(-10 * time.Minute).UnixMilli(),
+							},
+						},
+						Spec: provisioning.ConnectionSpec{
+							Type: provisioning.GithubConnectionType,
+						},
+					},
+				}
+				mockHealthChecker := NewMockConnectionHealthChecker(t)
+				mockStatusPatcher := NewMockConnectionStatusPatcher(t)
+				mockFactory := connection.NewMockFactory(t)
+				mockConnection := connection.NewMockConnection(t)
+				mockTokenConnection := connection.NewMockTokenConnection(t)
+				mockConnWithToken := &mockConnectionWithToken{
+					Connection:      mockConnection,
+					TokenConnection: mockTokenConnection,
+				}
+
+				testResults := &provisioning.TestResults{
+					Success: true,
+					Code:    http.StatusOK,
+				}
+				healthStatus := provisioning.HealthStatus{
+					Healthy: true,
+					Checked: time.Now().UnixMilli(),
+				}
+
+				mockHealthChecker.EXPECT().ShouldCheckHealth(mock.Anything).Return(true)
+				mockFactory.EXPECT().Build(mock.Anything, mock.Anything).Return(mockConnWithToken, nil)
+				mockTokenConnection.EXPECT().TokenCreationTime(mock.Anything).Return(time.Now().Add(-15*time.Second), nil)
+				// Token expires in 15 minutes - with buffer of 10m10s (2*5m + 10s), this will NOT trigger regeneration
+				mockTokenConnection.EXPECT().TokenExpiration(mock.Anything).Return(time.Now().Add(15*time.Minute), nil)
+				mockHealthChecker.EXPECT().RefreshHealthWithPatchOps(mock.Anything, mock.Anything).
+					Return(testResults, healthStatus, []map[string]interface{}{
+						{"op": "replace", "path": "/status/health", "value": healthStatus},
+					}, nil)
+				mockStatusPatcher.EXPECT().Patch(
+					mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+				).Run(
+					func(ctx context.Context, conn *provisioning.Connection, patchOperations ...map[string]interface{}) {
+						found := false
+						for _, op := range patchOperations {
+							if op["op"].(string) == "replace" &&
+								op["path"].(string) == "/secure/token" &&
+								op["value"].(map[string]string)["create"] == "someToken" {
+								found = true
+							}
+						}
+						require.False(t, found)
+					},
+				).Return(nil)
+
+				return mockLister, mockHealthChecker, mockStatusPatcher, mockFactory
 			},
 			conn: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{
@@ -374,7 +437,7 @@ func TestConnectionController_process(t *testing.T) {
 		},
 		{
 			name: "token not expired but regenerated",
-			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory, interface{}) {
+			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory) {
 				mockLister := &mockConnectionLister{
 					conn: &provisioning.Connection{
 						ObjectMeta: metav1.ObjectMeta{
@@ -397,7 +460,12 @@ func TestConnectionController_process(t *testing.T) {
 				mockHealthChecker := NewMockConnectionHealthChecker(t)
 				mockStatusPatcher := NewMockConnectionStatusPatcher(t)
 				mockFactory := connection.NewMockFactory(t)
-				mockConnWithToken := &mockConnectionWithToken{}
+				mockConnection := connection.NewMockConnection(t)
+				mockTokenConnection := connection.NewMockTokenConnection(t)
+				mockConnWithToken := &mockConnectionWithToken{
+					Connection:      mockConnection,
+					TokenConnection: mockTokenConnection,
+				}
 
 				testResults := &provisioning.TestResults{
 					Success: true,
@@ -410,9 +478,10 @@ func TestConnectionController_process(t *testing.T) {
 
 				mockHealthChecker.EXPECT().ShouldCheckHealth(mock.Anything).Return(true)
 				mockFactory.EXPECT().Build(mock.Anything, mock.Anything).Return(mockConnWithToken, nil)
+				mockTokenConnection.EXPECT().TokenCreationTime(mock.Anything).Return(time.Now().Add(-15*time.Second), nil)
 				// Token expires in 9 minutes - with buffer of 10m10s (2*5m + 10s), this WILL trigger regeneration
-				mockConnWithToken.On("TokenExpiration", mock.Anything).Return(time.Now().Add(9*time.Minute), nil)
-				mockConnWithToken.On("GenerateConnectionToken", mock.Anything).Return(common.RawSecureValue("someToken"), nil)
+				mockTokenConnection.EXPECT().TokenExpiration(mock.Anything).Return(time.Now().Add(9*time.Minute), nil)
+				mockTokenConnection.EXPECT().GenerateConnectionToken(mock.Anything).Return("someToken", nil)
 				mockHealthChecker.EXPECT().RefreshHealthWithPatchOps(mock.Anything, mock.Anything).
 					Return(testResults, healthStatus, []map[string]interface{}{
 						{"op": "replace", "path": "/status/health", "value": healthStatus},
@@ -433,7 +502,7 @@ func TestConnectionController_process(t *testing.T) {
 					},
 				).Return(nil)
 
-				return mockLister, mockHealthChecker, mockStatusPatcher, mockFactory, mockConnWithToken
+				return mockLister, mockHealthChecker, mockStatusPatcher, mockFactory
 			},
 			conn: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{
@@ -456,7 +525,7 @@ func TestConnectionController_process(t *testing.T) {
 		},
 		{
 			name: "health check failure",
-			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory, interface{}) {
+			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory) {
 				mockLister := &mockConnectionLister{
 					conn: &provisioning.Connection{
 						ObjectMeta: metav1.ObjectMeta{
@@ -485,7 +554,7 @@ func TestConnectionController_process(t *testing.T) {
 				mockHealthChecker.EXPECT().RefreshHealthWithPatchOps(mock.Anything, mock.Anything).
 					Return(nil, provisioning.HealthStatus{}, nil, errors.New("health check failed"))
 
-				return mockLister, mockHealthChecker, nil, mockFactory, mockConnection
+				return mockLister, mockHealthChecker, nil, mockFactory
 			},
 			conn: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{
@@ -509,7 +578,7 @@ func TestConnectionController_process(t *testing.T) {
 		},
 		{
 			name: "patch error",
-			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory, interface{}) {
+			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory) {
 				mockLister := &mockConnectionLister{
 					conn: &provisioning.Connection{
 						ObjectMeta: metav1.ObjectMeta{
@@ -549,7 +618,7 @@ func TestConnectionController_process(t *testing.T) {
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 				).Return(errors.New("patch failed"))
 
-				return mockLister, mockHealthChecker, mockStatusPatcher, mockFactory, mockConnection
+				return mockLister, mockHealthChecker, mockStatusPatcher, mockFactory
 			},
 			conn: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{
@@ -569,10 +638,10 @@ func TestConnectionController_process(t *testing.T) {
 		},
 		{
 			name: "connection not found",
-			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory, interface{}) {
+			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory) {
 				mockLister := &mockConnectionLister{}
 
-				return mockLister, nil, nil, nil, nil
+				return mockLister, nil, nil, nil
 			},
 			conn: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{
@@ -584,7 +653,7 @@ func TestConnectionController_process(t *testing.T) {
 		},
 		{
 			name: "build connection error",
-			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory, interface{}) {
+			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory) {
 				mockLister := &mockConnectionLister{
 					conn: &provisioning.Connection{
 						ObjectMeta: metav1.ObjectMeta{
@@ -607,7 +676,7 @@ func TestConnectionController_process(t *testing.T) {
 				mockFactory.EXPECT().Build(mock.Anything, mock.Anything).
 					Return(nil, errors.New("failed to build connection"))
 
-				return mockLister, mockHealthChecker, nil, mockFactory, nil
+				return mockLister, mockHealthChecker, nil, mockFactory
 			},
 			conn: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{
@@ -626,8 +695,8 @@ func TestConnectionController_process(t *testing.T) {
 			errorContains: "failed to build connection",
 		},
 		{
-			name: "token expiration check error",
-			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory, interface{}) {
+			name: "token creation check error",
+			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory) {
 				mockLister := &mockConnectionLister{
 					conn: &provisioning.Connection{
 						ObjectMeta: metav1.ObjectMeta{
@@ -649,14 +718,75 @@ func TestConnectionController_process(t *testing.T) {
 				}
 				mockHealthChecker := NewMockConnectionHealthChecker(t)
 				mockFactory := connection.NewMockFactory(t)
-				mockConnWithToken := &mockConnectionWithToken{}
+				mockConnection := connection.NewMockConnection(t)
+				mockTokenConnection := connection.NewMockTokenConnection(t)
+				mockConnWithToken := &mockConnectionWithToken{
+					Connection:      mockConnection,
+					TokenConnection: mockTokenConnection,
+				}
 
 				mockHealthChecker.EXPECT().ShouldCheckHealth(mock.Anything).Return(true)
 				mockFactory.EXPECT().Build(mock.Anything, mock.Anything).Return(mockConnWithToken, nil)
-				mockConnWithToken.On("TokenExpiration", mock.Anything).
-					Return(time.Time{}, errors.New("failed to check token expiration"))
+				mockTokenConnection.EXPECT().TokenCreationTime(mock.Anything).Return(time.Time{}, errors.New("failed to check token expiration"))
 
-				return mockLister, mockHealthChecker, nil, mockFactory, mockConnWithToken
+				return mockLister, mockHealthChecker, nil, mockFactory
+			},
+			conn: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-conn",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Status: provisioning.ConnectionStatus{
+					ObservedGeneration: 1,
+					Health: provisioning.HealthStatus{
+						Healthy: true,
+						Checked: time.Now().Add(-10 * time.Minute).UnixMilli(),
+					},
+				},
+				Spec: provisioning.ConnectionSpec{
+					Type: provisioning.GithubConnectionType,
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "token expiration check error",
+			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory) {
+				mockLister := &mockConnectionLister{
+					conn: &provisioning.Connection{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:       "test-conn",
+							Namespace:  "default",
+							Generation: 1,
+						},
+						Status: provisioning.ConnectionStatus{
+							ObservedGeneration: 1,
+							Health: provisioning.HealthStatus{
+								Healthy: true,
+								Checked: time.Now().Add(-10 * time.Minute).UnixMilli(),
+							},
+						},
+						Spec: provisioning.ConnectionSpec{
+							Type: provisioning.GithubConnectionType,
+						},
+					},
+				}
+				mockHealthChecker := NewMockConnectionHealthChecker(t)
+				mockFactory := connection.NewMockFactory(t)
+				mockConnection := connection.NewMockConnection(t)
+				mockTokenConnection := connection.NewMockTokenConnection(t)
+				mockConnWithToken := &mockConnectionWithToken{
+					Connection:      mockConnection,
+					TokenConnection: mockTokenConnection,
+				}
+
+				mockHealthChecker.EXPECT().ShouldCheckHealth(mock.Anything).Return(true)
+				mockFactory.EXPECT().Build(mock.Anything, mock.Anything).Return(mockConnWithToken, nil)
+				mockTokenConnection.EXPECT().TokenCreationTime(mock.Anything).Return(time.Now().Add(-15*time.Second), nil)
+				mockTokenConnection.EXPECT().TokenExpiration(mock.Anything).Return(time.Time{}, errors.New("failed to check token expiration"))
+
+				return mockLister, mockHealthChecker, nil, mockFactory
 			},
 			conn: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{
@@ -679,7 +809,7 @@ func TestConnectionController_process(t *testing.T) {
 		},
 		{
 			name: "token generation error - continues with health check",
-			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory, interface{}) {
+			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory) {
 				mockLister := &mockConnectionLister{
 					conn: &provisioning.Connection{
 						ObjectMeta: metav1.ObjectMeta{
@@ -702,7 +832,12 @@ func TestConnectionController_process(t *testing.T) {
 				mockHealthChecker := NewMockConnectionHealthChecker(t)
 				mockStatusPatcher := NewMockConnectionStatusPatcher(t)
 				mockFactory := connection.NewMockFactory(t)
-				mockConnWithToken := &mockConnectionWithToken{}
+				mockConnection := connection.NewMockConnection(t)
+				mockTokenConnection := connection.NewMockTokenConnection(t)
+				mockConnWithToken := &mockConnectionWithToken{
+					Connection:      mockConnection,
+					TokenConnection: mockTokenConnection,
+				}
 
 				testResults := &provisioning.TestResults{
 					Success: false,
@@ -716,9 +851,9 @@ func TestConnectionController_process(t *testing.T) {
 				mockHealthChecker.EXPECT().ShouldCheckHealth(mock.Anything).Return(true)
 				mockFactory.EXPECT().Build(mock.Anything, mock.Anything).Return(mockConnWithToken, nil)
 				// Token expires in 2 minutes - should trigger regeneration attempt (within 5-minute window)
-				mockConnWithToken.On("TokenExpiration", mock.Anything).Return(time.Now().Add(2*time.Minute), nil)
-				mockConnWithToken.On("GenerateConnectionToken", mock.Anything).
-					Return(common.RawSecureValue(""), errors.New("token generation failed"))
+				mockTokenConnection.EXPECT().TokenExpiration(mock.Anything).Return(time.Now().Add(2*time.Minute), nil)
+				mockTokenConnection.EXPECT().GenerateConnectionToken(mock.Anything).
+					Return("", errors.New("token generation failed"))
 				mockHealthChecker.EXPECT().RefreshHealthWithPatchOps(mock.Anything, mock.Anything).
 					Return(testResults, healthStatus, []map[string]interface{}{
 						{"op": "replace", "path": "/status/health", "value": healthStatus},
@@ -727,7 +862,7 @@ func TestConnectionController_process(t *testing.T) {
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 				).Return(nil)
 
-				return mockLister, mockHealthChecker, mockStatusPatcher, mockFactory, mockConnWithToken
+				return mockLister, mockHealthChecker, mockStatusPatcher, mockFactory
 			},
 			conn: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{
@@ -752,7 +887,7 @@ func TestConnectionController_process(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			mockLister, mockHealthChecker, mockStatusPatcher, mockFactory, extraMock := tt.setupMocks()
+			mockLister, mockHealthChecker, mockStatusPatcher, mockFactory := tt.setupMocks()
 			cc := &ConnectionController{
 				connLister:        mockLister,
 				healthChecker:     mockHealthChecker,
@@ -783,12 +918,6 @@ func TestConnectionController_process(t *testing.T) {
 			}
 			if mockFactory != nil {
 				mockFactory.AssertExpectations(t)
-			}
-			if extraMock != nil {
-				switch m := extraMock.(type) {
-				case *mockConnectionWithToken:
-					m.AssertExpectations(t)
-				}
 			}
 		})
 	}

--- a/pkg/registry/apis/provisioning/controller/connection_test.go
+++ b/pkg/registry/apis/provisioning/controller/connection_test.go
@@ -850,6 +850,7 @@ func TestConnectionController_process(t *testing.T) {
 
 				mockHealthChecker.EXPECT().ShouldCheckHealth(mock.Anything).Return(true)
 				mockFactory.EXPECT().Build(mock.Anything, mock.Anything).Return(mockConnWithToken, nil)
+				mockTokenConnection.EXPECT().TokenCreationTime(mock.Anything).Return(time.Now().Add(-15*time.Second), nil)
 				// Token expires in 2 minutes - should trigger regeneration attempt (within 5-minute window)
 				mockTokenConnection.EXPECT().TokenExpiration(mock.Anything).Return(time.Now().Add(2*time.Minute), nil)
 				mockTokenConnection.EXPECT().GenerateConnectionToken(mock.Anything).

--- a/pkg/registry/apis/provisioning/controller/connection_test.go
+++ b/pkg/registry/apis/provisioning/controller/connection_test.go
@@ -666,6 +666,7 @@ func TestConnectionController_process(t *testing.T) {
 				statusPatcher:     mockStatusPatcher,
 				connectionFactory: mockFactory,
 				logger:            logging.DefaultLogger,
+				resyncInterval:    5 * time.Minute,
 			}
 
 			item := &connectionQueueItem{key: tt.conn.Namespace + "/" + tt.conn.Name}

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -671,7 +671,7 @@ func (rc *RepositoryController) shouldGenerateTokenFromConnection(
 	// - The repo is not healthy
 	// - The token will expire before the next resync interval
 	// - The linked connection is healthy (which means it is able to generate valid tokens)
-	expirationBeforeNextResync := time.UnixMilli(obj.Status.Token.Expiration).Before(time.Now().Add(rc.resyncInterval))
+	expirationBeforeNextResync := shouldRefreshBeforeExpiration(time.UnixMilli(obj.Status.Token.Expiration), rc.resyncInterval)
 	return !healthStatus.Healthy &&
 		expirationBeforeNextResync &&
 		c.Status.Health.Healthy

--- a/pkg/registry/apis/provisioning/controller/token_refresh.go
+++ b/pkg/registry/apis/provisioning/controller/token_refresh.go
@@ -1,0 +1,19 @@
+package controller
+
+import "time"
+
+const tokenRefreshBufferSeconds = 10
+
+// shouldRefreshBeforeExpiration determines if a token should be refreshed based on its expiration time
+// and the controller's resync interval.
+//
+// The function uses a buffer calculation of (2 * resyncInterval + 10 seconds) to ensure tokens are
+// refreshed well before they expire, avoiding timing issues.
+//
+// Examples:
+//   - resyncInterval = 5 minutes: refresh 10 minutes and 10 seconds before expiration
+//   - resyncInterval = 60 seconds: refresh 130 seconds (2m10s) before expiration
+func shouldRefreshBeforeExpiration(expiration time.Time, resyncInterval time.Duration) bool {
+	buffer := (2 * resyncInterval) + (tokenRefreshBufferSeconds * time.Second)
+	return expiration.Before(time.Now().Add(buffer))
+}

--- a/pkg/registry/apis/provisioning/controller/token_refresh.go
+++ b/pkg/registry/apis/provisioning/controller/token_refresh.go
@@ -4,6 +4,10 @@ import "time"
 
 const tokenRefreshBufferSeconds = 10
 
+func tokenRecentlyCreated(issuingTime time.Time) bool {
+	return issuingTime.After(time.Now().Add(-tokenRefreshBufferSeconds * time.Second))
+}
+
 // shouldRefreshBeforeExpiration determines if a token should be refreshed based on its expiration time
 // and the controller's resync interval.
 //

--- a/pkg/registry/apis/provisioning/controller/token_refresh_test.go
+++ b/pkg/registry/apis/provisioning/controller/token_refresh_test.go
@@ -1,0 +1,97 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_shouldRefreshBeforeExpiration(t *testing.T) {
+	tests := []struct {
+		name           string
+		resyncInterval time.Duration
+		expiration     time.Time
+		want           bool
+	}{
+		{
+			name:           "should refresh when expiration is before buffer (5 minute interval)",
+			resyncInterval: 5 * time.Minute,
+			expiration:     time.Now().Add(9 * time.Minute), // Less than 2*5m + 10s (10m10s)
+			want:           true,
+		},
+		{
+			name:           "should not refresh when expiration is after buffer (5 minute interval)",
+			resyncInterval: 5 * time.Minute,
+			expiration:     time.Now().Add(11 * time.Minute), // More than 2*5m + 10s (10m10s)
+			want:           false,
+		},
+		{
+			name:           "should refresh when expiration is before buffer (60 second interval)",
+			resyncInterval: 60 * time.Second,
+			expiration:     time.Now().Add(2 * time.Minute), // Less than 2*60s + 10s (130s)
+			want:           true,
+		},
+		{
+			name:           "should not refresh when expiration is after buffer (60 second interval)",
+			resyncInterval: 60 * time.Second,
+			expiration:     time.Now().Add(3 * time.Minute), // More than 2*60s + 10s (130s)
+			want:           false,
+		},
+		{
+			name:           "should not refresh when expiration is just after buffer boundary",
+			resyncInterval: 5 * time.Minute,
+			expiration:     time.Now().Add((2 * 5 * time.Minute) + (10 * time.Second) + (1 * time.Second)),
+			want:           false, // Just after the threshold
+		},
+		{
+			name:           "should refresh when token already expired",
+			resyncInterval: 5 * time.Minute,
+			expiration:     time.Now().Add(-1 * time.Minute), // Already expired
+			want:           true,
+		},
+		{
+			name:           "should refresh with very short resync interval",
+			resyncInterval: 10 * time.Second,
+			expiration:     time.Now().Add(25 * time.Second), // Less than 2*10s + 10s (30s)
+			want:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldRefreshBeforeExpiration(tt.expiration, tt.resyncInterval)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_shouldRefreshBeforeExpiration_bufferCalculation(t *testing.T) {
+	// Test that the buffer is correctly calculated as 2 * resyncInterval + 10 seconds
+
+	t.Run("5 minute interval results in 10m10s buffer", func(t *testing.T) {
+		resyncInterval := 5 * time.Minute
+		expectedBuffer := (2 * resyncInterval) + (tokenRefreshBufferSeconds * time.Second)
+
+		// Token expiring just before the buffer should trigger refresh
+		expiration := time.Now().Add(expectedBuffer - time.Second)
+		assert.True(t, shouldRefreshBeforeExpiration(expiration, resyncInterval))
+
+		// Token expiring just after the buffer should not trigger refresh
+		expiration = time.Now().Add(expectedBuffer + time.Second)
+		assert.False(t, shouldRefreshBeforeExpiration(expiration, resyncInterval))
+	})
+
+	t.Run("1 minute interval results in 2m10s buffer", func(t *testing.T) {
+		resyncInterval := 1 * time.Minute
+		expectedBuffer := (2 * resyncInterval) + (tokenRefreshBufferSeconds * time.Second)
+
+		// Token expiring just before the buffer should trigger refresh
+		expiration := time.Now().Add(expectedBuffer - time.Second)
+		assert.True(t, shouldRefreshBeforeExpiration(expiration, resyncInterval))
+
+		// Token expiring just after the buffer should not trigger refresh
+		expiration = time.Now().Add(expectedBuffer + time.Second)
+		assert.False(t, shouldRefreshBeforeExpiration(expiration, resyncInterval))
+	})
+}

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -754,7 +754,8 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 			}
 
 			// Informer with resync interval used for health check and reconciliation
-			sharedInformerFactory := informers.NewSharedInformerFactory(c, 60*time.Second)
+			informerFactoryResyncInterval := 60 * time.Second
+			sharedInformerFactory := informers.NewSharedInformerFactory(c, informerFactoryResyncInterval)
 			repoInformer := sharedInformerFactory.Provisioning().V0alpha1().Repositories()
 			jobInformer := sharedInformerFactory.Provisioning().V0alpha1().Jobs()
 			connInformer := sharedInformerFactory.Provisioning().V0alpha1().Connections()
@@ -871,6 +872,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				b.registry,
 				b.tracer,
 				10,
+				informerFactoryResyncInterval,
 			)
 			if err != nil {
 				return err
@@ -888,6 +890,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				connStatusPatcher,
 				connHealthChecker,
 				b.connectionFactory,
+				informerFactoryResyncInterval,
 			)
 			if err != nil {
 				return err

--- a/pkg/tests/apis/provisioning/helper_test.go
+++ b/pkg/tests/apis/provisioning/helper_test.go
@@ -840,6 +840,17 @@ func unstructuredToRepository(t *testing.T, obj *unstructured.Unstructured) *pro
 	return repo
 }
 
+func unstructuredToConnection(t *testing.T, obj *unstructured.Unstructured) *provisioning.Connection {
+	bytes, err := obj.MarshalJSON()
+	require.NoError(t, err)
+
+	c := &provisioning.Connection{}
+	err = json.Unmarshal(bytes, c)
+	require.NoError(t, err)
+
+	return c
+}
+
 // postFilesRequest performs a direct HTTP POST request to the files API.
 // This bypasses Kubernetes REST client limitations with '/' characters in subresource names.
 type filesPostOptions struct {

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -1067,11 +1067,7 @@ func TestIntegrationProvisioning_RefsPermissions(t *testing.T) {
 }
 
 func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
-	// TODO: flaky test, its currently causing post merge checks to fail
-	// as well as gating PRs pretty consistently.
-	t.Skip("skipping repository connection test")
-
-	// testutil.SkipIntegrationTestInShortMode(t)
+	testutil.SkipIntegrationTestInShortMode(t)
 
 	helper := runGrafana(t)
 	ctx := context.Background()


### PR DESCRIPTION
**What is this feature?**

This PR updates the token refresh check in `Repository` and `Connection` controllers, so that it's bound to the resync inteval.
I.e. if the token is going to expire between resyncs, the controllers should update it. 

Additionally, it solved a flaky provisioning test

**Why do we need this feature?**

`Repository` and `Connection` controllers have the responsibility of updating the resources' `secure.token` value.
Current token refresh check might cause the token to be expired between resyncs. 
This new implementation fixes it.

**Who is this feature for?**

Users of GitSync.

**Which issue(s) does this PR fix?**:

No issues - this is a followup from https://github.com/grafana/grafana/pull/116613

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
