### PR TITLE
Authz: allow wildcard matching of k8s permission groups

### DIFF
--- a/pkg/services/authz/rbac/mapper.go
+++ b/pkg/services/authz/rbac/mapper.go
@@ -331,24 +331,24 @@ func NewMapperRegistry() MapperRegistry {
 	return mapper
 }
 
-// groupMatchesWildcard returns true if group matches the wildcard pattern.
-// Pattern must start with exactly one "*" (e.g. "*.datasource.grafana.app").
-// The group matches if it has the same suffix as the pattern after the "*".
+// groupMatchesWildcard returns true if group matches the wildcard key.
+// wildcardKey must start with exactly one "*" (e.g. "*.datasource.grafana.app").
+// The group matches if it has the same suffix as wildcardKey after the "*".
 // Wildcard groups (group starting with "*") never match.
-func groupMatchesWildcard(group, pattern string) bool {
+func groupMatchesWildcard(group, wildcardKey string) bool {
 	if strings.HasPrefix(group, "*") {
 		return false
 	}
-	if len(pattern) < 2 || pattern[0] != '*' || pattern[1] != '.' {
+	if len(wildcardKey) < 2 || wildcardKey[0] != '*' || wildcardKey[1] != '.' {
 		return false
 	}
-	suffix := pattern[1:] // everything after "*"
+	suffix := wildcardKey[1:] // everything after "*"
 	return len(group) > len(suffix) && strings.HasSuffix(group, suffix)
 }
 
 // groupPrefixForWildcard returns the prefix of group when matched against a wildcard key.
 // e.g. groupPrefixForWildcard("loki.datasource.grafana.app", "*.datasource.grafana.app") returns ("loki", true).
-// The second return is false if group does not match the wildcard pattern.
+// The second return is false if group does not match the wildcard key.
 func groupPrefixForWildcard(group, wildcardKey string) (string, bool) {
 	if len(wildcardKey) < 2 || wildcardKey[0] != '*' || wildcardKey[1] != '.' {
 		return "", false
@@ -360,7 +360,7 @@ func groupPrefixForWildcard(group, wildcardKey string) (string, bool) {
 	return group[:len(group)-len(suffix)], true
 }
 
-// translationAllowsGroupPrefix returns true if the translation allows the given group when the registry key is a wildcard.
+// translationAllowsGroupPrefix returns true if the translation allows the given group when the registry key (groupKey) is a wildcard.
 // If allowedWildcardPrefixes is nil or empty, any prefix is allowed. Otherwise the group's prefix must be in the list.
 // Security: prefix is matched by exact string equality (slices.Contains); no substring or case-insensitive match.
 func translationAllowsGroupPrefix(t translation, group, groupKey string) bool {

--- a/pkg/services/authz/rbac/mapper_test.go
+++ b/pkg/services/authz/rbac/mapper_test.go
@@ -1,0 +1,204 @@
+package rbac
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test-only wildcard pattern; not used in the real mapper.
+const testWildcardPattern = "*.test.grafana.app"
+
+func TestMapperRegistry_DatasourceWildcard_OnlyAllowedPrefixes(t *testing.T) {
+	reg := NewMapperRegistry()
+
+	allowedGroups := []string{"loki.datasource.grafana.app", "tempo.datasource.grafana.app", "prometheus.datasource.grafana.app"}
+	for _, group := range allowedGroups {
+		t.Run("allowed_"+group, func(t *testing.T) {
+			mapping, ok := reg.Get(group, "datasources")
+			require.True(t, ok, "Get(%q, \"datasources\") should find mapping", group)
+			require.NotNil(t, mapping)
+			assert.Equal(t, "datasources:uid:", mapping.Prefix())
+
+			all := reg.GetAll(group)
+			require.Len(t, all, 1, "GetAll(%q) should return datasources mapping", group)
+		})
+	}
+
+	disallowedGroups := []string{"mimir.datasource.grafana.app", "influxdb.datasource.grafana.app", "foo.datasource.grafana.app"}
+	for _, group := range disallowedGroups {
+		t.Run("disallowed_"+group, func(t *testing.T) {
+			_, ok := reg.Get(group, "datasources")
+			assert.False(t, ok, "Get(%q, \"datasources\") must not return a mapping", group)
+
+			all := reg.GetAll(group)
+			assert.Empty(t, all, "GetAll(%q) must not return any mappings", group)
+		})
+	}
+}
+
+// TestMapperRegistry_DatasourceWildcard_SecurityNoBypass verifies that there is no way to gain
+// affirmative access (Get or GetAll) for *.datasource.grafana.app except for the explicitly
+// allowed prefixes (loki, tempo, prometheus). This is security-critical: only exact prefix
+// matches must be allowed; no substring, case variation, or multi-segment bypass.
+func TestMapperRegistry_DatasourceWildcard_SecurityNoBypass(t *testing.T) {
+	reg := NewMapperRegistry()
+
+	// Security: only exact allowed prefixes must grant access. These must all be denied.
+	denyGroups := []struct {
+		name   string
+		group  string
+		reason string
+	}{
+		{"wildcard_input", "*.datasource.grafana.app", "wildcard group as input must never resolve"},
+		{"prefix_superset", "lokix.datasource.grafana.app", "prefix must be exact, not superset"},
+		{"prefix_with_segment", "loki.foo.datasource.grafana.app", "prefix is multi-segment; only 'loki' allowed, not 'loki.foo'"},
+		{"prefix_contains_allowed", "evil.loki.datasource.grafana.app", "prefix must equal allowed entry, not contain it"},
+		{"case_variation_loki", "Loki.datasource.grafana.app", "prefix check is case-sensitive"},
+		{"case_variation_tempo", "TEMPO.datasource.grafana.app", "prefix check is case-sensitive"},
+		{"empty_prefix", "datasource.grafana.app", "no prefix (suffix-only) must not match"},
+		{"wrong_suffix", "loki.datasource.grafana.app.evil", "suffix must match exactly"},
+	}
+
+	for _, tc := range denyGroups {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ok := reg.Get(tc.group, "datasources")
+			assert.False(t, ok, "Get: %s (group=%q)", tc.reason, tc.group)
+
+			all := reg.GetAll(tc.group)
+			assert.Empty(t, all, "GetAll: %s (group=%q)", tc.reason, tc.group)
+		})
+	}
+}
+
+func TestGroupMatchesWildcard(t *testing.T) {
+	tests := []struct {
+		group   string
+		pattern string
+		want    bool
+	}{
+		{"foo.test.grafana.app", testWildcardPattern, true},
+		{"bar.test.grafana.app", testWildcardPattern, true},
+		{"baz.test.grafana.app", testWildcardPattern, true},
+		{"dashboard.grafana.app", testWildcardPattern, false},
+		{"test.grafana.app", testWildcardPattern, false},
+		{"foo.test.grafana.app", "dashboard.grafana.app", false},
+		{"", testWildcardPattern, false},
+		{"foo.test.grafana.app", "*", false},
+		{"*.test.grafana.app", testWildcardPattern, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.group+"_"+tt.pattern, func(t *testing.T) {
+			got := groupMatchesWildcard(tt.group, tt.pattern)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapperRegistry_WildcardGroup(t *testing.T) {
+	// Use a test-only mapper with *.test.grafana.app (not the real *.datasource.grafana.app)
+	tr := newResourceTranslation("testresources", "uid", false, nil)
+	m := mapper{
+		testWildcardPattern: {
+			"testresources": tr,
+		},
+	}
+	var reg MapperRegistry = m
+
+	groups := []string{"foo.test.grafana.app", "bar.test.grafana.app", "baz.test.grafana.app"}
+	for _, group := range groups {
+		t.Run(group, func(t *testing.T) {
+			mapping, ok := reg.Get(group, "testresources")
+			require.True(t, ok, "Get(%q, \"testresources\") should find mapping", group)
+			require.NotNil(t, mapping)
+			assert.Equal(t, "testresources:uid:", mapping.Prefix())
+
+			all := reg.GetAll(group)
+			require.Len(t, all, 1)
+			assert.Equal(t, mapping.Prefix(), all[0].Prefix())
+		})
+	}
+}
+
+func TestMapperRegistry_ExactMatchPreferred(t *testing.T) {
+	reg := NewMapperRegistry()
+
+	// Exact group keys still work
+	mapping, ok := reg.Get("dashboard.grafana.app", "dashboards")
+	require.True(t, ok)
+	require.NotNil(t, mapping)
+	assert.Equal(t, "dashboards:uid:", mapping.Prefix())
+}
+
+func TestMapperRegistry_DisallowsWildcardGroups(t *testing.T) {
+	// Use a test-only mapper; requesting a wildcard group must never resolve
+	m := mapper{testWildcardPattern: {"testresources": newResourceTranslation("testresources", "uid", false, nil)}}
+	var reg MapperRegistry = m
+
+	_, ok := reg.Get(testWildcardPattern, "testresources")
+	assert.False(t, ok, "Get with wildcard group must not return a mapping")
+
+	all := reg.GetAll(testWildcardPattern)
+	assert.Nil(t, all, "GetAll with wildcard group must return nil")
+}
+
+func TestGroupPrefixForWildcard(t *testing.T) {
+	prefix, ok := groupPrefixForWildcard("foo.test.grafana.app", testWildcardPattern)
+	require.True(t, ok)
+	assert.Equal(t, "foo", prefix)
+
+	prefix, ok = groupPrefixForWildcard("bar.test.grafana.app", testWildcardPattern)
+	require.True(t, ok)
+	assert.Equal(t, "bar", prefix)
+
+	_, ok = groupPrefixForWildcard("dashboard.grafana.app", testWildcardPattern)
+	assert.False(t, ok)
+}
+
+func TestTranslationAllowsGroupPrefix(t *testing.T) {
+	tr := newResourceTranslation("testresources", "uid", false, nil)
+	tr.allowedWildcardPrefixes = []string{"foo", "bar"}
+
+	assert.True(t, translationAllowsGroupPrefix(tr, "foo.test.grafana.app", testWildcardPattern))
+	assert.True(t, translationAllowsGroupPrefix(tr, "bar.test.grafana.app", testWildcardPattern))
+	assert.False(t, translationAllowsGroupPrefix(tr, "baz.test.grafana.app", testWildcardPattern))
+
+	// nil or empty allowedWildcardPrefixes allows any prefix
+	tr.allowedWildcardPrefixes = nil
+	assert.True(t, translationAllowsGroupPrefix(tr, "baz.test.grafana.app", testWildcardPattern))
+	tr.allowedWildcardPrefixes = []string{}
+	assert.True(t, translationAllowsGroupPrefix(tr, "baz.test.grafana.app", testWildcardPattern))
+
+	// exact group key (non-wildcard) always allowed
+	tr.allowedWildcardPrefixes = []string{"foo"}
+	assert.True(t, translationAllowsGroupPrefix(tr, "dashboard.grafana.app", "dashboard.grafana.app"))
+}
+
+func TestMapperRegistry_AllowedWildcardPrefixes(t *testing.T) {
+	tr := newResourceTranslation("testresources", "uid", false, nil)
+	tr.allowedWildcardPrefixes = []string{"foo", "bar"}
+
+	m := mapper{
+		testWildcardPattern: {
+			"testresources": tr,
+		},
+	}
+	var reg MapperRegistry = m
+
+	// Allowed prefixes resolve
+	_, ok := reg.Get("foo.test.grafana.app", "testresources")
+	assert.True(t, ok)
+	_, ok = reg.Get("bar.test.grafana.app", "testresources")
+	assert.True(t, ok)
+
+	// Disallowed prefix does not resolve
+	_, ok = reg.Get("baz.test.grafana.app", "testresources")
+	assert.False(t, ok)
+
+	// GetAll only returns translations that allow this group's prefix
+	all := reg.GetAll("foo.test.grafana.app")
+	require.Len(t, all, 1)
+	all = reg.GetAll("baz.test.grafana.app")
+	assert.Empty(t, all)
+}

--- a/pkg/services/authz/rbac/mapper_test.go
+++ b/pkg/services/authz/rbac/mapper_test.go
@@ -24,6 +24,10 @@ func TestMapperRegistry_DatasourceWildcard(t *testing.T) {
 		all := reg.GetAll(group)
 		require.Len(t, all, 1)
 	}
+
+	// Security: wildcard-matched group must not resolve to resources from other groups
+	_, ok := reg.Get("loki.datasource.grafana.app", "dashboards")
+	assert.False(t, ok, "Get(datasource group, \"dashboards\") must not return a mapping")
 }
 
 func TestGroupMatchesWildcard(t *testing.T) {

--- a/pkg/services/authz/rbac/mapper_test.go
+++ b/pkg/services/authz/rbac/mapper_test.go
@@ -10,65 +10,19 @@ import (
 // Test-only wildcard pattern; not used in the real mapper.
 const testWildcardPattern = "*.test.grafana.app"
 
-func TestMapperRegistry_DatasourceWildcard_OnlyAllowedPrefixes(t *testing.T) {
+// TestMapperRegistry_DatasourceWildcard verifies the real mapper's *.datasource.grafana.app entry.
+// Generic wildcard behavior (match + deny cases) is covered by TestMapperRegistry_WildcardGroup.
+func TestMapperRegistry_DatasourceWildcard(t *testing.T) {
 	reg := NewMapperRegistry()
 
-	allowedGroups := []string{"loki.datasource.grafana.app", "tempo.datasource.grafana.app", "prometheus.datasource.grafana.app"}
-	for _, group := range allowedGroups {
-		t.Run("allowed_"+group, func(t *testing.T) {
-			mapping, ok := reg.Get(group, "datasources")
-			require.True(t, ok, "Get(%q, \"datasources\") should find mapping", group)
-			require.NotNil(t, mapping)
-			assert.Equal(t, "datasources:uid:", mapping.Prefix())
-
-			all := reg.GetAll(group)
-			require.Len(t, all, 1, "GetAll(%q) should return datasources mapping", group)
-		})
-	}
-
-	disallowedGroups := []string{"mimir.datasource.grafana.app", "influxdb.datasource.grafana.app", "foo.datasource.grafana.app"}
-	for _, group := range disallowedGroups {
-		t.Run("disallowed_"+group, func(t *testing.T) {
-			_, ok := reg.Get(group, "datasources")
-			assert.False(t, ok, "Get(%q, \"datasources\") must not return a mapping", group)
-
-			all := reg.GetAll(group)
-			assert.Empty(t, all, "GetAll(%q) must not return any mappings", group)
-		})
-	}
-}
-
-// TestMapperRegistry_DatasourceWildcard_SecurityNoBypass verifies that there is no way to gain
-// affirmative access (Get or GetAll) for *.datasource.grafana.app except for the explicitly
-// allowed prefixes (loki, tempo, prometheus). This is security-critical: only exact prefix
-// matches must be allowed; no substring, case variation, or multi-segment bypass.
-func TestMapperRegistry_DatasourceWildcard_SecurityNoBypass(t *testing.T) {
-	reg := NewMapperRegistry()
-
-	// Security: only exact allowed prefixes must grant access. These must all be denied.
-	denyGroups := []struct {
-		name   string
-		group  string
-		reason string
-	}{
-		{"wildcard_input", "*.datasource.grafana.app", "wildcard group as input must never resolve"},
-		{"prefix_superset", "lokix.datasource.grafana.app", "prefix must be exact, not superset"},
-		{"prefix_with_segment", "loki.foo.datasource.grafana.app", "prefix is multi-segment; only 'loki' allowed, not 'loki.foo'"},
-		{"prefix_contains_allowed", "evil.loki.datasource.grafana.app", "prefix must equal allowed entry, not contain it"},
-		{"case_variation_loki", "Loki.datasource.grafana.app", "prefix check is case-sensitive"},
-		{"case_variation_tempo", "TEMPO.datasource.grafana.app", "prefix check is case-sensitive"},
-		{"empty_prefix", "datasource.grafana.app", "no prefix (suffix-only) must not match"},
-		{"wrong_suffix", "loki.datasource.grafana.app.evil", "suffix must match exactly"},
-	}
-
-	for _, tc := range denyGroups {
-		t.Run(tc.name, func(t *testing.T) {
-			_, ok := reg.Get(tc.group, "datasources")
-			assert.False(t, ok, "Get: %s (group=%q)", tc.reason, tc.group)
-
-			all := reg.GetAll(tc.group)
-			assert.Empty(t, all, "GetAll: %s (group=%q)", tc.reason, tc.group)
-		})
+	// Real config: groups matching *.datasource.grafana.app get the datasources mapping
+	for _, group := range []string{"loki.datasource.grafana.app", "mimir.datasource.grafana.app"} {
+		mapping, ok := reg.Get(group, "datasources")
+		require.True(t, ok, "Get(%q, \"datasources\") should find mapping", group)
+		require.NotNil(t, mapping)
+		assert.Equal(t, "datasources:uid:", mapping.Prefix())
+		all := reg.GetAll(group)
+		require.Len(t, all, 1)
 	}
 }
 
@@ -97,7 +51,7 @@ func TestGroupMatchesWildcard(t *testing.T) {
 }
 
 func TestMapperRegistry_WildcardGroup(t *testing.T) {
-	// Use a test-only mapper with *.test.grafana.app (not the real *.datasource.grafana.app)
+	// Test-only mapper with *.test.grafana.app; exercises full wildcard behavior (match + deny)
 	tr := newResourceTranslation("testresources", "uid", false, nil)
 	m := mapper{
 		testWildcardPattern: {
@@ -106,17 +60,35 @@ func TestMapperRegistry_WildcardGroup(t *testing.T) {
 	}
 	var reg MapperRegistry = m
 
-	groups := []string{"foo.test.grafana.app", "bar.test.grafana.app", "baz.test.grafana.app"}
-	for _, group := range groups {
-		t.Run(group, func(t *testing.T) {
+	// Matching groups get the mapping
+	for _, group := range []string{"foo.test.grafana.app", "bar.test.grafana.app", "baz.test.grafana.app"} {
+		t.Run("matches_"+group, func(t *testing.T) {
 			mapping, ok := reg.Get(group, "testresources")
 			require.True(t, ok, "Get(%q, \"testresources\") should find mapping", group)
 			require.NotNil(t, mapping)
 			assert.Equal(t, "testresources:uid:", mapping.Prefix())
-
 			all := reg.GetAll(group)
 			require.Len(t, all, 1)
 			assert.Equal(t, mapping.Prefix(), all[0].Prefix())
+		})
+	}
+
+	// Wildcard as input, wrong suffix, no prefix, or unknown group must not resolve
+	denyCases := []struct {
+		name  string
+		group string
+	}{
+		{"wildcard_input", testWildcardPattern},
+		{"wrong_suffix", "foo.test.grafana.app.evil"},
+		{"no_prefix", "test.grafana.app"},
+		{"unknown_group", "unknown.grafana.app"},
+	}
+	for _, tc := range denyCases {
+		t.Run("deny_"+tc.name, func(t *testing.T) {
+			_, ok := reg.Get(tc.group, "testresources")
+			assert.False(t, ok, "Get(%q) must not return a mapping", tc.group)
+			all := reg.GetAll(tc.group)
+			assert.Empty(t, all, "GetAll(%q) must not return any mappings", tc.group)
 		})
 	}
 }
@@ -129,76 +101,4 @@ func TestMapperRegistry_ExactMatchPreferred(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, mapping)
 	assert.Equal(t, "dashboards:uid:", mapping.Prefix())
-}
-
-func TestMapperRegistry_DisallowsWildcardGroups(t *testing.T) {
-	// Use a test-only mapper; requesting a wildcard group must never resolve
-	m := mapper{testWildcardPattern: {"testresources": newResourceTranslation("testresources", "uid", false, nil)}}
-	var reg MapperRegistry = m
-
-	_, ok := reg.Get(testWildcardPattern, "testresources")
-	assert.False(t, ok, "Get with wildcard group must not return a mapping")
-
-	all := reg.GetAll(testWildcardPattern)
-	assert.Nil(t, all, "GetAll with wildcard group must return nil")
-}
-
-func TestGroupPrefixForWildcard(t *testing.T) {
-	prefix, ok := groupPrefixForWildcard("foo.test.grafana.app", testWildcardPattern)
-	require.True(t, ok)
-	assert.Equal(t, "foo", prefix)
-
-	prefix, ok = groupPrefixForWildcard("bar.test.grafana.app", testWildcardPattern)
-	require.True(t, ok)
-	assert.Equal(t, "bar", prefix)
-
-	_, ok = groupPrefixForWildcard("dashboard.grafana.app", testWildcardPattern)
-	assert.False(t, ok)
-}
-
-func TestTranslationAllowsGroupPrefix(t *testing.T) {
-	tr := newResourceTranslation("testresources", "uid", false, nil)
-	tr.allowedWildcardPrefixes = []string{"foo", "bar"}
-
-	assert.True(t, translationAllowsGroupPrefix(tr, "foo.test.grafana.app", testWildcardPattern))
-	assert.True(t, translationAllowsGroupPrefix(tr, "bar.test.grafana.app", testWildcardPattern))
-	assert.False(t, translationAllowsGroupPrefix(tr, "baz.test.grafana.app", testWildcardPattern))
-
-	// nil or empty allowedWildcardPrefixes allows any prefix
-	tr.allowedWildcardPrefixes = nil
-	assert.True(t, translationAllowsGroupPrefix(tr, "baz.test.grafana.app", testWildcardPattern))
-	tr.allowedWildcardPrefixes = []string{}
-	assert.True(t, translationAllowsGroupPrefix(tr, "baz.test.grafana.app", testWildcardPattern))
-
-	// exact group key (non-wildcard) always allowed
-	tr.allowedWildcardPrefixes = []string{"foo"}
-	assert.True(t, translationAllowsGroupPrefix(tr, "dashboard.grafana.app", "dashboard.grafana.app"))
-}
-
-func TestMapperRegistry_AllowedWildcardPrefixes(t *testing.T) {
-	tr := newResourceTranslation("testresources", "uid", false, nil)
-	tr.allowedWildcardPrefixes = []string{"foo", "bar"}
-
-	m := mapper{
-		testWildcardPattern: {
-			"testresources": tr,
-		},
-	}
-	var reg MapperRegistry = m
-
-	// Allowed prefixes resolve
-	_, ok := reg.Get("foo.test.grafana.app", "testresources")
-	assert.True(t, ok)
-	_, ok = reg.Get("bar.test.grafana.app", "testresources")
-	assert.True(t, ok)
-
-	// Disallowed prefix does not resolve
-	_, ok = reg.Get("baz.test.grafana.app", "testresources")
-	assert.False(t, ok)
-
-	// GetAll only returns translations that allow this group's prefix
-	all := reg.GetAll("foo.test.grafana.app")
-	require.Len(t, all, 1)
-	all = reg.GetAll("baz.test.grafana.app")
-	assert.Empty(t, all)
 }


### PR DESCRIPTION
With datasources moving to App Platform as separate apps per type (loki.datasource.grafana.app, tempo.datasource.grafana.app, etc), it would be useful to define a single mapping to legacy permissions for all future datasource-type apps.  This PR adds support for such a mapping.