### PR TITLE
Dashboards: Make clear all of variable dropdown accessible by keyboard navigation

### DIFF
--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -355,10 +355,18 @@ export function SelectBase<T, Rest = {}>({
                 role="button"
                 aria-label={t('grafana-ui.select.clear-value', 'Clear value')}
                 className={styles.singleValueRemove}
+                tabIndex={0}
                 onMouseDown={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
                   clearValue();
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    clearValue();
+                  }
                 }}
               />
             );


### PR DESCRIPTION
**What is this feature?**

Let's the user access the clear all control for dropdowns by keyboard navigation.