### PR TITLE
InteractiveTable: Prevent reset to first page after `data` property change unless `autoResetPage` property is specified

### DIFF
--- a/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.tsx
+++ b/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.tsx
@@ -157,6 +157,10 @@ interface BaseProps<TableData extends object> {
    * Disable the ability to remove sorting on columns (none -> asc -> desc -> asc)
    */
   disableSortRemove?: boolean;
+  /**
+   * Will automatically reset to the first page if the `data` prop is changed
+   */
+  autoResetPage?: boolean;
 }
 
 interface WithExpandableRow<TableData extends object> extends BaseProps<TableData> {
@@ -185,6 +189,7 @@ type Props<TableData extends object> = WithExpandableRow<TableData> | WithoutExp
  * @alpha
  */
 export function InteractiveTable<TableData extends object>({
+  autoResetPage,
   className,
   columns,
   data,
@@ -223,6 +228,7 @@ export function InteractiveTable<TableData extends object>({
       columns: tableColumns,
       data,
       autoResetExpanded: false,
+      autoResetPage: !!autoResetPage, // If undefined, we want to treat this as false to prevent page reset by default
       autoResetSortBy: false,
       disableMultiSort: true,
       // If fetchData is provided, we disable client-side sorting


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

If the InteractiveTable data was updated (e.g., due to a refetch), the table automatically resets to the first page. This is a disruptive experience for users who may be editing a value on a non-first page, and having the table reset back to the first page after successfully completing the edit.

Now, by default, the current page is retained after a change in the `data` property. The `autoResetPage` property can be set to explicitly request the previous behavior of resetting to the first page whenever the `data` property changes.

**Why do we need this feature?**

Improve the user experience for tables which may their values edited.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] ~If this is a pre-GA feature, it is behind a feature toggle.~
- [ ] ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
