### PR TITLE
Provisioning: Set JobStateError for any sync errors

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/job_resource_result.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result.go
@@ -16,9 +16,12 @@ func isWarningError(err error) bool {
 	}
 
 	var validationErr *resources.ResourceValidationError
+	var ownershipErr *resources.ResourceOwnershipConflictError
 
 	switch {
 	case errors.As(err, &validationErr):
+		return true
+	case errors.As(err, &ownershipErr):
 		return true
 	default:
 		return false

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -306,11 +306,10 @@ func (r *jobProgressRecorder) Complete(ctx context.Context, err error) provision
 	if len(jobStatus.Errors) > 0 && jobStatus.State != provisioning.JobStateError {
 		if tooManyErrors {
 			jobStatus.Message = "completed with too many errors"
-			jobStatus.State = provisioning.JobStateError
 		} else {
 			jobStatus.Message = "completed with errors"
-			jobStatus.State = provisioning.JobStateWarning
 		}
+		jobStatus.State = provisioning.JobStateError
 	} else if len(jobStatus.Warnings) > 0 {
 		jobStatus.State = provisioning.JobStateWarning
 		jobStatus.Message = "completed with warnings"

--- a/pkg/registry/apis/provisioning/jobs/progress_test.go
+++ b/pkg/registry/apis/provisioning/jobs/progress_test.go
@@ -209,9 +209,9 @@ func TestJobProgressRecorderWarningWithErrors(t *testing.T) {
 	// Complete the job
 	finalStatus := recorder.Complete(ctx, nil)
 
-	// When there are errors, the state should be Warning (not Error unless too many)
-	// and warnings should still be included
-	assert.Equal(t, provisioning.JobStateWarning, finalStatus.State)
+	// When there are errors, the state should be Error (any errors = error state)
+	// Warnings should still be included in the response
+	assert.Equal(t, provisioning.JobStateError, finalStatus.State)
 	assert.Equal(t, "completed with errors", finalStatus.Message)
 	assert.Len(t, finalStatus.Errors, 1)
 	assert.Contains(t, finalStatus.Errors[0], "failed to process")


### PR DESCRIPTION
## Summary

This PR fixes the issue where incremental syncs with errors still update the LastRef, and clarifies the distinction between errors (system failures) and warnings (user errors).

**Changes:**
- Any real errors now result in `JobStateError` (preserves LastRef for retry)
- Ownership conflicts are now treated as warnings, not errors (user error - e.g., copying a file with the same UID to a different repository)
- Validation/parsing errors continue to be treated as warnings

## Behavior

| Scenario | State | LastRef | Retry |
|----------|-------|---------|-------|
| Real errors (system failures) | `JobStateError` | Preserved | Yes |
| Ownership conflicts (user error) | `JobStateWarning` | Updated | No |
| Validation errors (user error) | `JobStateWarning` | Updated | No |
| Success | `JobStateSuccess` | Updated | No |

## Rationale

- **Real errors** (e.g., network failures, API errors) should preserve the LastRef so files are retried on subsequent syncs
- **Ownership conflicts** happen when a user accidentally uses the same resource name/UID as another repository - this is a user configuration error that won't be fixed by retrying
- **Validation errors** (malformed JSON, invalid schema) are also user errors that won't be fixed by retrying

## Test plan

- [x] Unit tests for `isWarningError` with `ResourceOwnershipConflictError`
- [x] Unit tests for progress recorder with errors
- [x] Integration tests for ownership protection updated to expect warnings

Fixes https://github.com/grafana/git-ui-sync-project/issues/742