### PR TITLE
fix (transformations): only generate markdown when script is run

### DIFF
--- a/scripts/docs/generate-transformations.ts
+++ b/scripts/docs/generate-transformations.ts
@@ -227,8 +227,15 @@ export function getJavaScriptContent(): string {
   return completeTemplate;
 }
 
-// Build the path to the Markdown file.
-const indexPath = resolve(__dirname, '../../' + WRITE_PATH);
+export function generateMarkdown(): void {
+  // Build the path to the Markdown file.
+  const indexPath = resolve(__dirname, '../../' + WRITE_PATH);
+  // Write content to the Markdown file.
+  writeFileSync(indexPath, completeTemplate, 'utf-8');
+}
 
-// Write content to the Markdown file.
-writeFileSync(indexPath, completeTemplate, 'utf-8');
+// Only run the generation if this file is executed directly (not imported)
+// This is a Node.js specific way to ensure the file is executed directly.
+if (require.main === module) {
+  generateMarkdown();
+}


### PR DESCRIPTION
Running `yarn test:coverage:by-codeowner @grafana/datapro` was triggering unexpected markdown file generation.

Specifically, `generate-transformations.ts` has a module-level `writeFileSync` that executes immediately on import:

```typescript
// This ran immediately when the file was imported into the corresponding test file
writeFileSync(indexPath, completeTemplate, 'utf-8');
```

This PR wraps the file write in a function and gated execution with the Node.js pattern for detecting direct execution. It will only execute when the file is run as a script.

```typescript
if (require.main === module) {
  generateMarkdown();
}
```
