### PR TITLE
DynamicDashboards: Prevent runtime error when custom variable query is emptied

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/editors/CustomVariableEditor/ModalEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/CustomVariableEditor/ModalEditor.tsx
@@ -144,9 +144,9 @@ function useModalEditor({ variable, onClose }: ModalEditorProps) {
         description: t('dashboard-scene.use-modal-editor.description.change-variable-query', 'Change variable query'),
         perform: async () => {
           if (!config.featureToggles.multiPropsVariables) {
-            variable.setState({ valuesFormat: 'csv', query, value: undefined });
+            variable.setState({ valuesFormat: 'csv', query });
           } else {
-            variable.setState({ valuesFormat, query, value: undefined });
+            variable.setState({ valuesFormat, query });
           }
 
           if (valuesFormat === 'json') {
@@ -159,12 +159,10 @@ function useModalEditor({ variable, onClose }: ModalEditorProps) {
           variable.setState({
             valuesFormat: initialValuesFormatRef.current,
             query: initialQueryRef.current,
-            value: undefined,
           });
 
           if (initialValuesFormatRef.current === 'json') {
-            variable.setState({ allowCustomValue: false });
-            variable.setState({ allValue: undefined });
+            variable.setState({ allowCustomValue: false, allValue: undefined });
           }
 
           await lastValueFrom(variable.validateAndUpdate!());


### PR DESCRIPTION
When the `multiPropsVariables` feature toggle is true, clearing the CSV or JSON of a custom variable leads to a runtime error:

```text
SelectBase.tsx:208 Uncaught TypeError: Cannot read properties of undefined (reading 'value')
    at SelectBase.tsx:208:53
    at Array.map (<anonymous>)
    at SelectBase (SelectBase.tsx:206:29)
    at renderWithHooks (react-dom.development.js:15486:1)
    at updateFunctionComponent (react-dom.development.js:19617:1)
    at beginWork (react-dom.development.js:21640:1)
    at HTMLUnknownElement.callCallback (react-dom.development.js:4164:1)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:4213:1)
    at invokeGuardedCallback (react-dom.development.js:4277:1)
    at beginWork$1 (react-dom.development.js:27490:1)
```

Happens because value is set to `undefined`. This PR fixes it.