### PR TITLE
Scaffold Explore toolbar with testids

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -86,6 +86,15 @@ export const versionedComponents = {
     '12.4.0': (identifier: string) => `data-testid Layout container ${identifier}`,
   },
   TimePicker: {
+    moveBackwardButton: {
+      '12.4.0': 'data-testid explore-toolbar-timepicker-move-backward-button',
+    },
+    moveForwardButton: {
+      '12.4.0': 'data-testid explore-toolbar-timepicker-move-forward-button',
+    },
+    zoomOut: {
+      '12.4.0': 'data-testid explore-toolbar-timepicker-zoom-out-button',
+    },
     openButton: {
       [MIN_GRAFANA_VERSION]: 'data-testid TimePicker Open Button',
     },

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -1005,6 +1005,9 @@ export const versionedPages = {
       live: {
         '12.4.0': 'data-testid explore-toolbar-live-button',
       },
+      refreshPicker: {
+        '12.4.0': 'data-testid explore-toolbar-refresh-picker',
+      },
       add: {
         '12.4.0': (key: string) => `data-testid explore-toolbar-add-button ${key}`,
       },

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -981,6 +981,30 @@ export const versionedPages = {
       },
     },
     toolbar: {
+      bar: {
+        '12.4.0': 'data-testid explore-toolbar',
+      },
+      contentOutline: {
+        '12.4.0': 'data-testid explore-toolbar-content-outline-button',
+      },
+      goQueryless: {
+        '12.4.0': 'data-testid explore-toolbar-go-queryless-button',
+      },
+      split: {
+        '12.4.0': 'data-testid explore-toolbar-split-button',
+      },
+      addTo: {
+        '12.4.0': 'data-testid explore-toolbar-add-dropdown-button',
+      },
+      share: {
+        '12.4.0': 'data-testid explore-toolbar-share-button',
+      },
+      copyLink: {
+        '12.4.0': 'data-testid explore-toolbar-copy-link-button',
+      },
+      live: {
+        '12.4.0': 'data-testid explore-toolbar-live-button',
+      },
       add: {
         '12.4.0': (key: string) => `data-testid explore-toolbar-add-button ${key}`,
       },

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -163,6 +163,7 @@ export function TimeRangePicker(props: TimeRangePickerProps) {
         icon="angle-double-left"
         type="button"
         iconSize="xl"
+        testId={selectors.components.TimePicker.moveBackwardButton}
         tooltip={
           moveBackwardTooltip ?? t('time-picker.range-picker.backwards-time-aria-label', 'Move time range backwards')
         }
@@ -223,6 +224,7 @@ export function TimeRangePicker(props: TimeRangePickerProps) {
         type="button"
         variant={variant}
         iconSize="xl"
+        testId={selectors.components.TimePicker.moveForwardButton}
         tooltip={
           moveForwardTooltip ?? t('time-picker.range-picker.forwards-time-aria-label', 'Move time range forwards')
         }
@@ -235,6 +237,7 @@ export function TimeRangePicker(props: TimeRangePickerProps) {
           onClick={onZoom}
           icon="search-minus"
           type="button"
+          testId={selectors.components.TimePicker.zoomOut}
           variant={variant}
         />
       </Tooltip>

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -163,7 +163,7 @@ export function TimeRangePicker(props: TimeRangePickerProps) {
         icon="angle-double-left"
         type="button"
         iconSize="xl"
-        testId={selectors.components.TimePicker.moveBackwardButton}
+        data-testid={selectors.components.TimePicker.moveBackwardButton}
         tooltip={
           moveBackwardTooltip ?? t('time-picker.range-picker.backwards-time-aria-label', 'Move time range backwards')
         }
@@ -224,7 +224,7 @@ export function TimeRangePicker(props: TimeRangePickerProps) {
         type="button"
         variant={variant}
         iconSize="xl"
-        testId={selectors.components.TimePicker.moveForwardButton}
+        data-testid={selectors.components.TimePicker.moveForwardButton}
         tooltip={
           moveForwardTooltip ?? t('time-picker.range-picker.forwards-time-aria-label', 'Move time range forwards')
         }
@@ -237,7 +237,7 @@ export function TimeRangePicker(props: TimeRangePickerProps) {
           onClick={onZoom}
           icon="search-minus"
           type="button"
-          testId={selectors.components.TimePicker.zoomOut}
+          data-testid={selectors.components.TimePicker.zoomOut}
           variant={variant}
         />
       </Tooltip>

--- a/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
+++ b/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
@@ -32,7 +32,7 @@ export interface Props {
    * By default left items are hidden on small screens.
    */
   forceShowLeftItems?: boolean;
-  testId?: string;
+  'data-testid'?: string;
 }
 
 /**

--- a/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
+++ b/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
@@ -57,7 +57,7 @@ export const PageToolbar = memo(
     'aria-label': ariaLabel,
     buttonOverflowAlignment = 'right',
     forceShowLeftItems = false,
-    testId,
+    'data-testid': testId,
   }: Props) => {
     const styles = useStyles2(getStyles);
 

--- a/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
+++ b/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
@@ -32,6 +32,7 @@ export interface Props {
    * By default left items are hidden on small screens.
    */
   forceShowLeftItems?: boolean;
+  testId?: string;
 }
 
 /**
@@ -56,6 +57,7 @@ export const PageToolbar = memo(
     'aria-label': ariaLabel,
     buttonOverflowAlignment = 'right',
     forceShowLeftItems = false,
+    testId,
   }: Props) => {
     const styles = useStyles2(getStyles);
 
@@ -97,7 +99,7 @@ export const PageToolbar = memo(
     const searchLinksLabel = t('grafana-ui.page-toolbar.search-links', 'Search links');
 
     return (
-      <nav className={mainStyle} aria-label={ariaLabel}>
+      <nav className={mainStyle} aria-label={ariaLabel} data-testid={testId}>
         <div className={styles.leftWrapper}>
           {pageIcon && !onGoBack && (
             <div className={styles.pageIcon}>

--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
@@ -104,7 +104,7 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>((
       aria-label={getButtonAriaLabel(ariaLabel, tooltip)}
       aria-expanded={isOpen}
       type="button"
-      data-testId={testId}
+      data-testid={testId}
       {...rest}
     >
       {renderIcon(icon, iconSize)}

--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
@@ -35,8 +35,6 @@ interface BaseProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   iconOnly?: boolean;
   /** Show highlight dot */
   isHighlighted?: boolean;
-  /** Test ID for testing purposes */
-  'data-testid'?: string;
 }
 
 interface BasePropsWithChildren extends BaseProps {
@@ -77,7 +75,6 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>((
     iconOnly,
     'aria-label': ariaLabel,
     isHighlighted,
-    'data-testid': testId,
     ...rest
   } = props;
 
@@ -104,7 +101,6 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>((
       aria-label={getButtonAriaLabel(ariaLabel, tooltip)}
       aria-expanded={isOpen}
       type="button"
-      data-testid={testId}
       {...rest}
     >
       {renderIcon(icon, iconSize)}

--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
@@ -77,7 +77,7 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>((
     iconOnly,
     'aria-label': ariaLabel,
     isHighlighted,
-    testId,
+    'data-testid': testId,
     ...rest
   } = props;
 

--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
@@ -36,7 +36,7 @@ interface BaseProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /** Show highlight dot */
   isHighlighted?: boolean;
   /** Test ID for testing purposes */
-  testId?: string;
+  'data-testid'?: string;
 }
 
 interface BasePropsWithChildren extends BaseProps {

--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
@@ -35,6 +35,8 @@ interface BaseProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   iconOnly?: boolean;
   /** Show highlight dot */
   isHighlighted?: boolean;
+  /** Test ID for testing purposes */
+  testId?: string;
 }
 
 interface BasePropsWithChildren extends BaseProps {
@@ -75,6 +77,7 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>((
     iconOnly,
     'aria-label': ariaLabel,
     isHighlighted,
+    testId,
     ...rest
   } = props;
 
@@ -101,6 +104,7 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>((
       aria-label={getButtonAriaLabel(ariaLabel, tooltip)}
       aria-expanded={isOpen}
       type="button"
+      data-testId={testId}
       {...rest}
     >
       {renderIcon(icon, iconSize)}

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { shallowEqual } from 'react-redux';
 
 import { DataSourceInstanceSettings, RawTimeRange, GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import {
@@ -204,11 +205,13 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
       {refreshInterval && <SetInterval func={onRunQuery} interval={refreshInterval} loading={loading} />}
       <PageToolbar
         aria-label={t('explore.toolbar.aria-label', 'Explore toolbar')}
+        testId={selectors.pages.Explore.toolbar.bar}
         leftItems={[
           <ToolbarButton
             key="content-outline"
             variant="canvas"
             tooltip={t('explore.explore-toolbar.tooltip-content-outline', 'Content outline')}
+            data-testid={selectors.pages.Explore.toolbar.contentOutline}
             icon="list-ui-alt"
             iconOnly={splitted}
             onClick={onContentOutlineToogle}
@@ -240,6 +243,7 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
             <ToolbarButton
               variant="canvas"
               key="split"
+              data-testid={selectors.pages.Explore.toolbar.split}
               tooltip={t('explore.toolbar.split-tooltip', 'Split the pane')}
               onClick={onOpenSplitView}
               icon="columns"

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -205,7 +205,7 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
       {refreshInterval && <SetInterval func={onRunQuery} interval={refreshInterval} loading={loading} />}
       <PageToolbar
         aria-label={t('explore.toolbar.aria-label', 'Explore toolbar')}
-        testId={selectors.pages.Explore.toolbar.bar}
+        data-testid={selectors.pages.Explore.toolbar.bar}
         leftItems={[
           <ToolbarButton
             key="content-outline"

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -310,6 +310,7 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
             noIntervalPicker={isLive}
             primary={true}
             width={(showSmallTimePicker ? 35 : 108) + 'px'}
+            testId={selectors.pages.Explore.toolbar.refreshPicker}
           />,
           (!splitted || !isLeftPane) && <ShortLinkButtonMenu key="share" hideText={showSmallTimePicker} />,
           datasourceInstance?.meta.streaming && (

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -310,7 +310,7 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
             noIntervalPicker={isLive}
             primary={true}
             width={(showSmallTimePicker ? 35 : 108) + 'px'}
-            testId={selectors.pages.Explore.toolbar.refreshPicker}
+            data-testid={selectors.pages.Explore.toolbar.refreshPicker}
           />,
           (!splitted || !isLeftPane) && <ShortLinkButtonMenu key="share" hideText={showSmallTimePicker} />,
           datasourceInstance?.meta.streaming && (

--- a/public/app/features/explore/LiveTailButton.tsx
+++ b/public/app/features/explore/LiveTailButton.tsx
@@ -30,7 +30,7 @@ export function LiveTailButton(props: LiveTailButtonProps) {
         variant={buttonVariant}
         icon={!isLive || isPaused ? 'play' : 'pause'}
         onClick={onClickMain}
-        testId={selectors.pages.Explore.toolbar.live}
+        data-testid={selectors.pages.Explore.toolbar.live}
         tooltip={
           !isLive || isPaused
             ? t('explore.live-tail-button.start-live-stream-your-logs', 'Start live stream your logs')

--- a/public/app/features/explore/LiveTailButton.tsx
+++ b/public/app/features/explore/LiveTailButton.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import { useRef } from 'react';
 import { CSSTransition } from 'react-transition-group';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { ButtonGroup, ToolbarButton } from '@grafana/ui';
 
@@ -29,6 +30,7 @@ export function LiveTailButton(props: LiveTailButtonProps) {
         variant={buttonVariant}
         icon={!isLive || isPaused ? 'play' : 'pause'}
         onClick={onClickMain}
+        testId={selectors.pages.Explore.toolbar.live}
         tooltip={
           !isLive || isPaused
             ? t('explore.live-tail-button.start-live-stream-your-logs', 'Start live stream your logs')

--- a/public/app/features/explore/ShortLinkButtonMenu.tsx
+++ b/public/app/features/explore/ShortLinkButtonMenu.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { IconName } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction, config } from '@grafana/runtime';
 import { Dropdown, Menu, MenuGroup, ButtonGroup, Button } from '@grafana/ui';
@@ -139,6 +140,7 @@ export function ShortLinkButtonMenu({ hideText }: { hideText: boolean }) {
           const url = lastSelected.getUrl();
           onCopyLink(lastSelected.shorten, lastSelected.absTime, url);
         }}
+        data-testid={selectors.pages.Explore.toolbar.share}
         aria-label={t('explore.toolbar.copy-shortened-link', 'Copy shortened URL')}
       >
         {!hideText && <Trans i18nKey="explore.toolbar.copy-shortened-link-label">Share</Trans>}
@@ -147,6 +149,7 @@ export function ShortLinkButtonMenu({ hideText }: { hideText: boolean }) {
         <Button
           variant={'secondary'}
           icon={isOpen ? 'angle-up' : 'angle-down'}
+          data-testid={selectors.pages.Explore.toolbar.copyLink}
           aria-label={t('explore.toolbar.copy-shortened-link-menu', 'Open copy link options')}
         />
       </Dropdown>

--- a/public/app/features/explore/extensions/toolbar/BasicExtensions.tsx
+++ b/public/app/features/explore/extensions/toolbar/BasicExtensions.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from 'react';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { Dropdown, ToolbarButton } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -40,6 +41,7 @@ export function BasicExtensions(props: ExtensionDropdownProps) {
       <Dropdown onVisibleChange={setIsModalOpen} placement="bottom-start" overlay={menu}>
         <ToolbarButton
           aria-label={t('explore.basic-extensions.aria-label-add', 'Add')}
+          testId={selectors.pages.Explore.toolbar.addTo}
           disabled={!Boolean(noQueriesInPane)}
           variant="canvas"
           isOpen={isModalOpen}

--- a/public/app/features/explore/extensions/toolbar/BasicExtensions.tsx
+++ b/public/app/features/explore/extensions/toolbar/BasicExtensions.tsx
@@ -41,7 +41,7 @@ export function BasicExtensions(props: ExtensionDropdownProps) {
       <Dropdown onVisibleChange={setIsModalOpen} placement="bottom-start" overlay={menu}>
         <ToolbarButton
           aria-label={t('explore.basic-extensions.aria-label-add', 'Add')}
-          testId={selectors.pages.Explore.toolbar.addTo}
+          data-testid={selectors.pages.Explore.toolbar.addTo}
           disabled={!Boolean(noQueriesInPane)}
           variant="canvas"
           isOpen={isModalOpen}

--- a/public/app/features/explore/extensions/toolbar/QuerylessAppsExtensions.tsx
+++ b/public/app/features/explore/extensions/toolbar/QuerylessAppsExtensions.tsx
@@ -1,5 +1,6 @@
 import { first } from 'lodash';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { Dropdown, ToolbarButton } from '@grafana/ui';
 
@@ -19,7 +20,12 @@ export function QuerylessAppsExtensions(props: ExtensionDropdownProps) {
   if (links.length === 1) {
     const link = first(links)!;
     return (
-      <ToolbarButton variant="canvas" icon={link.icon} onClick={() => setSelectedExtension(link)}>
+      <ToolbarButton
+        variant="canvas"
+        icon={link.icon}
+        onClick={() => setSelectedExtension(link)}
+        data-testid={selectors.pages.Explore.toolbar.goQueryless}
+      >
         <Trans i18nKey="explore.toolbar.add-to-queryless-extensions">Go queryless</Trans>
       </ToolbarButton>
     );


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Scaffolds the Explore toolbar with testids for all buttons.

Before:
<img width="1917" height="168" alt="Screenshot From 2026-01-30 15-00-25" src="https://github.com/user-attachments/assets/c156f999-e54e-4348-847c-d3a065ab7e3d" />

After:
<img width="1917" height="168" alt="Screenshot From 2026-01-30 15-00-33" src="https://github.com/user-attachments/assets/634c3535-cf77-4f35-917e-88479cb1b9be" />

**Why do we need this feature?**
Pathfinder needs to reliably target these elements.

**Who is this feature for?**
Everyone.

**Which issue(s) does this PR fix?**:

For https://github.com/grafana/website/issues/28731

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
