### PR TITLE
chore: reduce barrel in migrate-to-cloud

### DIFF
--- a/public/app/features/migrate-to-cloud/api/index.ts
+++ b/public/app/features/migrate-to-cloud/api/index.ts
@@ -20,6 +20,3 @@ export const cloudMigrationAPI = generatedAPI.injectEndpoints({
 });
 
 export const { useGetLocalPluginListQuery } = cloudMigrationAPI;
-
-// eslint-disable-next-line no-barrel-files/no-barrel-files
-export * from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';

--- a/public/app/features/migrate-to-cloud/fixtures/migrationItems.ts
+++ b/public/app/features/migrate-to-cloud/fixtures/migrationItems.ts
@@ -1,6 +1,6 @@
 import { Chance } from 'chance';
 
-import { MigrateDataResponseItemDto } from '../api';
+import { MigrateDataResponseItemDto } from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';
 
 export function wellFormedDatasourceMigrationItem(
   seed = 1,

--- a/public/app/features/migrate-to-cloud/onprem/ConfigureSnapshot.test.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/ConfigureSnapshot.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { ResourceDependencyDto } from '../api';
+import { ResourceDependencyDto } from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';
 
 import { ConfigureSnapshot } from './ConfigureSnapshot';
 import { ResourceTypeId } from './resourceDependency';

--- a/public/app/features/migrate-to-cloud/onprem/ConfigureSnapshot.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/ConfigureSnapshot.tsx
@@ -1,9 +1,8 @@
 import { useState, ChangeEvent, useEffect } from 'react';
 
+import { ResourceDependencyDto } from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';
 import { Trans } from '@grafana/i18n';
 import { Button, Icon, Stack, Checkbox, Text, Box, IconName, Space, Tooltip } from '@grafana/ui';
-
-import { ResourceDependencyDto } from '../api';
 
 import { ResourceTypeId, buildDependencyMaps, handleSelection, handleDeselection } from './resourceDependency';
 import { iconNameForResource, pluralizeResourceName } from './resourceInfo';

--- a/public/app/features/migrate-to-cloud/onprem/EmptyState/CallToAction/CallToAction.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/EmptyState/CallToAction/CallToAction.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react';
 
+import { useCreateSessionMutation } from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';
 import { Trans } from '@grafana/i18n';
 import { Box, Button, Text } from '@grafana/ui';
-
-import { useCreateSessionMutation } from '../../../api';
 
 import { ConnectModal } from './ConnectModal';
 

--- a/public/app/features/migrate-to-cloud/onprem/EmptyState/CallToAction/ConnectModal.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/EmptyState/CallToAction/ConnectModal.tsx
@@ -2,12 +2,12 @@ import { css } from '@emotion/css';
 import { useId } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
+import { CreateSessionApiArg } from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Modal, Button, Stack, TextLink, Field, Input, Text, useStyles2 } from '@grafana/ui';
 import { AlertWithTraceID } from 'app/features/migrate-to-cloud/shared/AlertWithTraceID';
 
-import { CreateSessionApiArg } from '../../../api';
 import { maybeAPIError } from '../../../api/errors';
 
 interface Props {

--- a/public/app/features/migrate-to-cloud/onprem/MigrationSummary.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/MigrationSummary.tsx
@@ -1,8 +1,7 @@
+import { GetSessionApiResponse, GetSnapshotResponseDto } from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';
 import { Trans, t } from '@grafana/i18n';
 import { Box, Button, Switch, Space, Stack, Text } from '@grafana/ui';
 import { formatDate } from 'app/core/internationalization/dates';
-
-import { GetSessionApiResponse, GetSnapshotResponseDto } from '../api';
 
 import { MigrationInfo } from './MigrationInfo';
 

--- a/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
@@ -2,6 +2,10 @@ import { css } from '@emotion/css';
 import { useMemo } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
+import {
+  useGetDashboardByUidQuery,
+  useGetLibraryElementByUidQuery,
+} from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';
 import { DataSourceInstanceSettings } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
@@ -10,7 +14,6 @@ import { getSvgSize } from '@grafana/ui/internal';
 import { useGetFolderQueryFacade } from 'app/api/clients/folder/v1beta1/hooks';
 
 import { LocalPlugin } from '../../plugins/admin/types';
-import { useGetDashboardByUidQuery, useGetLibraryElementByUidQuery } from '../api';
 
 import { iconNameForResource } from './resourceInfo';
 import { ResourceTableItem } from './types';

--- a/public/app/features/migrate-to-cloud/onprem/Page.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/Page.tsx
@@ -1,10 +1,6 @@
 import { skipToken } from '@reduxjs/toolkit/query/react';
 import { useCallback, useEffect, useState } from 'react';
 
-import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
-import { AlertVariant, Box, Stack, Text } from '@grafana/ui';
-
 import {
   GetSnapshotResponseDto,
   SnapshotDto,
@@ -16,8 +12,12 @@ import {
   useGetShapshotListQuery,
   useGetSnapshotQuery,
   useUploadSnapshotMutation,
-  useGetLocalPluginListQuery,
-} from '../api';
+} from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';
+import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
+import { AlertVariant, Box, Stack, Text } from '@grafana/ui';
+
+import { useGetLocalPluginListQuery } from '../api';
 import { maybeAPIError } from '../api/errors';
 import { AlertWithTraceID } from '../shared/AlertWithTraceID';
 

--- a/public/app/features/migrate-to-cloud/onprem/ResourceDetailsModal.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/ResourceDetailsModal.tsx
@@ -1,7 +1,6 @@
+import { MigrateDataResponseItemDto } from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';
 import { Trans, t } from '@grafana/i18n';
 import { Button, Modal, Stack, Text } from '@grafana/ui';
-
-import { MigrateDataResponseItemDto } from '../api';
 
 import { prettyTypeName } from './TypeCell';
 import { ResourceTableItem } from './types';

--- a/public/app/features/migrate-to-cloud/onprem/ResourcesTable.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/ResourcesTable.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useMemo, useState } from 'react';
 
