### PR TITLE
OpenFeature: Log error + reset provider if changed

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -1,9 +1,33 @@
 import { OFREPWebProvider } from '@openfeature/ofrep-web-provider';
-import { OpenFeature } from '@openfeature/react-sdk';
+import { OpenFeature, ProviderEvents, NOOP_PROVIDER, EventDetails } from '@openfeature/react-sdk';
 
-import { FeatureToggles } from '@grafana/data';
+import { AppEvents, FeatureToggles } from '@grafana/data';
 
 import { config } from '../../config';
+import { getAppEvents } from '../../services';
+import { logError } from '../../utils/logging';
+
+function checkDefaultProvider(event?: EventDetails) {
+  if (event?.domain) {
+    return;
+  }
+
+  // Warn plugin developers if we've detected OpenFeature's default provider has been changed,
+  //  as plugins should always be using a domain when setting a provider to avoid conflicts.
+  if (OpenFeature.getProvider() !== NOOP_PROVIDER) {
+    const err = new Error(
+      'OpenFeature default domain provider has been unexpectedly changed. This may be caused by a plugin that is incorrectly using the default domain.',
+      { cause: OpenFeature.getProvider() }
+    );
+    console.error(err);
+    logError(err);
+
+    getAppEvents().publish({
+      type: AppEvents.alertWarning.name,
+      payload: [err.message],
+    });
+  }
+}
 
 export type FeatureFlagName = keyof FeatureToggles;
 
@@ -17,6 +41,9 @@ export type FeatureFlagName = keyof FeatureToggles;
 export const GRAFANA_CORE_OPEN_FEATURE_DOMAIN = 'internal-grafana-core';
 
 export async function initOpenFeature() {
+  OpenFeature.addHandler(ProviderEvents.Ready, checkDefaultProvider);
+  OpenFeature.addHandler(ProviderEvents.Error, checkDefaultProvider);
+
   const subPath = config.appSubUrl || '';
   const baseUrl = `${subPath}/apis/features.grafana.app/v0alpha1/namespaces/${config.namespace}`;
 

--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -1,10 +1,9 @@
 import { OFREPWebProvider } from '@openfeature/ofrep-web-provider';
 import { OpenFeature, ProviderEvents, NOOP_PROVIDER, EventDetails } from '@openfeature/react-sdk';
 
-import { AppEvents, FeatureToggles } from '@grafana/data';
+import { FeatureToggles } from '@grafana/data';
 
 import { config } from '../../config';
-import { getAppEvents } from '../../services';
 import { logError } from '../../utils/logging';
 
 function checkDefaultProvider(event?: EventDetails) {
@@ -21,11 +20,6 @@ function checkDefaultProvider(event?: EventDetails) {
     );
     console.error(err);
     logError(err);
-
-    getAppEvents().publish({
-      type: AppEvents.alertWarning.name,
-      payload: [err.message],
-    });
   }
 }
 


### PR DESCRIPTION
**What is this feature?**

An alternative to the proactive protection in #112515, this listens for the provider on the default domain being changed and logs an error when it happens, as well as displaying a visual warning, to ensure that plugins using OpenFeature use a custom domain.

**Why do we need this feature?**

We've run into multiple instances of plugins not following the internal guidance around OpenFeature being a global singleton, leading to them using the default domain in their plugin. This previously would override Grafana's core usage (though this is now switched to using a domain), and still risks colliding with another misbehaving plugin.

Once https://github.com/open-feature/js-sdk/issues/1308 + https://github.com/open-feature/spec/issues/359 are resolved, while we will likely want to switch both core and all plugins over to using the non-singleton version, I do think it'd be good to keep this check around to help identify any misbehaving plugins long-term.

**Who is this feature for?**

Developers.