### PR TITLE
logging: fix db_query_time always reporting zero

### DIFF
--- a/pkg/infra/log/databaseQueryTimer.go
+++ b/pkg/infra/log/databaseQueryTimer.go
@@ -18,7 +18,7 @@ func InitDBQueryTimer(ctx context.Context) context.Context {
 // IncDBQueryTimer increments the database query timer on the context.
 func IncDBQueryTimer(ctx context.Context, queryTimeInMs int64) context.Context {
 	if val := ctx.Value(dbCallQueryTimerKey); val == nil {
-		ctx = InitCounter(ctx)
+		ctx = InitDBQueryTimer(ctx)
 	}
 
 	if val := ctx.Value(dbCallQueryTimerKey); val != nil {

--- a/pkg/infra/log/databaseQueryTimer_test.go
+++ b/pkg/infra/log/databaseQueryTimer_test.go
@@ -1,0 +1,42 @@
+package log
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatabaseQueryTimer(t *testing.T) {
+	testCases := []struct {
+		name       string
+		queryTimes []int64
+		expected   int64
+	}{
+		{
+			name:       "accumulates multiple query times",
+			queryTimes: []int64{100, 50, 25},
+			expected:   175,
+		},
+		{
+			name:       "single query time",
+			queryTimes: []int64{42},
+			expected:   42,
+		},
+		{
+			name:       "no queries returns zero",
+			queryTimes: []int64{},
+			expected:   0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			for _, queryTime := range tc.queryTimes {
+				ctx = IncDBQueryTimer(ctx, queryTime)
+			}
+			assert.Equal(t, tc.expected, TotalDBQueryTime(ctx))
+		})
+	}
+}

--- a/pkg/middleware/loggermw/logger.go
+++ b/pkg/middleware/loggermw/logger.go
@@ -59,8 +59,9 @@ func (l *loggerImpl) Middleware() web.Middleware {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 
-			// we have to init the context with the counter here to update the request
+			// we have to init the context with the counter and timer here to update the request
 			r = r.WithContext(log.InitCounter(r.Context()))
+			r = r.WithContext(log.InitDBQueryTimer(r.Context()))
 			// put the start time on context so we can measure it later.
 			r = r.WithContext(log.InitstartTime(r.Context(), time.Now()))
 


### PR DESCRIPTION
Fix bug where `db_query_time` in request logs was always 0. `IncDBQueryTimer` was calling `InitCounter(ctx)` instead of `InitDBQueryTimer(ctx)` when the context wasn't initialized. This set the wrong context key, causing the timer not to work.  