### PR TITLE
Dashboard: Autohide sidebar after inactivity

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -56,6 +56,9 @@ export const versionedComponents = {
     primaryBody: {
       '12.1.0': 'data-testid DashboardEditPaneSplitter primary body',
     },
+    bodyContainer: {
+      '12.4.0': 'data-testid DashboardEditPaneSplitter body container',
+    },
   },
   Sidebar: {
     closePane: {

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -61,6 +61,9 @@ export const versionedComponents = {
     },
   },
   Sidebar: {
+    container: {
+      '12.4.0': 'data-testid Sidebar container',
+    },
     closePane: {
       '12.4.0': 'data-testid Sidebar close pane',
     },

--- a/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
@@ -17,10 +17,10 @@ import { useCustomClickAway } from './useSidebarClickAway';
 export interface Props {
   children?: ReactNode;
   contextValue: SidebarContextValue;
-  className?: string;
+  hidden?: boolean;
 }
 
-export function SidebarComp({ children, contextValue, className: classNameProp = '' }: Props) {
+export function SidebarComp({ children, contextValue, hidden }: Props) {
   const styles = useStyles2(getStyles);
   const theme = useTheme2();
   const { isDocked, position, tabsMode, hasOpenPane, edgeMargin, bottomMargin } = contextValue;
@@ -30,7 +30,7 @@ export function SidebarComp({ children, contextValue, className: classNameProp =
     [styles.undockedPaneOpen]: hasOpenPane && !isDocked,
     [styles.containerLeft]: position === 'left',
     [styles.containerTabsMode]: tabsMode,
-    [classNameProp]: !!classNameProp,
+    [styles.containerHidden]: !!hidden,
   });
 
   const style = { [position]: theme.spacing(edgeMargin), bottom: theme.spacing(bottomMargin) };
@@ -54,6 +54,7 @@ export function SidebarComp({ children, contextValue, className: classNameProp =
         style={style}
         id="sidebar-container"
         data-testid={selectors.components.Sidebar.container}
+        aria-hidden={hidden}
       >
         {!tabsMode && <SidebarResizer />}
         {children}
@@ -131,6 +132,18 @@ export const getStyles = (theme: GrafanaTheme2) => {
       bottom: 0,
       top: 0,
       right: 0,
+      width: 'calc-size(auto, size)',
+
+      [theme.transitions.handleMotion('no-preference')]: {
+        transition: theme.transitions.create('width', {
+          duration: theme.transitions.duration.standard,
+        }),
+      },
+    }),
+    containerHidden: css({
+      width: 0,
+      border: 0,
+      overflow: 'hidden',
     }),
     containerTabsMode: css({
       position: 'relative',

--- a/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
@@ -17,9 +17,10 @@ import { useCustomClickAway } from './useSidebarClickAway';
 export interface Props {
   children?: ReactNode;
   contextValue: SidebarContextValue;
+  className?: string;
 }
 
-export function SidebarComp({ children, contextValue }: Props) {
+export function SidebarComp({ children, contextValue, className: classNameProp = '' }: Props) {
   const styles = useStyles2(getStyles);
   const theme = useTheme2();
   const { isDocked, position, tabsMode, hasOpenPane, edgeMargin, bottomMargin } = contextValue;
@@ -29,6 +30,7 @@ export function SidebarComp({ children, contextValue }: Props) {
     [styles.undockedPaneOpen]: hasOpenPane && !isDocked,
     [styles.containerLeft]: position === 'left',
     [styles.containerTabsMode]: tabsMode,
+    [classNameProp]: !!classNameProp,
   });
 
   const style = { [position]: theme.spacing(edgeMargin), bottom: theme.spacing(bottomMargin) };
@@ -46,7 +48,13 @@ export function SidebarComp({ children, contextValue }: Props) {
 
   return (
     <SidebarContext.Provider value={contextValue}>
-      <div ref={ref} className={className} style={style} id="sidebar-container">
+      <div
+        ref={ref}
+        className={className}
+        style={style}
+        id="sidebar-container"
+        data-testid={selectors.components.Sidebar.container}
+      >
         {!tabsMode && <SidebarResizer />}
         {children}
       </div>

--- a/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
@@ -17,10 +17,9 @@ import { useCustomClickAway } from './useSidebarClickAway';
 export interface Props {
   children?: ReactNode;
   contextValue: SidebarContextValue;
-  hidden?: boolean;
 }
 
-export function SidebarComp({ children, contextValue, hidden }: Props) {
+export function SidebarComp({ children, contextValue }: Props) {
   const styles = useStyles2(getStyles);
   const theme = useTheme2();
   const { isDocked, position, tabsMode, hasOpenPane, edgeMargin, bottomMargin } = contextValue;
@@ -30,7 +29,7 @@ export function SidebarComp({ children, contextValue, hidden }: Props) {
     [styles.undockedPaneOpen]: hasOpenPane && !isDocked,
     [styles.containerLeft]: position === 'left',
     [styles.containerTabsMode]: tabsMode,
-    [styles.containerHidden]: !!hidden,
+    [styles.containerHidden]: !!contextValue.isHidden,
   });
 
   const style = { [position]: theme.spacing(edgeMargin), bottom: theme.spacing(bottomMargin) };
@@ -54,7 +53,7 @@ export function SidebarComp({ children, contextValue, hidden }: Props) {
         style={style}
         id="sidebar-container"
         data-testid={selectors.components.Sidebar.container}
-        aria-hidden={hidden}
+        aria-hidden={contextValue.isHidden}
       >
         {!tabsMode && <SidebarResizer />}
         {children}

--- a/packages/grafana-ui/src/components/Sidebar/useSidebar.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/useSidebar.tsx
@@ -18,6 +18,7 @@ export interface SidebarContextValue {
   bottomMargin: number;
   edgeMargin: number;
   contentMargin: number;
+  isHidden: boolean;
   onToggleDock: () => void;
   onResize: (diff: number) => void;
   /** Called when pane is closed or clicked outside of (in undocked mode) */
@@ -49,6 +50,8 @@ export interface UseSideBarOptions {
    * Can only be app name as the final local storag key will be `grafana.ui.sidebar.{persistanceKey}.{docked|compact|size}`
    */
   persistanceKey?: string;
+  /** Whether the sidebar is hidden */
+  isHidden?: boolean;
 }
 
 export const SIDE_BAR_WIDTH_ICON_ONLY = 5;
@@ -65,6 +68,7 @@ export function useSidebar({
   contentMargin = 2,
   persistanceKey,
   onClosePane,
+  isHidden = false,
 }: UseSideBarOptions): SidebarContextValue {
   const theme = useTheme2();
 
@@ -87,11 +91,13 @@ export function useSidebar({
     ((compact ? SIDE_BAR_WIDTH_ICON_ONLY : SIDE_BAR_WIDTH_WITH_TEXT) + edgeMargin + contentMargin) *
     theme.spacing.gridSize;
 
-  const outerWrapperProps = {
-    style: {
-      [prop]: isDocked && hasOpenPane ? paneWidth + toolbarWidth : toolbarWidth,
-    },
-  };
+  const outerWrapperProps = isHidden
+    ? {}
+    : {
+        style: {
+          [prop]: isDocked && hasOpenPane ? paneWidth + toolbarWidth : toolbarWidth,
+        },
+      };
 
   const onResize = useCallback(
     (diff: number) => {
@@ -133,6 +139,7 @@ export function useSidebar({
     edgeMargin,
     bottomMargin,
     contentMargin,
+    isHidden,
     onClosePane,
   };
 }

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.test.tsx
@@ -101,29 +101,23 @@ describe('DashboardEditPaneRenderer', () => {
       const scene = buildTestScene();
       act(() => activateFullSceneTree(scene));
       render(<DashboardEditPaneSplitter dashboard={scene} />);
-      await waitFor(() =>
-        expect(screen.getByTestId(selectors.components.DashboardEditPaneSplitter.primaryBody)).toBeInTheDocument()
-      );
-      expect(screen.queryByTestId(selectors.pages.Dashboard.Sidebar.outlineButton)).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByTestId(selectors.components.DashboardEditPaneSplitter.primaryBody)).toBeVisible();
+      });
+      expect(window.getComputedStyle(screen.getByTestId(selectors.components.Sidebar.container)).width).toBe('0px');
     });
 
     it('should toggle sidebar visibility based on user activity', async () => {
       const scene = buildTestScene();
       act(() => activateFullSceneTree(scene));
       const { rerender } = render(<DashboardEditPaneSplitter dashboard={scene} />);
-      await waitFor(() =>
-        expect(screen.getByTestId(selectors.pages.Dashboard.Sidebar.outlineButton)).toBeInTheDocument()
-      );
+      expect(window.getComputedStyle(screen.getByTestId(selectors.components.Sidebar.container)).width).not.toBe('0px');
       mockUseUserActivity.mockReturnValue(false);
       await act(async () => rerender(<DashboardEditPaneSplitter dashboard={scene} />));
-      await waitFor(() =>
-        expect(screen.queryByTestId(selectors.pages.Dashboard.Sidebar.outlineButton)).not.toBeInTheDocument()
-      );
+      expect(window.getComputedStyle(screen.getByTestId(selectors.components.Sidebar.container)).width).toBe('0px');
       mockUseUserActivity.mockReturnValue(true);
       await act(async () => rerender(<DashboardEditPaneSplitter dashboard={scene} />));
-      await waitFor(() =>
-        expect(screen.getByTestId(selectors.pages.Dashboard.Sidebar.outlineButton)).toBeInTheDocument()
-      );
+      expect(window.getComputedStyle(screen.getByTestId(selectors.components.Sidebar.container)).width).not.toBe('0px');
     });
 
     it('should apply correct padding', async () => {
@@ -131,18 +125,12 @@ describe('DashboardEditPaneRenderer', () => {
       const scene = buildTestScene();
       act(() => activateFullSceneTree(scene));
       const { rerender } = render(<DashboardEditPaneSplitter dashboard={scene} />);
-      await waitFor(() =>
-        expect(screen.getByTestId(selectors.components.DashboardEditPaneSplitter.primaryBody)).toBeInTheDocument()
-      );
       expect(
         window.getComputedStyle(screen.getByTestId(selectors.components.DashboardEditPaneSplitter.bodyContainer))
           .paddingRight
       ).toBe(theme.spacing(1));
       mockUseUserActivity.mockReturnValue(false);
       await act(async () => rerender(<DashboardEditPaneSplitter dashboard={scene} />));
-      await waitFor(() =>
-        expect(screen.getByTestId(selectors.components.DashboardEditPaneSplitter.primaryBody)).toBeInTheDocument()
-      );
       expect(
         window.getComputedStyle(screen.getByTestId(selectors.components.DashboardEditPaneSplitter.bodyContainer))
           .paddingRight

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -58,7 +58,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
   const { chrome } = useGrafana();
   const { kioskMode } = chrome.useState();
   const { isPlaying } = playlistSrv.useState();
-  const isUserActive = useUserActivity(1000);
+  const isUserActive = useUserActivity(10000);
 
   /**
    * Adds star button and left side actions to app chrome breadcrumb area

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -58,7 +58,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
   const { chrome } = useGrafana();
   const { kioskMode } = chrome.useState();
   const { isPlaying } = playlistSrv.useState();
-  const isUserActive = useUserActivity(10000);
+  const isUserActive = useUserActivity(1000);
 
   /**
    * Adds star button and left side actions to app chrome breadcrumb area
@@ -137,7 +137,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
           {body}
         </div>
 
-        <Sidebar contextValue={sidebarContext} className={cx(styles.sidebar, !isUserActive && styles.sidebarHidden)}>
+        <Sidebar contextValue={sidebarContext} hidden={!isUserActive}>
           <DashboardEditPaneRenderer editPane={editPane} dashboard={dashboard} />
         </Sidebar>
       </div>
@@ -283,20 +283,6 @@ function getStyles(theme: GrafanaTheme2, headerHeight: number) {
         background: theme.colors.background.canvas,
         top: headerHeight,
       },
-    }),
-    sidebar: css({
-      width: 'calc-size(auto, size)',
-
-      [theme.transitions.handleMotion('no-preference')]: {
-        transition: theme.transitions.create('width', {
-          duration: theme.transitions.duration.standard,
-        }),
-      },
-    }),
-    sidebarHidden: css({
-      width: 0,
-      border: 0,
-      overflow: 'hidden',
     }),
   };
 }

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -84,6 +84,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
     position: 'right',
     persistanceKey: 'dashboard',
     onClosePane: () => editPane.closePane(),
+    isHidden: !isUserActive,
   });
 
   /**
@@ -126,7 +127,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
       <div
         className={styles.bodyWrapper}
         data-testid={selectors.components.DashboardEditPaneSplitter.primaryBody}
-        {...(isUserActive ? sidebarContext.outerWrapperProps : {})}
+        {...sidebarContext.outerWrapperProps}
       >
         <div
           className={cx(styles.scrollContainer, !isUserActive && styles.scrollContainerNoSidebar)}
@@ -137,7 +138,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
           {body}
         </div>
 
-        <Sidebar contextValue={sidebarContext} hidden={!isUserActive}>
+        <Sidebar contextValue={sidebarContext}>
           <DashboardEditPaneRenderer editPane={editPane} dashboard={dashboard} />
         </Sidebar>
       </div>

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -137,11 +137,9 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
           {body}
         </div>
 
-        {isUserActive && (
-          <Sidebar contextValue={sidebarContext}>
-            <DashboardEditPaneRenderer editPane={editPane} dashboard={dashboard} />
-          </Sidebar>
-        )}
+        <Sidebar contextValue={sidebarContext} className={cx(styles.sidebar, !isUserActive && styles.sidebarHidden)}>
+          <DashboardEditPaneRenderer editPane={editPane} dashboard={dashboard} />
+        </Sidebar>
       </div>
     );
   }
@@ -218,6 +216,12 @@ function getStyles(theme: GrafanaTheme2, headerHeight: number) {
       flex: '1 1 0',
       overflow: 'hidden',
 
+      [theme.transitions.handleMotion('no-preference')]: {
+        transition: theme.transitions.create('padding', {
+          duration: theme.transitions.duration.standard,
+        }),
+      },
+
       [theme.breakpoints.down('sm')]: {
         flex: 1,
 
@@ -240,6 +244,12 @@ function getStyles(theme: GrafanaTheme2, headerHeight: number) {
       scrollbarGutter: 'stable',
       // without top padding the fixed controls headers is rendered over the selection outline.
       padding: theme.spacing(0.125, 1, 2, 2),
+
+      [theme.transitions.handleMotion('no-preference')]: {
+        transition: theme.transitions.create('padding', {
+          duration: theme.transitions.duration.standard,
+        }),
+      },
     }),
     scrollContainerNoSidebar: css({
       paddingRight: theme.spacing(2),
@@ -273,6 +283,20 @@ function getStyles(theme: GrafanaTheme2, headerHeight: number) {
         background: theme.colors.background.canvas,
         top: headerHeight,
       },
+    }),
+    sidebar: css({
+      width: 'calc-size(auto, size)',
+
+      [theme.transitions.handleMotion('no-preference')]: {
+        transition: theme.transitions.create('width', {
+          duration: theme.transitions.duration.standard,
+        }),
+      },
+    }),
+    sidebarHidden: css({
+      width: 0,
+      border: 0,
+      overflow: 'hidden',
     }),
   };
 }

--- a/public/app/features/dashboard-scene/edit-pane/useUserActivity.test.ts
+++ b/public/app/features/dashboard-scene/edit-pane/useUserActivity.test.ts
@@ -1,0 +1,156 @@
+import { renderHook, act } from '@testing-library/react';
+
+import { useUserActivity } from './useUserActivity';
+
+describe('useUserActivity', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => jest.runOnlyPendingTimers());
+    jest.useRealTimers();
+  });
+
+  it('should start with user active', () => {
+    const { result } = renderHook(() => useUserActivity(3000));
+    expect(result.current).toBe(true);
+  });
+
+  it('should set user inactive after delay', () => {
+    const { result } = renderHook(() => useUserActivity(3000));
+    expect(result.current).toBe(true);
+    act(() => jest.advanceTimersByTime(3000));
+    expect(result.current).toBe(false);
+  });
+
+  it('should reset timer on click event', () => {
+    const { result } = renderHook(() => useUserActivity(3000));
+    act(() => jest.advanceTimersByTime(2000));
+    expect(result.current).toBe(true);
+    act(() => {
+      window.dispatchEvent(new MouseEvent('click'));
+      jest.advanceTimersByTime(2000);
+    });
+    expect(result.current).toBe(true);
+    act(() => jest.advanceTimersByTime(1000));
+    expect(result.current).toBe(false);
+  });
+
+  it('should reset timer on wheel event', () => {
+    const { result } = renderHook(() => useUserActivity(3000));
+    act(() => jest.advanceTimersByTime(2500));
+    act(() => {
+      window.dispatchEvent(new WheelEvent('wheel'));
+      jest.advanceTimersByTime(2500);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('should reset timer on keydown event', () => {
+    const { result } = renderHook(() => useUserActivity(3000));
+    act(() => jest.advanceTimersByTime(2500));
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown'));
+      jest.advanceTimersByTime(2500);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('should reset timer on visibilitychange event', () => {
+    const { result } = renderHook(() => useUserActivity(3000));
+    act(() => jest.advanceTimersByTime(2500));
+    act(() => {
+      window.dispatchEvent(new Event('visibilitychange'));
+      jest.advanceTimersByTime(2500);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('should throttle mousemove events with requestAnimationFrame', () => {
+    renderHook(() => useUserActivity(3000));
+    const rafSpy = jest.spyOn(window, 'requestAnimationFrame');
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousemove'));
+      window.dispatchEvent(new MouseEvent('mousemove'));
+      window.dispatchEvent(new MouseEvent('mousemove'));
+    });
+    expect(rafSpy).toHaveBeenCalledTimes(1);
+    rafSpy.mockRestore();
+  });
+
+  it('should handle mousemove after animation frame completes', () => {
+    const { result } = renderHook(() => useUserActivity(3000));
+    act(() => {
+      jest.advanceTimersByTime(2500);
+      window.dispatchEvent(new MouseEvent('mousemove'));
+      jest.advanceTimersByTime(500);
+    });
+    expect(result.current).toBe(true);
+    act(() => jest.advanceTimersByTime(3000));
+    expect(result.current).toBe(false);
+  });
+
+  it('should clean up event listeners on unmount', () => {
+    const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => useUserActivity(3000));
+    unmount();
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function));
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('wheel', expect.any(Function), {
+      capture: true,
+      passive: true,
+    });
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('mousemove', expect.any(Function));
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+    removeEventListenerSpy.mockRestore();
+  });
+
+  it('should cancel pending animation frame on unmount', () => {
+    const cancelAnimationFrameSpy = jest.spyOn(window, 'cancelAnimationFrame');
+    const { unmount } = renderHook(() => useUserActivity(3000));
+    act(() => window.dispatchEvent(new MouseEvent('mousemove')));
+    unmount();
+    expect(cancelAnimationFrameSpy).toHaveBeenCalled();
+    cancelAnimationFrameSpy.mockRestore();
+  });
+
+  it('should clear timeout on unmount', () => {
+    const clearTimeoutSpy = jest.spyOn(window, 'clearTimeout');
+    const { unmount } = renderHook(() => useUserActivity(3000));
+    unmount();
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+
+  it('should handle multiple activity events in sequence', () => {
+    const { result } = renderHook(() => useUserActivity(3000));
+    act(() => {
+      window.dispatchEvent(new MouseEvent('click'));
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current).toBe(true);
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown'));
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current).toBe(true);
+    act(() => {
+      window.dispatchEvent(new WheelEvent('wheel'));
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current).toBe(true);
+    act(() => jest.advanceTimersByTime(3000));
+    expect(result.current).toBe(false);
+  });
+
+  it('should reactivate user after going inactive', () => {
+    const { result } = renderHook(() => useUserActivity(3000));
+    act(() => jest.advanceTimersByTime(3000));
+    expect(result.current).toBe(false);
+    act(() => window.dispatchEvent(new MouseEvent('click')));
+    expect(result.current).toBe(true);
+    act(() => jest.advanceTimersByTime(3000));
+    expect(result.current).toBe(false);
+  });
+});

--- a/public/app/features/dashboard-scene/edit-pane/useUserActivity.test.ts
+++ b/public/app/features/dashboard-scene/edit-pane/useUserActivity.test.ts
@@ -12,6 +12,20 @@ describe('useUserActivity', () => {
     jest.useRealTimers();
   });
 
+  const createEvent = (type: string): Event => {
+    const eventConstructors: Record<string, () => Event> = {
+      pointerdown: () => new MouseEvent('pointerdown'),
+      pointermove: () => new MouseEvent('pointermove'),
+      wheel: () => new WheelEvent('wheel'),
+      scroll: () => new Event('scroll'),
+      keydown: () => new KeyboardEvent('keydown'),
+      visibilitychange: () => new Event('visibilitychange'),
+    };
+    return eventConstructors[type]();
+  };
+
+  const dispatchEvent = (type: string) => window.dispatchEvent(createEvent(type));
+
   it('should start with user active', () => {
     const { result } = renderHook(() => useUserActivity(3000));
     expect(result.current).toBe(true);
@@ -24,133 +38,199 @@ describe('useUserActivity', () => {
     expect(result.current).toBe(false);
   });
 
-  it('should reset timer on click event', () => {
-    const { result } = renderHook(() => useUserActivity(3000));
-    act(() => jest.advanceTimersByTime(2000));
-    expect(result.current).toBe(true);
-    act(() => {
-      window.dispatchEvent(new MouseEvent('click'));
-      jest.advanceTimersByTime(2000);
+  describe('activity events', () => {
+    ['pointerdown', 'pointermove', 'wheel', 'scroll', 'keydown', 'visibilitychange'].forEach((eventType) => {
+      it(`should reset timer on ${eventType} event`, () => {
+        const { result } = renderHook(() => useUserActivity(3000));
+
+        // Advance time but not enough to trigger inactivity
+        act(() => jest.advanceTimersByTime(2500));
+        expect(result.current).toBe(true);
+
+        // Trigger event and let all timers complete
+        act(() => {
+          dispatchEvent(eventType);
+          jest.runAllTimers();
+        });
+
+        // Should now be inactive after full delay
+        expect(result.current).toBe(false);
+      });
     });
-    expect(result.current).toBe(true);
-    act(() => jest.advanceTimersByTime(1000));
-    expect(result.current).toBe(false);
   });
 
-  it('should reset timer on wheel event', () => {
-    const { result } = renderHook(() => useUserActivity(3000));
-    act(() => jest.advanceTimersByTime(2500));
-    act(() => {
-      window.dispatchEvent(new WheelEvent('wheel'));
-      jest.advanceTimersByTime(2500);
+  describe('event throttling', () => {
+    it('should throttle all events with requestAnimationFrame', () => {
+      renderHook(() => useUserActivity(3000));
+      const spy = jest.spyOn(window, 'requestAnimationFrame');
+
+      act(() => {
+        // Dispatch multiple events rapidly
+        dispatchEvent('pointerdown');
+        dispatchEvent('pointermove');
+        dispatchEvent('scroll');
+        dispatchEvent('wheel');
+        dispatchEvent('keydown');
+      });
+
+      // Only one RAF should be scheduled despite multiple events
+      expect(spy).toHaveBeenCalledTimes(1);
+      spy.mockRestore();
     });
-    expect(result.current).toBe(true);
+
+    it('should process events after RAF callback completes', () => {
+      renderHook(() => useUserActivity(3000));
+      const rafSpy = jest.spyOn(window, 'requestAnimationFrame');
+
+      // First event
+      act(() => dispatchEvent('pointermove'));
+      expect(rafSpy).toHaveBeenCalledTimes(1);
+
+      // Complete the RAF and timers
+      act(() => jest.runAllTimers());
+
+      // Second event should schedule a new RAF
+      act(() => dispatchEvent('scroll'));
+      expect(rafSpy).toHaveBeenCalledTimes(2);
+
+      rafSpy.mockRestore();
+    });
   });
 
-  it('should reset timer on keydown event', () => {
-    const { result } = renderHook(() => useUserActivity(3000));
-    act(() => jest.advanceTimersByTime(2500));
-    act(() => {
-      window.dispatchEvent(new KeyboardEvent('keydown'));
-      jest.advanceTimersByTime(2500);
+  describe('cleanup', () => {
+    it('should clean up all event listeners on unmount', () => {
+      const spy = jest.spyOn(window, 'removeEventListener');
+      const { unmount } = renderHook(() => useUserActivity(3000));
+
+      unmount();
+
+      // Verify all event listeners are removed
+      expect(spy).toHaveBeenCalledWith('pointerdown', expect.any(Function));
+      expect(spy).toHaveBeenCalledWith('pointermove', expect.any(Function));
+      expect(spy).toHaveBeenCalledWith('wheel', expect.any(Function), { capture: true, passive: true });
+      expect(spy).toHaveBeenCalledWith('scroll', expect.any(Function), { capture: true, passive: true });
+      expect(spy).toHaveBeenCalledWith('keydown', expect.any(Function));
+      expect(spy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+
+      spy.mockRestore();
     });
-    expect(result.current).toBe(true);
+
+    it('should cancel pending animation frame on unmount', () => {
+      const spy = jest.spyOn(window, 'cancelAnimationFrame');
+      const { unmount } = renderHook(() => useUserActivity(3000));
+
+      // Trigger an event to schedule a RAF
+      act(() => dispatchEvent('pointermove'));
+
+      unmount();
+
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('should clear timeout on unmount', () => {
+      const spy = jest.spyOn(window, 'clearTimeout');
+      const { unmount } = renderHook(() => useUserActivity(3000));
+
+      unmount();
+
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
   });
 
-  it('should reset timer on visibilitychange event', () => {
-    const { result } = renderHook(() => useUserActivity(3000));
-    act(() => jest.advanceTimersByTime(2500));
-    act(() => {
-      window.dispatchEvent(new Event('visibilitychange'));
-      jest.advanceTimersByTime(2500);
-    });
-    expect(result.current).toBe(true);
-  });
+  describe('user activity lifecycle', () => {
+    it('should handle multiple activity events in sequence', () => {
+      const { result } = renderHook(() => useUserActivity(3000));
 
-  it('should throttle mousemove events with requestAnimationFrame', () => {
-    renderHook(() => useUserActivity(3000));
-    const rafSpy = jest.spyOn(window, 'requestAnimationFrame');
-    act(() => {
-      window.dispatchEvent(new MouseEvent('mousemove'));
-      window.dispatchEvent(new MouseEvent('mousemove'));
-      window.dispatchEvent(new MouseEvent('mousemove'));
-    });
-    expect(rafSpy).toHaveBeenCalledTimes(1);
-    rafSpy.mockRestore();
-  });
+      // Each event keeps the user active
+      act(() => {
+        dispatchEvent('pointerdown');
+        jest.advanceTimersByTime(1000);
+      });
 
-  it('should handle mousemove after animation frame completes', () => {
-    const { result } = renderHook(() => useUserActivity(3000));
-    act(() => {
-      jest.advanceTimersByTime(2500);
-      window.dispatchEvent(new MouseEvent('mousemove'));
-      jest.advanceTimersByTime(500);
-    });
-    expect(result.current).toBe(true);
-    act(() => jest.advanceTimersByTime(3000));
-    expect(result.current).toBe(false);
-  });
+      act(() => {
+        dispatchEvent('keydown');
+        jest.advanceTimersByTime(1000);
+      });
 
-  it('should clean up event listeners on unmount', () => {
-    const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
-    const { unmount } = renderHook(() => useUserActivity(3000));
-    unmount();
-    expect(removeEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function));
-    expect(removeEventListenerSpy).toHaveBeenCalledWith('wheel', expect.any(Function), {
-      capture: true,
-      passive: true,
-    });
-    expect(removeEventListenerSpy).toHaveBeenCalledWith('mousemove', expect.any(Function));
-    expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
-    expect(removeEventListenerSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
-    removeEventListenerSpy.mockRestore();
-  });
+      act(() => {
+        dispatchEvent('wheel');
+        jest.advanceTimersByTime(1000);
+      });
 
-  it('should cancel pending animation frame on unmount', () => {
-    const cancelAnimationFrameSpy = jest.spyOn(window, 'cancelAnimationFrame');
-    const { unmount } = renderHook(() => useUserActivity(3000));
-    act(() => window.dispatchEvent(new MouseEvent('mousemove')));
-    unmount();
-    expect(cancelAnimationFrameSpy).toHaveBeenCalled();
-    cancelAnimationFrameSpy.mockRestore();
-  });
+      expect(result.current).toBe(true);
 
-  it('should clear timeout on unmount', () => {
-    const clearTimeoutSpy = jest.spyOn(window, 'clearTimeout');
-    const { unmount } = renderHook(() => useUserActivity(3000));
-    unmount();
-    expect(clearTimeoutSpy).toHaveBeenCalled();
-    clearTimeoutSpy.mockRestore();
-  });
+      // Finally let the inactivity timer complete
+      act(() => jest.runAllTimers());
+      expect(result.current).toBe(false);
+    });
 
-  it('should handle multiple activity events in sequence', () => {
-    const { result } = renderHook(() => useUserActivity(3000));
-    act(() => {
-      window.dispatchEvent(new MouseEvent('click'));
-      jest.advanceTimersByTime(1000);
-    });
-    expect(result.current).toBe(true);
-    act(() => {
-      window.dispatchEvent(new KeyboardEvent('keydown'));
-      jest.advanceTimersByTime(1000);
-    });
-    expect(result.current).toBe(true);
-    act(() => {
-      window.dispatchEvent(new WheelEvent('wheel'));
-      jest.advanceTimersByTime(1000);
-    });
-    expect(result.current).toBe(true);
-    act(() => jest.advanceTimersByTime(3000));
-    expect(result.current).toBe(false);
-  });
+    it('should reactivate user after going inactive', () => {
+      const { result } = renderHook(() => useUserActivity(3000));
 
-  it('should reactivate user after going inactive', () => {
-    const { result } = renderHook(() => useUserActivity(3000));
-    act(() => jest.advanceTimersByTime(3000));
-    expect(result.current).toBe(false);
-    act(() => window.dispatchEvent(new MouseEvent('click')));
-    expect(result.current).toBe(true);
-    act(() => jest.advanceTimersByTime(3000));
-    expect(result.current).toBe(false);
+      // User becomes inactive
+      act(() => jest.advanceTimersByTime(3000));
+      expect(result.current).toBe(false);
+
+      // New activity triggers reactivation and then becomes inactive again
+      act(() => {
+        dispatchEvent('pointerdown');
+        jest.runAllTimers();
+      });
+
+      expect(result.current).toBe(false);
+    });
+
+    it('should reset timer with each activity event', () => {
+      const { result } = renderHook(() => useUserActivity(3000));
+
+      // Keep user active by triggering events before the 3s timeout
+      act(() => {
+        jest.advanceTimersByTime(2000);
+        dispatchEvent('keydown');
+        jest.advanceTimersByTime(2000); // Total: 4s but timer was reset
+      });
+
+      act(() => {
+        dispatchEvent('scroll');
+        jest.advanceTimersByTime(2000); // Total: 6s but timer was reset again
+      });
+
+      act(() => {
+        dispatchEvent('wheel');
+        jest.advanceTimersByTime(2000); // Total: 8s but timer was reset again
+      });
+
+      // User should still be active because timer kept resetting
+      expect(result.current).toBe(true);
+
+      // Now let it expire
+      act(() => jest.runAllTimers());
+      expect(result.current).toBe(false);
+    });
+
+    it('should respect updated delay parameter', () => {
+      const { result, rerender } = renderHook(({ delay }) => useUserActivity(delay), {
+        initialProps: { delay: 1000 },
+      });
+
+      expect(result.current).toBe(true);
+
+      // Advance time but not enough to trigger initial delay
+      act(() => jest.advanceTimersByTime(500));
+      expect(result.current).toBe(true);
+
+      // Change delay to 2000ms - effect should re-run
+      rerender({ delay: 2000 });
+
+      // Advance another 1000ms (total 1500ms from start, but delay was reset on rerender)
+      act(() => jest.advanceTimersByTime(1000));
+      expect(result.current).toBe(true);
+
+      // Advance remaining time to reach the 2000ms delay
+      act(() => jest.advanceTimersByTime(1000));
+      expect(result.current).toBe(false);
+    });
   });
 });

--- a/public/app/features/dashboard-scene/edit-pane/useUserActivity.ts
+++ b/public/app/features/dashboard-scene/edit-pane/useUserActivity.ts
@@ -12,39 +12,45 @@ export function useUserActivity(delay: number): boolean {
     let timeout: NodeJS.Timeout;
     let rafId: number | null = null;
     const otherEventsOpts = { passive: true };
-    const wheelEventOpts = { capture: true, passive: true };
+    const scrollEventOpts = { capture: true, passive: true };
 
     const setActivityTimer = () => setTimeout(() => setIsUserActive(false), delay);
 
     const handleActivity = () => {
-      setIsUserActive(true);
-      clearTimeout(timeout);
-      timeout = setActivityTimer();
-    };
-
-    const handleMouseMove = () => {
       if (rafId !== null) {
         return;
       }
 
       rafId = requestAnimationFrame(() => {
         rafId = null;
-        handleActivity();
+        setIsUserActive(true);
+        clearTimeout(timeout);
+        timeout = setActivityTimer();
       });
     };
 
-    window.addEventListener('click', handleActivity, otherEventsOpts);
-    window.addEventListener('wheel', handleActivity, wheelEventOpts);
-    window.addEventListener('mousemove', handleMouseMove, otherEventsOpts);
+    // Using pointer events instead of mouse events for more comprehensive input support
+    window.addEventListener('pointerdown', handleActivity, otherEventsOpts);
+    window.addEventListener('pointermove', handleActivity, otherEventsOpts);
+
+    // Wheel events refer to mouse wheel scrolling while scroll events refer to any scrolling (e.g. touchpad, mobile etc.)
+    // Wheel and scroll events can be passive and need to be captured to avoid missing them
+    window.addEventListener('wheel', handleActivity, scrollEventOpts);
+    window.addEventListener('scroll', handleActivity, scrollEventOpts);
+
+    // Keyboard events
     window.addEventListener('keydown', handleActivity, otherEventsOpts);
+
+    // Consider browser tab changes as activity
     window.addEventListener('visibilitychange', handleActivity);
 
     timeout = setActivityTimer();
 
     return () => {
-      window.removeEventListener('click', handleActivity);
-      window.removeEventListener('wheel', handleActivity, wheelEventOpts);
-      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('pointerdown', handleActivity);
+      window.removeEventListener('pointermove', handleActivity);
+      window.removeEventListener('wheel', handleActivity, scrollEventOpts);
+      window.removeEventListener('scroll', handleActivity, scrollEventOpts);
       window.removeEventListener('keydown', handleActivity);
       window.removeEventListener('visibilitychange', handleActivity);
 

--- a/public/app/features/dashboard-scene/edit-pane/useUserActivity.ts
+++ b/public/app/features/dashboard-scene/edit-pane/useUserActivity.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Tracks user activity and returns whether the user is currently active.
+ * User is considered active when they interact with the page via click, scroll,
+ * keyboard, or mouse movement. Becomes inactive after the specified delay.
+ */
+export function useUserActivity(delay: number): boolean {
+  const [isUserActive, setIsUserActive] = useState(true);
+
+  useEffect(() => {
+    let timeout: NodeJS.Timeout;
+    let rafId: number | null = null;
+    const otherEventsOpts = { passive: true };
+    const wheelEventOpts = { capture: true, passive: true };
+
+    const setActivityTimer = () => setTimeout(() => setIsUserActive(false), delay);
+
+    const handleActivity = () => {
+      setIsUserActive(true);
+      clearTimeout(timeout);
+      timeout = setActivityTimer();
+    };
+
+    const handleMouseMove = () => {
+      if (rafId !== null) {
+        return;
+      }
+
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        handleActivity();
+      });
+    };
+
+    window.addEventListener('click', handleActivity, otherEventsOpts);
+    window.addEventListener('wheel', handleActivity, wheelEventOpts);
+    window.addEventListener('mousemove', handleMouseMove, otherEventsOpts);
+    window.addEventListener('keydown', handleActivity, otherEventsOpts);
+    window.addEventListener('visibilitychange', handleActivity);
+
+    timeout = setActivityTimer();
+
+    return () => {
+      window.removeEventListener('click', handleActivity);
+      window.removeEventListener('wheel', handleActivity, wheelEventOpts);
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('keydown', handleActivity);
+      window.removeEventListener('visibilitychange', handleActivity);
+
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+      }
+
+      clearTimeout(timeout);
+    };
+  }, [delay]);
+
+  return isUserActive;
+}


### PR DESCRIPTION
**What is this feature?**

Autohide the sidebar completely after the user has been inactive for 10 seconds (this is subject to discussion).

**Why do we need this feature?**

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/116346

**Special notes for your reviewer:**

This is a new implementation of https://github.com/grafana/grafana/pull/117156

https://github.com/user-attachments/assets/eb9eacb9-addc-4815-8f71-78e98c67fe5c

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
