### PR TITLE
Chore: Send correct content-type header for json-patch requests

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/createBaseQuery.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/createBaseQuery.ts
@@ -21,13 +21,16 @@ export function createBaseQuery({ baseURL }: CreateBaseQueryOptions): BaseQueryF
         ...requestOptions.headers,
       };
 
-      // Add Content-Type header for PATCH requests to /apis/ endpoints if not already set
-      if (
-        requestOptions.method?.toUpperCase() === 'PATCH' &&
-        baseURL?.startsWith('/apis/') &&
-        !headers['Content-Type']
-      ) {
-        headers['Content-Type'] = 'application/strategic-merge-patch+json';
+      if (requestOptions.method?.toUpperCase() === 'PATCH' && baseURL?.startsWith('/apis/')) {
+        // If we're trying to do some `json-patch` operation, set Content-Type header accordingly
+        if (requestOptions.body && Array.isArray(requestOptions.body) && requestOptions.body.some((item) => item.op)) {
+          headers['Content-Type'] = 'application/json-patch+json';
+        }
+
+        // Add Content-Type header if not already set
+        if (!headers['Content-Type']) {
+          headers['Content-Type'] = 'application/strategic-merge-patch+json';
+        }
       }
 
       const { data: responseData, ...meta } = await lastValueFrom(

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -91,9 +91,12 @@ export const isContentTypeJson = (headers: Headers) => {
   const contentType = headers.get('content-type');
   if (
     contentType &&
-    ['application/json', 'application/merge-patch+json', 'application/strategic-merge-patch+json'].includes(
-      contentType.toLowerCase()
-    )
+    [
+      'application/json',
+      'application/json-patch+json',
+      'application/merge-patch+json',
+      'application/strategic-merge-patch+json',
+    ].includes(contentType.toLowerCase())
   ) {
     return true;
   }


### PR DESCRIPTION
**What is this feature?**
Sends the correct content-type header for json-patch requests

**Why do we need this feature?**
When patching resources in app platform, we can use a json-patch payload like this to describe how to change the resource:

```
[{
	op: 'delete',
	path: '/metadata/ownerReferences/0`
}]
```

When sending this, we need to specify the right content-type for the request, otherwise it won't be correctly interpreted by the API. We need to set the header in this way because right now, there isn't a way to set it with the generated clients

**Who is this feature for?**
UI devs/consumers of api clients package