### PR TITLE
Dashboard: Fixes performance issuing saving multiple times

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.test.tsx
@@ -46,6 +46,24 @@ describe('DashboardEditPane', () => {
 
     expect(editPane.state.redoStack).toHaveLength(0);
   });
+
+  it('clone should not include undo/redo history', () => {
+    const scene = buildTestScene();
+    const editPane = scene.state.editPane;
+
+    scene.onCreateNewPanel();
+    scene.onCreateNewPanel();
+
+    editPane.undoAction();
+
+    expect(editPane.state.redoStack).toHaveLength(1);
+    expect(editPane.state.undoStack).toHaveLength(1);
+
+    const cloned = editPane.clone({});
+
+    expect(cloned.state.redoStack).toHaveLength(0);
+    expect(cloned.state.undoStack).toHaveLength(0);
+  });
 });
 
 function buildTestScene() {

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
@@ -55,6 +55,11 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> {
     this.panelEditAction = editAction;
   }
 
+  public clone(withState: Partial<DashboardEditPaneState>): this {
+    // Clone without any undo/redo history
+    return super.clone({ ...withState, redoStack: [], undoStack: [] });
+  }
+
   private onActivate() {
     const dashboard = getDashboardSceneFor(this);
 


### PR DESCRIPTION
Fixes performance issue that got recursively worse as the history stack increased, the save times took longer and longer due to cloning scene object state, which included action history, took longer and longer  