### PR TITLE
Suggestions: Search area should be sticky

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -130,7 +130,7 @@ export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose
         <Stack direction="row" gap={1}>
           {showBackButton && (
             <Button
-              aria-label={t('dashboard-scene.panel-viz-type-picker.title-back', 'Back')}
+              aria-label={t('dashboard-scene.panel-viz-type-picker.title-close', 'Close')}
               fill="text"
               variant="secondary"
               icon="arrow-left"

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -187,7 +187,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     height: '100%',
   }),
   searchField: css({
-    margin: theme.spacing(2, 1.5, 0.1, 1.5), // input glow with the boundary without this
+    margin: theme.spacing(2, 1.5, 0, 1.5), // input glow with the boundary without this
     borderBottom: `1px solid ${theme.colors.border.weak}`, // add a border to the bottom of the search field
   }),
   tabs: css({

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -188,7 +188,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   searchField: css({
     margin: theme.spacing(0.5, 1.5, 1, 1.5), // input glow with the boundary without this
-    padding: theme.spacing(0, 0.5, 0, 0.5), // slight adjustment to align with scroll container
+    padding: theme.spacing(0, 0.5, 2, 0.5), // slight adjustment to align with scroll container
+    borderBottom: `1px solid ${theme.colors.border.weak}`, // add a border to the bottom of the search field
   }),
   tabs: css({
     width: '100%',

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -122,36 +122,36 @@ export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose
         ))}
       </TabsBar>
       <div className={styles.stickySearchWrapper}>
-      <Field
-        className={styles.searchField}
-        noMargin
-        htmlFor={filterId}
-        aria-label={t('dashboard-scene.panel-viz-type-picker.placeholder-search-for', 'Search for...')}
-      >
-        <Stack direction="row" gap={1}>
-          {showBackButton && (
-            <Button
-              aria-label={t('dashboard-scene.panel-viz-type-picker.title-close', 'Close')}
-              fill="text"
-              variant="secondary"
-              icon="arrow-left"
-              className={styles.backButton}
-              data-testid={selectors.components.PanelEditor.toggleVizPicker}
-              onClick={handleBackButtonClick}
-            >
-              <Trans i18nKey="dashboard-scene.panel-viz-type-picker.button.close">Back</Trans>
-            </Button>
-          )}
-          <FilterInput
-            id={filterId}
-            autoFocus={!isMobile}
-            className={styles.filter}
-            value={searchQuery}
-            onChange={setSearchQuery}
-            placeholder={t('dashboard-scene.panel-viz-type-picker.placeholder-search-for', 'Search for...')}
-          />
-        </Stack>
-      </Field>
+        <Field
+          className={styles.searchField}
+          noMargin
+          htmlFor={filterId}
+          aria-label={t('dashboard-scene.panel-viz-type-picker.placeholder-search-for', 'Search for...')}
+        >
+          <Stack direction="row" gap={1}>
+            {showBackButton && (
+              <Button
+                aria-label={t('dashboard-scene.panel-viz-type-picker.title-close', 'Close')}
+                fill="text"
+                variant="secondary"
+                icon="arrow-left"
+                className={styles.backButton}
+                data-testid={selectors.components.PanelEditor.toggleVizPicker}
+                onClick={handleBackButtonClick}
+              >
+                <Trans i18nKey="dashboard-scene.panel-viz-type-picker.button.close">Back</Trans>
+              </Button>
+            )}
+            <FilterInput
+              id={filterId}
+              autoFocus={!isMobile}
+              className={styles.filter}
+              value={searchQuery}
+              onChange={setSearchQuery}
+              placeholder={t('dashboard-scene.panel-viz-type-picker.placeholder-search-for', 'Search for...')}
+            />
+          </Stack>
+        </Field>
       </div>
       <ScrollContainer marginTop={1}>
         <TabContent className={styles.tabContent}>

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -189,7 +189,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     height: '100%',
   }),
   searchField: css({
-    margin: theme.spacing(2, 1.5, 0, 0), // input glow with the boundary without this
+    margin: theme.spacing(2, 1.5, 0, 0),
     width: '100%', // full size search area
     borderBottom: `1px solid ${theme.colors.border.weak}`, // add a border to the bottom of the search field
     paddingBottom: theme.spacing(0.75),

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -190,8 +190,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   searchField: css({
     margin: theme.spacing(2, 1.5, 0, 0),
-    width: '100%', // full size search area
-    borderBottom: `1px solid ${theme.colors.border.weak}`, // add a border to the bottom of the search field
+    width: '100%',
+    borderBottom: `1px solid ${theme.colors.border.weak}`,
     paddingBottom: theme.spacing(0.75),
   }),
   stickySearchWrapper: css({

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -191,6 +191,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     margin: theme.spacing(2, 1.5, 0.1, 0), // input glow with the boundary without this
     width: '100%', // full size search area
     borderBottom: `1px solid ${theme.colors.border.weak}`, // add a border to the bottom of the search field
+    paddingBottom: theme.spacing(0.75)
   }),
   ghostDiv: css({
     width: '100%',

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -153,7 +153,7 @@ export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose
           </Stack>
         </Field>
       </div>
-      <ScrollContainer marginTop={1}>
+      <ScrollContainer>
         <TabContent className={styles.tabContent}>
           <Stack gap={1} direction="column">
             {listMode === VisualizationSelectPaneTab.Suggestions && (
@@ -189,13 +189,14 @@ const getStyles = (theme: GrafanaTheme2) => ({
     height: '100%',
   }),
   searchField: css({
-    margin: theme.spacing(2, 1.5, 0.1, 0), // input glow with the boundary without this
+    margin: theme.spacing(2, 1.5, 0, 0), // input glow with the boundary without this
     width: '100%', // full size search area
     borderBottom: `1px solid ${theme.colors.border.weak}`, // add a border to the bottom of the search field
     paddingBottom: theme.spacing(0.75),
   }),
   stickySearchWrapper: css({
     boxShadow: theme.shadows.z1,
+    zIndex: 1,
   }),
   tabs: css({
     width: '100%',
@@ -206,6 +207,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     textAlign: 'center',
   }),
   tabContent: css({
+    paddingTop: theme.spacing(1),
     paddingInline: theme.spacing(2),
   }),
   backButton: css({

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -121,40 +121,38 @@ export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose
           />
         ))}
       </TabsBar>
+      <Field
+        className={styles.searchField}
+        noMargin
+        htmlFor={filterId}
+        aria-label={t('dashboard-scene.panel-viz-type-picker.placeholder-search-for', 'Search for...')}
+      >
+        <Stack direction="row" gap={1}>
+          {showBackButton && (
+            <Button
+              aria-label={t('dashboard-scene.panel-viz-type-picker.title-close', 'Close')}
+              fill="text"
+              variant="secondary"
+              icon="arrow-left"
+              data-testid={selectors.components.PanelEditor.toggleVizPicker}
+              onClick={handleBackButtonClick}
+            >
+              <Trans i18nKey="dashboard-scene.panel-viz-type-picker.button.close">Back</Trans>
+            </Button>
+          )}
+          <FilterInput
+            id={filterId}
+            autoFocus={!isMobile}
+            className={styles.filter}
+            value={searchQuery}
+            onChange={setSearchQuery}
+            placeholder={t('dashboard-scene.panel-viz-type-picker.placeholder-search-for', 'Search for...')}
+          />
+        </Stack>
+      </Field>
       <ScrollContainer>
         <TabContent className={styles.tabContent}>
           <Stack gap={1} direction="column">
-            <Field
-              tabIndex={0}
-              className={styles.searchField}
-              noMargin
-              htmlFor={filterId}
-              aria-label={t('dashboard-scene.panel-viz-type-picker.placeholder-search-for', 'Search for...')}
-            >
-              <Stack direction="row" gap={1}>
-                {showBackButton && (
-                  <Button
-                    aria-label={t('dashboard-scene.panel-viz-type-picker.title-close', 'Close')}
-                    fill="text"
-                    variant="secondary"
-                    icon="arrow-left"
-                    data-testid={selectors.components.PanelEditor.toggleVizPicker}
-                    onClick={handleBackButtonClick}
-                  >
-                    <Trans i18nKey="dashboard-scene.panel-viz-type-picker.button.close">Back</Trans>
-                  </Button>
-                )}
-                <FilterInput
-                  id={filterId}
-                  autoFocus={!isMobile}
-                  className={styles.filter}
-                  value={searchQuery}
-                  onChange={setSearchQuery}
-                  placeholder={t('dashboard-scene.panel-viz-type-picker.placeholder-search-for', 'Search for...')}
-                />
-              </Stack>
-            </Field>
-
             {listMode === VisualizationSelectPaneTab.Suggestions && (
               <VisualizationSuggestions
                 onChange={onChange}
@@ -189,7 +187,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     gap: theme.spacing(2),
   }),
   searchField: css({
-    margin: theme.spacing(0.5, 0, 1, 0), // input glow with the boundary without this
+    margin: theme.spacing(0.5, 1.5, 1, 1.5), // input glow with the boundary without this
+    padding: theme.spacing(0, 0.5, 0, 0.5), // slight adjustment to align with scroll container
   }),
   tabs: css({
     width: '100%',

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -187,8 +187,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     height: '100%',
   }),
   searchField: css({
-    margin: theme.spacing(2, 1.5, 0, 1.5), // input glow with the boundary without this
+    margin: theme.spacing(2, 1, 0, 0), // input glow with the boundary without this
     borderBottom: `1px solid ${theme.colors.border.weak}`, // add a border to the bottom of the search field
+    width: '100%', // full size search area
   }),
   tabs: css({
     width: '100%',
@@ -202,7 +203,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     paddingInline: theme.spacing(2),
   }),
   closeButton: css({
-    marginLeft: 'auto',
+    marginLeft: theme.spacing(1), // shift button to the right
   }),
   customFieldMargin: css({
     marginBottom: theme.spacing(1),
@@ -210,5 +211,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   filter: css({
     minHeight: theme.spacing(4),
     marginBottom: theme.spacing(1),
+    marginRight: theme.spacing(1),
+    marginLeft: theme.spacing(1),
   }),
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -134,6 +134,7 @@ export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose
               fill="text"
               variant="secondary"
               icon="arrow-left"
+              className={styles.closeButton}
               data-testid={selectors.components.PanelEditor.toggleVizPicker}
               onClick={handleBackButtonClick}
             >
@@ -184,11 +185,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     flexDirection: 'column',
     flexGrow: 1,
     height: '100%',
-    gap: theme.spacing(2),
   }),
   searchField: css({
-    margin: theme.spacing(0.5, 1.5, 1, 1.5), // input glow with the boundary without this
-    padding: theme.spacing(0, 0.5, 2, 0.5), // slight adjustment to align with scroll container
+    margin: theme.spacing(2, 1.5, 0, 1.5), // input glow with the boundary without this
     borderBottom: `1px solid ${theme.colors.border.weak}`, // add a border to the bottom of the search field
   }),
   tabs: css({
@@ -210,5 +209,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   filter: css({
     minHeight: theme.spacing(4),
+    marginBottom: theme.spacing(1),
   }),
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -134,7 +134,7 @@ export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose
               fill="text"
               variant="secondary"
               icon="arrow-left"
-              className={styles.closeButton}
+              className={styles.backButton}
               data-testid={selectors.components.PanelEditor.toggleVizPicker}
               onClick={handleBackButtonClick}
             >
@@ -154,6 +154,7 @@ export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose
       <ScrollContainer>
         <TabContent className={styles.tabContent}>
           <Stack gap={1} direction="column">
+            <div className={styles.ghostDiv}></div>
             {listMode === VisualizationSelectPaneTab.Suggestions && (
               <VisualizationSuggestions
                 onChange={onChange}
@@ -187,9 +188,13 @@ const getStyles = (theme: GrafanaTheme2) => ({
     height: '100%',
   }),
   searchField: css({
-    margin: theme.spacing(2, 1.5, 1.5, 0), // input glow with the boundary without this
-    borderBottom: `1px solid ${theme.colors.border.weak}`, // add a border to the bottom of the search field
+    margin: theme.spacing(2, 1.5, 0.1, 0), // input glow with the boundary without this
     width: '100%', // full size search area
+    borderBottom: `1px solid ${theme.colors.border.weak}`, // add a border to the bottom of the search field
+  }),
+  ghostDiv: css({
+    width: '100%',
+    height: theme.spacing(0.5),
   }),
   tabs: css({
     width: '100%',
@@ -202,11 +207,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
   tabContent: css({
     paddingInline: theme.spacing(2),
   }),
-  closeButton: css({
+  backButton: css({
     marginLeft: theme.spacing(1), // shift button to the right
-  }),
-  customFieldMargin: css({
-    marginBottom: theme.spacing(1),
   }),
   filter: css({
     minHeight: theme.spacing(4),

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -130,7 +130,7 @@ export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose
         <Stack direction="row" gap={1}>
           {showBackButton && (
             <Button
-              aria-label={t('dashboard-scene.panel-viz-type-picker.title-close', 'Close')}
+              aria-label={t('dashboard-scene.panel-viz-type-picker.title-back', 'Back')}
               fill="text"
               variant="secondary"
               icon="arrow-left"
@@ -187,7 +187,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     height: '100%',
   }),
   searchField: css({
-    margin: theme.spacing(2, 1, 0, 0), // input glow with the boundary without this
+    margin: theme.spacing(2, 1.5, 1.5, 0), // input glow with the boundary without this
     borderBottom: `1px solid ${theme.colors.border.weak}`, // add a border to the bottom of the search field
     width: '100%', // full size search area
   }),

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -151,10 +151,9 @@ export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose
           />
         </Stack>
       </Field>
-      <ScrollContainer>
+      <ScrollContainer marginTop={1}>
         <TabContent className={styles.tabContent}>
           <Stack gap={1} direction="column">
-            <div className={styles.ghostDiv}></div>
             {listMode === VisualizationSelectPaneTab.Suggestions && (
               <VisualizationSuggestions
                 onChange={onChange}
@@ -191,11 +190,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     margin: theme.spacing(2, 1.5, 0.1, 0), // input glow with the boundary without this
     width: '100%', // full size search area
     borderBottom: `1px solid ${theme.colors.border.weak}`, // add a border to the bottom of the search field
-    paddingBottom: theme.spacing(0.75)
-  }),
-  ghostDiv: css({
-    width: '100%',
-    height: theme.spacing(0.5),
+    paddingBottom: theme.spacing(0.75),
   }),
   tabs: css({
     width: '100%',

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -121,6 +121,7 @@ export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose
           />
         ))}
       </TabsBar>
+      <div className={styles.stickySearchWrapper}>
       <Field
         className={styles.searchField}
         noMargin
@@ -151,6 +152,7 @@ export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose
           />
         </Stack>
       </Field>
+      </div>
       <ScrollContainer marginTop={1}>
         <TabContent className={styles.tabContent}>
           <Stack gap={1} direction="column">
@@ -191,6 +193,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     width: '100%', // full size search area
     borderBottom: `1px solid ${theme.colors.border.weak}`, // add a border to the bottom of the search field
     paddingBottom: theme.spacing(0.75),
+  }),
+  stickySearchWrapper: css({
+    boxShadow: theme.shadows.z1,
   }),
   tabs: css({
     width: '100%',

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -187,7 +187,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     height: '100%',
   }),
   searchField: css({
-    margin: theme.spacing(2, 1.5, 0, 1.5), // input glow with the boundary without this
+    margin: theme.spacing(2, 1.5, 0.1, 1.5), // input glow with the boundary without this
     borderBottom: `1px solid ${theme.colors.border.weak}`, // add a border to the bottom of the search field
   }),
   tabs: css({


### PR DESCRIPTION

Always shows the "search field" and the "back" button in the visualization suggestions.

<img width="676" height="856" alt="image" src="https://github.com/user-attachments/assets/d4553150-da28-488e-8755-2822e16bcfc1" />

Fixes #117192

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
