### PR TITLE
Graphite: Ensure `targetFull` value is replaced

### DIFF
--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -995,6 +995,7 @@ describe('graphiteDatasource', () => {
         originalTargetMap
       );
       expect(results[2].target).toBe('asPercent(series1,series2)');
+      expect(results[2].targetFull).toBe('asPercent(series1,series2)');
     });
 
     it('should replace target placeholder for hidden series', () => {
@@ -1015,6 +1016,7 @@ describe('graphiteDatasource', () => {
         originalTargetMap
       );
       expect(results[0].target).toBe('asPercent(series1,sumSeries(series1))');
+      expect(results[0].targetFull).toBe('asPercent(series1,sumSeries(series1))');
     });
 
     it('should replace target placeholder when nesting query references', () => {
@@ -1035,6 +1037,7 @@ describe('graphiteDatasource', () => {
         originalTargetMap
       );
       expect(results[2].target).toBe('asPercent(series1,sumSeries(series1))');
+      expect(results[2].targetFull).toBe('asPercent(series1,sumSeries(series1))');
     });
 
     it('should replace target placeholder when nesting query references with template variables', () => {
@@ -1071,6 +1074,7 @@ describe('graphiteDatasource', () => {
         originalTargetMap
       );
       expect(results[2].target).toBe('asPercent(aMetricName,sumSeries(aMetricName))');
+      expect(results[2].targetFull).toBe('asPercent(aMetricName,sumSeries(aMetricName))');
     });
 
     it('should use scoped variables when nesting query references', () => {
@@ -1113,6 +1117,7 @@ describe('graphiteDatasource', () => {
       );
 
       expect(results[1].target).toBe('sumSeries(scopedValue)');
+      expect(results[1].targetFull).toBe('sumSeries(scopedValue)');
     });
 
     it('should apply scoped variables to nested references with hidden targets', () => {
@@ -1155,6 +1160,7 @@ describe('graphiteDatasource', () => {
       );
 
       expect(results[0].target).toBe('avg(web01.cpu)');
+      expect(results[0].targetFull).toBe('avg(web01.cpu)');
     });
 
     it('should not recursively replace queries that reference themselves', () => {
@@ -1169,6 +1175,9 @@ describe('graphiteDatasource', () => {
         originalTargetMap
       );
       expect(results[0].target).toBe(
+        'sumSeries(carbon.test.test-host.cpuUsage, sumSeries(carbon.test.test-host.cpuUsage, #A))'
+      );
+      expect(results[0].targetFull).toBe(
         'sumSeries(carbon.test.test-host.cpuUsage, sumSeries(carbon.test.test-host.cpuUsage, #A))'
       );
     });
@@ -1195,6 +1204,9 @@ describe('graphiteDatasource', () => {
         originalTargetMap
       );
       expect(results[0].target).toBe(
+        'sumSeries(carbon.test.test-host.cpuUsage, sumSeries(carbon.test.test-host.cpuUsage, #A, #B), add(carbon.test.test-host.cpuUsage, 1.5))'
+      );
+      expect(results[0].targetFull).toBe(
         'sumSeries(carbon.test.test-host.cpuUsage, sumSeries(carbon.test.test-host.cpuUsage, #A, #B), add(carbon.test.test-host.cpuUsage, 1.5))'
       );
     });
@@ -1244,6 +1256,7 @@ describe('graphiteDatasource', () => {
           originalTargetMap
         );
         expect(results[0].target).toEqual('my.b.*');
+        expect(results[0].targetFull).toEqual('my.b.*');
       });
 
       it('globs for more than one variable', () => {
@@ -1274,6 +1287,7 @@ describe('graphiteDatasource', () => {
         );
 
         expect(results[0].target).toEqual('my.{a,b}.*');
+        expect(results[0].targetFull).toEqual('my.{a,b}.*');
       });
     });
   });

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -268,7 +268,7 @@ export class GraphiteDatasource
   ): GraphiteQuery[] {
     const referenceTargets: Record<string, string> = {};
     const finalTargets: GraphiteQuery[] = [];
-    let target: GraphiteQuery, targetValue, i;
+    let target: GraphiteQuery, targetValue, i, targetFullValue;
 
     for (i = 0; i < options.targets.length; i++) {
       target = options.targets[i];
@@ -306,8 +306,13 @@ export class GraphiteDatasource
         referenceTargets[target.refId].replace(seriesReferenceRegex, nestedSeriesRegexReplacer),
         options.scopedVars
       );
+      targetFullValue = this.templateSrv.replace(
+        referenceTargets[target.refId].replace(seriesReferenceRegex, nestedSeriesRegexReplacer),
+        options.scopedVars
+      );
 
       targetClone.target = targetValue;
+      targetClone.targetFull = targetFullValue;
       if (this.isMetricTank) {
         targetClone.isMetricTank = true;
       }


### PR DESCRIPTION
This change ensures the `targetFull` value has any nested series' replaced. I've also expanded the tests to cover this case too.

In the backend we use `targetFull` whereas we previously used `target` in frontend queries. This change ensures that the entire target is used correctly.

Future work that may be worth carrying out: unifying the `target` properties rather than having two separate ones.