### PR TITLE
Alerting: Improve performance of folder access checks

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -400,10 +400,30 @@ type Namespaced interface {
 	GetNamespaceUID() string
 }
 
-type Namespace folder.FolderReference
+// NamespacedWithFullpath extends Namespaced with pre-computed folder path UIDs.
+type NamespacedWithFullpath interface {
+	Namespaced
+	GetFullpathUIDs() string
+}
+
+// Namespace represents a folder that can contain alert rules.
+type Namespace struct {
+	folder.FolderReference
+	FullpathUIDs string
+}
 
 func NewNamespace(f *folder.Folder) Namespace {
-	return Namespace(*f.ToFolderReference())
+	return Namespace{
+		FolderReference: *f.ToFolderReference(),
+		FullpathUIDs:    f.FullpathUIDs,
+	}
+}
+
+// NewNamespaceUID creates a Namespace with just a UID (no fullpath for optimized checks).
+func NewNamespaceUID(uid string) Namespace {
+	return Namespace{
+		FolderReference: folder.FolderReference{UID: uid},
+	}
 }
 
 func (n Namespace) ValidateForRuleStorage() error {
@@ -418,6 +438,10 @@ func (n Namespace) ValidateForRuleStorage() error {
 
 func (n Namespace) GetNamespaceUID() string {
 	return n.UID
+}
+
+func (n Namespace) GetFullpathUIDs() string {
+	return n.FullpathUIDs
 }
 
 // AlertRuleWithOptionals This is to avoid having to pass in additional arguments deep in the call stack. Alert rule

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -639,9 +639,7 @@ func (h *RemoteLokiBackend) getFolderUIDsForRuleFilter(ctx context.Context, quer
 			continue
 		}
 
-		hasAccess, err := h.ac.HasAccessInFolder(ctx, query.SignedInUser, models.Namespace{
-			UID: folderUID,
-		})
+		hasAccess, err := h.ac.HasAccessInFolder(ctx, query.SignedInUser, models.NewNamespaceUID(folderUID))
 		if err != nil {
 			// Including historical folders is an edge case enhancement, better to just log the error and continue
 			// with the current folder UID.

--- a/pkg/services/ngalert/store/namespace.go
+++ b/pkg/services/ngalert/store/namespace.go
@@ -16,9 +16,10 @@ import (
 // GetUserVisibleNamespaces returns the folders that are visible to the user
 func (st DBstore) GetUserVisibleNamespaces(ctx context.Context, orgID int64, user identity.Requester) (map[string]*folder.Folder, error) {
 	folders, err := st.FolderService.GetFolders(ctx, folder.GetFoldersQuery{
-		OrgID:        orgID,
-		WithFullpath: true,
-		SignedInUser: user,
+		OrgID:            orgID,
+		WithFullpath:     true,
+		WithFullpathUIDs: true,
+		SignedInUser:     user,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/services/ngalert/store/namespace_test.go
+++ b/pkg/services/ngalert/store/namespace_test.go
@@ -8,16 +8,15 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/folder/foldertest"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/util"
-
-	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 


### PR DESCRIPTION
**What is this feature?**

Optimizes folder access permission checks by performing in-memory permission evaluation using pre-computed fullpath UIDs when possible, reducing database calls to the scope resolver.

**Why do we need this feature?**

When checking if a user has access to alert rules in a folder, the current implementation always uses the scope resolver which can involve database lookups to resolve folder hierarchy. For operations that process many rules (like listing rules across folders), this creates unnecessary database load.

This change adds a fast path that checks permissions in-memory when the folder's fullpath UIDs are already available, falling back to the scope resolver only when needed.

**Special notes for your reviewer:**

- Added a new `NamespacedWithFullpath` interface to allow permission checks to access fullpath UIDs when they are available. For example, alert rule does not implement it and implements only `Namespaced`, so it uses the old way of checking. `Folder` implements both, so when fullpath UIDs are populated, it can use the fast path.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
