### PR TITLE
DynamicDashboards: Add variable_counts and new/delete variable tracking events

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/VariableAddEditableElement.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableAddEditableElement.test.tsx
@@ -1,0 +1,47 @@
+import { render } from '@testing-library/react';
+
+import { SceneGridLayout, SceneTimeRange, SceneVariableSet } from '@grafana/scenes';
+
+import { DashboardScene } from '../../scene/DashboardScene';
+import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
+import { DashboardInteractions } from '../../utils/interactions';
+import { activateFullSceneTree } from '../../utils/test-utils';
+
+import { VariableAdd, VariableTypeSelection } from './VariableAddEditableElement';
+
+function buildTestScene() {
+  const testScene = new DashboardScene({
+    $variables: new SceneVariableSet({ variables: [] }),
+    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+    isEditing: true,
+    body: new DefaultGridLayoutManager({
+      grid: new SceneGridLayout({
+        children: [],
+      }),
+    }),
+  });
+  activateFullSceneTree(testScene);
+  return testScene;
+}
+
+function renderTestScene() {
+  const dashboard = buildTestScene();
+  const variableAdd = new VariableAdd({ dashboardRef: dashboard.getRef() });
+  return render(<VariableTypeSelection variableAdd={variableAdd} />);
+}
+
+describe('VariableAddEditableElement', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('calls DashboardInteractions.newVariableTypeSelected when a variable type is clicked', () => {
+    const newVariableTypeSelectedSpy = jest.spyOn(DashboardInteractions, 'newVariableTypeSelected');
+
+    const { getByRole } = renderTestScene();
+
+    getByRole('button', { name: /query/i }).click();
+
+    expect(newVariableTypeSelectedSpy).toHaveBeenCalledWith({ type: 'query' });
+  });
+});

--- a/public/app/features/dashboard-scene/settings/variables/VariableAddEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableAddEditableElement.tsx
@@ -63,7 +63,8 @@ export class VariableAddEditableElement implements EditableDashboardElement {
   public useEditPaneOptions = useEditPaneOptions.bind(this, this.variableAdd);
 }
 
-function VariableTypeSelection({ variableAdd }: { variableAdd: VariableAdd }) {
+/** @internal Exported for testing */
+export function VariableTypeSelection({ variableAdd }: { variableAdd: VariableAdd }) {
   const options = useMemo(() => getVariableTypeSelectOptions(), []);
   const styles = useStyles2(getStyles);
 

--- a/public/app/features/dashboard-scene/settings/variables/VariableAddEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableAddEditableElement.tsx
@@ -12,6 +12,7 @@ import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/Pan
 import { dashboardEditActions } from '../../edit-pane/shared';
 import { DashboardScene } from '../../scene/DashboardScene';
 import { EditableDashboardElement, EditableDashboardElementInfo } from '../../scene/types/EditableDashboardElement';
+import { DashboardInteractions } from '../../utils/interactions';
 
 import { EditableVariableType, getNextAvailableId, getVariableScene, getVariableTypeSelectOptions } from './utils';
 
@@ -78,6 +79,7 @@ function VariableTypeSelection({ variableAdd }: { variableAdd: VariableAdd }) {
       const newVar = getVariableScene(type, { name: getNextAvailableId(type, variablesSet.state.variables ?? []) });
       dashboardEditActions.addVariable({ source: variablesSet, addedObject: newVar });
       dashboard.state.editPane.selectObject(newVar, newVar.state.key!, { force: true, multi: false });
+      DashboardInteractions.newVariableTypeSelected({ type });
     },
     [variableAdd]
   );

--- a/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx
@@ -15,6 +15,7 @@ import { BulkActionElement } from '../../scene/types/BulkActionElement';
 import { EditableDashboardElement, EditableDashboardElementInfo } from '../../scene/types/EditableDashboardElement';
 import { VariableDisplaySelect } from '../../settings/variables/components/VariableDisplaySelect';
 import { getEditableVariableDefinition, validateVariableName } from '../../settings/variables/utils';
+import { DashboardInteractions } from '../../utils/interactions';
 
 import { useVariableSelectionOptionsCategory } from './useVariableSelectionOptionsCategory';
 
@@ -112,6 +113,7 @@ export class VariableEditableElement implements EditableDashboardElement, BulkAc
         source: set,
         removedObject: this.variable,
       });
