### PR TITLE
Provisioning: Add granular condition reasons for Connection Controller

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
@@ -21,10 +21,10 @@ const (
 	// ReasonAvailable indicates the resource is available and ready for use.
 	ReasonAvailable = "Available"
 
-	// ReasonInvalidConfiguration indicates the resource has a configuration issue
+	// ReasonInvalidSpec indicates the resource has a configuration issue
 	// with the spec format or structure (validation errors, invalid fields, secret errors).
 	// Automation should NOT automatically retry - wait for user to fix configuration.
-	ReasonInvalidConfiguration = "InvalidConfiguration"
+	ReasonInvalidSpec = "InvalidSpec"
 
 	// ReasonAuthenticationFailed indicates authentication or authorization failed
 	// (invalid credentials, wrong app ID, expired token, insufficient permissions).

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
@@ -20,8 +20,25 @@ const (
 const (
 	// ReasonAvailable indicates the resource is available and ready for use.
 	ReasonAvailable = "Available"
-	// ReasonUnavailable indicates the resource is unavailable and not ready.
-	ReasonUnavailable = "Unavailable"
+
+	// ReasonInvalidConfiguration indicates the resource has a configuration issue
+	// with the spec format or structure (validation errors, invalid fields, secret errors).
+	// Automation should NOT automatically retry - wait for user to fix configuration.
+	ReasonInvalidConfiguration = "InvalidConfiguration"
+
+	// ReasonAuthenticationFailed indicates authentication or authorization failed
+	// (invalid credentials, wrong app ID, expired token, insufficient permissions).
+	// Automation should NOT automatically retry - wait for user to fix credentials.
+	ReasonAuthenticationFailed = "AuthenticationFailed"
+
+	// ReasonServiceUnavailable indicates an external service issue (API down, network timeout).
+	// Automation CAN retry with standard backoff - the issue is transient and outside user control.
+	ReasonServiceUnavailable = "ServiceUnavailable"
+
+	// ReasonRateLimited indicates the external service is rate limiting requests.
+	// User may need to take action (upgrade plan, reduce load). Automation should retry with
+	// longer backoff and respect Retry-After headers.
+	ReasonRateLimited = "RateLimited"
 )
 
 type HealthStatus struct {

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
@@ -21,10 +21,10 @@ const (
 	// ReasonAvailable indicates the resource is available and ready for use.
 	ReasonAvailable = "Available"
 
-	// ReasonInvalidSpec indicates the resource has a configuration issue
+	// ReasonInvalidConfiguration indicates the resource has a configuration issue
 	// with the spec format or structure (validation errors, invalid fields, secret errors).
 	// Automation should NOT automatically retry - wait for user to fix configuration.
-	ReasonInvalidSpec = "InvalidSpec"
+	ReasonInvalidConfiguration = "InvalidConfiguration"
 
 	// ReasonAuthenticationFailed indicates authentication or authorization failed
 	// (invalid credentials, wrong app ID, expired token, insufficient permissions).

--- a/apps/provisioning/pkg/connection/github/client.go
+++ b/apps/provisioning/pkg/connection/github/client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-github/v70/github"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // API errors that we need to convey after parsing real GH errors (or faking them).
@@ -18,6 +19,8 @@ var (
 	ErrAuthentication = apierrors.NewUnauthorized("authentication failed")
 	//lint:ignore ST1005 this is not punctuation
 	ErrServiceUnavailable = apierrors.NewServiceUnavailable("github is unavailable")
+	//lint:ignore ST1005 this is not punctuation
+	ErrNotFound = apierrors.NewNotFound(schema.GroupResource{Resource: "github"}, "resource not found")
 )
 
 //go:generate mockery --name Client --structname MockClient --inpackage --filename client_mock.go --with-expecter
@@ -81,6 +84,8 @@ func (r *githubClient) GetApp(ctx context.Context) (App, error) {
 			switch ghErr.Response.StatusCode {
 			case http.StatusUnauthorized, http.StatusForbidden:
 				return App{}, ErrAuthentication
+			case http.StatusNotFound:
+				return App{}, ErrNotFound
 			case http.StatusServiceUnavailable:
 				return App{}, ErrServiceUnavailable
 			}
@@ -109,6 +114,8 @@ func (r *githubClient) GetAppInstallation(ctx context.Context, installationID st
 			switch ghErr.Response.StatusCode {
 			case http.StatusUnauthorized, http.StatusForbidden:
 				return AppInstallation{}, ErrAuthentication
+			case http.StatusNotFound:
+				return AppInstallation{}, ErrNotFound
 			case http.StatusServiceUnavailable:
 				return AppInstallation{}, ErrServiceUnavailable
 			}

--- a/apps/provisioning/pkg/connection/github/client.go
+++ b/apps/provisioning/pkg/connection/github/client.go
@@ -10,45 +10,13 @@ import (
 
 	"github.com/google/go-github/v70/github"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // API errors that we need to convey after parsing real GH errors (or faking them).
-// These sentinel errors allow callers to distinguish between different error types.
 var (
-	//lint:ignore ST1005 this is not punctuation
-	ErrUnauthorized = apierrors.NewUnauthorized("authentication failed")
-	//lint:ignore ST1005 this is not punctuation
-	ErrForbidden = &apierrors.StatusError{ErrStatus: metav1.Status{Code: http.StatusForbidden, Message: "access forbidden", Reason: metav1.StatusReasonForbidden}}
-	//lint:ignore ST1005 this is not punctuation
-	ErrRateLimited = apierrors.NewTooManyRequests("rate limited", 0)
 	//lint:ignore ST1005 this is not punctuation
 	ErrServiceUnavailable = apierrors.NewServiceUnavailable("github is unavailable")
 )
-
-// extractHTTPError extracts HTTP status code from GitHub API errors and returns appropriate sentinel errors.
-// Returns a sentinel error for known status codes, or the original error otherwise.
-func extractHTTPError(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	var ghErr *github.ErrorResponse
-	if errors.As(err, &ghErr) && ghErr.Response != nil {
-		switch ghErr.Response.StatusCode {
-		case http.StatusUnauthorized:
-			return ErrUnauthorized
-		case http.StatusForbidden:
-			return ErrForbidden
-		case http.StatusTooManyRequests:
-			return ErrRateLimited
-		case http.StatusServiceUnavailable:
-			return ErrServiceUnavailable
-		}
-	}
-
-	return err
-}
 
 //go:generate mockery --name Client --structname MockClient --inpackage --filename client_mock.go --with-expecter
 type Client interface {
@@ -106,7 +74,11 @@ func NewClient(client *github.Client) Client {
 func (r *githubClient) GetApp(ctx context.Context) (App, error) {
 	app, _, err := r.gh.Apps.Get(ctx, "")
 	if err != nil {
-		return App{}, extractHTTPError(err)
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusServiceUnavailable {
+			return App{}, ErrServiceUnavailable
+		}
+		return App{}, err
 	}
 
 	return App{
@@ -125,7 +97,11 @@ func (r *githubClient) GetAppInstallation(ctx context.Context, installationID st
 
 	installation, _, err := r.gh.Apps.GetInstallation(ctx, int64(id))
 	if err != nil {
-		return AppInstallation{}, extractHTTPError(err)
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusServiceUnavailable {
+			return AppInstallation{}, ErrServiceUnavailable
+		}
+		return AppInstallation{}, err
 	}
 
 	return AppInstallation{
@@ -149,7 +125,11 @@ func (r *githubClient) ListInstallationRepositories(ctx context.Context, install
 	// Create an installation access token
 	installationToken, _, err := r.gh.Apps.CreateInstallationToken(ctx, id, nil)
 	if err != nil {
-		return nil, extractHTTPError(err)
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusServiceUnavailable {
+			return nil, ErrServiceUnavailable
+		}
+		return nil, fmt.Errorf("create installation token: %w", err)
 	}
 
 	// Create a new client with the installation token
@@ -165,7 +145,11 @@ func (r *githubClient) ListInstallationRepositories(ctx context.Context, install
 	for {
 		result, resp, err := tokenClient.Apps.ListRepos(ctx, opts)
 		if err != nil {
-			return nil, extractHTTPError(err)
+			var ghErr *github.ErrorResponse
+			if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusServiceUnavailable {
+				return nil, ErrServiceUnavailable
+			}
+			return nil, fmt.Errorf("list repositories: %w", err)
 		}
 
 		for _, repo := range result.Repositories {
@@ -207,7 +191,11 @@ func (r *githubClient) CreateInstallationAccessToken(ctx context.Context, instal
 
 	token, _, err := r.gh.Apps.CreateInstallationToken(ctx, int64(id), opts)
 	if err != nil {
-		return InstallationToken{}, extractHTTPError(err)
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusServiceUnavailable {
+			return InstallationToken{}, ErrServiceUnavailable
+		}
+		return InstallationToken{}, err
 	}
 
 	return InstallationToken{

--- a/apps/provisioning/pkg/connection/github/client_test.go
+++ b/apps/provisioning/pkg/connection/github/client_test.go
@@ -111,12 +111,27 @@ func TestGithubClient_GetApp(t *testing.T) {
 			),
 			token:   "invalid-token",
 			wantApp: conngh.App{},
-			wantErr: &github.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: http.StatusUnauthorized,
-				},
-				Message: "Bad credentials",
-			},
+			wantErr: conngh.ErrAuthentication,
+		},
+		{
+			name: "not found error",
+			mockHandler: mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetApp,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusNotFound)
+						require.NoError(t, json.NewEncoder(w).Encode(github.ErrorResponse{
+							Response: &http.Response{
+								StatusCode: http.StatusNotFound,
+							},
+							Message: "Integration not found",
+						}))
+					}),
+				),
+			),
+			token:   "test-token",
+			wantApp: conngh.App{},
+			wantErr: conngh.ErrNotFound,
 		},
 	}
 

--- a/apps/provisioning/pkg/connection/github/connection.go
+++ b/apps/provisioning/pkg/connection/github/connection.go
@@ -55,40 +55,35 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 
 	app, err := ghClient.GetApp(ctx)
 	if err != nil {
-		// Map sentinel errors to HTTP status codes
-		statusCode := http.StatusBadRequest
-		errorDetail := "invalid token"
-
-		switch {
-		case errors.Is(err, ErrUnauthorized):
-			statusCode = http.StatusUnauthorized
-			errorDetail = err.Error()
-		case errors.Is(err, ErrForbidden):
-			statusCode = http.StatusForbidden
-			errorDetail = err.Error()
-		case errors.Is(err, ErrRateLimited):
-			statusCode = http.StatusTooManyRequests
-			errorDetail = err.Error()
-		case errors.Is(err, ErrServiceUnavailable):
-			statusCode = http.StatusServiceUnavailable
-			errorDetail = err.Error()
-		default:
-			// Unknown error - keep default BadRequest
-			errorDetail = "invalid token"
+		if errors.Is(err, ErrServiceUnavailable) {
+			return &provisioning.TestResults{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: provisioning.APIVERSION,
+					Kind:       "TestResults",
+				},
+				Code:    http.StatusServiceUnavailable,
+				Success: false,
+				Errors: []provisioning.ErrorDetails{
+					{
+						Type:   metav1.CauseTypeFieldValueInvalid,
+						Field:  field.NewPath("spec", "token").String(),
+						Detail: ErrServiceUnavailable.Error(),
+					},
+				},
+			}, nil
 		}
-
 		return &provisioning.TestResults{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: provisioning.APIVERSION,
 				Kind:       "TestResults",
 			},
-			Code:    statusCode,
+			Code:    http.StatusBadRequest,
 			Success: false,
 			Errors: []provisioning.ErrorDetails{
 				{
 					Type:   metav1.CauseTypeFieldValueInvalid,
 					Field:  field.NewPath("spec", "token").String(),
-					Detail: errorDetail,
+					Detail: "invalid token",
 				},
 			},
 		}, nil
@@ -114,40 +109,35 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 
 	_, err = ghClient.GetAppInstallation(ctx, c.obj.Spec.GitHub.InstallationID)
 	if err != nil {
-		// Map sentinel errors to HTTP status codes
-		statusCode := http.StatusBadRequest
-		errorDetail := fmt.Sprintf("invalid installation ID: %s", c.obj.Spec.GitHub.InstallationID)
-
-		switch {
-		case errors.Is(err, ErrUnauthorized):
-			statusCode = http.StatusUnauthorized
-			errorDetail = err.Error()
-		case errors.Is(err, ErrForbidden):
-			statusCode = http.StatusForbidden
-			errorDetail = err.Error()
-		case errors.Is(err, ErrRateLimited):
-			statusCode = http.StatusTooManyRequests
-			errorDetail = err.Error()
-		case errors.Is(err, ErrServiceUnavailable):
-			statusCode = http.StatusServiceUnavailable
-			errorDetail = err.Error()
-		default:
-			// Unknown error - keep default message with installation ID
-			errorDetail = fmt.Sprintf("invalid installation ID: %s", c.obj.Spec.GitHub.InstallationID)
+		if errors.Is(err, ErrServiceUnavailable) {
+			return &provisioning.TestResults{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: provisioning.APIVERSION,
+					Kind:       "TestResults",
+				},
+				Code:    http.StatusServiceUnavailable,
+				Success: false,
+				Errors: []provisioning.ErrorDetails{
+					{
+						Type:   metav1.CauseTypeFieldValueInvalid,
+						Field:  field.NewPath("spec", "token").String(),
+						Detail: ErrServiceUnavailable.Error(),
+					},
+				},
+			}, nil
 		}
-
 		return &provisioning.TestResults{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: provisioning.APIVERSION,
 				Kind:       "TestResults",
 			},
-			Code:    statusCode,
+			Code:    http.StatusBadRequest,
 			Success: false,
 			Errors: []provisioning.ErrorDetails{
 				{
 					Type:   metav1.CauseTypeFieldValueInvalid,
 					Field:  field.NewPath("spec", "installationID").String(),
-					Detail: errorDetail,
+					Detail: fmt.Sprintf("invalid installation ID: %s", c.obj.Spec.GitHub.InstallationID),
 				},
 			},
 		}, nil

--- a/apps/provisioning/pkg/connection/github/connection.go
+++ b/apps/provisioning/pkg/connection/github/connection.go
@@ -55,7 +55,25 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 
 	app, err := ghClient.GetApp(ctx)
 	if err != nil {
-		if errors.Is(err, ErrServiceUnavailable) {
+		// Check for specific error types
+		switch {
+		case errors.Is(err, ErrAuthentication):
+			return &provisioning.TestResults{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: provisioning.APIVERSION,
+					Kind:       "TestResults",
+				},
+				Code:    http.StatusUnauthorized,
+				Success: false,
+				Errors: []provisioning.ErrorDetails{
+					{
+						Type:   metav1.CauseTypeFieldValueInvalid,
+						Field:  field.NewPath("spec", "token").String(),
+						Detail: ErrAuthentication.Error(),
+					},
+				},
+			}, nil
+		case errors.Is(err, ErrServiceUnavailable):
 			return &provisioning.TestResults{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: provisioning.APIVERSION,
@@ -71,22 +89,24 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 					},
 				},
 			}, nil
-		}
-		return &provisioning.TestResults{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: provisioning.APIVERSION,
-				Kind:       "TestResults",
-			},
-			Code:    http.StatusBadRequest,
-			Success: false,
-			Errors: []provisioning.ErrorDetails{
-				{
-					Type:   metav1.CauseTypeFieldValueInvalid,
-					Field:  field.NewPath("spec", "token").String(),
-					Detail: "invalid token",
+		default:
+			// Generic error - invalid spec
+			return &provisioning.TestResults{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: provisioning.APIVERSION,
+					Kind:       "TestResults",
 				},
-			},
-		}, nil
+				Code:    http.StatusUnprocessableEntity,
+				Success: false,
+				Errors: []provisioning.ErrorDetails{
+					{
+						Type:   metav1.CauseTypeFieldValueInvalid,
+						Field:  field.NewPath("spec", "token").String(),
+						Detail: "invalid token",
+					},
+				},
+			}, nil
+		}
 	}
 
 	if fmt.Sprintf("%d", app.ID) != c.obj.Spec.GitHub.AppID {
@@ -109,7 +129,25 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 
 	_, err = ghClient.GetAppInstallation(ctx, c.obj.Spec.GitHub.InstallationID)
 	if err != nil {
-		if errors.Is(err, ErrServiceUnavailable) {
+		// Check for specific error types
+		switch {
+		case errors.Is(err, ErrAuthentication):
+			return &provisioning.TestResults{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: provisioning.APIVERSION,
+					Kind:       "TestResults",
+				},
+				Code:    http.StatusUnauthorized,
+				Success: false,
+				Errors: []provisioning.ErrorDetails{
+					{
+						Type:   metav1.CauseTypeFieldValueInvalid,
+						Field:  field.NewPath("spec", "installationID").String(),
+						Detail: ErrAuthentication.Error(),
+					},
+				},
+			}, nil
+		case errors.Is(err, ErrServiceUnavailable):
 			return &provisioning.TestResults{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: provisioning.APIVERSION,
@@ -120,27 +158,29 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 				Errors: []provisioning.ErrorDetails{
 					{
 						Type:   metav1.CauseTypeFieldValueInvalid,
-						Field:  field.NewPath("spec", "token").String(),
+						Field:  field.NewPath("spec", "installationID").String(),
 						Detail: ErrServiceUnavailable.Error(),
 					},
 				},
 			}, nil
-		}
-		return &provisioning.TestResults{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: provisioning.APIVERSION,
-				Kind:       "TestResults",
-			},
-			Code:    http.StatusBadRequest,
-			Success: false,
-			Errors: []provisioning.ErrorDetails{
-				{
-					Type:   metav1.CauseTypeFieldValueInvalid,
-					Field:  field.NewPath("spec", "installationID").String(),
-					Detail: fmt.Sprintf("invalid installation ID: %s", c.obj.Spec.GitHub.InstallationID),
+		default:
+			// Generic error - invalid spec
+			return &provisioning.TestResults{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: provisioning.APIVERSION,
+					Kind:       "TestResults",
 				},
-			},
-		}, nil
+				Code:    http.StatusUnprocessableEntity,
+				Success: false,
+				Errors: []provisioning.ErrorDetails{
+					{
+						Type:   metav1.CauseTypeFieldValueInvalid,
+						Field:  field.NewPath("spec", "installationID").String(),
+						Detail: fmt.Sprintf("invalid installation ID: %s", c.obj.Spec.GitHub.InstallationID),
+					},
+				},
+			}, nil
+		}
 	}
 
 	return &provisioning.TestResults{

--- a/apps/provisioning/pkg/connection/github/connection.go
+++ b/apps/provisioning/pkg/connection/github/connection.go
@@ -73,6 +73,22 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 					},
 				},
 			}, nil
+		case errors.Is(err, ErrNotFound):
+			return &provisioning.TestResults{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: provisioning.APIVERSION,
+					Kind:       "TestResults",
+				},
+				Code:    http.StatusNotFound,
+				Success: false,
+				Errors: []provisioning.ErrorDetails{
+					{
+						Type:   metav1.CauseTypeFieldValueInvalid,
+						Field:  field.NewPath("spec", "appID").String(),
+						Detail: "app not found",
+					},
+				},
+			}, nil
 		case errors.Is(err, ErrServiceUnavailable):
 			return &provisioning.TestResults{
 				TypeMeta: metav1.TypeMeta{
@@ -144,6 +160,22 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 						Type:   metav1.CauseTypeFieldValueInvalid,
 						Field:  field.NewPath("spec", "installationID").String(),
 						Detail: ErrAuthentication.Error(),
+					},
+				},
+			}, nil
+		case errors.Is(err, ErrNotFound):
+			return &provisioning.TestResults{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: provisioning.APIVERSION,
+					Kind:       "TestResults",
+				},
+				Code:    http.StatusNotFound,
+				Success: false,
+				Errors: []provisioning.ErrorDetails{
+					{
+						Type:   metav1.CauseTypeFieldValueInvalid,
+						Field:  field.NewPath("spec", "installationID").String(),
+						Detail: "installation not found",
 					},
 				},
 			}, nil

