### PR TITLE
Mixed: Fix hidden queries being executed

### DIFF
--- a/public/app/plugins/datasource/mixed/MixedDataSource.test.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.test.ts
@@ -247,4 +247,37 @@ describe('MixedDatasource', () => {
       expect(results[0].data).toHaveLength(0);
     });
   });
+
+  describe('hidden query filtering', () => {
+    it('should not include hidden queries in the request', async () => {
+      const ds = new MixedDatasource({} as DataSourceInstanceSettings);
+      const request = {
+        targets: [
+          { refId: 'QA', hide: true, datasource: { uid: 'A' } },
+          { refId: 'QB', hide: false, datasource: { uid: 'B' } },
+        ],
+      } as DataQueryRequest;
+
+      await expect(ds.query(request)).toEmitValuesWith((results) => {
+        // Only QB should be executed, QA is hidden
+        expect(results).toHaveLength(1);
+        expect(results[0].data).toEqual(['BBBB']);
+      });
+    });
+
+    it('should return empty when all queries are hidden', async () => {
+      const ds = new MixedDatasource({} as DataSourceInstanceSettings);
+      const request = {
+        targets: [
+          { refId: 'QA', hide: true, datasource: { uid: 'A' } },
+          { refId: 'QB', hide: true, datasource: { uid: 'B' } },
+        ],
+      } as DataQueryRequest;
+
+      await expect(ds.query(request)).toEmitValuesWith((results) => {
+        expect(results).toHaveLength(1);
+        expect(results[0].data).toHaveLength(0);
+      });
+    });
+  });
 });

--- a/public/app/plugins/datasource/mixed/MixedDataSource.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.ts
@@ -17,6 +17,8 @@ import { CustomFormatterVariable } from '@grafana/scenes';
 
 import { SHARED_DASHBOARD_QUERY } from '../dashboard/constants';
 
+import { filterHiddenQueries } from './filterHiddenQueries';
+
 export const MIXED_DATASOURCE_NAME = '-- Mixed --';
 export const MIXED_REQUEST_PREFIX = 'mixed-';
 
