### PR TITLE
Loki Datasource: logContextProvider use all parsers in processContexFiltersToExpr

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3930,11 +3930,6 @@
       "count": 1
     }
   },
-  "public/app/plugins/datasource/loki/LogContextProvider.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
   "public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1

--- a/public/app/plugins/datasource/loki/LogContextProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.test.ts
@@ -300,7 +300,7 @@ describe('LogContextProvider', () => {
         }
       );
 
-      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | json | logfmt | foo=\`uniqueParsedLabel\``);
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | json | foo=\`uniqueParsedLabel\``);
     });
 
     it('should apply all parsers in correct order (json | logfmt)', async () => {
@@ -315,7 +315,7 @@ describe('LogContextProvider', () => {
         }
       );
 
-      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | json`);
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | json | logfmt`);
     });
 
     it('should apply parsers and drop operations when includePipelineOperations is enabled', async () => {
@@ -331,7 +331,7 @@ describe('LogContextProvider', () => {
         }
       );
 
-      expect(contextQuery.query.expr).toEqual(`{level="info"} | logfmt | json | drop __error__, __error_details__`);
+      expect(contextQuery.query.expr).toEqual(`{level="info"} | json | logfmt | drop __error__, __error_details__`);
     });
 
     it('should apply logfmt (with args) and regexp label parser from original query', async () => {
@@ -352,7 +352,7 @@ describe('LogContextProvider', () => {
 
       // Parsers are added after the selector; when multiple parsers exist, the later insertion ends up earlier.
       expect(contextQuery.query.expr).toEqual(
-        '{bar="baz",xyz="abc"} | regexp "(?P<foo>bar)" | logfmt --strict field="otherField", label'
+        '{bar="baz",xyz="abc"} | logfmt --strict field="otherField", label | regexp "(?P<foo>bar)"'
       );
     });
 
@@ -374,7 +374,7 @@ describe('LogContextProvider', () => {
       );
 
       expect(contextQuery.query.expr).toEqual(
-        '{bar="baz",xyz="abc"} | regexp "(?P<foo>bar)" | logfmt --strict field="otherField", label | foo=`uniqueParsedLabel`'
+        '{bar="baz",xyz="abc"} | logfmt --strict field="otherField", label | regexp "(?P<foo>bar)" | foo=`uniqueParsedLabel`'
       );
     });
 
@@ -395,7 +395,7 @@ describe('LogContextProvider', () => {
       );
 
       expect(contextQuery.query.expr).toEqual(
-        '{bar="baz",xyz="abc"} | pattern `<foo> <bar>` | logfmt --strict field="otherField", label'
+        '{bar="baz",xyz="abc"} | logfmt --strict field="otherField", label | pattern `<foo> <bar>`'
       );
     });
 
@@ -560,7 +560,7 @@ describe('LogContextProvider', () => {
       );
 
       // When includePipelineOperations is enabled, both parsers and pipeline stages are added
-      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | json | logfmt | line_format "foo" | label_format a="baz"`);
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | json | line_format "foo" | label_format a="baz"`);
     });
   });
 

