### PR TITLE
refactor(quotas): use the full namespace in quota files

### DIFF
--- a/pkg/storage/unified/resource/quotas.go
+++ b/pkg/storage/unified/resource/quotas.go
@@ -48,7 +48,7 @@ This service loads overrides (currently just quotas) from a YAML file with the f
 
 overrides:
 
-	"123":
+	"stacks-123":
 	  quotas:
 	    dashboard.grafana.app/dashboards:
 	      limit: 1500

--- a/pkg/storage/unified/resource/quotas.go
+++ b/pkg/storage/unified/resource/quotas.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/grafana/dskit/runtimeconfig"
@@ -118,9 +117,8 @@ func (q *OverridesService) GetQuota(_ context.Context, nsr NamespacedResource) (
 		return ResourceQuota{}, fmt.Errorf("failed to get quota overrides from config manager")
 	}
 
-	tenantId := strings.TrimPrefix(nsr.Namespace, "stacks-")
 	groupResource := nsr.Group + "/" + nsr.Resource
-	if tenantOverrides, ok := overrides.Namespaces[tenantId]; ok {
+	if tenantOverrides, ok := overrides.Namespaces[nsr.Namespace]; ok {
 		if resourceQuota, ok := tenantOverrides.Quotas[groupResource]; ok {
 			return resourceQuota, nil
 		}

--- a/pkg/storage/unified/resource/quotas_test.go
+++ b/pkg/storage/unified/resource/quotas_test.go
@@ -28,7 +28,7 @@ func TestNewQuotaService(t *testing.T) {
 			setupFile: func(t *testing.T) string {
 				tmpFile := filepath.Join(t.TempDir(), "overrides.yaml")
 				content := `overrides:
-  "123":
+  "stacks-123":
     quotas:
       grafana.dashboard.app/dashboards:
         limit: 1500
@@ -107,7 +107,7 @@ func TestQuotaService_ConfigReload(t *testing.T) {
 	// Create a temporary config file
 	tmpFile := filepath.Join(t.TempDir(), "overrides.yaml")
 	initialConfig := `overrides:
-  "123":
+  "stacks-123":
     quotas:
       grafana.dashboard.app/dashboards:
         limit: 1500
@@ -142,11 +142,11 @@ func TestQuotaService_ConfigReload(t *testing.T) {
 
 	// Update the config file with new values
 	updatedConfig := `overrides:
-  "123":
+  "stacks-123":
     quotas:
       grafana.dashboard.app/dashboards:
         limit: 2500
-  "456":
+  "stacks-456":
     quotas:
       grafana.folder.app/folders:
         limit: 3000
@@ -187,7 +187,7 @@ func TestQuotaService_GetQuota(t *testing.T) {
 			setupFile: func(t *testing.T) string {
 				tmpFile := filepath.Join(t.TempDir(), "overrides.yaml")
 				content := `overrides:
-  "123":
+  "stacks-123":
     quotas:
       grafana.dashboard.app/dashboards:
         limit: 1500
@@ -209,7 +209,7 @@ func TestQuotaService_GetQuota(t *testing.T) {
 			setupFile: func(t *testing.T) string {
 				tmpFile := filepath.Join(t.TempDir(), "overrides.yaml")
 				content := `overrides:
-  "123":
+  "stacks-123":
     quotas:
       grafana.dashboard.app/dashboards:
         limit: 1500
@@ -231,7 +231,7 @@ func TestQuotaService_GetQuota(t *testing.T) {
 			setupFile: func(t *testing.T) string {
 				tmpFile := filepath.Join(t.TempDir(), "overrides.yaml")
 				content := `overrides:
-  "123":
+  "stacks-123":
     quotas:
       grafana.dashboard.app/dashboards:
         limit: 1500
@@ -253,7 +253,7 @@ func TestQuotaService_GetQuota(t *testing.T) {
 			setupFile: func(t *testing.T) string {
 				tmpFile := filepath.Join(t.TempDir(), "overrides.yaml")
 				content := `overrides:
-  "123":
+  "stacks-123":
     quotas:
       grafana.dashboard.app/dashboards:
         limit: 1500
@@ -262,7 +262,7 @@ func TestQuotaService_GetQuota(t *testing.T) {
 				return tmpFile
 			},
 			nsr: NamespacedResource{
-				Namespace: "123",
+				Namespace: "stacks-123",
 				Group:     "grafana.dashboard.app",
 				Resource:  "dashboards",
 			},
@@ -292,7 +292,7 @@ func TestQuotaService_GetQuota(t *testing.T) {
 			setupFile: func(t *testing.T) string {
 				tmpFile := filepath.Join(t.TempDir(), "overrides.yaml")
 				content := `overrides:
-  "123":
+  "stacks-123":
     quotas:
       grafana.dashboard.app/dashboards:
         limit: 1500
@@ -316,7 +316,7 @@ func TestQuotaService_GetQuota(t *testing.T) {
 			setupFile: func(t *testing.T) string {
 				tmpFile := filepath.Join(t.TempDir(), "overrides.yaml")
 				content := `overrides:
-  "123":
+  "stacks-123":
     quotas:
       grafana.dashboard.app/dashboards:
         limit: 1500
@@ -340,7 +340,7 @@ func TestQuotaService_GetQuota(t *testing.T) {
 			setupFile: func(t *testing.T) string {
 				tmpFile := filepath.Join(t.TempDir(), "overrides.yaml")
 				content := `overrides:
-  "123":
+  "stacks-123":
     quotas:
       grafana.dashboard.app/dashboards:
         limit: 1500

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -644,7 +644,7 @@ func TestGetQuotaUsage(t *testing.T) {
 		// Create a temporary overrides config file
 		tmpFile := filepath.Join(t.TempDir(), "overrides.yaml")
 		content := `overrides:
-  "123":
+  "stacks-123":
     quotas:
       dashboard.grafana.app/dashboards:
         limit: 500


### PR DESCRIPTION
The namespace from the quota file should be in the expected format that grafana provides. This PR removes the custom parsing and uses the default grafana format.