### PR TITLE
 Dashboard: Add warning log when variable is skipped due to unsupported type

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
@@ -1002,6 +1002,8 @@ func transformVariables(ctx context.Context, dashboard map[string]interface{}, d
 
 	variables := make([]dashv2alpha1.DashboardVariableKind, 0, len(list))
 
+	dashboardUID := schemaversion.GetStringValue(dashboard, "uid")
+
 	for _, v := range list {
 		varMap, ok := v.(map[string]interface{})
 		if !ok {
@@ -1050,7 +1052,12 @@ func transformVariables(ctx context.Context, dashboard map[string]interface{}, d
 				variables = append(variables, groupByVar)
 			}
 		default:
-			// Skip unknown variable types
+			// Log and skip unsupported variable type
+			getLogger().Warn("Variable skipped during conversion: unsupported variable type",
+				"dashboardUID", dashboardUID,
+				"variableName", commonProps.Name,
+				"variableType", varType,
+			)
 			continue
 		}
 	}

--- a/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
@@ -1002,8 +1002,6 @@ func transformVariables(ctx context.Context, dashboard map[string]interface{}, d
 
 	variables := make([]dashv2alpha1.DashboardVariableKind, 0, len(list))
 
-	dashboardUID := schemaversion.GetStringValue(dashboard, "uid")
-
 	for _, v := range list {
 		varMap, ok := v.(map[string]interface{})
 		if !ok {
@@ -1054,7 +1052,6 @@ func transformVariables(ctx context.Context, dashboard map[string]interface{}, d
 		default:
 			// Log and skip unsupported variable type
 			getLogger().Warn("Variable skipped during conversion: unsupported variable type",
-				"dashboardUID", dashboardUID,
 				"variableName", commonProps.Name,
 				"variableType", varType,
 			)


### PR DESCRIPTION
**What is this feature?**

Adds a warning log when a dashboard variable is skipped during v0→v2 conversion due to an unsupported variable type.