### PR TITLE
AssistantPreview: route supports both v1 and v2 dashboard formats

### DIFF
--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
@@ -94,6 +94,12 @@ jest.mock('app/features/playlist/PlaylistSrv', () => ({
   },
 }));
 
+const mockUserStorageGetItem = jest.fn();
+jest.mock('@grafana/runtime/internal', () => ({
+  ...jest.requireActual('@grafana/runtime/internal'),
+  UserStorage: jest.fn().mockImplementation(() => ({ getItem: mockUserStorageGetItem })),
+}));
+
 const createTestStore = () =>
   configureStore({
     reducer: {
@@ -198,6 +204,7 @@ beforeEach(() => {
   mockDashboardLoader.loadDashboard.mockReset();
   mockDashboardLoader.loadSnapshot.mockReset();
   fetchMock.mockReset();
+  mockUserStorageGetItem.mockReset();
 
   // Reset locationService mocks
   locationService.getSearch = jest.fn().mockReturnValue(new URLSearchParams());
@@ -409,6 +416,30 @@ describe('DashboardScenePageStateManager v1', () => {
 
       expect(loader.state.dashboard).toBeInstanceOf(DashboardScene);
       expect(loader.state.isLoading).toBe(false);
+    });
+
+    describe('AssistantPreview', () => {
+      const previewUid = btoa('preview-key');
+      const v1StoredDashboard = { title: 'Preview', panels: [], schemaVersion: 40 };
+      const v2StoredDashboard = { title: 'Preview', elements: {}, layout: { kind: 'GridLayout', spec: { items: [] } } };
+
+      it('should load v1 dashboard from user storage', async () => {
+        mockUserStorageGetItem.mockResolvedValue(JSON.stringify(v1StoredDashboard));
+
+        const loader = new DashboardScenePageStateManager({});
+        const result = await loader.fetchDashboard({ uid: previewUid, route: DashboardRoutes.AssistantPreview });
+
+        expect(result).toEqual({ dashboard: v1StoredDashboard, meta: expect.any(Object) });
+      });
+
+      it('should throw DashboardVersionError when stored dashboard is v2', async () => {
+        mockUserStorageGetItem.mockResolvedValue(JSON.stringify(v2StoredDashboard));
+
+        const loader = new DashboardScenePageStateManager({});
+        await expect(
+          loader.fetchDashboard({ uid: previewUid, route: DashboardRoutes.AssistantPreview })
+        ).rejects.toThrow(DashboardVersionError);
+      });
     });
 
     describe('New dashboards', () => {
@@ -812,6 +843,31 @@ describe('DashboardScenePageStateManager v2', () => {
 
       expect(loader.state.dashboard).toBeInstanceOf(DashboardScene);
       expect(loader.state.isLoading).toBe(false);
+    });
+
+    describe('AssistantPreview', () => {
+      const previewUid = btoa('preview-key');
+      const v1StoredDashboard = { title: 'Preview', panels: [], schemaVersion: 40 };
+      const v2StoredDashboard = { title: 'Preview', elements: {}, layout: { kind: 'GridLayout', spec: { items: [] } } };
+
+      it('should load v2 dashboard from user storage', async () => {
+        mockUserStorageGetItem.mockResolvedValue(JSON.stringify(v2StoredDashboard));
+
+        const loader = new DashboardScenePageStateManagerV2({});
+        const result = await loader.fetchDashboard({ uid: previewUid, route: DashboardRoutes.AssistantPreview });
+
+        expect(result?.spec).toEqual(v2StoredDashboard);
+        expect(result?.apiVersion).toBe('v2beta1');
+      });
+
+      it('should throw DashboardVersionError when stored dashboard is v1', async () => {
+        mockUserStorageGetItem.mockResolvedValue(JSON.stringify(v1StoredDashboard));
+
+        const loader = new DashboardScenePageStateManagerV2({});
+        await expect(
+          loader.fetchDashboard({ uid: previewUid, route: DashboardRoutes.AssistantPreview })
+        ).rejects.toThrow(DashboardVersionError);
+      });
     });
 
     describe('Home dashboard', () => {
@@ -1457,6 +1513,16 @@ describe('UnifiedDashboardScenePageStateManager', () => {
       const v2Scene = manager.transformResponseToScene(v2Response, { uid: 'v2-dash', route: DashboardRoutes.Normal });
       expect(v2Scene).toBeInstanceOf(DashboardScene);
       expect(manager['activeManager']).toBeInstanceOf(DashboardScenePageStateManagerV2);
+    });
+
+    it('should switch to v2 manager when AssistantPreview contains v2 dashboard', async () => {
+      mockUserStorageGetItem.mockResolvedValue(JSON.stringify(defaultDashboardV2Spec()));
+
+      const manager = new UnifiedDashboardScenePageStateManager({});
+      await manager.loadDashboard({ uid: btoa('preview-key'), route: DashboardRoutes.AssistantPreview });
+
+      expect(manager['activeManager']).toBeInstanceOf(DashboardScenePageStateManagerV2);
+      expect(manager.state.dashboard).toBeDefined();
     });
   });
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -46,7 +46,6 @@ import {
   SceneCreationOptions,
   transformSaveModelToScene,
 } from '../serialization/transformSaveModelToScene';
-import { transformSceneToSaveModelSchemaV2 } from '../serialization/transformSceneToSaveModelSchemaV2';
 import { restoreDashboardStateFromLocalStorage } from '../utils/dashboardSessionState';
 
 import { processQueryParamsForDashboardLoad, updateNavModel } from './utils';
@@ -224,16 +223,18 @@ abstract class DashboardScenePageStateManagerBase<T>
   /**
    * Loads the assistant preview dashboard from the user storage
    * @param base64EncodedKey base64 encoded key of the dashboard in the user storage
-   * @returns Promise<DashboardDTO>
+   * @returns Promise with dashboard data (can be v1 or v2 format) and meta
    */
-  protected async loadAssistantPreviewDashboard(base64EncodedKey: string): Promise<DashboardDTO> {
+  protected async loadAssistantPreviewDashboard(
+    base64EncodedKey: string
+  ): Promise<{ dashboard: DashboardDataDTO | DashboardV2Spec; meta: DashboardDTO['meta'] }> {
     const decodedKey = atob(decodeURIComponent(base64EncodedKey));
     const userStorage = new UserStorage('grafana-assistant-app');
     const dashboard = await userStorage.getItem(decodeURIComponent(decodedKey));
     if (!dashboard) {
       throw new Error('Dashboard not found');
     }
-    let dashboardData: DashboardDataDTO;
+    let dashboardData: DashboardDataDTO | DashboardV2Spec;
     try {
       dashboardData = JSON.parse(dashboard);
     } catch (err) {
@@ -714,8 +715,17 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
           break;
         case DashboardRoutes.Provisioning:
           return this.loadProvisioningDashboard(slug || '', uid);
-        case DashboardRoutes.AssistantPreview:
-          return this.loadAssistantPreviewDashboard(uid);
+        case DashboardRoutes.AssistantPreview: {
+          const result = await this.loadAssistantPreviewDashboard(uid);
+          if (isDashboardV2Spec(result.dashboard)) {
+            // This will redirect to the v2 dashboard dashboard manager to correctly load a v2 dashboard
+            throw new DashboardVersionError('v2beta1', 'Assistant preview contains V2 dashboard');
+          }
+          return {
+            dashboard: result.dashboard,
+            meta: result.meta,
+          };
+        }
         case DashboardRoutes.Public: {
           const result = await dashboardLoaderSrv.loadDashboard('public', '', uid);
           // public dashboards use legacy API but can return V2 dashboards
@@ -922,24 +932,26 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
           return await this.loadProvisioningDashboard(slug || '', uid);
         }
         case DashboardRoutes.AssistantPreview: {
-          const v1Response = await this.loadAssistantPreviewDashboard(uid);
-          const scene = transformSaveModelToScene(v1Response, undefined, getSceneCreationOptions());
-          const spec = transformSceneToSaveModelSchemaV2(scene);
+          const result = await this.loadAssistantPreviewDashboard(uid);
+          if (!isDashboardV2Spec(result.dashboard)) {
+            // This will redirect to the v1 dashboard dashboard manager to correctly load a v2 dashboard
+            throw new DashboardVersionError('v0alpha1', 'Assistant preview contains V1 dashboard');
+          }
           return {
             apiVersion: 'v2beta1',
             kind: 'DashboardWithAccessInfo',
             metadata: {
               creationTimestamp: '',
-              name: v1Response.dashboard.uid ?? '',
-              resourceVersion: v1Response.dashboard.version?.toString() || '0',
+              name: '',
+              resourceVersion: '0',
             },
-            spec,
+            spec: result.dashboard,
             access: {
-              canSave: v1Response.meta.canSave ?? false,
-              canEdit: v1Response.meta.canEdit ?? false,
-              canDelete: v1Response.meta.canDelete ?? false,
-              canShare: v1Response.meta.canShare ?? false,
-              canStar: v1Response.meta.canStar ?? false,
+              canSave: result.meta.canSave ?? false,
+              canEdit: result.meta.canEdit ?? false,
+              canDelete: result.meta.canDelete ?? false,
+              canShare: result.meta.canShare ?? false,
+              canStar: result.meta.canStar ?? false,
             },
           };
         }


### PR DESCRIPTION
*Problem*

Grafana Assistant stores dashboard JSON in user storage via `getSaveModel()`, which can return either v1 or v2 depending on the current dashboard/serializer. The AssistantPreview route always treated that data as v1, so v2 dashboards failed to load.

*Solution*

- `loadAssistantPreviewDashboard` now returns the parsed payload without assuming a format (`DashboardDataDTO | DashboardV2Spec`).
- V1 manager: if the stored dashboard is v2, throw `DashboardVersionError('v2beta1')` so the unified manager retries with the v2 manager.
- V2 manager: if the stored dashboard is v1, throw `DashboardVersionError('v0alpha1')` so the unified manager retries with the v1 manager; if it is v2, return the v2 wrapper directly (no v1→scene→v2 conversion).
- Aligns AssistantPreview with the normal dashboard load path (version detection + `DashboardVersionError` + unified manager retry).

*How to test*

1. With dashboardNewLayouts off: have the assistant store a v1 dashboard and open its preview URL; dashboard should load.
2. With dashboardNewLayouts on: have the assistant store a v2 dashboard and open its preview URL; dashboard should load.

