### PR TITLE
datasources: querier: add explicit status-code metric

### DIFF
--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -179,6 +179,7 @@ func TestQueryAPI(t *testing.T) {
 				tracer:                 tracing.InitializeTracerForTest(),
 				log:                    log.New("test"),
 				legacyDatasourceLookup: &mockLegacyDataSourceLookup{},
+				reportStatus:           func(context.Context, int) {},
 			}
 
 			reqCtx := claims.WithAuthInfo(identity.WithRequester(context.Background(), mockUser{}), &mockAuthInfo{})


### PR DESCRIPTION
when using the `/apis/query.grafana.app` endpoint, we will explicitly track the returned status code in a metric.
