### PR TITLE
SQL Expressions: Add "NOT" keyword to allow list

### DIFF
--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -59,7 +59,7 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	case *sqlparser.AliasedExpr, *sqlparser.AliasedTableExpr:
 		return
 
-	case *sqlparser.AndExpr, *sqlparser.OrExpr:
+	case *sqlparser.AndExpr, *sqlparser.OrExpr, *sqlparser.NotExpr:
 		return
 
 	case *sqlparser.BinaryExpr, *sqlparser.UnaryExpr:

--- a/pkg/expr/sql/parser_allow_test.go
+++ b/pkg/expr/sql/parser_allow_test.go
@@ -48,6 +48,16 @@ func TestAllowQuery(t *testing.T) {
 			err:  nil,
 		},
 		{
+			name: "allows NOT expression",
+			q:    `SELECT * FROM a_table WHERE NOT a_column`,
+			err:  nil,
+		},
+		{
+			name: "allows NOT with parenthesized expression",
+			q:    `SELECT * FROM a_table WHERE NOT (a_column > 5)`,
+			err:  nil,
+		},
+		{
 			name: "null literal",
 			q:    `SELECT 1 as id, NULL as null_col`,
 			err:  nil,


### PR DESCRIPTION
## Summary
- Add `*sqlparser.NotExpr` to the allowlist in `allowedNode()` function
- Add test cases for NOT expressions

## Details
The SQL expression parser was blocking `NOT` expressions with the error:
> [sse.sql.blocked_node_or_func] did not execute the SQL expression B because the sql keyword '*sqlparser.NotExpr' is not allowed

This PR adds `NotExpr` to the allowlist alongside other logical operators (`AndExpr`, `OrExpr`), enabling queries like:
- `SELECT * FROM table WHERE NOT column`
- `SELECT * FROM table WHERE NOT (value > 5)`

Fixes #116616

## Test
- Added test cases for `NOT column` and `NOT (expression)` syntax
- All existing tests pass