### PR TITLE
fix(annotations): Fix driverName for dashboard UID migrations

### DIFF
--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -108,7 +108,7 @@ func triggerAlwaysOnMigrations(cfg *setting.Cfg, l log.Logger, db db.DB) {
 	// Run migration in a background goroutine to avoid blocking service startup
 	go func() {
 		l.Info("Starting annotation dashboard_uid migration in background")
-		err := migrations.RunDashboardUIDMigrations(db.GetEngine().NewSession(), db.GetEngine().DriverName(), l)
+		err := migrations.RunDashboardUIDMigrations(db.GetEngine().NewSession(), db.GetDialect().DriverName(), l)
 		if err != nil {
 			l.Error("failed to populate dashboard_uid for annotations", "error", err)
 		} else {


### PR DESCRIPTION
The migration is failing to run with the proper SQL dialect:
```
failed to set dashboard_uid for annotation batch 1: Error 1235 (42000): This version of MySQL doesn't yet support 'LIMIT & IN/ALL/ANY/SOME subquery'" 
```

It happens because the select for the driverName is getting an incorrect value from `GetEngine().DriverName()` (mysqlWithHooks) instead of `GetDialect().DriverName()` (mysql) in 
https://github.com/grafana/grafana/blob/6ce672dd00feca5e12b576e9a0b2f045b7d75351/pkg/services/sqlstore/migrations/annotation_mig.go#L273