+      DashboardInteractions.deleteVariableButtonClicked({ type: this.variable.state.type });
     }
   }
 

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -87,6 +87,18 @@ export const DashboardInteractions = {
     reportDashboardInteraction('add_variable_button_clicked', properties);
   },
 
+  // dashboards_new_variable_type_selected
+  // when a user selects a variable type when creating a new variable
+  newVariableTypeSelected: (properties: { type: string }) => {
+    reportDashboardInteraction('new_variable_type_selected', properties);
+  },
+
+  // dashboards_delete_variable_button_clicked
+  // when a user deletes a variable
+  deleteVariableButtonClicked: (properties: { type: string }) => {
+    reportDashboardInteraction('delete_variable_button_clicked', properties);
+  },
+
   // dashboards_variables_reordered
   // when a user drags and drops a variable in the content outline
   variablesReordered: (properties: { source: 'edit_pane' }) => {

--- a/public/app/features/dashboard-scene/utils/tracking.test.ts
+++ b/public/app/features/dashboard-scene/utils/tracking.test.ts
@@ -63,6 +63,14 @@ describe('dashboard tracking', () => {
           cloudwatch: 5,
           datasource: 1,
         },
+        variable_counts: {
+          custom: 3,
+          custom_csv: 2,
+          custom_json: 1,
+          query: 1,
+          datasource: 1,
+          adhoc: 1,
+        },
       });
     });
 
@@ -88,6 +96,14 @@ describe('dashboard tracking', () => {
         panelsByDatasourceType: {
           cloudwatch: 5,
           datasource: 1,
+        },
+        variable_counts: {
+          custom: 3,
+          custom_csv: 2,
+          custom_json: 1,
+          query: 1,
+          datasource: 1,
+          adhoc: 1,
         },
         transformation_counts: { organize: 2, reduce: 1 },
         expression_counts: { sql: 3, math: 1 },

--- a/public/app/features/dashboard-scene/utils/tracking.test.ts
+++ b/public/app/features/dashboard-scene/utils/tracking.test.ts
@@ -63,14 +63,12 @@ describe('dashboard tracking', () => {
           cloudwatch: 5,
           datasource: 1,
         },
-        variable_counts: {
-          custom: 3,
-          custom_csv: 2,
-          custom_json: 1,
-          query: 1,
-          datasource: 1,
-          adhoc: 1,
-        },
+        variable_type_custom_count: 3,
+        variable_type_custom_csv_count: 2,
+        variable_type_custom_json_count: 1,
+        variable_type_query_count: 1,
+        variable_type_datasource_count: 1,
+        variable_type_adhoc_count: 1,
       });
     });
 
@@ -97,14 +95,12 @@ describe('dashboard tracking', () => {
           cloudwatch: 5,
           datasource: 1,
         },
-        variable_counts: {
-          custom: 3,
-          custom_csv: 2,
-          custom_json: 1,
-          query: 1,
-          datasource: 1,
-          adhoc: 1,
-        },
+        variable_type_custom_count: 3,
+        variable_type_custom_csv_count: 2,
+        variable_type_custom_json_count: 1,
+        variable_type_query_count: 1,
+        variable_type_datasource_count: 1,
+        variable_type_adhoc_count: 1,
         transformation_counts: { organize: 2, reduce: 1 },
         expression_counts: { sql: 3, math: 1 },
       });

