### PR TITLE
Provisioning: Add Auth condition to Connection status

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
@@ -19,6 +19,15 @@ const (
 	// This is an aggregated condition that can track multiple quota types (resources, storage, etc.).
 	// True = within quota or no limits configured, False = quota reached or exceeded.
 	ConditionTypeQuota = "Quota"
+
+	// ConditionTypeSpec indicates whether the resource spec is valid.
+	// This provides a high-level validity status that complements fieldErrors.
+	// True = spec is valid, False = spec has validation errors.
+	ConditionTypeSpec = "Spec"
+
+	// ConditionTypeAuth indicates the authentication/token status for connections.
+	// True = token is valid and authentication succeeded, False = token issue or auth failed.
+	ConditionTypeAuth = "Auth"
 )
 
 // Condition reasons for the Ready condition
@@ -56,6 +65,26 @@ const (
 	ReasonResourceQuotaReached = "ResourceQuotaReached"
 	// ReasonResourceQuotaExceeded indicates the resource count exceeds the limit.
 	ReasonResourceQuotaExceeded = "ResourceQuotaExceeded"
+)
+
+// Condition reasons for the Spec condition
+const (
+	// ReasonSpecValid indicates the resource spec is valid and has no validation errors.
+	ReasonSpecValid = "Valid"
+	// ReasonSpecInvalid indicates the resource spec has validation errors.
+	ReasonSpecInvalid = "Invalid"
+)
+
+// Condition reasons for the Auth condition
+const (
+	// ReasonAuthValid indicates authentication is valid and token is working.
+	ReasonAuthValid = "Valid"
+	// ReasonAuthTokenExpired indicates the authentication token has expired.
+	ReasonAuthTokenExpired = "TokenExpired"
+	// ReasonAuthTokenGenerationFailed indicates token generation failed.
+	ReasonAuthTokenGenerationFailed = "TokenGenerationFailed"
+	// ReasonAuthTokenInvalid indicates the authentication token is invalid.
+	ReasonAuthTokenInvalid = "TokenInvalid"
 )
 
 type HealthStatus struct {

--- a/pkg/registry/apis/provisioning/controller/conditions.go
+++ b/pkg/registry/apis/provisioning/controller/conditions.go
@@ -66,3 +66,31 @@ func buildReadyConditionWithReason(healthStatus provisioning.HealthStatus, reaso
 		Message: message,
 	}
 }
+
+// buildSpecCondition creates a Spec condition based on field validation errors.
+// Returns a condition with status True if there are no errors, False otherwise.
+func buildSpecCondition(fieldErrors []provisioning.ErrorDetails) metav1.Condition {
+	if len(fieldErrors) == 0 {
+		return metav1.Condition{
+			Type:    provisioning.ConditionTypeSpec,
+			Status:  metav1.ConditionTrue,
+			Reason:  provisioning.ReasonSpecValid,
+			Message: "Spec is valid",
+		}
+	}
+
+	// Build message with error count
+	var message string
+	if len(fieldErrors) == 1 {
+		message = "Spec has 1 validation error"
+	} else {
+		message = "Spec has multiple validation errors"
+	}
+
+	return metav1.Condition{
+		Type:    provisioning.ConditionTypeSpec,
+		Status:  metav1.ConditionFalse,
+		Reason:  provisioning.ReasonSpecInvalid,
+		Message: message,
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds authentication/token status tracking to Connection resources through a new Auth condition.

## Changes
- Add `ConditionTypeAuth` constant and Auth condition reasons to `health.go`:
  - `ReasonAuthValid` - Token is valid and working
  - `ReasonAuthTokenExpired` - Token has expired
  - `ReasonAuthTokenGenerationFailed` - Token generation failed
  - `ReasonAuthTokenInvalid` - Token is invalid
- Update `generateConnectionToken` to build and return Auth condition based on token generation success/failure
- Update connection controller to apply Auth condition patch to connection status
- Add integration test verification for Auth condition after token generation

## Behavior
The Auth condition tracks token/authentication status:
- **status=True, reason=Valid**: Successful token generation
- **status=False, reason=TokenGenerationFailed**: Token generation failure

## Test Plan
- [x] Verify code compiles successfully
- [x] Add integration test to verify Auth condition is set correctly
- [ ] Run full integration test suite
- [ ] Verify Auth condition appears in connection status after token generation
- [ ] Test token generation failure scenarios

## Based On
This PR is based on `feat/backend-remove-state-field` and adds the Auth condition alongside the existing Ready condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)