### PR TITLE
Provisioning: Generate User Friendlier Kubernetes Names for Connections

### DIFF
--- a/apps/provisioning/go.mod
+++ b/apps/provisioning/go.mod
@@ -2,13 +2,18 @@ module github.com/grafana/grafana/apps/provisioning
 
 go 1.25.7
 
+// TODO: stop depending on grafana core.
+replace (
+	github.com/grafana/grafana => ../..
+)
+
 require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/go-github/v82 v82.0.0
 	github.com/google/uuid v1.6.0
 	github.com/grafana/authlib/types v0.0.0-20260203131350-b83e80394acc
-	github.com/grafana/grafana v6.1.6+incompatible
+	github.com/grafana/grafana v0.0.0-00010101000000-000000000000
 	github.com/grafana/grafana-app-sdk v0.49.1
 	github.com/grafana/grafana-app-sdk/logging v0.49.0
 	github.com/grafana/grafana/apps/secret v0.0.0-20260118065639-60cb766a97d6

--- a/apps/provisioning/go.mod
+++ b/apps/provisioning/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/go-github/v82 v82.0.0
 	github.com/google/uuid v1.6.0
 	github.com/grafana/authlib/types v0.0.0-20260203131350-b83e80394acc
+	github.com/grafana/grafana v6.1.6+incompatible
 	github.com/grafana/grafana-app-sdk v0.49.1
 	github.com/grafana/grafana-app-sdk/logging v0.49.0
 	github.com/grafana/grafana/apps/secret v0.0.0-20260118065639-60cb766a97d6
@@ -75,8 +76,10 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
+	github.com/smartystreets/goconvey v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569 // indirect
 	github.com/woodsbury/decimal128 v1.4.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/apps/provisioning/go.mod
+++ b/apps/provisioning/go.mod
@@ -2,18 +2,13 @@ module github.com/grafana/grafana/apps/provisioning
 
 go 1.25.7
 
