### PR TITLE
Elasticsearch: Docs able to use serverless

### DIFF
--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -67,15 +67,12 @@ If you use Amazon OpenSearch Service (the successor to Amazon Elasticsearch Serv
 
 ## Supported Elasticsearch versions
 
-{{< admonition type="warning" >}}
-The Elasticsearch data source plugin currently does not support Elastic Cloud Serverless, or any other serverless variant of Elasticsearch.
-{{< /admonition >}}
-
 This data source supports these versions of Elasticsearch:
 
 - ≥ v7.17
 - v8.x
 - v9.x
+- Elastic Cloud Serverless
 
 The Grafana maintenance policy for the Elasticsearch data source aligns with [Elastic Product End of Life Dates](https://www.elastic.co/support/eol). Grafana ensures proper functionality for supported versions only. If you use an EOL version of Elasticsearch, you can still run queries, but the query builder displays a warning. Grafana doesn't guarantee functionality or provide fixes for EOL versions.
 

--- a/docs/sources/datasources/elasticsearch/configure/index.md
+++ b/docs/sources/datasources/elasticsearch/configure/index.md
@@ -61,7 +61,7 @@ Administrators can also [configure the data source via YAML](ref:provisioning-da
 To configure the Elasticsearch data source, you need:
 
 - **Grafana administrator permissions:** Only users with the organization `administrator` role can add data sources.
-- **A supported Elasticsearch version:** v7.17 or later, v8.x, or v9.x. Elastic Cloud Serverless isn't supported.
+- **A supported Elasticsearch version:** v7.17 or later, v8.x, v9.x or Elastic Cloud Serverless.
 - **Elasticsearch server URL:** The HTTP or HTTPS endpoint for your Elasticsearch instance, including the port (default: `9200`).
 - **Authentication credentials:** Depending on your Elasticsearch security configuration, you need one of the following:
   - Username and password for basic authentication


### PR DESCRIPTION
Serverless is now supported. Still need to add docs for setting up serverless data source