### PR TITLE
Alerting: Restrict import UI to admin users only

### DIFF
--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -257,13 +257,7 @@ export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
     },
     {
       path: '/alerting/import-to-gma',
-      roles: evaluateAccess([
-        // For rules import
-        AccessControlAction.AlertingRuleCreate,
-        AccessControlAction.AlertingProvisioningSetStatus,
-        // For notifications import (contact points, policies, templates, time intervals)
-        AccessControlAction.AlertingNotificationsWrite,
-      ]),
+      roles: () => ['Admin'],
       component: config.featureToggles.alertingMigrationWizardUI
         ? importAlertingComponent(
             () =>

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
@@ -191,6 +191,7 @@ describe('RuleListActions', () => {
       newGrafanaRecordingRule: byRole('link', { name: /new grafana recording rule/i }),
       newDataSourceRecordingRule: byRole('link', { name: /new data source recording rule/i }),
       importAlertRules: byRole('link', { name: /import alert rules/i }),
+      importToGma: byRole('link', { name: /import to gma/i }),
       exportAllGrafanaRules: byRole('menuitem', { name: /export all grafana rules/i }),
     },
     exportDrawer: byRole('dialog', { name: /export/i }),
@@ -321,6 +322,32 @@ describe('RuleListActions', () => {
       const importMenuItem = ui.menuOptions.importAlertRules.get(menu);
 
       expect(importMenuItem).toHaveAttribute('href', '/alerting/import-datasource-managed-rules');
+    });
+  });
+
+  describe('Import to GMA Wizard', () => {
+    testWithFeatureToggles({ enable: ['alertingMigrationWizardUI'] });
+
+    it('should show "Import to GMA" option when user is admin with required permissions', async () => {
+      grantUserRole(OrgRole.Admin);
+      grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingNotificationsWrite]);
+
+      const { user } = render(<RuleListActions />);
+      await user.click(ui.moreButton.get());
+      const menu = await ui.moreMenu.find();
+
+      expect(ui.menuOptions.importToGma.query(menu)).toBeInTheDocument();
+    });
+
+    it('should not show "Import to GMA" option when user is not admin', async () => {
+      grantUserRole(OrgRole.Viewer);
+      grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingNotificationsWrite]);
+
+      const { user } = render(<RuleListActions />);
+      await user.click(ui.moreButton.get());
+      const menu = await ui.moreMenu.find();
+
+      expect(ui.menuOptions.importToGma.query(menu)).not.toBeInTheDocument();
     });
   });
 

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
@@ -15,6 +15,7 @@ import { AlertingAction, useAlertingAbility } from '../hooks/useAbilities';
 import { useRulesFilter } from '../hooks/useFilteredRules';
 import { useAlertRulesNav } from '../navigation/useAlertRulesNav';
 import { getRulesDataSources } from '../utils/datasource';
+import { isAdmin } from '../utils/misc';
 
 import { FilterView } from './FilterView';
 import { GroupedView } from './GroupedView';
@@ -59,12 +60,7 @@ export function RuleListActions() {
     contextSrv.hasPermission(AccessControlAction.AlertingRuleCreate) &&
     contextSrv.hasPermission(AccessControlAction.AlertingProvisioningSetStatus);
 
-  // Migration Wizard UI requires either notifications or rules import permission (user can skip one step)
-  const canAccessMigrationWizardUI =
-    config.featureToggles.alertingMigrationWizardUI &&
-    (contextSrv.hasPermission(AccessControlAction.AlertingNotificationsWrite) ||
-      (contextSrv.hasPermission(AccessControlAction.AlertingRuleCreate) &&
-        contextSrv.hasPermission(AccessControlAction.AlertingProvisioningSetStatus)));
+  const canAccessMigrationWizardUI = config.featureToggles.alertingMigrationWizardUI && isAdmin();
 
   const [showExportDrawer, toggleShowExportDrawer] = useToggle(false);
 


### PR DESCRIPTION
**What is this feature?**
This PR hides the navigation entrypoint and route for the import to GMA wizard from non admin users


**Why do we need this feature?**

The import function should only be available for admin users

**Who is this feature for?**

Alerting users migrating to grafana managed alerts

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1398

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

**How to test these chages**
- Ensure the `alertingMigrationWizardUI` feature flag is enabled
- Login with a non admin user
  - Navigate to the alert rules page
  - Check that the "Import to GMA" option is not visible when clicking the "More" button on the top right corner
  - Check that navigating directly to `/alerting/import-to-gma` is not possible

- Login with a admin user
  - Check that the navigation entrypoint to the import wizard is visible in the alert rules page
  - Check that you are able to navigate directly to `/alerting/import-to-gma`