### PR TITLE
TeamFolders: Add tracking event on OwenerReference

### DIFF
--- a/public/app/core/components/OwnerReferences/OwnerReference.tsx
+++ b/public/app/core/components/OwnerReferences/OwnerReference.tsx
@@ -1,6 +1,7 @@
 import { OwnerReference as OwnerReferenceType } from '@grafana/api-clients/rtkq/folder/v1beta1';
 import { useGetTeamMembersQuery, useGetTeamQuery } from '@grafana/api-clients/rtkq/iam/v0alpha1';
 import { Trans } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
 import { Stack, Text, Link, Tooltip } from '@grafana/ui';
 
 /**
@@ -35,7 +36,11 @@ const OwnerReference = ({
   }
 
   return (
-    <Link href={`/org/teams/edit/${ownerReference.uid}/members`} key={ownerReference.uid}>
+    <Link
+      href={`/org/teams/edit/${ownerReference.uid}/members`}
+      key={ownerReference.uid}
+      onClick={() => reportInteraction('grafana_owner_reference_link_clicked')}
+    >
       <Tooltip content={membersTooltip}>
         <Stack gap={1} alignItems="center">
           {team.spec.title}


### PR DESCRIPTION
**What is this feature?**
I'm adding a tracking event for Team Folders feature
- `grafana_owner_reference_link_clicked`: when users click on an owner reference in the header of folder view (BrowseDashboardsPage)
**NOTE:** This event is currently only triggered from the folder view but will also be included in the BrowseDashboardsPage and Manage Permissions drawer in the future. To distinguishing the origin of the event we can refer to `context_page_url` which is being automatically saved.

**Which issue(s) does this PR fix?**:
Contributes to #115237

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
