### PR TITLE
RecentlyViewedDashboards: Update styles and auto collapse for medium screen

### DIFF
--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAsyncRetry } from 'react-use';
 
 import { GrafanaTheme2, store } from '@grafana/data';
@@ -19,8 +19,8 @@ const recentDashboardsKey = `dashboard_impressions-${contextSrv.user.orgId}`;
 
 export function RecentlyViewedDashboards() {
   const styles = useStyles2(getStyles);
-  const isSmallScreen = !useMediaQueryMinWidth('sm');
-  const [isOpen, setIsOpen] = useState(!isSmallScreen); // Default to closed on small screens
+  const isMediumScreen = !useMediaQueryMinWidth('md');
+  const [isOpen, setIsOpen] = useState(!isMediumScreen); // Default to closed on small screens
 
   const {
     value: recentDashboards = [],
@@ -44,6 +44,11 @@ export function RecentlyViewedDashboards() {
     });
     setIsOpen(!isOpen);
   };
+
+  useEffect(() => {
+    // Auto collapse on small screens and expand on larger screens
+    setIsOpen(!isMediumScreen);
+  }, [isMediumScreen]);
 
   if (recentDashboards.length === 0) {
     return null;

--- a/public/app/plugins/panel/dashlist/DashListItem.tsx
+++ b/public/app/plugins/panel/dashlist/DashListItem.tsx
@@ -59,7 +59,7 @@ export function DashListItem({
         </div>
       ) : (
         <Card noMargin className={css.dashlistCardContainer}>
-          <Stack justifyContent="space-between" alignItems="start">
+          <Stack justifyContent="space-between" alignItems="start" height="100%">
             <Link
               className={css.dashlistCard}
               href={url}

--- a/public/app/plugins/panel/dashlist/styles.ts
+++ b/public/app/plugins/panel/dashlist/styles.ts
@@ -33,6 +33,8 @@ export const getStyles = (theme: GrafanaTheme2) => {
     dashlistCardContainer: css({
       display: 'block',
       height: '100%',
+      paddingTop: theme.spacing(1.25),
+      paddingBottom: theme.spacing(1.25),
 
       '&:has(a:hover)': {
         backgroundImage: gradient,
@@ -40,10 +42,10 @@ export const getStyles = (theme: GrafanaTheme2) => {
       },
     }),
     dashlistCard: css({
-      display: 'grid',
-      gridTemplateRows: '1fr 1fr',
-      gap: theme.spacing(2),
+      display: 'flex',
       flexDirection: 'column',
+      justifyContent: 'space-between',
+      gap: theme.spacing(0.75),
       height: '100%',
       width: '100%',
 
@@ -61,6 +63,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       marginTop: theme.spacing(0.25),
     }),
     dashlistCardLink: css({
+      paddingTop: theme.spacing(0.5),
       whiteSpace: 'normal',
       overflowWrap: 'break-word',
       wordBreak: 'break-word',
@@ -68,11 +71,14 @@ export const getStyles = (theme: GrafanaTheme2) => {
       WebkitBoxOrient: 'vertical',
       WebkitLineClamp: 2,
       overflow: 'hidden',
+      [theme.breakpoints.down('lg')]: {
+        WebkitLineClamp: 1,
+      },
     }),
     dashlistCardFolder: css({
       display: '-webkit-box',
       WebkitBoxOrient: 'vertical',
-      WebkitLineClamp: 2,
+      WebkitLineClamp: 1,
       overflow: 'hidden',
       whiteSpace: 'normal',
     }),


### PR DESCRIPTION
**What is this feature?**

`RecentlyViewedDashboards` : Auto collapse when screen is under medium screen width
`DashListItem`: Adjust spacing and only display 1 line title if on smaller screen

**Why do we need this feature?**

Better spacing 

**Who is this feature for?**

User who uses browse dashboard page

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/114798

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
