### PR TITLE
fix: add lock table into the resource info in unified migrations

### DIFF
--- a/pkg/storage/unified/migrations/resources.go
+++ b/pkg/storage/unified/migrations/resources.go
@@ -46,7 +46,7 @@ func registerMigration(mg *sqlstoremigrator.Migrator,
 	opts ...ResourceMigrationOption,
 ) {
 	validators := def.CreateValidators(client, mg.Dialect.DriverName())
-	migration := NewResourceMigration(migrator, def.Resources, def.ID, validators, opts...)
+	migration := NewResourceMigration(migrator, def.GetGroupResources(), def.ID, validators, opts...)
 	mg.AddMigration(def.MigrationID, migration)
 }
 

--- a/pkg/storage/unified/migrations/resources_test.go
+++ b/pkg/storage/unified/migrations/resources_test.go
@@ -28,12 +28,12 @@ func TestIsMigrationEnabled(t *testing.T) {
 	playlistDef := MigrationDefinition{
 		ID:          "test-playlists",
 		MigrationID: "playlists migration",
-		Resources:   []schema.GroupResource{playlistGR},
+		Resources:   []ResourceInfo{{GroupResource: playlistGR}},
 	}
 	foldersDashboardsDef := MigrationDefinition{
 		ID:          "test-folders-dashboards",
 		MigrationID: "folders and dashboards migration",
-		Resources:   []schema.GroupResource{folderGR, dashboardGR},
+		Resources:   []ResourceInfo{{GroupResource: folderGR}, {GroupResource: dashboardGR}},
 	}
 
 	// Build a minimal cfg with UnifiedStorage entries
@@ -116,12 +116,12 @@ func TestRegisterMigrations(t *testing.T) {
 		Registry.Register(MigrationDefinition{
 			ID:          "test-playlists",
 			MigrationID: "playlists migration",
-			Resources:   []schema.GroupResource{playlistGR},
+			Resources:   []ResourceInfo{{GroupResource: playlistGR}},
 		})
 		Registry.Register(MigrationDefinition{
 			ID:          "test-folders-dashboards",
 			MigrationID: "folders and dashboards migration",
-			Resources:   []schema.GroupResource{folderGR, dashboardGR},
+			Resources:   []ResourceInfo{{GroupResource: folderGR}, {GroupResource: dashboardGR}},
 		})
 	}
 


### PR DESCRIPTION
This is hopefully the last bit of information to move to grafana in order to fully decouple a migration configuration from migration controller. With this we would define migration related configurations **only** in grafana.

Ticket: https://github.com/grafana/search-and-storage-team/issues/624