@@ -35,10 +37,12 @@ export class MixedDatasource extends DataSourceApi<DataQuery> {
   }
 
   query(request: DataQueryRequest<DataQuery>): Observable<DataQueryResponse> {
-    // Remove any invalid queries
-    const queries = request.targets.filter((t) => {
-      return t.datasource?.uid !== MIXED_DATASOURCE_NAME;
-    });
+    // Remove any invalid queries and filter hidden queries
+    const queries = filterHiddenQueries(
+      request.targets.filter((t) => {
+        return t.datasource?.uid !== MIXED_DATASOURCE_NAME;
+      })
+    );
 
     if (!queries.length) {
       return of({ data: [] }); // nothing

--- a/public/app/plugins/datasource/mixed/filterHiddenQueries.test.ts
+++ b/public/app/plugins/datasource/mixed/filterHiddenQueries.test.ts
@@ -1,0 +1,190 @@
+import { DataQuery } from '@grafana/data';
+import { EvalFunction } from 'app/features/alerting/state/alertDef';
+import { ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
+
+import { filterHiddenQueries } from './filterHiddenQueries';
+
+describe('filterHiddenQueries', () => {
+  describe('basic filtering', () => {
+    it('returns all queries when none are hidden', () => {
+      const queries: DataQuery[] = [
+        { refId: 'A', hide: false },
+        { refId: 'B', hide: false },
+      ];
+      expect(filterHiddenQueries(queries)).toEqual(queries);
+    });
+
+    it('filters out hidden queries', () => {
+      const queries: DataQuery[] = [
+        { refId: 'A', hide: true },
+        { refId: 'B', hide: false },
+      ];
+      const result = filterHiddenQueries(queries);
+      expect(result.map((q) => q.refId)).toEqual(['B']);
+    });
+
+    it('returns empty array when all queries are hidden', () => {
+      const queries: DataQuery[] = [
+        { refId: 'A', hide: true },
+        { refId: 'B', hide: true },
+      ];
+      expect(filterHiddenQueries(queries)).toEqual([]);
+    });
+  });
+
+  describe('dependency handling', () => {
+    it('preserves hidden query referenced by Math expression', () => {
+      const queries: Array<DataQuery | ExpressionQuery> = [
+        { refId: 'A', hide: true },
+        {
+          refId: 'B',
+          hide: false,
+          datasource: { uid: '__expr__', type: 'datasource' },
+          expression: '$A * 2',
+          type: ExpressionQueryType.math,
+        },
+      ];
+      const result = filterHiddenQueries(queries);
+      expect(result.map((q) => q.refId).sort()).toEqual(['A', 'B']);
+    });
+
+    it('filters unreferenced hidden query when another is referenced', () => {
+      const queries: Array<DataQuery | ExpressionQuery> = [
+        { refId: 'A', hide: true }, // not referenced
+        { refId: 'B', hide: true }, // referenced by C
+        {
+          refId: 'C',
+          hide: false,
+          datasource: { uid: '__expr__', type: 'datasource' },
+          expression: '$B + 1',
+          type: ExpressionQueryType.math,
+        },
+      ];
+      const result = filterHiddenQueries(queries);
+      expect(result.map((q) => q.refId).sort()).toEqual(['B', 'C']);
+    });
+
+    it('handles chain dependencies (A->B->C)', () => {
+      const queries: Array<DataQuery | ExpressionQuery> = [
+        { refId: 'A', hide: true },
+        {
+          refId: 'B',
+          hide: true,
+          datasource: { uid: '__expr__', type: 'datasource' },
+          expression: '$A',
+          type: ExpressionQueryType.reduce,
+        },
+        {
+          refId: 'C',
+          hide: false,
+          datasource: { uid: '__expr__', type: 'datasource' },
+          expression: '$B > 10',
+          type: ExpressionQueryType.threshold,
+        },
+      ];
+      const result = filterHiddenQueries(queries);
+      expect(result.map((q) => q.refId).sort()).toEqual(['A', 'B', 'C']);
+    });
+
+    it('handles circular dependencies without infinite loop', () => {
+      const queries: Array<DataQuery | ExpressionQuery> = [
+        {
+          refId: 'A',
+          hide: true,
+          datasource: { uid: '__expr__', type: 'datasource' },
+          expression: '$B',
+          type: ExpressionQueryType.math,
+        },
+        {
+          refId: 'B',
+          hide: true,
+          datasource: { uid: '__expr__', type: 'datasource' },
+          expression: '$A',
+          type: ExpressionQueryType.math,
+        },
+        {
+          refId: 'C',
+          hide: false,
+          datasource: { uid: '__expr__', type: 'datasource' },
+          expression: '$A + $B',
+          type: ExpressionQueryType.math,
+        },
+      ];
+      const result = filterHiddenQueries(queries);
+      expect(result.map((q) => q.refId).sort()).toEqual(['A', 'B', 'C']);
+    });
+  });
+
+  describe('expression types', () => {
+    it('preserves hidden query referenced by Resample expression', () => {
+      const queries: Array<DataQuery | ExpressionQuery> = [
+        { refId: 'A', hide: true },
+        {
+          refId: 'B',
+          hide: false,
+          datasource: { uid: '__expr__', type: 'datasource' },
+          expression: '$A',
+          type: ExpressionQueryType.resample,
+          window: '1m',
+          downsampler: 'mean',
+          upsampler: 'pad',
+        },
+      ];
+      const result = filterHiddenQueries(queries);
+      expect(result.map((q) => q.refId).sort()).toEqual(['A', 'B']);
+    });
+
+    it('preserves hidden query referenced by SQL expression (FROM clause)', () => {
+      const queries: Array<DataQuery | ExpressionQuery> = [
+        { refId: 'A', hide: true },
+        {
+          refId: 'B',
+          hide: false,
+          datasource: { uid: '__expr__', type: 'datasource' },
+          expression: 'SELECT * FROM A WHERE value > 0',
+          type: ExpressionQueryType.sql,
+        },
+      ];
+      const result = filterHiddenQueries(queries);
+      expect(result.map((q) => q.refId).sort()).toEqual(['A', 'B']);
+    });
+
+    it('preserves multiple hidden queries referenced by SQL with JOINs', () => {
+      const queries: Array<DataQuery | ExpressionQuery> = [
+        { refId: 'A', hide: true },
+        { refId: 'B', hide: true },
+        {
+          refId: 'C',
+          hide: false,
+          datasource: { uid: '__expr__', type: 'datasource' },
+          expression: 'SELECT * FROM A JOIN B ON A.id = B.id',
+          type: ExpressionQueryType.sql,
+        },
+      ];
+      const result = filterHiddenQueries(queries);
+      expect(result.map((q) => q.refId).sort()).toEqual(['A', 'B', 'C']);
+    });
+
+    it('preserves hidden query referenced by Classic Conditions', () => {
+      const queries: Array<DataQuery | ExpressionQuery> = [
+        { refId: 'A', hide: true },
+        {
+          refId: 'B',
+          hide: false,
+          datasource: { uid: '__expr__', type: 'datasource' },
+          type: ExpressionQueryType.classic,
+          conditions: [
+            {
+              evaluator: { params: [0], type: EvalFunction.IsAbove },
+              query: { params: ['A'] },
+              reducer: { params: [], type: 'avg' as const },
+              type: 'query' as const,
+            },
+          ],
+        },
+      ];
+      const result = filterHiddenQueries(queries);
+      expect(result.map((q) => q.refId).sort()).toEqual(['A', 'B']);
+    });
+  });
+});

--- a/public/app/plugins/datasource/mixed/filterHiddenQueries.ts
+++ b/public/app/plugins/datasource/mixed/filterHiddenQueries.ts
@@ -1,0 +1,86 @@
+import { DataQuery } from '@grafana/data';
+import { ExpressionDatasourceUID, ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
+
+function isExpressionQuery(query: DataQuery): query is ExpressionQuery {
+  return query.datasource?.uid === ExpressionDatasourceUID;
+}
+
+/**
+ * Extracts refIds that an Expression query depends on.
+ */
+function extractDependencies(query: DataQuery): string[] {
+  if (!isExpressionQuery(query)) {
+    return [];
+  }
+
+  const deps: string[] = [];
+  const expr = query;
+
+  // Math/Reduce/Resample/Threshold: $A, $B pattern
+  if (expr.expression) {
+    const dollarMatches = expr.expression.match(/\$([A-Z])/g);
+    if (dollarMatches) {
+      deps.push(...dollarMatches.map((m) => m.slice(1)));
+    }
+
+    // SQL: FROM A, JOIN B pattern (single capital letter as table name)
+    if (expr.type === ExpressionQueryType.sql) {
+      const sqlMatches = expr.expression.match(/(?:FROM|JOIN)\s+([A-Z])(?:\s|$|,)/gi);
+      if (sqlMatches) {
+        deps.push(...sqlMatches.map((m) => m.replace(/(?:FROM|JOIN)\s+/i, '').trim().charAt(0)));
+      }
+    }
+  }
+
+  // Classic Conditions: conditions[].query.params[0]
+  if (expr.conditions) {
+    for (const condition of expr.conditions) {
+      if (condition.query?.params?.[0]) {
+        deps.push(condition.query.params[0]);
+      }
+    }
+  }
+
+  return [...new Set(deps)];
+}
+
+/**
+ * Filters hidden queries from the list, preserving queries that are
+ * referenced by visible Expression queries.
+ */
+export function filterHiddenQueries(queries: DataQuery[]): DataQuery[] {
+  const hiddenQueries = queries.filter((q) => q.hide);
+  if (hiddenQueries.length === 0) {
+    return queries;
+  }
+
+  const visibleQueries = queries.filter((q) => !q.hide);
+
+  // Pre-compute dependencies for all queries
+  const depsMap = new Map<string, string[]>();
+  for (const q of queries) {
+    depsMap.set(q.refId, extractDependencies(q));
+  }
+
+  // BFS to find all required refIds (using index to avoid O(n) shift)
+  const required = new Set<string>();
+  const visited = new Set<string>();
+  const queue = visibleQueries.flatMap((q) => depsMap.get(q.refId) || []);
+
+  for (let i = 0; i < queue.length; i++) {
+    const refId = queue[i];
+    if (visited.has(refId)) {
+      continue;
+    }
+    visited.add(refId);
+    required.add(refId);
+
+    const deps = depsMap.get(refId) || [];
+    queue.push(...deps.filter((d) => !visited.has(d)));
+  }
+
+  // Include visible queries + required hidden queries
+  const requiredHidden = hiddenQueries.filter((q) => required.has(q.refId));
+
+  return [...visibleQueries, ...requiredHidden];
+}


### PR DESCRIPTION
**What is this feature?**

Filter hidden queries before execution in MixedDatasource. Hidden queries that are not referenced by Expression queries are now excluded from execution.

**Why do we need this feature?**

When using Mixed datasource, hidden queries were still being executed even though the user intended to hide them. This is a regression introduced in v11 because `MixedDatasource` extends `DataSourceApi` directly instead of `DataSourceWithBackend`, which has the default `filterQuery()` implementation.

This causes:
- Unnecessary network traffic
- Query costs for cloud datasources (BigQuery, CloudWatch, etc.)
- Syntax errors in hidden queries causing panel errors

**Who is this feature for?**

All Grafana users who use Mixed datasource with hidden queries, especially those using cloud datasources where hidden queries incur unnecessary costs.

**Which issue(s) does this PR fix?**:

Fixes #92969

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. *(N/A - bug fix)*
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's
New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. *(N/A - bug fix, no doc changes needed)*

**Implementation details:**

- Added `filterHiddenQueries()` utility in `public/app/plugins/datasource/mixed/filterHiddenQueries.ts`
- Uses BFS traversal to analyze Expression query dependencies
- Preserves hidden queries that are referenced by visible Expression queries (Math, Reduce, Resample, Threshold, SQL, Classic Conditions)
- Integrated into `MixedDatasource.query()` method with minimal changes (~3 lines)

**Test plan:**

- Unit tests cover: basic filtering, dependency chains, circular dependencies, all Expression types (Math, Reduce, Resample,  Threshold, SQL, Classic Conditions)