### PR TITLE
Provisioning: use token generation check as a triggering condition

### DIFF
--- a/pkg/tests/apis/provisioning/helper_test.go
+++ b/pkg/tests/apis/provisioning/helper_test.go
@@ -840,6 +840,17 @@ func unstructuredToRepository(t *testing.T, obj *unstructured.Unstructured) *pro
 	return repo
 }
 
+func repositoryToUnstructured(t *testing.T, obj *provisioning.Repository) *unstructured.Unstructured {
+	bytes, err := json.Marshal(obj)
+	require.NoError(t, err)
+
+	res := &unstructured.Unstructured{}
+	err = res.UnmarshalJSON(bytes)
+	require.NoError(t, err)
+
+	return res
+}
+
 func unstructuredToConnection(t *testing.T, obj *unstructured.Unstructured) *provisioning.Connection {
 	bytes, err := obj.MarshalJSON()
 	require.NoError(t, err)

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -1181,7 +1181,7 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 
 	require.EventuallyWithT(t, func(collectT *assert.CollectT) {
 		repo, err := helper.Repositories.Resource.Get(ctx, "repo-with-connection", metav1.GetOptions{})
-		require.NoError(collectT, err, "can list values")
+		require.NoError(collectT, err, "can get repository")
 		r := unstructuredToRepository(t, repo)
 		require.NotEqual(collectT, 0, r.Status.ObservedGeneration, "resource should be reconciled at least once")
 		require.Equal(collectT, r.Status.ObservedGeneration, r.Generation, "resource should be reconciled")
@@ -1199,6 +1199,67 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 		require.NotNil(collectT, val)
 		require.Equal(collectT, "someToken", val.DangerouslyExposeAndConsumeValue())
 	}, time.Second*10, time.Second, "Expected repo to be reconciled")
+
+	repoUnstructured, err := helper.Repositories.Resource.Get(ctx, "repo-with-connection", metav1.GetOptions{})
+	require.NoError(t, err, "can get repository")
+	firstReconciledRepo := unstructuredToRepository(t, repoUnstructured)
+	// Setting up main triggering conditions to verify token is re-generated when
+	// needed, even if all other conditions are not triggered
+	now := time.Now()
+	firstReconciledRepo.Status.ObservedGeneration = firstReconciledRepo.Generation
+	firstReconciledRepo.Status.Sync = provisioning.SyncStatus{
+		State:     provisioning.JobStateSuccess,
+		JobID:     firstReconciledRepo.Status.Sync.JobID,
+		Started:   now.UnixMilli(),
+		Finished:  now.UnixMilli(),
+		Scheduled: now.UnixMilli(),
+		LastRef:   firstReconciledRepo.Status.Sync.LastRef,
+	}
+	firstReconciledRepo.Status.Health = provisioning.HealthStatus{
+		Healthy: true,
+		Checked: now.UnixMilli(),
+	}
+	firstReconciledRepo.Status.Token = provisioning.TokenStatus{
+		LastUpdated: now.Add(-2 * time.Minute).UnixMilli(),
+		Expiration:  now.Add(-time.Minute).UnixMilli(),
+	}
+	firstReconciledRepo.Status.FieldErrors = []provisioning.ErrorDetails{}
+	firstReconciledRepo.Status.Conditions = []metav1.Condition{
+		{
+			Type:               provisioning.ConditionTypeReady,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: firstReconciledRepo.Generation,
+			LastTransitionTime: metav1.Time{Time: now},
+			Reason:             provisioning.ReasonAvailable,
+		},
+	}
+	updatedRepo := repositoryToUnstructured(t, firstReconciledRepo)
+	// This should also trigger a reconciliation loop
+	_, err = helper.Repositories.Resource.UpdateStatus(ctx, updatedRepo, metav1.UpdateOptions{})
+	require.NoError(t, err, "failed to update status")
+
+	require.EventuallyWithT(t, func(collectT *assert.CollectT) {
+		repo, err := helper.Repositories.Resource.Get(ctx, "repo-with-connection", metav1.GetOptions{})
+		require.NoError(collectT, err, "can get repository")
+		r := unstructuredToRepository(t, repo)
+		// Token should be there
+		require.False(collectT, r.Secure.Token.IsZero())
+		// and different from the previous one
+		require.NotEqual(collectT,
+			firstReconciledRepo.Secure.Token.Name,
+			r.Secure.Token.Name,
+			"token should be updated",
+		)
+
+		// Just checking the token is what is going to be returned by the mock GH API
+		decrypted, err := decryptService.Decrypt(ctx, "provisioning.grafana.app", r.GetNamespace(), r.Secure.Token.Name)
+		require.NoError(collectT, err, "decryption error")
+		require.Len(collectT, decrypted, 1)
+
+		val := decrypted[r.Secure.Token.Name].Value()
+		require.NotNil(collectT, val)
+		require.Equal(collectT, "someToken", val.DangerouslyExposeAndConsumeValue())
+	}, time.Second*10, time.Second, "Expected repo token to be regenerated")
 }
 
 func TestIntegrationProvisioning_RepositoryUnhealthyWithValidationErrors(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

In Repository controller, move token generation check before main triggering conditions switch, and use it as one of the said conditions.

**Why do we need this feature?**

In case the other triggering conditions where not true, but the token needed to be generated, we might be skipping it.
This change ensures we never miss token regeneration when needed.

**Who is this feature for?**

Users of GitSync feature

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/788

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
