### PR TITLE
Suggestions: Always start new panels with Suggestions tab

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelOptionsPane.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelOptionsPane.tsx
@@ -238,6 +238,7 @@ function PanelOptionsPaneComponent({ model }: SceneComponentProps<PanelOptionsPa
           data={data}
           showBackButton={config.featureToggles.newVizSuggestions ? hasPickedViz || !isNewPanel : true}
           isNewPanel={isNewPanel}
+          hasPickedViz={hasPickedViz}
         />
       )}
     </>

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -38,6 +38,7 @@ export interface Props {
   onChange: (options: VizTypeChangeDetails, panel?: VizPanel) => void;
   onClose: () => void;
   isNewPanel?: boolean;
+  hasPickedViz?: boolean;
 }
 
 const getTabs = (): Array<{ label: string; value: VisualizationSelectPaneTab }> => {
@@ -54,7 +55,16 @@ const getTabs = (): Array<{ label: string; value: VisualizationSelectPaneTab }> 
     : [allVisualizationsTab, suggestionsTab];
 };
 
-export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose, showBackButton, isNewPanel }: Props) {
+export function PanelVizTypePicker({
+  panel,
+  editPreview,
+  data,
+  onChange,
+  onClose,
+  showBackButton,
+  isNewPanel,
+  hasPickedViz,
+}: Props) {
   const styles = useStyles2(getStyles);
   const theme = useTheme2();
   const panelModel = useMemo(() => new PanelModelCompatibilityWrapper(panel), [panel]);
@@ -83,7 +93,11 @@ export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose
   /** TABS */
   const tabs = useMemo(getTabs, []);
   const defaultTab = tabs[0].value;
-  const [listMode, setListMode] = useSessionStorage(LS_VISUALIZATION_SELECT_TAB_KEY, defaultTab);
+  const [storedListMode, setStoredListMode] = useSessionStorage(LS_VISUALIZATION_SELECT_TAB_KEY, defaultTab);
+
+  const shouldDefaultToSuggestions = isNewPanel && !hasPickedViz && config.featureToggles.newVizSuggestions;
+  const initialTab = shouldDefaultToSuggestions ? VisualizationSelectPaneTab.Suggestions : storedListMode;
+  const [listMode, setListMode] = useState(initialTab);
 
   const handleListModeChange = useCallback(
     (value: VisualizationSelectPaneTab) => {
@@ -94,8 +108,9 @@ export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose
         schema_version: '1.0.0',
       });
       setListMode(value);
+      setStoredListMode(value);
     },
-    [setListMode]
+    [setListMode, setStoredListMode]
   );
 
   const handleBackButtonClick = useCallback(() => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -95,7 +95,9 @@ export function PanelVizTypePicker({
   const defaultTab = tabs[0].value;
   const [storedListMode, setStoredListMode] = useSessionStorage(LS_VISUALIZATION_SELECT_TAB_KEY, defaultTab);
 
-  const shouldDefaultToSuggestions = isNewPanel && !hasPickedViz && config.featureToggles.newVizSuggestions;
+  const shouldDefaultToSuggestions =
+    (isNewPanel && !hasPickedViz && config.featureToggles.newVizSuggestions) ||
+    storedListMode === VisualizationSelectPaneTab.Suggestions;
   const initialTab = shouldDefaultToSuggestions ? VisualizationSelectPaneTab.Suggestions : storedListMode;
   const [listMode, setListMode] = useState(initialTab);
 


### PR DESCRIPTION
When `newVizSuggestions` is enabled, default to `Suggestions` tab, regardless if the session storage has a different tab.


https://github.com/user-attachments/assets/3ff73c8c-43b9-44e0-a844-8c9d4fcc0790



TO DO:

- [ ] Add tests

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
