### PR TITLE
Alerting Docs: update provisioning docs

### DIFF
--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -355,11 +355,11 @@ Content-Type: application/json
 
 The receiver permissions endpoints manage access control for contact point receivers. These endpoints require Grafana Enterprise and allow you to assign permissions to users, teams, or built-in roles for specific receivers.
 
-| Method | URI                                                           | Name                                                                          | Summary                                                  |
-| ------ | ------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------- |
-| POST   | /api/access-control/receivers/:uid/users/:userID              | [route set user receiver permission](#route-set-user-receiver-permission)     | Set permissions for a user on a specific receiver.       |
-| POST   | /api/access-control/receivers/:uid/teams/:teamID              | [route set team receiver permission](#route-set-team-receiver-permission)     | Set permissions for a team on a specific receiver.       |
-| POST   | /api/access-control/receivers/:uid/builtInRoles/:builtInRole  | [route set builtin receiver permission](#route-set-builtin-receiver-permission) | Set permissions for a built-in role on a specific receiver. |
+| Method | URI                                                          | Name                                                                            | Summary                                                     |
+| ------ | ------------------------------------------------------------ | ------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| POST   | /api/access-control/receivers/:uid/users/:userID             | [route set user receiver permission](#route-set-user-receiver-permission)       | Set permissions for a user on a specific receiver.          |
+| POST   | /api/access-control/receivers/:uid/teams/:teamID             | [route set team receiver permission](#route-set-team-receiver-permission)       | Set permissions for a team on a specific receiver.          |
+| POST   | /api/access-control/receivers/:uid/builtInRoles/:builtInRole | [route set builtin receiver permission](#route-set-builtin-receiver-permission) | Set permissions for a built-in role on a specific receiver. |
 
 **Example Request to assign permissions to a user:**
 
@@ -434,6 +434,7 @@ Content-Type: application/json
 ```
 
 **Available Permissions:**
+
 - `View` - Read-only access to the receiver
 - `Edit` - Ability to update the receiver
 - `Admin` - Full access including managing permissions
@@ -1018,19 +1019,19 @@ This endpoint requires Grafana Enterprise and the user must have the `receivers.
 
 #### Parameters
 
-| Name     | Source | Type   | Go type | Required | Default | Description                                                        |
-| -------- | ------ | ------ | ------- | :------: | ------- | ------------------------------------------------------------------ |
-| `uid`    | path   | string | string  |    ✓     |         | UID of the receiver                                                |
-| `userID` | path   | int64  | int64   |    ✓     |         | ID of the user to assign permissions to                            |
+| Name     | Source | Type   | Go type | Required | Default | Description                                                                           |
+| -------- | ------ | ------ | ------- | :------: | ------- | ------------------------------------------------------------------------------------- |
+| `uid`    | path   | string | string  |    ✓     |         | UID of the receiver                                                                   |
+| `userID` | path   | int64  | int64   |    ✓     |         | ID of the user to assign permissions to                                               |
 | `body`   | body   | object | object  |    ✓     |         | JSON body with `permission` field: `View`, `Edit`, `Admin`, or `""` (empty to remove) |
 
 #### All responses
 
-| Code                                              | Status | Description        | Has headers | Schema                                                      |
-| ------------------------------------------------- | ------ | ------------------ | :---------: | ----------------------------------------------------------- |
-| [200](#route-set-user-receiver-permission-200)    | OK     | Permission updated |             | [schema](#route-set-user-receiver-permission-200-schema)    |
-| [400](#route-set-user-receiver-permission-400)    | Bad Request | Invalid request    |             | [schema](#route-set-user-receiver-permission-400-schema) |
-| [403](#route-set-user-receiver-permission-403)    | Forbidden | Permission denied  |             | [schema](#route-set-user-receiver-permission-403-schema)    |
+| Code                                           | Status      | Description        | Has headers | Schema                                                   |
+| ---------------------------------------------- | ----------- | ------------------ | :---------: | -------------------------------------------------------- |
+| [200](#route-set-user-receiver-permission-200) | OK          | Permission updated |             | [schema](#route-set-user-receiver-permission-200-schema) |
+| [400](#route-set-user-receiver-permission-400) | Bad Request | Invalid request    |             | [schema](#route-set-user-receiver-permission-400-schema) |
+| [403](#route-set-user-receiver-permission-403) | Forbidden   | Permission denied  |             | [schema](#route-set-user-receiver-permission-403-schema) |
 
 #### Responses
 
@@ -1074,19 +1075,19 @@ This endpoint requires Grafana Enterprise and the user must have the `receivers.
 
 #### Parameters
 
-| Name     | Source | Type   | Go type | Required | Default | Description                                                        |
-| -------- | ------ | ------ | ------- | :------: | ------- | ------------------------------------------------------------------ |
-| `uid`    | path   | string | string  |    ✓     |         | UID of the receiver                                                |
-| `teamID` | path   | int64  | int64   |    ✓     |         | ID of the team to assign permissions to                            |
+| Name     | Source | Type   | Go type | Required | Default | Description                                                                           |
+| -------- | ------ | ------ | ------- | :------: | ------- | ------------------------------------------------------------------------------------- |
+| `uid`    | path   | string | string  |    ✓     |         | UID of the receiver                                                                   |
+| `teamID` | path   | int64  | int64   |    ✓     |         | ID of the team to assign permissions to                                               |
 | `body`   | body   | object | object  |    ✓     |         | JSON body with `permission` field: `View`, `Edit`, `Admin`, or `""` (empty to remove) |
 
 #### All responses
 
-| Code                                              | Status | Description        | Has headers | Schema                                                      |
-| ------------------------------------------------- | ------ | ------------------ | :---------: | ----------------------------------------------------------- |
-| [200](#route-set-team-receiver-permission-200)    | OK     | Permission updated |             | [schema](#route-set-team-receiver-permission-200-schema)    |
-| [400](#route-set-team-receiver-permission-400)    | Bad Request | Invalid request    |             | [schema](#route-set-team-receiver-permission-400-schema) |
-| [403](#route-set-team-receiver-permission-403)    | Forbidden | Permission denied  |             | [schema](#route-set-team-receiver-permission-403-schema)    |
+| Code                                           | Status      | Description        | Has headers | Schema                                                   |
+| ---------------------------------------------- | ----------- | ------------------ | :---------: | -------------------------------------------------------- |
+| [200](#route-set-team-receiver-permission-200) | OK          | Permission updated |             | [schema](#route-set-team-receiver-permission-200-schema) |
+| [400](#route-set-team-receiver-permission-400) | Bad Request | Invalid request    |             | [schema](#route-set-team-receiver-permission-400-schema) |
+| [403](#route-set-team-receiver-permission-403) | Forbidden   | Permission denied  |             | [schema](#route-set-team-receiver-permission-403-schema) |
 
 #### Responses
 
@@ -1130,19 +1131,19 @@ This endpoint requires Grafana Enterprise and the user must have the `receivers.
 
 #### Parameters
 
-| Name          | Source | Type   | Go type | Required | Default | Description                                                        |
-| ------------- | ------ | ------ | ------- | :------: | ------- | ------------------------------------------------------------------ |
-| `uid`         | path   | string | string  |    ✓     |         | UID of the receiver                                                |
-| `builtInRole` | path   | string | string  |    ✓     |         | Built-in role name: `Viewer`, `Editor`, or `Admin`                 |
+| Name          | Source | Type   | Go type | Required | Default | Description                                                                           |
+| ------------- | ------ | ------ | ------- | :------: | ------- | ------------------------------------------------------------------------------------- |
+| `uid`         | path   | string | string  |    ✓     |         | UID of the receiver                                                                   |
+| `builtInRole` | path   | string | string  |    ✓     |         | Built-in role name: `Viewer`, `Editor`, or `Admin`                                    |
 | `body`        | body   | object | object  |    ✓     |         | JSON body with `permission` field: `View`, `Edit`, `Admin`, or `""` (empty to remove) |
 
 #### All responses
 
-| Code                                                 | Status | Description        | Has headers | Schema                                                         |
-| ---------------------------------------------------- | ------ | ------------------ | :---------: | -------------------------------------------------------------- |
-| [200](#route-set-builtin-receiver-permission-200)    | OK     | Permission updated |             | [schema](#route-set-builtin-receiver-permission-200-schema)    |
-| [400](#route-set-builtin-receiver-permission-400)    | Bad Request | Invalid request    |             | [schema](#route-set-builtin-receiver-permission-400-schema) |
-| [403](#route-set-builtin-receiver-permission-403)    | Forbidden | Permission denied  |             | [schema](#route-set-builtin-receiver-permission-403-schema)    |
+| Code                                              | Status      | Description        | Has headers | Schema                                                      |
+| ------------------------------------------------- | ----------- | ------------------ | :---------: | ----------------------------------------------------------- |
+| [200](#route-set-builtin-receiver-permission-200) | OK          | Permission updated |             | [schema](#route-set-builtin-receiver-permission-200-schema) |
+| [400](#route-set-builtin-receiver-permission-400) | Bad Request | Invalid request    |             | [schema](#route-set-builtin-receiver-permission-400-schema) |
+| [403](#route-set-builtin-receiver-permission-403) | Forbidden   | Permission denied  |             | [schema](#route-set-builtin-receiver-permission-403-schema) |
 
 #### Responses
 
@@ -2178,10 +2179,10 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 {{% responsive-table %}}
 
-| Name                  | Type   | Go type | Required | Default | Description                                                                                              | Example                       |
-| --------------------- | ------ | ------- | :------: | ------- | -------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| `metric`              | string | string  |    ✓     |         | The name of the new metric to create. Must be a valid Prometheus metric name with no whitespace.        | `http_requests:rate5m:sum`    |
-| `from`                | string | string  |    ✓     |         | The query reference ID (refId) to use as the source for the recorded metric.                             | `A`                           |
+| Name                    | Type   | Go type | Required | Default | Description                                                                                                          | Example                        |
+| ----------------------- | ------ | ------- | :------: | ------- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `metric`                | string | string  |    ✓     |         | The name of the new metric to create. Must be a valid Prometheus metric name with no whitespace.                     | `http_requests:rate5m:sum`     |
+| `from`                  | string | string  |    ✓     |         | The query reference ID (refId) to use as the source for the recorded metric.                                         | `A`                            |
 | `target_datasource_uid` | string | string  |          |         | UID of the Prometheus-compatible data source to write results to. Falls back to configured default if not specified. | `my-prometheus-datasource-uid` |
 
 {{% /responsive-table %}}

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -353,7 +353,7 @@ Content-Type: application/json
 
 ### Receiver permissions
 
-The receiver permissions endpoints manage access control for contact point receivers. These endpoints require Grafana Enterprise and allow you to assign permissions to users, teams, or built-in roles for specific receivers.
+The receiver permissions endpoints manage access control for contact point receivers. These endpoints allow you to assign permissions to users, teams, or built-in roles for specific receivers.
 
 | Method | URI                                                          | Name                                                                            | Summary                                                     |
 | ------ | ------------------------------------------------------------ | ------------------------------------------------------------------------------- | ----------------------------------------------------------- |
@@ -433,12 +433,22 @@ Content-Type: application/json
 }
 ```
 
-**Available Permissions:**
+**Available Permissions sets:**
+- `View` - Read-only access to the receiver.
+  - Grants `alert.notifications.receivers:read`.
+- `Edit` - Ability to update and test the receiver.
+  - Grants `View` actions plus:
+    - `alert.notifications.receivers:write`
+    - `alert.notifications.receivers:delete`
+    - `alert.notifications.receivers.test:create`
+- `Admin` - Full access including managing permissions and reading secrets.
+  - Grants `Edit` actions plus:
+    - `alert.notifications.receivers.secrets:read`
+    - `receivers.permissions:read`
+    - `receivers.permissions:write`
+    - `alert.notifications.receivers.protected:write`
+- Empty string (`""`) - Removes the permission.
 
-- `View` - Read-only access to the receiver
-- `Edit` - Ability to update the receiver
-- `Admin` - Full access including managing permissions
-- Empty string (`""`) - Removes the permission
 
 ### Notification policies
 

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -434,6 +434,7 @@ Content-Type: application/json
 ```
 
 **Available Permissions sets:**
+
 - `View` - Read-only access to the receiver.
   - Grants `alert.notifications.receivers:read`.
 - `Edit` - Ability to update and test the receiver.
@@ -448,7 +449,6 @@ Content-Type: application/json
     - `receivers.permissions:write`
     - `alert.notifications.receivers.protected:write`
 - Empty string (`""`) - Removes the permission.
-
 
 ### Notification policies
 


### PR DESCRIPTION
From two support escalations: 
[Support request - creating a new public document #19616](https://github.com/grafana/support-escalations/issues/19616)

> **Requesting:** Alerting api documentation specific to the `/api/access-control/receivers` endpoint

[Support request - updating an existing public document - [...] alerting-resources #19216](https://github.com/grafana/support-escalations/issues/19216)
> The customer needs support to Provision Recording Rules via the API; however, no documentation is available (That I am able to find)

This pull request updates the alerting provisioning documentation to add support for recording rules and introduces new API endpoints for managing receiver permissions in Grafana Enterprise. The most important changes are grouped below by theme.

**Recording Rules Support:**

* Added documentation for creating recording rules via the alert rule provisioning endpoints, including request/response examples, required fields, and important usage notes. Recording rules allow pre-computing queries and saving results as new metrics.
* Documented the new `record` property in alert rule objects, including a detailed schema and description of its fields. [[1]](diffhunk://#diff-e11062bf59a6b3377ccc72f7fd4935151ddaa26b689195b5aac8b65452bd82f0R2157) [[2]](diffhunk://#diff-e11062bf59a6b3377ccc72f7fd4935151ddaa26b689195b5aac8b65452bd82f0R2173-R2188)

**Receiver Permissions Management (Grafana Enterprise):**

* Added a new section describing receiver permissions endpoints, including how to assign or remove permissions for users, teams, and built-in roles on specific receivers, with example requests and available permission levels.
* Provided detailed API reference documentation for the new endpoints to set or remove permissions for users, teams, and built-in roles on receivers, including required parameters, response schemas, and permission requirements.