### PR TITLE
UserStorage: Add `deleteItem` method for removing keys

### DIFF
--- a/packages/grafana-data/src/types/userStorage.ts
+++ b/packages/grafana-data/src/types/userStorage.ts
@@ -13,9 +13,9 @@ export interface UserStorage {
    */
   setItem(key: string, value: string): Promise<void>;
   /**
-   * Deletes an item from the backend user storage or local storage if not enabled.
-   * @param key - The key of the item to delete.
-   * @returns A promise that resolves when the item is deleted.
+   * Removes an item from the backend user storage or local storage if not enabled.
+   * @param key - The key of the item to remove.
+   * @returns A promise that resolves when the item is removed.
    */
-  deleteItem(key: string): Promise<void>;
+  removeItem(key: string): Promise<void>;
 }

--- a/packages/grafana-data/src/types/userStorage.ts
+++ b/packages/grafana-data/src/types/userStorage.ts
@@ -7,9 +7,16 @@ export interface UserStorage {
   getItem(key: string): Promise<string | null>;
   /**
    * Sets an item in the backend user storage or local storage if not enabled.
+   * If value is null, the item is deleted.
    * @param key - The key of the item to set.
-   * @param value - The value of the item to set.
-   * @returns A promise that resolves when the item is set.
+   * @param value - The value of the item to set, or null to delete the item.
+   * @returns A promise that resolves when the item is set or deleted.
    */
-  setItem(key: string, value: string): Promise<void>;
+  setItem(key: string, value: string | null): Promise<void>;
+  /**
+   * Deletes an item from the backend user storage or local storage if not enabled.
+   * @param key - The key of the item to delete.
+   * @returns A promise that resolves when the item is deleted.
+   */
+  deleteItem(key: string): Promise<void>;
 }

