### PR TITLE
fix: use global type as argument

### DIFF
--- a/pkg/storage/unified/migrations/resource_migration.go
+++ b/pkg/storage/unified/migrations/resource_migration.go
@@ -84,7 +84,12 @@ func (r *MigrationRunner) Run(ctx context.Context, sess *xorm.Session, opts RunO
 	}
 
 	for _, org := range orgs {
-		if err = r.MigrateOrg(ctx, sess, org, opts); err != nil {
+		info, err := types.ParseNamespace(types.OrgNamespaceFormatter(org.ID))
+		if err != nil {
+			r.log.Error("Failed to parse organization namespace", "org_id", org.ID, "error", err)
+			return fmt.Errorf("failed to parse namespace for org %d: %w", org.ID, err)
+		}
+		if err = r.MigrateOrg(ctx, sess, info, opts); err != nil {
 			return err
 		}
 	}
@@ -103,43 +108,42 @@ func (r *MigrationRunner) Run(ctx context.Context, sess *xorm.Session, opts RunO
 }
 
 // MigrateOrg handles migration for a single organization.
-func (r *MigrationRunner) MigrateOrg(ctx context.Context, sess *xorm.Session, org orgInfo, opts RunOptions) error {
-	namespace := types.OrgNamespaceFormatter(org.ID)
-	r.log.Info("Migrating organization", "org_id", org.ID, "org_name", org.Name, "namespace", namespace)
+func (r *MigrationRunner) MigrateOrg(ctx context.Context, sess *xorm.Session, info types.NamespaceInfo, opts RunOptions) error {
+	r.log.Info("Migrating organization", "org_id", info.OrgID, "namespace", info.Value)
 
 	// Create a service identity context for this namespace to authenticate with unified storage
-	ctx = identity.WithServiceIdentityForSingleNamespaceContext(ctx, namespace)
+	ctx = identity.WithServiceIdentityForSingleNamespaceContext(ctx, info.Value)
 
 	startTime := time.Now()
 
 	migrateOpts := legacy.MigrateOptions{
-		Namespace:   namespace,
+		Namespace:   info.Value,
 		Resources:   r.resources,
 		WithHistory: true, // Migrate with full history
 		Progress: func(count int, msg string) {
-			r.log.Info("Migration progress", "org_id", org.ID, "count", count, "message", msg)
+			r.log.Info("Migration progress", "org_id", info.OrgID, "count", count, "message", msg)
 		},
 	}
 
 	// Execute the migration via legacy migrator
 	response, err := r.unifiedMigrator.Migrate(ctx, migrateOpts)
 	if err != nil {
-		r.log.Error("Migration failed", "org_id", org.ID, "error", err, "duration", time.Since(startTime))
-		return fmt.Errorf("migration failed for org %d (%s): %w", org.ID, org.Name, err)
+		r.log.Error("Migration failed", "org_id", info.OrgID, "error", err, "duration", time.Since(startTime))
+		return fmt.Errorf("migration failed for org %d (%s): %w", info.OrgID, info.Value, err)
 	}
 	if response.Error != nil {
-		r.log.Error("Migration reported error", "org_id", org.ID, "error", response.Error.String(), "duration", time.Since(startTime))
-		return fmt.Errorf("migration failed for org %d (%s): %w", org.ID, org.Name, fmt.Errorf("migration error: %s", response.Error.Message))
+		r.log.Error("Migration reported error", "org_id", info.OrgID, "error", response.Error.String(), "duration", time.Since(startTime))
+		return fmt.Errorf("migration failed for org %d (%s): %w", info.OrgID, info.Value, fmt.Errorf("migration error: %s", response.Error.Message))
 	}
 
 	// Validate the migration results
 	if err := r.validateMigration(ctx, sess, response, r.validators); err != nil {
-		r.log.Error("Migration validation failed", "org_id", org.ID, "error", err, "duration", time.Since(startTime))
-		return fmt.Errorf("migration validation failed for org %d (%s): %w", org.ID, org.Name, err)
+		r.log.Error("Migration validation failed", "org_id", info.OrgID, "error", err, "duration", time.Since(startTime))
+		return fmt.Errorf("migration validation failed for org %d (%s): %w", info.OrgID, info.Value, err)
 	}
 
 	r.log.Info("Migration completed for organization",
-		"org_id", org.ID,
+		"org_id", info.OrgID,
 		"duration", time.Since(startTime),
 		"processed", response.Processed,
 		"summaries", len(response.Summary),


### PR DESCRIPTION
Use the namespace info as argument in order to be able to reference a global type from within migration controller.

Ticket: https://github.com/grafana/search-and-storage-team/issues/624