### PR TITLE
Fix/annotations alertid regression

### DIFF
--- a/pkg/services/annotations/models.go
+++ b/pkg/services/annotations/models.go
@@ -112,7 +112,7 @@ func (i Item) TableName() string {
 // swagger:model Annotation
 type ItemDTO struct {
 	ID        int64  `json:"id,omitempty" xorm:"id"`
-	AlertID   int64  `json:"alertId,omitempty" xorm:"alert_id"`
+	AlertID   int64  `json:"alertId" xorm:"alert_id"`
 	AlertName string `json:"alertName,omitempty"`
 	// Deprecated: Use DashboardUID and OrgID instead
 	DashboardID  int64            `json:"dashboardId,omitempty" xorm:"dashboard_id"`

--- a/pkg/services/annotations/models_test.go
+++ b/pkg/services/annotations/models_test.go
@@ -1,0 +1,85 @@
+package annotations
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestItemDTOJSONSerialization(t *testing.T) {
+	t.Run("alertId field should be present even when zero", func(t *testing.T) {
+		// Manual annotation with alertId = 0
+		annotation := &ItemDTO{
+			ID:      1,
+			AlertID: 0, // This should still appear in JSON
+			Text:    "Manual annotation",
+			Time:    1234567890000,
+		}
+
+		jsonBytes, err := json.Marshal(annotation)
+		require.NoError(t, err)
+
+		var result map[string]interface{}
+		err = json.Unmarshal(jsonBytes, &result)
+		require.NoError(t, err)
+
+		// Verify alertId field exists in JSON
+		_, exists := result["alertId"]
+		assert.True(t, exists, "alertId field should be present in JSON even when value is 0")
+		assert.Equal(t, float64(0), result["alertId"], "alertId should be 0")
+	})
+
+	t.Run("alertId field should be present with non-zero value", func(t *testing.T) {
+		// Alert annotation with alertId > 0
+		annotation := &ItemDTO{
+			ID:      1,
+			AlertID: 123,
+			Text:    "Alert annotation",
+			Time:    1234567890000,
+		}
+
+		jsonBytes, err := json.Marshal(annotation)
+		require.NoError(t, err)
+
+		var result map[string]interface{}
+		err = json.Unmarshal(jsonBytes, &result)
+		require.NoError(t, err)
+
+		_, exists := result["alertId"]
+		assert.True(t, exists, "alertId field should be present in JSON")
+		assert.Equal(t, float64(123), result["alertId"], "alertId should be 123")
+	})
+}
+
+func TestItemDTOGetType(t *testing.T) {
+	t.Run("should return Dashboard type when DashboardUID is set", func(t *testing.T) {
+		dashUID := "test-dash-uid"
+		annotation := &ItemDTO{
+			DashboardUID: &dashUID,
+		}
+
+		annotationType := annotation.GetType()
+		assert.Equal(t, Dashboard, annotationType)
+	})
+
+	t.Run("should return Organization type when DashboardUID is nil", func(t *testing.T) {
+		annotation := &ItemDTO{
+			DashboardUID: nil,
+		}
+
+		annotationType := annotation.GetType()
+		assert.Equal(t, Organization, annotationType)
+	})
+
+	t.Run("should return Organization type when DashboardUID is empty string", func(t *testing.T) {
+		emptyUID := ""
+		annotation := &ItemDTO{
+			DashboardUID: &emptyUID,
+		}
+
+		annotationType := annotation.GetType()
+		assert.Equal(t, Organization, annotationType)
+	})
+}

--- a/pkg/tests/api/annotations/annotations_test.go
+++ b/pkg/tests/api/annotations/annotations_test.go
@@ -116,13 +116,18 @@ func TestIntegrationAnnotations(t *testing.T) {
 		})
 
 		t.Run("should include alertId field even when zero for manual annotations", func(t *testing.T) {
-			// Create a manual annotation (no alertId)
+			// Create a manual annotation (no alertId) within a specific time range
+			annotationTime := int64(1234567890000) // milliseconds
 			createAnnotation(t, grafanaListedAddr, "admin", "admin", map[string]interface{}{
 				"text": "Manual annotation without alert",
-				"time": 1234567890000,
+				"time": annotationTime,
 			})
 
-			url := fmt.Sprintf("http://admin:admin@%s/api/annotations", grafanaListedAddr)
+			// Query /api/annotations endpoint with a time range containing the manual annotation
+			// This reproduces the exact scenario from the bug report
+			from := annotationTime - 86400000 // 1 day before
+			to := annotationTime + 86400000   // 1 day after
+			url := fmt.Sprintf("http://admin:admin@%s/api/annotations?from=%d&to=%d", grafanaListedAddr, from, to)
 			resp, err := http.Get(url) // nolint:gosec
 			require.NoError(t, err)
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -135,24 +140,26 @@ func TestIntegrationAnnotations(t *testing.T) {
 			var annotations []map[string]interface{}
 			err = json.Unmarshal(body, &annotations)
 			require.NoError(t, err)
-			require.NotEmpty(t, annotations, "should have at least one annotation")
+			require.NotEmpty(t, annotations, "should have at least one annotation in the time range")
 
-			// Verify that all annotations have the alertId field
+			// Access annotation['alertId'] field in response - this is what breaks in the bug
 			foundManualAnnotation := false
 			for _, annotation := range annotations {
-				_, exists := annotation["alertId"]
-				assert.True(t, exists, "alertId field must be present in API response even when zero (manual annotation)")
+				// Verify that alertId field exists (this is the key test - it should not be missing)
+				alertIDValue, exists := annotation["alertId"]
+				assert.True(t, exists, "alertId field must be present in API response even when zero (manual annotation). This prevents KeyError when accessing annotation['alertId']")
 
 				// Find the manual annotation we just created
 				if textVal, ok := annotation["text"].(string); ok && textVal == "Manual annotation without alert" {
 					foundManualAnnotation = true
-					alertID, ok := annotation["alertId"].(float64) // JSON numbers are float64
+					// Verify the value is 0 (not missing)
+					alertID, ok := alertIDValue.(float64) // JSON numbers are float64
 					assert.True(t, ok, "alertId should be a number")
-					assert.Equal(t, float64(0), alertID, "Manual annotation should have alertId = 0")
+					assert.Equal(t, float64(0), alertID, "Manual annotation should have alertId = 0, not be omitted from response")
 				}
 			}
 
-			assert.True(t, foundManualAnnotation, "Should find the manual annotation we created")
+			assert.True(t, foundManualAnnotation, "Should find the manual annotation we created in the time range")
 		})
 	})
 


### PR DESCRIPTION
Annotations: Fix regression where alertId was missing from API response when zero

**What is this feature?**

This PR removes the `omitempty` JSON tag from the `AlertID` field in the `ItemDTO` struct. It also adds both a unit test and an integration test to ensure `alertId` is explicitly returned as `0` for manual annotations.

**Why do we need this feature?**

In recent versions (v12.3.1), a regression was introduced where `alertId` was omitted from the API response when its value was `0` (which is the standard value for Manual Annotations).

This broke backward compatibility for API clients and scripts that rely on checking `if annotation['alertId'] == 0` to identify manual annotations. This fix restores the v12.1.0 behavior.

**Who is this feature for?**

Developers and API users who consume the `/api/annotations` endpoint programmatically.

**Which issue(s) does this PR fix?**:

Fixes #117304

**Special notes for your reviewer:**

I have verified this via a new unit test (`TestItemDTOJSONSerialization`) and an integration test.

Note on implementation: I knowingly removed `omitempty` ONLY from `AlertID` while leaving it on other fields (like `DashboardID`). This is intentional because `AlertID: 0` has a semantic meaning (Manual Annotation) that clients rely on, whereas `0` in other fields typically implies "null/unset" and is safe to omit.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.