### PR TITLE
Dynamic Dashboards: Add tracking for dropping panel cross layout

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -15,6 +15,7 @@ import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/Pan
 import { dashboardEditActions, NewObjectAddedToCanvasEvent } from '../../edit-pane/shared';
 import { serializeAutoGridLayout } from '../../serialization/layoutSerializers/AutoGridLayoutSerializer';
 import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
+import { trackDropItemCrossLayout } from '../../utils/tracking';
 import {
   forceRenderChildren,
   getDashboardSceneFor,
@@ -387,6 +388,7 @@ export class AutoGridLayoutManager
   }
 
   public draggedGridItemInside(gridItem: SceneGridItemLike, position?: number): void {
+    trackDropItemCrossLayout(gridItem);
     let newGridItem: AutoGridItem;
 
     if (gridItem instanceof AutoGridItem) {

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -22,6 +22,7 @@ import { ConditionalRenderingGroup } from '../../conditional-rendering/group/Con
 import { dashboardEditActions } from '../../edit-pane/shared';
 import { serializeRow } from '../../serialization/layoutSerializers/RowsLayoutSerializer';
 import { getElements } from '../../serialization/layoutSerializers/utils';
+import { trackDropItemCrossLayout } from '../../utils/tracking';
 import { getDashboardSceneFor } from '../../utils/utils';
 import { AutoGridItem } from '../layout-auto-grid/AutoGridItem';
 import { AutoGridLayout } from '../layout-auto-grid/AutoGridLayout';
@@ -223,6 +224,7 @@ export class RowItem
   }
 
   public draggedGridItemInside(gridItem: SceneGridItemLike): void {
+    trackDropItemCrossLayout(gridItem);
     const layout = this.getLayout();
 
     if (isDashboardLayoutGrid(layout)) {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -22,6 +22,7 @@ import { ConditionalRenderingGroup } from '../../conditional-rendering/group/Con
 import { dashboardEditActions } from '../../edit-pane/shared';
 import { serializeTab } from '../../serialization/layoutSerializers/TabsLayoutSerializer';
 import { getElements } from '../../serialization/layoutSerializers/utils';
+import { trackDropItemCrossLayout } from '../../utils/tracking';
 import { getDashboardSceneFor } from '../../utils/utils';
 import { AutoGridItem } from '../layout-auto-grid/AutoGridItem';
 import { AutoGridLayout } from '../layout-auto-grid/AutoGridLayout';
@@ -228,6 +229,7 @@ export class TabItem
   }
 
   public draggedGridItemInside(gridItem: SceneGridItemLike): void {
+    trackDropItemCrossLayout(gridItem);
     const layout = this.getLayout();
 
     if (isDashboardLayoutGrid(layout)) {

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -99,7 +99,7 @@ export const DashboardInteractions = {
   // dashboards_edit_action_clicked: when user adds or removes an item in edit mode
   // props: { item: string } - item is one of: add_panel, group_row, group_tab, ungroup, paste_panel, remove_row, remove_tab
   trackAddPanelClick(
-    source?: 'sidebar' | 'canvas',
+    source: 'sidebar' | 'canvas' = 'canvas',
     target?: 'row' | 'tab' | 'dashboard',
     action: 'drop' | 'click' = 'click'
   ) {
@@ -122,6 +122,12 @@ export const DashboardInteractions = {
   },
   trackRemoveTabClick() {
     reportDashboardInteraction('edit_action_clicked', { item: 'remove_tab' });
+  },
+
+  // grafana_dashboards_panel_configure_menu_opened
+  // when user opens the dropdown for the Configure button in a new panel
+  trackConfigurePanelMenuOpened() {
+    reportDashboardInteraction('panel_configure_menu_opened');
   },
 
   panelLinkClicked: (properties?: Record<string, unknown>) => {
@@ -250,6 +256,16 @@ export const DashboardInteractions = {
   },
   copyImageUrlClicked: (properties?: Record<string, unknown>) => {
     reportDashboardInteraction('dashboard_image_url_copied', properties);
+  },
+
+  // move item interactions
+  trackMoveItem: (
+    item: 'panel' | 'row' | 'tab',
+    action: 'drag' | 'drop',
+    context: { isCrossLayout: boolean }
+  ) => {
+    const properties = { item, action, context };
+    reportDashboardInteraction('move_item', properties);
   },
 };
 

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -259,11 +259,7 @@ export const DashboardInteractions = {
   },
 
   // move item interactions
-  trackMoveItem: (
-    item: 'panel' | 'row' | 'tab',
-    action: 'drag' | 'drop',
-    context: { isCrossLayout: boolean }
-  ) => {
+  trackMoveItem: (item: 'panel' | 'row' | 'tab', action: 'drag' | 'drop', context: { isCrossLayout: boolean }) => {
     const properties = { item, action, context };
     reportDashboardInteraction('move_item', properties);
   },

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -124,12 +124,6 @@ export const DashboardInteractions = {
     reportDashboardInteraction('edit_action_clicked', { item: 'remove_tab' });
   },
 
-  // grafana_dashboards_panel_configure_menu_opened
-  // when user opens the dropdown for the Configure button in a new panel
-  trackConfigurePanelMenuOpened() {
-    reportDashboardInteraction('panel_configure_menu_opened');
-  },
-
   panelLinkClicked: (properties?: Record<string, unknown>) => {
     reportDashboardInteraction('panelheader_datalink_clicked', properties);
   },

--- a/public/app/features/dashboard-scene/utils/tracking.ts
+++ b/public/app/features/dashboard-scene/utils/tracking.ts
@@ -1,8 +1,11 @@
 import { store } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { SceneGridItemLike } from '@grafana/scenes';
 import { getDatasourceTypes } from 'app/features/dashboard/dashgrid/DashboardLibrary/utils/dashboardLibraryHelpers';
 
 import { DashboardScene } from '../scene/DashboardScene';
+import { AutoGridItem } from '../scene/layout-auto-grid/AutoGridItem';
+import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { EditableDashboardElementInfo } from '../scene/types/EditableDashboardElement';
 
 import { DashboardInteractions } from './interactions';
@@ -103,4 +106,13 @@ export function trackDashboardSceneCreatedOrSaved(
           ...dashboardLibraryProperties,
         }),
   });
+}
+
+export function trackDropItemCrossLayout(gridItem: SceneGridItemLike) {
+  // only track panels for now
+  if (gridItem instanceof AutoGridItem || gridItem instanceof DashboardGridItem) {
+    DashboardInteractions.trackMoveItem('panel', 'drop', {
+      isCrossLayout: true,
+    });
+  }
 }


### PR DESCRIPTION
Fixes: #116839

Adds: 
- tracking for dropping panels cross layout. We will use this to track if New button works as intended, or if the panels are added in an unintended row/tav and the users have to move them around
- set "canvas" to be the default source for tracking adding new panels. not terrible important, since we can map undefined to canvas, but still good to have