### PR TITLE
Elasticsearch: add tracking events for query editor type

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/tracking.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/tracking.test.ts
@@ -89,7 +89,7 @@ describe('trackQuery', () => {
     expect(reportInteraction).toHaveBeenCalledWith(
       'grafana_elasticsearch_query_executed',
       expect.objectContaining({
-        editor_type: 'code'
+        editor_type: 'code',
       })
     );
   });

--- a/public/app/plugins/datasource/elasticsearch/tracking.ts
+++ b/public/app/plugins/datasource/elasticsearch/tracking.ts
@@ -138,6 +138,7 @@ export function trackQuery(
       time_range_from: request?.range?.from?.toISOString(),
       time_range_to: request?.range?.to?.toISOString(),
       time_taken: Date.now() - startTime.getTime(),
+      editor_type: query.editorType || 'builder',
     });
   }
 }


### PR DESCRIPTION
Tracks which editor type was used when making an elastic search query. 