### PR TITLE
GitHubAppStep: Add how to create a GitHub app instruction

### DIFF
--- a/public/app/features/provisioning/Wizard/GitHubAppStep.tsx
+++ b/public/app/features/provisioning/Wizard/GitHubAppStep.tsx
@@ -12,6 +12,7 @@ import { useCreateOrUpdateConnection } from '../hooks/useCreateOrUpdateConnectio
 import { ConnectionFormData } from '../types';
 
 import { SelectableConnectionCard } from './SelectableConnectionCard';
+import { GithubAppStepInstruction } from './components/GithubAppStepInstruction';
 import { ConnectionCreationResult, WizardFormData } from './types';
 
 export interface GitHubAppStepRef {
@@ -94,6 +95,7 @@ export const GitHubAppStep = forwardRef<GitHubAppStepRef | null, GitHubAppStepPr
 
   return (
     <Stack direction="column" gap={2}>
+      <GithubAppStepInstruction />
       <Field noMargin label={t('provisioning.wizard.github-app-mode-label', 'GitHub App configuration')}>
         <Controller
           name="githubAppMode"

--- a/public/app/features/provisioning/Wizard/components/GithubAppStepInstruction.tsx
+++ b/public/app/features/provisioning/Wizard/components/GithubAppStepInstruction.tsx
@@ -1,0 +1,23 @@
+import { Trans } from '@grafana/i18n';
+import { Text, TextLink } from '@grafana/ui';
+
+const githubAppDocsUrl = 'https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app';
+
+export function GithubAppStepInstruction() {
+  return (
+    <div>
+      <Text weight="bold" element="h6">
+        <Trans i18nKey="provisioning.wizard.github-app-help-title">Need help creating a GitHub App?</Trans>
+      </Text>
+
+      <Text element="p" color="secondary">
+        <Trans i18nKey="provisioning.wizard.github-app-help-instructions">
+          Create a GitHub App, generate a private key, install it, and paste the details below.{' '}
+          <TextLink external href={githubAppDocsUrl}>
+            View step-by-step instructions
+          </TextLink>
+        </Trans>
+      </Text>
+    </div>
+  );
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12345,6 +12345,8 @@
       "github-app-creation-failed": "Failed to create GitHub App connection",
       "github-app-error-loading": "Failed to load connections",
       "github-app-error-required": "Connection is required",
+      "github-app-help-instructions": "Create a GitHub App, generate a private key, install it, and paste the details below. <2>View step-by-step instructions</2>",
+      "github-app-help-title": "Need help creating a GitHub App?",
       "github-app-mode-existing": "Choose an existing app",
       "github-app-mode-label": "GitHub App configuration",
       "github-app-mode-new": "Connect to a new app",


### PR DESCRIPTION
**What is this feature?**

Add helping instruction to help user open external doc (so we have single source of insturction to avoid any side outdated issue)
<img width="1164" height="778" alt="image" src="https://github.com/user-attachments/assets/6d2d3530-7f8b-46ba-baef-78b3498710fb" />


**Why do we need this feature?**

Provide git sync user more guidance

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/722

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
