### PR TITLE
Provisioning: fix repository test endpoint

### DIFF
--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -139,9 +139,9 @@ func (s *testConnector) Connect(ctx context.Context, name string, _ runtime.Obje
 					cfg.SetNamespace(ns)
 				}
 
-				// The new repository should be connected to a Connection resource,
-				// i.e. we should be generating the token based on it.
-				if cfg.Secure.Token.IsZero() && cfg.Spec.Connection != nil && cfg.Spec.Connection.Name != "" {
+				// In case a connection is specified, we should try creating a new token with given info
+				// to check its validity
+				if cfg.Spec.Connection != nil && cfg.Spec.Connection.Name != "" {
 					// A connection must be there
 					c, err := s.connectionGetter.GetConnection(ctx, cfg.Spec.Connection.Name)
 					if err != nil {


### PR DESCRIPTION
**What is this feature?**

Fixes a check on the `/test` endpoint, including a hack which removes the `spec.connection` to let validation pass.

**Why do we need this feature?**

Currently, on provisioning onboarding for `Repository` resources having a connection, there's a bug which makes `/test` endpoint calls return `422` for existing repositories.

**Who is this feature for?**

Users of GitSync

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
