### PR TITLE
OpenQueryLibraryExposedComponent: pass context to Saved Queries

### DIFF
--- a/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.test.tsx
+++ b/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.test.tsx
@@ -96,6 +96,30 @@ describe('OpenQueryLibraryExposedComponent', () => {
     });
   });
 
+  it('calls openDrawer to load a query with for a given context', async () => {
+    const mockDatasourceFilters = ['loki'];
+    const mockOnSelectQuery = jest.fn();
+
+    render(
+      <OpenQueryLibraryExposedComponent
+        context="test"
+        datasourceFilters={mockDatasourceFilters}
+        onSelectQuery={mockOnSelectQuery}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(mockOpenDrawer).toHaveBeenCalledWith({
+      options: {
+        context: 'test',
+      },
+      datasourceFilters: mockDatasourceFilters,
+      onSelectQuery: mockOnSelectQuery,
+      query: undefined,
+    });
+  });
+
   it('opens the drawer when no arguments are provided', async () => {
     render(<OpenQueryLibraryExposedComponent />);
 

--- a/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
+++ b/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
@@ -9,6 +9,7 @@ import { useQueryLibraryContext } from './QueryLibraryContext';
 
 interface Props {
   className?: string;
+  context?: string;
   datasourceFilters?: string[];
   // Query to save
   query?: DataQuery;
@@ -64,6 +65,7 @@ interface Props {
  */
 export const OpenQueryLibraryExposedComponent = ({
   className,
+  context,
   datasourceFilters,
   icon = 'save',
   query,
@@ -73,9 +75,10 @@ export const OpenQueryLibraryExposedComponent = ({
   const { openDrawer, queryLibraryEnabled } = useQueryLibraryContext();
 
   const handleClick = useCallback(() => {
-    openDrawer({ datasourceFilters, onSelectQuery, query });
+    const options = context ? { context } : undefined;
+    openDrawer({ datasourceFilters, onSelectQuery, options, query });
     reportInteraction(`exposed_query_library-${onSelectQuery ? 'load-queries-open' : 'save-queries-open'}`);
-  }, [datasourceFilters, onSelectQuery, openDrawer, query]);
+  }, [context, datasourceFilters, onSelectQuery, openDrawer, query]);
 
   if (!queryLibraryEnabled) {
     console.warn(


### PR DESCRIPTION
This PR adds support to receive and pass a context value from the exposed component to Saved Queries. Needed for https://github.com/grafana/logs-drilldown/pull/1724