### PR TITLE
Provisioning: move token regeneration before hooks and healthchecks

### DIFF
--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -1305,10 +1305,9 @@ func TestIntegrationProvisioning_RepositoryUnhealthyWithValidationErrors(t *test
 
 		tokenError := repo.Status.FieldErrors[0]
 
-		// Verify all fields explicitly - authorization check fails first before branch check
 		assert.Equal(t, metav1.CauseTypeFieldValueInvalid, tokenError.Type, "Type must be FieldValueInvalid")
-		assert.Equal(t, "secure.token", tokenError.Field, "Field must be secure.token")
-		assert.Equal(t, "not authorized", tokenError.Detail, "Detail must be 'not authorized'")
+		assert.Equal(t, "spec.github.branch", tokenError.Field, "Field must be secure.token")
+		assert.Equal(t, "branch not found", tokenError.Detail, "Detail must be 'not authorized'")
 		assert.Empty(t, tokenError.Origin, "Origin must be empty")
 
 		t.Logf("Verified token fieldError: Type=%s, Field=%s, Detail=%s, Origin=%s",

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -1306,8 +1306,8 @@ func TestIntegrationProvisioning_RepositoryUnhealthyWithValidationErrors(t *test
 		tokenError := repo.Status.FieldErrors[0]
 
 		assert.Equal(t, metav1.CauseTypeFieldValueInvalid, tokenError.Type, "Type must be FieldValueInvalid")
-		assert.Equal(t, "spec.github.branch", tokenError.Field, "Field must be secure.token")
-		assert.Equal(t, "branch not found", tokenError.Detail, "Detail must be 'not authorized'")
+		assert.Equal(t, "secure.token", tokenError.Field, "Field must be secure.token")
+		assert.Equal(t, "not authorized", tokenError.Detail, "Detail must be 'not authorized'")
 		assert.Empty(t, tokenError.Origin, "Origin must be empty")
 
 		t.Logf("Verified token fieldError: Type=%s, Field=%s, Detail=%s, Origin=%s",


### PR DESCRIPTION
**What is this feature?**

During repository reconciliation, when the token is not yet generated, the hooks creation will always fail.
This PR fixes such issue, by generating the token first, before hook and healthchecks.

**Why do we need this feature?**

To correctly generate hooks for repositories connected via `Connection`s

**Who is this feature for?**

Users of GitSync

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/784

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
