### PR TITLE
SaveProvisionedDashboardForm: Fix Git Sync save reverting panel edits

### DIFF
--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
@@ -52,7 +52,7 @@ export function SaveProvisionedDashboardForm({
 }: Props) {
   const navigate = useNavigate();
   const appEvents = getAppEvents();
-  const { isDirty, editPanel: panelEditor } = dashboard.useState();
+  const { isDirty } = dashboard.useState();
 
   const [createOrUpdateFile, request] = useCreateOrUpdateRepositoryFile(isNew ? undefined : defaultValues.path);
 

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
@@ -111,15 +111,13 @@ export function SaveProvisionedDashboardForm({
   );
 
   const handleDismiss = useCallback(() => {
-    panelEditor?.onDiscard();
-
     const model = dashboard.getSaveModel();
     const resourceData = request?.data?.resource.upsert || request?.data?.resource.dryRun;
     const saveResponse = createSaveResponseFromResource(resourceData);
     dashboard.saveCompleted(model, saveResponse, defaultValues.folder?.uid);
 
     drawer.onClose();
-  }, [dashboard, defaultValues.folder?.uid, drawer, panelEditor, request?.data?.resource]);
+  }, [dashboard, defaultValues.folder?.uid, drawer, request?.data?.resource]);
 
   const onWriteSuccess = useCallback(
     (upsert: Resource<Dashboard>) => {


### PR DESCRIPTION
**What is this feature?**

`SaveProvisionedDashboardForm`: Fix Git Sync panel edits reverting after save by removing the discard call on successful save.

**Problem**
After saving panel changes to the configured branch, the UI immediately reverts to old values until a full page refresh.

**Root cause**
The save success path discards the panel editor state, which restores the pre-edit layout snapshot, and then marks that reverted model as the new saved baseline.

**Fix**
Skip `panelEditor?.onDiscard();` on successful save and rely on the existing save completion flow to mark the panel as saved.

**Why do we need this feature?**

Prevent user confusion after save dashboard seeing old values

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/116474

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