-// TODO: stop depending on grafana core.
-replace (
-	github.com/grafana/grafana => ../..
-)
-
 require (
+	github.com/bwmarrin/snowflake v0.3.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/go-github/v82 v82.0.0
 	github.com/google/uuid v1.6.0
 	github.com/grafana/authlib/types v0.0.0-20260203131350-b83e80394acc
-	github.com/grafana/grafana v0.0.0-00010101000000-000000000000
 	github.com/grafana/grafana-app-sdk v0.49.1
 	github.com/grafana/grafana-app-sdk/logging v0.49.0
 	github.com/grafana/grafana/apps/secret v0.0.0-20260118065639-60cb766a97d6
@@ -81,10 +76,8 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
-	github.com/smartystreets/goconvey v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569 // indirect
 	github.com/woodsbury/decimal128 v1.4.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/apps/provisioning/go.sum
+++ b/apps/provisioning/go.sum
@@ -83,6 +83,8 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=
+github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/grafana/authlib v0.0.0-20260203153107-16a114a99f67 h1:4t3595k0Ef94NOlg4Br785+cTgAKa4rqeo9lMHbV1fs=
@@ -91,6 +93,8 @@ github.com/grafana/authlib/types v0.0.0-20260203131350-b83e80394acc h1:wagsf4me4
 github.com/grafana/authlib/types v0.0.0-20260203131350-b83e80394acc/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260108123158-1a1acfb6ef2e h1:zP30ZbtnWjy0KJxToqCLARauAtgFD+TAEB/sk4IBb9s=
 github.com/grafana/dskit v0.0.0-20260108123158-1a1acfb6ef2e/go.mod h1:Tl9i4F2CPp3cOiXo06JObTh05tENG/NV/ombn2XOY7Y=
+github.com/grafana/grafana v6.1.6+incompatible h1:Eyeg3ifz220cWiu0hLoPjJJmle+nxR63ZEmSDgYDokg=
+github.com/grafana/grafana v6.1.6+incompatible/go.mod h1:U8QyUclJHj254BFcuw45p6sg7eeGYX44qn1ShYo5rGE=
 github.com/grafana/grafana-app-sdk v0.49.1 h1:Pz9e5tQ3YRfHuJDlvDbY7WzP/AMehRz1JcINE25EQPU=
 github.com/grafana/grafana-app-sdk v0.49.1/go.mod h1:bChypbGy+c+f/PDVuGE1PTzl7N/P8Wux17PAIUOKUhI=
 github.com/grafana/grafana-app-sdk/logging v0.49.0 h1:0X2QmqQk7yK48loxiXWBzi4GrDdgM2LIlCt5M40CVrM=
@@ -110,6 +114,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
@@ -161,6 +167,10 @@ github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/smarty/assertions v1.15.0 h1:cR//PqUBUiQRakZWqBiFFQ9wb8emQGDb0HeGdqGByCY=
+github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
+github.com/smartystreets/goconvey v1.8.1 h1:qGjIddxOk4grTu9JPOU31tVfq3cNdBlNa5sSznIX1xY=
+github.com/smartystreets/goconvey v1.8.1/go.mod h1:+/u4qLyY6x1jReYOp7GOM2FSt8aP9CzCZL03bI28W60=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -169,6 +179,8 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569 h1:xzABM9let0HLLqFypcxvLmlvEciCHL7+Lv+4vwZqecI=
+github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569/go.mod h1:2Ly+NIftZN4de9zRmENdYbvPQeaVIYKWpLFStLFEBgI=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/woodsbury/decimal128 v1.4.0 h1:xJATj7lLu4f2oObouMt2tgGiElE5gO6mSWUjQsBgUlc=

--- a/apps/provisioning/go.sum
+++ b/apps/provisioning/go.sum
@@ -2,6 +2,8 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/bwmarrin/snowflake v0.3.0 h1:xm67bEhkKh6ij1790JB83OujPR5CzNe8QuQqAgISZN0=
+github.com/bwmarrin/snowflake v0.3.0/go.mod h1:NdZxfVWX+oR6y2K0o6qAYv6gIOP9rjG0/E9WsDpxqwE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -83,8 +85,6 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=
-github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/grafana/authlib v0.0.0-20260203153107-16a114a99f67 h1:4t3595k0Ef94NOlg4Br785+cTgAKa4rqeo9lMHbV1fs=
@@ -93,8 +93,6 @@ github.com/grafana/authlib/types v0.0.0-20260203131350-b83e80394acc h1:wagsf4me4
 github.com/grafana/authlib/types v0.0.0-20260203131350-b83e80394acc/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260108123158-1a1acfb6ef2e h1:zP30ZbtnWjy0KJxToqCLARauAtgFD+TAEB/sk4IBb9s=
 github.com/grafana/dskit v0.0.0-20260108123158-1a1acfb6ef2e/go.mod h1:Tl9i4F2CPp3cOiXo06JObTh05tENG/NV/ombn2XOY7Y=
-github.com/grafana/grafana v6.1.6+incompatible h1:Eyeg3ifz220cWiu0hLoPjJJmle+nxR63ZEmSDgYDokg=
-github.com/grafana/grafana v6.1.6+incompatible/go.mod h1:U8QyUclJHj254BFcuw45p6sg7eeGYX44qn1ShYo5rGE=
 github.com/grafana/grafana-app-sdk v0.49.1 h1:Pz9e5tQ3YRfHuJDlvDbY7WzP/AMehRz1JcINE25EQPU=
 github.com/grafana/grafana-app-sdk v0.49.1/go.mod h1:bChypbGy+c+f/PDVuGE1PTzl7N/P8Wux17PAIUOKUhI=
 github.com/grafana/grafana-app-sdk/logging v0.49.0 h1:0X2QmqQk7yK48loxiXWBzi4GrDdgM2LIlCt5M40CVrM=
@@ -114,8 +112,6 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
-github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
@@ -167,10 +163,6 @@ github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/smarty/assertions v1.15.0 h1:cR//PqUBUiQRakZWqBiFFQ9wb8emQGDb0HeGdqGByCY=
-github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
-github.com/smartystreets/goconvey v1.8.1 h1:qGjIddxOk4grTu9JPOU31tVfq3cNdBlNa5sSznIX1xY=
-github.com/smartystreets/goconvey v1.8.1/go.mod h1:+/u4qLyY6x1jReYOp7GOM2FSt8aP9CzCZL03bI28W60=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -179,8 +171,6 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569 h1:xzABM9let0HLLqFypcxvLmlvEciCHL7+Lv+4vwZqecI=
-github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569/go.mod h1:2Ly+NIftZN4de9zRmENdYbvPQeaVIYKWpLFStLFEBgI=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/woodsbury/decimal128 v1.4.0 h1:xJATj7lLu4f2oObouMt2tgGiElE5gO6mSWUjQsBgUlc=

--- a/apps/provisioning/pkg/connection/mutator.go
+++ b/apps/provisioning/pkg/connection/mutator.go
@@ -1,13 +1,14 @@
 package connection
 
 import (
+	"cmp"
 	"context"
 	"fmt"
-	"strings"
 
 	"k8s.io/apiserver/pkg/admission"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 // AdmissionMutator handles mutation for Connection resources
@@ -34,9 +35,9 @@ func (m *AdmissionMutator) Mutate(ctx context.Context, a admission.Attributes, o
 		return fmt.Errorf("expected connection configuration, got %T", obj)
 	}
 
-	repositoryNamePrefix := fmt.Sprintf("%s-", c.Spec.Type)
-	if !strings.Contains(c.GetName(), repositoryNamePrefix) {
-		c.Name = repositoryNamePrefix + c.GetName()
+	namePrefix := fmt.Sprintf("%s-", c.Spec.Type)
+	if a.GetOperation() == admission.Create && c.GetName() == "" {
+		c.SetName(cmp.Or(c.GetGenerateName(), namePrefix) + util.GenerateShortUID())
 	}
 
 	return m.factory.Mutate(ctx, c)

--- a/apps/provisioning/pkg/connection/mutator.go
+++ b/apps/provisioning/pkg/connection/mutator.go
@@ -3,6 +3,7 @@ package connection
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"k8s.io/apiserver/pkg/admission"
 
@@ -31,6 +32,11 @@ func (m *AdmissionMutator) Mutate(ctx context.Context, a admission.Attributes, o
 	c, ok := obj.(*provisioning.Connection)
 	if !ok {
 		return fmt.Errorf("expected connection configuration, got %T", obj)
+	}
+
+	repositoryNamePrefix := fmt.Sprintf("%s-", c.Spec.Type)
+	if !strings.Contains(c.GetName(), repositoryNamePrefix) {
+		c.Name = repositoryNamePrefix + c.GetName()
 	}
 
 	return m.factory.Mutate(ctx, c)

--- a/apps/provisioning/pkg/connection/mutator.go
+++ b/apps/provisioning/pkg/connection/mutator.go
@@ -4,11 +4,15 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"math/rand"
+	"sync"
+	"time"
 
+	"github.com/bwmarrin/snowflake"
+	"github.com/google/uuid"
 	"k8s.io/apiserver/pkg/admission"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 // AdmissionMutator handles mutation for Connection resources
@@ -37,7 +41,7 @@ func (m *AdmissionMutator) Mutate(ctx context.Context, a admission.Attributes, o
 
 	namePrefix := fmt.Sprintf("%s-", c.Spec.Type)
 	if a.GetOperation() == admission.Create && c.GetName() == "" {
-		c.SetName(cmp.Or(c.GetGenerateName(), namePrefix) + util.GenerateShortUID())
+		c.SetName(cmp.Or(c.GetGenerateName(), namePrefix) + generateShortUID())
 	}
 
 	return m.factory.Mutate(ctx, c)
@@ -58,4 +62,53 @@ func CopySecureValues(new, old *provisioning.Connection) {
 	if new.Secure.ClientSecret.IsZero() {
 		new.Secure.ClientSecret = old.Secure.ClientSecret
 	}
+}
+
+/*
+NOTE: the code below is copied from pkg/util/shortid_generator.go.
+That function is part of core grafana, which we don't want to have as a dependency.
+TODO: use the util package once it's inside a separate go module.
+*/
+
+// We want to protect our number generator as they are not thread safe. Not using
+// the mutex could result in panics in certain cases where UIDs would be generated
+// at the same time.
+var mtx sync.Mutex
+
+var node *snowflake.Node
+
+var uidrand = rand.New(rand.NewSource(time.Now().UnixNano()))
+var hexLetters = []rune("abcdef")
+
+// generateShortUID will generate a UUID that can also be a k8s name
+// it is guaranteed to have a character as the first letter
+// This UID will be a valid k8s name
+func generateShortUID() string {
+	mtx.Lock()
+	defer mtx.Unlock()
+
+	if node == nil {
+		// ignoring the error happens when input outside 0-1023
+		node, _ = snowflake.NewNode(rand.Int63n(1024))
+	}
+
+	// Use UUIDs if snowflake failed (should be never)
+	if node == nil {
+		uid, err := uuid.NewRandom()
+		if err != nil {
+			// This should never happen... but this seems better than a panic
+			for i := range uid {
+				uid[i] = byte(uidrand.Intn(255))
+			}
+		}
+		uuid := uid.String()
+		if rune(uuid[0]) < rune('a') {
+			uuid = string(hexLetters[uidrand.Intn(len(hexLetters))]) + uuid[1:]
+		}
+		return uuid
+	}
+
+	return string(hexLetters[uidrand.Intn(len(hexLetters))]) + // start with a letter
+		node.Generate().Base36() +
+		string(hexLetters[uidrand.Intn(len(hexLetters))]) // a bit more entropy
 }

--- a/go.work.sum
+++ b/go.work.sum
@@ -1138,6 +1138,7 @@ github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636 h1:aSISeOcal5irEhJd1M+
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
+github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 h1:Jpy1PXuP99tXNrhbq2BaPz9B+jNAvH1JPQQpG/9GCXY=
 github.com/spf13/afero v1.10.0/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.7.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=

--- a/pkg/tests/apis/provisioning/connection_repositories_test.go
+++ b/pkg/tests/apis/provisioning/connection_repositories_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -23,9 +22,6 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 	ctx := context.Background()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(testPrivateKeyPEM))
 	connectionName := "connection-repositories-test"
-	connectionType := provisioning.GithubConnectionType
-	namePrefix := fmt.Sprintf("%s-", connectionType)
-	fullName := namePrefix + connectionName
 
 	// Create a connection for testing
 	connection := &unstructured.Unstructured{Object: map[string]any{
@@ -37,7 +33,7 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 		},
 		"spec": map[string]any{
 			"title": "Test Connection",
-			"type":  connectionType,
+			"type":  provisioning.GitHubRepositoryType,
 			"github": map[string]any{
 				"appID":          "123456",
 				"installationID": "454545",
@@ -58,7 +54,7 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 		result := helper.AdminREST.Get().
 			Namespace("default").
 			Resource("connections").
-			Name(fullName).
+			Name(connectionName).
 			SubResource("repositories").
 			Do(ctx).
 			StatusCode(&statusCode)
@@ -93,7 +89,7 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 		result := helper.EditorREST.Get().
 			Namespace("default").
 			Resource("connections").
-			Name(fullName).
+			Name(connectionName).
 			SubResource("repositories").
 			Do(ctx).StatusCode(&statusCode)
 
@@ -107,7 +103,7 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 		result := helper.ViewerREST.Get().
 			Namespace("default").
 			Resource("connections").
-			Name(fullName).
+			Name(connectionName).
 			SubResource("repositories").
 			Do(ctx).StatusCode(&statusCode)
 
@@ -123,7 +119,7 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 		result := helper.AdminREST.Post().
 			Namespace("default").
 			Resource("connections").
-			Name(fullName).
+			Name(connectionName).
 			SubResource("repositories").
 			Body(configBytes).
 			SetHeader("Content-Type", "application/json").

--- a/pkg/tests/apis/provisioning/connection_repositories_test.go
+++ b/pkg/tests/apis/provisioning/connection_repositories_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -21,18 +22,22 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 	helper := runGrafana(t)
 	ctx := context.Background()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(testPrivateKeyPEM))
+	connectionName := "connection-repositories-test"
+	connectionType := provisioning.GithubConnectionType
+	namePrefix := fmt.Sprintf("%s-", connectionType)
+	fullName := namePrefix + connectionName
 
 	// Create a connection for testing
 	connection := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "provisioning.grafana.app/v0alpha1",
 		"kind":       "Connection",
 		"metadata": map[string]any{
-			"name":      "connection-repositories-test",
+			"name":      connectionName,
 			"namespace": "default",
 		},
 		"spec": map[string]any{
 			"title": "Test Connection",
-			"type":  "github",
+			"type":  connectionType,
 			"github": map[string]any{
 				"appID":          "123456",
 				"installationID": "454545",
@@ -53,7 +58,7 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 		result := helper.AdminREST.Get().
 			Namespace("default").
 			Resource("connections").
-			Name("connection-repositories-test").
+			Name(fullName).
 			SubResource("repositories").
 			Do(ctx).
 			StatusCode(&statusCode)
@@ -88,7 +93,7 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 		result := helper.EditorREST.Get().
 			Namespace("default").
 			Resource("connections").
-			Name("connection-repositories-test").
+			Name(fullName).
 			SubResource("repositories").
 			Do(ctx).StatusCode(&statusCode)
 
@@ -102,7 +107,7 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 		result := helper.ViewerREST.Get().
 			Namespace("default").
 			Resource("connections").
-			Name("connection-repositories-test").
+			Name(fullName).
 			SubResource("repositories").
 			Do(ctx).StatusCode(&statusCode)
 
@@ -118,7 +123,7 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 		result := helper.AdminREST.Post().
 			Namespace("default").
 			Resource("connections").
-			Name("connection-repositories-test").
+			Name(fullName).
 			SubResource("repositories").
 			Body(configBytes).
 			SetHeader("Content-Type", "application/json").

--- a/pkg/tests/apis/provisioning/connection_status_auth_test.go
+++ b/pkg/tests/apis/provisioning/connection_status_auth_test.go
@@ -42,15 +42,17 @@ func TestIntegrationProvisioning_ConnectionStatusAuthorization(t *testing.T) {
 			},
 		},
 	}}
-	_, err := helper.CreateGithubConnection(t, ctx, connection)
+	c, err := helper.CreateGithubConnection(t, ctx, connection)
 	require.NoError(t, err)
+
+	connectionName := c.GetName()
 
 	t.Run("admin can GET connection status", func(t *testing.T) {
 		var statusCode int
 		result := helper.AdminREST.Get().
 			Namespace("default").
 			Resource("connections").
-			Name("connection-status-test").
+			Name(connectionName).
 			SubResource("status").
 			Do(ctx).StatusCode(&statusCode)
 
@@ -63,7 +65,7 @@ func TestIntegrationProvisioning_ConnectionStatusAuthorization(t *testing.T) {
 		result := helper.EditorREST.Get().
 			Namespace("default").
 			Resource("connections").
-			Name("connection-status-test").
+			Name(connectionName).
 			SubResource("status").
 			Do(ctx).StatusCode(&statusCode)
 
@@ -77,7 +79,7 @@ func TestIntegrationProvisioning_ConnectionStatusAuthorization(t *testing.T) {
 		result := helper.ViewerREST.Get().
 			Namespace("default").
 			Resource("connections").
-			Name("connection-status-test").
+			Name(connectionName).
 			SubResource("status").
 			Do(ctx).StatusCode(&statusCode)
 

--- a/pkg/tests/apis/provisioning/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection_test.go
@@ -252,8 +252,10 @@ func TestIntegrationProvisioning_ConnectionMutation(t *testing.T) {
 		require.Contains(t, c.GetName(), namePrefix, "name should be updated")
 
 		t.Cleanup(func() {
-			err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
-			require.NoError(t, err)
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				require.NoError(collect, err)
+			}, waitTimeoutDefault, waitIntervalDefault)
 		})
 	})
 
@@ -287,8 +289,10 @@ func TestIntegrationProvisioning_ConnectionMutation(t *testing.T) {
 		require.Contains(t, c.GetName(), generateName, "name should be updated")
 
 		t.Cleanup(func() {
-			err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
-			require.NoError(t, err)
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				require.NoError(collect, err)
+			}, waitTimeoutDefault, waitIntervalDefault)
 		})
 	})
 
@@ -322,8 +326,10 @@ func TestIntegrationProvisioning_ConnectionMutation(t *testing.T) {
 		require.Equal(t, name, c.GetName(), "name should be identical")
 
 		t.Cleanup(func() {
-			err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
-			require.NoError(t, err)
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				require.NoError(collect, err)
+			}, waitTimeoutDefault, waitIntervalDefault)
 		})
 	})
 }
