### PR TITLE
Rendering: Return ErrServerTimeout on remote requests that return a 408 status code

### DIFF
--- a/pkg/services/rendering/http_mode.go
+++ b/pkg/services/rendering/http_mode.go
@@ -186,6 +186,10 @@ func (rs *RenderingService) doRequest(ctx context.Context, u *url.URL, headers m
 		return nil, ErrTooManyRequests
 	}
 
+	if resp.StatusCode == http.StatusRequestTimeout {
+		return nil, ErrServerTimeout
+	}
+
 	return resp, nil
 }
 

--- a/pkg/services/rendering/rendering_test.go
+++ b/pkg/services/rendering/rendering_test.go
@@ -223,6 +223,18 @@ func TestRenderingServiceGetRemotePluginVersion(t *testing.T) {
 		require.Equal(t, version, "1.0.0")
 	})
 
+	t.Run("When renderer responds with 408 it returns a ErrServerTimeout error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusRequestTimeout)
+		}))
+		defer server.Close()
+
+		rs.Cfg.RendererServerUrl = server.URL + "/render"
+
+		_, err := rs.getRemotePluginVersion()
+		require.ErrorIs(t, err, ErrServerTimeout)
+	})
+
 	t.Run("When renderer responds with 500 should retry until success", func(t *testing.T) {
 		tries := uint(0)
 		ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
When a remote rendering request returned a 408 (timeout), the retry functionality was not working. This handles the status code and returns the appropriate domain error that gets retried.