### PR TITLE
Provisioning: return better errors when Connection fields are invalid

### DIFF
--- a/apps/provisioning/pkg/connection/connection.go
+++ b/apps/provisioning/pkg/connection/connection.go
@@ -42,6 +42,8 @@ type TokenConnection interface {
 	TokenCreationTime(ctx context.Context) (time.Time, error)
 	// TokenExpiration returns the underlying token expiration.
 	TokenExpiration(ctx context.Context) (time.Time, error)
+	// TokenValid returns whether the underlying token is valid.
+	TokenValid(ctx context.Context) bool
 	// GenerateConnectionToken generates a connection-level token.
 	// Returns the generated token value.
 	GenerateConnectionToken(ctx context.Context) (common.RawSecureValue, error)

--- a/apps/provisioning/pkg/connection/connection_token_mock.go
+++ b/apps/provisioning/pkg/connection/connection_token_mock.go
@@ -192,6 +192,52 @@ func (_c *MockTokenConnection_TokenExpiration_Call) RunAndReturn(run func(contex
 	return _c
 }
 
+// TokenValid provides a mock function with given fields: ctx
+func (_m *MockTokenConnection) TokenValid(ctx context.Context) bool {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TokenValid")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context) bool); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockTokenConnection_TokenValid_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TokenValid'
+type MockTokenConnection_TokenValid_Call struct {
+	*mock.Call
+}
+
+// TokenValid is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockTokenConnection_Expecter) TokenValid(ctx interface{}) *MockTokenConnection_TokenValid_Call {
+	return &MockTokenConnection_TokenValid_Call{Call: _e.mock.On("TokenValid", ctx)}
+}
+
+func (_c *MockTokenConnection_TokenValid_Call) Run(run func(ctx context.Context)) *MockTokenConnection_TokenValid_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockTokenConnection_TokenValid_Call) Return(_a0 bool) *MockTokenConnection_TokenValid_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockTokenConnection_TokenValid_Call) RunAndReturn(run func(context.Context) bool) *MockTokenConnection_TokenValid_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockTokenConnection creates a new instance of MockTokenConnection. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockTokenConnection(t interface {

--- a/apps/provisioning/pkg/connection/github/validator.go
+++ b/apps/provisioning/pkg/connection/github/validator.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"encoding/base64"
+	"strconv"
 
 	"github.com/golang-jwt/jwt/v4"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -58,12 +59,22 @@ func Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 		}
 	}
 
-	// Validate GitHub configuration fields
+	// Validate the existence of GitHub configuration fields
 	if conn.Spec.GitHub.AppID == "" {
 		list = append(list, field.Required(field.NewPath("spec", "github", "appID"), "appID must be specified for GitHub connection"))
 	}
 	if conn.Spec.GitHub.InstallationID == "" {
 		list = append(list, field.Required(field.NewPath("spec", "github", "installationID"), "installationID must be specified for GitHub connection"))
+	}
+
+	// Validating the correctness of Github config fields
+	_, err := strconv.Atoi(conn.Spec.GitHub.AppID)
+	if err != nil {
+		list = append(list, field.Invalid(field.NewPath("spec", "github", "appID"), conn.Spec.GitHub.AppID, "appID must be a numeric value"))
+	}
+	_, err = strconv.Atoi(conn.Spec.GitHub.InstallationID)
+	if err != nil {
+		list = append(list, field.Invalid(field.NewPath("spec", "github", "installationID"), conn.Spec.GitHub.InstallationID, "installationID must be a numeric value"))
 	}
 
 	return list

