### PR TITLE
`ResourceClient`: Do not extract id tokens on service call

### DIFF
--- a/pkg/storage/unified/resource/client.go
+++ b/pkg/storage/unified/resource/client.go
@@ -174,17 +174,20 @@ func idTokenExtractor(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("no claims found")
 	}
 
+	// If the identity is the service identity, we don't need to extract the ID token
+	if info.GetIdentityType() == types.TypeAccessPolicy {
+		return "", nil
+	}
+
 	if token := info.GetIDToken(); len(token) != 0 {
 		return token, nil
 	}
 
-	if !types.IsIdentityType(info.GetIdentityType(), types.TypeAccessPolicy) {
-		authLogger.FromContext(ctx).Warn(
-			"calling resource store as the service without id token or marking it as the service identity",
-			"subject", info.GetSubject(),
-			"uid", info.GetUID(),
-		)
-	}
+	authLogger.FromContext(ctx).Warn(
+		"calling resource store as the service without id token or marking it as the service identity",
+		"subject", info.GetSubject(),
+		"uid", info.GetUID(),
+	)
 
 	return "", nil
 }


### PR DESCRIPTION
The authn flow unconditionally signs id_tokens for all identities (even non-users), which causes an issue accessing the unistore's cluster scope resources in embedded Grafana:
1. ext_jwt client sets orgId to default org ([ext_jwt.go:214](https://github.com/grafana/grafana/blob/main/pkg/services/authn/clients/ext_jwt.go#L214))
2. ID token signing maps orgId to namespace ([auth/idimpl/service.go:104](https://github.com/grafana/grafana/blob/c720c6296c882656392158c537354ea44e03c9ab/pkg/services/auth/idimpl/service.go#L104))
   Result: namespace becomes "default" or "stack-{id}" instead of "*" for multi-tenant services
3. This token is sent to resource store ([unified/resource/client.go:178](https://github.com/grafana/grafana/blob/c720c6296c882656392158c537354ea44e03c9ab/pkg/storage/unified/resource/client.go#L178))
4. Store rejects access to `*` namespace resources due to namespace mismatch

This PR fixes the issue by ignoring ID tokens on service calls.