### PR TITLE
fix(unified): on-prem migration ignore soft-deleted dashboards & folders

### DIFF
--- a/pkg/storage/unified/migrations/registry.go
+++ b/pkg/storage/unified/migrations/registry.go
@@ -158,8 +158,8 @@ func init() {
 			dashboardGR: func(a legacy.MigrationDashboardAccessor) MigratorFunc { return a.MigrateDashboards },
 		},
 		Validators: []ValidatorFactory{
-			CountValidation(folderGR, "dashboard", "org_id = ? and is_folder = true"),
-			CountValidation(dashboardGR, "dashboard", "org_id = ? and is_folder = false"),
+			CountValidation(folderGR, "dashboard", "org_id = ? AND is_folder = true AND deleted IS NULL"),
+			CountValidation(dashboardGR, "dashboard", "org_id = ? AND is_folder = false AND deleted IS NULL"),
 			FolderTreeValidation(folderGR),
 		},
 	})

--- a/pkg/storage/unified/migrations/resources.go
+++ b/pkg/storage/unified/migrations/resources.go
@@ -141,18 +141,16 @@ func isMigrationEnabled(def MigrationDefinition, cfg *setting.Cfg) (bool, error)
 func countResource(ctx context.Context, sqlStore db.DB, resourceName string) (int64, error) {
 	var count int64
 	err := sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
+		var err error
 		switch resourceName {
 		case setting.DashboardResource:
-			var err error
-			count, err = sess.Table("dashboard").Where("is_folder = ?", false).Count()
-			return err
+			count, err = sess.Table("dashboard").Where("is_folder = ? AND deleted IS NULL", false).Count()
 		case setting.FolderResource:
-			var err error
-			count, err = sess.Table("dashboard").Where("is_folder = ?", true).Count()
-			return err
+			count, err = sess.Table("dashboard").Where("is_folder = ? AND deleted IS NULL", true).Count()
 		default:
 			return fmt.Errorf("unknown resource: %s", resourceName)
 		}
+		return err
 	})
 	return count, err
 }


### PR DESCRIPTION
**What is this feature?**

When checking for dashboards and folders count, the migration logic should ignore soft-deleted resources, as these are not going to be migrated to unified storage.

For reference, the deleted field from dashboard table might have been populated for some instances when the experimental dashboardRestore feature flag was enabled, around Grafana 11. Later on, this feature was entirely removed here: https://github.com/grafana/grafana/pull/103204.

**Why do we need this feature?**

To avoid migration failures in case customers used this experimental feature.

**Who is this feature for?**

OSS/On-Prem

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
