### PR TITLE
Alerting: Make saved search name clickable to apply search

### DIFF
--- a/e2e-playwright/alerting-suite/saved-searches.spec.ts
+++ b/e2e-playwright/alerting-suite/saved-searches.spec.ts
@@ -190,9 +190,9 @@ test.describe(
       await ui.searchInput(page).clear();
       await ui.searchInput(page).press('Enter');
 
-      // Apply the saved search
+      // Apply the saved search by clicking the search name
       await ui.savedSearchesButton(page).click();
-      await page.getByRole('button', { name: /apply.*search.*firing rules/i }).click();
+      await page.getByRole('button', { name: 'Firing Rules' }).click();
 
       // Verify the search input is updated
       await expect(ui.searchInput(page)).toHaveValue('state:firing');

--- a/e2e-playwright/alerting-suite/saved-searches.spec.ts
+++ b/e2e-playwright/alerting-suite/saved-searches.spec.ts
@@ -190,9 +190,9 @@ test.describe(
       await ui.searchInput(page).clear();
       await ui.searchInput(page).press('Enter');
 
-      // Apply the saved search by clicking the search name
+      // Apply the saved search by clicking the search name link
       await ui.savedSearchesButton(page).click();
-      await page.getByRole('button', { name: 'Firing Rules' }).click();
+      await page.getByRole('link', { name: 'Firing Rules' }).click();
 
       // Verify the search input is updated
       await expect(ui.searchInput(page)).toHaveValue('state:firing');

--- a/public/app/features/alerting/unified/rule-list/filter/SavedSearchItem.tsx
+++ b/public/app/features/alerting/unified/rule-list/filter/SavedSearchItem.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Dropdown, Icon, IconButton, Menu, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Dropdown, Icon, IconButton, Menu, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
 
 import { InlineRenameInput } from './InlineRenameInput';
 import { SavedSearch } from './savedSearchesSchema';
@@ -13,6 +13,8 @@ import { SavedSearch } from './savedSearchesSchema';
 
 export interface SavedSearchItemProps {
   search: SavedSearch;
+  /** URL to navigate to when clicking the search name */
+  href: string;
   isRenaming: boolean;
   isDeleting: boolean;
   isDisabled: boolean;
@@ -31,6 +33,7 @@ export interface SavedSearchItemProps {
 
 export function SavedSearchItem({
   search,
+  href,
   isRenaming,
   isDeleting,
   isDisabled,
@@ -107,9 +110,15 @@ export function SavedSearchItem({
       <Stack direction="row" alignItems="center" gap={1} wrap={false}>
         {/* Name and default indicator */}
         <Stack direction="row" alignItems="center" gap={0.5} flex={1}>
-          <button type="button" className={styles.clickableName} onClick={onApply} disabled={isDisabled}>
-            <Text truncate>{search.name}</Text>
-          </button>
+          {isDisabled ? (
+            <Text truncate color="disabled">
+              {search.name}
+            </Text>
+          ) : (
+            <TextLink href={href} color="primary" inline={false} onClick={onApply}>
+              {search.name}
+            </TextLink>
+          )}
           {search.isDefault && (
             <Icon
               name="favorite"
@@ -210,27 +219,6 @@ function getStyles(theme: GrafanaTheme2) {
     actionMenuWrapper: css({
       display: 'flex',
       alignItems: 'center',
-    }),
-    clickableName: css({
-      // Reset button styles
-      background: 'none',
-      border: 'none',
-      padding: 0,
-      font: 'inherit',
-      color: 'inherit',
-      textAlign: 'left',
-      cursor: 'pointer',
-      // Truncation support
-      minWidth: 0,
-      maxWidth: '100%',
-      // Hover effect
-      '&:hover': {
-        textDecoration: 'underline',
-      },
-      '&:disabled': {
-        cursor: 'not-allowed',
-        opacity: 0.6,
-      },
     }),
   };
 }

--- a/public/app/features/alerting/unified/rule-list/filter/SavedSearchItem.tsx
+++ b/public/app/features/alerting/unified/rule-list/filter/SavedSearchItem.tsx
@@ -107,7 +107,9 @@ export function SavedSearchItem({
       <Stack direction="row" alignItems="center" gap={1} wrap={false}>
         {/* Name and default indicator */}
         <Stack direction="row" alignItems="center" gap={0.5} flex={1}>
-          <Text truncate>{search.name}</Text>
+          <button type="button" className={styles.clickableName} onClick={onApply} disabled={isDisabled}>
+            <Text truncate>{search.name}</Text>
+          </button>
           {search.isDefault && (
             <Icon
               name="favorite"
@@ -117,18 +119,6 @@ export function SavedSearchItem({
             />
           )}
         </Stack>
-
-        {/* Apply button (magnifying glass) */}
-        <IconButton
-          name="search"
-          tooltip={t('alerting.saved-searches.apply-tooltip', 'Apply search "{{name}}"', {
-            name: search.name,
-          })}
-          onClick={onApply}
-          size="md"
-          variant="secondary"
-          disabled={isDisabled}
-        />
 
         {/* Action menu - stop propagation to prevent parent Dropdown from closing */}
         {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
@@ -220,6 +210,27 @@ function getStyles(theme: GrafanaTheme2) {
     actionMenuWrapper: css({
       display: 'flex',
       alignItems: 'center',
+    }),
+    clickableName: css({
+      // Reset button styles
+      background: 'none',
+      border: 'none',
+      padding: 0,
+      font: 'inherit',
+      color: 'inherit',
+      textAlign: 'left',
+      cursor: 'pointer',
+      // Truncation support
+      minWidth: 0,
+      maxWidth: '100%',
+      // Hover effect
+      '&:hover': {
+        textDecoration: 'underline',
+      },
+      '&:disabled': {
+        cursor: 'not-allowed',
+        opacity: 0.6,
+      },
     }),
   };
 }

--- a/public/app/features/alerting/unified/rule-list/filter/SavedSearches.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/filter/SavedSearches.test.tsx
@@ -19,7 +19,6 @@ const ui = {
   saveInput: byPlaceholderText(/enter a name/i),
   // Action buttons
   cancelButton: byRole('button', { name: /cancel/i }),
-  applyButtons: byRole('button', { name: /apply search/i }),
   actionMenuButtons: byRole('button', { name: /actions/i }),
   deleteButton: byRole('button', { name: /delete/i }),
   // Menu items (using byRole for proper accessibility testing)
@@ -88,12 +87,12 @@ describe('SavedSearches', () => {
 
       await user.click(ui.savedSearchesButton.get());
 
-      // Verify searches are displayed
-      const applyButtons = await ui.applyButtons.findAll();
-      expect(applyButtons).toHaveLength(3);
+      // Verify searches are displayed by checking for clickable name buttons
+      expect(await screen.findByRole('button', { name: 'Default Search' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Critical Alerts' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'My Firing Rules' })).toBeInTheDocument();
 
       // Verify the default search has a star icon
-      expect(screen.getByText('Default Search')).toBeInTheDocument();
       expect(screen.getByTitle('Default search')).toBeInTheDocument();
     });
   });
@@ -174,13 +173,12 @@ describe('SavedSearches', () => {
   });
 
   describe('Applying a search', () => {
-    it('applies the selected search and closes dropdown', async () => {
+    it('applies the selected search when clicking the search name', async () => {
       const { user } = render(<SavedSearches {...defaultProps} />);
 
       await user.click(ui.savedSearchesButton.get());
-      const applyButtons = await ui.applyButtons.findAll();
-      // Click the apply button for "My Firing Rules" (third in list: Default, Critical, My Firing)
-      await user.click(applyButtons[2]);
+      // Click directly on the search name "My Firing Rules"
+      await user.click(await screen.findByRole('button', { name: 'My Firing Rules' }));
 
       expect(defaultProps.onApply).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/public/app/features/alerting/unified/rule-list/filter/SavedSearches.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/filter/SavedSearches.test.tsx
@@ -87,10 +87,10 @@ describe('SavedSearches', () => {
 
       await user.click(ui.savedSearchesButton.get());
 
-      // Verify searches are displayed by checking for clickable name buttons
-      expect(await screen.findByRole('button', { name: 'Default Search' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Critical Alerts' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'My Firing Rules' })).toBeInTheDocument();
+      // Verify searches are displayed by checking for clickable name links
+      expect(await screen.findByRole('link', { name: 'Default Search' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Critical Alerts' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'My Firing Rules' })).toBeInTheDocument();
 
       // Verify the default search has a star icon
       expect(screen.getByTitle('Default search')).toBeInTheDocument();
@@ -177,8 +177,8 @@ describe('SavedSearches', () => {
       const { user } = render(<SavedSearches {...defaultProps} />);
 
       await user.click(ui.savedSearchesButton.get());
-      // Click directly on the search name "My Firing Rules"
-      await user.click(await screen.findByRole('button', { name: 'My Firing Rules' }));
+      // Click directly on the search name link "My Firing Rules"
+      await user.click(await screen.findByRole('link', { name: 'My Firing Rules' }));
 
       expect(defaultProps.onApply).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/public/app/features/alerting/unified/rule-list/filter/SavedSearches.tsx
+++ b/public/app/features/alerting/unified/rule-list/filter/SavedSearches.tsx
@@ -490,10 +490,13 @@ function ListMode({
               // Item is disabled if any action is active and this item is not the one being acted upon
               const isItemDisabled = isActionActive && !isRenaming && !isDeleting;
 
+              const href = `/alerting/list?search=${encodeURIComponent(search.query)}`;
+
               return (
                 <SavedSearchItem
                   key={search.id}
                   search={search}
+                  href={href}
                   isRenaming={isRenaming}
                   isDeleting={isDeleting}
                   isDisabled={isItemDisabled}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2697,7 +2697,6 @@
     },
     "saved-searches": {
       "actions-aria-label": "Actions",
-      "apply-tooltip": "Apply search \"{{name}}\"",
       "button-label": "Saved searches",
       "cancel": "Cancel",
       "default-indicator": "Default search",


### PR DESCRIPTION
Replace the magnifying glass icon with a clickable name for applying saved searches.
The name now underlines on hover and triggers the apply action when clicked, matching the Dashboard list page interaction pattern.


https://github.com/user-attachments/assets/87aac546-5690-4840-a7bf-541c4c0aea4b

