### PR TITLE
build(docker): Adding version marker to docker image to help with troubleshooting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -240,6 +240,9 @@ COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
 COPY --from=js-src /tmp/grafana/public ./public
 COPY --from=js-src /tmp/grafana/LICENSE ./
 
+RUN grafana server -v | sed -e 's/Version //' > /.grafana-version
+RUN chmod 644 /.grafana-version
+
 EXPOSE 3000
 
 ARG RUN_SH=./packaging/docker/run.sh


### PR DESCRIPTION
**What is this feature?**

Adding version marker to docker image to help with troubleshooting

**Who is this feature for?**



**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

A [previous version](https://github.com/grafana/grafana/pull/117206) of this change caused failures in ubuntu image builds. This is an updated change that takes into account the diffs between alpine and ubuntu


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
