### PR TITLE
Scopes: Increase test timeout for selector

### DIFF
--- a/public/app/features/scopes/tests/selector.test.ts
+++ b/public/app/features/scopes/tests/selector.test.ts
@@ -64,6 +64,7 @@ describe('Selector', () => {
 
   afterEach(async () => {
     locationService.replace('');
+    window.localStorage.clear();
     await resetScenes([fetchSelectedScopesSpy, dashboardReloadSpy]);
   });
 
@@ -102,8 +103,10 @@ describe('Selector', () => {
       state: null,
     };
 
-    jest.spyOn(locationService, 'getLocation').mockReturnValue(mockLocation);
-    jest.spyOn(locationService, 'getSearch').mockReturnValue(new URLSearchParams(mockLocation.search));
+    const getLocationSpy = jest.spyOn(locationService, 'getLocation').mockReturnValue(mockLocation);
+    const getSearchSpy = jest
+      .spyOn(locationService, 'getSearch')
+      .mockReturnValue(new URLSearchParams(mockLocation.search));
 
     await resetScenes([fetchSelectedScopesSpy, dashboardReloadSpy]);
     await renderDashboard();
@@ -112,11 +115,15 @@ describe('Selector', () => {
     await openSelector();
     expectResultApplicationsGrafanaSelected();
 
-    jest.spyOn(locationService, 'getLocation').mockRestore();
-    jest.spyOn(locationService, 'getSearch').mockRestore();
+    getLocationSpy.mockRestore();
+    getSearchSpy.mockRestore();
   });
 
   describe('Recent scopes', () => {
+    // Increased timeout for these tests as they involve many async operations
+    // and may timeout on slower CI environments with the default 30s timeout
+    jest.setTimeout(60000);
+
     it('Recent scopes should appear after selecting a second set of scopes', async () => {
       await openSelector();
       await expandResultApplications();


### PR DESCRIPTION
**What is this feature?**

- Increase timeout, as the test usually takes 28s on a good machine
- Imrpove mock handling

**Why do we need this feature?**

This test is timing out a lot in the CI

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
