### PR TITLE
Use new k8s API for UI updates to datasource config

### DIFF
--- a/public/app/features/datasources/api.test.ts
+++ b/public/app/features/datasources/api.test.ts
@@ -7,6 +7,7 @@ import { getBackendSrv } from 'app/core/services/backend_srv';
 import {
   getDataSourceByUid,
   convertK8sDatasourceSettingsToLegacyDatasourceSettings,
+  convertLegacyDatasourceSettingsToK8sDatasourceSettings,
   DataSourceSettingsK8s,
   K8sMetadata,
   DatasourceInstanceK8sSpec,
@@ -42,7 +43,7 @@ describe('Datasources / API', () => {
     });
   });
   describe('convertK8sDatasourceSettingsToLegacyDatasourceSettings()', () => {
-    it('should convert legacy datasource to k8s datasource', () => {
+    it('should convert k8s datasource to legacy datasource', () => {
       let dsLegacySettings: DataSourceSettings = {
         id: 42,
         uid: 'fortytwo',
@@ -86,13 +87,65 @@ describe('Datasources / API', () => {
         isDefault: true,
       };
       let dsK8sSettings: DataSourceSettingsK8s = {
-        kind: 'thingie',
+        kind: 'DataSource',
         metadata: k8sMetadata,
         spec: k8sSpec,
         apiVersion: 'marvin.datasource.grafana.app/v0alpha1',
         secure: { basicAuthPassword: { foo: 'bar' } },
       };
       expect(convertK8sDatasourceSettingsToLegacyDatasourceSettings(dsK8sSettings)).toEqual(dsLegacySettings);
+    });
+  });
+
+  describe('convertLegacyDatasourceSettingsToK8sDatasourceSettings()', () => {
+    it('should convert legacy datasource to k8s datasource', () => {
+      let dsLegacySettings: DataSourceSettings = {
+        id: 42,
+        uid: 'fortytwo',
+        orgId: 1,
+        name: 'slartybartfast',
+        typeLogoUrl: '',
+        type: 'marvin',
+        typeName: '',
+        access: 'all areas',
+        url: 'example.com',
+        user: '',
+        database: '',
+        basicAuth: true,
+        basicAuthUser: 'zaphod',
+        isDefault: true,
+        jsonData: { authType: 'bar' },
+        secureJsonFields: {},
+        readOnly: false,
+        withCredentials: false,
+      };
+      let k8sMetadata: K8sMetadata = {
+        name: 'fortytwo',
+        namespace: 'default',
+        resourceVersion: 'fortytwo',
+        labels: { 'grafana.app/deprecatedInternalID': '42' },
+        annotations: {},
+      };
+      let k8sSpec: DatasourceInstanceK8sSpec = {
+        access: 'all areas',
+        jsonData: { authType: 'bar' },
+        title: 'slartybartfast',
+        url: 'example.com',
+        basicAuth: true,
+        basicAuthUser: 'zaphod',
+        isDefault: true,
+      };
+      let dsK8sSettings: DataSourceSettingsK8s = {
+        kind: 'DataSource',
+        metadata: k8sMetadata,
+        spec: k8sSpec,
+        apiVersion: 'marvin.datasource.grafana.app/v0alpha1',
+      };
+      let k8sNamespace = 'default';
+      let k8sVersion = 'v0alpha1';
+      expect(
+        convertLegacyDatasourceSettingsToK8sDatasourceSettings(dsLegacySettings, k8sNamespace, k8sVersion)
+      ).toEqual(dsK8sSettings);
     });
   });
 });

--- a/public/app/features/datasources/api.ts
+++ b/public/app/features/datasources/api.ts
@@ -12,10 +12,10 @@ export const getDataSources = async (): Promise<DataSourceSettings[]> => {
 export interface K8sMetadata {
   name: string;
   namespace: string;
-  uid: string;
+  uid?: string;
   resourceVersion: string;
-  generation: number;
-  creationTimestamp: string;
+  generation?: number;
+  creationTimestamp?: string;
   labels: { [key: string]: string };
   annotations: { [key: string]: string };
 }
@@ -55,6 +55,55 @@ export const getDataSourceK8sGroup = (uid: string): string => {
   }
   return '';
 };
+
+export const convertLegacyDatasourceSettingsToK8sDatasourceSettings = (
+  dsSettings: DataSourceSettings,
+  namespace: string,
+  version: string
+): DataSourceSettingsK8s => {
+  let k8sMetadata: K8sMetadata = {
+    name: dsSettings.uid,
+    namespace: namespace,
+    resourceVersion: 'fortytwo',
+    labels: { 'grafana.app/deprecatedInternalID': dsSettings.id.toString() },
+    annotations: {},
+  };
+  let k8sSpec: DatasourceInstanceK8sSpec = {
+    access: dsSettings.access,
+    jsonData: dsSettings.jsonData,
+    title: dsSettings.name,
+    url: dsSettings.url,
+    basicAuth: dsSettings.basicAuth,
+    basicAuthUser: dsSettings.basicAuthUser,
+    isDefault: dsSettings.isDefault,
+  };
+  let dsK8sSettings: DataSourceSettingsK8s = {
+    kind: 'DataSource',
+    metadata: k8sMetadata,
+    spec: k8sSpec,
+    apiVersion: dsSettings.type + '.datasource.grafana.app/' + version,
+  };
+  if (dsSettings.secureJsonData) {
+    dsK8sSettings.secure = {};
+    for (let [k, v] of Object.entries(dsSettings.secureJsonData)) {
+      let value = { create: v };
+      if (isRecordOfString(value)) {
+        dsK8sSettings.secure[k] = value;
+      }
+    }
+  }
+  return dsK8sSettings;
+};
+
+function isRecordOfString(value: unknown): value is Record<string, string> {
+  if (value === null) {
+    return false;
+  }
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  return true;
+}
 
 export const convertK8sDatasourceSettingsToLegacyDatasourceSettings = (
   dsK8sSettings: DataSourceSettingsK8s
@@ -153,6 +202,23 @@ export const createDataSource = (dataSource: Partial<DataSourceSettings>) =>
 export const getDataSourcePlugins = () => getBackendSrv().get('/api/plugins', { enabled: 1, type: 'datasource' });
 
 export const updateDataSource = (dataSource: DataSourceSettings) => {
+  if (config.featureToggles.queryServiceWithConnections) {
+    let k8sVersion = 'v0alpha1';
+    let dsK8sSettings = convertLegacyDatasourceSettingsToK8sDatasourceSettings(
+      dataSource,
+      config.namespace,
+      k8sVersion
+    );
+    return getBackendSrv().put(
+      `/apis/${dsK8sSettings.apiVersion}/namespaces/${config.namespace}/datasources/${dsK8sSettings.metadata.name}`,
+      dsK8sSettings,
+      {
+        showErrorAlert: false,
+        showSuccessAlert: false,
+        validatePath: true,
+      }
+    );
+  }
   // we're setting showErrorAlert and showSuccessAlert to false to suppress the popover notifications. Request result will now be
   // handled by the data source config page
   return getBackendSrv().put(`/api/datasources/uid/${dataSource.uid}`, dataSource, {


### PR DESCRIPTION
Use new k8s API for UI updates to datasource config.

Companion to backend changes PR over [here](https://github.com/grafana/grafana/pull/118037).