### PR TITLE
Provisioning: Display connections on repository and repositories on connection page

### DIFF
--- a/public/app/features/provisioning/Connection/ConnectionFormPage.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionFormPage.tsx
@@ -2,19 +2,40 @@ import { skipToken } from '@reduxjs/toolkit/query/react';
 import { useParams } from 'react-router-dom-v5-compat';
 
 import { Trans, t } from '@grafana/i18n';
-import { EmptyState, Text, TextLink } from '@grafana/ui';
-import { useGetConnectionQuery } from 'app/api/clients/provisioning/v0alpha1';
+import { Card, EmptyState, Stack, Text, TextLink } from '@grafana/ui';
+import {
+  useGetConnectionQuery,
+  useGetConnectionRepositoriesQuery,
+  useListRepositoryQuery,
+} from 'app/api/clients/provisioning/v0alpha1';
 import { Page } from 'app/core/components/Page/Page';
 
-import { CONNECTIONS_URL } from '../constants';
+import { CONNECTIONS_URL, PROVISIONING_URL } from '../constants';
 
 import { ConnectionForm } from './ConnectionForm';
+
+// External repository from the provider (e.g., GitHub)
+// The API returns `items: any[]` so we define the expected shape here
+interface ExternalRepository {
+  name?: string;
+  url?: string;
+}
 
 export default function ConnectionFormPage() {
   const { name = '' } = useParams();
   const isCreate = !name;
 
   const query = useGetConnectionQuery(isCreate ? skipToken : { name });
+
+  // Grafana repositories that use this connection
+  const connectedReposQuery = useListRepositoryQuery(
+    isCreate ? skipToken : { fieldSelector: `spec.connection.name=${name}` }
+  );
+  const connectedRepos = connectedReposQuery.data?.items ?? [];
+
+  // Available external repositories from the provider
+  const availableReposQuery = useGetConnectionRepositoriesQuery(isCreate ? skipToken : { name });
+  const availableRepos = availableReposQuery.data?.items ?? [];
 
   //@ts-expect-error TODO add error types
   const notFound = !isCreate && query.isError && query.error?.status === 404;
@@ -47,7 +68,55 @@ export default function ConnectionFormPage() {
             </TextLink>
           </EmptyState>
         ) : (
-          <ConnectionForm data={isCreate ? undefined : query.data} />
+          <Stack direction="column" gap={2}>
+            {!isCreate && connectedRepos.length > 0 && (
+              <div style={{ maxWidth: 700 }}>
+                <Card noMargin>
+                  <Card.Heading>
+                    <Trans i18nKey="provisioning.connection-form.grafana-repositories">
+                      Repositories using this connection
+                    </Trans>
+                  </Card.Heading>
+                  <Card.Description>
+                    <Stack direction="column" gap={0.5}>
+                      {connectedRepos.map((repo) => (
+                        <TextLink key={repo.metadata?.name} href={`${PROVISIONING_URL}/${repo.metadata?.name}`}>
+                          {repo.spec?.title || repo.metadata?.name}
+                        </TextLink>
+                      ))}
+                    </Stack>
+                  </Card.Description>
+                </Card>
+              </div>
+            )}
+
+            {!isCreate && availableRepos.length > 0 && (
+              <div style={{ maxWidth: 700 }}>
+                <Card noMargin>
+                  <Card.Heading>
+                    <Trans i18nKey="provisioning.connection-form.available-repositories">
+                      Other available repositories
+                    </Trans>
+                  </Card.Heading>
+                  <Card.Description>
+                    <Stack direction="column" gap={0.5}>
+                      {availableRepos.map((repo: ExternalRepository, index: number) =>
+                        repo.url ? (
+                          <TextLink key={repo.name || index} href={repo.url} external>
+                            {repo.name || repo.url}
+                          </TextLink>
+                        ) : (
+                          <Text key={repo.name || index}>{repo.name || 'Unknown'}</Text>
+                        )
+                      )}
+                    </Stack>
+                  </Card.Description>
+                </Card>
+              </div>
+            )}
+
+            <ConnectionForm data={isCreate ? undefined : query.data} />
+          </Stack>
         )}
       </Page.Contents>
     </Page>

