### PR TITLE
fix: Make RefreshPicker WCAG 2.5.3 compliant

### DIFF
--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -48,7 +48,7 @@ export class RefreshPicker extends PureComponent<Props> {
   static autoOption = {
     label: 'Auto',
     value: 'auto',
-    ariaLabel: 'Select refresh from the query range',
+    ariaLabel: 'Turn on auto refresh',
   };
 
   static isLive = (refreshInterval?: string): boolean => refreshInterval === RefreshPicker.liveOption.value;
@@ -94,13 +94,17 @@ export class RefreshPicker extends PureComponent<Props> {
     const durationAriaLabel = selectedValue.ariaLabel;
     const ariaLabelDurationSelectedMessage = t(
       'refresh-picker.aria-label.duration-selected',
-      'Choose refresh time interval with current interval {{durationAriaLabel}} selected',
-      { durationAriaLabel }
+      '{{durationAriaLabel}} - interval selected',
+      {
+        durationAriaLabel,
+      }
     );
+
     const ariaLabelChooseIntervalMessage = t(
       'refresh-picker.aria-label.choose-interval',
       'Auto refresh turned off. Choose refresh time interval'
     );
+
     const ariaLabel = selectedValue.value === '' ? ariaLabelChooseIntervalMessage : ariaLabelDurationSelectedMessage;
 
     const tooltipIntervalSelected = t('refresh-picker.tooltip.interval-selected', 'Set auto refresh interval');

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12692,10 +12692,10 @@
   "refresh-picker": {
     "aria-label": {
       "choose-interval": "Auto refresh turned off. Choose refresh time interval",
-      "duration-selected": "Choose refresh time interval with current interval {{durationAriaLabel}} selected"
+      "duration-selected": "{{durationAriaLabel}} - interval selected"
     },
     "auto-option": {
-      "aria-label": "",
+      "aria-label": "Auto",
       "label": ""
     },
     "live-option": {


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR makes the RefreshPicker component WCAG 2.5.3 "Label in Name" compliant by ensuring that all aria-labels exactly match or start with the visible text labels. The changes remove verbose descriptions from aria-labels while keeping them available in tooltips.

**Why do we need this feature?**

WCAG 2.5.3 requires that for user interface components with visible text labels, that text must be included in the accessible name. This ensures:

- Screen readers announce what sighted users see
- Voice control users can activate controls using the visible text
- Predictable behavior for users with cognitive disabilities

**Who is this feature for?**

- Screen reader users who rely on consistent announcements
- Voice control users who activate controls by speaking visible labels
- Users with cognitive disabilities who benefit from predictable interfaces
- Users with low vision who partially see labels and use assistive technology

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #116511


