### PR TITLE
Scenes: Enable scenes with dashboardNewLayouts feature toggle

### DIFF
--- a/public/app/core/components/AppChrome/TopBar/useChromeHeaderHeight.ts
+++ b/public/app/core/components/AppChrome/TopBar/useChromeHeaderHeight.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { config, useScopes } from '@grafana/runtime';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
+import { isDashboardSceneEnabled } from 'app/features/dashboard-scene/utils/utils';
 
 import { AppChromeState } from '../AppChromeService';
 import { useExtensionSidebarContext } from '../ExtensionSidebar/ExtensionSidebarProvider';
@@ -59,7 +60,7 @@ function getHeaderLevelsGivenState(
   // We have actions
   // If mega menu docked always use two levels
   // If scenes disabled always use two levels (mainly because of the time range picker)
-  if (chromeState.megaMenuDocked || !config.featureToggles.dashboardScene) {
+  if (chromeState.megaMenuDocked || !isDashboardSceneEnabled()) {
     return 2;
   }
 

--- a/public/app/features/dashboard-scene/utils/utils.test.ts
+++ b/public/app/features/dashboard-scene/utils/utils.test.ts
@@ -1,6 +1,14 @@
+import { config } from '@grafana/runtime';
 import { Dashboard, Panel, RowPanel } from '@grafana/schema';
 
-import { isValidLibraryPanelRef, hasLibraryPanelsInV1Dashboard } from './utils';
+import {
+  isDashboardSceneEnabled,
+  isDashboardSceneForViewersEnabled,
+  isDashboardSceneSoloEnabled,
+  isPublicDashboardsSceneEnabled,
+  isValidLibraryPanelRef,
+  hasLibraryPanelsInV1Dashboard,
+} from './utils';
 
 describe('utils', () => {
   describe('isValidLibraryPanelRef', () => {
@@ -368,5 +376,77 @@ describe('utils', () => {
 
       expect(hasLibraryPanelsInV1Dashboard(dashboard)).toBe(true);
     });
+  });
+
+  describe('isDashboardSceneEnabled', () => {
+    it.each([
+      { dashboardScene: true, dashboardNewLayouts: false, expected: true },
+      { dashboardScene: false, dashboardNewLayouts: true, expected: true },
+      { dashboardScene: true, dashboardNewLayouts: true, expected: true },
+      { dashboardScene: false, dashboardNewLayouts: false, expected: false },
+    ])(
+      'should return $expected when dashboardScene=$dashboardScene and dashboardNewLayouts=$dashboardNewLayouts',
+      ({ dashboardScene, dashboardNewLayouts, expected }) => {
+        config.featureToggles = {
+          dashboardScene,
+          dashboardNewLayouts,
+        };
+        expect(isDashboardSceneEnabled()).toBe(expected);
+      }
+    );
+  });
+
+  describe('isPublicDashboardsSceneEnabled', () => {
+    it.each([
+      { publicDashboardsScene: true, dashboardNewLayouts: false, expected: true },
+      { publicDashboardsScene: false, dashboardNewLayouts: true, expected: true },
+      { publicDashboardsScene: true, dashboardNewLayouts: true, expected: true },
+      { publicDashboardsScene: false, dashboardNewLayouts: false, expected: false },
+    ])(
+      'should return $expected when publicDashboardsScene=$publicDashboardsScene and dashboardNewLayouts=$dashboardNewLayouts',
+      ({ publicDashboardsScene, dashboardNewLayouts, expected }) => {
+        config.featureToggles = {
+          publicDashboardsScene,
+          dashboardNewLayouts,
+        };
+        expect(isPublicDashboardsSceneEnabled()).toBe(expected);
+      }
+    );
+  });
+
+  describe('isDashboardSceneForViewersEnabled', () => {
+    it.each([
+      { dashboardSceneForViewers: true, dashboardNewLayouts: false, expected: true },
+      { dashboardSceneForViewers: false, dashboardNewLayouts: true, expected: true },
+      { dashboardSceneForViewers: true, dashboardNewLayouts: true, expected: true },
+      { dashboardSceneForViewers: false, dashboardNewLayouts: false, expected: false },
+    ])(
+      'should return $expected when dashboardSceneForViewers=$dashboardSceneForViewers and dashboardNewLayouts=$dashboardNewLayouts',
+      ({ dashboardSceneForViewers, dashboardNewLayouts, expected }) => {
+        config.featureToggles = {
+          dashboardSceneForViewers,
+          dashboardNewLayouts,
+        };
+        expect(isDashboardSceneForViewersEnabled()).toBe(expected);
+      }
+    );
+  });
+
+  describe('isDashboardSceneSoloEnabled', () => {
+    it.each([
+      { dashboardSceneSolo: true, dashboardNewLayouts: false, expected: true },
+      { dashboardSceneSolo: false, dashboardNewLayouts: true, expected: true },
+      { dashboardSceneSolo: true, dashboardNewLayouts: true, expected: true },
+      { dashboardSceneSolo: false, dashboardNewLayouts: false, expected: false },
+    ])(
+      'should return $expected when dashboardSceneSolo=$dashboardSceneSolo and dashboardNewLayouts=$dashboardNewLayouts',
+      ({ dashboardSceneSolo, dashboardNewLayouts, expected }) => {
+        config.featureToggles = {
+          dashboardSceneSolo,
+          dashboardNewLayouts,
+        };
+        expect(isDashboardSceneSoloEnabled()).toBe(expected);
+      }
+    );
   });
 });

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -494,3 +494,19 @@ export function hasActualSaveChanges(dashboard: DashboardScene) {
   const changes = dashboard.getDashboardChanges();
   return !!changes.diffCount;
 }
+
+export function isDashboardSceneEnabled(): boolean {
+  return !!(config.featureToggles.dashboardScene || config.featureToggles.dashboardNewLayouts);
+}
+
+export function isPublicDashboardsSceneEnabled(): boolean {
+  return !!(config.featureToggles.publicDashboardsScene || config.featureToggles.dashboardNewLayouts);
+}
+
+export function isDashboardSceneForViewersEnabled(): boolean {
+  return !!(config.featureToggles.dashboardSceneForViewers || config.featureToggles.dashboardNewLayouts);
+}
+
+export function isDashboardSceneSoloEnabled(): boolean {
+  return !!(config.featureToggles.dashboardSceneSolo || config.featureToggles.dashboardNewLayouts);
+}

--- a/public/app/features/dashboard/api/dashboard_api.test.ts
+++ b/public/app/features/dashboard/api/dashboard_api.test.ts
@@ -56,9 +56,10 @@ describe('DashboardApi', () => {
     });
   });
 
