### PR TITLE
Alerting: Validate provenance consistency before creating or editing rules

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -2110,9 +2110,6 @@ func createTestEnv(t *testing.T, testConfig string) testEnvironment {
 	quotas := &provisioning.MockQuotaChecker{}
 	quotas.EXPECT().LimitOK()
 	xact := &provisioning.NopTransactionManager{}
-	prov := &provisioning.MockProvisioningStore{}
-	prov.EXPECT().SaveSucceeds()
-	prov.EXPECT().GetReturns(models.ProvenanceNone)
 
 	dashboardService := dashboards.NewFakeDashboardService(t)
 	dashboardService.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Return(&dashboards.Dashboard{
@@ -2193,7 +2190,7 @@ func createTestEnv(t *testing.T, testConfig string) testEnvironment {
 		folderService:    folderService,
 		dashboardService: dashboardService,
 		xact:             xact,
-		prov:             prov,
+		prov:             store,
 		quotas:           quotas,
 		ac:               ac,
 		user:             user,

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -290,8 +290,8 @@ func (service *AlertRuleService) CreateAlertRule(ctx context.Context, user ident
 		rule.IntervalSeconds = interval
 	}
 
-	// Pass empty string for CREATE - we're adding a new rule, not updating an existing one.
-	if err := validation.ValidateProvisioningConsistency(ctx, service.provenanceStore, rule.OrgID, provenance, delta.AffectedGroups, ""); err != nil {
+	// Validate that adding this rule won't create a mixed-provenance group.
+	if err := validation.ValidateProvisioningConsistencyCreate(ctx, service.provenanceStore, rule.OrgID, provenance, delta.AffectedGroups); err != nil {
 		return models.AlertRule{}, err
 	}
 	err = rule.SetDashboardAndPanelFromAnnotations()
@@ -790,9 +790,8 @@ func (service *AlertRuleService) UpdateAlertRule(ctx context.Context, user ident
 		}
 	}
 
-	// Validate provenance consistency to prevent mixed-provenance groups.
-	// Pass rule UID for UPDATE - allows changing provenance if it's the only rule in the group.
-	if err := validation.ValidateProvisioningConsistency(ctx, service.provenanceStore, rule.OrgID, effectiveProvenance, deltaForValidation.AffectedGroups, rule.UID); err != nil {
+	// Validate that updating this rule won't create a mixed-provenance group.
+	if err := validation.ValidateProvisioningConsistencyUpdate(ctx, service.provenanceStore, rule.OrgID, effectiveProvenance, deltaForValidation.AffectedGroups, rule.UID); err != nil {
 		return models.AlertRule{}, err
 	}
 

--- a/pkg/services/ngalert/provisioning/testing.go
+++ b/pkg/services/ngalert/provisioning/testing.go
@@ -74,6 +74,15 @@ func (n *NopTransactionManager) InTransaction(ctx context.Context, work func(ctx
 func (m *MockProvisioningStore_Expecter) GetReturns(p models.Provenance) *MockProvisioningStore_Expecter {
 	m.GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(p, nil)
 	m.GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+	m.GetProvenancesByUIDs(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, orgID int64, resourceType string, uids []string) (map[string]models.Provenance, error) {
+			// Return a map with all requested UIDs having the same provenance.
+			result := make(map[string]models.Provenance, len(uids))
+			for _, uid := range uids {
+				result[uid] = p
+			}
+			return result, nil
+		})
 	return m
 }
 

--- a/pkg/services/ngalert/provisioning/validation/provenance_consistency.go
+++ b/pkg/services/ngalert/provisioning/validation/provenance_consistency.go
@@ -1,0 +1,112 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+// provenanceStore defines the interface for getting provenance information.
+// This matches the GetProvenances method from the ProvisioningStore interface in the parent package.
+type provenanceStore interface {
+	GetProvenances(ctx context.Context, orgID int64, resourceType string) (map[string]models.Provenance, error)
+}
+
+// ValidateProvisioningConsistency checks that adding/updating a rule with targetProvenance to the affected groups
+// would not create a mixed-provenance group (provisioned and non-provisioned rules in the same group).
+//
+// This prevents the scenario where provisioned rules are added to groups with non-provisioned rules,
+// which would lock the entire group from being editable in the UI.
+//
+// The ruleUID parameter should be:
+// - Empty string ("") for CREATE operations (adding a new rule)
+// - The rule's UID for UPDATE operations (changing an existing rule)
+//
+// Rules:
+// - If targetProvenance != ProvenanceNone: no OTHER existing rule in the group can have ProvenanceNone
+// - If targetProvenance == ProvenanceNone: no OTHER existing rule in the group can have provenance != ProvenanceNone
+// - Empty groups (no existing rules) are always allowed
+// - Single-rule groups being updated are allowed (can change the group's provenance entirely)
+func ValidateProvisioningConsistency(
+	ctx context.Context,
+	store provenanceStore,
+	orgID int64,
+	targetProvenance models.Provenance,
+	affectedGroups map[models.AlertRuleGroupKey]models.RulesGroup,
+	ruleUID string,
+) error {
+	if len(affectedGroups) == 0 {
+		return nil
+	}
+
+	// Get all provenances for the organization.
+	provenances, err := store.GetProvenances(ctx, orgID, (&models.AlertRule{}).ResourceType())
+	if err != nil {
+		return fmt.Errorf("failed to get provenances: %w", err)
+	}
+
+	// Check each affected group for conflicts
+	var conflictingGroups []string
+	for groupKey, rules := range affectedGroups {
+		// Special case: if updating a rule and it's the only rule in the group, allow changing provenance
+		if ruleUID != "" && len(rules) == 1 && rules[0] != nil && rules[0].UID == ruleUID {
+			continue
+		}
+
+		if hasProvenanceConflict(provenances, rules, targetProvenance, ruleUID) {
+			// Format the group identifier as orgID/namespace/group
+			conflictingGroups = append(conflictingGroups, fmt.Sprintf("%d/%s/%s", groupKey.OrgID, groupKey.NamespaceUID, groupKey.RuleGroup))
+		}
+	}
+
+	if len(conflictingGroups) > 0 {
+		// Sort for consistent error messages
+		sort.Strings(conflictingGroups)
+
+		var operation string
+		if targetProvenance != models.ProvenanceNone {
+			operation = fmt.Sprintf("cannot add provisioned (%s) rule to group containing non-provisioned rules", targetProvenance)
+		} else {
+			operation = "cannot add non-provisioned rule to group containing provisioned rules"
+		}
+
+		return fmt.Errorf("%w: %s [%s]", models.ErrAlertRuleFailedValidation, operation, strings.Join(conflictingGroups, ", "))
+	}
+
+	return nil
+}
+
+// hasProvenanceConflict checks if adding/updating a rule with targetProvenance would conflict with existing rules.
+// The ruleUID parameter (if provided) identifies the rule being updated, which should be excluded from conflict checking.
+func hasProvenanceConflict(provenances map[string]models.Provenance, rules []*models.AlertRule, targetProvenance models.Provenance, ruleUID string) bool {
+	for _, rule := range rules {
+		if rule == nil {
+			continue
+		}
+
+		// Skip the rule being updated when checking for conflicts in UPDATE operations
+		if ruleUID != "" && rule.UID == ruleUID {
+			continue
+		}
+
+		existingProvenance, ok := provenances[rule.UID]
+		if !ok {
+			existingProvenance = models.ProvenanceNone
+		}
+
+		// Check for conflict:
+		// 1. If we're adding a provisioned rule (targetProvenance != None) and existing rule is non-provisioned (ProvenanceNone)
+		// 2. If we're adding a non-provisioned rule (targetProvenance == None) and existing rule is provisioned (!= ProvenanceNone)
+		if targetProvenance != models.ProvenanceNone && existingProvenance == models.ProvenanceNone {
+			return true
+		}
+		if targetProvenance == models.ProvenanceNone && existingProvenance != models.ProvenanceNone {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/services/ngalert/provisioning/validation/provenance_consistency.go
+++ b/pkg/services/ngalert/provisioning/validation/provenance_consistency.go
@@ -15,23 +15,23 @@ type provenanceStore interface {
 	GetProvenancesByUIDs(ctx context.Context, orgID int64, resourceType string, uids []string) (map[string]models.Provenance, error)
 }
 
-// ValidateProvisioningConsistencyCreate validates that creating a new rule with targetProvenance
+// ValidateRuleProvenanceInGroupCreate validates that creating a new rule with targetProvenance
 // would not create a mixed-provenance group (provisioned and non-provisioned rules in the same group).
 // Use this function when adding a new rule to a group.
-func ValidateProvisioningConsistencyCreate(
+func ValidateRuleProvenanceInGroupCreate(
 	ctx context.Context,
 	store provenanceStore,
 	orgID int64,
 	targetProvenance models.Provenance,
 	affectedGroups map[models.AlertRuleGroupKey]models.RulesGroup,
 ) error {
-	return validateProvisioningConsistency(ctx, store, orgID, targetProvenance, affectedGroups, "")
+	return validateRuleProvenanceInGroup(ctx, store, orgID, targetProvenance, affectedGroups, "")
 }
 
-// ValidateProvisioningConsistencyUpdate validates that updating an existing rule with targetProvenance
+// ValidateRuleProvenanceInGroupUpdate validates that updating an existing rule with targetProvenance
 // would not create a mixed-provenance group (provisioned and non-provisioned rules in the same group).
 // Use this function when modifying an existing rule. Single-rule groups are allowed to change provenance.
-func ValidateProvisioningConsistencyUpdate(
+func ValidateRuleProvenanceInGroupUpdate(
 	ctx context.Context,
 	store provenanceStore,
 	orgID int64,
@@ -42,10 +42,10 @@ func ValidateProvisioningConsistencyUpdate(
 	if ruleUID == "" {
 		return fmt.Errorf("ruleUID cannot be empty for update operations")
 	}
-	return validateProvisioningConsistency(ctx, store, orgID, targetProvenance, affectedGroups, ruleUID)
+	return validateRuleProvenanceInGroup(ctx, store, orgID, targetProvenance, affectedGroups, ruleUID)
 }
 
-// validateProvisioningConsistency checks that adding/updating a rule with targetProvenance to the affected groups
+// validateRuleProvenanceInGroup checks that adding/updating a rule with targetProvenance to the affected groups
 // would not create a mixed-provenance group (provisioned and non-provisioned rules in the same group).
 //
 // This prevents the scenario where provisioned rules are added to groups with non-provisioned rules,
@@ -60,7 +60,7 @@ func ValidateProvisioningConsistencyUpdate(
 // - If targetProvenance == ProvenanceNone: no OTHER existing rule in the group can have provenance != ProvenanceNone
 // - Empty groups (no existing rules) are always allowed
 // - Single-rule groups being updated are allowed (can change the group's provenance entirely)
-func validateProvisioningConsistency(
+func validateRuleProvenanceInGroup(
 	ctx context.Context,
 	store provenanceStore,
 	orgID int64,

--- a/pkg/services/ngalert/provisioning/validation/provenance_consistency_test.go
+++ b/pkg/services/ngalert/provisioning/validation/provenance_consistency_test.go
@@ -1,0 +1,280 @@
+package validation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+// mockProvenanceStore implements the provenanceStore interface for testing.
+type mockProvenanceStore struct {
+	provenances map[string]models.Provenance
+	err         error
+}
+
+func (m *mockProvenanceStore) GetProvenances(ctx context.Context, orgID int64, resourceType string) (map[string]models.Provenance, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.provenances, nil
+}
+
+func TestValidateProvisioningConsistency(t *testing.T) {
+	ctx := context.Background()
+	orgID := int64(1)
+	groupKey := models.AlertRuleGroupKey{
+		OrgID:        orgID,
+		NamespaceUID: "test-namespace",
+		RuleGroup:    "test-group",
+	}
+
+	makeRule := func(uid string) *models.AlertRule {
+		return &models.AlertRule{
+			UID:          uid,
+			OrgID:        orgID,
+			NamespaceUID: groupKey.NamespaceUID,
+			RuleGroup:    groupKey.RuleGroup,
+		}
+	}
+
+	t.Run("empty affected groups - should allow", func(t *testing.T) {
+		store := &mockProvenanceStore{provenances: map[string]models.Provenance{}}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{}
+
+		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		require.NoError(t, err)
+	})
+
+	t.Run("empty group (no existing rules) - should allow any provenance", func(t *testing.T) {
+		store := &mockProvenanceStore{provenances: map[string]models.Provenance{}}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {},
+		}
+
+		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		require.NoError(t, err)
+	})
+
+	t.Run("adding provisioned rule to group with non-provisioned rules - should reject", func(t *testing.T) {
+		store := &mockProvenanceStore{
+			provenances: map[string]models.Provenance{
+				"rule-1": models.ProvenanceNone,
+				"rule-2": models.ProvenanceNone,
+			},
+		}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {makeRule("rule-1"), makeRule("rule-2")},
+		}
+
+		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, models.ErrAlertRuleFailedValidation)
+		assert.Contains(t, err.Error(), "cannot add provisioned (api) rule to group containing non-provisioned rules")
+		assert.Contains(t, err.Error(), "1/test-namespace/test-group")
+	})
+
+	t.Run("adding non-provisioned rule to group with provisioned rules - should reject", func(t *testing.T) {
+		store := &mockProvenanceStore{
+			provenances: map[string]models.Provenance{
+				"rule-1": models.ProvenanceAPI,
+				"rule-2": models.ProvenanceAPI,
+			},
+		}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {makeRule("rule-1"), makeRule("rule-2")},
+		}
+
+		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceNone, affectedGroups)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, models.ErrAlertRuleFailedValidation)
+		assert.Contains(t, err.Error(), "cannot add non-provisioned rule to group containing provisioned rules")
+		assert.Contains(t, err.Error(), "1/test-namespace/test-group")
+	})
+
+	t.Run("adding provisioned rule to group with provisioned rules - should allow", func(t *testing.T) {
+		store := &mockProvenanceStore{
+			provenances: map[string]models.Provenance{
+				"rule-1": models.ProvenanceAPI,
+				"rule-2": models.ProvenanceFile,
+			},
+		}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {makeRule("rule-1"), makeRule("rule-2")},
+		}
+
+		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		require.NoError(t, err)
+	})
+
+	t.Run("adding non-provisioned rule to group with non-provisioned rules - should allow", func(t *testing.T) {
+		store := &mockProvenanceStore{
+			provenances: map[string]models.Provenance{
+				"rule-1": models.ProvenanceNone,
+				"rule-2": models.ProvenanceNone,
+			},
+		}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {makeRule("rule-1"), makeRule("rule-2")},
+		}
+
+		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceNone, affectedGroups)
+		require.NoError(t, err)
+	})
+
+	t.Run("mixed provenances in different groups - should only reject groups with multiple rules", func(t *testing.T) {
+		groupKey2 := models.AlertRuleGroupKey{
+			OrgID:        orgID,
+			NamespaceUID: "test-namespace",
+			RuleGroup:    "test-group-2",
+		}
+
+		store := &mockProvenanceStore{
+			provenances: map[string]models.Provenance{
+				"rule-1": models.ProvenanceNone, // Single rule - no conflict
+				"rule-2": models.ProvenanceNone, // Multiple rules - conflict!
+				"rule-3": models.ProvenanceAPI,
+			},
+		}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey:  {makeRule("rule-1")},                  // Single rule - should be allowed
+			groupKey2: {makeRule("rule-2"), makeRule("rule-3")}, // Multiple with conflict - should fail
+		}
+
+		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, models.ErrAlertRuleFailedValidation)
+		// group-1 should not be in the error since it has only 1 rule
+		assert.NotContains(t, err.Error(), "test-group\"")
+		// group-2 should be in the error since it has multiple rules with conflict
+		assert.Contains(t, err.Error(), "test-group-2")
+	})
+
+	t.Run("updating single rule in group - should allow changing provenance", func(t *testing.T) {
+		store := &mockProvenanceStore{
+			provenances: map[string]models.Provenance{
+				"rule-1": models.ProvenanceNone,
+			},
+		}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {makeRule("rule-1")},
+		}
+
+		// Single rule in group being UPDATED - should allow changing provenance from None to API
+		err := ValidateProvisioningConsistencyUpdate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups, "rule-1")
+		require.NoError(t, err)
+	})
+
+	t.Run("nil rules in group are skipped", func(t *testing.T) {
+		store := &mockProvenanceStore{
+			provenances: map[string]models.Provenance{
+				"rule-1": models.ProvenanceAPI,
+			},
+		}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {nil, makeRule("rule-1"), nil},
+		}
+
+		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		require.NoError(t, err)
+	})
+
+	t.Run("provenance store error is propagated", func(t *testing.T) {
+		expectedErr := errors.New("database error")
+		store := &mockProvenanceStore{err: expectedErr}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {makeRule("rule-1")},
+		}
+
+		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get provenances")
+	})
+
+	t.Run("different provisioning sources (api, file, converted_prometheus) are compatible", func(t *testing.T) {
+		store := &mockProvenanceStore{
+			provenances: map[string]models.Provenance{
+				"rule-1": models.ProvenanceAPI,
+				"rule-2": models.ProvenanceFile,
+				"rule-3": models.ProvenanceConvertedPrometheus,
+			},
+		}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {makeRule("rule-1"), makeRule("rule-2"), makeRule("rule-3")},
+		}
+
+		// Adding another provisioned rule to a group with mixed provisioned sources should be fine
+		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		require.NoError(t, err)
+	})
+}
+
+func TestHasProvenanceConflict(t *testing.T) {
+	makeRule := func(uid string) *models.AlertRule {
+		return &models.AlertRule{UID: uid}
+	}
+
+	t.Run("no conflict when target and existing are both provisioned", func(t *testing.T) {
+		provenances := map[string]models.Provenance{
+			"rule-1": models.ProvenanceAPI,
+			"rule-2": models.ProvenanceFile,
+		}
+		rules := []*models.AlertRule{makeRule("rule-1"), makeRule("rule-2")}
+
+		conflict := hasProvenanceConflict(provenances, rules, models.ProvenanceAPI, "")
+		assert.False(t, conflict)
+	})
+
+	t.Run("no conflict when target and existing are both non-provisioned", func(t *testing.T) {
+		provenances := map[string]models.Provenance{
+			"rule-1": models.ProvenanceNone,
+			"rule-2": models.ProvenanceNone,
+		}
+		rules := []*models.AlertRule{makeRule("rule-1"), makeRule("rule-2")}
+
+		conflict := hasProvenanceConflict(provenances, rules, models.ProvenanceNone, "")
+		assert.False(t, conflict)
+	})
+
+	t.Run("conflict when adding provisioned to non-provisioned", func(t *testing.T) {
+		provenances := map[string]models.Provenance{
+			"rule-1": models.ProvenanceNone,
+		}
+		rules := []*models.AlertRule{makeRule("rule-1")}
+
+		conflict := hasProvenanceConflict(provenances, rules, models.ProvenanceAPI, "")
+		assert.True(t, conflict)
+	})
+
+	t.Run("conflict when adding non-provisioned to provisioned", func(t *testing.T) {
+		provenances := map[string]models.Provenance{
+			"rule-1": models.ProvenanceAPI,
+		}
+		rules := []*models.AlertRule{makeRule("rule-1")}
+
+		conflict := hasProvenanceConflict(provenances, rules, models.ProvenanceNone, "")
+		assert.True(t, conflict)
+	})
+
+	t.Run("no conflict with empty rules list", func(t *testing.T) {
+		provenances := map[string]models.Provenance{}
+		rules := []*models.AlertRule{}
+
+		conflict := hasProvenanceConflict(provenances, rules, models.ProvenanceAPI, "")
+		assert.False(t, conflict)
+	})
+
+	t.Run("nil rules are skipped", func(t *testing.T) {
+		provenances := map[string]models.Provenance{
+			"rule-1": models.ProvenanceAPI,
+		}
+		rules := []*models.AlertRule{nil, makeRule("rule-1"), nil}
+
+		conflict := hasProvenanceConflict(provenances, rules, models.ProvenanceAPI, "")
+		assert.False(t, conflict)
+	})
+}

