### PR TITLE
Provisioning: return better errors on /test for Repositories

### DIFF
--- a/apps/provisioning/pkg/connection/connection.go
+++ b/apps/provisioning/pkg/connection/connection.go
@@ -11,7 +11,10 @@ import (
 )
 
 var (
-	ErrNotImplemented = errors.New("not implemented")
+	ErrNotImplemented   = errors.New("not implemented")
+	ErrNotFound         = errors.New("not found")
+	ErrRepositoryAccess = errors.New("cannot access repository")
+	ErrAuthentication   = errors.New("authentication failed")
 )
 
 type ExpirableSecureValue struct {

--- a/apps/provisioning/pkg/connection/github/client.go
+++ b/apps/provisioning/pkg/connection/github/client.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/go-github/v70/github"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // API errors that we need to convey after parsing real GH errors (or faking them).
@@ -19,8 +18,9 @@ var (
 	ErrAuthentication = apierrors.NewUnauthorized("authentication failed")
 	//lint:ignore ST1005 this is not punctuation
 	ErrServiceUnavailable = apierrors.NewServiceUnavailable("github is unavailable")
-	//lint:ignore ST1005 this is not punctuation
-	ErrNotFound = apierrors.NewNotFound(schema.GroupResource{Resource: "github"}, "resource not found")
+
+	ErrNotFound            = errors.New("not found")
+	ErrUnprocessableEntity = errors.New("unprocessable entity")
 )
 
 //go:generate mockery --name Client --structname MockClient --inpackage --filename client_mock.go --with-expecter
@@ -85,7 +85,7 @@ func (r *githubClient) GetApp(ctx context.Context) (App, error) {
 			case http.StatusUnauthorized, http.StatusForbidden:
 				return App{}, ErrAuthentication
 			case http.StatusNotFound:
-				return App{}, ErrNotFound
+				return App{}, fmt.Errorf("app: %w", ErrNotFound)
 			case http.StatusServiceUnavailable:
 				return App{}, ErrServiceUnavailable
 			}
@@ -115,7 +115,7 @@ func (r *githubClient) GetAppInstallation(ctx context.Context, installationID st
 			case http.StatusUnauthorized, http.StatusForbidden:
 				return AppInstallation{}, ErrAuthentication
 			case http.StatusNotFound:
-				return AppInstallation{}, ErrNotFound
+				return AppInstallation{}, fmt.Errorf("installation: %w", ErrNotFound)
 			case http.StatusServiceUnavailable:
 				return AppInstallation{}, ErrServiceUnavailable
 			}
@@ -194,9 +194,20 @@ func (r *githubClient) CreateInstallationAccessToken(ctx context.Context, instal
 	token, _, err := r.gh.Apps.CreateInstallationToken(ctx, int64(id), opts)
 	if err != nil {
 		var ghErr *github.ErrorResponse
-		if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusServiceUnavailable {
-			return InstallationToken{}, ErrServiceUnavailable
+		if errors.As(err, &ghErr) {
+			switch ghErr.Response.StatusCode {
+			case http.StatusServiceUnavailable:
+				return InstallationToken{}, ErrServiceUnavailable
+			case http.StatusUnauthorized, http.StatusForbidden:
+				return InstallationToken{}, ErrAuthentication
+			case http.StatusNotFound:
+				// Not Found is returned by this API when the given installation is not present.
+				return InstallationToken{}, fmt.Errorf("installation: %w", ErrNotFound)
+			case http.StatusUnprocessableEntity:
+				return InstallationToken{}, fmt.Errorf("%s: %w", ghErr.Message, ErrUnprocessableEntity)
+			}
 		}
+
 		return InstallationToken{}, err
 	}
 

--- a/apps/provisioning/pkg/connection/github/connection_test.go
+++ b/apps/provisioning/pkg/connection/github/connection_test.go
@@ -498,7 +498,7 @@ func TestConnection_Test(t *testing.T) {
 			expectSuccess: false,
 			expectedErrors: []provisioning.ErrorDetails{
 				{
-					Type:   metav1.CauseTypeFieldValueInvalid,
+					Type:   metav1.CauseTypeFieldValueNotFound,
 					Field:  "spec.github.appID",
 					Detail: "app not found",
 				},
@@ -1080,6 +1080,108 @@ func TestConnection_GenerateRepositoryToken(t *testing.T) {
 					Return(github.InstallationToken{}, errors.New("API rate limit exceeded"))
 			},
 			expectedError: "failed to create installation access token",
+		},
+		{
+			name: "GitHub error - unprocessable entity",
+			connection: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
+				Spec: provisioning.ConnectionSpec{
+					Type: provisioning.GithubConnectionType,
+					GitHub: &provisioning.GitHubConnectionConfig{
+						AppID:          "123",
+						InstallationID: "456",
+					},
+				},
+				Secure: provisioning.ConnectionSecure{
+					Token: common.InlineSecureValue{
+						Create: common.RawSecureValue("jwt-token"),
+					},
+				},
+			},
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-repo"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL: "https://github.com/test-owner/test-repo",
+					},
+				},
+			},
+			setupMock: func(mockFactory *github.MockGithubFactory) {
+				mockClient := github.NewMockClient(t)
+				mockFactory.EXPECT().New(mock.Anything, common.RawSecureValue("jwt-token")).Return(mockClient)
+				mockClient.EXPECT().CreateInstallationAccessToken(mock.Anything, "456", "test-repo").
+					Return(github.InstallationToken{}, github.ErrUnprocessableEntity)
+			},
+			expectedError: connection.ErrRepositoryAccess.Error(),
+		},
+		{
+			name: "GitHub error - not found",
+			connection: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
+				Spec: provisioning.ConnectionSpec{
+					Type: provisioning.GithubConnectionType,
+					GitHub: &provisioning.GitHubConnectionConfig{
+						AppID:          "123",
+						InstallationID: "456",
+					},
+				},
+				Secure: provisioning.ConnectionSecure{
+					Token: common.InlineSecureValue{
+						Create: common.RawSecureValue("jwt-token"),
+					},
+				},
+			},
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-repo"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL: "https://github.com/test-owner/test-repo",
+					},
+				},
+			},
+			setupMock: func(mockFactory *github.MockGithubFactory) {
+				mockClient := github.NewMockClient(t)
+				mockFactory.EXPECT().New(mock.Anything, common.RawSecureValue("jwt-token")).Return(mockClient)
+				mockClient.EXPECT().CreateInstallationAccessToken(mock.Anything, "456", "test-repo").
+					Return(github.InstallationToken{}, github.ErrNotFound)
+			},
+			expectedError: connection.ErrNotFound.Error(),
+		},
+		{
+			name: "GitHub authentication error",
+			connection: &provisioning.Connection{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
+				Spec: provisioning.ConnectionSpec{
+					Type: provisioning.GithubConnectionType,
+					GitHub: &provisioning.GitHubConnectionConfig{
+						AppID:          "123",
+						InstallationID: "456",
+					},
+				},
+				Secure: provisioning.ConnectionSecure{
+					Token: common.InlineSecureValue{
+						Create: common.RawSecureValue("jwt-token"),
+					},
+				},
+			},
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-repo"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL: "https://github.com/test-owner/test-repo",
+					},
+				},
+			},
+			setupMock: func(mockFactory *github.MockGithubFactory) {
+				mockClient := github.NewMockClient(t)
+				mockFactory.EXPECT().New(mock.Anything, common.RawSecureValue("jwt-token")).Return(mockClient)
+				mockClient.EXPECT().CreateInstallationAccessToken(mock.Anything, "456", "test-repo").
+					Return(github.InstallationToken{}, github.ErrAuthentication)
+			},
+			expectedError: github.ErrAuthentication.Error(),
 		},
 	}
 


### PR DESCRIPTION
**What is this feature?**

There are few cases in `/test` for which we're returning 500 instead of proper status codes - all are related to `Repository` resource using `Connection`s. This PR fixes it.

- When the connection doesn't have access to given repo - this is what we're going to return now:
```json
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "There is at least one repository that does not exist or is not accessible to the parent installation.: unprocessable entity: cannot access repository",
  "reason": "UnprocessableEntity",
  "code": 422
}
```
- When the connection has a bad installationID:
```json
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "installation: not found",
  "reason": "NotFound",
  "code": 404
}
```

- When the connection has a bad appID:
```json
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "failed to generate repository token from connection: authentication failed",
  "reason": "Unauthorized",
  "code": 401
}
```

**Why do we need this feature?**

To return clearer status codes on the cases declared above.

**Who is this feature for?**

Users of GitSync feature

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/798

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
