### PR TITLE
Docs: Add note pointing to dynamic dashboards docs

### DIFF
--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/index.md
@@ -19,6 +19,10 @@ weight: 1
 
 ## Create a dashboard
 
+{{< admonition type="note" >}}
+For information on the new dynamic dashboards editing experience, refer to the [next version of the Grafana OSS documentation](https://grafana.com/docs/grafana/next/visualizations/dashboards/build-dashboards/create-dashboard/).
+{{< /admonition >}}
+
 Dashboards and panels allow you to show your data in visual form. Each panel needs at least one query to display a visualization.
 
 **Before you begin:**


### PR DESCRIPTION
This PR adds a note in the 12.3 docs pointing users to the `next` version if they want to see docs about the new editing experience.

**Backport this PR to 12.4 when that release branch is cut.**
