### PR TITLE
UI: Fix hover styling for UserIcon based on showTooltip + onClick

### DIFF
--- a/packages/grafana-ui/src/components/UsersIndicator/UserIcon.tsx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UserIcon.tsx
@@ -128,6 +128,7 @@ export const getStyles = (theme: GrafanaTheme2, isActive: boolean) => {
       background: 'none',
       border: 'none',
       borderRadius: theme.shape.radius.circle,
+      cursor: 'default',
       '& > *': {
         borderRadius: theme.shape.radius.circle,
       },

--- a/packages/grafana-ui/src/components/UsersIndicator/UserIcon.tsx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UserIcon.tsx
@@ -72,7 +72,7 @@ export const UserIcon = ({
     <button
       type={'button'}
       onClick={onClick}
-      className={cx(styles.container, onClick && styles.pointer, className)}
+      className={cx(styles.container, (showTooltip || onClick) && styles.hover, onClick && styles.pointer, className)}
       aria-label={t('grafana-ui.user-icon.label', '{{name}} icon', { name: user.name })}
     >
       {children ? (
@@ -139,9 +139,6 @@ export const getStyles = (theme: GrafanaTheme2, isActive: boolean) => {
       border: `3px ${theme.colors.background.primary} solid`,
       boxShadow: getIconBorder(shadowColor),
       backgroundClip: 'padding-box',
-      '&:hover': {
-        boxShadow: getIconBorder(shadowHoverColor),
-      },
     }),
     textContent: css({
       background: theme.colors.background.primary,
@@ -177,6 +174,11 @@ export const getStyles = (theme: GrafanaTheme2, isActive: boolean) => {
     }),
     pointer: css({
       cursor: 'pointer',
+    }),
+    hover: css({
+      '&:hover > *': {
+        boxShadow: getIconBorder(shadowHoverColor),
+      },
     }),
   };
 };


### PR DESCRIPTION
**What is this feature?**

Ensures that the hover styling for UserIcon is only applied when hovering on the icon will result in something happening. If the tooltip will show, or there is an onClick event, show the hover ring, and specifically, if there is an onClick event, switch the cursor to a pointer.

**Why do we need this feature?**

The logic had already been written to set the cursor to a point if there was an onClick event, specifically, but as this component uses a button, the default was also a cursor.

If you had no onClick, and tooltips turned off, such as happens in UserIndicator for the `+...` icon, you'd still get the hover ring effect even though nothing happened when you hovered, which seems like confusing UI.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

cc https://github.com/grafana/grafana-setupguide-app/pull/787 (🔐) where we had to override these behaviours.