--- a/pkg/services/ngalert/provisioning/validation/provenance_consistency_test.go
+++ b/pkg/services/ngalert/provisioning/validation/provenance_consistency_test.go
@@ -17,11 +17,19 @@ type mockProvenanceStore struct {
 	err         error
 }
 
-func (m *mockProvenanceStore) GetProvenances(ctx context.Context, orgID int64, resourceType string) (map[string]models.Provenance, error) {
+func (m *mockProvenanceStore) GetProvenancesByUIDs(ctx context.Context, orgID int64, resourceType string, uids []string) (map[string]models.Provenance, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
-	return m.provenances, nil
+
+	// Filter provenances to only return requested UIDs.
+	result := make(map[string]models.Provenance)
+	for _, uid := range uids {
+		if prov, exists := m.provenances[uid]; exists {
+			result[uid] = prov
+		}
+	}
+	return result, nil
 }
 
 func TestValidateProvisioningConsistency(t *testing.T) {

--- a/pkg/services/ngalert/provisioning/validation/provenance_consistency_test.go
+++ b/pkg/services/ngalert/provisioning/validation/provenance_consistency_test.go
@@ -54,7 +54,7 @@ func TestValidateProvisioningConsistency(t *testing.T) {
 		store := &mockProvenanceStore{provenances: map[string]models.Provenance{}}
 		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{}
 
-		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
 		require.NoError(t, err)
 	})
 
@@ -64,7 +64,7 @@ func TestValidateProvisioningConsistency(t *testing.T) {
 			groupKey: {},
 		}
 
-		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
 		require.NoError(t, err)
 	})
 
