### PR TITLE
Alerting: Include imported routes in k8s routes API responses

### DIFF
--- a/pkg/services/ngalert/models/errors.go
+++ b/pkg/services/ngalert/models/errors.go
@@ -71,6 +71,11 @@ var (
 		errutil.WithPublic("Provided version '{{ .Public.Version }}' of route '{{ .Public.Name }}' does not match current version '{{ .Public.CurrentVersion }}'"),
 	)
 	ErrRouteExists = errutil.Conflict("alerting.notifications.routes.exists", errutil.WithPublicMessage("Route with this name already exists. Use a different name or update an existing one."))
+
+	ErrRouteOrigin = errutil.BadRequest("alerting.notifications.routes.originInvalid").MustTemplate(
+		"Route '{{ .Public.Name }} cannot be {{ .Public.Action }}d because it belongs to an imported configuration.",
+		errutil.WithPublic("Route '{{ .Public.Name }} cannot be {{ .Public.Action }}d because it belongs to an imported configuration. Finish the import of the configuration first."),
+	)
 )
 
 func ErrAlertRuleConflict(ruleUID string, orgID int64, err error) error {
@@ -130,4 +135,8 @@ func MakeErrRouteVersionConflict(name, currentVersion, desiredVersion string) er
 		},
 	}
 	return ErrRouteVersionConflict.Build(data)
+}
+
+func MakeErrRouteOrigin(routeName, action string) error {
+	return ErrRouteOrigin.Build(errutil.TemplateData{Public: map[string]interface{}{"Action": action, "Name": routeName}})
 }

