### PR TITLE
Accessibility: Fix keyboard navigation for panel menus, expand/collapse buttons, and focus management

### DIFF
--- a/packages/grafana-ui/src/components/Menu/MenuItem.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItem.tsx
@@ -134,6 +134,16 @@ export const MenuItem = React.memo(
             setIsActive(true);
           }
           break;
+        case 'Enter':
+        case ' ':
+          if (hasSubMenu && !isSubMenuOpen) {
+            event.preventDefault();
+            event.stopPropagation();
+            setIsSubMenuOpen(true);
+            setIsActive(true);
+            return;
+          }
+          break;
         default:
           break;
       }

--- a/packages/grafana-ui/src/components/Menu/hooks.test.tsx
+++ b/packages/grafana-ui/src/components/Menu/hooks.test.tsx
@@ -159,6 +159,53 @@ describe('useMenuFocus', () => {
     expect(onClick).toHaveBeenCalled();
   });
 
+  it('clicks focused item when Space key is pressed', async () => {
+    const ref = createRef<HTMLDivElement>();
+    const onClick = jest.fn();
+    const { result } = renderHook(() => useMenuFocus({ localRef: ref }));
+    const [handleKeys] = result.current;
+    const { rerender } = render(getMenuElement(ref, handleKeys, undefined, onClick));
+
+    await user.type(screen.getByTestId(testid), '{ArrowDown}');
+
+    const [handleKeys2] = result.current;
+    rerender(getMenuElement(ref, handleKeys2, undefined, onClick));
+
+    await user.type(screen.getByTestId(testid), '{ }');
+
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('does not click submenu items when Enter key is pressed', async () => {
+    const ref = createRef<HTMLDivElement>();
+    const onClick = jest.fn();
+    const { result } = renderHook(() => useMenuFocus({ localRef: ref }));
+    const [handleKeys] = result.current;
+
+    // Create a menu element with a submenu item (has nested menuitem)
+    const getMenuElementWithSubmenu = (
+      ref: RefObject<HTMLDivElement>,
+      handleKeys?: (event: KeyboardEvent) => void,
+      onClick?: () => void
+    ) => (
+      <div data-testid={testid} ref={ref} tabIndex={0} onKeyDown={handleKeys}>
+        <span data-role="menuitem" onClick={onClick}>
+          Submenu Item
+          <span data-role="menuitem">Nested Item</span>
+        </span>
+        <span data-role="menuitem" onClick={onClick}>
+          Regular Item
+        </span>
+      </div>
+    );
+
+    render(getMenuElementWithSubmenu(ref, handleKeys, onClick));
+
+    await user.type(screen.getByTestId(testid), '{Enter}');
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
   it('calls onClose on Tab or Escape', async () => {
     const ref = createRef<HTMLDivElement>();
     const onClose = jest.fn();

--- a/packages/grafana-ui/src/components/Menu/hooks.ts
+++ b/packages/grafana-ui/src/components/Menu/hooks.ts
@@ -82,9 +82,16 @@ export const useMenuFocus = ({
         setFocusedItem(menuItemsCount - 1);
         break;
       case 'Enter':
+      case ' ':
         event.preventDefault();
         event.stopPropagation();
-        menuItems?.[focusedItem]?.click();
+        const focusedElement = menuItems?.[focusedItem];
+        // Check if the focused item has a submenu by looking for nested menuitems
+        const hasSubMenu = focusedElement?.querySelector('[data-role="menuitem"]') !== null;
+
+        if (!hasSubMenu) {
+          focusedElement?.click();
+        }
         break;
       case 'Escape':
         onClose?.();

--- a/public/app/core/components/QueryOperationRow/QueryOperationRowHeader.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRowHeader.tsx
@@ -65,6 +65,7 @@ export const QueryOperationRowHeader = ({
             onClick={onRowToggle}
             aria-expanded={isContentVisible}
             aria-controls={id}
+            tabIndex={0}
           />
         )}
         {title && (

--- a/public/app/features/inspector/QueryInspector.tsx
+++ b/public/app/features/inspector/QueryInspector.tsx
@@ -258,14 +258,17 @@ export class QueryInspector extends PureComponent<Props, State> {
             <Trans i18nKey="inspector.query.refresh">Refresh</Trans>
           </Button>
 
-          {haveData && allNodesExpanded && (
-            <Button icon="minus" variant="secondary" onClick={this.onToggleExpand}>
-              <Trans i18nKey="inspector.query.collapse-all">Collapse all</Trans>
-            </Button>
-          )}
-          {haveData && !allNodesExpanded && (
-            <Button icon="plus" variant="secondary" onClick={this.onToggleExpand}>
-              <Trans i18nKey="inspector.query.expand-all">Expand all</Trans>
+         {haveData && (
+            <Button
+              icon={allNodesExpanded ? 'minus' : 'plus'}
+              variant="secondary"
+              onClick={this.onToggleExpand}
+            >
+              {allNodesExpanded ? (
+                <Trans i18nKey="inspector.query.collapse-all">Collapse all</Trans>
+              ) : (
+                <Trans i18nKey="inspector.query.expand-all">Expand all</Trans>
+              )}
             </Button>
           )}
 

--- a/public/app/features/query/components/QueryEditorRows.test.tsx
+++ b/public/app/features/query/components/QueryEditorRows.test.tsx
@@ -245,6 +245,30 @@ describe('QueryEditorRows', () => {
     }
   });
 
+  it('Should have proper keyboard navigation for expand/collapse buttons', async () => {
+    renderScenario();
+    const queryEditorRows = await screen.findAllByTestId('query-editor-row');
+
+    for (const childQuery of queryEditorRows) {
+      const toggleExpandButton = queryByLabelText(childQuery, 'Collapse query row') as HTMLElement;
+
+      expect(toggleExpandButton).toBeInTheDocument();
+      // Verify the button is focusable via keyboard navigation
+      expect(toggleExpandButton.getAttribute('tabIndex')).toBe('0');
+
+      // Verify the button has proper ARIA attributes
+      expect(toggleExpandButton.getAttribute('aria-expanded')).toBe('true');
+      expect(toggleExpandButton.getAttribute('aria-controls')).toBeTruthy();
+
+      // Verify clicking still works for mouse users
+      fireEvent.click(toggleExpandButton);
+      expect(toggleExpandButton.getAttribute('aria-expanded')).toBe('false');
+
+      fireEvent.click(toggleExpandButton);
+      expect(toggleExpandButton.getAttribute('aria-expanded')).toBe('true');
+    }
+  });
+
   it('Should be able to duplicate queries', async () => {
     const onAddQuery = jest.fn();
     const onQueryCopied = jest.fn();


### PR DESCRIPTION
**What is this feature?**

This PR fixes critical keyboard accessibility issues across Grafana's dashboard interface, ensuring that expand/collapse buttons, panel menu items, and focus management expand/collapse buttons after refresh  work correctly for keyboard users.

**Why do we need this feature?**

The current implementation had multiple accessibility violations preventing keyboard users from properly navigating and interacting with the interface:

1. **Panel menu items** cannot be activated using keyboard (Space/Enter keys)
2. **Expand/collapse buttons** in query editor rows lack proper keyboard focus management  
3. **Focus flow** breaks after interacting with refresh controls
4. **Focus preservation** issues when toggling query inspector


**Who is this feature for?**

- Users with motor disabilities who cannot use a mouse
- Screen reader users who navigate via keyboard
- Power users who prefer keyboard navigation
- Users with temporary or permanent mobility impairments
- Anyone using assistive technology devices
**Why do we need this feature?**

The current implementation had multiple accessibility violations preventing keyboard users from properly navigating and interacting with the interface:

1. **Panel menu items** cannot be activated using keyboard (Space/Enter keys)
2. **Expand/collapse buttons** in query editor rows lack proper keyboard focus management  
3. **Focus flow** breaks after interacting with refresh controls
4. **Focus preservation** issues when toggling query inspector


https://github.com/user-attachments/assets/5a66755d-4869-4833-9432-8aad1a33607e




**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes  #116514


