### PR TITLE
Provisioning: Add Kubernetes Conditions support to Repository and Connection

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/connections.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/connections.go
@@ -106,6 +106,13 @@ type ConnectionStatus struct {
 	// +listType=atomic
 	FieldErrors []ErrorDetails `json:"fieldErrors,omitempty"`
 
+	// Conditions represent the latest available observations of the connection's state.
+	// +listType=map
+	// +listMapKey=type
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+
 	// Connection state
 	State ConnectionState `json:"state"`
 

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
@@ -9,6 +9,21 @@ const (
 	HealthFailureHealth HealthFailureType = "health"
 )
 
+// Condition types for Repository and Connection resources
+const (
+	// ConditionTypeReady indicates that the resource is ready for use.
+	// For repositories and connections, this reflects whether the health check is passing.
+	ConditionTypeReady = "Ready"
+)
+
+// Condition reasons for the Ready condition
+const (
+	// ReasonAvailable indicates the resource is available and ready for use.
+	ReasonAvailable = "Available"
+	// ReasonUnavailable indicates the resource is unavailable and not ready.
+	ReasonUnavailable = "Unavailable"
+)
+
 type HealthStatus struct {
 	// When not healthy, requests will not be executed
 	Healthy bool `json:"healthy"`

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
@@ -311,6 +311,13 @@ type RepositoryStatus struct {
 	// +listType=atomic
 	FieldErrors []ErrorDetails `json:"fieldErrors,omitempty"`
 
+	// Conditions represent the latest available observations of the repository's state.
+	// +listType=map
+	// +listMapKey=type
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+
 	// This will get updated with the current health status (and updated periodically)
 	Health HealthStatus `json:"health"`
 

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.deepcopy.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.deepcopy.go
@@ -8,6 +8,7 @@
 package v0alpha1
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -194,6 +195,13 @@ func (in *ConnectionStatus) DeepCopyInto(out *ConnectionStatus) {
 		in, out := &in.FieldErrors, &out.FieldErrors
 		*out = make([]ErrorDetails, len(*in))
 		copy(*out, *in)
+	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]v1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	in.Health.DeepCopyInto(&out.Health)
 	return
@@ -1015,6 +1023,13 @@ func (in *RepositoryStatus) DeepCopyInto(out *RepositoryStatus) {
 		in, out := &in.FieldErrors, &out.FieldErrors
 		*out = make([]ErrorDetails, len(*in))
 		copy(*out, *in)
+	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]v1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	in.Health.DeepCopyInto(&out.Health)
 	in.Sync.DeepCopyInto(&out.Sync)

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -419,6 +419,30 @@ func schema_pkg_apis_provisioning_v0alpha1_ConnectionStatus(ref common.Reference
 							},
 						},
 					},
+					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"type",
+								},
+								"x-kubernetes-list-type":       "map",
+								"x-kubernetes-patch-merge-key": "type",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Conditions represent the latest available observations of the connection's state.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.Condition"),
+									},
+								},
+							},
+						},
+					},
 					"state": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Connection state\n\nPossible enum values:\n - `\"connected\"`\n - `\"disconnected\"`",
@@ -440,7 +464,7 @@ func schema_pkg_apis_provisioning_v0alpha1_ConnectionStatus(ref common.Reference
 			},
 		},
 		Dependencies: []string{
-			"github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1.ErrorDetails", "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1.HealthStatus"},
+			"github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1.ErrorDetails", "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1.HealthStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.Condition"},
 	}
 }
 
@@ -2054,6 +2078,30 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositoryStatus(ref common.Reference
 							},
 						},
 					},
+					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"type",
+								},
+								"x-kubernetes-list-type":       "map",
+								"x-kubernetes-patch-merge-key": "type",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Conditions represent the latest available observations of the repository's state.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.Condition"),
+									},
+								},
+							},
+						},
+					},
 					"health": {
 						SchemaProps: spec.SchemaProps{
 							Description: "This will get updated with the current health status (and updated periodically)",
@@ -2112,7 +2160,7 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositoryStatus(ref common.Reference
 			},
 		},
 		Dependencies: []string{
-			"github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1.ErrorDetails", "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1.HealthStatus", "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1.ResourceCount", "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1.SyncStatus", "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1.TokenStatus", "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1.WebhookStatus"},
+			"github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1.ErrorDetails", "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1.HealthStatus", "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1.ResourceCount", "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1.SyncStatus", "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1.TokenStatus", "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1.WebhookStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.Condition"},
 	}
 }
 