+import { MigrateDataResponseItemDto } from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';
 import { InteractiveTable, Pagination, Stack, Column, type FetchDataFunc } from '@grafana/ui';
 
 import { LocalPlugin } from '../../plugins/admin/types';
-import { MigrateDataResponseItemDto } from '../api';
 
 import { NameCell } from './NameCell';
 import { ResourceDetailsModal } from './ResourceDetailsModal';

--- a/public/app/features/migrate-to-cloud/onprem/resourceDependency.test.ts
+++ b/public/app/features/migrate-to-cloud/onprem/resourceDependency.test.ts
@@ -1,4 +1,4 @@
-import { ResourceDependencyDto } from '../api';
+import { ResourceDependencyDto } from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';
 
 import { buildDependencyMaps, handleSelection, handleDeselection, ResourceTypeId } from './resourceDependency';
 

--- a/public/app/features/migrate-to-cloud/onprem/resourceDependency.ts
+++ b/public/app/features/migrate-to-cloud/onprem/resourceDependency.ts
@@ -1,6 +1,5 @@
+import { ResourceDependencyDto } from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';
 import { IconName } from '@grafana/ui';
-
-import { ResourceDependencyDto } from '../api';
 
 import { ResourceTableItem } from './types';
 

--- a/public/app/features/migrate-to-cloud/onprem/types.ts
+++ b/public/app/features/migrate-to-cloud/onprem/types.ts
@@ -1,5 +1,6 @@
+import { MigrateDataResponseItemDto } from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';
+
 import { LocalPlugin } from '../../plugins/admin/types';
-import { MigrateDataResponseItemDto } from '../api';
 
 export interface ResourceTableItem extends MigrateDataResponseItemDto {
   showDetails: (resource: ResourceTableItem) => void;

--- a/public/app/features/migrate-to-cloud/onprem/useNotifyOnSuccess.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/useNotifyOnSuccess.tsx
@@ -1,9 +1,8 @@
 import { useRef, useEffect } from 'react';
 
+import { GetSnapshotResponseDto, SnapshotDto } from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';
 import { t } from '@grafana/i18n';
 import { useAppNotification } from 'app/core/copy/appNotification';
-
-import { GetSnapshotResponseDto, SnapshotDto } from '../api';
 
 import { pluralizeResourceName } from './resourceInfo';
 import { ResourceTableItem } from './types';


### PR DESCRIPTION
**What is this feature?**

This pull request refactors the import paths for API types and hooks in the `migrate-to-cloud` feature, updating them to use the shared `@grafana/api-clients/rtkq/legacy/migrate-to-cloud` package instead of local barrel files. This change improves code consistency, reduces duplication, and prepares the codebase for easier maintenance and future updates.

**Why do we need this feature?**

Barrel files simplify and centralize imports making it easier to consume modules. However they also cause the following issues:

- Circular Dependencies - if two modules import from each other's barrel files, it can create a cycle that's hard to detect and debug.
- Tree Shaking Issues - barrel files can interfere with tree shaking
- Name Collisions - re-exporting many symbols from different modules come with the risk of name collisions creating confusing errors
- Hidden Dependencies - barrel files obscure where a symbol is originally defined
- Slower Compilation in Large Projects - using many barrel files can slow down TypeScript compilation and type-checking
- Unintentional Exports - makes it really easy to accidentally export internal or private modules

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates: #107611
**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
