### PR TITLE
CI(ephemeral-instances): limit to grafanistas

### DIFF
--- a/.github/workflows/ephemeral-instances-pr-comment.yml
+++ b/.github/workflows/ephemeral-instances-pr-comment.yml
@@ -10,7 +10,12 @@ permissions: {}
 
 jobs:
   handle-ephemeral-instances:
-    if: ${{ github.repository_owner == 'grafana' && ((github.event.issue.pull_request && startsWith(github.event.comment.body, '/deploy-to-hg')) || github.event.action == 'closed') }}
+    if: |
+      github.repository_owner == 'grafana' &&
+      (
+        (github.event.issue.pull_request && startsWith(github.event.comment.body, '/deploy-to-hg') && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')) ||
+        github.event.action == 'closed'
+      )
     runs-on:
       labels: ubuntu-x64-xlarge
     continue-on-error: true


### PR DESCRIPTION
This is already verified within the action itself, but we get bug bounty reports about this quite often. The reporters are requested not to test without explicit consent, and the action is private, so this would look like a legitimate issue to them, while it really isn't.

To make this explicit and ensure that we don't keep getting more of these reports, let's just limit the event.