### PR TITLE
PanelTimeRange: Fix timeshift rounding for 'to' boundary

### DIFF
--- a/packages/grafana-data/src/datetime/datemath.test.ts
+++ b/packages/grafana-data/src/datetime/datemath.test.ts
@@ -173,6 +173,7 @@ describe('DateMath', () => {
       ['-1d-1h-30m', [2014, 1, 5, 12, 0], [2014, 1, 4, 10, 30]],
       ['+1d-6h', [2014, 1, 5], [2014, 1, 5, 18]],
       ['-1w-1d', [2014, 1, 14], [2014, 1, 6]],
+      ['-1w/w', [2014, 1, 21], [2014, 1, 9]],
     ])('should handle multiple math expressions: %s', (expression, inputDate, expectedDate) => {
       const date = dateMath.parseDateMath(expression, dateTime(inputDate));
       expect(date!.valueOf()).toEqual(dateTime(expectedDate).valueOf());

--- a/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
@@ -194,7 +194,7 @@ export class PanelTimeRange extends SceneTimeRangeTransformerBase<PanelTimeRange
         const rawToShifted = `${newTimeData.timeRange.raw.to}${shift}`;
 
         const from = dateMath.toDateTime(rawFromShifted, { timezone });
-        const to = dateMath.toDateTime(rawToShifted, { timezone });
+        const to = dateMath.toDateTime(rawToShifted, { timezone, roundUp: true });
 
         if (!from || !to) {
           newTimeData.timeInfo = 'invalid timeshift';


### PR DESCRIPTION
**What is this feature?**

Adds `roundUp: true` when parsing the `to` boundary in panel timeshift, so rounding expressions like `now-1w/w` correctly round to the end of the period.

**Why do we need this feature?**

Without this, with URL like `from=now-1w/w&to=now-1w/w` both from and to round to the start of the time unit, causing incorrect time ranges.
