### PR TITLE
Scopes: Eliminate action method prop drilling via useScopeActions hook

### DIFF
--- a/public/app/features/scopes/selector/ScopesSelector.tsx
+++ b/public/app/features/scopes/selector/ScopesSelector.tsx
@@ -56,17 +56,7 @@ export const ScopesSelector = () => {
   } = selectorServiceState;
   const { scopesService, scopesSelectorService } = services;
   const { readOnly, loading } = scopes.state;
-  const {
-    open,
-    removeAllScopes,
-    closeAndApply,
-    closeAndReset,
-    filterNode,
-    selectScope,
-    deselectScope,
-    getRecentScopes,
-    toggleExpandedNode,
-  } = scopesSelectorService;
+  const { open, removeAllScopes, closeAndApply, closeAndReset, getRecentScopes } = scopesSelectorService;
 
   const recentScopes = getRecentScopes();
 
@@ -109,13 +99,9 @@ export const ScopesSelector = () => {
                         <ScopesTree
                           tree={tree}
                           loadingNodeName={loadingNodeName}
-                          filterNode={filterNode}
                           recentScopes={recentScopes}
                           selectedScopes={selectedScopes}
                           scopeNodes={nodes}
-                          selectScope={selectScope}
-                          deselectScope={deselectScope}
-                          toggleExpandedNode={toggleExpandedNode}
                           onRecentScopesSelect={(scopeIds: string[], parentNodeId?: string, scopeNodeId?: string) => {
                             scopesSelectorService.changeScopes(scopeIds, parentNodeId, scopeNodeId);
                             scopesSelectorService.closeAndReset();

--- a/public/app/features/scopes/selector/ScopesTree.test.tsx
+++ b/public/app/features/scopes/selector/ScopesTree.test.tsx
@@ -14,12 +14,20 @@ jest.mock('../ScopesContextProvider', () => ({
   }),
 }));
 
-describe('ScopesTree', () => {
-  const mockFilterNode = jest.fn();
-  const mockSelectScope = jest.fn();
-  const mockDeselectScope = jest.fn();
-  const mockToggleExpandedNode = jest.fn();
+// Mock useScopeActions hook
+const mockSelectScope = jest.fn();
+const mockDeselectScope = jest.fn();
+const mockToggleExpandedNode = jest.fn();
 
+jest.mock('./useScopeActions', () => ({
+  useScopeActions: () => ({
+    selectScope: mockSelectScope,
+    deselectScope: mockDeselectScope,
+    toggleExpandedNode: mockToggleExpandedNode,
+  }),
+}));
+
+describe('ScopesTree', () => {
   const createMockScopeNode = (name: string, parentName?: string): ScopeNode => ({
     metadata: { name },
     spec: {
@@ -60,10 +68,6 @@ describe('ScopesTree', () => {
     loadingNodeName: undefined,
     selectedScopes: [] as SelectedScope[],
     scopeNodes: defaultScopeNodes,
-    filterNode: mockFilterNode,
-    selectScope: mockSelectScope,
-    deselectScope: mockDeselectScope,
-    toggleExpandedNode: mockToggleExpandedNode,
   };
 
   beforeEach(() => {

--- a/public/app/features/scopes/selector/ScopesTree.tsx
+++ b/public/app/features/scopes/selector/ScopesTree.tsx
@@ -32,7 +32,7 @@ export function ScopesTree({
   onRecentScopesSelect,
   scopeNodes,
 }: ScopesTreeProps) {
-  const { filterNode, selectScope, deselectScope, toggleExpandedNode } = useScopeActions();
+  const { selectScope, deselectScope, toggleExpandedNode } = useScopeActions();
   const styles = useStyles2(getStyles);
 
   // Used for a11y reference

--- a/public/app/features/scopes/selector/ScopesTree.tsx
+++ b/public/app/features/scopes/selector/ScopesTree.tsx
@@ -10,6 +10,7 @@ import { ScopesTreeHeadline } from './ScopesTreeHeadline';
 import { ScopesTreeItemList } from './ScopesTreeItemList';
 import { ScopesTreeSearch } from './ScopesTreeSearch';
 import { NodesMap, SelectedScope, TreeNode } from './types';
+import { useScopeActions } from './useScopeActions';
 import { useScopesHighlighting } from './useScopesHighlighting';
 
 export interface ScopesTreeProps {
@@ -18,16 +19,9 @@ export interface ScopesTreeProps {
   selectedScopes: SelectedScope[];
   scopeNodes: NodesMap;
 
-  filterNode: (scopeNodeId: string, query: string) => void;
-
-  selectScope: (scopeNodeId: string) => void;
-  deselectScope: (scopeNodeId: string) => void;
-
   // Recent scopes are only shown at the root node
   recentScopes?: Scope[][];
   onRecentScopesSelect?: (scopeIds: string[], parentNodeId?: string, scopeNodeId?: string) => void;
-
-  toggleExpandedNode: (scopeNodeId: string) => void;
 }
 
 export function ScopesTree({
@@ -36,12 +30,9 @@ export function ScopesTree({
   selectedScopes,
   recentScopes,
   onRecentScopesSelect,
-  filterNode,
   scopeNodes,
-  selectScope,
-  deselectScope,
-  toggleExpandedNode,
 }: ScopesTreeProps) {
+  const { filterNode, selectScope, deselectScope, toggleExpandedNode } = useScopeActions();
   const styles = useStyles2(getStyles);
 
   // Used for a11y reference
@@ -95,7 +86,6 @@ export function ScopesTree({
       <ScopesTreeSearch
         anyChildExpanded={anyChildExpanded}
         searchArea={searchArea}
-        filterNode={filterNode}
         treeNode={tree}
         aria-controls={`${selectedNodesToShowId} ${childrenArrayId}`}
         aria-activedescendant={ariaActiveDescendant}
@@ -118,12 +108,8 @@ export function ScopesTree({
             anyChildExpanded={anyChildExpanded}
             lastExpandedNode={lastExpandedNode}
             loadingNodeName={loadingNodeName}
-            filterNode={filterNode}
             selectedScopes={selectedScopes}
             scopeNodes={scopeNodes}
-            selectScope={selectScope}
-            deselectScope={deselectScope}
-            toggleExpandedNode={toggleExpandedNode}
             maxHeight={`${Math.min(5, selectedNodesToShow.length) * 30}px`}
             highlightedId={highlightedId}
             id={selectedNodesToShowId}
@@ -141,12 +127,8 @@ export function ScopesTree({
             anyChildExpanded={anyChildExpanded}
             lastExpandedNode={lastExpandedNode}
             loadingNodeName={loadingNodeName}
-            filterNode={filterNode}
             selectedScopes={selectedScopes}
             scopeNodes={scopeNodes}
-            selectScope={selectScope}
-            toggleExpandedNode={toggleExpandedNode}
-            deselectScope={deselectScope}
             maxHeight={'100%'}
             highlightedId={highlightedId}
             id={childrenArrayId}

--- a/public/app/features/scopes/selector/ScopesTreeItem.tsx
+++ b/public/app/features/scopes/selector/ScopesTreeItem.tsx
@@ -9,6 +9,7 @@ import { useScopesServices } from '../ScopesContextProvider';
 import { ScopesTree } from './ScopesTree';
 import { isNodeExpandable, isNodeSelectable } from './scopesTreeUtils';
 import { NodesMap, SelectedScope, TreeNode } from './types';
+import { useScopeActions } from './useScopeActions';
 
 // Helper components for rendering different selectable content types
 interface RadioButtonDotProps {
@@ -181,26 +182,18 @@ export interface ScopesTreeItemProps {
   selected: boolean;
   selectedScopes: SelectedScope[];
   highlighted: boolean;
-
-  filterNode: (scopeNodeId: string, query: string) => void;
-  selectScope: (scopeNodeId: string) => void;
-  deselectScope: (scopeNodeId: string) => void;
-  toggleExpandedNode: (scopeNodeId: string) => void;
 }
 
 export function ScopesTreeItem({
   anyChildExpanded,
   loadingNodeName,
   treeNode,
-  filterNode,
   scopeNodes,
   selected,
   selectedScopes,
-  selectScope,
-  deselectScope,
   highlighted,
-  toggleExpandedNode,
 }: ScopesTreeItemProps) {
+  const { selectScope, deselectScope, toggleExpandedNode } = useScopeActions();
   const styles = useStyles2(getStyles);
   const services = useScopesServices();
   const { closeAndApply } = services?.scopesSelectorService || {};
@@ -301,12 +294,8 @@ export function ScopesTreeItem({
           <ScopesTree
             tree={treeNode}
             loadingNodeName={loadingNodeName}
-            filterNode={filterNode}
             scopeNodes={scopeNodes}
             selectedScopes={selectedScopes}
-            selectScope={selectScope}
-            deselectScope={deselectScope}
-            toggleExpandedNode={toggleExpandedNode}
           />
         )}
       </div>

--- a/public/app/features/scopes/selector/ScopesTreeItemList.test.tsx
+++ b/public/app/features/scopes/selector/ScopesTreeItemList.test.tsx
@@ -14,24 +14,28 @@ jest.mock('../ScopesContextProvider', () => ({
   }),
 }));
 
-describe('ScopesTreeItemList', () => {
-  const mockFilterNode = jest.fn();
-  const mockSelectScope = jest.fn();
-  const mockDeselectScope = jest.fn();
-  const mockToggleExpandedNode = jest.fn();
+// Mock useScopeActions hook (used by child ScopesTreeItem)
+const mockSelectScope = jest.fn();
+const mockDeselectScope = jest.fn();
+const mockToggleExpandedNode = jest.fn();
 
+jest.mock('./useScopeActions', () => ({
+  useScopeActions: () => ({
+    selectScope: mockSelectScope,
+    deselectScope: mockDeselectScope,
+    toggleExpandedNode: mockToggleExpandedNode,
+  }),
+}));
+
+describe('ScopesTreeItemList', () => {
   const defaultProps = {
     anyChildExpanded: false,
     lastExpandedNode: false,
     loadingNodeName: undefined,
     maxHeight: '100%',
     selectedScopes: [] as SelectedScope[],
-    filterNode: mockFilterNode,
-    selectScope: mockSelectScope,
-    deselectScope: mockDeselectScope,
     highlightedId: undefined,
     id: 'test-tree',
-    toggleExpandedNode: mockToggleExpandedNode,
   };
 
   const createMockScopeNode = (name: string, parentName = 'parent'): ScopeNode => ({

--- a/public/app/features/scopes/selector/ScopesTreeItemList.tsx
+++ b/public/app/features/scopes/selector/ScopesTreeItemList.tsx
@@ -15,12 +15,8 @@ type Props = {
   maxHeight: string;
   selectedScopes: SelectedScope[];
   scopeNodes: NodesMap;
-  filterNode: (scopeNodeId: string, query: string) => void;
-  selectScope: (scopeNodeId: string) => void;
-  deselectScope: (scopeNodeId: string) => void;
   highlightedId: string | undefined;
   id: string;
-  toggleExpandedNode: (scopeNodeId: string) => void;
 };
 
 export function ScopesTreeItemList({
@@ -31,12 +27,8 @@ export function ScopesTreeItemList({
   selectedScopes,
   scopeNodes,
   loadingNodeName,
-  filterNode,
-  selectScope,
-  deselectScope,
   highlightedId,
   id,
-  toggleExpandedNode,
 }: Props) {
   const styles = useStyles2(getStyles);
 
@@ -72,11 +64,7 @@ export function ScopesTreeItemList({
             scopeNodes={scopeNodes}
             loadingNodeName={loadingNodeName}
             anyChildExpanded={anyChildExpanded}
-            filterNode={filterNode}
-            selectScope={selectScope}
-            deselectScope={deselectScope}
             highlighted={childNode.scopeNodeId === highlightedId}
-            toggleExpandedNode={toggleExpandedNode}
           />
         );
       })}

--- a/public/app/features/scopes/selector/ScopesTreeSearch.tsx
+++ b/public/app/features/scopes/selector/ScopesTreeSearch.tsx
@@ -7,12 +7,12 @@ import { t } from '@grafana/i18n';
 import { FilterInput, useStyles2 } from '@grafana/ui';
 
 import { TreeNode } from './types';
+import { useScopeActions } from './useScopeActions';
 
 export interface ScopesTreeSearchProps {
   anyChildExpanded: boolean;
   searchArea: string;
   treeNode: TreeNode;
-  filterNode: (scopeNodeId: string, query: string) => void;
   onFocus: () => void;
   onBlur: () => void;
   'aria-controls': string;
@@ -22,13 +22,13 @@ export interface ScopesTreeSearchProps {
 export function ScopesTreeSearch({
   anyChildExpanded,
   treeNode,
-  filterNode,
   searchArea,
   onFocus,
   onBlur,
   'aria-controls': ariaControls,
   'aria-activedescendant': ariaActivedescendant,
 }: ScopesTreeSearchProps) {
+  const { filterNode } = useScopeActions();
   const styles = useStyles2(getStyles);
 
   const [inputState, setInputState] = useState<{ value: string; dirty: boolean }>({

--- a/public/app/features/scopes/selector/useScopeActions.test.ts
+++ b/public/app/features/scopes/selector/useScopeActions.test.ts
@@ -1,0 +1,97 @@
+import { renderHook } from '@testing-library/react';
+
+import { useScopeActions } from './useScopeActions';
+
+// Mock the ScopesContextProvider hook
+jest.mock('../ScopesContextProvider', () => ({
+  useScopesServices: jest.fn(),
+}));
+
+const { useScopesServices } = jest.requireMock('../ScopesContextProvider');
+
+describe('useScopeActions', () => {
+  const mockSelectScope = jest.fn();
+  const mockDeselectScope = jest.fn();
+  const mockFilterNode = jest.fn();
+  const mockToggleExpandedNode = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return action methods from scopesSelectorService', () => {
+    useScopesServices.mockReturnValue({
+      scopesSelectorService: {
+        selectScope: mockSelectScope,
+        deselectScope: mockDeselectScope,
+        filterNode: mockFilterNode,
+        toggleExpandedNode: mockToggleExpandedNode,
+      },
+    });
+
+    const { result } = renderHook(() => useScopeActions());
+
+    expect(result.current.selectScope).toBe(mockSelectScope);
+    expect(result.current.deselectScope).toBe(mockDeselectScope);
+    expect(result.current.filterNode).toBe(mockFilterNode);
+    expect(result.current.toggleExpandedNode).toBe(mockToggleExpandedNode);
+  });
+
+  it('should return empty functions when services are undefined', () => {
+    useScopesServices.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useScopeActions());
+
+    expect(result.current.selectScope).toBeInstanceOf(Function);
+    expect(result.current.deselectScope).toBeInstanceOf(Function);
+    expect(result.current.filterNode).toBeInstanceOf(Function);
+    expect(result.current.toggleExpandedNode).toBeInstanceOf(Function);
+
+    // Verify they don't throw
+    expect(() => result.current.selectScope('test')).not.toThrow();
+    expect(() => result.current.deselectScope('test')).not.toThrow();
+    expect(() => result.current.filterNode('test', 'query')).not.toThrow();
+    expect(() => result.current.toggleExpandedNode('test')).not.toThrow();
+  });
+
+  it('should return empty functions when scopesSelectorService is undefined', () => {
+    useScopesServices.mockReturnValue({
+      scopesSelectorService: undefined,
+    });
+
+    const { result } = renderHook(() => useScopeActions());
+
+    expect(result.current.selectScope).toBeInstanceOf(Function);
+    expect(result.current.deselectScope).toBeInstanceOf(Function);
+    expect(result.current.filterNode).toBeInstanceOf(Function);
+    expect(result.current.toggleExpandedNode).toBeInstanceOf(Function);
+  });
+
+  it('should memoize action methods to maintain stable references', () => {
+    useScopesServices.mockReturnValue({
+      scopesSelectorService: {
+        selectScope: mockSelectScope,
+        deselectScope: mockDeselectScope,
+        filterNode: mockFilterNode,
+        toggleExpandedNode: mockToggleExpandedNode,
+      },
+    });
+
+    const { result, rerender } = renderHook(() => useScopeActions());
+
+    const firstRender = {
+      selectScope: result.current.selectScope,
+      deselectScope: result.current.deselectScope,
+      filterNode: result.current.filterNode,
+      toggleExpandedNode: result.current.toggleExpandedNode,
+    };
+
+    rerender();
+
+    // References should be the same after rerender
+    expect(result.current.selectScope).toBe(firstRender.selectScope);
+    expect(result.current.deselectScope).toBe(firstRender.deselectScope);
+    expect(result.current.filterNode).toBe(firstRender.filterNode);
+    expect(result.current.toggleExpandedNode).toBe(firstRender.toggleExpandedNode);
+  });
+});

--- a/public/app/features/scopes/selector/useScopeActions.ts
+++ b/public/app/features/scopes/selector/useScopeActions.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+
+import { useScopesServices } from '../ScopesContextProvider';
+
+/**
+ * Hook that provides stable references to scope action methods.
+ * These methods never change, so they won't cause re-renders when passed as props.
+ *
+ * This eliminates the need to drill these action methods through multiple component layers.
+ */
+export function useScopeActions() {
+  const services = useScopesServices();
+  const selector = services?.scopesSelectorService;
+
+  return useMemo(
+    () => ({
+      selectScope: selector?.selectScope ?? (() => {}),
+      deselectScope: selector?.deselectScope ?? (() => {}),
+      filterNode: selector?.filterNode ?? (() => {}),
+      toggleExpandedNode: selector?.toggleExpandedNode ?? (() => {}),
+    }),
+    [selector]
+  );
+}


### PR DESCRIPTION
**What is this feature?**

Introduces `useScopeActions()` hook that eliminates prop drilling for scope action methods.

**Why do we need this feature?**

Currently, action methods (selectScope, deselectScope, filterNode, toggleExpandedNode) are drilled through 3-4 component layers:
- ScopesSelector → ScopesTree → ScopesTreeItemList → ScopesTreeItem

This creates maintenance burden and tight coupling. The useScopeActions() hook provides stable method references that never change, eliminating unnecessary prop passing.

**Implementation:**

Single hook that returns memoized action method references:
```typescript
const { selectScope, deselectScope, filterNode, toggleExpandedNode } = useScopeActions();
```

**Benefits:**
- Removes 4 props from each component in the chain
- Action methods never cause re-renders (stable references via useMemo)
- Improves component portability
- Reduces boilerplate

**Prop reduction:**
- ScopesTreeSearch: 8 → 7 props (-12%)
- ScopesTree: 10 → 6 props (-40%)
- ScopesTreeItemList: 13 → 9 props (-31%)
- ScopesTreeItem: 11 → 7 props (-36%)

**Who is this feature for?**

Scopes feature developers - improves maintainability without changing functionality.

**Part of larger refactoring:**

This is the first PR in a series to eliminate prop drilling in ScopesSelector. Future PRs will address state management after clarifying Redux/RTK Query integration questions.

**Special notes for your reviewer:**

- [x] No changes to service layer or business logic
- [x] No visual or functional changes
- [x] Focused on action methods only (state props unchanged)
- [x] All components still receive state as props
- [x] Action methods stable via useMemo