### PR TITLE
Snapshots MT: Update k8s client to fetch dashboard data

### DIFF
--- a/public/app/features/dashboard/services/SnapshotSrv.ts
+++ b/public/app/features/dashboard/services/SnapshotSrv.ts
@@ -1,8 +1,8 @@
-import { lastValueFrom, map } from 'rxjs';
+import { lastValueFrom } from 'rxjs';
 
-import { config, getBackendSrv, FetchResponse } from '@grafana/runtime';
+import { config, getBackendSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
-import { DashboardDTO, SnapshotSpec } from 'app/types/dashboard';
+import { DashboardDataDTO, DashboardDTO } from 'app/types/dashboard';
 
 import { getAPINamespace } from '../../../api/utils';
 
@@ -82,11 +82,12 @@ interface DashboardSnapshotList {
   items: K8sSnapshotResource[];
 }
 
-interface K8sDashboardSnapshot {
+// Response from the /dashboard subresource - returns a Dashboard with raw dashboard data in spec
+interface K8sDashboardSubresource {
   apiVersion: string;
-  kind: 'Snapshot';
+  kind: 'Dashboard';
   metadata: K8sMetadata;
-  spec: SnapshotSpec;
+  spec: DashboardDataDTO;
 }
 
 class K8sAPI implements DashboardSnapshotSrv {
@@ -128,32 +129,45 @@ class K8sAPI implements DashboardSnapshotSrv {
       const token = `??? TODO, get anon token for snapshots (${contextSrv.user?.name}) ???`;
       headers['Authorization'] = `Bearer ${token}`;
     }
-    return lastValueFrom(
-      getBackendSrv()
-        .fetch<K8sDashboardSnapshot>({
+
+    // Fetch both snapshot metadata and dashboard content in parallel
+    const [snapshotResponse, dashboardResponse] = await Promise.all([
+      lastValueFrom(
+        getBackendSrv().fetch<K8sSnapshotResource>({
           url: this.url + '/' + uid,
           method: 'GET',
           headers: headers,
         })
-        .pipe(
-          map((response: FetchResponse<K8sDashboardSnapshot>) => {
-            return {
-              dashboard: response.data.spec.dashboard,
-              meta: {
-                isSnapshot: true,
-                canSave: false,
-                canEdit: false,
-                canAdmin: false,
-                canStar: false,
-                canShare: false,
-                canDelete: false,
-                isFolder: false,
-                provisioned: false,
-              },
-            };
-          })
-        )
-    );
+      ),
+      lastValueFrom(
+        getBackendSrv().fetch<K8sDashboardSubresource>({
+          url: this.url + '/' + uid + '/dashboard',
+          method: 'GET',
+          headers: headers,
+        })
+      ),
+    ]);
+
+    const snapshot = snapshotResponse.data;
+    const dashboard = dashboardResponse.data;
+
+    return {
+      dashboard: dashboard.spec,
+      meta: {
+        isSnapshot: true,
+        canSave: false,
+        canEdit: false,
+        canAdmin: false,
+        canStar: false,
+        canShare: false,
+        canDelete: false,
+        isFolder: false,
+        provisioned: false,
+        created: snapshot.metadata.creationTimestamp,
+        expires: snapshot.spec.expires?.toString(),
+        k8s: snapshot.metadata,
+      },
+    };
   }
 }
 

--- a/public/app/features/dashboard/services/SnapshotSrv.ts
+++ b/public/app/features/dashboard/services/SnapshotSrv.ts
@@ -148,24 +148,11 @@ class K8sAPI implements DashboardSnapshotSrv {
       ),
     ]);
 
-    const snapshot = snapshotResponse.data;
-    const dashboard = dashboardResponse.data;
-
     return {
-      dashboard: dashboard.spec,
+      dashboard: dashboardResponse.data.spec,
       meta: {
         isSnapshot: true,
-        canSave: false,
-        canEdit: false,
-        canAdmin: false,
-        canStar: false,
-        canShare: false,
-        canDelete: false,
-        isFolder: false,
-        provisioned: false,
-        created: snapshot.metadata.creationTimestamp,
-        expires: snapshot.spec.expires?.toString(),
-        k8s: snapshot.metadata,
+        k8s: snapshotResponse.data.metadata,
       },
     };
   }


### PR DESCRIPTION
**What is this feature?**

Update the K8s snapshot API client to fetch dashboard data from the
new /dashboard subresource endpoint instead of embedding it directly
in the snapshot spec. This provides better separation of concerns
and aligns with the updated API design.

Changes:
- Replace K8sDashboardSnapshot with K8sDashboardSubresource interface
- Update getSnapshot to fetch both snapshot metadata and dashboard in parallel
- Add metadata fields (created, expires, k8s) to the returned dashboard meta
- Update imports to use DashboardDataDTO type

This change only applies when enabling flag `kubernetesSnapshots`
Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
