### PR TITLE
chore(setting): Include resource labels in Setting objects

### DIFF
--- a/pkg/services/setting/service.go
+++ b/pkg/services/setting/service.go
@@ -136,11 +136,19 @@ type Setting struct {
 	Key string `json:"key"`
 	// Setting value
 	Value string `json:"value"`
+	// Labels resource labels
+	Labels map[string]string `json:"-"`
+}
+
+// settingResourceMetadata contains the metadata fields we care about from the K8s resource.
+type settingResourceMetadata struct {
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // settingResource represents a single Setting resource from the K8s API.
 type settingResource struct {
-	Spec Setting `json:"spec"`
+	Metadata settingResourceMetadata `json:"metadata"`
+	Spec     Setting                 `json:"spec"`
 }
 
 // settingListMetadata contains pagination info from the K8s list response.
@@ -344,6 +352,7 @@ func parseItems(decoder *json.Decoder) ([]*Setting, error) {
 			Section: item.Spec.Section,
 			Key:     item.Spec.Key,
 			Value:   item.Spec.Value,
+			Labels:  item.Metadata.Labels,
 		})
 	}
 


### PR DESCRIPTION
**What is this feature?**

Including resource labels in Setting objects for consumers that rely on these values for additional processing.


**Which issue(s) does this PR fix?**:

Part of: https://github.com/grafana/grafana-org/issues/799

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
