### PR TITLE
Icon: Fix SVG not updating when icon name is changed quickly

### DIFF
--- a/packages/grafana-ui/src/components/Icon/Icon.test.tsx
+++ b/packages/grafana-ui/src/components/Icon/Icon.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+
+import { Icon } from './Icon';
+
+/**
+ * These tests are a bit weird because they use an entirely mocked out react-inlinesvg, so these are very superficial
+ * tests that should still not give us much confidence. They're primarily intended to catch simple logic bugs in the
+ * rendering logic of the Icon component.
+ */
+describe('Icon', () => {
+  it('should render an icon', () => {
+    render(<Icon name="heart" />);
+
+    const svg = screen.getByTestId('icon-heart');
+    expect(svg).toHaveAttribute('id', expect.stringContaining('heart.svg'));
+  });
+
+  it('should render with correct size', () => {
+    render(<Icon name="heart" size="lg" />);
+
+    const svg = screen.getByTestId('icon-heart');
+    expect(svg).toHaveAttribute('width', '18');
+    expect(svg).toHaveAttribute('height', '18');
+  });
+
+  it('should set aria-hidden when no accessibility props provided', () => {
+    render(<Icon name="heart" />);
+
+    const svg = screen.getByTestId('icon-heart');
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('should not set aria-hidden when title is provided', () => {
+    render(<Icon name="heart" title="Heart icon" />);
+
+    const svg = screen.getByTestId('icon-heart');
+    expect(svg).toHaveAttribute('aria-hidden', 'false');
+    expect(svg).toHaveAttribute('title', 'Heart icon');
+  });
+
+  it('should spin the spinner', () => {
+    // Not a great test - because the class name is generated we can't know if it's actually applied the spin class
+    // so we just check that the class name changes when its the spinner
+    render(<Icon name="heart" />);
+    const baseClassName = screen.getByTestId('icon-heart').getAttribute('class') || '';
+
+    render(<Icon name="spinner" />);
+
+    const svg = screen.getByTestId('icon-spinner');
+    const newClassName = svg.getAttribute('class') || '';
+    expect(newClassName).not.toBe(baseClassName);
+  });
+
+  // A *very* rudimentary test that the workaround somewhat works. We're not using the real react-inlinesvg,
+  // so this just tests the basics of the workaround logic
+  it('should update icon when name prop changes', () => {
+    const { rerender } = render(<Icon name="heart" />);
+
+    let svg = screen.getByTestId('icon-heart');
+    expect(svg).toHaveAttribute('id', expect.stringContaining('heart.svg'));
+
+    rerender(<Icon name="star" />);
+
+    svg = screen.getByTestId('icon-star');
+    expect(svg).toHaveAttribute('id', expect.stringContaining('star.svg'));
+  });
+});

--- a/packages/grafana-ui/src/components/Icon/Icon.tsx
+++ b/packages/grafana-ui/src/components/Icon/Icon.tsx
@@ -75,6 +75,10 @@ export const Icon = React.memo(
 
       return (
         <SVG
+          // The SVG can become 'stuck' if it's changed quickly before the previous icon finished loading.
+          // See https://github.com/gilbarbara/react-inlinesvg/issues/247
+          // By using the svgPath as the key, we ensure that the component is re-mounted and the new icon is loaded correctly.
+          key={svgPath}
           aria-hidden={
             rest.tabIndex === undefined &&
             !title &&

--- a/packages/grafana-ui/src/components/Icon/Icon.tsx
+++ b/packages/grafana-ui/src/components/Icon/Icon.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import * as React from 'react';
+import { useCallback, useState, useRef, memo, forwardRef } from 'react';
 import SVG from 'react-inlinesvg';
 
 import { GrafanaTheme2, isIconName } from '@grafana/data';
@@ -42,15 +42,58 @@ const getIconStyles = (theme: GrafanaTheme2) => {
   };
 };
 
+// The SVG can become 'stuck' if it's changed quickly before the previous icon finished loading.
+// See https://github.com/gilbarbara/react-inlinesvg/issues/247
+// By using the svgPath as the key, we ensure that the component is re-mounted and the new icon is loaded correctly.
+function useIconWorkaround(name: IconName) {
+  // Buffer name changes while the icon is loading until it stops loading, then apply the most recent name change.
+  // We use refs for state and a forceUpdate state to avoid needing to use the buffered name in the happy path
+  // of when the icon changes when its not currently loading.
+  // We want to avoid needless state updates to keep track of the lifecycle.
+
+  const [, setForceUpdate] = useState(0);
+  const isLoadingRef = useRef(false);
+  const currentNameRef = useRef(name);
+  const bufferedNameRef = useRef<IconName | null>(null);
+
+  // Decide which name to render THIS render
+  let nameToUse = name;
+
+  if (isLoadingRef.current && name !== currentNameRef.current) {
+    // Currently loading and name changed - buffer it, keep using current
+    nameToUse = currentNameRef.current;
+    bufferedNameRef.current = name;
+  } else if (!isLoadingRef.current && name !== currentNameRef.current) {
+    // Not loading - use new name immediately (happy path)
+    currentNameRef.current = name;
+    bufferedNameRef.current = null;
+    isLoadingRef.current = true; // Mark as loading when we accept a new name
+  }
+
+  const handleLoad = useCallback(() => {
+    isLoadingRef.current = false;
+
+    // Apply buffered name if one exists
+    if (bufferedNameRef.current) {
+      currentNameRef.current = bufferedNameRef.current;
+      bufferedNameRef.current = null;
+      setForceUpdate((n) => n + 1); // Trigger re-render with buffered name
+    }
+  }, []);
+
+  return { nameToUse, handleLoad };
+}
+
 /**
  * Grafana's icon wrapper component.
  *
  * https://developers.grafana.com/ui/latest/index.html?path=/docs/iconography-icon--docs
  */
-export const Icon = React.memo(
-  React.forwardRef<SVGElement, IconProps>(
-    ({ size = 'md', type = 'default', name, className, style, title = '', ...rest }, ref) => {
+export const Icon = memo(
+  forwardRef<SVGElement, IconProps>(
+    ({ size = 'md', type = 'default', name: nameProp, className, style, title = '', ...rest }, ref) => {
       const styles = useStyles2(getIconStyles);
+      const { nameToUse: name, handleLoad } = useIconWorkaround(nameProp);
 
       if (!isIconName(name)) {
         console.warn('Icon component passed an invalid icon name', name);
@@ -75,10 +118,7 @@ export const Icon = React.memo(
 
       return (
         <SVG
-          // The SVG can become 'stuck' if it's changed quickly before the previous icon finished loading.
-          // See https://github.com/gilbarbara/react-inlinesvg/issues/247
-          // By using the svgPath as the key, we ensure that the component is re-mounted and the new icon is loaded correctly.
-          key={svgPath}
+          data-testid={`icon-${iconName}`}
           aria-hidden={
             rest.tabIndex === undefined &&
             !title &&
@@ -86,6 +126,8 @@ export const Icon = React.memo(
             !rest['aria-labelledby'] &&
             !rest['aria-describedby']
           }
+          onLoad={handleLoad}
+          onError={handleLoad}
           innerRef={ref}
           src={svgPath}
           width={svgWid}

--- a/public/app/plugins/datasource/cloud-monitoring/components/__snapshots__/VariableQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/cloud-monitoring/components/__snapshots__/VariableQueryEditor.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`VariableQueryEditor renders correctly 1`] = `
               <svg
                 aria-hidden="true"
                 class="css-1d3xu67-Icon"
-                data-testid="angle-down"
+                data-testid="icon-angle-down"
                 height="16"
                 loader="[object Object]"
                 title=""

--- a/public/test/mocks/react-inlinesvg.tsx
+++ b/public/test/mocks/react-inlinesvg.tsx
@@ -1,17 +1,27 @@
-import { Ref } from 'react';
+import { Ref, useEffect } from 'react';
 
 export default function ReactInlineSVG({
   src,
   innerRef,
   cacheRequests,
   preProcessor,
+  onLoad,
   ...rest
 }: {
   src: string;
   innerRef: Ref<SVGSVGElement>;
   cacheRequests: boolean;
   preProcessor: () => string;
+  onLoad?: () => void;
 }) {
+  // Simulate async loading behavior
+  useEffect(() => {
+    if (onLoad) {
+      // Call onLoad synchronously in tests to avoid timing issues
+      onLoad();
+    }
+  }, [src, onLoad]);
+
   return <svg id={src} ref={innerRef} {...rest} />;
 }
 


### PR DESCRIPTION
react-inlinesvg / Icon has a problem where if the icon name changes while the SVG is still loading, the SVG will become ’stuck’ and out of sync with the name. See https://github.com/gilbarbara/react-inlinesvg/issues/247

Based on the fix in https://github.com/grafana/grafana/pull/115706, I’m generalising the approach here to remount the SVG component when the icon name changes to ensure the correct SVG is always displayed by removing any component caches.

Fixes https://github.com/grafana/grafana/issues/115552, where the Explore Run Query/Refresh button would get stuck.