### PR TITLE
Dashboard: Backport Switch variable to old architecture

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -116,6 +116,7 @@ import { getVariablesUrlParams } from './features/variables/getAllVariableValues
 import { createIntervalVariableAdapter } from './features/variables/interval/adapter';
 import { setVariableQueryRunner, VariableQueryRunner } from './features/variables/query/VariableQueryRunner';
 import { createQueryVariableAdapter } from './features/variables/query/adapter';
+import { createSwitchVariableAdapter } from './features/variables/switch/adapter';
 import { createSystemVariableAdapter } from './features/variables/system/adapter';
 import { createTextBoxVariableAdapter } from './features/variables/textbox/adapter';
 import { configureStore } from './store/configureStore';
@@ -216,6 +217,7 @@ export class GrafanaApp {
         createIntervalVariableAdapter(),
         createAdHocVariableAdapter(),
         createSystemVariableAdapter(),
+        createSwitchVariableAdapter(),
       ]);
 
       monacoLanguageRegistry.setInit(getDefaultMonacoLanguages);

--- a/public/app/features/variables/switch/SwitchVariableEditor.tsx
+++ b/public/app/features/variables/switch/SwitchVariableEditor.tsx
@@ -1,0 +1,71 @@
+import { memo } from 'react';
+
+import { SwitchVariableModel } from '@grafana/data';
+import { SwitchVariableForm } from 'app/features/dashboard-scene/settings/variables/components/SwitchVariableForm';
+
+import { VariableEditorProps } from '../editor/types';
+
+export interface Props extends VariableEditorProps<SwitchVariableModel> {}
+
+export const SwitchVariableEditor = memo(({ onPropChange, variable }: Props) => {
+  const onEnabledValueChange = (newEnabledValue: string) => {
+    const shouldUpdateCurrent = variable.current.value === variable.options[0].value;
+
+    const enabled = {
+      ...variable.options[0],
+      value: newEnabledValue,
+      text: newEnabledValue,
+    };
+
+    const disabled = variable.options[1];
+
+    onPropChange({
+      propName: 'options',
+      propValue: [enabled, disabled],
+      updateOptions: true,
+    });
+
+    if (shouldUpdateCurrent) {
+      onPropChange({
+        propName: 'current',
+        propValue: enabled,
+      });
+    }
+  };
+
+  const onDisabledValueChange = (newDisabledValue: string) => {
+    const shouldUpdateCurrent = variable.current.value === variable.options[1].value;
+
+    const enabled = variable.options[0];
+
+    const disabled = {
+      ...variable.options[1],
+      value: newDisabledValue,
+      text: newDisabledValue,
+    };
+
+    onPropChange({
+      propName: 'options',
+      propValue: [enabled, disabled],
+      updateOptions: true,
+    });
+
+    if (shouldUpdateCurrent) {
+      onPropChange({
+        propName: 'current',
+        propValue: disabled,
+      });
+    }
+  };
+
+  return (
+    <SwitchVariableForm
+      enabledValue={String(variable.options[0].value)}
+      disabledValue={String(variable.options[1].value)}
+      onEnabledValueChange={onEnabledValueChange}
+      onDisabledValueChange={onDisabledValueChange}
+    />
+  );
+});
+
+SwitchVariableEditor.displayName = 'SwitchVariableEditor';

--- a/public/app/features/variables/switch/SwitchVariablePicker.tsx
+++ b/public/app/features/variables/switch/SwitchVariablePicker.tsx
@@ -1,0 +1,45 @@
+import { ChangeEvent, ReactElement, useCallback } from 'react';
+
+import { SwitchVariableModel } from '@grafana/data';
+import { Switch } from '@grafana/ui';
+
+import { variableAdapters } from '../adapters';
+import { VariablePickerProps } from '../pickers/types';
+
+export interface Props extends VariablePickerProps<SwitchVariableModel> {}
+
+export function SwitchVariablePicker({ variable, onVariableChange }: Props): ReactElement {
+  const updateVariable = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      if (!variable.rootStateKey) {
+        console.error('Cannot update variable without rootStateKey');
+        return;
+      }
+
+      const newValue = event!.currentTarget.checked ? variable.options[0] : variable.options[1];
+
+      if (variable.current.value === newValue.value) {
+        return;
+      }
+
+      if (onVariableChange) {
+        onVariableChange({
+          ...variable,
+          current: newValue,
+        });
+        return;
+      }
+
+      variableAdapters.get(variable.type).updateOptions(variable);
+    },
+    [variable, onVariableChange]
+  );
+
+  return (
+    <Switch
+      id={`var-${variable.id}`}
+      value={variable.current.value === variable.options[0].value}
+      onChange={updateVariable}
+    />
+  );
+}

