### PR TITLE
Remove reference to kubernetesDashboards in e2e tests

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboard-conditional-rendering-load-change.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-conditional-rendering-load-change.spec.ts
@@ -8,7 +8,6 @@ import { checkRepeatedPanelTitles } from './utils';
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     dashboardUndoRedo: true,
     groupByVariable: true,

--- a/e2e-playwright/dashboard-new-layouts/dashboard-duplicate-panel.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-duplicate-panel.spec.ts
@@ -6,7 +6,6 @@ import { flows } from './utils';
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     dashboardUndoRedo: true,
     groupByVariable: true,

--- a/e2e-playwright/dashboard-new-layouts/dashboard-group-panels.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-group-panels.spec.ts
@@ -6,7 +6,6 @@ import testV2Dashboard from '../dashboards/TestV2Dashboard.json';
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     dashboardUndoRedo: true,
     groupByVariable: true,

--- a/e2e-playwright/dashboard-new-layouts/dashboard-keybindings.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-keybindings.spec.ts
@@ -2,7 +2,6 @@ import { test, expect } from '@grafana/plugin-e2e';
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
   },
 });

--- a/e2e-playwright/dashboard-new-layouts/dashboard-outline.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-outline.spec.ts
@@ -2,7 +2,6 @@ import { test, expect } from '@grafana/plugin-e2e';
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     dashboardUndoRedo: true,
     groupByVariable: true,

--- a/e2e-playwright/dashboard-new-layouts/dashboards-add-panel.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-add-panel.spec.ts
@@ -4,7 +4,6 @@ import { addNewPanelFromSidebar } from './utils';
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     dashboardUndoRedo: true,
     groupByVariable: true,

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-adhoc-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-adhoc-variables.spec.ts
@@ -4,7 +4,6 @@ import { flows, type Variable } from './utils';
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     dashboardUndoRedo: true,
     groupByVariable: true,

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-custom-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-custom-variables.spec.ts
@@ -6,7 +6,6 @@ import { flows } from './utils';
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     dashboardUndoRedo: true,
     groupByVariable: true,

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-datasource-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-datasource-variables.spec.ts
@@ -4,7 +4,6 @@ import { flows, type Variable } from './utils';
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     dashboardUndoRedo: true,
     groupByVariable: true,

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-group-by-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-group-by-variables.spec.ts
@@ -4,7 +4,6 @@ import { flows, type Variable } from './utils';
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     dashboardUndoRedo: true,
     groupByVariable: true,

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-panel-title-description.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-panel-title-description.spec.ts
@@ -4,7 +4,6 @@ import { flows } from './utils';
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     dashboardUndoRedo: true,
     groupByVariable: true,

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-panel-transparent-bg.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-panel-transparent-bg.spec.ts
@@ -2,7 +2,6 @@ import { test, expect } from '@grafana/plugin-e2e';
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     dashboardUndoRedo: true,
     groupByVariable: true,

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-query-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-query-variables.spec.ts
@@ -4,7 +4,6 @@ import { flows, type Variable } from './utils';
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     dashboardUndoRedo: true,
     groupByVariable: true,

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-variables.spec.ts
@@ -4,7 +4,6 @@ import { flows, saveDashboard, type Variable } from './utils';
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     dashboardUndoRedo: true,
     groupByVariable: true,

--- a/e2e-playwright/dashboard-new-layouts/dashboards-move-panel.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-move-panel.spec.ts
@@ -6,7 +6,6 @@ const PAGE_UNDER_TEST = 'ed155665/annotation-filtering';
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     dashboardUndoRedo: true,
     groupByVariable: true,

--- a/e2e-playwright/dashboard-new-layouts/dashboards-panel-layouts.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-panel-layouts.spec.ts
@@ -8,7 +8,6 @@ import { switchToAutoGrid } from './utils';
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     dashboardUndoRedo: true,
     groupByVariable: true,

--- a/e2e-playwright/dashboard-new-layouts/dashboards-remove-panel.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-remove-panel.spec.ts
@@ -2,7 +2,6 @@ import { test, expect, DashboardPage, E2ESelectorGroups } from '@grafana/plugin-
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     dashboardUndoRedo: true,
     groupByVariable: true,

--- a/e2e-playwright/dashboard-new-layouts/dashboards-repeats-auto-grid.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-repeats-auto-grid.spec.ts
@@ -20,8 +20,7 @@ const newTitleBase = 'edited rep - ';
 const repeatOptions = [1, 2, 3, 4];
 
 test.use({
-  featureToggles: {
-    kubernetesDashboards: true,
+  featureToggles: {    
     dashboardNewLayouts: true,
     groupByVariable: true,
   },

--- a/e2e-playwright/dashboard-new-layouts/dashboards-repeats-auto-grid.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-repeats-auto-grid.spec.ts
@@ -20,7 +20,7 @@ const newTitleBase = 'edited rep - ';
 const repeatOptions = [1, 2, 3, 4];
 
 test.use({
-  featureToggles: {    
+  featureToggles: {
     dashboardNewLayouts: true,
     groupByVariable: true,
   },

--- a/e2e-playwright/dashboard-new-layouts/dashboards-repeats-custom-grid.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-repeats-custom-grid.spec.ts
@@ -22,7 +22,6 @@ const getTitleInRepeatRow = (rowIndex: number, panelIndex: number) =>
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     groupByVariable: true,
   },

--- a/e2e-playwright/dashboard-new-layouts/dashboards-repeats-tabs-layout.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-repeats-tabs-layout.spec.ts
@@ -19,7 +19,6 @@ const repeatOptions = [1, 2, 3, 4];
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     groupByVariable: true,
   },

--- a/e2e-playwright/dashboard-new-layouts/dashboards-title-description.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-title-description.spec.ts
@@ -2,7 +2,6 @@ import { test, expect } from '@grafana/plugin-e2e';
 
 test.use({
   featureToggles: {
-    kubernetesDashboards: true,
     dashboardNewLayouts: true,
     dashboardUndoRedo: true,
     groupByVariable: true,


### PR DESCRIPTION
This toggle is enabled by default now