### PR TITLE
Alerting: Enhance alert annotations to include user-configured static labels in templates

### DIFF
--- a/docs/sources/alerting/alerting-rules/templates/reference.md
+++ b/docs/sources/alerting/alerting-rules/templates/reference.md
@@ -82,13 +82,13 @@ The following variables are available when templating annotations and labels:
 
 | Variables          | Description                                                                                                                                                                                                                                                                      |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [$labels](#labels) | Contains all labels from the query, only query labels.                                                                                                                                                                                                                           |
+| [$labels](#labels) | Contains labels from the query and user-configured static rule labels.                                                                                                                                                                                                           |
 | [$values](#values) | Contains the labels and floating point values of all instant queries and expressions, indexed by their Ref IDs.                                                                                                                                                                  |
 | [$value](#value)   | A string containing the labels and values of all instant queries; threshold, reduce and math expressions, and classic conditions in the alert rule. When a single data source is used, it returns the value of the query. It is generally recommended to use [$values](#values). |
 
 ### $labels
 
-The `$labels` variable contains all labels from the query. It excludes [user-configured and reserved labels](ref:label-types), containing only query labels.
+The `$labels` variable contains labels from the query as well as user-configured static rule labels. It excludes [reserved labels](ref:label-types).
 
 {{< figure src="/media/docs/alerting/query-labels-and-values.png" max-width="1200px" caption="An alert rule displaying labels and value from a query." >}}
 

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -136,9 +136,10 @@ func expandAnnotationsAndLabels(ctx context.Context, log log.Logger, alertRule *
 			log.Debug("Found collision of result labels and system reserved. Renamed labels with suffix '_user'", "renamedLabels", strings.Join(reserved, ","))
 		}
 	}
-	// Merge both the extra labels and the labels from the evaluation into a common set
-	// of labels that can be expanded in custom labels and annotations.
-	templateData := template.NewData(mergeLabels(extraLabels, resultLabels), result)
+	// Merge the extra labels, static rule labels, and the labels from the evaluation into
+	// a common set of labels that can be expanded in custom labels and annotations.
+	// Order of precedence: extraLabels > alertRule.Labels > resultLabels
+	templateData := template.NewData(mergeLabels(extraLabels, mergeLabels(alertRule.Labels, resultLabels)), result)
 
 	// For now, do nothing with these errors as they are already logged in expand.
 	// In the future, we want to show these errors to the user somehow.


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

## What is this feature?

This update enables static labels defined on alert rules to be accessible via `{{ $labels }}` in annotation and label templates. Previously, only labels returned by the query (e.g., `instance: server-01`) were available in templates; now user-configured static labels (e.g., `environment: production`) are also included.

## Why do we need this feature?

Users who define static labels on their alert rules expect to reference them in alert descriptions and annotations using `{{ $labels }}`. Without this fix, these labels were silently ignored during template expansion, causing confusion and limiting the ability to create meaningful, context-rich alert messages.

## Who is this feature for?

This feature is for Grafana Alerting users who:
- Define static labels on their alert rules for categorization (e.g., `environment`, `team`, `severity`)
- Want to include these labels in alert annotations and descriptions using Go templating
- Need dynamic, customized alert messages that reflect their organizational structure

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #116074"
-->

Fixes #116074

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
![Uploading Screenshot 2026-01-27 at 8.51.21 PM.png…]()

