### PR TITLE
UI: Fix number fields unexpectedly changing when scrolling

### DIFF
--- a/packages/grafana-ui/src/components/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Input/Input.tsx
@@ -95,6 +95,14 @@ export const Input = forwardRef<HTMLInputElement, Props>((props, ref) => {
           ref={ref}
           className={styles.input}
           {...restProps}
+          onWheel={
+            restProps.type === 'number'
+              ? (e) => {
+                  e.currentTarget.blur();
+                  restProps.onWheel?.(e);
+                }
+              : restProps.onWheel
+          }
           style={{
             paddingLeft: prefix ? prefixRect.width + 12 : undefined,
             paddingRight: suffix || loading ? suffixRect.width + 12 : undefined,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Prevents numeric input values from changing when the user scrolls the page while the cursor is over the input. The fix tracks hover state and only lets the mouse wheel change the value when the input is both focused and hovered. In all other cases, the wheel event is prevented and the input is blurred so the page scrolls normally and the value stays unchanged.

**Why do we need this feature?**

Browsers treat <input type="number"> so that scrolling over a focused input increments or decrements the value. On the New Alert Rule page, users often enter a threshold value, then scroll down to Save while the cursor is still over the input. That scroll changes the value without the user noticing, which can lead to incorrect thresholds and unexpected alerts. This is especially common on macOS trackpads.

**Who is this feature for?**

Anyone creating or editing alert rules with numeric thresholds (e.g. Threshold Expression, Simple Condition, hysteresis). It applies to all number inputs in Grafana via the shared Input component.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #117193

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective (value changes only when focused and hovered; page scrolls normally otherwise).
- [x] N/A – this is a bug fix, not a feature.
- [x] Docs do not need updates for this UX 