### PR TITLE
Dashboard: Don't show popup warning when switching rows<>tabs

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboard-group-panels.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-group-panels.spec.ts
@@ -419,9 +419,6 @@ test.describe(
       // Select tabs layout
       await page.getByLabel('layout-selection-option-Tabs').click();
 
-      // confirm layout change
-      await dashboardPage.getByGrafanaSelector(selectors.pages.ConfirmModal.delete).click();
-
       await expect(dashboardPage.getByGrafanaSelector(selectors.components.Tab.title('New row'))).toBeVisible();
       await expect(dashboardPage.getByGrafanaSelector(selectors.components.Tab.title('New row 1'))).toBeVisible();
       await expect(
@@ -761,9 +758,6 @@ test.describe(
 
       // Select rows layout
       await page.getByLabel('layout-selection-option-Rows').click();
-
-      // confirm layout change
-      await dashboardPage.getByGrafanaSelector(selectors.pages.ConfirmModal.delete).click();
 
       await dashboardPage
         .getByGrafanaSelector(selectors.components.DashboardRow.wrapper('New tab 1'))

--- a/public/app/features/dashboard-scene/scene/layouts-shared/DashboardLayoutSelector.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/DashboardLayoutSelector.tsx
@@ -47,19 +47,25 @@ export function DashboardLayoutSelector({ layoutManager }: Props) {
 
   const onChangeLayout = useCallback((newLayout: LayoutRegistryItem) => setNewLayout(newLayout), []);
 
+  const switchLayout = useCallback(
+    (layoutItem: LayoutRegistryItem) => {
+      const layoutParent = layoutManager.parent;
+
+      if (layoutParent && isLayoutParent(layoutParent)) {
+        layoutParent.switchLayout(layoutItem.createFromLayout(layoutManager));
+      }
+    },
+    [layoutManager]
+  );
+
   const onConfirmNewLayout = useCallback(() => {
     if (!newLayout) {
       return;
     }
 
-    const layoutParent = layoutManager.parent;
-
-    if (layoutParent && isLayoutParent(layoutParent)) {
-      layoutParent.switchLayout(newLayout.createFromLayout(layoutManager));
-    }
-
+    switchLayout(newLayout);
     setNewLayout(undefined);
-  }, [newLayout, layoutManager]);
+  }, [newLayout, switchLayout]);
 
   const onDismissNewLayout = useCallback(() => setNewLayout(undefined), []);
 
@@ -95,20 +101,22 @@ export function DashboardLayoutSelector({ layoutManager }: Props) {
           fullWidth
           value={layoutManager.descriptor}
           options={radioOptions}
-          onChange={onChangeLayout}
+          onChange={!isGridLayout ? switchLayout : onChangeLayout}
           disabledOptions={disabledOptions}
         />
       </Box>
-      <ConfirmModal
-        isOpen={!!newLayout}
-        title={t('dashboard.layout.panel.modal.title', 'Change layout')}
-        body={t('dashboard.layout.panel.modal.body', 'Changing the layout will reset all panel positions and sizes.')}
-        confirmText={t('dashboard.layout.panel.modal.confirm', 'Change layout')}
-        dismissText={t('dashboard.layout.panel.modal.dismiss', 'Cancel')}
-        confirmButtonVariant="primary"
-        onConfirm={onConfirmNewLayout}
-        onDismiss={onDismissNewLayout}
-      />
+      {isGridLayout && (
+        <ConfirmModal
+          isOpen={!!newLayout}
+          title={t('dashboard.layout.panel.modal.title', 'Change layout')}
+          body={t('dashboard.layout.panel.modal.body', 'Changing the layout will reset all panel positions and sizes.')}
+          confirmText={t('dashboard.layout.panel.modal.confirm', 'Change layout')}
+          dismissText={t('dashboard.layout.panel.modal.dismiss', 'Cancel')}
+          confirmButtonVariant="primary"
+          onConfirm={onConfirmNewLayout}
+          onDismiss={onDismissNewLayout}
+        />
+      )}
     </>
   );
 }

--- a/public/app/features/dashboard-scene/scene/layouts-shared/DashboardLayoutSelector.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/DashboardLayoutSelector.tsx
@@ -45,7 +45,7 @@ export function DashboardLayoutSelector({ layoutManager }: Props) {
     return undefined;
   }, [layoutManager]);
 
-  const onChangeLayout = useCallback((newLayout: LayoutRegistryItem) => setNewLayout(newLayout), []);
+  const promptLayoutChange = useCallback((newLayout: LayoutRegistryItem) => setNewLayout(newLayout), []);
 
   const switchLayout = useCallback(
     (layoutItem: LayoutRegistryItem) => {
@@ -101,7 +101,7 @@ export function DashboardLayoutSelector({ layoutManager }: Props) {
           fullWidth
           value={layoutManager.descriptor}
           options={radioOptions}
-          onChange={!isGridLayout ? switchLayout : onChangeLayout}
+          onChange={!isGridLayout ? switchLayout : promptLayoutChange}
           disabledOptions={disabledOptions}
         />
       </Box>


### PR DESCRIPTION
**What is this feature?**

Don't show the confirmation modal when changing between rows and tabs.

**Why do we need this feature?**

Fix bug

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
