### PR TITLE
Provisioning: Make title mandatory for Connection resources

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/connections.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/connections.go
@@ -70,7 +70,7 @@ const (
 
 type ConnectionSpec struct {
 	// The connection display name (shown in the UI)
-	Title string `json:"title,omitempty"`
+	Title string `json:"title"`
 	// The connection description
 	Description string `json:"description,omitempty"`
 	// The connection provider type

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -346,6 +346,7 @@ func schema_pkg_apis_provisioning_v0alpha1_ConnectionSpec(ref common.ReferenceCa
 					"title": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The connection display name (shown in the UI)",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -392,7 +393,7 @@ func schema_pkg_apis_provisioning_v0alpha1_ConnectionSpec(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"type"},
+				Required: []string{"title", "type"},
 			},
 		},
 		Dependencies: []string{

--- a/apps/provisioning/pkg/connection/factory.go
+++ b/apps/provisioning/pkg/connection/factory.go
@@ -94,6 +94,14 @@ func (f *factory) Validate(ctx context.Context, obj runtime.Object) field.ErrorL
 		return list
 	}
 
+	// Validate title is required
+	if conn.Spec.Title == "" {
+		list = append(list, field.Required(
+			field.NewPath("spec", "title"),
+			"title is required",
+		))
+	}
+
 	// Check if connection type is supported
 	var foundExtra Extra
 	for _, e := range f.extras {

--- a/apps/provisioning/pkg/connection/factory_test.go
+++ b/apps/provisioning/pkg/connection/factory_test.go
@@ -473,7 +473,8 @@ func TestFactory_Validate(t *testing.T) {
 			name: "should return no errors for valid enabled connection type",
 			connection: &provisioning.Connection{
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GithubConnectionType,
+					Title: "Test Connection",
+					Type:  provisioning.GithubConnectionType,
 					GitHub: &provisioning.GitHubConnectionConfig{
 						AppID:          "123456",
 						InstallationID: "454545",
@@ -506,11 +507,13 @@ func TestFactory_Validate(t *testing.T) {
 			enabled: map[provisioning.ConnectionType]struct{}{
 				provisioning.GithubConnectionType: {},
 			},
-			expectedErrs: 1,
+			expectedErrs: 2,
 			validateError: func(t *testing.T, errs []*field.Error) {
-				require.Len(t, errs, 1)
-				assert.Equal(t, "spec.type", errs[0].Field)
-				assert.Contains(t, errs[0].Detail, "connection type \"gitlab\" is not supported")
+				require.Len(t, errs, 2)
+				assert.Equal(t, "spec.title", errs[0].Field)
+				assert.Contains(t, errs[0].Detail, "title is required")
+				assert.Equal(t, "spec.type", errs[1].Field)
+				assert.Contains(t, errs[1].Detail, "connection type \"gitlab\" is not supported")
 			},
 		},
 		{
@@ -528,11 +531,13 @@ func TestFactory_Validate(t *testing.T) {
 			enabled: map[provisioning.ConnectionType]struct{}{
 				provisioning.GithubConnectionType: {},
 			},
-			expectedErrs: 1,
+			expectedErrs: 2,
 			validateError: func(t *testing.T, errs []*field.Error) {
-				require.Len(t, errs, 1)
-				assert.Equal(t, "spec.type", errs[0].Field)
-				assert.Contains(t, errs[0].Detail, "connection type \"\" is not supported")
+				require.Len(t, errs, 2)
+				assert.Equal(t, "spec.title", errs[0].Field)
+				assert.Contains(t, errs[0].Detail, "title is required")
+				assert.Equal(t, "spec.type", errs[1].Field)
+				assert.Contains(t, errs[1].Detail, "connection type \"\" is not supported")
 			},
 		},
 		{
@@ -550,11 +555,13 @@ func TestFactory_Validate(t *testing.T) {
 			enabled: map[provisioning.ConnectionType]struct{}{
 				provisioning.GithubConnectionType: {},
 			},
-			expectedErrs: 1,
+			expectedErrs: 2,
 			validateError: func(t *testing.T, errs []*field.Error) {
-				require.Len(t, errs, 1)
-				assert.Equal(t, "spec.type", errs[0].Field)
-				assert.Contains(t, errs[0].Detail, "connection type \"gitlab\" is not enabled")
+				require.Len(t, errs, 2)
+				assert.Equal(t, "spec.title", errs[0].Field)
+				assert.Contains(t, errs[0].Detail, "title is required")
+				assert.Equal(t, "spec.type", errs[1].Field)
+				assert.Contains(t, errs[1].Detail, "connection type \"gitlab\" is not enabled")
 			},
 		},
 		{
@@ -579,11 +586,13 @@ func TestFactory_Validate(t *testing.T) {
 			enabled: map[provisioning.ConnectionType]struct{}{
 				provisioning.GithubConnectionType: {},
 			},
-			expectedErrs: 2,
+			expectedErrs: 3,
 			validateError: func(t *testing.T, errs []*field.Error) {
-				require.Len(t, errs, 2)
-				assert.Equal(t, "spec.github.appID", errs[0].Field)
-				assert.Equal(t, "spec.github.installationID", errs[1].Field)
+				require.Len(t, errs, 3)
+				assert.Equal(t, "spec.title", errs[0].Field)
+				assert.Contains(t, errs[0].Detail, "title is required")
+				assert.Equal(t, "spec.github.appID", errs[1].Field)
+				assert.Equal(t, "spec.github.installationID", errs[2].Field)
 			},
 		},
 		{
@@ -603,7 +612,8 @@ func TestFactory_Validate(t *testing.T) {
 			name: "should validate with multiple extras registered",
 			connection: &provisioning.Connection{
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GithubConnectionType,
+					Title: "Test Connection",
+					Type:  provisioning.GithubConnectionType,
 					GitHub: &provisioning.GitHubConnectionConfig{
 						AppID:          "123456",
 						InstallationID: "454545",
@@ -643,11 +653,13 @@ func TestFactory_Validate(t *testing.T) {
 				provisioning.GithubConnectionType:    {},
 				provisioning.BitbucketConnectionType: {}, // Even if enabled, not supported
 			},
-			expectedErrs: 1,
+			expectedErrs: 2,
 			validateError: func(t *testing.T, errs []*field.Error) {
-				require.Len(t, errs, 1)
-				assert.Equal(t, "spec.type", errs[0].Field)
-				assert.Contains(t, errs[0].Detail, "connection type \"bitbucket\" is not supported")
+				require.Len(t, errs, 2)
+				assert.Equal(t, "spec.title", errs[0].Field)
+				assert.Contains(t, errs[0].Detail, "title is required")
+				assert.Equal(t, "spec.type", errs[1].Field)
+				assert.Contains(t, errs[1].Detail, "connection type \"bitbucket\" is not supported")
 			},
 		},
 	}

--- a/apps/provisioning/pkg/connection/validator_test.go
+++ b/apps/provisioning/pkg/connection/validator_test.go
@@ -66,17 +66,50 @@ func TestAdmissionValidator_Validate(t *testing.T) {
 			name: "valid connection passes validation",
 			obj: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
-				Spec:       provisioning.ConnectionSpec{Type: provisioning.GithubConnectionType},
+				Spec: provisioning.ConnectionSpec{
+					Title: "Test Connection",
+					Type:  provisioning.GithubConnectionType,
+				},
 			},
 			operation:     admission.Create,
 			factoryErrors: field.ErrorList{},
 			wantErr:       false,
 		},
 		{
-			name: "factory validation errors are returned",
+			name: "connection without title fails validation",
 			obj: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec:       provisioning.ConnectionSpec{Type: provisioning.GithubConnectionType},
+			},
+			operation: admission.Create,
+			factoryErrors: field.ErrorList{
+				field.Required(field.NewPath("spec", "title"), "title is required"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "connection with empty title fails validation",
+			obj: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: provisioning.ConnectionSpec{
+					Title: "",
+					Type:  provisioning.GithubConnectionType,
+				},
+			},
+			operation: admission.Create,
+			factoryErrors: field.ErrorList{
+				field.Required(field.NewPath("spec", "title"), "title is required"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "factory validation errors are returned",
+			obj: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: provisioning.ConnectionSpec{
+					Title: "Test Connection",
+					Type:  provisioning.GithubConnectionType,
+				},
 			},
 			operation: admission.Create,
 			factoryErrors: field.ErrorList{
@@ -102,7 +135,10 @@ func TestAdmissionValidator_Validate(t *testing.T) {
 			name: "skips validation for DELETE operations",
 			obj: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
-				Spec:       provisioning.ConnectionSpec{Type: provisioning.GithubConnectionType},
+				Spec: provisioning.ConnectionSpec{
+					Title: "Test Connection",
+					Type:  provisioning.GithubConnectionType,
+				},
 			},
 			operation: admission.Delete,
 			wantErr:   false,
@@ -114,7 +150,10 @@ func TestAdmissionValidator_Validate(t *testing.T) {
 					Name:              "test",
 					DeletionTimestamp: &metav1.Time{Time: time.Now()},
 				},
-				Spec: provisioning.ConnectionSpec{Type: provisioning.GithubConnectionType},
+				Spec: provisioning.ConnectionSpec{
+					Title: "Test Connection",
+					Type:  provisioning.GithubConnectionType,
+				},
 			},
 			operation: admission.Update,
 			wantErr:   false,
@@ -123,11 +162,17 @@ func TestAdmissionValidator_Validate(t *testing.T) {
 			name: "copies secure values from old connection on update",
 			obj: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
-				Spec:       provisioning.ConnectionSpec{Type: provisioning.GithubConnectionType},
+				Spec: provisioning.ConnectionSpec{
+					Title: "Test Connection",
+					Type:  provisioning.GithubConnectionType,
+				},
 			},
 			old: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
-				Spec:       provisioning.ConnectionSpec{Type: provisioning.GithubConnectionType},
+				Spec: provisioning.ConnectionSpec{
+					Title: "Test Connection",
+					Type:  provisioning.GithubConnectionType,
+				},
 				Secure: provisioning.ConnectionSecure{
 					Token: common.InlineSecureValue{Name: "old-token"},
 				},
@@ -189,7 +234,10 @@ func TestAdmissionValidator_CopiesSecureValuesOnUpdate(t *testing.T) {
 
 	oldConn := &provisioning.Connection{
 		ObjectMeta: metav1.ObjectMeta{Name: "test"},
-		Spec:       provisioning.ConnectionSpec{Type: provisioning.GithubConnectionType},
+		Spec: provisioning.ConnectionSpec{
+			Title: "Test Connection",
+			Type:  provisioning.GithubConnectionType,
+		},
 		Secure: provisioning.ConnectionSecure{
 			Token:        common.InlineSecureValue{Name: "old-token"},
 			PrivateKey:   common.InlineSecureValue{Name: "old-key"},
@@ -199,7 +247,10 @@ func TestAdmissionValidator_CopiesSecureValuesOnUpdate(t *testing.T) {
 
 	newConn := &provisioning.Connection{
 		ObjectMeta: metav1.ObjectMeta{Name: "test"},
-		Spec:       provisioning.ConnectionSpec{Type: provisioning.GithubConnectionType},
+		Spec: provisioning.ConnectionSpec{
+			Title: "Test Connection",
+			Type:  provisioning.GithubConnectionType,
+		},
 		// No secure values set
 	}
 
@@ -232,7 +283,8 @@ func TestAdmissionValidator_Validate_DryRun(t *testing.T) {
 			obj: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GithubConnectionType,
+					Title: "Test Connection",
+					Type:  provisioning.GithubConnectionType,
 					GitHub: &provisioning.GitHubConnectionConfig{
 						AppID:          "123",
 						InstallationID: "456",
@@ -259,7 +311,8 @@ func TestAdmissionValidator_Validate_DryRun(t *testing.T) {
 			obj: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GithubConnectionType,
+					Title: "Test Connection",
+					Type:  provisioning.GithubConnectionType,
 					GitHub: &provisioning.GitHubConnectionConfig{
 						AppID:          "123",
 						InstallationID: "999",
@@ -293,7 +346,8 @@ func TestAdmissionValidator_Validate_DryRun(t *testing.T) {
 			obj: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GithubConnectionType,
+					Title: "Test Connection",
+					Type:  provisioning.GithubConnectionType,
 					GitHub: &provisioning.GitHubConnectionConfig{
 						AppID:          "999",
 						InstallationID: "456",
@@ -327,7 +381,8 @@ func TestAdmissionValidator_Validate_DryRun(t *testing.T) {
 			obj: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GithubConnectionType,
+					Title: "Test Connection",
+					Type:  provisioning.GithubConnectionType,
 					GitHub: &provisioning.GitHubConnectionConfig{
 						AppID:          "123",
 						InstallationID: "456",
@@ -345,7 +400,10 @@ func TestAdmissionValidator_Validate_DryRun(t *testing.T) {
 			name: "dryRun skips runtime validation if structural validation fails",
 			obj: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
-				Spec:       provisioning.ConnectionSpec{Type: provisioning.GithubConnectionType},
+				Spec: provisioning.ConnectionSpec{
+					Title: "Test Connection",
+					Type:  provisioning.GithubConnectionType,
+				},
 			},
 			operation: admission.Create,
 			dryRun:    true,
@@ -359,7 +417,8 @@ func TestAdmissionValidator_Validate_DryRun(t *testing.T) {
 			obj: &provisioning.Connection{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GithubConnectionType,
+					Title: "Test Connection",
+					Type:  provisioning.GithubConnectionType,
 					GitHub: &provisioning.GitHubConnectionConfig{
 						AppID:          "123",
 						InstallationID: "456",

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1478,7 +1478,7 @@ export type ConnectionSpec = {
   /** Gitlab connection configuration Only applicable when provider is "gitlab" */
   gitlab?: GitlabConnectionConfig;
   /** The connection display name (shown in the UI) */
-  title?: string;
+  title: string;
   /** The connection provider type
     
     Possible enum values:

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -4284,6 +4284,7 @@
       "com.github.grafana.grafana.apps.provisioning.pkg.apis.provisioning.v0alpha1.ConnectionSpec": {
         "type": "object",
         "required": [
+          "title",
           "type"
         ],
         "properties": {
@@ -4317,7 +4318,8 @@
           },
           "title": {
             "description": "The connection display name (shown in the UI)",
-            "type": "string"
+            "type": "string",
+            "default": ""
           },
           "type": {
             "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"gitlab\"`",

--- a/pkg/tests/apis/provisioning/connection_repositories_test.go
+++ b/pkg/tests/apis/provisioning/connection_repositories_test.go
@@ -31,7 +31,8 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 			"namespace": "default",
 		},
 		"spec": map[string]any{
-			"type": "github",
+			"title": "Test Connection",
+			"type":  "github",
 			"github": map[string]any{
 				"appID":          "123456",
 				"installationID": "454545",
@@ -144,7 +145,8 @@ func TestIntegrationProvisioning_ConnectionRepositoriesResponseType(t *testing.T
 			"namespace": "default",
 		},
 		"spec": map[string]any{
-			"type": "github",
+			"title": "Test Connection",
+			"type":  "github",
 			"github": map[string]any{
 				"appID":          "123456",
 				"installationID": "454545",

--- a/pkg/tests/apis/provisioning/connection_status_auth_test.go
+++ b/pkg/tests/apis/provisioning/connection_status_auth_test.go
@@ -29,7 +29,8 @@ func TestIntegrationProvisioning_ConnectionStatusAuthorization(t *testing.T) {
 			"namespace": "default",
 		},
 		"spec": map[string]any{
-			"type": "github",
+			"title": "Test Connection",
+			"type":  "github",
 			"github": map[string]any{
 				"appID":          "123456",
 				"installationID": "454545",

--- a/pkg/tests/apis/provisioning/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection_test.go
@@ -72,7 +72,8 @@ func TestIntegrationProvisioning_ConnectionCRUDL(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "github",
+				"title": "Test Connection",
+				"type":  "github",
 				"github": map[string]any{
 					"appID":          "123456",
 					"installationID": "454545",
@@ -118,7 +119,8 @@ func TestIntegrationProvisioning_ConnectionCRUDL(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "github",
+				"title": "Test Connection",
+				"type":  "github",
 				"github": map[string]any{
 					"appID":          "123456",
 					"installationID": "454546",
@@ -169,7 +171,8 @@ func TestIntegrationProvisioning_ConnectionCRUDL(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "github",
+				"title": "Test Connection",
+				"type":  "github",
 				"github": map[string]any{
 					"appID":          "123456",
 					"installationID": "454545",
@@ -226,7 +229,8 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "",
+				"title": "Test Connection",
+				"type":  "",
 			},
 			"secure": map[string]any{
 				"privateKey": map[string]any{
@@ -248,7 +252,8 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "some-invalid-type",
+				"title": "Test Connection",
+				"type":  "some-invalid-type",
 			},
 			"secure": map[string]any{
 				"privateKey": map[string]any{
@@ -270,7 +275,8 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "git",
+				"title": "Test Connection",
+				"type":  "git",
 			},
 			"secure": map[string]any{
 				"privateKey": map[string]any{
@@ -292,7 +298,8 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "local",
+				"title": "Test Connection",
+				"type":  "local",
 			},
 			"secure": map[string]any{
 				"privateKey": map[string]any{
@@ -314,7 +321,8 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "github",
+				"title": "Test Connection",
+				"type":  "github",
 			},
 			"secure": map[string]any{
 				"privateKey": map[string]any{
@@ -336,7 +344,8 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "github",
+				"title": "Test Connection",
+				"type":  "github",
 				"github": map[string]any{
 					"appID":          "123456",
 					"installationID": "454545",
@@ -357,7 +366,8 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "github",
+				"title": "Test Connection",
+				"type":  "github",
 				"github": map[string]any{
 					"appID":          "123456",
 					"installationID": "454545",
@@ -403,7 +413,8 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "github",
+				"title": "Test Connection",
+				"type":  "github",
 				"github": map[string]any{
 					"appID":          "123456",
 					"installationID": "454545",
@@ -495,7 +506,8 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "github",
+				"title": "Test Connection",
+				"type":  "github",
 				"github": map[string]any{
 					"appID":          "123456",
 					"installationID": "454545",
@@ -585,7 +597,8 @@ func TestIntegrationProvisioning_ConnectionEnterpriseValidation(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "bitbucket",
+				"title": "Test Connection",
+				"type":  "bitbucket",
 			},
 			"secure": map[string]any{
 				"clientSecret": map[string]any{
@@ -607,7 +620,8 @@ func TestIntegrationProvisioning_ConnectionEnterpriseValidation(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "bitbucket",
+				"title": "Test Connection",
+				"type":  "bitbucket",
 				"bitbucket": map[string]any{
 					"clientID": "123456",
 				},
@@ -627,7 +641,8 @@ func TestIntegrationProvisioning_ConnectionEnterpriseValidation(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "bitbucket",
+				"title": "Test Connection",
+				"type":  "bitbucket",
 				"bitbucket": map[string]any{
 					"clientID": "123456",
 				},
@@ -655,7 +670,8 @@ func TestIntegrationProvisioning_ConnectionEnterpriseValidation(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "gitlab",
+				"title": "Test Connection",
+				"type":  "gitlab",
 			},
 			"secure": map[string]any{
 				"clientSecret": map[string]any{
@@ -677,7 +693,8 @@ func TestIntegrationProvisioning_ConnectionEnterpriseValidation(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "gitlab",
+				"title": "Test Connection",
+				"type":  "gitlab",
 				"gitlab": map[string]any{
 					"clientID": "123456",
 				},
@@ -697,7 +714,8 @@ func TestIntegrationProvisioning_ConnectionEnterpriseValidation(t *testing.T) {
 				"namespace": "default",
 			},
 			"spec": map[string]any{
-				"type": "gitlab",
+				"title": "Test Connection",
+				"type":  "gitlab",
 				"gitlab": map[string]any{
 					"clientID": "123456",
 				},
@@ -744,7 +762,8 @@ func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
 				"namespace": namespace,
 			},
 			"spec": map[string]any{
-				"type": "github",
+				"title": "Test Connection",
+				"type":  "github",
 				"github": map[string]any{
 					"appID":          "12345",
 					"installationID": "67890",
@@ -808,7 +827,8 @@ func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
 				"namespace": namespace,
 			},
 			"spec": map[string]any{
-				"type": "github",
+				"title": "Test Connection",
+				"type":  "github",
 				"github": map[string]any{
 					"appID":          "12345",
 					"installationID": "67890",
@@ -870,7 +890,8 @@ func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
 				"namespace": namespace,
 			},
 			"spec": map[string]any{
-				"type": "github",
+				"title": "Test Connection",
+				"type":  "github",
 				"github": map[string]any{
 					"appID":          "54321",
 					"installationID": "67890",
@@ -944,7 +965,8 @@ func TestIntegrationConnectionController_HealthCheckUpdates(t *testing.T) {
 				"namespace": namespace,
 			},
 			"spec": map[string]any{
-				"type": "github",
+				"title": "Test Connection",
+				"type":  "github",
 				"github": map[string]any{
 					"appID":          "12345",
 					"installationID": "67890",
@@ -1006,7 +1028,8 @@ func TestIntegrationConnectionController_HealthCheckUpdates(t *testing.T) {
 				"namespace": namespace,
 			},
 			"spec": map[string]any{
-				"type": "github",
+				"title": "Test Connection",
+				"type":  "github",
 				"github": map[string]any{
 					"appID":          "11111",
 					"installationID": "22222",
@@ -1111,7 +1134,8 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 				"namespace": namespace,
 			},
 			"spec": map[string]any{
-				"type": "github",
+				"title": "Test Connection",
+				"type":  "github",
 				"github": map[string]any{
 					"appID":          "123456",
 					"installationID": "999999999", // Invalid installation ID that doesn't exist
@@ -1216,7 +1240,8 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 				"namespace": namespace,
 			},
 			"spec": map[string]any{
-				"type": "github",
+				"title": "Test Connection",
+				"type":  "github",
 				"github": map[string]any{
 					"appID":          "123456", // This will mismatch with the returned app ID
 					"installationID": "789012",
@@ -1333,7 +1358,8 @@ func TestIntegrationConnectionController_FieldErrorsCleared(t *testing.T) {
 				"namespace": namespace,
 			},
 			"spec": map[string]any{
-				"type": "github",
+				"title": "Test Connection",
+				"type":  "github",
 				"github": map[string]any{
 					"appID":          "123456",
 					"installationID": "999999999", // Invalid installation ID
@@ -1471,7 +1497,8 @@ func TestIntegrationProvisioning_RepositoryFieldSelectorByConnection(t *testing.
 			"namespace": "default",
 		},
 		"spec": map[string]any{
-			"type": "github",
+			"title": "Test Connection",
+			"type":  "github",
 			"github": map[string]any{
 				"appID":          "123456",
 				"installationID": "789012",
@@ -1645,7 +1672,8 @@ func TestIntegrationProvisioning_ConnectionDeleteBlockedByRepository(t *testing.
 			"namespace": "default",
 		},
 		"spec": map[string]any{
-			"type": "github",
+			"title": "Test Connection",
+			"type":  "github",
 			"github": map[string]any{
 				"appID":          "123456",
 				"installationID": "454545",
@@ -1741,7 +1769,8 @@ func TestIntegrationProvisioning_ConnectionDeleteWithNoReferences(t *testing.T) 
 			"namespace": "default",
 		},
 		"spec": map[string]any{
-			"type": "github",
+			"title": "Test Connection",
+			"type":  "github",
 			"github": map[string]any{
 				"appID":          "789012",
 				"installationID": "121212",
@@ -1791,7 +1820,8 @@ func TestIntegrationConnectionController_GranularConditionReasons(t *testing.T) 
 				"namespace": namespace,
 			},
 			"spec": map[string]any{
-				"type": "github",
+				"title": "Test Connection",
+				"type":  "github",
 				"github": map[string]any{
 					"appID":          "123456",
 					"installationID": "789012",

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -1124,7 +1124,8 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 			"namespace": "default",
 		},
 		"spec": map[string]any{
-			"type": "github",
+			"title": "Test Connection",
+			"type":  "github",
 			"github": map[string]any{
 				"appID":          "123456",
 				"installationID": "789012",
@@ -1223,7 +1224,8 @@ func TestIntegrationProvisioning_RepositoryUnhealthyWithValidationErrors(t *test
 			"namespace": namespace,
 		},
 		"spec": map[string]any{
-			"type": "github",
+			"title": "Test Connection",
+			"type":  "github",
 			"github": map[string]any{
 				"appID":          "123456",
 				"installationID": "789012",

--- a/public/app/features/provisioning/Connection/ConnectionForm.test.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionForm.test.tsx
@@ -42,6 +42,7 @@ const createMockRequestState = (overrides: Partial<MockRequestState> = {}): Mock
 const createMockConnection = (overrides: Partial<Connection> = {}): Connection => ({
   metadata: { name: 'test-connection' },
   spec: {
+    title: 'Test Connection',
     type: 'github',
     url: 'https://github.com/settings/installations/12345678',
     github: {
@@ -174,6 +175,7 @@ describe('ConnectionForm', () => {
       await waitFor(() => {
         expect(mockSubmitData).toHaveBeenCalledWith(
           {
+            title: 'GitHub Connection',
             type: 'github',
             github: {
               appID: '123456',
@@ -196,6 +198,7 @@ describe('ConnectionForm', () => {
       await waitFor(() => {
         expect(mockSubmitData).toHaveBeenCalledWith(
           {
+            title: 'Test Connection',
             type: 'github',
             github: {
               appID: '123456',

--- a/public/app/features/provisioning/Connection/ConnectionForm.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionForm.tsx
@@ -65,7 +65,7 @@ export function ConnectionForm({ data }: ConnectionFormProps) {
   const onSubmit = async (form: ConnectionFormData) => {
     try {
       const spec = {
-        title: data?.spec?.title || 'GitHub Connection',
+        title: data?.spec?.title || t('provisioning.connection-form.default-title', 'GitHub Connection'),
         type: form.type,
         github: {
           appID: form.appID,

--- a/public/app/features/provisioning/Connection/ConnectionForm.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionForm.tsx
@@ -65,6 +65,7 @@ export function ConnectionForm({ data }: ConnectionFormProps) {
   const onSubmit = async (form: ConnectionFormData) => {
     try {
       const spec = {
+        title: data?.spec?.title || 'GitHub Connection',
         type: form.type,
         github: {
           appID: form.appID,

--- a/public/app/features/provisioning/Connection/ConnectionList.test.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionList.test.tsx
@@ -7,6 +7,7 @@ import { ConnectionList } from './ConnectionList';
 const createMockConnection = (overrides: Partial<Connection> = {}): Connection => ({
   metadata: { name: 'test-connection' },
   spec: {
+    title: 'Test Connection',
     type: 'github',
     url: 'https://github.com/settings/installations/12345678',
     github: {
@@ -36,6 +37,7 @@ const mockConnections: Connection[] = [
   createMockConnection({
     metadata: { name: 'github-conn-1' },
     spec: {
+      title: 'GitHub Connection 1',
       type: 'github',
       url: 'https://github.com/settings/installations/103343308',
       github: {
@@ -46,11 +48,12 @@ const mockConnections: Connection[] = [
   }),
   createMockConnection({
     metadata: { name: 'gitlab-conn-2' },
-    spec: { type: 'gitlab', url: 'https://gitlab.com/org2/repo2' },
+    spec: { title: 'GitLab Connection 2', type: 'gitlab', url: 'https://gitlab.com/org2/repo2' },
   }),
   createMockConnection({
     metadata: { name: 'another-github' },
     spec: {
+      title: 'Another GitHub Connection',
       type: 'github',
       url: 'https://github.com/settings/installations/987654321',
       github: {

--- a/public/app/features/provisioning/Wizard/GitHubAppStep.tsx
+++ b/public/app/features/provisioning/Wizard/GitHubAppStep.tsx
@@ -68,6 +68,7 @@ export const GitHubAppStep = forwardRef<GitHubAppStepRef | null, GitHubAppStepPr
 
         const { appID, installationID, privateKey } = credentialForm.getValues();
         const spec: ConnectionSpec = {
+          title: 'GitHub Connection',
           type: 'github',
           github: { appID, installationID },
         };

--- a/public/app/features/provisioning/Wizard/GitHubAppStep.tsx
+++ b/public/app/features/provisioning/Wizard/GitHubAppStep.tsx
@@ -68,7 +68,7 @@ export const GitHubAppStep = forwardRef<GitHubAppStepRef | null, GitHubAppStepPr
 
         const { appID, installationID, privateKey } = credentialForm.getValues();
         const spec: ConnectionSpec = {
-          title: 'GitHub Connection',
+          title: t('provisioning.wizard.default-connection-title', 'GitHub Connection'),
           type: 'github',
           github: { appID, installationID },
         };

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11858,6 +11858,7 @@
       "back-to-connections": "Back to connections",
       "button-save": "Save",
       "button-saving": "Saving...",
+      "default-title": "GitHub Connection",
       "description-app-id": "The ID of your GitHub App",
       "description-installation-id": "The installation ID of your GitHub App",
       "description-private-key": "The private key for your GitHub App in PEM format",
@@ -12354,6 +12355,7 @@
       "button-start": "Begin synchronization",
       "check-status-button": "Check repository status",
       "check-status-message": "Repository connecting, synchronize will be ready soon.",
+      "default-connection-title": "GitHub Connection",
       "discard-modal": {
         "body": "This will delete the repository configuration and you will lose all progress. Are you sure you want to discard your changes?",
         "confirm": "Yes, discard",


### PR DESCRIPTION
## Summary

This PR makes the `title` field mandatory for Connection resources in the provisioning API.

## Changes

1. **Added Title Validation** (`apps/provisioning/pkg/connection/factory.go`)
   - Added validation check in `factory.Validate()` to require non-empty `spec.title` field
   - Returns `field.Required` error if title is missing or empty

2. **Added Unit Tests** (`apps/provisioning/pkg/connection/validator_test.go`)
   - Added test case for connection without title
   - Added test case for connection with empty title
   - Updated all existing test cases to include title field

3. **Fixed Integration Tests** (`pkg/tests/apis/provisioning/`)
   - Updated 35 Connection objects across 4 test files to include mandatory title field:
     - `connection_test.go`: 30 connections
     - `connection_repositories_test.go`: 2 connections
     - `connection_status_auth_test.go`: 1 connection
     - `repository_test.go`: 2 connections

## Testing

- ✅ Unit tests pass: `TestAdmissionValidator_Validate`
- ✅ Integration tests pass: `TestIntegrationProvisioning_ConnectionCRUDL`
- ✅ Integration tests pass: `TestIntegrationProvisioning_ConnectionValidation`

## Related

This change aligns with the spec update in commit b48878c that made title mandatory in the Connection spec.