### PR TITLE
Dashboards: Fix setting ID when uid is changed

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -453,6 +453,10 @@ func (b *DashboardsAPIBuilder) validateUpdate(ctx context.Context, a admission.A
 		return fmt.Errorf("error getting new dash meta accessor: %w", err)
 	}
 
+	if oldAccessor.GetDeprecatedInternalID() != newAccessor.GetDeprecatedInternalID() { // nolint:staticcheck
+		return apierrors.NewBadRequest("cannot change the ID of a dashboard. set the label grafana.app/deprecatedInternalID to the previous value")
+	}
+
 	// Parse namespace for old dashboard
 	nsInfo, err := authlib.ParseNamespace(oldAccessor.GetNamespace())
 	if err != nil {

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -814,12 +814,6 @@ func (dr *DashboardServiceImpl) ValidateDashboardBeforeSave(ctx context.Context,
 
 		if dashboard.UID == "" {
 			dashboard.SetUID(existingById.UID)
-		} else if existingById.UID != dashboard.UID {
-			// if the uid changed from the existing dashboard with this id, clear the id
-			// so a new unique id gets generated. this prevents duplicate ids during duplication.
-			dashboard.SetID(0)
-			dashboard.Data.Del("id")
-			existingById = nil // treat as new dashboard
 		}
 	}
 	dashWithIdExists := (existingById != nil)

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -814,6 +814,12 @@ func (dr *DashboardServiceImpl) ValidateDashboardBeforeSave(ctx context.Context,
 
 		if dashboard.UID == "" {
 			dashboard.SetUID(existingById.UID)
+		} else if existingById.UID != dashboard.UID {
+			// if the uid changed from the existing dashboard with this id, clear the id
+			// so a new unique id gets generated. this prevents duplicate ids during duplication.
+			dashboard.SetID(0)
+			dashboard.Data.Del("id")
+			existingById = nil // treat as new dashboard
 		}
 	}
 	dashWithIdExists := (existingById != nil)

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -79,6 +79,15 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
     // as we implement the necessary backend conversions, we will drop this query param
     if (dashboard.uid) {
       obj.metadata.name = dashboard.uid;
+      // if the uid changed from the original k8s metadata (e.g., when editing JSON),
+      // clear the deprecated id label so the backend generates a new unique id to prevent duplicate ids.
+      const originalUid = options?.k8s?.name;
+      if (originalUid && dashboard.uid !== originalUid) {
+        delete obj.spec.id;
+        if (obj.metadata.labels && obj.metadata.labels['grafana.app/deprecatedInternalID']) {
+          delete obj.metadata.labels['grafana.app/deprecatedInternalID'];
+        }
+      }
       return this.client.update(obj, { fieldValidation: 'Ignore' }).then((v) => this.asSaveDashboardResponseDTO(v));
     }
     obj.metadata.annotations = {
@@ -87,6 +96,11 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
     };
     // non-scene dashboard will have obj.metadata.name when trying to save a dashboard copy
     delete obj.metadata.name;
+    // on create, always clear the id to prevent duplicate ids
+    delete obj.spec.id;
+    if (obj.metadata.labels && obj.metadata.labels['grafana.app/deprecatedInternalID']) {
+      delete obj.metadata.labels['grafana.app/deprecatedInternalID'];
+    }
     return this.client.create(obj, { fieldValidation: 'Ignore' }).then((v) => this.asSaveDashboardResponseDTO(v));
   }
 

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -139,10 +139,10 @@ export class K8sDashboardV2API
     if (obj.metadata.name) {
       // remove resource version when updating
       delete obj.metadata.resourceVersion;
-      // if the uid changed from the original k8s metadata (e.g., when editing JSON), 
+      // if the uid changed from the original k8s metadata (e.g., when editing JSON),
       // clear the deprecated id label so the backend generates a new unique id to prevent duplicate ids.
       const originalUid = options?.k8s?.name;
-      if (originalUid && obj.metadata.name !== originalUid) {
+      if (originalUid && obj.metadata.name !== originalUid && obj.metadata.labels) {
         delete obj.metadata.labels['grafana.app/deprecatedInternalID'];
       }
       return this.client.update(obj).then((v) => this.asSaveDashboardResponseDTO(v));

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -139,12 +139,22 @@ export class K8sDashboardV2API
     if (obj.metadata.name) {
       // remove resource version when updating
       delete obj.metadata.resourceVersion;
+      // if the uid changed from the original k8s metadata (e.g., when editing JSON), 
+      // clear the deprecated id label so the backend generates a new unique id to prevent duplicate ids.
+      const originalUid = options?.k8s?.name;
+      if (originalUid && obj.metadata.name !== originalUid) {
+        delete obj.metadata.labels['grafana.app/deprecatedInternalID'];
+      }
       return this.client.update(obj).then((v) => this.asSaveDashboardResponseDTO(v));
     }
     obj.metadata.annotations = {
       ...obj.metadata.annotations,
       [AnnoKeyGrantPermissions]: 'default',
     };
+    // clear the deprecated id label so the backend generates a new unique id to prevent duplicate ids.
+    if (obj.metadata.labels && obj.metadata.labels['grafana.app/deprecatedInternalID']) {
+      delete obj.metadata.labels['grafana.app/deprecatedInternalID'];
+    }
     return await this.client.create(obj).then((v) => this.asSaveDashboardResponseDTO(v));
   }
 


### PR DESCRIPTION
**What is this feature?**

This PR fixes an issue where if you went into the json editor and updated the UID of the dashboard, you'd create a dashboard with a duplicate ID, which would then fail all subsequent updates.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/20471