### PR TITLE
Provisioning: Add Bitbucket repository support

### DIFF
--- a/apps/provisioning/pkg/repository/bitbucket/extra.go
+++ b/apps/provisioning/pkg/repository/bitbucket/extra.go
@@ -1,0 +1,62 @@
+package bitbucket
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/grafana-app-sdk/logging"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository/git"
+)
+
+type extra struct {
+	decrypter repository.Decrypter
+}
+
+func Extra(decrypter repository.Decrypter) repository.Extra {
+	return &extra{
+		decrypter: decrypter,
+	}
+}
+
+func (e *extra) Type() provisioning.RepositoryType {
+	return provisioning.BitbucketRepositoryType
+}
+
+func (e *extra) Build(ctx context.Context, r *provisioning.Repository) (repository.Repository, error) {
+	if r == nil || r.Spec.Bitbucket == nil {
+		return nil, fmt.Errorf("bitbucket configuration is required")
+	}
+
+	cfg := r.Spec.Bitbucket
+	logger := logging.FromContext(ctx).With("url", cfg.URL, "branch", cfg.Branch, "path", cfg.Path)
+	logger.Info("Instantiating Bitbucket repository")
+
+	secure := e.decrypter(r)
+	token, err := secure.Token(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decrypt token: %w", err)
+	}
+
+	// Bitbucket uses the same Git protocol with HTTP Basic Auth, so we reuse git.Repository.
+	// TokenUser should be the user's email for Atlassian API tokens, or "x-token-auth" for Repository Access Tokens.
+	return git.NewRepository(ctx, r, git.RepositoryConfig{
+		URL:       cfg.URL,
+		Branch:    cfg.Branch,
+		Path:      cfg.Path,
+		TokenUser: cfg.TokenUser,
+		Token:     token,
+	})
+}
+
+func (e *extra) Mutate(ctx context.Context, obj runtime.Object) error {
+	return Mutate(ctx, obj)
+}
+
+func (e *extra) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	return Validate(ctx, obj)
+}

--- a/apps/provisioning/pkg/repository/bitbucket/mutator.go
+++ b/apps/provisioning/pkg/repository/bitbucket/mutator.go
@@ -1,0 +1,35 @@
+package bitbucket
+
+import (
+	"context"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+// Mutate normalizes the Bitbucket repository configuration.
+func Mutate(_ context.Context, obj runtime.Object) error {
+	repo, ok := obj.(*provisioning.Repository)
+	if !ok {
+		return nil
+	}
+
+	if repo.Spec.Bitbucket == nil {
+		return nil
+	}
+
+	// Normalize the Bitbucket URL and ensure it ends with .git for git protocol
+	if repo.Spec.Bitbucket.URL != "" {
+		url := strings.TrimSpace(repo.Spec.Bitbucket.URL)
+		url = strings.TrimRight(url, "/")
+		// Bitbucket git protocol requires .git suffix
+		if !strings.HasSuffix(url, ".git") {
+			url = url + ".git"
+		}
+		repo.Spec.Bitbucket.URL = url
+	}
+
+	return nil
+}

--- a/apps/provisioning/pkg/repository/bitbucket/validator.go
+++ b/apps/provisioning/pkg/repository/bitbucket/validator.go
@@ -1,0 +1,54 @@
+package bitbucket
+
+import (
+	"context"
+	"regexp"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository/git"
+)
+
+var bitbucketURLRegex = regexp.MustCompile(`^https://bitbucket\.org/[^/]+/[^/]+(\.git)?/?$`)
+
+// Validate validates the bitbucket repository configuration without requiring decrypted secrets.
+func Validate(_ context.Context, obj runtime.Object) field.ErrorList {
+	repo, ok := obj.(*provisioning.Repository)
+	if !ok {
+		return nil
+	}
+
+	if repo.Spec.Type != provisioning.BitbucketRepositoryType {
+		return nil
+	}
+
+	cfg := repo.Spec.Bitbucket
+	if cfg == nil {
+		return field.ErrorList{
+			field.Required(field.NewPath("spec", "bitbucket"), "bitbucket configuration is required for bitbucket repository type"),
+		}
+	}
+
+	var list field.ErrorList
+
+	// Validate URL format
+	if cfg.URL == "" {
+		list = append(list, field.Required(field.NewPath("spec", "bitbucket", "url"), "a bitbucket url is required"))
+	} else if !bitbucketURLRegex.MatchString(cfg.URL) {
+		list = append(list, field.Invalid(
+			field.NewPath("spec", "bitbucket", "url"),
+			cfg.URL,
+			"must be a valid Bitbucket repository URL (https://bitbucket.org/workspace/repo)",
+		))
+	}
+
+	if len(list) > 0 {
+		return list
+	}
+
+	// Validate git-related fields (branch, path, token/connection) using the shared git validator
+	list = append(list, git.ValidateGitConfigFields(repo, cfg.URL, cfg.Branch, cfg.Path)...)
+	return list
+}

--- a/pkg/registry/apis/provisioning/extras/register.go
+++ b/pkg/registry/apis/provisioning/extras/register.go
@@ -5,6 +5,7 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
 	ghconnection "github.com/grafana/grafana/apps/provisioning/pkg/connection/github"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository/bitbucket"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository/git"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository/github"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository/local"
@@ -41,6 +42,7 @@ func ProvideProvisioningOSSRepositoryExtras(
 			ghFactory,
 			webhooksBuilder,
 		),
+		bitbucket.Extra(decrypter),
 	}
 }
 

