### PR TITLE
Require dashboardScene feature toggle for dashboardNewLayouts to be enabled

### DIFF
--- a/public/app/core/components/AppChrome/TopBar/useChromeHeaderHeight.ts
+++ b/public/app/core/components/AppChrome/TopBar/useChromeHeaderHeight.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { config, useScopes } from '@grafana/runtime';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
+import { isDashboardNewLayoutsEnabled } from 'app/features/dashboard-scene/utils/utils';
 
 import { AppChromeState } from '../AppChromeService';
 import { useExtensionSidebarContext } from '../ExtensionSidebar/ExtensionSidebarProvider';
@@ -94,5 +95,5 @@ export function useChromeHeaderHeight() {
  **/
 export function getChromeHeaderLevelHeight() {
   // Waiting with switch to 48 until we have a story for scopes
-  return config.featureToggles.unifiedNavbars || config.featureToggles.dashboardNewLayouts ? 48 : 40;
+  return config.featureToggles.unifiedNavbars || isDashboardNewLayoutsEnabled() ? 48 : 40;
 }

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.test.tsx
@@ -57,6 +57,7 @@ function buildTestScene() {
     editable: true,
   });
 
+  config.featureToggles.dashboardScene = true;
   config.featureToggles.dashboardNewLayouts = true;
 
   activateFullSceneTree(scene);

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.test.tsx
@@ -45,6 +45,7 @@ export function buildTestScene() {
 }
 
 describe('DashboardEditPaneRenderer', () => {
+  config.featureToggles.dashboardScene = true;
   config.featureToggles.dashboardNewLayouts = true;
 
   it('Should render sidebar', async () => {

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -17,6 +17,7 @@ import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { PublicDashboardBadge } from '../scene/new-toolbar/actions/PublicDashboardBadge';
 import { StarButton } from '../scene/new-toolbar/actions/StarButton';
 import { dynamicDashNavActions } from '../utils/registerDynamicDashNavAction';
+import { isDashboardNewLayoutsEnabled } from '../utils/utils';
 
 import { DashboardEditPaneRenderer } from './DashboardEditPaneRenderer';
 interface Props {
@@ -27,7 +28,7 @@ interface Props {
 }
 
 export function DashboardEditPaneSplitter(props: Props) {
-  if (config.featureToggles.dashboardNewLayouts) {
+  if (isDashboardNewLayoutsEnabled()) {
     return <DashboardEditPaneSplitterNewLayouts {...props} />;
   } else {
     return <DashboardEditPaneSplitterLegacy {...props} />;

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditableElement.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditableElement.test.tsx
@@ -112,6 +112,7 @@ function setup(overrides?: Partial<DashboardSceneState>) {
   // Clear any data layers
   dashboard.setState({ $data: undefined });
 
+  config.featureToggles.dashboardScene = true;
   config.featureToggles.dashboardNewLayouts = true;
   activateFullSceneTree(dashboard);
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
@@ -1351,6 +1351,7 @@ describe('DashboardScenePageStateManager v2', () => {
 describe('UnifiedDashboardScenePageStateManager', () => {
   afterEach(() => {
     store.delete(DASHBOARD_FROM_LS_KEY);
+    config.featureToggles.dashboardScene = false;
     config.featureToggles.dashboardNewLayouts = false;
   });
 
@@ -1624,6 +1625,7 @@ describe('UnifiedDashboardScenePageStateManager', () => {
 
   describe('New dashboards', () => {
     it('should use v1 manager for new dashboards when dashboardNewLayouts feature toggle is disabled', async () => {
+      config.featureToggles.dashboardScene = false;
       config.featureToggles.dashboardNewLayouts = false;
 
       const manager = new UnifiedDashboardScenePageStateManager({});
@@ -1638,6 +1640,7 @@ describe('UnifiedDashboardScenePageStateManager', () => {
     });
 
     it('should use v2 manager for new dashboards when dashboardNewLayouts feature toggle is enabled', async () => {
+      config.featureToggles.dashboardScene = true;
       config.featureToggles.dashboardNewLayouts = true;
 
       const manager = new UnifiedDashboardScenePageStateManager({});
@@ -1652,6 +1655,7 @@ describe('UnifiedDashboardScenePageStateManager', () => {
     });
 
     it('should maintain manager version for subsequent loads based on feature toggle', async () => {
+      config.featureToggles.dashboardScene = false;
       config.featureToggles.dashboardNewLayouts = false;
       const manager1 = new UnifiedDashboardScenePageStateManager({});
       manager1.setActiveManager('v2');
@@ -1662,6 +1666,7 @@ describe('UnifiedDashboardScenePageStateManager', () => {
       await manager1.loadDashboard({ uid: '', route: DashboardRoutes.New });
       expect(manager1['activeManager']).toBeInstanceOf(DashboardScenePageStateManager);
 
+      config.featureToggles.dashboardScene = true;
       config.featureToggles.dashboardNewLayouts = true;
       const manager2 = new UnifiedDashboardScenePageStateManager({});
       manager2.setActiveManager('v1');
@@ -1694,6 +1699,7 @@ describe('UnifiedDashboardScenePageStateManager', () => {
     });
 
     it('should always use v1 manager for template dashboards even when dashboardNewLayouts is enabled', async () => {
+      config.featureToggles.dashboardScene = true;
       config.featureToggles.dashboardNewLayouts = true;
       config.featureToggles.suggestedDashboards = true;
 
@@ -1741,6 +1747,7 @@ describe('UnifiedDashboardScenePageStateManager', () => {
     });
 
     it('should reset to V2 manager when loading a new dashboard after template', async () => {
+      config.featureToggles.dashboardScene = true;
       config.featureToggles.dashboardNewLayouts = true;
       config.featureToggles.suggestedDashboards = true;
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -994,7 +994,7 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
 }
 
 export function shouldForceV2API(): boolean {
-  return Boolean(config.featureToggles.dashboardNewLayouts);
+  return Boolean(config.featureToggles.dashboardScene && config.featureToggles.dashboardNewLayouts);
 }
 
 export class UnifiedDashboardScenePageStateManager extends DashboardScenePageStateManagerBase<

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -34,6 +34,7 @@ import {
   getDefaultVizPanel,
   getLibraryPanelBehavior,
   getPanelIdForVizPanel,
+  isDashboardNewLayoutsEnabled,
 } from '../utils/utils';
 
 import { DataProviderSharer } from './PanelDataPane/DataProviderSharer';
@@ -130,7 +131,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
     this.setState({ editPreview: undefined });
 
     // Temp fix for old edit mode
-    if (this._layoutItem instanceof DashboardGridItem && !config.featureToggles.dashboardNewLayouts) {
+    if (this._layoutItem instanceof DashboardGridItem && !isDashboardNewLayoutsEnabled()) {
       this._layoutItem.handleEditChange();
       return;
     }

--- a/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
@@ -236,6 +236,7 @@ describe('DashboardControls', () => {
     const originalFeatureToggles = { ...config.featureToggles };
 
     beforeEach(() => {
+      config.featureToggles.dashboardScene = true;
       config.featureToggles.dashboardNewLayouts = true;
       jest.mocked(playlistSrv.useState).mockReturnValue({ isPlaying: false });
     });

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -23,7 +23,7 @@ import { playlistSrv } from 'app/features/playlist/PlaylistSrv';
 import { ContextualNavigationPaneToggle } from 'app/features/scopes/dashboards/ContextualNavigationPaneToggle';
 
 import { PanelEditControls } from '../panel-edit/PanelEditControls';
-import { getDashboardSceneFor } from '../utils/utils';
+import { getDashboardSceneFor, isDashboardNewLayoutsEnabled } from '../utils/utils';
 
 import { DashboardDataLayerControls } from './DashboardDataLayerControls';
 import { DashboardLinksControls } from './DashboardLinksControls';
@@ -189,7 +189,7 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
                 <refreshPicker.Component model={refreshPicker} />
               </div>
             )}
-            {config.featureToggles.dashboardNewLayouts && (
+            {isDashboardNewLayoutsEnabled() && (
               <div className={styles.fixedControlsNewLayout}>
                 <DashboardControlActions dashboard={dashboard} />
               </div>
@@ -223,7 +223,7 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
             <refreshPicker.Component model={refreshPicker} />
           </div>
         )}
-        {config.featureToggles.dashboardNewLayouts && (
+        {isDashboardNewLayoutsEnabled() && (
           <div className={styles.fixedControls}>
             <DashboardControlActions dashboard={dashboard} />
           </div>

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -204,6 +204,8 @@ describe('DashboardScene', () => {
 
       it('Should exit edit mode after saving from unsaved changes modal when dashboardNewLayouts is enabled', () => {
         const originalFeatureToggle = config.featureToggles.dashboardNewLayouts;
+        const originalDashboardScene = config.featureToggles.dashboardScene;
+        config.featureToggles.dashboardScene = true;
         config.featureToggles.dashboardNewLayouts = true;
 
         const publishSpy = jest.spyOn(appEvents, 'publish');
@@ -232,6 +234,7 @@ describe('DashboardScene', () => {
         publishSpy.mockRestore();
         hasActualSaveChangesSpy.mockRestore();
         config.featureToggles.dashboardNewLayouts = originalFeatureToggle;
+        config.featureToggles.dashboardScene = originalDashboardScene;
       });
 
       it('Should start the detect changes worker', () => {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -74,6 +74,7 @@ import {
   getLayoutManagerFor,
   getPanelIdForVizPanel,
   hasActualSaveChanges,
+  isDashboardNewLayoutsEnabled,
 } from '../utils/utils';
 import { SchemaV2EditorDrawer } from '../v2schema/SchemaV2EditorDrawer';
 
@@ -320,7 +321,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       return;
     }
 
-    if (config.featureToggles.dashboardNewLayouts) {
+    if (isDashboardNewLayoutsEnabled()) {
       appEvents.publish(
         new ShowConfirmModalEvent({
           title: t('dashboard-scene.dashboard-scene.modal.title.unsaved-changes', 'Unsaved changes'),
@@ -575,7 +576,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
   }
 
   public copyPanel(vizPanel: VizPanel) {
-    if (config.featureToggles.dashboardNewLayouts) {
+    if (isDashboardNewLayoutsEnabled()) {
       const gridItem = vizPanel.parent;
 
       if (gridItem instanceof AutoGridItem) {

--- a/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
@@ -8,7 +8,7 @@ import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 
 import { createPanelDataProvider } from '../utils/createPanelDataProvider';
-import { getDashboardSceneFor, getPanelIdForVizPanel } from '../utils/utils';
+import { getDashboardSceneFor, getPanelIdForVizPanel, isDashboardNewLayoutsEnabled } from '../utils/utils';
 
 import { VizPanelLinks, VizPanelLinksMenu } from './PanelLinks';
 import { panelLinksBehavior } from './PanelMenuBehavior';
@@ -107,8 +107,7 @@ export class LibraryPanelBehavior extends SceneObjectBase<LibraryPanelBehaviorSt
     const dashboard = getDashboardSceneFor(this);
     const isPublicDashboard = dashboard.state.meta.publicDashboardEnabled === true;
     const isScriptedDashboard = dashboard.state.meta.fromScript === true;
-    const shouldSkipRepeatMigration =
-      config.featureToggles.dashboardNewLayouts && !isPublicDashboard && !isScriptedDashboard;
+    const shouldSkipRepeatMigration = isDashboardNewLayoutsEnabled() && !isPublicDashboard && !isScriptedDashboard;
 
     // Migrate repeat options to layout element (only for legacy dashboards, or public/scripted dashboards)
     if (!shouldSkipRepeatMigration && libPanelModel.repeat && layoutElement instanceof DashboardGridItem) {

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -34,7 +34,7 @@ import ExportButton from '../sharing/ExportButton/ExportButton';
 import ShareButton from '../sharing/ShareButton/ShareButton';
 import { DashboardInteractions } from '../utils/interactions';
 import { DynamicDashNavButtonModel, dynamicDashNavActions } from '../utils/registerDynamicDashNavAction';
-import { isLibraryPanel } from '../utils/utils';
+import { isLibraryPanel, isDashboardNewLayoutsEnabled } from '../utils/utils';
 
 import { DashboardScene } from './DashboardScene';
 import { GoToSnapshotOriginButton } from './GoToSnapshotOriginButton';
@@ -48,7 +48,7 @@ interface Props {
 }
 
 export const NavToolbarActions = memo<Props>(({ dashboard }) => {
-  const hasNewToolbar = config.featureToggles.dashboardNewLayouts;
+  const hasNewToolbar = isDashboardNewLayoutsEnabled();
 
   return hasNewToolbar ? (
     <AppChromeUpdate

--- a/public/app/features/dashboard-scene/scene/VariableControls.test.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.test.tsx
@@ -14,6 +14,7 @@ jest.mock('@grafana/runtime', () => {
     config: {
       ...runtime.config,
       featureToggles: {
+        dashboardScene: true,
         dashboardNewLayouts: true,
       },
     },

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -14,13 +14,15 @@ import {
 } from '@grafana/scenes';
 import { useElementSelection, useStyles2 } from '@grafana/ui';
 
+import { isDashboardNewLayoutsEnabled } from '../utils/utils';
+
 import { DashboardScene } from './DashboardScene';
 import { AddVariableButton } from './VariableControlsAddButton';
 
 export function VariableControls({ dashboard }: { dashboard: DashboardScene }) {
   const { variables } = sceneGraph.getVariables(dashboard)!.useState();
   const { isEditing } = dashboard.useState();
-  const isEditingNewLayouts = isEditing && config.featureToggles.dashboardNewLayouts;
+  const isEditingNewLayouts = isEditing && isDashboardNewLayoutsEnabled();
 
   // Get visible variables for drilldown layout
   const visibleVariables = variables.filter((v) => v.state.hide !== VariableHide.inControlsMenu);
@@ -53,7 +55,7 @@ export function VariableControls({ dashboard }: { dashboard: DashboardScene }) {
           />
         ))}
 
-      {config.featureToggles.dashboardNewLayouts ? <AddVariableButton dashboard={dashboard} /> : null}
+      {isDashboardNewLayoutsEnabled() ? <AddVariableButton dashboard={dashboard} /> : null}
     </>
   );
 }

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -20,6 +20,7 @@ import {
   getDashboardSceneFor,
   getGridItemKeyForPanelId,
   getVizPanelKeyForPanelId,
+  isDashboardNewLayoutsEnabled,
 } from '../../utils/utils';
 import { DashboardGridItem } from '../layout-default/DashboardGridItem';
 import { clearClipboard, getAutoGridItemFromClipboard } from '../layouts-shared/paste';
@@ -135,7 +136,7 @@ export class AutoGridLayoutManager
 
   public pastePanel() {
     const panel = getAutoGridItemFromClipboard(getDashboardSceneFor(this));
-    if (config.featureToggles.dashboardNewLayouts) {
+    if (isDashboardNewLayoutsEnabled()) {
       dashboardEditActions.edit({
         description: t('dashboard.edit-actions.paste-panel', 'Paste panel'),
         addedObject: panel.state.body,

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemEditor.tsx
@@ -11,6 +11,7 @@ import { RepeatRowSelect2 } from 'app/features/dashboard/components/RepeatRowSel
 
 import { useConditionalRenderingEditor } from '../../conditional-rendering/hooks/useConditionalRenderingEditor';
 import { dashboardEditActions } from '../../edit-pane/shared';
+import { isDashboardNewLayoutsEnabled } from '../../utils/utils';
 
 import { DashboardGridItem } from './DashboardGridItem';
 
@@ -75,7 +76,7 @@ export function getDashboardGridItemOptions(gridItem: DashboardGridItem): Option
 
   const options = [repeatCategory];
 
-  if (config.featureToggles.dashboardNewLayouts) {
+  if (isDashboardNewLayoutsEnabled()) {
     options.push(conditionalRenderingCategory);
   }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -43,6 +43,7 @@ import {
   useDashboard,
   getLayoutOrchestratorFor,
   getDashboardSceneFor,
+  isDashboardNewLayoutsEnabled,
 } from '../../utils/utils';
 import { useSoloPanelContext } from '../SoloPanelContext';
 import { AutoGridItem } from '../layout-auto-grid/AutoGridItem';
@@ -124,7 +125,7 @@ export class DefaultGridLayoutManager
   }
 
   private _activationHandler() {
-    if (config.featureToggles.dashboardNewLayouts) {
+    if (isDashboardNewLayoutsEnabled()) {
       this._subs.add(
         this.subscribeToEvent(SceneGridLayoutDragStartEvent, ({ payload: { evt, panel } }) => {
           const gridItem = panel.parent;
@@ -151,7 +152,7 @@ export class DefaultGridLayoutManager
     vizPanel.clearParent();
 
     // With new edit mode we add panels to the bottom of the grid
-    if (config.featureToggles.dashboardNewLayouts) {
+    if (isDashboardNewLayoutsEnabled()) {
       const emptySpace = findSpaceForNewPanel(this.state.grid);
       const newGridItem = new DashboardGridItem({
         ...emptySpace,
@@ -189,7 +190,7 @@ export class DefaultGridLayoutManager
     const emptySpace = findSpaceForNewPanel(this.state.grid);
     const newGridItem = getDashboardGridItemFromClipboard(getDashboardSceneFor(this), emptySpace);
 
-    if (config.featureToggles.dashboardNewLayouts) {
+    if (isDashboardNewLayoutsEnabled()) {
       dashboardEditActions.edit({
         description: t('dashboard.edit-actions.paste-panel', 'Paste panel'),
         addedObject: newGridItem.state.body,
@@ -233,7 +234,7 @@ export class DefaultGridLayoutManager
       return;
     }
 
-    if (!config.featureToggles.dashboardNewLayouts) {
+    if (!isDashboardNewLayoutsEnabled()) {
       // No undo/redo support in legacy edit mode
       layout.setState({ children: layout.state.children.filter((child) => child !== gridItem) });
       return;
@@ -292,7 +293,7 @@ export class DefaultGridLayoutManager
     });
 
     // No undo/redo support in legacy edit mode
-    if (!config.featureToggles.dashboardNewLayouts) {
+    if (!isDashboardNewLayoutsEnabled()) {
       if (gridItem.parent instanceof SceneGridRow) {
         const row = gridItem.parent;
 
@@ -418,7 +419,7 @@ export class DefaultGridLayoutManager
       forceRenderChildren(this.state.grid, true);
     };
 
-    if (config.featureToggles.dashboardNewLayouts) {
+    if (isDashboardNewLayoutsEnabled()) {
       // We do this in a timeout to wait a bit with enabling dragging as dragging enables grid animations
       // if we show the edit pane without animations it opens much faster and feels more responsive
       setTimeout(updateResizeAndDragging, 10);
@@ -639,7 +640,7 @@ function DefaultGridLayoutManagerRenderer({ model }: SceneComponentProps<Default
   const { isEditing } = dashboard.useState();
   const hasClonedParents = isRepeatCloneOrChildOf(model);
   const styles = useStyles2(getStyles);
-  const showCanvasActions = isEditing && config.featureToggles.dashboardNewLayouts && !hasClonedParents;
+  const showCanvasActions = isEditing && isDashboardNewLayoutsEnabled() && !hasClonedParents;
   const soloPanelContext = useSoloPanelContext();
 
   if (soloPanelContext) {

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
@@ -2,6 +2,7 @@ import { config } from '@grafana/runtime';
 import { SceneGridRow } from '@grafana/scenes';
 
 import { NewObjectAddedToCanvasEvent } from '../../edit-pane/shared';
+import { isDashboardNewLayoutsEnabled } from '../../utils/utils';
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
 import { RowItem } from '../layout-rows/RowItem';
 import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
@@ -36,7 +37,7 @@ export function addNewRowTo(layout: DashboardLayoutManager): RowItem | SceneGrid
   /**
    * If new layouts feature is disabled we add old school rows to the custom grid layout
    */
-  if (!config.featureToggles.dashboardNewLayouts) {
+  if (!isDashboardNewLayoutsEnabled()) {
     if (layout instanceof DefaultGridLayoutManager) {
       return layout.addNewRow();
     } else {

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
@@ -816,9 +816,11 @@ describe('transformSaveModelToScene', () => {
   describe('Convert to new rows', () => {
     beforeEach(() => {
       // set feature flag to true
+      config.featureToggles.dashboardScene = true;
       config.featureToggles.dashboardNewLayouts = true;
     });
     afterEach(() => {
+      config.featureToggles.dashboardScene = false;
       config.featureToggles.dashboardNewLayouts = false;
     });
 

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
@@ -28,6 +28,7 @@ describe('ShareExportTab', () => {
 
   beforeEach(() => {
     config.featureToggles.kubernetesDashboards = true;
+    config.featureToggles.dashboardScene = false;
     config.featureToggles.dashboardNewLayouts = false;
 
     // Set up spies on the functions we want to track
@@ -231,10 +232,12 @@ describe('ShareExportTab', () => {
 
   describe('V2Resource export mode with dashboardNewLayouts disabled', () => {
     beforeEach(() => {
+      config.featureToggles.dashboardScene = false;
       config.featureToggles.dashboardNewLayouts = false;
     });
 
     afterEach(() => {
+      config.featureToggles.dashboardScene = true;
       config.featureToggles.dashboardNewLayouts = true;
     });
 

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -259,7 +259,8 @@ const reportDashboardInteraction = (
   interactionPrefix = 'dashboards'
 ) => {
   const meta = isScenesContextSet ? { scenesView: true } : {};
-  const isDynamicDashboard = config.featureToggles?.dashboardNewLayouts ?? false;
+  const isDynamicDashboard =
+    (config.featureToggles?.dashboardScene && config.featureToggles?.dashboardNewLayouts) ?? false;
 
   if (properties) {
     reportInteraction(`${interactionPrefix}_${name}`, { ...properties, ...meta, isDynamicDashboard });

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -279,8 +279,12 @@ export function getClosestVizPanel(sceneObject: SceneObject): VizPanel | null {
   return null;
 }
 
+export function isDashboardNewLayoutsEnabled(): boolean {
+  return config.featureToggles.dashboardScene && config.featureToggles.dashboardNewLayouts;
+}
+
 export function getDefaultPluginId(): string {
-  return config.featureToggles.dashboardNewLayouts || config.featureToggles.newVizSuggestions
+  return isDashboardNewLayoutsEnabled() || config.featureToggles.newVizSuggestions
     ? UNCONFIGURED_PANEL_PLUGIN_ID
     : 'timeseries';
 }

--- a/public/app/features/dashboard/api/utils.test.ts
+++ b/public/app/features/dashboard/api/utils.test.ts
@@ -7,36 +7,37 @@ describe('getDashboardsApiVersion', () => {
     jest.resetModules();
   });
 
-  it('should return v1 when dashboardScene is disabled and kubernetesDashboards is enabled', () => {
-    config.featureToggles = {
+  it.each([
+    {
       dashboardScene: false,
       kubernetesDashboards: true,
-    };
-    expect(getDashboardsApiVersion()).toBe('v1');
-  });
-
-  it('should return legacy when dashboardScene is disabled and kubernetesDashboards is disabled', () => {
-    config.featureToggles = {
+      expected: 'v1',
+      description: 'v1 when dashboardScene is disabled and kubernetesDashboards is enabled',
+    },
+    {
       dashboardScene: false,
       kubernetesDashboards: false,
-    };
-    expect(getDashboardsApiVersion()).toBe('legacy');
-  });
-
-  it('should return unified when dashboardScene is enabled and kubernetesDashboards is enabled', () => {
-    config.featureToggles = {
+      expected: 'legacy',
+      description: 'legacy when dashboardScene is disabled and kubernetesDashboards is disabled',
+    },
+    {
       dashboardScene: true,
       kubernetesDashboards: true,
-    };
-    expect(getDashboardsApiVersion()).toBe('unified');
-  });
-
-  it('should return legacy when dashboardScene is enabled and kubernetesDashboards is disabled', () => {
-    config.featureToggles = {
+      expected: 'unified',
+      description: 'unified when dashboardScene is enabled and kubernetesDashboards is enabled',
+    },
+    {
       dashboardScene: true,
       kubernetesDashboards: false,
+      expected: 'legacy',
+      description: 'legacy when dashboardScene is enabled and kubernetesDashboards is disabled',
+    },
+  ])('should return $expected - $description', ({ dashboardScene, kubernetesDashboards, expected }) => {
+    config.featureToggles = {
+      dashboardScene,
+      kubernetesDashboards,
     };
-    expect(getDashboardsApiVersion()).toBe('legacy');
+    expect(getDashboardsApiVersion()).toBe(expected);
   });
 
   describe('forcing scenes through URL', () => {
@@ -44,20 +45,53 @@ describe('getDashboardsApiVersion', () => {
       locationService.push('/test?scenes=false');
     });
 
-    it('should return legacy when kubernetesDashboards is disabled', () => {
-      config.featureToggles = {
-        dashboardScene: false,
+    it.each([
+      {
         kubernetesDashboards: false,
-      };
-      expect(getDashboardsApiVersion()).toBe('legacy');
-    });
-
-    it('should return v1 when kubernetesDashboards is enabled', () => {
+        expected: 'legacy',
+        description: 'legacy when kubernetesDashboards is disabled',
+      },
+      {
+        kubernetesDashboards: true,
+        expected: 'v1',
+        description: 'v1 when kubernetesDashboards is enabled',
+      },
+    ])('should return $expected - $description', ({ kubernetesDashboards, expected }) => {
       config.featureToggles = {
         dashboardScene: false,
+        kubernetesDashboards,
+      };
+      expect(getDashboardsApiVersion()).toBe(expected);
+    });
+  });
+
+  describe('dashboardNewLayouts requires dashboardScene', () => {
+    it.each([
+      {
+        dashboardScene: false,
+        dashboardNewLayouts: true,
+        expected: 'v1',
+        description: 'v1 when dashboardNewLayouts is enabled but dashboardScene is disabled',
+      },
+      {
+        dashboardScene: true,
+        dashboardNewLayouts: true,
+        expected: 'v2',
+        description: 'v2 when both dashboardScene and dashboardNewLayouts are enabled',
+      },
+      {
+        dashboardScene: true,
+        dashboardNewLayouts: false,
+        expected: 'unified',
+        description: 'unified when dashboardScene is enabled but dashboardNewLayouts is disabled',
+      },
+    ])('should return $expected - $description', ({ dashboardScene, dashboardNewLayouts, expected }) => {
+      config.featureToggles = {
+        dashboardScene,
+        dashboardNewLayouts,
         kubernetesDashboards: true,
       };
-      expect(getDashboardsApiVersion()).toBe('v1');
+      expect(getDashboardsApiVersion()).toBe(expected);
     });
   });
 });

--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -3,6 +3,7 @@ import { Dashboard } from '@grafana/schema/dist/esm/index.gen';
 import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { Status } from '@grafana/schema/src/schema/dashboard/v2';
 import { Resource } from 'app/features/apiserver/types';
+import { isDashboardNewLayoutsEnabled } from 'app/features/dashboard-scene/utils/utils';
 import { DashboardDataDTO, DashboardDTO } from 'app/types/dashboard';
 
 import { SaveDashboardCommand } from '../components/SaveDashboard/types';
@@ -20,7 +21,7 @@ export function isV0V1StoredVersion(version: string | undefined): boolean {
 export function getDashboardsApiVersion(responseFormat?: 'v1' | 'v2') {
   const isDashboardSceneEnabled = config.featureToggles.dashboardScene;
   const isKubernetesDashboardsEnabled = config.featureToggles.kubernetesDashboards;
-  const isDashboardNewLayoutsEnabled = config.featureToggles.dashboardNewLayouts;
+  const isDashboardNewLayoutsEnabledValue = isDashboardNewLayoutsEnabled();
 
   const forcingOldDashboardArch = locationService.getSearch().get('scenes') === 'false';
 
@@ -38,7 +39,7 @@ export function getDashboardsApiVersion(responseFormat?: 'v1' | 'v2') {
     if (responseFormat === 'v1') {
       return 'v1';
     }
-    if (responseFormat === 'v2' || isDashboardNewLayoutsEnabled) {
+    if (responseFormat === 'v2' || isDashboardNewLayoutsEnabledValue) {
       return 'v2';
     }
     return 'unified';

--- a/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.tsx
@@ -9,6 +9,7 @@ import { config } from '@grafana/runtime';
 import { Button, useStyles2, Text, Box, Stack, TextLink, Icon } from '@grafana/ui';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
+import { isDashboardNewLayoutsEnabled } from 'app/features/dashboard-scene/utils/utils';
 
 import { BasicProvisionedDashboardsEmptyPage } from '../DashboardLibrary/BasicProvisionedDashboardsEmptyPage';
 import { SuggestedDashboards } from '../DashboardLibrary/SuggestedDashboards';
@@ -42,7 +43,7 @@ const InternalDashboardEmpty = ({ onAddVisualization, onAddLibraryPanel, onImpor
               !dashboardLibraryDatasourceUid,
           })}
         >
-          {config.featureToggles.dashboardNewLayouts
+          {isDashboardNewLayoutsEnabled()
             ? renderNewLayoutEmpty({ styles, dashboardLibraryDatasourceUid })
             : renderOldLayoutEmpty({
                 dashboardLibraryDatasourceUid,

--- a/public/app/features/manage-dashboards/DashboardImportPage.tsx
+++ b/public/app/features/manage-dashboards/DashboardImportPage.tsx
@@ -31,6 +31,7 @@ import { dispatch } from 'app/store/store';
 import { StoreState } from 'app/types/store';
 
 import { cleanUpAction } from '../../core/actions/cleanUp';
+import { isDashboardNewLayoutsEnabled } from '../dashboard-scene/utils/utils';
 import { ImportDashboardOverviewV2 } from '../dashboard-scene/v2schema/ImportDashboardOverviewV2';
 
 import { ImportDashboardOverview } from './components/ImportDashboardOverview';
@@ -120,7 +121,7 @@ class UnthemedDashboardImport extends PureComponent<Props> {
 
     const dashboard = JSON.parse(formData.dashboardJson);
 
-    if ((dashboard.spec?.elements || dashboard.elements) && !config.featureToggles.dashboardNewLayouts) {
+    if ((dashboard.spec?.elements || dashboard.elements) && !isDashboardNewLayoutsEnabled()) {
       return appEvents.emit(AppEvents.alertError, [
         'Import failed',
         'Dashboard using new layout cannot be imported because the feature is not enabled',


### PR DESCRIPTION
*Problem*

The `dashboardNewLayouts` feature toggle can be enabled without `dashboardScene`, but it doesn't work properly without it, causing broken functionality.

*Solution*

Created a helper function `isDashboardNewLayoutsEnabled()` that checks both `dashboardScene` and `dashboardNewLayouts` are enabled. Replaced all direct checks of `dashboardNewLayouts` throughout the codebase with this helper function to ensure the feature only activates when both toggles are enabled.

*How to test*

1. Enable only `dashboardNewLayouts` (without `dashboardScene`) - new layout features should not activate
2. Enable both `dashboardScene` and `dashboardNewLayouts` - new layout features should work correctly
3. Run existing tests to ensure no regressions

Fixes #116424