### PR TITLE
Wrap error in token generation failure

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/connections.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/connections.go
@@ -70,7 +70,7 @@ const (
 
 type ConnectionSpec struct {
 	// The connection display name (shown in the UI)
-	Title string `json:"title,omitempty"`
+	Title string `json:"title"`
 	// The connection description
 	Description string `json:"description,omitempty"`
 	// The connection provider type

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -346,6 +346,7 @@ func schema_pkg_apis_provisioning_v0alpha1_ConnectionSpec(ref common.ReferenceCa
 					"title": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The connection display name (shown in the UI)",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -392,7 +393,7 @@ func schema_pkg_apis_provisioning_v0alpha1_ConnectionSpec(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"type"},
+				Required: []string{"title", "type"},
 			},
 		},
 		Dependencies: []string{

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1478,7 +1478,7 @@ export type ConnectionSpec = {
   /** Gitlab connection configuration Only applicable when provider is "gitlab" */
   gitlab?: GitlabConnectionConfig;
   /** The connection display name (shown in the UI) */
-  title?: string;
+  title: string;
   /** The connection provider type
     
     Possible enum values:

--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -170,14 +170,14 @@ func (s *testConnector) Connect(ctx context.Context, name string, _ runtime.Obje
 							return
 						}
 
-					responder.Error(&k8serrors.StatusError{
-						ErrStatus: metav1.Status{
-							Status:  metav1.StatusFailure,
-							Code:    http.StatusInternalServerError,
-							Reason:  "InternalServerError",
-							Message: fmt.Sprintf("failed to generate repository token from connection: %v", err),
-						},
-					})
+						responder.Error(&k8serrors.StatusError{
+							ErrStatus: metav1.Status{
+								Status:  metav1.StatusFailure,
+								Code:    http.StatusInternalServerError,
+								Reason:  "InternalServerError",
+								Message: fmt.Sprintf("failed to generate repository token from connection: %v", err),
+							},
+						})
 						return
 					}
 

--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -170,14 +170,14 @@ func (s *testConnector) Connect(ctx context.Context, name string, _ runtime.Obje
 							return
 						}
 
-						responder.Error(&k8serrors.StatusError{
-							ErrStatus: metav1.Status{
-								Status:  metav1.StatusFailure,
-								Code:    http.StatusInternalServerError,
-								Reason:  "InternalServerError",
-								Message: "failed to generate repository token from connection",
-							},
-						})
+					responder.Error(&k8serrors.StatusError{
+						ErrStatus: metav1.Status{
+							Status:  metav1.StatusFailure,
+							Code:    http.StatusInternalServerError,
+							Reason:  "InternalServerError",
+							Message: fmt.Sprintf("failed to generate repository token from connection: %v", err),
+						},
+					})
 						return
 					}
 

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -4284,6 +4284,7 @@
       "com.github.grafana.grafana.apps.provisioning.pkg.apis.provisioning.v0alpha1.ConnectionSpec": {
         "type": "object",
         "required": [
+          "title",
           "type"
         ],
         "properties": {
@@ -4317,7 +4318,8 @@
           },
           "title": {
             "description": "The connection display name (shown in the UI)",
-            "type": "string"
+            "type": "string",
+            "default": ""
           },
           "type": {
             "description": "The connection provider type\n\nPossible enum values:\n - `\"bitbucket\"`\n - `\"github\"`\n - `\"gitlab\"`",


### PR DESCRIPTION
Part of https://github.com/grafana/git-ui-sync-project/issues/785
## Summary

This PR wraps the error message when  fails to include the underlying error details, improving debugging capabilities.

## Changes

- Updated error handling in `pkg/registry/apis/provisioning/test.go` (line 178)
- Changed generic error message to include underlying error using `fmt.Sprintf`

## Context

Previously, when token generation failed, the error response only showed:
```
"failed to generate repository token from connection"
```

Now it includes the actual error details:
```
"failed to generate repository token from connection: <actual error>"
```

This makes it easier to diagnose issues when token generation fails.