@@ -367,8 +373,10 @@ func TestIntegrationProvisioning_ConnectionEnterpriseMutation(t *testing.T) {
 		require.Contains(t, c.GetName(), gitlabNamePrefix, "name should be updated")
 
 		t.Cleanup(func() {
-			err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
-			require.NoError(t, err)
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				require.NoError(collect, err)
+			}, waitTimeoutDefault, waitIntervalDefault)
 		})
 	})
 
@@ -400,8 +408,10 @@ func TestIntegrationProvisioning_ConnectionEnterpriseMutation(t *testing.T) {
 		require.Contains(t, c.GetName(), generateName, "name should be updated")
 
 		t.Cleanup(func() {
-			err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
-			require.NoError(t, err)
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				require.NoError(collect, err)
+			}, waitTimeoutDefault, waitIntervalDefault)
 		})
 	})
 
@@ -433,8 +443,10 @@ func TestIntegrationProvisioning_ConnectionEnterpriseMutation(t *testing.T) {
 		require.Equal(t, name, c.GetName(), "name should be identical")
 
 		t.Cleanup(func() {
-			err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
-			require.NoError(t, err)
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				require.NoError(collect, err)
+			}, waitTimeoutDefault, waitIntervalDefault)
 		})
 	})
 
@@ -464,8 +476,10 @@ func TestIntegrationProvisioning_ConnectionEnterpriseMutation(t *testing.T) {
 		require.Contains(t, c.GetName(), bitbucketNamePrefix, "name should be updated")
 
 		t.Cleanup(func() {
-			err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
-			require.NoError(t, err)
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				require.NoError(collect, err)
+			}, waitTimeoutDefault, waitIntervalDefault)
 		})
 	})
 
