### PR TITLE
Provisioning ConnectStep: When using Github flow, use internal refs endpoint for branch display

### DIFF
--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
@@ -486,8 +486,7 @@ describe('ProvisioningWizard', () => {
 
       await user.click(screen.getByRole('button', { name: /Choose what to synchronize/i }));
 
-      expect(await screen.findByRole('alert')).toBeInTheDocument();
-      expect(await screen.findByText('Repository request failed')).toBeInTheDocument();
+      expect(await screen.findByRole('alert', { name: 'Repository request failed' })).toBeInTheDocument();
 
       // Still on connection step (now step 2)
       expect(screen.getByRole('heading', { name: /2\. Configure repository/i })).toBeInTheDocument();

--- a/public/app/features/provisioning/guards.ts
+++ b/public/app/features/provisioning/guards.ts
@@ -4,8 +4,9 @@ export interface HttpError extends Error {
   status?: number;
 }
 
-export function isSupportedGitProvider(provider: string): provider is 'github' | 'gitlab' | 'bitbucket' {
-  return ['github', 'gitlab', 'bitbucket'].includes(provider);
+export function isSupportedGitProvider(provider: string): provider is 'gitlab' | 'bitbucket' {
+  // GitHub is excluded because the GitHub flow creates the repo one step earlier, so it can already use the internal /refs endpoint.
+  return ['gitlab', 'bitbucket'].includes(provider);
 }
 
 export function isHttpError(err: unknown): err is HttpError {

--- a/public/app/features/provisioning/hooks/useBranchOptions.ts
+++ b/public/app/features/provisioning/hooks/useBranchOptions.ts
@@ -1,7 +1,7 @@
 /**
  * A hook to fetch all branches from a given repository.
  * Used to populate the branch dropdown in the repository selection.
- * We can't use the '/ref` endpoint at this point because the repository connection hasn't been created yet.
+ * We can't use the '/ref` endpoint at this point (Gitlab and Bitbucket) because the repository connection hasn't been created yet.
  */
 import { useMemo } from 'react';
 import { useAsync } from 'react-use';

--- a/public/app/features/provisioning/hooks/useGetRepositoryRefs.ts
+++ b/public/app/features/provisioning/hooks/useGetRepositoryRefs.ts
@@ -1,6 +1,6 @@
 /**
  * A hook to fetch all branches from a given repository using internal /refs endpoint
- * Used to populate the branch dropdown in the repository selection.
+ * Used to populate the branch dropdown in onboarding wizard
  */
 import { skipToken } from '@reduxjs/toolkit/query';
 

--- a/public/app/features/provisioning/hooks/useGetRepositoryRefs.ts
+++ b/public/app/features/provisioning/hooks/useGetRepositoryRefs.ts
@@ -1,0 +1,44 @@
+/**
+ * A hook to fetch all branches from a given repository using internal /refs endpoint
+ * Used to populate the branch dropdown in the repository selection.
+ */
+import { skipToken } from '@reduxjs/toolkit/query';
+import { useMemo } from 'react';
+
+import { useGetRepositoryRefsQuery } from '@grafana/api-clients/rtkq/provisioning/v0alpha1';
+
+import { useRepositoryStatus } from '../Wizard/hooks/useRepositoryStatus';
+import { RepoType } from '../Wizard/types';
+import { getErrorMessage } from '../utils/httpUtils';
+import { isGitProvider } from '../utils/repositoryTypes';
+
+export interface UseGetRepositoryRefsProps {
+  repositoryType: RepoType;
+  repositoryTokenUser?: string;
+  repositoryName?: string;
+}
+
+export function useGetRepositoryRefs({ repositoryType, repositoryName }: UseGetRepositoryRefsProps) {
+  const { isReady: isRepositoryReady, isLoading: isRepositoryLoading, hasError } = useRepositoryStatus(repositoryName);
+
+  const {
+    data: branchData,
+    isLoading: branchLoading,
+    error: branchError,
+  } = useGetRepositoryRefsQuery(
+    !repositoryName || !isGitProvider(repositoryType) || !isRepositoryReady ? skipToken : { name: repositoryName }
+  );
+
+  const repositoryNotReady = !repositoryName || (!isRepositoryReady && !hasError);
+  const branchOptions = useMemo(
+    () => branchData?.items.map((item) => ({ label: item.name, value: item.name })) ?? [],
+    [branchData?.items]
+  );
+
+  return {
+    options: branchOptions,
+    loading: branchLoading || isRepositoryLoading || repositoryNotReady,
+    error: branchError ? getErrorMessage(branchError) : null,
+    branchData,
+  };
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11926,6 +11926,9 @@
       "free-tier-limit-tooltip": "Free-tier accounts are restricted to one connection",
       "instance-fully-managed-tooltip": "Configuration is disabled because this instance is fully managed"
     },
+    "connect-step": {
+      "text-repository-not-ready": "There was an issue connecting to the repository. You can still manually enter the branch name."
+    },
     "connection": {
       "disconnected-message": "This GitHub App connection has lost access. The app may have been uninstalled or the repository access was revoked.",
       "disconnected-title": "Connection is disconnected"


### PR DESCRIPTION
**What is this feature?**

During onboarding wizard, when its Github flow, use internal `/refs` endpoint to fetch branches. Bitbucket and Gitlab remains the same (using external api)

**Why do we need this feature?**

When user using Github App, we can display branches for them to select

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/753

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