--- a/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/connectionstatus.go
+++ b/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/connectionstatus.go
@@ -6,6 +6,7 @@ package v0alpha1
 
 import (
 	provisioningv0alpha1 "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
 // ConnectionStatusApplyConfiguration represents a declarative configuration of the ConnectionStatus type for use
@@ -13,6 +14,7 @@ import (
 type ConnectionStatusApplyConfiguration struct {
 	ObservedGeneration *int64                                `json:"observedGeneration,omitempty"`
 	FieldErrors        []ErrorDetailsApplyConfiguration      `json:"fieldErrors,omitempty"`
+	Conditions         []v1.ConditionApplyConfiguration      `json:"conditions,omitempty"`
 	State              *provisioningv0alpha1.ConnectionState `json:"state,omitempty"`
 	Health             *HealthStatusApplyConfiguration       `json:"health,omitempty"`
 }
@@ -40,6 +42,19 @@ func (b *ConnectionStatusApplyConfiguration) WithFieldErrors(values ...*ErrorDet
 			panic("nil value passed to WithFieldErrors")
 		}
 		b.FieldErrors = append(b.FieldErrors, *values[i])
+	}
+	return b
+}
+
+// WithConditions adds the given value to the Conditions field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Conditions field.
+func (b *ConnectionStatusApplyConfiguration) WithConditions(values ...*v1.ConditionApplyConfiguration) *ConnectionStatusApplyConfiguration {
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
 	}
 	return b
 }

--- a/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/repositorystatus.go
+++ b/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/repositorystatus.go
@@ -4,11 +4,16 @@
 
 package v0alpha1
 
+import (
+	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
+)
+
 // RepositoryStatusApplyConfiguration represents a declarative configuration of the RepositoryStatus type for use
 // with apply.
 type RepositoryStatusApplyConfiguration struct {
 	ObservedGeneration *int64                            `json:"observedGeneration,omitempty"`
 	FieldErrors        []ErrorDetailsApplyConfiguration  `json:"fieldErrors,omitempty"`
+	Conditions         []v1.ConditionApplyConfiguration  `json:"conditions,omitempty"`
 	Health             *HealthStatusApplyConfiguration   `json:"health,omitempty"`
 	Sync               *SyncStatusApplyConfiguration     `json:"sync,omitempty"`
 	Stats              []ResourceCountApplyConfiguration `json:"stats,omitempty"`
@@ -40,6 +45,19 @@ func (b *RepositoryStatusApplyConfiguration) WithFieldErrors(values ...*ErrorDet
 			panic("nil value passed to WithFieldErrors")
 		}
 		b.FieldErrors = append(b.FieldErrors, *values[i])
+	}
+	return b
+}
+
+// WithConditions adds the given value to the Conditions field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Conditions field.
+func (b *RepositoryStatusApplyConfiguration) WithConditions(values ...*v1.ConditionApplyConfiguration) *RepositoryStatusApplyConfiguration {
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
 	}
 	return b
 }

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1485,6 +1485,20 @@ export type ConnectionSpec = {
   /** The connection URL */
   url?: string;
 };
