### PR TITLE
Menu: Show Styles only in edit mode

### DIFF
--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
@@ -854,7 +854,7 @@ describe('panelMenuBehavior', () => {
   });
 
   describe('Panel styles menu', () => {
-    async function buildTimeseriesTestScene() {
+    async function buildTimeseriesTestScene(isEditing = true) {
       const menu = new VizPanelMenu({ $behaviors: [panelMenuBehavior] });
       const panel = new VizPanel({
         title: 'Timeseries Panel',
@@ -869,6 +869,7 @@ describe('panelMenuBehavior', () => {
         title: 'My dashboard',
         uid: 'dash-1',
         meta: { canEdit: true },
+        isEditing,
         body: DefaultGridLayoutManager.fromVizPanels([panel]),
       });
 
@@ -917,6 +918,18 @@ describe('panelMenuBehavior', () => {
 
     it('should not show styles menu for non-timeseries panels', async () => {
       const { menu } = await buildTestScene({});
+
+      expect(menu.state.items?.find((i) => i.text === 'Styles')).toBeUndefined();
+    });
+
+    it('should show styles menu when in edit mode', async () => {
+      const { menu } = await buildTimeseriesTestScene();
+
+      expect(menu.state.items?.find((i) => i.text === 'Styles')).toBeDefined();
+    });
+
+    it('should not show styles menu when not in edit mode', async () => {
+      const { menu } = await buildTimeseriesTestScene(false);
 
       expect(menu.state.items?.find((i) => i.text === 'Styles')).toBeUndefined();
     });

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -347,7 +347,7 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
       }
     }
 
-    if (panel.state.pluginId === 'timeseries' && config.featureToggles.panelStyleActions) {
+    if (panel.state.pluginId === 'timeseries' && config.featureToggles.panelStyleActions && dashboard.state.isEditing) {
       const stylesSubMenu: PanelMenuItem[] = [];
 
       stylesSubMenu.push({


### PR DESCRIPTION
This PR hides the Styles menu when not in edit mode. 



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
