### PR TITLE
SecretTextArea: Add visibility toggle

### DIFF
--- a/packages/grafana-ui/src/components/SecretTextArea/SecretTextArea.test.tsx
+++ b/packages/grafana-ui/src/components/SecretTextArea/SecretTextArea.test.tsx
@@ -68,4 +68,38 @@ describe('<SecretTextArea />', () => {
     expect(onChange).toHaveBeenCalled();
     expect(textArea).toHaveValue('Foo');
   });
+
+  it('should show a visibility toggle button when not configured', () => {
+    render(
+      <SecretTextArea isConfigured={false} onChange={() => {}} onReset={() => {}} placeholder={PLACEHOLDER_TEXT} />
+    );
+
+    expect(screen.getByRole('button', { name: /show secret content/i })).toBeInTheDocument();
+  });
+
+  it('should not show a visibility toggle button when configured', () => {
+    render(
+      <SecretTextArea isConfigured={true} onChange={() => {}} onReset={() => {}} placeholder={PLACEHOLDER_TEXT} />
+    );
+
+    expect(screen.queryByRole('button', { name: /show secret content/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /hide secret content/i })).not.toBeInTheDocument();
+  });
+
+  it('should toggle content visibility when the toggle button is clicked', async () => {
+    render(
+      <SecretTextArea isConfigured={false} onChange={() => {}} onReset={() => {}} placeholder={PLACEHOLDER_TEXT} />
+    );
+
+    // Initially shows "Show" button
+    expect(screen.getByRole('button', { name: /show secret content/i })).toBeInTheDocument();
+
+    // Click to reveal
+    await userEvent.click(screen.getByRole('button', { name: /show secret content/i }));
+    expect(screen.getByRole('button', { name: /hide secret content/i })).toBeInTheDocument();
+
+    // Click to hide again
+    await userEvent.click(screen.getByRole('button', { name: /hide secret content/i }));
+    expect(screen.getByRole('button', { name: /show secret content/i })).toBeInTheDocument();
+  });
 });

--- a/packages/grafana-ui/src/components/SecretTextArea/SecretTextArea.tsx
+++ b/packages/grafana-ui/src/components/SecretTextArea/SecretTextArea.tsx
@@ -1,10 +1,12 @@
 import { css, cx } from '@emotion/css';
-import * as React from 'react';
+import { useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { Button } from '../Button/Button';
+import { IconButton } from '../IconButton/IconButton';
 import { Box } from '../Layout/Box/Box';
 import { Stack } from '../Layout/Stack/Stack';
 import { TextArea } from '../TextArea/TextArea';
@@ -28,6 +30,18 @@ const getStyles = (theme: GrafanaTheme2) => {
       paddingTop: theme.spacing(0.5) /** Needed to mimic vertically centered text in an input box */,
       resize: 'none',
     }),
+    maskedTextArea: css({
+      WebkitTextSecurity: 'disc',
+    }),
+    textAreaWrapper: css({
+      position: 'relative',
+    }),
+    toggleButton: css({
+      position: 'absolute',
+      top: theme.spacing(1),
+      right: theme.spacing(3),
+      zIndex: 1,
+    }),
   };
 };
 
@@ -38,11 +52,28 @@ const getStyles = (theme: GrafanaTheme2) => {
  * https://developers.grafana.com/ui/latest/index.html?path=/docs/inputs-secrettextarea--docs
  */
 export const SecretTextArea = ({ isConfigured, onReset, grow, ...props }: Props) => {
+  const [contentVisible, setContentVisible] = useState(false);
   const styles = useStyles2(getStyles);
+  const toggleLabel = contentVisible
+    ? t('grafana-ui.secret-text-area.hide-content', 'Hide secret content')
+    : t('grafana-ui.secret-text-area.show-content', 'Show secret content');
+
   return (
     <Stack>
       <Box grow={grow ? 1 : undefined}>
-        {!isConfigured && <TextArea {...props} />}
+        {!isConfigured && (
+          <div className={styles.textAreaWrapper}>
+            <IconButton
+              className={styles.toggleButton}
+              name={contentVisible ? 'eye-slash' : 'eye'}
+              onClick={() => setContentVisible(!contentVisible)}
+              aria-label={toggleLabel}
+              tooltip={toggleLabel}
+              size="sm"
+            />
+            <TextArea {...props} className={cx(!contentVisible && styles.maskedTextArea, props.className)} />
+          </div>
+        )}
         {isConfigured && (
           <TextArea
             {...props}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9518,6 +9518,10 @@
     "secret-form-field": {
       "reset": "Reset"
     },
+    "secret-text-area": {
+      "hide-content": "Hide secret content",
+      "show-content": "Show secret content"
+    },
     "segment-async": {
       "error": "Failed to load options",
       "loading": "Loading options...",


### PR DESCRIPTION
**What is this feature?**

Add a show/hide toggle to SecretTextArea so content is masked by default with CSS -webkit-text-security: disc. Users can click an eye icon button to reveal or hide content, similar to password input fields.

**Why do we need this feature?**

SecretTextArea is used for sensitive multi-line content like PEM-encoded private keys. Currently the content is displayed in plain text.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/804

<img width="955" height="240" alt="Screenshot 2026-02-06 at 18 17 39" src="https://github.com/user-attachments/assets/51e013fd-1e29-4ef8-91bf-34f9108e6cc8" />