--- a/apps/provisioning/pkg/connection/github/connection_test.go
+++ b/apps/provisioning/pkg/connection/github/connection_test.go
@@ -357,7 +357,7 @@ func TestConnection_Test(t *testing.T) {
 			expectedErrors: []provisioning.ErrorDetails{
 				{
 					Type:   metav1.CauseTypeFieldValueInvalid,
-					Field:  "spec.installationID",
+					Field:  "spec.token",
 					Detail: github.ErrServiceUnavailable.Error(),
 				},
 			},
@@ -386,84 +386,6 @@ func TestConnection_Test(t *testing.T) {
 					Type:   metav1.CauseTypeFieldValueInvalid,
 					Field:  "spec.installationID",
 					Detail: "invalid installation ID: 456",
-				},
-			},
-		},
-		{
-			name: "failure - GetApp returns unauthorized (401)",
-			connection: &provisioning.Connection{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
-				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GithubConnectionType,
-					GitHub: &provisioning.GitHubConnectionConfig{
-						AppID:          "123",
-						InstallationID: "456",
-					},
-				},
-			},
-			setupMock: func(mockFactory *github.MockGithubFactory, mockClient *github.MockClient) {
-				mockFactory.EXPECT().New(mock.Anything, mock.Anything).Return(mockClient)
-				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{}, github.ErrUnauthorized)
-			},
-			expectedCode:  http.StatusUnauthorized,
-			expectSuccess: false,
-			expectedErrors: []provisioning.ErrorDetails{
-				{
-					Type:   metav1.CauseTypeFieldValueInvalid,
-					Field:  "spec.token",
-					Detail: github.ErrUnauthorized.Error(),
-				},
-			},
-		},
-		{
-			name: "failure - GetApp returns forbidden (403)",
-			connection: &provisioning.Connection{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
-				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GithubConnectionType,
-					GitHub: &provisioning.GitHubConnectionConfig{
-						AppID:          "123",
-						InstallationID: "456",
-					},
-				},
-			},
-			setupMock: func(mockFactory *github.MockGithubFactory, mockClient *github.MockClient) {
-				mockFactory.EXPECT().New(mock.Anything, mock.Anything).Return(mockClient)
-				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{}, github.ErrForbidden)
-			},
-			expectedCode:  http.StatusForbidden,
-			expectSuccess: false,
-			expectedErrors: []provisioning.ErrorDetails{
-				{
-					Type:   metav1.CauseTypeFieldValueInvalid,
-					Field:  "spec.token",
-					Detail: github.ErrForbidden.Error(),
-				},
-			},
-		},
-		{
-			name: "failure - GetApp returns rate limited (429)",
-			connection: &provisioning.Connection{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
-				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GithubConnectionType,
-					GitHub: &provisioning.GitHubConnectionConfig{
-						AppID:          "123",
-						InstallationID: "456",
-					},
-				},
-			},
-			setupMock: func(mockFactory *github.MockGithubFactory, mockClient *github.MockClient) {
-				mockFactory.EXPECT().New(mock.Anything, mock.Anything).Return(mockClient)
-				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{}, github.ErrRateLimited)
-			},
-			expectedCode:  http.StatusTooManyRequests,
-			expectSuccess: false,
-			expectedErrors: []provisioning.ErrorDetails{
-				{
-					Type:   metav1.CauseTypeFieldValueInvalid,
-					Field:  "spec.token",
-					Detail: github.ErrRateLimited.Error(),
 				},
 			},
 		},

