### PR TITLE
Tests: Emit test coverage metrics in Prometheus text exposition format

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1060,6 +1060,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /scripts/grafana-server/ @grafana/grafana-frontend-platform
 /scripts/check-frontend-dev.sh @grafana/grafana-frontend-platform
 /scripts/check-codeowner-affected.js @grafana/dataviz-squad
+/scripts/aggregate-coverage-metrics.js @grafana/dataviz-squad
 /scripts/compare-coverage-by-codeowner.js @grafana/dataviz-squad
 /scripts/helpers/ @grafana/grafana-developer-enablement-squad
 /scripts/import_many_dashboards.sh @torkelo
@@ -1299,6 +1300,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/publish-artifact.yml @grafana/grafana-developer-enablement-squad
 /.github/actions/changelog @zserge
 /.github/workflows/check-frontend-test-coverage.yml @grafana/dataviz-squad
+/.github/workflows/emit-frontend-test-coverage-metrics.yaml @grafana/dataviz-squad
 /.github/workflows/swagger-gen.yml @grafana/grafana-backend-group
 /.github/workflows/pr-frontend-unit-tests.yml @grafana/grafana-frontend-platform
 /.github/workflows/frontend-lint.yml @grafana/grafana-frontend-platform

--- a/.github/workflows/emit-frontend-test-coverage-metrics.yaml
+++ b/.github/workflows/emit-frontend-test-coverage-metrics.yaml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 0 * * *" # Run daily at midnight UTC
   workflow_dispatch: # Allow manual triggering
+  push:
+    branches:
+      - jesdavpet/111208-emit-test-coverage-metrics-prometheus-format # TEMPORARY: Remove before merge
 
 jobs:
   setup:
@@ -33,10 +36,9 @@ jobs:
       matrix:
         codeowner: ${{ fromJSON(needs.setup.outputs.opted-in-teams) }}
     steps:
-      - name: Checkout main branch
+      - name: Checkout branch
         uses: actions/checkout@v5
         with:
-          ref: main
           persist-credentials: false
 
       - name: Setup Node.js
@@ -78,10 +80,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Checkout main branch
+      - name: Checkout branch
         uses: actions/checkout@v5
         with:
-          ref: main
           persist-credentials: false
 
       - name: Setup Node.js

