### PR TITLE
Provisioning: Use provisioning identity in dualwriter operations

### DIFF
--- a/pkg/registry/apis/provisioning/resources/dualwriter.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter.go
@@ -126,6 +126,12 @@ func (r *DualReadWriter) Delete(ctx context.Context, opts DualWriteOptions) (*Pa
 		}
 	}
 
+	// Always use the provisioning identity when writing
+	ctx, _, err = identity.WithProvisioningIdentity(ctx, parsed.Obj.GetNamespace())
+	if err != nil {
+		return nil, fmt.Errorf("unable to use provisioning identity: %w", err)
+	}
+
 	err = r.repo.Delete(ctx, opts.Path, opts.Ref, opts.Message)
 	if err != nil {
 		return nil, fmt.Errorf("delete file from repository: %w", err)
@@ -155,6 +161,12 @@ func (r *DualReadWriter) CreateFolder(ctx context.Context, opts DualWriteOptions
 
 	if err := r.authorizeCreateFolder(ctx, opts.Path); err != nil {
 		return nil, err
+	}
+
+	// Always use the provisioning identity when writing
+	ctx, _, err := identity.WithProvisioningIdentity(ctx, r.repo.Config().Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("unable to use provisioning identity: %w", err)
 	}
 
 	// Now actually create the folder
@@ -542,8 +554,14 @@ func (r *DualReadWriter) deleteFolder(ctx context.Context, opts DualWriteOptions
 		}
 	}
 
+	// Always use the provisioning identity when writing
+	ctx, _, err := identity.WithProvisioningIdentity(ctx, r.repo.Config().Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("unable to use provisioning identity: %w", err)
+	}
+
 	// For branch operations, just delete from the repository without updating Grafana DB
-	err := r.repo.Delete(ctx, opts.Path, opts.Ref, opts.Message)
+	err = r.repo.Delete(ctx, opts.Path, opts.Ref, opts.Message)
 	if err != nil {
 		return nil, fmt.Errorf("error deleting folder from repository: %w", err)
 	}


### PR DESCRIPTION
## Problem

Some dualwriter operations were not using the provisioning identity when writing to the repository or Grafana DB. This can hit non-admin users using the git sync feature in single tenant. 

## Solution

Added `WithProvisioningIdentity` calls to all write operations in dualwriter that were missing it:

**Operations fixed:**
1. **Delete** - Added provisioning identity before `repo.Delete` and `parsed.Run` calls
2. **CreateFolder** - Added provisioning identity before `repo.Create` and folder operations
3. **deleteFolder** - Added provisioning identity before `repo.Delete` call

**Operations that already had it:**
- `createOrUpdate` - Already using provisioning identity ✓
- `moveDirectory` - Already using provisioning identity ✓
- `moveFile` - Already using provisioning identity ✓

This ensures all dualwriter operations use the provisioning identity.


🤖 Generated with [Claude Code](https://claude.com/claude-code)