### PR TITLE
Dashboards: Add Panel Layout option to JSON inspector for V2 dashboards

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2607,11 +2607,6 @@
       "count": 1
     }
   },
-  "public/app/features/inspector/InspectJSONTab.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "public/app/features/inspector/InspectStatsTab.tsx": {
     "@grafana/no-aria-label-selectors": {
       "count": 1

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.test.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.test.tsx
@@ -239,17 +239,8 @@ describe('InspectJsonTab', () => {
   });
 
   describe('Panel Layout', () => {
-    beforeEach(() => {
-      config.featureToggles.dashboardNewLayouts = true;
-    });
-
-    afterEach(() => {
-      config.featureToggles.dashboardNewLayouts = false;
-    });
-
-    it('does not show panel-layout option when feature toggle is disabled', async () => {
-      config.featureToggles.dashboardNewLayouts = false;
-      const { tab } = await buildTestSceneWithV2Spec();
+    it('does not show panel-layout option for non-v2 spec', async () => {
+      const { tab } = await buildTestScene();
       const options = tab.getOptions();
       expect(options.some((o) => o.value === 'panel-layout')).toBe(false);
     });

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.test.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.test.tsx
@@ -11,7 +11,7 @@ import {
   toDataFrame,
 } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
-import { config, setPluginImportUtils, setRunRequest } from '@grafana/runtime';
+import { setPluginImportUtils, setRunRequest } from '@grafana/runtime';
 import { SceneCanvasText, SceneDataTransformer, SceneGridLayout, SceneQueryRunner, VizPanel } from '@grafana/scenes';
 import * as libpanels from 'app/features/library-panels/state/api';
 import { getStandardTransformers } from 'app/features/transformers/standardTransformers';

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -4,7 +4,6 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import {
   SceneComponentProps,
   SceneDataTransformer,

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -35,6 +35,7 @@ import { buildVizPanel } from '../serialization/layoutSerializers/utils';
 import { buildGridItemForPanel } from '../serialization/transformSaveModelToScene';
 import { gridItemToPanel, vizPanelToPanel } from '../serialization/transformSceneToSaveModel';
 import { vizPanelToSchemaV2 } from '../serialization/transformSceneToSaveModelSchemaV2';
+import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 import {
   getDashboardSceneFor,
   getLibraryPanelBehavior,
@@ -77,7 +78,7 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
 
     const options: Array<SelectableValue<ShowContent>> = [
       {
-        label: t('dashboard.inspect-json.panel-json-label', 'Panel JSON'),
+        label: t('dashboard.inspect-json.panel-spec-label', 'Panel Spec'),
         description: t(
           'dashboard.inspect-json.panel-json-description',
           'The model saved in the dashboard JSON that configures how everything works.'
@@ -162,6 +163,17 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
 
     if (!(gridItem instanceof DashboardGridItem)) {
       console.error('Cannot update layout: panel parent is not a DashboardGridItem');
+      return;
+    }
+
+    const originalElementName = dashboardSceneGraph.getElementIdentifierForVizPanel(panel);
+    if (jsonObj.spec.element.name !== originalElementName) {
+      this.setState({
+        error: t(
+          'dashboard-scene.inspect-json-tab.error-element-changed',
+          'Cannot change the element reference. Only layout properties (x, y, width, height) can be modified.'
+        ),
+      });
       return;
     }
 

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -230,7 +230,7 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
     reportPanelInspectInteraction(InspectTab.JSON, 'apply', {
       panel_type_changed: panel.state.pluginId !== jsonObj.spec.vizConfig.group,
       panel_id_changed: getPanelIdForVizPanel(panel) !== jsonObj.spec.id,
-      panel_grid_pos_changed: false, // Grid cant be edited from inspect in v2 panels.
+      panel_grid_pos_changed: false,
       panel_targets_changed: hasQueriesChanged(getQueryRunnerFor(panel), getQueryRunnerFor(vizPanel.state.$data)),
     });
 

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -74,11 +74,15 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
 
   public getOptions(): Array<SelectableValue<ShowContent>> {
     const panel = this.state.panelRef.resolve();
+    const dashboard = getDashboardSceneFor(panel);
     const dataProvider = panel.state.$data ?? panel.parent?.state.$data;
+    const isV2 = isDashboardV2Spec(dashboard.getSaveModel());
 
     const options: Array<SelectableValue<ShowContent>> = [
       {
-        label: t('dashboard.inspect-json.panel-spec-label', 'Panel Spec'),
+        label: isV2
+          ? t('dashboard.inspect-json.panel-spec-label', 'Panel Spec')
+          : t('dashboard.inspect-json.panel-json-label', 'Panel JSON'),
         description: t(
           'dashboard.inspect-json.panel-json-description',
           'The model saved in the dashboard JSON that configures how everything works.'
@@ -87,7 +91,7 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
       },
     ];
 
-    if (config.featureToggles.dashboardNewLayouts && panel.parent instanceof DashboardGridItem) {
+    if (isV2 && panel.parent instanceof DashboardGridItem) {
       options.push({
         label: t('dashboard.inspect-json.panel-layout-label', 'Panel Layout'),
         description: t(

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -230,7 +230,7 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
     reportPanelInspectInteraction(InspectTab.JSON, 'apply', {
       panel_type_changed: panel.state.pluginId !== jsonObj.spec.vizConfig.group,
       panel_id_changed: getPanelIdForVizPanel(panel) !== jsonObj.spec.id,
-      panel_grid_pos_changed: false,
+      panel_grid_pos_changed: false, // Grid cant be edited from inspect in v2 panels.
       panel_targets_changed: hasQueriesChanged(getQueryRunnerFor(panel), getQueryRunnerFor(vizPanel.state.$data)),
     });
 

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -4,6 +4,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import {
   SceneComponentProps,
   SceneDataTransformer,
@@ -27,7 +28,9 @@ import { InspectTab } from 'app/features/inspector/types';
 import { getPrettyJSON } from 'app/features/inspector/utils/utils';
 import { reportPanelInspectInteraction } from 'app/features/search/page/reporting';
 
+import { DashboardScene } from '../scene/DashboardScene';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
+import { gridItemToGridLayoutItemKind } from '../serialization/layoutSerializers/DefaultGridLayoutSerializer';
 import { buildVizPanel } from '../serialization/layoutSerializers/utils';
 import { buildGridItemForPanel } from '../serialization/transformSaveModelToScene';
 import { gridItemToPanel, vizPanelToPanel } from '../serialization/transformSceneToSaveModel';
@@ -39,9 +42,9 @@ import {
   getQueryRunnerFor,
   isLibraryPanel,
 } from '../utils/utils';
-import { isPanelKindV2 } from '../v2schema/validation';
+import { isGridLayoutItemKind, isPanelKindV2 } from '../v2schema/validation';
 
-export type ShowContent = 'panel-json' | 'panel-data' | 'data-frames';
+export type ShowContent = 'panel-json' | 'panel-data' | 'data-frames' | 'panel-layout';
 
 export interface InspectJsonTabState extends SceneObjectState {
   panelRef: SceneObjectRef<VizPanel>;
@@ -83,6 +86,17 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
       },
     ];
 
+    if (config.featureToggles.dashboardNewLayouts && panel.parent instanceof DashboardGridItem) {
+      options.push({
+        label: t('dashboard.inspect-json.panel-layout-label', 'Panel Layout'),
+        description: t(
+          'dashboard.inspect-json.panel-layout-description',
+          'The grid position and size of the panel in the dashboard.'
+        ),
+        value: 'panel-layout',
+      });
+    }
+
     if (dataProvider) {
       options.push({
         label: t('dashboard.inspect-json.panel-data-label', 'Panel data'),
@@ -114,8 +128,6 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
   };
 
   public onApplyChange = () => {
-    const panel = this.state.panelRef.resolve();
-    const dashboard = getDashboardSceneFor(panel);
     let jsonObj: unknown;
     try {
       jsonObj = JSON.parse(this.state.jsonText);
@@ -126,71 +138,144 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
       return;
     }
 
-    if (isDashboardV2Spec(dashboard.getSaveModel())) {
-      if (!isPanelKindV2(jsonObj)) {
-        this.setState({
-          error: t(
-            'dashboard-scene.inspect-json-tab.error-invalid-v2-panel',
-            'Panel JSON did not pass validation. Please check the JSON and try again.'
-          ),
-        });
-        return;
-      }
-      const vizPanel = buildVizPanel(jsonObj, jsonObj.spec.id);
-
-      if (!dashboard.state.isEditing) {
-        dashboard.onEnterEditMode();
-      }
-
-      reportPanelInspectInteraction(InspectTab.JSON, 'apply', {
-        panel_type_changed: panel.state.pluginId !== jsonObj.spec.vizConfig.group,
-        panel_id_changed: getPanelIdForVizPanel(panel) !== jsonObj.spec.id,
-        panel_grid_pos_changed: false, // Grid cant be edited from inspect in v2 panels.
-        panel_targets_changed: hasQueriesChanged(getQueryRunnerFor(panel), getQueryRunnerFor(vizPanel.state.$data)),
-      });
-
-      panel.setState(vizPanel.state);
-      this.state.onClose();
-    } else {
-      const panelModel = new PanelModel(jsonObj);
-      const gridItem = buildGridItemForPanel(panelModel);
-      const newState = sceneUtils.cloneSceneObjectState(gridItem.state);
-
-      if (!(panel.parent instanceof DashboardGridItem)) {
-        console.error('Cannot update state of panel', panel, gridItem);
-        return;
-      }
-
-      this.state.onClose();
-
-      if (!dashboard.state.isEditing) {
-        dashboard.onEnterEditMode();
-      }
-
-      panel.parent.setState(newState);
-
-      // Force the grid layout to re-render with the new positions
-      const layout = sceneGraph.getLayout(panel);
-      if (layout instanceof SceneGridLayout) {
-        layout.forceRender();
-      }
-
-      //Report relevant updates
-      reportPanelInspectInteraction(InspectTab.JSON, 'apply', {
-        panel_type_changed: panel.state.pluginId !== panelModel.type,
-        panel_id_changed: getPanelIdForVizPanel(panel) !== panelModel.id,
-        panel_grid_pos_changed: hasGridPosChanged(panel.parent.state, newState),
-        panel_targets_changed: hasQueriesChanged(getQueryRunnerFor(panel), getQueryRunnerFor(newState.$data)),
-      });
+    if (this.state.source === 'panel-layout') {
+      this.applyLayoutChange(jsonObj);
+    } else if (this.state.source === 'panel-json') {
+      this.applyPanelJsonChange(jsonObj);
     }
   };
+
+  private applyLayoutChange(jsonObj: unknown) {
+    if (!isGridLayoutItemKind(jsonObj)) {
+      this.setState({
+        error: t(
+          'dashboard-scene.inspect-json-tab.error-invalid-layout',
+          'Layout JSON did not pass validation. Please check the JSON and try again.'
+        ),
+      });
+      return;
+    }
+
+    const panel = this.state.panelRef.resolve();
+    const dashboard = getDashboardSceneFor(panel);
+    const gridItem = panel.parent;
+
+    if (!(gridItem instanceof DashboardGridItem)) {
+      console.error('Cannot update layout: panel parent is not a DashboardGridItem');
+      return;
+    }
+
+    if (!dashboard.state.isEditing) {
+      dashboard.onEnterEditMode();
+    }
+
+    const oldState = gridItem.state;
+    const newLayoutState = {
+      x: jsonObj.spec.x,
+      y: jsonObj.spec.y,
+      width: jsonObj.spec.width,
+      height: jsonObj.spec.height,
+    };
+
+    gridItem.setState(newLayoutState);
+
+    // Force the grid layout to re-render with the new positions
+    const layout = sceneGraph.getLayout(panel);
+    if (layout instanceof SceneGridLayout) {
+      layout.forceRender();
+    }
+
+    reportPanelInspectInteraction(InspectTab.JSON, 'apply', {
+      panel_type_changed: false,
+      panel_id_changed: false,
+      panel_grid_pos_changed:
+        oldState.x !== newLayoutState.x ||
+        oldState.y !== newLayoutState.y ||
+        oldState.width !== newLayoutState.width ||
+        oldState.height !== newLayoutState.height,
+      panel_targets_changed: false,
+    });
+
+    this.state.onClose();
+  }
+
+  private applyPanelJsonChange(jsonObj: unknown) {
+    const panel = this.state.panelRef.resolve();
+    const dashboard = getDashboardSceneFor(panel);
+
+    if (isDashboardV2Spec(dashboard.getSaveModel())) {
+      this.applyV2PanelChange(jsonObj, panel, dashboard);
+    } else {
+      this.applyV1PanelChange(jsonObj, panel, dashboard);
+    }
+  }
+
+  private applyV2PanelChange(jsonObj: unknown, panel: VizPanel, dashboard: DashboardScene) {
+    if (!isPanelKindV2(jsonObj)) {
+      this.setState({
+        error: t(
+          'dashboard-scene.inspect-json-tab.error-invalid-v2-panel',
+          'Panel JSON did not pass validation. Please check the JSON and try again.'
+        ),
+      });
+      return;
+    }
+
+    const vizPanel = buildVizPanel(jsonObj, jsonObj.spec.id);
+
+    if (!dashboard.state.isEditing) {
+      dashboard.onEnterEditMode();
+    }
+
+    reportPanelInspectInteraction(InspectTab.JSON, 'apply', {
+      panel_type_changed: panel.state.pluginId !== jsonObj.spec.vizConfig.group,
+      panel_id_changed: getPanelIdForVizPanel(panel) !== jsonObj.spec.id,
+      panel_grid_pos_changed: false,
+      panel_targets_changed: hasQueriesChanged(getQueryRunnerFor(panel), getQueryRunnerFor(vizPanel.state.$data)),
+    });
+
+    panel.setState(vizPanel.state);
+    this.state.onClose();
+  }
+
+  private applyV1PanelChange(jsonObj: unknown, panel: VizPanel, dashboard: DashboardScene) {
+    const panelModel = new PanelModel(jsonObj);
+    const gridItem = buildGridItemForPanel(panelModel);
+    const newState = sceneUtils.cloneSceneObjectState(gridItem.state);
+
+    if (!(panel.parent instanceof DashboardGridItem)) {
+      console.error('Cannot update state of panel', panel, gridItem);
+      return;
+    }
+
+    if (!dashboard.state.isEditing) {
+      dashboard.onEnterEditMode();
+    }
+
+    panel.parent.setState(newState);
+
+    // Force the grid layout to re-render with the new positions
+    const layout = sceneGraph.getLayout(panel);
+    if (layout instanceof SceneGridLayout) {
+      layout.forceRender();
+    }
+
+    reportPanelInspectInteraction(InspectTab.JSON, 'apply', {
+      panel_type_changed: panel.state.pluginId !== panelModel.type,
+      panel_id_changed: getPanelIdForVizPanel(panel) !== panelModel.id,
+      panel_grid_pos_changed: hasGridPosChanged(panel.parent.state, newState),
+      panel_targets_changed: hasQueriesChanged(getQueryRunnerFor(panel), getQueryRunnerFor(newState.$data)),
+    });
+
+    this.state.onClose();
+  }
 
   public onCodeEditorBlur = (value: string) => {
     this.setState({ jsonText: value });
   };
 
   public isEditable() {
-    if (this.state.source !== 'panel-json') {
+    if (!['panel-json', 'panel-layout'].includes(this.state.source)) {
       return false;
     }
 
@@ -311,6 +396,20 @@ function getJsonText(show: ShowContent, panel: VizPanel): string {
           objToStringify = getPanelDataFrames(dataProvider.state.data);
         }
       }
+      break;
+    }
+
+    case 'panel-layout': {
+      reportPanelInspectInteraction(InspectTab.JSON, 'panelLayout');
+
+      const gridItem = panel.parent;
+
+      if (gridItem instanceof DashboardGridItem) {
+        if (isDashboardV2Spec(getDashboardSceneFor(panel).getSaveModel())) {
+          objToStringify = gridItemToGridLayoutItemKind(gridItem);
+        }
+      }
+      break;
     }
   }
 

--- a/public/app/features/dashboard-scene/v2schema/validation.ts
+++ b/public/app/features/dashboard-scene/v2schema/validation.ts
@@ -137,6 +137,13 @@ export function validatePanelKindV2(value: unknown): asserts value is PanelKind 
   }
 }
 
+function isElementReference(value: unknown): boolean {
+  if (!isObject(value)) {
+    return false;
+  }
+  return value.kind === 'ElementReference' && typeof value.name === 'string';
+}
+
 export function isGridLayoutItemKind(value: unknown): value is GridLayoutItemKind {
   if (!isObject(value)) {
     return false;
@@ -149,6 +156,7 @@ export function isGridLayoutItemKind(value: unknown): value is GridLayoutItemKin
     typeof spec.x === 'number' &&
     typeof spec.y === 'number' &&
     typeof spec.width === 'number' &&
-    typeof spec.height === 'number'
+    typeof spec.height === 'number' &&
+    isElementReference(spec.element)
   );
 }

--- a/public/app/features/dashboard-scene/v2schema/validation.ts
+++ b/public/app/features/dashboard-scene/v2schema/validation.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import {
   GridLayoutItemKind,
   PanelKind,
@@ -137,26 +139,22 @@ export function validatePanelKindV2(value: unknown): asserts value is PanelKind 
   }
 }
 
-function isElementReference(value: unknown): boolean {
-  if (!isObject(value)) {
-    return false;
-  }
-  return value.kind === 'ElementReference' && typeof value.name === 'string';
-}
+const ElementReferenceSchema = z.object({
+  kind: z.literal('ElementReference'),
+  name: z.string(),
+});
+
+const GridLayoutItemKindSchema = z.object({
+  kind: z.literal('GridLayoutItem'),
+  spec: z.object({
+    x: z.number(),
+    y: z.number(),
+    width: z.number(),
+    height: z.number(),
+    element: ElementReferenceSchema,
+  }),
+}) satisfies z.ZodType<GridLayoutItemKind>;
 
 export function isGridLayoutItemKind(value: unknown): value is GridLayoutItemKind {
-  if (!isObject(value)) {
-    return false;
-  }
-  if (value.kind !== 'GridLayoutItem' || !isObject(value.spec)) {
-    return false;
-  }
-  const spec = value.spec;
-  return (
-    typeof spec.x === 'number' &&
-    typeof spec.y === 'number' &&
-    typeof spec.width === 'number' &&
-    typeof spec.height === 'number' &&
-    isElementReference(spec.element)
-  );
+  return GridLayoutItemKindSchema.safeParse(value).success;
 }

--- a/public/app/features/dashboard-scene/v2schema/validation.ts
+++ b/public/app/features/dashboard-scene/v2schema/validation.ts
@@ -1,4 +1,5 @@
 import {
+  GridLayoutItemKind,
   PanelKind,
   QueryGroupKind,
   VizConfigKind,
@@ -134,4 +135,20 @@ export function validatePanelKindV2(value: unknown): asserts value is PanelKind 
   if (!isPanelKindV2(value)) {
     throw new Error('Provided JSON is not a valid v2 Panel spec');
   }
+}
+
+export function isGridLayoutItemKind(value: unknown): value is GridLayoutItemKind {
+  if (!isObject(value)) {
+    return false;
+  }
+  if (value.kind !== 'GridLayoutItem' || !isObject(value.spec)) {
+    return false;
+  }
+  const spec = value.spec;
+  return (
+    typeof spec.x === 'number' &&
+    typeof spec.y === 'number' &&
+    typeof spec.width === 'number' &&
+    typeof spec.height === 'number'
+  );
 }

--- a/public/app/features/inspector/InspectJSONTab.tsx
+++ b/public/app/features/inspector/InspectJSONTab.tsx
@@ -125,7 +125,7 @@ export function InspectJSONTab({ panel, dashboard, data, onClose }: Props) {
   return (
     <div className={styles.wrap}>
       <div className={styles.toolbar} data-testid={selectors.components.PanelInspector.Json.content}>
-        <Field label={t('dashboard.inspect-json.select-source', 'Select source')} className="flex-grow-1">
+        <Field label={t('dashboard.inspect-json.select-source', 'Select source')} className="flex-grow-1" noMargin>
           <Select
             inputId="select-source-dropdown"
             options={jsonOptions}

--- a/public/app/features/inspector/styles.ts
+++ b/public/app/features/inspector/styles.ts
@@ -27,7 +27,7 @@ export const getPanelInspectorStyles2 = (theme: GrafanaTheme2) => {
       display: 'flex',
       width: '100%',
       flexGrow: 0,
-      alignItems: 'center',
+      alignItems: 'flex-end',
       justifyContent: 'flex-end',
       marginBottom: theme.v1.spacing.sm,
     }),

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5151,6 +5151,8 @@
       "panel-data-label": "Panel data",
       "panel-json-description": "The model saved in the dashboard JSON that configures how everything works.",
       "panel-json-label": "Panel JSON",
+      "panel-layout-description": "The grid position and size of the panel in the dashboard.",
+      "panel-layout-label": "Panel Layout",
       "select-source": "Select source",
       "unknown": "Unknown Object: {{show}}"
     },
@@ -6241,6 +6243,7 @@
     "inspect-json-tab": {
       "apply": "Apply",
       "error-invalid-json": "Invalid JSON",
+      "error-invalid-layout": "Layout JSON did not pass validation. Please check the JSON and try again.",
       "error-invalid-v2-panel": "Panel JSON did not pass validation. Please check the JSON and try again.",
       "validation-error": "Validation error"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5153,6 +5153,7 @@
       "panel-json-label": "Panel JSON",
       "panel-layout-description": "The grid position and size of the panel in the dashboard.",
       "panel-layout-label": "Panel Layout",
+      "panel-spec-label": "Panel Spec",
       "select-source": "Select source",
       "unknown": "Unknown Object: {{show}}"
     },
@@ -6242,6 +6243,7 @@
     },
     "inspect-json-tab": {
       "apply": "Apply",
+      "error-element-changed": "Cannot change the element reference. Only layout properties (x, y, width, height) can be modified.",
       "error-invalid-json": "Invalid JSON",
       "error-invalid-layout": "Layout JSON did not pass validation. Please check the JSON and try again.",
       "error-invalid-v2-panel": "Panel JSON did not pass validation. Please check the JSON and try again.",


### PR DESCRIPTION
**What is this feature?**

Adds a new "Panel Layout" option to the panel inspector's JSON tab for V2 dashboard spec. This allows users to view and edit the panel's grid position (`x`, `y`, `width`, `height`) separately from the panel configuration.

**Why do we need this feature?**

In the V2 dashboard schema, layout (positioning) is stored separately from panel definitions. Previously, users could access these properties via view/edit panel JSON 

**Which issue(s) does this PR fix?**:

Fixes #116831
