### PR TITLE
datasources: query service: use feature-flag for per-datasource control

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -1,3 +1,4 @@
+import { OpenFeature } from '@openfeature/web-sdk';
 import { lastValueFrom, merge, Observable, of } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 
@@ -213,8 +214,13 @@ class DataSourceWithBackend<
     let url = '/api/ds/query?ds_type=' + this.type;
 
     // Use the new query service
-    if (config.featureToggles.queryServiceFromUI && isQueryServiceCompatible(datasources)) {
-      url = `/apis/query.grafana.app/v0alpha1/namespaces/${config.namespace}/query?ds_type=${this.type}`;
+    if (config.featureToggles.queryServiceFromUI) {
+      const allowedTypes = OpenFeature.getClient().getObjectValue('datasources.querier.fe-allowed-types', {
+        types: [],
+      });
+      if (isQueryServiceCompatible(datasources, allowedTypes)) {
+        url = `/apis/query.grafana.app/v0alpha1/namespaces/${config.namespace}/query?ds_type=${this.type}`;
+      }
     }
 
     if (hasExpr) {

--- a/packages/grafana-runtime/src/utils/qscheck.test.ts
+++ b/packages/grafana-runtime/src/utils/qscheck.test.ts
@@ -13,133 +13,316 @@ interface TestJsonData extends DataSourceJsonData {
 
 type TestCase = {
   name: string;
-  jsonDatas: TestJsonData[];
+  ds: Array<{
+    jsonData: TestJsonData;
+    type: string;
+  }>;
   expected: boolean;
+  flag: unknown;
+  errorLogs: number;
 };
 
 describe('qscheck', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
   const testCases: TestCase[] = [
     {
       name: 'no queries',
-      jsonDatas: [],
+      ds: [],
+      flag: { types: ['prometheus', 'loki'] },
       expected: true,
+      errorLogs: 0,
     },
     {
       name: 'empty jsondata',
-      jsonDatas: [{}],
+      ds: [
+        {
+          jsonData: {},
+          type: 'prometheus',
+        },
+      ],
+      flag: { types: ['prometheus', 'loki'] },
       expected: true,
+      errorLogs: 0,
     },
     {
       name: 'no oauth',
-      jsonDatas: [
+      ds: [
         {
-          thing1: 'http://localhost:9090',
-          thing2: 15,
+          jsonData: {
+            thing1: 'http://localhost:9090',
+            thing2: 15,
+          },
+          type: 'prometheus',
         },
       ],
+      flag: { types: ['prometheus', 'loki'] },
       expected: true,
+      errorLogs: 0,
     },
     {
       name: 'oauth false',
-      jsonDatas: [
+      ds: [
         {
-          thing1: 'http://localhost:9090',
-          thing2: 42,
-          oauthPassThru: false,
+          jsonData: {
+            thing1: 'http://localhost:9090',
+            thing2: 42,
+            oauthPassThru: false,
+          },
+          type: 'prometheus',
         },
       ],
+      flag: { types: ['prometheus', 'loki'] },
       expected: true,
+      errorLogs: 0,
     },
     {
       name: 'oauth true',
-      jsonDatas: [
+      ds: [
         {
-          thing1: 'http://localhost:9090',
-          thing2: 55,
-          oauthPassThru: true,
+          jsonData: {
+            thing1: 'http://localhost:9090',
+            thing2: 55,
+            oauthPassThru: true,
+          },
+          type: 'prometheus',
         },
       ],
+      flag: { types: ['prometheus', 'loki'] },
       expected: false,
+      errorLogs: 0,
     },
     {
       name: 'oauth non-boolean',
-      jsonDatas: [
+      ds: [
         {
-          thing1: 'http://localhost:9090',
-          thing2: 77,
-          oauthPassThru: 42,
+          jsonData: {
+            thing1: 'http://localhost:9090',
+            thing2: 77,
+            oauthPassThru: 42,
+          },
+          type: 'prometheus',
         },
       ],
+      flag: { types: ['prometheus', 'loki'] },
       expected: false,
+      errorLogs: 0,
     },
     {
       name: 'azureoauth missing',
-      jsonDatas: [
+      ds: [
         {
-          thing1: 'http://localhost:9090',
-          thing2: 77,
-          // azureCredentials not there
+          jsonData: {
+            thing1: 'http://localhost:9090',
+            thing2: 77,
+            // azureCredentials not there
+          },
+          type: 'prometheus',
         },
       ],
+      flag: { types: ['prometheus', 'loki'] },
       expected: true,
+      errorLogs: 0,
     },
     {
       name: 'azureoauth different auth',
-      jsonDatas: [
+      ds: [
         {
-          thing1: 'http://localhost:9090',
-          thing2: 77,
-          azureCredentials: {
-            authType: 'workloadidentity',
+          jsonData: {
+            thing1: 'http://localhost:9090',
+            thing2: 77,
+            azureCredentials: {
+              authType: 'workloadidentity',
+            },
           },
+          type: 'prometheus',
         },
       ],
+      flag: { types: ['prometheus', 'loki'] },
       expected: true,
+      errorLogs: 0,
     },
     {
       name: 'azureoauth currentuser auth',
-      jsonDatas: [
+      ds: [
         {
-          thing1: 'http://localhost:9090',
-          thing2: 77,
-          azureCredentials: {
-            authType: 'currentuser',
+          jsonData: {
+            thing1: 'http://localhost:9090',
+            thing2: 77,
+            azureCredentials: {
+              authType: 'currentuser',
+            },
           },
+          type: 'prometheus',
         },
       ],
+      flag: { types: ['prometheus', 'loki'] },
       expected: false,
+      errorLogs: 0,
     },
     {
       name: 'one good one bad',
-      jsonDatas: [
+      ds: [
         {
-          thing1: 'http://localhost:9090',
-          thing2: 15,
+          jsonData: {
+            thing1: 'http://localhost:9090',
+            thing2: 15,
+          },
+          type: 'prometheus',
         },
         {
-          thing1: 'http://localhost:9090',
-          thing2: 77,
-          oauthPassThru: true,
+          jsonData: {
+            thing1: 'http://localhost:9090',
+            thing2: 77,
+            oauthPassThru: true,
+          },
+          type: 'prometheus',
         },
       ],
+      flag: { types: ['prometheus', 'loki'] },
       expected: false,
+      errorLogs: 0,
+    },
+    {
+      name: 'allowed-types empty',
+      ds: [
+        {
+          jsonData: {
+            thing2: 15,
+          },
+          type: 'prometheus',
+        },
+      ],
+      flag: { types: [] },
+      expected: false,
+      errorLogs: 0,
+    },
+    {
+      name: 'one allowed, one not',
+      ds: [
+        {
+          jsonData: {
+            thing2: 15,
+          },
+          type: 'prometheus',
+        },
+        {
+          jsonData: {
+            thing2: 77,
+          },
+          type: 'loki',
+        },
+      ],
+      flag: { types: ['loki'] },
+      expected: false,
+      errorLogs: 0,
+    },
+    {
+      name: 'one allowed',
+      ds: [
+        {
+          jsonData: {
+            thing2: 15,
+          },
+          type: 'prometheus',
+        },
+      ],
+      flag: { types: ['prometheus', 'loki'] },
+      expected: true,
+      errorLogs: 0,
+    },
+    {
+      name: 'two allowed',
+      ds: [
+        {
+          jsonData: {
+            thing2: 15,
+          },
+          type: 'prometheus',
+        },
+        {
+          jsonData: {
+            thing2: 17,
+          },
+          type: 'loki',
+        },
+      ],
+      flag: { types: ['prometheus', 'loki'] },
+      expected: true,
+      errorLogs: 0,
+    },
+    {
+      name: 'malformed flag: undefined',
+      ds: [
+        {
+          jsonData: {},
+          type: 'prometheus',
+        },
+      ],
+      flag: undefined,
+      expected: false,
+      errorLogs: 1,
+    },
+    {
+      name: 'malformed flag: empty object',
+      ds: [
+        {
+          jsonData: {},
+          type: 'prometheus',
+        },
+      ],
+      flag: {},
+      expected: false,
+      errorLogs: 1,
+    },
+    {
+      name: 'malformed flag: allowed non-string',
+      ds: [
+        {
+          jsonData: {},
+          type: 'prometheus',
+        },
+      ],
+      flag: { types: ['prometheus', null] },
+      expected: false,
+      errorLogs: 1,
+    },
+    {
+      name: 'incorrect flag: empty-string in allowed',
+      ds: [
+        {
+          jsonData: {},
+          type: 'prometheus',
+        },
+      ],
+      flag: { types: ['', 'prometheus'] },
+      expected: true,
+      errorLogs: 0,
     },
   ];
 
   testCases.forEach((t) => {
     test(t.name, () => {
-      const settings: Array<DataSourceInstanceSettings<TestJsonData>> = t.jsonDatas.map((jsonData) => ({
-        jsonData: jsonData,
+      const settings: Array<DataSourceInstanceSettings<TestJsonData>> = t.ds.map((ds) => ({
+        jsonData: ds.jsonData,
         uid: 'uid1',
-        type: 'prometheus',
+        type: ds.type,
         name: 'prom1',
         meta: {} as DataSourcePluginMeta,
         readOnly: false,
         access: 'proxy',
       }));
 
-      const result = isQueryServiceCompatible(settings);
+      const result = isQueryServiceCompatible(settings, t.flag);
       expect(result).toBe(t.expected);
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(t.errorLogs);
     });
   });
 });

--- a/packages/grafana-runtime/src/utils/qscheck.ts
+++ b/packages/grafana-runtime/src/utils/qscheck.ts
@@ -27,17 +27,57 @@ function isOauthEnabled(ds: DataSourceInstanceSettings<JsonData>): boolean {
   return true;
 }
 
-function isProblematicAzureAuth(ds: DataSourceInstanceSettings<JsonData>): boolean {
+type DSSettings = DataSourceInstanceSettings<JsonData>;
+
+function isProblematicAzureAuth(ds: DSSettings): boolean {
   return ds.jsonData.azureCredentials?.authType === 'currentuser';
 }
 
-export function isQueryServiceCompatible(datasources: Array<DataSourceInstanceSettings<JsonData>>) {
-  for (let ds of datasources) {
+type AllowedTypes = {
+  types: string[];
+};
+
+// TODO: consider using a data-validation library
+function parseAllowedTypes(data: unknown): AllowedTypes {
+  // we want to be safe, this should never crash
+  if (data != null && typeof data === 'object' && 'types' in data && Array.isArray(data.types)) {
+    // typescript infers the array as any[], not unknown[], we need to correct this to have
+    // typescript protect us.
+    const types: unknown[] = data.types;
+
+    if (types.every((x) => typeof x === 'string')) {
+      return { types };
+    } else {
+      console.error('qscheck.parseFlags: non-string item in allowed');
+      return { types: [] };
+    }
+  } else {
+    console.error('qscheck.parseFlags: invalid data');
+    return { types: [] };
+  }
+}
+
+export function isQueryServiceCompatible(datasources: DSSettings[], allowedTypes: unknown) {
+  const at = parseAllowedTypes(allowedTypes);
+  if (!areDataSourceTypesAllowed(datasources, new Set(at.types))) {
+    return false;
+  }
+
+  for (const ds of datasources) {
     if (isOauthEnabled(ds)) {
       return false;
     }
 
     if (isProblematicAzureAuth(ds)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function areDataSourceTypesAllowed(datasources: DSSettings[], allowedTypes: Set<string>): boolean {
+  for (const ds of datasources) {
+    if (!allowedTypes.has(ds.type)) {
       return false;
     }
   }


### PR DESCRIPTION
we are switching from `/api/ds/query` to `/apis/query.grafana.app`.
as the new endpoint runs different code, we want to migrate slowly.
so we added a feature-flag where we define which datasource-types are "allowed", and whenever a datasource query is made from the browser, we check if every data source type involved in the query is allowed or not.
based on this check we either send the query to the old endpoint, or to the new endpoint.

to test it you can add a feature-flag to your `config.ini`'s `feature_toggles` section like this:
```ini
[feature_toggles]
datasources.querier.fe-allowed-types = {"allowed":["prometheus","loki"]}
```