### PR TITLE
Alerting: Add logic to check provisioning consistency when creating/updating rules

### DIFF
--- a/pkg/services/ngalert/provisioning/validation/provenance_consistency.go
+++ b/pkg/services/ngalert/provisioning/validation/provenance_consistency.go
@@ -1,0 +1,157 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+// provenanceStore defines the interface for getting provenance information.
+// This matches the GetProvenancesByUIDs method from the ProvisioningStore interface in the parent package.
+type provenanceStore interface {
+	GetProvenancesByUIDs(ctx context.Context, orgID int64, resourceType string, uids []string) (map[string]models.Provenance, error)
+}
+
+// ValidateRuleProvenanceInGroupCreate validates that creating a new rule with targetProvenance
+// would not create a mixed-provenance group (provisioned and non-provisioned rules in the same group).
+// Use this function when adding a new rule to a group.
+func ValidateRuleProvenanceInGroupCreate(
+	ctx context.Context,
+	store provenanceStore,
+	orgID int64,
+	targetProvenance models.Provenance,
+	affectedGroups map[models.AlertRuleGroupKey]models.RulesGroup,
+) error {
+	return validateRuleProvenanceInGroup(ctx, store, orgID, targetProvenance, affectedGroups, "")
+}
+
+// ValidateRuleProvenanceInGroupUpdate validates that updating an existing rule with targetProvenance
+// would not create a mixed-provenance group (provisioned and non-provisioned rules in the same group).
+// Use this function when modifying an existing rule. Single-rule groups are allowed to change provenance.
+func ValidateRuleProvenanceInGroupUpdate(
+	ctx context.Context,
+	store provenanceStore,
+	orgID int64,
+	targetProvenance models.Provenance,
+	affectedGroups map[models.AlertRuleGroupKey]models.RulesGroup,
+	ruleUID string,
+) error {
+	if ruleUID == "" {
+		return fmt.Errorf("ruleUID cannot be empty for update operations")
+	}
+	return validateRuleProvenanceInGroup(ctx, store, orgID, targetProvenance, affectedGroups, ruleUID)
+}
+
+// validateRuleProvenanceInGroup checks that adding/updating a rule with targetProvenance to the affected groups
+// would not create a mixed-provenance group (provisioned and non-provisioned rules in the same group).
+//
+// This prevents the scenario where provisioned rules are added to groups with non-provisioned rules,
+// which would lock the entire group from being editable in the UI.
+//
+// The ruleUID parameter should be:
+// - Empty string ("") for CREATE operations (adding a new rule)
+// - The rule's UID for UPDATE operations (changing an existing rule)
+//
+// Rules:
+// - If targetProvenance != ProvenanceNone: no OTHER existing rule in the group can have ProvenanceNone
+// - If targetProvenance == ProvenanceNone: no OTHER existing rule in the group can have provenance != ProvenanceNone
+// - Empty groups (no existing rules) are always allowed
+// - Single-rule groups being updated are allowed (can change the group's provenance entirely)
+func validateRuleProvenanceInGroup(
+	ctx context.Context,
+	store provenanceStore,
+	orgID int64,
+	targetProvenance models.Provenance,
+	affectedGroups map[models.AlertRuleGroupKey]models.RulesGroup,
+	ruleUID string,
+) error {
+	if len(affectedGroups) == 0 {
+		return nil
+	}
+
+	// Collect all rule UIDs from affected groups.
+	ruleUIDs := make([]string, 0)
+	for _, rules := range affectedGroups {
+		for _, rule := range rules {
+			if rule != nil {
+				ruleUIDs = append(ruleUIDs, rule.UID)
+			}
+		}
+	}
+
+	// If no rules to check, return early.
+	if len(ruleUIDs) == 0 {
+		return nil
+	}
+
+	// Get provenances only for the affected rules.
+	provenances, err := store.GetProvenancesByUIDs(ctx, orgID, (&models.AlertRule{}).ResourceType(), ruleUIDs)
+	if err != nil {
+		return fmt.Errorf("failed to get provenances: %w", err)
+	}
+
+	// Check each affected group for conflicts
+	var conflictingGroups []string
+	for groupKey, rules := range affectedGroups {
+		// Special case: if updating a rule and it's the only rule in the group, allow changing provenance
+		if ruleUID != "" && len(rules) == 1 && rules[0] != nil && rules[0].UID == ruleUID {
+			continue
+		}
+
+		if hasProvenanceConflict(provenances, rules, targetProvenance, ruleUID) {
+			// Format the group identifier as orgID/namespace/group
+			conflictingGroups = append(conflictingGroups, fmt.Sprintf("%d/%s/%s", groupKey.OrgID, groupKey.NamespaceUID, groupKey.RuleGroup))
+		}
+	}
+
+	if len(conflictingGroups) > 0 {
+		// Sort for consistent error messages
+		sort.Strings(conflictingGroups)
+
+		var operation string
+		if targetProvenance != models.ProvenanceNone {
+			operation = fmt.Sprintf("cannot add provisioned (%s) rule to group containing non-provisioned rules", targetProvenance)
+		} else {
+			operation = "cannot add non-provisioned rule to group containing provisioned rules"
+		}
+
+		return fmt.Errorf("%w: %s [%s]", models.ErrAlertRuleFailedValidation, operation, strings.Join(conflictingGroups, ", "))
+	}
+
+	return nil
+}
+
+// hasProvenanceConflict checks if adding/updating a rule with targetProvenance would conflict with existing rules.
+// The ruleUID parameter (if provided) identifies the rule being updated, which should be excluded from conflict checking.
+func hasProvenanceConflict(provenances map[string]models.Provenance, rules []*models.AlertRule, targetProvenance models.Provenance, ruleUID string) bool {
+	for _, rule := range rules {
+		if rule == nil {
+			continue
+		}
+
+		// Skip the rule being updated when checking for conflicts in UPDATE operations
+		if ruleUID != "" && rule.UID == ruleUID {
+			continue
+		}
+
+		existingProvenance, ok := provenances[rule.UID]
+		if !ok {
+			existingProvenance = models.ProvenanceNone
+		}
+
+		// Check for conflict:
+		// 1. If we're adding a provisioned rule (targetProvenance != None) and existing rule is non-provisioned (ProvenanceNone)
+		// 2. If we're adding a non-provisioned rule (targetProvenance == None) and existing rule is provisioned (!= ProvenanceNone)
+		if targetProvenance != models.ProvenanceNone && existingProvenance == models.ProvenanceNone {
+			return true
+		}
+		if targetProvenance == models.ProvenanceNone && existingProvenance != models.ProvenanceNone {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/services/ngalert/provisioning/validation/provenance_consistency_test.go
+++ b/pkg/services/ngalert/provisioning/validation/provenance_consistency_test.go
@@ -1,0 +1,288 @@
+package validation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+// mockProvenanceStore implements the provenanceStore interface for testing.
+type mockProvenanceStore struct {
+	provenances map[string]models.Provenance
+	err         error
+}
+
+func (m *mockProvenanceStore) GetProvenancesByUIDs(ctx context.Context, orgID int64, resourceType string, uids []string) (map[string]models.Provenance, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	// Filter provenances to only return requested UIDs.
+	result := make(map[string]models.Provenance)
+	for _, uid := range uids {
+		if prov, exists := m.provenances[uid]; exists {
+			result[uid] = prov
+		}
+	}
+	return result, nil
+}
+
+func TestValidateProvisioningConsistency(t *testing.T) {
+	ctx := context.Background()
+	orgID := int64(1)
+	groupKey := models.AlertRuleGroupKey{
+		OrgID:        orgID,
+		NamespaceUID: "test-namespace",
+		RuleGroup:    "test-group",
+	}
+
+	makeRule := func(uid string) *models.AlertRule {
+		return &models.AlertRule{
+			UID:          uid,
+			OrgID:        orgID,
+			NamespaceUID: groupKey.NamespaceUID,
+			RuleGroup:    groupKey.RuleGroup,
+		}
+	}
+
+	t.Run("empty affected groups - should allow", func(t *testing.T) {
+		store := &mockProvenanceStore{provenances: map[string]models.Provenance{}}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{}
+
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		require.NoError(t, err)
+	})
+
+	t.Run("empty group (no existing rules) - should allow any provenance", func(t *testing.T) {
+		store := &mockProvenanceStore{provenances: map[string]models.Provenance{}}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {},
+		}
+
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		require.NoError(t, err)
+	})
+
+	t.Run("adding provisioned rule to group with non-provisioned rules - should reject", func(t *testing.T) {
+		store := &mockProvenanceStore{
+			provenances: map[string]models.Provenance{
+				"rule-1": models.ProvenanceNone,
+				"rule-2": models.ProvenanceNone,
+			},
+		}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {makeRule("rule-1"), makeRule("rule-2")},
+		}
+
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, models.ErrAlertRuleFailedValidation)
+		assert.Contains(t, err.Error(), "cannot add provisioned (api) rule to group containing non-provisioned rules")
+		assert.Contains(t, err.Error(), "1/test-namespace/test-group")
+	})
+
+	t.Run("adding non-provisioned rule to group with provisioned rules - should reject", func(t *testing.T) {
+		store := &mockProvenanceStore{
+			provenances: map[string]models.Provenance{
+				"rule-1": models.ProvenanceAPI,
+				"rule-2": models.ProvenanceAPI,
+			},
+		}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {makeRule("rule-1"), makeRule("rule-2")},
+		}
+
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceNone, affectedGroups)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, models.ErrAlertRuleFailedValidation)
+		assert.Contains(t, err.Error(), "cannot add non-provisioned rule to group containing provisioned rules")
+		assert.Contains(t, err.Error(), "1/test-namespace/test-group")
+	})
+
+	t.Run("adding provisioned rule to group with provisioned rules - should allow", func(t *testing.T) {
+		store := &mockProvenanceStore{
+			provenances: map[string]models.Provenance{
+				"rule-1": models.ProvenanceAPI,
+				"rule-2": models.ProvenanceFile,
+			},
+		}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {makeRule("rule-1"), makeRule("rule-2")},
+		}
+
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		require.NoError(t, err)
+	})
+
+	t.Run("adding non-provisioned rule to group with non-provisioned rules - should allow", func(t *testing.T) {
+		store := &mockProvenanceStore{
+			provenances: map[string]models.Provenance{
+				"rule-1": models.ProvenanceNone,
+				"rule-2": models.ProvenanceNone,
+			},
+		}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {makeRule("rule-1"), makeRule("rule-2")},
+		}
+
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceNone, affectedGroups)
+		require.NoError(t, err)
+	})
+
+	t.Run("mixed provenances in different groups - should only reject groups with multiple rules", func(t *testing.T) {
+		groupKey2 := models.AlertRuleGroupKey{
+			OrgID:        orgID,
+			NamespaceUID: "test-namespace",
+			RuleGroup:    "test-group-2",
+		}
+
+		store := &mockProvenanceStore{
+			provenances: map[string]models.Provenance{
+				"rule-1": models.ProvenanceNone, // Single rule - no conflict
+				"rule-2": models.ProvenanceNone, // Multiple rules - conflict!
+				"rule-3": models.ProvenanceAPI,
+			},
+		}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey:  {makeRule("rule-1")},                     // Single rule - should be allowed
+			groupKey2: {makeRule("rule-2"), makeRule("rule-3")}, // Multiple with conflict - should fail
+		}
+
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, models.ErrAlertRuleFailedValidation)
+		// group-1 should not be in the error since it has only 1 rule
+		assert.NotContains(t, err.Error(), "test-group\"")
+		// group-2 should be in the error since it has multiple rules with conflict
+		assert.Contains(t, err.Error(), "test-group-2")
+	})
+
+	t.Run("updating single rule in group - should allow changing provenance", func(t *testing.T) {
+		store := &mockProvenanceStore{
+			provenances: map[string]models.Provenance{
+				"rule-1": models.ProvenanceNone,
+			},
+		}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {makeRule("rule-1")},
+		}
+
+		// Single rule in group being UPDATED - should allow changing provenance from None to API
+		err := ValidateRuleProvenanceInGroupUpdate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups, "rule-1")
+		require.NoError(t, err)
+	})
+
+	t.Run("nil rules in group are skipped", func(t *testing.T) {
+		store := &mockProvenanceStore{
+			provenances: map[string]models.Provenance{
+				"rule-1": models.ProvenanceAPI,
+			},
+		}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {nil, makeRule("rule-1"), nil},
+		}
+
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		require.NoError(t, err)
+	})
+
+	t.Run("provenance store error is propagated", func(t *testing.T) {
+		expectedErr := errors.New("database error")
+		store := &mockProvenanceStore{err: expectedErr}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {makeRule("rule-1")},
+		}
+
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get provenances")
+	})
+
+	t.Run("different provisioning sources (api, file, converted_prometheus) are compatible", func(t *testing.T) {
+		store := &mockProvenanceStore{
+			provenances: map[string]models.Provenance{
+				"rule-1": models.ProvenanceAPI,
+				"rule-2": models.ProvenanceFile,
+				"rule-3": models.ProvenanceConvertedPrometheus,
+			},
+		}
+		affectedGroups := map[models.AlertRuleGroupKey]models.RulesGroup{
+			groupKey: {makeRule("rule-1"), makeRule("rule-2"), makeRule("rule-3")},
+		}
+
+		// Adding another provisioned rule to a group with mixed provisioned sources should be fine
+		err := ValidateRuleProvenanceInGroupCreate(ctx, store, orgID, models.ProvenanceAPI, affectedGroups)
+		require.NoError(t, err)
+	})
+}
+
+func TestHasProvenanceConflict(t *testing.T) {
+	makeRule := func(uid string) *models.AlertRule {
+		return &models.AlertRule{UID: uid}
+	}
+
+	t.Run("no conflict when target and existing are both provisioned", func(t *testing.T) {
+		provenances := map[string]models.Provenance{
+			"rule-1": models.ProvenanceAPI,
+			"rule-2": models.ProvenanceFile,
+		}
+		rules := []*models.AlertRule{makeRule("rule-1"), makeRule("rule-2")}
+
+		conflict := hasProvenanceConflict(provenances, rules, models.ProvenanceAPI, "")
+		assert.False(t, conflict)
+	})
+
+	t.Run("no conflict when target and existing are both non-provisioned", func(t *testing.T) {
+		provenances := map[string]models.Provenance{
+			"rule-1": models.ProvenanceNone,
+			"rule-2": models.ProvenanceNone,
+		}
+		rules := []*models.AlertRule{makeRule("rule-1"), makeRule("rule-2")}
+
+		conflict := hasProvenanceConflict(provenances, rules, models.ProvenanceNone, "")
+		assert.False(t, conflict)
+	})
+
+	t.Run("conflict when adding provisioned to non-provisioned", func(t *testing.T) {
+		provenances := map[string]models.Provenance{
+			"rule-1": models.ProvenanceNone,
+		}
+		rules := []*models.AlertRule{makeRule("rule-1")}
+
+		conflict := hasProvenanceConflict(provenances, rules, models.ProvenanceAPI, "")
+		assert.True(t, conflict)
+	})
+
+	t.Run("conflict when adding non-provisioned to provisioned", func(t *testing.T) {
+		provenances := map[string]models.Provenance{
+			"rule-1": models.ProvenanceAPI,
+		}
+		rules := []*models.AlertRule{makeRule("rule-1")}
+
+		conflict := hasProvenanceConflict(provenances, rules, models.ProvenanceNone, "")
+		assert.True(t, conflict)
+	})
+
+	t.Run("no conflict with empty rules list", func(t *testing.T) {
+		provenances := map[string]models.Provenance{}
+		rules := []*models.AlertRule{}
+
+		conflict := hasProvenanceConflict(provenances, rules, models.ProvenanceAPI, "")
+		assert.False(t, conflict)
+	})
+
+	t.Run("nil rules are skipped", func(t *testing.T) {
+		provenances := map[string]models.Provenance{
+			"rule-1": models.ProvenanceAPI,
+		}
+		rules := []*models.AlertRule{nil, makeRule("rule-1"), nil}
+
+		conflict := hasProvenanceConflict(provenances, rules, models.ProvenanceAPI, "")
+		assert.False(t, conflict)
+	})
+}


### PR DESCRIPTION
Creating groups containing alert rules with mixed provisioning should not be allowed. This PR adds a way to check for consistency issues before creating or updating rules in a group.

Part of https://github.com/grafana/grafana/pull/116845