### PR TITLE
fix(search): owner references schema as an array

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/dashboard/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/dashboard/v0alpha1/endpoints.gen.ts
@@ -688,8 +688,8 @@ export type SearchDashboardsAndFoldersApiArg = {
   sort?: string;
   /** number of results to return */
   limit?: number;
-  /** filter by owner reference in the format {Group}/{Kind}/{Name} */
-  ownerReference?: string;
+  /** filter by owner reference in the format {Group}/{Kind}/{Name}. When you pass multiple values, the filter matches any of them. */
+  ownerReference?: string[];
   /** add debugging info that may help explain why the result matched */
   explain?: boolean;
   /** [experimental] optionally include matches from panel titles */

--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -212,23 +212,23 @@ func (s *SearchHandler) GetAPIRoutes(defs map[string]common.OpenAPIDefinition) *
 									ParameterProps: spec3.ParameterProps{
 										Name:        "ownerReference", // singular
 										In:          "query",
-										Description: "filter by owner reference in the format {Group}/{Kind}/{Name}",
+										Description: "filter by owner reference in the format {Group}/{Kind}/{Name}. When you pass multiple values, the filter matches any of them.",
 										Required:    false,
-										Schema:      spec.StringProperty(),
+										Schema:      spec.ArrayProperty(spec.StringProperty()),
 										Examples: map[string]*spec3.Example{
 											"": {
 												ExampleProps: spec3.ExampleProps{},
 											},
 											"team": {
 												ExampleProps: spec3.ExampleProps{
-													Summary: "Team owner reference",
-													Value:   "iam.grafana.app/Team/xyz",
+													Summary: "Owner references of team xyz or abc",
+													Value:   []string{"iam.grafana.app/Team/xyz", "iam.grafana.app/Team/abc"},
 												},
 											},
 											"user": {
 												ExampleProps: spec3.ExampleProps{
 													Summary: "User owner reference",
-													Value:   "iam.grafana.app/User/abc",
+													Value:   []string{"iam.grafana.app/User/abc"},
 												},
 											},
 										},

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
@@ -1737,19 +1737,27 @@
           {
             "name": "ownerReference",
             "in": "query",
-            "description": "filter by owner reference in the format {Group}/{Kind}/{Name}",
+            "description": "filter by owner reference in the format {Group}/{Kind}/{Name}. When you pass multiple values, the filter matches any of them.",
             "schema": {
-              "type": "string"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "examples": {
               "": {},
               "team": {
-                "summary": "Team owner reference",
-                "value": "iam.grafana.app/Team/xyz"
+                "summary": "Owner references of team xyz or abc",
+                "value": [
+                  "iam.grafana.app/Team/xyz",
+                  "iam.grafana.app/Team/abc"
+                ]
               },
               "user": {
                 "summary": "User owner reference",
-                "value": "iam.grafana.app/User/abc"
+                "value": [
+                  "iam.grafana.app/User/abc"
+                ]
               }
             }
           },


### PR DESCRIPTION
**What is this feature?**

Makes generated search client use string array for owner references

**Why do we need this feature?**

The search server already supports it, but the generated client was missing the array property.

**Who is this feature for?**

Front-end team for "team folders" project

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
