### PR TITLE
Logs: Instrument displayed fields

### DIFF
--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -23,7 +23,7 @@ import {
   store,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import { PopoverContent } from '@grafana/ui';
 
 import { checkLogsError, checkLogsSampled, downloadLogs as download, DownloadFormat } from '../../utils';
@@ -515,6 +515,26 @@ export const LogListContextProvider = ({
   const hasSampledLogs = useMemo(() => logs.some((log) => !!checkLogsSampled(log)), [logs]);
   const hasUnescapedContent = useMemo(() => logs.some((r) => r.hasUnescapedContent), [logs]);
 
+  const onClickShowFieldWrapper = useCallback((key: string) => {
+    if (!onClickShowField) {
+      return;
+    }
+    onClickShowField(key);
+    reportInteraction('logs_log_list_context_show_field', {
+      key,
+    });
+  }, [onClickShowField]);
+
+  const onClickHideFieldWrapper = useCallback((key: string) => {
+    if (!onClickHideField) {
+      return;
+    }
+    onClickHideField(key);
+    reportInteraction('logs_log_list_context_hide_field', {
+      key,
+    });
+  }, [onClickHideField]);
+
   return (
     <LogListContext.Provider
       value={{
@@ -539,8 +559,8 @@ export const LogListContextProvider = ({
         onClickFilterOutLabel,
         onClickFilterString,
         onClickFilterOutString,
-        onClickShowField,
-        onClickHideField,
+        onClickShowField: onClickShowField ? onClickShowFieldWrapper : undefined,
+        onClickHideField: onClickHideField ? onClickHideFieldWrapper : undefined,
         onLogLineHover,
         onPermalinkClick,
         onPinLine,

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -515,25 +515,31 @@ export const LogListContextProvider = ({
   const hasSampledLogs = useMemo(() => logs.some((log) => !!checkLogsSampled(log)), [logs]);
   const hasUnescapedContent = useMemo(() => logs.some((r) => r.hasUnescapedContent), [logs]);
 
-  const onClickShowFieldWrapper = useCallback((key: string) => {
-    if (!onClickShowField) {
-      return;
-    }
-    onClickShowField(key);
-    reportInteraction('logs_log_list_context_show_field', {
-      key,
-    });
-  }, [onClickShowField]);
+  const onClickShowFieldWrapper = useCallback(
+    (key: string) => {
+      if (!onClickShowField) {
+        return;
+      }
+      onClickShowField(key);
+      reportInteraction('logs_log_list_context_show_field', {
+        key,
+      });
+    },
+    [onClickShowField]
+  );
 
-  const onClickHideFieldWrapper = useCallback((key: string) => {
-    if (!onClickHideField) {
-      return;
-    }
-    onClickHideField(key);
-    reportInteraction('logs_log_list_context_hide_field', {
-      key,
-    });
-  }, [onClickHideField]);
+  const onClickHideFieldWrapper = useCallback(
+    (key: string) => {
+      if (!onClickHideField) {
+        return;
+      }
+      onClickHideField(key);
+      reportInteraction('logs_log_list_context_hide_field', {
+        key,
+      });
+    },
+    [onClickHideField]
+  );
 
   return (
     <LogListContext.Provider


### PR DESCRIPTION
To have a better understanding of meaningful and commonly used displayed fields, and have visibility over virtual fields like Log attributes for OTel.

Part of #101083 and #116243