### PR TITLE
fix: rendering: improve concurrency control for inProgressCount check

### DIFF
--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -32,7 +32,7 @@ type RenderingService struct {
 	renderAction        renderFunc
 	renderCSVAction     renderCSVFunc
 	domain              string
-	inProgressCount     int32
+	inProgressCount     atomic.Int32
 	version             string
 	versionMutex        sync.RWMutex
 	capabilities        []Capability
@@ -280,7 +280,9 @@ func (rs *RenderingService) render(ctx context.Context, renderType RenderType, o
 		return rs.renderUnavailableImage(), nil
 	}
 
-	if int(atomic.LoadInt32(&rs.inProgressCount)) > opts.ConcurrentLimit {
+	inProgressCount := rs.inProgressCount.Load()
+	newInProgressCount := inProgressCount + 1
+	if int(newInProgressCount) > opts.ConcurrentLimit || !rs.inProgressCount.CompareAndSwap(inProgressCount, newInProgressCount) {
 		logger.Warn("Could not render image, hit the currency limit", "concurrencyLimit", opts.ConcurrentLimit, "path", opts.Path)
 		if opts.ErrorConcurrentLimitReached {
 			return nil, ErrConcurrentLimitReached
@@ -297,9 +299,9 @@ func (rs *RenderingService) render(ctx context.Context, renderType RenderType, o
 	}
 
 	defer func() {
-		metrics.MRenderingQueue.Set(float64(atomic.AddInt32(&rs.inProgressCount, -1)))
+		metrics.MRenderingQueue.Set(float64(rs.inProgressCount.Add(-1)))
 	}()
-	metrics.MRenderingQueue.Set(float64(atomic.AddInt32(&rs.inProgressCount, 1)))
+	metrics.MRenderingQueue.Set(float64(newInProgressCount))
 
 	if renderType == RenderPDF {
 		if err := rs.IsCapabilitySupported(ctx, PDFRendering); err != nil {
@@ -350,7 +352,9 @@ func (rs *RenderingService) renderCSV(ctx context.Context, opts CSVOpts, renderK
 		return nil, ErrRenderUnavailable
 	}
 
-	if int(atomic.LoadInt32(&rs.inProgressCount)) > opts.ConcurrentLimit {
+	inProgressCount := rs.inProgressCount.Load()
+	newInProgressCount := inProgressCount + 1
+	if int(newInProgressCount) > opts.ConcurrentLimit || !rs.inProgressCount.CompareAndSwap(inProgressCount, newInProgressCount) {
 		return nil, ErrConcurrentLimitReached
 	}
 
@@ -363,10 +367,10 @@ func (rs *RenderingService) renderCSV(ctx context.Context, opts CSVOpts, renderK
 	defer renderKeyProvider.afterRequest(ctx, opts.AuthOpts, renderKey)
 
 	defer func() {
-		metrics.MRenderingQueue.Set(float64(atomic.AddInt32(&rs.inProgressCount, -1)))
+		metrics.MRenderingQueue.Set(float64(rs.inProgressCount.Add(-1)))
 	}()
 
-	metrics.MRenderingQueue.Set(float64(atomic.AddInt32(&rs.inProgressCount, 1)))
+	metrics.MRenderingQueue.Set(float64(newInProgressCount))
 	return rs.renderCSVAction(ctx, renderKey, opts)
 }
 

--- a/pkg/services/rendering/rendering_test.go
+++ b/pkg/services/rendering/rendering_test.go
@@ -132,9 +132,9 @@ func TestRenderLimitImage(t *testing.T) {
 			HomePath:          path,
 			RendererServerUrl: "http://localhost:8081/render",
 		},
-		inProgressCount: 2,
-		log:             log.New("test"),
+		log: log.New("test"),
 	}
+	rs.inProgressCount.Store(2)
 
 	tests := []struct {
 		name     string
@@ -173,9 +173,10 @@ func TestRenderLimitImageError(t *testing.T) {
 		Cfg: &setting.Cfg{
 			RendererServerUrl: "http://localhost:8081/render",
 		},
-		inProgressCount: 2,
-		log:             log.New("test"),
+		log: log.New("test"),
 	}
+	rs.inProgressCount.Store(2)
+
 	opts := Opts{
 		CommonOpts: CommonOpts{ConcurrentLimit: 1},
 		ErrorOpts:  ErrorOpts{ErrorConcurrentLimitReached: true},


### PR DESCRIPTION
What is this feature?

Improves the concurrency control logic for inProgressCount by replacing a simple integer comparison with atomic Compare-And-Swap (CAS) operation.

Why do we need this feature?

The original simple integer check had a race condition in high-concurrency scenarios, which could lead to the inProgressCount exceeding the configured ConcurrentLimit. Using atomic CAS ensures thread-safe increment of the counter and prevents exceeding the concurrency limit, improving the reliability of the concurrency control mechanism.

Who is this feature for?

This change benefits all Grafana users who rely on features with concurrent execution limits (e.g., data query processing, background task execution), especially those running Grafana in high-traffic environments with heavy concurrent workloads.

Which issue(s) does this PR fix?:

Fixes https://github.com/grafana/grafana/issues/116659