### PR TITLE
MySQL: Add variable query editor support

### DIFF
--- a/public/app/plugins/datasource/mysql/MySqlDatasource.ts
+++ b/public/app/plugins/datasource/mysql/MySqlDatasource.ts
@@ -2,7 +2,16 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { DataSourceInstanceSettings, TimeRange } from '@grafana/data';
 import { CompletionItemKind, LanguageDefinition, TableIdentifier } from '@grafana/plugin-ui';
-import { COMMON_FNS, DB, FuncParameter, MACRO_FUNCTIONS, SQLQuery, SqlDatasource, formatSQL } from '@grafana/sql';
+import {
+  COMMON_FNS,
+  DB,
+  FuncParameter,
+  MACRO_FUNCTIONS,
+  SQLQuery,
+  SQLVariableSupport,
+  SqlDatasource,
+  formatSQL,
+} from '@grafana/sql';
 
 import { mapFieldsToTypes } from './fields';
 import { buildColumnQuery, buildTableQuery, showDatabases } from './mySqlMetaQuery';
@@ -15,6 +24,8 @@ export class MySqlDatasource extends SqlDatasource {
 
   constructor(private instanceSettings: DataSourceInstanceSettings<MySQLOptions>) {
     super(instanceSettings);
+    this.dialect = 'other';
+    this.variables = new SQLVariableSupport(this);
   }
 
   getQueryModel() {

--- a/public/app/plugins/datasource/mysql/MySqlDatasource.ts
+++ b/public/app/plugins/datasource/mysql/MySqlDatasource.ts
@@ -24,7 +24,6 @@ export class MySqlDatasource extends SqlDatasource {
 
   constructor(private instanceSettings: DataSourceInstanceSettings<MySQLOptions>) {
     super(instanceSettings);
-    this.dialect = 'other';
     this.variables = new SQLVariableSupport(this);
   }
 


### PR DESCRIPTION
similar to https://github.com/grafana/grafana/pull/115974, this PR adds multi var support for MySQL and migrates away from metricFindQuery

Updated / new variable editor: 

<img width="934" height="597" alt="image" src="https://github.com/user-attachments/assets/483cfc9f-44ef-4359-b62e-78263c7b3ff7" />
