### PR TITLE
datasource: make query-service decision in javascript

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -670,6 +670,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/utils/migrationHandler* @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
 /packages/grafana-runtime/src/utils/plugin.ts @grafana/plugins-platform-frontend
 /packages/grafana-runtime/src/utils/publicDashboardQueryHandler.ts @grafana/grafana-operator-experience-squad
+/packages/grafana-runtime/src/utils/qscheck* @grafana/grafana-datasources-core-services
 /packages/grafana-runtime/src/utils/queryResponse* @grafana/grafana-datasources-core-services
 /packages/grafana-runtime/src/utils/rbac.ts @grafana/identity-access-team
 /packages/grafana-runtime/src/utils/returnToPrevious.ts @grafana/grafana-search-navigate-organise

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -32,6 +32,7 @@ import {
 } from '../services';
 
 import { publicDashboardQueryHandler } from './publicDashboardQueryHandler';
+import { isQueryServiceCompatible } from './qscheck';
 import { BackendDataSourceResponse, toDataQueryResponse } from './queryResponse';
 import { UserStorage } from './userStorage';
 
@@ -144,6 +145,7 @@ class DataSourceWithBackend<
     let hasExpr = false;
     const pluginIDs = new Set<string>();
     const dsUIDs = new Set<string>();
+    const datasources: DataSourceInstanceSettings[] = [];
     const queries: DataQuery[] = targets.map((q) => {
       let datasource = this.getRef();
       let datasourceId = this.id;
@@ -163,6 +165,8 @@ class DataSourceWithBackend<
         if (!ds) {
           throw new Error(`Unknown Datasource: ${JSON.stringify(q.datasource)}`);
         }
+
+        datasources.push(ds);
 
         const dsRef = ds.rawRef ?? getDataSourceRef(ds);
         const dsId = ds.id;
@@ -209,7 +213,7 @@ class DataSourceWithBackend<
     let url = '/api/ds/query?ds_type=' + this.type;
 
     // Use the new query service
-    if (config.featureToggles.queryServiceFromUI) {
+    if (config.featureToggles.queryServiceFromUI && isQueryServiceCompatible(datasources)) {
       url = `/apis/query.grafana.app/v0alpha1/namespaces/${config.namespace}/query?ds_type=${this.type}`;
     }
 

--- a/packages/grafana-runtime/src/utils/qscheck.test.ts
+++ b/packages/grafana-runtime/src/utils/qscheck.test.ts
@@ -13,97 +13,132 @@ interface TestJsonData extends DataSourceJsonData {
 
 type TestCase = {
   name: string;
-  jsonData: TestJsonData;
+  jsonDatas: TestJsonData[];
   expected: boolean;
 };
 
 describe('qscheck', () => {
   const testCases: TestCase[] = [
     {
+      name: 'no queries',
+      jsonDatas: [],
+      expected: true,
+    },
+    {
       name: 'empty jsondata',
-      jsonData: {},
+      jsonDatas: [{}],
       expected: true,
     },
     {
       name: 'no oauth',
-      jsonData: {
-        thing1: 'http://localhost:9090',
-        thing2: 15,
-      },
+      jsonDatas: [
+        {
+          thing1: 'http://localhost:9090',
+          thing2: 15,
+        },
+      ],
       expected: true,
     },
     {
       name: 'oauth false',
-      jsonData: {
-        thing1: 'http://localhost:9090',
-        thing2: 42,
-        oauthPassThru: false,
-      },
+      jsonDatas: [
+        {
+          thing1: 'http://localhost:9090',
+          thing2: 42,
+          oauthPassThru: false,
+        },
+      ],
       expected: true,
     },
     {
       name: 'oauth true',
-      jsonData: {
-        thing1: 'http://localhost:9090',
-        thing2: 55,
-        oauthPassThru: true,
-      },
+      jsonDatas: [
+        {
+          thing1: 'http://localhost:9090',
+          thing2: 55,
+          oauthPassThru: true,
+        },
+      ],
       expected: false,
     },
     {
       name: 'oauth non-boolean',
-      jsonData: {
-        thing1: 'http://localhost:9090',
-        thing2: 77,
-        oauthPassThru: 42,
-      },
+      jsonDatas: [
+        {
+          thing1: 'http://localhost:9090',
+          thing2: 77,
+          oauthPassThru: 42,
+        },
+      ],
       expected: false,
     },
     {
       name: 'azureoauth missing',
-      jsonData: {
-        thing1: 'http://localhost:9090',
-        thing2: 77,
-        // azureCredentials not there
-      },
+      jsonDatas: [
+        {
+          thing1: 'http://localhost:9090',
+          thing2: 77,
+          // azureCredentials not there
+        },
+      ],
       expected: true,
     },
     {
       name: 'azureoauth different auth',
-      jsonData: {
-        thing1: 'http://localhost:9090',
-        thing2: 77,
-        azureCredentials: {
-          authType: 'workloadidentity',
+      jsonDatas: [
+        {
+          thing1: 'http://localhost:9090',
+          thing2: 77,
+          azureCredentials: {
+            authType: 'workloadidentity',
+          },
         },
-      },
+      ],
       expected: true,
     },
     {
       name: 'azureoauth currentuser auth',
-      jsonData: {
-        thing1: 'http://localhost:9090',
-        thing2: 77,
-        azureCredentials: {
-          authType: 'currentuser',
+      jsonDatas: [
+        {
+          thing1: 'http://localhost:9090',
+          thing2: 77,
+          azureCredentials: {
+            authType: 'currentuser',
+          },
         },
-      },
+      ],
+      expected: false,
+    },
+    {
+      name: 'one good one bad',
+      jsonDatas: [
+        {
+          thing1: 'http://localhost:9090',
+          thing2: 15,
+        },
+        {
+          thing1: 'http://localhost:9090',
+          thing2: 77,
+          oauthPassThru: true,
+        },
+      ],
       expected: false,
     },
   ];
 
   testCases.forEach((t) => {
     test(t.name, () => {
-      const settings: DataSourceInstanceSettings<TestJsonData> = {
-        jsonData: t.jsonData,
+      const settings: Array<DataSourceInstanceSettings<TestJsonData>> = t.jsonDatas.map((jsonData) => ({
+        jsonData: jsonData,
         uid: 'uid1',
         type: 'prometheus',
         name: 'prom1',
         meta: {} as DataSourcePluginMeta,
         readOnly: false,
         access: 'proxy',
-      };
-      const result = isQueryServiceCompatible([settings]);
+      }));
+
+      const result = isQueryServiceCompatible(settings);
       expect(result).toBe(t.expected);
     });
   });

--- a/packages/grafana-runtime/src/utils/qscheck.test.ts
+++ b/packages/grafana-runtime/src/utils/qscheck.test.ts
@@ -1,0 +1,110 @@
+import { DataSourceInstanceSettings, DataSourcePluginMeta, DataSourceJsonData } from '@grafana/data';
+
+import { isQueryServiceCompatible } from './qscheck';
+
+interface TestJsonData extends DataSourceJsonData {
+  oauthPassThru?: unknown;
+  azureCredentials?: {
+    authType?: unknown;
+  };
+  thing1?: string;
+  thing2?: number;
+}
+
+type TestCase = {
+  name: string;
+  jsonData: TestJsonData;
+  expected: boolean;
+};
+
+describe('qscheck', () => {
+  const testCases: TestCase[] = [
+    {
+      name: 'empty jsondata',
+      jsonData: {},
+      expected: true,
+    },
+    {
+      name: 'no oauth',
+      jsonData: {
+        thing1: 'http://localhost:9090',
+        thing2: 15,
+      },
+      expected: true,
+    },
+    {
+      name: 'oauth false',
+      jsonData: {
+        thing1: 'http://localhost:9090',
+        thing2: 42,
+        oauthPassThru: false,
+      },
+      expected: true,
+    },
+    {
+      name: 'oauth true',
+      jsonData: {
+        thing1: 'http://localhost:9090',
+        thing2: 55,
+        oauthPassThru: true,
+      },
+      expected: false,
+    },
+    {
+      name: 'oauth non-boolean',
+      jsonData: {
+        thing1: 'http://localhost:9090',
+        thing2: 77,
+        oauthPassThru: 42,
+      },
+      expected: false,
+    },
+    {
+      name: 'azureoauth missing',
+      jsonData: {
+        thing1: 'http://localhost:9090',
+        thing2: 77,
+        // azureCredentials not there
+      },
+      expected: true,
+    },
+    {
+      name: 'azureoauth different auth',
+      jsonData: {
+        thing1: 'http://localhost:9090',
+        thing2: 77,
+        azureCredentials: {
+          authType: 'workloadidentity',
+        },
+      },
+      expected: true,
+    },
+    {
+      name: 'azureoauth currentuser auth',
+      jsonData: {
+        thing1: 'http://localhost:9090',
+        thing2: 77,
+        azureCredentials: {
+          authType: 'currentuser',
+        },
+      },
+      expected: false,
+    },
+  ];
+
+  testCases.forEach((t) => {
+    test(t.name, () => {
+      const settings: DataSourceInstanceSettings<TestJsonData> = {
+        jsonData: t.jsonData,
+        uid: 'uid1',
+        type: 'prometheus',
+        name: 'prom1',
+        meta: {} as DataSourcePluginMeta,
+        readOnly: false,
+        access: 'proxy',
+      };
+      const result = isQueryServiceCompatible([settings]);
+      expect(result).toBe(t.expected);
+    });
+  });
+});

--- a/packages/grafana-runtime/src/utils/qscheck.ts
+++ b/packages/grafana-runtime/src/utils/qscheck.ts
@@ -1,0 +1,45 @@
+import { DataSourceInstanceSettings, DataSourceJsonData } from '@grafana/data';
+
+interface JsonData extends DataSourceJsonData {
+  oauthPassThru?: unknown; // we do not assume boolean, to be more robust
+  azureCredentials?: {
+    authType?: unknown;
+  };
+}
+
+function isOauthEnabled(ds: DataSourceInstanceSettings<JsonData>): boolean {
+  const oauth = ds.jsonData.oauthPassThru;
+  // we are working with json-data here, the content may not necessarily be a boolean,
+  // so we do this in a careful way.
+  if (oauth === undefined) {
+    return false;
+  }
+
+  if (oauth === false) {
+    return false;
+  }
+
+  if (oauth === true) {
+    return true;
+  }
+
+  // for us it is safer to assume true when there is some weird value used in the jsondata.
+  return true;
+}
+
+function isProblematicAzureAuth(ds: DataSourceInstanceSettings<JsonData>): boolean {
+  return ds.jsonData.azureCredentials?.authType === 'currentuser';
+}
+
+export function isQueryServiceCompatible(datasources: Array<DataSourceInstanceSettings<JsonData>>) {
+  for (let ds of datasources) {
+    if (isOauthEnabled(ds)) {
+      return false;
+    }
+
+    if (isProblematicAzureAuth(ds)) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
curently we do not want to send queries with datasources with oauth-enabled to the query-service endpoint (`apis/query.grafana.app`) , so we check, and such queries go to the old `/api/ds/query/` endpoint.