### PR TITLE
Datasources: Fix permissions cleanup when deleting datasource by name

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -311,7 +311,7 @@ func (hs *HTTPServer) DeleteDataSourceByName(c *contextmodel.ReqContext) respons
 		return response.Error(http.StatusForbidden, "Cannot delete read-only data source", nil)
 	}
 
-	cmd := &datasources.DeleteDataSourceCommand{Name: name, OrgID: c.GetOrgID()}
+	cmd := &datasources.DeleteDataSourceCommand{Name: name, OrgID: c.GetOrgID(), UID: dataSource.UID}
 	err = hs.DataSourcesService.DeleteDataSource(c.Req.Context(), cmd)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to delete datasource", err)


### PR DESCRIPTION
When deleting datasources by name, the UID was not being properly forwarded. This was causing permissions to be improperly deleted from the DB.

Added UID forwarding and a unit test to verify it's being populated.

Fixes: CVE-2026-21725