### PR TITLE
Provisioning: check privateKey format in Connection validation

### DIFF
--- a/apps/provisioning/pkg/connection/github/validator.go
+++ b/apps/provisioning/pkg/connection/github/validator.go
@@ -2,7 +2,9 @@ package github
 
 import (
 	"context"
+	"encoding/base64"
 
+	"github.com/golang-jwt/jwt/v4"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -39,6 +41,21 @@ func Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	}
 	if !conn.Secure.ClientSecret.IsZero() {
 		list = append(list, field.Forbidden(field.NewPath("secure", "clientSecret"), "clientSecret is forbidden in GitHub connection"))
+	}
+
+	// Validate private key content if new is provided
+	if !conn.Secure.PrivateKey.Create.IsZero() {
+		// Decode base64-encoded private key
+		privateKeyPEM, err := base64.StdEncoding.DecodeString(string(conn.Secure.PrivateKey.Create))
+		if err != nil {
+			list = append(list, field.Invalid(field.NewPath("secure", "privateKey"), "[REDACTED]", "privateKey must be base64 encoded"))
+		} else {
+			// Parse the private key
+			_, err := jwt.ParseRSAPrivateKeyFromPEM(privateKeyPEM)
+			if err != nil {
+				list = append(list, field.Invalid(field.NewPath("secure", "privateKey"), "[REDACTED]", "privateKey must be a valid RSA private key"))
+			}
+		}
 	}
 
 	// Validate GitHub configuration fields

--- a/apps/provisioning/pkg/connection/github/validator_test.go
+++ b/apps/provisioning/pkg/connection/github/validator_test.go
@@ -2,6 +2,7 @@ package github_test
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
 
 	"github.com/grafana/grafana/apps/provisioning/pkg/connection/github"
@@ -14,6 +15,9 @@ import (
 )
 
 func TestValidate(t *testing.T) {
+	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(testPrivateKeyPEM))
+	invalidBase64 := base64.StdEncoding.EncodeToString([]byte("somePrivateKey"))
+
 	tests := []struct {
 		name          string
 		obj           runtime.Object
@@ -67,6 +71,50 @@ func TestValidate(t *testing.T) {
 			errorContains: []string{"privateKey"},
 		},
 		{
+			name: "private key invalid base64",
+			obj: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-conn",
+				},
+				Spec: provisioning.ConnectionSpec{
+					Type: provisioning.GithubConnectionType,
+					GitHub: &provisioning.GitHubConnectionConfig{
+						AppID:          "123",
+						InstallationID: "456",
+					},
+				},
+				Secure: provisioning.ConnectionSecure{
+					PrivateKey: common.InlineSecureValue{
+						Create: "invalid",
+					},
+				},
+			},
+			expectedError: true,
+			errorContains: []string{"privateKey"},
+		},
+		{
+			name: "privateKey invalid RSA private key",
+			obj: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-conn",
+				},
+				Spec: provisioning.ConnectionSpec{
+					Type: provisioning.GithubConnectionType,
+					GitHub: &provisioning.GitHubConnectionConfig{
+						AppID:          "123",
+						InstallationID: "456",
+					},
+				},
+				Secure: provisioning.ConnectionSecure{
+					PrivateKey: common.InlineSecureValue{
+						Create: common.NewSecretValue(invalidBase64),
+					},
+				},
+			},
+			expectedError: true,
+			errorContains: []string{"privateKey"},
+		},
+		{
 			name: "valid connection without token (controller will generate)",
 			obj: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{
@@ -81,7 +129,7 @@ func TestValidate(t *testing.T) {
 				},
 				Secure: provisioning.ConnectionSecure{
 					PrivateKey: common.InlineSecureValue{
-						Create: common.NewSecretValue("test-key"),
+						Create: common.NewSecretValue(privateKeyBase64),
 					},
 				},
 			},
@@ -178,7 +226,7 @@ func TestValidate(t *testing.T) {
 				},
 				Secure: provisioning.ConnectionSecure{
 					PrivateKey: common.InlineSecureValue{
-						Create: common.NewSecretValue("test-key"),
+						Create: common.NewSecretValue(privateKeyBase64),
 					},
 					Token: common.InlineSecureValue{
 						Create: common.NewSecretValue("test-token"),


### PR DESCRIPTION
**What is this feature?**

Checking `connection.secure.privateKey` format in validation.

**Why do we need this feature?**

In https://github.com/grafana/grafana/pull/116768, we're not erroring anymore when the private key is not in the proper format, this is adding those checks back.

**Who is this feature for?**

Users of GitSync

**Which issue(s) does this PR fix?**:

No issue, followup from https://github.com/grafana/grafana/pull/116768

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
