### PR TITLE
ResourceEditFormSharedFields: Reorder input fields

### DIFF
--- a/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
+++ b/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
@@ -68,37 +68,6 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
 
     return (
       <>
-        {/* Path */}
-        {!hidePath && (
-          <Field
-            noMargin
-            label={t('provisioned-resource-form.save-or-delete-resource-shared-fields.label-path', 'Path')}
-            description={t(
-              'provisioned-resource-form.save-or-delete-resource-shared-fields.description-inside-repository',
-              pathText
-            )}
-          >
-            <Input id="dashboard-path" type="text" {...register('path')} readOnly={!isNew} />
-          </Field>
-        )}
-
-        {/* Comment */}
-        <Field
-          noMargin
-          label={t('provisioned-resource-form.save-or-delete-resource-shared-fields.label-comment', 'Comment')}
-        >
-          <TextArea
-            id="provisioned-resource-form-comment"
-            {...register('comment')}
-            disabled={readOnly}
-            placeholder={t(
-              'provisioned-resource-form.save-or-delete-resource-shared-fields.comment-placeholder-describe-changes-optional',
-              'Add a note to describe your changes (optional)'
-            )}
-            rows={5}
-          />
-        </Field>
-
         {/* Workflow */}
         {repository?.type && isGitProvider(repository.type) && !readOnly && (
           <>
@@ -167,6 +136,37 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
             </Field>
           </>
         )}
+
+        {/* Path */}
+        {!hidePath && (
+          <Field
+            noMargin
+            label={t('provisioned-resource-form.save-or-delete-resource-shared-fields.label-path', 'Path')}
+            description={t(
+              'provisioned-resource-form.save-or-delete-resource-shared-fields.description-inside-repository',
+              pathText
+            )}
+          >
+            <Input id="dashboard-path" type="text" {...register('path')} readOnly={!isNew} />
+          </Field>
+        )}
+
+        {/* Comment */}
+        <Field
+          noMargin
+          label={t('provisioned-resource-form.save-or-delete-resource-shared-fields.label-comment', 'Comment')}
+        >
+          <TextArea
+            id="provisioned-resource-form-comment"
+            {...register('comment')}
+            disabled={readOnly}
+            placeholder={t(
+              'provisioned-resource-form.save-or-delete-resource-shared-fields.comment-placeholder-describe-changes-optional',
+              'Add a note to describe your changes (optional)'
+            )}
+            rows={5}
+          />
+        </Field>
       </>
     );
   }


### PR DESCRIPTION
**What is this feature?**

ResourceEditFormSharedFields: Instead of Commit -> Path -> Branch, update to branch -> path -> comment. 

<img width="730" height="602" alt="image" src="https://github.com/user-attachments/assets/8d46a732-a408-49ec-9279-fdc471c23856" />


**Why do we need this feature?**

more natural flow similar to Github

**Who is this feature for?**

Git sync users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/794

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
