### PR TITLE
fix: exclude cloud-home-app from preloading

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -99,7 +99,7 @@ import { usePluginComponent } from './features/plugins/extensions/usePluginCompo
 import { usePluginComponents } from './features/plugins/extensions/usePluginComponents';
 import { usePluginFunctions } from './features/plugins/extensions/usePluginFunctions';
 import { usePluginLinks } from './features/plugins/extensions/usePluginLinks';
-import { getAppPluginsToAwait, getAppPluginsToPreload } from './features/plugins/extensions/utils';
+import { getAppPluginsToPreload } from './features/plugins/extensions/utils';
 import { importPanelPlugin, syncGetPanelPlugin } from './features/plugins/importPanelPlugin';
 import { initSystemJSHooks } from './features/plugins/loader/systemjsHooks';
 import { preloadPlugins } from './features/plugins/pluginPreloader';
@@ -257,13 +257,7 @@ export class GrafanaApp {
       const skipAppPluginsPreload =
         config.featureToggles.rendererDisableAppPluginsPreload && contextSrv.user.authenticatedBy === 'render';
       if (contextSrv.user.orgRole !== '' && !skipAppPluginsPreload) {
-        const [appPluginsToAwait, appPluginsToPreload] = await Promise.all([
-          getAppPluginsToAwait(),
-          getAppPluginsToPreload(),
-        ]);
-
-        preloadPlugins(appPluginsToPreload);
-        await preloadPlugins(appPluginsToAwait);
+        preloadPlugins(await getAppPluginsToPreload());
       }
 
       setHelpNavItemHook(useHelpNode);

--- a/public/app/features/plugins/extensions/appUtils.tsx
+++ b/public/app/features/plugins/extensions/appUtils.tsx
@@ -160,7 +160,10 @@ export function getAppPluginsToPreloadSync(apps: AppPluginConfig[]): AppPluginCo
   const awaitedPluginIds = getAppPluginsToAwaitSync(apps).map((app) => app.id);
   const isNotAwaited = (app: AppPluginConfig) => !awaitedPluginIds.includes(app.id);
 
+  // TODO(@MattIPv4): cloud-home-app is deprecated and should not be preloaded
   return apps.filter((app) => {
-    return isNotAwaited(app) && (app.preload || dashboardPanelMenuPluginIds.includes(app.id));
+    return (
+      isNotAwaited(app) && app.id !== 'cloud-home-app' && (app.preload || dashboardPanelMenuPluginIds.includes(app.id))
+    );
   });
 }

--- a/public/app/features/plugins/extensions/appUtils.tsx
+++ b/public/app/features/plugins/extensions/appUtils.tsx
@@ -141,10 +141,7 @@ export function getAppPluginDependenciesSync(
  * @returns A list of app plugins that has to be loaded before core Grafana could finish the initialization.
  */
 export function getAppPluginsToAwaitSync(apps: AppPluginConfig[]): AppPluginConfig[] {
-  const pluginIds = [
-    // The "cloud-home-app" is registering banners once it's loaded, and this can cause a rerender in the AppChrome if it's loaded after the Grafana app init.
-    'cloud-home-app',
-  ];
+  const pluginIds: string[] = [];
 
   return apps.filter((app) => pluginIds.includes(app.id));
 }

--- a/public/app/features/plugins/extensions/appUtils.tsx
+++ b/public/app/features/plugins/extensions/appUtils.tsx
@@ -136,17 +136,6 @@ export function getAppPluginDependenciesSync(
 }
 
 /**
- * Returns a list of app plugins that has to be loaded before core Grafana could finish the initialization.
- * @param apps - The app plugin configs.
- * @returns A list of app plugins that has to be loaded before core Grafana could finish the initialization.
- */
-export function getAppPluginsToAwaitSync(apps: AppPluginConfig[]): AppPluginConfig[] {
-  const pluginIds: string[] = [];
-
-  return apps.filter((app) => pluginIds.includes(app.id));
-}
-
-/**
  * Returns a list of app plugins that has to be preloaded in parallel with the core Grafana initialization.
  * @param apps - The app plugin configs.
  * @returns An array of app plugin configs that has to be preloaded in parallel with the core Grafana initialization.
@@ -157,13 +146,9 @@ export function getAppPluginsToPreloadSync(apps: AppPluginConfig[]): AppPluginCo
     PluginExtensionPoints.DashboardPanelMenu,
     apps
   );
-  const awaitedPluginIds = getAppPluginsToAwaitSync(apps).map((app) => app.id);
-  const isNotAwaited = (app: AppPluginConfig) => !awaitedPluginIds.includes(app.id);
 
   // TODO(@MattIPv4): cloud-home-app is deprecated and should not be preloaded
   return apps.filter((app) => {
-    return (
-      isNotAwaited(app) && app.id !== 'cloud-home-app' && (app.preload || dashboardPanelMenuPluginIds.includes(app.id))
-    );
+    return app.id !== 'cloud-home-app' && (app.preload || dashboardPanelMenuPluginIds.includes(app.id));
   });
 }

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -32,7 +32,6 @@ import { RestrictedGrafanaApisProvider } from '../components/restrictedGrafanaAp
 import { ExtensionErrorBoundary } from './ExtensionErrorBoundary';
 import {
   getAppPluginConfigsSync,
-  getAppPluginsToAwaitSync,
   getAppPluginsToPreloadSync,
   getExposedComponentPluginDependenciesSync,
   getExtensionPointPluginDependenciesSync,
@@ -143,8 +142,8 @@ const getModalWrapper = ({
   const ModalWrapper = ({ onDismiss }: ModalWrapperProps) => {
     return (
       <Modal title={title} className={className} isOpen onDismiss={onDismiss} onClickBackdrop={onDismiss}>
-        {/* 
-          We also add an error boundary here (apart from the one in the `wrapWithPluginContext`) 
+        {/*
+          We also add an error boundary here (apart from the one in the `wrapWithPluginContext`)
           so the error appears inside the modal (and not at the bottom of the page.)
         */}
         <ExtensionErrorBoundary
@@ -661,15 +660,6 @@ export async function getExtensionPointPluginMeta(extensionPointId: string): Pro
 export async function getExposedComponentPluginDependencies(exposedComponentId: string): Promise<string[]> {
   const apps = await getAppPluginMetas();
   return getExposedComponentPluginDependenciesSync(exposedComponentId, apps);
-}
-
-/**
- * Returns a list of app plugins that has to be loaded before core Grafana could finish the initialization.
- * @returns A list of app plugins that has to be loaded before core Grafana could finish the initialization.
- */
-export async function getAppPluginsToAwait(): Promise<AppPluginConfig[]> {
-  const apps = await getAppPluginMetas();
-  return getAppPluginsToAwaitSync(apps);
 }
 
 /**


### PR DESCRIPTION
**What is this feature?**

Removes cloud-home-app from the hard-coded list of plugins that need to be preloaded async. Manually filter it out of the standard preload plugins list as the plugin itself is still marked preload, which can't be changed.

**Why do we need this feature?**

cloud-home-app is on its way out, and should no longer be serving any UI, including the preloading logic it previously had for serving in-app banners. The plugin can no longer be released and so the preload flag cannot be updated, hence needing to manually filter it out of preload here still until the plugin is fully removed.

**Who is this feature for?**

Cloud.

**Which issue(s) does this PR fix?**:

cc https://github.com/grafana/hg-cloud-home-admin/issues/996 (🔐)