### PR TITLE
Unified storage: Mode5 only resources

### DIFF
--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -25,6 +25,11 @@ var MigratedUnifiedResources = map[string]bool{
 	DashboardResource: false,
 }
 
+// Mode5OnlyResources maps resources that must always run in mode 5.
+var Mode5OnlyResources = map[string]bool{
+	PlaylistResource: true,
+}
+
 // AutoMigratedUnifiedResources maps resources that support auto-migration
 // TODO: remove this before Grafana 13 GA: https://github.com/grafana/search-and-storage-team/issues/613
 var AutoMigratedUnifiedResources = map[string]bool{
@@ -83,6 +88,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	} else {
 		// Helper log to find instances disabling migration
 		cfg.Logger.Info("Unified migration configs enforcement disabled", "storage_type", cfg.UnifiedStorageType(), "disable_data_migrations", cfg.DisableDataMigrations)
+		cfg.enforceMode5OnlyConfigs()
 	}
 	cfg.EnableSearch = section.Key("enable_search").MustBool(false)
 	cfg.MaxPageSizeBytes = section.Key("max_page_size_bytes").MustInt(0)
@@ -151,10 +157,15 @@ func (cfg *Cfg) enforceMigrationToUnifiedConfigs() {
 		resourceCfg, ok := cfg.UnifiedStorage[resource]
 		if ok {
 			if !resourceCfg.EnableMigration {
-				cfg.Logger.Info("Resource migration disabled", "resource", resource)
-				continue
+				if Mode5OnlyResources[resource] {
+					cfg.Logger.Info("Resource migration cannot be disabled; enforcing unified storage", "resource", resource, "old_config", resourceCfg)
+				} else {
+					cfg.Logger.Info("Resource migration disabled", "resource", resource)
+					continue
+				}
+			} else {
+				cfg.Logger.Info("Overriding unified storage config for migrated resource", "resource", resource, "old_config", resourceCfg)
 			}
-			cfg.Logger.Info("Overriding unified storage config for migrated resource", "resource", resource, "old_config", resourceCfg)
 		} else if !enabledByDefault {
 			continue
 		}
@@ -163,6 +174,22 @@ func (cfg *Cfg) enforceMigrationToUnifiedConfigs() {
 			DualWriterMode:         5,
 			EnableMigration:        true,
 			AutoMigrationThreshold: resourceCfg.AutoMigrationThreshold,
+		}
+	}
+}
+
+// enforceMode5OnlyConfigs forces mode 5 for resources that must always run in unified storage,
+// even when migrations are disabled or storage_type is legacy.
+func (cfg *Cfg) enforceMode5OnlyConfigs() {
+	for resource := range Mode5OnlyResources {
+		if cfg.UnifiedStorage == nil {
+			cfg.UnifiedStorage = make(map[string]UnifiedStorageConfig)
+		}
+
+		cfg.UnifiedStorage[resource] = UnifiedStorageConfig{
+			DualWriterMode:         rest.Mode5,
+			EnableMigration:        true,
+			AutoMigrationThreshold: 0,
 		}
 	}
 }

--- a/pkg/setting/setting_unified_storage_test.go
+++ b/pkg/setting/setting_unified_storage_test.go
@@ -122,7 +122,33 @@ func TestCfg_setUnifiedStorageConfig(t *testing.T) {
 		}
 
 		setSectionKey("grafana-apiserver", "storage_type", "legacy")
-		setSectionKey("unified_storage."+PlaylistResource, "dualWriterMode", "1")
+		setSectionKey("unified_storage."+PlaylistResource, "dualWriterMode", "4")
+		setSectionKey("unified_storage."+PlaylistResource, "enableMigration", "false")
+
+		cfg.setUnifiedStorageConfig()
+
+		resourceCfg, exists := cfg.UnifiedStorage[PlaylistResource]
+		assert.True(t, exists)
+		assert.Equal(t, UnifiedStorageConfig{
+			DualWriterMode:         rest.Mode5,
+			EnableMigration:        true,
+			AutoMigrationThreshold: 0,
+		}, resourceCfg)
+	})
+
+	t.Run("force mode 5 for mode5-only resources when mode is manually set to non-5", func(t *testing.T) {
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+		assert.NoError(t, err)
+
+		setSectionKey := func(sectionName, key, value string) {
+			section := cfg.Raw.Section(sectionName)
+			_, err := section.NewKey(key, value)
+			assert.NoError(t, err)
+		}
+
+		setSectionKey("grafana-apiserver", "storage_type", "unified")
+		setSectionKey("unified_storage."+PlaylistResource, "dualWriterMode", "4")
 		setSectionKey("unified_storage."+PlaylistResource, "enableMigration", "false")
 
 		cfg.setUnifiedStorageConfig()


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/114857, we have started migrating playlists to unified storage by default. However, it's still possible to disable that migration preventing us from deleting the legacy code path ([code path](https://github.com/grafana/grafana/blob/d72e048bfe8348c0a0b5d8ee3550cd46736ac718/pkg/registry/apps/playlist/legacy_storage.go#L31) -- not the table). This PR introduces the notion of mode5-only resources that are moved to unified storage regardless of the config.ini settings