--- a/apps/provisioning/pkg/connection/github/connection_test.go
+++ b/apps/provisioning/pkg/connection/github/connection_test.go
@@ -299,7 +299,7 @@ func TestConnection_Test(t *testing.T) {
 				mockFactory.EXPECT().New(mock.Anything, mock.Anything).Return(mockClient)
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{}, errors.New("unauthorized"))
 			},
-			expectedCode:  http.StatusBadRequest,
+			expectedCode:  http.StatusUnprocessableEntity,
 			expectSuccess: false,
 			expectedErrors: []provisioning.ErrorDetails{
 				{
@@ -357,7 +357,7 @@ func TestConnection_Test(t *testing.T) {
 			expectedErrors: []provisioning.ErrorDetails{
 				{
 					Type:   metav1.CauseTypeFieldValueInvalid,
-					Field:  "spec.token",
+					Field:  "spec.installationID",
 					Detail: github.ErrServiceUnavailable.Error(),
 				},
 			},
@@ -379,13 +379,39 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{ID: 123, Slug: "test-app"}, nil)
 				mockClient.EXPECT().GetAppInstallation(mock.Anything, "456").Return(github.AppInstallation{}, errors.New("not found"))
 			},
-			expectedCode:  http.StatusBadRequest,
+			expectedCode:  http.StatusUnprocessableEntity,
 			expectSuccess: false,
 			expectedErrors: []provisioning.ErrorDetails{
 				{
 					Type:   metav1.CauseTypeFieldValueInvalid,
 					Field:  "spec.installationID",
 					Detail: "invalid installation ID: 456",
+				},
+			},
+		},
+		{
+			name: "failure - GetApp returns authentication error (401)",
+			connection: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
+				Spec: provisioning.ConnectionSpec{
+					Type: provisioning.GithubConnectionType,
+					GitHub: &provisioning.GitHubConnectionConfig{
+						AppID:          "123",
+						InstallationID: "456",
+					},
+				},
+			},
+			setupMock: func(mockFactory *github.MockGithubFactory, mockClient *github.MockClient) {
+				mockFactory.EXPECT().New(mock.Anything, mock.Anything).Return(mockClient)
+				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{}, github.ErrAuthentication)
+			},
+			expectedCode:  http.StatusUnauthorized,
+			expectSuccess: false,
+			expectedErrors: []provisioning.ErrorDetails{
+				{
+					Type:   metav1.CauseTypeFieldValueInvalid,
+					Field:  "spec.token",
+					Detail: github.ErrAuthentication.Error(),
 				},
 			},
 		},

--- a/pkg/registry/apis/provisioning/controller/conditions.go
+++ b/pkg/registry/apis/provisioning/controller/conditions.go
@@ -63,7 +63,7 @@ func buildReadyConditionFromHealth(healthStatus provisioning.HealthStatus) metav
 	return metav1.Condition{
 		Type:    provisioning.ConditionTypeReady,
 		Status:  metav1.ConditionFalse,
-		Reason:  provisioning.ReasonInvalidConfiguration,
+		Reason:  provisioning.ReasonInvalidSpec,
 		Message: message,
 	}
 }

--- a/pkg/registry/apis/provisioning/controller/conditions.go
+++ b/pkg/registry/apis/provisioning/controller/conditions.go
@@ -41,35 +41,8 @@ func BuildConditionPatchOpsFromExisting(existingConditions []metav1.Condition, g
 	}
 }
 
