### PR TITLE
Dashboard: Autohide sidebar after inactivity

### DIFF
--- a/packages/grafana-ui/src/components/Sidebar/Sidebar.story.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/Sidebar.story.tsx
@@ -10,6 +10,8 @@ import mdx from './Sidebar.mdx';
 
 interface StoryProps {
   position: SidebarPosition;
+  autoHide?: boolean;
+  autoHideTimeout?: number;
 }
 
 const meta: Meta<StoryProps> = {
@@ -22,9 +24,19 @@ const meta: Meta<StoryProps> = {
   },
   args: {
     position: 'right',
+    autoHide: false,
+    autoHideTimeout: 10000,
   },
   argTypes: {
     position: { control: { type: 'radio' }, options: ['right', 'left'] },
+    autoHide: {
+      control: { type: 'boolean' },
+      description: 'Enable auto-hide functionality (only works in undocked mode)',
+    },
+    autoHideTimeout: {
+      control: { type: 'number', min: 1000, max: 30000, step: 500 },
+      description: 'Auto-hide timeout in milliseconds (only used when autoHide is true)',
+    },
   },
 };
 
@@ -63,6 +75,8 @@ export const Example: StoryFn<StoryProps> = (args) => {
     bottomMargin: 0,
     edgeMargin: 0,
     onClosePane: () => setOpenPane(''),
+    autoHide: args.autoHide,
+    autoHideTimeout: args.autoHideTimeout,
   });
 
   return (
@@ -186,6 +200,113 @@ export const VerticalTabs: StoryFn = (args) => {
               onClick={() => togglePane('transformations')}
             />
             <Sidebar.Button icon="bell" title="Alerts" />
+          </Sidebar.Toolbar>
+        </Sidebar>
+      </div>
+    </Box>
+  );
+};
+
+export const WithAutoHide: StoryFn = () => {
+  const [openPane, setOpenPane] = useState('');
+
+  const containerStyle = css({
+    flexGrow: 1,
+    height: '600px',
+    display: 'flex',
+    flexDirection: 'column',
+    position: 'relative',
+    overflow: 'hidden',
+  });
+
+  const gridStyle = css({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(2, 1fr)',
+    gridAutoRows: '300px',
+    gap: '8px',
+    flexGrow: 1,
+    overflow: 'auto',
+  });
+
+  const togglePane = (pane: string) => {
+    if (openPane === pane) {
+      setOpenPane('');
+    } else {
+      setOpenPane(pane);
+    }
+  };
+
+  const contextValue = useSidebar({
+    hasOpenPane: !!openPane,
+    position: 'right',
+    bottomMargin: 0,
+    edgeMargin: 0,
+    onClosePane: () => setOpenPane(''),
+    autoHide: true,
+    autoHideTimeout: 10000, // Auto-hide after 10 seconds of inactivity
+  });
+
+  return (
+    <Box padding={2} backgroundColor={'canvas'} maxWidth={100} borderStyle={'solid'} borderColor={'weak'}>
+      <Box marginBottom={2} padding={2} backgroundColor={'secondary'}>
+        <strong>Auto-Hide Demo:</strong> Open any pane and it will automatically close after 3 seconds of inactivity
+        (only when undocked). Interact with the sidebar (click, move mouse) to reset the timer. Try docking the sidebar
+        to see that auto-hide is disabled in docked mode.
+      </Box>
+      <div className={containerStyle} {...contextValue.outerWrapperProps}>
+        <div className={gridStyle}>
+          {renderBox('A')}
+          {renderBox('B')}
+          {renderBox('C')}
+          {renderBox('D')}
+          {renderBox('E')}
+          {renderBox('F')}
+          {renderBox('G')}
+        </div>
+        <Sidebar contextValue={contextValue}>
+          {openPane === 'settings' && (
+            <Sidebar.OpenPane>
+              <Sidebar.PaneHeader title="Settings (Auto-hide in 3s)">
+                <Button variant="secondary" size="sm">
+                  Action
+                </Button>
+              </Sidebar.PaneHeader>
+            </Sidebar.OpenPane>
+          )}
+          {openPane === 'outline' && (
+            <Sidebar.OpenPane>
+              <Sidebar.PaneHeader title="Outline (Auto-hide in 3s)" />
+            </Sidebar.OpenPane>
+          )}
+          {openPane === 'add' && (
+            <Sidebar.OpenPane>
+              <Sidebar.PaneHeader title="Add element (Auto-hide in 3s)" />
+            </Sidebar.OpenPane>
+          )}
+          <Sidebar.Toolbar>
+            <Sidebar.Button
+              icon="plus"
+              title="Add"
+              tooltip="Add element"
+              active={openPane === 'add'}
+              onClick={() => togglePane('add')}
+            />
+
+            <Sidebar.Button
+              icon="cog"
+              title="Settings"
+              active={openPane === 'settings'}
+              onClick={() => togglePane('settings')}
+            />
+            <Sidebar.Button
+              icon="list-ui-alt"
+              title="Outline"
+              active={openPane === 'outline'}
+              onClick={() => togglePane('outline')}
+            />
+            <Sidebar.Divider />
+            <Sidebar.Button icon="info-circle" title="Insights" />
+            <Sidebar.Button icon="code-branch" title="Integrations" />
           </Sidebar.Toolbar>
         </Sidebar>
       </div>

--- a/packages/grafana-ui/src/components/Sidebar/Sidebar.story.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/Sidebar.story.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import { Button } from '../Button/Button';
 import { Box } from '../Layout/Box/Box';
+import { Stack } from '../Layout/Stack/Stack';
 
 import { Sidebar, SidebarPosition, useSidebar } from './Sidebar';
 import mdx from './Sidebar.mdx';
@@ -209,6 +210,7 @@ export const VerticalTabs: StoryFn = (args) => {
 
 export const WithAutoHide: StoryFn = () => {
   const [openPane, setOpenPane] = useState('');
+  const [isPaused, setIsPaused] = useState(false);
 
   const containerStyle = css({
     flexGrow: 1,
@@ -243,15 +245,37 @@ export const WithAutoHide: StoryFn = () => {
     edgeMargin: 0,
     onClosePane: () => setOpenPane(''),
     autoHide: true,
-    autoHideTimeout: 10000, // Auto-hide after 10 seconds of inactivity
   });
 
+  const handlePause = () => {
+    contextValue.pauseAutoHide?.();
+    setIsPaused(true);
+  };
+
+  const handleResume = () => {
+    contextValue.resumeAutoHide?.();
+    setIsPaused(false);
+  };
+
   return (
-    <Box padding={2} backgroundColor={'canvas'} maxWidth={100} borderStyle={'solid'} borderColor={'weak'}>
-      <Box marginBottom={2} padding={2} backgroundColor={'secondary'}>
-        <strong>Auto-Hide Demo:</strong> Open any pane and it will automatically close after 3 seconds of inactivity
-        (only when undocked). Interact with the sidebar (click, move mouse) to reset the timer. Try docking the sidebar
-        to see that auto-hide is disabled in docked mode.
+    <Box padding={2} backgroundColor="canvas" maxWidth={100} borderStyle="solid" borderColor="weak">
+      <Box marginBottom={2} padding={2} backgroundColor="secondary">
+        <Stack gap={1} direction="column">
+          <p>
+            <strong>Auto-Hide Demo:</strong> Open any pane and it will automatically close after 10 seconds of
+            inactivity (only when undocked). Interact with the sidebar (click, move mouse) to reset the timer. Try
+            docking the sidebar to see that auto-hide is disabled in docked mode. You can also use the following buttons
+            to set pause/resume the auto-hide timer.
+          </p>
+          <Stack gap={1} direction="row">
+            <Button variant="secondary" size="sm" onClick={handlePause} disabled={isPaused}>
+              Pause Auto-Hide
+            </Button>
+            <Button variant="secondary" size="sm" onClick={handleResume} disabled={!isPaused}>
+              Resume Auto-Hide
+            </Button>
+          </Stack>
+        </Stack>
       </Box>
       <div className={containerStyle} {...contextValue.outerWrapperProps}>
         <div className={gridStyle}>
@@ -266,47 +290,20 @@ export const WithAutoHide: StoryFn = () => {
         <Sidebar contextValue={contextValue}>
           {openPane === 'settings' && (
             <Sidebar.OpenPane>
-              <Sidebar.PaneHeader title="Settings (Auto-hide in 3s)">
+              <Sidebar.PaneHeader title="Settings">
                 <Button variant="secondary" size="sm">
                   Action
                 </Button>
               </Sidebar.PaneHeader>
             </Sidebar.OpenPane>
           )}
-          {openPane === 'outline' && (
-            <Sidebar.OpenPane>
-              <Sidebar.PaneHeader title="Outline (Auto-hide in 3s)" />
-            </Sidebar.OpenPane>
-          )}
-          {openPane === 'add' && (
-            <Sidebar.OpenPane>
-              <Sidebar.PaneHeader title="Add element (Auto-hide in 3s)" />
-            </Sidebar.OpenPane>
-          )}
           <Sidebar.Toolbar>
-            <Sidebar.Button
-              icon="plus"
-              title="Add"
-              tooltip="Add element"
-              active={openPane === 'add'}
-              onClick={() => togglePane('add')}
-            />
-
             <Sidebar.Button
               icon="cog"
               title="Settings"
               active={openPane === 'settings'}
               onClick={() => togglePane('settings')}
             />
-            <Sidebar.Button
-              icon="list-ui-alt"
-              title="Outline"
-              active={openPane === 'outline'}
-              onClick={() => togglePane('outline')}
-            />
-            <Sidebar.Divider />
-            <Sidebar.Button icon="info-circle" title="Insights" />
-            <Sidebar.Button icon="code-branch" title="Integrations" />
           </Sidebar.Toolbar>
         </Sidebar>
       </div>

--- a/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { ReactNode, useContext } from 'react';
+import { ReactNode, useContext, useEffect } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -22,7 +22,7 @@ export interface Props {
 export function SidebarComp({ children, contextValue }: Props) {
   const styles = useStyles2(getStyles);
   const theme = useTheme2();
-  const { isDocked, position, tabsMode, hasOpenPane, edgeMargin, bottomMargin } = contextValue;
+  const { isDocked, position, tabsMode, hasOpenPane, edgeMargin, bottomMargin, onActivity } = contextValue;
 
   const className = cx({
     [styles.container]: true,
@@ -43,6 +43,47 @@ export function SidebarComp({ children, contextValue }: Props) {
       contextValue.onClosePane?.();
     }
   });
+
+  useEffect(() => {
+    if (!onActivity || !ref.current) {
+      return;
+    }
+
+    const element = ref.current;
+    const events = [
+      'pointerdown',
+      'pointerup',
+      'pointermove',
+      'pointerenter',
+      'mousedown',
+      'mouseup',
+      'mousemove',
+      'mouseenter',
+      'click',
+      'touchstart',
+      'touchmove',
+      'touchend',
+      'keydown',
+      'keyup',
+      'keypress',
+      'scroll',
+      'wheel',
+    ];
+
+    const handleActivity = () => {
+      onActivity();
+    };
+
+    events.forEach((event) => {
+      element.addEventListener(event, handleActivity);
+    });
+
+    return () => {
+      events.forEach((event) => {
+        element.removeEventListener(event, handleActivity);
+      });
+    };
+  }, [onActivity, ref]);
 
   return (
     <SidebarContext.Provider value={contextValue}>

--- a/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
@@ -45,11 +45,12 @@ export function SidebarComp({ children, contextValue }: Props) {
   });
 
   useEffect(() => {
-    if (!onActivity || !ref.current) {
+    const element = ref.current;
+
+    if (!onActivity || !element) {
       return;
     }
 
-    const element = ref.current;
     const events = [
       'pointerdown',
       'pointerup',
@@ -70,9 +71,7 @@ export function SidebarComp({ children, contextValue }: Props) {
       'wheel',
     ];
 
-    const handleActivity = () => {
-      onActivity();
-    };
+    const handleActivity = () => onActivity();
 
     events.forEach((event) => {
       element.addEventListener(event, handleActivity);

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
@@ -4,7 +4,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { sceneGraph, SceneObject, SceneObjectState, useSceneObjectState } from '@grafana/scenes';
-import { Sidebar } from '@grafana/ui';
+import { Sidebar, SidebarContextValue } from '@grafana/ui';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 
 import { DashboardScene } from '../scene/DashboardScene';
@@ -25,12 +25,13 @@ import { ElementEditPane } from './ElementEditPane';
 export interface Props {
   editPane: DashboardEditPane;
   dashboard: DashboardScene;
+  sidebar: SidebarContextValue;
 }
 
 /**
  * Making the EditPane rendering completely standalone (not using editPane.Component) in order to pass custom react props
  */
-export function DashboardEditPaneRenderer({ editPane, dashboard }: Props) {
+export function DashboardEditPaneRenderer({ editPane, dashboard, sidebar }: Props) {
   const { selection, openPane } = useSceneObjectState(editPane, { shouldActivateOrKeepAlive: true });
   const { isEditing, meta, uid } = dashboard.useState();
   const hasUid = Boolean(uid);
@@ -99,6 +100,8 @@ export function DashboardEditPaneRenderer({ editPane, dashboard }: Props) {
             onAddPanel={onAddNewPanel}
             dashboard={dashboard}
             selectedElement={selectedLayoutElement}
+            onDragStart={() => sidebar.pauseAutoHide?.()}
+            onDragEnd={() => sidebar.resumeAutoHide?.()}
           />
         </Sidebar.OpenPane>
       )}

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -81,6 +81,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
     position: 'right',
     persistanceKey: 'dashboard',
     onClosePane: () => editPane.closePane(),
+    autoHide: true,
   });
 
   /**

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -131,7 +131,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
         </div>
 
         <Sidebar contextValue={sidebarContext}>
-          <DashboardEditPaneRenderer editPane={editPane} dashboard={dashboard} />
+          <DashboardEditPaneRenderer editPane={editPane} dashboard={dashboard} sidebar={sidebarContext} />
         </Sidebar>
       </div>
     );

--- a/public/app/features/dashboard-scene/edit-pane/DashboardSidePaneNew.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardSidePaneNew.tsx
@@ -16,9 +16,11 @@ interface Props {
   dashboard: SceneObject;
   selectedElement: SceneObject | undefined;
   onAddPanel: () => void;
+  onDragStart: () => void;
+  onDragEnd: () => void;
 }
 
-export function DashboardSidePaneNew({ onAddPanel, dashboard, selectedElement }: Props) {
+export function DashboardSidePaneNew({ onAddPanel, dashboard, selectedElement, onDragStart, onDragEnd }: Props) {
   const styles = useStyles2(getStyles);
   const orchestrator = getDashboardSceneFor(dashboard).state.layoutOrchestrator;
 
@@ -28,7 +30,13 @@ export function DashboardSidePaneNew({ onAddPanel, dashboard, selectedElement }:
   };
 
   return (
-    <DragDropContext onDragStart={() => orchestrator?.startDraggingNewPanel()} onDragEnd={() => {}}>
+    <DragDropContext
+      onDragStart={() => {
+        orchestrator?.startDraggingNewPanel();
+        onDragStart();
+      }}
+      onDragEnd={() => onDragEnd()}
+    >
       <Droppable droppableId="side-drop-id" isDropDisabled>
         {(dropProvided) => (
           <div className={styles.sidePanel} ref={dropProvided.innerRef} {...dropProvided.droppableProps}>


### PR DESCRIPTION
**What is this feature?**

Autohide the sidebar when it's not docked. By default the functionality is disabled. The timer is set to 10s. The autohide functionality does not work when in docked mode.

We also make sure that the autohide does not trigger while drag'n'dropping from the sidebar.

**Why do we need this feature?**

Improve UX.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/116346

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
