### PR TITLE
Grafana Cli: Add admin flush-rbac-seed-assignment command

### DIFF
--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -119,7 +119,7 @@ var pluginCommands = []*cli.Command{
 	},
 }
 
-var adminCommands = append([]*cli.Command{
+var adminCommands = []*cli.Command{
 	{
 		Name:   "reset-admin-password",
 		Usage:  "reset-admin-password <new password>",
@@ -202,7 +202,7 @@ var adminCommands = append([]*cli.Command{
 		Usage:  "Clears RBAC seeding to force re-seeding on next startup. Use after running an Enterprise build, then an OSS build, then an Enterprise build again.",
 		Action: runDbCommand(flushSeedAssignment),
 	},
-})
+}
 
 var Commands = []*cli.Command{
 	{

--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -119,7 +119,7 @@ var pluginCommands = []*cli.Command{
 	},
 }
 
-var adminCommands = []*cli.Command{
+var adminCommands = append([]*cli.Command{
 	{
 		Name:   "reset-admin-password",
 		Usage:  "reset-admin-password <new password>",
@@ -197,7 +197,12 @@ var adminCommands = []*cli.Command{
 			},
 		},
 	},
-}
+	{
+		Name:   "flush-rbac-seed-assignment",
+		Usage:  "Clears RBAC seeding to force re-seeding on next startup. Use after running an Enterprise build, then an OSS build, then an Enterprise build again.",
+		Action: runDbCommand(flushSeedAssignment),
+	},
+})
 
 var Commands = []*cli.Command{
 	{

--- a/pkg/cmd/grafana-cli/commands/flush_rbac.go
+++ b/pkg/cmd/grafana-cli/commands/flush_rbac.go
@@ -27,7 +27,7 @@ func flushSeedAssignment(c utils.CommandLine, cfg *setting.Cfg, sqlStore db.DB) 
 
 		rowsAffected, _ := result.RowsAffected()
 		logger.Infof("Flushed seed_assignment table (%d rows deleted).", rowsAffected)
-		logger.Info("Seeding will repopulate this table on next startup.")
+		logger.Info("Restart Grafana to repopulate this table on next startup with the default RBAC assignments.")
 		return nil
 	})
 }

--- a/pkg/cmd/grafana-cli/commands/flush_rbac.go
+++ b/pkg/cmd/grafana-cli/commands/flush_rbac.go
@@ -1,0 +1,33 @@
+package commands
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func flushSeedAssignment(c utils.CommandLine, cfg *setting.Cfg, sqlStore db.DB) error {
+	return sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+		exists, err := sess.IsTableExist("seed_assignment")
+		if err != nil {
+			return err
+		}
+		if !exists {
+			logger.Infof("seed_assignment table does not exist, skipping.")
+			return nil
+		}
+
+		result, err := sess.Exec("DELETE FROM seed_assignment")
+		if err != nil {
+			return err
+		}
+
+		rowsAffected, _ := result.RowsAffected()
+		logger.Infof("Flushed seed_assignment table (%d rows deleted).", rowsAffected)
+		logger.Info("Seeding will repopulate this table on next startup.")
+		return nil
+	})
+}


### PR DESCRIPTION
This PR adds a new grafana-cli admin command:

`grafana cli admin flush-rbac-seed-assignment`

This will clear the `seed_assignment` table (if it exists). Then, Grafana should be restarted to re-seed the table to get things back to the default state.

This is needed for the edge case of a grafana instance going from Enterprise -> OSS -> Enterprise again (note: this has to be a _base image_ change, not just a license expiration with an enterprise image being run the whole time (see [here](https://github.com/grafana/grafana-enterprise/blob/2a510b4cf69fd223a5b1adda6a805b3375d0d914/src/pkg/extensions/accesscontrol/acimpl/service.go#L948) and [here](https://github.com/grafana/grafana-enterprise/blob/main/src/pkg/extensions/licensing/features.go#L53))). When this occurs, the OSS seeder will be run on Enterprise -> OSS, which will clean up Enterprise related seeding. Then when you go from OSS -> Enterprise, it will assume that those were purposefully deleted (as users can remove these purposefully). This allows the user to go back to the default Enterprise settings.

For local dev changes, see: https://github.com/grafana/grafana-enterprise/pull/10725

Background thread: https://raintank-corp.slack.com/archives/C06PNGH5H28/p1769010820454689