### PR TITLE
feat (query editor v2): Content sidebar updates, fix dependency issue

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.test.tsx
@@ -1,4 +1,3 @@
-import { DataSourceInstanceSettings, PluginType } from '@grafana/data';
 import { sceneGraph, SceneQueryRunner, SceneObjectRef, VizPanel } from '@grafana/scenes';
 
 import { PanelTimeRange, PanelTimeRangeState } from '../../scene/panel-timerange/PanelTimeRange';
@@ -238,94 +237,6 @@ describe('PanelDataPaneNext', () => {
       });
 
       expect(mockQueryRunner.runQueries).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('buildQueryOptions', () => {
-    it('should return options from SceneQueryRunner state', () => {
-      mockQueryRunnerState.queries = [{ refId: 'A' }];
-      mockQueryRunnerState.maxDataPoints = 1000;
-      mockQueryRunnerState.minInterval = '10s';
-
-      const options = dataPane.buildQueryOptions();
-
-      expect(options.queries).toEqual([{ refId: 'A' }]);
-      expect(options.maxDataPoints).toBe(1000);
-      expect(options.minInterval).toBe('10s');
-    });
-
-    it('should extract time range from PanelTimeRange', () => {
-      const mockPanelTimeRange = new PanelTimeRange({
-        timeFrom: '1h',
-        timeShift: '2h',
-        hideTimeOverride: true,
-      });
-
-      jest.spyOn(sceneGraph, 'getTimeRange').mockReturnValue(mockPanelTimeRange);
-
-      const options = dataPane.buildQueryOptions();
-
-      expect(options.timeRange?.from).toBe('1h');
-      expect(options.timeRange?.shift).toBe('2h');
-      expect(options.timeRange?.hide).toBe(true);
-    });
-
-    it('should return undefined time range when no PanelTimeRange exists', () => {
-      // Reset to non-PanelTimeRange object
-      jest.spyOn(sceneGraph, 'getTimeRange').mockReturnValue({} as ReturnType<typeof sceneGraph.getTimeRange>);
-
-      const options = dataPane.buildQueryOptions();
-
-      expect(options.timeRange?.from).toBeUndefined();
-      expect(options.timeRange?.shift).toBeUndefined();
-      expect(options.timeRange?.hide).toBeUndefined();
-    });
-
-    it('should include cacheTimeout when datasource supports it', () => {
-      mockQueryRunnerState.cacheTimeout = '60';
-
-      const dsSettings: DataSourceInstanceSettings = {
-        id: 1,
-        uid: 'test',
-        name: 'Test DS',
-        type: 'test',
-        meta: {
-          id: 'test',
-          name: 'Test',
-          type: PluginType.datasource,
-          info: {
-            author: { name: '' },
-            description: '',
-            links: [],
-            logos: { small: '', large: '' },
-            screenshots: [],
-            updated: '',
-            version: '',
-          },
-          module: '',
-          baseUrl: '',
-          queryOptions: { cacheTimeout: true },
-        },
-        access: 'proxy',
-        readOnly: false,
-        jsonData: {},
-      };
-
-      dataPane.setState({ dsSettings });
-
-      const options = dataPane.buildQueryOptions();
-
-      expect(options.cacheTimeout).toBe('60');
-    });
-
-    it('should return empty options when no queryRunner exists', () => {
-      // Mock getQueryRunnerFor to return undefined
-      jest.requireMock('../../utils/utils').getQueryRunnerFor = () => undefined;
-
-      const options = dataPane.buildQueryOptions();
-
-      expect(options.queries).toEqual([]);
-      expect(options.dataSource).toEqual({ type: undefined, uid: undefined });
     });
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
@@ -1,13 +1,6 @@
 import { CoreApp, DataSourceApi, DataSourceInstanceSettings, getDataSourceRef, getNextRefId } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
-import {
-  sceneGraph,
-  SceneObjectBase,
-  SceneObjectRef,
-  SceneObjectState,
-  SceneQueryRunner,
-  VizPanel,
-} from '@grafana/scenes';
+import { SceneObjectBase, SceneObjectRef, SceneObjectState, SceneQueryRunner, VizPanel } from '@grafana/scenes';
 import { DataQuery, DataSourceRef } from '@grafana/schema';
 import { addQuery } from 'app/core/utils/query';
 import { QueryGroupOptions } from 'app/types/query';
@@ -222,48 +215,6 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
   };
 
   // Query Options Operations
-  public buildQueryOptions = (): QueryGroupOptions => {
-    const panel = this.state.panelRef.resolve();
-    const queryRunner = getQueryRunnerFor(panel);
-    const { dsSettings } = this.state;
-
-    if (!queryRunner) {
-      return {
-        queries: [],
-        dataSource: { type: undefined, uid: undefined },
-      };
-    }
-
-    const timeRangeObj = sceneGraph.getTimeRange(panel);
-
-    let timeRangeOpts: QueryGroupOptions['timeRange'] = {
-      from: undefined,
-      shift: undefined,
-      hide: undefined,
-    };
-
-    if (timeRangeObj instanceof PanelTimeRange) {
-      timeRangeOpts = {
-        from: timeRangeObj.state.timeFrom,
-        shift: timeRangeObj.state.timeShift,
-        hide: timeRangeObj.state.hideTimeOverride,
-      };
-    }
-
-    return {
-      cacheTimeout: dsSettings?.meta.queryOptions?.cacheTimeout ? queryRunner.state.cacheTimeout : undefined,
-      queryCachingTTL: dsSettings?.cachingConfig?.enabled ? queryRunner.state.queryCachingTTL : undefined,
-      dataSource: {
-        default: dsSettings?.isDefault,
-        ...(dsSettings ? getDataSourceRef(dsSettings) : { type: undefined, uid: undefined }),
-      },
-      queries: queryRunner.state.queries,
-      maxDataPoints: queryRunner.state.maxDataPoints,
-      minInterval: queryRunner.state.minInterval,
-      timeRange: timeRangeOpts,
-    };
-  };
-
   public onQueryOptionsChange = (options: QueryGroupOptions) => {
     const panel = this.state.panelRef.resolve();
     const queryRunner = getQueryRunnerFor(panel);

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorDetailsSidebar.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorDetailsSidebar.test.tsx
@@ -11,7 +11,7 @@ import { ds1SettingsMock, mockActions, mockOptions } from '../testUtils';
 import { QueryEditorDetailsSidebar } from './QueryEditorDetailsSidebar';
 
 describe('QueryEditorDetailsSidebar', () => {
-  const mockSetIsQueryOptionsOpen = jest.fn();
+  const mockCloseSidebar = jest.fn();
 
   const defaultQrState: { queries: never[]; data: PanelData | undefined; isLoading: boolean } = {
     queries: [],
@@ -35,7 +35,9 @@ describe('QueryEditorDetailsSidebar', () => {
     const queryOptions: QueryOptionsState = {
       options,
       isQueryOptionsOpen: true,
-      setIsQueryOptionsOpen: mockSetIsQueryOptionsOpen,
+      openSidebar: jest.fn(),
+      closeSidebar: mockCloseSidebar,
+      focusedField: null,
     };
 
     return render(
@@ -78,7 +80,7 @@ describe('QueryEditorDetailsSidebar', () => {
     const header = screen.getByRole('button', { name: /query options/i });
     fireEvent.click(header);
 
-    expect(mockSetIsQueryOptionsOpen).toHaveBeenCalledWith(false);
+    expect(mockCloseSidebar).toHaveBeenCalled();
   });
 
   describe('maxDataPoints input', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorDetailsSidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorDetailsSidebar.tsx
@@ -91,180 +91,180 @@ export function QueryEditorDetailsSidebar() {
   return (
     <ClickOutsideWrapper onClick={handleCloseSidebar}>
       <div ref={sidebarRef} className={styles.container}>
-      <Button
-        fill="text"
-        size="lg"
-        icon="angle-right"
-        className={styles.header}
-        onClick={handleCloseSidebar}
-        aria-expanded={true}
-        aria-label={t('query-editor.details-sidebar.collapse', 'Collapse query options sidebar')}
-      >
-        <span className={styles.headerText}>
-          <Trans i18nKey="query-editor.details-sidebar.title">Query Options</Trans>
-        </span>
-      </Button>
-      <div className={styles.content}>
-        <Stack direction="column" gap={0.5}>
-          <div className={styles.field}>
-            <Tooltip
-              content={t(
-                'query-editor.details-sidebar.max-data-points-tooltip',
-                'The maximum data points per series. Used directly by some data sources and used in calculation of auto interval.'
-              )}
-            >
-              <Icon name="info-circle" size="md" className={styles.infoIcon} />
-            </Tooltip>
-            <span className={styles.fieldLabel}>
-              <Trans i18nKey="query-editor.details-sidebar.max-data-points">Max data points</Trans>
-            </span>
-            <Input
-              type="number"
-              defaultValue={options.maxDataPoints ?? ''}
-              placeholder={realMaxDataPoints ? String(realMaxDataPoints) : ''}
-              onBlur={(e) => handleBlur(e, QueryOptionFields.maxDataPoints)}
-              autoFocus={focusedField === QueryOptionFields.maxDataPoints}
-              aria-label={t('query-editor.details-sidebar.max-data-points', 'Max data points')}
-              className={styles.fieldInput}
-            />
-          </div>
-
-          <div className={styles.field}>
-            <Tooltip
-              content={t(
-                'query-editor.details-sidebar.min-interval-tooltip',
-                'A lower limit for the interval. Recommended to be set to write frequency, for example 1m if your data is written every minute.'
-              )}
-            >
-              <Icon name="info-circle" size="md" className={styles.infoIcon} />
-            </Tooltip>
-            <span className={styles.fieldLabel}>
-              <Trans i18nKey="query-editor.details-sidebar.min-interval">Min interval</Trans>
-            </span>
-            <Input
-              type="text"
-              defaultValue={options.minInterval ?? ''}
-              placeholder={String(minIntervalOnDs)}
-              onBlur={(e) => handleBlur(e, QueryOptionFields.minInterval)}
-              autoFocus={focusedField === QueryOptionFields.minInterval}
-              aria-label={t('query-editor.details-sidebar.min-interval', 'Min interval')}
-              className={styles.fieldInput}
-            />
-          </div>
-
-          <div className={styles.field}>
-            <Tooltip
-              content={t(
-                'query-editor.details-sidebar.interval-tooltip',
-                'The evaluated interval that is sent to data source and is used in $__interval and $__interval_ms.'
-              )}
-            >
-              <Icon name="info-circle" size="md" className={styles.infoIcon} />
-            </Tooltip>
-            <span className={styles.fieldLabel}>
-              <Trans i18nKey="query-editor.details-sidebar.interval">Interval</Trans>
-            </span>
-            <span className={styles.fieldValue}>{realInterval ?? '-'}</span>
-          </div>
-
-          <div className={styles.field}>
-            <Tooltip
-              content={t(
-                'query-editor.details-sidebar.relative-time-tooltip',
-                'Overrides the relative time range for individual panels. For example, to configure the Last 5 minutes use now-5m.'
-              )}
-            >
-              <Icon name="info-circle" size="md" className={styles.infoIcon} />
-            </Tooltip>
-            <span className={styles.fieldLabel}>
-              <Trans i18nKey="query-editor.details-sidebar.relative-time">Relative time</Trans>
-            </span>
-            <Input
-              type="text"
-              defaultValue={options.timeRange?.from ?? ''}
-              placeholder={TIME_OPTION_PLACEHOLDER}
-              onBlur={(e) => handleBlur(e, QueryOptionFields.relativeTime)}
-              autoFocus={focusedField === QueryOptionFields.relativeTime}
-              aria-label={t('query-editor.details-sidebar.relative-time', 'Relative time')}
-              className={styles.fieldInput}
-            />
-          </div>
-
-          <div className={styles.field}>
-            <Tooltip
-              content={t(
-                'query-editor.details-sidebar.time-shift-tooltip',
-                'Overrides the time range for individual panels by shifting its start and end relative to the time picker.'
-              )}
-            >
-              <Icon name="info-circle" size="md" className={styles.infoIcon} />
-            </Tooltip>
-            <span className={styles.fieldLabel}>
-              <Trans i18nKey="query-editor.details-sidebar.time-shift">Time shift</Trans>
-            </span>
-            <Input
-              type="text"
-              defaultValue={options.timeRange?.shift ?? ''}
-              placeholder={TIME_OPTION_PLACEHOLDER}
-              onBlur={(e) => handleBlur(e, QueryOptionFields.timeShift)}
-              autoFocus={focusedField === QueryOptionFields.timeShift}
-              aria-label={t('query-editor.details-sidebar.time-shift', 'Time shift')}
-              className={styles.fieldInput}
-            />
-          </div>
-
-          {showCacheTimeout && (
+        <Button
+          fill="text"
+          size="lg"
+          icon="angle-right"
+          className={styles.header}
+          onClick={handleCloseSidebar}
+          aria-expanded={true}
+          aria-label={t('query-editor.details-sidebar.collapse', 'Collapse query options sidebar')}
+        >
+          <span className={styles.headerText}>
+            <Trans i18nKey="query-editor.details-sidebar.title">Query Options</Trans>
+          </span>
+        </Button>
+        <div className={styles.content}>
+          <Stack direction="column" gap={0.5}>
             <div className={styles.field}>
               <Tooltip
                 content={t(
-                  'query-editor.details-sidebar.cache-timeout-tooltip',
-                  'If your time series store has a query cache this option can override the default cache timeout. Specify a numeric value in seconds.'
+                  'query-editor.details-sidebar.max-data-points-tooltip',
+                  'The maximum data points per series. Used directly by some data sources and used in calculation of auto interval.'
                 )}
               >
                 <Icon name="info-circle" size="md" className={styles.infoIcon} />
               </Tooltip>
               <span className={styles.fieldLabel}>
-                <Trans i18nKey="query-editor.details-sidebar.cache-timeout">Cache timeout</Trans>
-              </span>
-              <Input
-                type="text"
-                defaultValue={options.cacheTimeout ?? ''}
-                // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
-                placeholder="60"
-                onBlur={(e) => handleBlur(e, QueryOptionFields.cacheTimeout)}
-                autoFocus={focusedField === QueryOptionFields.cacheTimeout}
-                aria-label={t('query-editor.details-sidebar.cache-timeout', 'Cache timeout')}
-                className={styles.fieldInput}
-              />
-            </div>
-          )}
-
-          {showCacheTTL && (
-            <div className={styles.field}>
-              <Tooltip
-                content={t(
-                  'query-editor.details-sidebar.cache-ttl-tooltip',
-                  'Cache time-to-live: How long results from the queries in this panel will be cached, in milliseconds.'
-                )}
-              >
-                <Icon name="info-circle" size="md" className={styles.infoIcon} />
-              </Tooltip>
-              <span className={styles.fieldLabel}>
-                <Trans i18nKey="query-editor.details-sidebar.cache-ttl">Cache TTL</Trans>
+                <Trans i18nKey="query-editor.details-sidebar.max-data-points">Max data points</Trans>
               </span>
               <Input
                 type="number"
-                defaultValue={options.queryCachingTTL ?? ''}
-                placeholder={dsSettings?.cachingConfig?.TTLMs ? String(dsSettings.cachingConfig.TTLMs) : ''}
-                onBlur={(e) => handleBlur(e, QueryOptionFields.queryCachingTTL)}
-                autoFocus={focusedField === QueryOptionFields.cacheTTL}
-                aria-label={t('query-editor.details-sidebar.cache-ttl', 'Cache TTL')}
+                defaultValue={options.maxDataPoints ?? ''}
+                placeholder={realMaxDataPoints ? String(realMaxDataPoints) : ''}
+                onBlur={(e) => handleBlur(e, QueryOptionFields.maxDataPoints)}
+                autoFocus={focusedField === QueryOptionFields.maxDataPoints}
+                aria-label={t('query-editor.details-sidebar.max-data-points', 'Max data points')}
                 className={styles.fieldInput}
               />
             </div>
-          )}
-        </Stack>
-      </div>
+
+            <div className={styles.field}>
+              <Tooltip
+                content={t(
+                  'query-editor.details-sidebar.min-interval-tooltip',
+                  'A lower limit for the interval. Recommended to be set to write frequency, for example 1m if your data is written every minute.'
+                )}
+              >
+                <Icon name="info-circle" size="md" className={styles.infoIcon} />
+              </Tooltip>
+              <span className={styles.fieldLabel}>
+                <Trans i18nKey="query-editor.details-sidebar.min-interval">Min interval</Trans>
+              </span>
+              <Input
+                type="text"
+                defaultValue={options.minInterval ?? ''}
+                placeholder={String(minIntervalOnDs)}
+                onBlur={(e) => handleBlur(e, QueryOptionFields.minInterval)}
+                autoFocus={focusedField === QueryOptionFields.minInterval}
+                aria-label={t('query-editor.details-sidebar.min-interval', 'Min interval')}
+                className={styles.fieldInput}
+              />
+            </div>
+
+            <div className={styles.field}>
+              <Tooltip
+                content={t(
+                  'query-editor.details-sidebar.interval-tooltip',
+                  'The evaluated interval that is sent to data source and is used in $__interval and $__interval_ms.'
+                )}
+              >
+                <Icon name="info-circle" size="md" className={styles.infoIcon} />
+              </Tooltip>
+              <span className={styles.fieldLabel}>
+                <Trans i18nKey="query-editor.details-sidebar.interval">Interval</Trans>
+              </span>
+              <span className={styles.fieldValue}>{realInterval ?? '-'}</span>
+            </div>
+
+            <div className={styles.field}>
+              <Tooltip
+                content={t(
+                  'query-editor.details-sidebar.relative-time-tooltip',
+                  'Overrides the relative time range for individual panels. For example, to configure the Last 5 minutes use now-5m.'
+                )}
+              >
+                <Icon name="info-circle" size="md" className={styles.infoIcon} />
+              </Tooltip>
+              <span className={styles.fieldLabel}>
+                <Trans i18nKey="query-editor.details-sidebar.relative-time">Relative time</Trans>
+              </span>
+              <Input
+                type="text"
+                defaultValue={options.timeRange?.from ?? ''}
+                placeholder={TIME_OPTION_PLACEHOLDER}
+                onBlur={(e) => handleBlur(e, QueryOptionFields.relativeTime)}
+                autoFocus={focusedField === QueryOptionFields.relativeTime}
+                aria-label={t('query-editor.details-sidebar.relative-time', 'Relative time')}
+                className={styles.fieldInput}
+              />
+            </div>
+
+            <div className={styles.field}>
+              <Tooltip
+                content={t(
+                  'query-editor.details-sidebar.time-shift-tooltip',
+                  'Overrides the time range for individual panels by shifting its start and end relative to the time picker.'
+                )}
+              >
+                <Icon name="info-circle" size="md" className={styles.infoIcon} />
+              </Tooltip>
+              <span className={styles.fieldLabel}>
+                <Trans i18nKey="query-editor.details-sidebar.time-shift">Time shift</Trans>
+              </span>
+              <Input
+                type="text"
+                defaultValue={options.timeRange?.shift ?? ''}
+                placeholder={TIME_OPTION_PLACEHOLDER}
+                onBlur={(e) => handleBlur(e, QueryOptionFields.timeShift)}
+                autoFocus={focusedField === QueryOptionFields.timeShift}
+                aria-label={t('query-editor.details-sidebar.time-shift', 'Time shift')}
+                className={styles.fieldInput}
+              />
+            </div>
+
+            {showCacheTimeout && (
+              <div className={styles.field}>
+                <Tooltip
+                  content={t(
+                    'query-editor.details-sidebar.cache-timeout-tooltip',
+                    'If your time series store has a query cache this option can override the default cache timeout. Specify a numeric value in seconds.'
+                  )}
+                >
+                  <Icon name="info-circle" size="md" className={styles.infoIcon} />
+                </Tooltip>
+                <span className={styles.fieldLabel}>
+                  <Trans i18nKey="query-editor.details-sidebar.cache-timeout">Cache timeout</Trans>
+                </span>
+                <Input
+                  type="text"
+                  defaultValue={options.cacheTimeout ?? ''}
+                  // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+                  placeholder="60"
+                  onBlur={(e) => handleBlur(e, QueryOptionFields.cacheTimeout)}
+                  autoFocus={focusedField === QueryOptionFields.cacheTimeout}
+                  aria-label={t('query-editor.details-sidebar.cache-timeout', 'Cache timeout')}
+                  className={styles.fieldInput}
+                />
+              </div>
+            )}
+
+            {showCacheTTL && (
+              <div className={styles.field}>
+                <Tooltip
+                  content={t(
+                    'query-editor.details-sidebar.cache-ttl-tooltip',
+                    'Cache time-to-live: How long results from the queries in this panel will be cached, in milliseconds.'
+                  )}
+                >
+                  <Icon name="info-circle" size="md" className={styles.infoIcon} />
+                </Tooltip>
+                <span className={styles.fieldLabel}>
+                  <Trans i18nKey="query-editor.details-sidebar.cache-ttl">Cache TTL</Trans>
+                </span>
+                <Input
+                  type="number"
+                  defaultValue={options.queryCachingTTL ?? ''}
+                  placeholder={dsSettings?.cachingConfig?.TTLMs ? String(dsSettings.cachingConfig.TTLMs) : ''}
+                  onBlur={(e) => handleBlur(e, QueryOptionFields.queryCachingTTL)}
+                  autoFocus={focusedField === QueryOptionFields.cacheTTL}
+                  aria-label={t('query-editor.details-sidebar.cache-ttl', 'Cache TTL')}
+                  className={styles.fieldInput}
+                />
+              </div>
+            )}
+          </Stack>
+        </div>
       </div>
     </ClickOutsideWrapper>
   );

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorDetailsSidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorDetailsSidebar.tsx
@@ -273,10 +273,11 @@ export function QueryEditorDetailsSidebar() {
 function getStyles(theme: GrafanaTheme2) {
   return {
     container: css({
+      height: '100%',
+      minHeight: '100vh',
       display: 'flex',
       flexDirection: 'column',
       width: CONTENT_SIDE_BAR.width,
-      height: '100%',
       backgroundColor: theme.colors.background.primary,
     }),
     header: css({

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorDetailsSidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorDetailsSidebar.tsx
@@ -12,7 +12,7 @@ import {
   useQueryEditorUIContext,
   useQueryRunnerContext,
 } from '../QueryEditorContext';
-import { QueryOptionField, QueryOptionFields } from '../types';
+import { QueryOptionField } from '../types';
 
 function timeRangeValidation(value: string | null) {
   return !value || rangeUtil.isValidTimeSpan(value);
@@ -52,7 +52,7 @@ export function QueryEditorDetailsSidebar() {
       const value = event.currentTarget.value;
 
       // Handle number fields
-      if (field === QueryOptionFields.maxDataPoints || field === QueryOptionFields.queryCachingTTL) {
+      if (field === QueryOptionField.maxDataPoints || field === QueryOptionField.queryCachingTTL) {
         let numValue: number | null = parseInt(value, 10);
         if (isNaN(numValue) || numValue === 0) {
           numValue = null;
@@ -64,10 +64,10 @@ export function QueryEditorDetailsSidebar() {
       }
 
       // Handle time range fields
-      if (field === QueryOptionFields.relativeTime || field === QueryOptionFields.timeShift) {
+      if (field === QueryOptionField.relativeTime || field === QueryOptionField.timeShift) {
         const stringValue = emptyToNull(value);
         const isValid = timeRangeValidation(stringValue);
-        const timeRangeField = field === QueryOptionFields.relativeTime ? 'from' : 'shift';
+        const timeRangeField = field === QueryOptionField.relativeTime ? 'from' : 'shift';
         if (isValid && stringValue !== options.timeRange?.[timeRangeField]) {
           onQueryOptionsChange({
             ...options,
@@ -79,9 +79,9 @@ export function QueryEditorDetailsSidebar() {
 
       // Handle string fields (minInterval, cacheTimeout)
       const stringValue = emptyToNull(value);
-      if (field === QueryOptionFields.minInterval && stringValue !== options.minInterval) {
+      if (field === QueryOptionField.minInterval && stringValue !== options.minInterval) {
         onQueryOptionsChange({ ...options, minInterval: stringValue });
-      } else if (field === QueryOptionFields.cacheTimeout && stringValue !== options.cacheTimeout) {
+      } else if (field === QueryOptionField.cacheTimeout && stringValue !== options.cacheTimeout) {
         onQueryOptionsChange({ ...options, cacheTimeout: stringValue });
       }
     },
@@ -122,8 +122,8 @@ export function QueryEditorDetailsSidebar() {
                 type="number"
                 defaultValue={options.maxDataPoints ?? ''}
                 placeholder={realMaxDataPoints ? String(realMaxDataPoints) : ''}
-                onBlur={(e) => handleBlur(e, QueryOptionFields.maxDataPoints)}
-                autoFocus={focusedField === QueryOptionFields.maxDataPoints}
+                onBlur={(e) => handleBlur(e, QueryOptionField.maxDataPoints)}
+                autoFocus={focusedField === QueryOptionField.maxDataPoints}
                 aria-label={t('query-editor.details-sidebar.max-data-points', 'Max data points')}
                 className={styles.fieldInput}
               />
@@ -145,8 +145,8 @@ export function QueryEditorDetailsSidebar() {
                 type="text"
                 defaultValue={options.minInterval ?? ''}
                 placeholder={String(minIntervalOnDs)}
-                onBlur={(e) => handleBlur(e, QueryOptionFields.minInterval)}
-                autoFocus={focusedField === QueryOptionFields.minInterval}
+                onBlur={(e) => handleBlur(e, QueryOptionField.minInterval)}
+                autoFocus={focusedField === QueryOptionField.minInterval}
                 aria-label={t('query-editor.details-sidebar.min-interval', 'Min interval')}
                 className={styles.fieldInput}
               />
@@ -183,8 +183,8 @@ export function QueryEditorDetailsSidebar() {
                 type="text"
                 defaultValue={options.timeRange?.from ?? ''}
                 placeholder={TIME_OPTION_PLACEHOLDER}
-                onBlur={(e) => handleBlur(e, QueryOptionFields.relativeTime)}
-                autoFocus={focusedField === QueryOptionFields.relativeTime}
+                onBlur={(e) => handleBlur(e, QueryOptionField.relativeTime)}
+                autoFocus={focusedField === QueryOptionField.relativeTime}
                 aria-label={t('query-editor.details-sidebar.relative-time', 'Relative time')}
                 className={styles.fieldInput}
               />
@@ -206,8 +206,8 @@ export function QueryEditorDetailsSidebar() {
                 type="text"
                 defaultValue={options.timeRange?.shift ?? ''}
                 placeholder={TIME_OPTION_PLACEHOLDER}
-                onBlur={(e) => handleBlur(e, QueryOptionFields.timeShift)}
-                autoFocus={focusedField === QueryOptionFields.timeShift}
+                onBlur={(e) => handleBlur(e, QueryOptionField.timeShift)}
+                autoFocus={focusedField === QueryOptionField.timeShift}
                 aria-label={t('query-editor.details-sidebar.time-shift', 'Time shift')}
                 className={styles.fieldInput}
               />
@@ -231,8 +231,8 @@ export function QueryEditorDetailsSidebar() {
                   defaultValue={options.cacheTimeout ?? ''}
                   // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
                   placeholder="60"
-                  onBlur={(e) => handleBlur(e, QueryOptionFields.cacheTimeout)}
-                  autoFocus={focusedField === QueryOptionFields.cacheTimeout}
+                  onBlur={(e) => handleBlur(e, QueryOptionField.cacheTimeout)}
+                  autoFocus={focusedField === QueryOptionField.cacheTimeout}
                   aria-label={t('query-editor.details-sidebar.cache-timeout', 'Cache timeout')}
                   className={styles.fieldInput}
                 />
@@ -256,8 +256,8 @@ export function QueryEditorDetailsSidebar() {
                   type="number"
                   defaultValue={options.queryCachingTTL ?? ''}
                   placeholder={dsSettings?.cachingConfig?.TTLMs ? String(dsSettings.cachingConfig.TTLMs) : ''}
-                  onBlur={(e) => handleBlur(e, QueryOptionFields.queryCachingTTL)}
-                  autoFocus={focusedField === QueryOptionFields.cacheTTL}
+                  onBlur={(e) => handleBlur(e, QueryOptionField.queryCachingTTL)}
+                  autoFocus={focusedField === QueryOptionField.queryCachingTTL}
                   aria-label={t('query-editor.details-sidebar.cache-ttl', 'Cache TTL')}
                   className={styles.fieldInput}
                 />

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Footer/QueryEditorFooter.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Footer/QueryEditorFooter.tsx
@@ -7,7 +7,7 @@ import { Button, useStyles2 } from '@grafana/ui';
 
 import { TIME_OPTION_PLACEHOLDER } from '../../constants';
 import { useDatasourceContext, useQueryEditorUIContext, useQueryRunnerContext } from '../QueryEditorContext';
-import { QueryOptionField, QueryOptionFields } from '../types';
+import { QueryOptionField } from '../types';
 
 interface FooterLabelValue {
   id: QueryOptionField;
@@ -33,31 +33,31 @@ export function QueryEditorFooter() {
 
     return [
       {
-        id: QueryOptionFields.maxDataPoints,
+        id: QueryOptionField.maxDataPoints,
         label: t('query-editor.footer.label.max-data-points', 'Max data points'),
         value: options.maxDataPoints != null ? String(options.maxDataPoints) : String(realMaxDataPoints ?? '-'),
         isActive: options.maxDataPoints != null,
       },
       {
-        id: QueryOptionFields.minInterval,
+        id: QueryOptionField.minInterval,
         label: t('query-editor.footer.label.min-interval', 'Min interval'),
         value: options.minInterval ?? minIntervalOnDs,
         isActive: options.minInterval != null,
       },
       {
-        id: QueryOptionFields.interval,
+        id: QueryOptionField.interval,
         label: t('query-editor.footer.label.interval', 'Interval'),
         value: realInterval ?? '-',
         isActive: false, // Interval is always computed, never user-set
       },
       {
-        id: QueryOptionFields.relativeTime,
+        id: QueryOptionField.relativeTime,
         label: t('query-editor.footer.label.relative-time', 'Relative time'),
         value: options.timeRange?.from ?? TIME_OPTION_PLACEHOLDER,
         isActive: options.timeRange?.from != null,
       },
       {
-        id: QueryOptionFields.timeShift,
+        id: QueryOptionField.timeShift,
         label: t('query-editor.footer.label.time-shift', 'Time shift'),
         value: options.timeRange?.shift ?? TIME_OPTION_PLACEHOLDER,
         isActive: options.timeRange?.shift != null,
@@ -70,7 +70,7 @@ export function QueryEditorFooter() {
     event.stopPropagation();
 
     // Don't focus interval since it's read-only
-    if (fieldId && fieldId !== QueryOptionFields.interval) {
+    if (fieldId && fieldId !== QueryOptionField.interval) {
       openSidebar(fieldId);
     } else {
       openSidebar();

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Footer/QueryEditorFooter.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Footer/QueryEditorFooter.tsx
@@ -7,9 +7,10 @@ import { Button, useStyles2 } from '@grafana/ui';
 
 import { TIME_OPTION_PLACEHOLDER } from '../../constants';
 import { useDatasourceContext, useQueryEditorUIContext, useQueryRunnerContext } from '../QueryEditorContext';
+import { QueryOptionField, QueryOptionFields } from '../types';
 
 interface FooterLabelValue {
-  id: string;
+  id: QueryOptionField;
   label: string;
   value: string;
   isActive?: boolean;
@@ -19,7 +20,7 @@ export function QueryEditorFooter() {
   const styles = useStyles2(getStyles);
 
   const { queryOptions } = useQueryEditorUIContext();
-  const { options, setIsQueryOptionsOpen } = queryOptions;
+  const { options, openSidebar } = queryOptions;
   const { data } = useQueryRunnerContext();
   const { datasource } = useDatasourceContext();
 
@@ -32,31 +33,31 @@ export function QueryEditorFooter() {
 
     return [
       {
-        id: 'maxDataPoints',
+        id: QueryOptionFields.maxDataPoints,
         label: t('query-editor.footer.label.max-data-points', 'Max data points'),
         value: options.maxDataPoints != null ? String(options.maxDataPoints) : String(realMaxDataPoints ?? '-'),
         isActive: options.maxDataPoints != null,
       },
       {
-        id: 'minInterval',
+        id: QueryOptionFields.minInterval,
         label: t('query-editor.footer.label.min-interval', 'Min interval'),
         value: options.minInterval ?? minIntervalOnDs,
         isActive: options.minInterval != null,
       },
       {
-        id: 'interval',
+        id: QueryOptionFields.interval,
         label: t('query-editor.footer.label.interval', 'Interval'),
         value: realInterval ?? '-',
         isActive: false, // Interval is always computed, never user-set
       },
       {
-        id: 'relativeTime',
+        id: QueryOptionFields.relativeTime,
         label: t('query-editor.footer.label.relative-time', 'Relative time'),
         value: options.timeRange?.from ?? TIME_OPTION_PLACEHOLDER,
         isActive: options.timeRange?.from != null,
       },
       {
-        id: 'timeShift',
+        id: QueryOptionFields.timeShift,
         label: t('query-editor.footer.label.time-shift', 'Time shift'),
         value: options.timeRange?.shift ?? TIME_OPTION_PLACEHOLDER,
         isActive: options.timeRange?.shift != null,
@@ -64,8 +65,16 @@ export function QueryEditorFooter() {
     ];
   }, [options, data, datasource]);
 
-  const handleOpenSidebar = () => {
-    setIsQueryOptionsOpen(true);
+  const handleItemClick = (event: React.MouseEvent, fieldId?: QueryOptionField) => {
+    // Stop propagation to prevent ClickOutsideWrapper from immediately closing
+    event.stopPropagation();
+
+    // Don't focus interval since it's read-only
+    if (fieldId && fieldId !== QueryOptionFields.interval) {
+      openSidebar(fieldId);
+    } else {
+      openSidebar();
+    }
   };
 
   return (
@@ -77,7 +86,7 @@ export function QueryEditorFooter() {
               fill="text"
               size="sm"
               className={styles.itemButton}
-              onClick={handleOpenSidebar}
+              onClick={(e) => handleItemClick(e, item.id)}
               aria-label={t('query-editor.footer.edit-option', 'Edit {{label}}', { label: item.label })}
             >
               {item.isActive && <span className={styles.activeIndicator} />}
@@ -92,7 +101,7 @@ export function QueryEditorFooter() {
         size="sm"
         icon="angle-left"
         iconPlacement="right"
-        onClick={handleOpenSidebar}
+        onClick={(e) => handleItemClick(e)}
         aria-label={t('query-editor.footer.query-options', 'Query Options')}
       >
         <Trans i18nKey="query-editor.footer.query-options">Query Options</Trans>
@@ -149,6 +158,8 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     value: css({
       color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontFamily: theme.typography.fontFamilyMonospace,
     }),
     valueActive: css({
       color: theme.colors.success.text,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Footer/QueryEditorFooter.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Footer/QueryEditorFooter.tsx
@@ -132,7 +132,7 @@ function getStyles(theme: GrafanaTheme2) {
     itemsList: css({
       display: 'flex',
       alignItems: 'center',
-      gap: theme.spacing(2),
+      gap: theme.spacing(1),
       listStyle: 'none',
       margin: 0,
       padding: 0,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
@@ -8,7 +8,7 @@ import { QueryGroupOptions } from 'app/types/query';
 
 import { QueryEditorType } from '../constants';
 
-import { Transformation } from './types';
+import { QueryOptionField, Transformation } from './types';
 
 export interface DatasourceState {
   datasource?: DataSourceApi;
@@ -31,7 +31,9 @@ export interface PanelState {
 export interface QueryOptionsState {
   options: QueryGroupOptions;
   isQueryOptionsOpen: boolean;
-  setIsQueryOptionsOpen: (open: boolean) => void;
+  openSidebar: (focusField?: QueryOptionField) => void;
+  closeSidebar: () => void;
+  focusedField: QueryOptionField | null;
 }
 
 export interface QueryEditorUIState {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/testUtils.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/testUtils.tsx
@@ -68,7 +68,9 @@ export const mockOptions: QueryGroupOptions = {
 export const mockQueryOptionsState: QueryOptionsState = {
   options: mockOptions,
   isQueryOptionsOpen: false,
-  setIsQueryOptionsOpen: jest.fn(),
+  openSidebar: jest.fn(),
+  closeSidebar: jest.fn(),
+  focusedField: null,
 };
 
 export const mockUIStateBase = {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/types.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/types.ts
@@ -5,3 +5,16 @@ export type Transformation = {
   transformId: string;
   transformConfig: DataTransformerConfig;
 };
+
+export const QueryOptionFields = {
+  maxDataPoints: 'maxDataPoints',
+  minInterval: 'minInterval',
+  interval: 'interval',
+  relativeTime: 'relativeTime',
+  timeShift: 'timeShift',
+  cacheTimeout: 'cacheTimeout',
+  cacheTTL: 'cacheTTL',
+  queryCachingTTL: 'queryCachingTTL',
+} as const;
+
+export type QueryOptionField = (typeof QueryOptionFields)[keyof typeof QueryOptionFields];

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/types.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/types.ts
@@ -6,15 +6,12 @@ export type Transformation = {
   transformConfig: DataTransformerConfig;
 };
 
-export const QueryOptionFields = {
-  maxDataPoints: 'maxDataPoints',
-  minInterval: 'minInterval',
-  interval: 'interval',
-  relativeTime: 'relativeTime',
-  timeShift: 'timeShift',
-  cacheTimeout: 'cacheTimeout',
-  cacheTTL: 'cacheTTL',
-  queryCachingTTL: 'queryCachingTTL',
-} as const;
-
-export type QueryOptionField = (typeof QueryOptionFields)[keyof typeof QueryOptionFields];
+export enum QueryOptionField {
+  maxDataPoints = 'maxDataPoints',
+  minInterval = 'minInterval',
+  interval = 'interval',
+  relativeTime = 'relativeTime',
+  timeShift = 'timeShift',
+  cacheTimeout = 'cacheTimeout',
+  queryCachingTTL = 'queryCachingTTL',
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/useQueryOptions.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/useQueryOptions.test.ts
@@ -1,0 +1,89 @@
+import { renderHook } from '@testing-library/react';
+
+import { SceneQueryRunner, VizPanel } from '@grafana/scenes';
+
+import { PanelTimeRange } from '../../../scene/panel-timerange/PanelTimeRange';
+
+import { ds1SettingsMock } from './testUtils';
+import { useQueryOptions } from './useQueryOptions';
+
+describe('useQueryOptions', () => {
+  it('should build QueryGroupOptions from panel, queryRunner, and datasource state', () => {
+    const panel = new VizPanel({
+      key: 'panel-1',
+      $timeRange: new PanelTimeRange({
+        timeFrom: 'now-1h',
+        timeShift: '1d',
+        hideTimeOverride: false,
+      }),
+    });
+
+    const queryRunner = new SceneQueryRunner({
+      queries: [],
+      maxDataPoints: 2000,
+      minInterval: '10s',
+    });
+
+    const { result } = renderHook(() =>
+      useQueryOptions({
+        panel,
+        queryRunner,
+        dsSettings: ds1SettingsMock,
+      })
+    );
+
+    expect(result.current.maxDataPoints).toBe(2000);
+    expect(result.current.minInterval).toBe('10s');
+    expect(result.current.timeRange).toEqual({
+      from: 'now-1h',
+      shift: '1d',
+      hide: false,
+    });
+    expect(result.current.dataSource.uid).toBe('test');
+  });
+
+  it('should conditionally include cacheTimeout and queryCachingTTL based on datasource capabilities', () => {
+    const dsWithCaching = {
+      ...ds1SettingsMock,
+      meta: {
+        ...ds1SettingsMock.meta,
+        queryOptions: {
+          cacheTimeout: true,
+        },
+      },
+      cachingConfig: {
+        enabled: true,
+      },
+    };
+
+    const panel = new VizPanel({ key: 'panel-1' });
+    const queryRunner = new SceneQueryRunner({
+      queries: [],
+      cacheTimeout: '60',
+      queryCachingTTL: 300000,
+    });
+
+    const { result } = renderHook(() =>
+      useQueryOptions({
+        panel,
+        queryRunner,
+        dsSettings: dsWithCaching,
+      })
+    );
+
+    expect(result.current.cacheTimeout).toBe('60');
+    expect(result.current.queryCachingTTL).toBe(300000);
+
+    // Now test without caching support
+    const { result: resultNoCaching } = renderHook(() =>
+      useQueryOptions({
+        panel,
+        queryRunner,
+        dsSettings: ds1SettingsMock,
+      })
+    );
+
+    expect(resultNoCaching.current.cacheTimeout).toBeUndefined();
+    expect(resultNoCaching.current.queryCachingTTL).toBeUndefined();
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/useQueryOptions.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/useQueryOptions.ts
@@ -56,7 +56,7 @@ export function useQueryOptions({ panel, queryRunner, dsSettings }: UseQueryOpti
       timeRange,
     };
   }, [
-    panelState,
+    panelState.$timeRange,
     queryRunnerState?.maxDataPoints,
     queryRunnerState?.minInterval,
     queryRunnerState?.cacheTimeout,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/useQueryOptions.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/useQueryOptions.ts
@@ -1,0 +1,68 @@
+import { useMemo } from 'react';
+
+import { DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
+import { SceneQueryRunner, VizPanel } from '@grafana/scenes';
+import { QueryGroupOptions } from 'app/types/query';
+
+import { PanelTimeRange } from '../../../scene/panel-timerange/PanelTimeRange';
+
+interface UseQueryOptionsParams {
+  panel: VizPanel;
+  queryRunner: SceneQueryRunner | undefined;
+  dsSettings: DataSourceInstanceSettings | undefined;
+}
+
+/**
+ * Extracts time range values from panel's $timeRange object.
+ */
+function extractTimeRange(timeRangeObj: unknown): QueryGroupOptions['timeRange'] {
+  if (!(timeRangeObj instanceof PanelTimeRange)) {
+    return { from: undefined, shift: undefined, hide: undefined };
+  }
+
+  const { timeFrom, timeShift, hideTimeOverride } = timeRangeObj.state;
+  return {
+    from: timeFrom,
+    shift: timeShift,
+    hide: hideTimeOverride,
+  };
+}
+
+/**
+ * Custom hook to build QueryGroupOptions from Scene state with proper memoization.
+ * Only recomputes when the actual option values change, not on every query run.
+ */
+export function useQueryOptions({ panel, queryRunner, dsSettings }: UseQueryOptionsParams): QueryGroupOptions {
+  const panelState = panel.useState();
+  const queryRunnerState = queryRunner?.useState();
+
+  const queryOptions: QueryGroupOptions = useMemo(() => {
+    const showCacheTimeout = dsSettings?.meta.queryOptions?.cacheTimeout;
+    const showCacheTTL = dsSettings?.cachingConfig?.enabled;
+
+    const dataSource = dsSettings
+      ? { default: dsSettings.isDefault, ...getDataSourceRef(dsSettings) }
+      : { default: undefined, type: undefined, uid: undefined };
+
+    const timeRange = extractTimeRange(panelState.$timeRange);
+
+    return {
+      cacheTimeout: showCacheTimeout ? queryRunnerState?.cacheTimeout : undefined,
+      queryCachingTTL: showCacheTTL ? queryRunnerState?.queryCachingTTL : undefined,
+      dataSource,
+      queries: [],
+      maxDataPoints: queryRunnerState?.maxDataPoints,
+      minInterval: queryRunnerState?.minInterval,
+      timeRange,
+    };
+  }, [
+    panelState,
+    queryRunnerState?.maxDataPoints,
+    queryRunnerState?.minInterval,
+    queryRunnerState?.cacheTimeout,
+    queryRunnerState?.queryCachingTTL,
+    dsSettings,
+  ]);
+
+  return queryOptions;
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
@@ -41,3 +41,8 @@ export const QUERY_EDITOR_TYPE_CONFIG: Record<QueryEditorType, QueryEditorTypeCo
  * This is a common example value shown when no value is set.
  */
 export const TIME_OPTION_PLACEHOLDER = '1h';
+
+export const CONTENT_SIDE_BAR = {
+  width: 300,
+  labelWidth: 80,
+};


### PR DESCRIPTION
## Description
I noticed a strange dependency issue in the content sidebar logic. Decided to fix that. While I was in the code, made some other updates as well. The main fix is to move the creation of the query options object outside of `PanelDataPaneNext`, it really belongs in the context wrapper component. However, it's a lot of logic, so I moved it to a hook 🚀 

## Changes
* There's now logic around `focusedField`, so that when a user clicks on the field in the footer, it autofocuses that field in the sidebar.
* Cleaned up some logic around closing the sidebar, I think we should save the users changes and close the sidebar on blur.
* Other general updates

## Risks
* I don't see many risks associated with this at this point in time.

## Demo
Please pull down and see for yourself, but here's a screenshot. 

<img width="1384" height="620" alt="image" src="https://github.com/user-attachments/assets/701bfe08-0e45-45c9-b4ed-b72803af73ed" />

## Testing Instructions
* Please pull down this branch and test this pretty heavily. There's a lot going on here 😄 

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable