### PR TITLE
Docs: Update restore dashboards documentation to public preview

### DIFF
--- a/docs/sources/visualizations/dashboards/manage-dashboards/index.md
+++ b/docs/sources/visualizations/dashboards/manage-dashboards/index.md
@@ -124,9 +124,9 @@ For more information about dashboard permissions, refer to [Dashboard permission
 ## Restore deleted dashboards
 
 {{% admonition type="caution" %}}
-Restoring deleted dashboards is currently in private preview. Grafana Labs offers support on a best-effort basis, and breaking changes might occur prior to the feature being made generally available.
+Restoring deleted dashboards is currently in [public preview](https://grafana.com/docs/release-life-cycle/). Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
 
-The feature is only available in Grafana Cloud.  
+The feature is only available in Grafana Cloud.
 {{% /admonition %}}
 
 When you delete dashboards, they’re stored in the deletion history for up to 12 months, allowing you to restore them if needed.
@@ -136,7 +136,7 @@ After this limit is reached, the oldest deleted dashboards are permanently remov
 You can access the list of deleted dashboards from the **Dashboards** page by clicking the **Recently deleted** button, or by navigating to **Dashboards > Recently deleted**.
 
 {{% admonition type="note" %}}
-Only users with admin rights can access the **Restore dashboards** page.
+You can restore dashboards that you deleted. Users with admin rights can restore any dashboard.
 {{% /admonition %}}
 
 To restore one or more dashboards, follow these steps:


### PR DESCRIPTION
**What is this feature?**

Update to the dashboard restoration documentation to reflect the feature's advancement from private to public preview, along with clarifications on user permissions.

**Why do we need this feature?**

The restore dashboards feature has moved to public preview and the permissions model has been refined. The documentation needs to reflect these changes to accurately inform users about who can restore which dashboards.

**Key changes:**

- Feature status updated from private preview to public preview with link to release lifecycle docs
- Updated support level from "best-effort basis" to "limited support" (standard public preview wording)
- Clarified that users can restore dashboards they deleted, and admins can restore any dashboard

**Which issue(s) does this PR fix?**

Fixes https://github.com/grafana/grafana/issues/117239

**Special notes for reviewer:**

Please check that:
- [ ] The documentation clearly explains the restore dashboard permissions
- [ ] The public preview language matches other parts of the docs