-// buildReadyConditionFromHealth creates a Ready condition based on health status.
-// Uses a default reason (InvalidConfiguration) for unhealthy resources.
-// For more specific error classification, use buildReadyConditionWithReason.
-func buildReadyConditionFromHealth(healthStatus provisioning.HealthStatus) metav1.Condition {
-	if healthStatus.Healthy {
-		return metav1.Condition{
-			Type:    provisioning.ConditionTypeReady,
-			Status:  metav1.ConditionTrue,
-			Reason:  provisioning.ReasonAvailable,
-			Message: "Resource is available",
-		}
-	}
-
-	// Build message from health status messages
-	message := "Resource is unavailable"
-	if len(healthStatus.Message) > 0 {
-		message = healthStatus.Message[0]
-	}
-
-	return metav1.Condition{
-		Type:    provisioning.ConditionTypeReady,
-		Status:  metav1.ConditionFalse,
-		Reason:  provisioning.ReasonInvalidSpec,
-		Message: message,
-	}
-}
-
 // buildReadyConditionWithReason creates a Ready condition with a specific reason.
-// This allows for granular error classification (InvalidConfiguration, AuthenticationFailed, ServiceUnavailable, RateLimited).
+// This allows for granular error classification (InvalidSpec, AuthenticationFailed, ServiceUnavailable, RateLimited).
 func buildReadyConditionWithReason(healthStatus provisioning.HealthStatus, reason string) metav1.Condition {
 	if healthStatus.Healthy {
 		return metav1.Condition{

--- a/pkg/registry/apis/provisioning/controller/conditions.go
+++ b/pkg/registry/apis/provisioning/controller/conditions.go
@@ -42,6 +42,8 @@ func buildConditionPatchOpsFromExisting(existingConditions []metav1.Condition, g
 }
 
 // buildReadyConditionFromHealth creates a Ready condition based on health status.
+// Uses a default reason (InvalidConfiguration) for unhealthy resources.
+// For more specific error classification, use buildReadyConditionWithReason.
 func buildReadyConditionFromHealth(healthStatus provisioning.HealthStatus) metav1.Condition {
 	if healthStatus.Healthy {
 		return metav1.Condition{
@@ -61,7 +63,33 @@ func buildReadyConditionFromHealth(healthStatus provisioning.HealthStatus) metav
 	return metav1.Condition{
 		Type:    provisioning.ConditionTypeReady,
 		Status:  metav1.ConditionFalse,
-		Reason:  provisioning.ReasonUnavailable,
+		Reason:  provisioning.ReasonInvalidConfiguration,
+		Message: message,
+	}
+}
+
+// buildReadyConditionWithReason creates a Ready condition with a specific reason.
+// This allows for granular error classification (InvalidConfiguration, AuthenticationFailed, ServiceUnavailable, RateLimited).
+func buildReadyConditionWithReason(healthStatus provisioning.HealthStatus, reason string) metav1.Condition {
+	if healthStatus.Healthy {
+		return metav1.Condition{
+			Type:    provisioning.ConditionTypeReady,
+			Status:  metav1.ConditionTrue,
+			Reason:  provisioning.ReasonAvailable,
+			Message: "Resource is available",
+		}
+	}
+
+	// Build message from health status messages
+	message := "Resource is unavailable"
+	if len(healthStatus.Message) > 0 {
+		message = healthStatus.Message[0]
+	}
+
+	return metav1.Condition{
+		Type:    provisioning.ConditionTypeReady,
+		Status:  metav1.ConditionFalse,
+		Reason:  reason,
 		Message: message,
 	}
 }

--- a/pkg/registry/apis/provisioning/controller/conditions.go
+++ b/pkg/registry/apis/provisioning/controller/conditions.go
@@ -42,7 +42,7 @@ func buildConditionPatchOpsFromExisting(existingConditions []metav1.Condition, g
 }
 
 // buildReadyConditionFromHealth creates a Ready condition based on health status.
-// Uses a default reason (InvalidSpec) for unhealthy resources.
+// Uses a default reason (InvalidConfiguration) for unhealthy resources.
 // For more specific error classification, use buildReadyConditionWithReason.
 func buildReadyConditionFromHealth(healthStatus provisioning.HealthStatus) metav1.Condition {
 	if healthStatus.Healthy {
@@ -63,7 +63,7 @@ func buildReadyConditionFromHealth(healthStatus provisioning.HealthStatus) metav
 	return metav1.Condition{
 		Type:    provisioning.ConditionTypeReady,
 		Status:  metav1.ConditionFalse,
-		Reason:  provisioning.ReasonInvalidSpec,
+		Reason:  provisioning.ReasonInvalidConfiguration,
 		Message: message,
 	}
 }

--- a/pkg/registry/apis/provisioning/controller/conditions.go
+++ b/pkg/registry/apis/provisioning/controller/conditions.go
@@ -42,7 +42,7 @@ func buildConditionPatchOpsFromExisting(existingConditions []metav1.Condition, g
 }
 
 // buildReadyConditionFromHealth creates a Ready condition based on health status.
-// Uses a default reason (InvalidConfiguration) for unhealthy resources.
+// Uses a default reason (InvalidSpec) for unhealthy resources.
 // For more specific error classification, use buildReadyConditionWithReason.
 func buildReadyConditionFromHealth(healthStatus provisioning.HealthStatus) metav1.Condition {
 	if healthStatus.Healthy {
@@ -63,7 +63,7 @@ func buildReadyConditionFromHealth(healthStatus provisioning.HealthStatus) metav
 	return metav1.Condition{
 		Type:    provisioning.ConditionTypeReady,
 		Status:  metav1.ConditionFalse,
-		Reason:  provisioning.ReasonInvalidConfiguration,
+		Reason:  provisioning.ReasonInvalidSpec,
 		Message: message,
 	}
 }

--- a/pkg/registry/apis/provisioning/controller/conditions_test.go
+++ b/pkg/registry/apis/provisioning/controller/conditions_test.go
@@ -37,7 +37,7 @@ func TestBuildReadyConditionFromHealth(t *testing.T) {
 				Message: []string{"connection failed"},
 			},
 			expectedStatus: metav1.ConditionFalse,
-			expectedReason: provisioning.ReasonInvalidSpec,
+			expectedReason: provisioning.ReasonInvalidConfiguration,
 			expectedMsg:    "connection failed",
 		},
 		{
@@ -47,7 +47,7 @@ func TestBuildReadyConditionFromHealth(t *testing.T) {
 				Checked: time.Now().UnixMilli(),
 			},
 			expectedStatus: metav1.ConditionFalse,
-			expectedReason: provisioning.ReasonInvalidSpec,
+			expectedReason: provisioning.ReasonInvalidConfiguration,
 			expectedMsg:    "Resource is unavailable",
 		},
 		{
@@ -58,7 +58,7 @@ func TestBuildReadyConditionFromHealth(t *testing.T) {
 				Message: []string{"first error", "second error"},
 			},
 			expectedStatus: metav1.ConditionFalse,
-			expectedReason: provisioning.ReasonInvalidSpec,
+			expectedReason: provisioning.ReasonInvalidConfiguration,
 			expectedMsg:    "first error",
 		},
 	}
@@ -106,7 +106,7 @@ func TestBuildConditionPatchOpsFromExisting(t *testing.T) {
 				{
 					Type:               provisioning.ConditionTypeReady,
 					Status:             metav1.ConditionFalse,
-					Reason:             provisioning.ReasonInvalidSpec,
+					Reason:             provisioning.ReasonInvalidConfiguration,
 					Message:            "Resource is unavailable",
 					ObservedGeneration: 1,
 					LastTransitionTime: fixedTime,

--- a/pkg/registry/apis/provisioning/controller/conditions_test.go
+++ b/pkg/registry/apis/provisioning/controller/conditions_test.go
@@ -37,7 +37,7 @@ func TestBuildReadyConditionFromHealth(t *testing.T) {
 				Message: []string{"connection failed"},
 			},
 			expectedStatus: metav1.ConditionFalse,
-			expectedReason: provisioning.ReasonUnavailable,
+			expectedReason: provisioning.ReasonInvalidConfiguration,
 			expectedMsg:    "connection failed",
 		},
 		{
@@ -47,7 +47,7 @@ func TestBuildReadyConditionFromHealth(t *testing.T) {
 				Checked: time.Now().UnixMilli(),
 			},
 			expectedStatus: metav1.ConditionFalse,
-			expectedReason: provisioning.ReasonUnavailable,
+			expectedReason: provisioning.ReasonInvalidConfiguration,
 			expectedMsg:    "Resource is unavailable",
 		},
 		{
@@ -58,7 +58,7 @@ func TestBuildReadyConditionFromHealth(t *testing.T) {
 				Message: []string{"first error", "second error"},
 			},
 			expectedStatus: metav1.ConditionFalse,
-			expectedReason: provisioning.ReasonUnavailable,
+			expectedReason: provisioning.ReasonInvalidConfiguration,
 			expectedMsg:    "first error",
 		},
 	}
@@ -106,7 +106,7 @@ func TestBuildConditionPatchOpsFromExisting(t *testing.T) {
 				{
 					Type:               provisioning.ConditionTypeReady,
 					Status:             metav1.ConditionFalse,
-					Reason:             provisioning.ReasonUnavailable,
+					Reason:             provisioning.ReasonInvalidConfiguration,
 					Message:            "Resource is unavailable",
 					ObservedGeneration: 1,
 					LastTransitionTime: fixedTime,

--- a/pkg/registry/apis/provisioning/controller/conditions_test.go
+++ b/pkg/registry/apis/provisioning/controller/conditions_test.go
@@ -37,7 +37,7 @@ func TestBuildReadyConditionFromHealth(t *testing.T) {
 				Message: []string{"connection failed"},
 			},
 			expectedStatus: metav1.ConditionFalse,
-			expectedReason: provisioning.ReasonInvalidConfiguration,
+			expectedReason: provisioning.ReasonInvalidSpec,
 			expectedMsg:    "connection failed",
 		},
 		{
@@ -47,7 +47,7 @@ func TestBuildReadyConditionFromHealth(t *testing.T) {
 				Checked: time.Now().UnixMilli(),
 			},
 			expectedStatus: metav1.ConditionFalse,
-			expectedReason: provisioning.ReasonInvalidConfiguration,
+			expectedReason: provisioning.ReasonInvalidSpec,
 			expectedMsg:    "Resource is unavailable",
 		},
 		{
@@ -58,7 +58,7 @@ func TestBuildReadyConditionFromHealth(t *testing.T) {
 				Message: []string{"first error", "second error"},
 			},
 			expectedStatus: metav1.ConditionFalse,
-			expectedReason: provisioning.ReasonInvalidConfiguration,
+			expectedReason: provisioning.ReasonInvalidSpec,
 			expectedMsg:    "first error",
 		},
 	}
@@ -106,7 +106,7 @@ func TestBuildConditionPatchOpsFromExisting(t *testing.T) {
 				{
 					Type:               provisioning.ConditionTypeReady,
 					Status:             metav1.ConditionFalse,
-					Reason:             provisioning.ReasonInvalidConfiguration,
+					Reason:             provisioning.ReasonInvalidSpec,
 					Message:            "Resource is unavailable",
 					ObservedGeneration: 1,
 					LastTransitionTime: fixedTime,

--- a/pkg/registry/apis/provisioning/controller/conditions_test.go
+++ b/pkg/registry/apis/provisioning/controller/conditions_test.go
@@ -65,7 +65,7 @@ func TestBuildReadyConditionFromHealth(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			condition := buildReadyConditionFromHealth(tt.healthStatus)
+			condition := buildReadyConditionWithReason(tt.healthStatus, provisioning.ReasonInvalidSpec)
 
 			assert.Equal(t, provisioning.ConditionTypeReady, condition.Type)
 			assert.Equal(t, tt.expectedStatus, condition.Status)

--- a/pkg/registry/apis/provisioning/controller/connection_health.go
+++ b/pkg/registry/apis/provisioning/controller/connection_health.go
@@ -112,18 +112,18 @@ func classifyConnectionError(testResults *provisioning.TestResults) string {
 	// Map HTTP status codes to condition reasons
 	switch testResults.Code {
 	case 422: // Unprocessable Entity - spec validation failed
-		return provisioning.ReasonInvalidConfiguration
+		return provisioning.ReasonInvalidSpec
 	case 400, 401, 403: // Client errors - authentication/authorization issues
 		return provisioning.ReasonAuthenticationFailed
 	case 500, 502: // Server errors - usually secret/build issues
-		return provisioning.ReasonInvalidConfiguration
+		return provisioning.ReasonInvalidSpec
 	case 503, 504: // Service unavailable, gateway timeout
 		return provisioning.ReasonServiceUnavailable
 	case 429: // Too many requests - rate limited
 		return provisioning.ReasonRateLimited
 	default:
 		// Unknown error - default to configuration error to prompt investigation
-		return provisioning.ReasonInvalidConfiguration
+		return provisioning.ReasonInvalidSpec
 	}
 }
 

--- a/pkg/registry/apis/provisioning/controller/connection_health.go
+++ b/pkg/registry/apis/provisioning/controller/connection_health.go
@@ -118,7 +118,7 @@ func classifyConnectionError(testResults *provisioning.TestResults) string {
 		return provisioning.ReasonServiceUnavailable
 	default:
 		// All other errors (422, 500, etc.) are spec/configuration issues
-		return provisioning.ReasonInvalidConfiguration
+		return provisioning.ReasonInvalidSpec
 	}
 }
 

--- a/pkg/registry/apis/provisioning/controller/connection_health.go
+++ b/pkg/registry/apis/provisioning/controller/connection_health.go
@@ -112,18 +112,18 @@ func classifyConnectionError(testResults *provisioning.TestResults) string {
 	// Map HTTP status codes to condition reasons
 	switch testResults.Code {
 	case 422: // Unprocessable Entity - spec validation failed
-		return provisioning.ReasonInvalidSpec
+		return provisioning.ReasonInvalidConfiguration
 	case 400, 401, 403: // Client errors - authentication/authorization issues
 		return provisioning.ReasonAuthenticationFailed
 	case 500, 502: // Server errors - usually secret/build issues
-		return provisioning.ReasonInvalidSpec
+		return provisioning.ReasonInvalidConfiguration
 	case 503, 504: // Service unavailable, gateway timeout
 		return provisioning.ReasonServiceUnavailable
 	case 429: // Too many requests - rate limited
 		return provisioning.ReasonRateLimited
 	default:
 		// Unknown error - default to configuration error to prompt investigation
-		return provisioning.ReasonInvalidSpec
+		return provisioning.ReasonInvalidConfiguration
 	}
 }
 

--- a/pkg/registry/apis/provisioning/controller/connection_health.go
+++ b/pkg/registry/apis/provisioning/controller/connection_health.go
@@ -117,7 +117,7 @@ func classifyConnectionError(testResults *provisioning.TestResults) string {
 	case 503: // Service unavailable
 		return provisioning.ReasonServiceUnavailable
 	default:
-		// All other errors (422, 500, etc.) are spec/configuration issues
+		// All other errors (404, 422, 500, etc.) are spec/configuration issues
 		return provisioning.ReasonInvalidSpec
 	}
 }

--- a/pkg/registry/apis/provisioning/controller/connection_health_test.go
+++ b/pkg/registry/apis/provisioning/controller/connection_health_test.go
@@ -310,7 +310,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    http.StatusUnprocessableEntity,
 				Errors:  []provisioning.ErrorDetails{{Detail: "missing required field"}},
 			},
-			expectedReason: provisioning.ReasonInvalidSpec,
+			expectedReason: provisioning.ReasonInvalidConfiguration,
 		},
 		{
 			name: "bad request (400)",
@@ -346,7 +346,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    http.StatusInternalServerError,
 				Errors:  []provisioning.ErrorDetails{{Detail: "secret decryption failed"}},
 			},
-			expectedReason: provisioning.ReasonInvalidSpec,
+			expectedReason: provisioning.ReasonInvalidConfiguration,
 		},
 		{
 			name: "bad gateway (502)",
@@ -355,7 +355,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    http.StatusBadGateway,
 				Errors:  []provisioning.ErrorDetails{{Detail: "token generation failed"}},
 			},
-			expectedReason: provisioning.ReasonInvalidSpec,
+			expectedReason: provisioning.ReasonInvalidConfiguration,
 		},
 		{
 			name: "service unavailable (503)",
@@ -391,7 +391,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    999,
 				Errors:  []provisioning.ErrorDetails{{Detail: "unknown error"}},
 			},
-			expectedReason: provisioning.ReasonInvalidSpec,
+			expectedReason: provisioning.ReasonInvalidConfiguration,
 		},
 	}
 

