### PR TITLE
Alerting: Improve performance when filtering rules by state or health

### DIFF
--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -792,6 +792,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 				fakeAIM,
 				fakeSch,
 				ruleStore,
+				nil, // instanceQuerier
 				&fakeRuleAccessControlService{},
 				fakes.NewFakeProvisioningStore(),
 			)
@@ -866,6 +867,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 			fakeAIM,
 			newFakeSchedulerReader(t).setupStates(fakeAIM),
 			ruleStore,
+			nil, // instanceQuerier
 			accesscontrol.NewRuleService(acimpl.ProvideAccessControl(featuremgmt.WithFeatures())),
 			fakes.NewFakeProvisioningStore(),
 		)
@@ -1088,6 +1090,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 			fakeAIM,
 			newFakeSchedulerReader(t).setupStates(fakeAIM),
 			ruleStore,
+			nil, // instanceQuerier
 			accesscontrol.NewRuleService(acimpl.ProvideAccessControl(featuremgmt.WithFeatures())),
 			fakes.NewFakeProvisioningStore(),
 		)
@@ -1243,6 +1246,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 			fakeAIM,
 			newFakeSchedulerReader(t).setupStates(fakeAIM),
 			ruleStore,
+			nil, // instanceQuerier
 			accesscontrol.NewRuleService(acimpl.ProvideAccessControl(featuremgmt.WithFeatures())),
 			fakes.NewFakeProvisioningStore(),
 		)
@@ -1381,6 +1385,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 				fakeAIM,
 				newFakeSchedulerReader(t).setupStates(fakeAIM),
 				ruleStore,
+				nil, // instanceQuerier
 				accesscontrol.NewRuleService(acimpl.ProvideAccessControl(featuremgmt.WithFeatures())),
 				fakes.NewFakeProvisioningStore(),
 			)
@@ -3387,6 +3392,7 @@ func setupAPIFull(t *testing.T) (*fakes.RuleStore, *fakeAlertInstanceManager, Pr
 		fakeAIM,
 		fakeSch,
 		fakeStore,
+		nil, // instanceQuerier
 		fakeAuthz,
 		fakeProvisioning,
 	)

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -468,6 +468,7 @@ func (ng *AlertNG) init() error {
 		QuotaService:         ng.QuotaService,
 		TransactionManager:   ng.store,
 		RuleStore:            ng.store,
+		InstanceStore:        ng.InstanceStore,
 		AlertingStore:        ng.store,
 		AdminConfigStore:     ng.store,
 		ProvenanceStore:      ng.store,

--- a/pkg/services/ngalert/store/instance_database_prefilter_test.go
+++ b/pkg/services/ngalert/store/instance_database_prefilter_test.go
@@ -1,0 +1,122 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+func TestGetDistinctRuleUIDsByState(t *testing.T) {
+	sqlStore := db.InitTestDB(t)
+	store := &InstanceDBStore{
+		SQLStore: sqlStore,
+		Logger:   log.NewNopLogger(),
+	}
+
+	orgID := int64(1)
+	ctx := context.Background()
+
+	// Insert test alert instances with different states
+	instances := []models.AlertInstance{
+		{
+			AlertInstanceKey: models.AlertInstanceKey{
+				RuleOrgID:  orgID,
+				RuleUID:    "rule1",
+				LabelsHash: "hash1",
+			},
+			CurrentState: models.InstanceStateFiring,
+			Labels:       models.InstanceLabels{"alertname": "test1"},
+		},
+		{
+			AlertInstanceKey: models.AlertInstanceKey{
+				RuleOrgID:  orgID,
+				RuleUID:    "rule1",
+				LabelsHash: "hash2",
+			},
+			CurrentState: models.InstanceStatePending,
+			Labels:       models.InstanceLabels{"alertname": "test1"},
+		},
+		{
+			AlertInstanceKey: models.AlertInstanceKey{
+				RuleOrgID:  orgID,
+				RuleUID:    "rule2",
+				LabelsHash: "hash3",
+			},
+			CurrentState: models.InstanceStateError,
+			Labels:       models.InstanceLabels{"alertname": "test2"},
+		},
+		{
+			AlertInstanceKey: models.AlertInstanceKey{
+				RuleOrgID:  orgID,
+				RuleUID:    "rule3",
+				LabelsHash: "hash4",
+			},
+			CurrentState: models.InstanceStateNormal,
+			Labels:       models.InstanceLabels{"alertname": "test3"},
+		},
+		{
+			AlertInstanceKey: models.AlertInstanceKey{
+				RuleOrgID:  orgID,
+				RuleUID:    "rule4",
+				LabelsHash: "hash5",
+			},
+			CurrentState: models.InstanceStateNoData,
+			Labels:       models.InstanceLabels{"alertname": "test4"},
+		},
+	}
+
+	// Save all instances
+	for _, instance := range instances {
+		err := store.SaveAlertInstance(ctx, instance)
+		require.NoError(t, err)
+	}
+
+	t.Run("single state filter - Pending", func(t *testing.T) {
+		uids, err := store.GetDistinctRuleUIDsByState(ctx, orgID, []string{"Pending"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"rule1"}, uids)
+	})
+
+	t.Run("single state filter - Error", func(t *testing.T) {
+		uids, err := store.GetDistinctRuleUIDsByState(ctx, orgID, []string{"Error"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"rule2"}, uids)
+	})
+
+	t.Run("multiple state filter", func(t *testing.T) {
+		uids, err := store.GetDistinctRuleUIDsByState(ctx, orgID, []string{"Error", "NoData"})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"rule2", "rule4"}, uids)
+	})
+
+	t.Run("state filter with multiple instances per rule", func(t *testing.T) {
+		// rule1 has both Firing and Pending instances, should be returned once
+		uids, err := store.GetDistinctRuleUIDsByState(ctx, orgID, []string{"Alerting", "Pending"})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"rule1"}, uids)
+	})
+
+	t.Run("empty state filter", func(t *testing.T) {
+		uids, err := store.GetDistinctRuleUIDsByState(ctx, orgID, []string{})
+		require.NoError(t, err)
+		assert.Nil(t, uids)
+	})
+
+	t.Run("non-existent state", func(t *testing.T) {
+		uids, err := store.GetDistinctRuleUIDsByState(ctx, orgID, []string{"NonExistent"})
+		require.NoError(t, err)
+		assert.Empty(t, uids)
+	})
+
+	t.Run("wrong org ID", func(t *testing.T) {
+		uids, err := store.GetDistinctRuleUIDsByState(ctx, 999, []string{"Error"})
+		require.NoError(t, err)
+		assert.Empty(t, uids)
+	})
+}


### PR DESCRIPTION
Filtering by `health` or `state` can be much slower than using the rest of the filters. Filters are applied after fetching all rules from the database, requiring N+1 queries to compute health/state for each rule via `GetStatesForRuleUID()`.

This PR adds pre-filtering at the DB level using existing indexes from the `alert_instance` table. The API now queries `alert_instance` first to get matching rule UIDs, then fetches only those rules. This optimization only applies to filters that commonly return small result sets (`error`, `nodata`, `pending`). The common case (`health=ok`) skips pre-filtering to avoid fetching most rules.