### PR TITLE
chore: remove candelstick barrel file

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3953,11 +3953,6 @@
       "count": 1
     }
   },
-  "public/app/plugins/panel/candlestick/types.ts": {
-    "no-barrel-files/no-barrel-files": {
-      "count": 8
-    }
-  },
   "public/app/plugins/panel/canvas/CanvasPanel.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1

--- a/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
+++ b/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
@@ -27,7 +27,7 @@ import { ThresholdControlsPlugin } from '../timeseries/plugins/ThresholdControls
 import { getXAnnotationFrames } from '../timeseries/plugins/utils';
 
 import { prepareCandlestickFields } from './fields';
-import { Options, defaultCandlestickColors, VizDisplayMode } from './types';
+import { type Options, defaultCandlestickColors, VizDisplayMode } from './panelcfg.gen';
 import { drawMarkers, FieldIndices } from './utils';
 
 interface CandlestickPanelProps extends PanelProps<Options> {}

--- a/public/app/plugins/panel/candlestick/defaultOptions.ts
+++ b/public/app/plugins/panel/candlestick/defaultOptions.ts
@@ -1,16 +1,6 @@
 import { LegendDisplayMode, SortOrder, TooltipDisplayMode } from '@grafana/schema';
 
-import {
-  defaultOptions as defaultOptionsBase,
-  defaultCandlestickColors,
-  Options,
-  CandlestickColors,
-  CandleStyle,
-  ColorStrategy,
-  VizDisplayMode,
-  CandlestickFieldMap,
-  FieldConfig,
-} from './panelcfg.gen';
+import { defaultOptions as defaultOptionsBase, Options } from './panelcfg.gen';
 
 export const defaultOptions: Partial<Options> = {
   ...defaultOptionsBase,
@@ -25,15 +15,4 @@ export const defaultOptions: Partial<Options> = {
     mode: TooltipDisplayMode.Multi,
     sort: SortOrder.None,
   },
-};
-
-export {
-  type Options,
-  type CandlestickColors,
-  defaultCandlestickColors,
-  CandleStyle,
-  ColorStrategy,
-  VizDisplayMode,
-  type CandlestickFieldMap,
-  type FieldConfig,
 };

--- a/public/app/plugins/panel/candlestick/fields.test.ts
+++ b/public/app/plugins/panel/candlestick/fields.test.ts
@@ -1,7 +1,7 @@
 import { createTheme, toDataFrame } from '@grafana/data';
 
 import { prepareCandlestickFields } from './fields';
-import { Options, VizDisplayMode } from './types';
+import { type Options, VizDisplayMode } from './panelcfg.gen';
 
 const theme = createTheme();
 

--- a/public/app/plugins/panel/candlestick/fields.ts
+++ b/public/app/plugins/panel/candlestick/fields.ts
@@ -13,7 +13,7 @@ import { findField } from 'app/features/dimensions/utils';
 
 import { prepareGraphableFields } from '../timeseries/utils';
 
-import { Options, CandlestickFieldMap, VizDisplayMode } from './types';
+import { type Options, type CandlestickFieldMap, VizDisplayMode } from './panelcfg.gen';
 
 export interface FieldPickerInfo {
   /** property name */

--- a/public/app/plugins/panel/candlestick/module.tsx
+++ b/public/app/plugins/panel/candlestick/module.tsx
@@ -7,9 +7,10 @@ import { commonOptionsBuilder } from '@grafana/ui';
 import { defaultGraphConfig, getGraphFieldConfig } from '../timeseries/config';
 
 import { CandlestickPanel } from './CandlestickPanel';
+import { defaultOptions } from './defaultOptions';
 import { CandlestickData, getCandlestickFieldsInfo, FieldPickerInfo, prepareCandlestickFields } from './fields';
+import { defaultCandlestickColors, type Options, VizDisplayMode, ColorStrategy, CandleStyle } from './panelcfg.gen';
 import { candlestickSuggestionSupplier } from './suggestions';
-import { defaultCandlestickColors, defaultOptions, Options, VizDisplayMode, ColorStrategy, CandleStyle } from './types';
 
 const numericFieldFilter = (f: Field) => f.type === FieldType.number;
 

--- a/public/app/plugins/panel/candlestick/suggestions.ts
+++ b/public/app/plugins/panel/candlestick/suggestions.ts
@@ -1,8 +1,9 @@
 import { FieldType, VisualizationSuggestionScore, VisualizationSuggestionsSupplier } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
+import { defaultOptions } from './defaultOptions';
 import { prepareCandlestickFields } from './fields';
-import { defaultOptions, Options } from './types';
+import { type Options } from './panelcfg.gen';
 
 export const candlestickSuggestionSupplier: VisualizationSuggestionsSupplier<Options> = (dataSummary) => {
   if (

--- a/public/app/plugins/panel/candlestick/utils.ts
+++ b/public/app/plugins/panel/candlestick/utils.ts
@@ -2,7 +2,7 @@ import uPlot from 'uplot';
 
 import { colorManipulator } from '@grafana/data';
 
-import { VizDisplayMode, ColorStrategy, CandleStyle } from './types';
+import { VizDisplayMode, ColorStrategy, CandleStyle } from './panelcfg.gen';
 
 const { alpha } = colorManipulator;
 


### PR DESCRIPTION
**What is this feature?**

This pull request refactors the candlestick panel code by removing the `types.ts` file and consolidating all type and default option imports to use the generated `panelcfg.gen` module. This streamlines type management and reduces redundancy. Additionally, the `defaultOptions` logic is moved to its own file, and all relevant imports are updated accordingly.

**Why do we need this feature?**

Barrel files simplify and centralize imports making it easier to consume modules. However they also cause the following issues:

- Circular Dependencies - if two modules import from each other's barrel files, it can create a cycle that's hard to detect and debug.
- Tree Shaking Issues - barrel files can interfere with tree shaking
- Name Collisions - re-exporting many symbols from different modules come with the risk of name collisions creating confusing errors
- Hidden Dependencies - barrel files obscure where a symbol is originally defined
- Slower Compilation in Large Projects - using many barrel files can slow down TypeScript compilation and type-checking
- Unintentional Exports - makes it really easy to accidentally export internal or private modules

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates: #107611
**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