--- a/pkg/registry/apis/provisioning/controller/connection_health_test.go
+++ b/pkg/registry/apis/provisioning/controller/connection_health_test.go
@@ -319,7 +319,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    http.StatusBadRequest,
 				Errors:  []provisioning.ErrorDetails{{Detail: "invalid appID"}},
 			},
-			expectedReason: provisioning.ReasonAuthenticationFailed,
+			expectedReason: provisioning.ReasonInvalidConfiguration,
 		},
 		{
 			name: "unauthorized (401)",
@@ -373,7 +373,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    http.StatusGatewayTimeout,
 				Errors:  []provisioning.ErrorDetails{{Detail: "connection timeout"}},
 			},
-			expectedReason: provisioning.ReasonServiceUnavailable,
+			expectedReason: provisioning.ReasonInvalidConfiguration,
 		},
 		{
 			name: "too many requests (429)",
@@ -382,7 +382,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    http.StatusTooManyRequests,
 				Errors:  []provisioning.ErrorDetails{{Detail: "rate limit exceeded"}},
 			},
-			expectedReason: provisioning.ReasonRateLimited,
+			expectedReason: provisioning.ReasonInvalidConfiguration,
 		},
 		{
 			name: "unknown error code defaults to invalid configuration",
@@ -452,7 +452,7 @@ func TestConnectionHealthChecker_RefreshHealthWithPatchOps(t *testing.T) {
 			},
 			testResults: &provisioning.TestResults{
 				Success: false,
-				Code:    http.StatusBadRequest,
+				Code:    http.StatusUnauthorized,
 				Errors: []provisioning.ErrorDetails{
 					{Detail: "invalid credentials"},
 				},

--- a/pkg/registry/apis/provisioning/controller/connection_health_test.go
+++ b/pkg/registry/apis/provisioning/controller/connection_health_test.go
@@ -289,6 +289,120 @@ func TestConnectionHealthChecker_hasHealthStatusChanged(t *testing.T) {
 	}
 }
 
+func TestClassifyConnectionError(t *testing.T) {
+	testCases := []struct {
+		name           string
+		testResults    *provisioning.TestResults
+		expectedReason string
+	}{
+		{
+			name: "successful test",
+			testResults: &provisioning.TestResults{
+				Success: true,
+				Code:    http.StatusOK,
+			},
+			expectedReason: provisioning.ReasonAvailable,
+		},
+		{
+			name: "validation error (422)",
+			testResults: &provisioning.TestResults{
+				Success: false,
+				Code:    http.StatusUnprocessableEntity,
+				Errors:  []provisioning.ErrorDetails{{Detail: "missing required field"}},
+			},
+			expectedReason: provisioning.ReasonInvalidConfiguration,
+		},
+		{
+			name: "bad request (400)",
+			testResults: &provisioning.TestResults{
+				Success: false,
+				Code:    http.StatusBadRequest,
+				Errors:  []provisioning.ErrorDetails{{Detail: "invalid appID"}},
+			},
+			expectedReason: provisioning.ReasonAuthenticationFailed,
+		},
+		{
+			name: "unauthorized (401)",
+			testResults: &provisioning.TestResults{
+				Success: false,
+				Code:    http.StatusUnauthorized,
+				Errors:  []provisioning.ErrorDetails{{Detail: "invalid credentials"}},
+			},
+			expectedReason: provisioning.ReasonAuthenticationFailed,
+		},
+		{
+			name: "forbidden (403)",
+			testResults: &provisioning.TestResults{
+				Success: false,
+				Code:    http.StatusForbidden,
+				Errors:  []provisioning.ErrorDetails{{Detail: "permission denied"}},
+			},
+			expectedReason: provisioning.ReasonAuthenticationFailed,
+		},
+		{
+			name: "internal server error (500)",
+			testResults: &provisioning.TestResults{
+				Success: false,
+				Code:    http.StatusInternalServerError,
+				Errors:  []provisioning.ErrorDetails{{Detail: "secret decryption failed"}},
+			},
+			expectedReason: provisioning.ReasonInvalidConfiguration,
+		},
+		{
+			name: "bad gateway (502)",
+			testResults: &provisioning.TestResults{
+				Success: false,
+				Code:    http.StatusBadGateway,
+				Errors:  []provisioning.ErrorDetails{{Detail: "token generation failed"}},
+			},
+			expectedReason: provisioning.ReasonInvalidConfiguration,
+		},
+		{
+			name: "service unavailable (503)",
+			testResults: &provisioning.TestResults{
+				Success: false,
+				Code:    http.StatusServiceUnavailable,
+				Errors:  []provisioning.ErrorDetails{{Detail: "GitHub API unavailable"}},
+			},
+			expectedReason: provisioning.ReasonServiceUnavailable,
+		},
+		{
+			name: "gateway timeout (504)",
+			testResults: &provisioning.TestResults{
+				Success: false,
+				Code:    http.StatusGatewayTimeout,
+				Errors:  []provisioning.ErrorDetails{{Detail: "connection timeout"}},
+			},
+			expectedReason: provisioning.ReasonServiceUnavailable,
+		},
+		{
+			name: "too many requests (429)",
+			testResults: &provisioning.TestResults{
+				Success: false,
+				Code:    http.StatusTooManyRequests,
+				Errors:  []provisioning.ErrorDetails{{Detail: "rate limit exceeded"}},
+			},
+			expectedReason: provisioning.ReasonRateLimited,
+		},
+		{
+			name: "unknown error code defaults to invalid configuration",
+			testResults: &provisioning.TestResults{
+				Success: false,
+				Code:    999,
+				Errors:  []provisioning.ErrorDetails{{Detail: "unknown error"}},
+			},
+			expectedReason: provisioning.ReasonInvalidConfiguration,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			reason := classifyConnectionError(tc.testResults)
+			assert.Equal(t, tc.expectedReason, reason)
+		})
+	}
+}
+
 func TestConnectionHealthChecker_RefreshHealthWithPatchOps(t *testing.T) {
 	testCases := []struct {
 		name           string
@@ -298,6 +412,7 @@ func TestConnectionHealthChecker_RefreshHealthWithPatchOps(t *testing.T) {
 		expectError    bool
 		expectPatches  bool
 		expectedHealth bool
+		expectedReason string
 	}{
 		{
 			name: "successful health check with status change",
@@ -319,9 +434,10 @@ func TestConnectionHealthChecker_RefreshHealthWithPatchOps(t *testing.T) {
 			},
 			expectPatches:  true,
 			expectedHealth: true,
+			expectedReason: provisioning.ReasonAvailable,
 		},
 		{
-			name: "failed health check",
+			name: "failed health check - authentication failed",
 			conn: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-conn",
@@ -338,11 +454,37 @@ func TestConnectionHealthChecker_RefreshHealthWithPatchOps(t *testing.T) {
 				Success: false,
 				Code:    http.StatusBadRequest,
 				Errors: []provisioning.ErrorDetails{
-					{Detail: "connection failed"},
+					{Detail: "invalid credentials"},
 				},
 			},
 			expectPatches:  true,
 			expectedHealth: false,
+			expectedReason: provisioning.ReasonAuthenticationFailed,
+		},
+		{
+			name: "failed health check - service unavailable",
+			conn: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-conn",
+					Namespace: "default",
+				},
+				Status: provisioning.ConnectionStatus{
+					Health: provisioning.HealthStatus{
+						Healthy: true,
+						Checked: time.Now().Add(-10 * time.Minute).UnixMilli(),
+					},
+				},
+			},
+			testResults: &provisioning.TestResults{
+				Success: false,
+				Code:    http.StatusServiceUnavailable,
+				Errors: []provisioning.ErrorDetails{
+					{Detail: "service unavailable"},
+				},
+			},
+			expectPatches:  true,
+			expectedHealth: false,
+			expectedReason: provisioning.ReasonServiceUnavailable,
 		},
 		{
 			name: "no status change - no patches",
@@ -438,7 +580,7 @@ func TestConnectionHealthChecker_RefreshHealthWithPatchOps(t *testing.T) {
 					assert.Equal(t, provisioning.ReasonAvailable, readyCondition.Reason)
 				} else {
 					assert.Equal(t, metav1.ConditionFalse, readyCondition.Status)
-					assert.Equal(t, provisioning.ReasonUnavailable, readyCondition.Reason)
+					assert.Equal(t, tt.expectedReason, readyCondition.Reason)
 				}
 			} else {
 				assert.Empty(t, patchOps)

--- a/pkg/registry/apis/provisioning/controller/connection_health_test.go
+++ b/pkg/registry/apis/provisioning/controller/connection_health_test.go
@@ -310,7 +310,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    http.StatusUnprocessableEntity,
 				Errors:  []provisioning.ErrorDetails{{Detail: "missing required field"}},
 			},
-			expectedReason: provisioning.ReasonInvalidConfiguration,
+			expectedReason: provisioning.ReasonInvalidSpec,
 		},
 		{
 			name: "bad request (400)",
@@ -319,7 +319,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    http.StatusBadRequest,
 				Errors:  []provisioning.ErrorDetails{{Detail: "invalid appID"}},
 			},
