### PR TITLE
chore(infra/tracing): Deprecate TracingMiddleware, replace with NewTracingMiddleware

### DIFF
--- a/pkg/infra/httpclient/httpclientprovider/http_client_provider.go
+++ b/pkg/infra/httpclient/httpclientprovider/http_client_provider.go
@@ -7,10 +7,10 @@ import (
 	"github.com/grafana/grafana-aws-sdk/pkg/awsauth"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/mwitkow/go-conntrack"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics/metricutil"
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/validations"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -18,11 +18,11 @@ import (
 var newProviderFunc = sdkhttpclient.NewProvider
 
 // New creates a new HTTP client provider with pre-configured middlewares.
-func New(cfg *setting.Cfg, validator validations.DataSourceRequestURLValidator, tracer tracing.Tracer) *sdkhttpclient.Provider {
+func New(cfg *setting.Cfg, validator validations.DataSourceRequestURLValidator, _ trace.Tracer) *sdkhttpclient.Provider {
 	logger := log.New("httpclient")
 
 	middlewares := []sdkhttpclient.Middleware{
-		TracingMiddleware(logger, tracer),
+		NewTracingMiddleware(),
 		DataSourceMetricsMiddleware(),
 		sdkhttpclient.ContextualMiddleware(),
 		SetUserAgentMiddleware(cfg.DataProxyUserAgent),

--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/services"
 	jaegerpropagator "go.opentelemetry.io/contrib/propagators/jaeger"
 	"go.opentelemetry.io/contrib/samplers/jaegerremote"
 	"go.opentelemetry.io/otel"
@@ -27,9 +29,6 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc/credentials"
 
-	"github.com/go-kit/log/level"
-
-	"github.com/grafana/dskit/services"
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/infra/log"
 )
@@ -66,6 +65,8 @@ type tracerProvider interface {
 }
 
 // Tracer defines the service used to create new spans.
+//
+// Soon to be deprecated: use [go.opentelemetry.io/otel/trace.Tracer] instead.
 type Tracer interface {
 	trace.Tracer
 
@@ -77,6 +78,8 @@ type Tracer interface {
 	// information passed as [Span] is preferred.
 	// Both the context and span must be derived from the same call to
 	// [Tracer.Start].
+	//
+	// Deprecated: Use otel.GetTextMapPropagator().Inject directly instead.
 	Inject(context.Context, http.Header, trace.Span)
 }
 
@@ -342,6 +345,7 @@ func (ots *TracingService) Run(ctx context.Context) error {
 	return ots.AwaitTerminated(ctx)
 }
 
+// Deprecated: Use otel.GetTextMapPropagator().Inject directly instead.
 func (ots *TracingService) Inject(ctx context.Context, header http.Header, _ trace.Span) {
 	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(header))
 }

--- a/pkg/infra/usagestats/service/service.go
+++ b/pkg/infra/usagestats/service/service.go
@@ -6,10 +6,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/supportbundles"
@@ -23,7 +24,7 @@ type UsageStats struct {
 	accesscontrol ac.AccessControl
 
 	log    log.Logger
-	tracer tracing.Tracer
+	tracer trace.Tracer
 
 	externalMetrics     []usagestats.MetricsFunc
 	sendReportCallbacks []usagestats.SendReportCallbackFunc
@@ -34,7 +35,7 @@ type UsageStats struct {
 func ProvideService(cfg *setting.Cfg,
 	kvStore kvstore.KVStore,
 	routeRegister routing.RouteRegister,
-	tracer tracing.Tracer,
+	tracer trace.Tracer,
 	accesscontrol ac.AccessControl,
 	bundleRegistry supportbundles.Service,
 ) (*UsageStats, error) {

--- a/pkg/infra/usagestats/service/usage_stats.go
+++ b/pkg/infra/usagestats/service/usage_stats.go
@@ -14,8 +14,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
@@ -171,7 +173,7 @@ var sendUsageStats = func(uss *UsageStats, ctx context.Context, data *bytes.Buff
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	uss.tracer.Inject(ctx, req.Header, span)
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
 	resp, err := client.Do(req)
 	if err != nil {
 		span.SetStatus(codes.Error, fmt.Sprintf("failed to send usage stats: %v", err))

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -325,9 +325,10 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 		return nil, err
 	}
 	kvStore := kvstore.ProvideService(sqlStore)
+	tracer := otelTracer()
 	accessControl := acimpl.ProvideAccessControl(featureToggles)
 	bundleregistryService := bundleregistry.ProvideService()
-	usageStats, err := service.ProvideService(cfg, kvStore, routeRegisterImpl, tracingService, accessControl, bundleregistryService)
+	usageStats, err := service.ProvideService(cfg, kvStore, routeRegisterImpl, tracer, accessControl, bundleregistryService)
 	if err != nil {
 		return nil, err
 	}
@@ -394,9 +395,8 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 		return nil, err
 	}
 	validate := pipeline.ProvideValidationStage(pluginManagementCfg, validation, angularinspectorService)
-	tracer := otelTracer()
 	ossDataSourceRequestURLValidator := validations.ProvideURLValidator()
-	httpclientProvider := httpclientprovider.New(cfg, ossDataSourceRequestURLValidator, tracingService)
+	httpclientProvider := httpclientprovider.New(cfg, ossDataSourceRequestURLValidator, tracer)
 	azuremonitorService := azuremonitor.ProvideService(httpclientProvider)
 	cloudwatchService := cloudwatch.ProvideService()
 	cloudmonitoringService := cloudmonitoring.ProvideService(httpclientProvider)
@@ -711,14 +711,14 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	if err != nil {
 		return nil, err
 	}
-	grafanaService, err := updatemanager.ProvideGrafanaService(cfg, tracingService)
+	grafanaService, err := updatemanager.ProvideGrafanaService(cfg, tracer)
 	if err != nil {
 		return nil, err
 	}
 	managedpluginsNoop := managedplugins.NewNoop()
 	preinstallImpl := pluginchecker.ProvidePreinstall(cfg)
 	plugincheckerService := pluginchecker.ProvideService(managedpluginsNoop, noop, preinstallImpl)
-	pluginsService, err := updatemanager.ProvidePluginsService(cfg, pluginstoreService, pluginInstaller, tracingService, featureToggles, plugincheckerService)
+	pluginsService, err := updatemanager.ProvidePluginsService(cfg, pluginstoreService, pluginInstaller, tracer, featureToggles, plugincheckerService)
 	if err != nil {
 		return nil, err
 	}
@@ -1014,9 +1014,10 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 		return nil, err
 	}
 	kvStore := kvstore.ProvideService(sqlStore)
+	tracer := otelTracer()
 	accessControl := acimpl.ProvideAccessControl(featureToggles)
 	bundleregistryService := bundleregistry.ProvideService()
-	usageStats, err := service.ProvideService(cfg, kvStore, routeRegisterImpl, tracingService, accessControl, bundleregistryService)
+	usageStats, err := service.ProvideService(cfg, kvStore, routeRegisterImpl, tracer, accessControl, bundleregistryService)
 	if err != nil {
 		return nil, err
 	}
@@ -1083,9 +1084,8 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 		return nil, err
 	}
 	validate := pipeline.ProvideValidationStage(pluginManagementCfg, validation, angularinspectorService)
-	tracer := otelTracer()
 	ossDataSourceRequestURLValidator := validations.ProvideURLValidator()
-	httpclientProvider := httpclientprovider.New(cfg, ossDataSourceRequestURLValidator, tracingService)
+	httpclientProvider := httpclientprovider.New(cfg, ossDataSourceRequestURLValidator, tracer)
 	azuremonitorService := azuremonitor.ProvideService(httpclientProvider)
 	cloudwatchService := cloudwatch.ProvideService()
 	cloudmonitoringService := cloudmonitoring.ProvideService(httpclientProvider)
@@ -1402,14 +1402,14 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	if err != nil {
 		return nil, err
 	}
-	grafanaService, err := updatemanager.ProvideGrafanaService(cfg, tracingService)
+	grafanaService, err := updatemanager.ProvideGrafanaService(cfg, tracer)
 	if err != nil {
 		return nil, err
 	}
 	managedpluginsNoop := managedplugins.NewNoop()
 	preinstallImpl := pluginchecker.ProvidePreinstall(cfg)
 	plugincheckerService := pluginchecker.ProvideService(managedpluginsNoop, noop, preinstallImpl)
-	pluginsService, err := updatemanager.ProvidePluginsService(cfg, pluginstoreService, pluginInstaller, tracingService, featureToggles, plugincheckerService)
+	pluginsService, err := updatemanager.ProvidePluginsService(cfg, pluginstoreService, pluginInstaller, tracer, featureToggles, plugincheckerService)
 	if err != nil {
 		return nil, err
 	}
@@ -1704,9 +1704,10 @@ func InitializeForCLI(ctx context.Context, cfg *setting.Cfg) (Runner, error) {
 	providerProvider := provider.ProvideEncryptionProvider()
 	kvStore := kvstore.ProvideService(sqlStore)
 	routeRegisterImpl := routing.ProvideRegister()
+	tracer := otelTracer()
 	accessControl := acimpl.ProvideAccessControl(featureToggles)
 	bundleregistryService := bundleregistry.ProvideService()
-	usageStats, err := service.ProvideService(cfg, kvStore, routeRegisterImpl, tracingService, accessControl, bundleregistryService)
+	usageStats, err := service.ProvideService(cfg, kvStore, routeRegisterImpl, tracer, accessControl, bundleregistryService)
 	if err != nil {
 		return Runner{}, err
 	}
@@ -1739,7 +1740,6 @@ func InitializeForCLI(ctx context.Context, cfg *setting.Cfg) (Runner, error) {
 	if err != nil {
 		return Runner{}, err
 	}
-	tracer := otelTracer()
 	databaseDatabase := database4.ProvideDatabase(sqlStore, tracer)
 	registerer := metrics.ProvideRegisterer()
 	globalDataKeyStorage, err := encryption.ProvideGlobalDataKeyStorage(databaseDatabase, tracer, registerer)

--- a/pkg/server/wireexts_oss.go
+++ b/pkg/server/wireexts_oss.go
@@ -188,6 +188,7 @@ var wireExtsBaseCLISet = wire.NewSet(
 	setting.ProvideProvider, wire.Bind(new(setting.Provider), new(*setting.OSSImpl)),
 	licensing.ProvideService, wire.Bind(new(licensing.Licensing), new(*licensing.OSSLicensingService)),
 	configProviderExtras,
+	withOTelSet,
 )
 
 // wireModuleServerSet is a wire set for the ModuleServer.

--- a/pkg/services/updatemanager/grafana.go
+++ b/pkg/services/updatemanager/grafana.go
@@ -13,10 +13,10 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/hashicorp/go-version"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana/pkg/infra/httpclient/httpclientprovider"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -31,14 +31,14 @@ type GrafanaService struct {
 	httpClient     httpClient
 	mutex          sync.RWMutex
 	log            log.Logger
-	tracer         tracing.Tracer
+	tracer         trace.Tracer
 }
 
-func ProvideGrafanaService(cfg *setting.Cfg, tracer tracing.Tracer) (*GrafanaService, error) {
+func ProvideGrafanaService(cfg *setting.Cfg, tracer trace.Tracer) (*GrafanaService, error) {
 	logger := log.New("grafana.update.checker")
 	cl, err := httpclient.New(httpclient.Options{
 		Middlewares: []httpclient.Middleware{
-			httpclientprovider.TracingMiddleware(logger, tracer),
+			httpclientprovider.NewTracingMiddleware(),
 		},
 	})
 	if err != nil {

--- a/pkg/services/updatemanager/plugins.go
+++ b/pkg/services/updatemanager/plugins.go
@@ -15,10 +15,10 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/open-feature/go-sdk/openfeature"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana/pkg/infra/httpclient/httpclientprovider"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginchecker"
@@ -40,7 +40,7 @@ type PluginsService struct {
 	httpClient      httpClient
 	mutex           sync.RWMutex
 	log             log.Logger
-	tracer          tracing.Tracer
+	tracer          trace.Tracer
 	updateCheckURL  *url.URL
 	pluginInstaller plugins.Installer
 	updateChecker   *pluginchecker.Service
@@ -53,14 +53,14 @@ type PluginsService struct {
 func ProvidePluginsService(cfg *setting.Cfg,
 	pluginStore pluginstore.Store,
 	pluginInstaller plugins.Installer,
-	tracer tracing.Tracer,
+	tracer trace.Tracer,
 	features featuremgmt.FeatureToggles,
 	updateChecker *pluginchecker.Service,
 ) (*PluginsService, error) {
 	logger := log.New("plugins.update.checker")
 	cl, err := httpclient.New(httpclient.Options{
 		Middlewares: []httpclient.Middleware{
-			httpclientprovider.TracingMiddleware(logger, tracer),
+			httpclientprovider.NewTracingMiddleware(),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
**What is this feature?**

Deprecates `Tracer.Inject` and simplifies the HTTP client tracing middleware to use OTel's propagator directly.

Also `TracingMiddleware` is deprecated in favour of `NewTracingMiddleware()` (no params).

**Why do we need this feature?**

Removes unnecessary abstraction layer the custom `Inject` method just wraps `otel.GetTextMapPropagator().Inject`.

**Who is this feature for?**

Backend maintainers

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