+export type Condition = {
+  /** lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable. */
+  lastTransitionTime: Time;
+  /** message is a human readable message indicating details about the transition. This may be an empty string. */
+  message: string;
+  /** observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance. */
+  observedGeneration?: number;
+  /** reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty. */
+  reason: string;
+  /** status of the condition, one of True, False, Unknown. */
+  status: string;
+  /** type of condition in CamelCase or in foo.example.com/CamelCase. */
+  type: string;
+};
 export type ErrorDetails = {
   /** Detail provides a human-readable explanation of what went wrong. This message may be shown directly to users and should be actionable. */
   detail?: string;
@@ -1510,6 +1524,8 @@ export type HealthStatus = {
   message?: string[];
 };
 export type ConnectionStatus = {
+  /** Conditions represent the latest available observations of the connection's state. */
+  conditions?: Condition[];
   /** FieldErrors are errors that occurred during validation of the connection spec. These errors are intended to help users identify and fix issues in the spec. */
   fieldErrors?: ErrorDetails[];
   /** The connection health status */
@@ -1881,6 +1897,8 @@ export type WebhookStatus = {
   url?: string;
 };
 export type RepositoryStatus = {
+  /** Conditions represent the latest available observations of the repository's state. */
+  conditions?: Condition[];
   /** Error information during repository deletion (if any) */
   deleteError?: string;
   /** FieldErrors are errors that occurred during validation of the repository spec. These errors are intended to help users identify and fix issues in the spec. */

--- a/pkg/registry/apis/provisioning/controller/conditions.go
+++ b/pkg/registry/apis/provisioning/controller/conditions.go
@@ -39,43 +39,9 @@ func buildConditionPatchOps(obj *provisioning.Repository, newCondition metav1.Co
 	}
 }
 
-// buildConditionPatchOpsForRepository creates condition patch operations for a Repository.
+// buildConditionPatchOpsFromExisting creates condition patch operations for Repository or Connection resources.
 // Returns nil if the condition hasn't changed to avoid unnecessary patches.
-func buildConditionPatchOpsForRepository(existingConditions []metav1.Condition, generation int64, newCondition metav1.Condition) []map[string]interface{} {
-	// Check if condition already exists and is unchanged
-	existingCondition := meta.FindStatusCondition(existingConditions, newCondition.Type)
-	if existingCondition != nil &&
-		existingCondition.Status == newCondition.Status &&
-		existingCondition.Reason == newCondition.Reason &&
-		existingCondition.Message == newCondition.Message &&
-		existingCondition.ObservedGeneration == generation {
-		// Condition hasn't changed, no need to patch
-		return nil
-	}
-
-	// Clone the conditions to avoid mutating the original
-	conditions := make([]metav1.Condition, len(existingConditions))
-	copy(conditions, existingConditions)
-
-	// Ensure ObservedGeneration is set
-	newCondition.ObservedGeneration = generation
-
-	// Use meta.SetStatusCondition to handle LastTransitionTime correctly
-	meta.SetStatusCondition(&conditions, newCondition)
-
-	// Return patch operation to replace the entire conditions array
-	return []map[string]interface{}{
-		{
-			"op":    "replace",
-			"path":  "/status/conditions",
-			"value": conditions,
-		},
-	}
-}
-
-// buildConditionPatchOpsForConnection creates condition patch operations for a Connection.
-// Returns nil if the condition hasn't changed to avoid unnecessary patches.
-func buildConditionPatchOpsForConnection(existingConditions []metav1.Condition, generation int64, newCondition metav1.Condition) []map[string]interface{} {
+func buildConditionPatchOpsFromExisting(existingConditions []metav1.Condition, generation int64, newCondition metav1.Condition) []map[string]interface{} {
 	// Check if condition already exists and is unchanged
 	existingCondition := meta.FindStatusCondition(existingConditions, newCondition.Type)
 	if existingCondition != nil &&

--- a/pkg/registry/apis/provisioning/controller/conditions_helpers.go
+++ b/pkg/registry/apis/provisioning/controller/conditions_helpers.go
@@ -1,0 +1,133 @@
+package controller
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+// buildConditionPatchOps creates patch operations to update conditions using meta.SetStatusCondition logic
+// This ensures LastTransitionTime is only updated when the condition actually changes
+// Returns empty slice if the condition hasn't changed to avoid unnecessary patches
+func buildConditionPatchOps(obj *provisioning.Repository, newCondition metav1.Condition) []map[string]interface{} {
+	// Check if condition already exists and is unchanged
+	existingCondition := meta.FindStatusCondition(obj.Status.Conditions, newCondition.Type)
+	if existingCondition != nil &&
+		existingCondition.Status == newCondition.Status &&
+		existingCondition.Reason == newCondition.Reason &&
+		existingCondition.Message == newCondition.Message &&
+		existingCondition.ObservedGeneration == newCondition.ObservedGeneration {
+		// Condition hasn't changed, no need to patch
+		return nil
+	}
+
+	// Clone the conditions to avoid mutating the original
+	conditions := make([]metav1.Condition, len(obj.Status.Conditions))
+	copy(conditions, obj.Status.Conditions)
+
+	// Use meta.SetStatusCondition to handle LastTransitionTime correctly
+	meta.SetStatusCondition(&conditions, newCondition)
+
+	// Return patch operation to replace the entire conditions array
+	return []map[string]interface{}{
+		{
+			"op":    "replace",
+			"path":  "/status/conditions",
+			"value": conditions,
+		},
+	}
+}
+
+// buildConditionPatchOpsForRepository creates condition patch operations for a Repository.
+// Returns nil if the condition hasn't changed to avoid unnecessary patches.
+func buildConditionPatchOpsForRepository(existingConditions []metav1.Condition, generation int64, newCondition metav1.Condition) []map[string]interface{} {
+	// Check if condition already exists and is unchanged
+	existingCondition := meta.FindStatusCondition(existingConditions, newCondition.Type)
+	if existingCondition != nil &&
+		existingCondition.Status == newCondition.Status &&
+		existingCondition.Reason == newCondition.Reason &&
+		existingCondition.Message == newCondition.Message &&
+		existingCondition.ObservedGeneration == generation {
+		// Condition hasn't changed, no need to patch
+		return nil
+	}
+
+	// Clone the conditions to avoid mutating the original
+	conditions := make([]metav1.Condition, len(existingConditions))
+	copy(conditions, existingConditions)
+
+	// Ensure ObservedGeneration is set
+	newCondition.ObservedGeneration = generation
+
+	// Use meta.SetStatusCondition to handle LastTransitionTime correctly
+	meta.SetStatusCondition(&conditions, newCondition)
+
+	// Return patch operation to replace the entire conditions array
+	return []map[string]interface{}{
+		{
+			"op":    "replace",
+			"path":  "/status/conditions",
+			"value": conditions,
+		},
+	}
+}
+
+// buildConditionPatchOpsForConnection creates condition patch operations for a Connection.
+// Returns nil if the condition hasn't changed to avoid unnecessary patches.
+func buildConditionPatchOpsForConnection(existingConditions []metav1.Condition, generation int64, newCondition metav1.Condition) []map[string]interface{} {
+	// Check if condition already exists and is unchanged
+	existingCondition := meta.FindStatusCondition(existingConditions, newCondition.Type)
+	if existingCondition != nil &&
+		existingCondition.Status == newCondition.Status &&
+		existingCondition.Reason == newCondition.Reason &&
+		existingCondition.Message == newCondition.Message &&
+		existingCondition.ObservedGeneration == generation {
+		// Condition hasn't changed, no need to patch
+		return nil
+	}
+
+	// Clone the conditions to avoid mutating the original
+	conditions := make([]metav1.Condition, len(existingConditions))
+	copy(conditions, existingConditions)
+
+	// Ensure ObservedGeneration is set
+	newCondition.ObservedGeneration = generation
+
+	// Use meta.SetStatusCondition to handle LastTransitionTime correctly
+	meta.SetStatusCondition(&conditions, newCondition)
+
+	// Return patch operation to replace the entire conditions array
+	return []map[string]interface{}{
+		{
+			"op":    "replace",
+			"path":  "/status/conditions",
+			"value": conditions,
+		},
+	}
+}
+
+// buildReadyConditionFromHealth creates a Ready condition based on health status.
+func buildReadyConditionFromHealth(healthStatus provisioning.HealthStatus) metav1.Condition {
+	if healthStatus.Healthy {
+		return metav1.Condition{
+			Type:    provisioning.ConditionTypeReady,
+			Status:  metav1.ConditionTrue,
+			Reason:  provisioning.ReasonAvailable,
+			Message: "Resource is available",
+		}
+	}
+
+	// Build message from health status messages
+	message := "Resource is unavailable"
+	if len(healthStatus.Message) > 0 {
+		message = healthStatus.Message[0]
+	}
+
+	return metav1.Condition{
+		Type:    provisioning.ConditionTypeReady,
+		Status:  metav1.ConditionFalse,
+		Reason:  provisioning.ReasonUnavailable,
+		Message: message,
+	}
+}

--- a/pkg/registry/apis/provisioning/controller/conditions_test.go
+++ b/pkg/registry/apis/provisioning/controller/conditions_test.go
@@ -1,0 +1,314 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+func TestBuildReadyConditionFromHealth(t *testing.T) {
+	tests := []struct {
+		name           string
+		healthStatus   provisioning.HealthStatus
+		expectedStatus metav1.ConditionStatus
+		expectedReason string
+		expectedMsg    string
+	}{
+		{
+			name: "healthy status creates Ready=True condition",
+			healthStatus: provisioning.HealthStatus{
+				Healthy: true,
+				Checked: time.Now().UnixMilli(),
+			},
+			expectedStatus: metav1.ConditionTrue,
+			expectedReason: provisioning.ReasonAvailable,
+			expectedMsg:    "Resource is available",
+		},
+		{
+			name: "unhealthy status creates Ready=False condition",
+			healthStatus: provisioning.HealthStatus{
+				Healthy: false,
+				Checked: time.Now().UnixMilli(),
+				Message: []string{"connection failed"},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: provisioning.ReasonUnavailable,
+			expectedMsg:    "connection failed",
+		},
+		{
+			name: "unhealthy with no message uses default message",
+			healthStatus: provisioning.HealthStatus{
+				Healthy: false,
+				Checked: time.Now().UnixMilli(),
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: provisioning.ReasonUnavailable,
+			expectedMsg:    "Resource is unavailable",
+		},
+		{
+			name: "unhealthy with multiple messages uses first message",
+			healthStatus: provisioning.HealthStatus{
+				Healthy: false,
+				Checked: time.Now().UnixMilli(),
+				Message: []string{"first error", "second error"},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: provisioning.ReasonUnavailable,
+			expectedMsg:    "first error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			condition := buildReadyConditionFromHealth(tt.healthStatus)
+
+			assert.Equal(t, provisioning.ConditionTypeReady, condition.Type)
+			assert.Equal(t, tt.expectedStatus, condition.Status)
+			assert.Equal(t, tt.expectedReason, condition.Reason)
+			assert.Equal(t, tt.expectedMsg, condition.Message)
+		})
+	}
+}
+
+func TestBuildConditionPatchOpsFromExisting(t *testing.T) {
+	fixedTime := metav1.NewTime(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	tests := []struct {
+		name                string
+		existingConditions  []metav1.Condition
+		generation          int64
+		newCondition        metav1.Condition
+		expectPatch         bool
+		expectedConditions  int
+		validateLastTransit bool
+	}{
+		{
+			name:               "creates patch when no existing conditions",
+			existingConditions: nil,
+			generation:         1,
+			newCondition: metav1.Condition{
+				Type:    provisioning.ConditionTypeReady,
+				Status:  metav1.ConditionTrue,
+				Reason:  provisioning.ReasonAvailable,
+				Message: "Resource is available",
+			},
+			expectPatch:        true,
+			expectedConditions: 1,
+		},
+		{
+			name: "creates patch when condition changes",
+			existingConditions: []metav1.Condition{
+				{
+					Type:               provisioning.ConditionTypeReady,
+					Status:             metav1.ConditionFalse,
+					Reason:             provisioning.ReasonUnavailable,
+					Message:            "Resource is unavailable",
+					ObservedGeneration: 1,
+					LastTransitionTime: fixedTime,
+				},
+			},
+			generation: 1,
+			newCondition: metav1.Condition{
+				Type:    provisioning.ConditionTypeReady,
+				Status:  metav1.ConditionTrue,
+				Reason:  provisioning.ReasonAvailable,
+				Message: "Resource is available",
+			},
+			expectPatch:        true,
+			expectedConditions: 1,
+		},
+		{
+			name: "no patch when condition unchanged",
+			existingConditions: []metav1.Condition{
+				{
+					Type:               provisioning.ConditionTypeReady,
+					Status:             metav1.ConditionTrue,
+					Reason:             provisioning.ReasonAvailable,
+					Message:            "Resource is available",
+					ObservedGeneration: 1,
+					LastTransitionTime: fixedTime,
+				},
+			},
+			generation: 1,
+			newCondition: metav1.Condition{
+				Type:    provisioning.ConditionTypeReady,
+				Status:  metav1.ConditionTrue,
+				Reason:  provisioning.ReasonAvailable,
+				Message: "Resource is available",
+			},
+			expectPatch: false,
+		},
+		{
+			name: "creates patch when generation changes",
+			existingConditions: []metav1.Condition{
+				{
+					Type:               provisioning.ConditionTypeReady,
+					Status:             metav1.ConditionTrue,
+					Reason:             provisioning.ReasonAvailable,
+					Message:            "Resource is available",
+					ObservedGeneration: 1,
+					LastTransitionTime: fixedTime,
+				},
+			},
+			generation: 2,
+			newCondition: metav1.Condition{
+				Type:    provisioning.ConditionTypeReady,
+				Status:  metav1.ConditionTrue,
+				Reason:  provisioning.ReasonAvailable,
+				Message: "Resource is available",
+			},
+			expectPatch:        true,
+			expectedConditions: 1,
+		},
+		{
+			name: "creates patch when reason changes",
+			existingConditions: []metav1.Condition{
+				{
+					Type:               provisioning.ConditionTypeReady,
+					Status:             metav1.ConditionTrue,
+					Reason:             provisioning.ReasonAvailable,
+					Message:            "Resource is available",
+					ObservedGeneration: 1,
+					LastTransitionTime: fixedTime,
+				},
+			},
+			generation: 1,
+			newCondition: metav1.Condition{
+				Type:    provisioning.ConditionTypeReady,
+				Status:  metav1.ConditionTrue,
+				Reason:  "DifferentReason",
+				Message: "Resource is available",
+			},
+			expectPatch:        true,
+			expectedConditions: 1,
+		},
+		{
+			name: "creates patch when message changes",
+			existingConditions: []metav1.Condition{
+				{
+					Type:               provisioning.ConditionTypeReady,
+					Status:             metav1.ConditionTrue,
+					Reason:             provisioning.ReasonAvailable,
+					Message:            "Resource is available",
+					ObservedGeneration: 1,
+					LastTransitionTime: fixedTime,
+				},
+			},
+			generation: 1,
+			newCondition: metav1.Condition{
+				Type:    provisioning.ConditionTypeReady,
+				Status:  metav1.ConditionTrue,
+				Reason:  provisioning.ReasonAvailable,
+				Message: "Different message",
+			},
+			expectPatch:        true,
+			expectedConditions: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patchOps := buildConditionPatchOpsFromExisting(tt.existingConditions, tt.generation, tt.newCondition)
+
+			if !tt.expectPatch {
+				assert.Nil(t, patchOps, "expected no patch operations")
+				return
+			}
+
+			require.NotNil(t, patchOps, "expected patch operations")
+			require.Len(t, patchOps, 1, "expected exactly one patch operation")
+
+			patch := patchOps[0]
+			assert.Equal(t, "replace", patch["op"])
+			assert.Equal(t, "/status/conditions", patch["path"])
+
+			conditions, ok := patch["value"].([]metav1.Condition)
+			require.True(t, ok, "patch value should be []metav1.Condition")
+			assert.Len(t, conditions, tt.expectedConditions)
+
+			// Verify ObservedGeneration is set
+			readyCondition := conditions[0]
+			assert.Equal(t, tt.generation, readyCondition.ObservedGeneration)
+			assert.Equal(t, tt.newCondition.Type, readyCondition.Type)
+			assert.Equal(t, tt.newCondition.Status, readyCondition.Status)
+			assert.Equal(t, tt.newCondition.Reason, readyCondition.Reason)
+			assert.Equal(t, tt.newCondition.Message, readyCondition.Message)
+		})
+	}
+}
+
+func TestBuildConditionPatchOpsFromExisting_Connection(t *testing.T) {
+	fixedTime := metav1.NewTime(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	tests := []struct {
+		name               string
+		existingConditions []metav1.Condition
+		generation         int64
+		newCondition       metav1.Condition
+		expectPatch        bool
+	}{
+		{
+			name:               "creates patch when no existing conditions",
+			existingConditions: nil,
+			generation:         1,
+			newCondition: metav1.Condition{
+				Type:    provisioning.ConditionTypeReady,
+				Status:  metav1.ConditionTrue,
+				Reason:  provisioning.ReasonAvailable,
+				Message: "Resource is available",
+			},
+			expectPatch: true,
+		},
+		{
+			name: "no patch when condition unchanged",
+			existingConditions: []metav1.Condition{
+				{
+					Type:               provisioning.ConditionTypeReady,
+					Status:             metav1.ConditionTrue,
+					Reason:             provisioning.ReasonAvailable,
+					Message:            "Resource is available",
+					ObservedGeneration: 1,
+					LastTransitionTime: fixedTime,
+				},
+			},
+			generation: 1,
+			newCondition: metav1.Condition{
+				Type:    provisioning.ConditionTypeReady,
+				Status:  metav1.ConditionTrue,
+				Reason:  provisioning.ReasonAvailable,
+				Message: "Resource is available",
+			},
+			expectPatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patchOps := buildConditionPatchOpsFromExisting(tt.existingConditions, tt.generation, tt.newCondition)
+
+			if !tt.expectPatch {
+				assert.Nil(t, patchOps, "expected no patch operations")
+				return
+			}
+
+			require.NotNil(t, patchOps, "expected patch operations")
+			require.Len(t, patchOps, 1, "expected exactly one patch operation")
+
+			patch := patchOps[0]
+			assert.Equal(t, "replace", patch["op"])
+			assert.Equal(t, "/status/conditions", patch["path"])
+
+			conditions, ok := patch["value"].([]metav1.Condition)
+			require.True(t, ok, "patch value should be []metav1.Condition")
+
+			// Verify ObservedGeneration is set
+			readyCondition := conditions[0]
+			assert.Equal(t, tt.generation, readyCondition.ObservedGeneration)
+		})
+	}
+}

--- a/pkg/registry/apis/provisioning/controller/connection_health.go
+++ b/pkg/registry/apis/provisioning/controller/connection_health.go
@@ -126,7 +126,7 @@ func (hc *ConnectionHealthChecker) RefreshHealthWithPatchOps(ctx context.Context
 
 	// Update Ready condition based on health status
 	readyCondition := buildReadyConditionFromHealth(newHealthStatus)
-	if conditionPatchOps := buildConditionPatchOpsForConnection(conn.Status.Conditions, conn.GetGeneration(), readyCondition); conditionPatchOps != nil {
+	if conditionPatchOps := buildConditionPatchOpsFromExisting(conn.Status.Conditions, conn.GetGeneration(), readyCondition); conditionPatchOps != nil {
 		patchOps = append(patchOps, conditionPatchOps...)
 	}
 

--- a/pkg/registry/apis/provisioning/controller/connection_health.go
+++ b/pkg/registry/apis/provisioning/controller/connection_health.go
@@ -124,6 +124,12 @@ func (hc *ConnectionHealthChecker) RefreshHealthWithPatchOps(ctx context.Context
 		})
 	}
 
+	// Update Ready condition based on health status
+	readyCondition := buildReadyConditionFromHealth(newHealthStatus)
+	if conditionPatchOps := buildConditionPatchOpsForConnection(conn.Status.Conditions, conn.GetGeneration(), readyCondition); conditionPatchOps != nil {
+		patchOps = append(patchOps, conditionPatchOps...)
+	}
+
 	return testResults, newHealthStatus, patchOps, nil
 }
 

--- a/pkg/registry/apis/provisioning/controller/health.go
+++ b/pkg/registry/apis/provisioning/controller/health.go
@@ -200,6 +200,12 @@ func (hc *RepositoryHealthChecker) RefreshHealthWithPatchOps(ctx context.Context
 		})
 	}
 
+	// Update Ready condition based on health status
+	readyCondition := buildReadyConditionFromHealth(newHealthStatus)
+	if conditionPatchOps := buildConditionPatchOpsForRepository(cfg.Status.Conditions, cfg.GetGeneration(), readyCondition); conditionPatchOps != nil {
+		patchOps = append(patchOps, conditionPatchOps...)
+	}
+
 	return testResults, newHealthStatus, patchOps, nil
 }
 

--- a/pkg/registry/apis/provisioning/controller/health.go
+++ b/pkg/registry/apis/provisioning/controller/health.go
@@ -202,7 +202,7 @@ func (hc *RepositoryHealthChecker) RefreshHealthWithPatchOps(ctx context.Context
 
 	// Update Ready condition based on health status
 	readyCondition := buildReadyConditionFromHealth(newHealthStatus)
-	if conditionPatchOps := buildConditionPatchOpsForRepository(cfg.Status.Conditions, cfg.GetGeneration(), readyCondition); conditionPatchOps != nil {
+	if conditionPatchOps := buildConditionPatchOpsFromExisting(cfg.Status.Conditions, cfg.GetGeneration(), readyCondition); conditionPatchOps != nil {
 		patchOps = append(patchOps, conditionPatchOps...)
 	}
 

--- a/pkg/registry/apis/provisioning/controller/health_test.go
+++ b/pkg/registry/apis/provisioning/controller/health_test.go
@@ -611,6 +611,7 @@ func TestRefreshHealthWithPatchOps(t *testing.T) {
 			expectError:    false,
 			expectedHealth: true,
 			expectPatchOps: false,
+			// Note: Need to add existing condition to the mock repo below
 		},
 		{
 			name:       "test repository error",
@@ -629,15 +630,34 @@ func TestRefreshHealthWithPatchOps(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create mock repository
+			repoStatus := provisioning.RepositoryStatus{
+				Health: tt.existingStatus,
+			}
+
+			// For "no status change" test, add existing condition
+			if tt.name == "no status change - no patch ops returned" {
+				repoStatus.Conditions = []metav1.Condition{
+					{
+						Type:               provisioning.ConditionTypeReady,
+						Status:             metav1.ConditionTrue,
+						Reason:             provisioning.ReasonAvailable,
+						Message:            "Resource is available",
+						ObservedGeneration: 1,
+						LastTransitionTime: metav1.Now(),
+					},
+				}
+			}
+
 			mockRepo := &mockRepository{
 				config: &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Generation: 1,
+					},
 					Spec: provisioning.RepositorySpec{
 						Title: "Test Repository",
 						Type:  provisioning.LocalRepositoryType,
 					},
-					Status: provisioning.RepositoryStatus{
-						Health: tt.existingStatus,
-					},
+					Status: repoStatus,
 				},
 				testResult: tt.testResult,
 				testError:  tt.testError,
@@ -668,10 +688,33 @@ func TestRefreshHealthWithPatchOps(t *testing.T) {
 			// Verify patch operations
 			if tt.expectPatchOps {
 				assert.NotEmpty(t, patchOps, "expected patch operations to be returned")
-				assert.Len(t, patchOps, 1)
+				// Should have 2 patches: health and condition
+				assert.Len(t, patchOps, 2)
+
+				// First patch should be health
 				assert.Equal(t, "replace", patchOps[0]["op"])
 				assert.Equal(t, tt.expectedPatchPath, patchOps[0]["path"])
 				assert.Equal(t, healthStatus, patchOps[0]["value"])
+
+				// Second patch should be conditions with Ready condition
+				assert.Equal(t, "replace", patchOps[1]["op"])
+				assert.Equal(t, "/status/conditions", patchOps[1]["path"])
+
+				// Verify Ready condition is set correctly
+				conditions, ok := patchOps[1]["value"].([]metav1.Condition)
+				assert.True(t, ok, "conditions should be of type []metav1.Condition")
+				assert.Len(t, conditions, 1, "should have exactly one condition")
+
+				readyCondition := conditions[0]
+				assert.Equal(t, provisioning.ConditionTypeReady, readyCondition.Type)
+
+				if tt.expectedHealth {
+					assert.Equal(t, metav1.ConditionTrue, readyCondition.Status)
+					assert.Equal(t, provisioning.ReasonAvailable, readyCondition.Reason)
+				} else {
+					assert.Equal(t, metav1.ConditionFalse, readyCondition.Status)
+					assert.Equal(t, provisioning.ReasonUnavailable, readyCondition.Reason)
+				}
 			} else {
 				assert.Empty(t, patchOps, "expected no patch operations to be returned")
 			}

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -4336,6 +4336,24 @@
           "health"
         ],
         "properties": {
+          "conditions": {
+            "description": "Conditions represent the latest available observations of the connection's state.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+                }
+              ]
+            },
+            "x-kubernetes-list-map-keys": [
+              "type"
+            ],
+            "x-kubernetes-list-type": "map",
+            "x-kubernetes-patch-merge-key": "type",
+            "x-kubernetes-patch-strategy": "merge"
+          },
           "fieldErrors": {
             "description": "FieldErrors are errors that occurred during validation of the connection spec. These errors are intended to help users identify and fix issues in the spec.",
             "type": "array",
@@ -5500,6 +5518,24 @@
           "webhook"
         ],
         "properties": {
+          "conditions": {
+            "description": "Conditions represent the latest available observations of the repository's state.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+                }
+              ]
+            },
+            "x-kubernetes-list-map-keys": [
+              "type"
+            ],
+            "x-kubernetes-list-type": "map",
+            "x-kubernetes-patch-merge-key": "type",
+            "x-kubernetes-patch-strategy": "merge"
+          },
           "deleteError": {
             "description": "Error information during repository deletion (if any)",
             "type": "string"
@@ -6496,6 +6532,52 @@
               ]
             },
             "x-kubernetes-list-type": "atomic"
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+        "description": "Condition contains details for one aspect of the current state of this API Resource.",
+        "type": "object",
+        "required": [
+          "type",
+          "status",
+          "lastTransitionTime",
+          "reason",
+          "message"
+        ],
+        "properties": {
+          "lastTransitionTime": {
+            "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+              }
+            ]
+          },
+          "message": {
+            "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+            "type": "string",
+            "default": ""
+          },
+          "observedGeneration": {
+            "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "reason": {
+            "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+            "type": "string",
+            "default": ""
+          },
+          "status": {
+            "description": "status of the condition, one of True, False, Unknown.",
+            "type": "string",
+            "default": ""
+          },
+          "type": {
+            "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+            "type": "string",
+            "default": ""
           }
         }
       },