--- a/public/app/features/dashboard-scene/utils/tracking.ts
+++ b/public/app/features/dashboard-scene/utils/tracking.ts
@@ -77,15 +77,13 @@ export function trackDashboardSceneCreatedOrSaved(
   const sceneDashboardTrackingInfo = dashboard.getTrackingInformation();
   const dynamicDashboardsTrackingInformation = dashboard.getDynamicDashboardsTrackingInformation();
 
-  // Extract variable type counts from tracking info and group them
-  const variableCountsByType = sceneDashboardTrackingInfo
-    ? Object.fromEntries(
-        Object.entries(sceneDashboardTrackingInfo).flatMap(([key, value]) => {
-          const [, type] = key.match(/^variable_type_(.+)_count$/) || [];
-          return type ? [[type, value]] : [];
-        })
-      )
-    : {};
+  // Extract variable type counts from tracking info
+  const variables = Object.entries(sceneDashboardTrackingInfo ?? {})
+    .filter(([key]) => /^variable_type_.+_count$/.test(key))
+    .reduce<Record<string, number>>((acc, [key, value]) => {
+      acc[key] = value;
+      return acc;
+    }, {});
 
   const dashboardLibraryProperties =
     config.featureToggles.dashboardLibrary ||
@@ -112,14 +110,14 @@ export function trackDashboardSceneCreatedOrSaved(
           autoLayoutCount: dynamicDashboardsTrackingInformation.autoLayoutCount,
           customGridLayoutCount: dynamicDashboardsTrackingInformation.customGridLayoutCount,
           panelsByDatasourceType: dynamicDashboardsTrackingInformation.panelsByDatasourceType,
-          variable_counts: variableCountsByType,
+          ...variables,
           ...dashboardLibraryProperties,
         }
       : {
           uid: dashboard.state.uid || '',
           numPanels: sceneDashboardTrackingInfo?.panels_count || 0,
           numRows: sceneDashboardTrackingInfo?.rowCount || 0,
-          variable_counts: variableCountsByType,
+          ...variables,
           ...dashboardLibraryProperties,
         }),
   });

--- a/public/app/features/dashboard-scene/utils/tracking.ts
+++ b/public/app/features/dashboard-scene/utils/tracking.ts
@@ -80,9 +80,10 @@ export function trackDashboardSceneCreatedOrSaved(
   // Extract variable type counts from tracking info and group them
   const variableCountsByType = sceneDashboardTrackingInfo
     ? Object.fromEntries(
-        Object.entries(sceneDashboardTrackingInfo)
-          .filter(([key]) => key.startsWith('variable_type_'))
-          .map(([key, value]) => [key.replace('variable_type_', '').replace('_count', ''), value])
+        Object.entries(sceneDashboardTrackingInfo).flatMap(([key, value]) => {
+          const [, type] = key.match(/^variable_type_(.+)_count$/) || [];
+          return type ? [[type, value]] : [];
+        })
       )
     : {};
 

--- a/public/app/features/dashboard-scene/utils/tracking.ts
+++ b/public/app/features/dashboard-scene/utils/tracking.ts
@@ -77,6 +77,15 @@ export function trackDashboardSceneCreatedOrSaved(
   const sceneDashboardTrackingInfo = dashboard.getTrackingInformation();
   const dynamicDashboardsTrackingInformation = dashboard.getDynamicDashboardsTrackingInformation();
 
+  // Extract variable type counts from tracking info and group them
+  const variableCountsByType = sceneDashboardTrackingInfo
+    ? Object.fromEntries(
+        Object.entries(sceneDashboardTrackingInfo)
+          .filter(([key]) => key.startsWith('variable_type_'))
+          .map(([key, value]) => [key.replace('variable_type_', '').replace('_count', ''), value])
+      )
+    : {};
+
   const dashboardLibraryProperties =
     config.featureToggles.dashboardLibrary ||
     config.featureToggles.dashboardTemplates ||
@@ -102,12 +111,14 @@ export function trackDashboardSceneCreatedOrSaved(
           autoLayoutCount: dynamicDashboardsTrackingInformation.autoLayoutCount,
           customGridLayoutCount: dynamicDashboardsTrackingInformation.customGridLayoutCount,
           panelsByDatasourceType: dynamicDashboardsTrackingInformation.panelsByDatasourceType,
+          variable_counts: variableCountsByType,
           ...dashboardLibraryProperties,
         }
       : {
           uid: dashboard.state.uid || '',
           numPanels: sceneDashboardTrackingInfo?.panels_count || 0,
           numRows: sceneDashboardTrackingInfo?.rowCount || 0,
+          variable_counts: variableCountsByType,
           ...dashboardLibraryProperties,
         }),
   });


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana-org/issues/718

**"Update" events**

- `grafana_dashboard_saved` includes the type of variables that were added to dashboard
- `grafana_dashboard_created` includes the type of variables that were included in the dashboard

**"New" events**

- `dashboards_variable_type_selected` when a user select one of "Choose variable type" 
- `dashboards_delete_variable_button_clicked` when a user deletes a variable