### PR TITLE
VizSuggestions: Update empty state

### DIFF
--- a/public/app/features/panel/components/PanelDataErrorView.test.tsx
+++ b/public/app/features/panel/components/PanelDataErrorView.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { defaultsDeep } from 'lodash';
 import { Provider } from 'react-redux';
 
-import { CoreApp, EventBusSrv, FieldType, getDefaultTimeRange, LoadingState } from '@grafana/data';
+import { CoreApp, DataQueryRequest, EventBusSrv, FieldType, getDefaultTimeRange, LoadingState } from '@grafana/data';
 import { config, PanelDataErrorViewProps } from '@grafana/runtime';
 import { usePanelContext } from '@grafana/ui';
 import { configureStore } from 'app/store/configureStore';
@@ -26,6 +26,11 @@ const mockUsePanelContext = jest.mocked(usePanelContext);
 const RUN_QUERY_MESSAGE = 'Run a query to visualize it here or go to all visualizations to add other panel types';
 const panelContextRoot = {
   app: CoreApp.Dashboard,
+  eventsScope: 'global',
+  eventBus: new EventBusSrv(),
+};
+const panelContextEditor = {
+  app: CoreApp.PanelEditor,
   eventsScope: 'global',
   eventBus: new EventBusSrv(),
 };
@@ -89,7 +94,49 @@ describe('PanelDataErrorView', () => {
     expect(screen.getByText('Query returned nothing')).toBeInTheDocument();
   });
 
-  it('should show "Run a query..." message when no query is configured and feature toggle is enabled', () => {
+  it('should show "Run a query..." message when no query is configured and feature toggle is enabled in panel editor', () => {
+    mockUsePanelContext.mockReturnValue(panelContextEditor);
+
+    const originalFeatureToggle = config.featureToggles.newVizSuggestions;
+    config.featureToggles.newVizSuggestions = true;
+
+    const { container } = renderWithProps({
+      data: {
+        state: LoadingState.Done,
+        series: [],
+        timeRange: getDefaultTimeRange(),
+      },
+    });
+
+    expect(screen.getByText(RUN_QUERY_MESSAGE)).toBeInTheDocument();
+    // icon
+    const icon = container.querySelector('svg');
+    expect(icon).toBeInTheDocument();
+
+    config.featureToggles.newVizSuggestions = originalFeatureToggle;
+  });
+
+  it('should show "No data" message when feature toggle is disabled even without queries', () => {
+    mockUsePanelContext.mockReturnValue(panelContextEditor);
+
+    const originalFeatureToggle = config.featureToggles.newVizSuggestions;
+    config.featureToggles.newVizSuggestions = false;
+
+    renderWithProps({
+      data: {
+        state: LoadingState.Done,
+        series: [],
+        timeRange: getDefaultTimeRange(),
+      },
+    });
+
+    expect(screen.getByText('No data')).toBeInTheDocument();
+    expect(screen.queryByText(RUN_QUERY_MESSAGE)).not.toBeInTheDocument();
+
+    config.featureToggles.newVizSuggestions = originalFeatureToggle;
+  });
+
+  it('should show "No data" message when feature toggle is enabled but not in panel editor', () => {
     mockUsePanelContext.mockReturnValue(panelContextRoot);
 
     const originalFeatureToggle = config.featureToggles.newVizSuggestions;
@@ -103,22 +150,26 @@ describe('PanelDataErrorView', () => {
       },
     });
 
-    expect(screen.getByText(RUN_QUERY_MESSAGE)).toBeInTheDocument();
+    expect(screen.getByText('No data')).toBeInTheDocument();
+    expect(screen.queryByText(RUN_QUERY_MESSAGE)).not.toBeInTheDocument();
 
     config.featureToggles.newVizSuggestions = originalFeatureToggle;
   });
 
-  it('should show "No data" message when feature toggle is disabled even without queries', () => {
-    mockUsePanelContext.mockReturnValue(panelContextRoot);
+  it('should show "No data" message when feature toggle is enabled in panel editor and query is configured', () => {
+    mockUsePanelContext.mockReturnValue(panelContextEditor);
 
     const originalFeatureToggle = config.featureToggles.newVizSuggestions;
-    config.featureToggles.newVizSuggestions = false;
+    config.featureToggles.newVizSuggestions = true;
 
     renderWithProps({
       data: {
         state: LoadingState.Done,
         series: [],
         timeRange: getDefaultTimeRange(),
+        request: {
+          targets: [{ refId: 'A' }],
+        } as unknown as DataQueryRequest,
       },
     });
 

--- a/public/app/features/panel/components/PanelDataErrorView.tsx
+++ b/public/app/features/panel/components/PanelDataErrorView.tsx
@@ -35,7 +35,6 @@ export function PanelDataErrorView(props: PanelDataErrorViewProps) {
   const styles = useStyles2(getStyles);
   const context = usePanelContext();
   const dataSummary = getPanelDataSummary(props.data.series);
-  const message = getMessageFor(props, dataSummary);
   const dispatch = useDispatch();
 
   const dashboardScene: DashboardScene | undefined = window.__grafanaSceneContext;
@@ -101,8 +100,10 @@ export function PanelDataErrorView(props: PanelDataErrorViewProps) {
 
   const noData = !hasData(props.data);
   const noQueryConfigured = hasNoQueryConfigured(props.data);
-  const showEmptyState =
-    config.featureToggles.newVizSuggestions && context.app === CoreApp.PanelEditor && noQueryConfigured && noData;
+  const showEmptyState = Boolean(
+    config.featureToggles.newVizSuggestions && context.app === CoreApp.PanelEditor && noQueryConfigured && noData
+  );
+  const message = getMessageFor(props, dataSummary, showEmptyState);
 
   return (
     <div className={styles.wrapper}>
@@ -137,16 +138,16 @@ export function PanelDataErrorView(props: PanelDataErrorViewProps) {
 
 function getMessageFor(
   { data, fieldConfig, message, needsNumberField, needsTimeField, needsStringField }: PanelDataErrorViewProps,
-  dataSummary: PanelDataSummary
+  dataSummary: PanelDataSummary,
+  showEmptyState: boolean
 ): string {
   if (message) {
     return message;
   }
 
   const noData = !hasData(data);
-  const noQueryConfigured = hasNoQueryConfigured(data);
 
-  if (config.featureToggles.newVizSuggestions && noQueryConfigured && noData) {
+  if (showEmptyState) {
     return t(
       'dashboard.new-panel.empty-state-message',
       'Run a query to visualize it here or go to all visualizations to add other panel types'


### PR DESCRIPTION
This PR prevents showing the the new empty state in explore (ie - only show it in panel edit).



**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
