### PR TITLE
Panel Data Export: Process nested frames when exporting

### DIFF
--- a/packages/grafana-data/src/utils/csv.test.ts
+++ b/packages/grafana-data/src/utils/csv.test.ts
@@ -201,6 +201,32 @@ describe('DataFrame to CSV', () => {
     `);
   });
 
+  it('should flatten nested frame rows', () => {
+    const nestedFrame = {
+      fields: [
+        { name: 'Alarm Name', type: FieldType.string, values: ['ForwardPowerlow', 'PowerFoldback'], config: {} },
+        { name: 'dateRange1', type: FieldType.number, values: [1, 0], config: {} },
+        { name: 'dateRange2', type: FieldType.number, values: [3, 2], config: {} },
+        { name: 'dateRange3', type: FieldType.number, values: [4, 4], config: {} },
+      ],
+      length: 2,
+    };
+
+    const dataFrame = new MutableDataFrame({
+      fields: [
+        { name: 'Alarm Category', type: FieldType.string, values: ['Base Station Alarm'] },
+        { name: '__nestedFrames', type: FieldType.nestedFrames, values: [[nestedFrame]] },
+      ],
+    });
+
+    const csv = toCSV([dataFrame]);
+    expect(csv).toMatchInlineSnapshot(`
+      ""Alarm Category","Alarm Name","dateRange1","dateRange2","dateRange3"
+      Base Station Alarm,ForwardPowerlow,1,3,4
+      Base Station Alarm,PowerFoldback,0,2,4"
+    `);
+  });
+
   it('should handle null values', () => {
     const dataFrame = new MutableDataFrame({
       fields: [


### PR DESCRIPTION
This PR fixes exporting a nested table. Currently, only the parent group is included in the frame and exported data looks like this:

```csv
"Time","__nestedFrames"
2026-01-22 12:03:45,[object Object]
2026-01-22 12:03:45,[object Object]
2026-01-22 12:03:45,[object Object]
```

With this fix:
```csv
"Time","{__name__=""go_cpu_classes_gc_total_cpu_seconds_total"", instance=""host.docker.internal:3000"", job=""grafana""}"
2026-01-22 12:03:45,0.666
2026-01-22 12:03:45,0.666
2026-01-22 12:03:45,0.666
```

I've used a single Prometheus query here, so grouping by just creates a table with a single column and value. 

For more clarity, here's how nested tables are exported as csv:

### Example input

Parent table (DataFrame)
| time                | host   | rows (nestedFrames) |
|---------------------|--------|---------------------|
| 2026-01-22 10:00:00 | web-01 | [childFrameA, childFrameB] |
| 2026-01-22 10:01:00 | web-02 | []                  |

childFrameA
| path  | status |
|-------|--------|
| /api  | 200    |
| /login| 401    |

childFrameB
| path  | status |
|-------|--------|
| /health | 200  |


### What `expandNestedFrames` outputs
The nested frames are flattened so each child row becomes its own row, and parent fields are duplicated. If there are no child rows, it emits one row with `null` child values.

Flattened table
| time                | host   | path   | status |
|---------------------|--------|--------|--------|
| 2026-01-22 10:00:00 | web-01 | /api   | 200    |
| 2026-01-22 10:00:00 | web-01 | /login | 401    |
| 2026-01-22 10:00:00 | web-01 | /health| 200    |
| 2026-01-22 10:01:00 | web-02 | null   | null   |

Fixes https://github.com/grafana/grafana/issues/114457

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
