### PR TITLE
Alerting: Update import wizard to use policyTreeName as config identifier

### DIFF
--- a/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.tsx
@@ -37,6 +37,10 @@ interface Step1ContentProps {
   dryRunResult?: DryRunValidationResult;
   /** Callback to trigger dry-run validation */
   onTriggerDryRun?: () => void;
+  /** State of existing extra config: 'none' | 'same' (will overwrite) | 'different' (blocked) */
+  extraConfigState?: 'none' | 'same' | 'different';
+  /** Identifier of existing extra config, if any */
+  existingIdentifier?: string;
 }
 
 /**
@@ -50,6 +54,8 @@ export function Step1Content({
   dryRunState,
   dryRunResult,
   onTriggerDryRun,
+  extraConfigState = 'none',
+  existingIdentifier,
 }: Step1ContentProps) {
   const styles = useStyles2(getStyles);
   const {
@@ -118,6 +124,37 @@ export function Step1Content({
             You do not have permission to import notification resources. You need the{' '}
             <strong>alerting.notifications:write</strong> permission. You can skip this step.
           </Trans>
+        </Alert>
+      )}
+
+      {/* Extra config conflict - blocked */}
+      {extraConfigState === 'different' && existingIdentifier && (
+        <Alert
+          severity="error"
+          title={t('alerting.import-to-gma.step1.extra-config-conflict-title', 'Cannot import notification resources')}
+        >
+          {t(
+            'alerting.import-to-gma.step1.extra-config-conflict-desc',
+            'There is already an uncommitted imported configuration named "{{identifier}}". You need to commit or discard it before importing a new configuration.',
+            { identifier: existingIdentifier }
+          )}
+        </Alert>
+      )}
+
+      {/* Extra config overwrite warning */}
+      {extraConfigState === 'same' && existingIdentifier && (
+        <Alert
+          severity="warning"
+          title={t(
+            'alerting.import-to-gma.step1.extra-config-overwrite-title',
+            'Existing configuration will be replaced'
+          )}
+        >
+          {t(
+            'alerting.import-to-gma.step1.extra-config-overwrite-desc',
+            'An imported configuration named "{{identifier}}" already exists. Importing will replace it with the new configuration.',
+            { identifier: existingIdentifier }
+          )}
         </Alert>
       )}
 

