### PR TITLE
Dashboards: Add support for fieldMinMax in FieldConfig

### DIFF
--- a/apps/dashboard/pkg/apis/dashboard/v0alpha1/dashboard_kind.cue
+++ b/apps/dashboard/pkg/apis/dashboard/v0alpha1/dashboard_kind.cue
@@ -801,6 +801,11 @@ lineage: schemas: [{
 			// The maximum value used in percentage threshold calculations. Leave blank for auto calculation based on all series and fields.
 			max?: number @grafanamaturity(NeedsExpertReview)
 
+      // By default, the calculated Min and Max are based on the minimum and maximum of all series and fields. 
+			// When you enable Field min/max, Grafana calculates the min or max of each field individually, 
+			// based on the minimum or maximum value of the field.
+			fieldMinMax: bool @grafanamaturity(NeedsExpertReview)
+
 			// Convert input values into a display string
 			mappings?: [...#ValueMapping] @grafanamaturity(NeedsExpertReview)
 

--- a/apps/dashboard/pkg/apis/dashboard/v1beta1/dashboard_kind.cue
+++ b/apps/dashboard/pkg/apis/dashboard/v1beta1/dashboard_kind.cue
@@ -801,6 +801,11 @@ lineage: schemas: [{
 			// The maximum value used in percentage threshold calculations. Leave blank for auto calculation based on all series and fields.
 			max?: number @grafanamaturity(NeedsExpertReview)
 
+      // By default, the calculated Min and Max are based on the minimum and maximum of all series and fields. 
+			// When you enable Field min/max, Grafana calculates the min or max of each field individually, 
+			// based on the minimum or maximum value of the field.
+			fieldMinMax: bool @grafanamaturity(NeedsExpertReview)
+
 			// Convert input values into a display string
 			mappings?: [...#ValueMapping] @grafanamaturity(NeedsExpertReview)
 

--- a/kinds/dashboard/dashboard_kind.cue
+++ b/kinds/dashboard/dashboard_kind.cue
@@ -797,6 +797,11 @@ lineage: schemas: [{
 			// The maximum value used in percentage threshold calculations. Leave blank for auto calculation based on all series and fields.
 			max?: number @grafanamaturity(NeedsExpertReview)
 
+      // By default, the calculated Min and Max are based on the minimum and maximum of all series and fields. 
+			// When you enable Field min/max, Grafana calculates the min or max of each field individually, 
+			// based on the minimum or maximum value of the field.
+			fieldMinMax: bool @grafanamaturity(NeedsExpertReview)
+
 			// Convert input values into a display string
 			mappings?: [...#ValueMapping] @grafanamaturity(NeedsExpertReview)
 

--- a/packages/grafana-schema/src/raw/dashboard/x/dashboard_types.gen.ts
+++ b/packages/grafana-schema/src/raw/dashboard/x/dashboard_types.gen.ts
@@ -1077,6 +1077,12 @@ export interface FieldConfig {
    */
   displayNameFromDS?: string;
   /**
+   * By default, the calculated Min and Max are based on the minimum and maximum of all series and fields.
+   * When you enable Field min/max, Grafana calculates the min or max of each field individually,
+   * based on the minimum or maximum value of the field.
+   */
+  fieldMinMax: boolean;
+  /**
    * True if data source field supports ad-hoc filters
    */
   filterable?: boolean;

--- a/pkg/kinds/dashboard/dashboard_spec_gen.go
+++ b/pkg/kinds/dashboard/dashboard_spec_gen.go
@@ -426,6 +426,10 @@ type FieldConfig struct {
 	Min *float64 `json:"min,omitempty"`
 	// The maximum value used in percentage threshold calculations. Leave blank for auto calculation based on all series and fields.
 	Max *float64 `json:"max,omitempty"`
+	// By default, the calculated Min and Max are based on the minimum and maximum of all series and fields.
+	// When you enable Field min/max, Grafana calculates the min or max of each field individually,
+	// based on the minimum or maximum value of the field.
+	FieldMinMax bool `json:"fieldMinMax"`
 	// Convert input values into a display string
 	Mappings []ValueMapping `json:"mappings,omitempty"`
 	// Map numeric values to states


### PR DESCRIPTION
Right now when utilizing the grafana-sdk many of our pre-configured panels do not work against the sdk because fieldMinMax is not available. This adds that field.

> By default, the calculated Min and Max are based on the minimum and maximum of all series and fields. When you enable Field min/max, Grafana calculates the min or max of each field individually, based on the minimum or maximum value of the field.

Per the official Grafana documentation: https://grafana.com/docs/grafana/latest/visualizations/panels-visualizations/configure-standard-options/#field-minmax

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This adds the field `fieldMinMax` to `FieldConfig` which will allow users to toggle whether their fields are ordered or not. This is already an officially supported field in Grafana, this just makes it available for downstream libraries that rely on generated configs. 

**Why do we need this feature?**

Currently when we attempt to create Panels that include `fieldMinMax` in their config, those panels fail to be created because this field is not presently supported even though it is an officially supported feature per the Grafana documentation.

**Who is this feature for?**

All users of generated configs from Grafana. This specifically came up in the grafana-foundation-sdk: https://github.com/grafana/grafana-foundation-sdk/issues/957

**Which issue(s) does this PR fix?**:

Currently when we attempt to create Panels that include `fieldMinMax` in their config, those panels fail to be created because this field is not presently supported even though it is an officially supported feature per the Grafana documentation.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
