### PR TITLE
FieldOverrides: Fix array merge order so overrides take precedence over defaults

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -1035,9 +1035,9 @@ describe('setDynamicConfigValue', () => {
     );
 
     expect(config.mappings).toHaveLength(3);
-    expect(config.mappings![0]).toEqual({ type: MappingType.ValueToText, options: { existing: { text: 'existing' } } });
+    expect(config.mappings![0]).toEqual({ type: MappingType.ValueToText, options: { second: { text: 'second' } } });
     expect(config.mappings![1]).toEqual({ type: MappingType.ValueToText, options: { first: { text: 'first' } } });
-    expect(config.mappings![2]).toEqual({ type: MappingType.ValueToText, options: { second: { text: 'second' } } });
+    expect(config.mappings![2]).toEqual({ type: MappingType.ValueToText, options: { existing: { text: 'existing' } } });
   });
 });
 

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -353,11 +353,12 @@ export function setDynamicConfigValue(config: FieldConfig, value: DynamicConfigV
     }
   } else {
     // Merge arrays (e.g. mappings) when multiple overrides target the same field
+    // Override values come first so they take precedence (first match wins in getValueMappingResult)
     if (Array.isArray(val)) {
       const existingValue = item.isCustom ? get(config.custom, item.path) : get(config, item.path);
 
       if (Array.isArray(existingValue)) {
-        val = [...existingValue, ...val];
+        val = [...val, ...existingValue];
       }
     }
 


### PR DESCRIPTION
**What is this feature?**

Fixes the array merge order in setDynamicConfigValue from `[...existingValue, ...val]` to `[...val, ...existingValue]`

**Why do we need this feature?**

Value mappings in overrides were being ignored because defaults came first in the merged array. Since `getValueMappingResult` returns on first match, defaults always won. 

**Which issue(s) does this PR fix?**:

Fixes #116980