-			expectedReason: provisioning.ReasonInvalidConfiguration,
+			expectedReason: provisioning.ReasonInvalidSpec,
 		},
 		{
 			name: "unauthorized (401)",
@@ -346,7 +346,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    http.StatusInternalServerError,
 				Errors:  []provisioning.ErrorDetails{{Detail: "secret decryption failed"}},
 			},
-			expectedReason: provisioning.ReasonInvalidConfiguration,
+			expectedReason: provisioning.ReasonInvalidSpec,
 		},
 		{
 			name: "bad gateway (502)",
@@ -355,7 +355,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    http.StatusBadGateway,
 				Errors:  []provisioning.ErrorDetails{{Detail: "token generation failed"}},
 			},
-			expectedReason: provisioning.ReasonInvalidConfiguration,
+			expectedReason: provisioning.ReasonInvalidSpec,
 		},
 		{
 			name: "service unavailable (503)",
@@ -373,7 +373,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    http.StatusGatewayTimeout,
 				Errors:  []provisioning.ErrorDetails{{Detail: "connection timeout"}},
 			},
-			expectedReason: provisioning.ReasonInvalidConfiguration,
+			expectedReason: provisioning.ReasonInvalidSpec,
 		},
 		{
 			name: "too many requests (429)",
@@ -382,7 +382,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    http.StatusTooManyRequests,
 				Errors:  []provisioning.ErrorDetails{{Detail: "rate limit exceeded"}},
 			},
-			expectedReason: provisioning.ReasonInvalidConfiguration,
+			expectedReason: provisioning.ReasonInvalidSpec,
 		},
 		{
 			name: "unknown error code defaults to invalid configuration",
@@ -391,7 +391,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    999,
 				Errors:  []provisioning.ErrorDetails{{Detail: "unknown error"}},
 			},
-			expectedReason: provisioning.ReasonInvalidConfiguration,
+			expectedReason: provisioning.ReasonInvalidSpec,
 		},
 	}
 

