### PR TITLE
Provisioning: Always show tabs

### DIFF
--- a/public/app/features/provisioning/Connection/ConnectionFormPage.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionFormPage.tsx
@@ -102,7 +102,7 @@ export default function ConnectionFormPage() {
                 <Card noMargin>
                   <Card.Heading>
                     <Trans i18nKey="provisioning.connection-form.available-repositories">
-                      Other available repositories
+                      This connection has access to the following repositories
                     </Trans>
                   </Card.Heading>
                   <Card.Description>

--- a/public/app/features/provisioning/Connection/ConnectionList.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionList.tsx
@@ -27,11 +27,13 @@ export function ConnectionList({ items }: Props) {
 
   return (
     <Stack direction={'column'} gap={3}>
-      <FilterInput
-        placeholder={t('provisioning.connections.search-placeholder', 'Search connections')}
-        value={query}
-        onChange={setQuery}
-      />
+      {!isEmpty && (
+        <FilterInput
+          placeholder={t('provisioning.connections.search-placeholder', 'Search connections')}
+          value={query}
+          onChange={setQuery}
+        />
+      )}
       <Stack direction={'column'} gap={2}>
         {filteredItems.length ? (
           filteredItems.map((item) => <ConnectionListItem key={item.metadata?.name} connection={item} />)

--- a/public/app/features/provisioning/Connection/ConnectionList.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionList.tsx
@@ -39,7 +39,7 @@ export function ConnectionList({ items }: Props) {
           filteredItems.map((item) => <ConnectionListItem key={item.metadata?.name} connection={item} />)
         ) : (
           <EmptyState
-            variant={isEmpty ? 'completed' : 'not-found'}
+            variant="not-found"
             message={
               isEmpty
                 ? t('provisioning.connections.no-connections', 'No connections configured')

--- a/public/app/features/provisioning/Connection/ConnectionsTabContent.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionsTabContent.tsx
@@ -1,18 +1,20 @@
-import { t } from '@grafana/i18n';
-import { Alert, Spinner } from '@grafana/ui';
+import { SerializedError } from '@reduxjs/toolkit';
+import { FetchBaseQueryError } from '@reduxjs/toolkit/query/react';
 
-import { useConnectionList } from '../hooks/useConnectionList';
+import { t } from '@grafana/i18n';
+import { Alert } from '@grafana/ui';
+import { Connection } from 'app/api/clients/provisioning/v0alpha1';
+
 import { getErrorMessage } from '../utils/httpUtils';
 
 import { ConnectionList } from './ConnectionList';
 
-export function ConnectionsTabContent() {
-  const [items, isLoading, error] = useConnectionList({ watch: true });
+interface Props {
+  items: Connection[];
+  error?: FetchBaseQueryError | SerializedError;
+}
 
-  if (isLoading) {
-    return <Spinner />;
-  }
-
+export function ConnectionsTabContent({ items, error }: Props) {
   if (error) {
     return (
       <Alert severity="error" title={t('provisioning.connections.error-loading', 'Failed to load connections')}>
@@ -21,5 +23,5 @@ export function ConnectionsTabContent() {
     );
   }
 
-  return <ConnectionList items={items ?? []} />;
+  return <ConnectionList items={items} />;
 }

--- a/public/app/features/provisioning/Connection/ConnectionsTabContent.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionsTabContent.tsx
@@ -1,6 +1,3 @@
-import { SerializedError } from '@reduxjs/toolkit';
-import { FetchBaseQueryError } from '@reduxjs/toolkit/query/react';
-
 import { t } from '@grafana/i18n';
 import { Alert } from '@grafana/ui';
 import { Connection } from 'app/api/clients/provisioning/v0alpha1';
@@ -11,7 +8,7 @@ import { ConnectionList } from './ConnectionList';
 
 interface Props {
   items: Connection[];
-  error?: FetchBaseQueryError | SerializedError;
+  error?: unknown;
 }
 
 export function ConnectionsTabContent({ items, error }: Props) {

--- a/public/app/features/provisioning/HomePage.tsx
+++ b/public/app/features/provisioning/HomePage.tsx
@@ -23,19 +23,18 @@ export default function HomePage() {
 
   const isLoading = isLoadingRepos || isLoadingConnections;
 
-  // Read tab from URL, with smart default based on data
   const urlTab = searchParams.get('tab');
   const defaultTab = useMemo(() => {
     if (isLoading) {
-      return 'repositories'; // Default to repositories while loading
+      return 'repositories';
     }
     if (items?.length) {
-      return 'repositories'; // Has repos → repositories tab
+      return 'repositories';
     }
     if (connections?.length) {
-      return 'connections'; // Has connections but no repos → connections tab
+      return 'connections';
     }
-    return 'getting-started'; // Neither → getting started tab
+    return 'getting-started';
   }, [isLoading, items?.length, connections?.length]);
 
   const activeTab = urlTab ?? defaultTab;

--- a/public/app/features/provisioning/HomePage.tsx
+++ b/public/app/features/provisioning/HomePage.tsx
@@ -16,7 +16,7 @@ import { useRepositoryList } from './hooks/useRepositoryList';
 
 export default function HomePage() {
   const [items, isLoadingRepos] = useRepositoryList({ watch: true });
-  const [connections, isLoadingConnections] = useConnectionList({ watch: true });
+  const [connections, isLoadingConnections, connectionsError] = useConnectionList({ watch: true });
   const [deleteAll] = useDeletecollectionRepositoryMutation();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
@@ -74,7 +74,7 @@ export default function HomePage() {
   const renderTabContent = () => {
     switch (activeTab) {
       case 'connections':
-        return <ConnectionsTabContent />;
+        return <ConnectionsTabContent items={connections ?? []} error={connectionsError} />;
       case 'getting-started':
         return <GettingStarted items={items ?? []} />;
       case 'repositories':

--- a/public/app/features/provisioning/Shared/RepositoryList.tsx
+++ b/public/app/features/provisioning/Shared/RepositoryList.tsx
@@ -26,7 +26,7 @@ export function RepositoryList({ items }: Props) {
   if (isEmpty) {
     return (
       <EmptyState
-        variant="completed"
+        variant="not-found"
         message={t('provisioning.repository-list.no-repositories', 'No repositories configured')}
       />
     );
@@ -114,7 +114,7 @@ export function RepositoryList({ items }: Props) {
             filteredItems.map((item) => <RepositoryListItem key={item.metadata?.name} repository={item} />)
           ) : (
             <EmptyState
-              variant={isEmpty ? 'completed' : 'not-found'}
+              variant="not-found"
               message={
                 isEmpty
                   ? t('provisioning.repository-list.no-repositories', 'No repositories configured')

--- a/public/app/features/provisioning/Shared/RepositoryList.tsx
+++ b/public/app/features/provisioning/Shared/RepositoryList.tsx
@@ -115,14 +115,10 @@ export function RepositoryList({ items }: Props) {
           ) : (
             <EmptyState
               variant="not-found"
-              message={
-                isEmpty
-                  ? t('provisioning.repository-list.no-repositories', 'No repositories configured')
-                  : t(
-                      'provisioning.folder-repository-list.no-results-matching-your-query',
-                      'No results matching your query'
-                    )
-              }
+              message={t(
+                'provisioning.folder-repository-list.no-results-matching-your-query',
+                'No results matching your query'
+              )}
             />
           )}
         </Stack>

--- a/public/app/features/provisioning/Shared/RepositoryList.tsx
+++ b/public/app/features/provisioning/Shared/RepositoryList.tsx
@@ -18,9 +18,19 @@ interface Props {
 export function RepositoryList({ items }: Props) {
   const [query, setQuery] = useState('');
   const isProvisionedInstance = useIsProvisionedInstance();
-  const { resourceCount, managedCount, unmanagedCount } = useResourceStats(items[0].metadata?.name);
+  const { resourceCount, managedCount, unmanagedCount } = useResourceStats(items[0]?.metadata?.name);
 
   const filteredItems = items.filter((item) => item.metadata?.name?.includes(query));
+  const isEmpty = items.length === 0;
+
+  if (isEmpty) {
+    return (
+      <EmptyState
+        variant="completed"
+        message={t('provisioning.repository-list.no-repositories', 'No repositories configured')}
+      />
+    );
+  }
   const { instanceConnected } = checkSyncSettings(items);
   const hasInstanceSyncRepo = items.some((item) => item.spec?.sync?.target === 'instance');
 
@@ -104,11 +114,15 @@ export function RepositoryList({ items }: Props) {
             filteredItems.map((item) => <RepositoryListItem key={item.metadata?.name} repository={item} />)
           ) : (
             <EmptyState
-              variant="not-found"
-              message={t(
-                'provisioning.folder-repository-list.no-results-matching-your-query',
-                'No results matching your query'
-              )}
+              variant={isEmpty ? 'completed' : 'not-found'}
+              message={
+                isEmpty
+                  ? t('provisioning.repository-list.no-repositories', 'No repositories configured')
+                  : t(
+                      'provisioning.folder-repository-list.no-results-matching-your-query',
+                      'No results matching your query'
+                    )
+              }
             />
           )}
         </Stack>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11932,7 +11932,7 @@
       "alert-connection-deleted": "Connection deleted",
       "alert-connection-saved": "Connection saved",
       "alert-connection-updated": "Connection updated",
-      "available-repositories": "Other available repositories",
+      "available-repositories": "This connection has access to the following repositories",
       "back-to-connections": "Back to connections",
       "button-save": "Save",
       "button-saving": "Saving...",
@@ -12275,6 +12275,9 @@
       "sync-job": {
         "view-repository": "View repository"
       }
+    },
+    "repository-list": {
+      "no-repositories": "No repositories configured"
     },
     "repository-overview": {
       "checked": "Checked:",


### PR DESCRIPTION
**What is this feature?**

Always display the provisioning tabs and intelligently default to the appropriate tab based on whether repositories and/or connections are configured.

**Why do we need this feature?**

Users need to access all tabs regardless of data state. The getting-started tab should be the default when neither repositories nor connections are configured.

Fixes https://github.com/grafana/git-ui-sync-project/issues/820

**Special notes for your reviewer:**

- Tabs are now always visible (no early return hiding them)
- Default tab logic: repos → repositories tab, connections only → connections tab, neither → getting-started tab