### PR TITLE
LogLineDetailsComponent: use empty group if label types are not supported

### DIFF
--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -481,7 +481,7 @@ describe('LogLineDetails', () => {
         },
       });
 
-      beforeAll(() => {
+      beforeEach(() => {
         jest.requireMock('@grafana/runtime').getDataSourceSrv = jest.fn().mockImplementation(() => ({
           get: (uid: string) =>
             Promise.resolve(
@@ -534,6 +534,40 @@ describe('LogLineDetails', () => {
         expect(screen.getByText(/Parsed field/)).toBeInTheDocument();
         expect(screen.getByText('Structured metadata')).toBeInTheDocument();
       });
+
+      test('should fallback to a single group of Fields if not supported', async () => {
+        jest.requireMock('@grafana/runtime').getDataSourceSrv = jest.fn().mockImplementation(() => ({
+          get: (uid: string) => Promise.resolve(undefined),
+        }));
+
+        await setup(
+          undefined,
+          {
+            entry,
+            dataFrame,
+            entryFieldIndex: 0,
+            rowIndex: 0,
+            labels,
+            rowId: '1',
+          },
+          undefined,
+          undefined,
+          'Fields'
+        );
+
+        // Show labels and links
+        expect(screen.getByText('label1')).toBeInTheDocument();
+        expect(screen.getByText('value1')).toBeInTheDocument();
+        expect(screen.getByText('label2')).toBeInTheDocument();
+        expect(screen.getByText('value2')).toBeInTheDocument();
+        expect(screen.getByText('label3')).toBeInTheDocument();
+        expect(screen.getByText('value3')).toBeInTheDocument();
+        expect(screen.queryByText('Fields')).toBeInTheDocument();
+        expect(screen.queryByText(/Indexed label/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Parsed field/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Structured metadata/)).not.toBeInTheDocument();
+      });
+
       test('Should allow to search within fields', async () => {
         await setup(
           undefined,

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -84,7 +84,9 @@ export const LogLineDetailsComponent = memo(
 
     const groupedLabels = useMemo(() => {
       if (!ds) {
-        return {};
+        return {
+          '': labelsWithLinks
+        };
       }
       return groupBy(
         labelsWithLinks,

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -247,7 +247,7 @@ export const LogLineDetailsComponent = memo(
             </ControlledCollapse>
           )}
           {noDetails && (
-            <Box marginTop={1} paddingLeft={1}>
+            <Box marginTop={1} paddingLeft={0.5}>
               <Trans i18nKey="logs.log-line-details.no-details">No fields to display.</Trans>
             </Box>
           )}

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -12,7 +12,7 @@ import {
 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
-import { ControlledCollapse, useStyles2 } from '@grafana/ui';
+import { Box, ControlledCollapse, useStyles2 } from '@grafana/ui';
 
 import { useAttributesExtensionLinks } from '../LogDetails';
 import { createLogLineLinks } from '../logParser';
@@ -84,9 +84,11 @@ export const LogLineDetailsComponent = memo(
 
     const groupedLabels = useMemo(() => {
       if (!ds) {
-        return {
-          '': labelsWithLinks
-        };
+        return labelsWithLinks.length > 0
+          ? {
+              '': labelsWithLinks,
+            }
+          : {};
       }
       return groupBy(
         labelsWithLinks,
@@ -244,7 +246,11 @@ export const LogLineDetailsComponent = memo(
               <LogLineDetailsFields log={log} logs={logs} fields={fieldsWithoutLinks} search={search} />
             </ControlledCollapse>
           )}
-          {noDetails && <Trans i18nKey="logs.log-line-details.no-details">No fields to display.</Trans>}
+          {noDetails && (
+            <Box marginTop={1} paddingLeft={1}>
+              <Trans i18nKey="logs.log-line-details.no-details">No fields to display.</Trans>
+            </Box>
+          )}
         </div>
       </>
     );

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -2,7 +2,14 @@ import { css } from '@emotion/css';
 import { camelCase, groupBy } from 'lodash';
 import { memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { DataFrameType, DataSourceApi, GrafanaTheme2, hasLogsLabelTypesSupport, store, TimeRange } from '@grafana/data';
+import {
+  DataFrameType,
+  DataSourceWithLogsLabelTypesSupport,
+  GrafanaTheme2,
+  hasLogsLabelTypesSupport,
+  store,
+  TimeRange,
+} from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import { Box, ControlledCollapse, useStyles2 } from '@grafana/ui';
@@ -34,7 +41,7 @@ export const LogLineDetailsComponent = memo(
     const { displayedFields, noInteractions, logOptionsStorageKey, setDisplayedFields, syntaxHighlighting } =
       useLogListContext();
     const [search, setSearch] = useState('');
-    const [ds, setDs] = useState<DataSourceApi | null | undefined>(undefined);
+    const [ds, setDs] = useState<DataSourceWithLogsLabelTypesSupport | null>(null);
     const inputRef = useRef('');
     const styles = useStyles2(getStyles);
 
@@ -76,7 +83,7 @@ export const LogLineDetailsComponent = memo(
     const trace = useMemo(() => getTempoTraceFromLinks(fieldsWithLinks.links), [fieldsWithLinks.links]);
 
     const groupedLabels = useMemo(() => {
-      if (!ds || !hasLogsLabelTypesSupport(ds)) {
+      if (!ds) {
         return labelsWithLinks.length > 0
           ? {
               '': labelsWithLinks,
@@ -156,16 +163,13 @@ export const LogLineDetailsComponent = memo(
     useEffect(() => {
       const setDatasource = async () => {
         const datasource = await getDataSourceSrv().get(log.datasourceUid);
-        setDs(datasource ? datasource : null);
+        if (datasource && hasLogsLabelTypesSupport(datasource)) {
+          setDs(datasource);
+        }
       };
 
       setDatasource();
     }, [log.datasourceUid]);
-
-    // Wait for the data source to be resolved before showing fields or labels
-    if (ds === undefined) {
-      return null;
-    }
 
     return (
       <>


### PR DESCRIPTION
If labels are present, but the datasource doesn't support DataSourceWithLogsLabelTypesSupport, we need to fall back to an empty group containing all the labels, instead of nothing.

Additionally, improving the empty state styles by adding a bit of space.

<img width="970" height="169" alt="imagen" src="https://github.com/user-attachments/assets/aad19180-d7e1-45f7-bd9f-fed8466301c7" />
