### PR TITLE
PROTOTYPING: implement new running query counter

### DIFF
--- a/public/app/features/query/state/runningQueryCount.test.ts
+++ b/public/app/features/query/state/runningQueryCount.test.ts
@@ -1,0 +1,147 @@
+import { CoreApp, DataQueryRequest, DataQueryResponse, LoadingState } from '@grafana/data';
+
+import {
+  finalizeDashboardRequestTracking,
+  initializeDashboardRunningQueryCount,
+  startDashboardRequestTracking,
+  trackDashboardRequestPacket,
+} from './runningQueryCount';
+
+const getCount = () => window.__grafanaRunningQueryCount;
+
+const makeRequest = (overrides: Partial<DataQueryRequest> = {}): DataQueryRequest => {
+  return {
+    app: CoreApp.Dashboard,
+    panelId: 1,
+    requestId: 'req-1',
+    targets: [{ refId: 'A' }],
+    range: { from: 0, to: 0, raw: { from: 'now-1h', to: 'now' } },
+    ...overrides,
+  } as DataQueryRequest;
+};
+
+const makePacket = (overrides: Partial<DataQueryResponse> = {}): DataQueryResponse => {
+  return {
+    data: [{ refId: 'A' }] as any,
+    ...overrides,
+  };
+};
+
+describe('runningQueryCount', () => {
+  beforeEach(() => {
+    initializeDashboardRunningQueryCount([]);
+  });
+
+  it('sets total panel count and completes non-query panels', () => {
+    initializeDashboardRunningQueryCount([
+      { id: 1, hasQueries: true },
+      { id: 2, hasQueries: false },
+      { id: 3, hasQueries: true },
+    ]);
+
+    expect(getCount()).toBe(2);
+  });
+
+  it('adds expected queries and decrements per completed query and panel', () => {
+    initializeDashboardRunningQueryCount([{ id: 1, hasQueries: true }]);
+
+    const request = makeRequest({
+      requestId: 'req-queries',
+      targets: [{ refId: 'A' }, { refId: 'B' }],
+    });
+
+    startDashboardRequestTracking(request);
+    expect(getCount()).toBe(3);
+
+    trackDashboardRequestPacket(
+      request.requestId!,
+      makePacket({ key: 'A', state: LoadingState.Done, data: [{ refId: 'A' }] as any })
+    );
+    expect(getCount()).toBe(2);
+
+    trackDashboardRequestPacket(
+      request.requestId!,
+      makePacket({ key: 'B', state: LoadingState.Done, data: [{ refId: 'B' }] as any })
+    );
+    expect(getCount()).toBe(0);
+  });
+
+  it('treats streaming packet as query completion only once', () => {
+    initializeDashboardRunningQueryCount([{ id: 1, hasQueries: true }]);
+
+    const request = makeRequest({ requestId: 'req-stream', targets: [{ refId: 'A' }] });
+    startDashboardRequestTracking(request);
+    expect(getCount()).toBe(2);
+
+    trackDashboardRequestPacket(
+      request.requestId!,
+      makePacket({ key: 'A', state: LoadingState.Streaming })
+    );
+    expect(getCount()).toBe(0);
+
+    trackDashboardRequestPacket(
+      request.requestId!,
+      makePacket({ key: 'A', state: LoadingState.Streaming })
+    );
+    expect(getCount()).toBe(0);
+
+    finalizeDashboardRequestTracking(request.requestId!);
+    expect(getCount()).toBe(0);
+  });
+
+  it('accounts for extra query keys beyond expected', () => {
+    initializeDashboardRunningQueryCount([{ id: 1, hasQueries: true }]);
+
+    const request = makeRequest({ requestId: 'req-split', targets: [{ refId: 'A' }] });
+    startDashboardRequestTracking(request);
+    expect(getCount()).toBe(2);
+
+    trackDashboardRequestPacket(
+      request.requestId!,
+      makePacket({ key: 'A', state: LoadingState.Done, data: [{ refId: 'A' }] as any })
+    );
+    expect(getCount()).toBe(0);
+
+    trackDashboardRequestPacket(
+      request.requestId!,
+      makePacket({ key: 'B', state: LoadingState.Loading, data: [{ refId: 'B' }] as any })
+    );
+    expect(getCount()).toBe(2);
+
+    trackDashboardRequestPacket(
+      request.requestId!,
+      makePacket({ key: 'B', state: LoadingState.Done, data: [{ refId: 'B' }] as any })
+    );
+    expect(getCount()).toBe(0);
+  });
+
+  it('finalizes remaining queries on completion', () => {
+    initializeDashboardRunningQueryCount([{ id: 1, hasQueries: true }]);
+
+    const request = makeRequest({
+      requestId: 'req-finalize',
+      targets: [{ refId: 'A' }, { refId: 'B' }],
+    });
+
+    startDashboardRequestTracking(request);
+    expect(getCount()).toBe(3);
+
+    trackDashboardRequestPacket(
+      request.requestId!,
+      makePacket({ key: 'A', state: LoadingState.Done, data: [{ refId: 'A' }] as any })
+    );
+    expect(getCount()).toBe(2);
+
+    finalizeDashboardRequestTracking(request.requestId!);
+    expect(getCount()).toBe(0);
+  });
+
+  it('ignores non-dashboard requests', () => {
+    initializeDashboardRunningQueryCount([{ id: 1, hasQueries: true }]);
+    const request = makeRequest({ app: CoreApp.Explore, requestId: 'req-ignore' });
+
+    const started = startDashboardRequestTracking(request);
+    expect(started).toBe(false);
+    expect(getCount()).toBe(1);
+  });
+});