@@ -79,7 +79,7 @@ func TestValidateProvisioningConsistency(t *testing.T) {
 			groupKey: {makeRule("rule-1"), makeRule("rule-2")},
 		}
 
-		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, models.ErrAlertRuleFailedValidation)
 		assert.Contains(t, err.Error(), "cannot add provisioned (api) rule to group containing non-provisioned rules")
@@ -97,7 +97,7 @@ func TestValidateProvisioningConsistency(t *testing.T) {
 			groupKey: {makeRule("rule-1"), makeRule("rule-2")},
 		}
 
-		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceNone, affectedGroups)
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceNone, affectedGroups)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, models.ErrAlertRuleFailedValidation)
 		assert.Contains(t, err.Error(), "cannot add non-provisioned rule to group containing provisioned rules")
@@ -115,7 +115,7 @@ func TestValidateProvisioningConsistency(t *testing.T) {
 			groupKey: {makeRule("rule-1"), makeRule("rule-2")},
 		}
 
-		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
 		require.NoError(t, err)
 	})
 
@@ -130,7 +130,7 @@ func TestValidateProvisioningConsistency(t *testing.T) {
 			groupKey: {makeRule("rule-1"), makeRule("rule-2")},
 		}
 
-		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceNone, affectedGroups)
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceNone, affectedGroups)
 		require.NoError(t, err)
 	})
 
