### PR TITLE
Provisioning: Fix permissions for non-admin Git Sync users

### DIFF
--- a/pkg/registry/apis/provisioning/accesscontrol.go
+++ b/pkg/registry/apis/provisioning/accesscontrol.go
@@ -48,7 +48,7 @@ func registerAccessControlRoles(service accesscontrol.Service) error {
 				},
 			},
 		},
-		Grants: []string{string(org.RoleAdmin)},
+		Grants: []string{string(org.RoleViewer)},
 	}
 
 	repositoriesWriter := accesscontrol.RoleRegistration{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fix the permissions to read repositories by non-admin users. This is needed to read the branches to submit PRs or push to main. 

refs endpoint

```
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "repositories.provisioning.grafana.app \"grafana-manifests-dev\" is forbidden: User \"Roberto Jiménez Sánchez\" cannot get resource \"repositories/refs\" in API group \"provisioning.grafana.app\" in the namespace \"stacks-13\": repositories.provisioning.grafana.app \"grafana-manifests-dev\" is forbidden: permission denied",
  "reason": "Forbidden",
  "details": {
    "name": "grafana-manifests-dev",
    "group": "provisioning.grafana.app",
    "kind": "repositories"
  },
  "code": 403
}
```
