### PR TITLE
Unified Storage: Adds search client to be used by storage-api

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -624,6 +624,7 @@ type Cfg struct {
 	HttpsSkipVerify                            bool
 	ResourceServerJoinRingTimeout              time.Duration
 	EnableSearch                               bool
+	EnableSearchClient                         bool
 	OverridesFilePath                          string
 	OverridesReloadInterval                    time.Duration
 	EnableSQLKVBackend                         bool

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -85,6 +85,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 		cfg.Logger.Info("Unified migration configs enforcement disabled", "storage_type", cfg.UnifiedStorageType(), "disable_data_migrations", cfg.DisableDataMigrations)
 	}
 	cfg.EnableSearch = section.Key("enable_search").MustBool(false)
+	cfg.EnableSearchClient = section.Key("enable_search_client").MustBool(false)
 	cfg.MaxPageSizeBytes = section.Key("max_page_size_bytes").MustInt(0)
 	cfg.IndexPath = section.Key("index_path").String()
 	cfg.IndexWorkers = section.Key("index_workers").MustInt(10)

--- a/pkg/storage/unified/client_test.go
+++ b/pkg/storage/unified/client_test.go
@@ -121,7 +121,7 @@ func TestNewSearchClient(t *testing.T) {
 		cfg.EnableSearchClient = true
 		cfg.Raw.Section("grafana-apiserver").Key("search_server_address").SetValue("localhost:12345")
 
-		client, err := NewSearchClient(cfg, featuremgmt.WithFeatures())
+		client, err := NewStorageApiSearchClient(cfg, featuremgmt.WithFeatures())
 		require.NoError(t, err)
 		require.NotNil(t, client)
 	})

--- a/pkg/storage/unified/client_test.go
+++ b/pkg/storage/unified/client_test.go
@@ -98,6 +98,35 @@ func TestUnifiedStorageClient(t *testing.T) {
 	})
 }
 
+func TestNewSearchClient(t *testing.T) {
+	t.Run("new search client fails when address is empty", func(t *testing.T) {
+		cfg := setting.NewCfg()
+
+		_, err := NewSearchClient(cfg, featuremgmt.WithFeatures())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "search_server_address")
+	})
+
+	t.Run("returns nil when creating storage api search client when EnableSearchClient is false", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		cfg.EnableSearchClient = false
+
+		client, err := NewStorageApiSearchClient(cfg, featuremgmt.WithFeatures())
+		require.NoError(t, err)
+		require.Nil(t, client)
+	})
+
+	t.Run("new search client succeeds when address is provided", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		cfg.EnableSearchClient = true
+		cfg.Raw.Section("grafana-apiserver").Key("search_server_address").SetValue("localhost:12345")
+
+		client, err := NewSearchClient(cfg, featuremgmt.WithFeatures())
+		require.NoError(t, err)
+		require.NotNil(t, client)
+	})
+}
+
 func testCallAllMethods(client resource.ResourceClient) {
 	_, _ = client.Read(identity.WithServiceIdentityContext(context.Background(), 1), &resourcepb.ReadRequest{})
 	_, _ = client.Create(identity.WithServiceIdentityContext(context.Background(), 1), &resourcepb.CreateRequest{})

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -229,6 +229,9 @@ type ResourceServerOptions struct {
 	// Search options
 	Search SearchOptions
 
+	// Search client for the storage api
+	SearchClient resourcepb.ResourceIndexClient
+
 	// Quota service
 	OverridesService *OverridesService
 

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
 
@@ -41,6 +42,7 @@ type ServerOptions struct {
 	Reg              prometheus.Registerer
 	AccessClient     types.AccessClient
 	SearchOptions    resource.SearchOptions
+	SearchClient     resourcepb.ResourceIndexClient
 	StorageMetrics   *resource.StorageMetrics
 	IndexMetrics     *resource.BleveIndexMetrics
 	Features         featuremgmt.FeatureToggles
@@ -174,6 +176,7 @@ func NewResourceServer(opts ServerOptions) (resource.ResourceServer, error) {
 		}
 	}
 
+	serverOptions.SearchClient = opts.SearchClient
 	serverOptions.Search = opts.SearchOptions
 	serverOptions.IndexMetrics = opts.IndexMetrics
 	serverOptions.QOSQueue = opts.QOSQueue

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -59,6 +59,7 @@ type service struct {
 	hasSubservices     bool
 
 	backend       resource.StorageBackend
+	searchClient  resourcepb.ResourceIndexClient
 	serverStopper resource.ResourceServerStopper
 	cfg           *setting.Cfg
 	features      featuremgmt.FeatureToggles
@@ -97,6 +98,7 @@ func ProvideUnifiedStorageGrpcService(
 	memberlistKVConfig kv.Config,
 	httpServerRouter *mux.Router,
 	backend resource.StorageBackend,
+	searchClient resourcepb.ResourceIndexClient,
 ) (UnifiedStorageGrpcService, error) {
 	var err error
 	tracer := otel.Tracer("unified-storage")
@@ -121,6 +123,7 @@ func ProvideUnifiedStorageGrpcService(
 		storageMetrics:     storageMetrics,
 		indexMetrics:       indexMetrics,
 		searchRing:         searchRing,
+		searchClient:       searchClient,
 		subservicesWatcher: services.NewFailureWatcher(),
 	}
 
@@ -270,6 +273,7 @@ func (s *service) starting(ctx context.Context) error {
 		Reg:            s.reg,
 		AccessClient:   authzClient,
 		SearchOptions:  searchOptions,
+		SearchClient:   s.searchClient,
 		StorageMetrics: s.storageMetrics,
 		IndexMetrics:   s.indexMetrics,
 		Features:       s.features,

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -198,7 +198,7 @@ func TestClientServer(t *testing.T) {
 
 	features := featuremgmt.WithFeatures()
 
-	svc, err := sql.ProvideUnifiedStorageGrpcService(cfg, features, dbstore, nil, prometheus.NewPedanticRegistry(), nil, nil, nil, nil, kv.Config{}, nil, nil)
+	svc, err := sql.ProvideUnifiedStorageGrpcService(cfg, features, dbstore, nil, prometheus.NewPedanticRegistry(), nil, nil, nil, nil, kv.Config{}, nil, nil, nil)
 	require.NoError(t, err)
 	var client resourcepb.ResourceStoreClient
 

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -137,7 +137,7 @@ func StartGrafanaEnvWithDB(t *testing.T, grafDir, cfgPath string) (string, *serv
 	var storage sql.UnifiedStorageGrpcService
 	if runstore {
 		storage, err = sql.ProvideUnifiedStorageGrpcService(env.Cfg, env.FeatureToggles, env.SQLStore,
-			env.Cfg.Logger, prometheus.NewPedanticRegistry(), nil, nil, nil, nil, kv.Config{}, nil, nil)
+			env.Cfg.Logger, prometheus.NewPedanticRegistry(), nil, nil, nil, nil, kv.Config{}, nil, nil, nil)
 		require.NoError(t, err)
 		ctx := context.Background()
 		err = storage.StartAsync(ctx)


### PR DESCRIPTION
Adds unified storage config `enable_search_client`. If enabled, it will attempt to create a grpc search client using the `search_server_address` under the `[grafana-apiserver]` section.

The search client isn't included for the single-binary which is fine I think.