### PR TITLE
Provisioning: use repository status to check quotas while syncing

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/sync/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
-	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
@@ -141,6 +140,11 @@ func TestSyncWorker_Process_QuotaCondition(t *testing.T) {
 					Namespace:  "test-namespace",
 					Generation: 1,
 				},
+				Status: provisioning.RepositoryStatus{
+					Quota: provisioning.QuotaStatus{
+						MaxResourcesPerRepository: tt.maxResourcesPerRepository,
+					},
+				},
 			}
 			readerWriter.MockRepository.On("Config").Return(repoConfig)
 
@@ -201,7 +205,6 @@ func TestSyncWorker_Process_QuotaCondition(t *testing.T) {
 				tracing.NewNoopTracerService(),
 				10,
 			)
-			worker.SetQuotaLimits(quotas.QuotaLimits{MaxResources: tt.maxResourcesPerRepository})
 
 			// Create test job
 			job := provisioning.Job{

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -809,9 +809,6 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				b.tracer,
 				10,
 			)
-			// HACK: Set quota limits after construction to avoid changing NewSyncWorker signature.
-			// See SetQuotaLimits for details. Use the same quotaLimits constructed for the validator.
-			syncWorker.SetQuotaLimits(b.quotaLimits)
 
 			cleaner := migrate.NewNamespaceCleaner(b.clients)
 			unifiedStorageMigrator := migrate.NewUnifiedStorageMigrator(


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR changes how job controller is getting repo quota. Once this is merged, job controller will use the repo status quota (that is kept up to date by repo controller).

This works with repos that does not have QuotaStatus set because it defaults to 0, which is the intended default. Repo controller will take care of updating the value if needed.

**Why do we need this feature?**

It will allow job controller to use 

It is also a step forward on removing QuotaLimits struct in favor of QuotaStatus, which contains the exact same data (avoid repetition).

**Who is this feature for?**

Customers and operators of provisioning feature.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/git-ui-sync-project/issues/762

**Special notes for your reviewer:**

Please check that:
- [ X ] It works as expected from a user's perspective.
- [ X ] If this is a pre-GA feature, it is behind a feature toggle.
- [ X ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
