### PR TITLE
AssistantPreview: Go back to `ensureV2Response`

### DIFF
--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -922,26 +922,8 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
           return await this.loadProvisioningDashboard(slug || '', uid);
         }
         case DashboardRoutes.AssistantPreview: {
-          const v1Response = await this.loadAssistantPreviewDashboard(uid);
-          const scene = transformSaveModelToScene(v1Response, undefined, getSceneCreationOptions());
-          const spec = transformSceneToSaveModelSchemaV2(scene);
-          return {
-            apiVersion: 'v2beta1',
-            kind: 'DashboardWithAccessInfo',
-            metadata: {
-              creationTimestamp: '',
-              name: v1Response.dashboard.uid ?? '',
-              resourceVersion: v1Response.dashboard.version?.toString() || '0',
-            },
-            spec,
-            access: {
-              canSave: v1Response.meta.canSave ?? false,
-              canEdit: v1Response.meta.canEdit ?? false,
-              canDelete: v1Response.meta.canDelete ?? false,
-              canShare: v1Response.meta.canShare ?? false,
-              canStar: v1Response.meta.canStar ?? false,
-            },
-          };
+          const rsp = await this.loadAssistantPreviewDashboard(uid);
+          return ensureV2Response(rsp);
         }
         case DashboardRoutes.Public: {
           return await this.dashboardLoader.loadDashboard('public', '', uid);

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -46,7 +46,6 @@ import {
   SceneCreationOptions,
   transformSaveModelToScene,
 } from '../serialization/transformSaveModelToScene';
-import { transformSceneToSaveModelSchemaV2 } from '../serialization/transformSceneToSaveModelSchemaV2';
 import { restoreDashboardStateFromLocalStorage } from '../utils/dashboardSessionState';
 
 import { processQueryParamsForDashboardLoad, updateNavModel } from './utils';


### PR DESCRIPTION
**What is this feature?**
Assistant stores dashboards in both `v1` or `v2` formats. So we need to handle both cases.