### PR TITLE
Default value for allowCustomValue property in vars is enabled

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/useVariableSelectionOptionsCategory.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/useVariableSelectionOptionsCategory.tsx
@@ -109,7 +109,7 @@ function AllowCustomSwitch({ variable, id }: InputProps) {
   return (
     <Switch
       id={id}
-      value={allowCustomValue}
+      value={allowCustomValue ?? true}
       onChange={(evt) => variable.setState({ allowCustomValue: evt.currentTarget.checked })}
     />
   );


### PR DESCRIPTION
When creating a new variable that supports custom values, the switch shows the toggle false and not interacting with it will not add the prop to the schema -- but in scenes if the prop is undefined it defaults to true. As such there is a bit of confusion between the UI and schema as the toggle will show false but the var will actually support custom values and show it in the schema. 

This addresses that by explicitly setting the value to default true.