### PR TITLE
[release-12.0.10] Build: Update alpine version to 3.23.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG JS_SRC=js-builder
 
 # Dependabot cannot update dependencies listed in ARGs
 # By using FROM instructions we can delegate dependency updates to dependabot
-FROM alpine:3.23.0 AS alpine-base
+FROM alpine:3.23.3 AS alpine-base
 FROM ubuntu:22.04 AS ubuntu-base
 FROM golang:1.25.6-alpine AS go-builder-base
 FROM --platform=${JS_PLATFORM} node:22-alpine AS js-builder-base

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -59,7 +59,7 @@ docker_build () {
   esac
   if [ $UBUNTU_BASE = "0" ]; then
     libc="-musl"
-    base_image="${base_arch}alpine:3.18.5"
+    base_image="${base_arch}alpine:3.23.3"
   else
     libc=""
     base_image="${base_arch}ubuntu:22.04"

--- a/pkg/build/daggerbuild/artifacts/package_targz.go
+++ b/pkg/build/daggerbuild/artifacts/package_targz.go
@@ -219,7 +219,7 @@ func (t *Tarball) Builder(ctx context.Context, opts *pipeline.ArtifactContainerO
 	version := t.Version
 
 	container := opts.Client.Container().
-		From("alpine:3.18.4").
+		From("alpine:3.23.3").
 		WithExec([]string{"apk", "add", "--update", "tar"}).
 		WithExec([]string{"/bin/sh", "-c", fmt.Sprintf("echo %s > VERSION", version)})
 

--- a/pkg/build/daggerbuild/frontend/node.go
+++ b/pkg/build/daggerbuild/frontend/node.go
@@ -9,7 +9,7 @@ import (
 
 // NodeVersionContainer returns a container whose `stdout` will return the node version from the '.nvmrc' file in the directory 'src'.
 func NodeVersion(d *dagger.Client, src *dagger.Directory) *dagger.Container {
-	return d.Container().From("alpine:3.17").
+	return d.Container().From("alpine:3.23.3").
 		WithMountedDirectory("/src", src).
 		WithWorkdir("/src").
 		WithExec([]string{"cat", ".nvmrc"})


### PR DESCRIPTION
Should clear up security scanner warnings for:
- CVE-2025-15467
- CVE-2025-69420
- CVE-2026-22796
- CVE-2025-69419
- CVE-2025-66199
- CVE-2025-15468
- CVE-2025-69421
- CVE-2026-22795
- CVE-2025-68160
- CVE-2025-11187
- CVE-2025-15469
- CVE-2025-69418