### PR TITLE
Prometheus: Fix units in Prometheus 2.0 stats dashboard panels

### DIFF
--- a/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
+++ b/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
@@ -109,7 +109,6 @@
           },
           "links": [],
           "mappings": [],
-          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -123,7 +122,7 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "cps"
         },
         "overrides": [
           {
@@ -242,7 +241,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "cps"
         },
         "overrides": []
       },
@@ -499,7 +498,7 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -1022,7 +1021,7 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -1115,7 +1114,7 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -1287,7 +1286,7 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "eps"
         },
         "overrides": []
       },

--- a/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
+++ b/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
@@ -498,7 +498,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "short"
         },
         "overrides": []
       },

--- a/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
+++ b/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
@@ -241,7 +241,7 @@
               }
             ]
           },
-          "unit": "cps"
+          "unit": "s"
         },
         "overrides": []
       },


### PR DESCRIPTION
**What is this feature?**

This PR fixes incorrect and missing units in the built-in Prometheus 2.0 Stats dashboard to improve metric readability and correctness.

**Why do we need this feature?**

Several panels in the dashboard were using generic units ("short") or incorrect scaling, making it unclear what the values represented (e.g., rates, durations, or event counts). This change ensures metrics are displayed with proper semantic units.

**Who is this feature for?**

Grafana users who use the built-in Prometheus datasource dashboards, especially operators and SREs monitoring Prometheus internals.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/116810

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.