@@ -497,8 +511,10 @@ func TestIntegrationProvisioning_ConnectionEnterpriseMutation(t *testing.T) {
 		require.Contains(t, c.GetName(), generateName, "name should be updated")
 
 		t.Cleanup(func() {
-			err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
-			require.NoError(t, err)
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				require.NoError(collect, err)
+			}, waitTimeoutDefault, waitIntervalDefault)
 		})
 	})
 
@@ -530,8 +546,10 @@ func TestIntegrationProvisioning_ConnectionEnterpriseMutation(t *testing.T) {
 		require.Equal(t, name, c.GetName(), "name should be identical")
 
 		t.Cleanup(func() {
-			err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
-			require.NoError(t, err)
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				require.NoError(collect, err)
+			}, waitTimeoutDefault, waitIntervalDefault)
 		})
 	})
 }

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -1213,11 +1213,13 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 		},
 	}}
 
-	_, err := helper.CreateGithubConnection(t, ctx, connection)
+	c, err := helper.CreateGithubConnection(t, ctx, connection)
 	require.NoError(t, err, "failed to create connection")
 
+	connectionName := c.GetName()
+
 	require.EventuallyWithT(t, func(collectT *assert.CollectT) {
-		c, err := helper.Connections.Resource.Get(ctx, "test-connection", metav1.GetOptions{})
+		c, err := helper.Connections.Resource.Get(ctx, connectionName, metav1.GetOptions{})
 		require.NoError(collectT, err, "can list values")
 		conn := unstructuredToConnection(t, c)
 		require.NotEqual(collectT, 0, conn.Status.ObservedGeneration, "resource should be reconciled at least once")
@@ -1246,7 +1248,7 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 				"branch": "main",
 			},
 			"connection": map[string]any{
-				"name": "test-connection",
+				"name": connectionName,
 			},
 		},
 	}}
