### PR TITLE
Alerting: Extract centralised file for document URLs

### DIFF
--- a/public/app/features/alerting/unified/components/InhibitionRulesAlert.test.tsx
+++ b/public/app/features/alerting/unified/components/InhibitionRulesAlert.test.tsx
@@ -8,6 +8,7 @@ import {
   setAlertmanagerConfig,
 } from 'app/features/alerting/unified/mocks/server/entities/alertmanagers';
 import { GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
+import { DOCS_URL_INHIBITION_RULES } from 'app/features/alerting/unified/utils/docs';
 
 import { InhibitionRulesAlert } from './InhibitionRulesAlert';
 
@@ -68,10 +69,7 @@ describe('InhibitionRulesAlert', () => {
 
     const link = await screen.findByRole('link', { name: /Learn more about inhibition rules/i });
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute(
-      'href',
-      'https://grafana.com/docs/grafana/latest/alerting/configure-notifications/create-silence/#inhibition-rules'
-    );
+    expect(link).toHaveAttribute('href', DOCS_URL_INHIBITION_RULES);
   });
 
   it('should not render when alertmanagerSourceName is empty', async () => {

--- a/public/app/features/alerting/unified/components/InhibitionRulesAlert.tsx
+++ b/public/app/features/alerting/unified/components/InhibitionRulesAlert.tsx
@@ -4,9 +4,7 @@ import { Trans, t } from '@grafana/i18n';
 import { Alert, TextLink } from '@grafana/ui';
 
 import { useHasInhibitionRules } from '../hooks/useHasInhibitionRules';
-
-const INHIBITION_RULES_DOCS_URL =
-  'https://grafana.com/docs/grafana/latest/alerting/configure-notifications/create-silence/#inhibition-rules';
+import { DOCS_URL_INHIBITION_RULES } from '../utils/docs';
 
 type ExtraAlertProps = Omit<ComponentPropsWithoutRef<typeof Alert>, 'title' | 'severity'>;
 
@@ -27,7 +25,7 @@ export function InhibitionRulesAlert({ alertmanagerSourceName, ...rest }: Inhibi
         This Alertmanager has inhibition rules configured. Some alerts may be suppressed when matching alerts are
         firing.
       </Trans>{' '}
-      <TextLink href={INHIBITION_RULES_DOCS_URL} external>
+      <TextLink href={DOCS_URL_INHIBITION_RULES} external>
         <Trans i18nKey="alerting.inhibition-rules.learn-more">Learn more about inhibition rules</Trans>
       </TextLink>
     </Alert>

--- a/public/app/features/alerting/unified/components/export/FileExportPreview.tsx
+++ b/public/app/features/alerting/unified/components/export/FileExportPreview.tsx
@@ -8,6 +8,12 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Alert, Button, ClipboardButton, CodeEditor, TextLink, useStyles2 } from '@grafana/ui';
 
+import {
+  DOCS_URL_FILE_PROVISIONING,
+  DOCS_URL_HTTP_API_PROVISIONING,
+  DOCS_URL_TERRAFORM_PROVISIONING,
+} from '../../utils/docs';
+
 import { ExportFormats, ExportProvider, ProvisioningType, allGrafanaExportProviders } from './providers';
 
 interface FileExportPreviewProps {
@@ -103,10 +109,7 @@ function FileExportInlineDocumentation({ exportProvider }: { exportProvider: Exp
       component: (
         <Trans i18nKey="alerting.file-export-inline-documentation.file-provisioning">
           {{ name }} format is only valid for File Provisioning.{' '}
-          <TextLink
-            href="https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/file-provisioning/"
-            external
-          >
+          <TextLink href={DOCS_URL_FILE_PROVISIONING} external>
             Read more in the docs.
           </TextLink>
         </Trans>
@@ -120,10 +123,7 @@ function FileExportInlineDocumentation({ exportProvider }: { exportProvider: Exp
       component: (
         <Trans i18nKey="alerting.file-export-inline-documentation.api-provisioning">
           {{ name }} format is only valid for API Provisioning.{' '}
-          <TextLink
-            href="https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/http-api-provisioning/"
-            external
-          >
+          <TextLink href={DOCS_URL_HTTP_API_PROVISIONING} external>
             Read more in the docs.
           </TextLink>
         </Trans>
@@ -137,10 +137,7 @@ function FileExportInlineDocumentation({ exportProvider }: { exportProvider: Exp
       component: (
         <Trans i18nKey="alerting.file-export-inline-documentation.terraform-provisioning">
           {{ name }} format is only valid for Terraform Provisioning.{' '}
-          <TextLink
-            href="https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/"
-            external
-          >
+          <TextLink href={DOCS_URL_TERRAFORM_PROVISIONING} external>
             Read more in the docs.
           </TextLink>
         </Trans>

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.tsx
@@ -30,6 +30,7 @@ import {
   isSupportedExternalPrometheusFlavoredRulesSourceType,
   isValidRecordingRulesTarget,
 } from '../../utils/datasource';
+import { DOCS_URL_ALERTING_MIGRATION } from '../../utils/docs';
 import { stringifyErrorLike } from '../../utils/misc';
 import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { AlertingPageWrapper } from '../AlertingPageWrapper';
@@ -454,7 +455,7 @@ function DataSourceField() {
             {t('alerting.import-to-gma.datasource.label', 'Data source')}
           </Text>
           <NeedHelpInfo
-            externalLink={'https://grafana.com/docs/grafana/latest/alerting/alerting-rules/alerting-migration/'}
+            externalLink={DOCS_URL_ALERTING_MIGRATION}
             linkText={`Read importing to Grafana alerting`}
             contentText={t(
               'alerting.import-to-gma.datasource.help-info.content',

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -34,6 +34,7 @@ import { AccessControlAction } from 'app/types/accessControl';
 import { AITemplateButtonComponent } from '../../enterprise-components/AI/AIGenTemplateButton/addAITemplateButton';
 import { KnownProvenance } from '../../types/knownProvenance';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
+import { DOCS_URL_TEMPLATE_EXAMPLES, DOCS_URL_TEMPLATE_NOTIFICATIONS } from '../../utils/docs';
 import { isProvisionedResource } from '../../utils/k8s/utils';
 import { makeAMLink, stringifyErrorLike } from '../../utils/misc';
 import { EditorColumnHeader } from '../EditorColumnHeader';
@@ -293,7 +294,7 @@ export const TemplateForm = ({ originalTemplate, prefill, alertmanager }: Props)
                                             'alerting.template-form.label-examples-documentation',
                                             'Examples documentation'
                                           )}
-                                          url="https://grafana.com/docs/grafana/latest/alerting/configure-notifications/template-notifications/examples/"
+                                          url={DOCS_URL_TEMPLATE_EXAMPLES}
                                           target="_blank"
                                           icon="external-link-alt"
                                         />
@@ -419,7 +420,7 @@ For detailed information about notification templates, refer to our documentatio
           <div style={{ whiteSpace: 'pre' }}>{intro}</div>
           <div>
             <LinkButton
-              href="https://grafana.com/docs/grafana/latest/alerting/manage-notifications/template-notifications/"
+              href={DOCS_URL_TEMPLATE_NOTIFICATIONS}
               target="_blank"
               icon="external-link-alt"
               variant="secondary"

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
@@ -11,6 +11,7 @@ import { Button, Field, Input, Stack, Text, TextArea, useStyles2 } from '@grafan
 import { AIImproveAnnotationsButtonComponent } from '../../enterprise-components/AI/AIGenImproveAnnotationsButton/addAIImproveAnnotationsButton';
 import { RuleFormValues } from '../../types/rule-form';
 import { Annotation, annotationLabels } from '../../utils/constants';
+import { DOCS_URL_ANNOTATIONS } from '../../utils/docs';
 import { isGrafanaManagedRuleByType } from '../../utils/rules';
 
 import AnnotationHeaderField from './AnnotationHeaderField';
@@ -98,9 +99,7 @@ const AnnotationsStep = () => {
           <Trans i18nKey="alerting.annotations.description">Add more context to your alert notifications.</Trans>
         </Text>
         <NeedHelpInfo
-          externalLink={
-            'https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/annotation-label/#annotations'
-          }
+          externalLink={DOCS_URL_ANNOTATIONS}
           linkText={`Read about annotations`}
           contentText={
             <>

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -29,6 +29,11 @@ import { useFetchGroupsForFolder } from '../../hooks/useFetchGroupsForFolder';
 import { DEFAULT_GROUP_EVALUATION_INTERVAL } from '../../rule-editor/formDefaults';
 import { RuleFormValues } from '../../types/rule-form';
 import {
+  DOCS_URL_NO_DATA_ERROR_HANDLING,
+  DOCS_URL_RULE_EVALUATION,
+  DOCS_URL_STALE_ALERT_INSTANCES,
+} from '../../utils/docs';
+import {
   isGrafanaAlertingRuleByType,
   isGrafanaManagedRuleByType,
   isGrafanaRecordingRuleByType,
@@ -420,9 +425,7 @@ export function GrafanaEvaluationBehaviorStep({
                         )}
                       </>
                     }
-                    externalLink={
-                      'https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rule-evaluation/stale-alert-instances/'
-                    }
+                    externalLink={DOCS_URL_STALE_ALERT_INSTANCES}
                     linkText={t(
                       'alerting.alert-missing-evaluations-to-stale.help-info.link-text',
                       `Read more about stale alert instances`
@@ -672,9 +675,6 @@ function KeepFiringFor({ evaluateEvery }: { evaluateEvery: string }) {
 }
 
 function NeedHelpInfoForConfigureNoDataError() {
-  const docsLink =
-    'https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/#configure-no-data-and-error-handling';
-
   return (
     <Stack direction="row" gap={0.5} alignItems="center">
       <Text variant="bodySmall" color="secondary">
@@ -687,7 +687,7 @@ function NeedHelpInfoForConfigureNoDataError() {
           'alerting.rule-form.evaluation-behaviour.info-help.content',
           'These settings can help mitigate temporary data source issues, preventing alerts from unintentionally firing due to lack of data, errors, or timeouts.'
         )}
-        externalLink={docsLink}
+        externalLink={DOCS_URL_NO_DATA_ERROR_HANDLING}
         linkText={t('alerting.rule-form.evaluation-behaviour.info-help.link-text', `Read more about this option`)}
         title={t(
           'alerting.rule-form.evaluation-behaviour.info-help.link-title',
@@ -699,8 +699,6 @@ function NeedHelpInfoForConfigureNoDataError() {
 }
 
 function getDescription(isGrafanaRecordingRule: boolean) {
-  const docsLink = 'https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/rule-evaluation/';
-
   return (
     <Stack direction="row" gap={0.5} alignItems="center">
       <Text variant="bodySmall" color="secondary">
@@ -736,7 +734,7 @@ function getDescription(isGrafanaRecordingRule: boolean) {
             </p>
           </>
         }
-        externalLink={docsLink}
+        externalLink={DOCS_URL_RULE_EVALUATION}
         linkText={t(
           'alerting.rule-form.evaluation-behaviour.info-help2.link-text',
           `Read about evaluation and alert states`

--- a/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
@@ -11,6 +11,7 @@ import { AlertmanagerChoice } from 'app/plugins/datasource/alertmanager/types';
 import { alertmanagerApi } from '../../api/alertmanagerApi';
 import { KBObjectArray, RuleFormType, RuleFormValues } from '../../types/rule-form';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
+import { DOCS_URL_NOTIFICATIONS, DOCS_URL_NOTIFICATION_POLICIES } from '../../utils/docs';
 import { isGrafanaManagedRuleByType, isGrafanaRecordingRuleByType, isRecordingRuleByType } from '../../utils/rules';
 
 import { NeedHelpInfo } from './NeedHelpInfo';
@@ -266,10 +267,7 @@ function NeedHelpInfoForNotificationPolicy() {
               Custom labels change the way your notifications are routed. First, add labels to your alert rule and then
               connect them to your notification policy by adding label matchers.
             </Trans>
-            <TextLink
-              href={`https://grafana.com/docs/grafana/latest/alerting/fundamentals/notifications/notification-policies/`}
-              external
-            >
+            <TextLink href={DOCS_URL_NOTIFICATION_POLICIES} external>
               <Trans i18nKey="alerting.need-help-info-for-notification-policy.read-more">
                 Read about notification policies.
               </Trans>
@@ -302,7 +300,7 @@ function NeedHelpInfoForContactpoint() {
           </Trans>
         </>
       }
-      externalLink="https://grafana.com/docs/grafana/latest/alerting/fundamentals/notifications/"
+      externalLink={DOCS_URL_NOTIFICATIONS}
       linkText="Read more about notifications"
       title={t(
         'alerting.need-help-info-for-contactpoint.title-notify-by-selecting-a-contact-point',

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -25,6 +25,7 @@ import { QueryEditorRow } from 'app/features/query/components/QueryEditorRow';
 import { AlertDataQuery, AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { RuleFormValues } from '../../types/rule-form';
+import { DOCS_URL_DATA_SOURCE_ALERTING } from '../../utils/docs';
 import { msToSingleUnitDuration } from '../../utils/time';
 import { ExpressionStatusIndicator } from '../expressions/ExpressionStatusIndicator';
 import { AlertingRuleQueryExtensionPoint } from '../extensions/AlertingRuleQueryExtensionPoint';
@@ -130,15 +131,7 @@ export const QueryWrapper = ({
             </Trans>
           }
         >
-          <Icon
-            name="info-circle"
-            onClick={() =>
-              window.open(
-                ' https://grafana.com/docs/grafana/latest/alerting/fundamentals/data-source-alerting/',
-                '_blank'
-              )
-            }
-          />
+          <Icon name="info-circle" onClick={() => window.open(DOCS_URL_DATA_SOURCE_ALERTING, '_blank')} />
         </Tooltip>
       </div>
     );

--- a/public/app/features/alerting/unified/components/rule-editor/RuleInspector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RuleInspector.tsx
@@ -10,6 +10,7 @@ import { Button, CodeEditor, Drawer, Icon, Tab, TabsBar, TextLink, Tooltip, useS
 
 import { RulerRuleDTO } from '../../../../../types/unified-alerting-dto';
 import { RuleFormValues } from '../../types/rule-form';
+import { EXTERNAL_URL_PROMETHEUS_ALERTING_RULES } from '../../utils/docs';
 import {
   alertingRulerRuleToRuleForm,
   formValuesToRulerRuleDTO,
@@ -135,7 +136,7 @@ function YamlContentInfo() {
       <Trans i18nKey="alerting.yaml-content-info.body">
         The YAML content in the editor only contains alert rule configuration <br />
         To configure Prometheus, you need to provide the rest of the{' '}
-        <TextLink href="https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/" external>
+        <TextLink href={EXTERNAL_URL_PROMETHEUS_ALERTING_RULES} external>
           configuration file content.
         </TextLink>
       </Trans>

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/AlertManagerRouting.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/AlertManagerRouting.tsx
@@ -6,6 +6,7 @@ import { Trans, t } from '@grafana/i18n';
 import { CollapsableSection, Stack, Text, useStyles2 } from '@grafana/ui';
 import { RuleFormValues } from 'app/features/alerting/unified/types/rule-form';
 import { AlertManagerDataSource } from 'app/features/alerting/unified/utils/datasource';
+import { DOCS_URL_GROUP_ALERT_NOTIFICATIONS } from 'app/features/alerting/unified/utils/docs';
 
 import { NeedHelpInfo } from '../../NeedHelpInfo';
 
@@ -71,9 +72,7 @@ export function AlertManagerManualRouting({ alertManager }: AlertManagerManualRo
                   'Muting, grouping, and timings'
                 )}
                 linkText={'Read about notification grouping'}
-                externalLink={
-                  'https://grafana.com/docs/grafana/latest/alerting/fundamentals/notifications/group-alert-notifications/'
-                }
+                externalLink={DOCS_URL_GROUP_ALERT_NOTIFICATIONS}
                 contentText={
                   <>
                     <p>

--- a/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
@@ -11,6 +11,7 @@ import { labelsApi } from '../../../api/labelsApi';
 import { usePluginBridge } from '../../../hooks/usePluginBridge';
 import { SupportedPlugin } from '../../../types/pluginBridges';
 import { KBObjectArray, RuleFormType, RuleFormValues } from '../../../types/rule-form';
+import { DOCS_URL_ANNOTATION_LABEL } from '../../../utils/docs';
 import { isPrivateLabelKey } from '../../../utils/labels';
 import { isRecordingRuleByType } from '../../../utils/rules';
 import AlertLabelDropdown, { AsyncOptionsLoader } from '../../AlertLabelDropdown';
@@ -407,7 +408,7 @@ function LabelsField() {
             {getLabelText(type)}
           </Text>
           <NeedHelpInfo
-            externalLink={'https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/annotation-label/'}
+            externalLink={DOCS_URL_ANNOTATION_LABEL}
             linkText={`Read about labels`}
             contentText="The dropdown only displays labels that you have previously used for alerts.
             Select a label from the options below or type in a new one."

--- a/public/app/features/alerting/unified/components/rule-editor/labels/LabelsFieldInForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/labels/LabelsFieldInForm.tsx
@@ -5,6 +5,7 @@ import { Button, Stack, Text } from '@grafana/ui';
 
 import { AIImproveLabelsButtonComponent } from '../../../enterprise-components/AI/AIGenImproveLabelsButton/addAIImproveLabelsButton';
 import { RuleFormValues } from '../../../types/rule-form';
+import { DOCS_URL_ANNOTATION_LABEL } from '../../../utils/docs';
 import { isGrafanaManagedRuleByType, isRecordingRuleByType } from '../../../utils/rules';
 import { NeedHelpInfo } from '../NeedHelpInfo';
 
@@ -43,9 +44,7 @@ export function LabelsFieldInForm({ onEditClick }: LabelsFieldInFormProps) {
               {text}
             </Text>
             <NeedHelpInfo
-              externalLink={
-                'https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/annotation-label/'
-              }
+              externalLink={DOCS_URL_ANNOTATION_LABEL}
               linkText={`Read about labels`}
               contentText="The dropdown only displays labels that you have previously used for alerts.
               Select a label from the options below or type in a new one."

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SmartAlertTypeDetector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SmartAlertTypeDetector.tsx
@@ -5,6 +5,7 @@ import { RadioButtonGroup, Stack, Text } from '@grafana/ui';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { RuleFormType, RuleFormValues } from '../../../types/rule-form';
+import { DOCS_URL_ALERT_RULE_TYPES } from '../../../utils/docs';
 import { NeedHelpInfo } from '../NeedHelpInfo';
 
 import { useGetCanSwitch } from './utils';
@@ -75,7 +76,7 @@ export function SmartAlertTypeDetector({ editingExistingRule, queries, onClickSw
                 </p>
               </>
             }
-            externalLink="https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/alert-rule-types/"
+            externalLink={DOCS_URL_ALERT_RULE_TYPES}
             linkText="Read about alert rule types"
             title={t('alerting.smart-alert-type-detector.title-alert-rule-types', 'Alert rule types')}
           />

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/descriptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/descriptions.tsx
@@ -1,4 +1,5 @@
 import { RuleFormType } from '../../../types/rule-form';
+import { DOCS_URL_QUERY_TRANSFORM_DATA, DOCS_URL_RECORDING_RULES } from '../../../utils/docs';
 
 type FormDescriptions = {
   sectionTitle: string;
@@ -13,27 +14,27 @@ export const DESCRIPTIONS: Record<RuleFormType, FormDescriptions> = {
     helpLabel: 'Define your recording rule',
     helpContent:
       'Pre-compute frequently needed or computationally expensive expressions and save their result as a new set of time series.',
-    helpLink: 'https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-recording-rules/',
+    helpLink: DOCS_URL_RECORDING_RULES,
   },
   [RuleFormType.grafanaRecording]: {
     sectionTitle: 'Define recording rule',
     helpLabel: 'Define your recording rule',
     helpContent:
       'Pre-compute frequently needed or computationally expensive expressions and save their result as a new set of time series.',
-    helpLink: 'https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-recording-rules/',
+    helpLink: DOCS_URL_RECORDING_RULES,
   },
   [RuleFormType.grafana]: {
     sectionTitle: 'Define query and alert condition',
     helpLabel: 'Define query and alert condition',
     helpContent:
       'An alert rule consists of one or more queries and expressions that select the data you want to measure. Define queries and/or expressions and then choose one of them as the alert rule condition. This is the threshold that an alert rule must meet or exceed in order to fire. For more information on queries and expressions, see Query and transform data.',
-    helpLink: 'https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/',
+    helpLink: DOCS_URL_QUERY_TRANSFORM_DATA,
   },
   [RuleFormType.cloudAlerting]: {
     sectionTitle: 'Define query and alert condition',
     helpLabel: 'Define query and alert condition',
     helpContent:
       'An alert rule consists of one or more queries and expressions that select the data you want to measure. Define queries and/or expressions and then choose one of them as the alert rule condition. This is the threshold that an alert rule must meet or exceed in order to fire. For more information on queries and expressions, see Query and transform data.',
-    helpLink: 'https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/',
+    helpLink: DOCS_URL_QUERY_TRANSFORM_DATA,
   },
 };

--- a/public/app/features/alerting/unified/components/rule-viewer/FederatedRuleWarning.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/FederatedRuleWarning.tsx
@@ -1,6 +1,8 @@
 import { Trans, t } from '@grafana/i18n';
 import { Alert, Button, Stack } from '@grafana/ui';
 
+import { DOCS_URL_FEDERATED_RULES } from '../../utils/docs';
+
 export function FederatedRuleWarning() {
   return (
     <Alert
@@ -14,7 +16,7 @@ export function FederatedRuleWarning() {
           Federated rule groups are currently an experimental feature.
         </Trans>
         <Button fill="text" icon="book">
-          <a href="https://grafana.com/docs/metrics-enterprise/latest/tenant-management/tenant-federation/#cross-tenant-alerting-and-recording-rule-federation">
+          <a href={DOCS_URL_FEDERATED_RULES}>
             <Trans i18nKey="alerting.federated-rule-warning.read-documentation">Read documentation</Trans>
           </a>
         </Button>

--- a/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
+++ b/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
@@ -7,6 +7,7 @@ import { Dropdown, EmptyState, LinkButton, Menu, MenuItem, Stack, Text, TextLink
 
 import { RuleFormType, RuleFormValues } from '../../types/rule-form';
 import { useRulesAccess } from '../../utils/accessControlHooks';
+import { DOCS_URL_PROVISION_ALERTING } from '../../utils/docs';
 import { createRelativeUrl } from '../../utils/url';
 
 const RecordingRulesButtons = () => {
@@ -90,7 +91,7 @@ export const NoRulesSplash = () => {
         <Trans i18nKey="alerting.list-view.empty.provisioning">
           You can also define rules through file provisioning or Terraform
         </Trans>
-        <TextLink href="https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/" external>
+        <TextLink href={DOCS_URL_PROVISION_ALERTING} external>
           <Trans i18nKey="alerting.common.learn-more">Learn more</Trans>
         </TextLink>
       </EmptyState>
@@ -113,10 +114,7 @@ export function GrafanaNoRulesCTA() {
           <Trans i18nKey="alerting.list-view.empty.provisioning">
             You can also define rules through file provisioning or Terraform
           </Trans>
-          <TextLink
-            href="https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/"
-            external
-          >
+          <TextLink href={DOCS_URL_PROVISION_ALERTING} external>
             <Trans i18nKey="alerting.common.learn-more">Learn more</Trans>
           </TextLink>
         </Stack>

--- a/public/app/features/alerting/unified/home/GettingStarted.tsx
+++ b/public/app/features/alerting/unified/home/GettingStarted.tsx
@@ -9,6 +9,8 @@ import { Stack, Text, TextLink, useStyles2, useTheme2 } from '@grafana/ui';
 import atAGlanceDarkSvg from 'img/alerting/at_a_glance_dark.svg';
 import atAGlanceLightSvg from 'img/alerting/at_a_glance_light.svg';
 
+import { TUTORIAL_URL_ALERTING_GET_STARTED } from '../utils/docs';
+
 export default function GettingStarted() {
   const theme = useTheme2();
   const styles = useStyles2(getWelcomePageStyles);
@@ -78,7 +80,7 @@ export default function GettingStarted() {
           <p>
             <Trans i18nKey="alerting.getting-stared.learn-more">
               For a hands-on introduction, refer to our{' '}
-              <TextLink href="https://grafana.com/tutorials/alerting-get-started/" inline={true} external>
+              <TextLink href={TUTORIAL_URL_ALERTING_GET_STARTED} inline={true} external>
                 tutorial to get started with Grafana Alerting
               </TextLink>
             </Trans>

--- a/public/app/features/alerting/unified/utils/docs.ts
+++ b/public/app/features/alerting/unified/utils/docs.ts
@@ -1,0 +1,42 @@
+// Base URL for easier maintenance
+const DOCS_BASE_URL = 'https://grafana.com/docs/grafana/latest';
+
+// Alerting Rules
+export const DOCS_URL_ALERT_RULE_TYPES = `${DOCS_BASE_URL}/alerting/fundamentals/alert-rules/alert-rule-types/`;
+export const DOCS_URL_RULE_EVALUATION = `${DOCS_BASE_URL}/alerting/fundamentals/alert-rules/rule-evaluation/`;
+export const DOCS_URL_STALE_ALERT_INSTANCES = `${DOCS_BASE_URL}/alerting/fundamentals/alert-rule-evaluation/stale-alert-instances/`;
+export const DOCS_URL_NO_DATA_ERROR_HANDLING = `${DOCS_BASE_URL}/alerting/alerting-rules/create-grafana-managed-rule/#configure-no-data-and-error-handling`;
+export const DOCS_URL_RECORDING_RULES = `${DOCS_BASE_URL}/alerting/alerting-rules/create-recording-rules/`;
+
+// Labels and Annotations
+export const DOCS_URL_ANNOTATION_LABEL = `${DOCS_BASE_URL}/alerting/fundamentals/alert-rules/annotation-label/`;
+export const DOCS_URL_ANNOTATIONS = `${DOCS_BASE_URL}/alerting/fundamentals/alert-rules/annotation-label/#annotations`;
+
+// Notifications
+export const DOCS_URL_NOTIFICATIONS = `${DOCS_BASE_URL}/alerting/fundamentals/notifications/`;
+export const DOCS_URL_NOTIFICATION_POLICIES = `${DOCS_BASE_URL}/alerting/fundamentals/notifications/notification-policies/`;
+export const DOCS_URL_GROUP_ALERT_NOTIFICATIONS = `${DOCS_BASE_URL}/alerting/fundamentals/notifications/group-alert-notifications/`;
+export const DOCS_URL_INHIBITION_RULES = `${DOCS_BASE_URL}/alerting/configure-notifications/create-silence/#inhibition-rules`;
+
+// Templates
+export const DOCS_URL_TEMPLATE_NOTIFICATIONS = `${DOCS_BASE_URL}/alerting/manage-notifications/template-notifications/`;
+export const DOCS_URL_TEMPLATE_EXAMPLES = `${DOCS_BASE_URL}/alerting/configure-notifications/template-notifications/examples/`;
+
+// Provisioning
+export const DOCS_URL_PROVISION_ALERTING = `${DOCS_BASE_URL}/alerting/set-up/provision-alerting-resources/`;
+export const DOCS_URL_FILE_PROVISIONING = `${DOCS_BASE_URL}/alerting/set-up/provision-alerting-resources/file-provisioning/`;
+export const DOCS_URL_HTTP_API_PROVISIONING = `${DOCS_BASE_URL}/alerting/set-up/provision-alerting-resources/http-api-provisioning/`;
+export const DOCS_URL_TERRAFORM_PROVISIONING = `${DOCS_BASE_URL}/alerting/set-up/provision-alerting-resources/terraform-provisioning/`;
+
+// Migration
+export const DOCS_URL_ALERTING_MIGRATION = `${DOCS_BASE_URL}/alerting/alerting-rules/alerting-migration/`;
+
+// Data Sources
+export const DOCS_URL_DATA_SOURCE_ALERTING = `${DOCS_BASE_URL}/alerting/fundamentals/data-source-alerting/`;
+
+// Query and Transform
+export const DOCS_URL_QUERY_TRANSFORM_DATA = `${DOCS_BASE_URL}/panels-visualizations/query-transform-data/`;
+
+// External (Mimir/Metrics Enterprise)
+export const DOCS_URL_FEDERATED_RULES =
+  'https://grafana.com/docs/metrics-enterprise/latest/tenant-management/tenant-federation/#cross-tenant-alerting-and-recording-rule-federation';

--- a/public/app/features/alerting/unified/utils/docs.ts
+++ b/public/app/features/alerting/unified/utils/docs.ts
@@ -37,6 +37,13 @@ export const DOCS_URL_DATA_SOURCE_ALERTING = `${DOCS_BASE_URL}/alerting/fundamen
 // Query and Transform
 export const DOCS_URL_QUERY_TRANSFORM_DATA = `${DOCS_BASE_URL}/panels-visualizations/query-transform-data/`;
 
+// Tutorials
+export const TUTORIAL_URL_ALERTING_GET_STARTED = 'https://grafana.com/tutorials/alerting-get-started/';
+
 // External (Mimir/Metrics Enterprise)
 export const DOCS_URL_FEDERATED_RULES =
   'https://grafana.com/docs/metrics-enterprise/latest/tenant-management/tenant-federation/#cross-tenant-alerting-and-recording-rule-federation';
+
+// External (Prometheus)
+export const EXTERNAL_URL_PROMETHEUS_ALERTING_RULES =
+  'https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/';


### PR DESCRIPTION
**What is this feature?**

This PR adds a module to centralize the documentation urls used in the alerting codebase

**Changes**
 The urls used in the following files where extracted to constants in the `public/app/features/alerting/unified/utils/docs.ts` module:
 
 | File | Constant Used |
|------|---------------|
| InhibitionRulesAlert.tsx | `DOCS_URL_INHIBITION_RULES` |
| FileExportPreview.tsx | `DOCS_URL_FILE_PROVISIONING`, `DOCS_URL_HTTP_API_PROVISIONING`, `DOCS_URL_TERRAFORM_PROVISIONING` |
| ImportToGMARules.tsx | `DOCS_URL_ALERTING_MIGRATION` |
| TemplateForm.tsx | `DOCS_URL_TEMPLATE_EXAMPLES`, `DOCS_URL_TEMPLATE_NOTIFICATIONS` |
| AnnotationsStep.tsx | `DOCS_URL_ANNOTATIONS` |
| GrafanaEvaluationBehavior.tsx | `DOCS_URL_STALE_ALERT_INSTANCES`, `DOCS_URL_NO_DATA_ERROR_HANDLING`, `DOCS_URL_RULE_EVALUATION` |
| NotificationsStep.tsx | `DOCS_URL_NOTIFICATION_POLICIES`, `DOCS_URL_NOTIFICATIONS` |
| QueryWrapper.tsx | `DOCS_URL_DATA_SOURCE_ALERTING` |
| AlertManagerRouting.tsx | `DOCS_URL_GROUP_ALERT_NOTIFICATIONS` |
| LabelsField.tsx, LabelsFieldInForm.tsx | `DOCS_URL_ANNOTATION_LABEL` |
| SmartAlertTypeDetector.tsx | `DOCS_URL_ALERT_RULE_TYPES` |
| descriptions.tsx | `DOCS_URL_RECORDING_RULES`, `DOCS_URL_QUERY_TRANSFORM_DATA` |
| FederatedRuleWarning.tsx | `DOCS_URL_FEDERATED_RULES` |
| NoRulesCTA.tsx | `DOCS_URL_PROVISION_ALERTING` |