--- a/pkg/registry/apis/provisioning/controller/connection_health_test.go
+++ b/pkg/registry/apis/provisioning/controller/connection_health_test.go
@@ -340,6 +340,15 @@ func TestClassifyConnectionError(t *testing.T) {
 			expectedReason: provisioning.ReasonAuthenticationFailed,
 		},
 		{
+			name: "not found (404)",
+			testResults: &provisioning.TestResults{
+				Success: false,
+				Code:    http.StatusNotFound,
+				Errors:  []provisioning.ErrorDetails{{Detail: "app not found"}},
+			},
+			expectedReason: provisioning.ReasonInvalidSpec,
+		},
+		{
 			name: "internal server error (500)",
 			testResults: &provisioning.TestResults{
 				Success: false,

--- a/pkg/registry/apis/provisioning/controller/connection_health_test.go
+++ b/pkg/registry/apis/provisioning/controller/connection_health_test.go
@@ -310,7 +310,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    http.StatusUnprocessableEntity,
 				Errors:  []provisioning.ErrorDetails{{Detail: "missing required field"}},
 			},
-			expectedReason: provisioning.ReasonInvalidConfiguration,
+			expectedReason: provisioning.ReasonInvalidSpec,
 		},
 		{
 			name: "bad request (400)",
@@ -346,7 +346,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    http.StatusInternalServerError,
 				Errors:  []provisioning.ErrorDetails{{Detail: "secret decryption failed"}},
 			},
-			expectedReason: provisioning.ReasonInvalidConfiguration,
+			expectedReason: provisioning.ReasonInvalidSpec,
 		},
 		{
 			name: "bad gateway (502)",
@@ -355,7 +355,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    http.StatusBadGateway,
 				Errors:  []provisioning.ErrorDetails{{Detail: "token generation failed"}},
 			},
-			expectedReason: provisioning.ReasonInvalidConfiguration,
+			expectedReason: provisioning.ReasonInvalidSpec,
 		},
 		{
 			name: "service unavailable (503)",
@@ -391,7 +391,7 @@ func TestClassifyConnectionError(t *testing.T) {
 				Code:    999,
 				Errors:  []provisioning.ErrorDetails{{Detail: "unknown error"}},
 			},
-			expectedReason: provisioning.ReasonInvalidConfiguration,
+			expectedReason: provisioning.ReasonInvalidSpec,
 		},
 	}
 

--- a/pkg/registry/apis/provisioning/controller/health.go
+++ b/pkg/registry/apis/provisioning/controller/health.go
@@ -201,7 +201,8 @@ func (hc *RepositoryHealthChecker) RefreshHealthWithPatchOps(ctx context.Context
 	}
 
 	// Update Ready condition based on health status
-	readyCondition := buildReadyConditionFromHealth(newHealthStatus)
+	// Repository health checks don't classify error types, so we use InvalidSpec as the default reason
+	readyCondition := buildReadyConditionWithReason(newHealthStatus, provisioning.ReasonInvalidSpec)
 	if conditionPatchOps := BuildConditionPatchOpsFromExisting(cfg.Status.Conditions, cfg.GetGeneration(), readyCondition); conditionPatchOps != nil {
 		patchOps = append(patchOps, conditionPatchOps...)
 	}

--- a/pkg/registry/apis/provisioning/controller/health_test.go
+++ b/pkg/registry/apis/provisioning/controller/health_test.go
@@ -708,7 +708,7 @@ func TestRefreshHealthWithPatchOps(t *testing.T) {
 					assert.Equal(t, provisioning.ReasonAvailable, readyCondition.Reason)
 				} else {
 					assert.Equal(t, metav1.ConditionFalse, readyCondition.Status)
-					assert.Equal(t, provisioning.ReasonInvalidConfiguration, readyCondition.Reason)
+					assert.Equal(t, provisioning.ReasonInvalidSpec, readyCondition.Reason)
 				}
 			} else {
 				assert.Empty(t, patchOps, "expected no patch operations to be returned")

--- a/pkg/registry/apis/provisioning/controller/health_test.go
+++ b/pkg/registry/apis/provisioning/controller/health_test.go
@@ -708,7 +708,7 @@ func TestRefreshHealthWithPatchOps(t *testing.T) {
 					assert.Equal(t, provisioning.ReasonAvailable, readyCondition.Reason)
 				} else {
 					assert.Equal(t, metav1.ConditionFalse, readyCondition.Status)
-					assert.Equal(t, provisioning.ReasonInvalidSpec, readyCondition.Reason)
+					assert.Equal(t, provisioning.ReasonInvalidConfiguration, readyCondition.Reason)
 				}
 			} else {
 				assert.Empty(t, patchOps, "expected no patch operations to be returned")

--- a/pkg/registry/apis/provisioning/controller/health_test.go
+++ b/pkg/registry/apis/provisioning/controller/health_test.go
@@ -708,7 +708,7 @@ func TestRefreshHealthWithPatchOps(t *testing.T) {
 					assert.Equal(t, provisioning.ReasonAvailable, readyCondition.Reason)
 				} else {
 					assert.Equal(t, metav1.ConditionFalse, readyCondition.Status)
-					assert.Equal(t, provisioning.ReasonUnavailable, readyCondition.Reason)
+					assert.Equal(t, provisioning.ReasonInvalidConfiguration, readyCondition.Reason)
 				}
 			} else {
 				assert.Empty(t, patchOps, "expected no patch operations to be returned")

--- a/pkg/tests/apis/provisioning/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection_test.go
@@ -995,7 +995,7 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 		readyCondition := findCondition(conn.Status.Conditions, provisioning.ConditionTypeReady)
 		assert.NotNil(t, readyCondition, "Ready condition should exist")
 		assert.Equal(t, metav1.ConditionFalse, readyCondition.Status, "Ready condition should be False for unhealthy connection")
-		assert.Equal(t, provisioning.ReasonAuthenticationFailed, readyCondition.Reason, "Ready condition should have AuthenticationFailed reason for authentication failures")
+		assert.Equal(t, provisioning.ReasonInvalidSpec, readyCondition.Reason, "Ready condition should have InvalidConfiguration reason for invalid installation ID")
 
 		// Verify fieldErrors are populated with validation errors - be strict and explicit
 		require.Len(t, conn.Status.FieldErrors, 1, "fieldErrors should contain exactly one error for invalid installation ID")
@@ -1089,7 +1089,7 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 		readyCondition := findCondition(conn.Status.Conditions, provisioning.ConditionTypeReady)
 		assert.NotNil(t, readyCondition, "Ready condition should exist")
 		assert.Equal(t, metav1.ConditionFalse, readyCondition.Status, "Ready condition should be False for unhealthy connection")
-		assert.Equal(t, provisioning.ReasonAuthenticationFailed, readyCondition.Reason, "Ready condition should have AuthenticationFailed reason for authentication failures")
+		assert.Equal(t, provisioning.ReasonInvalidSpec, readyCondition.Reason, "Ready condition should have InvalidConfiguration reason for app ID mismatch")
 
 		// Verify fieldErrors are populated with validation errors - be strict and explicit
 		require.Len(t, conn.Status.FieldErrors, 1, "fieldErrors should contain exactly one error for app ID mismatch")

--- a/pkg/tests/apis/provisioning/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection_test.go
@@ -1005,7 +1005,7 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 		// Verify all fields explicitly
 		assert.Equal(t, metav1.CauseTypeFieldValueInvalid, installationIDError.Type, "Type must be FieldValueInvalid")
 		assert.Equal(t, "spec.installationID", installationIDError.Field, "Field must be spec.installationID")
-		assert.Equal(t, "invalid installation ID: 999999999", installationIDError.Detail, "Detail must match expected error message")
+		assert.Equal(t, "installation not found", installationIDError.Detail, "Detail must match expected error message")
 		assert.Empty(t, installationIDError.Origin, "Origin should be empty")
 
 		t.Logf("Verified installationID fieldError: Type=%s, Field=%s, Detail=%s, Origin=%s",

--- a/pkg/tests/apis/provisioning/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection_test.go
@@ -995,7 +995,7 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 		readyCondition := findCondition(conn.Status.Conditions, provisioning.ConditionTypeReady)
 		assert.NotNil(t, readyCondition, "Ready condition should exist")
 		assert.Equal(t, metav1.ConditionFalse, readyCondition.Status, "Ready condition should be False for unhealthy connection")
-		assert.Equal(t, provisioning.ReasonUnavailable, readyCondition.Reason, "Ready condition should have Unavailable reason")
+		assert.Equal(t, provisioning.ReasonAuthenticationFailed, readyCondition.Reason, "Ready condition should have AuthenticationFailed reason for authentication failures")
 
 		// Verify fieldErrors are populated with validation errors - be strict and explicit
 		require.Len(t, conn.Status.FieldErrors, 1, "fieldErrors should contain exactly one error for invalid installation ID")
@@ -1089,7 +1089,7 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 		readyCondition := findCondition(conn.Status.Conditions, provisioning.ConditionTypeReady)
 		assert.NotNil(t, readyCondition, "Ready condition should exist")
 		assert.Equal(t, metav1.ConditionFalse, readyCondition.Status, "Ready condition should be False for unhealthy connection")
-		assert.Equal(t, provisioning.ReasonUnavailable, readyCondition.Reason, "Ready condition should have Unavailable reason")
+		assert.Equal(t, provisioning.ReasonAuthenticationFailed, readyCondition.Reason, "Ready condition should have AuthenticationFailed reason for authentication failures")
 
 		// Verify fieldErrors are populated with validation errors - be strict and explicit
 		require.Len(t, conn.Status.FieldErrors, 1, "fieldErrors should contain exactly one error for app ID mismatch")
@@ -1583,4 +1583,97 @@ func verifyToken(t *testing.T, appID, publicKey, token string) (bool, error) {
 	}
 
 	return claims.VerifyIssuer(appID, true), nil
+}
+func TestIntegrationConnectionController_GranularConditionReasons(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafana(t)
+	ctx := context.Background()
+	namespace := "default"
+
+	// Create typed client from REST config
+	restConfig := helper.Org1.Admin.NewRestConfig()
+	provisioningClient, err := clientset.NewForConfig(restConfig)
+	require.NoError(t, err)
+	connClient := provisioningClient.ProvisioningV0alpha1().Connections(namespace)
+	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(testPrivateKeyPEM))
+
+	t.Run("ServiceUnavailable reason when GitHub API returns 503", func(t *testing.T) {
+		// Create a connection
+		connUnstructured := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"name":      "test-connection-service-unavailable",
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"type": "github",
+				"github": map[string]any{
+					"appID":          "123456",
+					"installationID": "789012",
+				},
+			},
+			"secure": map[string]any{
+				"privateKey": map[string]any{
+					"create": privateKeyBase64,
+				},
+			},
+		}}
+
+		createdUnstructured, err := helper.CreateGithubConnection(t, ctx, connUnstructured)
+		require.NoError(t, err)
+		require.NotNil(t, createdUnstructured)
+
+		// Set up mock to return 503 Service Unavailable
+		connectionFactory := helper.GetEnv().GithubConnectionFactory.(*githubConnection.Factory)
+		connectionFactory.Client = ghmock.NewMockedHTTPClient(
+			ghmock.WithRequestMatchHandler(
+				ghmock.GetApp,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// Return 503 Service Unavailable
+					w.WriteHeader(http.StatusServiceUnavailable)
+					_, _ = w.Write(ghmock.MustMarshal(github.ErrorResponse{
+						Response: &http.Response{
+							StatusCode: http.StatusServiceUnavailable,
+						},
+						Message: "Service temporarily unavailable",
+					}))
+				}),
+			),
+		)
+		helper.SetGithubConnectionFactory(connectionFactory)
+
+		connName := createdUnstructured.GetName()
+
+		t.Cleanup(func() {
+			_ = helper.Connections.Resource.Delete(ctx, connName, metav1.DeleteOptions{})
+		})
+
+		// Wait for reconciliation - connection should become unhealthy with ServiceUnavailable reason
+		require.Eventually(t, func() bool {
+			conn, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			return conn.Status.ObservedGeneration == conn.Generation &&
+				conn.Status.Health.Checked > 0 &&
+				!conn.Status.Health.Healthy
+		}, 15*time.Second, 500*time.Millisecond, "connection should be reconciled and marked unhealthy")
+
+		// Verify the connection has ServiceUnavailable reason
+		conn, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.False(t, conn.Status.Health.Healthy, "connection should be unhealthy")
+		assert.Equal(t, provisioning.ConnectionStateDisconnected, conn.Status.State, "connection should be disconnected")
+
+		// Verify Ready condition has ServiceUnavailable reason
+		assert.NotEmpty(t, conn.Status.Conditions, "conditions should be set")
+		readyCondition := findCondition(conn.Status.Conditions, provisioning.ConditionTypeReady)
+		require.NotNil(t, readyCondition, "Ready condition should exist")
+		assert.Equal(t, metav1.ConditionFalse, readyCondition.Status, "Ready condition should be False")
+		assert.Equal(t, provisioning.ReasonServiceUnavailable, readyCondition.Reason, "Ready condition should have ServiceUnavailable reason for 503 errors")
+		// Verify message contains the actual error returned by the GitHub client
+		assert.Contains(t, readyCondition.Message, "github is unavailable", "condition message should contain the actual error text")
+	})
 }