--- a/packages/grafana-data/src/types/userStorage.ts
+++ b/packages/grafana-data/src/types/userStorage.ts
@@ -7,12 +7,11 @@ export interface UserStorage {
   getItem(key: string): Promise<string | null>;
   /**
    * Sets an item in the backend user storage or local storage if not enabled.
-   * If value is null, the item is deleted.
    * @param key - The key of the item to set.
-   * @param value - The value of the item to set, or null to delete the item.
-   * @returns A promise that resolves when the item is set or deleted.
+   * @param value - The value of the item to set.
+   * @returns A promise that resolves when the item is set.
    */
-  setItem(key: string, value: string | null): Promise<void>;
+  setItem(key: string, value: string): Promise<void>;
   /**
    * Deletes an item from the backend user storage or local storage if not enabled.
    * @param key - The key of the item to delete.

--- a/packages/grafana-runtime/src/utils/userStorage.test.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.test.tsx
@@ -392,11 +392,11 @@ describe('userStorage', () => {
     });
   });
 
-  describe('deleteItem', () => {
+  describe('removeItem', () => {
     it('uses localStorage delete if the user is not logged in', async () => {
       config.bootData.user.isSignedIn = false;
       const storage = usePluginUserStorage();
-      await storage.deleteItem('key');
+      await storage.removeItem('key');
       expect(getStoreMocks().delete).toHaveBeenCalledWith('plugin-id:abc:key');
     });
 
@@ -412,7 +412,7 @@ describe('userStorage', () => {
       request.mockReturnValueOnce(Promise.resolve({ status: 200 } as FetchResponse));
 
       const storage = usePluginUserStorage();
-      await storage.deleteItem('key');
+      await storage.removeItem('key');
 
       expect(request).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -439,7 +439,7 @@ describe('userStorage', () => {
       request.mockReturnValueOnce(Promise.resolve({ status: 200 } as FetchResponse));
 
       const storage = usePluginUserStorage();
-      await storage.deleteItem('key');
+      await storage.removeItem('key');
 
       // Verify the key was removed from cache
       const deletedValue = await storage.getItem('key');
@@ -453,7 +453,7 @@ describe('userStorage', () => {
       request.mockReturnValueOnce(Promise.reject({ status: 404 } as FetchError));
 
       const storage = usePluginUserStorage();
-      await storage.deleteItem('key');
+      await storage.removeItem('key');
 
       // Should only make the GET request, no PATCH since storage doesn't exist
       expect(request).toHaveBeenCalledTimes(1);
@@ -476,7 +476,7 @@ describe('userStorage', () => {
       request.mockReturnValueOnce(Promise.reject({ status: 500 } as FetchError));
 
       const storage = usePluginUserStorage();
-      await storage.deleteItem('key');
+      await storage.removeItem('key');
 
       expect(getStoreMocks().delete).toHaveBeenCalledWith('plugin-id:abc:key');
     });
@@ -486,7 +486,7 @@ describe('userStorage', () => {
       request.mockReturnValueOnce(Promise.reject({ status: 500 } as FetchError));
 
       const storage = usePluginUserStorage();
-      await storage.deleteItem('key');
+      await storage.removeItem('key');
 
       expect(getStoreMocks().delete).toHaveBeenCalledWith('plugin-id:abc:key');
     });

--- a/packages/grafana-runtime/src/utils/userStorage.test.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.test.tsx
@@ -400,13 +400,6 @@ describe('userStorage', () => {
       expect(getStoreMocks().delete).toHaveBeenCalledWith('plugin-id:abc:key');
     });
 
-    it('uses localStorage delete via setItem(key, null) if the user is not logged in', async () => {
-      config.bootData.user.isSignedIn = false;
-      const storage = usePluginUserStorage();
-      await storage.setItem('key', null);
-      expect(getStoreMocks().delete).toHaveBeenCalledWith('plugin-id:abc:key');
-    });
-
     it('sends PATCH with null value to delete from backend', async () => {
       // Initial GET returns existing data
       request.mockReturnValueOnce(

--- a/packages/grafana-runtime/src/utils/userStorage.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.tsx
@@ -222,7 +222,7 @@ export class UserStorage implements UserStorageType {
     return this.setOrDeleteItem(key, value);
   }
 
-  async deleteItem(key: string): Promise<void> {
+  async removeItem(key: string): Promise<void> {
     return this.setOrDeleteItem(key, null);
   }
 

--- a/packages/grafana-runtime/src/utils/userStorage.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.tsx
@@ -218,7 +218,15 @@ export class UserStorage implements UserStorageType {
     }
   }
 
-  async setItem(key: string, value: string | null): Promise<void> {
+  async setItem(key: string, value: string): Promise<void> {
+    return this.setOrDeleteItem(key, value);
+  }
+
+  async deleteItem(key: string): Promise<void> {
+    return this.setOrDeleteItem(key, null);
+  }
+
+  private async setOrDeleteItem(key: string, value: string | null): Promise<void> {
     if (!this.canUseUserStorage) {
       this.setLocalStorage(key, value);
       return;
@@ -288,10 +296,6 @@ export class UserStorage implements UserStorageType {
     } finally {
       releaseLock();
     }
-  }
-
-  async deleteItem(key: string): Promise<void> {
-    return this.setItem(key, null);
   }
 }
 


### PR DESCRIPTION
**What is this feature?**

Adds a `deleteItem` method to the `UserStorage` API that allows removing individual keys from user storage. Also extends `setItem` to accept `null` as a value, which triggers deletion.

**Why do we need this feature?**

Currently, `UserStorage` only supports `getItem` and `setItem`, with no way to remove stored keys. This addition provides a complete CRUD interface for user storage.

**Who is this feature for?**

Plugin developers and internal Grafana code that uses the `UserStorage` API to persist user preferences.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Implementation details:
- `setItem(key, value)` now accepts `string | null` - passing `null` deletes the key
- `deleteItem(key)` is a convenience method that calls `setItem(key, null)`
- Uses JSON Merge Patch semantics where `null` removes the key on the backend
- Falls back to `localStorage.delete` when user is not signed in
- Includes comprehensive tests for all delete scenarios