### PR TITLE
FolderActionsButton: Hide delete folder action for provision root fol…

### DIFF
--- a/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
@@ -157,28 +157,27 @@ describe('browse-dashboards FolderActionsButton', () => {
     jest.spyOn(permissions, 'getFolderPermissions').mockImplementation(() => {
       return {
         ...mockPermissions,
-        canViewPermissions: false,
+        canDeleteFolders: true, // provisioned folder can be deleted too (if not repo root)
       };
     });
-    render(<FolderActionsButton folder={{ ...mockFolder, managedBy: ManagerKind.Repo }} />);
+    // passing parentUid to make it not a repo root folder
+    render(<FolderActionsButton folder={{ ...mockFolder, managedBy: ManagerKind.Repo, parentUid: '123' }} />);
 
     await userEvent.click(screen.getByRole('button', { name: 'Folder actions' }));
     expect(screen.queryByRole('menuitem', { name: managePermissionsLabel })).not.toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: deleteMenuItemLabel })).toBeInTheDocument();
   });
 
-  it('does not render the "Move" option if folder is provisioned and is root repo folder', async () => {
+  it('does not render any actions if folder is provisioned and is root repo folder', async () => {
     jest.spyOn(permissions, 'getFolderPermissions').mockImplementation(() => {
       return {
         ...mockPermissions,
-        canViewPermissions: false,
       };
     });
+    // passing undefined to parentUid to make it root repo folder
     render(<FolderActionsButton folder={{ ...mockFolder, managedBy: ManagerKind.Repo, parentUid: undefined }} />);
 
-    await userEvent.click(screen.getByRole('button', { name: 'Folder actions' }));
-    expect(screen.queryByRole('menuitem', { name: moveMenuItemLabel })).not.toBeInTheDocument();
-    expect(screen.getByRole('menuitem', { name: deleteMenuItemLabel })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Folder actions' })).not.toBeInTheDocument();
   });
 
   it('does render the "Move" option if folder is provisioned and is NOT root repo folder', async () => {
@@ -192,6 +191,12 @@ describe('browse-dashboards FolderActionsButton', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Folder actions' }));
     expect(screen.getByRole('menuitem', { name: moveMenuItemLabel })).toBeInTheDocument();
-    expect(screen.getByRole('menuitem', { name: deleteMenuItemLabel })).toBeInTheDocument();
+  });
+
+  it('does not render any actions when repo is read-only', () => {
+    render(
+      <FolderActionsButton folder={{ ...mockFolder, managedBy: ManagerKind.Repo, parentUid: '123' }} isReadOnlyRepo />
+    );
+    expect(screen.queryByRole('button', { name: 'Folder actions' })).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
@@ -10,7 +10,6 @@ import { RepoType } from 'app/features/provisioning/Wizard/types';
 import { BulkMoveProvisionedResource } from 'app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource';
 import { DeleteProvisionedFolderForm } from 'app/features/provisioning/components/Folders/DeleteProvisionedFolderForm';
 import { useIsProvisionedInstance } from 'app/features/provisioning/hooks/useIsProvisionedInstance';
-import { getReadOnlyTooltipText } from 'app/features/provisioning/utils/repository';
 import { ShowModalReactEvent } from 'app/types/events';
 import { FolderDTO } from 'app/types/folders';
 
@@ -23,6 +22,7 @@ import { MoveModal } from './BrowseActions/MoveModal';
 
 interface Props {
   folder: FolderDTO;
+  /* If the folder is managed by a provisioned repo and is read-only */
   isReadOnlyRepo?: boolean;
   repoType?: RepoType;
 }
@@ -37,12 +37,21 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
 
   const deleteFolder = useDeleteFolderMutationFacade();
 
-  const { canEditFolders, canDeleteFolders, canViewPermissions, canSetPermissions } = getFolderPermissions(folder);
+  const {
+    canEditFolders,
+    canDeleteFolders: canDeleteFoldersPermissions,
+    canViewPermissions,
+    canSetPermissions,
+  } = getFolderPermissions(folder);
+
   const isProvisionedFolder = folder.managedBy === ManagerKind.Repo;
-  // When its single provisioned folder, cannot move the root repository folder
   const isProvisionedRootFolder = isProvisionedFolder && !isProvisionedInstance && folder.parentUid === undefined;
   // Can only move folders when the folder is not provisioned
-  const canMoveFolder = canEditFolders && !isProvisionedRootFolder;
+  const canMoveFolder = canEditFolders && !isProvisionedRootFolder && !isReadOnlyRepo;
+  // Can only delete folders when the folder has the right permission and is not provisioned root folder
+  const canDeleteFolders = canDeleteFoldersPermissions && !isProvisionedRootFolder && !isReadOnlyRepo;
+  // Show permissions only if the folder is not provisioned
+  const canShowPermissions = canViewPermissions && !isProvisionedFolder;
 
   const onMove = async (destinationUID: string) => {
     await moveFolder({ folderUID: folder.uid, destinationUID: destinationUID });
@@ -131,16 +140,14 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
 
   const menu = (
     <Menu>
-      {canViewPermissions && !isProvisionedFolder && (
-        <MenuItem onClick={() => setShowPermissionsDrawer(true)} label={managePermissionsLabel} />
-      )}
-      {canMoveFolder && !isReadOnlyRepo && (
+      {canShowPermissions && <MenuItem onClick={() => setShowPermissionsDrawer(true)} label={managePermissionsLabel} />}
+      {canMoveFolder && (
         <MenuItem
           onClick={isProvisionedFolder ? handleShowMoveProvisionedFolderDrawer : showMoveModal}
           label={moveLabel}
         />
       )}
-      {canDeleteFolders && !isReadOnlyRepo && (
+      {canDeleteFolders && (
         <MenuItem
           destructive
           onClick={isProvisionedFolder ? showDeleteProvisionedModal : showDeleteModal}
@@ -150,22 +157,14 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
     </Menu>
   );
 
-  if (!canViewPermissions && !canMoveFolder && !canDeleteFolders) {
+  if (!canShowPermissions && !canMoveFolder && !canDeleteFolders) {
     return null;
   }
 
   return (
     <>
       <Dropdown overlay={menu} onVisibleChange={setIsOpen}>
-        <Button
-          variant="secondary"
-          disabled={isReadOnlyRepo && !canViewPermissions}
-          tooltip={
-            isReadOnlyRepo && !canViewPermissions
-              ? getReadOnlyTooltipText({ isLocal: repoType === 'local' })
-              : undefined
-          }
-        >
+        <Button variant="secondary" disabled={isReadOnlyRepo && !canViewPermissions}>
           <Trans i18nKey="browse-dashboards.folder-actions-button.folder-actions">Folder actions</Trans>
           <Icon name={isOpen ? 'angle-up' : 'angle-down'} />
         </Button>


### PR DESCRIPTION
**What is this feature?**

- `FolderActionsButton`: Fixes the folder actions button to properly return early when no actions are available, preventing unnecessary Menu rendering.
- `FolderActionsButton`:  Added necessary tests

**Why do we need this feature?**

Make sure we show/hide right actions to different users

**Who is this feature for?**

Git sync users and whoever manage folders

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/830

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
