### PR TITLE
Log Line Context: Internally manage displayed fields

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -785,8 +785,6 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
           logOptionsStorageKey={SETTING_KEY_ROOT}
           timeZone={timeZone}
           displayedFields={displayedFields}
-          onClickShowField={showField}
-          onClickHideField={hideField}
         />
       )}
       <div className={styles.logsVolumePanel}>

--- a/public/app/features/logs/components/panel/LogLineContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.test.tsx
@@ -572,4 +572,38 @@ describe('LogLineContext', () => {
       timeWindowMs: DEFAULT_TIME_WINDOW,
     });
   });
+
+  test('Should show and clear displayed fields', async () => {
+    const displayedFields = ['level', 'label'];
+
+    render(
+      <LogLineContext
+        log={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+        displayedFields={displayedFields}
+      />
+    );
+
+    expect(screen.getByText('Log context')).toBeInTheDocument();
+    expect(screen.queryByText('foo123')).not.toBeInTheDocument();
+
+    const showOriginalLogsButton = screen.getByRole('button', {
+      name: /show original logs/i,
+    });
+
+    expect(showOriginalLogsButton).toBeInTheDocument();
+
+    await userEvent.click(showOriginalLogsButton);
+
+    expect(
+      screen.queryByRole('button', {
+        name: /show original logs/i,
+      })
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByText('foo123')).toHaveLength(3);
+  });
 });

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -544,6 +544,9 @@ const getStyles = (theme: GrafanaTheme2) => {
         flexDirection: 'column',
         alignItems: 'flex-start',
       },
+      [theme.breakpoints.down('sm')]: {
+        alignItems: 'center',
+      },
     }),
   };
 };

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -363,48 +363,52 @@ export const LogLineContext = memo(
           <LogLineDetailsLog log={logListModel} syntaxHighlighting={syntaxHighlighting} />
         </Collapse>
         <div className={styles.controls}>
-          {datasourceInstance?.supportsAdjustableWindow && (
-            <Stack>
-              <InlineLabel
-                htmlFor="time-window-control"
+          <div className={styles.controlGroup}>
+            {datasourceInstance?.supportsAdjustableWindow && (
+              <Stack>
+                <InlineLabel
+                  htmlFor="time-window-control"
+                  tooltip={t(
+                    'logs.log-line-context.time-window-tooltip',
+                    'Amount of time before and after the referenced log'
+                  )}
+                  width="auto"
+                >
+                  {t('logs.log-line-context.time-window-label', 'Context time window')}
+                </InlineLabel>
+                <Combobox
+                  id="time-window-control"
+                  options={getTimeWindowOptions()}
+                  onChange={handleTimeWindowChange}
+                  value={timeWindow.toString()}
+                  minWidth={5}
+                  width="auto"
+                />
+              </Stack>
+            )}
+            {displayedFields.length > 0 && (
+              <Button
+                variant="secondary"
+                onClick={resetFields}
                 tooltip={t(
-                  'logs.log-line-context.time-window-tooltip',
-                  'Amount of time before and after the referenced log'
+                  'logs.log-line-context.show-original-log-tooltip',
+                  'Clear displayed fields and show the original log line message'
                 )}
-                width="auto"
               >
-                {t('logs.log-line-context.time-window-label', 'Context time window')}
-              </InlineLabel>
-              <Combobox
-                id="time-window-control"
-                options={getTimeWindowOptions()}
-                onChange={handleTimeWindowChange}
-                value={timeWindow.toString()}
-                minWidth={5}
-                width="auto"
-              />
-            </Stack>
-          )}
-          {displayedFields.length > 0 && (
-            <Button
-              variant="secondary"
-              onClick={resetFields}
-              tooltip={t(
-                'logs.log-line-context.show-original-log-tooltip',
-                'Clear displayed fields and show the original log line message'
-              )}
-            >
-              <Trans i18nKey="logs.log-line-context.show-original-log">Show original logs</Trans>
+                <Trans i18nKey="logs.log-line-context.show-original-log">Show original logs</Trans>
+              </Button>
+            )}
+          </div>
+          <div className={styles.controlGroup}>
+            <Button variant="secondary" onClick={onScrollCenterClick}>
+              <Trans i18nKey="logs.log-line-context.center-matched-line">Center matched line</Trans>
             </Button>
-          )}
-          <Button variant="secondary" onClick={onScrollCenterClick}>
-            <Trans i18nKey="logs.log-line-context.center-matched-line">Center matched line</Trans>
-          </Button>
-          {contextQuery?.datasource?.uid && (
-            <Button variant="secondary" onClick={onSplitViewClick}>
-              <Trans i18nKey="logs.log-line-context.open-in-split-view">Open in split view</Trans>
-            </Button>
-          )}
+            {contextQuery?.datasource?.uid && (
+              <Button variant="secondary" onClick={onSplitViewClick}>
+                <Trans i18nKey="logs.log-line-context.open-in-split-view">Open in split view</Trans>
+              </Button>
+            )}
+          </div>
         </div>
         <div className={styles.loadingIndicator}>
           {aboveState === LoadingState.Loading && (
@@ -526,8 +530,20 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     controls: css({
       display: 'flex',
-      justifyContent: 'flex-end',
+      justifyContent: 'space-between',
       gap: theme.spacing(2),
+      [theme.breakpoints.down('sm')]: {
+        flexDirection: 'column',
+      },
+    }),
+    controlGroup: css({
+      display: 'flex',
+      gap: theme.spacing(1),
+      flexDirection: 'row',
+      [theme.breakpoints.down('lg')]: {
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+      },
     }),
   };
 };

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -572,8 +572,6 @@ export const LogsPanel = ({
           logLineMenuCustomItems={isLogLineMenuCustomItems(logLineMenuCustomItems) ? logLineMenuCustomItems : undefined}
           timeZone={timeZone}
           displayedFields={displayedFields}
-          onClickShowField={showField}
-          onClickHideField={hideField}
         />
       )}
       {config.featureToggles.newLogsPanel && (

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10033,6 +10033,8 @@
       "no-more-logs-available": "No more logs available.",
       "older-logs": "older",
       "open-in-split-view": "Open in split view",
+      "show-original-log": "Show original logs",
+      "show-original-log-tooltip": "Clear displayed fields and show the original log line message",
       "time-window-label": "Context time window",
       "time-window-tooltip": "Amount of time before and after the referenced log",
       "title-log-context": "Log context",


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/116778

This PR adds support to internally manage displayed fields state inside Log Context, with the purpose of allowing users to reset or change displayed fields.