### PR TITLE
Alerting: Refactor state persisters to create ticker in Async()

### DIFF
--- a/pkg/services/ngalert/ngalert_test.go
+++ b/pkg/services/ngalert/ngalert_test.go
@@ -470,7 +470,7 @@ func TestInitStatePersister(t *testing.T) {
 				featuremgmt.FlagAlertingSaveStateCompressed,
 				featuremgmt.FlagAlertingSaveStatePeriodic,
 			),
-			expectedStatePersisterType: &state.SyncRuleStatePersister{},
+			expectedStatePersisterType: &state.AsyncRuleStatePersister{},
 		},
 	}
 

--- a/pkg/services/ngalert/state/persister_async_rule.go
+++ b/pkg/services/ngalert/state/persister_async_rule.go
@@ -1,0 +1,71 @@
+package state
+
+import (
+	"context"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+// AsyncRuleStatePersister persists alert state periodically using compressed rule-based storage.
+// It performs full syncs on a ticker interval and on shutdown.
+// Sync operations are no-ops since persistence happens asynchronously.
+type AsyncRuleStatePersister struct {
+	log      log.Logger
+	store    InstanceStore
+	clock    clock.Clock
+	interval time.Duration
+}
+
+func NewAsyncRuleStatePersister(log log.Logger, clk clock.Clock, interval time.Duration, cfg ManagerCfg) StatePersister {
+	return &AsyncRuleStatePersister{
+		log:      log,
+		store:    cfg.InstanceStore,
+		clock:    clk,
+		interval: interval,
+	}
+}
+
+func (a *AsyncRuleStatePersister) Async(ctx context.Context, instancesProvider AlertInstancesProvider) {
+	ticker := a.clock.Ticker(a.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := a.fullSync(ctx, instancesProvider); err != nil {
+				a.log.Error("Failed to do a full compressed state sync to database", "err", err)
+			}
+		case <-ctx.Done():
+			a.log.Info("Scheduler is shutting down, doing a final state sync.")
+			if err := a.fullSync(context.Background(), instancesProvider); err != nil {
+				a.log.Error("Failed to do a full compressed state sync to database", "err", err)
+			}
+			a.log.Info("Compressed state async worker is shut down.")
+			return
+		}
+	}
+}
+
+func (a *AsyncRuleStatePersister) fullSync(ctx context.Context, instancesProvider AlertInstancesProvider) error {
+	startTime := time.Now()
+	a.log.Debug("Full compressed state sync start")
+	instances := instancesProvider.GetAlertInstances()
+
+	// batchSize is set to 0 because compressed storage groups instances by ruleUID, not by batch size
+	err := a.store.FullSync(ctx, instances, 0, nil)
+	if err != nil {
+		a.log.Error("Full compressed state sync failed", "duration", time.Since(startTime), "instances", len(instances))
+		return err
+	}
+	a.log.Debug("Full compressed state sync done", "duration", time.Since(startTime), "instances", len(instances))
+	return nil
+}
+
+func (a *AsyncRuleStatePersister) Sync(_ context.Context, _ trace.Span, _ models.AlertRuleKeyWithGroup, _ StateTransitions) {
+	a.log.Debug("Sync: No-Op, using periodic save instead")
+}

--- a/pkg/services/ngalert/state/persister_sync_rule.go
+++ b/pkg/services/ngalert/state/persister_sync_rule.go
@@ -4,71 +4,32 @@ import (
 	"context"
 	"time"
 
-	"github.com/benbjohnson/clock"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
+// SyncRuleStatePersister persists alert state synchronously after each rule evaluation
+// using compressed rule-based storage. It saves all instances for a rule in a single operation.
+// Async operations are no-ops since persistence happens synchronously.
 type SyncRuleStatePersister struct {
-	log    log.Logger
-	store  InstanceStore
-	ticker *clock.Ticker
+	log   log.Logger
+	store InstanceStore
 }
 
-func NewSyncRuleStatePersisiter(log log.Logger, ticker *clock.Ticker, cfg ManagerCfg) StatePersister {
+func NewSyncRuleStatePersister(log log.Logger, cfg ManagerCfg) StatePersister {
 	return &SyncRuleStatePersister{
-		log:    log,
-		store:  cfg.InstanceStore,
-		ticker: ticker,
+		log:   log,
+		store: cfg.InstanceStore,
 	}
 }
 
-func (a *SyncRuleStatePersister) Async(ctx context.Context, instancesProvider AlertInstancesProvider) {
-	if a.ticker == nil {
-		return
-	}
-
-	for {
-		select {
-		case <-a.ticker.C:
-			if err := a.fullSync(ctx, instancesProvider); err != nil {
-				a.log.Error("Failed to do a full compressed state sync to database", "err", err)
-			}
-		case <-ctx.Done():
-			a.log.Info("Scheduler is shutting down, doing a final state sync.")
-			if err := a.fullSync(context.Background(), instancesProvider); err != nil {
-				a.log.Error("Failed to do a full compressed state sync to database", "err", err)
-			}
-			a.ticker.Stop()
-			a.log.Info("Compressed state async worker is shut down.")
-			return
-		}
-	}
-}
-
-func (a *SyncRuleStatePersister) fullSync(ctx context.Context, instancesProvider AlertInstancesProvider) error {
-	startTime := time.Now()
-	a.log.Debug("Full compressed state sync start")
-	instances := instancesProvider.GetAlertInstances()
-
-	// batchSize is set to 0 because compressed storage groups instances by ruleUID, not by batch size
-	err := a.store.FullSync(ctx, instances, 0, nil)
-	if err != nil {
-		a.log.Error("Full compressed state sync failed", "duration", time.Since(startTime), "instances", len(instances))
-		return err
-	}
-	a.log.Debug("Full compressed state sync done", "duration", time.Since(startTime), "instances", len(instances))
-	return nil
+func (a *SyncRuleStatePersister) Async(_ context.Context, _ AlertInstancesProvider) {
+	a.log.Debug("Async: No-Op")
 }
 
 func (a *SyncRuleStatePersister) Sync(ctx context.Context, span trace.Span, ruleKey models.AlertRuleKeyWithGroup, states StateTransitions) {
-	if a.ticker != nil {
-		a.log.Debug("Skip immediate save, using periodic save instead")
-		return
-	}
-
 	if a.store == nil || len(states) == 0 {
 		return
 	}


### PR DESCRIPTION
**What is this feature?**

This makes async state persisters reusable across multiple start/stop cycles. The ticker is now created when `Async()` is called and cleaned up when the context is cancelled, allowing the same persister instance to be started and stopped repeatedly without recreation.

Also split the `SyncRuleStatePersister` into two: `AsyncRuleStatePersister` and `SyncRuleStatePersister`, following the same pattern as we have in the other state persister

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/116545