### PR TITLE
Docs: Add cross-reference from service accounts to Cloud Access Policies

### DIFF
--- a/docs/sources/administration/service-accounts/_index.md
+++ b/docs/sources/administration/service-accounts/_index.md
@@ -69,6 +69,10 @@ A service account is not the same as a Grafana [user](/docs/grafana/latest/admin
 Service accounts replace [API keys](ref:migrate-api-keys) as the primary way to authenticate applications that interact with Grafana.
 {{< /admonition >}}
 
+{{< admonition type="note" >}}
+Service accounts are for accessing the Grafana HTTP API (dashboards, users, data sources, alerts). For Grafana Cloud users who need to send or query telemetry data (metrics, logs, traces), use [Cloud Access Policies](/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/) instead.
+{{< /admonition >}}
+
 A common use case for creating a service account is to perform operations on automated or triggered tasks. You can use service accounts to:
 
 - Schedule reports for specific dashboards to be delivered on a daily/weekly/monthly basis

--- a/docs/sources/administration/service-accounts/_index.md
+++ b/docs/sources/administration/service-accounts/_index.md
@@ -70,7 +70,7 @@ Service accounts replace [API keys](ref:migrate-api-keys) as the primary way to 
 {{< /admonition >}}
 
 {{< admonition type="note" >}}
-Service accounts are for accessing the Grafana HTTP API (dashboards, users, data sources, alerts). For Grafana Cloud users who need to send or query telemetry data (metrics, logs, traces), use [Cloud Access Policies](/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/) instead.
+Use service accounts to access the Grafana HTTP API (dashboards, users, data sources, alerts). If you're a Grafana Cloud user and need to send or query telemetry data (metrics, logs, traces), use [Cloud Access Policies](/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/) instead.
 {{< /admonition >}}
 
 A common use case for creating a service account is to perform operations on automated or triggered tasks. You can use service accounts to:


### PR DESCRIPTION
Adds cross-reference to help Cloud users understand when to use Cloud Access Policies instead of service accounts for telemetry data. Companion to grafana/website#28843.