### PR TITLE
fix: add missing comma to metrics output

### DIFF
--- a/scripts/ci-frontend-metrics.sh
+++ b/scripts/ci-frontend-metrics.sh
@@ -66,6 +66,6 @@ echo "Metrics: {
   \"grafana.ci-code.props.className\": \"${CLASSNAME_PROP}\",
   \"grafana.ci-code.imports.emotion\": \"${EMOTION_IMPORTS}\",
   \"grafana.ci-code.tsFiles\": \"${TS_FILES}\",
-  \"grafana.ci-code.scssFiles\": \"${SCSS_FILES}\"
+  \"grafana.ci-code.scssFiles\": \"${SCSS_FILES}\",
   \"grafana.ci-code.dependencies.circular\": \"${TOTAL_CIRCULAR_DEPENDENCIES}\"
 }"


### PR DESCRIPTION
**What is this feature?**

This pull request adds a missing comma to the metrics output
https://github.com/grafana/grafana/actions/runs/21662626296/job/62451488248

**Why do we need this feature?**

So metrics reporting works

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
