### PR TITLE
Provisioning: Handle connection deletion errors

### DIFF
--- a/public/app/features/provisioning/Connection/DeleteConnectionButton.tsx
+++ b/public/app/features/provisioning/Connection/DeleteConnectionButton.tsx
@@ -1,10 +1,12 @@
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
+import { AppEvents, isObject } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+import { getAppEvents, reportInteraction } from '@grafana/runtime';
 import { Button } from '@grafana/ui';
 import { Connection, useDeleteConnectionMutation } from 'app/api/clients/provisioning/v0alpha1';
+import { extractErrorMessage, extractStatusCauses } from 'app/api/utils';
 import { appEvents } from 'app/core/app_events';
 import { ShowConfirmModalEvent } from 'app/types/events';
 
@@ -25,8 +27,18 @@ export function DeleteConnectionButton({ name, connection }: Props) {
       connectionType: connection?.spec?.type ?? 'unknown',
     });
 
-    await deleteConnection({ name });
-    navigate(CONNECTIONS_TAB_URL);
+    try {
+      await deleteConnection({ name }).unwrap();
+      navigate(CONNECTIONS_TAB_URL);
+    } catch (error) {
+      const causes = isObject(error) && 'data' in error ? extractStatusCauses(error.data) : [];
+      const errorMessage = causes[0]?.message ?? extractErrorMessage(error);
+
+      getAppEvents().publish({
+        type: AppEvents.alertError.name,
+        payload: [errorMessage],
+      });
+    }
   }, [deleteConnection, name, connection, navigate]);
 
   const showDeleteModal = useCallback(() => {


### PR DESCRIPTION
**What is this feature?**

Properly handle errors when deleting connections, showing the error message to the user instead of silently redirecting away.

**Why do we need this feature?**

When attempting to delete a connection that is referenced by a repository, the backend returns an error, but the frontend was unconditionally navigating to the connections listing page. This meant users couldn't see why the deletion failed or retry the operation.

**Which issue(s) does this PR fix?**

Fixes https://github.com/grafana/git-ui-sync-project/issues/799