### PR TITLE
Test: Update mock to satisfy typecheck

### DIFF
--- a/public/app/features/manage-dashboards/import/components/ImportOverviewV2.test.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportOverviewV2.test.tsx
@@ -95,6 +95,9 @@ describe('ImportOverviewV2', () => {
       deleteDashboard: jest.fn(),
       listDeletedDashboards: jest.fn(),
       restoreDashboard: jest.fn(),
+      listDashboardHistory: jest.fn(),
+      getDashboardHistoryVersions: jest.fn(),
+      restoreDashboardVersion: jest.fn(),
     });
   });
 


### PR DESCRIPTION
Noticed this typescript issue [causing failures in other PRs](https://github.com/grafana/grafana/actions/runs/21639335480/job/62374089185?pr=117278).

There's a number of other possible ways to address this if we don't like this one:

- `as unknown as <type>`
- `// @ts-ignore`

but I felt this was the least hacky.