### PR TITLE
Provisioning: Hide unavailable sync options

### DIFF
--- a/public/app/features/provisioning/Wizard/BootstrapStep.test.tsx
+++ b/public/app/features/provisioning/Wizard/BootstrapStep.test.tsx
@@ -269,7 +269,7 @@ describe('BootstrapStep', () => {
       expect(screen.queryByText('Sync all resources with external storage')).not.toBeInTheDocument();
     });
 
-    it('should only display instance option when legacy storage exists', async () => {
+    it('should only display instance option when legacy storage exists and hide disabled options', async () => {
       (useModeOptions as jest.Mock).mockReturnValue({
         enabledOptions: [
           {
@@ -300,7 +300,8 @@ describe('BootstrapStep', () => {
       });
 
       expect(await screen.findByText('Sync all resources with external storage')).toBeInTheDocument();
-      expect(await screen.findByText('Sync external storage to a new Grafana folder')).not.toBeChecked();
+      // Disabled options should not be rendered at all
+      expect(screen.queryByText('Sync external storage to a new Grafana folder')).not.toBeInTheDocument();
     });
 
     it('should allow selecting different sync targets', async () => {

--- a/public/app/features/provisioning/Wizard/BootstrapStep.tsx
+++ b/public/app/features/provisioning/Wizard/BootstrapStep.tsx
@@ -4,7 +4,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Box, Card, Field, Icon, Input, LoadingPlaceholder, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Box, Card, Field, Input, LoadingPlaceholder, Stack, Text, useStyles2 } from '@grafana/ui';
 import { RepositoryViewList } from 'app/api/clients/provisioning/v0alpha1';
 import { generateRepositoryTitle } from 'app/features/provisioning/utils/data';
 
@@ -36,7 +36,7 @@ export const BootstrapStep = memo(function BootstrapStep({ settingsData, repoNam
 
   const selectedTarget = watch('repository.sync.target');
   const repositoryType = watch('repository.type');
-  const { enabledOptions, disabledOptions } = useModeOptions(repoName, settingsData);
+  const { enabledOptions } = useModeOptions(repoName, settingsData);
   const { target } = enabledOptions?.[0];
 
   const {
@@ -182,28 +182,6 @@ export const BootstrapStep = memo(function BootstrapStep({ settingsData, repoNam
             />
           </Field>
         )}
-
-        {disabledOptions?.length > 0 && (
-          <>
-            {/* Unavailable options */}
-            <Box marginTop={3}>
-              <Text variant="h4">
-                {t('provisioning.bootstrap-step.unavailable-options.title', 'Unavailable options')}
-              </Text>
-            </Box>
-            {disabledOptions?.map((action) => (
-              <Card key={action.target} noMargin disabled={action.disabled}>
-                <Card.Heading>
-                  <Text variant="h5">{action.label}</Text>
-                </Card.Heading>
-                <Card.Description>
-                  <div className={styles.divider} />
-                  <Icon name="info-circle" className={styles.infoIcon} /> {action.disabledReason}
-                </Card.Description>
-              </Card>
-            ))}
-          </>
-        )}
       </Stack>
     </Stack>
   );
@@ -216,10 +194,5 @@ const getStyles = (theme: GrafanaTheme2) => ({
     backgroundColor: theme.colors.border.medium,
     marginTop: theme.spacing(2),
     marginBottom: theme.spacing(2),
-  }),
-  infoIcon: css({
-    color: theme.colors.primary.main,
-    marginRight: theme.spacing(0.25),
-    marginBottom: theme.spacing(0.25),
   }),
 });

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11866,9 +11866,6 @@
       "label-display-name": "Display name",
       "placeholder-my-repository-connection": "My repository connection",
       "text-loading-resource-information": "Loading resource information...",
-      "unavailable-options": {
-        "title": "Unavailable options"
-      },
       "unmanaged-resources-label": "Unmanaged resources"
     },
     "check-repository": {


### PR DESCRIPTION
**What is this feature?**

Hides sync options that are disabled by provisioning configuration in the Git Sync bootstrap step. Previously, disabled options were shown in an "Unavailable options" section, which was confusing since they cannot be enabled through the UI.

**Why do we need this feature?**

When provisioning settings restrict available sync targets (e.g., only allowing folder sync, not instance sync), users saw disabled options that couldn't be enabled. This created confusion about whether there was an issue or missing configuration.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/805

**Special notes for your reviewer:**

<img width="1351" height="747" alt="Screenshot 2026-02-03 at 7 54 37" src="https://github.com/user-attachments/assets/2d27f72e-30e6-41c0-a5a3-bf565ea13315" />