--- a/.github/workflows/emit-frontend-test-coverage-metrics.yaml
+++ b/.github/workflows/emit-frontend-test-coverage-metrics.yaml
@@ -1,0 +1,162 @@
+name: Emit Frontend Test Coverage Metrics
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Run daily at midnight UTC
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  setup:
+    name: Setup opted-in teams
+    runs-on: ubuntu-x64-small
+    outputs:
+      # NOTE: Only collects coverage metrics for opted-in codeowners.
+      #       Please add the GitHub user/team or email used in
+      #       CODEOWNERS to the list below to opt-in.
+      opted-in-teams: >-
+        [
+          "@grafana/datapro",
+          "@grafana/dataviz-squad"
+        ]
+    steps:
+      - name: Define opted-in teams
+        run: echo "Opted-in teams defined in job outputs"
+
+  coverage:
+    name: Coverage - ${{ matrix.codeowner }}
+    needs: setup
+    runs-on: ubuntu-x64-large
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        codeowner: ${{ fromJSON(needs.setup.outputs.opted-in-teams) }}
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Install dependencies
+        run: yarn install --immutable
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
+          CYPRESS_INSTALL_BINARY: 0
+
+      - name: Get codeowner slug
+        id: codeowner-slug
+        run: |
+          SLUG=$(node -e "
+            const { createCodeownerSlug } = require('./scripts/codeowners-manifest/utils.js');
+            console.log(createCodeownerSlug('${{ matrix.codeowner }}'));
+          ")
+          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
+
+      - name: Run coverage for ${{ matrix.codeowner }}
+        run: yarn test:coverage:by-codeowner "${{ matrix.codeowner }}" --maxWorkers=1
+        env:
+          SHOULD_OPEN_COVERAGE_REPORT: 'false'
+          CI: 'true'
+
+      - name: Upload coverage summary
+        uses: actions/upload-artifact@v5
+        with:
+          name: coverage-main-${{ steps.codeowner-slug.outputs.slug }}
+          path: coverage-summary.json
+          retention-days: 1
+
+  aggregate-and-upload:
+    name: Aggregate and upload metrics
+    needs: [setup, coverage]
+    runs-on: ubuntu-x64-small
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Install dependencies for slug generation
+        run: yarn install --immutable
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
+          CYPRESS_INSTALL_BINARY: 0
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v6
+        with:
+          pattern: coverage-main-*
+          path: coverage/summaries-raw
+
+      - name: Organize coverage files
+        run: |
+          for dir in coverage/summaries-raw/coverage-main-*; do
+            if [ -d "$dir" ]; then
+              slug=$(basename "$dir" | sed 's/^coverage-main-//')
+              echo "Organizing coverage for slug: $slug"
+              mkdir -p "coverage/summaries/$slug"
+              mv "$dir/coverage-summary.json" "coverage/summaries/$slug/"
+            fi
+          done
+
+      - name: Aggregate coverage metrics
+        run: node scripts/aggregate-coverage-metrics.js
+
+      - name: Display generated metrics
+        run: cat coverage/coverage-metrics.txt
+
+      # - name: Get Vault secrets
+      #   id: get-secrets
+      #   uses: grafana/shared-workflows/actions/get-vault-secrets@62722333225a1fae03ae27a63d638f9bc2176edb #get-vault-secrets-v1.2.0
+      #   with:
+      #     repo_secrets: |
+      #       PROMETHEUS_URL=frontend_perf_tests:prometheus_push_url
+      #       PROMETHEUS_USER=frontend_perf_tests:prometheus_user
+      #       PROMETHEUS_TOKEN=frontend_perf_tests:prometheus_token
+
+      # - name: Authenticate Docker
+      #   uses: grafana/shared-workflows/actions/login-to-gar@main
+      #   id: login-to-gar
+      #   with:
+      #     registry: 'us-docker.pkg.dev'
+
+      # - name: Upload metrics to Grafana Bench
+      #   id: bench-upload
+      #   continue-on-error: true
+      #   run: |
+      #     docker run \
+      #       --rm \
+      #       --volume="./coverage/coverage-metrics.txt:/metrics.txt" \
+      #       -e PROMETHEUS_URL="$PROMETHEUS_URL" \
+      #       -e PROMETHEUS_USER="$PROMETHEUS_USER" \
+      #       -e PROMETHEUS_PASSWORD="$PROMETHEUS_TOKEN" \
+      #       us-docker.pkg.dev/grafanalabs-global/docker-grafana-bench-prod/grafana-bench:v0.6.1 report \
+      #         --test-suite-name "FrontendCoverage" \
+      #         --report-output log \
+      #         --prometheus-metrics \
+      #         --run-metrics-file "/metrics.txt" \
+      #         --log-level DEBUG
+
+      # - name: Check upload status
+      #   env:
+      #     BENCH_OUTCOME: ${{ steps.bench-upload.outcome }}
+      #   run: |
+      #     echo "BENCH_OUTCOME: $BENCH_OUTCOME"
+      #
+      #     if [[ "$BENCH_OUTCOME" != "success" ]]; then
+      #       echo "❌ Metrics upload failed"
+      #       exit 1
+      #     fi
+      #
+      #     echo "✅ Metrics uploaded successfully"

--- a/scripts/aggregate-coverage-metrics.js
+++ b/scripts/aggregate-coverage-metrics.js
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+
+/**
+ * Aggregates coverage summary JSON files into Prometheus metrics format.
+ *
+ * Usage: node scripts/aggregate-coverage-metrics.js [summaries-dir] [output-file]
+ * Defaults: ./coverage/summaries → ./coverage/coverage-metrics.txt
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const COVERAGE_SUMMARIES_DIR = './coverage/summaries';
+const METRICS_OUTPUT_PATH = './coverage/coverage-metrics.txt';
+const PACKAGE_NAME = '@grafana/grafana';
+
+/**
+ * Aggregates coverage metrics from JSON files to Prometheus format
+ * @param {string} summariesDir - Directory containing coverage summaries
+ * @param {string} outputPath - Path to output metrics file
+ * @throws {Error} If no coverage files found, invalid file format, or write fails
+ */
+function aggregateCoverageMetricsFromFiles(summariesDir = COVERAGE_SUMMARIES_DIR, outputPath = METRICS_OUTPUT_PATH) {
+  const coverageData = readCoverageDataFromDirectory(summariesDir);
+  const metricsContent = generatePrometheusMetrics(coverageData);
+  writeMetricsFile(outputPath, metricsContent);
+}
+
+/**
+ * Reads coverage summary files from directory
+ * @param {string} summariesDir - Directory containing coverage summaries
+ * @returns {Array<Object>} Normalized coverage data
+ * @throws {Error} If no coverage files found or directory cannot be read
+ */
+function readCoverageDataFromDirectory(summariesDir) {
+  const summaryFiles = findCoverageSummaryFiles(summariesDir);
+
+  if (summaryFiles.length === 0) {
+    throw new Error(
+      `No coverage-summary.json files found in ${summariesDir}. Please ensure coverage summaries are present in subdirectories`
+    );
+  }
+
+  console.log(`Found ${summaryFiles.length} coverage summary file(s)`);
+
+  return summaryFiles.map(parseCoverageSummary);
+}
+
+/**
+ * Converts coverage data to Prometheus metrics format
+ * @param {Array<Object>} coverageDataByCodeowner - Coverage data array
+ * @returns {string} Prometheus text exposition format
+ */
+function generatePrometheusMetrics(coverageDataByCodeowner) {
+  const lineMetrics = coverageDataByCodeowner.map((d) => ({
+    codeowner: d.codeowner,
+    value: d.summary.lines.pct,
+    timestamp: d.timestamp,
+  }));
+
+  const branchMetrics = coverageDataByCodeowner.map((d) => ({
+    codeowner: d.codeowner,
+    value: d.summary.branches.pct,
+    timestamp: d.timestamp,
+  }));
+
+  const functionMetrics = coverageDataByCodeowner.map((d) => ({
+    codeowner: d.codeowner,
+    value: d.summary.functions.pct,
+    timestamp: d.timestamp,
+  }));
+
+  const statementMetrics = coverageDataByCodeowner.map((d) => ({
+    codeowner: d.codeowner,
+    value: d.summary.statements.pct,
+    timestamp: d.timestamp,
+  }));
+
+  const metricBlocks = [
+    generateMetricBlock('grafana_frontend_line_coverage_percent', 'Line test coverage percentage', lineMetrics),
+    generateMetricBlock('grafana_frontend_branch_coverage_percent', 'Branch test coverage percentage', branchMetrics),
+    generateMetricBlock(
+      'grafana_frontend_function_coverage_percent',
+      'Function test coverage percentage',
+      functionMetrics
+    ),
+    generateMetricBlock(
+      'grafana_frontend_statement_coverage_percent',
+      'Statement test coverage percentage',
+      statementMetrics
+    ),
+  ];
+
+  return metricBlocks.join('\n\n') + '\n';
+}
+
+/**
+ * Writes metrics to file
+ * @param {string} outputPath - Output file path
+ * @param {string} content - Metrics content
+ * @throws {Error} If file cannot be written
+ */
+function writeMetricsFile(outputPath, content) {
+  fs.writeFileSync(outputPath, content, 'utf8');
+  console.log(`✅ Coverage metrics written to ${outputPath}`);
+}
+
+/**
+ * Finds coverage-summary.json files in immediate subdirectories
+ * @param {string} dir - Directory to search
+ * @returns {string[]} File paths
+ * @throws {Error} If directory cannot be read
+ */
+function findCoverageSummaryFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  return entries.map((entry) => findCoverageSummaryInEntry(dir, entry)).filter((path) => path !== null);
+}
+
+/**
+ * Parses coverage summary file
+ * @param {string} filePath - Coverage summary file path
+ * @returns {Object} Normalized coverage data
+ * @throws {Error} If file cannot be read or format is invalid
+ */
+function parseCoverageSummary(filePath) {
+  const data = readCoverageSummary(filePath);
+
+  if (!data.summary || !data.team || !data.timestamp) {
+    throw new Error(`Invalid coverage summary format in ${filePath}`);
+  }
+
+  return {
+    codeowner: data.team,
+    timestamp: convertToUnixMilliseconds(data.timestamp),
+    summary: data.summary,
+  };
+}
+
+/**
+ * Generates Prometheus metric block for a metric type
+ * @param {string} metricName - Metric name
+ * @param {string} helpText - HELP text
+ * @param {Array<Object>} codeowners - Codeowner data with codeowner, value, timestamp
+ * @returns {string} Prometheus formatted metrics
+ */
+function generateMetricBlock(metricName, helpText, codeowners) {
+  const header = [`# HELP ${metricName} ${helpText}`, `# TYPE ${metricName} gauge`];
+
+  const metricLines = codeowners.map((codeowner) => formatMetricLine(metricName, codeowner));
+
+  return [...header, ...metricLines].join('\n');
+}
+
+/**
+ * Checks if directory entry contains coverage-summary.json
+ * @param {string} dir - Parent directory path
+ * @param {fs.Dirent} entry - Directory entry
+ * @returns {string|null} Coverage summary path or null
+ */
+function findCoverageSummaryInEntry(dir, entry) {
+  if (!entry.isDirectory()) {
+    return null;
+  }
+
+  const fullPath = path.join(dir, entry.name);
+  const summaryPath = path.join(fullPath, 'coverage-summary.json');
+
+  return fs.existsSync(summaryPath) ? summaryPath : null;
+}
+
+/**
+ * Reads and parses coverage summary JSON file
+ * @param {string} filePath - Coverage summary file path
+ * @returns {Object} Parsed coverage data
+ * @throws {Error} If file cannot be read or JSON is invalid
+ */
+function readCoverageSummary(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(content);
+}
+
+/**
+ * Converts ISO timestamp to Unix milliseconds
+ * @param {string} isoTimestamp - ISO 8601 timestamp
+ * @returns {number} Unix milliseconds
+ * @throws {Error} If timestamp is invalid
+ */
+function convertToUnixMilliseconds(isoTimestamp) {
+  const timestamp = new Date(isoTimestamp).getTime();
+  if (isNaN(timestamp)) {
+    throw new Error(`Invalid ISO timestamp: ${isoTimestamp}`);
+  }
+  return timestamp;
+}
+
+/**
+ * Formats codeowner coverage as Prometheus metric line
+ * @param {string} metricName - Metric name
+ * @param {Object} codeowner - Codeowner data
+ * @returns {string} Prometheus metric line
+ */
+function formatMetricLine(metricName, codeowner) {
+  return `${metricName}{codeowner="${codeowner.codeowner}",package="${PACKAGE_NAME}"} ${codeowner.value} ${codeowner.timestamp}`;
+}
+
+if (require.main === module) {
+  const summariesDir = process.argv[2] || COVERAGE_SUMMARIES_DIR;
+  const outputPath = process.argv[3] || METRICS_OUTPUT_PATH;
+
+  try {
+    aggregateCoverageMetricsFromFiles(summariesDir, outputPath);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  readCoverageDataFromDirectory,
+  generatePrometheusMetrics,
+  aggregateCoverageMetricsFromFiles,
+};


### PR DESCRIPTION
# 🚧 WIP 👷 

**What is this feature?**

This change adds a new Node.js script and GitHub Actions workflow to emit test coverage metrics in the Prometheus text exposition format, based on an opt-in list of codeowners.


Example GHA workflow run on this branch:
- https://github.com/grafana/grafana/actions/runs/21375519514

Example of test coverage metrics for @grafana/dataviz-squad and @grafana/datapro in a `coverage-metrics.txt` file:
```
# HELP grafana_frontend_line_coverage_percent Line test coverage percentage
# TYPE grafana_frontend_line_coverage_percent gauge
grafana_frontend_line_coverage_percent{codeowner="@grafana/datapro",package="@grafana/grafana"} 67.28 1769464898033
grafana_frontend_line_coverage_percent{codeowner="@grafana/dataviz-squad",package="@grafana/grafana"} 40.59 1769464879545

# HELP grafana_frontend_branch_coverage_percent Branch test coverage percentage
# TYPE grafana_frontend_branch_coverage_percent gauge
grafana_frontend_branch_coverage_percent{codeowner="@grafana/datapro",package="@grafana/grafana"} 55.05 1769464898033
grafana_frontend_branch_coverage_percent{codeowner="@grafana/dataviz-squad",package="@grafana/grafana"} 41.85 1769464879545

# HELP grafana_frontend_function_coverage_percent Function test coverage percentage
# TYPE grafana_frontend_function_coverage_percent gauge
grafana_frontend_function_coverage_percent{codeowner="@grafana/datapro",package="@grafana/grafana"} 58.91 1769464898033
grafana_frontend_function_coverage_percent{codeowner="@grafana/dataviz-squad",package="@grafana/grafana"} 45.82 1769464879545

# HELP grafana_frontend_statement_coverage_percent Statement test coverage percentage
# TYPE grafana_frontend_statement_coverage_percent gauge
grafana_frontend_statement_coverage_percent{codeowner="@grafana/datapro",package="@grafana/grafana"} 75.49 1769464898033
grafana_frontend_statement_coverage_percent{codeowner="@grafana/dataviz-squad",package="@grafana/grafana"} 59.45 1769464879545

```

**Why do we need this feature?**

So that we can send frontend test coverage metrics to Bench and track them our progress on testing over time.

**Who is this feature for?**

Grafanistas who work on frontend code.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/111208

**Special notes for your reviewer:**



Please check that:
- [x] It works as expected from a user's perspective.
- `N/A` ~If this is a pre-GA feature, it is behind a feature toggle.~
- `N/A` ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
