### PR TITLE
Alerting: Fix groupBy in simplified routing UI

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1491,11 +1491,6 @@
       "count": 1
     }
   },
-  "public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/RouteSettings.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/RouteTimings.tsx": {
     "no-restricted-syntax": {
       "count": 3

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2328,7 +2328,8 @@
     },
     "routing-settings": {
       "aria-label-group-by": "Group by",
-      "description-group-by": "Combine multiple alerts into a single notification by grouping them by the same label values. If empty, it is inherited from the default notification policy.",
+      "description-group-by": "Alerts are always grouped by grafana_folder and alertname, plus any additional labels you select. Select \"Disable (...)\" to send each alert as a separate notification.",
+      "group-by-hint": "grafana_folder and alertname are always included unless you select Disable (...).",
       "group-interval": "Group interval: <strong>{{groupIntervalValue}}</strong>",
       "group-wait": "Group wait: <strong>{{groupWaitValue}}</strong>",
       "grouping": "Grouping: <strong>{{fields}}</strong>",


### PR DESCRIPTION
**What is this feature?**

Fixed the "Override grouping" feature in Simplified Routing to allow users to select "Disable (...)" to disable alert grouping entirely.

**Why do we need this feature?**

Users reported they couldn't clear `grafana_folder` and `alertname` labels to select only "Disable (...)" in the group by field. The labels were marked as "fixed" in the UI, preventing removal.

Context:
In the backend, simplified Routing, alerts are always grouped by `grafana_folder` and `alertname`:
- Either inherited from the default notification policy
- Or automatically added by backend normalization via `NormalizedGroupBy()`

The bug: The frontend marked `grafana_folder` and `alertname` as "fixed" labels that couldn't be removed, making it impossible for users to select only `...` to disable grouping.

Fixes #
Related to this [escalation](https://github.com/grafana/support-escalations/issues/20452)

**Special notes for your reviewer:**


https://github.com/user-attachments/assets/858b46f0-80ae-4cd7-9841-1b560d28afb6


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
