### PR TITLE
Alerting: Reset scheduler metrics oт shutdown

### DIFF
--- a/pkg/services/ngalert/metrics/scheduler.go
+++ b/pkg/services/ngalert/metrics/scheduler.go
@@ -204,3 +204,20 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 		),
 	}
 }
+
+func (s *Scheduler) ResetRuleMetrics() {
+	s.GroupRules.Reset()
+	s.SimpleNotificationRules.Reset()
+	s.Groups.Reset()
+	s.SimplifiedEditorRules.Reset()
+	s.PrometheusImportedRules.Reset()
+	s.SchedulableAlertRules.Set(0)
+	s.SchedulableAlertRulesHash.Set(0)
+}
+
+func (s *Scheduler) ResetOnStop() {
+	s.BehindSeconds.Set(0)
+	s.Ticker.LastTickTime.Set(0)
+	s.Ticker.NextTickTime.Set(0)
+	s.ResetRuleMetrics()
+}

--- a/pkg/services/ngalert/schedule/metrics.go
+++ b/pkg/services/ngalert/schedule/metrics.go
@@ -109,11 +109,7 @@ func (sch *schedule) updateRulesMetrics(alertRules []*models.AlertRule) {
 	}
 
 	// Reset metrics to avoid stale data
-	sch.metrics.GroupRules.Reset()
-	sch.metrics.SimpleNotificationRules.Reset()
-	sch.metrics.Groups.Reset()
-	sch.metrics.SimplifiedEditorRules.Reset()
-	sch.metrics.PrometheusImportedRules.Reset()
+	sch.metrics.ResetRuleMetrics()
 
 	// Set metrics
 	for key, count := range buckets {

--- a/pkg/services/ngalert/schedule/metrics_test.go
+++ b/pkg/services/ngalert/schedule/metrics_test.go
@@ -1,10 +1,18 @@
 package schedule
 
 import (
+	"bytes"
+	"context"
 	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	models "github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestHashUIDs(t *testing.T) {
@@ -22,4 +30,63 @@ func TestHashUIDs(t *testing.T) {
 	// a different slice with no items should have the same hash
 	r = []*models.AlertRule{}
 	assert.Equal(t, uint64(0xcbf29ce484222325), hashUIDs(r))
+}
+
+func TestSchedule_resetMetricsOnStop(t *testing.T) {
+	const orgID int64 = 1
+
+	ruleStore := newFakeRulesStore()
+	reg := prometheus.NewPedanticRegistry()
+	mockedClock := clock.NewMock()
+	sch := setupScheduler(t, ruleStore, nil, reg, nil, nil, nil, withSchedulerClock(mockedClock))
+
+	alertRule := models.RuleGen.With(
+		models.RuleGen.WithOrgID(orgID),
+		models.RuleGen.WithInterval(time.Second),
+		models.RuleGen.WithNotificationSettingsGen(models.NotificationSettingsGen()),
+		models.RuleGen.WithEditorSettingsSimplifiedQueryAndExpressionsSection(true),
+		models.RuleGen.WithPrometheusOriginalRuleDefinition("test"),
+	).GenerateRef()
+	ruleStore.PutRule(context.Background(), alertRule)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := make(chan struct{})
+	go func() {
+		_ = sch.Run(ctx)
+		close(stopped)
+	}()
+
+	// Advance mock clock to trigger ticks and populate metrics
+	for i := 0; i < 3; i++ {
+		mockedClock.Add(time.Second)
+	}
+
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(sch.metrics.SchedulableAlertRules) > 0
+	}, time.Second, 50*time.Millisecond)
+
+	groupRulesCount, err := testutil.GatherAndCount(reg, "grafana_alerting_rule_group_rules")
+	require.NoError(t, err)
+	require.Greater(t, groupRulesCount, 0)
+
+	cancel()
+	<-stopped
+
+	// Verify metrics are reset after stop
+	require.Equal(t, 0.0, testutil.ToFloat64(sch.metrics.BehindSeconds))
+	require.Equal(t, 0.0, testutil.ToFloat64(sch.metrics.Ticker.LastTickTime))
+	require.Equal(t, 0.0, testutil.ToFloat64(sch.metrics.Ticker.NextTickTime))
+	require.Equal(t, 0.0, testutil.ToFloat64(sch.metrics.SchedulableAlertRules))
+	require.Equal(t, 0.0, testutil.ToFloat64(sch.metrics.SchedulableAlertRulesHash))
+
+	err = testutil.GatherAndCompare(reg, bytes.NewBufferString(""), "grafana_alerting_rule_group_rules")
+	require.NoError(t, err)
+	err = testutil.GatherAndCompare(reg, bytes.NewBufferString(""), "grafana_alerting_rule_groups")
+	require.NoError(t, err)
+	err = testutil.GatherAndCompare(reg, bytes.NewBufferString(""), "grafana_alerting_simple_routing_rules")
+	require.NoError(t, err)
+	err = testutil.GatherAndCompare(reg, bytes.NewBufferString(""), "grafana_alerting_simplified_editor_rules")
+	require.NoError(t, err)
+	err = testutil.GatherAndCompare(reg, bytes.NewBufferString(""), "grafana_alerting_prometheus_imported_rules")
+	require.NoError(t, err)
 }

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -263,6 +263,7 @@ func (sch *schedule) schedulePeriodic(ctx context.Context, t *ticker.T) error {
 		case <-ctx.Done():
 			// waiting for all rule evaluation routines to stop
 			waitErr := dispatcherGroup.Wait()
+			sch.metrics.ResetOnStop()
 			return waitErr
 		}
 	}


### PR DESCRIPTION
**What is this feature?**

Reset scheduler gauge metrics when the scheduler stops. This clears metrics like `grafana_alerting_schedule_alert_rules`, `grafana_alerting_scheduler_behind_seconds`, and rule group gauges when the scheduler shuts down.

**Why do we need this feature?**

When the scheduler stops (for example, during HA failover), gauge metrics keep their last values. Resetting gauges to zero provides a clear signal that the scheduler is no longer running.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/116545

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
