### PR TITLE
Log Line Context: Add support for default displayed fields

### DIFF
--- a/public/app/features/logs/components/panel/LogLineContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, userEvent } from 'test/test-utils';
+import { render, screen, waitFor, userEvent, act } from 'test/test-utils';
 
 import {
   createDataFrame,
@@ -7,8 +7,11 @@ import {
   LogsSortOrder,
   SplitOpenOptions,
 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 
-import { dataFrameToLogsModel } from '../../logsModel';
+import { dataFrameToLogsModel, } from '../../logsModel';
+import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
+import { getDisplayedFieldsForLogs, identifyOTelLanguages, OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME } from '../otel/formats';
 
 import { DEFAULT_TIME_WINDOW, LogLineContext, PAGE_SIZE } from './LogLineContext';
 
@@ -19,6 +22,7 @@ jest.mock('@grafana/assistant', () => ({
     openAssistant: jest.fn(),
   }),
 }));
+jest.mock('../otel/formats');
 
 const dfBefore = createDataFrame({
   fields: [
@@ -78,6 +82,9 @@ jest.mock('app/features/explore/state/main', () => ({
     return splitOpen(arg);
   },
 }));
+
+jest.mocked(getDisplayedFieldsForLogs).mockReturnValue([]);
+jest.mocked(identifyOTelLanguages).mockReturnValue([]);
 
 const logs = dataFrameToLogsModel([dfNow]);
 const row = logs.rows[0];
@@ -605,5 +612,119 @@ describe('LogLineContext', () => {
       })
     ).not.toBeInTheDocument();
     expect(screen.getAllByText('foo123')).toHaveLength(3);
+  });
+
+  test('Should hide "Show original logs" button when there are no displayed fields', async () => {
+    render(
+      <LogLineContext
+        log={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+        displayedFields={[]}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Log context')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole('button', {
+        name: /show original logs/i,
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  test('Should show "Show original logs" button when displayed fields are provided', async () => {
+    const displayedFields = ['level', 'label'];
+
+    render(
+      <LogLineContext
+        log={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+        displayedFields={displayedFields}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Log context')).toBeInTheDocument();
+    });
+
+    // Button should be visible when displayedFields are provided and differ from defaultDisplayedFields
+    expect(
+      screen.getByRole('button', {
+        name: /show original logs/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  describe('Default displayed fields', () => {
+    const originalFlagValue = config.featureToggles.otelLogsFormatting;
+    beforeEach(() => {
+      config.featureToggles.otelLogsFormatting = true;
+      jest.mocked(getDisplayedFieldsForLogs).mockReturnValue([LOG_LINE_BODY_FIELD_NAME, OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME]);
+    });
+    afterAll(() => {
+      config.featureToggles.otelLogsFormatting = originalFlagValue;
+    })
+
+    test('Should show "Show original logs" button when displayed fields are different than the default fields', async () => {
+      const displayedFields = ['level', 'label'];
+
+      render(
+        <LogLineContext
+          log={row}
+          open={true}
+          onClose={() => {}}
+          getRowContext={getRowContext}
+          timeZone={timeZone}
+          sortOrder={LogsSortOrder.Descending}
+          displayedFields={displayedFields}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Log context')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole('button', {
+          name: /show original logs/i,
+        })
+      ).toBeInTheDocument();
+    });
+
+    test('Should not show "Show original logs" button when displayed fields match the default fields', async () => {
+      const displayedFields = [LOG_LINE_BODY_FIELD_NAME, OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME];
+
+      render(
+        <LogLineContext
+          log={row}
+          open={true}
+          onClose={() => {}}
+          getRowContext={getRowContext}
+          timeZone={timeZone}
+          sortOrder={LogsSortOrder.Descending}
+          displayedFields={displayedFields}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Log context')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByRole('button', {
+          name: /show original logs/i,
+        })
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/public/app/features/logs/components/panel/LogLineContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, userEvent, act } from 'test/test-utils';
+import { render, screen, waitFor, userEvent } from 'test/test-utils';
 
 import {
   createDataFrame,

--- a/public/app/features/logs/components/panel/LogLineContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.test.tsx
@@ -9,7 +9,7 @@ import {
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
-import { dataFrameToLogsModel, } from '../../logsModel';
+import { dataFrameToLogsModel } from '../../logsModel';
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { getDisplayedFieldsForLogs, identifyOTelLanguages, OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME } from '../otel/formats';
 
@@ -669,11 +669,13 @@ describe('LogLineContext', () => {
     const originalFlagValue = config.featureToggles.otelLogsFormatting;
     beforeEach(() => {
       config.featureToggles.otelLogsFormatting = true;
-      jest.mocked(getDisplayedFieldsForLogs).mockReturnValue([LOG_LINE_BODY_FIELD_NAME, OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME]);
+      jest
+        .mocked(getDisplayedFieldsForLogs)
+        .mockReturnValue([LOG_LINE_BODY_FIELD_NAME, OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME]);
     });
     afterAll(() => {
       config.featureToggles.otelLogsFormatting = originalFlagValue;
-    })
+    });
 
     test('Should show "Show original logs" button when displayed fields are different than the default fields', async () => {
       const displayedFields = ['level', 'label'];


### PR DESCRIPTION
Related with https://github.com/grafana/grafana/issues/101083

Small follow up to https://github.com/grafana/grafana/pull/116912 to add support for default displayed fields, analog to Explore and LogsMetaRow.

https://github.com/grafana/grafana/blob/main/public/app/features/explore/Logs/LogsMetaRow.tsx#L76-L88

### How to test

Using an OTel logs source, such as `{service_name="flux-commit-tracker"} `:

- With the default displayed fields, when opening Log Context, there should not be a visible button with the copy "show original logs".
- Change the displayed fields, open log context, where should be a visible button with copy "show original logs".
- With an OTel logs source, and displayed fields, when "show original logs" in Log Context is clicked, it should show the default fields and disappear.