### PR TITLE
Graphite: Revert naming convention changes

### DIFF
--- a/pkg/tsdb/graphite/healthcheck.go
+++ b/pkg/tsdb/graphite/healthcheck.go
@@ -81,7 +81,7 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 		}
 	}()
 
-	_, err = s.toDataFrames(res, healthCheckQuery.RefID, false, targetStr)
+	_, err = s.toDataFrames(res, healthCheckQuery.RefID)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/pkg/tsdb/graphite/query_test.go
+++ b/pkg/tsdb/graphite/query_test.go
@@ -182,7 +182,7 @@ func TestConvertResponses(t *testing.T) {
 		expectedFrames := data.Frames{expectedFrame}
 
 		httpResponse := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}
-		dataFrames, err := service.toDataFrames(httpResponse, refId, false, "target")
+		dataFrames, err := service.toDataFrames(httpResponse, refId)
 
 		require.NoError(t, err)
 		if !reflect.DeepEqual(expectedFrames, dataFrames) {
@@ -217,7 +217,7 @@ func TestConvertResponses(t *testing.T) {
 		expectedFrames := data.Frames{expectedFrame}
 
 		httpResponse := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}
-		dataFrames, err := service.toDataFrames(httpResponse, refId, false, "alias(target)")
+		dataFrames, err := service.toDataFrames(httpResponse, refId)
 
 		require.NoError(t, err)
 		if !reflect.DeepEqual(expectedFrames, dataFrames) {
@@ -240,7 +240,7 @@ func TestConvertResponses(t *testing.T) {
 		expectedFrames := data.Frames{}
 
 		httpResponse := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}
-		dataFrames, err := service.toDataFrames(httpResponse, refId, false, "")
+		dataFrames, err := service.toDataFrames(httpResponse, refId)
 
 		require.NoError(t, err)
 		if !reflect.DeepEqual(expectedFrames, dataFrames) {
@@ -281,7 +281,7 @@ func TestConvertResponses(t *testing.T) {
 		expectedFrames := data.Frames{expectedFrame}
 
 		httpResponse := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}
-		dataFrames, err := service.toDataFrames(httpResponse, refId, false, "target")
+		dataFrames, err := service.toDataFrames(httpResponse, refId)
 
 		require.NoError(t, err)
 		if !reflect.DeepEqual(expectedFrames, dataFrames) {
@@ -316,7 +316,7 @@ func TestConvertResponses(t *testing.T) {
 		expectedFrames := data.Frames{expectedFrame}
 
 		httpResponse := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}
-		dataFrames, err := service.toDataFrames(httpResponse, refId, true, "alias(target)")
+		dataFrames, err := service.toDataFrames(httpResponse, refId)
 
 		require.NoError(t, err)
 		if !reflect.DeepEqual(expectedFrames, dataFrames) {
@@ -833,7 +833,7 @@ func TestAliasMatching(t *testing.T) {
 			]`, tc.target, tc.tagsName)
 
 			httpResponse := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}
-			dataFrames, err := service.toDataFrames(httpResponse, "A", tc.fromAlert, tc.target)
+			dataFrames, err := service.toDataFrames(httpResponse, "A")
 
 			require.NoError(t, err)
 			require.Len(t, dataFrames, 1)


### PR DESCRIPTION
Reverting the changes made in #116213 and #115588 (so we're back at the state of #94563). The original change in #94563 more closely matches the original frontend behaviour so we will keep that convention going forward.