--- a/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.tsx
@@ -135,7 +135,7 @@ export function Step1Content({
         >
           {t(
             'alerting.import-to-gma.step1.extra-config-conflict-desc',
-            'There is already an uncommitted imported configuration named "{{identifier}}". You need to commit or discard it before importing a new configuration.',
+            'There is already an uncommitted imported configuration named "{{identifier}}". To proceed, either use "{{identifier}}" as your policy tree name to replace it, or commit/discard the existing configuration first.',
             { identifier: existingIdentifier }
           )}
         </Alert>

--- a/public/app/features/alerting/unified/components/import-to-gma/useExtraConfigState.ts
+++ b/public/app/features/alerting/unified/components/import-to-gma/useExtraConfigState.ts
@@ -1,0 +1,48 @@
+import { useMemo } from 'react';
+
+import { useAlertmanagerConfig } from '../../hooks/useAlertmanagerConfig';
+import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
+
+export type ExtraConfigState = 'none' | 'same' | 'different';
+
+interface UseExtraConfigStateResult {
+  /** State of existing extra config relative to the provided identifier */
+  extraConfigState: ExtraConfigState;
+  /** Identifier of the existing extra config, if any */
+  existingIdentifier?: string;
+  /** Whether data is still loading */
+  isLoading: boolean;
+}
+
+/**
+ * Hook to determine the state of existing extra Alertmanager configurations.
+ *
+ * Returns the relationship between any existing extra config and the provided identifier:
+ * - 'none': No existing extra config, can import freely
+ * - 'same': Existing config with same identifier, will overwrite (warning)
+ * - 'different': Existing config with different identifier, cannot import (blocked)
+ *
+ * @param policyTreeName - The identifier to compare against existing extra configs
+ */
+export function useExtraConfigState(policyTreeName: string): UseExtraConfigStateResult {
+  const { data: grafanaConfig, isLoading } = useAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);
+
+  const existingExtraConfig = grafanaConfig?.extra_config?.[0];
+  const existingIdentifier = existingExtraConfig?.identifier;
+
+  const extraConfigState = useMemo((): ExtraConfigState => {
+    if (!existingIdentifier) {
+      return 'none';
+    }
+    if (existingIdentifier === policyTreeName) {
+      return 'same';
+    }
+    return 'different';
+  }, [existingIdentifier, policyTreeName]);
+
+  return {
+    extraConfigState,
+    existingIdentifier,
+    isLoading,
+  };
+}

--- a/public/app/features/alerting/unified/components/import-to-gma/useImport.ts
+++ b/public/app/features/alerting/unified/components/import-to-gma/useImport.ts
@@ -12,7 +12,8 @@ interface MigrateNotificationsParams {
   /** Datasource name (not UID) - required when source is 'datasource' */
   datasourceName?: string;
   yamlFile: File | null;
-  mergeMatchers: string; // e.g., "__grafana_managed_route__=my-policy" (uses MERGE_MATCHERS_LABEL_NAME constant)
+  /** Configuration identifier - the name of the extra config (policy tree name) */
+  configIdentifier: string;
 }
 
 interface MigrateRulesParams {
@@ -35,7 +36,7 @@ export function useImportNotifications() {
 
   return useCallback(
     async (params: MigrateNotificationsParams) => {
-      const { source, datasourceName, yamlFile, mergeMatchers } = params;
+      const { source, datasourceName, yamlFile, configIdentifier } = params;
 
       let alertmanagerConfig: string;
       let templateFiles: Record<string, string> = {};
@@ -57,7 +58,7 @@ export function useImportNotifications() {
       await convertAlertmanagerConfig({
         alertmanagerConfig,
         templateFiles,
-        mergeMatchers,
+        configIdentifier,
       }).unwrap();
     },
     [convertAlertmanagerConfig]
@@ -172,7 +173,8 @@ interface DryRunNotificationsParams {
   /** Datasource name (not UID) - required when source is 'datasource' */
   datasourceName?: string;
   yamlFile: File | null;
-  mergeMatchers: string;
+  /** Configuration identifier - the name of the extra config (policy tree name) */
+  configIdentifier: string;
 }
 
 /**
@@ -202,7 +204,7 @@ export function useDryRunNotifications() {
       params: DryRunNotificationsParams,
       options: { skipValidation?: boolean } = {}
     ): Promise<DryRunValidationResult> => {
-      const { source, datasourceName, yamlFile, mergeMatchers } = params;
+      const { source, datasourceName, yamlFile, configIdentifier } = params;
       const { skipValidation = false } = options;
 
       // If skipValidation is true, return a success result immediately
@@ -239,7 +241,7 @@ export function useDryRunNotifications() {
         // const response = await dryRunAlertmanagerConfig({
         //   alertmanagerConfig,
         //   templateFiles,
-        //   mergeMatchers,
+        //   configIdentifier,
         // }).unwrap();
         // setResult(response);
         // return response;
@@ -250,7 +252,7 @@ export function useDryRunNotifications() {
         console.warn('[useDryRunNotifications] Backend endpoint not implemented yet. Using mock response.', {
           alertmanagerConfig: alertmanagerConfig.substring(0, 100) + '...',
           templateFiles,
-          mergeMatchers,
+          configIdentifier,
         });
 
         // Simulate a small delay to show loading state

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1696,6 +1696,10 @@
       },
       "step1": {
         "datasource": "Alertmanager data source",
+        "extra-config-conflict-desc": "There is already an uncommitted imported configuration named \"{{identifier}}\". You need to commit or discard it before importing a new configuration.",
+        "extra-config-conflict-title": "Cannot import notification resources",
+        "extra-config-overwrite-desc": "An imported configuration named \"{{identifier}}\" already exists. Importing will replace it with the new configuration.",
+        "extra-config-overwrite-title": "Existing configuration will be replaced",
         "heading": "Import Notification Resources",
         "no-datasources": "No Alertmanager data sources found",
         "no-permission-desc": "You do not have permission to import notification resources. You need the <strong>alerting.notifications:write</strong> permission. You can skip this step.",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1696,7 +1696,7 @@
       },
       "step1": {
         "datasource": "Alertmanager data source",
-        "extra-config-conflict-desc": "There is already an uncommitted imported configuration named \"{{identifier}}\". You need to commit or discard it before importing a new configuration.",
+        "extra-config-conflict-desc": "There is already an uncommitted imported configuration named \"{{identifier}}\". To proceed, either use \"{{identifier}}\" as your policy tree name to replace it, or commit/discard the existing configuration first.",
         "extra-config-conflict-title": "Cannot import notification resources",
         "extra-config-overwrite-desc": "An imported configuration named \"{{identifier}}\" already exists. Importing will replace it with the new configuration.",
         "extra-config-overwrite-title": "Existing configuration will be replaced",


### PR DESCRIPTION
**What is this feature?**

This PR Updates the Import to Grafana Alerting wizard to properly handle the `X-Grafana-Alerting-Config-Identifier` header and add validation for existing extra Alertmanager configurations.

## Changes

### Header Updates
- **Use `policyTreeName` as `X-Grafana-Alerting-Config-Identifier`**: The policy tree name entered by the user is now used as the configuration identifier, allowing proper identification of imported configurations.
- **Temporarily keep `X-Grafana-Alerting-Merge-Matchers` header**: Added back the merge matchers header with value `__grafana_managed_route__={policyTreeName}` until the backend is updated to no longer require it. Marked with TODO for removal.

### Extra Config Conflict Detection
Added validation to detect and handle existing extra Alertmanager configurations:

| State | Condition | Behavior |
|-------|-----------|----------|
| `different` | Uncommitted config with different identifier exists | Import blocked with error message |
| `same` | Config with same identifier exists | Warning shown (will overwrite) |
| `none` | No existing extra config | Import proceeds normally |

### Code Refactoring
- Extracted extra config state logic into a new `useExtraConfigState` hook for better separation of concerns
- Renamed `mergeMatchers` parameter to `configIdentifier` in `useImport` hooks for clarity

## How to test

1. Enable `alertingMigrationWizardUI` feature flag
2. Navigate to **Alerting → Import to Grafana Alerting**
3. Test the following scenarios:
   - Import with no existing extra config → should work normally
   - Import with same policy tree name as existing → should show warning
   - Import when different uncommitted config exists → should show error and block import

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:


Fixes https://github.com/grafana/alerting-squad/issues/1399

**Special notes for your reviewer:**

<img width="1148" height="939" alt="Screenshot 2026-02-04 at 10 52 15" src="https://github.com/user-attachments/assets/6f41e4bd-9f2f-4dca-b34a-107771be9c14" />

<img width="1084" height="948" alt="Screenshot 2026-02-04 at 10 51 48" src="https://github.com/user-attachments/assets/ae05b33e-c688-4673-baee-952e1d2dc05e" />


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