--- a/pkg/tests/apis/provisioning/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection_test.go
@@ -1584,13 +1584,3 @@ func verifyToken(t *testing.T, appID, publicKey, token string) (bool, error) {
 
 	return claims.VerifyIssuer(appID, true), nil
 }
-
-// findCondition finds a condition by type in the conditions list
-func findCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
-	for i := range conditions {
-		if conditions[i].Type == conditionType {
-			return &conditions[i]
-		}
-	}
-	return nil
-}

--- a/pkg/tests/apis/provisioning/health_test.go
+++ b/pkg/tests/apis/provisioning/health_test.go
@@ -213,16 +213,6 @@ func TestIntegrationHealth(t *testing.T) {
 	})
 }
 
-// findCondition finds a condition by type in the conditions list
-func findCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
-	for i := range conditions {
-		if conditions[i].Type == conditionType {
-			return &conditions[i]
-		}
-	}
-	return nil
-}
-
 // parseTestResults extracts TestResults from the API response
 func parseTestResults(t *testing.T, obj runtime.Object) *provisioning.TestResults {
 	t.Helper()

--- a/pkg/tests/apis/provisioning/helper_test.go
+++ b/pkg/tests/apis/provisioning/helper_test.go
@@ -1147,3 +1147,13 @@ func requestHelper(
 
 	return result, resp.Response.StatusCode, nil
 }
+
+// findCondition finds a condition by type in the conditions list
+func findCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes https://github.com/grafana/git-ui-sync-project/issues/744

## Summary

This PR introduces basic Kubernetes Conditions support to Repository and Connection resources, following standard Kubernetes API conventions.

### What changed?

- **API Changes**: Added `Conditions []metav1.Condition` field to both `RepositoryStatus` and `ConnectionStatus`
- **Ready Condition**: Automatically set based on health check results
  - `Status=True, Reason=Available` when health check passes
  - `Status=False, Reason=Unavailable` when health check fails
- **Condition Management**: Added helpers to manage conditions with proper `LastTransitionTime` tracking
- **Test Coverage**: Updated tests to verify conditions are set correctly

### Implementation Details

The implementation is intentionally simple and focused:

1. **Single Condition Type**: Only the `Ready` condition is implemented
2. **Mirrors Health Status**: Ready condition directly reflects the existing health check results
3. **No Breaking Changes**: Existing `Health` field remains unchanged; conditions are additive
4. **Efficient Updates**: Conditions are only patched when they change to avoid unnecessary API calls

## Why Kubernetes Conditions?

Conditions are the standard way for Kubernetes resources to communicate their state. This change brings several benefits:

### 1. **Standardization & Conventions**
Kubernetes operators, controllers, and tooling expect resources to use conditions. By adopting this pattern, our Repository and Connection resources become more idiomatic and easier to integrate with the broader Kubernetes ecosystem.

### 2. **Rich State Representation**
While we currently have a simple `Healthy: bool` field, conditions allow us to represent multiple independent aspects of resource state:
- Ready (is it operational?)
- Synced (is sync up to date?)
- Validated (does the spec pass validation?)

Each condition can have its own status, reason, and message.

### 3. **Automatic Transition Tracking**
The `LastTransitionTime` field is automatically managed by `meta.SetStatusCondition()`, giving us free tracking of when conditions change without manual timestamp management.

### 4. **Better Observability**
Standard tooling can display condition status:
```bash
kubectl get repositories -o wide
kubectl describe repository my-repo
```

This makes debugging easier for users who are familiar with Kubernetes.

### 5. **Future Extensibility**
Adding new condition types (e.g., `Synced`, `Validated`) doesn't require API changes or versioning - we simply start populating a new condition type. This gives us a clear path for future enhancements without breaking compatibility.

### 6. **Kubernetes API Guidelines**
The [Kubernetes API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties) recommend conditions for status:

> "Conditions represent the latest available observations of an object's state."

By following these conventions, we make our API more predictable for Kubernetes users.

## What's Next?

This PR establishes the foundation for conditions. Future work could include:
- Adding a `Synced` condition to track sync status
- Adding a `Validated` condition for spec validation errors
- Gradually migrating logic to rely on conditions instead of the legacy `Health.Healthy` field

## Testing

- ✅ Unit tests updated to verify condition patches
- ✅ Tests verify correct condition status, reason, and message
- ✅ Tests verify conditions only patch when changed
- ✅ Code regenerated with `./hack/update-codegen.sh provisioning`

🤖 Generated with [Claude Code](https://claude.com/claude-code)