### PR TITLE
Dynamic Dashboards: Trigger open pane from dashboard empty component

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -56,7 +56,6 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
   const { chrome } = useGrafana();
   const { kioskMode } = chrome.useState();
   const { isPlaying } = playlistSrv.useState();
-  const isEditingNewDashboard = isEditing && !dashboard.state.uid;
 
   /**
    * Adds star button and left side actions to app chrome breadcrumb area
@@ -74,16 +73,10 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
     }
   }, [isEditing, editPane]);
 
-  useEffect(() => {
-    if (isEditingNewDashboard) {
-      editPane.openPane('add');
-    }
-  }, [isEditingNewDashboard, editPane]);
-
   const { selectionContext, openPane } = useSceneObjectState(editPane, { shouldActivateOrKeepAlive: true });
 
   const sidebarContext = useSidebar({
-    hasOpenPane: Boolean(openPane) || isEditingNewDashboard,
+    hasOpenPane: Boolean(openPane),
     contentMargin: 1,
     position: 'right',
     persistanceKey: 'dashboard',


### PR DESCRIPTION
Fixes: #116747

If empty dashboard is loaded through an extension, we don't want to open the sidebar automatically. The reason for this is that empty dashboard page that is custom, might have different ways of indicating next steps. See the thread here:https://raintank-corp.slack.com/archives/C03KVDHTWAH/p1769094292776409

I moved the logic from `EditPaneSplitter` to the `InternalDashboardEmpty` component, which will be loaded when the default dashboard is shown and side pane behavior should be triggered.

<img width="1200" height="642" alt="Screenshot 2026-01-27 at 18 40 30" src="https://github.com/user-attachments/assets/51aaf2e4-1d59-4527-a972-3d0e1c58f8b1" />