--- a/public/app/features/provisioning/Repository/RepositoryActions.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryActions.tsx
@@ -4,7 +4,7 @@ import { Badge, Button, LinkButton, Stack } from '@grafana/ui';
 import { Repository } from 'app/api/clients/provisioning/v0alpha1';
 
 import { StatusBadge } from '../Shared/StatusBadge';
-import { PROVISIONING_URL } from '../constants';
+import { CONNECTIONS_URL, PROVISIONING_URL } from '../constants';
 import { getRepoHrefForProvider } from '../utils/git';
 import { getIsReadOnlyWorkflows } from '../utils/repository';
 import { getRepositoryTypeConfig } from '../utils/repositoryTypes';
@@ -18,6 +18,7 @@ interface RepositoryActionsProps {
 export function RepositoryActions({ repository }: RepositoryActionsProps) {
   const name = repository.metadata?.name ?? '';
   const repoHref = getRepoHrefForProvider(repository.spec);
+  const connectionName = repository.spec?.connection?.name;
 
   const repoType = repository.spec?.type;
   const repoConfig = repoType ? getRepositoryTypeConfig(repoType) : undefined;
@@ -34,6 +35,21 @@ export function RepositoryActions({ repository }: RepositoryActionsProps) {
         </Button>
       )}
       <SyncRepository repository={repository} />
+      {connectionName && (
+        <LinkButton
+          variant="secondary"
+          icon="link"
+          href={`${CONNECTIONS_URL}/${connectionName}/edit`}
+          onClick={() => {
+            reportInteraction('grafana_provisioning_repository_connection_opened', {
+              repositoryName: name,
+              connectionName,
+            });
+          }}
+        >
+          <Trans i18nKey="provisioning.repository-actions.connection">Connection</Trans>
+        </LinkButton>
+      )}
       <LinkButton
         variant="secondary"
         icon="cog"

--- a/public/app/features/provisioning/Repository/RepositoryHealthCard.test.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryHealthCard.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen } from 'test/test-utils';
+
+import { Connection, Repository, useGetConnectionQuery } from 'app/api/clients/provisioning/v0alpha1';
+
+import { RepositoryHealthCard } from './RepositoryHealthCard';
+
+jest.mock('app/api/clients/provisioning/v0alpha1', () => ({
+  ...jest.requireActual('app/api/clients/provisioning/v0alpha1'),
+  useGetConnectionQuery: jest.fn(),
+}));
+
+const mockUseGetConnectionQuery = useGetConnectionQuery as jest.Mock;
+
+const createMockRepository = (overrides: Partial<Repository> = {}): Repository => ({
+  metadata: { name: 'test-repo' },
+  spec: {
+    title: 'Test Repository',
+    type: 'github',
+    sync: { target: 'folder', enabled: true },
+    workflows: [],
+  },
+  status: {
+    health: {
+      healthy: true,
+      checked: Date.now(),
+    },
+    sync: { state: 'success', message: [] },
+    observedGeneration: 1,
+    webhook: {},
+  },
+  ...overrides,
+});
+
+const createMockConnection = (overrides: Partial<Connection> = {}): Connection => ({
+  metadata: { name: 'test-connection' },
+  spec: {
+    title: 'Test Connection',
+    type: 'github',
+  },
+  status: {
+    health: { healthy: true },
+    observedGeneration: 1,
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'Available',
+        message: 'Connection is available',
+        lastTransitionTime: new Date().toISOString(),
+        observedGeneration: 1,
+      },
+    ],
+  },
+  ...overrides,
+});
+
+describe('RepositoryHealthCard', () => {
+  beforeEach(() => {
+    mockUseGetConnectionQuery.mockReturnValue({ data: undefined, isLoading: false });
+  });
+
+  describe('Connection info', () => {
+    it('should not show connection row when repository has no connection', () => {
+      const repo = createMockRepository();
+      render(<RepositoryHealthCard repo={repo} />);
+
+      expect(screen.queryByText('Connection:')).not.toBeInTheDocument();
+    });
+
+    it('should show connection name with link when connection exists', () => {
+      const connection = createMockConnection();
+      mockUseGetConnectionQuery.mockReturnValue({ data: connection, isLoading: false });
+
+      const repo = createMockRepository({
+        spec: {
+          title: 'Test Repository',
+          type: 'github',
+          sync: { target: 'folder', enabled: true },
+          workflows: [],
+          connection: { name: 'test-connection' },
+        },
+      });
+
+      render(<RepositoryHealthCard repo={repo} />);
+
+      expect(screen.getByText('Connection:')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Test Connection' })).toHaveAttribute(
+        'href',
+        '/admin/provisioning/connections/test-connection/edit'
+      );
+    });
+
+    it('should show connection name as fallback when connection data is not loaded', () => {
+      mockUseGetConnectionQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+      const repo = createMockRepository({
+        spec: {
+          title: 'Test Repository',
+          type: 'github',
+          sync: { target: 'folder', enabled: true },
+          workflows: [],
+          connection: { name: 'my-connection' },
+        },
+      });
+
+      render(<RepositoryHealthCard repo={repo} />);
+
+      expect(screen.getByText('Connection:')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'my-connection' })).toBeInTheDocument();
+    });
+
+    it('should show ConnectionStatusBadge for connection on separate row', () => {
+      const connection = createMockConnection();
+      mockUseGetConnectionQuery.mockReturnValue({ data: connection, isLoading: false });
+
+      const repo = createMockRepository({
+        spec: {
+          title: 'Test Repository',
+          type: 'github',
+          sync: { target: 'folder', enabled: true },
+          workflows: [],
+          connection: { name: 'test-connection' },
+        },
+      });
+
+      render(<RepositoryHealthCard repo={repo} />);
+
+      expect(screen.getByText('Connection Status:')).toBeInTheDocument();
+      expect(screen.getByText('Connected')).toBeInTheDocument();
+    });
+  });
+
+  describe('Health status', () => {
+    it('should show healthy status when repository is healthy', () => {
+      const repo = createMockRepository({
+        status: {
+          health: { healthy: true, checked: Date.now() },
+          sync: { state: 'success', message: [] },
+          observedGeneration: 1,
+          webhook: {},
+        },
+      });
+
+      render(<RepositoryHealthCard repo={repo} />);
+
+      expect(screen.getByText('Healthy')).toBeInTheDocument();
+    });
+
+    it('should show unhealthy status when repository is unhealthy', () => {
+      const repo = createMockRepository({
+        status: {
+          health: { healthy: false, checked: Date.now() },
+          sync: { state: 'error', message: [] },
+          observedGeneration: 1,
+          webhook: {},
+        },
+      });
+
+      render(<RepositoryHealthCard repo={repo} />);
+
+      expect(screen.getByText('Unhealthy')).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/provisioning/Repository/RepositoryHealthCard.test.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryHealthCard.test.tsx
@@ -59,15 +59,15 @@ describe('RepositoryHealthCard', () => {
     mockUseGetConnectionQuery.mockReturnValue({ data: undefined, isLoading: false });
   });
 
-  describe('Connection info', () => {
-    it('should not show connection row when repository has no connection', () => {
+  describe('Connection status', () => {
+    it('should not show connection status when repository has no connection', () => {
       const repo = createMockRepository();
       render(<RepositoryHealthCard repo={repo} />);
 
-      expect(screen.queryByText('Connection:')).not.toBeInTheDocument();
+      expect(screen.queryByText('Connection status:')).not.toBeInTheDocument();
     });
 
-    it('should show connection name with link when connection exists', () => {
+    it('should show connection status badge when connection exists', () => {
       const connection = createMockConnection();
       mockUseGetConnectionQuery.mockReturnValue({ data: connection, isLoading: false });
 
@@ -83,49 +83,7 @@ describe('RepositoryHealthCard', () => {
 
       render(<RepositoryHealthCard repo={repo} />);
 
-      expect(screen.getByText('Connection:')).toBeInTheDocument();
-      expect(screen.getByRole('link', { name: 'Test Connection' })).toHaveAttribute(
-        'href',
-        '/admin/provisioning/connections/test-connection/edit'
-      );
-    });
-
-    it('should show connection name as fallback when connection data is not loaded', () => {
-      mockUseGetConnectionQuery.mockReturnValue({ data: undefined, isLoading: false });
-
-      const repo = createMockRepository({
-        spec: {
-          title: 'Test Repository',
-          type: 'github',
-          sync: { target: 'folder', enabled: true },
-          workflows: [],
-          connection: { name: 'my-connection' },
-        },
-      });
-
-      render(<RepositoryHealthCard repo={repo} />);
-
-      expect(screen.getByText('Connection:')).toBeInTheDocument();
-      expect(screen.getByRole('link', { name: 'my-connection' })).toBeInTheDocument();
-    });
-
-    it('should show ConnectionStatusBadge for connection on separate row', () => {
-      const connection = createMockConnection();
-      mockUseGetConnectionQuery.mockReturnValue({ data: connection, isLoading: false });
-
-      const repo = createMockRepository({
-        spec: {
-          title: 'Test Repository',
-          type: 'github',
-          sync: { target: 'folder', enabled: true },
-          workflows: [],
-          connection: { name: 'test-connection' },
-        },
-      });
-
-      render(<RepositoryHealthCard repo={repo} />);
-
-      expect(screen.getByText('Connection Status:')).toBeInTheDocument();
+      expect(screen.getByText('Connection status:')).toBeInTheDocument();
       expect(screen.getByText('Connected')).toBeInTheDocument();
     });
   });

--- a/public/app/features/provisioning/Repository/RepositoryHealthCard.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryHealthCard.tsx
@@ -1,9 +1,12 @@
 import { css } from '@emotion/css';
+import { skipToken } from '@reduxjs/toolkit/query/react';
 
 import { t, Trans } from '@grafana/i18n';
-import { Badge, Card, Grid, Stack, Text, useStyles2 } from '@grafana/ui';
-import { Repository } from 'app/api/clients/provisioning/v0alpha1';
+import { Badge, Card, Grid, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
+import { Repository, useGetConnectionQuery } from 'app/api/clients/provisioning/v0alpha1';
 
+import { ConnectionStatusBadge } from '../Connection/ConnectionStatusBadge';
+import { CONNECTIONS_URL } from '../constants';
 import { formatTimestamp } from '../utils/time';
 
 import { CheckRepository } from './CheckRepository';
@@ -11,6 +14,8 @@ import { CheckRepository } from './CheckRepository';
 export function RepositoryHealthCard({ repo }: { repo: Repository }) {
   const styles = useStyles2(getStyles);
   const status = repo.status;
+  const connectionName = repo.spec?.connection?.name;
+  const { data: connection } = useGetConnectionQuery(connectionName ? { name: connectionName } : skipToken);
 
   return (
     <Card noMargin className={styles.card}>
@@ -19,6 +24,20 @@ export function RepositoryHealthCard({ repo }: { repo: Repository }) {
       </Card.Heading>
       <Card.Description>
         <Grid columns={3} gap={1} alignItems="baseline">
+          {/* Connection */}
+          {connectionName && (
+            <>
+              <Text color="secondary">
+                <Trans i18nKey="provisioning.repository-overview.connection">Connection:</Trans>
+              </Text>
+              <div className={styles.spanTwo}>
+                <TextLink href={`${CONNECTIONS_URL}/${connectionName}/edit`}>
+                  {connection?.spec?.title || connectionName}
+                </TextLink>
+              </div>
+            </>
+          )}
+
           {/* Status */}
           <Text color="secondary">
             <Trans i18nKey="provisioning.repository-overview.status">Status:</Trans>
@@ -59,6 +78,18 @@ export function RepositoryHealthCard({ repo }: { repo: Repository }) {
                     </Text>
                   ))}
                 </Stack>
+              </div>
+            </>
+          )}
+
+          {/* Connection Status */}
+          {connectionName && (
+            <>
+              <Text color="secondary">
+                <Trans i18nKey="provisioning.repository-overview.connection-status">Connection Status:</Trans>
+              </Text>
+              <div className={styles.spanTwo}>
+                <ConnectionStatusBadge status={connection?.status} />
               </div>
             </>
           )}

--- a/public/app/features/provisioning/Repository/RepositoryHealthCard.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryHealthCard.tsx
@@ -2,11 +2,10 @@ import { css } from '@emotion/css';
 import { skipToken } from '@reduxjs/toolkit/query/react';
 
 import { t, Trans } from '@grafana/i18n';
-import { Badge, Card, Grid, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
+import { Badge, Card, Grid, Stack, Text, useStyles2 } from '@grafana/ui';
 import { Repository, useGetConnectionQuery } from 'app/api/clients/provisioning/v0alpha1';
 
 import { ConnectionStatusBadge } from '../Connection/ConnectionStatusBadge';
-import { CONNECTIONS_URL } from '../constants';
 import { formatTimestamp } from '../utils/time';
 
 import { CheckRepository } from './CheckRepository';
@@ -24,20 +23,6 @@ export function RepositoryHealthCard({ repo }: { repo: Repository }) {
       </Card.Heading>
       <Card.Description>
         <Grid columns={3} gap={1} alignItems="baseline">
-          {/* Connection */}
-          {connectionName && (
-            <>
-              <Text color="secondary">
-                <Trans i18nKey="provisioning.repository-overview.connection">Connection:</Trans>
-              </Text>
-              <div className={styles.spanTwo}>
-                <TextLink href={`${CONNECTIONS_URL}/${connectionName}/edit`}>
-                  {connection?.spec?.title || connectionName}
-                </TextLink>
-              </div>
-            </>
-          )}
-
           {/* Status */}
           <Text color="secondary">
             <Trans i18nKey="provisioning.repository-overview.status">Status:</Trans>
@@ -82,11 +67,11 @@ export function RepositoryHealthCard({ repo }: { repo: Repository }) {
             </>
           )}
 
-          {/* Connection Status */}
+          {/* Connection status */}
           {connectionName && (
             <>
               <Text color="secondary">
-                <Trans i18nKey="provisioning.repository-overview.connection-status">Connection Status:</Trans>
+                <Trans i18nKey="provisioning.repository-overview.connection-status">Connection status:</Trans>
               </Text>
               <div className={styles.spanTwo}>
                 <ConnectionStatusBadge status={connection?.status} />

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11898,6 +11898,7 @@
       "alert-connection-deleted": "Connection deleted",
       "alert-connection-saved": "Connection saved",
       "alert-connection-updated": "Connection updated",
+      "available-repositories": "Other allowed repositories",
       "back-to-connections": "Back to connections",
       "button-save": "Save",
       "button-saving": "Saving...",
@@ -11910,6 +11911,7 @@
       "error-delete-connection": "Failed to delete connection",
       "error-required": "This field is required",
       "error-save-connection": "Failed to save connection",
+      "grafana-repositories": "Repositories using this connection",
       "label-app-id": "GitHub App ID",
       "label-description": "Description",
       "label-installation-id": "GitHub Installation ID",
@@ -12219,6 +12221,7 @@
       "jobs": "Jobs"
     },
     "repository-actions": {
+      "connection": "Connection",
       "settings": "Settings",
       "source-code": "Source code"
     },
@@ -12241,6 +12244,8 @@
     },
     "repository-overview": {
       "checked": "Checked:",
+      "connection": "Connection:",
+      "connection-status": "Connection Status:",
       "finished": "Last successful pull:",
       "health": "Health",
       "healthy": "Healthy",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11898,7 +11898,7 @@
       "alert-connection-deleted": "Connection deleted",
       "alert-connection-saved": "Connection saved",
       "alert-connection-updated": "Connection updated",
-      "available-repositories": "Other allowed repositories",
+      "available-repositories": "Other available repositories",
       "back-to-connections": "Back to connections",
       "button-save": "Save",
       "button-saving": "Saving...",
@@ -12244,8 +12244,7 @@
     },
     "repository-overview": {
       "checked": "Checked:",
-      "connection": "Connection:",
-      "connection-status": "Connection Status:",
+      "connection-status": "Connection status:",
       "finished": "Last successful pull:",
       "health": "Health",
       "healthy": "Healthy",


### PR DESCRIPTION
**What is this feature?**

This PR displays connection information on repository pages and lists repositories on connection pages. It adds connection details to the repository health card with a link to the connection edit page, a connection button in the repository actions, and shows both Grafana repositories using a connection and available external repositories on the connection edit page.

**Why do we need this feature?**

This improves the user experience by making connections more discoverable and providing quick navigation between related resources.

**Which issue(s) does this PR fix?**

Fixes https://github.com/grafana/git-ui-sync-project/issues/724
Fixes https://github.com/grafana/git-ui-sync-project/issues/736

**Special notes for your reviewer**
<img width="755" height="518" alt="Screenshot 2026-01-30 at 14 10 58" src="https://github.com/user-attachments/assets/5a8b5a3f-3ce4-406f-bcd8-4f61939418c6" />
<img width="986" height="423" alt="Screenshot 2026-01-30 at 14 16 54" src="https://github.com/user-attachments/assets/5da2da93-9bf7-4b7c-b352-7c4d4a4fce20" />
