### PR TITLE
Provisioning: use min resync interval in Repo Controller

### DIFF
--- a/pkg/operators/provisioning/repo_operator.go
+++ b/pkg/operators/provisioning/repo_operator.go
@@ -119,6 +119,7 @@ func RunRepoController(deps server.OperatorDependencies) error {
 		tracer,
 		controllerCfg.Settings.SectionWithEnvOverrides("operator").Key("parallel_operations").MustInt(10),
 		controllerCfg.ResyncInterval(),
+		controllerCfg.Settings.SectionWithEnvOverrides("provisioning").Key("min_sync_interval").MustDuration(1*time.Minute),
 		quotaGetter,
 	)
 	if err != nil {

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -899,6 +899,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				b.tracer,
 				10,
 				informerFactoryResyncInterval,
+				b.minSyncInterval,
 				quotaGetter,
 			)
 			if err != nil {


### PR DESCRIPTION
**What is this feature?**

Using a "Minimum Resync interval" parameter inside the repository controller which will force resync only after a certain period has elapsed since last resync.

This will override the `spec.sync.intervalseconds` value in `Repository` resources, when its value is lower than the minimum.

**Why do we need this feature?**

We want a way of controlling when reconciliation happens, so that we can reduce the amount of resyncs if we want, or have a better control in case `spec.sync.intervalseconds` is too low. 

**Who is this feature for?**

Users of GitSync.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/git-ui-sync-project/issues/475

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
