### PR TITLE
Gauge: Fix percentage thresholds

### DIFF
--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
@@ -15,7 +15,7 @@ import { RadialSparkline } from './RadialSparkline';
 import { RadialText } from './RadialText';
 import { ThresholdsBar } from './ThresholdsBar';
 import { buildGradientColors } from './colors';
-import { ARC_END, ARC_START } from './constants';
+import { ARC_END, ARC_START, DEFAULT_DECIMALS } from './constants';
 import { GlowGradient, MiddleCircleGlow, SpotlightGradient } from './effects';
 import { RadialShape, RadialTextMode } from './types';
 import { calculateDimensions, getValueAngleForValue } from './utils';
@@ -225,8 +225,11 @@ export function RadialGauge(props: RadialGaugeProps) {
       );
 
       if (showScaleLabels || thresholdsBar) {
-        const decimals = displayValue.field.decimals ?? 2;
-        const thresholds = getFormattedThresholds(decimals, displayValue.field, theme);
+        const thresholds = getFormattedThresholds(
+          displayValue.field.decimals ?? DEFAULT_DECIMALS,
+          displayValue.field,
+          theme
+        );
 
         if (showScaleLabels) {
           graphics.push(
@@ -249,7 +252,7 @@ export function RadialGauge(props: RadialGaugeProps) {
             <ThresholdsBar
               key="thresholds-bar"
               thresholds={thresholds}
-              thresholdsMode={displayValue.field.thresholds?.mode!}
+              thresholdsMode={displayValue.field.thresholds?.mode}
               dimensions={dimensions}
               fieldDisplay={displayValue}
               startAngle={startAngle}

--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
@@ -15,6 +15,7 @@ import { RadialSparkline } from './RadialSparkline';
 import { RadialText } from './RadialText';
 import { ThresholdsBar } from './ThresholdsBar';
 import { buildGradientColors } from './colors';
+import { ARC_END, ARC_START } from './constants';
 import { GlowGradient, MiddleCircleGlow, SpotlightGradient } from './effects';
 import { RadialShape, RadialTextMode } from './types';
 import { calculateDimensions, getValueAngleForValue } from './utils';
@@ -110,8 +111,8 @@ export function RadialGauge(props: RadialGaugeProps) {
     effectiveTextMode = vizCount === 1 ? 'value' : 'value_and_name';
   }
 
-  const startAngle = shape === 'gauge' ? 250 : 0;
-  const endAngle = shape === 'gauge' ? 110 : 360;
+  const startAngle = shape === 'gauge' ? ARC_START : 0;
+  const endAngle = shape === 'gauge' ? ARC_END : 360;
 
   const defs: ReactNode[] = [];
   const graphics: ReactNode[] = [];
@@ -248,6 +249,7 @@ export function RadialGauge(props: RadialGaugeProps) {
             <ThresholdsBar
               key="thresholds-bar"
               thresholds={thresholds}
+              thresholdsMode={displayValue.field.thresholds?.mode!}
               dimensions={dimensions}
               fieldDisplay={displayValue}
               startAngle={startAngle}

--- a/packages/grafana-ui/src/components/RadialGauge/ThresholdsBar.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/ThresholdsBar.tsx
@@ -1,8 +1,8 @@
-import { FieldDisplay, Threshold } from '@grafana/data';
+import { FieldDisplay, Threshold, ThresholdsMode } from '@grafana/data';
 
 import { RadialArcPath } from './RadialArcPath';
 import { GradientStop, RadialGaugeDimensions, RadialShape } from './types';
-import { getFieldConfigMinMax } from './utils';
+import { getThresholdPercentageValue } from './utils';
 
 interface ThresholdsBarProps {
   dimensions: RadialGaugeDimensions;
@@ -14,6 +14,7 @@ interface ThresholdsBarProps {
   roundedBars?: boolean;
   glowFilter?: string;
   thresholds: Threshold[];
+  thresholdsMode: ThresholdsMode;
   gradient?: GradientStop[];
 }
 
@@ -25,6 +26,7 @@ export function ThresholdsBar({
   roundedBars,
   glowFilter,
   thresholds,
+  thresholdsMode,
   shape,
   gradient,
 }: ThresholdsBarProps) {
@@ -34,14 +36,13 @@ export function ThresholdsBar({
     radius: dimensions.thresholdsBarRadius,
   };
 
-  const [min, max] = getFieldConfigMinMax(fieldDisplay);
-
   let currentStart = startAngle;
   let paths: React.ReactNode[] = [];
 
   for (let i = 1; i < thresholds.length; i++) {
     const threshold = thresholds[i];
-    let valueDeg = ((threshold.value - min) / (max - min)) * angleRange;
+    const percentage = getThresholdPercentageValue(threshold, thresholdsMode, fieldDisplay);
+    let valueDeg = percentage * angleRange;
 
     if (valueDeg > angleRange) {
       valueDeg = angleRange;

--- a/packages/grafana-ui/src/components/RadialGauge/ThresholdsBar.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/ThresholdsBar.tsx
@@ -14,7 +14,7 @@ interface ThresholdsBarProps {
   roundedBars?: boolean;
   glowFilter?: string;
   thresholds: Threshold[];
-  thresholdsMode: ThresholdsMode;
+  thresholdsMode?: ThresholdsMode;
   gradient?: GradientStop[];
 }
 
@@ -26,7 +26,7 @@ export function ThresholdsBar({
   roundedBars,
   glowFilter,
   thresholds,
-  thresholdsMode,
+  thresholdsMode = ThresholdsMode.Absolute,
   shape,
   gradient,
 }: ThresholdsBarProps) {

--- a/packages/grafana-ui/src/components/RadialGauge/__snapshots__/colors.test.ts.snap
+++ b/packages/grafana-ui/src/components/RadialGauge/__snapshots__/colors.test.ts.snap
@@ -1,21 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RadialGauge color utils buildGradientColors should map threshold colors correctly (with baseColor if displayProcessor does not return colors) 1`] = `
+exports[`RadialGauge color utils buildGradientColors should map threshold colors correctly (for percentage thresholds) 1`] = `
 [
   {
-    "color": "#444444",
+    "color": "#73BF69",
     "percent": 0,
   },
   {
-    "color": "#FADE2A",
+    "color": "#73BF69",
     "percent": 0.5,
   },
   {
-    "color": "#F2495C",
+    "color": "#FADE2A",
     "percent": 0.8,
   },
   {
-    "color": "#444444",
+    "color": "#F2495C",
+    "percent": 1,
+  },
+]
+`;
+
+exports[`RadialGauge color utils buildGradientColors should map threshold colors correctly (with baseColor if displayProcessor does not return colors) 1`] = `
+[
+  {
+    "color": "#73BF69",
+    "percent": 0,
+  },
+  {
+    "color": "#73BF69",
+    "percent": 0.5,
+  },
+  {
+    "color": "#FADE2A",
+    "percent": 0.8,
+  },
+  {
+    "color": "#F2495C",
     "percent": 1,
   },
 ]
@@ -24,19 +45,19 @@ exports[`RadialGauge color utils buildGradientColors should map threshold colors
 exports[`RadialGauge color utils buildGradientColors should map threshold colors correctly (with baseColor if displayProcessor does not return colors) 2`] = `
 [
   {
-    "color": "#FF0000",
+    "color": "#73BF69",
     "percent": 0,
   },
   {
-    "color": "#FADE2A",
+    "color": "#73BF69",
     "percent": 0.5,
   },
   {
-    "color": "#F2495C",
+    "color": "#FADE2A",
     "percent": 0.8,
   },
   {
-    "color": "#FF0000",
+    "color": "#F2495C",
     "percent": 1,
   },
 ]

--- a/packages/grafana-ui/src/components/RadialGauge/colors.test.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/colors.test.ts
@@ -67,6 +67,21 @@ describe('RadialGauge color utils', () => {
       ).toMatchSnapshot();
     });
 
+    it('should map threshold colors correctly (for percentage thresholds)', () => {
+      expect(
+        buildGradientColors(
+          createTheme(),
+          buildFieldDisplay(createField(FieldColorModeId.Thresholds), {
+            field: {
+              thresholds: {
+                mode: ThresholdsMode.Percentage,
+              },
+            },
+          })
+        )
+      ).toMatchSnapshot();
+    });
+
     it('should return gradient colors for continuous color modes', () => {
       expect(
         buildGradientColors(

--- a/packages/grafana-ui/src/components/RadialGauge/colors.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/colors.ts
@@ -1,10 +1,19 @@
 import tinycolor from 'tinycolor2';
 
-import { colorManipulator, FALLBACK_COLOR, FieldDisplay, getFieldColorMode, GrafanaTheme2 } from '@grafana/data';
+import {
+  colorManipulator,
+  FALLBACK_COLOR,
+  FieldDisplay,
+  getFieldColorMode,
+  GrafanaTheme2,
+  ThresholdsMode,
+} from '@grafana/data';
 import { FieldColorModeId } from '@grafana/schema';
 
+import { getFormattedThresholds } from '../Gauge/utils';
+
 import { GradientStop, RadialShape } from './types';
-import { getFieldConfigMinMax, getFieldDisplayProcessor, getValuePercentageForValue } from './utils';
+import { getThresholdPercentageValue, getValuePercentageForValue } from './utils';
 
 export function buildGradientColors(
   theme: GrafanaTheme2,
@@ -15,24 +24,14 @@ export function buildGradientColors(
 
   // thresholds get special handling
   if (colorMode.id === FieldColorModeId.Thresholds) {
-    const displayProcessor = getFieldDisplayProcessor(fieldDisplay);
-    const [min, max] = getFieldConfigMinMax(fieldDisplay);
-    const thresholds = fieldDisplay.field.thresholds?.steps ?? [];
-
-    const result: Array<{ color: string; percent: number }> = [
-      { color: displayProcessor(min).color ?? baseColor, percent: 0 },
-    ];
-
-    for (const threshold of thresholds) {
-      if (threshold.value > min && threshold.value < max) {
-        const percent = (threshold.value - min) / (max - min);
-        result.push({ color: theme.visualization.getColorByName(threshold.color), percent });
-      }
-    }
-
-    result.push({ color: displayProcessor(max).color ?? baseColor, percent: 1 });
-
-    return result;
+    return getFormattedThresholds(fieldDisplay.field.decimals ?? 2, fieldDisplay.field, theme).map((threshold) => {
+      const percent = getThresholdPercentageValue(
+        threshold,
+        fieldDisplay.field.thresholds?.mode ?? ThresholdsMode.Absolute,
+        fieldDisplay
+      );
+      return { color: theme.visualization.getColorByName(threshold.color), percent };
+    });
   }
 
   // Handle continuous color modes before other by-value modes

--- a/packages/grafana-ui/src/components/RadialGauge/colors.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/colors.ts
@@ -12,6 +12,7 @@ import { FieldColorModeId } from '@grafana/schema';
 
 import { getFormattedThresholds } from '../Gauge/utils';
 
+import { DEFAULT_DECIMALS } from './constants';
 import { GradientStop, RadialShape } from './types';
 import { getThresholdPercentageValue, getValuePercentageForValue } from './utils';
 
@@ -24,14 +25,16 @@ export function buildGradientColors(
 
   // thresholds get special handling
   if (colorMode.id === FieldColorModeId.Thresholds) {
-    return getFormattedThresholds(fieldDisplay.field.decimals ?? 2, fieldDisplay.field, theme).map((threshold) => {
-      const percent = getThresholdPercentageValue(
-        threshold,
-        fieldDisplay.field.thresholds?.mode ?? ThresholdsMode.Absolute,
-        fieldDisplay
-      );
-      return { color: theme.visualization.getColorByName(threshold.color), percent };
-    });
+    return getFormattedThresholds(fieldDisplay.field.decimals ?? DEFAULT_DECIMALS, fieldDisplay.field, theme).map(
+      (threshold) => {
+        const percent = getThresholdPercentageValue(
+          threshold,
+          fieldDisplay.field.thresholds?.mode ?? ThresholdsMode.Absolute,
+          fieldDisplay
+        );
+        return { color: theme.visualization.getColorByName(threshold.color), percent };
+      }
+    );
   }
 
   // Handle continuous color modes before other by-value modes

--- a/packages/grafana-ui/src/components/RadialGauge/constants.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/constants.ts
@@ -1,0 +1,2 @@
+export const ARC_START = 250;
+export const ARC_END = 110;

--- a/packages/grafana-ui/src/components/RadialGauge/constants.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/constants.ts
@@ -1,2 +1,3 @@
 export const ARC_START = 250;
 export const ARC_END = 110;
+export const DEFAULT_DECIMALS = 2;

--- a/packages/grafana-ui/src/components/RadialGauge/utils.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.ts
@@ -1,4 +1,4 @@
-import { FieldDisplay, getDisplayProcessor } from '@grafana/data';
+import { FieldDisplay, getDisplayProcessor, Threshold, ThresholdsMode } from '@grafana/data';
 
 import { RadialGaugeDimensions } from './types';
 
@@ -252,4 +252,16 @@ export function getOptimalSegmentCount(
   const maxSegments = Math.floor(circumference / (angleBetweenSegments + 3));
 
   return Math.min(maxSegments, segmentCount);
+}
+
+export function getThresholdPercentageValue(
+  threshold: Threshold,
+  thresholdsMode: ThresholdsMode,
+  fieldDisplay: FieldDisplay
+): number {
+  if (thresholdsMode === ThresholdsMode.Percentage) {
+    return threshold.value! / 100;
+  }
+  const [min, max] = getFieldConfigMinMax(fieldDisplay);
+  return (threshold.value - min) / (max - min);
 }

--- a/packages/grafana-ui/src/components/RadialGauge/utils.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.ts
@@ -260,7 +260,7 @@ export function getThresholdPercentageValue(
   fieldDisplay: FieldDisplay
 ): number {
   if (thresholdsMode === ThresholdsMode.Percentage) {
-    return threshold.value! / 100;
+    return threshold.value / 100;
   }
   const [min, max] = getFieldConfigMinMax(fieldDisplay);
   return (threshold.value - min) / (max - min);


### PR DESCRIPTION
Fixes an internally-reported issue with the Gauge panel.

- updates logic in RadialGauge to correctly interpret percentage thresholds
- adds tests for the updates

<details>
    <summary>test dashboard</summary>

```json
{
  "panels": [
    {
      "id": 2,
      "type": "gauge",
      "title": "Reproduced with embedded data",
      "gridPos": {
        "h": 13,
        "w": 15,
        "x": 0,
        "y": 0
      },
      "fieldConfig": {
        "defaults": {
          "mappings": [],
          "thresholds": {
            "mode": "percentage",
            "steps": [
              {
                "value": null,
                "color": "green"
              },
              {
                "value": 20,
                "color": "blue"
              },
              {
                "value": 40,
                "color": "purple"
              },
              {
                "value": 60,
                "color": "red"
              },
              {
                "value": 80,
                "color": "orange"
              },
              {
                "value": 100,
                "color": "yellow"
              }
            ]
          },
          "min": 0,
          "max": 10,
          "color": {
            "mode": "thresholds"
          }
        },
        "overrides": []
      },
      "pluginVersion": "12.4.0-21490573584",
      "targets": [
        {
          "refId": "A",
          "datasource": {
            "type": "grafana",
            "uid": "grafana"
          },
          "queryType": "snapshot",
          "snapshot": [
            {
              "schema": {
                "refId": "A",
                "fields": [
                  {
                    "name": "time",
                    "type": "time",
                    "typeInfo": {
                      "frame": "time.Time"
                    },
                    "config": {}
                  },
                  {
                    "name": "A-series",
                    "type": "number",
                    "typeInfo": {
                      "frame": "int64",
                      "nullable": true
                    },
                    "config": {}
                  }
                ]
              },
              "data": {
                "values": [
                  [
                    1770021367891,
                    1770025687891,
                    1770030007891,
                    1770034327891,
                    1770038647891,
                    1770042967891
                  ],
                  [
                    1,
                    2,
                    9,
                    10,
                    3,
                    5
                  ]
                ]
              }
            }
          ]
        }
      ],
      "options": {
        "reduceOptions": {
          "values": false,
          "calcs": [
            "lastNotNull"
          ],
          "fields": ""
        },
        "shape": "gauge",
        "orientation": "auto",
        "sizing": "auto",
        "minVizWidth": 75,
        "minVizHeight": 75,
        "barWidthFactor": 0.5,
        "segmentCount": 1,
        "segmentSpacing": 0.3,
        "barShape": "flat",
        "endpointMarker": "point",
        "textMode": "auto",
        "sparkline": true,
        "showThresholdMarkers": true,
        "showThresholdLabels": true,
        "effects": {
          "barGlow": false,
          "centerGlow": false,
          "gradient": true
        }
      },
      "datasource": {
        "type": "grafana",
        "uid": "grafana"
      }
    },
    {
      "gridPos": {
        "h": 7,
        "w": 9,
        "x": 15,
        "y": 0
      },
      "id": 5,
      "options": {
        "content": "<table width=\"100%\">\n    <tr>\n      <th width=\"2%\">Panel</th>\n      <td >gauge @ 12.4.0-21490573584</td>\n    </tr>\n    <tr>\n      <th>Queries</th>\n      <td>A[grafana-testdata-datasource]</td>\n    </tr>\n    \n    <tr><th>Data</th><td> 1 frames, 2 fields, 6 rows </td></tr>\n    \n    <tr>\n      <th>Grafana</th>\n      <td>Grafana Cloud (fast) // Enterprise</td>\n    </tr>\n  </table>",
        "mode": "html"
      },
      "title": "Debug info",
      "type": "text"
    },
    {
      "id": 6,
      "title": "Original Panel JSON",
      "type": "text",
      "gridPos": {
        "h": 13,
        "w": 9,
        "x": 15,
        "y": 7
      },
      "options": {
        "content": "{\n  \"id\": 2,\n  \"type\": \"gauge\",\n  \"title\": \"1,2,9,10,3,5 - is this bugged?\",\n  \"gridPos\": {\n    \"x\": 0,\n    \"y\": 0,\n    \"h\": 0,\n    \"w\": 0\n  },\n  \"fieldConfig\": {\n    \"defaults\": {\n      \"mappings\": [],\n      \"thresholds\": {\n        \"mode\": \"percentage\",\n        \"steps\": [\n          {\n            \"value\": null,\n            \"color\": \"green\"\n          },\n          {\n            \"value\": 20,\n            \"color\": \"blue\"\n          },\n          {\n            \"value\": 40,\n            \"color\": \"purple\"\n          },\n          {\n            \"value\": 60,\n            \"color\": \"red\"\n          },\n          {\n            \"value\": 80,\n            \"color\": \"orange\"\n          },\n          {\n            \"value\": 100,\n            \"color\": \"yellow\"\n          }\n        ]\n      },\n      \"min\": 0,\n      \"max\": 10,\n      \"color\": {\n        \"mode\": \"thresholds\"\n      }\n    },\n    \"overrides\": []\n  },\n  \"pluginVersion\": \"12.4.0-21490573584\",\n  \"targets\": [\n    {\n      \"refId\": \"A\",\n      \"datasource\": {\n        \"uid\": \"s-9W0n5Vz\",\n        \"type\": \"grafana-testdata-datasource\"\n      },\n      \"scenarioId\": \"csv_metric_values\",\n      \"stringInput\": \"1,2,9,10,3,5\"\n    }\n  ],\n  \"options\": {\n    \"reduceOptions\": {\n      \"values\": false,\n      \"calcs\": [\n        \"lastNotNull\"\n      ],\n      \"fields\": \"\"\n    },\n    \"shape\": \"gauge\",\n    \"orientation\": \"auto\",\n    \"sizing\": \"auto\",\n    \"minVizWidth\": 75,\n    \"minVizHeight\": 75,\n    \"barWidthFactor\": 0.5,\n    \"segmentCount\": 1,\n    \"segmentSpacing\": 0.3,\n    \"barShape\": \"flat\",\n    \"endpointMarker\": \"point\",\n    \"textMode\": \"auto\",\n    \"sparkline\": true,\n    \"showThresholdMarkers\": true,\n    \"showThresholdLabels\": true,\n    \"effects\": {\n      \"barGlow\": false,\n      \"centerGlow\": false,\n      \"gradient\": true\n    }\n  }\n}",
        "mode": "code",
        "code": {
          "language": "json",
          "showLineNumbers": true,
          "showMiniMap": true
        }
      }
    },
    {
      "id": 3,
      "title": "Data from panel above",
      "type": "table",
      "datasource": {
        "type": "datasource",
        "uid": "-- Dashboard --"
      },
      "gridPos": {
        "h": 7,
        "w": 15,
        "x": 0,
        "y": 13
      },
      "options": {
        "showTypeIcons": true
      },
      "targets": [
        {
          "datasource": {
            "type": "datasource",
            "uid": "-- Dashboard --"
          },
          "panelId": 2,
          "withTransforms": true,
          "refId": "A"
        }
      ]
    }
  ],
  "schemaVersion": 37,
  "title": "Debug: 1,2,9,10,3,5 - is this bugged? // 2026-02-02 14:36:19",
  "tags": [
    "debug",
    "debug-gauge"
  ],
  "time": {
    "from": "2026-02-02T08:36:16.016Z",
    "to": "2026-02-02T14:36:16.016Z"
  }
}
```
</details>

<details>
   <summary>screenshots</summary>

### Before

#### Normal

<img width="882" height="375" alt="Screenshot 2026-02-02 at 11 31 55 AM" src="https://github.com/user-attachments/assets/811a3ffd-5b36-44f6-8737-17c1a1b8e27a" />

#### Gradient

<img width="708" height="453" alt="Screenshot 2026-02-02 at 11 31 44 AM" src="https://github.com/user-attachments/assets/2bf368d0-ad28-4b2e-858c-ccc1ab29d02b" />

### After

#### Normal
<img width="468" height="332" alt="Screenshot 2026-02-02 at 9 57 54 AM" src="https://github.com/user-attachments/assets/86fe5725-2ce0-466d-89eb-e607dac5baf1" />

#### Gradient
<img width="714" height="460" alt="Screenshot 2026-02-02 at 11 29 14 AM" src="https://github.com/user-attachments/assets/868b8b2d-3390-442d-a83c-f174a136db82" />

### Behavior in old gauge, for reference

<img width="716" height="464" alt="Screenshot 2026-02-02 at 11 30 12 AM" src="https://github.com/user-attachments/assets/0c3b7290-6825-4cb8-a211-dc1f97f21c05" />

</details>