--- a/pkg/services/ngalert/notifier/legacy_storage/imported.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported.go
@@ -12,6 +12,7 @@ import (
 )
 
 type ImportedConfigRevision struct {
+	identifier     string
 	rev            *ConfigRevision
 	opts           definition.MergeOpts
 	importedConfig *definition.PostableApiAlertingConfig
@@ -26,6 +27,7 @@ func (rev *ConfigRevision) Imported() (ImportedConfigRevision, error) {
 	}
 	// support only one config for now
 	mimirCfg := rev.Config.ExtraConfigs[0]
+	result.identifier = mimirCfg.Identifier
 	opts := definition.MergeOpts{
 		DedupSuffix:     mimirCfg.Identifier,
 		SubtreeMatchers: mimirCfg.MergeMatchers,
@@ -160,7 +162,7 @@ func (e ImportedConfigRevision) GetManagedRoute() (*ManagedRoute, error) {
 	}
 	importedRoute := mergeResult.Config.Route.Routes[0]
 
-	mr := NewManagedRoute(e.opts.DedupSuffix, importedRoute)
+	mr := NewManagedRoute(e.identifier, importedRoute)
 	mr.Provenance = models.ProvenanceConvertedPrometheus
 	mr.Origin = models.ResourceOriginImported
 	return mr, nil

--- a/pkg/services/ngalert/notifier/legacy_storage/imported.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported.go
@@ -133,3 +133,35 @@ func (e ImportedConfigRevision) ReceiverUseByName() map[string]int {
 	}
 	return m
 }
+
+func (e ImportedConfigRevision) GetManagedRoute() (*ManagedRoute, error) {
+	if e.importedConfig == nil {
+		return nil, nil
+	}
+
+	// We use a stub config so that calling definition.Merge doesn't modify the original Route.
+	// We leave out parts that are irrelevant to constructing the correctly imported route with renamed receivers and
+	// time intervals.
+	mergeResult, err := definition.Merge(definitions.PostableApiAlertingConfig{
+		Config: definitions.Config{
+			Route:             &definitions.Route{},
+			MuteTimeIntervals: e.rev.Config.AlertmanagerConfig.MuteTimeIntervals,
+			TimeIntervals:     e.rev.Config.AlertmanagerConfig.TimeIntervals,
+		},
+		Receivers: e.rev.Config.AlertmanagerConfig.Receivers,
+	}, *e.importedConfig, e.opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge imported config: %w", err)
+	}
+	// The imported route should have been injected into the stub and be the only subroute.
+	if len(mergeResult.Config.Route.Routes) != 1 {
+		// This really shouldn't happen, but just in case.
+		return nil, fmt.Errorf("failed to merge imported config: missing imported route")
+	}
+	importedRoute := mergeResult.Config.Route.Routes[0]
+
+	mr := NewManagedRoute(e.opts.DedupSuffix, importedRoute)
+	mr.Provenance = models.ProvenanceConvertedPrometheus
+	mr.Origin = models.ResourceOriginImported
+	return mr, nil
+}

--- a/pkg/services/ngalert/notifier/legacy_storage/imported_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported_test.go
@@ -3,13 +3,17 @@ package legacy_storage
 import (
 	"testing"
 
+	"github.com/grafana/alerting/definition"
 	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/dispatch"
 	"github.com/prometheus/alertmanager/pkg/labels"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 func TestConfigRevisionImported(t *testing.T) {
@@ -150,7 +154,7 @@ receivers:
 		const dupeConfig = `
 route:
   receiver: receiver1
-  routes: 
+  routes:
     - receiver: dupe-receiver
     - receiver: r1
 receivers:
@@ -170,6 +174,101 @@ receivers:
 			"dupe-receiver" + expectedDedupSuffix: 1,
 			"r1":                                  1,
 		}, actual)
+	})
+}
+
+func TestConfigRevisionImported_GetManagedRoute(t *testing.T) {
+	t.Run("should be empty if no configuration", func(t *testing.T) {
+		rev := getConfigRevisionForTest()
+		imported, err := rev.Imported()
+		require.NoError(t, err)
+		route, err := imported.GetManagedRoute()
+		require.NoError(t, err)
+		require.Nil(t, route)
+	})
+	t.Run("should return the imported route", func(t *testing.T) {
+		const cfg = `
+route:
+  receiver: r1
+  routes:
+  - receiver: r2
+    routes:
+    - receiver: r1
+  - routes:
+    - receiver: r2
+receivers:
+- name: r1
+- name: r2
+`
+		extra := extraConfig(cfg)
+		rev := getConfigRevisionForTest(withExtraConfig(extra))
+
+		imported, err := rev.Imported()
+		require.NoError(t, err)
+		route, err := imported.GetManagedRoute()
+		require.NoError(t, err)
+		assert.NotEmpty(t, route.Version) // Test separately so we don't couple this test to version consistency.
+		route.Version = ""
+		require.Equal(t, &ManagedRoute{
+			Name:           extra.Identifier,
+			Version:        "",
+			Receiver:       "r1",
+			GroupWait:      util.Pointer(model.Duration(dispatch.DefaultRouteOpts.GroupWait)),
+			GroupInterval:  util.Pointer(model.Duration(dispatch.DefaultRouteOpts.GroupInterval)),
+			RepeatInterval: util.Pointer(model.Duration(dispatch.DefaultRouteOpts.RepeatInterval)),
+			Routes: []*definitions.Route{
+				{Receiver: "r2", Routes: []*definitions.Route{{Receiver: "r1", Routes: make([]*definition.Route, 0)}}},
+				{Receiver: "", Routes: []*definitions.Route{{Receiver: "r2", Routes: make([]*definition.Route, 0)}}},
+			},
+			Provenance: models.ProvenanceConvertedPrometheus,
+			Origin:     models.ResourceOriginImported,
+		}, route)
+	})
+
+	t.Run("should correctly handle deduplicated names", func(t *testing.T) {
+		const dupeConfig = `
+route:
+  receiver: receiver1
+  routes:
+    - receiver: dupe-receiver
+      mute_time_intervals:
+        - mute-interval-1
+    - receiver: r1
+      active_time_intervals:
+        - time-interval-1
+receivers:
+  - name: receiver1
+  - name: dupe-receiver
+  - name: r1
+time_intervals:
+  - name: time-interval-1
+mute_time_intervals:
+  - name: mute-interval-1
+`
+		extra := extraConfig(dupeConfig)
+		expectedDedupSuffix := extra.Identifier
+		rev := getConfigRevisionForTest(withExtraConfig(extra))
+
+		imported, err := rev.Imported()
+		require.NoError(t, err)
+		route, err := imported.GetManagedRoute()
+		require.NoError(t, err)
+		assert.NotEmpty(t, route.Version) // Test separately so we don't couple this test to version consistency.
+		route.Version = ""
+		require.Equal(t, &ManagedRoute{
+			Name:           extra.Identifier,
+			Version:        "",
+			Receiver:       "receiver1" + expectedDedupSuffix,
+			GroupWait:      util.Pointer(model.Duration(dispatch.DefaultRouteOpts.GroupWait)),
+			GroupInterval:  util.Pointer(model.Duration(dispatch.DefaultRouteOpts.GroupInterval)),
+			RepeatInterval: util.Pointer(model.Duration(dispatch.DefaultRouteOpts.RepeatInterval)),
+			Routes: []*definitions.Route{
+				{Receiver: "dupe-receiver" + expectedDedupSuffix, MuteTimeIntervals: []string{"mute-interval-1" + expectedDedupSuffix}, Routes: make([]*definition.Route, 0)},
+				{Receiver: "r1", ActiveTimeIntervals: []string{"time-interval-1" + expectedDedupSuffix}, Routes: make([]*definition.Route, 0)},
+			},
+			Provenance: models.ProvenanceConvertedPrometheus,
+			Origin:     models.ResourceOriginImported,
+		}, route)
 	})
 }
 

--- a/pkg/services/ngalert/notifier/legacy_storage/imported_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported_test.go
@@ -5,15 +5,12 @@ import (
 
 	"github.com/grafana/alerting/definition"
 	"github.com/prometheus/alertmanager/config"
-	"github.com/prometheus/alertmanager/dispatch"
 	"github.com/prometheus/alertmanager/pkg/labels"
-	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 func TestConfigRevisionImported(t *testing.T) {
@@ -210,12 +207,9 @@ receivers:
 		assert.NotEmpty(t, route.Version) // Test separately so we don't couple this test to version consistency.
 		route.Version = ""
 		require.Equal(t, &ManagedRoute{
-			Name:           extra.Identifier,
-			Version:        "",
-			Receiver:       "r1",
-			GroupWait:      util.Pointer(model.Duration(dispatch.DefaultRouteOpts.GroupWait)),
-			GroupInterval:  util.Pointer(model.Duration(dispatch.DefaultRouteOpts.GroupInterval)),
-			RepeatInterval: util.Pointer(model.Duration(dispatch.DefaultRouteOpts.RepeatInterval)),
+			Name:     extra.Identifier,
+			Version:  "",
+			Receiver: "r1",
 			Routes: []*definitions.Route{
 				{Receiver: "r2", Routes: []*definitions.Route{{Receiver: "r1", Routes: make([]*definition.Route, 0)}}},
 				{Receiver: "", Routes: []*definitions.Route{{Receiver: "r2", Routes: make([]*definition.Route, 0)}}},
@@ -256,12 +250,9 @@ mute_time_intervals:
 		assert.NotEmpty(t, route.Version) // Test separately so we don't couple this test to version consistency.
 		route.Version = ""
 		require.Equal(t, &ManagedRoute{
-			Name:           extra.Identifier,
-			Version:        "",
-			Receiver:       "receiver1" + expectedDedupSuffix,
-			GroupWait:      util.Pointer(model.Duration(dispatch.DefaultRouteOpts.GroupWait)),
-			GroupInterval:  util.Pointer(model.Duration(dispatch.DefaultRouteOpts.GroupInterval)),
-			RepeatInterval: util.Pointer(model.Duration(dispatch.DefaultRouteOpts.RepeatInterval)),
+			Name:     extra.Identifier,
+			Version:  "",
+			Receiver: "receiver1" + expectedDedupSuffix,
 			Routes: []*definitions.Route{
 				{Receiver: "dupe-receiver" + expectedDedupSuffix, MuteTimeIntervals: []string{"mute-interval-1" + expectedDedupSuffix}, Routes: make([]*definition.Route, 0)},
 				{Receiver: "r1", ActiveTimeIntervals: []string{"time-interval-1" + expectedDedupSuffix}, Routes: make([]*definition.Route, 0)},

--- a/pkg/services/ngalert/notifier/legacy_storage/receivers_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/receivers_test.go
@@ -538,6 +538,12 @@ func getConfigRevisionForTest(opts ...opt) *ConfigRevision {
 			AlertmanagerConfig: definitions.PostableApiAlertingConfig{
 				Config: definitions.Config{
 					Route: &definitions.Route{Receiver: "receiver1"},
+					TimeIntervals: []config.TimeInterval{
+						{Name: "time-interval-1"},
+					},
+					MuteTimeIntervals: []config.MuteTimeInterval{
+						{Name: "mute-interval-1"},
+					},
 				},
 				Receivers: []*definition.PostableApiReceiver{
 					{

--- a/pkg/services/ngalert/notifier/legacy_storage/routes.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/routes.go
@@ -34,6 +34,7 @@ type ManagedRoute struct {
 	Routes         []*definition.Route
 
 	Provenance models.Provenance
+	Origin     models.ResourceOrigin
 }
 
 func (r *ManagedRoute) GeneratedSubRoute() *definition.Route {
@@ -85,6 +86,7 @@ func NewManagedRoute(name string, r *definition.Route) *ManagedRoute {
 		Routes:         r.Routes,
 
 		Provenance: models.Provenance(r.Provenance),
+		Origin:     models.ResourceOriginGrafana,
 	}
 }
 
@@ -109,6 +111,15 @@ func (m ManagedRoutes) Sort() {
 		}
 		return strings.Compare(a.Name, b.Name)
 	})
+}
+
+func (m ManagedRoutes) Contains(name string) bool {
+	for _, r := range m {
+		if r.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func WithManagedRoutes(root *definitions.Route, managedRoutes map[string]*definition.Route) *definitions.Route {

--- a/pkg/services/ngalert/notifier/legacy_storage/routes_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/routes_test.go
@@ -102,6 +102,18 @@ func TestManagedRoutes_Sort(t *testing.T) {
 	require.Equal(t, UserDefinedRoutingTreeName, routes[2].Name)
 }
 
+func TestManagedRoutes_Contains(t *testing.T) {
+	routes := ManagedRoutes{
+		{Name: "x"},
+		{Name: UserDefinedRoutingTreeName},
+		{Name: "z"},
+	}
+	assert.True(t, routes.Contains("x"))
+	assert.True(t, routes.Contains("z"))
+	assert.True(t, routes.Contains(UserDefinedRoutingTreeName))
+	assert.False(t, routes.Contains("missing"))
+}
+
 func TestWithManagedRoutes(t *testing.T) {
 	rev := func(root *definitions.Route, managedRoutes map[string]*definitions.Route) *ConfigRevision {
 		return &ConfigRevision{

--- a/pkg/tests/apis/alerting/notifications/routingtree/imported_test.go
+++ b/pkg/tests/apis/alerting/notifications/routingtree/imported_test.go
@@ -99,7 +99,7 @@ func TestIntegrationReadImported_Snapshot(t *testing.T) {
 			},
 		},
 	}
-	expected.ObjectMeta.UID = importedRoute.ObjectMeta.UID // UID is generated.
+	expected.UID = importedRoute.UID // UID is generated.
 	expected.SetProvenanceStatus(string(models.ProvenanceConvertedPrometheus))
 	require.Equal(t, expected, importedRoute)
 

--- a/pkg/tests/apis/alerting/notifications/routingtree/imported_test.go
+++ b/pkg/tests/apis/alerting/notifications/routingtree/imported_test.go
@@ -1,0 +1,144 @@
+package routingtree
+
+import (
+	"context"
+	"embed"
+	"path"
+	"testing"
+
+	"github.com/grafana/grafana-app-sdk/resource"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/tests/api/alerting"
+	"github.com/grafana/grafana/pkg/tests/apis"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+//go:embed test-data/*.*
+var testData embed.FS
+
+func TestIntegrationReadImported_Snapshot(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	ctx := context.Background()
+
+	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+		EnableFeatureToggles: []string{
+			featuremgmt.FlagAlertingImportAlertmanagerAPI,
+			featuremgmt.FlagAlertingMultiplePolicies,
+		},
+	})
+
+	client, err := v0alpha1.NewRoutingTreeClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
+
+	cliCfg := helper.Org1.Admin.NewRestConfig()
+	alertingApi := alerting.NewAlertingLegacyAPIClient(helper.GetEnv().Server.HTTPServer.Listener.Addr().String(), cliCfg.Username, cliCfg.Password)
+
+	configYaml, err := testData.ReadFile(path.Join("test-data", "imported.yaml"))
+	require.NoError(t, err)
+
+	identifier := "test-create-get-config"
+	mergeMatchers := "_imported=true"
+
+	headers := map[string]string{
+		"Content-Type":                         "application/yaml",
+		"X-Grafana-Alerting-Config-Identifier": identifier,
+		"X-Grafana-Alerting-Merge-Matchers":    mergeMatchers,
+	}
+
+	amConfig := apimodels.AlertmanagerUserConfig{
+		AlertmanagerConfig: string(configYaml),
+	}
+
+	response := alertingApi.ConvertPrometheusPostAlertmanagerConfig(t, amConfig, headers)
+	require.Equal(t, "success", response.Status)
+
+	routes, err := client.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, routes.Items, 2)
+	var importedRoute *v0alpha1.RoutingTree
+	for _, r := range routes.Items {
+		if r.Name == identifier {
+			importedRoute = &r
+		}
+	}
+	require.NotNil(t, importedRoute)
+	expected := &v0alpha1.RoutingTree{
+		ObjectMeta: v1.ObjectMeta{
+			Name:            identifier,
+			Namespace:       apis.DefaultNamespace,
+			ResourceVersion: "60514828ecf72916",
+		},
+		Spec: v0alpha1.RoutingTreeSpec{
+			Defaults: v0alpha1.RoutingTreeRouteDefaults{
+				GroupBy:        []string{"alertname", "cluster"},
+				GroupWait:      util.Pointer("1s"),
+				GroupInterval:  util.Pointer("5s"),
+				RepeatInterval: util.Pointer("4h"),
+				Receiver:       "noop",
+			},
+			Routes: []v0alpha1.RoutingTreeRoute{
+				{
+					Receiver:          util.Pointer("noop-warn"),
+					Matchers:          []v0alpha1.RoutingTreeMatcher{{Label: "severity", Type: v0alpha1.RoutingTreeMatcherTypeEqual, Value: "warn"}},
+					MuteTimeIntervals: []string{"mute-interval-1"},
+				},
+				{
+					Receiver:            util.Pointer("noop-critical"),
+					Matchers:            []v0alpha1.RoutingTreeMatcher{{Label: "severity", Type: v0alpha1.RoutingTreeMatcherTypeEqual, Value: "critical"}},
+					ActiveTimeIntervals: []string{"time-interval-1"},
+				},
+			},
+		},
+	}
+	expected.ObjectMeta.UID = importedRoute.ObjectMeta.UID // UID is generated.
+	expected.SetProvenanceStatus(string(models.ProvenanceConvertedPrometheus))
+	require.Equal(t, expected, importedRoute)
+
+	t.Run("should not be able to update", func(t *testing.T) {
+		toUpdate := importedRoute.Copy().(*v0alpha1.RoutingTree)
+		toUpdate.Spec.Defaults.GroupWait = util.Pointer("10s")
+
+		_, err = client.Update(ctx, toUpdate, resource.UpdateOptions{})
+		require.Truef(t, errors.IsBadRequest(err), "Expected BadRequest but got %s", err)
+		require.ErrorContains(t, err, "imported configuration")
+	})
+
+	t.Run("should not be able to delete", func(t *testing.T) {
+		toDelete := importedRoute.Copy().(*v0alpha1.RoutingTree)
+
+		err = client.Delete(ctx, toDelete.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
+		require.Truef(t, errors.IsBadRequest(err), "Expected BadRequest but got %s", err)
+		require.ErrorContains(t, err, "imported configuration")
+	})
+
+	t.Run("should not return if flag is disabled", func(t *testing.T) {
+		helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+			EnableFeatureToggles: []string{
+				featuremgmt.FlagAlertingMultiplePolicies,
+			},
+		})
+
+		client, err := v0alpha1.NewRoutingTreeClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+		require.NoError(t, err)
+
+		routes, err := client.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, routes.Items, 1)
+		var importedRoute *v0alpha1.RoutingTree
+		for _, r := range routes.Items {
+			if r.Name == identifier {
+				importedRoute = &r
+			}
+		}
+		require.Nil(t, importedRoute)
+	})
+}

--- a/pkg/tests/apis/alerting/notifications/routingtree/imported_test.go
+++ b/pkg/tests/apis/alerting/notifications/routingtree/imported_test.go
@@ -75,15 +75,14 @@ func TestIntegrationReadImported_Snapshot(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:            identifier,
 			Namespace:       apis.DefaultNamespace,
-			ResourceVersion: "60514828ecf72916",
+			ResourceVersion: "624f4696d803bc64",
 		},
 		Spec: v0alpha1.RoutingTreeSpec{
 			Defaults: v0alpha1.RoutingTreeRouteDefaults{
-				GroupBy:        []string{"alertname", "cluster"},
-				GroupWait:      util.Pointer("1s"),
-				GroupInterval:  util.Pointer("5s"),
-				RepeatInterval: util.Pointer("4h"),
-				Receiver:       "noop",
+				GroupBy:       []string{"alertname", "cluster"},
+				GroupWait:     util.Pointer("1s"),
+				GroupInterval: util.Pointer("5s"),
+				Receiver:      "noop",
 			},
 			Routes: []v0alpha1.RoutingTreeRoute{
 				{

--- a/pkg/tests/apis/alerting/notifications/routingtree/test-data/imported.yaml
+++ b/pkg/tests/apis/alerting/notifications/routingtree/test-data/imported.yaml
@@ -1,0 +1,26 @@
+route:
+  receiver: noop
+  group_by:
+    - alertname
+    - cluster
+  group_wait: 1s
+  group_interval: 5s
+  routes:
+    - matchers:
+        - severity="warn"
+      receiver: noop-warn
+      mute_time_intervals:
+        - mute-interval-1
+    - matchers:
+        - severity="critical"
+      receiver: noop-critical
+      active_time_intervals:
+        - time-interval-1
+receivers:
+  - name: noop
+  - name: noop-warn
+  - name: noop-critical
+time_intervals:
+  - name: time-interval-1
+mute_time_intervals:
+  - name: mute-interval-1


### PR DESCRIPTION
This change modifies the routes API to treat an imported extra Alertmanager configuration as an additional managed route when the import feature flag is enabled. As a result, listing and fetching managed routes will include the imported route.

Similar to receivers and time interval, this includes several guardrails:
- Creating a managed route with the same name as the imported route is rejected. (When we introduce UIDs to routes, we can remove this restriction in favour of de-duplicating the name instead)
- Attempts to update or delete the imported route return a dedicated bad-request error explaining that the route belongs to an imported configuration.
- If the imported route cannot be loaded or merged, the service logs the error and skips it.
- If a name conflict is detected during listing, the imported route is skipped to avoid returning duplicate names. (This shouldn't normally be possible because of the above guardrails, but in the edge case this is what would happen)

### Review Notes:

- The imported route is constructed by merging the imported configuration into a stub route structure to avoid mutating the original config.
- We are intentionally ignoring `SubtreeMatchers` here as they are incompatible with Managed Routes. The import API will be modified in a followup reconcile the two concepts.


Related to https://github.com/grafana/alerting-squad/issues/1153