### PR TITLE
DynamicDashboards: Prevent clicks on panel menu items to open the sidebar

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -216,17 +216,12 @@ export function PanelChrome({
   // Mainly the tricky bit of differentiating between dragging and selecting
   const onPointerUp = React.useCallback(
     (evt: React.PointerEvent) => {
-      if (pointerDistance.check(evt) || !(evt.target instanceof Element)) {
+      if (
+        pointerDistance.check(evt) ||
+        (dragClassCancel && evt.target instanceof Element && evt.target.closest(`.${dragClassCancel}`))
+      ) {
         return;
       }
-      if (dragClassCancel && evt.target.closest(`.${dragClassCancel}`)) {
-        return;
-      }
-      // prevents clicks on panel menu items to select the panel
-      if (evt.target.closest('button')) {
-        return;
-      }
-
       // setTimeout is needed here because onSelect stops the event propagation
       // By doing so, the event won't get to the document and drag will never be stopped
       setTimeout(() => onSelect?.(evt));
@@ -438,6 +433,7 @@ export function PanelChrome({
                   placement="bottom-end"
                   menuButtonClass={cx(styles.menuItem, dragClassCancel, showOnHoverClass)}
                   onOpenMenu={onOpenMenu}
+                  dragClassCancel={dragClassCancel}
                 />
               )}
             </div>

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -216,10 +216,14 @@ export function PanelChrome({
   // Mainly the tricky bit of differentiating between dragging and selecting
   const onPointerUp = React.useCallback(
     (evt: React.PointerEvent) => {
-      if (
-        pointerDistance.check(evt) ||
-        (dragClassCancel && evt.target instanceof Element && evt.target.closest(`.${dragClassCancel}`))
-      ) {
+      if (pointerDistance.check(evt) || !(evt.target instanceof Element)) {
+        return;
+      }
+      if (dragClassCancel && evt.target.closest(`.${dragClassCancel}`)) {
+        return;
+      }
+      // prevents clicks on panel menu items to select the panel
+      if (evt.target.closest('button')) {
         return;
       }
 

--- a/packages/grafana-ui/src/components/PanelChrome/PanelMenu.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelMenu.tsx
@@ -38,8 +38,13 @@ export function PanelMenu({
     [onOpenMenu]
   );
 
+  const overlay = () => {
+    const menuContent = typeof menu === 'function' ? menu() : menu;
+    return <div className={dragClassCancel}>{menuContent}</div>;
+  };
+
   return (
-    <Dropdown overlay={menu} placement={placement} offset={offset} onVisibleChange={handleVisibility}>
+    <Dropdown overlay={overlay} placement={placement} offset={offset} onVisibleChange={handleVisibility}>
       <Button
         aria-label={t('grafana-ui.panel-menu.label', 'Menu for panel {{ title }}', { title: title ?? 'Untitled' })}
         title={t('grafana-ui.panel-menu.title', 'Menu')}


### PR DESCRIPTION
Fixes: #116834

**What is this feature?**

https://github.com/user-attachments/assets/83124577-a592-430c-8743-6cad69e17974

**Why do we need this feature?**

To prevent the sidebar to open when it's not needed

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Issue reported in Slack

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
