### PR TITLE
Graphite: Fix to remove refID from targets and tags

### DIFF
--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -1737,4 +1737,24 @@ describe('access scenarios', () => {
       });
     });
   });
+
+  describe('remove refID', () => {
+    const ds = new GraphiteDatasource(instanceSettings);
+    const refIdMap = { A: 'A' };
+
+    it('should remove refID from target name', () => {
+      const response = createFetchResponse([
+        {
+          target: 'metric.name A',
+          datapoints: [[123, 456]],
+          tags: { 'tag A': 'value' },
+        },
+      ]);
+
+      const result = ds.convertResponseToDataFrames(response, refIdMap);
+      const frame = result.data[0];
+
+      expect(frame.name).toBe('metric.name');
+    });
+  });
 });

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -423,6 +423,7 @@ export class GraphiteDatasource
         // refID should always be the last element
         refId = splitTarget.pop() || '';
         s.target = splitTarget.join(' ');
+        s.tags['name'] = s.target;
       }
       // Disables Grafana own series naming
       s.title = s.target;

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -423,6 +423,7 @@ export class GraphiteDatasource
         // refID should always be the last element
         refId = splitTarget.pop() || '';
         s.target = splitTarget.join(' ');
+        s.tags = s.tags || {};
         s.tags['name'] = s.target;
       }
       // Disables Grafana own series naming


### PR DESCRIPTION
This PR fixes an issue where refIDs in Graphite query targets were not properly removed. The fix ensures that the refID is stripped from the target and t he stripped value is also set in the corresponding tags.