### PR TITLE
Add a per-request query time logger

### DIFF
--- a/pkg/infra/log/databaseQueryTimer.go
+++ b/pkg/infra/log/databaseQueryTimer.go
@@ -1,0 +1,44 @@
+package log
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+type dbCallQueryTimerContextKey struct{}
+
+var dbCallQueryTimerKey = dbCallQueryTimerContextKey{}
+
+// InitDBQueryTimer creates a pointer on the context that can be incremented later
+func InitDBQueryTimer(ctx context.Context) context.Context {
+	var ptr = new(int64)
+	return context.WithValue(ctx, dbCallQueryTimerKey, ptr)
+}
+
+// IncDBQueryTimer increments the database query timer on the context.
+func IncDBQueryTimer(ctx context.Context, queryTimeInMs int64) context.Context {
+	if val := ctx.Value(dbCallQueryTimerKey); val == nil {
+		ctx = InitCounter(ctx)
+	}
+
+	if val := ctx.Value(dbCallQueryTimerKey); val != nil {
+		v2, ok := val.(*int64)
+		if ok {
+			atomic.AddInt64(v2, queryTimeInMs)
+		}
+	}
+
+	return ctx
+}
+
+// TotalDBQueryTime returns the total number of query time for this context
+func TotalDBQueryTime(ctx context.Context) int64 {
+	if val := ctx.Value(dbCallQueryTimerKey); val != nil {
+		v2, ok := val.(*int64)
+		if ok {
+			return *v2
+		}
+	}
+
+	return 0
+}

--- a/pkg/middleware/loggermw/logger.go
+++ b/pkg/middleware/loggermw/logger.go
@@ -121,6 +121,7 @@ func (l *loggerImpl) prepareLogParams(c *contextmodel.ReqContext, duration time.
 
 	if l.cfg.DatabaseInstrumentQueries {
 		logParams = append(logParams, "db_call_count", log.TotalDBCallCount(c.Req.Context()))
+		logParams = append(logParams, "db_query_time", log.TotalDBQueryTime(c.Req.Context()))
 	}
 
 	if handler, exist := middleware.RouteOperationName(c.Req); exist {

--- a/pkg/services/sqlstore/database_wrapper.go
+++ b/pkg/services/sqlstore/database_wrapper.go
@@ -97,6 +97,7 @@ func (h *databaseQueryWrapper) instrument(ctx context.Context, status string, qu
 	}
 
 	ctx = log.IncDBCallCounter(ctx)
+	ctx = log.IncDBQueryTimer(ctx, elapsed.Milliseconds())
 
 	// timestamp overridden and recorded AFTER query is run
 	_, span := h.tracer.Start(ctx, "database query", trace.WithTimestamp(begin))


### PR DESCRIPTION
When looking at log lines for slow requests, it would be very useful to see total query time as well as query count.

This PR adds a query time accumulator on the context, modeled on the existing query counter.

