### PR TITLE
Provisioning: fix connection repo list

### DIFF
--- a/apps/provisioning/pkg/connection/github/client.go
+++ b/apps/provisioning/pkg/connection/github/client.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/google/go-github/v70/github"
-	"golang.org/x/oauth2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -28,7 +27,7 @@ var (
 type Client interface {
 	GetApp(ctx context.Context) (App, error)
 	GetAppInstallation(ctx context.Context, installationID string) (AppInstallation, error)
-	ListInstallationRepositories(ctx context.Context, installationID string) ([]Repository, error)
+	ListInstallationRepositories(ctx context.Context) ([]Repository, error)
 	CreateInstallationAccessToken(ctx context.Context, installationID string, repo string) (InstallationToken, error)
 }
 
@@ -74,16 +73,6 @@ type githubClient struct {
 
 func NewClient(client *github.Client) Client {
 	return &githubClient{gh: client}
-}
-
-func (r *githubClient) withToken(ctx context.Context, token string) *githubClient {
-	tokenSrc := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
-	tokenClient := oauth2.NewClient(ctx, tokenSrc)
-	r.gh = github.NewClient(tokenClient)
-
-	return r
 }
 
 // GetApp gets the app by using the given token.
@@ -145,23 +134,7 @@ const (
 )
 
 // ListInstallationRepositories lists all repositories accessible by the specified GitHub App installation.
-// It first creates an installation access token using the JWT, then uses that token to list repositories.
-func (r *githubClient) ListInstallationRepositories(ctx context.Context, installationID string) ([]Repository, error) {
-	id, err := strconv.ParseInt(installationID, 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf("invalid installation ID: %s", installationID)
-	}
-
-	// Create an installation access token
-	installationToken, _, err := r.gh.Apps.CreateInstallationToken(ctx, id, nil)
-	if err != nil {
-		var ghErr *github.ErrorResponse
-		if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusServiceUnavailable {
-			return nil, ErrServiceUnavailable
-		}
-		return nil, fmt.Errorf("create installation token: %w", err)
-	}
-
+func (r *githubClient) ListInstallationRepositories(ctx context.Context) ([]Repository, error) {
 	var allRepos []Repository
 	opts := &github.ListOptions{
 		Page:    1,
@@ -169,7 +142,7 @@ func (r *githubClient) ListInstallationRepositories(ctx context.Context, install
 	}
 
 	for {
-		result, resp, err := r.withToken(ctx, installationToken.GetToken()).gh.Apps.ListRepos(ctx, opts)
+		result, resp, err := r.gh.Apps.ListRepos(ctx, opts)
 		if err != nil {
 			var ghErr *github.ErrorResponse
 			if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusServiceUnavailable {
@@ -211,8 +184,11 @@ func (r *githubClient) CreateInstallationAccessToken(ctx context.Context, instal
 		return InstallationToken{}, fmt.Errorf("invalid installation ID: %s", installationID)
 	}
 
-	opts := &github.InstallationTokenOptions{
-		Repositories: []string{repo},
+	var opts *github.InstallationTokenOptions
+	if repo != "" {
+		opts = &github.InstallationTokenOptions{
+			Repositories: []string{repo},
+		}
 	}
 
 	token, _, err := r.gh.Apps.CreateInstallationToken(ctx, int64(id), opts)

--- a/apps/provisioning/pkg/connection/github/client_mock.go
+++ b/apps/provisioning/pkg/connection/github/client_mock.go
@@ -192,9 +192,9 @@ func (_c *MockClient_GetAppInstallation_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
-// ListInstallationRepositories provides a mock function with given fields: ctx, installationID
-func (_m *MockClient) ListInstallationRepositories(ctx context.Context, installationID string) ([]Repository, error) {
-	ret := _m.Called(ctx, installationID)
+// ListInstallationRepositories provides a mock function with given fields: ctx
+func (_m *MockClient) ListInstallationRepositories(ctx context.Context) ([]Repository, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListInstallationRepositories")
@@ -202,19 +202,19 @@ func (_m *MockClient) ListInstallationRepositories(ctx context.Context, installa
 
 	var r0 []Repository
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) ([]Repository, error)); ok {
-		return rf(ctx, installationID)
+	if rf, ok := ret.Get(0).(func(context.Context) ([]Repository, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) []Repository); ok {
-		r0 = rf(ctx, installationID)
+	if rf, ok := ret.Get(0).(func(context.Context) []Repository); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]Repository)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, installationID)
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -229,14 +229,13 @@ type MockClient_ListInstallationRepositories_Call struct {
 
 // ListInstallationRepositories is a helper method to define mock.On call
 //   - ctx context.Context
-//   - installationID string
-func (_e *MockClient_Expecter) ListInstallationRepositories(ctx interface{}, installationID interface{}) *MockClient_ListInstallationRepositories_Call {
-	return &MockClient_ListInstallationRepositories_Call{Call: _e.mock.On("ListInstallationRepositories", ctx, installationID)}
+func (_e *MockClient_Expecter) ListInstallationRepositories(ctx interface{}) *MockClient_ListInstallationRepositories_Call {
+	return &MockClient_ListInstallationRepositories_Call{Call: _e.mock.On("ListInstallationRepositories", ctx)}
 }
 
-func (_c *MockClient_ListInstallationRepositories_Call) Run(run func(ctx context.Context, installationID string)) *MockClient_ListInstallationRepositories_Call {
+func (_c *MockClient_ListInstallationRepositories_Call) Run(run func(ctx context.Context)) *MockClient_ListInstallationRepositories_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -246,7 +245,7 @@ func (_c *MockClient_ListInstallationRepositories_Call) Return(_a0 []Repository,
 	return _c
 }
 
-func (_c *MockClient_ListInstallationRepositories_Call) RunAndReturn(run func(context.Context, string) ([]Repository, error)) *MockClient_ListInstallationRepositories_Call {
+func (_c *MockClient_ListInstallationRepositories_Call) RunAndReturn(run func(context.Context) ([]Repository, error)) *MockClient_ListInstallationRepositories_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/apps/provisioning/pkg/connection/github/client_test.go
+++ b/apps/provisioning/pkg/connection/github/client_test.go
@@ -363,7 +363,8 @@ func TestGithubClient_ListInstallationRepositories(t *testing.T) {
 					mockhub.GetInstallationRepositories,
 					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 						page := r.URL.Query().Get("page")
-						if page == "" || page == "1" {
+						switch page {
+						case "", "1":
 							// First page
 							response := &github.ListRepositories{
 								TotalCount: github.Ptr(3),
@@ -380,7 +381,7 @@ func TestGithubClient_ListInstallationRepositories(t *testing.T) {
 							w.Header().Set("Link", `<https://api.github.com/installation/repositories?page=2>; rel="next"`)
 							w.WriteHeader(http.StatusOK)
 							require.NoError(t, json.NewEncoder(w).Encode(response))
-						} else if page == "2" {
+						case "2":
 							// Second page
 							response := &github.ListRepositories{
 								TotalCount: github.Ptr(3),

--- a/apps/provisioning/pkg/connection/github/client_test.go
+++ b/apps/provisioning/pkg/connection/github/client_test.go
@@ -3,6 +3,7 @@ package github_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -307,6 +308,276 @@ func TestGithubClient_GetAppInstallation(t *testing.T) {
 
 			// Check the result
 			assert.Equal(t, tt.wantInstallation, installation)
+		})
+	}
+}
+
+func TestGithubClient_ListInstallationRepositories(t *testing.T) {
+	tests := []struct {
+		name        string
+		mockHandler *http.Client
+		wantRepos   []conngh.Repository
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "list repositories successfully - single page",
+			mockHandler: mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetInstallationRepositories,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						response := &github.ListRepositories{
+							TotalCount: github.Ptr(2),
+							Repositories: []*github.Repository{
+								{
+									Name: github.Ptr("repo1"),
+									Owner: &github.User{
+										Login: github.Ptr("owner1"),
+									},
+									HTMLURL: github.Ptr("https://github.com/owner1/repo1"),
+								},
+								{
+									Name: github.Ptr("repo2"),
+									Owner: &github.User{
+										Login: github.Ptr("owner2"),
+									},
+									HTMLURL: github.Ptr("https://github.com/owner2/repo2"),
+								},
+							},
+						}
+						w.WriteHeader(http.StatusOK)
+						require.NoError(t, json.NewEncoder(w).Encode(response))
+					}),
+				),
+			),
+			wantRepos: []conngh.Repository{
+				{Name: "repo1", Owner: "owner1", URL: "https://github.com/owner1/repo1"},
+				{Name: "repo2", Owner: "owner2", URL: "https://github.com/owner2/repo2"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "list repositories successfully - multiple pages",
+			mockHandler: mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetInstallationRepositories,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						page := r.URL.Query().Get("page")
+						if page == "" || page == "1" {
+							// First page
+							response := &github.ListRepositories{
+								TotalCount: github.Ptr(3),
+								Repositories: []*github.Repository{
+									{
+										Name: github.Ptr("repo1"),
+										Owner: &github.User{
+											Login: github.Ptr("owner1"),
+										},
+										HTMLURL: github.Ptr("https://github.com/owner1/repo1"),
+									},
+								},
+							}
+							w.Header().Set("Link", `<https://api.github.com/installation/repositories?page=2>; rel="next"`)
+							w.WriteHeader(http.StatusOK)
+							require.NoError(t, json.NewEncoder(w).Encode(response))
+						} else if page == "2" {
+							// Second page
+							response := &github.ListRepositories{
+								TotalCount: github.Ptr(3),
+								Repositories: []*github.Repository{
+									{
+										Name: github.Ptr("repo2"),
+										Owner: &github.User{
+											Login: github.Ptr("owner2"),
+										},
+										HTMLURL: github.Ptr("https://github.com/owner2/repo2"),
+									},
+									{
+										Name: github.Ptr("repo3"),
+										Owner: &github.User{
+											Login: github.Ptr("owner3"),
+										},
+										HTMLURL: github.Ptr("https://github.com/owner3/repo3"),
+									},
+								},
+							}
+							w.WriteHeader(http.StatusOK)
+							require.NoError(t, json.NewEncoder(w).Encode(response))
+						}
+					}),
+				),
+			),
+			wantRepos: []conngh.Repository{
+				{Name: "repo1", Owner: "owner1", URL: "https://github.com/owner1/repo1"},
+				{Name: "repo2", Owner: "owner2", URL: "https://github.com/owner2/repo2"},
+				{Name: "repo3", Owner: "owner3", URL: "https://github.com/owner3/repo3"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty repository list",
+			mockHandler: mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetInstallationRepositories,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						response := &github.ListRepositories{
+							TotalCount:   github.Ptr(0),
+							Repositories: []*github.Repository{},
+						}
+						w.WriteHeader(http.StatusOK)
+						require.NoError(t, json.NewEncoder(w).Encode(response))
+					}),
+				),
+			),
+			wantRepos: nil,
+			wantErr:   false,
+		},
+		{
+			name: "service unavailable",
+			mockHandler: mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetInstallationRepositories,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusServiceUnavailable)
+						require.NoError(t, json.NewEncoder(w).Encode(github.ErrorResponse{
+							Response: &http.Response{
+								StatusCode: http.StatusServiceUnavailable,
+							},
+							Message: "Service unavailable",
+						}))
+					}),
+				),
+			),
+			wantRepos:   nil,
+			wantErr:     true,
+			errContains: conngh.ErrServiceUnavailable.Error(),
+		},
+		{
+			name: "unauthorized error",
+			mockHandler: mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetInstallationRepositories,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusUnauthorized)
+						require.NoError(t, json.NewEncoder(w).Encode(github.ErrorResponse{
+							Response: &http.Response{
+								StatusCode: http.StatusUnauthorized,
+							},
+							Message: "Bad credentials",
+						}))
+					}),
+				),
+			),
+			wantRepos:   nil,
+			wantErr:     true,
+			errContains: "list repositories",
+		},
+		{
+			name: "forbidden error",
+			mockHandler: mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetInstallationRepositories,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusForbidden)
+						require.NoError(t, json.NewEncoder(w).Encode(github.ErrorResponse{
+							Response: &http.Response{
+								StatusCode: http.StatusForbidden,
+							},
+							Message: "Resource not accessible by integration",
+						}))
+					}),
+				),
+			),
+			wantRepos:   nil,
+			wantErr:     true,
+			errContains: "list repositories",
+		},
+		{
+			name: "internal server error",
+			mockHandler: mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetInstallationRepositories,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusInternalServerError)
+						require.NoError(t, json.NewEncoder(w).Encode(github.ErrorResponse{
+							Response: &http.Response{
+								StatusCode: http.StatusInternalServerError,
+							},
+							Message: "Internal server error",
+						}))
+					}),
+				),
+			),
+			wantRepos:   nil,
+			wantErr:     true,
+			errContains: "list repositories",
+		},
+		{
+			name: "too many repositories - exceeds max limit",
+			mockHandler: mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetInstallationRepositories,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						page := r.URL.Query().Get("page")
+						pageNum := 1
+						if page != "" && page != "1" {
+							// Parse page number
+							var err error
+							_, err = fmt.Sscanf(page, "%d", &pageNum)
+							require.NoError(t, err)
+						}
+
+						// Create 100 repos per page to simulate going over 1000 limit
+						repos := make([]*github.Repository, 100)
+						for i := 0; i < 100; i++ {
+							repoNum := (pageNum-1)*100 + i + 1
+							repos[i] = &github.Repository{
+								Name: github.Ptr(fmt.Sprintf("repo%d", repoNum)),
+								Owner: &github.User{
+									Login: github.Ptr(fmt.Sprintf("owner%d", repoNum)),
+								},
+								HTMLURL: github.Ptr(fmt.Sprintf("https://github.com/owner%d/repo%d", repoNum, repoNum)),
+							}
+						}
+
+						response := &github.ListRepositories{
+							TotalCount:   github.Ptr(1200),
+							Repositories: repos,
+						}
+
+						// Simulate pagination - 12 pages of 100 repos each
+						if pageNum < 12 {
+							w.Header().Set("Link", fmt.Sprintf(`<https://api.github.com/installation/repositories?page=%d>; rel="next"`, pageNum+1))
+						}
+
+						w.WriteHeader(http.StatusOK)
+						require.NoError(t, json.NewEncoder(w).Encode(response))
+					}),
+				),
+			),
+			wantRepos:   nil,
+			wantErr:     true,
+			errContains: "too many repositories",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ghClient := github.NewClient(tt.mockHandler)
+			client := conngh.NewClient(ghClient)
+
+			repos, err := client.ListInstallationRepositories(context.Background())
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantRepos, repos)
 		})
 	}
 }

