### PR TITLE
Login: Skip default password warning in development mode

### DIFF
--- a/e2e-playwright/unauthenticated/login.spec.ts
+++ b/e2e-playwright/unauthenticated/login.spec.ts
@@ -6,34 +6,20 @@ test(
     tag: ['@acceptance'],
   },
   async ({ selectors, page, grafanaAPICredentials }) => {
-    test.skip(grafanaAPICredentials.password === 'admin', 'Does not run with default password');
-
     await page.goto(selectors.pages.Login.url);
 
     await page.getByTestId(selectors.pages.Login.username).fill(grafanaAPICredentials.user);
     await page.getByTestId(selectors.pages.Login.password).fill(grafanaAPICredentials.password);
 
     await page.getByTestId(selectors.pages.Login.submit).click();
+    await expect(page.getByTestId(selectors.pages.Login.submit)).toHaveCount(0);
 
-    await expect(page.getByTestId(selectors.components.NavToolbar.commandPaletteTrigger)).toBeVisible();
-  }
-);
-
-test(
-  'Can login successfully and skip password change',
-  {
-    tag: ['@acceptance'],
-  },
-  async ({ selectors, page, grafanaAPICredentials }) => {
-    test.skip(grafanaAPICredentials.password !== 'admin', 'Only runs with the default password');
-
-    await page.goto(selectors.pages.Login.url);
-
-    await page.getByTestId(selectors.pages.Login.username).fill(grafanaAPICredentials.user);
-    await page.getByTestId(selectors.pages.Login.password).fill(grafanaAPICredentials.password);
-
-    await page.getByTestId(selectors.pages.Login.submit).click();
-    await page.getByTestId(selectors.pages.Login.skip).click();
+    // Click the skip button, if it is offered, if we know we used the default password
+    if (grafanaAPICredentials.password === 'admin') {
+      if ((await page.getByTestId(selectors.pages.Login.skip).count()) > 0) {
+        await page.getByTestId(selectors.pages.Login.skip).click();
+      }
+    }
 
     await expect(page.getByTestId(selectors.components.NavToolbar.commandPaletteTrigger)).toBeVisible();
   }

--- a/e2e/old-arch/utils/flows/login.ts
+++ b/e2e/old-arch/utils/flows/login.ts
@@ -1,4 +1,7 @@
+import { selectors } from '@grafana/e2e-selectors';
+
 import { e2e } from '../index';
+import { Selector } from '../support';
 import { fromBaseUrl } from '../support/url';
 
 const DEFAULT_USERNAME = 'admin';
@@ -23,10 +26,16 @@ const loginUi = (username: string, password: string) => {
     .type(username);
   e2e.pages.Login.password().type(password);
   e2e.pages.Login.submit().click();
+  e2e.pages.Login.submit().should('not.exist');
 
-  // Local tests will have insecure credentials
+  // Click the skip button, if it is offered, if we know we used the default password
   if (password === DEFAULT_PASSWORD) {
-    e2e.pages.Login.skip().should('be.visible').click();
+    cy.get('body').then(($body) => {
+      if ($body.find(Selector.fromDataTestId(selectors.pages.Login.skip)).length > 0) {
+        cy.logToConsole('Skipping password change for username:', username);
+        e2e.pages.Login.skip().should('be.visible').click();
+      }
+    });
   }
 
   cy.get('.login-page').should('not.exist');

--- a/e2e/pa11yci.conf.js
+++ b/e2e/pa11yci.conf.js
@@ -26,7 +26,7 @@ const config = {
         "set field input[name='user'] to admin",
         "set field input[name='password'] to admin",
         "click element button[data-testid='data-testid Login button']",
-        "wait for element button[data-testid='data-testid Skip change password button'] to be visible",
+        "wait for element button[data-testid='data-testid Login button'] to be removed",
       ],
       threshold: 2,
     },

--- a/e2e/utils/flows/login.ts
+++ b/e2e/utils/flows/login.ts
@@ -1,4 +1,7 @@
+import { selectors } from '@grafana/e2e-selectors';
+
 import { e2e } from '../index';
+import { Selector } from '../support';
 import { fromBaseUrl } from '../support/url';
 
 const DEFAULT_USERNAME = 'admin';
@@ -23,10 +26,16 @@ const loginUi = (username: string, password: string) => {
     .type(username);
   e2e.pages.Login.password().type(password);
   e2e.pages.Login.submit().click();
+  e2e.pages.Login.submit().should('not.exist');
 
-  // Local tests will have insecure credentials
+  // Click the skip button, if it is offered, if we know we used the default password
   if (password === DEFAULT_PASSWORD) {
-    e2e.pages.Login.skip().should('be.visible').click();
+    cy.get('body').then(($body) => {
+      if ($body.find(Selector.fromDataTestId(selectors.pages.Login.skip)).length > 0) {
+        cy.logToConsole('Skipping password change for username:', username);
+        e2e.pages.Login.skip().should('be.visible').click();
+      }
+    });
   }
 
   cy.get('.login-page').should('not.exist');

--- a/public/app/core/components/Login/LoginCtrl.tsx
+++ b/public/app/core/components/Login/LoginCtrl.tsx
@@ -127,7 +127,12 @@ export const LoginCtrl = memo(({ resetCode, children }: Props) => {
         .post<LoginDTO>('/login', formModel, { showErrorAlert: false })
         .then((result) => {
           setResult(result);
-          if (formModel.password !== 'admin' || config.ldapEnabled || config.authProxyEnabled) {
+          if (
+            formModel.password !== 'admin' ||
+            config.buildInfo.env === 'development' ||
+            config.ldapEnabled ||
+            config.authProxyEnabled
+          ) {
             toGrafana();
             return;
           } else {


### PR DESCRIPTION
**What is this feature?**

If Grafana is being run in development mode, skip the default password warning for `admin/admin`.

I've opted to make the tests compatible with this by adding conditional logic to look for the skip button and click it if present -- I realise conditionals are generally a sin in tests, especially where the conditional is reliant on the DOM. The alternative here would probably be to do a conditional based on `window.grafanaBootData.settings.buildInfo.env` to mirror the env check I've introduced to the login form. Personally, I do prefer the notion of clicking a button if it's there, rather than reading from esoteric window properties.

**Why do we need this feature?**

Making it that bit faster for developers of Grafana itself, and of plugins, to work locally.

Those running Grafana normally, in production mode, will still be shown the warning + password change prompt when signing in with the default password -- this is a change only for Grafana running in development mode.

**Who is this feature for?**

Developers.