### PR TITLE
Alerting: Propagate loading states from child loaders to GroupedView parent

### DIFF
--- a/public/app/features/alerting/unified/rule-list/GroupedView.tsx
+++ b/public/app/features/alerting/unified/rule-list/GroupedView.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from 'react';
-import Skeleton from 'react-loading-skeleton';
+import { isEmpty } from 'lodash';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Stack } from '@grafana/ui';
 import { DataSourceRulesSourceIdentifier } from 'app/types/unified-alerting';
@@ -9,10 +9,17 @@ import { GrafanaRulesSource, getExternalRulesSources } from '../utils/datasource
 
 import { PaginatedDataSourceLoader } from './PaginatedDataSourceLoader';
 import { PaginatedGrafanaLoader } from './PaginatedGrafanaLoader';
+import { AlertRuleListItemSkeleton } from './components/AlertRuleListItemLoader';
 import { DataSourceErrorBoundary } from './components/DataSourceErrorBoundary';
 import { DataSourceSection } from './components/DataSourceSection';
 
 const { useDiscoverDsFeaturesQuery } = featureDiscoveryApi;
+
+export interface DataSourceLoadState {
+  isLoading: boolean;
+  rulesCount: number;
+  error?: unknown;
+}
 
 interface GroupedViewProps {
   groupFilter?: string;
@@ -20,7 +27,48 @@ interface GroupedViewProps {
 }
 
 export function GroupedView({ groupFilter, namespaceFilter }: GroupedViewProps) {
+  const hasFilters = Boolean(groupFilter || namespaceFilter);
   const externalRuleSources = useMemo(() => getExternalRulesSources(), []);
+
+  // Track detailed state for each datasource
+  const [dataSourceStates, setDataSourceStates] = useState<Map<string, DataSourceLoadState>>(new Map());
+
+  const handleLoadingStateChange = useCallback((uid: string, newState: DataSourceLoadState) => {
+    setDataSourceStates((prev) => {
+      const currentState = prev.get(uid);
+
+      // Deep comparison - only update if state actually changed
+      if (
+        currentState &&
+        currentState.isLoading === newState.isLoading &&
+        currentState.rulesCount === newState.rulesCount &&
+        currentState.error === newState.error
+      ) {
+        return prev; // No change, return same Map reference
+      }
+
+      // State changed - create new Map
+      const next = new Map(prev);
+      next.set(uid, newState);
+      return next;
+    });
+  }, []);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      setDataSourceStates(new Map());
+    };
+  }, []);
+
+  // Derive useful values for rendering
+  const loadingDataSources = useMemo(
+    () =>
+      Array.from(dataSourceStates.entries())
+        .filter(([_, state]) => state.isLoading)
+        .map(([uid]) => uid),
+    [dataSourceStates]
+  );
 
   return (
     <Stack direction="column" gap={1} role="list">
@@ -28,6 +76,7 @@ export function GroupedView({ groupFilter, namespaceFilter }: GroupedViewProps) 
         <PaginatedGrafanaLoader
           groupFilter={groupFilter}
           namespaceFilter={namespaceFilter}
+          onLoadingStateChange={handleLoadingStateChange}
           key={`${groupFilter}-${namespaceFilter}`}
         />
       </DataSourceErrorBoundary>
@@ -38,9 +87,11 @@ export function GroupedView({ groupFilter, namespaceFilter }: GroupedViewProps) 
             rulesSourceIdentifier={ruleSource}
             groupFilter={groupFilter}
             namespaceFilter={namespaceFilter}
+            onLoadingStateChange={handleLoadingStateChange}
           />
         );
       })}
+      {hasFilters && !isEmpty(loadingDataSources) && <AlertRuleListItemSkeleton />}
     </Stack>
   );
 }
@@ -49,19 +100,28 @@ interface DataSourceLoaderProps {
   rulesSourceIdentifier: DataSourceRulesSourceIdentifier;
   groupFilter?: string;
   namespaceFilter?: string;
+  onLoadingStateChange?: (uid: string, state: DataSourceLoadState) => void;
 }
 
 export function GrafanaDataSourceLoader() {
   return <DataSourceSection name="Grafana" application="grafana" uid="grafana" isLoading={true} />;
 }
 
