### PR TITLE
Dashboard: Make legend colors and link rows keyboard accessible

### DIFF
--- a/packages/grafana-ui/src/components/VizLegend/SeriesIcon.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/SeriesIcon.tsx
@@ -12,6 +12,7 @@ export interface Props extends React.HTMLAttributes<HTMLDivElement> {
   gradient?: string;
   lineStyle?: LineStyle;
   noMargin?: boolean;
+  tabIndex?: number;
 }
 
 export const SeriesIcon = React.memo(

--- a/packages/grafana-ui/src/components/VizLegend/SeriesIcon.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/SeriesIcon.tsx
@@ -12,7 +12,6 @@ export interface Props extends React.HTMLAttributes<HTMLDivElement> {
   gradient?: string;
   lineStyle?: LineStyle;
   noMargin?: boolean;
-  tabIndex?: number;
 }
 
 export const SeriesIcon = React.memo(

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendSeriesIcon.test.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendSeriesIcon.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+
+import { EventBusSrv } from '@grafana/data';
+
+import { PanelContextProvider } from '../PanelChrome';
+
+import { VizLegendSeriesIcon } from './VizLegendSeriesIcon';
+
+describe('VizLegendSeriesIcon', () => {
+  const mockOnSeriesColorChange = jest.fn();
+
+  const mockPanelContext = {
+    eventsScope: 'global',
+    eventBus: new EventBusSrv(),
+    onSeriesColorChange: mockOnSeriesColorChange,
+  };
+
+  describe('keyboard accessibility', () => {
+    it('should render a focusable icon with tabIndex when editable', () => {
+      render(
+        <PanelContextProvider value={mockPanelContext}>
+          <VizLegendSeriesIcon seriesName="test-series" color="blue" />
+        </PanelContextProvider>
+      );
+
+      const icon = screen.getByTestId('series-icon');
+      expect(icon).toHaveAttribute('tabindex', '0');
+    });
+
+    it('should not have tabIndex when readonly', () => {
+      render(<VizLegendSeriesIcon seriesName="test-series" color="blue" readonly={true} />);
+
+      const icon = screen.getByTestId('series-icon');
+      expect(icon).not.toHaveAttribute('tabindex');
+    });
+  });
+});

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendSeriesIcon.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendSeriesIcon.tsx
@@ -40,6 +40,7 @@ export const VizLegendSeriesIcon = memo(({ seriesName, color, gradient, readonly
           return (
             <SeriesIcon
               tabIndex={0}
+              role="button"
               color={color}
               className="pointer"
               ref={ref}

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendSeriesIcon.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendSeriesIcon.tsx
@@ -30,16 +30,26 @@ export const VizLegendSeriesIcon = memo(({ seriesName, color, gradient, readonly
   if (seriesName && onSeriesColorChange && color && !readonly) {
     return (
       <SeriesColorPicker color={color} onChange={onChange} enableNamedColors>
-        {({ ref, showColorPicker, hideColorPicker }) => (
-          <SeriesIcon
-            color={color}
-            className="pointer"
-            ref={ref}
-            onClick={showColorPicker}
-            onMouseLeave={hideColorPicker}
-            lineStyle={lineStyle}
-          />
-        )}
+        {({ ref, showColorPicker, hideColorPicker }) => {
+          function handleKeyDown(e: React.KeyboardEvent<HTMLSpanElement>) {
+            if (e.key === ' ' || e.key === 'Enter') {
+              e.preventDefault();
+              showColorPicker();
+            }
+          }
+          return (
+            <SeriesIcon
+              tabIndex={0}
+              color={color}
+              className="pointer"
+              ref={ref}
+              onClick={showColorPicker}
+              onKeyDown={handleKeyDown}
+              onMouseLeave={hideColorPicker}
+              lineStyle={lineStyle}
+            />
+          );
+        }}
       </SeriesColorPicker>
     );
   }

--- a/public/app/features/dashboard-scene/settings/links/DashboardLinkList.test.tsx
+++ b/public/app/features/dashboard-scene/settings/links/DashboardLinkList.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { DashboardLink } from '@grafana/schema';
+
+import { DashboardLinkList } from './DashboardLinkList';
+
+function setup(jsx: JSX.Element) {
+  return {
+    user: userEvent.setup(),
+    ...render(jsx),
+  };
+}
+
+const createMockLink = (overrides: Partial<DashboardLink> = {}): DashboardLink => ({
+  title: 'Test Link',
+  type: 'link',
+  url: 'https://example.com',
+  icon: 'external link',
+  tags: [],
+  asDropdown: false,
+  targetBlank: false,
+  includeVars: false,
+  keepTime: false,
+  tooltip: '',
+  ...overrides,
+});
+
+describe('DashboardLinkList', () => {
+  const mockOnNew = jest.fn();
+  const mockOnEdit = jest.fn();
+  const mockOnDuplicate = jest.fn();
+  const mockOnDelete = jest.fn();
+  const mockOnOrderChange = jest.fn();
+
+  const defaultProps = {
+    onNew: mockOnNew,
+    onEdit: mockOnEdit,
+    onDuplicate: mockOnDuplicate,
+    onDelete: mockOnDelete,
+    onOrderChange: mockOnOrderChange,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('keyboard accessibility', () => {
+    it('should have focusable rows with tabIndex', () => {
+      const links = [createMockLink({ title: 'Test Link' })];
+      render(<DashboardLinkList {...defaultProps} links={links} />);
+
+      const rows = screen.getAllByRole('row');
+      const dataRow = rows[1]; // First row is header
+      expect(dataRow).toHaveAttribute('tabindex', '0');
+    });
+
+    it('should call onEdit when Enter key is pressed on a focused row', async () => {
+      const links = [createMockLink({ title: 'Test Link' })];
+      const { user } = setup(<DashboardLinkList {...defaultProps} links={links} />);
+
+      const rows = screen.getAllByRole('row');
+      rows[1].focus();
+      await user.keyboard('{Enter}');
+
+      expect(mockOnEdit).toHaveBeenCalledWith(0);
+    });
+
+    it('should call onEdit when Space key is pressed on a focused row', async () => {
+      const links = [createMockLink({ title: 'Test Link' })];
+      const { user } = setup(<DashboardLinkList {...defaultProps} links={links} />);
+
+      const rows = screen.getAllByRole('row');
+      rows[1].focus();
+      await user.keyboard(' ');
+
+      expect(mockOnEdit).toHaveBeenCalledWith(0);
+    });
+
+    it('should not call onEdit when button inside the row is clicked', async () => {
+      const links = [createMockLink({ title: 'Link 1' }), createMockLink({ title: 'Link 2' })];
+      const { user } = setup(<DashboardLinkList {...defaultProps} links={links} />);
+
+      // Click a button inside the row - should NOT trigger row's onEdit
+      const copyButtons = screen.getAllByRole('button', { name: 'Copy link' });
+      await user.click(copyButtons[0]);
+
+      expect(mockOnEdit).not.toHaveBeenCalled();
+      expect(mockOnDuplicate).toHaveBeenCalled();
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/settings/links/DashboardLinkList.tsx
+++ b/public/app/features/dashboard-scene/settings/links/DashboardLinkList.tsx
@@ -53,6 +53,13 @@ export function DashboardLinkList({
     );
   }
 
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTableRowElement>, idx: number) {
+    if (e.target === e.currentTarget && (e.key === ' ' || e.key === 'Enter')) {
+      e.preventDefault();
+      onEdit(idx);
+    }
+  }
+
   return (
     <>
       <table role="grid" className="filter-table filter-table--hover">
@@ -69,7 +76,7 @@ export function DashboardLinkList({
         </thead>
         <tbody>
           {links.map((link, idx) => (
-            <tr key={`${link.title}-${idx}`}>
+            <tr key={`${link.title}-${idx}`} onKeyDown={(e) => handleKeyDown(e, idx)} tabIndex={0}>
               <td role="gridcell" className="pointer" onClick={() => onEdit(idx)}>
                 <Icon name="external-link-alt" /> &nbsp; {link.type}
               </td>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->
**Which issue(s) does this PR fix?**:


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #116513

### Scope Clarification
This PR addresses **Issue 1** and **Issue 2** from the linked issue:
- **Issue 1**: Legend color button not keyboard accessible
- **Issue 2**: Dashboard link rows not keyboard accessible
**Note**: The main flow (steps 1-6) appears to be working correctly in my testing - I was able to navigate through panel sections, visualization controls, and legend settings using keyboard. If this is still an issue, additional reproduction details would be helpful.