--- a/apps/provisioning/pkg/connection/github/validator_test.go
+++ b/apps/provisioning/pkg/connection/github/validator_test.go
@@ -212,6 +212,72 @@ func TestValidate(t *testing.T) {
 			errorContains: []string{"installationID"},
 		},
 		{
+			name: "non-numeric app ID",
+			obj: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-conn",
+				},
+				Spec: provisioning.ConnectionSpec{
+					Type: provisioning.GithubConnectionType,
+					GitHub: &provisioning.GitHubConnectionConfig{
+						AppID:          "abc123",
+						InstallationID: "456",
+					},
+				},
+				Secure: provisioning.ConnectionSecure{
+					PrivateKey: common.InlineSecureValue{
+						Create: common.NewSecretValue(privateKeyBase64),
+					},
+				},
+			},
+			expectedError: true,
+			errorContains: []string{"appID must be a numeric value"},
+		},
+		{
+			name: "non-numeric installation ID",
+			obj: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-conn",
+				},
+				Spec: provisioning.ConnectionSpec{
+					Type: provisioning.GithubConnectionType,
+					GitHub: &provisioning.GitHubConnectionConfig{
+						AppID:          "123",
+						InstallationID: "xyz789",
+					},
+				},
+				Secure: provisioning.ConnectionSecure{
+					PrivateKey: common.InlineSecureValue{
+						Create: common.NewSecretValue(privateKeyBase64),
+					},
+				},
+			},
+			expectedError: true,
+			errorContains: []string{"installationID must be a numeric value"},
+		},
+		{
+			name: "both app ID and installation ID non-numeric",
+			obj: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-conn",
+				},
+				Spec: provisioning.ConnectionSpec{
+					Type: provisioning.GithubConnectionType,
+					GitHub: &provisioning.GitHubConnectionConfig{
+						AppID:          "app-id",
+						InstallationID: "install-id",
+					},
+				},
+				Secure: provisioning.ConnectionSecure{
+					PrivateKey: common.InlineSecureValue{
+						Create: common.NewSecretValue(privateKeyBase64),
+					},
+				},
+			},
+			expectedError: true,
+			errorContains: []string{"appID must be a numeric value", "installationID must be a numeric value"},
+		},
+		{
 			name: "valid github connection",
 			obj: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/registry/apis/provisioning/controller/connection.go
+++ b/pkg/registry/apis/provisioning/controller/connection.go
@@ -292,8 +292,13 @@ func (cc *ConnectionController) shouldGenerateToken(
 	obj *provisioning.Connection,
 	c connection.TokenConnection,
 ) (bool, error) {
-	// In case token is not there, we should always generate it.
+	// In case the token is not there, we should always generate it.
 	if obj.Secure.Token.IsZero() {
+		return true, nil
+	}
+
+	// In case the current token is not valid, then generate a new one.
+	if !c.TokenValid(ctx) {
 		return true, nil
 	}
 

--- a/pkg/tests/apis/provisioning/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection_test.go
@@ -797,6 +797,127 @@ func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
 		require.NoError(t, err, "error verifying token: %s", k)
 		require.True(t, valid, "token should be valid: %s", k)
 	})
+
+	t.Run("token gets updated if appID changes", func(t *testing.T) {
+		// Create a connection using unstructured (like other connection tests)
+		connUnstructured := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"name":      "test-connection-health",
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"type": "github",
+				"github": map[string]any{
+					"appID":          "12345",
+					"installationID": "67890",
+				},
+			},
+			"secure": map[string]any{
+				"privateKey": map[string]any{
+					"create": privateKeyBase64,
+				},
+			},
+		}}
+
+		createdUnstructured, err := helper.CreateGithubConnection(t, ctx, connUnstructured)
+		require.NoError(t, err)
+		require.NotNil(t, createdUnstructured)
+
+		connName := createdUnstructured.GetName()
+
+		t.Cleanup(func() {
+			_ = helper.Connections.Resource.Delete(ctx, connName, metav1.DeleteOptions{})
+		})
+
+		// Wait for initial reconciliation - controller should update status
+		require.Eventually(t, func() bool {
+			updated, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			return updated.Status.ObservedGeneration == updated.Generation &&
+				updated.Status.Health.Checked > 0 &&
+				updated.Status.State == provisioning.ConnectionStateConnected &&
+				updated.Status.Health.Healthy
+		}, 10*time.Second, 500*time.Millisecond, "connection should be reconciled")
+
+		// Verify initial health check was set
+		initial, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, initial)
+		require.False(t, initial.Secure.Token.IsZero())
+
+		// Verifying token
+		decrypted, err := decryptService.Decrypt(ctx, "provisioning.grafana.app", initial.Namespace, initial.Secure.Token.Name)
+		require.NoError(t, err, "decryption error")
+		require.Len(t, decrypted, 1)
+
+		val := decrypted[initial.Secure.Token.Name].Value()
+		require.NotNil(t, val)
+		k := val.DangerouslyExposeAndConsumeValue()
+		valid, err := verifyToken(t, "12345", k)
+		require.NoError(t, err, "error verifying token: %s", k)
+		require.True(t, valid, "token should be valid: %s", k)
+
+		// Create a connection using unstructured (like other connection tests)
+		updated := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"name":      connName,
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"type": "github",
+				"github": map[string]any{
+					"appID":          "54321",
+					"installationID": "67890",
+				},
+			},
+			"secure": map[string]any{
+				"privateKey": map[string]any{
+					"create": privateKeyBase64,
+				},
+			},
+		}}
+
+		updatedUnstructured, err := helper.UpdateGithubConnection(t, ctx, updated)
+		require.NoError(t, err)
+		require.NotNil(t, updatedUnstructured)
+
+		// Wait for initial reconciliation - controller should update status
+		require.Eventually(t, func() bool {
+			updated, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			return updated.Status.ObservedGeneration == updated.Generation &&
+				updated.Status.Health.Checked > 0 &&
+				updated.Status.State == provisioning.ConnectionStateConnected &&
+				updated.Status.Health.Healthy
+		}, 10*time.Second, 500*time.Millisecond, "connection should be reconciled again")
+
+		c, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, c)
+		// Verify secret got updated
+		require.NotEqual(t, c.Secure.Token.Name, initial.Secure.Token.Name)
+
+		// Verifying token
+		newSecretDecrypted, err := decryptService.Decrypt(ctx, "provisioning.grafana.app", c.Namespace, c.Secure.Token.Name)
+		require.NoError(t, err, "decryption error")
+		require.Len(t, decrypted, 1)
+
+		newVal := newSecretDecrypted[c.Secure.Token.Name].Value()
+		require.NotNil(t, newVal)
+		newK := newVal.DangerouslyExposeAndConsumeValue()
+		require.NotEqual(t, k, newK)
+		valid, err = verifyToken(t, "54321", newK)
+		require.NoError(t, err, "error verifying token: %s", newK)
+		require.True(t, valid, "token should be valid: %s", newK)
+	})
 }
 
 func TestIntegrationConnectionController_HealthCheckUpdates(t *testing.T) {
@@ -1077,7 +1198,7 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 
 		// Verify all fields explicitly
 		assert.Equal(t, metav1.CauseTypeFieldValueInvalid, installationIDError.Type, "Type must be FieldValueInvalid")
-		assert.Equal(t, "spec.installationID", installationIDError.Field, "Field must be spec.installationID")
+		assert.Equal(t, "spec.github.installationID", installationIDError.Field, "Field must be spec.installationID")
 		assert.Equal(t, "installation not found", installationIDError.Detail, "Detail must match expected error message")
 		assert.Empty(t, installationIDError.Origin, "Origin should be empty")
 
@@ -1179,7 +1300,7 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 
 		// Verify all fields explicitly
 		assert.Equal(t, metav1.CauseTypeFieldValueInvalid, appIDError.Type, "Type must be FieldValueInvalid")
-		assert.Equal(t, "spec.appID", appIDError.Field, "Field must be spec.appID")
+		assert.Equal(t, "spec.github.appID", appIDError.Field, "Field must be spec.appID")
 		assert.Equal(t, "appID mismatch: expected 123456, got 999999", appIDError.Detail, "Detail must match expected error message")
 		assert.Empty(t, appIDError.Origin, "Origin should be empty")
 
@@ -1646,29 +1767,6 @@ func TestIntegrationProvisioning_ConnectionDeleteWithNoReferences(t *testing.T) 
 	})
 }
 
