### PR TITLE
Suggestions: Ensure results with equal preferredVisualizationType are stable sorted

### DIFF
--- a/public/app/features/panel/suggestions/getAllSuggestions.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.ts
@@ -103,12 +103,14 @@ export function sortSuggestions(suggestions: PanelPluginVisualizationSuggestion[
 
     // if a preferred visualisation type matches the data, prioritize it
     const mappedA = mapPreferredVisualisationTypeToPlugin(a.pluginId);
-    if (mappedA && dataSummary.hasPreferredVisualisationType(mappedA)) {
-      return -1;
-    }
     const mappedB = mapPreferredVisualisationTypeToPlugin(b.pluginId);
-    if (mappedB && dataSummary.hasPreferredVisualisationType(mappedB)) {
-      return 1;
+    if (mappedA !== mappedB) {
+      if (mappedA && dataSummary.hasPreferredVisualisationType(mappedA)) {
+        return -1;
+      }
+      if (mappedB && dataSummary.hasPreferredVisualisationType(mappedB)) {
+        return 1;
+      }
     }
 
     // compare scores directly if there are no other factors


### PR DESCRIPTION
Fixes an issue discovered during internal dogfooding.

When sorting suggestions, if two suggestions have identical preferredVisualizationTypes, those results could become unordered from the underlying order returned by their suggestion supplier. This is a subtle issue but impactful since we auto-select the top suggestion, and for timeseries that could reesult in a kind of weird order of suggestions.

To test, use this debug dashboard and edit the panel, then observe the order of the timeseries options. The buggy behavior would be to return anything other than a plain `Line chart` first. (see the [timeseries suggestions supplier](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/timeseries/suggestions.ts) - the results should be in the same order as the plugin returned since they all satisfy the `preferredVisualizationType` check, but the previous logic reversed the order.)

[debug-New panel-2026-02-06 14_57_34.json.txt](https://github.com/user-attachments/files/25131395/debug-New.panel-2026-02-06.14_57_34.json.txt)
