### PR TITLE
DO NOT MERGE: test repoduction

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -1,3 +1,4 @@
+import { OpenFeature } from '@openfeature/web-sdk';
 import { lastValueFrom, merge, Observable, of } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 
@@ -135,6 +136,8 @@ class DataSourceWithBackend<
    * Ideally final -- any other implementation may not work as expected
    */
   query(request: DataQueryRequest<TQuery>): Observable<DataQueryResponse> {
+    window.alert(JSON.stringify(OpenFeature.getClient().getObjectDetails('testflag42',{})));
+
     if (config.publicDashboardAccessToken) {
       return publicDashboardQueryHandler(request);
     }


### PR DESCRIPTION
### how to reproduce the problem:

- 1. in your `feature_toggles` section add a new feature flag:
```ini
[feature_toggles]
testflag42 = {"a":1, "b":2}
```
- 2. run grafana locally (`yarn install`, `yarn run dev`, build grafana-binary and run it)
- 3. go to explore-page and run a query.

### result
- A. it will show in a popup the result of evaluating the `testflag42`, it will claim `not found`
<img width="479" height="220" alt="flag" src="https://github.com/user-attachments/assets/ef75e2b4-b7c8-49af-bab3-2ee47c5dd5fa" />

- B. if you check the grafana-server logs, when you do this the first time, it emits this error message: `ERROR ... failed to evaluate flag during bulk evaluation logger=static-evaluator flagKey=testflag42 error="error code: TYPE_MISMATCH: incorrect type association"`