### PR TITLE
Folders: Use `update` folder method rather than replace

### DIFF
--- a/public/app/api/clients/folder/v1beta1/hooks.test.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.test.ts
@@ -271,6 +271,14 @@ describe.each([
   });
 
   describe('useUpdateFolder', () => {
+    // TODO: Remove manual mocking and move this to MSW handlers instead
+    const mockUpdateFolder = jest.fn(() => ({ error: undefined, result: { isSuccess: true } }));
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      (useUpdateFolderMutation as jest.Mock).mockReturnValue([mockUpdateFolder, { isSuccess: true }]);
+    });
+
     it('updates a folder', async () => {
       const { user } = await setupUpdateFolder(folderA_folderA.item.uid);
 

--- a/public/app/api/clients/folder/v1beta1/hooks.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.ts
@@ -58,8 +58,7 @@ import {
   useUpdateFolderMutation,
   Folder,
   CreateFolderApiArg,
-  useReplaceFolderMutation,
-  ReplaceFolderApiArg,
+  UpdateFolderApiArg,
   useGetAffectedItemsQuery,
   FolderInfo,
   ObjectMeta,
@@ -437,7 +436,7 @@ export function useCreateFolder() {
 }
 
 export function useUpdateFolder() {
-  const [updateFolder, result] = useReplaceFolderMutation();
+  const [updateFolder, result] = useUpdateFolderMutation();
   const legacyHook = useLegacySaveFolderMutation();
   const refresh = useRefreshFolders();
 
@@ -446,9 +445,9 @@ export function useUpdateFolder() {
   }
 
   const updateFolderAppPlatform = async (folder: Pick<FolderDTO, 'uid' | 'title' | 'version' | 'parentUid'>) => {
-    const payload: ReplaceFolderApiArg = {
+    const payload: UpdateFolderApiArg = {
       name: folder.uid,
-      folder: {
+      patch: {
         spec: { title: folder.title },
         metadata: {
           name: folder.uid,


### PR DESCRIPTION
**What is this feature?**
Uses update method rather than replace for folder updates

**Why do we need this feature?**
Using the `replace` method was requiring us to send all of the existing payload for folder updates. This was easily removing folder parents or owner references if we weren't careful

**Who is this feature for?**
Folder users! And to make sure we don't lose owner references etc