### PR TITLE
Chore: Add OpenFeature tests

### DIFF
--- a/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/openFeature.spec.ts
+++ b/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/openFeature.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from '@grafana/plugin-e2e';
+
+test.use({
+  openFeature: {
+    flags: {
+      testFlagTrue: true,
+      testFlagFalse: false,
+    },
+  },
+});
+
+test(
+  'should intercept OFREP bulk evaluation and override flags via openFeature',
+  {
+    tag: ['@plugins'],
+  },
+  async ({ page, selectors, namespace }) => {
+    // set up a listener to capture the OFREP response
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes(selectors.apis.OpenFeature.ofrepBulkPath(namespace)) && !response.url().endsWith('/'),
+      { timeout: 5000 }
+    );
+
+    // trigger a navigation that would cause OpenFeature to fetch flags
+    await page.goto('/');
+
+    // wait for the OFREP response (may not happen if OpenFeature is not enabled in the Grafana instance)
+    try {
+      const response = await responsePromise;
+      const body = await response.json();
+
+      // response should contain our overridden flags from openFeature
+      const testFlagTrue = body.flags?.find((f: { key: string }) => f.key === 'testFlagTrue');
+      const testFlagFalse = body.flags?.find((f: { key: string }) => f.key === 'testFlagFalse');
+
+      if (testFlagTrue) {
+        expect(testFlagTrue.value).toBe(true);
+        expect(testFlagTrue.reason).toBe('STATIC');
+        expect(testFlagTrue.variant).toBe('playwright-override');
+      }
+
+      if (testFlagFalse) {
+        expect(testFlagFalse.value).toBe(false);
+        expect(testFlagFalse.reason).toBe('STATIC');
+        expect(testFlagFalse.variant).toBe('playwright-override');
+      }
+    } catch {
+      console.log('OFREP endpoint not called - OpenFeature may not be enabled');
+    }
+  }
+);
+
+test(
+  'should merge custom openFeature flags with backend default flags',
+  {
+    tag: ['@plugins'],
+  },
+  async ({ page, selectors, namespace }) => {
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes(selectors.apis.OpenFeature.ofrepBulkPath(namespace)) && !response.url().endsWith('/'),
+      { timeout: 5000 }
+    );
+
+    // wait for the OFREP response
+    try {
+      const response = await responsePromise;
+      const body = await response.json();
+
+      // define how many custom flags we set
+      const customFlagCount = 2; // testFlagTrue and testFlagFalse
+
+      // verify we have more flags than just our custom ones (backend flags should be present)
+      expect(body.flags.length).toBeGreaterThan(customFlagCount);
+
+      // custom flags are present and overridden
+      const customFlags = body.flags.filter((f: { variant: string }) => f.variant === 'playwright-override');
+      expect(customFlags.length).toBeGreaterThanOrEqual(customFlagCount);
+
+      // backend flags (without playwright-override variant) are still present
+      const backendFlags = body.flags.filter((f: { variant: string }) => f.variant !== 'playwright-override');
+      expect(backendFlags.length).toBeGreaterThan(0);
+
+      // our specific custom flags have the correct values
+      const testFlagTrue = body.flags.find((f: { key: string }) => f.key === 'testFlagTrue');
+      const testFlagFalse = body.flags.find((f: { key: string }) => f.key === 'testFlagFalse');
+
+      expect(testFlagTrue?.value).toBe(true);
+      expect(testFlagTrue?.variant).toBe('playwright-override');
+
+      expect(testFlagFalse?.value).toBe(false);
+      expect(testFlagFalse?.variant).toBe('playwright-override');
+    } catch {
+      console.log('OFREP endpoint not called - OpenFeature may not be enabled');
+    }
+  }
+);
+
+test(
+  'should retrieve flag values using getBooleanOpenFeatureFlag fixture',
+  {
+    tag: ['@plugins'],
+  },
+  async ({ getBooleanOpenFeatureFlag }) => {
+    // should retrieve our overridden flags
+    const testFlagTrue = await getBooleanOpenFeatureFlag('testFlagTrue');
+    const testFlagFalse = await getBooleanOpenFeatureFlag('testFlagFalse');
+
+    expect(testFlagTrue).toBe(true);
+    expect(testFlagFalse).toBe(false);
+  }
+);

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@emotion/eslint-plugin": "11.12.0",
     "@grafana/eslint-config": "8.2.0",
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules",
-    "@grafana/plugin-e2e": "^3.1.3",
+    "@grafana/plugin-e2e": "3.2.0",
     "@grafana/test-utils": "workspace:*",
     "@manypkg/get-packages": "^3.0.0",
     "@npmcli/package-json": "^6.0.0",

--- a/packages/grafana-e2e-selectors/src/resolver.ts
+++ b/packages/grafana-e2e-selectors/src/resolver.ts
@@ -21,7 +21,10 @@ export function resolveSelectors<T extends VersionedSelectorGroup>(
 ): SelectorsOf<T> {
   const version = grafanaVersion.replace(/\-.*/, '');
 
-  return resolveSelectorGroup(versionedSelectors, version);
+  // If version is empty or invalid after regex replacement, use 'latest'
+  const finalVersion = version && valid(version) ? version : 'latest';
+
+  return resolveSelectorGroup(versionedSelectors, finalVersion);
 }
 
 function resolveSelectorGroup<T extends VersionedSelectorGroup>(group: T, grafanaVersion: string): SelectorsOf<T> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3679,17 +3679,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/plugin-e2e@npm:^3.1.3":
-  version: 3.1.3
-  resolution: "@grafana/plugin-e2e@npm:3.1.3"
+"@grafana/plugin-e2e@npm:3.2.0":
+  version: 3.2.0
+  resolution: "@grafana/plugin-e2e@npm:3.2.0"
   dependencies:
-    "@grafana/e2e-selectors": "npm:12.4.0-20331417332"
+    "@grafana/e2e-selectors": "npm:12.4.0-21205677807"
     semver: "npm:^7.5.4"
     uuid: "npm:^13.0.0"
     yaml: "npm:^2.3.4"
   peerDependencies:
     "@playwright/test": ^1.52.0
-  checksum: 10/16276e45eede97bdabe1d116c6007957a96fd7424070ec4cc22a9a28cfe43e549499367c027f60d438df93437b6eb909206a444c156b7c52095542499b343b1f
+  checksum: 10/16bad2ac140624119f35b31857115b17164b672316a7855617ce8507badcf0f1f056132e560fb7300be8430b773d0a6bf21d74e53e1dc54359960faf06347694
   languageName: node
   linkType: hard
 
@@ -19940,7 +19940,7 @@ __metadata:
     "@grafana/llm": "npm:1.0.1"
     "@grafana/monaco-logql": "npm:^0.0.8"
     "@grafana/o11y-ds-frontend": "workspace:*"
-    "@grafana/plugin-e2e": "npm:^3.1.3"
+    "@grafana/plugin-e2e": "npm:3.2.0"
     "@grafana/plugin-ui": "npm:^0.11.1"
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"


### PR DESCRIPTION
**What is this feature?**

This PR bumps to the latest version of plugin-e2e and adds simple api tests for the new [OpenFeature support](https://github.com/grafana/plugin-tools/pull/2408). This allows us to detect any breakages of the plugin-e2 API in case the OF implementation were to change in Grafana. Also fixes storybook test failures caused by circular dependency passing empty version string to resolveSelectors.

**Why do we need this feature?**

To override OF flags in Grafana frontend

**Who is this feature for?**

Grafana / plugin developers 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
