### PR TITLE
Alerting: Add backend support for named notification policies

### DIFF
--- a/pkg/registry/apps/alerting/notifications/register.go
+++ b/pkg/registry/apps/alerting/notifications/register.go
@@ -115,7 +115,7 @@ func (a AppInstaller) GetLegacyStorage(gvr schema.GroupVersionResource) grafanar
 		}
 		return templategroup.NewStorage(srv, namespacer)
 	} else if gvr == routingtree.ResourceInfo.GroupVersionResource() {
-		return routingtree.NewStorage(api.Policies, namespacer)
+		return routingtree.NewStorage(api.RouteService, namespacer)
 	}
 	panic("unknown legacy storage requested: " + gvr.String())
 }

--- a/pkg/registry/apps/alerting/notifications/routingtree/conversions.go
+++ b/pkg/registry/apps/alerting/notifications/routingtree/conversions.go
@@ -15,13 +15,28 @@ import (
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	gapiutil "github.com/grafana/grafana/pkg/services/apiserver/utils"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func ConvertToK8sResource(orgID int64, r definitions.Route, version string, namespacer request.NamespaceMapper) (*model.RoutingTree, error) {
+func ConvertToK8sResources(orgID int64, routes legacy_storage.ManagedRoutes, namespacer request.NamespaceMapper) (*model.RoutingTreeList, error) {
+	result := &model.RoutingTreeList{
+		Items: make([]model.RoutingTree, 0, len(routes)),
+	}
+	for _, r := range routes {
+		k8sResource, err := ConvertToK8sResource(orgID, r, namespacer)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert route %q to k8s resource: %w", r.Name, err)
+		}
+		result.Items = append(result.Items, *k8sResource)
+	}
+	return result, nil
+}
+
+func ConvertToK8sResource(orgID int64, r *legacy_storage.ManagedRoute, namespacer request.NamespaceMapper) (*model.RoutingTree, error) {
 	spec := model.RoutingTreeSpec{
 		Defaults: model.RoutingTreeRouteDefaults{
-			GroupBy:        r.GroupByStr,
+			GroupBy:        r.GroupBy,
 			GroupWait:      optionalPrometheusDurationToString(r.GroupWait),
 			GroupInterval:  optionalPrometheusDurationToString(r.GroupInterval),
 			RepeatInterval: optionalPrometheusDurationToString(r.RepeatInterval),
@@ -38,9 +53,9 @@ func ConvertToK8sResource(orgID int64, r definitions.Route, version string, name
 
 	var result = &model.RoutingTree{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            model.UserDefinedRoutingTreeName,
+			Name:            r.Name,
 			Namespace:       namespacer(orgID),
-			ResourceVersion: version,
+			ResourceVersion: r.Version,
 		},
 		Spec: spec,
 	}

--- a/pkg/registry/apps/alerting/notifications/routingtree/legacy_storage.go
+++ b/pkg/registry/apps/alerting/notifications/routingtree/legacy_storage.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	alerting_models "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 )
 
 var (
@@ -22,9 +23,11 @@ var (
 )
 
 type RouteService interface {
-	GetPolicyTree(ctx context.Context, orgID int64) (definitions.Route, string, error)
-	UpdatePolicyTree(ctx context.Context, orgID int64, tree definitions.Route, p alerting_models.Provenance, version string) (definitions.Route, string, error)
-	ResetPolicyTree(ctx context.Context, orgID int64, p alerting_models.Provenance) (definitions.Route, error)
+	GetManagedRoutes(ctx context.Context, orgID int64) (legacy_storage.ManagedRoutes, error)
+	GetManagedRoute(ctx context.Context, orgID int64, name string) (legacy_storage.ManagedRoute, error)
+	DeleteManagedRoute(ctx context.Context, orgID int64, name string, p alerting_models.Provenance, version string) error
+	CreateManagedRoute(ctx context.Context, orgID int64, name string, subtree definitions.Route, p alerting_models.Provenance) (*legacy_storage.ManagedRoute, error)
+	UpdateManagedRoute(ctx context.Context, orgID int64, name string, subtree definitions.Route, p alerting_models.Provenance, version string) (*legacy_storage.ManagedRoute, error)
 }
 
 type legacyStorage struct {
@@ -55,56 +58,76 @@ func (s *legacyStorage) ConvertToTable(ctx context.Context, object runtime.Objec
 	return s.tableConverter.ConvertToTable(ctx, object, tableOptions)
 }
 
-func (s *legacyStorage) getUserDefinedRoutingTree(ctx context.Context) (*model.RoutingTree, error) {
+func (s *legacyStorage) List(ctx context.Context, _ *internalversion.ListOptions) (runtime.Object, error) {
 	orgId, err := request.OrgIDForList(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	res, version, err := s.service.GetPolicyTree(ctx, orgId)
+	managedRoutes, err := s.service.GetManagedRoutes(ctx, orgId)
 	if err != nil {
 		return nil, err
 	}
-	return ConvertToK8sResource(orgId, res, version, s.namespacer)
-}
-
-func (s *legacyStorage) List(ctx context.Context, _ *internalversion.ListOptions) (runtime.Object, error) {
-	user, err := s.getUserDefinedRoutingTree(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return &model.RoutingTreeList{
-		Items: []model.RoutingTree{
-			*user,
-		},
-	}, nil
+	return ConvertToK8sResources(orgId, managedRoutes, s.namespacer)
 }
 
 func (s *legacyStorage) Get(ctx context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
-	if name != model.UserDefinedRoutingTreeName {
-		return nil, errors.NewNotFound(ResourceInfo.GroupResource(), name)
+	info, err := request.NamespaceInfoFrom(ctx, true)
+	if err != nil {
+		return nil, err
 	}
-	return s.getUserDefinedRoutingTree(ctx)
+	managedRoute, err := s.service.GetManagedRoute(ctx, info.OrgID, name)
+	if err != nil {
+		return nil, err
+	}
+	return ConvertToK8sResource(info.OrgID, &managedRoute, s.namespacer)
 }
 
-func (s *legacyStorage) Create(_ context.Context,
-	_ runtime.Object,
-	_ rest.ValidateObjectFunc,
+func (s *legacyStorage) Create(ctx context.Context,
+	obj runtime.Object,
+	createValidation rest.ValidateObjectFunc,
 	_ *metav1.CreateOptions,
 ) (runtime.Object, error) {
-	return nil, errors.NewMethodNotSupported(ResourceInfo.GroupResource(), "create")
+	info, err := request.NamespaceInfoFrom(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	if createValidation != nil {
+		if err := createValidation(ctx, obj.DeepCopyObject()); err != nil {
+			return nil, err
+		}
+	}
+	p, ok := obj.(*model.RoutingTree)
+	if !ok {
+		return nil, fmt.Errorf("expected %s but got %s", ResourceInfo.GroupVersionKind(), obj.GetObjectKind().GroupVersionKind())
+	}
+	domainModel, _, err := convertToDomainModel(p)
+	if err != nil {
+		return nil, err
+	}
+	created, err := s.service.CreateManagedRoute(ctx, info.OrgID, p.Name, domainModel, alerting_models.ProvenanceNone)
+	if err != nil {
+		return nil, err
+	}
+
+	return ConvertToK8sResource(info.OrgID, created, s.namespacer)
 }
 
-func (s *legacyStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, _ rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, _ bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
-	if name != model.UserDefinedRoutingTreeName {
-		return nil, false, errors.NewNotFound(ResourceInfo.GroupResource(), name)
-	}
+func (s *legacyStorage) Update(
+	ctx context.Context,
+	name string,
+	objInfo rest.UpdatedObjectInfo,
+	_ rest.ValidateObjectFunc,
+	updateValidation rest.ValidateObjectUpdateFunc,
+	_ bool,
+	_ *metav1.UpdateOptions,
+) (runtime.Object, bool, error) {
 	info, err := request.NamespaceInfoFrom(ctx, true)
 	if err != nil {
 		return nil, false, err
 	}
 
-	old, err := s.Get(ctx, model.UserDefinedRoutingTreeName, nil)
+	old, err := s.Get(ctx, name, nil)
 	if err != nil {
 		return old, false, err
 	}
@@ -122,24 +145,26 @@ func (s *legacyStorage) Update(ctx context.Context, name string, objInfo rest.Up
 		return nil, false, fmt.Errorf("expected %s but got %s", ResourceInfo.GroupVersionKind(), obj.GetObjectKind().GroupVersionKind())
 	}
 
-	model, version, err := convertToDomainModel(p)
+	domainModel, version, err := convertToDomainModel(p)
 	if err != nil {
 		return nil, false, err
 	}
-	updated, updatedVersion, err := s.service.UpdatePolicyTree(ctx, info.OrgID, model, alerting_models.ProvenanceNone, version)
+	updated, err := s.service.UpdateManagedRoute(ctx, info.OrgID, p.Name, domainModel, alerting_models.ProvenanceNone, version)
 	if err != nil {
 		return nil, false, err
 	}
 
-	obj, err = ConvertToK8sResource(info.OrgID, updated, updatedVersion, s.namespacer)
+	obj, err = ConvertToK8sResource(info.OrgID, updated, s.namespacer)
 	return obj, false, err
 }
 
 // Delete implements rest.GracefulDeleter. It is needed for API server to not crash when it registers DeleteCollection method
-func (s *legacyStorage) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, opts *metav1.DeleteOptions) (runtime.Object, bool, error) {
-	if name != model.UserDefinedRoutingTreeName {
-		return nil, false, errors.NewNotFound(ResourceInfo.GroupResource(), name)
-	}
+func (s *legacyStorage) Delete(
+	ctx context.Context,
+	name string,
+	deleteValidation rest.ValidateObjectFunc,
+	options *metav1.DeleteOptions,
+) (runtime.Object, bool, error) {
 	info, err := request.NamespaceInfoFrom(ctx, true)
 	if err != nil {
 		return nil, false, err
@@ -155,10 +180,14 @@ func (s *legacyStorage) Delete(ctx context.Context, name string, deleteValidatio
 			return nil, false, err
 		}
 	}
-	_, err = s.service.ResetPolicyTree(ctx, info.OrgID, alerting_models.ProvenanceNone) // TODO add support for dry-run option
+	version := ""
+	if options.Preconditions != nil && options.Preconditions.ResourceVersion != nil {
+		version = *options.Preconditions.ResourceVersion
+	}
+	err = s.service.DeleteManagedRoute(ctx, info.OrgID, name, alerting_models.ProvenanceNone, version) // TODO add support for dry-run option
 	return old, false, err
 }
 
 func (s *legacyStorage) DeleteCollection(_ context.Context, _ rest.ValidateObjectFunc, _ *metav1.DeleteOptions, _ *internalversion.ListOptions) (runtime.Object, error) {
-	return nil, errors.NewMethodNotSupported(ResourceInfo.GroupResource(), "delete")
+	return nil, errors.NewMethodNotSupported(ResourceInfo.GroupResource(), "deleteCollection")
 }

--- a/pkg/registry/apps/alerting/notifications/routingtree/type.go
+++ b/pkg/registry/apps/alerting/notifications/routingtree/type.go
@@ -1,8 +1,10 @@
 package routingtree
 
 import (
+	"fmt"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	model "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v0alpha1"
@@ -14,5 +16,18 @@ var ResourceInfo = utils.NewResourceInfo(kind.Group(), kind.Version(),
 	kind.GroupVersionResource().Resource, strings.ToLower(kind.Kind()), kind.Kind(),
 	func() runtime.Object { return kind.ZeroValue() },
 	func() runtime.Object { return kind.ZeroListValue() },
-	utils.TableColumns{},
+	utils.TableColumns{
+		Definition: []metav1.TableColumnDefinition{
+			{Name: "Name", Type: "string", Format: "name"},
+		},
+		Reader: func(obj any) ([]interface{}, error) {
+			r, ok := obj.(*model.RoutingTree)
+			if !ok {
+				return nil, fmt.Errorf("expected resource or info")
+			}
+			return []interface{}{
+				r.Name,
+			}, nil
+		},
+	},
 )

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/routes"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/sender"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
@@ -67,9 +68,10 @@ type API struct {
 	StateManager         state.AlertInstanceManager
 	RuleStatusReader     apiprometheus.StatusReader
 	AccessControl        ac.AccessControl
-	Policies             *provisioning.NotificationPolicyService
 	ReceiverService      *notifier.ReceiverService
 	ReceiverTestService  *notifier.ReceiverTestingService
+	RouteService         *routes.Service
+	Policies             *provisioning.NotificationPolicyService
 	ContactPointService  *provisioning.ContactPointService
 	Templates            *provisioning.TemplateService
 	MuteTimings          *provisioning.MuteTimingService
@@ -181,6 +183,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 	api.RegisterProvisioningApiEndpoints(NewProvisioningApi(&ProvisioningSrv{
 		log:                 logger,
 		policies:            api.Policies,
+		routeService:        api.RouteService,
 		contactPointService: api.ContactPointService,
 		templates:           api.Templates,
 		muteTimings:         api.MuteTimings,

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -125,7 +125,7 @@ func (srv *ProvisioningSrv) RouteGetPolicyTreeExport(c *contextmodel.ReqContext)
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to export notification policy tree", err)
 	}
 
-	e, err := AlertingFileExportFromRoute(c.GetOrgID(), managedRoute.AsRoute())
+	e, err := AlertingFileExportFromRoute(c.GetOrgID(), legacy_storage.ManagedRouteToRoute(&managedRoute))
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "failed to create alerting file export")
 	}

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/api/hcl"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	alerting_models "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/util"
@@ -30,6 +31,7 @@ const disableProvenanceHeaderName = "X-Disable-Provenance"
 type ProvisioningSrv struct {
 	log                 log.Logger
 	policies            NotificationPolicyService
+	routeService        routeService
 	contactPointService ContactPointService
 	templates           TemplateService
 	muteTimings         MuteTimingService
@@ -58,6 +60,10 @@ type NotificationPolicyService interface {
 	GetPolicyTree(ctx context.Context, orgID int64) (definitions.Route, string, error)
 	UpdatePolicyTree(ctx context.Context, orgID int64, tree definitions.Route, p alerting_models.Provenance, version string) (definitions.Route, string, error)
 	ResetPolicyTree(ctx context.Context, orgID int64, provenance alerting_models.Provenance) (definitions.Route, error)
+}
+
+type routeService interface {
+	GetManagedRoute(ctx context.Context, orgID int64, name string) (legacy_storage.ManagedRoute, error)
 }
 
 type MuteTimingService interface {
@@ -96,19 +102,33 @@ func (srv *ProvisioningSrv) RouteGetPolicyTree(c *contextmodel.ReqContext) respo
 }
 
 func (srv *ProvisioningSrv) RouteGetPolicyTreeExport(c *contextmodel.ReqContext) response.Response {
-	policies, _, err := srv.policies.GetPolicyTree(c.Req.Context(), c.GetOrgID())
-	if err != nil {
-		if errors.Is(err, store.ErrNoAlertmanagerConfiguration) {
-			return ErrResp(http.StatusNotFound, err, "")
+	routeName := c.Query("routeName")
+	//nolint:staticcheck // not yet migrated to OpenFeature
+	if !srv.featureManager.IsEnabledGlobally(featuremgmt.FlagAlertingMultiplePolicies) || routeName == "" {
+		// Default to the old behavior of exporting the single user-defined policy tree without a "name" field.
+		policy, _, err := srv.policies.GetPolicyTree(c.Req.Context(), c.GetOrgID())
+		if err != nil {
+			if errors.Is(err, store.ErrNoAlertmanagerConfiguration) {
+				return ErrResp(http.StatusNotFound, err, "")
+			}
+			return ErrResp(http.StatusInternalServerError, err, "")
 		}
-		return ErrResp(http.StatusInternalServerError, err, "")
+		e, err := AlertingFileExportFromRoute(c.GetOrgID(), policy)
+		if err != nil {
+			return ErrResp(http.StatusInternalServerError, err, "failed to create alerting file export")
+		}
+		return exportResponse(c, e)
 	}
 
-	e, err := AlertingFileExportFromRoute(c.GetOrgID(), policies)
+	managedRoute, err := srv.routeService.GetManagedRoute(c.Req.Context(), c.GetOrgID(), routeName)
+	if err != nil {
+		return response.ErrOrFallback(http.StatusInternalServerError, "failed to export notification policy tree", err)
+	}
+
+	e, err := AlertingFileExportFromRoute(c.GetOrgID(), managedRoute.AsRoute())
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "failed to create alerting file export")
 	}
-
 	return exportResponse(c, e)
 }
 

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/routes"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	ngalertfakes "github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
@@ -2072,16 +2073,31 @@ func TestApiContactPointExportSnapshot(t *testing.T) {
 }
 
 func TestApiNotificationPolicyExportSnapshot(t *testing.T) {
-	// These tests are focused on exports using featuremgmt.FlagAlertingMultiplePolicies, but are using the `user-defined` for now.
+	// These tests are focused on exports using featuremgmt.FlagAlertingMultiplePolicies.
 	env := createTestEnv(t, testConfig) // testConfig should be unused here, we're overriding the policy service.
-	sut := createProvisioningSrvSutFromEnv(t, &env)
+	env.features = featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies)
 
-	for policyName, route := range policy_exports.AllRoutes() {
+	sut := createProvisioningSrvSutFromEnv(t, &env)
+	rev := legacy_storage.ConfigRevision{
+		Config: policy_exports.Config(),
+	}
+	sut.policies = newFakeNotificationPolicyService(rev)
+	sut.routeService = routes.NewFakeService(rev)
+
+	policies := []string{legacy_storage.UserDefinedRoutingTreeName}
+	for policy := range policy_exports.Config().ManagedRoutes {
+		policies = append(policies, policy)
+	}
+
+	for _, policyName := range policies {
 		t.Run(fmt.Sprintf("policy=%s", policyName), func(t *testing.T) {
-			sut.policies = newFakeNotificationPolicyService(route)
 			for _, exportType := range []string{"json", "yaml", "hcl"} {
 				t.Run(fmt.Sprintf("exportType=%s", exportType), func(t *testing.T) {
 					rc := createTestRequestCtx()
+
+					if policyName != "all" { // All export requires an empty route name query param.
+						rc.Req.Form.Add("routeName", policyName)
+					}
 
 					switch exportType {
 					case "yaml":
@@ -2264,12 +2280,27 @@ func createProvisioningSrvSut(t *testing.T) ProvisioningSrv {
 func createProvisioningSrvSutFromEnv(t *testing.T, env *testEnvironment) ProvisioningSrv {
 	t.Helper()
 	tracer := tracing.InitializeTracerForTest()
+
+	rev := legacy_storage.ConfigRevision{
+		Config: &definitions.PostableUserConfig{
+			AlertmanagerConfig: definitions.PostableApiAlertingConfig{
+				Config: definitions.Config{
+					Route: &definitions.Route{
+						Receiver: "some-receiver",
+					},
+				},
+			},
+		},
+	}
+
 	configStore := legacy_storage.NewAlertmanagerConfigStore(env.configs, notifier.NewExtraConfigsCrypto(env.secrets), env.features)
+	rs := routes.NewFakeService(rev)
 	receiverSvc := notifier.NewReceiverService(
 		ac.NewReceiverAccess[*models.Receiver](env.ac, true),
 		configStore,
 		env.prov,
 		env.store,
+		rs,
 		env.secrets,
 		env.xact,
 		env.log,
@@ -2278,13 +2309,12 @@ func createProvisioningSrvSutFromEnv(t *testing.T, env *testEnvironment) Provisi
 		false,
 	)
 	return ProvisioningSrv{
-		log: env.log,
-		policies: newFakeNotificationPolicyService(&definitions.Route{
-			Receiver: "some-receiver",
-		}),
+		log:                 env.log,
+		policies:            newFakeNotificationPolicyService(rev),
+		routeService:        rs,
 		contactPointService: provisioning.NewContactPointService(configStore, env.secrets, env.prov, env.xact, receiverSvc, env.log, env.store, ngalertfakes.NewFakeReceiverPermissionsService()),
 		templates:           provisioning.NewTemplateService(configStore, env.prov, env.xact, env.log),
-		muteTimings:         provisioning.NewMuteTimingService(configStore, env.prov, env.xact, env.log, env.store),
+		muteTimings:         provisioning.NewMuteTimingService(configStore, env.prov, env.xact, env.log, env.store, rs),
 		alertRules:          provisioning.NewAlertRuleService(env.store, env.prov, env.folderService, env.quotas, env.xact, 60, 10, 100, env.log, env.nsValidator, env.rulesAuthz),
 		folderSvc:           env.folderService,
 		featureManager:      env.features,
@@ -2316,18 +2346,10 @@ type fakeNotificationPolicyService struct {
 	prov   models.Provenance
 }
 
-func newFakeNotificationPolicyService(route *definitions.Route) *fakeNotificationPolicyService {
+func newFakeNotificationPolicyService(rev legacy_storage.ConfigRevision) *fakeNotificationPolicyService {
 	return &fakeNotificationPolicyService{
-		config: legacy_storage.ConfigRevision{
-			Config: &definitions.PostableUserConfig{
-				AlertmanagerConfig: definitions.PostableApiAlertingConfig{
-					Config: definitions.Config{
-						Route: route,
-					},
-				},
-			},
-		},
-		prov: models.ProvenanceNone,
+		config: rev,
+		prov:   models.ProvenanceNone,
 	}
 }
 

--- a/pkg/services/ngalert/api/test-data/policy-exports/testing.go
+++ b/pkg/services/ngalert/api/test-data/policy-exports/testing.go
@@ -60,6 +60,13 @@ var Config = func() *definitions.PostableUserConfig {
 				{Receiver: prometheus.Receiver{Name: "nested-receiver"}},
 			},
 		},
+		ManagedRoutes: map[string]*definition.Route{
+			"empty":            Empty(),
+			"override-inherit": OverrideInherit(),
+			"matcher-variety":  MatcherVariety(),
+			"special-cases":    SpecialCases(),
+			"deeply-nested":    DeeplyNested(),
+		},
 	}
 }
 

--- a/pkg/services/ngalert/models/errors.go
+++ b/pkg/services/ngalert/models/errors.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
 var (
@@ -52,6 +53,8 @@ var (
 
 // Route errors.
 var (
+	ErrRouteNotFound = errutil.NotFound("alerting.notifications.routes.notFound", errutil.WithPublicMessage("Route not found"))
+
 	ErrRouteInvalidFormat = errutil.BadRequest("alerting.notifications.routes.invalidFormat").MustTemplate(
 		"Invalid format of the submitted route.",
 		errutil.WithPublic("Invalid format of the submitted route: {{.Public.Error}}. Correct the payload and try again."),
@@ -60,6 +63,10 @@ var (
 	ErrRouteConflictingMatchers = errutil.BadRequest("alerting.notifications.routes.conflictingMatchers").MustTemplate("Routing tree conflicts with the external configuration",
 		errutil.WithPublic("Cannot add\\update route: matchers conflict with an external routing tree merging matchers {{ .Public.Matchers }}, making the added\\updated route unreachable."),
 	)
+
+	ErrMultipleRoutesNotSupported = errutil.NotImplemented("alerting.notifications.routes.multipleNotSupported", errutil.WithPublicMessage(fmt.Sprintf("Multiple routes are not supported, see feature toggle %q", featuremgmt.FlagAlertingMultiplePolicies)))
+
+	ErrVersionConflict = errutil.Conflict("alerting.notifications.routes.conflict")
 )
 
 func ErrAlertRuleConflict(ruleUID string, orgID int64, err error) error {

--- a/pkg/services/ngalert/models/errors.go
+++ b/pkg/services/ngalert/models/errors.go
@@ -56,7 +56,7 @@ var (
 	ErrRouteNotFound = errutil.NotFound("alerting.notifications.routes.notFound", errutil.WithPublicMessage("Route not found"))
 
 	ErrRouteInvalidFormat = errutil.BadRequest("alerting.notifications.routes.invalidFormat").MustTemplate(
-		"Invalid format of the submitted route.",
+		"Invalid format of the submitted route: {{.Public.Error}}.",
 		errutil.WithPublic("Invalid format of the submitted route: {{.Public.Error}}. Correct the payload and try again."),
 	)
 
@@ -67,6 +67,7 @@ var (
 	ErrMultipleRoutesNotSupported = errutil.NotImplemented("alerting.notifications.routes.multipleNotSupported", errutil.WithPublicMessage(fmt.Sprintf("Multiple routes are not supported, see feature toggle %q", featuremgmt.FlagAlertingMultiplePolicies)))
 
 	ErrVersionConflict = errutil.Conflict("alerting.notifications.routes.conflict")
+	ErrRouteExists     = errutil.Conflict("alerting.notifications.routes.exists", errutil.WithPublicMessage("Route with this name already exists. Use a different name or update an existing one."))
 )
 
 func ErrAlertRuleConflict(ruleUID string, orgID int64, err error) error {

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -15,6 +15,8 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/lokiconfig"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/routes"
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning/validation"
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/bus"
@@ -436,12 +438,16 @@ func (ng *AlertNG) init() error {
 	}
 
 	configStore := legacy_storage.NewAlertmanagerConfigStore(ng.store, notifier.NewExtraConfigsCrypto(ng.SecretsService), ng.FeatureToggles)
+
+	routeService := routes.NewService(configStore, ng.store, ng.store, ng.Cfg.UnifiedAlerting, ng.FeatureToggles, ng.Log, validation.ValidateProvenanceRelaxed)
+
 	receiverAccess := ac.NewReceiverAccess[*models.Receiver](ng.accesscontrol, false)
 	receiverService := notifier.NewReceiverService(
 		receiverAccess,
 		configStore,
 		ng.store,
 		ng.store,
+		routeService,
 		ng.SecretsService,
 		ng.store,
 		ng.Log,
@@ -462,6 +468,7 @@ func (ng *AlertNG) init() error {
 		configStore,
 		ng.store,
 		ng.store,
+		routeService,
 		ng.SecretsService,
 		ng.store,
 		ng.Log,
@@ -474,7 +481,7 @@ func (ng *AlertNG) init() error {
 	policyService := provisioning.NewNotificationPolicyService(configStore, ng.store, ng.store, ng.Cfg.UnifiedAlerting, ng.Log)
 	contactPointService := provisioning.NewContactPointService(configStore, ng.SecretsService, ng.store, ng.store, provisioningReceiverService, ng.Log, ng.store, ng.ResourcePermissions)
 	templateService := provisioning.NewTemplateService(configStore, ng.store, ng.store, ng.Log)
-	muteTimingService := provisioning.NewMuteTimingService(configStore, ng.store, ng.store, ng.Log, ng.store)
+	muteTimingService := provisioning.NewMuteTimingService(configStore, ng.store, ng.store, ng.Log, ng.store, routeService)
 	alertRuleService := provisioning.NewAlertRuleService(ng.store, ng.store, ng.folderService, ng.QuotaService, ng.store,
 		int64(ng.Cfg.UnifiedAlerting.DefaultRuleEvaluationInterval.Seconds()),
 		int64(ng.Cfg.UnifiedAlerting.BaseInterval.Seconds()),
@@ -498,6 +505,7 @@ func (ng *AlertNG) init() error {
 		RuleStatusReader:     apiStatusReader,
 		AccessControl:        ng.accesscontrol,
 		Policies:             policyService,
+		RouteService:         routeService,
 		ReceiverService:      receiverService,
 		ReceiverTestService:  receiverTestService,
 		ContactPointService:  contactPointService,

--- a/pkg/services/ngalert/notifier/legacy_storage/errors.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/errors.go
@@ -5,12 +5,6 @@ import "github.com/grafana/grafana/pkg/apimachinery/errutil"
 var (
 	ErrNoAlertmanagerConfiguration  = errutil.Internal("alerting.notification.configMissing", errutil.WithPublicMessage("No alertmanager configuration present in this organization"))
 	ErrBadAlertmanagerConfiguration = errutil.Internal("alerting.notification.configCorrupted").MustTemplate("Failed to unmarshal the Alertmanager configuration", errutil.WithPublic("Current Alertmanager configuration in the storage is corrupted. Reset the configuration or rollback to a recent valid one."))
-
-	ErrRouteExists        = errutil.Conflict("alerting.notifications.routes.exists", errutil.WithPublicMessage("Route with this name already exists. Use a different name or update an existing one."))
-	ErrRouteInvalidFormat = errutil.BadRequest("alerting.notifications.routes.invalidFormat").MustTemplate(
-		"Invalid format of the submitted route: {{.Public.Error}}.",
-		errutil.WithPublic("Invalid format of the submitted route: {{.Public.Error}}. Correct the payload and try again."),
-	)
 )
 
 func makeErrBadAlertmanagerConfiguration(err error) error {
@@ -21,13 +15,4 @@ func makeErrBadAlertmanagerConfiguration(err error) error {
 		Error: err,
 	}
 	return ErrBadAlertmanagerConfiguration.Build(data)
-}
-
-func MakeErrRouteInvalidFormat(err error) error {
-	return ErrRouteInvalidFormat.Build(errutil.TemplateData{
-		Public: map[string]any{
-			"Error": err.Error(),
-		},
-		Error: err,
-	})
 }

--- a/pkg/services/ngalert/notifier/legacy_storage/errors.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/errors.go
@@ -5,6 +5,12 @@ import "github.com/grafana/grafana/pkg/apimachinery/errutil"
 var (
 	ErrNoAlertmanagerConfiguration  = errutil.Internal("alerting.notification.configMissing", errutil.WithPublicMessage("No alertmanager configuration present in this organization"))
 	ErrBadAlertmanagerConfiguration = errutil.Internal("alerting.notification.configCorrupted").MustTemplate("Failed to unmarshal the Alertmanager configuration", errutil.WithPublic("Current Alertmanager configuration in the storage is corrupted. Reset the configuration or rollback to a recent valid one."))
+
+	ErrRouteExists        = errutil.Conflict("alerting.notifications.routes.exists", errutil.WithPublicMessage("Route with this name already exists. Use a different name or update an existing one."))
+	ErrRouteInvalidFormat = errutil.BadRequest("alerting.notifications.routes.invalidFormat").MustTemplate(
+		"Invalid format of the submitted route: {{.Public.Error}}.",
+		errutil.WithPublic("Invalid format of the submitted route: {{.Public.Error}}. Correct the payload and try again."),
+	)
 )
 
 func makeErrBadAlertmanagerConfiguration(err error) error {
@@ -15,4 +21,13 @@ func makeErrBadAlertmanagerConfiguration(err error) error {
 		Error: err,
 	}
 	return ErrBadAlertmanagerConfiguration.Build(data)
+}
+
+func MakeErrRouteInvalidFormat(err error) error {
+	return ErrRouteInvalidFormat.Build(errutil.TemplateData{
+		Public: map[string]any{
+			"Error": err.Error(),
+		},
+		Error: err,
+	})
 }

--- a/pkg/services/ngalert/notifier/legacy_storage/routes.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/routes.go
@@ -7,15 +7,242 @@ import (
 	"hash/fnv"
 	"maps"
 	"slices"
+	"strings"
 	"unsafe"
 
+	"github.com/grafana/alerting/definition"
+	"github.com/prometheus/alertmanager/dispatch"
+	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-func (rev *ConfigRevision) ResetUserDefinedRoute(defaultCfg *definitions.PostableUserConfig) error {
+const UserDefinedRoutingTreeName = "user-defined"
+const NamedRouteMatcher = "__grafana_managed_route__"
+
+type ManagedRoute struct {
+	Name    string
+	Version string
+
+	Receiver       string
+	GroupBy        []string
+	GroupWait      *model.Duration
+	GroupInterval  *model.Duration
+	RepeatInterval *model.Duration
+	Routes         []*definition.Route
+
+	Provenance models.Provenance
+}
+
+func (r *ManagedRoute) AsRoute() definition.Route {
+	groupByAll, groupBy := ToGroupBy(r.GroupBy...)
+
+	// Only need to copy the fields that are valid for a root route.
+	return definition.Route{
+		Receiver:       r.Receiver,
+		GroupByStr:     r.GroupBy,
+		GroupWait:      r.GroupWait,
+		GroupInterval:  r.GroupInterval,
+		RepeatInterval: r.RepeatInterval,
+		Routes:         r.Routes,
+		Provenance:     definitions.Provenance(r.Provenance),
+
+		// These are deceptively necessary since they are normally generated during unmarshalling and assumed to be
+		// present in upstream alertmanager code. We can't assume we'll be unmarshalling the route again, so we need to
+		// set them here.
+		GroupBy:    groupBy,
+		GroupByAll: groupByAll,
+	}
+}
+
+func (r *ManagedRoute) GeneratedSubRoute() *definition.Route {
+	amRoute := r.AsRoute()
+
+	// It's important that the generated sub-route is fully defined so that they will never rely on the values of the root.
+	defaultOpts := dispatch.DefaultRouteOpts
+	if amRoute.GroupWait == nil {
+		gw := model.Duration(defaultOpts.GroupWait)
+		amRoute.GroupWait = &gw
+	}
+	if amRoute.GroupInterval == nil {
+		gi := model.Duration(defaultOpts.GroupInterval)
+		amRoute.GroupInterval = &gi
+	}
+	if amRoute.RepeatInterval == nil {
+		ri := model.Duration(defaultOpts.RepeatInterval)
+		amRoute.RepeatInterval = &ri
+	}
+	if r.Name != UserDefinedRoutingTreeName {
+		// Set label matcher.
+		amRoute.ObjectMatchers = definitions.ObjectMatchers{managedRouteMatcher(r.Name)}
+	}
+	return &amRoute
+}
+
+func (r *ManagedRoute) ResourceType() string {
+	return (&definition.Route{}).ResourceType()
+}
+
+func (r *ManagedRoute) ResourceID() string {
+	if r.Name == UserDefinedRoutingTreeName {
+		// Backwards compatibility with legacy user-defined routing tree.
+		return ""
+	}
+	return r.Name
+}
+
+func NewManagedRoute(name string, r *definition.Route) *ManagedRoute {
+	return &ManagedRoute{
+		Name:    name,
+		Version: CalculateRouteFingerprint(*r),
+
+		Receiver:       r.Receiver,
+		GroupBy:        r.GroupByStr,
+		GroupWait:      r.GroupWait,
+		GroupInterval:  r.GroupInterval,
+		RepeatInterval: r.RepeatInterval,
+		Routes:         r.Routes,
+
+		Provenance: models.Provenance(r.Provenance),
+	}
+}
+
+func managedRouteMatcher(name string) *labels.Matcher {
+	return &labels.Matcher{
+		Type:  labels.MatchEqual,
+		Name:  NamedRouteMatcher,
+		Value: name,
+	}
+}
+
+type ManagedRoutes []*ManagedRoute
+
+func (m ManagedRoutes) Sort() {
+	// Sort the keys of the map to ensure consistent ordering. Always ensure that the legacy user-defined routing tree is last.
+	slices.SortFunc(m, func(a, b *ManagedRoute) int {
+		if a.Name == UserDefinedRoutingTreeName {
+			return 1
+		}
+		if b.Name == UserDefinedRoutingTreeName {
+			return -1
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+}
+
+func WithManagedRoutes(root *definitions.Route, managedRoutes map[string]*definition.Route) *definitions.Route {
+	if len(managedRoutes) == 0 {
+		// If there are no managed routes, we just return the original root.
+		return root
+	}
+	newRoot := *root
+	newManagedRoutes := make([]*definition.Route, 0, len(newRoot.Routes)+len(managedRoutes))
+	for _, k := range slices.Sorted(maps.Keys(managedRoutes)) {
+		// On the off chance that the route is nil or invalid managed route with the restricted name, we skip it.
+		if managedRoutes[k] == nil || k == UserDefinedRoutingTreeName {
+			continue
+		}
+		newManagedRoutes = append(newManagedRoutes, NewManagedRoute(k, managedRoutes[k]).GeneratedSubRoute())
+	}
+
+	// Add the user-defined routing tree at the end.
+	newManagedRoutes = append(newManagedRoutes, newRoot.Routes...)
+	newRoot.Routes = newManagedRoutes
+	return &newRoot
+}
+
+func (rev *ConfigRevision) GetManagedRoute(name string) *ManagedRoute {
+	if name == UserDefinedRoutingTreeName {
+		return NewManagedRoute(UserDefinedRoutingTreeName, rev.Config.AlertmanagerConfig.Route)
+	}
+	route, ok := rev.Config.ManagedRoutes[name]
+	if !ok {
+		return nil
+	}
+	return NewManagedRoute(name, route)
+}
+
+func (rev *ConfigRevision) GetManagedRoutes(includeManagedRoutes bool) ManagedRoutes {
+	managedRoutes := make(ManagedRoutes, 0, len(rev.Config.ManagedRoutes)+1)
+	if includeManagedRoutes {
+		for _, k := range slices.Sorted(maps.Keys(rev.Config.ManagedRoutes)) {
+			// On the off chance that the route is nil or invalid managed route with the restricted name, we skip it.
+			if rev.Config.ManagedRoutes[k] == nil || k == UserDefinedRoutingTreeName {
+				continue
+			}
+			managedRoutes = append(managedRoutes, NewManagedRoute(k, rev.Config.ManagedRoutes[k]))
+		}
+	}
+	managedRoutes = append(managedRoutes, NewManagedRoute(UserDefinedRoutingTreeName, rev.Config.AlertmanagerConfig.Route))
+
+	return managedRoutes
+}
+
+func (rev *ConfigRevision) DeleteManagedRoute(name string) {
+	delete(rev.Config.ManagedRoutes, name)
+}
+
+func (rev *ConfigRevision) CreateManagedRoute(name string, subtree definitions.Route) (*ManagedRoute, error) {
+	if name == "" {
+		return nil, fmt.Errorf("route name is required")
+	}
+
+	if name == UserDefinedRoutingTreeName {
+		return nil, fmt.Errorf("cannot create a managed route with the name %q, this name is reserved for the user-defined routing tree", UserDefinedRoutingTreeName)
+	}
+
+	if _, exists := rev.Config.ManagedRoutes[name]; exists {
+		return nil, ErrRouteExists.Errorf("")
+	}
+
+	managedRoute := NewManagedRoute(name, &subtree)
+	amRoute := managedRoute.AsRoute()
+
+	err := rev.ValidateRoute(amRoute)
+	if err != nil {
+		return nil, MakeErrRouteInvalidFormat(err)
+	}
+
+	if rev.Config.ManagedRoutes == nil {
+		rev.Config.ManagedRoutes = make(map[string]*definition.Route, 1)
+	}
+	rev.Config.ManagedRoutes[name] = &amRoute
+
+	return managedRoute, nil
+}
+
+func (rev *ConfigRevision) UpdateNamedRoute(name string, subtree definitions.Route) (*ManagedRoute, error) {
+	if name == "" {
+		return nil, fmt.Errorf("route name is required")
+	}
+
+	if existing := rev.GetManagedRoute(name); existing == nil {
+		return nil, fmt.Errorf("managed route %q not found", name)
+	}
+
+	managedRoute := NewManagedRoute(name, &subtree)
+	amRoute := managedRoute.AsRoute()
+
+	err := rev.ValidateRoute(amRoute)
+	if err != nil {
+		return nil, MakeErrRouteInvalidFormat(err)
+	}
+
+	if name == UserDefinedRoutingTreeName {
+		rev.Config.AlertmanagerConfig.Route = &amRoute
+	} else {
+		if rev.Config.ManagedRoutes == nil {
+			rev.Config.ManagedRoutes = make(map[string]*definition.Route, 1)
+		}
+		rev.Config.ManagedRoutes[name] = &amRoute
+	}
+
+	return managedRoute, nil
+}
+
+func (rev *ConfigRevision) ResetUserDefinedRoute(defaultCfg *definitions.PostableUserConfig) (*ManagedRoute, error) {
 	// Ensure the new default receiver exists and if not, create it.
 	if err := rev.validateReceiverReferences(*defaultCfg.AlertmanagerConfig.Route); err != nil {
 		// Default receiver doesn't exist, create it.
@@ -27,13 +254,12 @@ func (rev *ConfigRevision) ResetUserDefinedRoute(defaultCfg *definitions.Postabl
 			}
 		}
 		if defaultRcv == nil {
-			return fmt.Errorf("inconsistent default configuration: default receiver %q not found", defaultCfg.AlertmanagerConfig.Route.Receiver)
+			return nil, fmt.Errorf("inconsistent default configuration: default receiver %q not found", defaultCfg.AlertmanagerConfig.Route.Receiver)
 		}
 		rev.Config.AlertmanagerConfig.Receivers = append(rev.Config.AlertmanagerConfig.Receivers, defaultRcv)
 	}
 
-	rev.Config.AlertmanagerConfig.Route = defaultCfg.AlertmanagerConfig.Route
-	return nil
+	return rev.UpdateNamedRoute(UserDefinedRoutingTreeName, *defaultCfg.AlertmanagerConfig.Route)
 }
 
 func (rev *ConfigRevision) ValidateRoute(route definitions.Route) error {
@@ -72,8 +298,19 @@ func (rev *ConfigRevision) validateTimeIntervalReferences(route definitions.Rout
 }
 
 // RenameReceiverInRoutes renames all references to a receiver in all routes. Returns number of routes that were updated
-func (rev *ConfigRevision) RenameReceiverInRoutes(oldName, newName string) int {
-	return renameReceiverInRoute(oldName, newName, rev.Config.AlertmanagerConfig.Route)
+func (rev *ConfigRevision) RenameReceiverInRoutes(oldName, newName string, includeManagedRoutes bool) map[*definitions.Route]int {
+	res := make(map[*definitions.Route]int)
+	if cnt := renameReceiverInRoute(oldName, newName, rev.Config.AlertmanagerConfig.Route); cnt > 0 {
+		res[rev.Config.AlertmanagerConfig.Route] = cnt
+	}
+	for _, r := range rev.Config.ManagedRoutes {
+		// Still attempt to rename receivers in any managed routes if not supported for data consistency, but
+		// don't return them int he results.
+		if cnt := renameReceiverInRoute(oldName, newName, r); includeManagedRoutes && cnt > 0 {
+			res[r] = cnt
+		}
+	}
+	return res
 }
 
 func renameReceiverInRoute(oldName, newName string, routes ...*definitions.Route) int {
@@ -92,8 +329,19 @@ func renameReceiverInRoute(oldName, newName string, routes ...*definitions.Route
 }
 
 // RenameTimeIntervalInRoutes renames all references to a time interval in all routes. Returns number of routes that were updated
-func (rev *ConfigRevision) RenameTimeIntervalInRoutes(oldName, newName string) int {
-	return renameTimeIntervalInRoute(oldName, newName, rev.Config.AlertmanagerConfig.Route)
+func (rev *ConfigRevision) RenameTimeIntervalInRoutes(oldName, newName string, includeManagedRoutes bool) map[*definitions.Route]int {
+	res := make(map[*definitions.Route]int)
+	if cnt := renameTimeIntervalInRoute(oldName, newName, rev.Config.AlertmanagerConfig.Route); cnt > 0 {
+		res[rev.Config.AlertmanagerConfig.Route] = cnt
+	}
+	for _, r := range rev.Config.ManagedRoutes {
+		// Still attempt to rename time intervals in any managed routes if not supported for data consistency, but
+		// don't return them int he results.
+		if cnt := renameTimeIntervalInRoute(oldName, newName, r); includeManagedRoutes && cnt > 0 {
+			res[r] = cnt
+		}
+	}
+	return res
 }
 
 func renameTimeIntervalInRoute(oldName, newName string, routes ...*definitions.Route) int {

--- a/pkg/services/ngalert/notifier/legacy_storage/routes.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/routes.go
@@ -194,7 +194,7 @@ func (rev *ConfigRevision) CreateManagedRoute(name string, subtree definitions.R
 	}
 
 	if _, exists := rev.Config.ManagedRoutes[name]; exists {
-		return nil, ErrRouteExists.Errorf("")
+		return nil, models.ErrRouteExists.Errorf("")
 	}
 
 	managedRoute := NewManagedRoute(name, &subtree)
@@ -202,7 +202,7 @@ func (rev *ConfigRevision) CreateManagedRoute(name string, subtree definitions.R
 
 	err := rev.ValidateRoute(amRoute)
 	if err != nil {
-		return nil, MakeErrRouteInvalidFormat(err)
+		return nil, models.MakeErrRouteInvalidFormat(err)
 	}
 
 	if rev.Config.ManagedRoutes == nil {
@@ -227,7 +227,7 @@ func (rev *ConfigRevision) UpdateNamedRoute(name string, subtree definitions.Rou
 
 	err := rev.ValidateRoute(amRoute)
 	if err != nil {
-		return nil, MakeErrRouteInvalidFormat(err)
+		return nil, models.MakeErrRouteInvalidFormat(err)
 	}
 
 	if name == UserDefinedRoutingTreeName {

--- a/pkg/services/ngalert/notifier/legacy_storage/routes_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/routes_test.go
@@ -284,12 +284,12 @@ func TestConfigRevision_CreateManagedRoute(t *testing.T) {
 	t.Run("rejects duplicate name", func(t *testing.T) {
 		rev := testConfig()
 		_, err := rev.CreateManagedRoute(getAnyKey(t, rev.Config.ManagedRoutes), subtree)
-		assert.ErrorIs(t, err, ErrRouteExists.Errorf(""))
+		assert.ErrorIs(t, err, models.ErrRouteExists.Errorf(""))
 	})
 
 	t.Run("rejects invalid route", func(t *testing.T) {
 		_, err := testConfig().CreateManagedRoute("test", definitions.Route{})
-		assert.ErrorIs(t, err, ErrRouteInvalidFormat)
+		assert.ErrorIs(t, err, models.ErrRouteInvalidFormat)
 	})
 
 	t.Run("creates valid managed route", func(t *testing.T) {
@@ -327,7 +327,7 @@ func TestConfigRevision_UpdateNamedRoute(t *testing.T) {
 	t.Run("rejects invalid route", func(t *testing.T) {
 		rev := testConfig()
 		_, err := rev.UpdateNamedRoute(getAnyKey(t, rev.Config.ManagedRoutes), definitions.Route{})
-		assert.ErrorIs(t, err, ErrRouteInvalidFormat)
+		assert.ErrorIs(t, err, models.ErrRouteInvalidFormat)
 	})
 
 	t.Run("updates valid managed route", func(t *testing.T) {

--- a/pkg/services/ngalert/notifier/legacy_storage/routes_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/routes_test.go
@@ -1,9 +1,13 @@
 package legacy_storage
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/dispatch"
+	"github.com/prometheus/alertmanager/pkg/labels"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -11,7 +15,343 @@ import (
 
 	policy_exports "github.com/grafana/grafana/pkg/services/ngalert/api/test-data/policy-exports"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/util"
 )
+
+func TestManagedRoute_AsRoute(t *testing.T) {
+	gw := model.Duration(10)
+	gi := model.Duration(20)
+	ri := model.Duration(30)
+
+	mr := &ManagedRoute{
+		Name:           "test",
+		Receiver:       "receiver",
+		GroupBy:        []string{"alertname"},
+		GroupWait:      &gw,
+		GroupInterval:  &gi,
+		RepeatInterval: &ri,
+		Routes:         []*definition.Route{{Receiver: "child"}},
+		Provenance:     models.Provenance("test"),
+	}
+
+	route := mr.AsRoute()
+
+	assert.Equal(t, "receiver", route.Receiver)
+	assert.Equal(t, []string{"alertname"}, route.GroupByStr)
+	assert.Equal(t, &gw, route.GroupWait)
+	assert.Equal(t, &gi, route.GroupInterval)
+	assert.Equal(t, &ri, route.RepeatInterval)
+	assert.Len(t, route.Routes, 1)
+	assert.EqualValues(t, definitions.Provenance("test"), route.Provenance)
+}
+
+func TestManagedRoute_GeneratedSubRoute_DefaultsAndMatcher(t *testing.T) {
+	mr := &ManagedRoute{
+		Name:     "managed",
+		Receiver: "receiver",
+	}
+
+	route := mr.GeneratedSubRoute()
+
+	assert.Equal(t, model.Duration(dispatch.DefaultRouteOpts.GroupWait), *route.GroupWait)
+	assert.Equal(t, model.Duration(dispatch.DefaultRouteOpts.GroupInterval), *route.GroupInterval)
+	assert.Equal(t, model.Duration(dispatch.DefaultRouteOpts.RepeatInterval), *route.RepeatInterval)
+
+	require.Len(t, route.ObjectMatchers, 1)
+	assert.Equal(t, NamedRouteMatcher, route.ObjectMatchers[0].Name)
+	assert.Equal(t, "managed", route.ObjectMatchers[0].Value)
+}
+
+func TestManagedRoute_GeneratedSubRoute_UserDefinedHasNoMatcher(t *testing.T) {
+	mr := &ManagedRoute{
+		Name:     UserDefinedRoutingTreeName,
+		Receiver: "receiver",
+	}
+
+	route := mr.GeneratedSubRoute()
+	require.Empty(t, route.ObjectMatchers)
+}
+
+func TestManagedRoute_GeneratedSubRoute_PreservesFields(t *testing.T) {
+	gw := model.Duration(10)
+	gi := model.Duration(20)
+	ri := model.Duration(30)
+
+	child := &definition.Route{
+		Receiver: "child",
+	}
+
+	mr := &ManagedRoute{
+		Name:           "managed",
+		Receiver:       "receiver",
+		GroupBy:        []string{"alertname", "cluster"},
+		GroupWait:      &gw,
+		GroupInterval:  &gi,
+		RepeatInterval: &ri,
+		Routes:         []*definition.Route{child},
+		Provenance:     models.Provenance("test"),
+	}
+
+	route := mr.GeneratedSubRoute()
+
+	// Basic fields preserved
+	assert.Equal(t, "receiver", route.Receiver)
+	assert.Equal(t, []string{"alertname", "cluster"}, route.GroupByStr)
+	assert.Equal(t, &gw, route.GroupWait)
+	assert.Equal(t, &gi, route.GroupInterval)
+	assert.Equal(t, &ri, route.RepeatInterval)
+
+	// Child routes preserved
+	require.Len(t, route.Routes, 1)
+	assert.Equal(t, "child", route.Routes[0].Receiver)
+
+	// Managed route matcher added
+	require.Len(t, route.ObjectMatchers, 1)
+	assert.Equal(t, NamedRouteMatcher, route.ObjectMatchers[0].Name)
+	assert.Equal(t, "managed", route.ObjectMatchers[0].Value)
+
+	// Provenance propagated
+	assert.EqualValues(t, definitions.Provenance("test"), route.Provenance)
+}
+
+func TestManagedRoutes_Sort(t *testing.T) {
+	routes := ManagedRoutes{
+		{Name: "x"},
+		{Name: UserDefinedRoutingTreeName},
+		{Name: "z"},
+	}
+
+	routes.Sort()
+
+	require.Equal(t, "x", routes[0].Name)
+	require.Equal(t, "z", routes[1].Name)
+	require.Equal(t, UserDefinedRoutingTreeName, routes[2].Name)
+}
+
+func TestWithManagedRoutes(t *testing.T) {
+	rev := func(root *definitions.Route, managedRoutes map[string]*definitions.Route) *ConfigRevision {
+		return &ConfigRevision{
+			Config: &definitions.PostableUserConfig{
+				AlertmanagerConfig: definitions.PostableApiAlertingConfig{
+					Config: definitions.Config{
+						Route: root,
+					},
+				},
+				ManagedRoutes: managedRoutes,
+			},
+		}
+	}
+	testCases := []struct {
+		name string
+
+		rev *ConfigRevision
+
+		expectedRoute *definitions.Route
+	}{
+		{
+			name: "simple, root is empty just adds managed routes",
+			rev: rev(policy_exports.Empty(),
+				map[string]*definitions.Route{
+					"override-inherit": policy_exports.OverrideInherit(),
+					"matcher-variety":  policy_exports.MatcherVariety(),
+				},
+			),
+			expectedRoute: &definitions.Route{
+				Receiver: policy_exports.Empty().Receiver,
+				Routes: []*definitions.Route{
+					NewManagedRoute("matcher-variety", policy_exports.MatcherVariety()).GeneratedSubRoute(),
+					NewManagedRoute("override-inherit", policy_exports.OverrideInherit()).GeneratedSubRoute(),
+				},
+			},
+		},
+		{
+			name: "complex root with existing routes merges to end of routes",
+			rev: rev(&definitions.Route{
+				Receiver: "root-receiver",
+				Routes: []*definitions.Route{
+					{ObjectMatchers: definitions.ObjectMatchers{{Name: "severity", Type: labels.MatchEqual, Value: "warn"}}, Continue: true},
+					{ObjectMatchers: definitions.ObjectMatchers{{Name: "severity", Type: labels.MatchNotEqual, Value: "critical"}}, Continue: true},
+					{ObjectMatchers: definitions.ObjectMatchers{{Name: "severity", Type: labels.MatchRegexp, Value: "info"}}, Continue: true},
+					{ObjectMatchers: definitions.ObjectMatchers{{Name: "severity", Type: labels.MatchNotRegexp, Value: "debug"}}, Continue: true},
+				},
+			},
+				map[string]*definitions.Route{
+					"r1": {Receiver: "recv1"},
+					"r2": {Receiver: "recv2"},
+				},
+			),
+			expectedRoute: &definitions.Route{
+				Receiver: "root-receiver",
+				Routes: []*definitions.Route{
+					{
+						Receiver:       "recv1",
+						ObjectMatchers: definitions.ObjectMatchers{{Name: NamedRouteMatcher, Type: labels.MatchEqual, Value: "r1"}},
+						GroupWait:      util.Pointer(model.Duration(dispatch.DefaultRouteOpts.GroupWait)),
+						GroupInterval:  util.Pointer(model.Duration(dispatch.DefaultRouteOpts.GroupInterval)),
+						RepeatInterval: util.Pointer(model.Duration(dispatch.DefaultRouteOpts.RepeatInterval)),
+					},
+					{
+						Receiver:       "recv2",
+						ObjectMatchers: definitions.ObjectMatchers{{Name: NamedRouteMatcher, Type: labels.MatchEqual, Value: "r2"}},
+						GroupWait:      util.Pointer(model.Duration(dispatch.DefaultRouteOpts.GroupWait)),
+						GroupInterval:  util.Pointer(model.Duration(dispatch.DefaultRouteOpts.GroupInterval)),
+						RepeatInterval: util.Pointer(model.Duration(dispatch.DefaultRouteOpts.RepeatInterval)),
+					},
+					{ObjectMatchers: definitions.ObjectMatchers{{Name: "severity", Type: labels.MatchEqual, Value: "warn"}}, Continue: true},
+					{ObjectMatchers: definitions.ObjectMatchers{{Name: "severity", Type: labels.MatchNotEqual, Value: "critical"}}, Continue: true},
+					{ObjectMatchers: definitions.ObjectMatchers{{Name: "severity", Type: labels.MatchRegexp, Value: "info"}}, Continue: true},
+					{ObjectMatchers: definitions.ObjectMatchers{{Name: "severity", Type: labels.MatchNotRegexp, Value: "debug"}}, Continue: true},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := WithManagedRoutes(tc.rev.Config.AlertmanagerConfig.Route, tc.rev.Config.ManagedRoutes)
+			assert.Equal(t, tc.expectedRoute, result)
+		})
+	}
+}
+
+func TestConfigRevision_GetManagedRoute(t *testing.T) {
+	rev := testConfig()
+
+	for name, expected := range rev.Config.ManagedRoutes {
+		t.Run(fmt.Sprintf("returns managed route %s", name), func(t *testing.T) {
+			got := rev.GetManagedRoute(name)
+			require.NotNil(t, got)
+			assert.Equal(t, NewManagedRoute(name, expected), got)
+		})
+	}
+
+	t.Run("returns user-defined route", func(t *testing.T) {
+		got := rev.GetManagedRoute(UserDefinedRoutingTreeName)
+		require.NotNil(t, got)
+		assert.Equal(t, UserDefinedRoutingTreeName, got.Name)
+		assert.Equal(t, NewManagedRoute(UserDefinedRoutingTreeName, rev.Config.AlertmanagerConfig.Route), got)
+	})
+
+	t.Run("returns nil if not found", func(t *testing.T) {
+		require.Nil(t, rev.GetManagedRoute("missing"))
+	})
+}
+
+func TestConfigRevision_GetManagedRoutes(t *testing.T) {
+	rev := testConfig()
+
+	t.Run("returns all managed routes", func(t *testing.T) {
+		routes := rev.GetManagedRoutes(true)
+
+		expected := make([]*ManagedRoute, 0, len(rev.Config.ManagedRoutes)+1)
+		for name, mr := range rev.Config.ManagedRoutes {
+			expected = append(expected, NewManagedRoute(name, mr))
+		}
+		expected = append(expected, NewManagedRoute(UserDefinedRoutingTreeName, rev.Config.AlertmanagerConfig.Route))
+
+		assert.Len(t, routes, len(expected))
+		assert.ElementsMatch(t, routes, expected)
+	})
+
+	t.Run("returns only default route when flag is false", func(t *testing.T) {
+		// Ignore non-default routes when `includeManagedRoutes=false`
+		routes := rev.GetManagedRoutes(false)
+
+		assert.Len(t, routes, 1)
+		assert.Equal(t, routes[0], NewManagedRoute(UserDefinedRoutingTreeName, rev.Config.AlertmanagerConfig.Route))
+	})
+}
+
+func TestConfigRevision_CreateManagedRoute(t *testing.T) {
+	origRev := testConfig()
+	subtree := definitions.Route{
+		Receiver: origRev.Config.AlertmanagerConfig.Receivers[0].Name,
+	}
+
+	t.Run("rejects empty name", func(t *testing.T) {
+		_, err := testConfig().CreateManagedRoute("", subtree)
+		assert.ErrorContains(t, err, "name")
+		assert.ErrorContains(t, err, "required")
+	})
+
+	t.Run("rejects reserved name", func(t *testing.T) {
+		_, err := testConfig().CreateManagedRoute(UserDefinedRoutingTreeName, subtree)
+		assert.ErrorContains(t, err, "reserved")
+		assert.ErrorContains(t, err, UserDefinedRoutingTreeName)
+	})
+
+	t.Run("rejects duplicate name", func(t *testing.T) {
+		rev := testConfig()
+		_, err := rev.CreateManagedRoute(getAnyKey(t, rev.Config.ManagedRoutes), subtree)
+		assert.ErrorIs(t, err, ErrRouteExists.Errorf(""))
+	})
+
+	t.Run("rejects invalid route", func(t *testing.T) {
+		_, err := testConfig().CreateManagedRoute("test", definitions.Route{})
+		assert.ErrorIs(t, err, ErrRouteInvalidFormat)
+	})
+
+	t.Run("creates valid managed route", func(t *testing.T) {
+		rev := testConfig()
+		name := "test"
+		mr, err := rev.CreateManagedRoute(name, subtree)
+		assert.NoError(t, err)
+		assert.NotNil(t, mr)
+		assert.Equal(t, name, mr.Name)
+
+		assert.Contains(t, rev.Config.ManagedRoutes, name)
+		assert.Equal(t, &subtree, rev.Config.ManagedRoutes[name])
+	})
+}
+
+func TestConfigRevision_UpdateNamedRoute(t *testing.T) {
+	origRev := testConfig()
+	subtree := definitions.Route{
+		Receiver: origRev.Config.AlertmanagerConfig.Receivers[0].Name,
+	}
+
+	t.Run("rejects empty name", func(t *testing.T) {
+		_, err := testConfig().UpdateNamedRoute("", subtree)
+		assert.ErrorContains(t, err, "name")
+		assert.ErrorContains(t, err, "required")
+	})
+
+	t.Run("reserved name updates default", func(t *testing.T) {
+		rev := testConfig()
+		_, err := rev.UpdateNamedRoute(UserDefinedRoutingTreeName, subtree)
+		assert.NoError(t, err)
+		assert.Equal(t, &subtree, rev.Config.AlertmanagerConfig.Route)
+	})
+
+	t.Run("rejects invalid route", func(t *testing.T) {
+		rev := testConfig()
+		_, err := rev.UpdateNamedRoute(getAnyKey(t, rev.Config.ManagedRoutes), definitions.Route{})
+		assert.ErrorIs(t, err, ErrRouteInvalidFormat)
+	})
+
+	t.Run("updates valid managed route", func(t *testing.T) {
+		rev := testConfig()
+		name := getAnyKey(t, rev.Config.ManagedRoutes)
+		mr, err := rev.UpdateNamedRoute(name, subtree)
+		assert.NoError(t, err)
+		assert.NotNil(t, mr)
+		assert.Equal(t, name, mr.Name)
+
+		assert.Contains(t, rev.Config.ManagedRoutes, name)
+		assert.Equal(t, &subtree, rev.Config.ManagedRoutes[name])
+	})
+}
+
+func TestConfigRevision_DeleteManagedRoute(t *testing.T) {
+	rev := testConfig()
+	for name := range policy_exports.Config().ManagedRoutes {
+		rev.DeleteManagedRoute(name)
+
+		assert.NotContains(t, rev.Config.ManagedRoutes, name)
+		assert.Nil(t, rev.GetManagedRoute(name))
+	}
+}
 
 func TestConfigRevision_ResetUserDefinedRoute(t *testing.T) {
 	rev := testConfig()
@@ -26,8 +366,10 @@ func TestConfigRevision_ResetUserDefinedRoute(t *testing.T) {
 			},
 		},
 	}
-	err := rev.ResetUserDefinedRoute(&defaultCfg)
+	mr, err := rev.ResetUserDefinedRoute(&defaultCfg)
 	assert.NoError(t, err)
+	assert.NotNil(t, mr)
+	assert.Equal(t, UserDefinedRoutingTreeName, mr.Name)
 
 	assert.Equal(t, &newRoute, rev.Config.AlertmanagerConfig.Route)
 	assert.NotEqual(t, original, rev.Config.AlertmanagerConfig.Route)
@@ -55,8 +397,10 @@ func TestConfigRevision_ResetUserDefinedRoute(t *testing.T) {
 			},
 		},
 	}
-	err = rev.ResetUserDefinedRoute(&defaultCfg)
+	mr, err = rev.ResetUserDefinedRoute(&defaultCfg)
 	assert.NoError(t, err)
+	assert.NotNil(t, mr)
+	assert.Equal(t, UserDefinedRoutingTreeName, mr.Name)
 
 	assert.Equal(t, &newRoute, rev.Config.AlertmanagerConfig.Route)
 	assert.NotEqual(t, original, rev.Config.AlertmanagerConfig.Route)
@@ -137,4 +481,12 @@ func testConfig() *ConfigRevision {
 		Config: policy_exports.Config(),
 	}
 	return rev
+}
+
+func getAnyKey[T any](t *testing.T, m map[string]*T) string {
+	for k := range m {
+		return k
+	}
+	t.Error("map is empty")
+	return ""
 }

--- a/pkg/services/ngalert/notifier/receiver_svc.go
+++ b/pkg/services/ngalert/notifier/receiver_svc.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning/validation"
@@ -27,6 +28,7 @@ type ReceiverService struct {
 	provisioningStore      provisoningStore
 	cfgStore               alertmanagerConfigStore
 	ruleNotificationsStore alertRuleNotificationSettingsStore
+	routeService           routeService
 	encryptionService      secretService
 	xact                   transactionManager
 	log                    log.Logger
@@ -34,6 +36,12 @@ type ReceiverService struct {
 	resourcePermissions    ac.ReceiverPermissionsService
 	tracer                 tracing.Tracer
 	includeImported        bool
+}
+
+type routeService interface {
+	ReceiverUseByName(ctx context.Context, rev *legacy_storage.ConfigRevision) map[string]int
+	ReceiverNameUsedByRoutes(ctx context.Context, rev *legacy_storage.ConfigRevision, name string) bool
+	RenameReceiverInRoutes(ctx context.Context, rev *legacy_storage.ConfigRevision, oldName, newName string) map[*definitions.Route]int
 }
 
 type alertRuleNotificationSettingsStore interface {
@@ -85,6 +93,7 @@ func NewReceiverService(
 	cfgStore alertmanagerConfigStore,
 	provisioningStore provisoningStore,
 	ruleNotificationsStore alertRuleNotificationSettingsStore,
+	routeService routeService,
 	encryptionService secretService,
 	xact transactionManager,
 	log log.Logger,
@@ -97,6 +106,7 @@ func NewReceiverService(
 		provisioningStore:      provisioningStore,
 		cfgStore:               cfgStore,
 		ruleNotificationsStore: ruleNotificationsStore,
+		routeService:           routeService,
 		encryptionService:      encryptionService,
 		xact:                   xact,
 		log:                    log,
@@ -300,7 +310,7 @@ func (rs *ReceiverService) DeleteReceiver(ctx context.Context, uid string, calle
 		return err
 	}
 
-	usedByRoutes := revision.ReceiverNameUsedByRoutes(existing.Name)
+	usedByRoutes := rs.routeService.ReceiverNameUsedByRoutes(ctx, revision, existing.Name)
 	usedByRules, err := rs.UsedByRules(ctx, orgID, existing.Name)
 	if err != nil {
 		return err
@@ -583,7 +593,7 @@ func (rs *ReceiverService) InUseMetadata(ctx context.Context, orgID int64, recei
 	var importedUsesInRoutes map[string]int
 	receiverUsesInRules := map[string][]models.AlertRuleKey{}
 	if hasGrafanaOrigin {
-		receiverUsesInRoutes = revision.ReceiverUseByName()
+		receiverUsesInRoutes = rs.routeService.ReceiverUseByName(ctx, revision)
 		q := models.ListNotificationSettingsQuery{OrgID: orgID}
 		if len(receivers) == 1 {
 			q.ReceiverName = receivers[0].Name
@@ -768,14 +778,19 @@ func (rs *ReceiverService) RenameReceiverInDependentResources(ctx context.Contex
 
 	validate := validation.ValidateProvenanceOfDependentResources(receiverProvenance)
 	// if there are no references to the old time interval, exit
-	updatedRoutes := revision.RenameReceiverInRoutes(oldName, newName)
 	canUpdate := true
-	if updatedRoutes > 0 {
-		routeProvenance, err := rs.provisioningStore.GetProvenance(ctx, revision.Config.AlertmanagerConfig.Route, orgID)
-		if err != nil {
-			return err
+	updatedRouteCnt := 0
+	if updatedRoutes := rs.routeService.RenameReceiverInRoutes(ctx, revision, oldName, newName); len(updatedRoutes) > 0 {
+		for route, updatedCnt := range updatedRoutes {
+			if updatedCnt > 0 {
+				updatedRouteCnt += updatedCnt
+				routeProvenance, err := rs.provisioningStore.GetProvenance(ctx, route, orgID)
+				if err != nil {
+					return err
+				}
+				canUpdate = validate(routeProvenance)
+			}
 		}
-		canUpdate = validate(routeProvenance)
 	}
 	dryRun := !canUpdate
 	affected, invalidProvenance, err := rs.ruleNotificationsStore.RenameReceiverInNotificationSettings(ctx, orgID, oldName, newName, validate, dryRun)
@@ -783,17 +798,21 @@ func (rs *ReceiverService) RenameReceiverInDependentResources(ctx context.Contex
 		return err
 	}
 	if !canUpdate || len(invalidProvenance) > 0 {
-		err := makeErrReceiverDependentResourcesProvenance(updatedRoutes > 0, invalidProvenance)
+		err := makeErrReceiverDependentResourcesProvenance(updatedRouteCnt > 0, invalidProvenance)
 		span.RecordError(err, trace.WithAttributes(
 			attribute.Bool("invalid_route_provenance", canUpdate),
 			attribute.Int("invalid_rule_provenances", len(invalidProvenance)),
 		))
 		return err
 	}
-	if len(affected) > 0 || updatedRoutes > 0 {
-		rs.log.FromContext(ctx).Info("Updated rules and routes that use renamed receiver", "oldName", oldName, "newName", newName, "rules", len(affected), "routes", updatedRoutes)
+	if len(affected) > 0 || updatedRouteCnt > 0 {
+		rs.log.FromContext(ctx).Info("Updated rules and routes that use renamed receiver", "oldName", oldName, "newName", newName, "rules", len(affected), "routes", updatedRouteCnt)
 	}
 	return nil
+}
+
+func (rs *ReceiverService) ReceiverNameUsedByRoutes(ctx context.Context, rev *legacy_storage.ConfigRevision, name string) bool {
+	return rs.routeService.ReceiverNameUsedByRoutes(ctx, rev, name)
 }
 
 func (rs *ReceiverService) getImportedReceivers(ctx context.Context, span trace.Span, uids []string, revision *legacy_storage.ConfigRevision) []*models.Receiver {

--- a/pkg/services/ngalert/notifier/receiver_svc.go
+++ b/pkg/services/ngalert/notifier/receiver_svc.go
@@ -788,7 +788,7 @@ func (rs *ReceiverService) RenameReceiverInDependentResources(ctx context.Contex
 				if err != nil {
 					return err
 				}
-				canUpdate = validate(routeProvenance)
+				canUpdate = canUpdate && validate(routeProvenance)
 			}
 		}
 	}

--- a/pkg/services/ngalert/notifier/receiver_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_svc_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/routes"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning/validation"
 	"github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -973,8 +974,8 @@ func TestReceiverService_UpdateReceiverName(t *testing.T) {
 		revision, err := sut.cfgStore.Get(context.Background(), writer.GetOrgID())
 		require.NoError(t, err)
 
-		assert.Falsef(t, revision.ReceiverNameUsedByRoutes(receiverName), "old receiver name '%s' should not be used by routes", receiverName)
-		assert.Truef(t, revision.ReceiverNameUsedByRoutes(newReceiverName), "new receiver name '%s' should be used by routes", newReceiverName)
+		assert.Falsef(t, revision.ReceiverNameUsedByRoutes(receiverName, false), "old receiver name '%s' should not be used by routes", receiverName)
+		assert.Truef(t, revision.ReceiverNameUsedByRoutes(newReceiverName, false), "new receiver name '%s' should be used by routes", newReceiverName)
 	})
 
 	t.Run("returns ErrReceiverDependentResourcesProvenance if route has different provenance status", func(t *testing.T) {
@@ -1802,6 +1803,7 @@ func createReceiverServiceSut(t *testing.T, encryptSvc secretService, opts ...cr
 		legacy_storage.NewAlertmanagerConfigStore(store, NewExtraConfigsCrypto(encryptSvc), featuremgmt.WithFeatures()),
 		provisioningStore,
 		&fakeAlertRuleNotificationStore{},
+		routes.NewFakeService(legacy_storage.ConfigRevision{}),
 		encryptSvc,
 		xact,
 		log.NewNopLogger(),

--- a/pkg/services/ngalert/notifier/routes/service.go
+++ b/pkg/services/ngalert/notifier/routes/service.go
@@ -64,11 +64,6 @@ func NewService(
 }
 
 func (nps *Service) GetManagedRoute(ctx context.Context, orgID int64, name string) (legacy_storage.ManagedRoute, error) {
-	// TODO: Keep this?
-	if name == "" {
-		name = legacy_storage.UserDefinedRoutingTreeName
-	}
-
 	// Backwards compatibility when managed routes FF is disabled. Only allow the default route.
 	if !nps.managedRoutesEnabled() && name != legacy_storage.UserDefinedRoutingTreeName {
 		return legacy_storage.ManagedRoute{}, models.ErrRouteNotFound.Errorf("route %q not found", name)
@@ -118,11 +113,6 @@ func (nps *Service) GetManagedRoutes(ctx context.Context, orgID int64) (legacy_s
 }
 
 func (nps *Service) UpdateManagedRoute(ctx context.Context, orgID int64, name string, subtree definitions.Route, p models.Provenance, version string) (*legacy_storage.ManagedRoute, error) {
-	// TODO: Keep this?
-	if name == "" {
-		name = legacy_storage.UserDefinedRoutingTreeName
-	}
-
 	// Backwards compatibility when managed routes FF is disabled. Only allow the default route.
 	if !nps.managedRoutesEnabled() && name != legacy_storage.UserDefinedRoutingTreeName {
 		return nil, models.ErrRouteNotFound.Errorf("route %q not found", name)
@@ -185,11 +175,6 @@ func (nps *Service) UpdateManagedRoute(ctx context.Context, orgID int64, name st
 }
 
 func (nps *Service) DeleteManagedRoute(ctx context.Context, orgID int64, name string, p models.Provenance, version string) error {
-	// TODO: Keep this?
-	if name == "" {
-		name = legacy_storage.UserDefinedRoutingTreeName
-	}
-
 	// Backwards compatibility when managed routes FF is disabled. Only allow the default route.
 	if !nps.managedRoutesEnabled() && name != legacy_storage.UserDefinedRoutingTreeName {
 		return models.ErrRouteNotFound.Errorf("route %q not found", name)

--- a/pkg/services/ngalert/notifier/routes/service.go
+++ b/pkg/services/ngalert/notifier/routes/service.go
@@ -206,7 +206,6 @@ func (nps *Service) DeleteManagedRoute(ctx context.Context, orgID int64, name st
 	if name == legacy_storage.UserDefinedRoutingTreeName {
 		defaultCfg, err := legacy_storage.DeserializeAlertmanagerConfig([]byte(nps.settings.DefaultConfiguration))
 		if err != nil {
-			nps.log.Error("Failed to parse default alertmanager config: %w", err)
 			return fmt.Errorf("failed to parse default alertmanager config: %w", err)
 		}
 

--- a/pkg/services/ngalert/notifier/routes/service.go
+++ b/pkg/services/ngalert/notifier/routes/service.go
@@ -1,0 +1,323 @@
+package routes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/grafana/alerting/definition"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type routeProvenanceStore interface {
+	GetProvenance(ctx context.Context, o models.Provisionable, org int64) (models.Provenance, error)
+	GetProvenances(ctx context.Context, org int64, resourceType string) (map[string]models.Provenance, error)
+	SetProvenance(ctx context.Context, o models.Provisionable, org int64, p models.Provenance) error
+	DeleteProvenance(ctx context.Context, o models.Provisionable, org int64) error
+}
+
+type transactionManager interface {
+	InTransaction(ctx context.Context, work func(ctx context.Context) error) error
+}
+
+type alertmanagerConfigStore interface {
+	Get(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error)
+	Save(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64) error
+}
+
+type provenanceValidator func(from, to models.Provenance) error
+
+type Service struct {
+	configStore     alertmanagerConfigStore
+	provenanceStore routeProvenanceStore
+	xact            transactionManager
+	log             log.Logger
+	settings        setting.UnifiedAlertingSettings
+	validator       provenanceValidator
+	FeatureToggles  featuremgmt.FeatureToggles
+}
+
+func NewService(
+	am alertmanagerConfigStore,
+	prov routeProvenanceStore,
+	xact transactionManager,
+	settings setting.UnifiedAlertingSettings,
+	features featuremgmt.FeatureToggles,
+	log log.Logger,
+	validator provenanceValidator,
+) *Service {
+	return &Service{
+		configStore:     am,
+		provenanceStore: prov,
+		xact:            xact,
+		log:             log,
+		settings:        settings,
+		FeatureToggles:  features,
+		validator:       validator,
+	}
+}
+
+func (nps *Service) GetManagedRoute(ctx context.Context, orgID int64, name string) (legacy_storage.ManagedRoute, error) {
+	// TODO: Keep this?
+	if name == "" {
+		name = legacy_storage.UserDefinedRoutingTreeName
+	}
+
+	// Backwards compatibility when managed routes FF is disabled. Only allow the default route.
+	if !nps.managedRoutesEnabled() && name != legacy_storage.UserDefinedRoutingTreeName {
+		return legacy_storage.ManagedRoute{}, models.ErrRouteNotFound.Errorf("route %q not found", name)
+	}
+
+	rev, err := nps.configStore.Get(ctx, orgID)
+	if err != nil {
+		return legacy_storage.ManagedRoute{}, err
+	}
+
+	route := rev.GetManagedRoute(name)
+	if route == nil {
+		return legacy_storage.ManagedRoute{}, models.ErrRouteNotFound.Errorf("route %q not found", name)
+	}
+
+	provenance, err := nps.provenanceStore.GetProvenance(ctx, route, orgID)
+	if err != nil {
+		return legacy_storage.ManagedRoute{}, err
+	}
+	route.Provenance = provenance
+
+	return *route, nil
+}
+
+func (nps *Service) GetManagedRoutes(ctx context.Context, orgID int64) (legacy_storage.ManagedRoutes, error) {
+	rev, err := nps.configStore.Get(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+
+	provenances, err := nps.provenanceStore.GetProvenances(ctx, orgID, (&legacy_storage.ManagedRoute{}).ResourceType())
+	if err != nil {
+		return nil, err
+	}
+
+	// Backwards compatibility when managed routes FF is disabled. Don't include any custom managed routes.
+	managedRoutes := rev.GetManagedRoutes(nps.managedRoutesEnabled())
+	for _, mr := range managedRoutes {
+		provenance, ok := provenances[mr.ResourceID()]
+		if !ok {
+			provenance = models.ProvenanceNone
+		}
+		mr.Provenance = provenance
+	}
+	managedRoutes.Sort()
+	return managedRoutes, nil
+}
+
+func (nps *Service) UpdateManagedRoute(ctx context.Context, orgID int64, name string, subtree definitions.Route, p models.Provenance, version string) (*legacy_storage.ManagedRoute, error) {
+	// TODO: Keep this?
+	if name == "" {
+		name = legacy_storage.UserDefinedRoutingTreeName
+	}
+
+	// Backwards compatibility when managed routes FF is disabled. Only allow the default route.
+	if !nps.managedRoutesEnabled() && name != legacy_storage.UserDefinedRoutingTreeName {
+		return nil, models.ErrRouteNotFound.Errorf("route %q not found", name)
+	}
+
+	err := subtree.Validate()
+	if err != nil {
+		return nil, models.MakeErrRouteInvalidFormat(err)
+	}
+
+	revision, err := nps.configStore.Get(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+
+	existing := revision.GetManagedRoute(name)
+	if existing == nil {
+		return nil, models.ErrRouteNotFound.Errorf("route %q not found", name)
+	}
+
+	err = nps.checkOptimisticConcurrency(existing, p, version, "update")
+	if err != nil {
+		return nil, err
+	}
+
+	// check that provenance is not changed in an invalid way
+	storedProvenance, err := nps.provenanceStore.GetProvenance(ctx, existing, orgID)
+	if err != nil {
+		return nil, err
+	}
+	if err := nps.validator(storedProvenance, p); err != nil {
+		return nil, err
+	}
+
+	updated, err := revision.UpdateNamedRoute(name, subtree)
+	if err != nil {
+		return nil, err
+	}
+	updated.Provenance = storedProvenance
+
+	_, err = revision.Config.GetMergedAlertmanagerConfig()
+	if err != nil {
+		if errors.Is(err, definition.ErrSubtreeMatchersConflict) {
+			// TODO temporarily get the conflicting matchers
+			return nil, models.MakeErrRouteConflictingMatchers(fmt.Sprintf("%s", revision.Config.ExtraConfigs[0].MergeMatchers))
+		}
+		nps.log.Warn("Unable to validate the combined routing tree because of an error during merging. This could be a sign of broken external configuration. Skipping", "error", err)
+	}
+
+	err = nps.xact.InTransaction(ctx, func(ctx context.Context) error {
+		if err := nps.configStore.Save(ctx, revision, orgID); err != nil {
+			return err
+		}
+		return nps.provenanceStore.SetProvenance(ctx, updated, orgID, p)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func (nps *Service) DeleteManagedRoute(ctx context.Context, orgID int64, name string, p models.Provenance, version string) error {
+	// TODO: Keep this?
+	if name == "" {
+		name = legacy_storage.UserDefinedRoutingTreeName
+	}
+
+	// Backwards compatibility when managed routes FF is disabled. Only allow the default route.
+	if !nps.managedRoutesEnabled() && name != legacy_storage.UserDefinedRoutingTreeName {
+		return models.ErrRouteNotFound.Errorf("route %q not found", name)
+	}
+
+	revision, err := nps.configStore.Get(ctx, orgID)
+	if err != nil {
+		return err
+	}
+
+	existing := revision.GetManagedRoute(name)
+	if existing == nil {
+		return models.ErrRouteNotFound.Errorf("route %q not found", name)
+	}
+
+	err = nps.checkOptimisticConcurrency(existing, p, version, "delete")
+	if err != nil {
+		return err
+	}
+
+	storedProvenance, err := nps.provenanceStore.GetProvenance(ctx, existing, orgID)
+	if err != nil {
+		return err
+	}
+	if err := nps.validator(storedProvenance, p); err != nil {
+		return err
+	}
+
+	if name == legacy_storage.UserDefinedRoutingTreeName {
+		defaultCfg, err := legacy_storage.DeserializeAlertmanagerConfig([]byte(nps.settings.DefaultConfiguration))
+		if err != nil {
+			nps.log.Error("Failed to parse default alertmanager config: %w", err)
+			return fmt.Errorf("failed to parse default alertmanager config: %w", err)
+		}
+
+		_, err = revision.ResetUserDefinedRoute(defaultCfg)
+		if err != nil {
+			return err
+		}
+	} else {
+		revision.DeleteManagedRoute(name)
+	}
+
+	_, err = revision.Config.GetMergedAlertmanagerConfig()
+	if err != nil {
+		return fmt.Errorf("new routing tree is not compatible with extra configuration: %w", err)
+	}
+
+	return nps.xact.InTransaction(ctx, func(ctx context.Context) error {
+		if err := nps.configStore.Save(ctx, revision, orgID); err != nil {
+			return err
+		}
+		return nps.provenanceStore.DeleteProvenance(ctx, existing, orgID)
+	})
+}
+
+func (nps *Service) CreateManagedRoute(ctx context.Context, orgID int64, name string, subtree definitions.Route, p models.Provenance) (*legacy_storage.ManagedRoute, error) {
+	// Backwards compatibility when managed routes FF is disabled. This is not allowed.
+	if !nps.managedRoutesEnabled() {
+		return nil, models.ErrMultipleRoutesNotSupported.Errorf("")
+	}
+
+	err := subtree.Validate()
+	if err != nil {
+		return nil, models.MakeErrRouteInvalidFormat(err)
+	}
+
+	revision, err := nps.configStore.Get(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+
+	created, err := revision.CreateManagedRoute(name, subtree)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = revision.Config.GetMergedAlertmanagerConfig()
+	if err != nil {
+		return nil, fmt.Errorf("new routing tree is not compatible with extra configuration: %w", err)
+	}
+
+	err = nps.xact.InTransaction(ctx, func(ctx context.Context) error {
+		if err := nps.configStore.Save(ctx, revision, orgID); err != nil {
+			return err
+		}
+		return nps.provenanceStore.SetProvenance(ctx, created, orgID, p)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return created, nil
+}
+
+func (nps *Service) checkOptimisticConcurrency(current *legacy_storage.ManagedRoute, provenance models.Provenance, desiredVersion string, action string) error {
+	if desiredVersion == "" {
+		if provenance != models.ProvenanceFile {
+			// if version is not specified and it's not a file provisioning, emit a log message to reflect that optimistic concurrency is disabled for this request
+			nps.log.Debug("ignoring optimistic concurrency check because version was not provided", "operation", action)
+		}
+		return nil
+	}
+	if current.Version != desiredVersion {
+		return models.ErrVersionConflict.Errorf("provided version %s of routing tree does not match current version %s", desiredVersion, current.Version)
+	}
+	return nil
+}
+
+func (nps *Service) ReceiverUseByName(_ context.Context, rev *legacy_storage.ConfigRevision) map[string]int {
+	return rev.ReceiverUseByName(nps.managedRoutesEnabled())
+}
+
+func (nps *Service) ReceiverNameUsedByRoutes(_ context.Context, rev *legacy_storage.ConfigRevision, name string) bool {
+	return rev.ReceiverNameUsedByRoutes(name, nps.managedRoutesEnabled())
+}
+
+func (nps *Service) RenameReceiverInRoutes(_ context.Context, rev *legacy_storage.ConfigRevision, oldName, newName string) map[*definitions.Route]int {
+	return rev.RenameReceiverInRoutes(oldName, newName, nps.managedRoutesEnabled())
+}
+
+func (nps *Service) RenameTimeIntervalInRoutes(_ context.Context, rev *legacy_storage.ConfigRevision, oldName string, newName string) map[*definitions.Route]int {
+	return rev.RenameTimeIntervalInRoutes(oldName, newName, nps.managedRoutesEnabled())
+}
+
+func (nps *Service) managedRoutesEnabled() bool {
+	if nps.FeatureToggles == nil {
+		return false
+	}
+	//nolint:staticcheck // not yet migrated to OpenFeature
+	return nps.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertingMultiplePolicies)
+}

--- a/pkg/services/ngalert/notifier/routes/testing.go
+++ b/pkg/services/ngalert/notifier/routes/testing.go
@@ -1,0 +1,48 @@
+package routes
+
+import (
+	"context"
+
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
+)
+
+type FakeService struct {
+	Service
+	Config               legacy_storage.ConfigRevision
+	Provenances          map[string]models.Provenance
+	IncludeManagedRoutes bool
+}
+
+func NewFakeService(config legacy_storage.ConfigRevision) *FakeService {
+	return &FakeService{
+		Config:               config,
+		Provenances:          make(map[string]models.Provenance),
+		IncludeManagedRoutes: true,
+	}
+}
+
+func (f *FakeService) GetManagedRoute(_ context.Context, _ int64, name string) (legacy_storage.ManagedRoute, error) {
+	r := f.Config.GetManagedRoute(name)
+	if r == nil {
+		return legacy_storage.ManagedRoute{}, models.ErrRouteNotFound.Errorf("route %q not found", name)
+	}
+	if p, ok := f.Provenances[name]; ok {
+		r.Provenance = p
+	}
+	return *r, nil
+}
+func (f *FakeService) GetManagedRoutes(_ context.Context, _ int64) (legacy_storage.ManagedRoutes, error) {
+	routes := f.Config.GetManagedRoutes(f.IncludeManagedRoutes)
+	for _, r := range routes {
+		if p, ok := f.Provenances[r.Name]; ok {
+			r.Provenance = p
+		}
+	}
+	return routes, nil
+}
+
+func (f *FakeService) RenameTimeIntervalInRoutes(_ context.Context, rev *legacy_storage.ConfigRevision, oldName string, newName string) map[*apimodels.Route]int {
+	return rev.RenameTimeIntervalInRoutes(oldName, newName, f.IncludeManagedRoutes)
+}

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -44,6 +44,7 @@ type ContactPointService struct {
 type receiverService interface {
 	GetReceivers(ctx context.Context, query models.GetReceiversQuery, user identity.Requester) ([]*models.Receiver, error)
 	RenameReceiverInDependentResources(ctx context.Context, orgID int64, route *legacy_storage.ConfigRevision, oldName, newName string, receiverProvenance models.Provenance) error
+	ReceiverNameUsedByRoutes(ctx context.Context, rev *legacy_storage.ConfigRevision, name string) bool
 }
 
 func NewContactPointService(
@@ -374,7 +375,7 @@ func (ecp *ContactPointService) DeleteContactPoint(ctx context.Context, orgID in
 			}
 		}
 	}
-	if fullRemoval && name != "" && revision.ReceiverNameUsedByRoutes(name) {
+	if fullRemoval && name != "" && ecp.receiverService.ReceiverNameUsedByRoutes(ctx, revision, name) {
 		return ErrContactPointReferenced.Errorf("")
 	}
 

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/routes"
 	"github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/services/secrets/database"
@@ -265,7 +266,7 @@ func TestIntegrationContactPointService(t *testing.T) {
 		newCp.Name = newName
 
 		svc.RenameReceiverInDependentResourcesFunc = func(ctx context.Context, orgID int64, revision *legacy_storage.ConfigRevision, oldName, newName string, receiverProvenance models.Provenance) error {
-			revision.RenameReceiverInRoutes(oldName, newName)
+			revision.RenameReceiverInRoutes(oldName, newName, false)
 			return nil
 		}
 
@@ -565,6 +566,7 @@ func createContactPointServiceSutWithConfigStore(t *testing.T, secretService sec
 		legacy_storage.NewAlertmanagerConfigStore(configStore, notifier.NewExtraConfigsCrypto(secretService), featuremgmt.WithFeatures()),
 		provisioningStore,
 		&fakeAlertRuleNotificationStore{},
+		routes.NewFakeService(legacy_storage.ConfigRevision{}),
 		secretService,
 		xact,
 		log.NewNopLogger(),

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -535,7 +535,7 @@ func (svc *MuteTimingService) renameTimeIntervalInDependentResources(ctx context
 				if err != nil {
 					return err
 				}
-				canUpdate = validate(routeProvenance)
+				canUpdate = canUpdate && validate(routeProvenance)
 			}
 		}
 	}

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/routes"
 )
 
 func TestGetMuteTimings(t *testing.T) {
@@ -1406,6 +1407,7 @@ func createMuteTimingSvcSut() (*MuteTimingService, *legacy_storage.AlertmanagerC
 			return nil
 		},
 		ruleNotificationsStore: &fakeAlertRuleNotificationStore{},
+		routeService:           routes.NewFakeService(legacy_storage.ConfigRevision{}),
 	}, store, prov
 }
 

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -2,10 +2,17 @@ package provisioning
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"hash"
+	"hash/fnv"
+	"slices"
+	"unsafe"
 
 	"github.com/grafana/alerting/definition"
+	"github.com/prometheus/common/model"
+	"golang.org/x/exp/maps"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -81,7 +88,23 @@ func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgI
 		return definitions.Route{}, "", err
 	}
 
-	if err := revision.ValidateRoute(tree); err != nil {
+	receivers := revision.GetReceiversNames()
+	receivers[""] = struct{}{} // Allow empty receiver (inheriting from parent)
+
+	err = tree.ValidateReceivers(receivers)
+	if err != nil {
+		return definitions.Route{}, "", models.MakeErrRouteInvalidFormat(err)
+	}
+
+	timeIntervals := map[string]struct{}{}
+	for _, mt := range revision.Config.AlertmanagerConfig.MuteTimeIntervals {
+		timeIntervals[mt.Name] = struct{}{}
+	}
+	for _, mt := range revision.Config.AlertmanagerConfig.TimeIntervals {
+		timeIntervals[mt.Name] = struct{}{}
+	}
+	err = tree.ValidateTimeIntervals(timeIntervals)
+	if err != nil {
 		return definitions.Route{}, "", models.MakeErrRouteInvalidFormat(err)
 	}
 
@@ -128,8 +151,9 @@ func (nps *NotificationPolicyService) ResetPolicyTree(ctx context.Context, orgID
 	if err != nil {
 		return definitions.Route{}, err
 	}
-
-	if err := revision.ResetUserDefinedRoute(defaultCfg); err != nil {
+	revision.Config.AlertmanagerConfig.Route = route
+	err = nps.ensureDefaultReceiverExists(revision.Config, defaultCfg)
+	if err != nil {
 		return definitions.Route{}, err
 	}
 
@@ -147,8 +171,118 @@ func (nps *NotificationPolicyService) ResetPolicyTree(ctx context.Context, orgID
 	return *route, nil
 }
 
+func (nps *NotificationPolicyService) ensureDefaultReceiverExists(cfg *definitions.PostableUserConfig, defaultCfg *definitions.PostableUserConfig) error {
+	defaultRcv := cfg.AlertmanagerConfig.Route.Receiver
+
+	for _, rcv := range cfg.AlertmanagerConfig.Receivers {
+		if rcv.Name == defaultRcv {
+			return nil
+		}
+	}
+
+	for _, rcv := range defaultCfg.AlertmanagerConfig.Receivers {
+		if rcv.Name == defaultRcv {
+			cfg.AlertmanagerConfig.Receivers = append(cfg.AlertmanagerConfig.Receivers, rcv)
+			return nil
+		}
+	}
+
+	nps.log.Error("Grafana Alerting has been configured with a default configuration that is internally inconsistent! The default configuration's notification policy must have a corresponding receiver.")
+	return fmt.Errorf("inconsistent default configuration")
+}
+
 func calculateRouteFingerprint(route definitions.Route) string {
-	return legacy_storage.CalculateRouteFingerprint(route)
+	sum := fnv.New64a()
+	writeToHash(sum, &route)
+	return fmt.Sprintf("%016x", sum.Sum64())
+}
+
+func writeToHash(sum hash.Hash, r *definitions.Route) {
+	writeBytes := func(b []byte) {
+		_, _ = sum.Write(b)
+		// add a byte sequence that cannot happen in UTF-8 strings.
+		_, _ = sum.Write([]byte{255})
+	}
+	writeString := func(s string) {
+		if len(s) == 0 {
+			writeBytes(nil)
+			return
+		}
+		// #nosec G103
+		// avoid allocation when converting string to byte slice
+		writeBytes(unsafe.Slice(unsafe.StringData(s), len(s)))
+	}
+
+	// this temp slice is used to convert ints to bytes.
+	tmp := make([]byte, 8)
+	writeInt := func(u int64) {
+		binary.LittleEndian.PutUint64(tmp, uint64(u))
+		writeBytes(tmp)
+	}
+	writeBool := func(b bool) {
+		if b {
+			writeInt(1)
+		} else {
+			writeInt(0)
+		}
+	}
+	writeDuration := func(d *model.Duration) {
+		if d == nil {
+			_, _ = sum.Write([]byte{255})
+		} else {
+			binary.LittleEndian.PutUint64(tmp, uint64(*d))
+			_, _ = sum.Write(tmp)
+			_, _ = sum.Write([]byte{255})
+		}
+	}
+
+	writeString(r.Receiver)
+	for _, s := range r.GroupByStr {
+		writeString(s)
+	}
+	for _, labelName := range r.GroupBy {
+		writeString(string(labelName))
+	}
+	writeBool(r.GroupByAll)
+	if len(r.Match) > 0 {
+		keys := maps.Keys(r.Match)
+		slices.Sort(keys)
+		for _, key := range keys {
+			writeString(key)
+			writeString(r.Match[key])
+		}
+	}
+	if len(r.MatchRE) > 0 {
+		keys := maps.Keys(r.MatchRE)
+		slices.Sort(keys)
+		for _, key := range keys {
+			writeString(key)
+			str, err := r.MatchRE[key].MarshalJSON()
+			if err != nil {
+				writeString(fmt.Sprintf("%+v", r.MatchRE))
+			}
+			writeBytes(str)
+		}
+	}
+	for _, matcher := range r.Matchers {
+		writeString(matcher.String())
+	}
+	for _, matcher := range r.ObjectMatchers {
+		writeString(matcher.String())
+	}
+	for _, timeInterval := range r.MuteTimeIntervals {
+		writeString(timeInterval)
+	}
+	for _, timeInterval := range r.ActiveTimeIntervals {
+		writeString(timeInterval)
+	}
+	writeBool(r.Continue)
+	writeDuration(r.GroupWait)
+	writeDuration(r.GroupInterval)
+	writeDuration(r.RepeatInterval)
+	for _, route := range r.Routes {
+		writeToHash(sum, route)
+	}
 }
 
 func (nps *NotificationPolicyService) checkOptimisticConcurrency(current definitions.Route, provenance models.Provenance, desiredVersion string, action string) error {

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -2,17 +2,10 @@ package provisioning
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
 	"fmt"
-	"hash"
-	"hash/fnv"
-	"slices"
-	"unsafe"
 
 	"github.com/grafana/alerting/definition"
-	"github.com/prometheus/common/model"
-	"golang.org/x/exp/maps"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -88,23 +81,7 @@ func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgI
 		return definitions.Route{}, "", err
 	}
 
-	receivers := revision.GetReceiversNames()
-	receivers[""] = struct{}{} // Allow empty receiver (inheriting from parent)
-
-	err = tree.ValidateReceivers(receivers)
-	if err != nil {
-		return definitions.Route{}, "", models.MakeErrRouteInvalidFormat(err)
-	}
-
-	timeIntervals := map[string]struct{}{}
-	for _, mt := range revision.Config.AlertmanagerConfig.MuteTimeIntervals {
-		timeIntervals[mt.Name] = struct{}{}
-	}
-	for _, mt := range revision.Config.AlertmanagerConfig.TimeIntervals {
-		timeIntervals[mt.Name] = struct{}{}
-	}
-	err = tree.ValidateTimeIntervals(timeIntervals)
-	if err != nil {
+	if err := revision.ValidateRoute(tree); err != nil {
 		return definitions.Route{}, "", models.MakeErrRouteInvalidFormat(err)
 	}
 
@@ -151,9 +128,8 @@ func (nps *NotificationPolicyService) ResetPolicyTree(ctx context.Context, orgID
 	if err != nil {
 		return definitions.Route{}, err
 	}
-	revision.Config.AlertmanagerConfig.Route = route
-	err = nps.ensureDefaultReceiverExists(revision.Config, defaultCfg)
-	if err != nil {
+
+	if _, err := revision.ResetUserDefinedRoute(defaultCfg); err != nil {
 		return definitions.Route{}, err
 	}
 
@@ -171,118 +147,8 @@ func (nps *NotificationPolicyService) ResetPolicyTree(ctx context.Context, orgID
 	return *route, nil
 }
 
-func (nps *NotificationPolicyService) ensureDefaultReceiverExists(cfg *definitions.PostableUserConfig, defaultCfg *definitions.PostableUserConfig) error {
-	defaultRcv := cfg.AlertmanagerConfig.Route.Receiver
-
-	for _, rcv := range cfg.AlertmanagerConfig.Receivers {
-		if rcv.Name == defaultRcv {
-			return nil
-		}
-	}
-
-	for _, rcv := range defaultCfg.AlertmanagerConfig.Receivers {
-		if rcv.Name == defaultRcv {
-			cfg.AlertmanagerConfig.Receivers = append(cfg.AlertmanagerConfig.Receivers, rcv)
-			return nil
-		}
-	}
-
-	nps.log.Error("Grafana Alerting has been configured with a default configuration that is internally inconsistent! The default configuration's notification policy must have a corresponding receiver.")
-	return fmt.Errorf("inconsistent default configuration")
-}
-
 func calculateRouteFingerprint(route definitions.Route) string {
-	sum := fnv.New64a()
-	writeToHash(sum, &route)
-	return fmt.Sprintf("%016x", sum.Sum64())
-}
-
-func writeToHash(sum hash.Hash, r *definitions.Route) {
-	writeBytes := func(b []byte) {
-		_, _ = sum.Write(b)
-		// add a byte sequence that cannot happen in UTF-8 strings.
-		_, _ = sum.Write([]byte{255})
-	}
-	writeString := func(s string) {
-		if len(s) == 0 {
-			writeBytes(nil)
-			return
-		}
-		// #nosec G103
-		// avoid allocation when converting string to byte slice
-		writeBytes(unsafe.Slice(unsafe.StringData(s), len(s)))
-	}
-
-	// this temp slice is used to convert ints to bytes.
-	tmp := make([]byte, 8)
-	writeInt := func(u int64) {
-		binary.LittleEndian.PutUint64(tmp, uint64(u))
-		writeBytes(tmp)
-	}
-	writeBool := func(b bool) {
-		if b {
-			writeInt(1)
-		} else {
-			writeInt(0)
-		}
-	}
-	writeDuration := func(d *model.Duration) {
-		if d == nil {
-			_, _ = sum.Write([]byte{255})
-		} else {
-			binary.LittleEndian.PutUint64(tmp, uint64(*d))
-			_, _ = sum.Write(tmp)
-			_, _ = sum.Write([]byte{255})
-		}
-	}
-
-	writeString(r.Receiver)
-	for _, s := range r.GroupByStr {
-		writeString(s)
-	}
-	for _, labelName := range r.GroupBy {
-		writeString(string(labelName))
-	}
-	writeBool(r.GroupByAll)
-	if len(r.Match) > 0 {
-		keys := maps.Keys(r.Match)
-		slices.Sort(keys)
-		for _, key := range keys {
-			writeString(key)
-			writeString(r.Match[key])
-		}
-	}
-	if len(r.MatchRE) > 0 {
-		keys := maps.Keys(r.MatchRE)
-		slices.Sort(keys)
-		for _, key := range keys {
-			writeString(key)
-			str, err := r.MatchRE[key].MarshalJSON()
-			if err != nil {
-				writeString(fmt.Sprintf("%+v", r.MatchRE))
-			}
-			writeBytes(str)
-		}
-	}
-	for _, matcher := range r.Matchers {
-		writeString(matcher.String())
-	}
-	for _, matcher := range r.ObjectMatchers {
-		writeString(matcher.String())
-	}
-	for _, timeInterval := range r.MuteTimeIntervals {
-		writeString(timeInterval)
-	}
-	for _, timeInterval := range r.ActiveTimeIntervals {
-		writeString(timeInterval)
-	}
-	writeBool(r.Continue)
-	writeDuration(r.GroupWait)
-	writeDuration(r.GroupInterval)
-	writeDuration(r.RepeatInterval)
-	for _, route := range r.Routes {
-		writeToHash(sum, route)
-	}
+	return legacy_storage.CalculateRouteFingerprint(route)
 }
 
 func (nps *NotificationPolicyService) checkOptimisticConcurrency(current definitions.Route, provenance models.Provenance, desiredVersion string, action string) error {

--- a/pkg/services/ngalert/provisioning/testing.go
+++ b/pkg/services/ngalert/provisioning/testing.go
@@ -233,6 +233,7 @@ type fakeReceiverService struct {
 	Calls                                  []call
 	GetReceiversFunc                       func(ctx context.Context, query models.GetReceiversQuery, user identity.Requester) ([]*models.Receiver, error)
 	RenameReceiverInDependentResourcesFunc func(ctx context.Context, orgID int64, revision *legacy_storage.ConfigRevision, oldName, newName string, receiverProvenance models.Provenance) error
+	ReceiverNameUsedByRoutesFunc           func(ctx context.Context, revision *legacy_storage.ConfigRevision, name string) bool
 }
 
 func (f *fakeReceiverService) GetReceivers(ctx context.Context, query models.GetReceiversQuery, user identity.Requester) ([]*models.Receiver, error) {
@@ -249,4 +250,12 @@ func (f *fakeReceiverService) RenameReceiverInDependentResources(ctx context.Con
 		return f.RenameReceiverInDependentResourcesFunc(ctx, orgID, revision, oldName, newName, receiverProvenance)
 	}
 	return nil
+}
+
+func (f *fakeReceiverService) ReceiverNameUsedByRoutes(ctx context.Context, revision *legacy_storage.ConfigRevision, name string) bool {
+	f.Calls = append(f.Calls, call{Method: "ReceiverNameUsedByRoutes", Args: []interface{}{ctx, revision, name}})
+	if f.ReceiverNameUsedByRoutesFunc != nil {
+		return f.ReceiverNameUsedByRoutesFunc(ctx, revision, name)
+	}
+	return false
 }

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -25,7 +25,9 @@ import (
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/routes"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning/validation"
 	alertstore "github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -323,11 +325,13 @@ func (ps *ProvisioningServiceImpl) ProvisionAlerting(ctx context.Context) error 
 		features = ps.alertingStore.FeatureToggles
 	}
 	configStore := legacy_storage.NewAlertmanagerConfigStore(ps.alertingStore, notifier.NewExtraConfigsCrypto(ps.secretService), features)
+	routeService := routes.NewService(configStore, ps.alertingStore, ps.alertingStore, ps.Cfg.UnifiedAlerting, features, ps.log, validation.ValidateProvenanceRelaxed)
 	receiverSvc := notifier.NewReceiverService(
 		alertingauthz.NewReceiverAccess[*ngmodels.Receiver](ps.ac, true),
 		configStore,
 		ps.alertingStore,
 		ps.alertingStore,
+		routeService,
 		ps.secretService,
 		ps.SQLStore,
 		ps.log,
@@ -339,7 +343,7 @@ func (ps *ProvisioningServiceImpl) ProvisionAlerting(ctx context.Context) error 
 		ps.alertingStore, ps.SQLStore, receiverSvc, ps.log, ps.alertingStore, ps.resourcePermissions)
 	notificationPolicyService := provisioning.NewNotificationPolicyService(configStore,
 		ps.alertingStore, ps.SQLStore, ps.Cfg.UnifiedAlerting, ps.log)
-	mutetimingsService := provisioning.NewMuteTimingService(configStore, ps.alertingStore, ps.alertingStore, ps.log, ps.alertingStore)
+	mutetimingsService := provisioning.NewMuteTimingService(configStore, ps.alertingStore, ps.alertingStore, ps.log, ps.alertingStore, routeService)
 	templateService := provisioning.NewTemplateService(configStore, ps.alertingStore, ps.alertingStore, ps.log)
 	cfg := prov_alerting.ProvisionerConfig{
 		Path:                       alertingPath,


### PR DESCRIPTION
## What is this feature?

NOTE: This is the backend-only portion from https://github.com/grafana/grafana/pull/116945 for ease of review.

This PR introduces multiple named notification policies to Grafana Alerting. In addition to the existing single "user-defined" routing tree, notification policies can now be created, managed, selected by alert rules, and provisioned individually.

The feature is gated behind an experimental feature flag `alertingMultiplePolicies`. When the flag is disabled, the system behaves exactly as before and continues to expose a single legacy routing tree in both frontend and backend APIs.

## Why do we need this feature?

Grafana Alerting has historically assumed a single, global notification policy tree per Alertmanager. While this model works, it becomes increasingly limiting as organizations scale in size, team count, and alerting complexity.

This feature allows routing logic can be split into smaller, independently managed trees.

This enables:
- Individual provisioning and lifecycle management of policies instead of an all-or-nothing single tree.
- Clearer organization of routing logic by team, service, or domain, keeping policies smaller and easier to reason about.
- A foundation for future improvements, such as policy-level RBAC and ownership.
- A required building block for the single-Alertmanager work, providing a structured place to store imported routing configurations.

## Technical Notes

### Backend changes

- Refactors notification policy routes to be first-class named resources with full CRUD k8s API.
- Export APIs can now return ~all policies or~ a single policy (selectable via query parameter).
- Named policy provenance by `name`.
- ~File provisioning:~
  - ~Adds optional `name` (defaults to legacy `"user-defined"` for backwards compatibility).~
  - ~Supports explicit deletion of a specific named policy.~
- `applyConfig` now injects managed routes into the effective Alertmanager routing tree.
- Existing behavior is preserved when the feature flag is disabled.

### Notes
- No support in Provisioning API yet as it will be a breaking change so we'll need to discuss implementation.
- Add UIDs to the named routes metadata and move name to spec.
- Dynamically convert ExtraConfig imported routes to a managed route at runtime.
- Improve alert rule policy selector to use notification_settings and UID instead of the label directly.
- File provisioning support was temporarily removed in 187572f7f619d488082674c34f467f28eeee5a57, to be added back in a separate PR.


Related to https://github.com/grafana/alerting-squad/issues/1153