### PR TITLE
docs: fix folder access control page errors

### DIFF
--- a/docs/sources/administration/roles-and-permissions/folder-access-control/index.md
+++ b/docs/sources/administration/roles-and-permissions/folder-access-control/index.md
@@ -21,7 +21,7 @@ This page explains how folder permissions work and how to use them effectively t
 - To create folders, you need the Folder Creator role or appropriate organization permissions
 - Folder permissions are available in all Grafana editions (OSS, Enterprise, and Cloud)
 
-{{< admonition type="note" >}}
+{{< admonition type="caution" >}}
 **Folder limitations:**
 
 - Folders can be nested up to **4 levels deep**

--- a/docs/sources/administration/roles-and-permissions/folder-access-control/index.md
+++ b/docs/sources/administration/roles-and-permissions/folder-access-control/index.md
@@ -26,7 +26,7 @@ This page explains how folder permissions work and how to use them effectively t
 
 - Folders can be nested up to **4 levels deep**
 - Folder names cannot contain underscores (`_`) or percent signs (`%`)
-{{< /admonition >}}
+  {{< /admonition >}}
 
 ## Default permissions for new folders
 

--- a/docs/sources/administration/roles-and-permissions/folder-access-control/index.md
+++ b/docs/sources/administration/roles-and-permissions/folder-access-control/index.md
@@ -21,12 +21,19 @@ This page explains how folder permissions work and how to use them effectively t
 - To create folders, you need the Folder Creator role or appropriate organization permissions
 - Folder permissions are available in all Grafana editions (OSS, Enterprise, and Cloud)
 
-## Folder limitations
+{{< admonition type="note" >}}
+**Folder limitations:**
 
 - Folders can be nested up to **4 levels deep**
 - Folder names cannot contain underscores (`_`) or percent signs (`%`)
-- The **General** folder cannot have its permissions modified through RBAC
-- You cannot set permissions on individual dashboards if the user already has folder-level access
+{{< /admonition >}}
+
+## Default permissions for new folders
+
+How a folder is created determines its initial permissions:
+
+- **Folders created in the UI** are automatically granted: Admin role gets Admin permission, Editor role gets Edit permission, Viewer role gets View permission
+- **Folders created via as-code** (Terraform, API, provisioning) only have permissions explicitly defined in the configuration, plus Admin role gets Admin permission by default
 
 ## How folder permissions work
 
@@ -151,6 +158,7 @@ The permissions dialog shows all users, teams, and roles with access to this fol
 1. Select who to grant access to:
    - **User** - A specific user account
    - **Team** - All members of a team
+   - **Service Account** - A service account for API or automation access
    - **Role** - Users with a specific organization role (Viewer, Editor, Admin)
 1. Select the permission level (View, Edit, or Admin).
 1. Click **Save**.


### PR DESCRIPTION
## Summary

Fixes several errors and missing information on the recently released folder access control page.

**Changes:**
- Removed incorrect statement about General folder (no longer exists in Grafana)
- Added new section explaining default permissions for folders created via UI vs as-code (Terraform, API, provisioning)
- Removed incorrect statement about not being able to set dashboard permissions with folder access
- Added service accounts to the list of permission grant options
- Moved folder limitations into a note admonition box for better visibility

## Test plan

- [ ] Verify page renders correctly with new admonition
- [ ] Review content accuracy with IAM team

🤖 Generated with [Claude Code](https://claude.com/claude-code)