### PR TITLE
Provisioning: generate token on the fly in connection tester

### DIFF
--- a/apps/provisioning/pkg/connection/github/connection.go
+++ b/apps/provisioning/pkg/connection/github/connection.go
@@ -51,41 +51,68 @@ const (
 
 // Test validates the appID and installationID against the given github token.
 func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error) {
-	claims, err := parseJWTToken(c.secrets.Token, c.secrets.PrivateKey)
-	if err != nil {
-		// Error parsing JWT token means the given private key is invalid
-		return &provisioning.TestResults{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: provisioning.APIVERSION,
-				Kind:       "TestResults",
-			},
-			Code:    http.StatusUnauthorized,
-			Success: false,
-			Errors: []provisioning.ErrorDetails{
-				{
-					Type:   metav1.CauseTypeFieldValueInvalid,
-					Field:  field.NewPath("secure", "privateKey").String(),
-					Detail: "invalid private key",
+	if c.obj.Secure.Token.IsZero() {
+		// In case the token is not generated, we create one on the fly
+		// to testing that the other fields are valid.
+		token, err := GenerateJWTToken(c.obj.Spec.GitHub.AppID, c.secrets.PrivateKey)
+		if err != nil {
+			// Error generating JWT token means the privateKey is not valid.
+			return &provisioning.TestResults{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: provisioning.APIVERSION,
+					Kind:       "TestResults",
 				},
-			},
-		}, nil
-	}
-	if claims.Issuer != c.obj.Spec.GitHub.AppID {
-		return &provisioning.TestResults{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: provisioning.APIVERSION,
-				Kind:       "TestResults",
-			},
-			Code:    http.StatusUnauthorized,
-			Success: false,
-			Errors: []provisioning.ErrorDetails{
-				{
-					Type:   metav1.CauseTypeFieldValueInvalid,
-					Field:  field.NewPath("spec", "github", "appID").String(),
-					Detail: fmt.Sprintf("invalid app ID: %s", c.obj.Spec.GitHub.AppID),
+				Code:    http.StatusUnauthorized,
+				Success: false,
+				Errors: []provisioning.ErrorDetails{
+					{
+						Type:   metav1.CauseTypeFieldValueInvalid,
+						Field:  field.NewPath("secure", "privateKey").String(),
+						Detail: "invalid private key",
+					},
 				},
-			},
-		}, nil
+			}, nil
+		}
+		c.obj.Secure.Token.Create = token
+		c.secrets.Token = token
+	} else {
+		// In case the token is there, we verify it's correct.
+		claims, err := parseJWTToken(c.secrets.Token, c.secrets.PrivateKey)
+		if err != nil {
+			// Error parsing JWT token means the given private key is invalid
+			return &provisioning.TestResults{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: provisioning.APIVERSION,
+					Kind:       "TestResults",
+				},
+				Code:    http.StatusUnauthorized,
+				Success: false,
+				Errors: []provisioning.ErrorDetails{
+					{
+						Type:   metav1.CauseTypeFieldValueInvalid,
+						Field:  field.NewPath("secure", "privateKey").String(),
+						Detail: "invalid private key",
+					},
+				},
+			}, nil
+		}
+		if claims.Issuer != c.obj.Spec.GitHub.AppID {
+			return &provisioning.TestResults{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: provisioning.APIVERSION,
+					Kind:       "TestResults",
+				},
+				Code:    http.StatusUnauthorized,
+				Success: false,
+				Errors: []provisioning.ErrorDetails{
+					{
+						Type:   metav1.CauseTypeFieldValueInvalid,
+						Field:  field.NewPath("spec", "github", "appID").String(),
+						Detail: fmt.Sprintf("invalid app ID: %s", c.obj.Spec.GitHub.AppID),
+					},
+				},
+			}, nil
+		}
 	}
 
 	ghClient := c.ghFactory.New(ctx, c.secrets.Token)

--- a/apps/provisioning/pkg/connection/github/connection.go
+++ b/apps/provisioning/pkg/connection/github/connection.go
@@ -51,7 +51,7 @@ const (
 
 // Test validates the appID and installationID against the given github token.
 func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error) {
-	if c.obj.Secure.Token.IsZero() {
+	if c.secrets.Token.IsZero() {
 		// In case the token is not generated, we create one on the fly
 		// to testing that the other fields are valid.
 		token, err := GenerateJWTToken(c.obj.Spec.GitHub.AppID, c.secrets.PrivateKey)


### PR DESCRIPTION
**What is this feature?**

Generating the Connection JWT token on the fly in its tester

**Why do we need this feature?**

The `POST` with `dryRun=all` currently fails. That's because we don't have generated a token yet for that - this PR fixes it by generating such token on the fly.

**Who is this feature for?**

Users of GitSync.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/789

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
