### PR TITLE
chore: reduce circular deps in explore/contentoutline

### DIFF
--- a/public/app/features/explore/ContentOutline/ContentOutline.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutline.tsx
@@ -7,8 +7,9 @@ import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { useStyles2, PanelContainer, ScrollContainer } from '@grafana/ui';
 
-import { ContentOutlineItemContextProps, useContentOutlineContext } from './ContentOutlineContext';
+import { useContentOutlineContext } from './ContentOutlineContext';
 import { ContentOutlineItemButton } from './ContentOutlineItemButton';
+import { ContentOutlineItemContextProps } from './types';
 
 function scrollableChildren(item: ContentOutlineItemContextProps) {
   return item.children?.filter((child) => child.type !== 'filter') || [];

--- a/public/app/features/explore/ContentOutline/ContentOutlineContext.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutlineContext.tsx
@@ -1,29 +1,7 @@
 import { uniqueId } from 'lodash';
 import { useState, useContext, createContext, ReactNode, useCallback, useRef, useEffect } from 'react';
-import { SetOptional } from 'type-fest';
 
-import { ContentOutlineItemBaseProps, ITEM_TYPES } from './ContentOutlineItem';
-
-export interface ContentOutlineItemContextProps extends ContentOutlineItemBaseProps {
-  id: string;
-  ref: HTMLElement | null;
-  color?: string;
-  children?: ContentOutlineItemContextProps[];
-}
-
-type RegisterFunction = (outlineItem: SetOptional<ContentOutlineItemContextProps, 'id'>) => string;
-
-export interface ContentOutlineContextProps {
-  outlineItems: ContentOutlineItemContextProps[];
-  register: RegisterFunction;
-  unregister: (id: string) => void;
-  unregisterAllChildren: (
-    parentIdGetter: (items: ContentOutlineItemContextProps[]) => string | undefined,
-    childType: ITEM_TYPES
-  ) => void;
-  updateOutlineItems: (newItems: ContentOutlineItemContextProps[]) => void;
-  updateItem: (id: string, properties: Partial<Omit<ContentOutlineItemContextProps, 'id'>>) => void;
-}
+import { ContentOutlineContextProps, ContentOutlineItemContextProps, ITEM_TYPES, RegisterFunction } from './types';
 
 interface ContentOutlineContextProviderProps {
   children: ReactNode;

--- a/public/app/features/explore/ContentOutline/ContentOutlineItem.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutlineItem.tsx
@@ -1,54 +1,7 @@
-import { useEffect, useRef, ReactNode } from 'react';
-import * as React from 'react';
+import { useEffect, useRef } from 'react';
 
 import { useContentOutlineContext } from './ContentOutlineContext';
-
-type INDENT_LEVELS = 'root' | 'child';
-
-export type ITEM_TYPES = 'scrollIntoView' | 'filter';
-
-export interface ContentOutlineItemBaseProps {
-  panelId: string;
-  title: string;
-  icon: string;
-  /**
-   * Custom offset from the top of the Explore container when scrolling to this item.
-   * Items like query row need some offset so the top of the query row is not hidden behind the header.
-   */
-  customTopOffset?: number;
-  /**
-   * The level of indentation for this item.
-   * - `root` is the top level item.
-   * - `child` is an item that is a child of an item with `root` level.
-   */
-  level?: INDENT_LEVELS;
-  /**
-   * Merges a single child of this item with this item.
-   * e.g. It doesn't make sense to nest a single query row under a queries container
-   * because user can navigate to the query row by navigating to the queries container.
-   */
-  mergeSingleChild?: boolean;
-  // callback that is called when the item is clicked
-  // need this for filtering logs
-  onClick?: (e: React.MouseEvent) => void;
-  type?: ITEM_TYPES;
-  /**
-   * Client can additionally mark filter actions as highlighted
-   */
-  highlight?: boolean;
-  onRemove?: (id: string) => void;
-  /**
-   * Child that will always be on top of the list
-   * e.g. pinned log in Logs section
-   */
-  childOnTop?: boolean;
-  expanded?: boolean;
-}
-
-interface ContentOutlineItemProps extends ContentOutlineItemBaseProps {
-  children: ReactNode;
-  className?: string;
-}
+import { ContentOutlineItemProps } from './types';
 
 export function ContentOutlineItem({
   panelId,

--- a/public/app/features/explore/ContentOutline/types.ts
+++ b/public/app/features/explore/ContentOutline/types.ts
@@ -1,0 +1,66 @@
+import type { MouseEvent, ReactNode } from 'react';
+import { SetOptional } from 'type-fest';
+
+type INDENT_LEVELS = 'root' | 'child';
+
+export type ITEM_TYPES = 'scrollIntoView' | 'filter';
+
+export interface ContentOutlineItemBaseProps {
+  panelId: string;
+  title: string;
+  icon: string;
+  /**
+   * Custom offset from the top of the Explore container when scrolling to this item.
+   * Items like query row need some offset so the top of the query row is not hidden behind the header.
+   */
+  customTopOffset?: number;
+  /**
+   * The level of indentation for this item.
+   * - `root` is the top level item.
+   * - `child` is an item that is a child of an item with `root` level.
+   */
+  level?: INDENT_LEVELS;
+  /**
+   * Merges a single child of this item with this item.
+   * e.g. It doesn't make sense to nest a single query row under a queries container
+   * because user can navigate to the query row by navigating to the queries container.
+   */
+  mergeSingleChild?: boolean;
+  // callback that is called when the item is clicked
+  // need this for filtering logs
+  onClick?: (e: MouseEvent) => void;
+  type?: ITEM_TYPES;
+  /**
+   * Client can additionally mark filter actions as highlighted
+   */
+  highlight?: boolean;
+  onRemove?: (id: string) => void;
+  /**
+   * Child that will always be on top of the list
+   * e.g. pinned log in Logs section
+   */
+  childOnTop?: boolean;
+  expanded?: boolean;
+}
+export interface ContentOutlineItemProps extends ContentOutlineItemBaseProps {
+  children: ReactNode;
+  className?: string;
+}
+export interface ContentOutlineItemContextProps extends ContentOutlineItemBaseProps {
+  id: string;
+  ref: HTMLElement | null;
+  color?: string;
+  children?: ContentOutlineItemContextProps[];
+}
+export type RegisterFunction = (outlineItem: SetOptional<ContentOutlineItemContextProps, 'id'>) => string;
+export interface ContentOutlineContextProps {
+  outlineItems: ContentOutlineItemContextProps[];
+  register: RegisterFunction;
+  unregister: (id: string) => void;
+  unregisterAllChildren: (
+    parentIdGetter: (items: ContentOutlineItemContextProps[]) => string | undefined,
+    childType: ITEM_TYPES
+  ) => void;
+  updateOutlineItems: (newItems: ContentOutlineItemContextProps[]) => void;
+  updateItem: (id: string, properties: Partial<Omit<ContentOutlineItemContextProps, 'id'>>) => void;
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This pull request primarily refactors the explore ContentOutline feature by extracting type definitions from files into a dedicated types.ts file, updates import paths throughout the codebase to reflect this change. But also any functions that are causing circular dependencies are extracted to their own files.

**Why do we need this feature?**

Circular dependencies negatively impact our tooling and developer feedback loops. They complicate static analysis and module resolution, making tools slower and less reliable as the codebase grows. In particular, circular imports increase the cost of dependency graph construction, which can significantly affect unit test startup time, test isolation, and watch mode performance. This slows down local development and CI, making iteration and refactoring more expensive over time.

See circular dependency chains below:
- features/explore/ContentOutline/ContentOutlineContext.tsx > features/explore/ContentOutline/ContentOutlineItem.tsx

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related #117124

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