--- a/public/app/features/query/state/runningQueryCount.ts
+++ b/public/app/features/query/state/runningQueryCount.ts
@@ -1,0 +1,239 @@
+import { CoreApp, DataQueryRequest, DataQueryResponse, LoadingState } from '@grafana/data';
+
+type PanelKey = number;
+
+type PanelState = {
+  incomplete: boolean;
+  activeRequests: Set<string>;
+};
+
+type RequestState = {
+  requestId: string;
+  panelId: PanelKey;
+  expectedQueries: number;
+  seenKeys: Set<string>;
+  completedKeys: Set<string>;
+  panelCompleted: boolean;
+};
+
+const isBrowser = typeof window !== 'undefined';
+let runningQueryCount = 0;
+let panelStates = new Map<PanelKey, PanelState>();
+let requestStates = new Map<string, RequestState>();
+let propertyDefined = false;
+let useDirectAssignment = false;
+
+function ensureGlobalProperty() {
+  if (!isBrowser || propertyDefined) {
+    return;
+  }
+
+  const existing = Object.getOwnPropertyDescriptor(window, '__grafanaRunningQueryCount');
+  if (existing?.get && existing?.set) {
+    propertyDefined = true;
+    return;
+  }
+
+  try {
+    Object.defineProperty(window, '__grafanaRunningQueryCount', {
+      configurable: true,
+      get: () => runningQueryCount,
+      set: () => {
+        // Ignore external writes; we manage the counter explicitly.
+      },
+    });
+    propertyDefined = true;
+  } catch (err) {
+    useDirectAssignment = true;
+    propertyDefined = true;
+  }
+}
+
+function syncWindowCount() {
+  if (!isBrowser || !useDirectAssignment) {
+    return;
+  }
+
+  window.__grafanaRunningQueryCount = runningQueryCount;
+}
+
+function setCount(next: number) {
+  runningQueryCount = next;
+  syncWindowCount();
+}
+
+function adjustCount(delta: number) {
+  runningQueryCount += delta;
+  syncWindowCount();
+}
+
+function isDashboardPanelRequest(request: DataQueryRequest): request is DataQueryRequest & { panelId: number } {
+  return request.app === CoreApp.Dashboard && typeof request.panelId === 'number';
+}
+
+function getPacketKey(packet: DataQueryResponse): string {
+  return packet.key ?? packet.data?.[0]?.refId ?? 'A';
+}
+
+function isPacketComplete(packet: DataQueryResponse): boolean {
+  const state = packet.state ?? LoadingState.Done;
+  return state === LoadingState.Done || state === LoadingState.Error || state === LoadingState.Streaming;
+}
+
+function markPanelCompleteForRequest(state: RequestState) {
+  if (state.panelCompleted) {
+    return;
+  }
+
+  state.panelCompleted = true;
+  const panelState = panelStates.get(state.panelId);
+  if (panelState) {
+    panelState.activeRequests.delete(state.requestId);
+    if (panelState.activeRequests.size === 0 && panelState.incomplete) {
+      panelState.incomplete = false;
+      adjustCount(-1);
+    }
+  }
+}
+
+function maybeCompleteRequest(state: RequestState) {
+  const totalExpected = Math.max(state.expectedQueries, state.seenKeys.size);
+  if (state.completedKeys.size >= totalExpected) {
+    markPanelCompleteForRequest(state);
+  }
+}
+
+function ensureRequestActive(state: RequestState) {
+  const panelState = panelStates.get(state.panelId);
+  if (!panelState) {
+    return;
+  }
+
+  if (!panelState.incomplete) {
+    panelState.incomplete = true;
+    adjustCount(1);
+  }
+
+  panelState.activeRequests.add(state.requestId);
+  state.panelCompleted = false;
+}
+
+export function setupRunningQueryCount() {
+  ensureGlobalProperty();
+}
+
+export function initializeDashboardRunningQueryCount(
+  panels: Array<{ id: PanelKey; hasQueries: boolean }>
+): void {
+  if (!isBrowser) {
+    return;
+  }
+
+  ensureGlobalProperty();
+
+  panelStates = new Map();
+  requestStates = new Map();
+  setCount(panels.length);
+
+  for (const panel of panels) {
+    panelStates.set(panel.id, { incomplete: true, activeRequests: new Set() });
+  }
+
+  for (const panel of panels) {
+    if (!panel.hasQueries) {
+      const panelState = panelStates.get(panel.id);
+      if (panelState && panelState.incomplete && panelState.activeRequests.size === 0) {
+        panelState.incomplete = false;
+        adjustCount(-1);
+      }
+    }
+  }
+}
+
+export function startDashboardRequestTracking(request: DataQueryRequest): boolean {
+  if (!isBrowser || !isDashboardPanelRequest(request)) {
+    return false;
+  }
+
+  ensureGlobalProperty();
+
+  const panelId = request.panelId;
+  const requestId = request.requestId;
+
+  let panelState = panelStates.get(panelId);
+  if (!panelState) {
+    panelState = { incomplete: false, activeRequests: new Set() };
+    panelStates.set(panelId, panelState);
+  }
+
+  if (!panelState.incomplete) {
+    panelState.incomplete = true;
+    adjustCount(1);
+  }
+
+  panelState.activeRequests.add(requestId);
+
+  const expectedQueries = request.targets.length;
+  if (expectedQueries > 0) {
+    adjustCount(expectedQueries);
+  }
+
+  const requestState: RequestState = {
+    requestId,
+    panelId,
+    expectedQueries,
+    seenKeys: new Set(),
+    completedKeys: new Set(),
+    panelCompleted: false,
+  };
+
+  requestStates.set(requestId, requestState);
+
+  if (expectedQueries === 0) {
+    maybeCompleteRequest(requestState);
+  }
+
+  return true;
+}
+
+export function trackDashboardRequestPacket(requestId: string, packet: DataQueryResponse): void {
+  const requestState = requestStates.get(requestId);
+  if (!requestState) {
+    return;
+  }
+
+  const key = getPacketKey(packet);
+  if (!requestState.seenKeys.has(key)) {
+    requestState.seenKeys.add(key);
+    if (requestState.seenKeys.size > requestState.expectedQueries) {
+      adjustCount(1);
+    }
+
+    if (requestState.panelCompleted || !panelStates.get(requestState.panelId)?.activeRequests.has(requestState.requestId)) {
+      ensureRequestActive(requestState);
+    }
+  }
+
+  if (isPacketComplete(packet) && !requestState.completedKeys.has(key)) {
+    requestState.completedKeys.add(key);
+    adjustCount(-1);
+  }
+
+  maybeCompleteRequest(requestState);
+}
+
+export function finalizeDashboardRequestTracking(requestId: string): void {
+  const requestState = requestStates.get(requestId);
+  if (!requestState) {
+    return;
+  }
+
+  const totalExpected = Math.max(requestState.expectedQueries, requestState.seenKeys.size);
+  const remaining = totalExpected - requestState.completedKeys.size;
+  if (remaining > 0) {
+    adjustCount(-remaining);
+  }
+
+  markPanelCompleteForRequest(requestState);
+  requestStates.delete(requestId);
+}

--- a/public/app/types/window.d.ts
+++ b/public/app/types/window.d.ts
@@ -3,6 +3,7 @@ export declare global {
     __grafanaSceneContext: SceneObject;
     __grafana_app_bundle_loaded: boolean;
     __grafana_public_path__: string;
+    __grafanaRunningQueryCount?: number;
     __grafana_load_failed: () => void;
     grafanaBootData: import('@grafana/data').BootData;
 


### PR DESCRIPTION
This is a prototype of a new counter for running queries.

The idea is:
* Start off with a counter equalling the number of queryable panels in a dashboard,
* When the panel starts its queries, it will increment it per query,
* When the panel finishes its queries, it will decrement it per query, and for itself.
* When the counter reaches zero, the dashboard is truly fully loaded (although not necessarily rendered by the browser yet...).

This is all AI-generated code, and has not been reviewed whatsoever. It has only been tested in practice. I would not recommend PRing this anywhere without manually going through it.