### PR TITLE
DynamicDashboards: Track configure panel dropdown clicks

### DIFF
--- a/public/app/features/dashboard-scene/scene/UnconfiguredPanel.tsx
+++ b/public/app/features/dashboard-scene/scene/UnconfiguredPanel.tsx
@@ -33,9 +33,15 @@ function UnconfiguredPanelComp(props: PanelProps) {
   const panelContext = usePanelContext();
   const styles = useStyles2(getStyles);
 
-  const onMenuClick = useCallback((isOpen: boolean) => {
-    setIsOpen(isOpen);
-  }, []);
+  const onMenuClick = useCallback(
+    (isOpen: boolean) => {
+      if (isOpen) {
+        DashboardInteractions.panelActionClicked('configure_dropdown', props.id, 'panel');
+      }
+      setIsOpen(isOpen);
+    },
+    [props.id]
+  );
 
   const onConfigure = () => {
     locationService.partial({ editPanel: props.id });

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -88,7 +88,7 @@ export const DashboardInteractions = {
   },
 
   panelActionClicked(
-    item: 'configure' | 'edit' | 'copy' | 'duplicate' | 'delete' | 'view',
+    item: 'configure' | 'configure_dropdown' | 'edit' | 'copy' | 'duplicate' | 'delete' | 'view',
     id: number,
     source: 'panel' | 'edit_pane'
   ) {


### PR DESCRIPTION
Solves https://github.com/grafana/grafana/issues/116839

@danmm-grafana `SELECT * FROM grafanalabs-global.rudderstack.dashboards_panel_action_clicked WHERE is_dynamic_dashboard IS TRUE AND source="panel" AND item="configure_dropdown" LIMIT 10`