### PR TITLE
Plugins: Ensure plugin settings API returns empty object for jsonData instead of null

### DIFF
--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -232,6 +232,9 @@ func (hs *HTTPServer) GetPluginSettingByID(c *contextmodel.ReqContext) response.
 		dto.Enabled = ps.Enabled
 		dto.Pinned = ps.Pinned
 		dto.JsonData = ps.JSONData
+		if dto.JsonData == nil {
+			dto.JsonData = make(map[string]any)
+		}
 
 		for k, v := range hs.PluginSettings.DecryptedValues(ps) {
 			if len(v) > 0 {

--- a/pkg/api/plugins_test.go
+++ b/pkg/api/plugins_test.go
@@ -821,6 +821,7 @@ func Test_PluginsSettings(t *testing.T) {
 				},
 				SecureJsonFields: map[string]bool{},
 				LoadingStrategy:  plugins.LoadingStrategyScript,
+				JsonData:         map[string]any{},
 			},
 		},
 		{


### PR DESCRIPTION
**What changed:**
Updated the [GetPluginSettingByID](cci:1://file:///Users/tejassathe/OSContribution/grafana/pkg/api/plugins.go) API handler in [pkg/api/plugins.go](cci:7://file:///Users/tejassathe/OSContribution/grafana/pkg/api/plugins.go) to initialize `JsonData` to an empty map (`{}`) if the underlying service returns `nil`. This typically occurs for unconfigured or config-less plugins.

**Why:**
Fixes #116656.

Config-less apps (such as the Grafana Profiles Drilldown app) were triggering a "Error while retrieving the plugin settings" warning in the UI. This happened because the settings endpoint was returning `jsonData: null`, while the frontend logic expects a valid object (even if empty). Returning `{}` satisfies this requirement and suppresses the misleading warning without affecting backend logic.

**How it was tested:**
- **Unit Testing:** Updated the existing unit test [Test_PluginsSettings](cci:1://file:///Users/tejassathe/OSContribution/grafana/pkg/api/plugins_test.go:786:0-884:1) in [pkg/api/plugins_test.go](cci:7://file:///Users/tejassathe/OSContribution/grafana/pkg/api/plugins_test.go:0:0-0:0) to assert that `JsonData` is an empty map (`{}`) instead of `nil` when no settings are stored.
- Verified that all plugin API tests pass: `go test -v ./pkg/api -run Test_PluginsSettings`.

**Risk/Rollback:**
- **Risk:** Low. This change only affects the JSON serialization of `null` vs `{}` for the `jsonData` field in the `GET /api/plugins/:id/settings` response.
- **Rollback:** Revert this PR to restore the previous behavior of returning `null` for unconfigured plugins.