### PR TITLE
Documentation: Fix links to Grafana community Helm Charts repository

### DIFF
--- a/docs/sources/setup-grafana/installation/helm/index.md
+++ b/docs/sources/setup-grafana/installation/helm/index.md
@@ -17,7 +17,7 @@ This topic includes instructions for installing and running Grafana on Kubernete
 [Helm](https://helm.sh/) is an open-source command line tool used for managing Kubernetes applications. It is a graduate project in the [CNCF Landscape](https://www.cncf.io/projects/helm/).
 
 {{< admonition type="note" >}}
-The Grafana open-source community offers Helm Charts for running it on Kubernetes. Please be aware that the code is provided without any warranties. If you encounter any problems, you can report them to the [Official GitHub repository](https://github.com/grafana/helm-charts/).
+The Grafana open-source community offers Helm Charts for running it on Kubernetes. Please be aware that the code is provided without any warranties. If you encounter any problems, you can report them to the [Official GitHub repository](https://github.com/grafana-community/helm-charts/).
 {{< /admonition >}}
 
 Watch this video to learn more about installing Grafana using Helm Charts: {{< youtube id="sgYrEleW24E">}}
@@ -195,7 +195,7 @@ By modifying the values in the `values.yaml` file, you can tailor the deployment
 
 In order to make any configuration changes, download the `values.yaml` file from the Grafana Helm Charts repository:
 
-https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
+https://github.com/grafana-community/helm-charts/blob/main/charts/grafana/values.yaml
 
 {{< admonition type="note" >}}
 Depending on your use case requirements, you can use a single YAML file that contains your configuration changes or you can create multiple YAML files.


### PR DESCRIPTION
Updated links to point to the correct Grafana community Helm Charts repository.

**What is this feature?**

Follow up on https://github.com/grafana/helm-charts/pull/4113, which finalized the migration of Helm Charts to the new repository. Updating the links in the documentation to point to the correct repository.

**Why do we need this feature?**

Updating documentation

**Who is this feature for?**

Everyone

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
