### PR TITLE
TeamFolders: Add tracking in New Folder drawer

### DIFF
--- a/public/app/features/browse-dashboards/components/NewFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewFolderForm.tsx
@@ -55,7 +55,7 @@ export function NewFolderForm({ onCancel, onConfirm, parentFolder }: Props) {
       onSubmit={handleSubmit((form) => {
         reportInteraction('grafana_browse_dashboards_page_action_create_folder', {
           teamFolder: !!selectedTeam,
-          teamUid: selectedTeam?.uid ?? 'Not a team folder',
+          teamUid: selectedTeam?.uid,
         });
 
         onConfirm(form.folderName, createTeamFolder && selectedTeam ? [selectedTeam] : []);

--- a/public/app/features/browse-dashboards/components/NewFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewFolderForm.tsx
@@ -55,6 +55,7 @@ export function NewFolderForm({ onCancel, onConfirm, parentFolder }: Props) {
       onSubmit={handleSubmit((form) => {
         reportInteraction('grafana_browse_dashboards_page_action_create_folder', {
           teamFolder: !!selectedTeam,
+          teamUid: selectedTeam?.uid ?? 'Not a team folder',
         });
 
         onConfirm(form.folderName, createTeamFolder && selectedTeam ? [selectedTeam] : []);

--- a/public/app/features/browse-dashboards/components/NewFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewFolderForm.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { Box, Button, Checkbox, Field, Icon, Input, Space, Stack, Text, Tooltip } from '@grafana/ui';
 import { OwnerReference } from 'app/api/clients/folder/v1beta1';
 import { FolderDTO } from 'app/types/folders';
@@ -52,9 +52,13 @@ export function NewFolderForm({ onCancel, onConfirm, parentFolder }: Props) {
   return (
     <form
       name="addFolder"
-      onSubmit={handleSubmit((form) =>
-        onConfirm(form.folderName, createTeamFolder && selectedTeam ? [selectedTeam] : [])
-      )}
+      onSubmit={handleSubmit((form) => {
+        reportInteraction('browse-dashboards-action-new-folder-as-team-folder', {
+          teamFolder: !!selectedTeam,
+        });
+
+        onConfirm(form.folderName, createTeamFolder && selectedTeam ? [selectedTeam] : []);
+      })}
       data-testid={selectors.pages.BrowseDashboards.NewFolderForm.form}
     >
       <Stack gap={1} direction="column">

--- a/public/app/features/browse-dashboards/components/NewFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewFolderForm.tsx
@@ -53,7 +53,7 @@ export function NewFolderForm({ onCancel, onConfirm, parentFolder }: Props) {
     <form
       name="addFolder"
       onSubmit={handleSubmit((form) => {
-        reportInteraction('browse-dashboards-action-new-folder-as-team-folder', {
+        reportInteraction('grafana_browse_dashboards_page_action_create_folder', {
           teamFolder: !!selectedTeam,
         });
 


### PR DESCRIPTION
**What is this feature?**
I'm adding a tracking event for Team Folders feature
- `grafana_browse_dashboards_page_action_create_folder`: when a user creates a new folder, payload contains a prop to highlight whether the folder is assigned to an owner (boolean) 

**Which issue(s) does this PR fix?**:
Contributes to #115237

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
