### PR TITLE
FS: Use Settings Service for per-request config

### DIFF
--- a/pkg/services/frontend/frontend_service.go
+++ b/pkg/services/frontend/frontend_service.go
@@ -160,7 +160,7 @@ func (s *frontendService) addMiddlewares(m *web.Mux) {
 	m.UseMiddleware(loggermiddleware.Middleware())
 
 	// Must run before CSP middleware since CSP reads config from context
-	m.UseMiddleware(RequestConfigMiddleware(s.baseRequestConfig))
+	m.UseMiddleware(RequestConfigMiddleware(s.baseRequestConfig, s.settingsService))
 
 	m.UseMiddleware(CSPMiddleware())
 

--- a/pkg/services/frontend/frontend_service_test.go
+++ b/pkg/services/frontend/frontend_service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/ini.v1"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
@@ -46,6 +47,7 @@ func TestFrontendService_ServerCreation(t *testing.T) {
 	t.Run("should create HTTP server with correct configuration", func(t *testing.T) {
 		publicDir := setupTestWebAssets(t)
 		cfg := &setting.Cfg{
+			Raw:            ini.Empty(),
 			HTTPPort:       "1234",
 			StaticRootPath: publicDir,
 		}
@@ -64,6 +66,7 @@ func TestFrontendService_ServerCreation(t *testing.T) {
 func TestFrontendService_Routes(t *testing.T) {
 	publicDir := setupTestWebAssets(t)
 	cfg := &setting.Cfg{
+		Raw:            ini.Empty(),
 		HTTPPort:       "3000",
 		StaticRootPath: publicDir,
 	}
@@ -139,6 +142,7 @@ func TestFrontendService_Routes(t *testing.T) {
 func TestFrontendService_Middleware(t *testing.T) {
 	publicDir := setupTestWebAssets(t)
 	cfg := &setting.Cfg{
+		Raw:            ini.Empty(),
 		HTTPPort:       "3000",
 		StaticRootPath: publicDir,
 	}
@@ -190,6 +194,7 @@ func TestFrontendService_Middleware(t *testing.T) {
 func TestFrontendService_LoginErrorCookie(t *testing.T) {
 	publicDir := setupTestWebAssets(t)
 	cfg := &setting.Cfg{
+		Raw:                    ini.Empty(),
 		HTTPPort:               "3000",
 		StaticRootPath:         publicDir,
 		BuildVersion:           "10.3.0",
@@ -262,6 +267,7 @@ func TestFrontendService_LoginErrorCookie(t *testing.T) {
 
 	t.Run("should handle custom OAuth error message from config", func(t *testing.T) {
 		customCfg := &setting.Cfg{
+			Raw:                    ini.Empty(),
 			HTTPPort:               "3000",
 			StaticRootPath:         publicDir,
 			BuildVersion:           "10.3.0",
@@ -296,6 +302,7 @@ func TestFrontendService_LoginErrorCookie(t *testing.T) {
 func TestFrontendService_IndexHooks(t *testing.T) {
 	publicDir := setupTestWebAssets(t)
 	cfg := &setting.Cfg{
+		Raw:            ini.Empty(),
 		HTTPPort:       "3000",
 		StaticRootPath: publicDir,
 		BuildVersion:   "10.3.0",
@@ -351,6 +358,7 @@ func TestFrontendService_CSP(t *testing.T) {
 
 	t.Run("should set CSP headers when enabled", func(t *testing.T) {
 		cfg := &setting.Cfg{
+			Raw:            ini.Empty(),
 			HTTPPort:       "3000",
 			StaticRootPath: publicDir,
 			BuildVersion:   "10.3.0",
@@ -379,6 +387,7 @@ func TestFrontendService_CSP(t *testing.T) {
 
 	t.Run("should set CSP-Report-Only header when enabled", func(t *testing.T) {
 		cfg := &setting.Cfg{
+			Raw:                   ini.Empty(),
 			HTTPPort:              "3000",
 			StaticRootPath:        publicDir,
 			BuildVersion:          "10.3.0",
@@ -406,6 +415,7 @@ func TestFrontendService_CSP(t *testing.T) {
 
 	t.Run("should set both CSP headers when both enabled", func(t *testing.T) {
 		cfg := &setting.Cfg{
+			Raw:                   ini.Empty(),
 			HTTPPort:              "3000",
 			StaticRootPath:        publicDir,
 			BuildVersion:          "10.3.0",
@@ -436,6 +446,7 @@ func TestFrontendService_CSP(t *testing.T) {
 
 	t.Run("should not set CSP headers when disabled", func(t *testing.T) {
 		cfg := &setting.Cfg{
+			Raw:            ini.Empty(),
 			HTTPPort:       "3000",
 			StaticRootPath: publicDir,
 			BuildVersion:   "10.3.0",
@@ -463,6 +474,7 @@ func TestFrontendService_CSP(t *testing.T) {
 
 	t.Run("should store nonce in request context", func(t *testing.T) {
 		cfg := &setting.Cfg{
+			Raw:            ini.Empty(),
 			HTTPPort:       "3000",
 			StaticRootPath: publicDir,
 			BuildVersion:   "10.3.0",
@@ -496,6 +508,7 @@ func TestFrontendService_CSP(t *testing.T) {
 
 	t.Run("should use base config when Tenant-ID header is present", func(t *testing.T) {
 		cfg := &setting.Cfg{
+			Raw:            ini.Empty(),
 			HTTPPort:       "3000",
 			StaticRootPath: publicDir,
 			BuildVersion:   "10.3.0",

--- a/pkg/services/frontend/index_test.go
+++ b/pkg/services/frontend/index_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/ini.v1"
 
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
@@ -74,6 +75,7 @@ func TestFrontendService_WebAssets(t *testing.T) {
 	t.Run("should serve index with proper assets", func(t *testing.T) {
 		publicDir := setupTestWebAssets(t)
 		cfg := &setting.Cfg{
+			Raw:            ini.Empty(),
 			HTTPPort:       "3000",
 			StaticRootPath: publicDir,
 			Env:            setting.Dev, // needs to be dev to bypass the cache

--- a/pkg/services/frontend/request_config.go
+++ b/pkg/services/frontend/request_config.go
@@ -3,9 +3,13 @@ package frontend
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 
+	"gopkg.in/ini.v1"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -82,6 +86,21 @@ func (c FSRequestConfig) WithContext(ctx context.Context) context.Context {
 	return context.WithValue(ctx, requestConfigKey{}, c)
 }
 
+// Copy creates a deep copy of the FSRequestConfig.
+// This is necessary because FSFrontendSettings contains reference types (maps)
+// that would be shared in a shallow copy.
+func (c FSRequestConfig) Copy() FSRequestConfig {
+	result := c // Shallow copy primitives and structs
+
+	// Deep copy the ReportingStaticContext map
+	if c.ReportingStaticContext != nil {
+		result.ReportingStaticContext = make(map[string]string, len(c.ReportingStaticContext))
+		maps.Copy(result.ReportingStaticContext, c.ReportingStaticContext)
+	}
+
+	return result
+}
+
 func getBuildInfo(license licensing.Licensing, cfg *setting.Cfg) dtos.FrontendSettingsBuildInfoDTO {
 	version := setting.BuildVersion
 	commit := setting.BuildCommit
@@ -107,4 +126,51 @@ func getShortCommitHash(commitHash string, maxLength int) string {
 		return commitHash[:maxLength]
 	}
 	return commitHash
+}
+
+// WithOverrides merges tenant-specific settings from ini.File with this configuration.
+// Returns a new FSRequestConfig with overrides applied, using a deep copy to avoid
+// shared map references.
+func (c FSRequestConfig) WithOverrides(settings *ini.File, logger log.Logger) FSRequestConfig {
+	// Apply overrides from the settings service ini to the config. Theoretically we could use setting.NewCfgFromINIFile, but
+	// because we only want overrides, and not default values, we need to manually get them out of the ini structure.
+
+	result := c.Copy() // Deep copy to avoid shared map references
+
+	// TODO: We should apply all overrides for values in FSRequestConfig
+	applyBool(settings, "security", "content_security_policy", &result.CSPEnabled)
+	applyString(settings, "security", "content_security_policy_template", &result.CSPTemplate)
+	applyBool(settings, "security", "content_security_policy_report_only", &result.CSPReportOnlyEnabled)
+	applyString(settings, "security", "content_security_policy_report_only_template", &result.CSPReportOnlyTemplate)
+
+	logger.Debug("applied tenant overrides",
+		"sections", settings.SectionStrings(),
+		"csp_enabled", result.CSPEnabled,
+		"app_url", result.AppURL)
+
+	return result
+}
+
+// applyString applies a string value from ini settings to a target field if it exists.
+func applyString(settings *ini.File, section, key string, target *string) {
+	if !settings.HasSection(section) {
+		return
+	}
+	sec := settings.Section(section)
+	if !sec.HasKey(key) {
+		return
+	}
+	*target = sec.Key(key).String()
+}
+
+// applyBool applies a boolean value from ini settings to a target field if it exists.
+func applyBool(settings *ini.File, section, key string, target *bool) {
+	if !settings.HasSection(section) {
+		return
+	}
+	sec := settings.Section(section)
+	if !sec.HasKey(key) {
+		return
+	}
+	*target = sec.Key(key).MustBool(false)
 }

--- a/pkg/services/frontend/request_config_middleware.go
+++ b/pkg/services/frontend/request_config_middleware.go
@@ -51,6 +51,11 @@ func RequestConfigMiddleware(baseConfig FSRequestConfig, settingsService setting
 						Key:      "section",
 						Operator: metav1.LabelSelectorOpIn,
 						Values:   []string{"security"}, // TODO: get correct list
+					}, {
+						// don't return values from defaults.ini as they conflict with the services's own defaults
+						Key:      "source",
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values:   []string{"defaults"},
 					}},
 				}
 

--- a/pkg/services/frontend/request_config_middleware.go
+++ b/pkg/services/frontend/request_config_middleware.go
@@ -3,17 +3,60 @@ package frontend
 import (
 	"net/http"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/contexthandler"
+	settingservice "github.com/grafana/grafana/pkg/services/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
 
-func RequestConfigMiddleware(baseConfig FSRequestConfig) web.Middleware {
+// RequestConfigMiddleware manages per-request configuration.
+//
+// When Settings Service is configured and Grafana-Namespace header is present:
+// - Fetches tenant-specific overrides from Settings Service
+// - Merges overrides with base configuration
+// - Stores final configuration in context
+//
+// Otherwise, uses base configuration for all requests.
+func RequestConfigMiddleware(baseConfig FSRequestConfig, settingsService settingservice.Service) web.Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// TODO: In the future fetch and override request-specific config here
+			ctx, span := tracing.Start(r.Context(), "frontend.RequestConfigMiddleware")
+			defer span.End()
+
+			namespace := r.Header.Get("Grafana-Namespace")
+			ctx = request.WithNamespace(ctx, namespace)
+
+			reqCtx := contexthandler.FromContext(ctx)
+			logger := reqCtx.Logger
+
 			finalConfig := baseConfig
 
+			// Fetch tenant-specific configuration if namespace is present
+			if namespace != "" && settingsService != nil {
+				// Fetch tenant overrides for relevant sections only
+				selector := metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{{
+						Key:      "section",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"security"}, // TODO: get correct list
+					}},
+				}
+
+				settings, err := settingsService.ListAsIni(ctx, selector)
+				if err != nil {
+					logger.Error("failed to fetch tenant settings", "namespace", namespace, "err", err)
+					// Fall back to base config
+				} else {
+					// Merge tenant overrides with base config
+					finalConfig = baseConfig.WithOverrides(settings, logger)
+				}
+			}
+
 			// Store config in context
-			ctx := finalConfig.WithContext(r.Context())
+			ctx = finalConfig.WithContext(ctx)
 
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})

--- a/pkg/services/frontend/request_config_middleware_test.go
+++ b/pkg/services/frontend/request_config_middleware_test.go
@@ -1,11 +1,17 @@
 package frontend
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"gopkg.in/ini.v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
+	settingservice "github.com/grafana/grafana/pkg/services/setting"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +31,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 			AppURL:      "https://grafana.example.com",
 		}
 
-		middleware := RequestConfigMiddleware(baseConfig)
+		middleware := RequestConfigMiddleware(baseConfig, nil)
 
 		var capturedConfig FSRequestConfig
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -53,7 +59,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 
 	t.Run("should call next handler", func(t *testing.T) {
 		baseConfig := FSRequestConfig{}
-		middleware := RequestConfigMiddleware(baseConfig)
+		middleware := RequestConfigMiddleware(baseConfig, nil)
 
 		nextCalled := false
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -77,7 +83,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 			FSFrontendSettings: FSFrontendSettings{},
 		}
 
-		middleware := RequestConfigMiddleware(baseConfig)
+		middleware := RequestConfigMiddleware(baseConfig, nil)
 
 		var capturedConfig FSRequestConfig
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -98,4 +104,155 @@ func TestRequestConfigMiddleware(t *testing.T) {
 		assert.Equal(t, false, capturedConfig.CSPEnabled)
 		assert.Equal(t, "", capturedConfig.CSPTemplate)
 	})
+
+	t.Run("should fetch and apply tenant overrides from settings service", func(t *testing.T) {
+		baseConfig := FSRequestConfig{
+			FSFrontendSettings: FSFrontendSettings{
+				AnonymousEnabled: false,
+				DisableLoginForm: false,
+			},
+			AppURL:     "https://base.example.com",
+			CSPEnabled: false,
+		}
+
+		// Create mock settings service that returns CSP overrides
+		mockSettingsService := &mockSettingsService{
+			settings: []*settingservice.Setting{
+				{Section: "security", Key: "content_security_policy", Value: "true"},
+				{Section: "security", Key: "content_security_policy_template", Value: "script-src 'self'"},
+			},
+		}
+
+		middleware := RequestConfigMiddleware(baseConfig, mockSettingsService)
+
+		var capturedConfig FSRequestConfig
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var err error
+			capturedConfig, err = FSRequestConfigFromContext(r.Context())
+			require.NoError(t, err)
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := middleware(testHandler)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Grafana-Namespace", "stacks-123")
+		recorder := httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+
+		// Verify CSP overrides were applied
+		assert.True(t, capturedConfig.CSPEnabled)
+		assert.Equal(t, "script-src 'self'", capturedConfig.CSPTemplate)
+
+		// Verify other settings remain at base values (not overridden)
+		assert.Equal(t, "https://base.example.com", capturedConfig.AppURL)
+		assert.False(t, capturedConfig.AnonymousEnabled)
+		assert.False(t, capturedConfig.DisableLoginForm)
+
+		// Verify settings service was called
+		assert.True(t, mockSettingsService.called)
+	})
+
+	t.Run("should fallback to base config on settings service error", func(t *testing.T) {
+		baseConfig := FSRequestConfig{
+			AppURL:     "https://base.example.com",
+			CSPEnabled: true,
+		}
+
+		// Create mock that returns an error
+		mockSettingsService := &mockSettingsService{
+			err: assert.AnError,
+		}
+
+		middleware := RequestConfigMiddleware(baseConfig, mockSettingsService)
+
+		var capturedConfig FSRequestConfig
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var err error
+			capturedConfig, err = FSRequestConfigFromContext(r.Context())
+			require.NoError(t, err)
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := middleware(testHandler)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Grafana-Namespace", "stacks-123")
+		recorder := httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+
+		// Verify base config was used (no overrides)
+		assert.Equal(t, "https://base.example.com", capturedConfig.AppURL)
+		assert.True(t, capturedConfig.CSPEnabled)
+
+		// Verify settings service was called
+		assert.True(t, mockSettingsService.called)
+	})
+
+	t.Run("should not call settings service without namespace header", func(t *testing.T) {
+		baseConfig := FSRequestConfig{
+			AppURL: "https://base.example.com",
+		}
+
+		mockSettingsService := &mockSettingsService{}
+
+		middleware := RequestConfigMiddleware(baseConfig, mockSettingsService)
+
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := middleware(testHandler)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		// No Grafana-Namespace header
+		recorder := httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.False(t, mockSettingsService.called)
+	})
 }
+
+// mockSettingsService is a simple mock for testing
+type mockSettingsService struct {
+	called   bool
+	settings []*settingservice.Setting
+	err      error
+}
+
+func (m *mockSettingsService) ListAsIni(ctx context.Context, selector metav1.LabelSelector) (*ini.File, error) {
+	m.called = true
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	// Convert settings to ini format (same logic as real service)
+	conf := ini.Empty()
+	for _, setting := range m.settings {
+		if !conf.HasSection(setting.Section) {
+			_, _ = conf.NewSection(setting.Section)
+		}
+		_, _ = conf.Section(setting.Section).NewKey(setting.Key, setting.Value)
+	}
+	return conf, nil
+}
+
+func (m *mockSettingsService) List(ctx context.Context, selector metav1.LabelSelector) ([]*settingservice.Setting, error) {
+	m.called = true
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.settings, nil
+}
+
+// Implement prometheus.Collector interface
+func (m *mockSettingsService) Describe(ch chan<- *prometheus.Desc) {}
+func (m *mockSettingsService) Collect(ch chan<- prometheus.Metric) {}

--- a/pkg/services/frontend/request_config_test.go
+++ b/pkg/services/frontend/request_config_test.go
@@ -1,0 +1,187 @@
+package frontend
+
+import (
+	"testing"
+
+	"gopkg.in/ini.v1"
+
+	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFSRequestConfig_Copy(t *testing.T) {
+	t.Run("should deep copy ReportingStaticContext map", func(t *testing.T) {
+		original := FSRequestConfig{
+			FSFrontendSettings: FSFrontendSettings{
+				ReportingStaticContext: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+				AnonymousEnabled: true,
+			},
+			CSPEnabled: true,
+			AppURL:     "https://example.com",
+		}
+
+		copied := original.Copy()
+
+		// Modify the copied map
+		copied.ReportingStaticContext["key1"] = "modified"
+		copied.ReportingStaticContext["key3"] = "new"
+
+		// Original should be unchanged
+		assert.Equal(t, "value1", original.ReportingStaticContext["key1"])
+		assert.NotContains(t, original.ReportingStaticContext, "key3")
+
+		// Copied should have modifications
+		assert.Equal(t, "modified", copied.ReportingStaticContext["key1"])
+		assert.Equal(t, "new", copied.ReportingStaticContext["key3"])
+	})
+
+	t.Run("should handle nil map", func(t *testing.T) {
+		original := FSRequestConfig{
+			FSFrontendSettings: FSFrontendSettings{
+				ReportingStaticContext: nil,
+			},
+		}
+
+		copied := original.Copy()
+
+		assert.Nil(t, copied.ReportingStaticContext)
+	})
+
+	t.Run("should copy primitive fields", func(t *testing.T) {
+		original := FSRequestConfig{
+			FSFrontendSettings: FSFrontendSettings{
+				AnonymousEnabled: true,
+				DisableLoginForm: true,
+				LoginHint:        "test@example.com",
+				BuildInfo: dtos.FrontendSettingsBuildInfoDTO{
+					Version: "10.3.0",
+					Edition: "Enterprise",
+				},
+			},
+			CSPEnabled:  true,
+			CSPTemplate: "default-src 'self'",
+			AppURL:      "https://example.com",
+		}
+
+		copied := original.Copy()
+
+		assert.Equal(t, original.AnonymousEnabled, copied.AnonymousEnabled)
+		assert.Equal(t, original.DisableLoginForm, copied.DisableLoginForm)
+		assert.Equal(t, original.LoginHint, copied.LoginHint)
+		assert.Equal(t, original.BuildInfo.Version, copied.BuildInfo.Version)
+		assert.Equal(t, original.BuildInfo.Edition, copied.BuildInfo.Edition)
+		assert.Equal(t, original.CSPEnabled, copied.CSPEnabled)
+		assert.Equal(t, original.CSPTemplate, copied.CSPTemplate)
+		assert.Equal(t, original.AppURL, copied.AppURL)
+	})
+}
+
+func TestFSRequestConfig_ApplyOverrides(t *testing.T) {
+	t.Run("should handle empty ini file", func(t *testing.T) {
+		baseConfig := FSRequestConfig{
+			AppURL:     "https://base.example.com",
+			CSPEnabled: true,
+		}
+
+		iniFile := ini.Empty()
+
+		result := baseConfig.WithOverrides(iniFile, log.New("test"))
+
+		assert.Equal(t, baseConfig.AppURL, result.AppURL)
+		assert.Equal(t, baseConfig.CSPEnabled, result.CSPEnabled)
+	})
+
+	t.Run("should preserve non-overridden fields", func(t *testing.T) {
+		baseConfig := FSRequestConfig{
+			FSFrontendSettings: FSFrontendSettings{
+				AnonymousEnabled: true,
+				DisableLoginForm: true,
+				LoginHint:        "test@example.com",
+				BuildInfo: dtos.FrontendSettingsBuildInfoDTO{
+					Version: "10.3.0",
+				},
+			},
+			AppURL:     "https://base.example.com",
+			CSPEnabled: false,
+		}
+
+		iniFile := ini.Empty()
+		securitySection, _ := iniFile.NewSection("security")
+		_, _ = securitySection.NewKey("content_security_policy", "true")
+
+		result := baseConfig.WithOverrides(iniFile, log.New("test"))
+
+		// CSP overridden field
+		assert.True(t, result.CSPEnabled)
+
+		// Non-overridden fields should be preserved
+		assert.Equal(t, "https://base.example.com", result.AppURL)
+		assert.True(t, result.AnonymousEnabled)
+		assert.True(t, result.DisableLoginForm)
+		assert.Equal(t, "test@example.com", result.LoginHint)
+		assert.Equal(t, "10.3.0", result.BuildInfo.Version)
+	})
+
+	t.Run("should deep copy map to avoid shared references", func(t *testing.T) {
+		baseConfig := FSRequestConfig{
+			FSFrontendSettings: FSFrontendSettings{
+				ReportingStaticContext: map[string]string{
+					"original": "value",
+				},
+			},
+		}
+
+		iniFile := ini.Empty()
+		securitySection, _ := iniFile.NewSection("security")
+		_, _ = securitySection.NewKey("content_security_policy", "true")
+
+		result := baseConfig.WithOverrides(iniFile, log.New("test"))
+
+		// Modify the result's map
+		result.ReportingStaticContext["new"] = "value"
+
+		// Original should be unaffected
+		assert.NotContains(t, baseConfig.ReportingStaticContext, "new")
+		assert.Equal(t, 1, len(baseConfig.ReportingStaticContext))
+	})
+
+	t.Run("should apply multiple CSP overrides at once", func(t *testing.T) {
+		baseConfig := FSRequestConfig{
+			FSFrontendSettings: FSFrontendSettings{
+				AnonymousEnabled:  false,
+				DisableLoginForm:  false,
+				DisableUserSignUp: false,
+			},
+			AppURL:                "https://base.example.com",
+			CSPEnabled:            false,
+			CSPTemplate:           "",
+			CSPReportOnlyEnabled:  false,
+			CSPReportOnlyTemplate: "",
+		}
+
+		iniFile := ini.Empty()
+
+		securitySection, _ := iniFile.NewSection("security")
+		_, _ = securitySection.NewKey("content_security_policy", "true")
+		_, _ = securitySection.NewKey("content_security_policy_template", "script-src 'self'")
+		_, _ = securitySection.NewKey("content_security_policy_report_only", "true")
+		_, _ = securitySection.NewKey("content_security_policy_report_only_template", "default-src 'none'")
+
+		result := baseConfig.WithOverrides(iniFile, log.New("test"))
+
+		// All CSP settings should be overridden
+		assert.True(t, result.CSPEnabled)
+		assert.Equal(t, "script-src 'self'", result.CSPTemplate)
+		assert.True(t, result.CSPReportOnlyEnabled)
+		assert.Equal(t, "default-src 'none'", result.CSPReportOnlyTemplate)
+
+		// Other settings should remain unchanged
+		assert.Equal(t, "https://base.example.com", result.AppURL)
+		assert.False(t, result.DisableLoginForm)
+		assert.False(t, result.AnonymousEnabled)
+	})
+}

--- a/pkg/services/frontend/request_config_test.go
+++ b/pkg/services/frontend/request_config_test.go
@@ -10,93 +10,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFSRequestConfig_Copy(t *testing.T) {
-	t.Run("should deep copy ReportingStaticContext map", func(t *testing.T) {
-		original := FSRequestConfig{
-			FSFrontendSettings: FSFrontendSettings{
-				ReportingStaticContext: map[string]string{
-					"key1": "value1",
-					"key2": "value2",
-				},
-				AnonymousEnabled: true,
-			},
-			CSPEnabled: true,
-			AppURL:     "https://example.com",
-		}
-
-		copied := original.Copy()
-
-		// Modify the copied map
-		copied.ReportingStaticContext["key1"] = "modified"
-		copied.ReportingStaticContext["key3"] = "new"
-
-		// Original should be unchanged
-		assert.Equal(t, "value1", original.ReportingStaticContext["key1"])
-		assert.NotContains(t, original.ReportingStaticContext, "key3")
-
-		// Copied should have modifications
-		assert.Equal(t, "modified", copied.ReportingStaticContext["key1"])
-		assert.Equal(t, "new", copied.ReportingStaticContext["key3"])
-	})
-
-	t.Run("should handle nil map", func(t *testing.T) {
-		original := FSRequestConfig{
-			FSFrontendSettings: FSFrontendSettings{
-				ReportingStaticContext: nil,
-			},
-		}
-
-		copied := original.Copy()
-
-		assert.Nil(t, copied.ReportingStaticContext)
-	})
-
-	t.Run("should copy primitive fields", func(t *testing.T) {
-		original := FSRequestConfig{
-			FSFrontendSettings: FSFrontendSettings{
-				AnonymousEnabled: true,
-				DisableLoginForm: true,
-				LoginHint:        "test@example.com",
-				BuildInfo: dtos.FrontendSettingsBuildInfoDTO{
-					Version: "10.3.0",
-					Edition: "Enterprise",
-				},
-			},
-			CSPEnabled:  true,
-			CSPTemplate: "default-src 'self'",
-			AppURL:      "https://example.com",
-		}
-
-		copied := original.Copy()
-
-		assert.Equal(t, original.AnonymousEnabled, copied.AnonymousEnabled)
-		assert.Equal(t, original.DisableLoginForm, copied.DisableLoginForm)
-		assert.Equal(t, original.LoginHint, copied.LoginHint)
-		assert.Equal(t, original.BuildInfo.Version, copied.BuildInfo.Version)
-		assert.Equal(t, original.BuildInfo.Edition, copied.BuildInfo.Edition)
-		assert.Equal(t, original.CSPEnabled, copied.CSPEnabled)
-		assert.Equal(t, original.CSPTemplate, copied.CSPTemplate)
-		assert.Equal(t, original.AppURL, copied.AppURL)
-	})
-}
-
 func TestFSRequestConfig_ApplyOverrides(t *testing.T) {
 	t.Run("should handle empty ini file", func(t *testing.T) {
-		baseConfig := FSRequestConfig{
+		config := FSRequestConfig{
 			AppURL:     "https://base.example.com",
 			CSPEnabled: true,
 		}
 
 		iniFile := ini.Empty()
 
-		result := baseConfig.WithOverrides(iniFile, log.New("test"))
+		config.ApplyOverrides(iniFile, log.New("test"))
 
-		assert.Equal(t, baseConfig.AppURL, result.AppURL)
-		assert.Equal(t, baseConfig.CSPEnabled, result.CSPEnabled)
+		assert.Equal(t, "https://base.example.com", config.AppURL)
+		assert.Equal(t, true, config.CSPEnabled)
 	})
 
 	t.Run("should preserve non-overridden fields", func(t *testing.T) {
-		baseConfig := FSRequestConfig{
+		config := FSRequestConfig{
 			FSFrontendSettings: FSFrontendSettings{
 				AnonymousEnabled: true,
 				DisableLoginForm: true,
@@ -113,44 +43,21 @@ func TestFSRequestConfig_ApplyOverrides(t *testing.T) {
 		securitySection, _ := iniFile.NewSection("security")
 		_, _ = securitySection.NewKey("content_security_policy", "true")
 
-		result := baseConfig.WithOverrides(iniFile, log.New("test"))
+		config.ApplyOverrides(iniFile, log.New("test"))
 
 		// CSP overridden field
-		assert.True(t, result.CSPEnabled)
+		assert.True(t, config.CSPEnabled)
 
 		// Non-overridden fields should be preserved
-		assert.Equal(t, "https://base.example.com", result.AppURL)
-		assert.True(t, result.AnonymousEnabled)
-		assert.True(t, result.DisableLoginForm)
-		assert.Equal(t, "test@example.com", result.LoginHint)
-		assert.Equal(t, "10.3.0", result.BuildInfo.Version)
-	})
-
-	t.Run("should deep copy map to avoid shared references", func(t *testing.T) {
-		baseConfig := FSRequestConfig{
-			FSFrontendSettings: FSFrontendSettings{
-				ReportingStaticContext: map[string]string{
-					"original": "value",
-				},
-			},
-		}
-
-		iniFile := ini.Empty()
-		securitySection, _ := iniFile.NewSection("security")
-		_, _ = securitySection.NewKey("content_security_policy", "true")
-
-		result := baseConfig.WithOverrides(iniFile, log.New("test"))
-
-		// Modify the result's map
-		result.ReportingStaticContext["new"] = "value"
-
-		// Original should be unaffected
-		assert.NotContains(t, baseConfig.ReportingStaticContext, "new")
-		assert.Equal(t, 1, len(baseConfig.ReportingStaticContext))
+		assert.Equal(t, "https://base.example.com", config.AppURL)
+		assert.True(t, config.AnonymousEnabled)
+		assert.True(t, config.DisableLoginForm)
+		assert.Equal(t, "test@example.com", config.LoginHint)
+		assert.Equal(t, "10.3.0", config.BuildInfo.Version)
 	})
 
 	t.Run("should apply multiple CSP overrides at once", func(t *testing.T) {
-		baseConfig := FSRequestConfig{
+		config := FSRequestConfig{
 			FSFrontendSettings: FSFrontendSettings{
 				AnonymousEnabled:  false,
 				DisableLoginForm:  false,
@@ -171,17 +78,17 @@ func TestFSRequestConfig_ApplyOverrides(t *testing.T) {
 		_, _ = securitySection.NewKey("content_security_policy_report_only", "true")
 		_, _ = securitySection.NewKey("content_security_policy_report_only_template", "default-src 'none'")
 
-		result := baseConfig.WithOverrides(iniFile, log.New("test"))
+		config.ApplyOverrides(iniFile, log.New("test"))
 
 		// All CSP settings should be overridden
-		assert.True(t, result.CSPEnabled)
-		assert.Equal(t, "script-src 'self'", result.CSPTemplate)
-		assert.True(t, result.CSPReportOnlyEnabled)
-		assert.Equal(t, "default-src 'none'", result.CSPReportOnlyTemplate)
+		assert.True(t, config.CSPEnabled)
+		assert.Equal(t, "script-src 'self'", config.CSPTemplate)
+		assert.True(t, config.CSPReportOnlyEnabled)
+		assert.Equal(t, "default-src 'none'", config.CSPReportOnlyTemplate)
 
 		// Other settings should remain unchanged
-		assert.Equal(t, "https://base.example.com", result.AppURL)
-		assert.False(t, result.DisableLoginForm)
-		assert.False(t, result.AnonymousEnabled)
+		assert.Equal(t, "https://base.example.com", config.AppURL)
+		assert.False(t, config.DisableLoginForm)
+		assert.False(t, config.AnonymousEnabled)
 	})
 }

--- a/pkg/services/frontend/settings_service.go
+++ b/pkg/services/frontend/settings_service.go
@@ -1,0 +1,67 @@
+package frontend
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/grafana/authlib/authn"
+	"github.com/prometheus/client_golang/prometheus"
+
+	settingservice "github.com/grafana/grafana/pkg/services/setting"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// setupSettingsService initializes the Settings Service client if configured.
+// Expected configuration:
+// [grpc_client_authentication]
+// token =
+// token_exchange_url =
+//
+// [settings_service]
+// url =
+//
+// Returns nil if not configured (this is not an error condition). Errors returned should
+// be considered critical.
+func setupSettingsService(cfg *setting.Cfg, promRegister prometheus.Registerer) (settingservice.Service, error) {
+	settingsSec := cfg.SectionWithEnvOverrides("settings_service")
+	settingsServiceURL := settingsSec.Key("url").String()
+	if settingsServiceURL == "" {
+		// If settings service URL is configured, return nil without error
+		return nil, nil
+	}
+
+	gRPCAuth := cfg.SectionWithEnvOverrides("grpc_client_authentication")
+	token := gRPCAuth.Key("token").String()
+	tokenExchangeURL := gRPCAuth.Key("token_exchange_url").String()
+	if token == "" {
+		return nil, fmt.Errorf("grpc_client_authentication.token is required for settings service")
+	}
+	if tokenExchangeURL == "" {
+		return nil, fmt.Errorf("grpc_client_authentication.token_exchange_url is required for settings service")
+	}
+
+	tokenClient, err := authn.NewTokenExchangeClient(authn.TokenExchangeConfig{
+		Token:            token,
+		TokenExchangeURL: tokenExchangeURL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token exchange client: %w", err)
+	}
+
+	settingsService, err := settingservice.New(settingservice.Config{
+		URL:                 settingsServiceURL,
+		TokenExchangeClient: tokenClient,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create settings service client: %w", err)
+	}
+
+	if err := promRegister.Register(settingsService); err != nil {
+		var alreadyRegisteredErr prometheus.AlreadyRegisteredError
+		if !errors.As(err, &alreadyRegisteredErr) {
+			return nil, fmt.Errorf("failed to register settings service metrics: %w", err)
+		}
+	}
+
+	return settingsService, nil
+}

--- a/pkg/services/frontend/settings_service.go
+++ b/pkg/services/frontend/settings_service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/authlib/authn"
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/rest"
 
 	settingservice "github.com/grafana/grafana/pkg/services/setting"
 	"github.com/grafana/grafana/pkg/setting"
@@ -19,6 +20,7 @@ import (
 //
 // [settings_service]
 // url =
+// tls_skip_verify = false
 //
 // Returns nil if not configured (this is not an error condition). Errors returned should
 // be considered critical.
@@ -29,6 +31,7 @@ func setupSettingsService(cfg *setting.Cfg, promRegister prometheus.Registerer) 
 		// If settings service URL is configured, return nil without error
 		return nil, nil
 	}
+	tlsSkipVerify := settingsSec.Key("tls_skip_verify").MustBool(false)
 
 	gRPCAuth := cfg.SectionWithEnvOverrides("grpc_client_authentication")
 	token := gRPCAuth.Key("token").String()
@@ -51,6 +54,9 @@ func setupSettingsService(cfg *setting.Cfg, promRegister prometheus.Registerer) 
 	settingsService, err := settingservice.New(settingservice.Config{
 		URL:                 settingsServiceURL,
 		TokenExchangeClient: tokenClient,
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: tlsSkipVerify,
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create settings service client: %w", err)


### PR DESCRIPTION
This PR initiates and uses the settings service to request per-request configuration based on an incoming `Grafana-Namespace` header (naming tbd). This involves:
- [based on provisioning](https://github.com/grafana/grafana/blob/0c36b63de58b23d7e01feb446714439fae4dc636/pkg/operators/provisioning/config.go#L76), use `cfg.SectionWithEnvOverrides` to load custom config.ini values for authentication, and to find the settings service
- create a CAP authentication client with `authn.NewTokenExchangeClient`. Theoretically this would be reused across multiple services we communicate with, but currently just with settings service
- create a Settings Service client with `settingservice.New`
- In `RequestConfigMiddleware` request settings from the settings service client based on the `Grafana-Namespace` header and merge them with the defaults for that request
- Because `CSPMiddleware` already uses `FSRequestConfigFromContext`, it will automatically get the right config for the tenant’s request

For more details, see comment on issue https://github.com/grafana/grafana-frontend-platform/issues/115#issuecomment-3791612589 

In later work (not yet planned) we would fetch and apply overrides for the rest of the config in `FSFrontendSettings`.

TODO:
- [x] Actually test this with settings service
   - I've managed to test this locally, but setup is a bit of a pain. Happy to run people through it, or let people test through my setup on a call if they want 👍 
- [x] Confirm the `Grafana-Namespace` header name, or change later


Part of https://github.com/grafana/grafana-frontend-platform/issues/115

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #116822 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #116820 
- <kbd>&nbsp;1&nbsp;</kbd> #116819 
<!-- GitButler Footer Boundary Bottom -->

