### PR TITLE
Provisioning: Display warnings for disconnected apps

### DIFF
--- a/public/app/features/provisioning/Connection/ConnectionForm.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionForm.tsx
@@ -64,6 +64,15 @@ export function ConnectionForm({ data }: ConnectionFormProps) {
     }
   }, [request.isSuccess, reset, getValues, connectionName, navigate]);
 
+  useEffect(() => {
+    if (isEdit && data?.status?.fieldErrors?.length) {
+      const errors = getConnectionFormErrors(data.status.fieldErrors);
+      for (const [field, errorMessage] of errors) {
+        setError(field, errorMessage);
+      }
+    }
+  }, [isEdit, data?.status?.fieldErrors, setError]);
+
   const onSubmit = async (form: ConnectionFormData) => {
     try {
       const spec = {

--- a/public/app/features/provisioning/Connection/ConnectionFormPage.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionFormPage.tsx
@@ -77,7 +77,10 @@ export default function ConnectionFormPage() {
                   This GitHub App connection has lost access. The app may have been uninstalled or the repository access
                   was revoked.
                 </Trans>
-                {disconnectMessage && <Text element="p">{disconnectMessage}</Text>}
+                {/*Field errors are shown inline in the form*/}
+                {!!disconnectMessage && !connection?.status?.fieldErrors?.length && (
+                  <Text element="p">{disconnectMessage}</Text>
+                )}
               </Alert>
             )}
             {!isCreate && connectedRepos.length > 0 && (

--- a/public/app/features/provisioning/Connection/ConnectionFormPage.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionFormPage.tsx
@@ -2,6 +2,7 @@ import { skipToken } from '@reduxjs/toolkit/query/react';
 import { useParams } from 'react-router-dom-v5-compat';
 
 import { Trans, t } from '@grafana/i18n';
+import { isFetchError } from '@grafana/runtime';
 import { Alert, Card, EmptyState, Stack, Text, TextLink } from '@grafana/ui';
 import { useGetConnectionRepositoriesQuery, useListRepositoryQuery } from 'app/api/clients/provisioning/v0alpha1';
 import { Page } from 'app/core/components/Page/Page';
@@ -36,8 +37,7 @@ export default function ConnectionFormPage() {
   const availableReposQuery = useGetConnectionRepositoriesQuery(isCreate ? skipToken : { name });
   const availableRepos = availableReposQuery.data?.items ?? [];
 
-  //@ts-expect-error TODO add error types
-  const notFound = !isCreate && isError && error?.status === 404;
+  const notFound = !isCreate && isError && isFetchError(error) && error.status === 404;
 
   const pageTitle = isCreate
     ? t('provisioning.connection-form.page-title-create', 'Create connection')

--- a/public/app/features/provisioning/Connection/ConnectionFormPage.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionFormPage.tsx
@@ -38,6 +38,7 @@ export default function ConnectionFormPage() {
   const availableRepos = availableReposQuery.data?.items ?? [];
 
   const notFound = !isCreate && isError && isFetchError(error) && error.status === 404;
+  const showDisconnectMessage = disconnectMessage && !connection?.status?.fieldErrors?.length;
 
   const pageTitle = isCreate
     ? t('provisioning.connection-form.page-title-create', 'Create connection')
@@ -77,10 +78,8 @@ export default function ConnectionFormPage() {
                   This GitHub App connection has lost access. The app may have been uninstalled or the repository access
                   was revoked.
                 </Trans>
-                {/*Field errors are shown inline in the form*/}
-                {!!disconnectMessage && !connection?.status?.fieldErrors?.length && (
-                  <Text element="p">{disconnectMessage}</Text>
-                )}
+                {/* Field errors are shown inline in the form */}
+                {showDisconnectMessage && <Text element="p">{disconnectMessage}</Text>}
               </Alert>
             )}
             {!isCreate && connectedRepos.length > 0 && (

--- a/public/app/features/provisioning/Repository/RepositoryHealthCard.test.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryHealthCard.test.tsx
@@ -1,15 +1,15 @@
 import { render, screen } from 'test/test-utils';
 
-import { Connection, Repository, useGetConnectionQuery } from 'app/api/clients/provisioning/v0alpha1';
+import { Connection, Repository, useListConnectionQuery } from 'app/api/clients/provisioning/v0alpha1';
 
 import { RepositoryHealthCard } from './RepositoryHealthCard';
 
 jest.mock('app/api/clients/provisioning/v0alpha1', () => ({
   ...jest.requireActual('app/api/clients/provisioning/v0alpha1'),
-  useGetConnectionQuery: jest.fn(),
+  useListConnectionQuery: jest.fn(),
 }));
 
-const mockUseGetConnectionQuery = useGetConnectionQuery as jest.Mock;
+const mockUseListConnectionQuery = useListConnectionQuery as jest.Mock;
 
 const createMockRepository = (overrides: Partial<Repository> = {}): Repository => ({
   metadata: { name: 'test-repo' },
@@ -56,7 +56,7 @@ const createMockConnection = (overrides: Partial<Connection> = {}): Connection =
 
 describe('RepositoryHealthCard', () => {
   beforeEach(() => {
-    mockUseGetConnectionQuery.mockReturnValue({ data: undefined, isLoading: false });
+    mockUseListConnectionQuery.mockReturnValue({ data: { items: [] }, isLoading: false });
   });
 
   describe('Connection status', () => {
@@ -69,7 +69,7 @@ describe('RepositoryHealthCard', () => {
 
     it('should show connection status badge when connection exists', () => {
       const connection = createMockConnection();
-      mockUseGetConnectionQuery.mockReturnValue({ data: connection, isLoading: false });
+      mockUseListConnectionQuery.mockReturnValue({ data: { items: [connection] }, isLoading: false });
 
       const repo = createMockRepository({
         spec: {

--- a/public/app/features/provisioning/Repository/RepositoryHealthCard.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryHealthCard.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { Link } from 'react-router-dom-v5-compat';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
@@ -6,6 +7,7 @@ import { Badge, Card, Grid, Stack, Text, useStyles2 } from '@grafana/ui';
 import { Repository } from 'app/api/clients/provisioning/v0alpha1';
 
 import { ConnectionStatusBadge } from '../Connection/ConnectionStatusBadge';
+import { CONNECTIONS_URL } from '../constants';
 import { useConnectionStatus } from '../hooks/useConnectionStatus';
 import { formatTimestamp } from '../utils/time';
 
@@ -15,7 +17,7 @@ export function RepositoryHealthCard({ repo }: { repo: Repository }) {
   const styles = useStyles2(getStyles);
   const status = repo.status;
   const connectionName = repo.spec?.connection?.name;
-  const { connection, isDisconnected } = useConnectionStatus(connectionName);
+  const { connection } = useConnectionStatus(connectionName);
 
   return (
     <Card noMargin className={styles.card}>
@@ -73,24 +75,12 @@ export function RepositoryHealthCard({ repo }: { repo: Repository }) {
                 <Trans i18nKey="provisioning.repository-overview.connection-status">Connection status:</Trans>
               </Text>
               <div className={styles.spanTwo}>
-                <ConnectionStatusBadge
-                  key={connection?.status?.conditions?.find((c) => c.type === 'Ready')?.status || 'pending'}
-                  status={connection?.status}
-                />
-              </div>
-            </>
-          )}
-
-          {/* Connection disconnected warning */}
-          {connectionName && isDisconnected && (
-            <>
-              <div />
-              <div className={styles.spanTwo}>
-                <Text color="error">
-                  <Trans i18nKey="provisioning.repository-health.connection-disconnected-message">
-                    This repository can no longer access GitHub through this connection.
-                  </Trans>
-                </Text>
+                <Link to={`${CONNECTIONS_URL}/${connectionName}/edit`}>
+                  <ConnectionStatusBadge
+                    key={connection?.status?.conditions?.find((c) => c.type === 'Ready')?.status || 'pending'}
+                    status={connection?.status}
+                  />
+                </Link>
               </div>
             </>
           )}

--- a/public/app/features/provisioning/Repository/RepositoryHealthCard.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryHealthCard.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 
+import { GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { Badge, Card, Grid, Stack, Text, useStyles2 } from '@grafana/ui';
 import { Repository } from 'app/api/clients/provisioning/v0alpha1';
@@ -50,12 +51,10 @@ export function RepositoryHealthCard({ repo }: { repo: Repository }) {
 
           {!!status?.health?.message?.length && (
             <>
-              <div>
-                <Text color="secondary">
-                  <Trans i18nKey="provisioning.repository-overview.messages">Messages:</Trans>
-                </Text>
-              </div>
-              <div>
+              <Text color="secondary">
+                <Trans i18nKey="provisioning.repository-overview.messages">Messages:</Trans>
+              </Text>
+              <div className={styles.spanTwo}>
                 <Stack gap={1}>
                   {status.health.message.map((msg, idx) => (
                     <Text key={idx} variant="body">
@@ -74,20 +73,25 @@ export function RepositoryHealthCard({ repo }: { repo: Repository }) {
                 <Trans i18nKey="provisioning.repository-overview.connection-status">Connection status:</Trans>
               </Text>
               <div className={styles.spanTwo}>
-                <ConnectionStatusBadge status={connection?.status} />
+                <ConnectionStatusBadge
+                  key={connection?.status?.conditions?.find((c) => c.type === 'Ready')?.status || 'pending'}
+                  status={connection?.status}
+                />
               </div>
-              {isDisconnected && (
-                <>
-                  <div />
-                  <div className={styles.spanTwo}>
-                    <Text color="error">
-                      <Trans i18nKey="provisioning.repository-health.connection-disconnected-message">
-                        This repository can no longer access GitHub through this connection.
-                      </Trans>
-                    </Text>
-                  </div>
-                </>
-              )}
+            </>
+          )}
+
+          {/* Connection disconnected warning */}
+          {connectionName && isDisconnected && (
+            <>
+              <div />
+              <div className={styles.spanTwo}>
+                <Text color="error">
+                  <Trans i18nKey="provisioning.repository-health.connection-disconnected-message">
+                    This repository can no longer access GitHub through this connection.
+                  </Trans>
+                </Text>
+              </div>
             </>
           )}
         </Grid>
@@ -99,7 +103,7 @@ export function RepositoryHealthCard({ repo }: { repo: Repository }) {
   );
 }
 
-const getStyles = () => {
+const getStyles = (theme: GrafanaTheme2) => {
   return {
     spanTwo: css({
       gridColumn: 'span 2',
@@ -108,6 +112,7 @@ const getStyles = () => {
       height: '100%',
       display: 'flex',
       flexDirection: 'column',
+      gap: theme.spacing(2),
     }),
     actions: css({
       marginTop: 'auto',

--- a/public/app/features/provisioning/Repository/RepositoryHealthCard.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryHealthCard.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/css';
-import { skipToken } from '@reduxjs/toolkit/query/react';
 
 import { t, Trans } from '@grafana/i18n';
 import { Badge, Card, Grid, Stack, Text, useStyles2 } from '@grafana/ui';
-import { Repository, useGetConnectionQuery } from 'app/api/clients/provisioning/v0alpha1';
+import { Repository } from 'app/api/clients/provisioning/v0alpha1';
 
 import { ConnectionStatusBadge } from '../Connection/ConnectionStatusBadge';
+import { useConnectionStatus } from '../hooks/useConnectionStatus';
 import { formatTimestamp } from '../utils/time';
 
 import { CheckRepository } from './CheckRepository';
@@ -14,7 +14,7 @@ export function RepositoryHealthCard({ repo }: { repo: Repository }) {
   const styles = useStyles2(getStyles);
   const status = repo.status;
   const connectionName = repo.spec?.connection?.name;
-  const { data: connection } = useGetConnectionQuery(connectionName ? { name: connectionName } : skipToken);
+  const { connection, isDisconnected } = useConnectionStatus(connectionName);
 
   return (
     <Card noMargin className={styles.card}>
@@ -76,6 +76,18 @@ export function RepositoryHealthCard({ repo }: { repo: Repository }) {
               <div className={styles.spanTwo}>
                 <ConnectionStatusBadge status={connection?.status} />
               </div>
+              {isDisconnected && (
+                <>
+                  <div />
+                  <div className={styles.spanTwo}>
+                    <Text color="error">
+                      <Trans i18nKey="provisioning.repository-health.connection-disconnected-message">
+                        This repository can no longer access GitHub through this connection.
+                      </Trans>
+                    </Text>
+                  </div>
+                </>
+              )}
             </>
           )}
         </Grid>

--- a/public/app/features/provisioning/hooks/useConnectionStatus.ts
+++ b/public/app/features/provisioning/hooks/useConnectionStatus.ts
@@ -1,0 +1,32 @@
+import { skipToken } from '@reduxjs/toolkit/query';
+
+import { useListConnectionQuery } from 'app/api/clients/provisioning/v0alpha1';
+
+export function useConnectionStatus(name: string | undefined) {
+  const query = useListConnectionQuery(
+    name
+      ? {
+          fieldSelector: `metadata.name=${name}`,
+          watch: true,
+        }
+      : skipToken
+  );
+
+  const connection = query.data?.items?.[0];
+  const readyCondition = connection?.status?.conditions?.find((c) => c.type === 'Ready');
+
+  const isConnected = readyCondition?.status === 'True';
+  const isDisconnected = readyCondition?.status === 'False';
+
+  return {
+    connection,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+    isConnected,
+    isDisconnected,
+    disconnectReason: isDisconnected ? readyCondition?.reason : undefined,
+    disconnectMessage: isDisconnected ? readyCondition?.message : undefined,
+    health: connection?.status?.health,
+  };
+}

--- a/public/app/features/provisioning/utils/getFormErrors.ts
+++ b/public/app/features/provisioning/utils/getFormErrors.ts
@@ -35,6 +35,11 @@ function hasErrorsArray(data: object): data is { errors: ErrorDetails[] } {
  * Returns errors in ErrorDetails[] format.
  */
 export function extractFormErrors(data: ErrorDetails[] | Status): ErrorDetails[] {
+  // If data is already an ErrorDetails array, return it directly
+  if (Array.isArray(data)) {
+    return data;
+  }
+
   const causes = extractStatusCauses<StatusCause>(data);
   if (causes.length > 0) {
     return causes.map(statusCauseToErrorDetails);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11897,6 +11897,10 @@
       "free-tier-limit-tooltip": "Free-tier accounts are restricted to one connection",
       "instance-fully-managed-tooltip": "Configuration is disabled because this instance is fully managed"
     },
+    "connection": {
+      "disconnected-message": "This GitHub App connection has lost access. The app may have been uninstalled or the repository access was revoked.",
+      "disconnected-title": "Connection is disconnected"
+    },
     "connection-form": {
       "alert-connection-deleted": "Connection deleted",
       "alert-connection-saved": "Connection saved",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Surface backend states when GitHub app access is revoked or expired.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/git-ui-sync-project/issues/726

**Special notes for your reviewer:**
<img width="1349" height="973" alt="Screenshot 2026-02-02 at 15 13 06" src="https://github.com/user-attachments/assets/d9d1c6cf-1be3-4bb5-bdd5-eca36f7eeda4" />

<img width="327" height="285" alt="Screenshot 2026-02-02 at 15 17 49" src="https://github.com/user-attachments/assets/e427a226-77d2-47ca-b8ab-06fccbdafa04" />

<img width="1317" height="185" alt="Screenshot 2026-02-02 at 15 18 10" src="https://github.com/user-attachments/assets/d772c43c-c755-442c-8f93-711cd3abc3e7" />