-function DataSourceLoader({ rulesSourceIdentifier, groupFilter, namespaceFilter }: DataSourceLoaderProps) {
+function DataSourceLoader({
+  rulesSourceIdentifier,
+  groupFilter,
+  namespaceFilter,
+  onLoadingStateChange,
+}: DataSourceLoaderProps) {
+  const hasFilters = Boolean(groupFilter || namespaceFilter);
   const { data: dataSourceInfo, isLoading, error } = useDiscoverDsFeaturesQuery({ uid: rulesSourceIdentifier.uid });
 
   const { uid, name } = rulesSourceIdentifier;
 
-  if (isLoading) {
-    return <DataSourceSection loader={<Skeleton width={250} height={16} />} uid={uid} name={name} />;
+  // if we are loading and there are filters configured – we shouldn't show any data source headers
+  // dito for errors, we shouldn't show those when we're in filter mode
+  if (hasFilters && (isLoading || Boolean(error))) {
+    return null;
   }
 
   if (error) {
@@ -77,6 +137,7 @@ function DataSourceLoader({ rulesSourceIdentifier, groupFilter, namespaceFilter 
           application={dataSourceInfo.application}
           groupFilter={groupFilter}
           namespaceFilter={namespaceFilter}
+          onLoadingStateChange={onLoadingStateChange}
         />
       </DataSourceErrorBoundary>
     );

--- a/public/app/features/alerting/unified/rule-list/hooks/useDataSourceLoadingReporter.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useDataSourceLoadingReporter.ts
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+
+import { DataSourceLoadState } from './useDataSourceLoadingStates';
+
+/**
+ * Reports datasource loading state to parent with automatic cleanup.
+ * Replaces dual useEffect pattern with single hook call.
+ *
+ * @param uid - Unique identifier for the datasource
+ * @param state - Current loading state
+ * @param onLoadingStateChange - Optional callback to parent
+ */
+export function useDataSourceLoadingReporter(
+  uid: string,
+  state: DataSourceLoadState,
+  onLoadingStateChange?: (uid: string, state: DataSourceLoadState) => void
+) {
+  const { isLoading, rulesCount, error } = state;
+
+  // Report state changes
+  useEffect(() => {
+    if (onLoadingStateChange) {
+      onLoadingStateChange(uid, { isLoading, rulesCount, error });
+    }
+  }, [uid, isLoading, rulesCount, error, onLoadingStateChange]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (onLoadingStateChange) {
+        onLoadingStateChange(uid, {
+          isLoading: false,
+          rulesCount: 0,
+          error: undefined,
+        });
+      }
+    };
+  }, [uid, onLoadingStateChange]);
+}

--- a/public/app/features/alerting/unified/rule-list/hooks/useDataSourceLoadingStates.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useDataSourceLoadingStates.ts
@@ -1,0 +1,66 @@
+import { isEqual } from 'lodash';
+import { useCallback, useMemo, useState } from 'react';
+
+export interface DataSourceLoadState {
+  isLoading: boolean;
+  rulesCount: number;
+  error?: unknown;
+}
+
+interface DerivedStates {
+  loadingDataSources: string[];
+  totalRulesCount: number;
+  dataSourcesWithErrors: Array<{ uid: string; error: unknown }>;
+  hasAnyLoading: boolean;
+  hasAnyErrors: boolean;
+}
+
+/**
+ * Manages loading states for multiple datasources with automatic cleanup.
+ * Centralizes state management for datasource loaders in GroupedView.
+ */
+export function useDataSourceLoadingStates() {
+  const [states, setStates] = useState<Map<string, DataSourceLoadState>>(new Map());
+
+  // Update state function with deep comparison
+  const updateState = useCallback((uid: string, newState: DataSourceLoadState) => {
+    setStates((prev) => {
+      const currentState = prev.get(uid);
+
+      // Deep comparison - only update if state actually changed
+      if (isEqual(currentState, newState)) {
+        return prev;
+      }
+
+      const next = new Map(prev);
+      next.set(uid, newState);
+      return next;
+    });
+  }, []);
+
+  // Derive useful values - memoized for performance
+  const derived = useMemo<DerivedStates>(() => {
+    const entries = Array.from(states.entries());
+
+    const loadingDataSources = entries.filter(([_, state]) => state.isLoading).map(([uid]) => uid);
+
+    const totalRulesCount = entries.reduce((sum, [_, state]) => sum + state.rulesCount, 0);
+
+    const dataSourcesWithErrors = entries
+      .filter(([_, state]) => state.error !== undefined)
+      .map(([uid, state]) => ({ uid, error: state.error! }));
+
+    return {
+      loadingDataSources,
+      totalRulesCount,
+      dataSourcesWithErrors,
+      hasAnyLoading: loadingDataSources.length > 0,
+      hasAnyErrors: dataSourcesWithErrors.length > 0,
+    };
+  }, [states]);
+
+  return {
+    updateState,
+    ...derived,
+  };
+}


### PR DESCRIPTION
This PR implements a loading state propagation system that allows the `GroupedView` parent component to display loading indicators when any of its child paginated loaders (`PaginatedGrafanaLoader` or `PaginatedDataSourceLoader`) are actively loading rules.

Previously, each child component managed its own loading state independently with no way for the parent to be informed. This meant the parent couldn't show aggregate loading feedback to users when filters were applied.

**Before**

https://github.com/user-attachments/assets/289a8dc8-c6e9-4274-ad84-352b2b82fc8d




**After**

https://github.com/user-attachments/assets/1af6bca3-46a8-46ea-883b-86ddba6ba04d


