### PR TITLE
Fix typos: recieve -> receive, seperate -> separate, teh -> the

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1551,7 +1551,7 @@ Options are `debug`, `info`, `warn`, `error`. `critical` is an alias for `error`
 Optional settings to set different levels for specific loggers.
 For example: `filters = sqlstore:debug`
 
-You can use multiple filters with a comma-seperated list:
+You can use multiple filters with a comma-separated list:
 For example: `filters = sqlstore:debug,plugins:info`
 
 The equivalent for a `docker-compose.yaml` looks like this:

--- a/e2e-playwright/utils/RequestsRecorder.ts
+++ b/e2e-playwright/utils/RequestsRecorder.ts
@@ -71,7 +71,7 @@ export class RequestsRecorder {
   async #handleRequest(request: Request) {
     const type = request.resourceType();
 
-    // Once we've recieved a document response, create a list of requests that we'll count the responses of.
+    // Once we've received a document response, create a list of requests that we'll count the responses of.
     // We also want to count the document request itself.
     if (this.#documentUrl || type === 'document') {
       this.#currentRequests.add(request);
@@ -95,7 +95,7 @@ export class RequestsRecorder {
     // Record when a document response comes in so we can keep track of future requests
     if (type === 'document') {
       if (this.#documentUrl) {
-        console.warn('recieved additional document response', url);
+        console.warn('received additional document response', url);
       }
 
       this.#documentUrl = url;

--- a/public/app/features/browse-dashboards/state/hooks.ts
+++ b/public/app/features/browse-dashboards/state/hooks.ts
@@ -204,7 +204,7 @@ export function createFlatTree(
   const collection = folderUID ? childrenByUID[folderUID] : rootCollection;
 
   const items = folderUID
-    ? isOpen && collection?.items // keep seperate lines
+    ? isOpen && collection?.items // keep separate lines
     : collection?.items;
 
   let children = (items || []).flatMap((item) => {

--- a/public/app/features/browse-dashboards/types.ts
+++ b/public/app/features/browse-dashboards/types.ts
@@ -27,7 +27,7 @@ export interface BrowseDashboardsState {
   childrenByParentUID: Record<string, DashboardViewItemCollection | undefined>;
   selectedItems: DashboardTreeSelection;
 
-  // Only folders can ever be open or closed, so no need to seperate this by kind
+  // Only folders can ever be open or closed, so no need to separate this by kind
   openFolders: Record<string, boolean>;
 }
 

--- a/public/app/features/explore/state/utils.ts
+++ b/public/app/features/explore/state/utils.ts
@@ -143,7 +143,7 @@ export async function loadAndInitDatasource(
   }
 
   if (history.length < MAX_HISTORY_AUTOCOMPLETE_ITEMS) {
-    // check the last 100 mixed history results seperately
+    // check the last 100 mixed history results separately
     const historyMixedResults = await localStorageHistory.getRichHistory({
       search: '',
       sortOrder: SortOrder.Ascending,

--- a/public/app/features/logs/legacyLogsFrame.ts
+++ b/public/app/features/logs/legacyLogsFrame.ts
@@ -50,7 +50,7 @@ export function parseLegacyLogsFrame(frame: DataFrame): LogsFrame | null {
 
   // extracting the labels is done very differently for old-loki-style and simple-style
   // dataframes, so it's a little awkward to handle it,
-  // we both need to on-demand extract the labels, and also get teh labelsField,
+  // we both need to on-demand extract the labels, and also get the labelsField,
   // but only if the labelsField is used.
   const [labelsField, getL] = makeLabelsGetter(cache, bodyField, frame);
 

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
@@ -158,7 +158,7 @@ describe('AzureMonitor resourcePickerData', () => {
       });
     });
 
-    it('throws an error if it does not recieve data from arg', async () => {
+    it('throws an error if it does not receive data from arg', async () => {
       const mockResponse = { data: [] };
       const { resourcePickerData } = createResourcePickerData([mockResponse]);
       try {
@@ -319,7 +319,7 @@ describe('AzureMonitor resourcePickerData', () => {
       });
     });
 
-    it('throws an error if it recieves data with a malformed uri', async () => {
+    it('throws an error if it receives data with a malformed uri', async () => {
       const mockResponse = {
         data: [
           {

--- a/public/app/plugins/datasource/cloudwatch/hooks.ts
+++ b/public/app/plugins/datasource/cloudwatch/hooks.ts
@@ -44,7 +44,7 @@ export const useNamespaces = (datasource: CloudWatchDatasource) => {
 export const useMetrics = (datasource: CloudWatchDatasource, { region, namespace, accountId }: GetMetricsRequest) => {
   const [metrics, setMetrics] = useState<Array<SelectableValue<string>>>([]);
 
-  // need to ensure dependency array below recieves the interpolated value so that the effect is triggered when a variable is changed
+  // need to ensure dependency array below receives the interpolated value so that the effect is triggered when a variable is changed
   if (region) {
     region = datasource.templateSrv.replace(region, {});
   }


### PR DESCRIPTION
## What is this pull request for?

Fixes various spelling errors across the codebase.

## Changes

Fixed the following spelling errors:

### recieve → receive
- `e2e-playwright/utils/RequestsRecorder.ts` (2 occurrences)
- `public/app/plugins/datasource/cloudwatch/hooks.ts`
- `public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts` (2 occurrences)

### seperate → separate
- `docs/sources/setup-grafana/configure-grafana/_index.md` (comma-separated)
- `public/app/features/explore/state/utils.ts` (separately)
- `public/app/features/browse-dashboards/state/hooks.ts`
- `public/app/features/browse-dashboards/types.ts`

### teh → the
- `public/app/features/logs/legacyLogsFrame.ts`

## Checklist

- [x] This is a purely cosmetic/typo fix and doesn't change functionality