### PR TITLE
Provisioning: Change Git Sync badge to public preview

### DIFF
--- a/public/app/features/provisioning/GettingStarted/FeaturesList.tsx
+++ b/public/app/features/provisioning/GettingStarted/FeaturesList.tsx
@@ -22,7 +22,7 @@ export const FeaturesList = ({ hasRequiredFeatures, onSetupFeatures }: FeaturesL
         <Trans i18nKey="provisioning.features-list.manage-your-dashboards-with-remote-provisioning">
           Get started with Git Sync
         </Trans>{' '}
-        {!isOnPrem() && <FeatureBadge featureState={FeatureState.privatePreview} />}
+        {!isOnPrem() && <FeatureBadge featureState={FeatureState.preview} />}
       </Text>
       <ul className={styles.featuresList}>
         <li>


### PR DESCRIPTION
**What is this feature?**

Changes the Git Sync feature badge from "Private preview" to "Preview" (public preview) for Cloud users in the provisioning feature's getting started page.

**Why do we need this feature?**

Git Sync is now generally available for public preview for both Grafana Cloud and OSS/Enterprise editions, so the badge should reflect this change.

**Fixes:** https://github.com/grafana/git-ui-sync-project/issues/810

**Special notes for your reviewer:**