### PR TITLE
Add video tutorial link for Grafana MySQL plugin

### DIFF
--- a/docs/sources/datasources/mysql/_index.md
+++ b/docs/sources/datasources/mysql/_index.md
@@ -86,9 +86,7 @@ You can query and visualize data from MySQL-compatible databases like [MariaDB](
 
 Use this data source to create dashboards, explore SQL data, and monitor MySQL-based workloads in real time.
 
-Watch this video to learn more about using the Grafana MySQL data source plugin:  {{< youtube id="p_RDHfHS-P8">}}
-
-
+Watch this video to learn more about using the Grafana MySQL data source plugin: {{< youtube id="p_RDHfHS-P8">}}
 
 {{< docs/play title="MySQL Overview" url="https://play.grafana.org/d/edyh1ib7db6rkb/mysql-overview" >}}
 

--- a/docs/sources/datasources/mysql/_index.md
+++ b/docs/sources/datasources/mysql/_index.md
@@ -86,6 +86,10 @@ You can query and visualize data from MySQL-compatible databases like [MariaDB](
 
 Use this data source to create dashboards, explore SQL data, and monitor MySQL-based workloads in real time.
 
+Watch this video to learn more about using the Grafana MySQL data source plugin:  {{< youtube id="p_RDHfHS-P8">}}
+
+
+
 {{< docs/play title="MySQL Overview" url="https://play.grafana.org/d/edyh1ib7db6rkb/mysql-overview" >}}
 
 ## Supported databases


### PR DESCRIPTION
Added a video link for learning about the Grafana MySQL data source plugin.

Homepage: https://grafana.com/docs/grafana/latest/datasources/mysql/