--- a/public/app/features/variables/switch/adapter.ts
+++ b/public/app/features/variables/switch/adapter.ts
@@ -1,0 +1,42 @@
+import { cloneDeep } from 'lodash';
+
+import { SwitchVariableModel } from '@grafana/data';
+import { t } from '@grafana/i18n';
+
+import { dispatch } from '../../../store/store';
+import { VariableAdapter } from '../adapters';
+import { setOptionAsCurrent, setOptionFromUrl } from '../state/actions';
+import { containsVariable, toKeyedVariableIdentifier } from '../utils';
+
+import { SwitchVariableEditor } from './SwitchVariableEditor';
+import { SwitchVariablePicker } from './SwitchVariablePicker';
+import { switchVariableReducer, initialSwitchVariableModelState } from './reducer';
+
+export const createSwitchVariableAdapter = (): VariableAdapter<SwitchVariableModel> => {
+  return {
+    id: 'switch',
+    description: t('variables.create-switch-variable-adapter.description', 'A variable that can be toggled on and off'),
+    name: 'Switch',
+    initialState: initialSwitchVariableModelState,
+    reducer: switchVariableReducer,
+    picker: SwitchVariablePicker,
+    editor: SwitchVariableEditor,
+    dependsOn: (variable, variableToTest) => {
+      return containsVariable(variable.query, variableToTest.name);
+    },
+    setValue: async (variable, option, emitChanges = false) => {
+      await dispatch(setOptionAsCurrent(toKeyedVariableIdentifier(variable), option, emitChanges));
+    },
+    setValueFromUrl: async (variable, urlValue) => {
+      await dispatch(setOptionFromUrl(toKeyedVariableIdentifier(variable), urlValue));
+    },
+    updateOptions: async () => {},
+    getSaveModel: (variable) => {
+      const { index, id, state, global, rootStateKey, ...rest } = cloneDeep(variable);
+      return rest;
+    },
+    getValueForUrl: (variable) => {
+      return variable.current.value;
+    },
+  };
+};

--- a/public/app/features/variables/switch/reducer.ts
+++ b/public/app/features/variables/switch/reducer.ts
@@ -1,0 +1,37 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import { SwitchVariableModel } from '@grafana/data';
+
+import { initialVariablesState } from '../state/types';
+import { initialVariableModelState } from '../types';
+
+export const initialSwitchVariableModelState: SwitchVariableModel = {
+  ...initialVariableModelState,
+  type: 'switch',
+  query: '',
+  current: {
+    selected: true,
+    text: 'false',
+    value: 'false',
+  },
+  options: [
+    {
+      selected: true,
+      text: 'true',
+      value: 'true',
+    },
+    {
+      selected: false,
+      text: 'false',
+      value: 'false',
+    },
+  ],
+};
+
+export const switchVariableSlice = createSlice({
+  name: 'templating/switch',
+  initialState: initialVariablesState,
+  reducers: {},
+});
+
+export const switchVariableReducer = switchVariableSlice.reducer;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14809,6 +14809,9 @@
         "variable-values-fetched-datasource-query": "Variable values are fetched from a datasource query"
       }
     },
+    "create-switch-variable-adapter": {
+      "description": "A variable that can be toggled on and off"
+    },
     "data-source-variable-slice": {
       "text": {
         "default": "default",


### PR DESCRIPTION
**What is this feature?**

Create an adapter for the switch variable.

**Why do we need this feature?**

Fix escalation: https://github.com/grafana/support-escalations/issues/20377

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