### PR DESCRIPTION
Fixes https://github.com/grafana/git-ui-sync-project/issues/758

## Summary

This PR enhances the Ready condition on Connection resources by adding granular reasons that distinguish between different types of failures, enabling better automation and user guidance.

**Building on:** The basic Kubernetes Conditions support merged in #116718

## Changes

### 1. New Condition Reasons (health.go)

Added three specific reason constants that align with Kubernetes CRD conventions:

- **`ReasonInvalidSpec`**: Configuration issue with spec format or structure (validation errors, invalid fields, secret errors). User must fix configuration. Automation should NOT retry.

- **`ReasonAuthenticationFailed`**: Authentication or authorization failed (invalid credentials, expired token, insufficient permissions). User must fix credentials. Automation should NOT retry.

- **`ReasonServiceUnavailable`**: External service issue (API down, network timeout). Issue is transient and outside user control. Automation CAN retry with standard backoff.

Note: `ReasonRateLimited` is defined but not currently used (GitHub connection doesn't detect rate limits yet).

### 2. GitHub Connection Error Detection

Added `ErrAuthentication` sentinel error in the GitHub client (client.go):
- Detects 401 (Unauthorized) and 403 (Forbidden) responses from GitHub API
- GitHub client returns specific errors: `ErrAuthentication` (401/403) or `ErrServiceUnavailable` (503)
- Connection.Test() maps these to appropriate HTTP status codes:
  - **401** (Unauthorized) → Authentication errors
  - **422** (Unprocessable Entity) → Configuration errors  
  - **503** (Service Unavailable) → GitHub API down

### 3. Error Classification Logic (connection_health.go)

Added `classifyConnectionError()` function that maps HTTP status codes to condition reasons:
- **401/403** (Auth errors) → AuthenticationFailed
- **503** (Service unavailable) → ServiceUnavailable
- **Everything else** (422, 500, etc.) → InvalidSpec

Simplified logic only handles status codes that connections actually return.

### 4. Enhanced Condition Builder (conditions.go)

Added `buildReadyConditionWithReason()` function that accepts an explicit reason parameter for granular error classification.

### 5. Comprehensive Tests

- Updated GitHub connection tests to handle authentication errors (401)
- Added `TestClassifyConnectionError` unit test covering all HTTP status code mappings  
- Updated `TestConnectionHealthChecker_RefreshHealthWithPatchOps` to verify correct reasons
- Fixed integration tests to expect `InvalidSpec` (not `AuthenticationFailed`) for configuration errors
- All unit and integration tests pass

## Benefits

### For kubectl Users
```bash
$ kubectl get connections
NAME              READY   STATUS                    AGE
github-prod       False   AuthenticationFailed      5m    # Check your credentials!
github-staging    False   ServiceUnavailable        2m    # Transient issue
github-dev        False   InvalidSpec               1m    # Configuration error
```

### For Automation
```go
switch readyCondition.Reason {
case provisioning.ReasonAuthenticationFailed,
     provisioning.ReasonInvalidSpec:
    // User must fix - don't retry
    return ctrl.Result{}, nil

case provisioning.ReasonServiceUnavailable:
    // Transient - retry soon
    return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
}
```

### For UI
- **InvalidSpec**: "Check your configuration for validation errors"
- **AuthenticationFailed**: "Verify your credentials and permissions"
- **ServiceUnavailable**: "Service temporarily unavailable, retrying automatically"

## Testing

All tests pass:
```
✓ TestConnection_Test (7 test cases)
  - Authentication error (401) → Detected via ErrAuthentication
  - Service unavailable (503) → Detected via ErrServiceUnavailable  
  - Generic errors → 422 (Unprocessable Entity)
✓ TestClassifyConnectionError (11 test cases)
  - Auth failures (401/403) → AuthenticationFailed
  - Service issues (503) → ServiceUnavailable
  - All other errors → InvalidSpec
✓ TestConnectionHealthChecker_RefreshHealthWithPatchOps (5 test cases)
✓ Integration tests updated and passing
```

## Design Rationale

### Why these specific reasons?

1. **InvalidSpec vs AuthenticationFailed**: Different user actions needed
   - InvalidSpec: Fix YAML, update configuration
   - AuthenticationFailed: Check credentials, verify permissions

2. **ServiceUnavailable**: Transient errors outside user control
   - Automation can retry automatically
   - No user action needed

3. **Alignment with Kubernetes**: These reason names match patterns used in cert-manager, Cluster API, and other mature CRDs (using "InvalidSpec" instead of "InvalidConfiguration")

4. **Honest implementation**: Only handle what we can actually detect. RateLimited will be added in a future PR when we implement rate limit detection.

## Migration Path

This is Phase 2 of the conditions rollout:
1. ✅ **Phase 1** (#116718): Add basic Ready condition with Available reason
2. ✅ **Phase 2** (This PR): Add granular reasons for Connections (InvalidSpec, AuthenticationFailed, ServiceUnavailable)
3. 🔜 **Phase 3**: Apply same pattern to Repositories
4. 🔜 **Phase 4**: Deprecate Health.Healthy field, use conditions as source of truth
5. 🔜 **Future**: Add RateLimited detection when implementing rate limit handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)