### PR TITLE
refactor: unified storage migration registry flow

### DIFF
--- a/pkg/storage/unified/migrations/migrator.go
+++ b/pkg/storage/unified/migrations/migrator.go
@@ -39,7 +39,7 @@ func buildCollectionSettings(opts legacy.MigrateOptions) resource.BulkSettings {
 		SkipValidation:    true,
 	}
 	for _, res := range opts.Resources {
-		key := buildResourceKey(res.Group, res.Resource, opts.Namespace)
+		key := buildResourceKey(res, opts.Namespace)
 		if key != nil {
 			settings.Collection = append(settings.Collection, key)
 		}
@@ -103,8 +103,6 @@ func newUnifiedMigrator(
 	}
 }
 
-type migratorFunc = func(ctx context.Context, orgId int64, opts legacy.MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) error
-
 func (m *unifiedMigration) Migrate(ctx context.Context, opts legacy.MigrateOptions) (*resourcepb.BulkResponse, error) {
 	info, err := authlib.ParseNamespace(opts.Namespace)
 	if err != nil {
@@ -127,9 +125,9 @@ func (m *unifiedMigration) Migrate(ctx context.Context, opts legacy.MigrateOptio
 		return nil, err
 	}
 
-	migratorFuncs := []migratorFunc{}
+	migratorFuncs := []MigratorFunc{}
 	for _, res := range opts.Resources {
-		fn := getMigratorFunc(m.MigrationDashboardAccessor, res.Group, res.Resource)
+		fn := Registry.GetMigratorFunc(m.MigrationDashboardAccessor, res)
 		if fn == nil {
 			return nil, fmt.Errorf("unsupported resource: %s/%s", res.Group, res.Resource)
 		}

--- a/pkg/storage/unified/migrations/registry.go
+++ b/pkg/storage/unified/migrations/registry.go
@@ -1,0 +1,178 @@
+package migrations
+
+import (
+	"context"
+	"sync"
+
+	v1beta1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1beta1"
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
+	playlists "github.com/grafana/grafana/apps/playlist/pkg/apis/playlist/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/registry/apis/dashboard/legacy"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/util/xorm"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Validator interface validates migration results.
+type Validator interface {
+	Name() string
+	Validate(ctx context.Context, sess *xorm.Session, response *resourcepb.BulkResponse, log log.Logger) error
+}
+
+// ValidatorFactory creates a validator with the given context.
+type ValidatorFactory func(client resourcepb.ResourceIndexClient, driverName string) Validator
+
+// MigratorFunc is the signature for resource migration functions.
+type MigratorFunc = func(ctx context.Context, orgId int64, opts legacy.MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) error
+
+// MigratorFactory creates a migrator function given an accessor.
+// This allows the registry to store type-safe method references without
+// requiring the accessor at registration time.
+type MigratorFactory func(accessor legacy.MigrationDashboardAccessor) MigratorFunc
+
+// MigrationDefinition defines a resource migration.
+// This is the public API for defining and registering migrations.
+type MigrationDefinition struct {
+	ID          string                                   // Unique identifier for registry lookup (e.g., "folders-dashboards", "playlists")
+	MigrationID string                                   // ID for the migration log table entry (e.g., "folders and dashboards migration")
+	Resources   []schema.GroupResource                   // Resources to migrate together
+	Migrators   map[schema.GroupResource]MigratorFactory // Type-safe migrator factories per resource
+	Validators  []ValidatorFactory                       // Optional validator factories
+}
+
+// ConfigResources returns the resource identifiers in the format used by setting.UnifiedStorage config.
+// The format is "resource.group" (e.g., "dashboards.dashboard.grafana.app").
+func (d *MigrationDefinition) ConfigResources() []string {
+	result := make([]string, len(d.Resources))
+	for i, gr := range d.Resources {
+		result[i] = gr.Resource + "." + gr.Group
+	}
+	return result
+}
+
+// CreateValidators instantiates validators with the provided runtime dependencies.
+func (d *MigrationDefinition) CreateValidators(client resourcepb.ResourceIndexClient, driverName string) []Validator {
+	validators := make([]Validator, 0, len(d.Validators))
+	for _, factory := range d.Validators {
+		validators = append(validators, factory(client, driverName))
+	}
+	return validators
+}
+
+// GetMigratorFunc returns the migrator function for a given resource.
+func (d *MigrationDefinition) GetMigratorFunc(accessor legacy.MigrationDashboardAccessor, gr schema.GroupResource) MigratorFunc {
+	if factory, ok := d.Migrators[gr]; ok {
+		return factory(accessor)
+	}
+	return nil
+}
+
+// MigrationRegistry is a thread-safe registry of migration definitions.
+type MigrationRegistry struct {
+	mu          sync.RWMutex
+	definitions map[string]*MigrationDefinition
+	order       []string // Maintains insertion order for iteration
+}
+
+// NewMigrationRegistry creates a new empty migration registry.
+func NewMigrationRegistry() *MigrationRegistry {
+	return &MigrationRegistry{
+		definitions: make(map[string]*MigrationDefinition),
+		order:       make([]string, 0),
+	}
+}
+
+// Register adds a migration definition to the registry.
+func (r *MigrationRegistry) Register(def *MigrationDefinition) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.definitions[def.ID]; !exists {
+		r.order = append(r.order, def.ID)
+	}
+	r.definitions[def.ID] = def
+}
+
+// Get retrieves a migration definition by ID.
+func (r *MigrationRegistry) Get(id string) *MigrationDefinition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.definitions[id]
+}
+
+// All returns all registered migration definitions in registration order.
+func (r *MigrationRegistry) All() []*MigrationDefinition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	result := make([]*MigrationDefinition, 0, len(r.order))
+	for _, id := range r.order {
+		if def, ok := r.definitions[id]; ok {
+			result = append(result, def)
+		}
+	}
+	return result
+}
+
+// GetMigratorFunc searches all definitions for a migrator matching the given resource.
+func (r *MigrationRegistry) GetMigratorFunc(accessor legacy.MigrationDashboardAccessor, gr schema.GroupResource) MigratorFunc {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, def := range r.definitions {
+		if fn := def.GetMigratorFunc(accessor, gr); fn != nil {
+			return fn
+		}
+	}
+	return nil
+}
+
+// HasResource checks if a resource is registered in any migration definition.
+func (r *MigrationRegistry) HasResource(gr schema.GroupResource) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, def := range r.definitions {
+		if _, ok := def.Migrators[gr]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// Registry is the public migration registry containing all migration definitions.
+// It can be used from other packages to access migrations without the SQL migration interface.
+var Registry = NewMigrationRegistry()
+
+func init() {
+	// Register folders and dashboards migration
+	folderGR := schema.GroupResource{Group: folders.GROUP, Resource: folders.RESOURCE}
+	dashboardGR := schema.GroupResource{Group: v1beta1.GROUP, Resource: v1beta1.DASHBOARD_RESOURCE}
+
+	Registry.Register(&MigrationDefinition{
+		ID:          "folders-dashboards",
+		MigrationID: "folders and dashboards migration",
+		Resources:   []schema.GroupResource{folderGR, dashboardGR},
+		Migrators: map[schema.GroupResource]MigratorFactory{
+			folderGR:    func(a legacy.MigrationDashboardAccessor) MigratorFunc { return a.MigrateFolders },
+			dashboardGR: func(a legacy.MigrationDashboardAccessor) MigratorFunc { return a.MigrateDashboards },
+		},
+		Validators: []ValidatorFactory{
+			CountValidation(folderGR, "dashboard", "org_id = ? and is_folder = true"),
+			CountValidation(dashboardGR, "dashboard", "org_id = ? and is_folder = false"),
+			FolderTreeValidation(folderGR),
+		},
+	})
+
+	// Register playlists migration
+	playlistGR := schema.GroupResource{Group: playlists.APIGroup, Resource: "playlists"}
+
+	Registry.Register(&MigrationDefinition{
+		ID:          "playlists",
+		MigrationID: "playlists migration",
+		Resources:   []schema.GroupResource{playlistGR},
+		Migrators: map[schema.GroupResource]MigratorFactory{
+			playlistGR: func(a legacy.MigrationDashboardAccessor) MigratorFunc { return a.MigratePlaylists },
+		},
+		Validators: []ValidatorFactory{
+			CountValidation(playlistGR, "playlist", "org_id = ?"),
+		},
+	})
+}

--- a/pkg/storage/unified/migrations/registry_test.go
+++ b/pkg/storage/unified/migrations/registry_test.go
@@ -1,0 +1,743 @@
+package migrations
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/registry/apis/dashboard/legacy"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/util/xorm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Test helper to create a simple MigrationDefinition for testing
+func testMigrationDefinition(id string, resources ...schema.GroupResource) MigrationDefinition {
+	return MigrationDefinition{
+		ID:          id,
+		MigrationID: id + " migration",
+		Resources:   resources,
+		Migrators:   make(map[schema.GroupResource]MigratorFactory),
+	}
+}
+
+// Test helper to create a GroupResource
+func testGroupResource(group, resource string) schema.GroupResource {
+	return schema.GroupResource{Group: group, Resource: resource}
+}
+
+func TestNewMigrationRegistry(t *testing.T) {
+	t.Run("creates empty registry with initialized maps", func(t *testing.T) {
+		r := NewMigrationRegistry()
+
+		require.NotNil(t, r)
+		require.NotNil(t, r.definitions)
+		require.NotNil(t, r.order)
+		require.Empty(t, r.definitions)
+		require.Empty(t, r.order)
+	})
+}
+
+func TestMigrationRegistry_Register(t *testing.T) {
+	t.Run("registers single definition", func(t *testing.T) {
+		r := NewMigrationRegistry()
+		def := testMigrationDefinition("test-1", testGroupResource("group1", "resource1"))
+
+		r.Register(def)
+
+		require.Len(t, r.definitions, 1)
+		require.Len(t, r.order, 1)
+		require.Equal(t, "test-1", r.order[0])
+		stored, ok := r.definitions["test-1"]
+		require.True(t, ok)
+		require.Equal(t, def.ID, stored.ID)
+	})
+
+	t.Run("registers multiple definitions", func(t *testing.T) {
+		r := NewMigrationRegistry()
+		def1 := testMigrationDefinition("test-1", testGroupResource("group1", "resource1"))
+		def2 := testMigrationDefinition("test-2", testGroupResource("group2", "resource2"))
+		def3 := testMigrationDefinition("test-3", testGroupResource("group3", "resource3"))
+
+		r.Register(def1)
+		r.Register(def2)
+		r.Register(def3)
+
+		require.Len(t, r.definitions, 3)
+		require.Len(t, r.order, 3)
+	})
+
+	t.Run("preserves insertion order", func(t *testing.T) {
+		r := NewMigrationRegistry()
+
+		r.Register(testMigrationDefinition("alpha"))
+		r.Register(testMigrationDefinition("beta"))
+		r.Register(testMigrationDefinition("gamma"))
+		r.Register(testMigrationDefinition("delta"))
+
+		require.Equal(t, []string{"alpha", "beta", "gamma", "delta"}, r.order)
+	})
+
+	t.Run("stores definition with all fields", func(t *testing.T) {
+		r := NewMigrationRegistry()
+		gr := testGroupResource("test.grafana.app", "widgets")
+		def := MigrationDefinition{
+			ID:          "widgets-migration",
+			MigrationID: "widgets migration log id",
+			Resources:   []schema.GroupResource{gr},
+			Migrators: map[schema.GroupResource]MigratorFactory{
+				gr: func(a legacy.MigrationDashboardAccessor) MigratorFunc {
+					return nil
+				},
+			},
+		}
+
+		r.Register(def)
+
+		stored, ok := r.Get("widgets-migration")
+		require.True(t, ok)
+		require.Equal(t, "widgets-migration", stored.ID)
+		require.Equal(t, "widgets migration log id", stored.MigrationID)
+		require.Len(t, stored.Resources, 1)
+		require.Equal(t, gr, stored.Resources[0])
+	})
+}
+
+func TestMigrationRegistry_Register_DuplicatePanics(t *testing.T) {
+	t.Run("panics on duplicate ID", func(t *testing.T) {
+		r := NewMigrationRegistry()
+		def := testMigrationDefinition("duplicate-id")
+
+		r.Register(def)
+
+		require.Panics(t, func() {
+			r.Register(def)
+		}, "registering duplicate ID should panic")
+	})
+
+	t.Run("panics with correct message", func(t *testing.T) {
+		r := NewMigrationRegistry()
+		def := testMigrationDefinition("my-migration")
+
+		r.Register(def)
+
+		defer func() {
+			if rec := recover(); rec != nil {
+				msg, ok := rec.(string)
+				require.True(t, ok, "panic value should be a string")
+				require.Contains(t, msg, "my-migration")
+				require.Contains(t, msg, "already registered")
+			}
+		}()
+
+		r.Register(def)
+		t.Fatal("expected panic but none occurred")
+	})
+}
+
+func TestMigrationRegistry_Get(t *testing.T) {
+	t.Run("returns definition and true for existing ID", func(t *testing.T) {
+		r := NewMigrationRegistry()
+		def := testMigrationDefinition("existing", testGroupResource("g", "r"))
+		r.Register(def)
+
+		result, ok := r.Get("existing")
+
+		require.True(t, ok)
+		require.Equal(t, def.ID, result.ID)
+		require.Equal(t, def.MigrationID, result.MigrationID)
+		require.Equal(t, def.Resources, result.Resources)
+	})
+
+	t.Run("returns empty definition and false for non-existing ID", func(t *testing.T) {
+		r := NewMigrationRegistry()
+		r.Register(testMigrationDefinition("other"))
+
+		result, ok := r.Get("non-existing")
+
+		require.False(t, ok)
+		require.Equal(t, MigrationDefinition{}, result)
+	})
+
+	t.Run("returns false for empty registry", func(t *testing.T) {
+		r := NewMigrationRegistry()
+
+		result, ok := r.Get("any-id")
+
+		require.False(t, ok)
+		require.Equal(t, MigrationDefinition{}, result)
+	})
+
+	t.Run("retrieves correct definition among multiple", func(t *testing.T) {
+		r := NewMigrationRegistry()
+		r.Register(testMigrationDefinition("first", testGroupResource("g1", "r1")))
+		r.Register(testMigrationDefinition("second", testGroupResource("g2", "r2")))
+		r.Register(testMigrationDefinition("third", testGroupResource("g3", "r3")))
+
+		result, ok := r.Get("second")
+
+		require.True(t, ok)
+		require.Equal(t, "second", result.ID)
+		require.Equal(t, testGroupResource("g2", "r2"), result.Resources[0])
+	})
+}
+
+func TestMigrationRegistry_All(t *testing.T) {
+	t.Run("returns empty slice for empty registry", func(t *testing.T) {
+		r := NewMigrationRegistry()
+
+		result := r.All()
+
+		require.NotNil(t, result)
+		require.Empty(t, result)
+	})
+
+	t.Run("returns single definition", func(t *testing.T) {
+		r := NewMigrationRegistry()
+		def := testMigrationDefinition("single")
+		r.Register(def)
+
+		result := r.All()
+
+		require.Len(t, result, 1)
+		require.Equal(t, "single", result[0].ID)
+	})
+
+	t.Run("returns all definitions in registration order", func(t *testing.T) {
+		r := NewMigrationRegistry()
+		r.Register(testMigrationDefinition("first"))
+		r.Register(testMigrationDefinition("second"))
+		r.Register(testMigrationDefinition("third"))
+		r.Register(testMigrationDefinition("fourth"))
+
+		result := r.All()
+
+		require.Len(t, result, 4)
+		require.Equal(t, "first", result[0].ID)
+		require.Equal(t, "second", result[1].ID)
+		require.Equal(t, "third", result[2].ID)
+		require.Equal(t, "fourth", result[3].ID)
+	})
+
+	t.Run("returns copy of definitions not affecting internal state", func(t *testing.T) {
+		r := NewMigrationRegistry()
+		r.Register(testMigrationDefinition("original"))
+
+		result := r.All()
+		result[0] = testMigrationDefinition("modified")
+
+		// Original should be unchanged
+		stored, _ := r.Get("original")
+		require.Equal(t, "original", stored.ID)
+	})
+}
+
+func TestMigrationRegistry_HasResource(t *testing.T) {
+	t.Run("returns true when resource exists in single definition", func(t *testing.T) {
+		r := NewMigrationRegistry()
+		gr := testGroupResource("test.grafana.app", "widgets")
+		def := testMigrationDefinition("test")
+		def.Migrators[gr] = func(a legacy.MigrationDashboardAccessor) MigratorFunc {
+			return nil
+		}
+		r.Register(def)
+
+		result := r.HasResource(gr)
+
+		require.True(t, result)
+	})
+
+	t.Run("returns true when resource exists in one of multiple definitions", func(t *testing.T) {
+		r := NewMigrationRegistry()
+
+		gr1 := testGroupResource("group1", "resource1")
+		gr2 := testGroupResource("group2", "resource2")
+		gr3 := testGroupResource("group3", "resource3")
+
+		def1 := testMigrationDefinition("def1")
+		def1.Migrators[gr1] = func(a legacy.MigrationDashboardAccessor) MigratorFunc {
+			return nil
+		}
+
+		def2 := testMigrationDefinition("def2")
+		def2.Migrators[gr2] = func(a legacy.MigrationDashboardAccessor) MigratorFunc {
+			return nil
+		}
+		def2.Migrators[gr3] = func(a legacy.MigrationDashboardAccessor) MigratorFunc {
+			return nil
+		}
+
+		r.Register(def1)
+		r.Register(def2)
+
+		require.True(t, r.HasResource(gr1))
+		require.True(t, r.HasResource(gr2))
+		require.True(t, r.HasResource(gr3))
+	})
+
+	t.Run("returns false when resource does not exist", func(t *testing.T) {
+		r := NewMigrationRegistry()
+		existingGR := testGroupResource("existing.group", "existing")
+		def := testMigrationDefinition("test")
+		def.Migrators[existingGR] = func(a legacy.MigrationDashboardAccessor) MigratorFunc {
+			return nil
+		}
+		r.Register(def)
+
+		nonExistingGR := testGroupResource("nonexisting.group", "nonexisting")
+		result := r.HasResource(nonExistingGR)
+
+		require.False(t, result)
+	})
+
+	t.Run("returns false for empty registry", func(t *testing.T) {
+		r := NewMigrationRegistry()
+
+		result := r.HasResource(testGroupResource("any", "resource"))
+
+		require.False(t, result)
+	})
+
+	t.Run("distinguishes between group and resource", func(t *testing.T) {
+		r := NewMigrationRegistry()
+		gr := testGroupResource("my.group", "my-resource")
+		def := testMigrationDefinition("test")
+		def.Migrators[gr] = func(a legacy.MigrationDashboardAccessor) MigratorFunc {
+			return nil
+		}
+		r.Register(def)
+
+		// Same resource, different group
+		require.False(t, r.HasResource(testGroupResource("other.group", "my-resource")))
+		// Same group, different resource
+		require.False(t, r.HasResource(testGroupResource("my.group", "other-resource")))
+		// Exact match
+		require.True(t, r.HasResource(testGroupResource("my.group", "my-resource")))
+	})
+}
+
+func TestMigrationDefinition_ConfigResources(t *testing.T) {
+	t.Run("formats single resource correctly", func(t *testing.T) {
+		def := MigrationDefinition{
+			Resources: []schema.GroupResource{
+				{Group: "dashboard.grafana.app", Resource: "dashboards"},
+			},
+		}
+
+		result := def.ConfigResources()
+
+		require.Len(t, result, 1)
+		require.Equal(t, "dashboards.dashboard.grafana.app", result[0])
+	})
+
+	t.Run("formats multiple resources correctly", func(t *testing.T) {
+		def := MigrationDefinition{
+			Resources: []schema.GroupResource{
+				{Group: "folder.grafana.app", Resource: "folders"},
+				{Group: "dashboard.grafana.app", Resource: "dashboards"},
+				{Group: "playlist.grafana.app", Resource: "playlists"},
+			},
+		}
+
+		result := def.ConfigResources()
+
+		require.Len(t, result, 3)
+		require.Equal(t, "folders.folder.grafana.app", result[0])
+		require.Equal(t, "dashboards.dashboard.grafana.app", result[1])
+		require.Equal(t, "playlists.playlist.grafana.app", result[2])
+	})
+
+	t.Run("returns empty slice for no resources", func(t *testing.T) {
+		def := MigrationDefinition{
+			Resources: []schema.GroupResource{},
+		}
+
+		result := def.ConfigResources()
+
+		require.NotNil(t, result)
+		require.Empty(t, result)
+	})
+
+	t.Run("handles empty group", func(t *testing.T) {
+		def := MigrationDefinition{
+			Resources: []schema.GroupResource{
+				{Group: "", Resource: "configmaps"},
+			},
+		}
+
+		result := def.ConfigResources()
+
+		require.Len(t, result, 1)
+		require.Equal(t, "configmaps.", result[0])
+	})
+
+	t.Run("handles empty resource", func(t *testing.T) {
+		def := MigrationDefinition{
+			Resources: []schema.GroupResource{
+				{Group: "some.group", Resource: ""},
+			},
+		}
+
+		result := def.ConfigResources()
+
+		require.Len(t, result, 1)
+		require.Equal(t, ".some.group", result[0])
+	})
+}
+
+func TestMigrationDefinition_GetMigratorFunc(t *testing.T) {
+	t.Run("returns migrator function for existing resource", func(t *testing.T) {
+		gr := testGroupResource("test.group", "widgets")
+		called := false
+		def := MigrationDefinition{
+			Migrators: map[schema.GroupResource]MigratorFactory{
+				gr: func(a legacy.MigrationDashboardAccessor) MigratorFunc {
+					return func(ctx context.Context, orgId int64, opts legacy.MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) error {
+						called = true
+						return nil
+					}
+				},
+			},
+		}
+
+		// Pass nil accessor since our mock doesn't use it
+		result := def.GetMigratorFunc(nil, gr)
+
+		require.NotNil(t, result)
+		// Verify the function is actually callable
+		err := result(context.Background(), 1, legacy.MigrateOptions{}, nil)
+		require.NoError(t, err)
+		require.True(t, called)
+	})
+
+	t.Run("returns nil for non-existing resource", func(t *testing.T) {
+		existingGR := testGroupResource("existing.group", "widgets")
+		def := MigrationDefinition{
+			Migrators: map[schema.GroupResource]MigratorFactory{
+				existingGR: func(a legacy.MigrationDashboardAccessor) MigratorFunc {
+					return nil
+				},
+			},
+		}
+
+		nonExistingGR := testGroupResource("other.group", "gadgets")
+		result := def.GetMigratorFunc(nil, nonExistingGR)
+
+		require.Nil(t, result)
+	})
+
+	t.Run("returns nil for empty migrators map", func(t *testing.T) {
+		def := MigrationDefinition{
+			Migrators: make(map[schema.GroupResource]MigratorFactory),
+		}
+
+		result := def.GetMigratorFunc(nil, testGroupResource("any", "resource"))
+
+		require.Nil(t, result)
+	})
+}
+
+func TestMigrationDefinition_CreateValidators(t *testing.T) {
+	t.Run("creates validators from factories", func(t *testing.T) {
+		factory1Called := false
+		factory2Called := false
+
+		def := MigrationDefinition{
+			Validators: []ValidatorFactory{
+				func(client resourcepb.ResourceIndexClient, driverName string) Validator {
+					factory1Called = true
+					return &mockValidator{name: "validator1"}
+				},
+				func(client resourcepb.ResourceIndexClient, driverName string) Validator {
+					factory2Called = true
+					return &mockValidator{name: "validator2"}
+				},
+			},
+		}
+
+		result := def.CreateValidators(nil, "sqlite3")
+
+		require.Len(t, result, 2)
+		require.True(t, factory1Called)
+		require.True(t, factory2Called)
+		require.Equal(t, "validator1", result[0].Name())
+		require.Equal(t, "validator2", result[1].Name())
+	})
+
+	t.Run("passes client and driver name to factory", func(t *testing.T) {
+		var capturedDriverName string
+
+		def := MigrationDefinition{
+			Validators: []ValidatorFactory{
+				func(client resourcepb.ResourceIndexClient, driverName string) Validator {
+					capturedDriverName = driverName
+					return &mockValidator{}
+				},
+			},
+		}
+
+		def.CreateValidators(nil, "postgres")
+
+		require.Equal(t, "postgres", capturedDriverName)
+	})
+
+	t.Run("returns empty slice for no validators", func(t *testing.T) {
+		def := MigrationDefinition{
+			Validators: []ValidatorFactory{},
+		}
+
+		result := def.CreateValidators(nil, "mysql")
+
+		require.NotNil(t, result)
+		require.Empty(t, result)
+	})
+
+	t.Run("returns empty slice for nil validators", func(t *testing.T) {
+		def := MigrationDefinition{
+			Validators: nil,
+		}
+
+		result := def.CreateValidators(nil, "mysql")
+
+		require.NotNil(t, result)
+		require.Empty(t, result)
+	})
+}
+
+func TestMigrationRegistry_GetMigratorFunc(t *testing.T) {
+	t.Run("finds migrator in first definition", func(t *testing.T) {
+		r := NewMigrationRegistry()
+
+		gr := testGroupResource("first.group", "resource")
+		def := testMigrationDefinition("first")
+		def.Migrators[gr] = func(a legacy.MigrationDashboardAccessor) MigratorFunc {
+			return func(ctx context.Context, orgId int64, opts legacy.MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) error {
+				return nil
+			}
+		}
+		r.Register(def)
+
+		result := r.GetMigratorFunc(nil, gr)
+
+		require.NotNil(t, result)
+	})
+
+	t.Run("finds migrator in second definition", func(t *testing.T) {
+		r := NewMigrationRegistry()
+
+		gr1 := testGroupResource("first.group", "resource1")
+		def1 := testMigrationDefinition("first")
+		def1.Migrators[gr1] = func(a legacy.MigrationDashboardAccessor) MigratorFunc {
+			return func(ctx context.Context, orgId int64, opts legacy.MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) error {
+				return nil
+			}
+		}
+
+		gr2 := testGroupResource("second.group", "resource2")
+		def2 := testMigrationDefinition("second")
+		def2.Migrators[gr2] = func(a legacy.MigrationDashboardAccessor) MigratorFunc {
+			return func(ctx context.Context, orgId int64, opts legacy.MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) error {
+				return nil
+			}
+		}
+
+		r.Register(def1)
+		r.Register(def2)
+
+		result := r.GetMigratorFunc(nil, gr2)
+
+		require.NotNil(t, result)
+	})
+
+	t.Run("returns nil when not found in any definition", func(t *testing.T) {
+		r := NewMigrationRegistry()
+
+		gr := testGroupResource("existing.group", "resource")
+		def := testMigrationDefinition("test")
+		def.Migrators[gr] = func(a legacy.MigrationDashboardAccessor) MigratorFunc {
+			return func(ctx context.Context, orgId int64, opts legacy.MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) error {
+				return nil
+			}
+		}
+		r.Register(def)
+
+		nonExisting := testGroupResource("nonexisting.group", "other")
+		result := r.GetMigratorFunc(nil, nonExisting)
+
+		require.Nil(t, result)
+	})
+
+	t.Run("returns nil for empty registry", func(t *testing.T) {
+		r := NewMigrationRegistry()
+
+		result := r.GetMigratorFunc(nil, testGroupResource("any", "resource"))
+
+		require.Nil(t, result)
+	})
+}
+
+func TestMigrationRegistry_ConcurrentAccess(t *testing.T) {
+	t.Run("concurrent register and get operations", func(t *testing.T) {
+		r := NewMigrationRegistry()
+		var wg sync.WaitGroup
+		numGoroutines := 100
+
+		// Pre-register some definitions to avoid panic from duplicates
+		for i := 0; i < numGoroutines; i++ {
+			def := testMigrationDefinition("def-" + string(rune('a'+i%26)) + string(rune('0'+i/26)))
+			gr := testGroupResource("group", "resource-"+string(rune('a'+i%26))+string(rune('0'+i/26)))
+			def.Migrators[gr] = func(a legacy.MigrationDashboardAccessor) MigratorFunc {
+				return nil
+			}
+			r.Register(def)
+		}
+
+		// Concurrent reads
+		wg.Add(numGoroutines * 3)
+
+		// Goroutines calling Get
+		for i := 0; i < numGoroutines; i++ {
+			go func(i int) {
+				defer wg.Done()
+				id := "def-" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+				_, _ = r.Get(id)
+			}(i)
+		}
+
+		// Goroutines calling All
+		for i := 0; i < numGoroutines; i++ {
+			go func() {
+				defer wg.Done()
+				_ = r.All()
+			}()
+		}
+
+		// Goroutines calling HasResource
+		for i := 0; i < numGoroutines; i++ {
+			go func(i int) {
+				defer wg.Done()
+				gr := testGroupResource("group", "resource-"+string(rune('a'+i%26))+string(rune('0'+i/26)))
+				_ = r.HasResource(gr)
+			}(i)
+		}
+
+		wg.Wait()
+	})
+
+	t.Run("concurrent All calls return consistent data", func(t *testing.T) {
+		r := NewMigrationRegistry()
+
+		// Register some definitions
+		for i := 0; i < 10; i++ {
+			r.Register(testMigrationDefinition("def-" + string(rune('a'+i))))
+		}
+
+		var wg sync.WaitGroup
+		results := make([][]MigrationDefinition, 50)
+
+		for i := 0; i < 50; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				results[idx] = r.All()
+			}(i)
+		}
+
+		wg.Wait()
+
+		// All results should be identical
+		expected := results[0]
+		for i, result := range results {
+			require.Len(t, result, len(expected), "result %d has different length", i)
+			for j := range result {
+				require.Equal(t, expected[j].ID, result[j].ID, "result %d has different ID at index %d", i, j)
+			}
+		}
+	})
+
+	t.Run("concurrent GetMigratorFunc calls", func(t *testing.T) {
+		r := NewMigrationRegistry()
+
+		gr := testGroupResource("test.group", "widgets")
+		def := testMigrationDefinition("test")
+		def.Migrators[gr] = func(a legacy.MigrationDashboardAccessor) MigratorFunc {
+			return func(ctx context.Context, orgId int64, opts legacy.MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) error {
+				return nil
+			}
+		}
+		r.Register(def)
+
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				fn := r.GetMigratorFunc(nil, gr)
+				require.NotNil(t, fn)
+			}()
+		}
+
+		wg.Wait()
+	})
+}
+
+// mockValidator is a simple test implementation of Validator
+type mockValidator struct {
+	name string
+}
+
+func (m *mockValidator) Name() string {
+	return m.name
+}
+
+func (m *mockValidator) Validate(ctx context.Context, sess *xorm.Session, response *resourcepb.BulkResponse, logger log.Logger) error {
+	return nil
+}
+
+func TestGlobalRegistry(t *testing.T) {
+	t.Run("global Registry is initialized", func(t *testing.T) {
+		require.NotNil(t, Registry)
+		require.NotNil(t, Registry.definitions)
+		require.NotNil(t, Registry.order)
+	})
+
+	t.Run("global Registry contains folders-dashboards migration", func(t *testing.T) {
+		def, ok := Registry.Get("folders-dashboards")
+		require.True(t, ok)
+		require.Equal(t, "folders-dashboards", def.ID)
+		require.Equal(t, "folders and dashboards migration", def.MigrationID)
+		require.Len(t, def.Resources, 2)
+	})
+
+	t.Run("global Registry contains playlists migration", func(t *testing.T) {
+		def, ok := Registry.Get("playlists")
+		require.True(t, ok)
+		require.Equal(t, "playlists", def.ID)
+		require.Equal(t, "playlists migration", def.MigrationID)
+		require.Len(t, def.Resources, 1)
+	})
+
+	t.Run("global Registry All returns definitions in order", func(t *testing.T) {
+		all := Registry.All()
+
+		// Find the positions of our known migrations
+		foldersIdx := -1
+		playlistsIdx := -1
+		for i, def := range all {
+			if def.ID == "folders-dashboards" {
+				foldersIdx = i
+			}
+			if def.ID == "playlists" {
+				playlistsIdx = i
+			}
+		}
+
+		require.NotEqual(t, -1, foldersIdx, "folders-dashboards should be registered")
+		require.NotEqual(t, -1, playlistsIdx, "playlists should be registered")
+		// folders-dashboards is registered before playlists in init()
+		assert.Less(t, foldersIdx, playlistsIdx, "folders-dashboards should come before playlists")
+	})
+}

