### PR TITLE
Dashboards: Query guards on per panel groupBy action

### DIFF
--- a/public/app/features/dashboard-scene/scene/VizPanelHeaderActions.tsx
+++ b/public/app/features/dashboard-scene/scene/VizPanelHeaderActions.tsx
@@ -122,7 +122,7 @@ export function VizPanelHeaderActionsRenderer({ model }: SceneComponentProps<Viz
   const variables = sceneGraph.getVariables(model);
   const groupByVariable = variables.state.variables.find((variable) => variable instanceof GroupByVariable);
   const queryRunner = model.getQueryRunner();
-  const queries = queryRunner?.state.data?.request?.targets ?? [];
+  const queries = queryRunner?.state.queries ?? [];
 
   return (
     <>

--- a/public/app/features/dashboard-scene/scene/panel-actions/PanelGroupByAction/PanelGroupByAction.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-actions/PanelGroupByAction/PanelGroupByAction.tsx
@@ -6,6 +6,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Trans } from '@grafana/i18n';
 import { GroupByVariable, SceneDataQuery, VariableValueOption, VariableValueSingle } from '@grafana/scenes';
 import { Button, Icon, Popover } from '@grafana/ui';
+import { getApplicableGroupByOptions } from 'app/features/dashboard-scene/utils/getApplicableGroupByOptions';
 
 import { PanelGroupByActionPopover } from './PanelGroupByActionPopover';
 
@@ -134,21 +135,4 @@ function getGroupByValue(groupByVariable: GroupByVariable) {
     : groupByVariable.state.value
       ? [groupByVariable.state.value]
       : [];
-}
-
-async function getApplicableGroupByOptions(
-  groupByVariable: GroupByVariable,
-  options: VariableValueOption[],
-  queries: SceneDataQuery[]
-) {
-  if (!queries.length) {
-    return options;
-  }
-
-  const values = options.map((option) => option.value);
-  const applicability = await groupByVariable.getGroupByApplicabilityForQueries(values, queries);
-
-  return applicability?.length
-    ? applicability.filter((item) => item.applicable).map((item) => ({ label: item.key, value: item.key }))
-    : options;
 }

--- a/public/app/features/dashboard-scene/scene/panel-actions/PanelGroupByAction/PanelGroupByAction.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-actions/PanelGroupByAction/PanelGroupByAction.tsx
@@ -141,10 +141,14 @@ async function getApplicableGroupByOptions(
   options: VariableValueOption[],
   queries: SceneDataQuery[]
 ) {
+  if (!queries.length) {
+    return options;
+  }
+
   const values = options.map((option) => option.value);
   const applicability = await groupByVariable.getGroupByApplicabilityForQueries(values, queries);
 
-  return applicability
+  return applicability?.length
     ? applicability.filter((item) => item.applicable).map((item) => ({ label: item.key, value: item.key }))
     : options;
 }

--- a/public/app/features/dashboard-scene/utils/getApplicableGroupByOptions.test.ts
+++ b/public/app/features/dashboard-scene/utils/getApplicableGroupByOptions.test.ts
@@ -1,0 +1,86 @@
+import { GroupByVariable, SceneDataQuery, VariableValueOption } from '@grafana/scenes';
+
+import { getApplicableGroupByOptions } from './getApplicableGroupByOptions';
+
+type GroupByVariableMock = {
+  getGroupByApplicabilityForQueries: jest.MockedFunction<GroupByVariable['getGroupByApplicabilityForQueries']>;
+};
+
+const createGroupByVariableMock = (): GroupByVariableMock => ({
+  getGroupByApplicabilityForQueries: jest.fn() as GroupByVariableMock['getGroupByApplicabilityForQueries'],
+});
+
+const asGroupByVariable = (mock: GroupByVariableMock): GroupByVariable => mock as unknown as GroupByVariable;
+
+describe('getApplicableGroupByOptions', () => {
+  it('returns empty array when options are empty', async () => {
+    const groupByVariable = createGroupByVariableMock();
+    const queries: SceneDataQuery[] = [{ refId: 'A' } as SceneDataQuery];
+
+    const result = await getApplicableGroupByOptions(asGroupByVariable(groupByVariable), [], queries);
+
+    expect(result).toEqual([]);
+    expect(groupByVariable.getGroupByApplicabilityForQueries).not.toHaveBeenCalled();
+  });
+
+  it('returns options when queries are empty', async () => {
+    const groupByVariable = createGroupByVariableMock();
+    const options: VariableValueOption[] = [
+      { label: 'Region', value: 'region' },
+      { label: 'Instance', value: 'instance' },
+    ];
+    const result = await getApplicableGroupByOptions(asGroupByVariable(groupByVariable), options, []);
+
+    expect(result).toBe(options);
+    expect(groupByVariable.getGroupByApplicabilityForQueries).not.toHaveBeenCalled();
+  });
+
+  it('filters options using applicability response', async () => {
+    const groupByVariable = createGroupByVariableMock();
+    const queries: SceneDataQuery[] = [{ refId: 'A' } as SceneDataQuery];
+    const options: VariableValueOption[] = [
+      { label: 'Region', value: 'region' },
+      { label: 'Instance', value: 'instance' },
+    ];
+
+    groupByVariable.getGroupByApplicabilityForQueries.mockResolvedValue([
+      { key: 'region', applicable: true },
+      { key: 'instance', applicable: false },
+    ]);
+
+    const result = await getApplicableGroupByOptions(asGroupByVariable(groupByVariable), options, queries);
+
+    expect(groupByVariable.getGroupByApplicabilityForQueries).toHaveBeenCalledWith(['region', 'instance'], queries);
+    expect(result).toEqual([{ label: 'region', value: 'region' }]);
+  });
+
+  it('returns original options when applicability is empty', async () => {
+    const groupByVariable = createGroupByVariableMock();
+    const queries: SceneDataQuery[] = [{ refId: 'A' } as SceneDataQuery];
+    const options: VariableValueOption[] = [
+      { label: 'Region', value: 'region' },
+      { label: 'Instance', value: 'instance' },
+    ];
+
+    groupByVariable.getGroupByApplicabilityForQueries.mockResolvedValue([]);
+
+    const result = await getApplicableGroupByOptions(asGroupByVariable(groupByVariable), options, queries);
+
+    expect(result).toBe(options);
+  });
+
+  it('returns original options when applicability is undefined', async () => {
+    const groupByVariable = createGroupByVariableMock();
+    const queries: SceneDataQuery[] = [{ refId: 'A' } as SceneDataQuery];
+    const options: VariableValueOption[] = [
+      { label: 'Region', value: 'region' },
+      { label: 'Instance', value: 'instance' },
+    ];
+
+    groupByVariable.getGroupByApplicabilityForQueries.mockResolvedValue(undefined);
+
+    const result = await getApplicableGroupByOptions(asGroupByVariable(groupByVariable), options, queries);
+
+    expect(result).toBe(options);
+  });
+});

--- a/public/app/features/dashboard-scene/utils/getApplicableGroupByOptions.ts
+++ b/public/app/features/dashboard-scene/utils/getApplicableGroupByOptions.ts
@@ -1,0 +1,22 @@
+import { GroupByVariable, SceneDataQuery, VariableValueOption } from '@grafana/scenes';
+
+export async function getApplicableGroupByOptions(
+  groupByVariable: GroupByVariable,
+  options: VariableValueOption[],
+  queries: SceneDataQuery[]
+) {
+  if (!options.length) {
+    return [];
+  }
+
+  if (!queries.length) {
+    return options;
+  }
+
+  const values = options.map((option) => option.value);
+  const applicability = await groupByVariable.getGroupByApplicabilityForQueries(values, queries);
+
+  return applicability?.length
+    ? applicability.filter((item) => item.applicable).map((item) => ({ label: item.key, value: item.key }))
+    : options;
+}


### PR DESCRIPTION
Fetches correct queries from the queryRunner and sets extra guards on the groupBy applicability calculation. Also extracts the function into utils and tests it