### PR TITLE
Unified Storage: Adds quota enforcement

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -628,6 +628,7 @@ type Cfg struct {
 	EnableSearchClient                         bool
 	OverridesFilePath                          string
 	OverridesReloadInterval                    time.Duration
+	EnforceQuotas                              bool
 	EnableSQLKVBackend                         bool
 	EnableSQLKVCompatibilityMode               bool
 	EnableGarbageCollection                    bool

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -629,6 +629,7 @@ type Cfg struct {
 	OverridesFilePath                          string
 	OverridesReloadInterval                    time.Duration
 	EnforceQuotas                              bool
+	QuotasErrorMessageSupportInfo              string
 	EnableSQLKVBackend                         bool
 	EnableSQLKVCompatibilityMode               bool
 	EnableGarbageCollection                    bool

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -118,6 +118,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.OverridesFilePath = section.Key("overrides_path").String()
 	cfg.OverridesReloadInterval = section.Key("overrides_reload_period").MustDuration(30 * time.Second)
 	cfg.EnforceQuotas = section.Key("enforce_quotas").MustBool(false)
+	cfg.QuotasErrorMessageSupportInfo = section.Key("quotas_error_message_support_info").MustString("Please contact your administrator to increase it.")
 
 	// garbage collection
 	cfg.EnableGarbageCollection = section.Key("garbage_collection_enabled").MustBool(false)

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -117,6 +117,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	// quotas/limits config
 	cfg.OverridesFilePath = section.Key("overrides_path").String()
 	cfg.OverridesReloadInterval = section.Key("overrides_reload_period").MustDuration(30 * time.Second)
+	cfg.EnforceQuotas = section.Key("enforce_quotas").MustBool(false)
 
 	// garbage collection
 	cfg.EnableGarbageCollection = section.Key("garbage_collection_enabled").MustBool(false)

--- a/pkg/storage/unified/resource/quotas.go
+++ b/pkg/storage/unified/resource/quotas.go
@@ -18,6 +18,20 @@ import (
 
 const DEFAULT_RESOURCE_LIMIT = 1000
 
+type QuotaExceededError struct {
+	Resource string
+	Used     int64
+	Limit    int
+}
+
+func (e QuotaExceededError) Error() string {
+	return fmt.Sprintf("limit reached for resource %s", e.Resource)
+}
+
+func (e QuotaExceededError) Message() string {
+	return fmt.Sprintf("Limit reached for resource %s: %d/%d. Please contact support to increase it.", e.Resource, e.Used, e.Limit)
+}
+
 type OverridesService struct {
 	manager *runtimeconfig.Manager
 	logger  log.Logger
@@ -42,6 +56,11 @@ type NamespaceOverrides struct {
 // Overrides represents the entire overrides configuration file
 type Overrides struct {
 	Namespaces map[string]NamespaceOverrides
+}
+
+type QuotaCheck struct {
+	Limit int
+	Used  int
 }
 
 /*

--- a/pkg/storage/unified/resource/quotas.go
+++ b/pkg/storage/unified/resource/quotas.go
@@ -58,11 +58,6 @@ type Overrides struct {
 	Namespaces map[string]NamespaceOverrides
 }
 
-type QuotaCheck struct {
-	Limit int
-	Used  int
-}
-
 /*
 This service loads overrides (currently just quotas) from a YAML file with the following yaml structure:
 

--- a/pkg/storage/unified/resource/quotas.go
+++ b/pkg/storage/unified/resource/quotas.go
@@ -18,10 +18,16 @@ import (
 
 const DEFAULT_RESOURCE_LIMIT = 1000
 
+type QuotasConfig struct {
+	EnforceQuotas  bool
+	SupportMessage string
+}
+
 type QuotaExceededError struct {
-	Resource string
-	Used     int64
-	Limit    int
+	Resource       string
+	Used           int64
+	Limit          int
+	SupportMessage string
 }
 
 func (e QuotaExceededError) Error() string {
@@ -29,7 +35,7 @@ func (e QuotaExceededError) Error() string {
 }
 
 func (e QuotaExceededError) Message() string {
-	return fmt.Sprintf("Limit reached for resource %s: %d/%d. Please contact support to increase it.", e.Resource, e.Used, e.Limit)
+	return fmt.Sprintf("Limit reached for resource %s: %d/%d %s", e.Resource, e.Used, e.Limit, e.SupportMessage)
 }
 
 type OverridesService struct {

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -684,4 +685,72 @@ func TestGetQuotaUsage(t *testing.T) {
 		assert.Equal(t, int64(42), resp.Usage)
 		assert.Equal(t, int64(500), resp.Limit)
 	})
+}
+
+func TestCheckQuotas(t *testing.T) {
+	tests := []struct {
+		name        string
+		limit       int
+		expectError bool
+	}{
+		{
+			name:        "will return error if quota exceeded",
+			limit:       1,
+			expectError: true,
+		},
+		{
+			name:        "will return nil if within quota",
+			limit:       2,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			overridesFile := filepath.Join(t.TempDir(), "overrides.yaml")
+			overrides := fmt.Sprintf(`overrides:
+  "123":
+    quotas:
+      grafana.dashboard.app/dashboards:
+        limit: %d
+`, tt.limit)
+			require.NoError(t, os.WriteFile(overridesFile, []byte(overrides), 0644))
+
+			tcr := tracing.NewNoopTracerService()
+			overridesService, err := NewOverridesService(ctx, log.NewNopLogger(), prometheus.NewRegistry(), tcr.Tracer, ReloadOptions{
+				FilePath: overridesFile,
+			})
+			require.NoError(t, err)
+
+			nsr := NamespacedResource{
+				Namespace: "stacks-123",
+				Group:     "grafana.dashboard.app",
+				Resource:  "dashboards",
+			}
+
+			server, err := NewResourceServer(ResourceServerOptions{
+				Backend: &mockStorageBackend{
+					resourceStats: []ResourceStats{{
+						NamespacedResource: nsr,
+						Count:              1,
+					}},
+				},
+				OverridesService: overridesService,
+				EnforceQuotas:    true,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = server.Stop(ctx)
+			})
+
+			err = server.checkQuota(ctx, nsr)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -738,7 +738,7 @@ func TestCheckQuotas(t *testing.T) {
 					}},
 				},
 				OverridesService: overridesService,
-				EnforceQuotas:    true,
+				QuotasConfig:     QuotasConfig{EnforceQuotas: true},
 			})
 			require.NoError(t, err)
 			t.Cleanup(func() {

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -70,6 +70,7 @@ func NewResourceServer(opts ServerOptions) (resource.ResourceServer, error) {
 		withOverridesService,
 		withSearch,
 		withSearchClient,
+		withQuotaEnforcement,
 	)
 	if err != nil {
 		return nil, err
@@ -266,6 +267,11 @@ func withQOSQueue(opts *ServerOptions, resourceOpts *resource.ResourceServerOpti
 
 func withOverridesService(opts *ServerOptions, resourceOpts *resource.ResourceServerOptions) error {
 	resourceOpts.OverridesService = opts.OverridesService
+	return nil
+}
+
+func withQuotaEnforcement(opts *ServerOptions, resourceOpts *resource.ResourceServerOptions) error {
+	resourceOpts.EnforceQuotas = opts.Cfg.EnforceQuotas
 	return nil
 }
 

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -70,7 +70,7 @@ func NewResourceServer(opts ServerOptions) (resource.ResourceServer, error) {
 		withOverridesService,
 		withSearch,
 		withSearchClient,
-		withQuotaEnforcement,
+		withQuotaConfig,
 	)
 	if err != nil {
 		return nil, err
@@ -270,8 +270,11 @@ func withOverridesService(opts *ServerOptions, resourceOpts *resource.ResourceSe
 	return nil
 }
 
-func withQuotaEnforcement(opts *ServerOptions, resourceOpts *resource.ResourceServerOptions) error {
-	resourceOpts.EnforceQuotas = opts.Cfg.EnforceQuotas
+func withQuotaConfig(opts *ServerOptions, resourceOpts *resource.ResourceServerOptions) error {
+	resourceOpts.QuotasConfig = resource.QuotasConfig{
+		EnforceQuotas:  opts.Cfg.EnforceQuotas,
+		SupportMessage: opts.Cfg.QuotasErrorMessageSupportInfo,
+	}
 	return nil
 }
 


### PR DESCRIPTION
When the config is enabled, this will return an error when a resource quota is reached.

The config defaults to false, so this PR will be a noop until we enable it.