### PR TITLE
fix(search): do not panic on negative limit/offset

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -393,6 +393,18 @@ func (s *searchSupport) Search(ctx context.Context, req *resourcepb.ResourceSear
 		}, nil
 	}
 
+	if req.Limit < 0 {
+		return &resourcepb.ResourceSearchResponse{
+			Error: NewBadRequestError("limit cannot be negative"),
+		}, nil
+	}
+
+	if req.Offset < 0 {
+		return &resourcepb.ResourceSearchResponse{
+			Error: NewBadRequestError("offset cannot be negative"),
+		}, nil
+	}
+
 	stats := NewSearchStats("Search")
 	defer s.logStats(ctx, stats, span, "namespace", req.Options.Key.Namespace, "group", req.Options.Key.Group, "resource", req.Options.Key.Resource, "query", req.Query)
 


### PR DESCRIPTION
**What is this feature?**

Returns an error when bleve search is requested with negative limit/offset instead of panicking.

**Why do we need this feature?**

Fix panic:

```
2026-01-29 03:20:55.502 github.com/blevesearch/bleve/v2/search/collector.getOptimalCollectorStore(0x792f4619ba78?, 0x30?, 0xc00350d070) 
2026-01-29 03:20:55.502 	github.com/blevesearch/bleve/v2@v2.5.7/search/collector/slice.go:28 
2026-01-29 03:20:55.502 github.com/blevesearch/bleve/v2/search/collector.newStoreSlice(...) 
2026-01-29 03:20:55.502 goroutine 10978 [running]: 
2026-01-29 03:20:55.502 ERROR panic: runtime error: makeslice: cap out of range 
2026-01-29 03:20:55.495 	github.com/blevesearch/bleve/v2@v2.5.7/index_alias_impl.go:1012 +0x178 
2026-01-29 03:20:55.495 created by github.com/blevesearch/bleve/v2.MultiSearch in goroutine 10963 
2026-01-29 03:20:55.495 	github.com/blevesearch/bleve/v2@v2.5.7/index_alias_impl.go:1001 +0xe8 
2026-01-29 03:20:55.495 github.com/blevesearch/bleve/v2.MultiSearch.func1({0x4048150, 0xc00046af50}, 0xc0020e1500) 
2026-01-29 03:20:55.495 	github.com/blevesearch/bleve/v2@v2.5.7/index_impl.go:723 +0x785 
2026-01-29 03:20:55.495 github.com/blevesearch/bleve/v2.(*indexImpl).SearchInContext(0xc00046af50, {0x3ef3860, 0xc0021efad0}, 0xc0020e1500)
2026-01-29 03:20:55.495 	github.com/blevesearch/bleve/v2@v2.5.7/search/collector/topn.go:91 
2026-01-29 03:20:55.495 github.com/blevesearch/bleve/v2/search/collector.NewTopNCollector(...) 
2026-01-29 03:20:55.495 	github.com/blevesearch/bleve/v2@v2.5.7/search/collector/topn.go:106 +0x105 
2026-01-29 03:20:55.495 github.com/blevesearch/bleve/v2/search/collector.newTopNCollector(0xfffffffffffff8d1, 0x0, {0xc002a47300, 0x1, 0x1})
2026-01-29 03:20:55.495 	github.com/blevesearch/bleve/v2@v2.5.7/search/collector/topn.go:216 +0xde 
2026-01-29 03:20:55.495 github.com/blevesearch/bleve/v2/search/collector.getOptimalCollectorStore(0x792f4619cd58?, 0x30?, 0xc002a47350)
2026-01-29 03:20:55.495 	github.com/blevesearch/bleve/v2@v2.5.7/search/collector/slice.go:28 
2026-01-29 03:20:55.495 github.com/blevesearch/bleve/v2/search/collector.newStoreSlice(...) 
2026-01-29 03:20:55.495 goroutine 10929 [running]: 
2026-01-29 03:20:55.495 ERROR panic: runtime error: makeslice: cap out of range 
```

**Who is this feature for?**

Unified Storage search users

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