--- a/pkg/storage/unified/migrations/resource_migration.go
+++ b/pkg/storage/unified/migrations/resource_migration.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/grafana/authlib/types"
@@ -14,58 +15,272 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/util/xorm"
-	"github.com/grafana/grafana/pkg/util/xorm/core"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// ValidationFunc is a function that validates migration results.
-
+// Validator interface validates migration results.
 type Validator interface {
 	Name() string
 	Validate(ctx context.Context, sess *xorm.Session, response *resourcepb.BulkResponse, log log.Logger) error
 }
 
+// ValidatorFactory creates a validator with the given context.
+type ValidatorFactory func(client resourcepb.ResourceIndexClient, driverName string) Validator
+
+// MigrationDefinition defines a resource migration without implementing the SQL migration interface.
+// This is the public API for third-party packages to register migrations.
+type MigrationDefinition struct {
+	ID         string                 // Unique migration identifier
+	Resources  []schema.GroupResource // Resources to migrate together
+	Validators []ValidatorFactory     // Optional validator factories
+}
+
+// CreateValidators instantiates validators with the provided runtime dependencies.
+func (d *MigrationDefinition) CreateValidators(client resourcepb.ResourceIndexClient, driverName string) []Validator {
+	validators := make([]Validator, 0, len(d.Validators))
+	for _, factory := range d.Validators {
+		validators = append(validators, factory(client, driverName))
+	}
+	return validators
+}
+
+// MigrationRegistry is a thread-safe registry of migration definitions.
+type MigrationRegistry struct {
+	mu          sync.RWMutex
+	definitions map[string]*MigrationDefinition
+}
+
+// NewMigrationRegistry creates a new empty migration registry.
+func NewMigrationRegistry() *MigrationRegistry {
+	return &MigrationRegistry{
+		definitions: make(map[string]*MigrationDefinition),
+	}
+}
+
+// Register adds a migration definition to the registry.
+func (r *MigrationRegistry) Register(def *MigrationDefinition) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.definitions[def.ID] = def
+}
+
+// Get retrieves a migration definition by ID.
+func (r *MigrationRegistry) Get(id string) *MigrationDefinition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.definitions[id]
+}
+
+// All returns all registered migration definitions.
+func (r *MigrationRegistry) All() []*MigrationDefinition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	result := make([]*MigrationDefinition, 0, len(r.definitions))
+	for _, def := range r.definitions {
+		result = append(result, def)
+	}
+	return result
+}
+
+// MigrationRunnerOption is a functional option for configuring MigrationRunner.
+type MigrationRunnerOption func(*MigrationRunner)
+
+// WithAutoEnableMode5 configures the runner to auto-enable mode 5 after successful migration.
+func WithAutoEnableMode5(cfg *setting.Cfg) MigrationRunnerOption {
+	return func(r *MigrationRunner) {
+		r.cfg = cfg
+		r.autoEnableMode5 = true
+	}
+}
+
+// MigrationRunner executes migrations without implementing the SQL migration interface.
+type MigrationRunner struct {
+	unifiedMigrator UnifiedMigrator
+	cfg             *setting.Cfg
+	autoEnableMode5 bool
+	log             log.Logger
+}
+
+// NewMigrationRunner creates a new migration runner.
+func NewMigrationRunner(unifiedMigrator UnifiedMigrator, migrationID string, opts ...MigrationRunnerOption) *MigrationRunner {
+	r := &MigrationRunner{
+		unifiedMigrator: unifiedMigrator,
+		log:             log.New("storage.unified.migration_runner." + migrationID),
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// RunOptions configures a migration run.
+type RunOptions struct {
+	DriverName string
+	Resources  []schema.GroupResource
+	Validators []Validator
+}
+
+// Run executes the migration logic for all organizations.
+func (r *MigrationRunner) Run(ctx context.Context, sess *xorm.Session, opts RunOptions) error {
+	orgs, err := r.getAllOrgs(sess)
+	if err != nil {
+		r.log.Error("failed to get organizations", "error", err)
+		return fmt.Errorf("failed to get organizations: %w", err)
+	}
+
+	if len(orgs) == 0 {
+		r.log.Info("No organizations found to migrate, skipping migration")
+		return nil
+	}
+
+	r.log.Info("Starting migration for all organizations", "org_count", len(orgs), "resources", opts.Resources)
+
+	if opts.DriverName == migrator.SQLite {
+		// reuse transaction in SQLite to avoid "database is locked" errors
+		tx, err := sess.Tx()
+		if err != nil {
+			r.log.Error("Failed to get transaction from session", "error", err)
+			return fmt.Errorf("failed to get transaction: %w", err)
+		}
+		ctx = resource.ContextWithTransaction(ctx, tx.Tx)
+		r.log.Info("Stored migrator transaction in context for bulk operations (SQLite compatibility)")
+	}
+
+	for _, org := range orgs {
+		if err = r.MigrateOrg(ctx, sess, org, opts); err != nil {
+			return err
+		}
+	}
+
+	// Auto-enable mode 5 for resources after successful migration
+	if r.autoEnableMode5 && r.cfg != nil {
+		for _, gr := range opts.Resources {
+			r.log.Info("Auto-enabling mode 5 for resource", "resource", gr.Resource+"."+gr.Group)
+			r.cfg.EnableMode5(gr.Resource + "." + gr.Group)
+		}
+	}
+
+	r.log.Info("Migration completed successfully for all organizations", "org_count", len(orgs))
+
+	return nil
+}
+
+// MigrateOrg handles migration for a single organization.
+func (r *MigrationRunner) MigrateOrg(ctx context.Context, sess *xorm.Session, org orgInfo, opts RunOptions) error {
+	namespace := types.OrgNamespaceFormatter(org.ID)
+	r.log.Info("Migrating organization", "org_id", org.ID, "org_name", org.Name, "namespace", namespace)
+
+	// Create a service identity context for this namespace to authenticate with unified storage
+	ctx = identity.WithServiceIdentityForSingleNamespaceContext(ctx, namespace)
+
+	startTime := time.Now()
+
+	migrateOpts := legacy.MigrateOptions{
+		Namespace:   namespace,
+		Resources:   opts.Resources,
+		WithHistory: true, // Migrate with full history
+		Progress: func(count int, msg string) {
+			r.log.Info("Migration progress", "org_id", org.ID, "count", count, "message", msg)
+		},
+	}
+
+	// Execute the migration via legacy migrator
+	response, err := r.unifiedMigrator.Migrate(ctx, migrateOpts)
+	if err != nil {
+		r.log.Error("Migration failed", "org_id", org.ID, "error", err, "duration", time.Since(startTime))
+		return fmt.Errorf("migration failed for org %d (%s): %w", org.ID, org.Name, err)
+	}
+	if response.Error != nil {
+		r.log.Error("Migration reported error", "org_id", org.ID, "error", response.Error.String(), "duration", time.Since(startTime))
+		return fmt.Errorf("migration failed for org %d (%s): %w", org.ID, org.Name, fmt.Errorf("migration error: %s", response.Error.Message))
+	}
+
+	// Validate the migration results
+	if err := r.validateMigration(ctx, sess, response, opts.Validators); err != nil {
+		r.log.Error("Migration validation failed", "org_id", org.ID, "error", err, "duration", time.Since(startTime))
+		return fmt.Errorf("migration validation failed for org %d (%s): %w", org.ID, org.Name, err)
+	}
+
+	r.log.Info("Migration completed for organization",
+		"org_id", org.ID,
+		"duration", time.Since(startTime),
+		"processed", response.Processed,
+		"summaries", len(response.Summary),
+		"rejected", len(response.Rejected))
+
+	return nil
+}
+
+// validateMigration runs all validators in sequence.
+func (r *MigrationRunner) validateMigration(ctx context.Context, sess *xorm.Session, response *resourcepb.BulkResponse, validators []Validator) error {
+	if len(validators) == 0 {
+		r.log.Debug("No validators provided, skipping validation")
+		return nil
+	}
+
+	for _, validator := range validators {
+		r.log.Debug("Running validator", "name", validator.Name(), "total", len(validators))
+		if err := validator.Validate(ctx, sess, response, r.log); err != nil {
+			return fmt.Errorf("validator %s failed: %w", validator.Name(), err)
+		}
+	}
+
+	r.log.Debug("All validators passed", "count", len(validators))
+	return nil
+}
+
+// getAllOrgs retrieves all organizations from the database.
+func (r *MigrationRunner) getAllOrgs(sess *xorm.Session) ([]orgInfo, error) {
+	var orgs []orgInfo
+	err := sess.Table("org").Cols("id", "name").Find(&orgs)
+	if err != nil {
+		return nil, err
+	}
+	return orgs, nil
+}
+
 // ResourceMigration handles migration of specific resource types from legacy to unified storage.
+// It implements the SQL migration interface and delegates to MigrationRunner for the actual logic.
 type ResourceMigration struct {
 	migrator.MigrationBase
-	migrator    UnifiedMigrator
+	runner      *MigrationRunner
 	resources   []schema.GroupResource
 	migrationID string
-	validators  []Validator // Optional: custom validation logic for this migration
-	log         log.Logger
-	cfg         *setting.Cfg
+	validators  []Validator
 	autoMigrate bool // If true, auto-migrate resource if count is below threshold
 	hadErrors   bool // Tracks if errors occurred during migration (used with ignoreErrors)
 }
 
 // ResourceMigrationOption is a functional option for configuring ResourceMigration.
-type ResourceMigrationOption func(*ResourceMigration)
+type ResourceMigrationOption func(*ResourceMigration, *MigrationRunner)
 
 // WithAutoMigrate configures the migration to auto-migrate resource if count is below threshold.
 func WithAutoMigrate(cfg *setting.Cfg) ResourceMigrationOption {
-	return func(m *ResourceMigration) {
-		m.cfg = cfg
+	return func(m *ResourceMigration, r *MigrationRunner) {
 		m.autoMigrate = true
+		r.cfg = cfg
+		r.autoEnableMode5 = true
 	}
 }
 
 // NewResourceMigration creates a new migration for the specified resources.
+// It internally creates a MigrationRunner to handle the actual migration logic.
 func NewResourceMigration(
-	migrator UnifiedMigrator,
+	unifiedMigrator UnifiedMigrator,
 	resources []schema.GroupResource,
 	migrationID string,
 	validators []Validator,
 	opts ...ResourceMigrationOption,
 ) *ResourceMigration {
+	runner := NewMigrationRunner(unifiedMigrator, migrationID)
 	m := &ResourceMigration{
-		migrator:    migrator,
+		runner:      runner,
 		resources:   resources,
 		migrationID: migrationID,
 		validators:  validators,
-		log:         log.New("storage.unified.resource_migration." + migrationID),
 	}
 	for _, opt := range opts {
-		opt(m)
+		opt(m, runner)
 	}
 	return m
 }
@@ -83,16 +298,17 @@ func (m *ResourceMigration) SQL(_ migrator.Dialect) string {
 }
 
 // Exec implements migrator.CodeMigration interface. Executes the migration across all organizations.
+// It delegates to the internal MigrationRunner for the actual migration logic.
 func (m *ResourceMigration) Exec(sess *xorm.Session, mg *migrator.Migrator) (err error) {
 	// Track any errors that occur during migration
 	defer func() {
 		if err != nil {
 			if m.autoMigrate {
-				m.log.Warn(
-					`[WARN] Resource migration failed and is currently skipped. 
+				m.runner.log.Warn(
+					`[WARN] Resource migration failed and is currently skipped.
 This migration will be enforced in the next major Grafana release, where failures will block startup or resource loading.
 
-This warning is intended to help you detect and report issues early. 
+This warning is intended to help you detect and report issues early.
 Please investigate the failure and report it to the Grafana team so it can be addressed before the next major release.`,
 					"error", err)
 			}
@@ -102,113 +318,11 @@ Please investigate the failure and report it to the Grafana team so it can be ad
 
 	ctx := context.Background()
 
-	orgs, err := m.getAllOrgs(sess)
-	if err != nil {
-		m.log.Error("failed to get organizations", "error", err)
-		return fmt.Errorf("failed to get organizations: %w", err)
-	}
-
-	if len(orgs) == 0 {
-		m.log.Info("No organizations found to migrate, skipping migration")
-		return nil
-	}
-
-	m.log.Info("Starting migration for all organizations", "org_count", len(orgs), "resources", m.resources)
-
-	if mg.Dialect.DriverName() == migrator.SQLite {
-		// reuse transaction in SQLite to avoid "database is locked" errors
-		var tx *core.Tx
-		tx, err = sess.Tx()
-		if err != nil {
-			m.log.Error("Failed to get transaction from session", "error", err)
-			return fmt.Errorf("failed to get transaction: %w", err)
-		}
-		ctx = resource.ContextWithTransaction(ctx, tx.Tx)
-		m.log.Info("Stored migrator transaction in context for bulk operations (SQLite compatibility)")
-	}
-
-	for _, org := range orgs {
-		if err = m.migrateOrg(ctx, sess, org); err != nil {
-			return err
-		}
-	}
-
-	// Auto-enable mode 5 for resources after successful migration
-	// TODO: remove this before Grafana 13 GA: https://github.com/grafana/search-and-storage-team/issues/613
-	if m.autoMigrate {
-		for _, gr := range m.resources {
-			m.log.Info("Auto-enabling mode 5 for resource", "resource", gr.Resource+"."+gr.Group)
-			m.cfg.EnableMode5(gr.Resource + "." + gr.Group)
-		}
-	}
-
-	m.log.Info("Migration completed successfully for all organizations", "org_count", len(orgs))
-
-	return nil
-}
-
-// migrateOrg handles migration for a single organization
-func (m *ResourceMigration) migrateOrg(ctx context.Context, sess *xorm.Session, org orgInfo) error {
-	namespace := types.OrgNamespaceFormatter(org.ID)
-	m.log.Info("Migrating organization", "org_id", org.ID, "org_name", org.Name, "namespace", namespace)
-
-	// Create a service identity context for this namespace to authenticate with unified storage
-	migrationCtx, _ := identity.WithServiceIdentityForSingleNamespace(ctx, namespace)
-
-	startTime := time.Now()
-
-	opts := legacy.MigrateOptions{
-		Namespace:   namespace,
-		Resources:   m.resources,
-		WithHistory: true, // Migrate with full history
-		Progress: func(count int, msg string) {
-			m.log.Info("Migration progress", "org_id", org.ID, "count", count, "message", msg)
-		},
-	}
-
-	// Execute the migration via legacy migrator
-	response, err := m.migrator.Migrate(migrationCtx, opts)
-	if err != nil {
-		m.log.Error("Migration failed", "org_id", org.ID, "error", err, "duration", time.Since(startTime))
-		return fmt.Errorf("migration failed for org %d (%s): %w", org.ID, org.Name, err)
-	}
-	if response.Error != nil {
-		m.log.Error("Migration reported error", "org_id", org.ID, "error", response.Error.String(), "duration", time.Since(startTime))
-		return fmt.Errorf("migration failed for org %d (%s): %w", org.ID, org.Name, fmt.Errorf("migration error: %s", response.Error.Message))
-	}
-
-	// Validate the migration results
-	if err := m.validateMigration(migrationCtx, sess, response); err != nil {
-		m.log.Error("Migration validation failed", "org_id", org.ID, "error", err, "duration", time.Since(startTime))
-		return fmt.Errorf("migration validation failed for org %d (%s): %w", org.ID, org.Name, err)
-	}
-
-	m.log.Info("Migration completed for organization",
-		"org_id", org.ID,
-		"duration", time.Since(startTime),
-		"processed", response.Processed,
-		"summaries", len(response.Summary),
-		"rejected", len(response.Rejected))
-
-	return nil
-}
-
-// validateMigration runs all validators in sequence
-func (m *ResourceMigration) validateMigration(ctx context.Context, sess *xorm.Session, response *resourcepb.BulkResponse) error {
-	if len(m.validators) == 0 {
-		m.log.Debug("No validators provided, skipping validation")
-		return nil
-	}
-
-	for _, validator := range m.validators {
-		m.log.Debug("Running validator", "name", validator.Name(), "total", len(m.validators))
-		if err := validator.Validate(ctx, sess, response, m.log); err != nil {
-			return fmt.Errorf("validator %s failed: %w", validator.Name(), err)
-		}
-	}
-
-	m.log.Debug("All validators passed", "count", len(m.validators))
-	return nil
+	return m.runner.Run(ctx, sess, RunOptions{
+		DriverName: mg.Dialect.DriverName(),
+		Resources:  m.resources,
+		Validators: m.validators,
+	})
 }
 
 func ParseOrgIDFromNamespace(namespace string) (int64, error) {
@@ -224,14 +338,4 @@ func ParseOrgIDFromNamespace(namespace string) (int64, error) {
 type orgInfo struct {
 	ID   int64  `xorm:"id"`
 	Name string `xorm:"name"`
-}
-
-// getAllOrgs retrieves all organizations from the database
-func (m *ResourceMigration) getAllOrgs(sess *xorm.Session) ([]orgInfo, error) {
-	var orgs []orgInfo
-	err := sess.Table("org").Cols("id", "name").Find(&orgs)
-	if err != nil {
-		return nil, err
-	}
-	return orgs, nil
 }

--- a/pkg/storage/unified/migrations/resources.go
+++ b/pkg/storage/unified/migrations/resources.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	sqlstoremigrator "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
@@ -203,13 +204,12 @@ func validateRegisteredResources() error {
 func parseConfigResource(configResource string) schema.GroupResource {
 	// Format is "resource.group" e.g. "dashboards.dashboard.grafana.app"
 	// Find the first dot to split resource from group
-	for i, c := range configResource {
-		if c == '.' {
-			return schema.GroupResource{
-				Resource: configResource[:i],
-				Group:    configResource[i+1:],
-			}
-		}
+	resource, group, found := strings.Cut(configResource, ".")
+	if !found {
+		return schema.GroupResource{Resource: configResource}
 	}
-	return schema.GroupResource{Resource: configResource}
+	return schema.GroupResource{
+		Resource: resource,
+		Group:    group,
+	}
 }

--- a/pkg/storage/unified/migrations/resources.go
+++ b/pkg/storage/unified/migrations/resources.go
@@ -4,94 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	v1beta1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1beta1"
-	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
-	playlists "github.com/grafana/grafana/apps/playlist/pkg/apis/playlist/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/registry/apis/dashboard/legacy"
 	sqlstoremigrator "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
-
-// Registry is the public migration registry containing all migration definitions.
-// It can be used from other packages to access migrations without the SQL migration interface.
-var Registry = NewMigrationRegistry()
-
-func init() {
-	// Register folders and dashboards migration
-	folderGR := schema.GroupResource{Group: folders.GROUP, Resource: folders.RESOURCE}
-	dashboardGR := schema.GroupResource{Group: v1beta1.GROUP, Resource: v1beta1.DASHBOARD_RESOURCE}
-
-	Registry.Register(&MigrationDefinition{
-		ID:        "folders-dashboards",
-		Resources: []schema.GroupResource{folderGR, dashboardGR},
-		Validators: []ValidatorFactory{
-			CountValidation(folderGR, "dashboard", "org_id = ? and is_folder = true"),
-			CountValidation(dashboardGR, "dashboard", "org_id = ? and is_folder = false"),
-			FolderTreeValidation(folderGR),
-		},
-	})
-
-	// Register playlists migration
-	playlistGR := schema.GroupResource{Group: playlists.APIGroup, Resource: "playlists"}
-
-	Registry.Register(&MigrationDefinition{
-		ID:        "playlists",
-		Resources: []schema.GroupResource{playlistGR},
-		Validators: []ValidatorFactory{
-			CountValidation(playlistGR, "playlist", "org_id = ?"),
-		},
-	})
-}
-
-type resourceDefinition struct {
-	groupResource schema.GroupResource
-	migratorFunc  string // Name of the method: "MigrateFolders", "MigrateDashboards", etc.
-}
-
-type migrationDefinition struct {
-	name         string
-	migrationID  string // The ID stored in the migration log table (e.g., "playlists migration")
-	resources    []string
-	registerFunc func(mg *sqlstoremigrator.Migrator, migrator UnifiedMigrator, client resource.ResourceClient, opts ...ResourceMigrationOption)
-}
-
-var resourceRegistry = []resourceDefinition{
-	{
-		groupResource: schema.GroupResource{Group: folders.GROUP, Resource: folders.RESOURCE},
-		migratorFunc:  "MigrateFolders",
-	},
-	{
-		groupResource: schema.GroupResource{Group: v1beta1.GROUP, Resource: v1beta1.LIBRARY_PANEL_RESOURCE},
-		migratorFunc:  "MigrateLibraryPanels",
-	},
-	{
-		groupResource: schema.GroupResource{Group: v1beta1.GROUP, Resource: v1beta1.DASHBOARD_RESOURCE},
-		migratorFunc:  "MigrateDashboards",
-	},
-	{
-		groupResource: schema.GroupResource{Group: playlists.APIGroup, Resource: "playlists"},
-		migratorFunc:  "MigratePlaylists",
-	},
-}
-
-var migrationRegistry = []migrationDefinition{
-	{
-		name:         "playlists",
-		migrationID:  "playlists migration",
-		resources:    []string{setting.PlaylistResource},
-		registerFunc: registerPlaylistMigration,
-	},
-	{
-		name:         "folders and dashboards",
-		migrationID:  "folders and dashboards migration",
-		resources:    []string{setting.FolderResource, setting.DashboardResource},
-		registerFunc: registerDashboardAndFolderMigration,
-	},
-}
 
 func registerMigrations(ctx context.Context,
 	cfg *setting.Cfg,
@@ -100,62 +19,42 @@ func registerMigrations(ctx context.Context,
 	client resource.ResourceClient,
 	sqlStore db.DB,
 ) error {
-	for _, migration := range migrationRegistry {
-		if shouldAutoMigrate(ctx, migration, cfg, sqlStore) {
-			migration.registerFunc(mg, migrator, client, WithAutoMigrate(cfg))
+	for _, def := range Registry.All() {
+		if shouldAutoMigrate(ctx, def, cfg, sqlStore) {
+			registerMigration(mg, migrator, client, def, WithAutoMigrate(cfg))
 			continue
 		}
 
-		enabled, err := isMigrationEnabled(migration, cfg)
+		enabled, err := isMigrationEnabled(def, cfg)
 		if err != nil {
 			return err
 		}
 		if !enabled {
-			logger.Info("Migration is disabled in config, skipping", "migration", migration.name)
+			logger.Info("Migration is disabled in config, skipping", "migration", def.ID)
 			continue
 		}
-		migration.registerFunc(mg, migrator, client)
+		registerMigration(mg, migrator, client, def)
 	}
 	return nil
 }
 
-func registerDashboardAndFolderMigration(mg *sqlstoremigrator.Migrator,
+func registerMigration(mg *sqlstoremigrator.Migrator,
 	migrator UnifiedMigrator,
 	client resource.ResourceClient,
+	def *MigrationDefinition,
 	opts ...ResourceMigrationOption,
 ) {
-	def := Registry.Get("folders-dashboards")
-	if def == nil {
-		logger.Error("folders-dashboards migration definition not found in registry")
-		return
-	}
-
 	validators := def.CreateValidators(client, mg.Dialect.DriverName())
 	migration := NewResourceMigration(migrator, def.Resources, def.ID, validators, opts...)
-	mg.AddMigration("folders and dashboards migration", migration)
-}
-
-func registerPlaylistMigration(mg *sqlstoremigrator.Migrator,
-	migrator UnifiedMigrator,
-	client resource.ResourceClient,
-	opts ...ResourceMigrationOption,
-) {
-	def := Registry.Get("playlists")
-	if def == nil {
-		logger.Error("playlists migration definition not found in registry")
-		return
-	}
-
-	validators := def.CreateValidators(client, mg.Dialect.DriverName())
-	migration := NewResourceMigration(migrator, def.Resources, def.ID, validators, opts...)
-	mg.AddMigration("playlists migration", migration)
+	mg.AddMigration(def.MigrationID, migration)
 }
 
 // TODO: remove this before Grafana 13 GA: https://github.com/grafana/search-and-storage-team/issues/613
-func shouldAutoMigrate(ctx context.Context, migration migrationDefinition, cfg *setting.Cfg, sqlStore db.DB) bool {
+func shouldAutoMigrate(ctx context.Context, def *MigrationDefinition, cfg *setting.Cfg, sqlStore db.DB) bool {
 	autoMigrate := false
+	configResources := def.ConfigResources()
 
-	for _, res := range migration.resources {
+	for _, res := range configResources {
 		config := cfg.UnifiedStorageConfig(res)
 
 		if config.DualWriterMode == 5 {
@@ -166,11 +65,11 @@ func shouldAutoMigrate(ctx context.Context, migration migrationDefinition, cfg *
 			continue
 		}
 
-		if checkIfAlreadyMigrated(ctx, migration, sqlStore) {
-			for _, res := range migration.resources {
+		if checkIfAlreadyMigrated(ctx, def, sqlStore) {
+			for _, res := range configResources {
 				cfg.EnableMode5(res)
 			}
-			logger.Info("Auto-migration already completed, enabling mode 5 for resources", "migration", migration.name)
+			logger.Info("Auto-migration already completed, enabling mode 5 for resources", "migration", def.ID)
 			return true
 		}
 
@@ -197,31 +96,32 @@ func shouldAutoMigrate(ctx context.Context, migration migrationDefinition, cfg *
 		return false
 	}
 
-	logger.Info("Auto-migration enabled for migration", "migration", migration.name)
+	logger.Info("Auto-migration enabled for migration", "migration", def.ID)
 	return true
 }
 
-func checkIfAlreadyMigrated(ctx context.Context, migration migrationDefinition, sqlStore db.DB) bool {
-	if migration.migrationID == "" {
+func checkIfAlreadyMigrated(ctx context.Context, def *MigrationDefinition, sqlStore db.DB) bool {
+	if def.MigrationID == "" {
 		return false
 	}
 
-	exists, err := migrationExists(ctx, sqlStore, migration.migrationID)
+	exists, err := migrationExists(ctx, sqlStore, def.MigrationID)
 	if err != nil {
-		logger.Warn("Failed to check if migration exists", "migration", migration.name, "error", err)
+		logger.Warn("Failed to check if migration exists", "migration", def.ID, "error", err)
 		return false
 	}
 
 	return exists
 }
 
-func isMigrationEnabled(migration migrationDefinition, cfg *setting.Cfg) (bool, error) {
+func isMigrationEnabled(def *MigrationDefinition, cfg *setting.Cfg) (bool, error) {
 	var (
 		hasValue   bool
 		allEnabled bool
 	)
+	configResources := def.ConfigResources()
 
-	for _, res := range migration.resources {
+	for _, res := range configResources {
 		enabled := cfg.UnifiedStorage[res].EnableMigration
 		if !hasValue {
 			allEnabled = enabled
@@ -229,7 +129,7 @@ func isMigrationEnabled(migration migrationDefinition, cfg *setting.Cfg) (bool, 
 			continue
 		}
 		if enabled != allEnabled {
-			return false, fmt.Errorf("cannot migrate resources separately: %v migration must be either all enabled or all disabled", migration.resources)
+			return false, fmt.Errorf("cannot migrate resources separately: %v migration must be either all enabled or all disabled", configResources)
 		}
 	}
 
@@ -271,58 +171,23 @@ func migrationExists(ctx context.Context, sqlStore db.DB, migrationID string) (b
 	return count > 0, nil
 }
 
-func getResourceDefinition(group, resource string) *resourceDefinition {
-	for i := range resourceRegistry {
-		r := &resourceRegistry[i]
-		if r.groupResource.Group == group && r.groupResource.Resource == resource {
-			return r
-		}
-	}
-	return nil
-}
-
-func buildResourceKey(group, resource, namespace string) *resourcepb.ResourceKey {
-	def := getResourceDefinition(group, resource)
-	if def == nil {
+func buildResourceKey(gr schema.GroupResource, namespace string) *resourcepb.ResourceKey {
+	if !Registry.HasResource(gr) {
 		return nil
 	}
 	return &resourcepb.ResourceKey{
 		Namespace: namespace,
-		Group:     def.groupResource.Group,
-		Resource:  def.groupResource.Resource,
-	}
-}
-
-func getMigratorFunc(accessor legacy.MigrationDashboardAccessor, group, resource string) migratorFunc {
-	def := getResourceDefinition(group, resource)
-	if def == nil {
-		return nil
-	}
-
-	switch def.migratorFunc {
-	case "MigrateFolders":
-		return accessor.MigrateFolders
-	case "MigrateLibraryPanels":
-		return accessor.MigrateLibraryPanels
-	case "MigrateDashboards":
-		return accessor.MigrateDashboards
-	case "MigratePlaylists":
-		return accessor.MigratePlaylists
-	default:
-		return nil
+		Group:     gr.Group,
+		Resource:  gr.Resource,
 	}
 }
 
 func validateRegisteredResources() error {
-	registeredMap := make(map[string]bool)
-	for _, gr := range resourceRegistry {
-		key := fmt.Sprintf("%s.%s", gr.groupResource.Resource, gr.groupResource.Group)
-		registeredMap[key] = true
-	}
-
 	var missing []string
 	for expected := range setting.MigratedUnifiedResources {
-		if !registeredMap[expected] {
+		// Parse the expected format "resource.group" into a GroupResource
+		gr := parseConfigResource(expected)
+		if !Registry.HasResource(gr) {
 			missing = append(missing, expected)
 		}
 	}
@@ -332,4 +197,19 @@ func validateRegisteredResources() error {
 	}
 
 	return nil
+}
+
+// parseConfigResource parses a config resource string "resource.group" into a GroupResource.
+func parseConfigResource(configResource string) schema.GroupResource {
+	// Format is "resource.group" e.g. "dashboards.dashboard.grafana.app"
+	// Find the first dot to split resource from group
+	for i, c := range configResource {
+		if c == '.' {
+			return schema.GroupResource{
+				Resource: configResource[:i],
+				Group:    configResource[i+1:],
+			}
+		}
+	}
+	return schema.GroupResource{Resource: configResource}
 }

--- a/pkg/storage/unified/migrations/resources.go
+++ b/pkg/storage/unified/migrations/resources.go
@@ -41,7 +41,7 @@ func registerMigrations(ctx context.Context,
 func registerMigration(mg *sqlstoremigrator.Migrator,
 	migrator UnifiedMigrator,
 	client resource.ResourceClient,
-	def *MigrationDefinition,
+	def MigrationDefinition,
 	opts ...ResourceMigrationOption,
 ) {
 	validators := def.CreateValidators(client, mg.Dialect.DriverName())
@@ -50,7 +50,7 @@ func registerMigration(mg *sqlstoremigrator.Migrator,
 }
 
 // TODO: remove this before Grafana 13 GA: https://github.com/grafana/search-and-storage-team/issues/613
-func shouldAutoMigrate(ctx context.Context, def *MigrationDefinition, cfg *setting.Cfg, sqlStore db.DB) bool {
+func shouldAutoMigrate(ctx context.Context, def MigrationDefinition, cfg *setting.Cfg, sqlStore db.DB) bool {
 	autoMigrate := false
 	configResources := def.ConfigResources()
 
@@ -100,7 +100,7 @@ func shouldAutoMigrate(ctx context.Context, def *MigrationDefinition, cfg *setti
 	return true
 }
 
-func checkIfAlreadyMigrated(ctx context.Context, def *MigrationDefinition, sqlStore db.DB) bool {
+func checkIfAlreadyMigrated(ctx context.Context, def MigrationDefinition, sqlStore db.DB) bool {
 	if def.MigrationID == "" {
 		return false
 	}
@@ -114,7 +114,7 @@ func checkIfAlreadyMigrated(ctx context.Context, def *MigrationDefinition, sqlSt
 	return exists
 }
 
-func isMigrationEnabled(def *MigrationDefinition, cfg *setting.Cfg) (bool, error) {
+func isMigrationEnabled(def MigrationDefinition, cfg *setting.Cfg) (bool, error) {
 	var (
 		hasValue   bool
 		allEnabled bool

--- a/pkg/storage/unified/migrations/resources_test.go
+++ b/pkg/storage/unified/migrations/resources_test.go
@@ -195,10 +195,11 @@ func TestResourceMigration_AutoMigrateEnablesMode5(t *testing.T) {
 			m := NewResourceMigration(nil, resources, "test-auto-migrate", nil, opts...)
 
 			// Simulate what happens at the end of a successful migration
-			// This is the logic from Exec() that we're testing
-			if m.autoMigrate && m.cfg != nil && m.cfg.UnifiedStorageType() == "unified" {
+			// This is the logic from MigrationRunner.Run() that we're testing
+			// Note: EnableMode5 should only be called for unified storage type
+			if m.runner.autoEnableMode5 && m.runner.cfg != nil && m.runner.cfg.UnifiedStorageType() == "unified" {
 				for _, gr := range m.resources {
-					m.cfg.EnableMode5(gr.Resource + "." + gr.Group)
+					m.runner.cfg.EnableMode5(gr.Resource + "." + gr.Group)
 				}
 			}
 

--- a/pkg/storage/unified/migrations/resources_test.go
+++ b/pkg/storage/unified/migrations/resources_test.go
@@ -25,12 +25,12 @@ func TestIsMigrationEnabled(t *testing.T) {
 	folderGR := schema.GroupResource{Resource: "fake", Group: "folders.resource"}
 	dashboardGR := schema.GroupResource{Resource: "fake", Group: "dashboards.resource"}
 
-	playlistDef := &MigrationDefinition{
+	playlistDef := MigrationDefinition{
 		ID:          "test-playlists",
 		MigrationID: "playlists migration",
 		Resources:   []schema.GroupResource{playlistGR},
 	}
-	foldersDashboardsDef := &MigrationDefinition{
+	foldersDashboardsDef := MigrationDefinition{
 		ID:          "test-folders-dashboards",
 		MigrationID: "folders and dashboards migration",
 		Resources:   []schema.GroupResource{folderGR, dashboardGR},
@@ -50,7 +50,7 @@ func TestIsMigrationEnabled(t *testing.T) {
 	// Table of scenarios
 	tests := []struct {
 		name            string
-		def             *MigrationDefinition
+		def             MigrationDefinition
 		enablePlaylist  bool
 		enableFolder    bool
 		enableDashboard bool
@@ -105,7 +105,7 @@ func TestRegisterMigrations(t *testing.T) {
 
 	// helper to build a fake registry with test migration definitions
 	setupFakeRegistry := func() {
-		Registry.definitions = make(map[string]*MigrationDefinition)
+		Registry.definitions = make(map[string]MigrationDefinition)
 		Registry.order = make([]string, 0)
 
 		// Create fake GroupResources that map to our fake config resources
@@ -113,12 +113,12 @@ func TestRegisterMigrations(t *testing.T) {
 		folderGR := schema.GroupResource{Resource: "fake", Group: "folders.resource"}
 		dashboardGR := schema.GroupResource{Resource: "fake", Group: "dashboards.resource"}
 
-		Registry.Register(&MigrationDefinition{
+		Registry.Register(MigrationDefinition{
 			ID:          "test-playlists",
 			MigrationID: "playlists migration",
 			Resources:   []schema.GroupResource{playlistGR},
 		})
-		Registry.Register(&MigrationDefinition{
+		Registry.Register(MigrationDefinition{
 			ID:          "test-folders-dashboards",
 			MigrationID: "folders and dashboards migration",
 			Resources:   []schema.GroupResource{folderGR, dashboardGR},

--- a/pkg/storage/unified/migrations/resources_test.go
+++ b/pkg/storage/unified/migrations/resources_test.go
@@ -7,15 +7,93 @@ import (
 
 	sqlstoremigrator "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// TestIsMigrationEnabled tests the isMigrationEnabled function directly
+func TestIsMigrationEnabled(t *testing.T) {
+	// Use fake resource names that are NOT in setting.AutoMigratedUnifiedResources
+	const (
+		fakePlaylistResource  = "fake.playlists.resource"
+		fakeFolderResource    = "fake.folders.resource"
+		fakeDashboardResource = "fake.dashboards.resource"
+	)
+
+	// Create fake GroupResources that map to our fake config resources
+	playlistGR := schema.GroupResource{Resource: "fake", Group: "playlists.resource"}
+	folderGR := schema.GroupResource{Resource: "fake", Group: "folders.resource"}
+	dashboardGR := schema.GroupResource{Resource: "fake", Group: "dashboards.resource"}
+
+	playlistDef := &MigrationDefinition{
+		ID:          "test-playlists",
+		MigrationID: "playlists migration",
+		Resources:   []schema.GroupResource{playlistGR},
+	}
+	foldersDashboardsDef := &MigrationDefinition{
+		ID:          "test-folders-dashboards",
+		MigrationID: "folders and dashboards migration",
+		Resources:   []schema.GroupResource{folderGR, dashboardGR},
+	}
+
+	// Build a minimal cfg with UnifiedStorage entries
+	makeCfg := func(vals map[string]bool) *setting.Cfg {
+		cfg := &setting.Cfg{UnifiedStorage: make(map[string]setting.UnifiedStorageConfig)}
+		for k, v := range vals {
+			cfg.UnifiedStorage[k] = setting.UnifiedStorageConfig{
+				EnableMigration: v,
+			}
+		}
+		return cfg
+	}
+
+	// Table of scenarios
+	tests := []struct {
+		name            string
+		def             *MigrationDefinition
+		enablePlaylist  bool
+		enableFolder    bool
+		enableDashboard bool
+		wantEnabled     bool
+		wantErr         bool
+	}{
+		{name: "playlists enabled", def: playlistDef, enablePlaylist: true, wantEnabled: true},
+		{name: "playlists disabled", def: playlistDef, enablePlaylist: false, wantEnabled: false},
+		{name: "folders+dashboards both enabled", def: foldersDashboardsDef, enableFolder: true, enableDashboard: true, wantEnabled: true},
+		{name: "folders enabled, dashboards disabled (mismatch)", def: foldersDashboardsDef, enableFolder: true, enableDashboard: false, wantErr: true},
+		{name: "folders disabled, dashboards enabled (mismatch)", def: foldersDashboardsDef, enableFolder: false, enableDashboard: true, wantErr: true},
+		{name: "folders+dashboards both disabled", def: foldersDashboardsDef, enableFolder: false, enableDashboard: false, wantEnabled: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := makeCfg(map[string]bool{
+				fakePlaylistResource:  tt.enablePlaylist,
+				fakeFolderResource:    tt.enableFolder,
+				fakeDashboardResource: tt.enableDashboard,
+			})
+
+			enabled, err := isMigrationEnabled(tt.def, cfg)
+
+			if tt.wantErr {
+				require.Error(t, err, "expected error for mismatched enablement")
+			} else {
+				require.NoError(t, err, "unexpected error")
+				require.Equal(t, tt.wantEnabled, enabled, "enabled mismatch")
+			}
+		})
+	}
+}
+
 // TestRegisterMigrations exercises registerMigrations with various EnableMigration configs using a table-driven test.
 func TestRegisterMigrations(t *testing.T) {
-	origRegistry := migrationRegistry
-	t.Cleanup(func() { migrationRegistry = origRegistry })
+	// Save original registry and restore after test
+	origDefinitions := Registry.definitions
+	origOrder := Registry.order
+	t.Cleanup(func() {
+		Registry.definitions = origDefinitions
+		Registry.order = origOrder
+	})
 
 	// Use fake resource names that are NOT in setting.AutoMigratedUnifiedResources
 	// to avoid triggering the auto-migrate code path which requires a non-nil sqlStore.
@@ -25,24 +103,26 @@ func TestRegisterMigrations(t *testing.T) {
 		fakeDashboardResource = "fake.dashboards.resource"
 	)
 
-	// helper to build a fake registry with custom register funcs that bump counters
-	makeFakeRegistry := func(migrationCalls map[string]int) []migrationDefinition {
-		return []migrationDefinition{
-			{
-				name:      "playlists",
-				resources: []string{fakePlaylistResource},
-				registerFunc: func(mg *sqlstoremigrator.Migrator, migrator UnifiedMigrator, client resource.ResourceClient, opts ...ResourceMigrationOption) {
-					migrationCalls["playlists"]++
-				},
-			},
-			{
-				name:      "folders and dashboards",
-				resources: []string{fakeFolderResource, fakeDashboardResource},
-				registerFunc: func(mg *sqlstoremigrator.Migrator, migrator UnifiedMigrator, client resource.ResourceClient, opts ...ResourceMigrationOption) {
-					migrationCalls["folders and dashboards"]++
-				},
-			},
-		}
+	// helper to build a fake registry with test migration definitions
+	setupFakeRegistry := func() {
+		Registry.definitions = make(map[string]*MigrationDefinition)
+		Registry.order = make([]string, 0)
+
+		// Create fake GroupResources that map to our fake config resources
+		playlistGR := schema.GroupResource{Resource: "fake", Group: "playlists.resource"}
+		folderGR := schema.GroupResource{Resource: "fake", Group: "folders.resource"}
+		dashboardGR := schema.GroupResource{Resource: "fake", Group: "dashboards.resource"}
+
+		Registry.Register(&MigrationDefinition{
+			ID:          "test-playlists",
+			MigrationID: "playlists migration",
+			Resources:   []schema.GroupResource{playlistGR},
+		})
+		Registry.Register(&MigrationDefinition{
+			ID:          "test-folders-dashboards",
+			MigrationID: "folders and dashboards migration",
+			Resources:   []schema.GroupResource{folderGR, dashboardGR},
+		})
 	}
 
 	// Build a minimal cfg with UnifiedStorage entries used by registerMigrations
@@ -56,52 +136,71 @@ func TestRegisterMigrations(t *testing.T) {
 		return cfg
 	}
 
-	// Table of scenarios
-	tests := []struct {
-		name              string
-		enablePlaylist    bool
-		enableFolder      bool
-		enableDashboard   bool
-		wantPlaylistCalls int
-		wantFDCalls       int
-		wantErr           bool
-	}{
-		{name: "playlists enabled", enablePlaylist: true, wantPlaylistCalls: 1},
-		{name: "playlists disabled", enablePlaylist: false, wantPlaylistCalls: 0},
-		{name: "folders+dashboards both enabled", enableFolder: true, enableDashboard: true, wantFDCalls: 1},
-		{name: "folders enabled, dashboards disabled (mismatch)", enableFolder: true, enableDashboard: false, wantFDCalls: 0, wantErr: true},
-		{name: "folders disabled, dashboards enabled (mismatch)", enableFolder: false, enableDashboard: true, wantFDCalls: 0, wantErr: true},
-		{name: "folders+dashboards both disabled", enableFolder: false, enableDashboard: false, wantFDCalls: 0},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			migrationCalls := map[string]int{
-				"playlists":              0,
-				"folders and dashboards": 0,
-			}
-
-			migrationRegistry = makeFakeRegistry(migrationCalls)
-
-			cfg := makeCfg(map[string]bool{
-				fakePlaylistResource:  tt.enablePlaylist,
-				fakeFolderResource:    tt.enableFolder,
-				fakeDashboardResource: tt.enableDashboard,
+	// Helper to run registerMigrations and capture the registered migration IDs
+	runAndGetMigrationIDs := func(cfg *setting.Cfg) ([]string, error) {
+		var ids []string
+		var capturedErr error
+		_ = sqlstoremigrator.CheckExpectedMigrations(sqlstoremigrator.SQLite,
+			[]sqlstoremigrator.ExpectedMigration{},
+			func(mg *sqlstoremigrator.Migrator) {
+				capturedErr = registerMigrations(context.Background(), cfg, mg, nil, nil, nil)
+				ids = mg.GetMigrationIDs(false)
 			})
-
-			// We pass nils for migrator dependencies because our fake registerFuncs don't use them
-			err := registerMigrations(context.Background(), cfg, nil, nil, nil, nil)
-
-			if tt.wantErr {
-				require.Error(t, err, "expected error for mismatched enablement")
-			} else {
-				require.NoError(t, err, "unexpected error")
-			}
-
-			require.Equal(t, tt.wantPlaylistCalls, migrationCalls["playlists"], "playlists register call count")
-			require.Equal(t, tt.wantFDCalls, migrationCalls["folders and dashboards"], "folders+dashboards register call count")
-		})
+		return ids, capturedErr
 	}
+
+	t.Run("playlists enabled registers migration", func(t *testing.T) {
+		setupFakeRegistry()
+		cfg := makeCfg(map[string]bool{
+			fakePlaylistResource:  true,
+			fakeFolderResource:    false,
+			fakeDashboardResource: false,
+		})
+
+		ids, err := runAndGetMigrationIDs(cfg)
+		require.NoError(t, err)
+		require.Contains(t, ids, "playlists migration")
+		require.NotContains(t, ids, "folders and dashboards migration")
+	})
+
+	t.Run("folders+dashboards both enabled registers migration", func(t *testing.T) {
+		setupFakeRegistry()
+		cfg := makeCfg(map[string]bool{
+			fakePlaylistResource:  false,
+			fakeFolderResource:    true,
+			fakeDashboardResource: true,
+		})
+
+		ids, err := runAndGetMigrationIDs(cfg)
+		require.NoError(t, err)
+		require.Contains(t, ids, "folders and dashboards migration")
+		require.NotContains(t, ids, "playlists migration")
+	})
+
+	t.Run("mismatched enablement returns error", func(t *testing.T) {
+		setupFakeRegistry()
+		cfg := makeCfg(map[string]bool{
+			fakePlaylistResource:  false,
+			fakeFolderResource:    true,
+			fakeDashboardResource: false,
+		})
+
+		_, err := runAndGetMigrationIDs(cfg)
+		require.Error(t, err, "expected error for mismatched enablement")
+	})
+
+	t.Run("all disabled registers nothing", func(t *testing.T) {
+		setupFakeRegistry()
+		cfg := makeCfg(map[string]bool{
+			fakePlaylistResource:  false,
+			fakeFolderResource:    false,
+			fakeDashboardResource: false,
+		})
+
+		ids, err := runAndGetMigrationIDs(cfg)
+		require.NoError(t, err)
+		require.Empty(t, ids)
+	})
 }
 
 // TestResourceMigration_AutoMigrateEnablesMode5 verifies the autoMigrate behavior:

--- a/pkg/storage/unified/migrations/validator.go
+++ b/pkg/storage/unified/migrations/validator.go
@@ -403,3 +403,19 @@ func (v *FolderTreeValidator) buildUnifiedFolderParentMapSQLite(sess *xorm.Sessi
 
 	return parentMap, nil
 }
+
+// CountValidation creates a ValidatorFactory for count-based validation.
+// It compares the count of resources in the legacy table with unified storage.
+func CountValidation(resource schema.GroupResource, table, whereClause string) ValidatorFactory {
+	return func(client resourcepb.ResourceIndexClient, driverName string) Validator {
+		return NewCountValidator(client, resource, table, whereClause, driverName)
+	}
+}
+
+// FolderTreeValidation creates a ValidatorFactory for folder tree structure validation.
+// It validates that folder parent relationships are preserved after migration.
+func FolderTreeValidation(resource schema.GroupResource) ValidatorFactory {
+	return func(client resourcepb.ResourceIndexClient, driverName string) Validator {
+		return NewFolderTreeValidator(client, resource, driverName)
+	}
+}

--- a/pkg/storage/unified/migrations/validator.go
+++ b/pkg/storage/unified/migrations/validator.go
@@ -61,7 +61,7 @@ type CountValidator struct {
 	driverName  string
 }
 
-func NewCountValidator(
+func newCountValidator(
 	client resourcepb.ResourceIndexClient,
 	resource schema.GroupResource,
 	table string,
@@ -182,7 +182,7 @@ type FolderTreeValidator struct {
 	driverName string
 }
 
-func NewFolderTreeValidator(
+func newFolderTreeValidator(
 	client resourcepb.ResourceIndexClient,
 	resource schema.GroupResource,
 	driverName string,
@@ -408,7 +408,7 @@ func (v *FolderTreeValidator) buildUnifiedFolderParentMapSQLite(sess *xorm.Sessi
 // It compares the count of resources in the legacy table with unified storage.
 func CountValidation(resource schema.GroupResource, table, whereClause string) ValidatorFactory {
 	return func(client resourcepb.ResourceIndexClient, driverName string) Validator {
-		return NewCountValidator(client, resource, table, whereClause, driverName)
+		return newCountValidator(client, resource, table, whereClause, driverName)
 	}
 }
 
@@ -416,6 +416,6 @@ func CountValidation(resource schema.GroupResource, table, whereClause string) V
 // It validates that folder parent relationships are preserved after migration.
 func FolderTreeValidation(resource schema.GroupResource) ValidatorFactory {
 	return func(client resourcepb.ResourceIndexClient, driverName string) Validator {
-		return NewFolderTreeValidator(client, resource, driverName)
+		return newFolderTreeValidator(client, resource, driverName)
 	}
 }


### PR DESCRIPTION
Refactor the current unified storage migration setup. Decoupling the `MigrationRunner` (handling the migration+validation) from the grafana sql migration registration. This enables us to use the `MigrationRunner` independently from the migration controller. Thus, we will have a centralized way of defining the unified storage migrations in grafana and only reference it from the migration controller.

Grafana new resource (`X`) migration registration (currently in `registry.go`):
```go
	// Register X migration
	xGR := schema.GroupResource{Group: X.APIGroup, Resource: "X"}

	Registry.Register(&MigrationDefinition{
		ID:          "X",
		MigrationID: "X migration",
		Resources:   []schema.GroupResource{xGR},
		Migrators: map[schema.GroupResource]MigratorFactory{
            // This needs to be adapted by the teams that introduce the actual Migration logic.
			xGR: func(a Accessor) MigratorFunc { return a.MigrateX },
		},
		Validators: []ValidatorFactory{
			CountValidation(xGR, "X "org_id = ?"),
		},
	})
```

The code will be referenced from the migration controller roughly as below:
```go
import grafana
def := grafana.Registry.Get(migrationID)
validators := def.CreateValidators(resourceClient, driverName)
migrator := grafana.NewMigrationRunner(migrator, def.ID, def.Resources, validators)
migrator.MigrateOrg(ctx, sess, org)
```

Ticket: https://github.com/grafana/search-and-storage-team/issues/624