### PR TITLE
Alerting: Make alerting frontend codeowners for relevant API clients

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -747,6 +747,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 
 # @grafana/api-clients
 /packages/grafana-api-clients/ @grafana/grafana-frontend-platform @grafana/grafana-search-navigate-organise
+/packages/grafana-api-clients/src/clients/rtkq/*.alerting/ @grafana/alerting-frontend
 /packages/grafana-api-clients/src/clients/rtkq/advisor/ @grafana/plugins-platform-frontend
 /packages/grafana-api-clients/src/clients/rtkq/correlations/ @grafana/datapro
 /packages/grafana-api-clients/src/clients/rtkq/dashboard/ @grafana/dashboards-squad


### PR DESCRIPTION
**What is this feature?**
Make alerting frontend codeowners for relevant API clients

**Why do we need this feature?**
Currently it falls back to search nav organise team - e.g. changes in https://github.com/grafana/grafana/pull/111338 pinged SNO team, but alerting FE should probably have been told 😁 