@@ -1374,11 +1376,13 @@ func TestIntegrationProvisioning_RepositoryUnhealthyWithValidationErrors(t *test
 		},
 	}}
 
-	_, err = helper.CreateGithubConnection(t, ctx, connection)
+	c, err := helper.CreateGithubConnection(t, ctx, connection)
 	require.NoError(t, err, "failed to create connection")
 
+	connectionName := c.GetName()
+
 	t.Cleanup(func() {
-		_ = helper.Connections.Resource.Delete(ctx, "test-connection-invalid-repo", metav1.DeleteOptions{})
+		_ = helper.Connections.Resource.Delete(ctx, connectionName, metav1.DeleteOptions{})
 	})
 
 	t.Run("repository with non-existent branch becomes unhealthy with fieldErrors", func(t *testing.T) {
@@ -1402,7 +1406,7 @@ func TestIntegrationProvisioning_RepositoryUnhealthyWithValidationErrors(t *test
 					"branch": "non-existent-branch-12345", // This branch doesn't exist
 				},
 				"connection": map[string]any{
-					"name": "test-connection-invalid-repo",
+					"name": connectionName,
 				},
 			},
 		}}
@@ -1471,7 +1475,7 @@ func TestIntegrationProvisioning_RepositoryUnhealthyWithValidationErrors(t *test
 					"branch": "main",
 				},
 				"connection": map[string]any{
-					"name": "test-connection-invalid-repo",
+					"name": connectionName,
 				},
 			},
 		}}


### PR DESCRIPTION
**What is this feature?**

This PR updates the connection Mutator, generating a more user friendly name, by adding the connection type as a prefix.
This is done only if the connection name doesn't already contain it.

**Why do we need this feature?**

The connection select dropdown in the edit repository page doesn't look descriptive enough on the connection list - this addition will make things a bit clearer, by referencing the type of the connection itself. 

**Who is this feature for?**

Users of GitSync

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/787

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
