### PR TITLE
Alerting: Refactor processMissingSeriesStates

### DIFF
--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -510,8 +510,7 @@ func (st *Manager) processMissingSeriesStates(logger log.Logger, evaluatedAt tim
 		}
 
 		oldState, oldReason := s.State, s.StateReason
-		isStale := stateIsStale(evaluatedAt, s.LastEvaluationTime, alertRule.IntervalSeconds, missingEvalsToResolve)
-		if isStale {
+		if stateIsStale(evaluatedAt, s.LastEvaluationTime, alertRule.IntervalSeconds, missingEvalsToResolve) {
 			logger.Info("Detected stale state entry", "cacheID", s.CacheID, "state", s.State, "reason", s.StateReason)
 
 			s.State = eval.Normal

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -488,7 +488,7 @@ func (st *Manager) Put(states []*State) {
 // findAndResolveMissingSeriesStates finds cached states missing from the current evaluation,
 // resolves any that are stale, and returns them to be sent to the Alertmanager if needed.
 func (st *Manager) findAndResolveMissingSeriesStates(logger log.Logger, evaluatedAt time.Time, alertRule *ngModels.AlertRule, takeImageFn takeImageFn) ([]StateTransition, int) {
-	var missingTransitions []StateTransition
+	missingTransitions := []StateTransition{}
 	toDeleteStates := map[data.Fingerprint]struct{}{}
 
 	for _, s := range st.cache.getStatesForRuleUID(alertRule.OrgID, alertRule.UID) {

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -338,7 +338,7 @@ func (st *Manager) ProcessEvalResults(
 	logger.Debug("State manager processing evaluation results", "resultCount", len(results))
 	states := st.setNextStateForRule(ctx, alertRule, results, extraLabels, logger, fn, evaluatedAt)
 
-	missingSeriesStates, staleCount := st.findAndResolveMissingSeriesStates(logger, evaluatedAt, alertRule, fn)
+	missingSeriesStates, staleCount := st.processMissingSeriesStates(logger, evaluatedAt, alertRule, fn)
 	span.AddEvent("results processed", trace.WithAttributes(
 		attribute.Int("state_transitions", len(states)),
 		attribute.Int("stale_states", staleCount),
@@ -485,9 +485,9 @@ func (st *Manager) Put(states []*State) {
 	}
 }
 
-// findAndResolveMissingSeriesStates finds cached states missing from the current evaluation,
+// processMissingSeriesStates finds cached states missing from the current evaluation,
 // resolves any that are stale, and returns them to be sent to the Alertmanager if needed.
-func (st *Manager) findAndResolveMissingSeriesStates(logger log.Logger, evaluatedAt time.Time, alertRule *ngModels.AlertRule, takeImageFn takeImageFn) ([]StateTransition, int) {
+func (st *Manager) processMissingSeriesStates(logger log.Logger, evaluatedAt time.Time, alertRule *ngModels.AlertRule, takeImageFn takeImageFn) ([]StateTransition, int) {
 	missingTransitions := []StateTransition{}
 	toDeleteStates := map[data.Fingerprint]struct{}{}
 


### PR DESCRIPTION
## Summary

Refactors `processMissingSeriesStates` for clarity:

- Removed `toDelete` closure with side effects, inlined the logic into the main loop
- Replaced `staleStatesCount` counter with `len(toDeleteStates)`, no need to keep a separate counter

No functional changes, refactor only.
