### PR TITLE
Gauge: Use more height for rounded gauge

### DIFF
--- a/packages/grafana-ui/src/components/RadialGauge/RadialArcPath.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialArcPath.tsx
@@ -55,7 +55,7 @@ export const RadialArcPath = memo(
     const boxY = Math.round(centerY - radius - barWidth - pad);
     const boxSize = Math.round((radius + barWidth) * 2 + pad * 2);
 
-    const path = drawRadialArcPath(angle, arcLengthDeg, dimensions, roundedBars);
+    const path = drawRadialArcPath(angle, arcLengthDeg, dimensions);
 
     const startRadians = toRad(angle);
     const endRadians = toRad(angle + arcLengthDeg);

--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.test.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.test.tsx
@@ -123,7 +123,7 @@ describe('RadialGauge', () => {
       expect(screen.queryByTestId('radial-gauge-thresholds-bar')).not.toBeInTheDocument();
     });
 
-    it.skip('should not render thresholds bar the prop is not set', () => {
+    it('should not render thresholds bar if the prop is not set', () => {
       render(
         <RadialGaugeExample
           min={50}

--- a/packages/grafana-ui/src/components/RadialGauge/__snapshots__/utils.test.ts.snap
+++ b/packages/grafana-ui/src/components/RadialGauge/__snapshots__/utils.test.ts.snap
@@ -10,8 +10,6 @@ exports[`RadialGauge utils drawRadialArcPath should draw correct path for narrow
 
 exports[`RadialGauge utils drawRadialArcPath should draw correct path for quarter arc 1`] = `"M 100 20 A 80 80 0 0 1 180 100"`;
 
-exports[`RadialGauge utils drawRadialArcPath should draw correct path for rounded bars 1`] = `"M 100 20 A 80 80 0 1 1 20 100.00000000000001"`;
-
 exports[`RadialGauge utils drawRadialArcPath should draw correct path for three quarter arc 1`] = `"M 100 20 A 80 80 0 1 1 20 100.00000000000001"`;
 
 exports[`RadialGauge utils drawRadialArcPath should draw correct path for wide bar width 1`] = `"M 100 20 A 80 80 0 0 1 100 180"`;

--- a/packages/grafana-ui/src/components/RadialGauge/utils.test.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.test.ts
@@ -156,13 +156,16 @@ describe('RadialGauge utils', () => {
       expect(withGlow.radius).toBeLessThan(withoutGlow.radius); // glow reduces available space
     });
 
-    it('should adjust radius for rounded bars when endAngle < 180', () => {
+    it('should adjust radius and centerY for rounded bars when endAngle < 180', () => {
       const sharpBars = calc({});
-      const roundedBars = calc({ roundedBars: true });
-      const roundedGauge = calc({ roundedBars: true, shape: 'gauge' });
+      const roundedCircle = calc({ roundedBars: true, shape: 'circle' });
+      const roundedArc = calc({ roundedBars: true, shape: 'gauge' });
 
-      expect(roundedBars.radius).toEqual(sharpBars.radius);
-      expect(roundedGauge.radius).toBeLessThan(sharpBars.radius);
+      expect(roundedCircle.radius).toEqual(sharpBars.radius);
+      expect(roundedArc.radius).toBeLessThan(sharpBars.radius);
+
+      expect(roundedCircle.centerY).toEqual(sharpBars.centerY);
+      expect(roundedArc.centerY).not.toEqual(sharpBars.centerY);
     });
 
     it('should handle threshold bars', () => {

--- a/packages/grafana-ui/src/components/RadialGauge/utils.test.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.test.ts
@@ -358,7 +358,6 @@ describe('RadialGauge utils', () => {
       { description: 'quarter arc', startAngle: 0, endAngle: 90 },
       { description: 'half arc', startAngle: 0, endAngle: 180 },
       { description: 'three quarter arc', startAngle: 0, endAngle: 270 },
-      { description: 'rounded bars', startAngle: 0, endAngle: 270, roundedBars: true },
       { description: 'wide bar width', startAngle: 0, endAngle: 180, dimensions: { barWidth: 50 } },
       { description: 'narrow bar width', startAngle: 0, endAngle: 180, dimensions: { barWidth: 5 } },
       { description: 'narrow radius', startAngle: 0, endAngle: 180, dimensions: { radius: 50 } },
@@ -366,11 +365,10 @@ describe('RadialGauge utils', () => {
         description: 'center x and y',
         startAngle: 0,
         endAngle: 360,
-        roundedBars: true,
         dimensions: { centerX: 150, centerY: 200 },
       },
-    ])(`should draw correct path for $description`, ({ startAngle, endAngle, dimensions, roundedBars }) => {
-      const path = drawRadialArcPath(startAngle, endAngle, { ...defaultDims, ...dimensions }, roundedBars);
+    ])(`should draw correct path for $description`, ({ startAngle, endAngle, dimensions }) => {
+      const path = drawRadialArcPath(startAngle, endAngle, { ...defaultDims, ...dimensions });
       expect(path).toMatchSnapshot();
     });
 

--- a/packages/grafana-ui/src/components/RadialGauge/utils.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.ts
@@ -121,14 +121,17 @@ export function calculateDimensions(
   // When enabling stroke-linecap="round" on a path, the circular endcap is appended outside of the path.
   // If you don't adjust the positioning or the path, then the endcaps will probably clip off the bottom
   // of the panel. To account for this, the circular endcap radius (which is half the bar width) needs
-  // to be accounted for. To get the best visual result, we will take some off the radius of the visualization
-  // overall and some off of the vertical space by offsetting the centerY upwards.
-  if (yMaxAngle < 180 && roundedBars) {
-    const radiusAdjustment = barWidth / 4; // stroke-linecap="round" | half of the endcap radius.
-    outerRadius -= radiusAdjustment;
-    maxRadiusH -= radiusAdjustment;
-    maxRadiusW -= radiusAdjustment;
-  }
+  // to be accounted for. To get the best visual result, we will take some off the radius of the
+  // visualization overall and some off of the vertical space by offsetting the centerY upwards.
+  const totalEndcapAdjustment = yMaxAngle < 180 && roundedBars ? barWidth * 0.5 : 0;
+
+  // change the factor we multiply here to steal more or less from the size of the gauge vs. the centerY position.
+  // there's actually a range of values you could use here to make this work, the 50/50 split looks the best
+  // to me, because it handles use cases like bar glow well and avoids clipping on either vertical edge of the panel.
+  const radiusEndcapAdjustment = totalEndcapAdjustment * 0.5;
+  outerRadius -= radiusEndcapAdjustment;
+  maxRadiusH -= radiusEndcapAdjustment;
+  maxRadiusW -= radiusEndcapAdjustment;
 
   // Scale labels
   let scaleLabelsFontSize = 0;
@@ -174,11 +177,8 @@ export function calculateDimensions(
   const belowCenterY = maxRadius * Math.sin(toRad(yMaxAngle));
   const rest = height - belowCenterY - margin * 2 - maxRadius;
   const centerX = width / 2;
-  let centerY = maxRadius + margin + rest / 2;
-
-  if (yMaxAngle < 180 && roundedBars) {
-    centerY -= barWidth / 4; // stroke-linecap="round" | the other half of the endcap radius.
-  }
+  const centerYEndcapAdjustment = totalEndcapAdjustment - radiusEndcapAdjustment;
+  const centerY = maxRadius + margin + rest / 2 - centerYEndcapAdjustment;
 
   if (barIndex > 0) {
     innerRadius = innerRadius - (barWidth + 4) * barIndex;

--- a/packages/grafana-ui/src/components/RadialGauge/utils.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.ts
@@ -118,9 +118,13 @@ export function calculateDimensions(
 
   const barWidth = Math.max(barWidthFactor * (maxRadius / 3), 2);
 
-  // If rounded bars are enabled, they need a bit more vertical space
+  // When enabling stroke-linecap="round" on a path, the circular endcap is appended outside of the path.
+  // If you don't adjust the positioning or the path, then the endcaps will probably clip off the bottom
+  // of the panel. To account for this, the circular endcap radius (which is half the bar width) needs
+  // to be accounted for. To get the best visual result, we will take some off the radius of the visualization
+  // overall and some off of the vertical space by offsetting the centerY upwards.
   if (yMaxAngle < 180 && roundedBars) {
-    const radiusAdjustment = barWidth / 4;
+    const radiusAdjustment = barWidth / 4; // stroke-linecap="round" | half of the endcap radius.
     outerRadius -= radiusAdjustment;
     maxRadiusH -= radiusAdjustment;
     maxRadiusW -= radiusAdjustment;
@@ -173,7 +177,7 @@ export function calculateDimensions(
   let centerY = maxRadius + margin + rest / 2;
 
   if (yMaxAngle < 180 && roundedBars) {
-    centerY -= barWidth / 4;
+    centerY -= barWidth / 4; // stroke-linecap="round" | the other half of the endcap radius.
   }
 
   if (barIndex > 0) {

--- a/packages/grafana-ui/src/components/RadialGauge/utils.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.ts
@@ -120,9 +120,9 @@ export function calculateDimensions(
 
   // If rounded bars is enabled they need a bit more vertical space
   if (yMaxAngle < 180 && roundedBars) {
-    outerRadius -= barWidth;
-    maxRadiusH -= barWidth;
-    maxRadiusW -= barWidth;
+    outerRadius -= barWidth / 4;
+    maxRadiusH -= barWidth / 4;
+    maxRadiusW -= barWidth / 4;
   }
 
   // Scale labels
@@ -169,7 +169,11 @@ export function calculateDimensions(
   const belowCenterY = maxRadius * Math.sin(toRad(yMaxAngle));
   const rest = height - belowCenterY - margin * 2 - maxRadius;
   const centerX = width / 2;
-  const centerY = maxRadius + margin + rest / 2;
+  let centerY = maxRadius + margin + rest / 2;
+
+  if (yMaxAngle < 180 && roundedBars) {
+    centerY -= barWidth / 4;
+  }
 
   if (barIndex > 0) {
     innerRadius = innerRadius - (barWidth + 4) * barIndex;
@@ -202,12 +206,7 @@ export function toCartesian(centerX: number, centerY: number, radius: number, an
   };
 }
 
-export function drawRadialArcPath(
-  startAngle: number,
-  endAngle: number,
-  dimensions: RadialGaugeDimensions,
-  roundedBars?: boolean
-): string {
+export function drawRadialArcPath(startAngle: number, endAngle: number, dimensions: RadialGaugeDimensions): string {
   const { radius, centerX, centerY } = dimensions;
 
   // For some reason a 100% full arc cannot be rendered

--- a/packages/grafana-ui/src/components/RadialGauge/utils.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.ts
@@ -118,11 +118,12 @@ export function calculateDimensions(
 
   const barWidth = Math.max(barWidthFactor * (maxRadius / 3), 2);
 
-  // If rounded bars is enabled they need a bit more vertical space
+  // If rounded bars are enabled, they need a bit more vertical space
   if (yMaxAngle < 180 && roundedBars) {
-    outerRadius -= barWidth / 4;
-    maxRadiusH -= barWidth / 4;
-    maxRadiusW -= barWidth / 4;
+    const radiusAdjustment = barWidth / 4;
+    outerRadius -= radiusAdjustment;
+    maxRadiusH -= radiusAdjustment;
+    maxRadiusW -= radiusAdjustment;
   }
 
   // Scale labels


### PR DESCRIPTION
Reported from internal testing.

The rounded gauge uses considerably less room than the flat gauge. This is because rounded butts on the gauge would clip below the boundary of the panel in a dashboard for square or landscape panel shapes, so we're forced to remove some height from the visualization. However, right now we remove more height than we need to, and that problem is made worse depending on how thick the bar is. This PR restores much of the lost height removed and also helps solve the problem by translating the whole viz up a bit in that situation. 

### Before

https://github.com/user-attachments/assets/a562dd07-ad54-4846-96be-96f8f72ad262

### After

https://github.com/user-attachments/assets/e4571a75-b8b2-478a-a0a5-9c125e2f6290


