### PR TITLE
feat(query-editor): Add switch for new query editor experience

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
@@ -37,11 +37,9 @@ export class PanelDataPane extends SceneObjectBase<PanelDataPaneState> {
   /**
    * Create a data pane for the given panel.
    * @param panel The VizPanel to create the data pane for
-   * @param useQueryEditorNext Optional override for which version to use.
-   *   If undefined, uses the queryEditorNext feature toggle value.
-   *   Only has effect when the feature toggle is enabled (allows toggling back to v1).
+   * @param useQueryEditorNext Signals whether to use the query editor v2 experience or the original (v1) experience.
    */
-  public static createFor(panel: VizPanel, useQueryEditorNext: boolean | undefined) {
+  public static createFor(panel: VizPanel, useQueryEditorNext: boolean) {
     const panelRef = panel.getRef();
 
     // Query experience v2

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
@@ -34,14 +34,18 @@ export class PanelDataPane extends SceneObjectBase<PanelDataPaneState> {
   static Component = PanelDataPaneRendered;
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['tab'] });
 
-  public static createFor(panel: VizPanel) {
+  /**
+   * Create a data pane for the given panel.
+   * @param panel The VizPanel to create the data pane for
+   * @param useQueryEditorNext Optional override for which version to use.
+   *   If undefined, uses the queryEditorNext feature toggle value.
+   *   Only has effect when the feature toggle is enabled (allows toggling back to v1).
+   */
+  public static createFor(panel: VizPanel, useQueryEditorNext: boolean | undefined) {
     const panelRef = panel.getRef();
 
-    const config = getConfig();
-    const queryExperienceNext = config.featureToggles.queryEditorNext;
-
     // Query experience v2
-    if (queryExperienceNext) {
+    if (useQueryEditorNext) {
       return new PanelDataPaneNext({ panelRef });
     }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
@@ -39,7 +39,7 @@ export class PanelDataPane extends SceneObjectBase<PanelDataPaneState> {
    * @param panel The VizPanel to create the data pane for
    * @param useQueryEditorNext Signals whether to use the query editor v2 experience or the original (v1) experience.
    */
-  public static createFor(panel: VizPanel, useQueryEditorNext: boolean) {
+  public static createFor(panel: VizPanel, useQueryEditorNext: boolean | undefined) {
     const panelRef = panel.getRef();
 
     // Query experience v2

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditControls.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditControls.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { InlineSwitch, useStyles2 } from '@grafana/ui';
 
 import { PanelEditor } from './PanelEditor';
@@ -12,23 +13,35 @@ export interface Props {
 }
 
 export function PanelEditControls({ panelEditor }: Props) {
-  const { tableView, dataPane } = panelEditor.useState();
+  const { tableView, dataPane, useQueryExperienceNext } = panelEditor.useState();
   const styles = useStyles2(getStyles);
+
+  if (!dataPane) {
+    return null;
+  }
 
   return (
     <div className={styles.container}>
-      {dataPane && (
+      <InlineSwitch
+        label={t('dashboard-scene.panel-edit-controls.table-view-label-table-view', 'Table view')}
+        showLabel={true}
+        id="table-view"
+        value={tableView ? true : false}
+        onClick={panelEditor.onToggleTableView}
+        aria-label={t('dashboard-scene.panel-edit-controls.table-view-aria-label-toggletableview', 'Toggle table view')}
+        data-testid={selectors.components.PanelEditor.toggleTableView}
+      />
+      {config.featureToggles.queryEditorNext && (
         <InlineSwitch
-          label={t('dashboard-scene.panel-edit-controls.table-view-label-table-view', 'Table view')}
+          label={t('dashboard-scene.panel-edit-controls.query-editor-version', 'Query editor v2')}
           showLabel={true}
-          id="table-view"
-          value={tableView ? true : false}
-          onClick={panelEditor.onToggleTableView}
+          id="query-editor-version"
+          value={useQueryExperienceNext ?? true}
+          onClick={panelEditor.onToggleQueryEditorVersion}
           aria-label={t(
-            'dashboard-scene.panel-edit-controls.table-view-aria-label-toggletableview',
-            'Toggle table view'
+            'dashboard-scene.panel-edit-controls.query-editor-version-toggle',
+            'Toggle between query editor v1 and v2'
           )}
-          data-testid={selectors.components.PanelEditor.toggleTableView}
         />
       )}
     </div>
@@ -43,6 +56,7 @@ function getStyles(theme: GrafanaTheme2) {
       verticalAlign: 'middle',
       marginBottom: theme.spacing(1),
       marginRight: theme.spacing(1),
+      gap: theme.spacing(1),
     }),
   };
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -424,10 +424,16 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
    * Toggle between v1 and v2 query editor.
    */
   public onToggleQueryEditorVersion = () => {
+    const newUseQueryExperienceNext = !this.state.useQueryExperienceNext;
+    const dataPane = PanelDataPane.createFor(this.getPanel(), newUseQueryExperienceNext);
+
     this.setState({
-      useQueryExperienceNext: !this.state.useQueryExperienceNext,
-      dataPane: PanelDataPane.createFor(this.getPanel(), !this.state.useQueryExperienceNext),
+      useQueryExperienceNext: newUseQueryExperienceNext,
+      dataPane,
     });
+
+    // This is to notify UrlSyncManager that a new object has been added to scene that requires url sync
+    this.publishEvent(new NewSceneObjectAddedEvent(dataPane), true);
   };
 
   public static buildEditPreview(panel: VizPanel): VizPanel {

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -149,7 +149,7 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
   } = model.useState();
   const dashboard = getDashboardSceneFor(model);
   const { links, editPanel } = dashboard.useState();
-  const isQueryEditorNext = Boolean(config.featureToggles.queryEditorNext);
+  const isQueryEditorNext = Boolean(editPanel?.state.useQueryExperienceNext);
   const styles = useStyles2(getStyles, isQueryEditorNext);
   const showDebugger = window.location.search.includes('scene-debugger');
   const hasDashboardControls = useHasDashboardControls(dashboard);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6434,6 +6434,8 @@
       "title-delete-all-transformations": "Delete all transformations?"
     },
     "panel-edit-controls": {
+      "query-editor-version": "Query editor v2",
+      "query-editor-version-toggle": "Toggle between query editor v1 and v2",
       "table-view-aria-label-toggletableview": "Toggle table view",
       "table-view-label-table-view": "Table view"
     },


### PR DESCRIPTION
## Description

This PR closes #117026, and aims to do everything in that issue except for adding a feedback button. Let's tackle that as a separate item.

The goal of this PR is to add a switch that toggles whether or not the classic (v1) or new (v2) Query Editor experience is enabled. The switch only appears when the `queryEditorNext` feature toggle is enabled, and it defaults to presenting the v2 experience.

This is expected to be a short-lived feature, but having the switch will make it much easier for contributors working on the v2 experience to compare features-in-progress to their v1 counterparts.

## Changes
<!--- Describe your changes in detail -->
- Adds `useQueryExperienceNext` to `PanelEditorState` to help orchestrate the v1/v2 toggling
- Adds an `InlineSwitch` next to the **Table view** switch

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->

In general, I'd like to be cautious about adding to `PanelEditorState`, but I think this is worth it.

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->

### With the `queryEditorNext` feature toggle enabled

The switch appears and does its job:

https://github.com/user-attachments/assets/7993189d-2c80-4e99-ba6d-914251bb0f32

### With the `queryEditorNext` feature toggle disabled

The switch does not appear:

<img width="1912" height="1046" alt="demo no switch without queryEditorNext" src="https://github.com/user-attachments/assets/12353f0c-d050-47f8-ab96-73be1451107f" />

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->

After checking out the `117026/query-editor-version-toggle` feature branch and running `make run` + `yarn dev`, verify that your `queryEditorNext` setting in `conf/custom.ini` produces the same behavior as shown above in the **Demo**.

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable