### PR TITLE
Provisioning: Wrap error in token generation failure

### DIFF
--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -175,7 +175,7 @@ func (s *testConnector) Connect(ctx context.Context, name string, _ runtime.Obje
 								Status:  metav1.StatusFailure,
 								Code:    http.StatusInternalServerError,
 								Reason:  "InternalServerError",
-								Message: "failed to generate repository token from connection",
+								Message: fmt.Sprintf("failed to generate repository token from connection: %v", err),
 							},
 						})
 						return

--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -170,12 +170,13 @@ func (s *testConnector) Connect(ctx context.Context, name string, _ runtime.Obje
 							return
 						}
 
+						wrappedErr := fmt.Errorf("failed to generate repository token from connection: %w", err)
 						responder.Error(&k8serrors.StatusError{
 							ErrStatus: metav1.Status{
 								Status:  metav1.StatusFailure,
 								Code:    http.StatusInternalServerError,
 								Reason:  "InternalServerError",
-								Message: fmt.Sprintf("failed to generate repository token from connection: %v", err),
+								Message: wrappedErr.Error(),
 							},
 						})
 						return

--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -170,13 +170,12 @@ func (s *testConnector) Connect(ctx context.Context, name string, _ runtime.Obje
 							return
 						}
 
-						wrappedErr := fmt.Errorf("failed to generate repository token from connection: %w", err)
 						responder.Error(&k8serrors.StatusError{
 							ErrStatus: metav1.Status{
 								Status:  metav1.StatusFailure,
 								Code:    http.StatusInternalServerError,
 								Reason:  "InternalServerError",
-								Message: wrappedErr.Error(),
+								Message: fmt.Sprintf("failed to generate repository token from connection: %v", err),
 							},
 						})
 						return


### PR DESCRIPTION
Part of https://github.com/grafana/git-ui-sync-project/issues/785

## Summary

This PR wraps the error message when GenerateRepositoryToken fails to include the underlying error details, improving debugging capabilities.

## Changes

- Updated error handling in `pkg/registry/apis/provisioning/test.go` (line 178)
- Changed generic error message to include underlying error using `fmt.Sprintf`

## Context

Previously, when token generation failed, the error response only showed:
```
"failed to generate repository token from connection"
```

Now it includes the actual error details:
```
"failed to generate repository token from connection: <actual error>"
```

This makes it easier to diagnose issues when token generation fails.