### PR TITLE
Alerting: Add instance-wide UI disable setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features and enhancements
 
 - **Alerting:** Update alerting dependency [#114259](https://github.com/grafana/grafana/pull/114259), [@moustafab](https://github.com/moustafab)
-- **Alerting:** Add `ui_enabled` setting to hide the alerting UI.
+- **Alerting:** Add `ui_enabled` setting to hide the alerting UI [#116735](https://github.com/grafana/grafana/pull/116735), [@sandy2008](https://github.com/sandy2008)
 - **Azure:** Improved column handling in logs query builder [#114841](https://github.com/grafana/grafana/pull/114841), [@aangelisc](https://github.com/aangelisc)
 - **Azure:** Include aggregate columns in logs builder [#114835](https://github.com/grafana/grafana/pull/114835), [@aangelisc](https://github.com/aangelisc)
 - **Dependencies:** Bump Go to v1.25.5 [#114751](https://github.com/grafana/grafana/pull/114751), [@macabu](https://github.com/macabu)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features and enhancements
 
 - **Alerting:** Update alerting dependency [#114259](https://github.com/grafana/grafana/pull/114259), [@moustafab](https://github.com/moustafab)
+- **Alerting:** Add `ui_enabled` setting to hide the alerting UI.
 - **Azure:** Improved column handling in logs query builder [#114841](https://github.com/grafana/grafana/pull/114841), [@aangelisc](https://github.com/aangelisc)
 - **Azure:** Include aggregate columns in logs builder [#114835](https://github.com/grafana/grafana/pull/114835), [@aangelisc](https://github.com/aangelisc)
 - **Dependencies:** Bump Go to v1.25.5 [#114751](https://github.com/grafana/grafana/pull/114751), [@macabu](https://github.com/macabu)

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1310,6 +1310,9 @@ alerting_rule_evaluation_results = -1
 # Enable the Alerting sub-system and interface.
 enabled =
 
+# Enable the Alerting UI.
+ui_enabled =
+
 # Comma-separated list of organization IDs for which to disable unified alerting. Only supported if unified alerting is enabled.
 disabled_orgs =
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1276,6 +1276,9 @@
 #Enable the Unified Alerting sub-system and interface. When enabled we'll migrate all of your alert rules and notification channels to the new system. New alert rules will be created and your notification channels will be converted into an Alertmanager configuration. Previous data is preserved to enable backwards compatibility but new data is removed.```
 ;enabled = true
 
+# Enable the Alerting UI.
+;ui_enabled = true
+
 # Comma-separated list of organization IDs for which to disable unified alerting. Only supported if unified alerting is enabled.
 ;disabled_orgs =
 

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -280,6 +280,7 @@ export interface GrafanaConfig {
   geomapDefaultBaseLayerConfig?: MapLayerOptions;
   geomapDisableCustomBaseLayer: boolean;
   unifiedAlertingEnabled: boolean;
+  unifiedAlertingUIEnabled: boolean;
   unifiedAlerting: UnifiedAlertingConfig;
   feedbackLinksEnabled: boolean;
   supportBundlesEnabled: boolean;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -189,6 +189,7 @@ export class GrafanaBootConfig {
   geomapDefaultBaseLayerConfig?: MapLayerOptions;
   geomapDisableCustomBaseLayer?: boolean;
   unifiedAlertingEnabled = false;
+  unifiedAlertingUIEnabled = true;
   unifiedAlerting: UnifiedAlertingConfig = {
     minInterval: '',
     stateHistory: {

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -273,6 +273,7 @@ type FrontendSettingsDTO struct {
 	Reporting               FrontendSettingsReportingDTO       `json:"reporting"`
 	Analytics               FrontendSettingsAnalyticsDTO       `json:"analytics"`
 	UnifiedAlertingEnabled  bool                               `json:"unifiedAlertingEnabled"`
+	UnifiedAlertingUIEnabled bool                              `json:"unifiedAlertingUIEnabled"`
 	UnifiedAlerting         FrontendSettingsUnifiedAlertingDTO `json:"unifiedAlerting"`
 	Oauth                   map[string]any                     `json:"oauth"`
 	SamlEnabled             bool                               `json:"samlEnabled"`

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -379,6 +379,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 
 	frontendSettings.UnifiedAlerting.RecordingRulesEnabled = hs.Cfg.UnifiedAlerting.RecordingRules.Enabled
 	frontendSettings.UnifiedAlerting.DefaultRecordingRulesTargetDatasourceUID = hs.Cfg.UnifiedAlerting.RecordingRules.DefaultDatasourceUID
+	frontendSettings.UnifiedAlertingUIEnabled = hs.Cfg.UnifiedAlerting.UIEnabled
 
 	if hs.Cfg.UnifiedAlerting.Enabled != nil {
 		frontendSettings.UnifiedAlertingEnabled = *hs.Cfg.UnifiedAlerting.Enabled

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -150,7 +150,7 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 	}
 
 	_, uaIsDisabledForOrg := s.cfg.UnifiedAlerting.DisabledOrgs[c.GetOrgID()]
-	uaVisibleForOrg := s.cfg.UnifiedAlerting.IsEnabled() && !uaIsDisabledForOrg
+	uaVisibleForOrg := s.cfg.UnifiedAlerting.IsEnabled() && s.cfg.UnifiedAlerting.UIEnabled && !uaIsDisabledForOrg
 
 	if uaVisibleForOrg {
 		if alertingSection := s.buildAlertNavLinks(c); alertingSection != nil {

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -112,6 +112,7 @@ type UnifiedAlertingSettings struct {
 	ExecuteAlerts                   bool
 	DefaultConfiguration            string
 	Enabled                         *bool // determines whether unified alerting is enabled. If it is nil then user did not define it and therefore its value will be determined during migration. Services should not use it directly.
+	UIEnabled                       bool
 	DisabledOrgs                    map[int64]struct{}
 	// BaseInterval interval of time the scheduler updates the rules and evaluates rules.
 	// Only for internal use and not user configuration.
@@ -262,6 +263,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	if err != nil {
 		return fmt.Errorf("failed to read unified alerting enabled setting: %w", err)
 	}
+	uaCfg.UIEnabled = ua.Key("ui_enabled").MustBool(true)
 
 	uaCfg.DisabledOrgs = make(map[int64]struct{})
 	orgsStr := valueAsString(ua, "disabled_orgs", "")

--- a/pkg/setting/setting_unified_alerting_test.go
+++ b/pkg/setting/setting_unified_alerting_test.go
@@ -27,6 +27,7 @@ func TestCfg_ReadUnifiedAlertingSettings(t *testing.T) {
 		require.Equal(t, time.Minute, cfg.UnifiedAlerting.HAPushPullInterval)
 		require.Equal(t, 6*time.Hour, cfg.UnifiedAlerting.HAReconnectTimeout)
 		require.Equal(t, alertingDefaultInitializationTimeout, cfg.UnifiedAlerting.InitializationTimeout)
+		require.True(t, cfg.UnifiedAlerting.UIEnabled)
 	}
 
 	// With peers set, it correctly parses them.
@@ -38,11 +39,14 @@ func TestCfg_ReadUnifiedAlertingSettings(t *testing.T) {
 		require.NoError(t, err)
 		_, err = s.NewKey("initialization_timeout", "123s")
 		require.NoError(t, err)
+		_, err = s.NewKey("ui_enabled", "false")
+		require.NoError(t, err)
 
 		require.NoError(t, cfg.ReadUnifiedAlertingSettings(cfg.Raw))
 		require.Len(t, cfg.UnifiedAlerting.HAPeers, 3)
 		require.ElementsMatch(t, []string{"hostname1:9090", "hostname2:9090", "hostname3:9090"}, cfg.UnifiedAlerting.HAPeers)
 		require.Equal(t, 123*time.Second, cfg.UnifiedAlerting.InitializationTimeout)
+		require.False(t, cfg.UnifiedAlerting.UIEnabled)
 	}
 
 	t.Run("should read 'scheduler_tick_interval'", func(t *testing.T) {

--- a/public/app/features/admin/AdminSettings.tsx
+++ b/public/app/features/admin/AdminSettings.tsx
@@ -2,9 +2,10 @@ import { useAsync } from 'react-use';
 
 import { Trans } from '@grafana/i18n';
 import { getBackendSrv } from '@grafana/runtime';
-import { Alert } from '@grafana/ui';
+import { Alert, Stack } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 
+import { AlertingSettingsCard } from './AlertingSettingsCard';
 import { AdminSettingsTable } from './AdminSettingsTable';
 
 export type Settings = { [key: string]: { [key: string]: string } };
@@ -15,16 +16,17 @@ function AdminSettings() {
   return (
     <Page navId="server-settings">
       <Page.Contents>
-        <Alert severity="info" title="">
-          <Trans i18nKey="admin.settings.info-description">
-            These system settings are defined in grafana.ini or custom.ini (or overridden in ENV variables). To change
-            these you currently need to restart Grafana.
-          </Trans>
-        </Alert>
-
-        {loading && <AdminSettingsTable.Skeleton />}
-
-        {settings && <AdminSettingsTable settings={settings} />}
+        <Stack direction="column" gap={2}>
+          <Alert severity="info" title="">
+            <Trans i18nKey="admin.settings.info-description">
+              These system settings are defined in grafana.ini or custom.ini (or overridden in ENV variables). To
+              change these you currently need to restart Grafana.
+            </Trans>
+          </Alert>
+          <AlertingSettingsCard />
+          {loading && <AdminSettingsTable.Skeleton />}
+          {settings && <AdminSettingsTable settings={settings} />}
+        </Stack>
       </Page.Contents>
     </Page>
   );

--- a/public/app/features/admin/AlertingSettingsCard.test.tsx
+++ b/public/app/features/admin/AlertingSettingsCard.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+
+import { config } from '@grafana/runtime';
+
+import { AlertingSettingsCard } from './AlertingSettingsCard';
+
+describe('AlertingSettingsCard', () => {
+  const originalEnabled = config.unifiedAlertingEnabled;
+  const originalUIEnabled = config.unifiedAlertingUIEnabled;
+
+  afterEach(() => {
+    config.unifiedAlertingEnabled = originalEnabled;
+    config.unifiedAlertingUIEnabled = originalUIEnabled;
+  });
+
+  it('shows the disable snippet when alerting is enabled', () => {
+    config.unifiedAlertingEnabled = true;
+    config.unifiedAlertingUIEnabled = true;
+    render(<AlertingSettingsCard />);
+
+    expect(screen.getByText('Enabled')).toBeInTheDocument();
+    const [backendSnippet, uiSnippet] = screen.getAllByText(/\[unified_alerting\]/);
+    expect(backendSnippet).toHaveTextContent('enabled = false');
+    expect(screen.getByText('Visible')).toBeInTheDocument();
+    expect(uiSnippet).toHaveTextContent('ui_enabled = false');
+  });
+
+  it('shows the enable snippet when alerting is disabled', () => {
+    config.unifiedAlertingEnabled = false;
+    config.unifiedAlertingUIEnabled = false;
+    render(<AlertingSettingsCard />);
+
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+    const [backendSnippet, uiSnippet] = screen.getAllByText(/\[unified_alerting\]/);
+    expect(backendSnippet).toHaveTextContent('enabled = true');
+    expect(screen.getByText('Hidden')).toBeInTheDocument();
+    expect(uiSnippet).toHaveTextContent('ui_enabled = true');
+  });
+});

--- a/public/app/features/admin/AlertingSettingsCard.tsx
+++ b/public/app/features/admin/AlertingSettingsCard.tsx
@@ -1,0 +1,118 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
+import { Badge, Card, ClipboardButton, Stack, Text, useStyles2 } from '@grafana/ui';
+
+const ENABLE_ALERTING_SNIPPET = `[unified_alerting]
+enabled = true
+`;
+
+const DISABLE_ALERTING_SNIPPET = `[unified_alerting]
+enabled = false
+`;
+
+const ENABLE_UI_SNIPPET = `[unified_alerting]
+ui_enabled = true
+`;
+
+const DISABLE_UI_SNIPPET = `[unified_alerting]
+ui_enabled = false
+`;
+
+export function AlertingSettingsCard() {
+  const styles = useStyles2(getStyles);
+  const isEnabled = config.unifiedAlertingEnabled;
+  const isUIEnabled = config.unifiedAlertingUIEnabled !== false;
+  const statusText = isEnabled
+    ? t('admin.alerting.status.enabled', 'Enabled')
+    : t('admin.alerting.status.disabled', 'Disabled');
+  const actionText = isEnabled
+    ? t('admin.alerting.action.disable', 'disable alerting')
+    : t('admin.alerting.action.enable', 'enable alerting');
+  const snippet = isEnabled ? DISABLE_ALERTING_SNIPPET : ENABLE_ALERTING_SNIPPET;
+  const uiStatusText = isUIEnabled
+    ? t('admin.alerting.ui-status.visible', 'Visible')
+    : t('admin.alerting.ui-status.hidden', 'Hidden');
+  const uiActionText = isUIEnabled
+    ? t('admin.alerting.ui-action.hide', 'hide alerting UI')
+    : t('admin.alerting.ui-action.show', 'show alerting UI');
+  const uiSnippet = isUIEnabled ? DISABLE_UI_SNIPPET : ENABLE_UI_SNIPPET;
+
+  return (
+    <Card noMargin className={styles.card}>
+      <Stack direction="column" gap={1.5}>
+        <Text variant="h5">{t('admin.alerting.title', 'Grafana Alerting')}</Text>
+        <Stack justifyContent="space-between" alignItems="center">
+          <Text weight="medium">{t('admin.alerting.backend-title', 'Alerting backend')}</Text>
+          <Badge color={isEnabled ? 'green' : 'orange'} text={statusText} />
+        </Stack>
+        <Text>
+          {t(
+            'admin.alerting.backend-description',
+            'Controls rule evaluation and notifications for this instance.'
+          )}
+        </Text>
+        <Text>
+          {t(
+            'admin.alerting.instructions',
+            'To {actionText}, update grafana.ini (or environment variables) and restart Grafana:',
+            { actionText }
+          )}
+        </Text>
+        <Stack direction="row" gap={1} alignItems="center" wrap="wrap">
+          <pre className={styles.code}>{snippet}</pre>
+          <ClipboardButton icon="copy" variant="primary" size="sm" getText={() => snippet}>
+            {t('admin.alerting.copy', 'Copy config snippet')}
+          </ClipboardButton>
+        </Stack>
+        <Stack justifyContent="space-between" alignItems="center">
+          <Text weight="medium">{t('admin.alerting.ui-title', 'Alerting UI')}</Text>
+          <Badge color={isUIEnabled ? 'green' : 'orange'} text={uiStatusText} />
+        </Stack>
+        <Text>
+          {t(
+            'admin.alerting.ui-description',
+            'Controls visibility for alerting pages, tabs, and menu actions.'
+          )}
+        </Text>
+        <Text>
+          {t(
+            'admin.alerting.ui-instructions',
+            'To {uiActionText}, update grafana.ini (or environment variables) and restart Grafana:',
+            { uiActionText }
+          )}
+        </Text>
+        <Stack direction="row" gap={1} alignItems="center" wrap="wrap">
+          <pre className={styles.code}>{uiSnippet}</pre>
+          <ClipboardButton icon="copy" variant="primary" size="sm" getText={() => uiSnippet}>
+            {t('admin.alerting.copy-ui', 'Copy UI config snippet')}
+          </ClipboardButton>
+        </Stack>
+        <Text color="secondary" variant="bodySmall">
+          {t('admin.alerting.restart-note', 'Restart Grafana after changing the configuration.')}
+        </Text>
+      </Stack>
+    </Card>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  card: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+    padding: theme.spacing(2),
+  }),
+  code: css({
+    background: theme.colors.background.secondary,
+    border: `1px solid ${theme.colors.border.weak}`,
+    borderRadius: theme.shape.radius.default,
+    fontFamily: theme.typography.fontFamilyMonospace,
+    fontSize: theme.typography.size.sm,
+    margin: 0,
+    padding: theme.spacing(1),
+    whiteSpace: 'pre',
+  }),
+});

--- a/public/app/features/admin/ServerStats.test.tsx
+++ b/public/app/features/admin/ServerStats.test.tsx
@@ -5,6 +5,9 @@ import config from 'app/core/config';
 import { ServerStats } from './ServerStats';
 import { ServerStat } from './state/apis';
 
+const originalUnifiedAlertingEnabled = config.unifiedAlertingEnabled;
+const originalUnifiedAlertingUIEnabled = config.unifiedAlertingUIEnabled;
+
 const stats: ServerStat = {
   activeAdmins: 1,
   activeEditors: 0,
@@ -36,6 +39,16 @@ jest.mock('../../core/services/context_srv', () => ({
 }));
 
 describe('ServerStats', () => {
+  beforeEach(() => {
+    config.unifiedAlertingEnabled = true;
+    config.unifiedAlertingUIEnabled = true;
+  });
+
+  afterEach(() => {
+    config.unifiedAlertingEnabled = originalUnifiedAlertingEnabled;
+    config.unifiedAlertingUIEnabled = originalUnifiedAlertingUIEnabled;
+  });
+
   it('Should render page with stats', async () => {
     render(<ServerStats />);
     expect(await screen.findByRole('heading', { name: /instance statistics/i })).toBeInTheDocument();

--- a/public/app/features/admin/ServerStats.tsx
+++ b/public/app/features/admin/ServerStats.tsx
@@ -19,6 +19,7 @@ export const ServerStats = () => {
 
   const hasAccessToDataSources = contextSrv.hasPermission(AccessControlAction.DataSourcesRead);
   const hasAccessToAdminUsers = contextSrv.hasPermission(AccessControlAction.UsersRead);
+  const alertingUIEnabled = config.unifiedAlertingEnabled && config.unifiedAlertingUIEnabled !== false;
 
   useEffect(() => {
     if (contextSrv.hasPermission(AccessControlAction.ActionServerStatsRead)) {
@@ -77,15 +78,17 @@ export const ServerStats = () => {
                 )
               }
             />
-            <ServerStatsCard
-              isLoading={isLoading}
-              content={[{ name: 'Alerts', value: stats?.alerts }]}
-              footer={
-                <LinkButton href={'/alerting/list'} variant={'secondary'}>
-                  <Trans i18nKey="admin.server-settings.alerts-button">Manage alerts</Trans>
-                </LinkButton>
-              }
-            />
+            {alertingUIEnabled && (
+              <ServerStatsCard
+                isLoading={isLoading}
+                content={[{ name: 'Alerts', value: stats?.alerts }]}
+                footer={
+                  <LinkButton href={'/alerting/list'} variant={'secondary'}>
+                    <Trans i18nKey="admin.server-settings.alerts-button">Manage alerts</Trans>
+                  </LinkButton>
+                }
+              />
+            )}
           </Stack>
           <ServerStatsCard
             isLoading={isLoading}

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -350,5 +350,6 @@ export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
 function importAlertingComponent(loader: () => any): GrafanaRouteComponent {
   const featureDisabledPageLoader = () =>
     import(/* webpackChunkName: "AlertingDisabled" */ 'app/features/alerting/unified/AlertingNotEnabled');
-  return SafeDynamicImport(config.unifiedAlertingEnabled ? loader : featureDisabledPageLoader);
+  const alertingUIEnabled = config.unifiedAlertingEnabled && config.unifiedAlertingUIEnabled !== false;
+  return SafeDynamicImport(alertingUIEnabled ? loader : featureDisabledPageLoader);
 }

--- a/public/app/features/alerting/unified/AlertingNotEnabled.tsx
+++ b/public/app/features/alerting/unified/AlertingNotEnabled.tsx
@@ -1,32 +1,68 @@
 import { NavModel } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { Page } from 'app/core/components/Page/Page';
 
 import { withPageErrorBoundary } from './withPageErrorBoundary';
 
 function FeatureTogglePage() {
-  const navModel: NavModel = {
-    node: {
-      text: t('alerting.feature-toggle-page.nav-model.text.alerting-is-not-enabled', 'Alerting is not enabled'),
-      hideFromBreadcrumbs: true,
-      subTitle: t(
+  const alertingEnabled = config.unifiedAlertingEnabled;
+  const alertingUIEnabled = config.unifiedAlertingUIEnabled !== false;
+  const isAlertingUIHidden = alertingEnabled && !alertingUIEnabled;
+
+  const titleText = isAlertingUIHidden
+    ? t('alerting.feature-toggle-page.nav-model.text.alerting-ui-hidden', 'Alerting UI is hidden')
+    : t('alerting.feature-toggle-page.nav-model.text.alerting-is-not-enabled', 'Alerting is not enabled');
+  const subTitleText = isAlertingUIHidden
+    ? t(
+        'alerting.feature-toggle-page.nav-model.subTitle.enable-alerting-ui-grafana-config',
+        'To show the alerting UI, enable it in the Grafana config'
+      )
+    : t(
         'alerting.feature-toggle-page.nav-model.subTitle.enable-alerting-grafana-config',
         'To enable alerting, enable it in the Grafana config'
-      ),
+      );
+  const snippet = isAlertingUIHidden
+    ? `[unified_alerting]
+ui_enabled = true
+`
+    : `[unified_alerting]
+enabled = true
+`;
+    ? t('alerting.feature-toggle-page.nav-model.text.alerting-is-not-enabled', 'Alerting is not enabled')
+    : t('alerting.feature-toggle-page.nav-model.text.alerting-ui-hidden', 'Alerting UI is hidden');
+  const subTitleText = isAlertingDisabled
+    ? t(
+        'alerting.feature-toggle-page.nav-model.subTitle.enable-alerting-grafana-config',
+        'To enable alerting, enable it in the Grafana config'
+      )
+    : t(
+        'alerting.feature-toggle-page.nav-model.subTitle.enable-alerting-ui-grafana-config',
+        'To show the alerting UI, enable it in the Grafana config'
+      );
+  const snippet = isAlertingDisabled
+    ? `[unified_alerting]
+enabled = true
+`
+    : `[unified_alerting]
+ui_enabled = true
+`;
+
+  const navModel: NavModel = {
+    node: {
+      text: titleText,
+      hideFromBreadcrumbs: true,
+      subTitle: subTitleText,
     },
     main: {
-      text: t('alerting.feature-toggle-page.nav-model.text.alerting-is-not-enabled', 'Alerting is not enabled'),
+      text: titleText,
     },
   };
 
   return (
     <Page navModel={navModel}>
       <Page.Contents>
-        <pre>
-          {`[unified_alerting]
-enabled = true
-`}
-        </pre>
+        <pre>{snippet}</pre>
       </Page.Contents>
     </Page>
   );

--- a/public/app/features/alerting/unified/PanelAlertTabContent.tsx
+++ b/public/app/features/alerting/unified/PanelAlertTabContent.tsx
@@ -29,7 +29,8 @@ export const PanelAlertTabContent = ({ dashboard, panel }: Props) => {
   });
 
   const permissions = getRulesPermissions('grafana');
-  const canCreateRules = config.unifiedAlertingEnabled && contextSrv.hasPermission(permissions.create);
+  const alertingEnabled = config.unifiedAlertingEnabled && config.unifiedAlertingUIEnabled !== false;
+  const canCreateRules = alertingEnabled && contextSrv.hasPermission(permissions.create);
 
   const alert = errors.length ? (
     <Alert

--- a/public/app/features/alerting/unified/initAlerting.tsx
+++ b/public/app/features/alerting/unified/initAlerting.tsx
@@ -14,7 +14,7 @@ const AlertRulesToolbarButton = lazy(
 
 export function initAlerting() {
   const grafanaRulesPermissions = getRulesPermissions(GRAFANA_RULES_SOURCE_NAME);
-  const alertingEnabled = config.unifiedAlertingEnabled;
+  const alertingEnabled = config.unifiedAlertingEnabled && config.unifiedAlertingUIEnabled !== false;
 
   if (contextSrv.hasPermission(grafanaRulesPermissions.read)) {
     addCustomRightAction({

--- a/public/app/features/alerting/unified/utils/access-control.ts
+++ b/public/app/features/alerting/unified/utils/access-control.ts
@@ -143,10 +143,11 @@ export function getRulesAccess() {
 }
 
 export function getCreateAlertInMenuAvailability() {
-  const { unifiedAlertingEnabled } = getConfig();
+  const { unifiedAlertingEnabled, unifiedAlertingUIEnabled } = getConfig();
   const hasRuleReadPermissions = contextSrv.hasPermission(getRulesPermissions(GRAFANA_RULES_SOURCE_NAME).read);
   const hasRuleUpdatePermissions = contextSrv.hasPermission(getRulesPermissions(GRAFANA_RULES_SOURCE_NAME).update);
-  const isAlertingAvailableForRead = unifiedAlertingEnabled && hasRuleReadPermissions;
+  const isAlertingAvailableForRead =
+    unifiedAlertingEnabled && unifiedAlertingUIEnabled !== false && hasRuleReadPermissions;
 
   return isAlertingAvailableForRead && hasRuleUpdatePermissions;
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
@@ -95,9 +95,9 @@ function PanelDataPaneRendered({ model }: SceneComponentProps<PanelDataPane>) {
 }
 
 export function shouldShowAlertingTab(pluginId: string) {
-  const { unifiedAlertingEnabled = false } = getConfig();
+  const { unifiedAlertingEnabled = false, unifiedAlertingUIEnabled } = getConfig();
   const hasRuleReadPermissions = contextSrv.hasPermission(getRulesPermissions(GRAFANA_RULES_SOURCE_NAME).read);
-  const isAlertingAvailable = unifiedAlertingEnabled && hasRuleReadPermissions;
+  const isAlertingAvailable = unifiedAlertingEnabled && unifiedAlertingUIEnabled !== false && hasRuleReadPermissions;
   if (!isAlertingAvailable) {
     return false;
   }

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -126,7 +126,7 @@ export function transformSaveModelSchemaV2ToScene(dto: DashboardWithAccessInfo<D
 
   // Create alert states data layer if unified alerting is enabled
   let alertStatesLayer: AlertStatesDataLayer | undefined;
-  if (config.unifiedAlertingEnabled) {
+  if (config.unifiedAlertingEnabled && config.unifiedAlertingUIEnabled !== false) {
     alertStatesLayer = new AlertStatesDataLayer({
       key: 'alert-states',
       name: 'Alert States',

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -330,7 +330,7 @@ export function createDashboardSceneFromDashboardModel(
     });
   }
 
-  let shouldUseAlertStatesLayer = config.unifiedAlertingEnabled;
+  let shouldUseAlertStatesLayer = config.unifiedAlertingEnabled && config.unifiedAlertingUIEnabled !== false;
   if (!shouldUseAlertStatesLayer) {
     if (oldModel.panels.find((panel) => Boolean(panel.alert))) {
       shouldUseAlertStatesLayer = true;

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
@@ -53,7 +53,7 @@ export const PanelEditorTabs = memo(({ panel, dashboard, tabs, onChangeTab }: Pa
     return null;
   }
 
-  const alertingEnabled = config.unifiedAlertingEnabled;
+  const alertingEnabled = config.unifiedAlertingEnabled && config.unifiedAlertingUIEnabled !== false;
 
   return (
     <div className={styles.wrapper}>

--- a/public/app/features/dashboard/components/PanelEditor/state/selectors.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/selectors.ts
@@ -56,9 +56,9 @@ export const getPanelEditorTabs = memoizeOne((tab?: string, plugin?: PanelPlugin
 });
 
 export function shouldShowAlertingTab(plugin: PanelPlugin) {
-  const { unifiedAlertingEnabled = false } = getConfig();
+  const { unifiedAlertingEnabled = false, unifiedAlertingUIEnabled } = getConfig();
   const hasRuleReadPermissions = contextSrv.hasPermission(getRulesPermissions(GRAFANA_RULES_SOURCE_NAME).read);
-  const isAlertingAvailable = unifiedAlertingEnabled && hasRuleReadPermissions;
+  const isAlertingAvailable = unifiedAlertingEnabled && unifiedAlertingUIEnabled !== false && hasRuleReadPermissions;
   if (!isAlertingAvailable) {
     return false;
   }

--- a/public/app/features/folders/state/navModel.test.ts
+++ b/public/app/features/folders/state/navModel.test.ts
@@ -10,6 +10,7 @@ jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   config: {
     unifiedAlertingEnabled: true,
+    unifiedAlertingUIEnabled: true,
   },
 }));
 
@@ -41,6 +42,7 @@ describe('buildNavModel', () => {
     jest.clearAllMocks();
     (contextSrv.hasPermission as jest.Mock).mockReturnValue(true);
     config.unifiedAlertingEnabled = true;
+    config.unifiedAlertingUIEnabled = true;
   });
 
   describe('Alerts tab visibility', () => {
@@ -76,6 +78,15 @@ describe('buildNavModel', () => {
 
     it('should hide Alerts tab when unified alerting is disabled', () => {
       config.unifiedAlertingEnabled = false;
+
+      const navModel = buildNavModel(mockFolder);
+      const alertingTab = navModel.children?.find((child) => child.id === getAlertingTabID(mockFolder.uid));
+
+      expect(alertingTab).toBeUndefined();
+    });
+
+    it('should hide Alerts tab when alerting UI is disabled', () => {
+      config.unifiedAlertingUIEnabled = false;
 
       const navModel = buildNavModel(mockFolder);
       const alertingTab = navModel.children?.find((child) => child.id === getAlertingTabID(mockFolder.uid));

--- a/public/app/features/folders/state/navModel.ts
+++ b/public/app/features/folders/state/navModel.ts
@@ -55,7 +55,8 @@ export function buildNavModel(folder: FolderDTO | FolderParent, parentsArg?: Fol
   if (
     !isProvisioned &&
     contextSrv.hasPermission(AccessControlAction.AlertingRuleRead) &&
-    config.unifiedAlertingEnabled
+    config.unifiedAlertingEnabled &&
+    config.unifiedAlertingUIEnabled !== false
   ) {
     model.children!.push({
       active: false,

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -30,6 +30,7 @@ const isDevEnv = config.buildInfo.env === 'development';
 export const extraRoutes: RouteDescriptor[] = [];
 
 export function getAppRoutes(): RouteDescriptor[] {
+  const alertingUIEnabled = config.unifiedAlertingEnabled && config.unifiedAlertingUIEnabled !== false;
   const routes: Array<RouteDescriptor | undefined | false> = [
     // Based on the Grafana configuration standalone plugin pages can even override and extend existing core pages, or they can register new routes under existing ones.
     // In order to make it possible we need to register them first due to how `<Switch>` is evaluating routes. (This will be unnecessary once/when we upgrade to React Router v6 and start using `<Routes>` instead.)
@@ -498,7 +499,12 @@ export function getAppRoutes(): RouteDescriptor[] {
       path: '/dashboards/f/:uid/:slug/alerting',
       roles: () => contextSrv.evaluatePermission([AccessControlAction.AlertingRuleRead]),
       component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "FolderAlerting"*/ 'app/features/browse-dashboards/BrowseFolderAlertingPage')
+        alertingUIEnabled
+          ? () =>
+              import(
+                /* webpackChunkName: "FolderAlerting"*/ 'app/features/browse-dashboards/BrowseFolderAlertingPage'
+              )
+          : () => import(/* webpackChunkName: "AlertingDisabled" */ 'app/features/alerting/unified/AlertingNotEnabled')
       ),
     },
     {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Adds instance-wide alerting disable and UI hide controls via `[unified_alerting] enabled` and `ui_enabled`, exposes the UI flag to the frontend, and hides alerting pages/tabs/menus and nav entries when the UI is disabled. `/admin/settings` now shows status and copyable snippets.

**Why do we need this feature?**
- Prevent duplicate notifications in multi-instance deployments where only one instance should evaluate and send alerts.
- Allow Grafana to run as dashboards-only while alerting is handled by Cortex/Alertmanager (including cases where Grafana could be down).
- Reduce alerting evaluation load on read-only or viewer-heavy instances.
- Avoid user confusion in environments where alerting is centrally managed or disallowed for compliance/security.

**Who is this feature for?**
Grafana operators running HA/multi-instance setups, teams using external alerting backends, and admins who want dashboards-only instances without alerting UI.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
