### PR TITLE
Live: namespace rename, change to using "stream" internally

### DIFF
--- a/packages/grafana-data/src/types/live.test.ts
+++ b/packages/grafana-data/src/types/live.test.ts
@@ -4,14 +4,14 @@ describe('parse address', () => {
   it('simple address', () => {
     const addr = parseLiveChannelAddress('plugin/testdata/random-flakey-stream');
     expect(addr?.scope).toBe(LiveChannelScope.Plugin);
-    expect(addr?.namespace).toBe('testdata');
+    expect(addr?.stream).toBe('testdata');
     expect(addr?.path).toBe('random-flakey-stream');
   });
 
   it('suppors full path', () => {
     const addr = parseLiveChannelAddress('plugin/testdata/a/b/c/d   ');
     expect(addr?.scope).toBe(LiveChannelScope.Plugin);
-    expect(addr?.namespace).toBe('testdata');
+    expect(addr?.stream).toBe('testdata');
     expect(addr?.path).toBe('a/b/c/d');
   });
 });

--- a/packages/grafana-data/src/types/live.ts
+++ b/packages/grafana-data/src/types/live.ts
@@ -138,7 +138,7 @@ export type LiveChannelId = string;
  */
 export interface LiveChannelAddress {
   scope: LiveChannelScope;
-  namespace: string; // depends on the scope
+  stream: string; // depends on the scope
   path: string;
 
   /**
@@ -160,7 +160,7 @@ export function parseLiveChannelAddress(id?: string): LiveChannelAddress | undef
     if (parts.length >= 3) {
       return {
         scope: parts[0] as LiveChannelScope,
-        namespace: parts[1],
+        stream: parts[1],
         path: parts.slice(2).join('/'),
       };
     }
@@ -174,7 +174,7 @@ export function parseLiveChannelAddress(id?: string): LiveChannelAddress | undef
  * @alpha -- experimental
  */
 export function isValidLiveChannelAddress(addr?: LiveChannelAddress): addr is LiveChannelAddress {
-  return !!(addr?.path && addr.namespace && addr.scope);
+  return !!(addr?.path && addr.stream && addr.scope);
 }
 
 /**
@@ -187,10 +187,10 @@ export function toLiveChannelId(addr: LiveChannelAddress): LiveChannelId {
     return '';
   }
   let id: string = addr.scope;
-  if (!addr.namespace) {
+  if (!addr.stream) {
     return id;
   }
-  id += '/' + addr.namespace;
+  id += '/' + addr.stream;
   if (!addr.path) {
     return id;
   }

--- a/pkg/services/live/managedstream/runner_test.go
+++ b/pkg/services/live/managedstream/runner_test.go
@@ -20,13 +20,13 @@ func (p *testPublisher) publish(_ string, _ string, _ []byte) error {
 
 func TestNewManagedStream(t *testing.T) {
 	publisher := &testPublisher{t: t}
-	c := NewNamespaceStream("default", "stream", "a", publisher.publish, nil, NewMemoryFrameCache())
+	c := NewStream("default", "stream", "a", publisher.publish, nil, NewMemoryFrameCache())
 	require.NotNil(t, c)
 }
 
 func TestManagedStreamMinuteRate(t *testing.T) {
 	publisher := &testPublisher{t: t}
-	c := NewNamespaceStream("default", "stream", "a", publisher.publish, nil, NewMemoryFrameCache())
+	c := NewStream("default", "stream", "a", publisher.publish, nil, NewMemoryFrameCache())
 	require.NotNil(t, c)
 
 	c.incRate("test1", time.Now().Unix())

--- a/pkg/services/live/pipeline/frame_output_managed_stream.go
+++ b/pkg/services/live/pipeline/frame_output_managed_stream.go
@@ -23,7 +23,7 @@ func (out *ManagedStreamFrameOutput) Type() string {
 }
 
 func (out *ManagedStreamFrameOutput) OutputFrame(ctx context.Context, vars Vars, frame *data.Frame) ([]*ChannelFrame, error) {
-	stream, err := out.managedStream.GetOrCreateStream(vars.NS, vars.Scope, vars.Namespace)
+	stream, err := out.managedStream.GetOrCreateStream(vars.NS, vars.Scope, vars.Stream)
 	if err != nil {
 		logger.Error("Error getting stream", "error", err)
 		return nil, err

--- a/pkg/services/live/pipeline/pipeline.go
+++ b/pkg/services/live/pipeline/pipeline.go
@@ -72,11 +72,11 @@ type ChannelFrame struct {
 
 // Vars has some helpful things pipeline entities could use.
 type Vars struct {
-	NS        string // k8s namespace
-	Channel   string
-	Scope     string
-	Namespace string // the thing within a scope
-	Path      string
+	NS      string // k8s namespace, maps to the Grafana org id or stack ID
+	Channel string
+	Scope   string
+	Stream  string // the thing within a scope, maps to the Grafana live "namespace"
+	Path    string
 }
 
 // DataOutputter can output incoming data before conversion to frames.
@@ -296,11 +296,11 @@ func (p *Pipeline) DataToChannelFrames(ctx context.Context, rule LiveChannelRule
 	}
 
 	vars := Vars{
-		NS:        ns,
-		Channel:   channelID,
-		Scope:     channel.Scope,
-		Namespace: channel.Namespace,
-		Path:      channel.Path,
+		NS:      ns,
+		Channel: channelID,
+		Scope:   channel.Scope,
+		Stream:  channel.Namespace,
+		Path:    channel.Path,
 	}
 
 	frames, err := rule.Converter.Convert(ctx, vars, body)
@@ -399,11 +399,11 @@ func (p *Pipeline) processFrame(ctx context.Context, ns string, channelID string
 	}
 
 	vars := Vars{
-		NS:        ns,
-		Channel:   channelID,
-		Scope:     ch.Scope,
-		Namespace: ch.Namespace,
-		Path:      ch.Path,
+		NS:      ns,
+		Channel: channelID,
+		Scope:   ch.Scope,
+		Stream:  ch.Namespace,
+		Path:    ch.Path,
 	}
 
 	if len(rule.FrameProcessors) > 0 {
@@ -502,11 +502,11 @@ func (p *Pipeline) processData(ctx context.Context, ns string, channelID string,
 	}
 
 	vars := Vars{
-		NS:        ns,
-		Channel:   channelID,
-		Scope:     ch.Scope,
-		Namespace: ch.Namespace,
-		Path:      ch.Path,
+		NS:      ns,
+		Channel: channelID,
+		Scope:   ch.Scope,
+		Stream:  ch.Namespace,
+		Path:    ch.Path,
 	}
 
 	if len(rule.DataOutputters) > 0 {

--- a/pkg/services/live/pipeline/subscribe_managed_stream.go
+++ b/pkg/services/live/pipeline/subscribe_managed_stream.go
@@ -25,7 +25,7 @@ func (s *ManagedStreamSubscriber) Type() string {
 }
 
 func (s *ManagedStreamSubscriber) Subscribe(ctx context.Context, vars Vars, _ []byte) (model.SubscribeReply, backend.SubscribeStreamStatus, error) {
-	stream, err := s.managedStream.GetOrCreateStream(vars.NS, vars.Scope, vars.Namespace)
+	stream, err := s.managedStream.GetOrCreateStream(vars.NS, vars.Scope, vars.Stream)
 	if err != nil {
 		logger.Error("Error getting managed stream", "error", err)
 		return model.SubscribeReply{}, 0, err

--- a/pkg/services/live/survey/survey.go
+++ b/pkg/services/live/survey/survey.go
@@ -33,7 +33,7 @@ func (c *Caller) SetupHandlers() error {
 }
 
 type NodeManagedChannelsRequest struct {
-	Namespace string `json:"namespace"`
+	NS string `json:"ns"`
 }
 
 type NodeManagedChannelsResponse struct {
@@ -72,7 +72,7 @@ func (c *Caller) handleManagedStreams(data []byte) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	channels, err := c.managedStreamRunner.GetManagedChannels(req.Namespace)
+	channels, err := c.managedStreamRunner.GetManagedChannels(req.NS)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func (c *Caller) handleManagedStreams(data []byte) (any, error) {
 }
 
 func (c *Caller) CallManagedStreams(ns string) ([]*managedstream.ManagedChannel, error) {
-	req := NodeManagedChannelsRequest{Namespace: ns}
+	req := NodeManagedChannelsRequest{NS: ns}
 	jsonData, err := json.Marshal(req)
 	if err != nil {
 		return nil, err

--- a/public/app/features/apiserver/client.ts
+++ b/public/app/features/apiserver/client.ts
@@ -57,7 +57,7 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
       return getGrafanaLiveSrv()
         .getStream<ResourceEvent<T, S, K>>({
           scope: LiveChannelScope.Watch,
-          namespace: this.gvr.group,
+          stream: this.gvr.group,
           path: `${this.gvr.version}/${this.gvr.resource}${query}/${contextSrv.user.uid}`,
         })
         .pipe(

--- a/public/app/features/live/centrifuge/LiveDataStream.test.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.test.ts
@@ -155,7 +155,7 @@ describe('LiveDataStream', () => {
 
   const dummyLiveChannelAddress: LiveChannelAddress = {
     scope: LiveChannelScope.Grafana,
-    namespace: 'stream',
+    stream: 'stream',
     path: 'abc',
   };
 

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -154,7 +154,7 @@ export class CentrifugeService implements CentrifugeSrv {
    * channel will be returned with an error state indicated in its status
    */
   private getChannel<TMessage>(addr: LiveChannelAddress): CentrifugeLiveChannel<TMessage> {
-    const id = `${this.deps.namespace}/${addr.scope}/${addr.namespace}/${addr.path}`;
+    const id = `${this.deps.namespace}/${addr.scope}/${addr.stream}/${addr.path}`;
     let channel = this.open.get(id);
     if (channel != null) {
       return channel;

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -67,7 +67,7 @@ class DashboardWatcher {
     if (uid !== this.uid) {
       this.channel = {
         scope: LiveChannelScope.Grafana,
-        namespace: 'dashboard',
+        stream: 'dashboard',
         path: `uid/${uid}`,
       };
       this.leave();

--- a/public/app/features/live/live.test.ts
+++ b/public/app/features/live/live.test.ts
@@ -21,7 +21,7 @@ describe('GrafanaLiveService', () => {
   const liveDataStreamOptions = {
     addr: {
       scope: LiveChannelScope.Grafana,
-      namespace: ' abc',
+      stream: ' abc',
       path: 'abc',
     },
   };

--- a/public/app/plugins/datasource/grafana-testdata-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/datasource.ts
@@ -509,7 +509,7 @@ function runGrafanaLiveQuery(
   return getGrafanaLiveSrv().getDataStream({
     addr: {
       scope: LiveChannelScope.Plugin,
-      namespace: 'testdata',
+      stream: 'testdata',
       path: target.channel,
     },
     key: `testStream.${liveQueryCounter++}`,

--- a/public/app/plugins/datasource/loki/streaming.ts
+++ b/public/app/plugins/datasource/loki/streaming.ts
@@ -65,7 +65,7 @@ export function doLokiChannelStream(
       return getGrafanaLiveSrv()
         .getStream({
           scope: LiveChannelScope.DataSource,
-          namespace: ds.uid,
+          stream: ds.uid,
           path: `tail/${key}`,
           data: {
             ...query,

--- a/public/app/plugins/datasource/tempo/streaming.ts
+++ b/public/app/plugins/datasource/tempo/streaming.ts
@@ -46,7 +46,7 @@ export function doTempoSearchStreaming(
   return getGrafanaLiveSrv()
     .getStream<MutableDataFrame>({
       scope: LiveChannelScope.DataSource,
-      namespace: ds.uid,
+      stream: ds.uid,
       path: `search/${getLiveStreamKey()}`,
       data: {
         ...query,
@@ -123,7 +123,7 @@ export function doTempoMetricsStreaming(
   return getGrafanaLiveSrv()
     .getStream<MutableDataFrame>({
       scope: LiveChannelScope.DataSource,
-      namespace: ds.uid,
+      stream: ds.uid,
       path: `metrics/${key}`,
       data: {
         ...query,

--- a/public/app/plugins/panel/live/LiveChannelEditor.tsx
+++ b/public/app/plugins/panel/live/LiveChannelEditor.tsx
@@ -29,13 +29,13 @@ const scopes: Array<SelectableValue<LiveChannelScope>> = [
 
 export function LiveChannelEditor(props: Props) {
   const [channels, setChannels] = useState<Array<SelectableValue<string>>>([]);
-  const [namespaces, paths] = useMemo(() => {
-    const namespaces: Array<SelectableValue<string>> = [];
+  const [streams, paths] = useMemo(() => {
+    const streams: Array<SelectableValue<string>> = [];
     const paths: Array<SelectableValue<string>> = [];
     const scope = props.value.scope;
-    const namespace = props.value.namespace;
+    const stream = props.value.stream;
     if (!scope?.length) {
-      return [namespaces, paths];
+      return [streams, paths];
     }
     const used: Record<string, boolean> = {};
 
@@ -45,23 +45,23 @@ export function LiveChannelEditor(props: Props) {
         continue;
       }
 
-      if (!used[addr.namespace]) {
-        namespaces.push({
-          value: addr.namespace,
-          label: addr.namespace,
+      if (!used[addr.stream]) {
+        streams.push({
+          value: addr.stream,
+          label: addr.stream,
         });
-        used[addr.namespace] = true;
+        used[addr.stream] = true;
       }
 
-      if (namespace?.length && namespace === addr.namespace) {
+      if (stream?.length && stream === addr.stream) {
         paths.push({
           ...channel,
           value: addr.path,
         });
       }
     }
-    return [namespaces, paths];
-  }, [channels, props.value.scope, props.value.namespace]);
+    return [streams, paths];
+  }, [channels, props.value.scope, props.value.stream]);
 
   useEffect(() => {
     getManagedChannelInfo().then((v) => {
@@ -73,16 +73,16 @@ export function LiveChannelEditor(props: Props) {
     if (v.value) {
       props.onChange({
         scope: v.value,
-        namespace: undefined,
+        stream: undefined,
         path: undefined,
       });
     }
   };
 
-  const onNamespaceChanged = (v: SelectableValue<string>) => {
+  const onStreamChanged = (v: SelectableValue<string>) => {
     props.onChange({
       scope: props.value?.scope,
-      namespace: v?.value,
+      stream: v?.value,
       path: undefined,
     });
   };
@@ -91,7 +91,7 @@ export function LiveChannelEditor(props: Props) {
     const { value, onChange } = props;
     onChange({
       scope: value.scope,
-      namespace: value.namespace,
+      stream: value.stream,
       path: v?.value,
     });
   };
@@ -106,7 +106,7 @@ export function LiveChannelEditor(props: Props) {
       }));
   };
 
-  const { scope, namespace, path } = props.value;
+  const { scope, stream, path } = props.value;
   const style = getStyles(config.theme2);
 
   return (
@@ -139,7 +139,7 @@ export function LiveChannelEditor(props: Props) {
                 if (resource) {
                   props.onChange({
                     scope: LiveChannelScope.Watch,
-                    namespace: resource.responseKind.group,
+                    stream: resource.responseKind.group,
                     path: `${resource.responseKind.version}/${resource.resource}/${config.bootData.user.uid}`, // only works for this user
                   });
                 }
@@ -154,12 +154,9 @@ export function LiveChannelEditor(props: Props) {
               <Trans i18nKey="live.live-channel-editor.namespace">Namespace</Trans>
             </Label>
             <Select
-              options={namespaces}
-              value={
-                namespaces.find((s) => s.value === namespace) ??
-                (namespace ? { label: namespace, value: namespace } : undefined)
-              }
-              onChange={onNamespaceChanged}
+              options={streams}
+              value={streams.find((s) => s.value === stream) ?? (stream ? { label: stream, value: stream } : undefined)}
+              onChange={onStreamChanged}
               allowCustomValue={true}
               backspaceRemovesValue={true}
               isClearable={true}
@@ -167,7 +164,7 @@ export function LiveChannelEditor(props: Props) {
           </div>
         )}
 
-        {scope && namespace && (
+        {scope && stream && (
           <div className={style.dropWrap}>
             <Label>
               <Trans i18nKey="live.live-channel-editor.path">Path</Trans>

--- a/public/app/plugins/panel/live/LivePanel.tsx
+++ b/public/app/plugins/panel/live/LivePanel.tsx
@@ -148,7 +148,7 @@ export class LivePanel extends PureComponent<Props, State> {
           <h4>
             <Trans i18nKey="live.live-panel.waiting-for-data">Waiting for data:</Trans>
           </h4>
-          {options.channel?.scope}/{options.channel?.namespace}/{options.channel?.path}
+          {options.channel?.scope}/{options.channel?.stream}/{options.channel?.path}
         </div>
       );
     }

--- a/public/app/plugins/panel/live/LivePublish.tsx
+++ b/public/app/plugins/panel/live/LivePublish.tsx
@@ -37,7 +37,7 @@ export function LivePublish({ height, mode, body, addr, onSave }: Props) {
         alert('expected stream scope!');
         return;
       }
-      return getBackendSrv().post(`api/live/push/${addr.namespace}`, body);
+      return getBackendSrv().post(`api/live/push/${addr.stream}`, body);
     }
 
     if (!isValidLiveChannelAddress(addr)) {


### PR DESCRIPTION
not sure if this is better since the plugin sdk calls it a namespace still.. but maybe will help to internally call it a `stream` instead of a `namespace` to try to prevent accidentally switching them around?