### PR TITLE
Use exact term search for selectable fields.

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1652,7 +1652,7 @@ func requirementQuery(req *resourcepb.Requirement, prefix string) (query.Query, 
 			return query.NewMatchAllQuery(), nil
 		}
 
-		if len(req.Values) == 1 && useExactTermQuery {
+		if len(req.Values) == 1 && (useExactTermQuery || strings.HasPrefix(req.Key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX)) {
 			return newExactTermsQuery(req.Key, req.Values[0], prefix), nil
 		}
 

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1645,14 +1645,14 @@ var exactTermFields = []string{
 
 // Convert a "requirement" into a bleve query
 func requirementQuery(req *resourcepb.Requirement, prefix string) (query.Query, *resourcepb.ErrorResult) {
-	useExactTermQuery := slices.Contains(exactTermFields, req.Key)
+	useExactTermQuery := slices.Contains(exactTermFields, req.Key) || strings.HasPrefix(req.Key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX)
 	switch selection.Operator(req.Operator) {
 	case selection.Equals, selection.DoubleEquals:
 		if len(req.Values) == 0 {
 			return query.NewMatchAllQuery(), nil
 		}
 
-		if len(req.Values) == 1 && (useExactTermQuery || strings.HasPrefix(req.Key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX)) {
+		if len(req.Values) == 1 && useExactTermQuery {
 			return newExactTermsQuery(req.Key, req.Values[0], prefix), nil
 		}
 

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -390,6 +390,17 @@ func TestIndexAndSearchSelectableFields(t *testing.T) {
 					},
 				},
 			},
+			{
+				Action: resource.ActionIndex,
+				Doc: &resource.IndexableDocument{
+					Key:   &resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: "doc3"},
+					Title: "Document with field values with token terminating characters",
+					SelectableFields: map[string]string{
+						"spec.some.field":       "doc3-field#value!",
+						"spec.some.other.field": "some other.field>value",
+					},
+				},
+			},
 		},
 	})
 	require.NoError(t, err)
@@ -397,6 +408,10 @@ func TestIndexAndSearchSelectableFields(t *testing.T) {
 	checkSearchQuery(t, index, selectableFieldQuery(key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX+"spec.some.field", "doc1_field_value"), []string{"doc1"})
 	checkSearchQuery(t, index, selectableFieldQuery(key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX+"spec.some.field", "doc2_field_value"), []string{"doc2"})
 	checkSearchQuery(t, index, selectableFieldQuery(key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX+"spec.some.other.field", "other_field_value"), []string{"doc1", "doc2"})
+
+	// tests for doc3 with token-terminating characters
+	checkSearchQuery(t, index, selectableFieldQuery(key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX+"spec.some.field", "doc3-field#value!"), []string{"doc3"})
+	checkSearchQuery(t, index, selectableFieldQuery(key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX+"spec.some.other.field", "some other.field>value"), []string{"doc3"})
 
 	// Only known selectable fields are indexed.
 	checkSearchQuery(t, index, selectableFieldQuery(key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX+"unknown.field", "another_value"), nil)


### PR DESCRIPTION
This PR changes searching for selectable-fields to use exact-term matching.