### PR TITLE
InteractiveTable: Support specific column widths

### DIFF
--- a/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.mdx
+++ b/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.mdx
@@ -117,6 +117,34 @@ export const MyComponent = () => {
 };
 ```
 
+### Column Widths
+
+Columns can be configured with optional fixed widths using pixels, percentages, or any valid CSS width value.
+
+<Story id="experimental-interactivetable--with-column-width" />
+
+```tsx
+const columns: Array<Column<TableData>> = [
+  // Percentage width - takes 25% of table width
+  { id: 'firstName', header: 'First Name', width: '25%' },
+
+  // Pixel width - takes specified pixels (proportionally scaled if table is 100% width)
+  { id: 'lastName', header: 'Last Name', width: 200 },
+
+  // Auto width - fills remaining space
+  { id: 'description', header: 'Description' },
+
+  // Narrow fixed width
+  { id: 'actions', header: '', width: '80px' },
+];
+```
+
+**Width behavior:**
+
+- **Percentage widths** (`'25%'`): Column takes the specified percentage of the table width.
+- **Pixel widths** (`200` or `'200px'`): When all columns have explicit widths, they are proportionally scaled to fill the table. To get exact pixel widths, leave at least one column without a width to absorb remaining space.
+- **No width** (default): Column width is determined automatically based on content.
+
 ### Custom Header Rendering
 
 Column headers can be customized using strings, React elements, or renderer functions. The `header` property accepts any value that matches React Table's `Renderer` type.

--- a/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.story.tsx
+++ b/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.story.tsx
@@ -336,4 +336,37 @@ export const WithCustomHeader: TableStoryObj = {
     getRowId: (r) => r.id,
   },
 };
+
+export const WithColumnWidth: TableStoryObj = {
+  args: {
+    columns: [
+      {
+        id: 'firstName',
+        header: 'First Name',
+        sortType: 'string',
+        width: '25%', // Percentage width - 25% of table
+      },
+      {
+        id: 'lastName',
+        header: 'Last Name',
+        sortType: 'string',
+        width: 200, // Pixel width as number
+      },
+      {
+        id: 'car',
+        header: 'Car',
+        sortType: 'string',
+        // No width - auto-sized, fills remaining space
+      },
+      {
+        id: 'age',
+        header: 'Age',
+        sortType: 'number',
+        width: '100px', // Pixel width as string
+      },
+    ],
+    data: pageableData.slice(0, 10),
+    getRowId: (r) => r.id,
+  },
+};
 export default meta;

--- a/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.test.tsx
+++ b/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.test.tsx
@@ -350,4 +350,52 @@ describe('InteractiveTable', () => {
       expect(screen.getByText('Value 2')).toBeInTheDocument();
     });
   });
+
+  describe('column width', () => {
+    it('should apply width style to header and cell when width is specified', () => {
+      const columns: Array<Column<TableData>> = [
+        { id: 'id', header: 'ID', width: '100px' },
+        { id: 'country', header: 'Country', width: 200 },
+      ];
+      const data: TableData[] = [{ id: '1', country: 'Sweden' }];
+      render(<InteractiveTable columns={columns} data={data} getRowId={getRowId} />);
+
+      const idHeader = screen.getByRole('columnheader', { name: 'ID' });
+      const countryHeader = screen.getByRole('columnheader', { name: 'Country' });
+
+      expect(idHeader).toHaveStyle({ width: '100px' });
+      expect(countryHeader).toHaveStyle({ width: '200px' });
+
+      // Check cells have the width applied
+      const cells = screen.getAllByRole('cell');
+      expect(cells[0]).toHaveStyle({ width: '100px' });
+      expect(cells[1]).toHaveStyle({ width: '200px' });
+    });
+
+    it('should not apply width style when width is not specified', () => {
+      const columns: Array<Column<TableData>> = [
+        { id: 'id', header: 'ID' },
+        { id: 'country', header: 'Country' },
+      ];
+      const data: TableData[] = [{ id: '1', country: 'Sweden' }];
+      render(<InteractiveTable columns={columns} data={data} getRowId={getRowId} />);
+
+      const idHeader = screen.getByRole('columnheader', { name: 'ID' });
+      const countryHeader = screen.getByRole('columnheader', { name: 'Country' });
+
+      // Headers should not have inline width style
+      expect(idHeader).not.toHaveAttribute('style');
+      expect(countryHeader).not.toHaveAttribute('style');
+    });
+
+    it('should not apply width style when width is 0 (disableGrow case)', () => {
+      const columns: Array<Column<TableData>> = [{ id: 'id', header: 'ID', width: 0 }];
+      const data: TableData[] = [{ id: '1' }];
+      render(<InteractiveTable columns={columns} data={data} getRowId={getRowId} />);
+
+      const idHeader = screen.getByRole('columnheader', { name: 'ID' });
+      // width: 0 should trigger disableGrow class, not inline style
+      expect(idHeader).not.toHaveAttribute('style');
+    });
+  });
 });

--- a/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.tsx
+++ b/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.tsx
@@ -281,6 +281,7 @@ export function InteractiveTable<TableData extends object>({
                       })}
                       {...headerCellProps}
                       {...(column.isSorted && { 'aria-sort': column.isSortedDesc ? 'descending' : 'ascending' })}
+                      style={column.width ? { width: column.width } : undefined}
                     >
                       <ColumnHeader column={column} headerTooltip={headerTooltip} />
                     </th>
@@ -306,7 +307,12 @@ export function InteractiveTable<TableData extends object>({
                   {row.cells.map((cell) => {
                     const { key, ...otherCellProps } = cell.getCellProps();
                     return (
-                      <td className={styles.cell} key={key} {...otherCellProps}>
+                      <td
+                        className={styles.cell}
+                        key={key}
+                        {...otherCellProps}
+                        style={cell.column.width ? { width: cell.column.width } : undefined}
+                      >
                         {cell.render('Cell', { __rowID: rowId })}
                       </td>
                     );

--- a/packages/grafana-ui/src/components/InteractiveTable/types.ts
+++ b/packages/grafana-ui/src/components/InteractiveTable/types.ts
@@ -30,4 +30,10 @@ export interface Column<TableData extends object> {
    * Determines starting sort direction when the column header is clicked.
    */
   sortDescFirst?: boolean;
+  /**
+   * Optional fixed width for the column. Can be any valid CSS width value
+   * (e.g., '100px', '20%', 'auto'). If not provided, column width is determined automatically.
+   * This is applied as an inline style to both header and cell elements.
+   */
+  width?: string | number;
 }

--- a/packages/grafana-ui/src/components/InteractiveTable/utils.ts
+++ b/packages/grafana-ui/src/components/InteractiveTable/utils.ts
@@ -9,6 +9,18 @@ type InternalColumn<T extends object> = RTColumn<T> & {
   visible?: (data: T[]) => boolean;
 };
 
+function getColumnWidth<K extends object>(column: Column<K>): number | string | undefined {
+  // If explicit width is provided, use it
+  if (column.width !== undefined) {
+    return column.width;
+  }
+  // disableGrow sets width to 0, which triggers the disableGrow CSS class
+  if (column.disableGrow) {
+    return 0;
+  }
+  return undefined;
+}
+
 // Returns the columns in a "react-table" acceptable format
 export function getColumns<K extends object>(
   columns: Array<Column<K>>,
@@ -31,7 +43,7 @@ export function getColumns<K extends object>(
       Header: column.header || (() => null),
       sortType: column.sortType || 'alphanumeric',
       disableSortBy: !Boolean(column.sortType),
-      width: column.disableGrow ? 0 : undefined,
+      width: getColumnWidth(column),
       visible: column.visible,
       ...(column.sortDescFirst !== undefined && { sortDescFirst: column.sortDescFirst }),
       ...(column.cell && { Cell: column.cell }),


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature adds support for optional explicit column widths to the InteractiveTable component. It extends the Column interface with an optional width property that accepts string | number (e.g., '100px', '25%', 200). ensuring that the specified widths are respected while maintaining backward compatibility for tables that rely on auto-sizing.

**Why do we need this feature?**

Currently, InteractiveTable columns are automatically sized based on their content, with limited control via disableGrow. This makes it difficult to create tables with predictable layouts or specific design requirements (e.g., a "Name" column that should always take up 25% of the space, or an "Actions" column fixed to 80px). This feature provides developers with direct control over column sizing to build more polished and consistent table interfaces.

**Who is this feature for?**

Developers using @grafana/ui to build features that require data tables with precise layout requirements

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #80980

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
