### PR TITLE
Correlations: Add labels to CREATE and UPDATE operations for searching

### DIFF
--- a/apps/correlations/kinds/correlations.cue
+++ b/apps/correlations/kinds/correlations.cue
@@ -3,6 +3,12 @@ package kinds
 correlationsv0alpha1: {
 	kind:       "Correlation"  // note: must be uppercase
 	pluralName: "Correlations"
+	mutation: {
+		operations: [
+			"CREATE",
+			"UPDATE",
+		]
+	}
 	schema: {
 		spec: {
 			type:         CorrelationType

--- a/apps/correlations/pkg/apis/correlation/v0alpha1/correlation_object_gen.go
+++ b/apps/correlations/pkg/apis/correlation/v0alpha1/correlation_object_gen.go
@@ -23,6 +23,12 @@ type Correlation struct {
 	Spec CorrelationSpec `json:"spec" yaml:"spec"`
 }
 
+func NewCorrelation() *Correlation {
+	return &Correlation{
+		Spec: *NewCorrelationSpec(),
+	}
+}
+
 func (o *Correlation) GetSpec() any {
 	return o.Spec
 }

--- a/apps/correlations/pkg/apis/correlation/v0alpha1/correlation_schema_gen.go
+++ b/apps/correlations/pkg/apis/correlation/v0alpha1/correlation_schema_gen.go
@@ -10,7 +10,7 @@ import (
 
 // schema is unexported to prevent accidental overwrites
 var (
-	schemaCorrelation = resource.NewSimpleSchema("correlations.grafana.app", "v0alpha1", &Correlation{}, &CorrelationList{}, resource.WithKind("Correlation"),
+	schemaCorrelation = resource.NewSimpleSchema("correlations.grafana.app", "v0alpha1", NewCorrelation(), &CorrelationList{}, resource.WithKind("Correlation"),
 		resource.WithPlural("correlations"), resource.WithScope(resource.NamespacedScope))
 	kindCorrelation = resource.Kind{
 		Schema: schemaCorrelation,

--- a/apps/correlations/pkg/apis/correlation_manifest.go
+++ b/apps/correlations/pkg/apis/correlation_manifest.go
@@ -39,7 +39,16 @@ var appManifestData = app.ManifestData{
 					Plural:     "Correlations",
 					Scope:      "Namespaced",
 					Conversion: false,
-					Schema:     &versionSchemaCorrelationv0alpha1,
+					Admission: &app.AdmissionCapabilities{
+
+						Mutation: &app.MutationCapability{
+							Operations: []app.AdmissionOperation{
+								app.AdmissionOperationCreate,
+								app.AdmissionOperationUpdate,
+							},
+						},
+					},
+					Schema: &versionSchemaCorrelationv0alpha1,
 					SelectableFields: []string{
 						"spec.datasource.name",
 					},

--- a/apps/correlations/pkg/app/app.go
+++ b/apps/correlations/pkg/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/grafana/grafana-app-sdk/app"
 	"github.com/grafana/grafana-app-sdk/logging"
@@ -26,7 +27,8 @@ func New(cfg app.Config) (app.App, error) {
 		},
 		ManagedKinds: []simple.AppManagedKind{
 			{
-				Kind: correlationsv0alpha1.CorrelationKind(),
+				Kind:    correlationsv0alpha1.CorrelationKind(),
+				Mutator: DataSourceMutator(),
 			},
 		},
 	}
@@ -51,5 +53,42 @@ func GetKinds() map[schema.GroupVersion][]resource.Kind {
 	}
 	return map[schema.GroupVersion][]resource.Kind{
 		gv: {correlationsv0alpha1.CorrelationKind()},
+	}
+}
+
+const (
+	// SourceRefLabelKey is the label key for the composite source reference (group.name)
+	SourceRefLabelKey = "correlations.grafana.app/sourceDS-ref"
+
+	// TargetRefLabelKey is the label key for the composite target reference (group.name)
+	TargetRefLabelKey = "correlations.grafana.app/targetDS-ref"
+)
+
+func DataSourceMutator() *simple.Mutator {
+	return &simple.Mutator{
+		MutateFunc: func(ctx context.Context, req *app.AdmissionRequest) (*app.MutatingResponse, error) {
+			c, ok := req.Object.(*correlationsv0alpha1.Correlation)
+			if !ok || c == nil {
+				return nil, nil
+			}
+
+			if c.Labels == nil {
+				c.Labels = make(map[string]string)
+			}
+
+			// Derive source label: "group.name" format
+			c.Labels[SourceRefLabelKey] = fmt.Sprintf("%s.%s",
+				c.Spec.Source.Group,
+				c.Spec.Source.Name)
+
+			// Derive target label if target is present
+			if c.Spec.Target != nil {
+				c.Labels[TargetRefLabelKey] = fmt.Sprintf("%s.%s",
+					c.Spec.Target.Group,
+					c.Spec.Target.Name)
+			}
+
+			return &app.MutatingResponse{UpdatedObject: c}, nil
+		},
 	}
 }


### PR DESCRIPTION
Add mutator to correlations that will add and update a label with the datasources name and group.

Tested by running a POST of a correlation with the following body

```
{
  "apiVersion": "correlations.grafana.app/v0alpha1",
  "kind": "Correlation",
  "metadata": {
      "name": "vcbcvb"
  },
  "spec": {
    "config": {
      "field":"Line",
      "target":{"csvContent":"${counter}","refId":"","scenarioId":"csv_content"},
      "transformations":[{"type":"logfmt"}] 
    },
    "description": "test3",
    "label": "test3",
    "source": {
      "group": "1",
      "name": "gdev-loki"
    },
    "target": {
      "group": "2",
      "name": "gdev-prometheus"
    },
    "type": "query"
  }
}
```

Correlation contains label block of the following as expected
`"labels":{"correlations.grafana.app/sourceDS-ref":"1.gdev-loki","correlations.grafana.app/targetDS-ref":"2.gdev-prometheus"}`

Fixes #116942