--- a/apps/provisioning/pkg/connection/github/connection.go
+++ b/apps/provisioning/pkg/connection/github/connection.go
@@ -266,7 +266,14 @@ func (c *Connection) ListRepositories(ctx context.Context) ([]provisioning.Exter
 	// Create the GitHub client with the JWT token
 	ghClient := c.ghFactory.New(ctx, c.secrets.Token)
 
-	repos, err := ghClient.ListInstallationRepositories(ctx, c.obj.Spec.GitHub.InstallationID)
+	token, err := ghClient.CreateInstallationAccessToken(ctx, c.obj.Spec.GitHub.InstallationID, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create installation access token: %w", err)
+	}
+
+	installationGhClient := c.ghFactory.New(ctx, common.RawSecureValue(token.Token))
+
+	repos, err := installationGhClient.ListInstallationRepositories(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list installation repositories: %w", err)
 	}

--- a/apps/provisioning/pkg/connection/github/connection_test.go
+++ b/apps/provisioning/pkg/connection/github/connection_test.go
@@ -981,8 +981,15 @@ func TestConnection_ListRepositories(t *testing.T) {
 		mockFactory := github.NewMockGithubFactory(t)
 		mockClient := github.NewMockClient(t)
 
-		mockFactory.EXPECT().New(mock.Anything, common.RawSecureValue("test-token")).Return(mockClient)
-		mockClient.EXPECT().ListInstallationRepositories(mock.Anything, "456").Return([]github.Repository{
+		mockFactory.EXPECT().New(mock.Anything, common.RawSecureValue("test-token")).Return(mockClient).Once()
+		mockClient.EXPECT().CreateInstallationAccessToken(mock.Anything, "456", "").Return(github.InstallationToken{
+			Token:     "ghs_installation_token",
+			ExpiresAt: time.Now().Add(time.Hour),
+		}, nil)
+
+		mockInstallationClient := github.NewMockClient(t)
+		mockFactory.EXPECT().New(mock.Anything, common.RawSecureValue("ghs_installation_token")).Return(mockInstallationClient)
+		mockInstallationClient.EXPECT().ListInstallationRepositories(mock.Anything).Return([]github.Repository{
 			{Name: "repo1", Owner: "owner1", URL: "https://github.com/owner1/repo1"},
 			{Name: "repo2", Owner: "owner2", URL: "https://github.com/owner2/repo2"},
 		}, nil)
@@ -1038,8 +1045,15 @@ func TestConnection_ListRepositories(t *testing.T) {
 		mockFactory := github.NewMockGithubFactory(t)
 		mockClient := github.NewMockClient(t)
 
-		mockFactory.EXPECT().New(mock.Anything, common.RawSecureValue("test-token")).Return(mockClient)
-		mockClient.EXPECT().ListInstallationRepositories(mock.Anything, "456").Return(nil, assert.AnError)
+		mockFactory.EXPECT().New(mock.Anything, common.RawSecureValue("test-token")).Return(mockClient).Once()
+		mockClient.EXPECT().CreateInstallationAccessToken(mock.Anything, "456", "").Return(github.InstallationToken{
+			Token:     "ghs_installation_token",
+			ExpiresAt: time.Now().Add(time.Hour),
+		}, nil)
+
+		mockInstallationClient := github.NewMockClient(t)
+		mockFactory.EXPECT().New(mock.Anything, common.RawSecureValue("ghs_installation_token")).Return(mockInstallationClient)
+		mockInstallationClient.EXPECT().ListInstallationRepositories(mock.Anything).Return(nil, assert.AnError)
 
 		conn := github.NewConnection(c, mockFactory, github.ConnectionSecrets{
 			Token: common.RawSecureValue("test-token"),
@@ -1048,6 +1062,70 @@ func TestConnection_ListRepositories(t *testing.T) {
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "list installation repositories")
+	})
+
+	t.Run("should return error when creating installation token fails", func(t *testing.T) {
+		c := &provisioning.Connection{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
+			Spec: provisioning.ConnectionSpec{
+				Type: provisioning.GithubConnectionType,
+				GitHub: &provisioning.GitHubConnectionConfig{
+					AppID:          "123",
+					InstallationID: "456",
+				},
+			},
+			Secure: provisioning.ConnectionSecure{
+				Token: common.InlineSecureValue{
+					Create: common.NewSecretValue("test-token"),
+				},
+			},
+		}
+
+		mockFactory := github.NewMockGithubFactory(t)
+		mockClient := github.NewMockClient(t)
+
+		mockFactory.EXPECT().New(mock.Anything, common.RawSecureValue("test-token")).Return(mockClient)
+		mockClient.EXPECT().CreateInstallationAccessToken(mock.Anything, "456", "").Return(github.InstallationToken{}, assert.AnError)
+
+		conn := github.NewConnection(c, mockFactory, github.ConnectionSecrets{
+			Token: common.RawSecureValue("test-token"),
+		})
+		_, err := conn.ListRepositories(context.Background())
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create installation access token")
+	})
+
+	t.Run("should return error when service unavailable during token creation", func(t *testing.T) {
+		c := &provisioning.Connection{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
+			Spec: provisioning.ConnectionSpec{
+				Type: provisioning.GithubConnectionType,
+				GitHub: &provisioning.GitHubConnectionConfig{
+					AppID:          "123",
+					InstallationID: "456",
+				},
+			},
+			Secure: provisioning.ConnectionSecure{
+				Token: common.InlineSecureValue{
+					Create: common.NewSecretValue("test-token"),
+				},
+			},
+		}
+
+		mockFactory := github.NewMockGithubFactory(t)
+		mockClient := github.NewMockClient(t)
+
+		mockFactory.EXPECT().New(mock.Anything, common.RawSecureValue("test-token")).Return(mockClient)
+		mockClient.EXPECT().CreateInstallationAccessToken(mock.Anything, "456", "").Return(github.InstallationToken{}, github.ErrServiceUnavailable)
+
+		conn := github.NewConnection(c, mockFactory, github.ConnectionSecrets{
+			Token: common.RawSecureValue("test-token"),
+		})
+		_, err := conn.ListRepositories(context.Background())
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create installation access token")
 	})
 
 	t.Run("should return empty list when no repositories", func(t *testing.T) {
@@ -1070,8 +1148,15 @@ func TestConnection_ListRepositories(t *testing.T) {
 		mockFactory := github.NewMockGithubFactory(t)
 		mockClient := github.NewMockClient(t)
 
-		mockFactory.EXPECT().New(mock.Anything, common.RawSecureValue("test-token")).Return(mockClient)
-		mockClient.EXPECT().ListInstallationRepositories(mock.Anything, "456").Return([]github.Repository{}, nil)
+		mockFactory.EXPECT().New(mock.Anything, common.RawSecureValue("test-token")).Return(mockClient).Once()
+		mockClient.EXPECT().CreateInstallationAccessToken(mock.Anything, "456", "").Return(github.InstallationToken{
+			Token:     "ghs_installation_token",
+			ExpiresAt: time.Now().Add(time.Hour),
+		}, nil)
+
+		mockInstallationClient := github.NewMockClient(t)
+		mockFactory.EXPECT().New(mock.Anything, common.RawSecureValue("ghs_installation_token")).Return(mockInstallationClient)
+		mockInstallationClient.EXPECT().ListInstallationRepositories(mock.Anything).Return([]github.Repository{}, nil)
 
 		conn := github.NewConnection(c, mockFactory, github.ConnectionSecrets{
 			Token: common.RawSecureValue("test-token"),

--- a/pkg/registry/apis/provisioning/connection_repositories_test.go
+++ b/pkg/registry/apis/provisioning/connection_repositories_test.go
@@ -225,8 +225,14 @@ func TestConnectionRepositoriesConnector_WithGitHubConnection(t *testing.T) {
 		mockFactory.EXPECT().
 			New(mock.Anything, common.RawSecureValue("test-token")).
 			Return(mockClient)
+		mockFactory.EXPECT().
+			New(mock.Anything, common.RawSecureValue("someToken")).
+			Return(mockClient)
 		mockClient.EXPECT().
-			ListInstallationRepositories(mock.Anything, "789012").
+			CreateInstallationAccessToken(mock.Anything, "789012", "").
+			Return(github.InstallationToken{Token: "someToken"}, nil)
+		mockClient.EXPECT().
+			ListInstallationRepositories(mock.Anything).
 			Return(expectedRepos, nil)
 
 		// Create GitHub connection
@@ -306,8 +312,14 @@ func TestConnectionRepositoriesConnector_WithGitHubConnection(t *testing.T) {
 		mockFactory.EXPECT().
 			New(mock.Anything, common.RawSecureValue("test-token")).
 			Return(mockClient)
+		mockFactory.EXPECT().
+			New(mock.Anything, common.RawSecureValue("someToken")).
+			Return(mockClient)
 		mockClient.EXPECT().
-			ListInstallationRepositories(mock.Anything, "789012").
+			CreateInstallationAccessToken(mock.Anything, "789012", "").
+			Return(github.InstallationToken{Token: "someToken"}, nil)
+		mockClient.EXPECT().
+			ListInstallationRepositories(mock.Anything).
 			Return(nil, errors.New("github API unavailable"))
 
 		// Create GitHub connection


### PR DESCRIPTION
**What is this feature?**

Fixes an issue related to how App repository are listed in the Github client.

**Why do we need this feature?**

So that `GET /connection/<name>/repositories` works as expected

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