@@ -153,7 +153,7 @@ func TestValidateProvisioningConsistency(t *testing.T) {
 			groupKey2: {makeRule("rule-2"), makeRule("rule-3")}, // Multiple with conflict - should fail
 		}
 
-		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, models.ErrAlertRuleFailedValidation)
 		// group-1 should not be in the error since it has only 1 rule
@@ -173,7 +173,7 @@ func TestValidateProvisioningConsistency(t *testing.T) {
 		}
 
 		// Single rule in group being UPDATED - should allow changing provenance from None to API
-		err := ValidateProvisioningConsistencyUpdate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups, "rule-1")
+		err := ValidateRuleProvenanceInGroupUpdate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups, "rule-1")
 		require.NoError(t, err)
 	})
 
@@ -187,7 +187,7 @@ func TestValidateProvisioningConsistency(t *testing.T) {
 			groupKey: {nil, makeRule("rule-1"), nil},
 		}
 
-		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
 		require.NoError(t, err)
 	})
 
@@ -198,7 +198,7 @@ func TestValidateProvisioningConsistency(t *testing.T) {
 			groupKey: {makeRule("rule-1")},
 		}
 
-		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to get provenances")
 	})
@@ -216,7 +216,7 @@ func TestValidateProvisioningConsistency(t *testing.T) {
 		}
 
 		// Adding another provisioned rule to a group with mixed provisioned sources should be fine
-		err := ValidateProvisioningConsistencyCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
 		require.NoError(t, err)
 	})
 }

--- a/pkg/services/ngalert/provisioning/validation/provenance_consistency_test.go
+++ b/pkg/services/ngalert/provisioning/validation/provenance_consistency_test.go
@@ -149,7 +149,7 @@ func TestValidateProvisioningConsistency(t *testing.T) {
 			},
 		}
 		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
-			groupKey:  {makeRule("rule-1")},                  // Single rule - should be allowed
+			groupKey:  {makeRule("rule-1")},                     // Single rule - should be allowed
 			groupKey2: {makeRule("rule-2"), makeRule("rule-3")}, // Multiple with conflict - should fail
 		}
 


### PR DESCRIPTION
This PR fixes a bug where provisioned alert rules could be added to groups containing non-provisioned rules, which would lock the entire group from being editable in the UI.

The fix adds validation to both `CreateAlertRule` and `UpdateAlertRule` endpoints to check for provenance conflicts before allowing operations. If a user tries to add a provisioned rule to a group that has non-provisioned rules, they'll now get a clear error message instead of silently creating a mixed group that becomes locked.