### PR TITLE
Dashboard Scenes: Fix ScopesVariable blocking query execution in new dashboards

### DIFF
--- a/public/app/features/dashboard-scene/scene/VariableControls.test.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.test.tsx
@@ -21,13 +21,24 @@ jest.mock('@grafana/runtime', () => {
 });
 
 describe('VariableControls', () => {
-  it('should not render scopes variable', () => {
-    const variables = [new ScopesVariable({ hide: VariableHide.hideVariable, name: '__scopes' })];
+  it('should not show scopes variable label but should mount its component', () => {
+    const scopesVariable = new ScopesVariable({ hide: VariableHide.hideVariable, name: '__scopes' });
+    const variables = [scopesVariable];
     const dashboard = buildScene(variables);
     dashboard.activate();
 
     render(<VariableControls dashboard={dashboard} />);
+    expect(screen.queryByText('__scopes')).not.toBeInTheDocument();
+  });
 
+  it('should not show scopes variable in edit mode but should mount its component', () => {
+    const scopesVariable = new ScopesVariable({ hide: VariableHide.hideVariable, name: '__scopes' });
+    const variables = [scopesVariable];
+    const dashboard = buildScene(variables);
+    dashboard.activate();
+    dashboard.setState({ isEditing: true });
+
+    render(<VariableControls dashboard={dashboard} />);
     expect(screen.queryByText('__scopes')).not.toBeInTheDocument();
   });
 
@@ -45,12 +56,10 @@ describe('VariableControls', () => {
     expect(screen.queryByText('HiddenVar')).not.toBeInTheDocument();
   });
 
-  it('should render regular hidden variables in edit mode', async () => {
-    const hiddenVariable = new TextBoxVariable({
-      name: 'HiddenVar',
-      hide: VariableHide.hideVariable,
-    });
-    const variables = [hiddenVariable];
+  it('should render regular hidden variables but not scopes variable in edit mode', async () => {
+    const scopesVariable = new ScopesVariable({ hide: VariableHide.hideVariable, name: '__scopes' });
+    const hiddenVariable = new TextBoxVariable({ name: 'HiddenVar', hide: VariableHide.hideVariable });
+    const variables = [scopesVariable, hiddenVariable];
     const dashboard = buildScene(variables);
     dashboard.activate();
 
@@ -58,6 +67,7 @@ describe('VariableControls', () => {
     render(<VariableControls dashboard={dashboard} />);
 
     expect(await screen.findByText('HiddenVar')).toBeInTheDocument();
+    expect(screen.queryByText('__scopes')).not.toBeInTheDocument();
   });
 
   it('should not render variables hidden in controls menu in edit mode', async () => {

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -35,17 +35,12 @@ export function VariableControls({ dashboard }: { dashboard: DashboardScene }) {
   );
 
   //  Variables to render (exclude adhoc/groupby when drilldown controls are shown in top row)
+  // Only filter out inControlsMenu - VariableValueSelectWrapper handles rendering logic:
+  // - UNSAFE_renderAsHidden variables render invisibly (for ScopesVariable)
+  // - Regular hidden variables render greyed out in edit mode, or not at all otherwise
   const variablesToRender = hasDrilldownControls
     ? restVariables.filter((v) => v.state.hide !== VariableHide.inControlsMenu)
-    : isEditingNewLayouts
-      ? variables.filter(
-          (v) =>
-            v.state.hide !== VariableHide.inControlsMenu &&
-            // UNSAFE_renderAsHidden used for scopes variables, should always be hidden
-            // if we're editing in dynamic dashboards, still shows hidden variable but greyed out
-            (v.state.hide !== VariableHide.hideVariable || !v.UNSAFE_renderAsHidden)
-        )
-      : variables.filter((v) => v.state.hide !== VariableHide.inControlsMenu);
+    : variables.filter((v) => v.state.hide !== VariableHide.inControlsMenu);
 
   return (
     <>
@@ -76,11 +71,13 @@ export function VariableValueSelectWrapper({ variable, inMenu, isEditingNewLayou
   const shouldShowHiddenVariables = isEditingNewLayouts && isHidden;
   const styles = useStyles2(getStyles);
 
-  if (isHidden && !isEditingNewLayouts) {
-    if (variable.UNSAFE_renderAsHidden) {
-      return <variable.Component model={variable} />;
-    }
+  // UNSAFE_renderAsHidden variables (like ScopesVariable) should always render invisibly,
+  // regardless of edit mode - they need to mount to receive their React context
+  if (isHidden && variable.UNSAFE_renderAsHidden) {
+    return <variable.Component model={variable} />;
+  }
 
+  if (isHidden && !isEditingNewLayouts) {
     return null;
   }
 

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -71,8 +71,7 @@ export function VariableValueSelectWrapper({ variable, inMenu, isEditingNewLayou
   const shouldShowHiddenVariables = isEditingNewLayouts && isHidden;
   const styles = useStyles2(getStyles);
 
-  // UNSAFE_renderAsHidden variables (like ScopesVariable) should always render invisibly,
-  // regardless of edit mode - they need to mount to receive their React context
+  // UNSAFE_renderAsHidden variables (like ScopesVariable) should always render invisibly
   if (isHidden && variable.UNSAFE_renderAsHidden) {
     return <variable.Component model={variable} />;
   }


### PR DESCRIPTION
**What is this feature?**

Fixes a regression where ScopesVariable was excluded from the render loop, causing it to remain stuck in `loading: true` state and blocking all query execution.

**Special notes for your reviewer:**

- The root cause was a logic error: `!v.UNSAFE_renderAsHidden` excluded variables that need to render invisibly
- Added unit tests to verify both ScopesVariable invisibility and regular hidden variable behaviour