### PR TITLE
Revert "build(docker): Adding version marker to docker image to help with troubleshooting"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -240,9 +240,6 @@ COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
 COPY --from=js-src /tmp/grafana/public ./public
 COPY --from=js-src /tmp/grafana/LICENSE ./
 
-RUN set -o pipefail && grafana server -v | sed -e 's/Version //' > /.grafana-version && \
-  chmod 644 /.grafana-version
-
 EXPOSE 3000
 
 ARG RUN_SH=./packaging/docker/run.sh


### PR DESCRIPTION
Reverts grafana/grafana#117206 as it prevents docker builds in certain configurations