### PR TITLE
UI: Clarify service accounts use case and add cross-reference to Cloud Access Policies

### DIFF
--- a/docs/sources/administration/service-accounts/_index.md
+++ b/docs/sources/administration/service-accounts/_index.md
@@ -73,7 +73,11 @@ Note the following:
 
 ## When to use service accounts
 
-Use service accounts and tokens to perform operations on automated or triggered tasks such as:
+{{< admonition type="note" >}}
+Service accounts are for accessing the Grafana HTTP API (dashboards, users, data sources, alerts). For Grafana Cloud users who need to send or query telemetry data (metrics, logs, traces), use [Cloud Access Policies](/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/) instead.
+{{< /admonition >}}
+
+A common use case for creating a service account is to perform operations on automated or triggered tasks. You can use service accounts to:
 
 - Authenticate applications, such as Terraform, with the Grafana API.
 - Schedule reports for specific dashboards to be delivered on a daily/weekly/monthly basis.

--- a/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
@@ -177,7 +177,11 @@ export const ServiceAccountsListPageUnconnected = ({
   const subTitle = (
     <span>
       <Trans i18nKey="serviceaccounts.service-accounts-list-page-unconnected.sub-title">
-        Service accounts and their tokens can be used to authenticate against the Grafana API. Find out more in our{' '}
+        Service accounts authenticate applications with the Grafana HTTP API to manage dashboards, users, and data sources. For sending or querying telemetry data (metrics, logs, traces), use{' '}
+        <TextLink href="https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/" external>
+          Cloud Access Policies
+        </TextLink>{' '}
+        instead. Find out more in our{' '}
         <TextLink href="https://grafana.com/docs/grafana/latest/administration/service-accounts/" external>
           documentation.
         </TextLink>

--- a/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
@@ -23,6 +23,8 @@ import { AccessControlAction } from 'app/types/accessControl';
 import { ServiceAccountStateFilter, ServiceAccountDTO } from 'app/types/serviceaccount';
 import { StoreState } from 'app/types/store';
 
+import { isOnPrem } from '../provisioning/utils/isOnPrem';
+
 import { ServiceAccountTable } from './ServiceAccountTable';
 import { CreateTokenModal, ServiceAccountToken } from './components/CreateTokenModal';
 import {
@@ -176,16 +178,30 @@ export const ServiceAccountsListPageUnconnected = ({
 
   const subTitle = (
     <span>
-      <Trans i18nKey="serviceaccounts.service-accounts-list-page-unconnected.sub-title">
-        Service accounts authenticate applications with the Grafana HTTP API to manage dashboards, users, and data sources. For sending or querying telemetry data (metrics, logs, traces), use{' '}
-        <TextLink href="https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/" external>
-          Cloud Access Policies
-        </TextLink>{' '}
-        instead. Find out more in our{' '}
-        <TextLink href="https://grafana.com/docs/grafana/latest/administration/service-accounts/" external>
-          documentation.
-        </TextLink>
-      </Trans>
+      {isOnPrem() ? (
+        <Trans i18nKey="serviceaccounts.service-accounts-list-page-unconnected.sub-title-onprem">
+          Service accounts authenticate applications with the Grafana HTTP API to manage dashboards, users, and data
+          sources. Find out more in our{' '}
+          <TextLink href="https://grafana.com/docs/grafana/latest/administration/service-accounts/" external>
+            documentation.
+          </TextLink>
+        </Trans>
+      ) : (
+        <Trans i18nKey="serviceaccounts.service-accounts-list-page-unconnected.sub-title">
+          Service accounts authenticate applications with the Grafana HTTP API to manage dashboards, users, and data
+          sources. For sending or querying telemetry data (metrics, logs, traces), use{' '}
+          <TextLink
+            href="https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/"
+            external
+          >
+            Cloud Access Policies
+          </TextLink>{' '}
+          instead. Find out more in our{' '}
+          <TextLink href="https://grafana.com/docs/grafana/latest/administration/service-accounts/" external>
+            documentation.
+          </TextLink>
+        </Trans>
+      )}
     </span>
   );
 


### PR DESCRIPTION
Addresses user confusion between service accounts and Cloud Access Policies by clarifying what service accounts are for and pointing to access policies for telemetry data.