-  describe('when scenes disabled', () => {
+  describe('when scenes and dashboardNewLayouts are disabled', () => {
     beforeEach(() => {
       config.featureToggles.dashboardScene = false;
+      config.featureToggles.dashboardNewLayouts = false;
     });
 
     it('should use legacy api when kubernetesDashboards toggle is disabled', () => {
@@ -80,8 +81,20 @@ describe('DashboardApi', () => {
       expect(getDashboardAPI('v1')).toBeInstanceOf(K8sDashboardAPI);
     });
 
-    it('should use v2 when v2 is passed in the params', () => {
+    it('should throw when v2 is passed in the params', () => {
       expect(() => getDashboardAPI('v2')).toThrow('v2 is not supported for legacy architecture');
+    });
+  });
+
+  describe('when dashboardScene disabled but dashboardNewLayouts enabled', () => {
+    beforeEach(() => {
+      config.featureToggles.dashboardScene = false;
+      config.featureToggles.dashboardNewLayouts = true;
+    });
+
+    it('should use v2 when v2 is passed in the params', () => {
+      config.featureToggles.kubernetesDashboards = true;
+      expect(getDashboardAPI('v2')).toBeInstanceOf(K8sDashboardV2API);
     });
   });
 });

--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -25,7 +25,7 @@ export function getDashboardsApiVersion(responseFormat?: 'v1' | 'v2') {
   const forcingOldDashboardArch = locationService.getSearch().get('scenes') === 'false';
 
   // Force legacy API when dashboard scene is disabled or explicitly forced
-  if (!isDashboardSceneEnabled || forcingOldDashboardArch) {
+  if (!isDashboardSceneEnabled() || forcingOldDashboardArch) {
     if (responseFormat === 'v2') {
       throw new Error('v2 is not supported for legacy architecture');
     }

--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -19,14 +19,13 @@ export function isV0V1StoredVersion(version: string | undefined): boolean {
 }
 
 export function getDashboardsApiVersion(responseFormat?: 'v1' | 'v2') {
-  const isDashboardSceneEnabledValue = isDashboardSceneEnabled();
   const isKubernetesDashboardsEnabled = config.featureToggles.kubernetesDashboards;
   const isDashboardNewLayoutsEnabled = config.featureToggles.dashboardNewLayouts;
 
   const forcingOldDashboardArch = locationService.getSearch().get('scenes') === 'false';
 
   // Force legacy API when dashboard scene is disabled or explicitly forced
-  if (!isDashboardSceneEnabledValue || forcingOldDashboardArch) {
+  if (!isDashboardSceneEnabled || forcingOldDashboardArch) {
     if (responseFormat === 'v2') {
       throw new Error('v2 is not supported for legacy architecture');
     }

--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -3,6 +3,7 @@ import { Dashboard } from '@grafana/schema/dist/esm/index.gen';
 import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { Status } from '@grafana/schema/src/schema/dashboard/v2';
 import { Resource } from 'app/features/apiserver/types';
+import { isDashboardSceneEnabled } from 'app/features/dashboard-scene/utils/utils';
 import { DashboardDataDTO, DashboardDTO } from 'app/types/dashboard';
 
 import { SaveDashboardCommand } from '../components/SaveDashboard/types';
@@ -18,14 +19,14 @@ export function isV0V1StoredVersion(version: string | undefined): boolean {
 }
 
 export function getDashboardsApiVersion(responseFormat?: 'v1' | 'v2') {
-  const isDashboardSceneEnabled = config.featureToggles.dashboardScene;
+  const isDashboardSceneEnabledValue = isDashboardSceneEnabled();
   const isKubernetesDashboardsEnabled = config.featureToggles.kubernetesDashboards;
   const isDashboardNewLayoutsEnabled = config.featureToggles.dashboardNewLayouts;
 
   const forcingOldDashboardArch = locationService.getSearch().get('scenes') === 'false';
 
   // Force legacy API when dashboard scene is disabled or explicitly forced
-  if (!isDashboardSceneEnabled || forcingOldDashboardArch) {
+  if (!isDashboardSceneEnabledValue || forcingOldDashboardArch) {
     if (responseFormat === 'v2') {
       throw new Error('v2 is not supported for legacy architecture');
     }

--- a/public/app/features/dashboard/containers/DashboardPageProxy.tsx
+++ b/public/app/features/dashboard/containers/DashboardPageProxy.tsx
@@ -1,7 +1,6 @@
 import { useLocation, useParams } from 'react-router-dom-v5-compat';
 import { useAsync } from 'react-use';
 
-
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import DashboardScenePage from 'app/features/dashboard-scene/pages/DashboardScenePage';
 import { getDashboardScenePageStateManager } from 'app/features/dashboard-scene/pages/DashboardScenePageStateManager';

--- a/public/app/features/dashboard/containers/DashboardPageProxy.tsx
+++ b/public/app/features/dashboard/containers/DashboardPageProxy.tsx
@@ -1,7 +1,7 @@
 import { useLocation, useParams } from 'react-router-dom-v5-compat';
 import { useAsync } from 'react-use';
 
-import { config } from '@grafana/runtime';
+
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import DashboardScenePage from 'app/features/dashboard-scene/pages/DashboardScenePage';
 import { getDashboardScenePageStateManager } from 'app/features/dashboard-scene/pages/DashboardScenePageStateManager';

--- a/public/app/features/dashboard/containers/DashboardPageProxy.tsx
+++ b/public/app/features/dashboard/containers/DashboardPageProxy.tsx
@@ -7,6 +7,7 @@ import DashboardScenePage from 'app/features/dashboard-scene/pages/DashboardScen
 import { getDashboardScenePageStateManager } from 'app/features/dashboard-scene/pages/DashboardScenePageStateManager';
 import { DashboardRoutes } from 'app/types/dashboard';
 
+import { isDashboardSceneEnabled, isDashboardSceneForViewersEnabled } from '../../dashboard-scene/utils/utils';
 import { isDashboardV2Resource } from '../api/utils';
 
 import DashboardPage, { DashboardPageParams } from './DashboardPage';
@@ -27,7 +28,7 @@ function DashboardPageProxy(props: DashboardPageProxyProps) {
   const location = useLocation();
   const stateManager = getDashboardScenePageStateManager();
 
-  if (forceScenes || (config.featureToggles.dashboardScene && !forceOld)) {
+  if (forceScenes || (isDashboardSceneEnabled() && !forceOld)) {
     return <DashboardScenePage {...props} />;
   }
 
@@ -75,7 +76,7 @@ function DashboardPageProxy(props: DashboardPageProxyProps) {
     return null;
   }
 
-  if (!config.featureToggles.dashboardSceneForViewers) {
+  if (!isDashboardSceneForViewersEnabled()) {
     return <DashboardPage {...props} params={params} location={location} />;
   }
 

--- a/public/app/features/dashboard/containers/PublicDashboardPageProxy.tsx
+++ b/public/app/features/dashboard/containers/PublicDashboardPageProxy.tsx
@@ -1,13 +1,12 @@
-import { config } from '@grafana/runtime';
-
 import { PublicDashboardScenePage } from '../../dashboard-scene/pages/PublicDashboardScenePage';
+import { isPublicDashboardsSceneEnabled } from '../../dashboard-scene/utils/utils';
 
 import PublicDashboardPage, { type Props } from './PublicDashboardPage';
 
 export type PublicDashboardPageProxyProps = Props;
 
 function PublicDashboardPageProxy(props: PublicDashboardPageProxyProps) {
-  if (config.featureToggles.publicDashboardsScene) {
+  if (isPublicDashboardsSceneEnabled()) {
     return <PublicDashboardScenePage {...props} />;
   }
 

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -24,6 +24,7 @@ import { DashboardRoutes } from 'app/types/dashboard';
 import { SafeDynamicImport } from '../core/components/DynamicImports/SafeDynamicImport';
 import { RouteDescriptor } from '../core/navigation/types';
 import { getPublicDashboardRoutes } from '../features/dashboard/routes';
+import { isDashboardSceneSoloEnabled } from '../features/dashboard-scene/utils/utils';
 import { getProvisioningRoutes } from '../features/provisioning/utils/routes';
 
 const isDevEnv = config.buildInfo.env === 'development';
@@ -99,7 +100,7 @@ export function getAppRoutes(): RouteDescriptor[] {
       routeName: DashboardRoutes.Normal,
       chromeless: true,
       component: SafeDynamicImport(() =>
-        config.featureToggles.dashboardSceneSolo
+        isDashboardSceneSoloEnabled()
           ? import(/* webpackChunkName: "SoloPanelPage" */ '../features/dashboard-scene/solo/SoloPanelPage')
           : import(/* webpackChunkName: "SoloPanelPageOld" */ '../features/dashboard/containers/SoloPanelPage')
       ),
@@ -110,7 +111,7 @@ export function getAppRoutes(): RouteDescriptor[] {
       routeName: DashboardRoutes.Normal,
       chromeless: true,
       component: SafeDynamicImport(() =>
-        config.featureToggles.dashboardSceneSolo
+        isDashboardSceneSoloEnabled()
           ? import(/* webpackChunkName: "SoloPanelPage" */ '../features/dashboard-scene/solo/SoloPanelPage')
           : import(/* webpackChunkName: "SoloPanelPageOld" */ '../features/dashboard/containers/SoloPanelPage')
       ),


### PR DESCRIPTION
Alternative to #116806

When `dashboardNewLayouts` is enabled, the related scene feature flags (`dashboardScene`, `publicDashboardsScene`, `dashboardSceneForViewers`, `dashboardSceneSolo`) should also be enabled to ensure because dynamic dashboard cannot work without scenes.

*The simplest solution*

Created helper functions in `dashboard-scene/utils/utils.ts` that check both the individual flag and `dashboardNewLayouts`. Updated all components to use these helpers instead of directly checking feature flags.

This is a better alternative than not enabling DD if Scenes is not enabled, because Scenes is enabled by default and we are in progress to have everyone on Scenes soon. Also, it is simpler from a code perspective.

*How to test*

1. Enable `dashboardNewLayouts` feature flag
2. Verify dashboards render using scenes architecture
3. Verify public dashboards use scenes
4. Verify solo panel routes use scenes
5. Verify header height calculation uses scenes logic

Fixes #116424