### PR TITLE
Snapshots: Fix docs broken link

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ShareButton/share-snapshot/UpsertSnapshot.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareButton/share-snapshot/UpsertSnapshot.tsx
@@ -9,9 +9,9 @@ import { Alert, Button, Divider, Field, Input, RadioButtonGroup, Stack, Text, us
 import { getExpireOptions } from '../../ShareSnapshotTab';
 
 const DASHBOARD_SNAPSHOT_URL =
-  'https://grafana.com/docs/grafana/next/dashboards/share-dashboards-panels/#share-a-snapshot';
+  'https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/#share-a-snapshot';
 
-const PANEL_SNAPSHOT_URL = 'https://grafana.com/docs/grafana/next/dashboards/share-dashboards-panels/#panel-snapshot';
+const PANEL_SNAPSHOT_URL = 'https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/#panel-snapshot';
 
 interface Props {
   name: string;


### PR DESCRIPTION
**What is this feature?**

Fixing broken link from drawer:
<img width="686" height="213" alt="image" src="https://github.com/user-attachments/assets/472c84e5-4d39-4ec8-8b0c-b7c852944bc9" />
<img width="636" height="445" alt="image" src="https://github.com/user-attachments/assets/a60c4d82-ef15-4da7-9004-17dab5dce256" />

Now points to: https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/#share-a-snapshot

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
