### PR TITLE
Alerting: Use canUse instead of provenance to filter out time intervals

### DIFF
--- a/public/app/features/alerting/unified/components/alertmanager-entities/MuteTimingsSelector.test.tsx
+++ b/public/app/features/alerting/unified/components/alertmanager-entities/MuteTimingsSelector.test.tsx
@@ -132,7 +132,7 @@ describe('MuteTimingsSelector', () => {
     expect(screen.queryByText('imported-2')).not.toBeInTheDocument();
   });
 
-  it('should not filter out intervals with missing canUse annotation', async () => {
+  it('should filter out intervals with missing canUse annotation', async () => {
     const user = userEvent.setup();
     // Manually create intervals without canUse annotation
     const listMuteTimingsPath = listNamespacedTimeIntervalHandler().info.path;
@@ -179,6 +179,6 @@ describe('MuteTimingsSelector', () => {
 
     // Only interval with canUse: 'true' should be visible
     expect(await screen.findByText('interval-with-canuse')).toBeInTheDocument();
-    expect(await screen.findByText('interval-without-canuse')).toBeInTheDocument();
+    expect(screen.queryByText('interval-without-canuse')).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/alerting/unified/components/alertmanager-entities/MuteTimingsSelector.tsx
+++ b/public/app/features/alerting/unified/components/alertmanager-entities/MuteTimingsSelector.tsx
@@ -15,7 +15,7 @@ const mapTimeInterval = ({ name, time_intervals }: MuteTiming): SelectableValue<
 /** Check if a time interval can be used in routes and rules */
 const isUsableTimeInterval = (timing: MuteTiming): boolean => {
   const canUse = timing.metadata?.annotations?.[K8sAnnotations.CanUse];
-  return canUse !== 'false';
+  return canUse === 'true';
 };
 
 /** Provides a MultiSelect with available time intervals for the given alertmanager */

--- a/public/app/features/alerting/unified/components/alertmanager-entities/MuteTimingsSelector.tsx
+++ b/public/app/features/alerting/unified/components/alertmanager-entities/MuteTimingsSelector.tsx
@@ -25,7 +25,7 @@ const TimeIntervalSelector = ({
 }: BaseAlertmanagerArgs & { selectProps: MultiSelectCommonProps<string> }) => {
   const { data } = useMuteTimings({ alertmanager, skip: selectProps.disabled });
 
-  // Filter to only show usable time intervals (canUse !== 'false')
+  // Filter to only show usable time intervals (canUse === 'true')
   const availableTimings = data?.filter(isUsableTimeInterval) || [];
   const timeIntervalOptions = availableTimings.map((value) => mapTimeInterval(value));
 

--- a/public/app/features/alerting/unified/mocks/server/handlers/k8s/timeIntervals.k8s.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/k8s/timeIntervals.k8s.ts
@@ -23,6 +23,7 @@ const allTimeIntervals = getK8sResponse<ComGithubGrafanaGrafanaPkgApisAlertingNo
       metadata: {
         annotations: {
           [K8sAnnotations.Provenance]: KnownProvenance.None,
+          [K8sAnnotations.CanUse]: 'true',
         },
         name: base64UrlEncode(TIME_INTERVAL_NAME_HAPPY_PATH),
         uid: TIME_INTERVAL_UID_HAPPY_PATH,
@@ -35,6 +36,7 @@ const allTimeIntervals = getK8sResponse<ComGithubGrafanaGrafanaPkgApisAlertingNo
       metadata: {
         annotations: {
           [K8sAnnotations.Provenance]: 'file',
+          [K8sAnnotations.CanUse]: 'true',
         },
         name: base64UrlEncode(TIME_INTERVAL_NAME_FILE_PROVISIONED),
         uid: TIME_INTERVAL_UID_FILE_PROVISIONED,


### PR DESCRIPTION
**What is this feature?**

This PR updates the logic used to filter imported time intervals in the time intervals select component, using the `grafana.com/canUse` annotation instead of the `grafana.com/provenance`.
Both annotations are indicators of imported state so no visual changes should be observed when testing this feature.

**Why do we need this feature?**

We already use the canUse annotation to filter contact points in the UI, so we are standardizing the way we filter those resources. 

**Who is this feature for?**

Alerting users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1381

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