--- a/public/app/plugins/datasource/loki/LogContextProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.test.ts
@@ -304,9 +304,7 @@ describe('LogContextProvider', () => {
     });
 
     it('should apply all parsers in correct order (json | logfmt)', async () => {
-      logContextProvider.cachedContextFilters = [
-        { value: 'baz', enabled: true, nonIndexed: false, label: 'bar' },
-      ];
+      logContextProvider.cachedContextFilters = [{ value: 'baz', enabled: true, nonIndexed: false, label: 'bar' }];
       const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
         defaultLogRow,
         10,

--- a/public/app/plugins/datasource/loki/LogContextProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.test.ts
@@ -318,7 +318,8 @@ describe('LogContextProvider', () => {
       expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | json`);
     });
 
-    it('should apply parsers and drop operations', async () => {
+    it('should apply parsers and drop operations when includePipelineOperations is enabled', async () => {
+      window.localStorage.setItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS, 'true');
       logContextProvider.cachedContextFilters = [{ value: 'info', enabled: true, nonIndexed: false, label: 'level' }];
       const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
         defaultLogRow,
@@ -331,6 +332,22 @@ describe('LogContextProvider', () => {
       );
 
       expect(contextQuery.query.expr).toEqual(`{level="info"} | logfmt | json | drop __error__, __error_details__`);
+    });
+
+    it('should not apply drop operations when includePipelineOperations is disabled', async () => {
+      window.localStorage.setItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS, 'false');
+      logContextProvider.cachedContextFilters = [{ value: 'info', enabled: true, nonIndexed: false, label: 'level' }];
+      const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
+        defaultLogRow,
+        10,
+        LogRowContextQueryDirection.Backward,
+        {
+          expr: '{level="info"} | json | logfmt | drop __error__, __error_details__',
+          refId: 'A',
+        }
+      );
+
+      expect(contextQuery.query.expr).toEqual(`{level="info"} | logfmt | json`);
     });
 
     it('should not apply line_format if flag is not set by default', async () => {

--- a/public/app/plugins/datasource/loki/LogContextProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.test.ts
@@ -318,6 +318,23 @@ describe('LogContextProvider', () => {
       expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | json`);
     });
 
+    it('should apply parsers and drop operations', async () => {
+      logContextProvider.cachedContextFilters = [
+        { value: 'info', enabled: true, nonIndexed: false, label: 'level' },
+      ];
+      const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
+        defaultLogRow,
+        10,
+        LogRowContextQueryDirection.Backward,
+        {
+          expr: '{level="info"} | json | logfmt | drop __error__, __error_details__',
+          refId: 'A',
+        }
+      );
+
+      expect(contextQuery.query.expr).toEqual(`{level="info"} | drop __error__, __error_details__ | logfmt | json`);
+    });
+
     it('should not apply line_format if flag is not set by default', async () => {
       logContextProvider.cachedContextFilters = [{ value: 'baz', enabled: true, nonIndexed: false, label: 'bar' }];
       const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(

--- a/public/app/plugins/datasource/loki/LogContextProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.test.ts
@@ -330,7 +330,7 @@ describe('LogContextProvider', () => {
         }
       );
 
-      expect(contextQuery.query.expr).toEqual(`{level="info"} | drop __error__, __error_details__ | logfmt | json`);
+      expect(contextQuery.query.expr).toEqual(`{level="info"} | logfmt | json | drop __error__, __error_details__`);
     });
 
     it('should not apply line_format if flag is not set by default', async () => {

--- a/public/app/plugins/datasource/loki/LogContextProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.test.ts
@@ -319,9 +319,7 @@ describe('LogContextProvider', () => {
     });
 
     it('should apply parsers and drop operations', async () => {
-      logContextProvider.cachedContextFilters = [
-        { value: 'info', enabled: true, nonIndexed: false, label: 'level' },
-      ];
+      logContextProvider.cachedContextFilters = [{ value: 'info', enabled: true, nonIndexed: false, label: 'level' }];
       const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
         defaultLogRow,
         10,

--- a/public/app/plugins/datasource/loki/LogContextProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.test.ts
@@ -318,8 +318,7 @@ describe('LogContextProvider', () => {
       expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | json`);
     });
 
-    it('should apply parsers and drop operations when includePipelineOperations is enabled', async () => {
-      window.localStorage.setItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS, 'true');
+    it('should apply parsers and drop operations', async () => {
       logContextProvider.cachedContextFilters = [{ value: 'info', enabled: true, nonIndexed: false, label: 'level' }];
       const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
         defaultLogRow,
@@ -332,22 +331,6 @@ describe('LogContextProvider', () => {
       );
 
       expect(contextQuery.query.expr).toEqual(`{level="info"} | logfmt | json | drop __error__, __error_details__`);
-    });
-
-    it('should not apply drop operations when includePipelineOperations is disabled', async () => {
-      window.localStorage.setItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS, 'false');
-      logContextProvider.cachedContextFilters = [{ value: 'info', enabled: true, nonIndexed: false, label: 'level' }];
-      const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
-        defaultLogRow,
-        10,
-        LogRowContextQueryDirection.Backward,
-        {
-          expr: '{level="info"} | json | logfmt | drop __error__, __error_details__',
-          refId: 'A',
-        }
-      );
-
-      expect(contextQuery.query.expr).toEqual(`{level="info"} | logfmt | json`);
     });
 
     it('should not apply line_format if flag is not set by default', async () => {

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -268,13 +268,13 @@ export class LogContextProvider {
         // Extract parsers and drop operations separately
         const parserNodes = getNodesFromQuery(query.expr, [LabelParser, JsonExpressionParser, Logfmt]);
         const dropNodes = getNodesFromQuery(query.expr, [DropLabelsExpr]);
-        
+
         // Add parsers first
         for (const node of parserNodes) {
           const parserName = query.expr.substring(node.from, node.to).trim();
           expr = addParserToQuery(expr, parserName);
         }
-        
+
         // Add drop operations at the end
         for (const node of dropNodes) {
           const dropExpression = query.expr.substring(node.from, node.to).trim();

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -25,6 +25,8 @@ import {
   Logfmt,
   Json,
   JsonExpressionParser,
+  LogfmtParser,
+  LogfmtExpressionParser,
 } from '@grafana/lezer-logql';
 
 import { LokiContextUi } from './components/LokiContextUi';
@@ -265,8 +267,13 @@ export class LogContextProvider {
       const parserInfo = isQueryWithParser(query.expr);
       if (parserInfo.parserCount >= 1) {
         hasParser = true;
-        // Extract parsers and drop operations separately
-        const parserNodes = getNodesFromQuery(query.expr, [LabelParser, JsonExpressionParser, Logfmt]);
+        // Extract parsers
+        const parserNodes = getNodesFromQuery(query.expr, [
+          LabelParser,
+          JsonExpressionParser,
+          LogfmtParser,
+          LogfmtExpressionParser,
+        ]);
 
         // Add parsers first
         for (const node of parserNodes) {

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -15,6 +15,7 @@ import {
   LogRowContextOptions,
   dateTime,
   ScopedVars,
+  store,
 } from '@grafana/data';
 import {
   LabelParser,
@@ -24,7 +25,6 @@ import {
   Logfmt,
   Json,
   JsonExpressionParser,
-  DropLabelsExpr,
 } from '@grafana/lezer-logql';
 
 import { LokiContextUi } from './components/LokiContextUi';
@@ -237,7 +237,7 @@ export class LogContextProvider {
 
   prepareExpression(contextFilters: ContextFilter[], query: LokiQuery | undefined): string {
     let preparedExpression = this.processContextFiltersToExpr(contextFilters, query);
-    if (window.localStorage.getItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS) === 'true') {
+    if (store.get(SHOULD_INCLUDE_PIPELINE_OPERATIONS) === 'true') {
       preparedExpression = this.processPipelineStagesToExpr(preparedExpression, query);
     }
     return preparedExpression;
@@ -376,7 +376,7 @@ export class LogContextProvider {
 
     // Secondly we check for preserved labels and update enabled state of filters based on that
     let preservedLabels: undefined | PreservedLabels = undefined;
-    const preservedLabelsString = window.localStorage.getItem(LOKI_LOG_CONTEXT_PRESERVED_LABELS);
+    const preservedLabelsString = store.get(LOKI_LOG_CONTEXT_PRESERVED_LABELS);
     if (preservedLabelsString) {
       try {
         preservedLabels = JSON.parse(preservedLabelsString);

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -275,6 +275,8 @@ export class LogContextProvider {
           LogfmtExpressionParser,
         ]);
 
+        parserNodes.sort((a, b) => b.from - a.from);
+
         // Add parsers first
         for (const node of parserNodes) {
           const parserName = query.expr.substring(node.from, node.to).trim();

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -267,18 +267,11 @@ export class LogContextProvider {
         hasParser = true;
         // Extract parsers and drop operations separately
         const parserNodes = getNodesFromQuery(query.expr, [LabelParser, JsonExpressionParser, Logfmt]);
-        const dropNodes = getNodesFromQuery(query.expr, [DropLabelsExpr]);
 
         // Add parsers first
         for (const node of parserNodes) {
           const parserName = query.expr.substring(node.from, node.to).trim();
           expr = addParserToQuery(expr, parserName);
-        }
-
-        // Add drop operations at the end
-        for (const node of dropNodes) {
-          const dropExpression = query.expr.substring(node.from, node.to).trim();
-          expr += ` | ${dropExpression}`;
         }
       }
 
@@ -302,10 +295,6 @@ export class LogContextProvider {
   processPipelineStagesToExpr = (currentExpr: string, query: LokiQuery | undefined): string => {
     let newExpr = currentExpr;
     const origExpr = query?.expr ?? '';
-
-    if (isQueryWithParser(origExpr).parserCount > 1) {
-      return newExpr;
-    }
 
     const allNodePositions = getNodePositionsFromQuery(origExpr, [
       PipelineStage,

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -24,6 +24,7 @@ import {
   Logfmt,
   Json,
   JsonExpressionParser,
+  DropLabelsExpr,
 } from '@grafana/lezer-logql';
 
 import { LokiContextUi } from './components/LokiContextUi';
@@ -264,8 +265,8 @@ export class LogContextProvider {
       const parserInfo = isQueryWithParser(query.expr);
       if (parserInfo.parserCount >= 1) {
         hasParser = true;
-        // Extract all parsers and add them to the context query
-        const parserNodes = getNodesFromQuery(query.expr, [LabelParser, JsonExpressionParser, Logfmt]);
+        // Extract all parsers and drop operations, then add them to the context query
+        const parserNodes = getNodesFromQuery(query.expr, [LabelParser, JsonExpressionParser, Logfmt, DropLabelsExpr]);
         for (const node of parserNodes) {
           const parserName = query.expr.substring(node.from, node.to).trim();
           expr = addParserToQuery(expr, parserName);

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -15,7 +15,6 @@ import {
   LogRowContextOptions,
   dateTime,
   ScopedVars,
-  store,
 } from '@grafana/data';
 import {
   LabelParser,
@@ -238,7 +237,7 @@ export class LogContextProvider {
 
   prepareExpression(contextFilters: ContextFilter[], query: LokiQuery | undefined): string {
     let preparedExpression = this.processContextFiltersToExpr(contextFilters, query);
-    if (store.get(SHOULD_INCLUDE_PIPELINE_OPERATIONS) === 'true') {
+    if (window.localStorage.getItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS) === 'true') {
       preparedExpression = this.processPipelineStagesToExpr(preparedExpression, query);
     }
     return preparedExpression;
@@ -266,19 +265,17 @@ export class LogContextProvider {
       const parserInfo = isQueryWithParser(query.expr);
       if (parserInfo.parserCount >= 1) {
         hasParser = true;
-        // Extract parsers
+        // Extract parsers and drop operations separately
         const parserNodes = getNodesFromQuery(query.expr, [LabelParser, JsonExpressionParser, Logfmt]);
+        const dropNodes = getNodesFromQuery(query.expr, [DropLabelsExpr]);
 
-        // Add parsers
+        // Add parsers first
         for (const node of parserNodes) {
           const parserName = query.expr.substring(node.from, node.to).trim();
           expr = addParserToQuery(expr, parserName);
         }
-      }
 
-      // Add drop operations at the end only if includePipelineOperations is enabled
-      if (store.get(SHOULD_INCLUDE_PIPELINE_OPERATIONS) === 'true') {
-        const dropNodes = getNodesFromQuery(query.expr, [DropLabelsExpr]);
+        // Add drop operations at the end
         for (const node of dropNodes) {
           const dropExpression = query.expr.substring(node.from, node.to).trim();
           expr += ` | ${dropExpression}`;
@@ -390,7 +387,7 @@ export class LogContextProvider {
 
     // Secondly we check for preserved labels and update enabled state of filters based on that
     let preservedLabels: undefined | PreservedLabels = undefined;
-    const preservedLabelsString = store.get(LOKI_LOG_CONTEXT_PRESERVED_LABELS);
+    const preservedLabelsString = window.localStorage.getItem(LOKI_LOG_CONTEXT_PRESERVED_LABELS);
     if (preservedLabelsString) {
       try {
         preservedLabels = JSON.parse(preservedLabelsString);

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -265,11 +265,20 @@ export class LogContextProvider {
       const parserInfo = isQueryWithParser(query.expr);
       if (parserInfo.parserCount >= 1) {
         hasParser = true;
-        // Extract all parsers and drop operations, then add them to the context query
-        const parserNodes = getNodesFromQuery(query.expr, [LabelParser, JsonExpressionParser, Logfmt, DropLabelsExpr]);
+        // Extract parsers and drop operations separately
+        const parserNodes = getNodesFromQuery(query.expr, [LabelParser, JsonExpressionParser, Logfmt]);
+        const dropNodes = getNodesFromQuery(query.expr, [DropLabelsExpr]);
+        
+        // Add parsers first
         for (const node of parserNodes) {
           const parserName = query.expr.substring(node.from, node.to).trim();
           expr = addParserToQuery(expr, parserName);
+        }
+        
+        // Add drop operations at the end
+        for (const node of dropNodes) {
+          const dropExpression = query.expr.substring(node.from, node.to).trim();
+          expr += ` | ${dropExpression}`;
         }
       }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Fix the 🐛 for Logs Context not showing display fields. Let me know if there was more to this ticket!
1. Datasource: gdev-loki
2. Query: {service_name="faro"} | json | logfmt | drop __error__, __error_details__
3. Click show context and see the missing default fields on the log line
<img width="1053" height="266" alt="Screenshot 2026-01-26 at 10 49 31 AM" src="https://github.com/user-attachments/assets/2c83b138-dd45-4a44-9222-de59a08b6209" />
4. Run this branch and now click show context and observer the default fields being applied
<img width="888" height="521" alt="Screenshot 2026-01-26 at 12 30 16 PM" src="https://github.com/user-attachments/assets/923b2e64-b424-41b5-8deb-77eef727b153" />

Fixes #
Fix for https://github.com/grafana/support-escalations/issues/20372 and https://github.com/grafana/grafana/issues/116779

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