-func verifyToken(t *testing.T, appID, token string) (bool, error) {
-	t.Helper()
-
-	// Parse the private key
-	key, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(testPrivateKeyPEM))
-	if err != nil {
-		return false, err
-	}
-
-	parsedToken, err := jwt.Parse(token, func(token *jwt.Token) (any, error) {
-		return &key.PublicKey, nil
-	}, jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()}))
-	if err != nil {
-		return false, err
-	}
-
-	claims, ok := parsedToken.Claims.(jwt.MapClaims)
-	if !ok || !parsedToken.Valid {
-		return false, fmt.Errorf("invalid token")
-	}
-
-	return claims.VerifyIssuer(appID, true), nil
-}
 func TestIntegrationConnectionController_GranularConditionReasons(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
@@ -1761,4 +1859,28 @@ func TestIntegrationConnectionController_GranularConditionReasons(t *testing.T) 
 		// Verify message contains the actual error returned by the GitHub client
 		assert.Contains(t, readyCondition.Message, "github is unavailable", "condition message should contain the actual error text")
 	})
+}
+
+func verifyToken(t *testing.T, appID, token string) (bool, error) {
+	t.Helper()
+
+	// Parse the private key
+	key, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(testPrivateKeyPEM))
+	if err != nil {
+		return false, err
+	}
+
+	parsedToken, err := jwt.Parse(token, func(token *jwt.Token) (any, error) {
+		return &key.PublicKey, nil
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()}))
+	if err != nil {
+		return false, err
+	}
+
+	claims, ok := parsedToken.Claims.(jwt.MapClaims)
+	if !ok || !parsedToken.Valid {
+		return false, fmt.Errorf("invalid token")
+	}
+
+	return claims.VerifyIssuer(appID, true), nil
 }


### PR DESCRIPTION
**What is this feature?**

- Improves the errors returned by the `Test` on `Connection` when `spec.github.appID`/`secure.privateKey` are invalid, or when `secure.token` becomes invalid due to the former fields being not correct.
- Updates the codes for some existing errors;
- Fixes the path for some existing errors;
- When the `connection.secure.token` gets invalidated by an update on specific fields, the connection controller will update the token.

**Why do we need this feature?**

- In some cases, the error returned by `provisioning.grafana.app` API is not clear enough, as it mentions the `secure.token` field, which is not something the user provides, but something we build based on what the user gives to the API;
- The connection controller should update the underneath token in case the user updates the `Connection` with info that invalidates such token.

**Who is this feature for?**

Users of Provisioning Feature.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/756

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