--- a/public/app/features/provisioning/Wizard/fields.ts
+++ b/public/app/features/provisioning/Wizard/fields.ts
@@ -127,10 +127,13 @@ const getProviderConfigs = (): Record<RepoType, Record<string, FieldConfig>> => 
   },
   bitbucket: {
     token: {
-      label: t('provisioning.bitbucket.token-label', 'App Password'),
-      description: t('provisioning.bitbucket.token-description', 'Bitbucket App Password with repository permissions'),
+      label: t('provisioning.bitbucket.token-label', 'Repository Access Token'),
+      description: t(
+        'provisioning.bitbucket.token-description',
+        'Bitbucket Repository Access Token or App Password with repository permissions'
+      ),
       // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
-      placeholder: 'ATBBxxxxxxxxxxxxxxxx',
+      placeholder: 'Repository Access Token or App Password',
       required: true,
       validation: {
         required: t('provisioning.bitbucket.token-required', 'Bitbucket token is required'),
@@ -140,10 +143,10 @@ const getProviderConfigs = (): Record<RepoType, Record<string, FieldConfig>> => 
       label: t('provisioning.bitbucket.token-user-label', 'Username'),
       description: t(
         'provisioning.bitbucket.token-user-description',
-        'The username that will be used to access the repository with the app password'
+        'Your Bitbucket username for App Passwords, or "x-token-auth" for Repository Access Tokens'
       ),
       // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
-      placeholder: 'username',
+      placeholder: 'x-token-auth or your-username',
       required: true,
       validation: {
         required: t('provisioning.bitbucket.token-user-required', 'Username is required'),

--- a/public/app/features/provisioning/utils/data.ts
+++ b/public/app/features/provisioning/utils/data.ts
@@ -45,10 +45,16 @@ export const dataToSpec = (data: RepositoryFormData, connectionName?: string): R
       spec.gitlab = baseConfig;
       break;
     case 'bitbucket':
-      spec.bitbucket = baseConfig;
+      spec.bitbucket = {
+        ...baseConfig,
+        tokenUser: data.tokenUser,
+      };
       break;
     case 'git':
-      spec.git = baseConfig;
+      spec.git = {
+        ...baseConfig,
+        tokenUser: data.tokenUser,
+      };
       break;
     case 'local':
       spec.local = {
@@ -64,6 +70,7 @@ export const dataToSpec = (data: RepositoryFormData, connectionName?: string): R
 
 export const specToData = (spec: RepositorySpec): RepositoryFormData => {
   const remoteConfig = spec.github || spec.gitlab || spec.bitbucket || spec.git;
+  const tokenUser = spec.bitbucket?.tokenUser || spec.git?.tokenUser;
 
   return structuredClone({
     ...spec,
@@ -71,6 +78,7 @@ export const specToData = (spec: RepositorySpec): RepositoryFormData => {
     ...spec.local,
     branch: remoteConfig?.branch || '',
     url: remoteConfig?.url || '',
+    tokenUser: tokenUser || '',
     generateDashboardPreviews: spec.github?.generateDashboardPreviews || false,
     readOnly: !spec.workflows.length,
     prWorkflow: spec.workflows.includes('branch'),


### PR DESCRIPTION
Implement backend support for Bitbucket repositories in the provisioning feature. Bitbucket uses standard Git protocol with HTTP Basic Auth, so the implementation reuses the existing git.Repository with Bitbucket-specific validation and URL normalization.

Changes:
- Add bitbucket package with extra.go, validator.go, and mutator.go
- Register Bitbucket extra in OSS repository extras
- Fix frontend to pass tokenUser field for Bitbucket and Git types
- Update UI labels to support both Repository Access Tokens and App Passwords

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR adds backend support for Bitbucket repositories in Grafana's provisioning feature. Users can now connect Bitbucket Cloud repositories to Grafana for provisioning dashboards, alerting rules, and other resources directly from their Bitbucket repositories.

**Why do we need this feature?**

The provisioning UI already supports Bitbucket as an option, but the backend implementation was missing. Users selecting Bitbucket would encounter "not authorized" errors because there was no handler to process Bitbucket repository connections. This PR completes the Bitbucket integration by implementing the backend using the existing Git protocol (which Bitbucket supports via HTTP Basic Auth).

**Who is this feature for?**

Teams who want to use BitBucket as a gitsync backend

**Which issue(s) does this PR fix?**:

Fixes #105365
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.