### PR TITLE
Provisioning: update admission on Repository's sync interval

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
@@ -295,7 +295,9 @@ type SyncOptions struct {
 	// The value is a reference to the Kubernetes metadata name of the folder in the same namespace
 	// Folder string `json:"folder,omitempty"`
 
-	// When non-zero, the sync will run periodically
+	// The interval between sync runs.
+	// The system defines a default value for this field, which will overwrite the
+	// user-defined one in case the latter is zero or lower than the system-defined one.
 	IntervalSeconds int64 `json:"intervalSeconds,omitempty"`
 }
 

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -3014,7 +3014,7 @@ func schema_pkg_apis_provisioning_v0alpha1_SyncOptions(ref common.ReferenceCallb
 					},
 					"intervalSeconds": {
 						SchemaProps: spec.SchemaProps{
-							Description: "When non-zero, the sync will run periodically",
+							Description: "The interval between sync runs. The system defines a default value for this field, which will overwrite the user-defined one in case the latter is zero or lower than the system-defined one.",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},

--- a/apps/provisioning/pkg/repository/tester_test.go
+++ b/apps/provisioning/pkg/repository/tester_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -102,7 +101,7 @@ func TestTester_Test_Cases(t *testing.T) {
 
 	mockFactory := NewMockFactory(t)
 	mockFactory.EXPECT().Validate(mock.Anything, mock.Anything).Return(field.ErrorList{}).Maybe()
-	validator := NewValidator(10*time.Second, true, mockFactory)
+	validator := NewValidator(true, mockFactory)
 	// Use basic RepositoryValidator since Tester is used for health checks
 	tester := NewTester(validator)
 	for _, tt := range tests {
@@ -144,7 +143,7 @@ func TestTester_Test(t *testing.T) {
 
 	mockFactory := NewMockFactory(t)
 	mockFactory.EXPECT().Validate(mock.Anything, mock.Anything).Return(field.ErrorList{}).Maybe()
-	validator := NewValidator(10*time.Second, true, mockFactory)
+	validator := NewValidator(true, mockFactory)
 	// Use basic RepositoryValidator since Tester is used for health checks
 	tester := NewTester(validator)
 	results, err := tester.Test(context.Background(), repository)

--- a/apps/provisioning/pkg/repository/validator.go
+++ b/apps/provisioning/pkg/repository/validator.go
@@ -63,11 +63,6 @@ func (v *RepositoryValidator) Validate(ctx context.Context, cfg *provisioning.Re
 			list = append(list, field.Required(field.NewPath("spec", "sync", "target"),
 				"The target type is required when sync is enabled"))
 		}
-
-		if cfg.Spec.Sync.IntervalSeconds < int64(v.minSyncInterval.Seconds()) {
-			list = append(list, field.Invalid(field.NewPath("spec", "sync", "intervalSeconds"),
-				cfg.Spec.Sync.IntervalSeconds, fmt.Sprintf("Interval must be at least %d seconds", int64(v.minSyncInterval.Seconds()))))
-		}
 	}
 
 	// Reserved names (for now)

--- a/apps/provisioning/pkg/repository/validator.go
+++ b/apps/provisioning/pkg/repository/validator.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
-	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,22 +24,15 @@ type Validator interface {
 // RepositoryValidator implements Validator for basic repository configuration checks.
 type RepositoryValidator struct {
 	allowImageRendering bool
-	minSyncInterval     time.Duration
 	repoFactory         Factory
 }
 
 // FIXME: The separation of concerns here is not ideal. RepositoryValidator should not depend on Factory,
 // but we need to call Factory.Validate() for structural validation (URL, branch, path, etc.) before
 // doing configuration validation. This coupling was introduced to avoid more extensive refactoring.
-func NewValidator(minSyncInterval time.Duration, allowImageRendering bool, repoFactory Factory) Validator {
-	// do not allow minsync interval to be less than 10
-	if minSyncInterval <= 10*time.Second {
-		minSyncInterval = 10 * time.Second
-	}
-
+func NewValidator(allowImageRendering bool, repoFactory Factory) Validator {
 	return &RepositoryValidator{
 		allowImageRendering: allowImageRendering,
-		minSyncInterval:     minSyncInterval,
 		repoFactory:         repoFactory,
 	}
 }

--- a/apps/provisioning/pkg/repository/validator_test.go
+++ b/apps/provisioning/pkg/repository/validator_test.go
@@ -249,7 +249,7 @@ func TestValidator_Validate(t *testing.T) {
 
 	mockFactory := NewMockFactory(t)
 	mockFactory.EXPECT().Validate(mock.Anything, mock.Anything).Return(field.ErrorList{}).Maybe()
-	validator := NewValidator(10*time.Second, false, mockFactory)
+	validator := NewValidator(false, mockFactory)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Tests validate new configurations, so always pass isCreate=true
@@ -405,7 +405,7 @@ func TestAdmissionValidator_Validate(t *testing.T) {
 			mockFactory := NewMockFactory(t)
 			mockFactory.EXPECT().Validate(mock.Anything, mock.Anything).Return(field.ErrorList{}).Maybe()
 
-			validator := NewValidator(10*time.Second, false, mockFactory)
+			validator := NewValidator(false, mockFactory)
 
 			admissionValidator := NewAdmissionValidator(
 				[]provisioning.SyncTargetType{
@@ -436,7 +436,7 @@ func TestAdmissionValidator_CopiesSecureValuesOnUpdate(t *testing.T) {
 	mockFactory := NewMockFactory(t)
 	mockFactory.EXPECT().Validate(mock.Anything, mock.Anything).Return(field.ErrorList{}).Maybe()
 
-	validator := NewValidator(10*time.Second, false, mockFactory)
+	validator := NewValidator(false, mockFactory)
 	admissionValidator := NewAdmissionValidator(
 		[]provisioning.SyncTargetType{provisioning.SyncTargetTypeFolder},
 		validator,
@@ -490,7 +490,7 @@ func TestAdmissionValidator_CallsMultipleValidators(t *testing.T) {
 	mockFactory := NewMockFactory(t)
 	mockFactory.EXPECT().Validate(mock.Anything, mock.Anything).Return(field.ErrorList{}).Maybe()
 
-	baseValidator := NewValidator(10*time.Second, false, mockFactory)
+	baseValidator := NewValidator(false, mockFactory)
 	additionalValidator := &mockValidator{}
 
 	admissionValidator := NewAdmissionValidator(
@@ -519,7 +519,7 @@ func TestAdmissionValidator_ValidatorError(t *testing.T) {
 	mockFactory := NewMockFactory(t)
 	mockFactory.EXPECT().Validate(mock.Anything, mock.Anything).Return(field.ErrorList{}).Maybe()
 
-	baseValidator := NewValidator(10*time.Second, false, mockFactory)
+	baseValidator := NewValidator(false, mockFactory)
 	additionalValidator := &mockValidator{
 		errors: field.ErrorList{field.Forbidden(field.NewPath("spec"), "duplicate repository")},
 	}

--- a/apps/provisioning/pkg/repository/validator_test.go
+++ b/apps/provisioning/pkg/repository/validator_test.go
@@ -69,24 +69,6 @@ func TestValidator_Validate(t *testing.T) {
 			},
 		},
 		{
-			name: "sync interval too low",
-			repository: func() *provisioning.Repository {
-				return &provisioning.Repository{
-					Spec: provisioning.RepositorySpec{
-						Title: "Test Repo",
-						Sync: provisioning.SyncOptions{
-							Enabled:         true,
-							Target:          provisioning.SyncTargetTypeFolder,
-							IntervalSeconds: 5,
-						}},
-				}
-			}(),
-			expectedErrs: 1,
-			validateError: func(t *testing.T, errors field.ErrorList) {
-				require.Contains(t, errors.ToAggregate().Error(), "spec.sync.intervalSeconds: Invalid value")
-			},
-		},
-		{
 			name: "reserved name",
 			repository: func() *provisioning.Repository {
 				return &provisioning.Repository{
@@ -183,14 +165,14 @@ func TestValidator_Validate(t *testing.T) {
 						Sync: provisioning.SyncOptions{
 							Enabled:         true,
 							IntervalSeconds: 5,
-							Target:          provisioning.SyncTargetTypeInstance,
+							Target:          "",
 						},
 					},
 				}
 			}(),
 			expectedErrs: 2,
 			// 1. reserved name
-			// 2. sync interval too low
+			// 2. Empty target
 			// Note: "sync target not supported" is now checked in AdmissionValidator, not RepositoryValidator
 		},
 		{

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1816,7 +1816,7 @@ export type LocalRepositoryConfig = {
 export type SyncOptions = {
   /** Enabled must be saved as true before any sync job will run */
   enabled: boolean;
-  /** When non-zero, the sync will run periodically */
+  /** The interval between sync runs. The system defines a default value for this field, which will overwrite the user-defined one in case the latter is zero or lower than the system-defined one. */
   intervalSeconds?: number;
   /** Where values should be saved
     

--- a/pkg/operators/provisioning/repo_operator.go
+++ b/pkg/operators/provisioning/repo_operator.go
@@ -70,7 +70,7 @@ func RunRepoController(deps server.OperatorDependencies) error {
 		return fmt.Errorf("create API client job store: %w", err)
 	}
 
-	validator := repository.NewValidator(controllerCfg.minSyncInterval, controllerCfg.allowImageRendering, controllerCfg.repoFactory)
+	validator := repository.NewValidator(controllerCfg.allowImageRendering, controllerCfg.repoFactory)
 	statusPatcher := appcontroller.NewRepositoryStatusPatcher(controllerCfg.provisioningClient.ProvisioningV0alpha1())
 	// Health checker uses basic validation only - no need to validate against existing repositories
 	// since the repository already passed admission validation when it was created/updated.

--- a/pkg/registry/apis/provisioning/controller/health_test.go
+++ b/pkg/registry/apis/provisioning/controller/health_test.go
@@ -21,7 +21,7 @@ func TestNewRepositoryHealthChecker(t *testing.T) {
 	mockFactory := repository.NewMockFactory(t)
 	mockFactory.EXPECT().Validate(mock.Anything, mock.Anything).Return(field.ErrorList{}).Maybe()
 
-	validator := repository.NewValidator(30*time.Second, true, mockFactory)
+	validator := repository.NewValidator(true, mockFactory)
 	mockMetricsRecorder := NewMockHealthMetricsRecorder(t)
 	hc := NewRepositoryHealthChecker(mockPatcher, repository.NewTester(validator), mockMetricsRecorder)
 
@@ -142,7 +142,7 @@ func TestShouldCheckHealth(t *testing.T) {
 			mockPatcher := mocks.NewStatusPatcher(t)
 			mockFactory := repository.NewMockFactory(t)
 			mockFactory.EXPECT().Validate(mock.Anything, mock.Anything).Return(field.ErrorList{}).Maybe()
-			validator := repository.NewValidator(30*time.Second, true, mockFactory)
+			validator := repository.NewValidator(true, mockFactory)
 			mockMetricsRecorder := NewMockHealthMetricsRecorder(t)
 			hc := NewRepositoryHealthChecker(mockPatcher, repository.NewTester(validator), mockMetricsRecorder)
 
@@ -233,7 +233,7 @@ func TestHasRecentFailure(t *testing.T) {
 			mockPatcher := mocks.NewStatusPatcher(t)
 			mockFactory := repository.NewMockFactory(t)
 			mockFactory.EXPECT().Validate(mock.Anything, mock.Anything).Return(field.ErrorList{}).Maybe()
-			validator := repository.NewValidator(30*time.Second, true, mockFactory)
+			validator := repository.NewValidator(true, mockFactory)
 			mockMetricsRecorder := NewMockHealthMetricsRecorder(t)
 			hc := NewRepositoryHealthChecker(mockPatcher, repository.NewTester(validator), mockMetricsRecorder)
 
@@ -279,7 +279,7 @@ func TestRecordFailure(t *testing.T) {
 			mockPatcher := mocks.NewStatusPatcher(t)
 			mockFactory := repository.NewMockFactory(t)
 			mockFactory.EXPECT().Validate(mock.Anything, mock.Anything).Return(field.ErrorList{}).Maybe()
-			validator := repository.NewValidator(30*time.Second, true, mockFactory)
+			validator := repository.NewValidator(true, mockFactory)
 			mockMetricsRecorder := NewMockHealthMetricsRecorder(t)
 			hc := NewRepositoryHealthChecker(mockPatcher, repository.NewTester(validator), mockMetricsRecorder)
 
@@ -328,7 +328,7 @@ func TestRecordFailureFunction(t *testing.T) {
 	mockPatcher := mocks.NewStatusPatcher(t)
 	mockFactory := repository.NewMockFactory(t)
 	mockFactory.EXPECT().Validate(mock.Anything, mock.Anything).Return(field.ErrorList{}).Maybe()
-	validator := repository.NewValidator(30*time.Second, true, mockFactory)
+	validator := repository.NewValidator(true, mockFactory)
 	mockMetricsRecorder := NewMockHealthMetricsRecorder(t)
 	hc := NewRepositoryHealthChecker(mockPatcher, repository.NewTester(validator), mockMetricsRecorder)
 
@@ -509,7 +509,7 @@ func TestRefreshHealth(t *testing.T) {
 
 			mockFactory := repository.NewMockFactory(t)
 			mockFactory.EXPECT().Validate(mock.Anything, mock.Anything).Return(field.ErrorList{}).Maybe()
-			validator := repository.NewValidator(30*time.Second, true, mockFactory)
+			validator := repository.NewValidator(true, mockFactory)
 			mockMetricsRecorder := NewMockHealthMetricsRecorder(t)
 			mockMetricsRecorder.EXPECT().RecordHealthCheck("repository", mock.Anything, mock.Anything).Return()
 			hc := NewRepositoryHealthChecker(mockPatcher, repository.NewTester(validator), mockMetricsRecorder)
@@ -661,7 +661,7 @@ func TestRefreshHealthWithPatchOps(t *testing.T) {
 			// Create health checker with validator and tester
 			mockFactory := repository.NewMockFactory(t)
 			mockFactory.EXPECT().Validate(mock.Anything, mock.Anything).Return(field.ErrorList{}).Maybe()
-			validator := repository.NewValidator(30*time.Second, true, mockFactory)
+			validator := repository.NewValidator(true, mockFactory)
 			mockMetricsRecorder := NewMockHealthMetricsRecorder(t)
 			mockMetricsRecorder.EXPECT().RecordHealthCheck("repository", mock.Anything, mock.Anything).Return()
 			hc := NewRepositoryHealthChecker(nil, repository.NewTester(validator), mockMetricsRecorder)
@@ -796,7 +796,7 @@ func TestHasHealthStatusChanged(t *testing.T) {
 			mockPatcher := mocks.NewStatusPatcher(t)
 			mockFactory := repository.NewMockFactory(t)
 			mockFactory.EXPECT().Validate(mock.Anything, mock.Anything).Return(field.ErrorList{}).Maybe()
-			validator := repository.NewValidator(30*time.Second, true, mockFactory)
+			validator := repository.NewValidator(true, mockFactory)
 			mockMetricsRecorder := NewMockHealthMetricsRecorder(t)
 			hc := NewRepositoryHealthChecker(mockPatcher, repository.NewTester(validator), mockMetricsRecorder)
 

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -641,7 +641,7 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	// This avoids the need for SetQuotaLimits and moves the HACK logic to construction.
 	existingReposValidatorRaw := repository.NewVerifyAgainstExistingRepositoriesValidatorWithQuotas(b.repoLister, b.quotaLimits)
 	repoAdmissionValidator := repository.NewAdmissionValidator(b.allowedTargets, b.repoValidator, existingReposValidatorRaw)
-	b.admissionHandler.RegisterMutator(provisioning.RepositoryResourceInfo.GetName(), repository.NewAdmissionMutator(b.repoFactory))
+	b.admissionHandler.RegisterMutator(provisioning.RepositoryResourceInfo.GetName(), repository.NewAdmissionMutator(b.repoFactory, b.minSyncInterval))
 	b.admissionHandler.RegisterValidator(provisioning.RepositoryResourceInfo.GetName(), repoAdmissionValidator)
 	// Connection mutator and validator
 	connAdmissionValidator := connection.NewAdmissionValidator(b.connectionFactory)

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -634,7 +634,7 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	b.admissionHandler = appadmission.NewHandler()
 
 	// Repository mutator and validator
-	b.repoValidator = repository.NewValidator(b.minSyncInterval, b.allowImageRendering, b.repoFactory)
+	b.repoValidator = repository.NewValidator(b.allowImageRendering, b.repoFactory)
 	// quotaLimits is set via SetQuotas HACK method, use it directly
 
 	// HACK: Use NewVerifyAgainstExistingRepositoriesValidatorWithQuotas to pass QuotaLimits directly.

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -6223,7 +6223,7 @@
             "default": false
           },
           "intervalSeconds": {
-            "description": "When non-zero, the sync will run periodically",
+            "description": "The interval between sync runs. The system defines a default value for this field, which will overwrite the user-defined one in case the latter is zero or lower than the system-defined one.",
             "type": "integer",
             "format": "int64"
           },

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -339,6 +339,19 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("should update sync interval", func(t *testing.T) {
+		r := helper.RenderObject(t, "testdata/local-readonly.json.tmpl", map[string]any{
+			"Name":                "valid-repo-testinterval",
+			"SyncEnabled":         true,
+			"SyncIntervalSeconds": 5,
+		})
+		created, err := helper.Repositories.Resource.Create(ctx, r, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		createdRepo := unstructuredToRepository(t, created)
+		require.Equal(t, int64(10), createdRepo.Spec.Sync.IntervalSeconds, "interval should be updated with default value")
+	})
 }
 
 func TestIntegrationProvisioning_FailInvalidSchema(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Updating admission on `repository.sync.intervalSeconds` field:
- **Mutation**: In case `repository.sync.intervalSeconds < minInterval`, default it to the `minInterval`;
- **Validation**: Don't error in case `repository.sync.intervalSeconds < minInterval` (for backwards compatibility).

**Why do we need this feature?**

The Repositories sync interval needs to be bound to the minimum interval which is set to the provisioning API. 

**Who is this feature for?**

Users of GitSync.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/765

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
