### PR TITLE
Cypress/E2E: Only check dashboard uid if the fixture has one

### DIFF
--- a/e2e/utils/flows/importDashboard.ts
+++ b/e2e/utils/flows/importDashboard.ts
@@ -42,7 +42,9 @@ export const importDashboard = (dashboardToImport: Dashboard, queryTimeout?: num
         });
       });
 
-      expect(dashboardToImport.uid).to.equal(uid);
+      if (dashboardToImport.uid !== '') {
+        expect(dashboardToImport.uid).to.equal(uid);
+      }
     });
 
   if (!skipPanelValidation) {


### PR DESCRIPTION
For dashboard fixtures that have no `uid` set, when importing them, it will generate one, so we can't make this assertion always.