### PR TITLE
Chore: Replace trivial lodash functions with native equivalents in grafana-ui

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerFooter.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerFooter.tsx
@@ -1,5 +1,4 @@
 import { css, cx } from '@emotion/css';
-import { isString } from 'lodash';
 import { useCallback, useId, useState } from 'react';
 import * as React from 'react';
 
@@ -56,7 +55,7 @@ export const TimePickerFooter = (props: Props) => {
 
   const style = useStyles2(getStyle);
 
-  if (!isString(timeZone)) {
+  if (typeof timeZone !== 'string') {
     return null;
   }
 
@@ -126,7 +125,7 @@ export const TimePickerFooter = (props: Props) => {
                   onChange={(timeZone) => {
                     onToggleChangeTimeSettings();
 
-                    if (isString(timeZone)) {
+                    if (typeof timeZone === 'string') {
                       onChangeTimeZone(timeZone);
                     }
                   }}

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.tsx
@@ -1,4 +1,3 @@
-import { toLower, isEmpty, isString } from 'lodash';
 import { useMemo, useCallback } from 'react';
 
 import {
@@ -54,7 +53,7 @@ export const TimeZonePicker = (props: Props) => {
 
   const onChangeTz = useCallback(
     (selectable: SelectableValue<string>) => {
-      if (!selectable || !isString(selectable.value)) {
+      if (!selectable || typeof selectable.value !== 'string') {
         return onChange(value);
       }
       onChange(selectable.value);
@@ -128,20 +127,20 @@ const useSelectedTimeZone = (
       return undefined;
     }
 
-    const tz = toLower(timeZone);
+    const tz = timeZone?.toLowerCase() ?? '';
 
     const group = groups.find((group) => {
       if (!group.label) {
         return isInternal(tz);
       }
-      return tz.startsWith(toLower(group.label));
+      return tz.startsWith(group.label.toLowerCase());
     });
 
     return group?.options.find((option) => {
-      if (isEmpty(tz)) {
+      if (tz === '') {
         return option.value === InternalTimeZones.default;
       }
-      return toLower(option.value) === tz;
+      return option.value?.toLowerCase() === tz;
     });
   }, [groups, timeZone]);
 };
@@ -163,24 +162,24 @@ const useFilterBySearchIndex = () => {
     if (!searchQuery || !option.data || !option.data.searchIndex) {
       return true;
     }
-    return option.data.searchIndex.indexOf(toLower(searchQuery)) > -1;
+    return option.data.searchIndex.indexOf(searchQuery.toLowerCase()) > -1;
   }, []);
 };
 
 const getSearchIndex = (label: string, info: TimeZoneInfo, timestamp: number): string => {
   const parts: string[] = [
-    toLower(info.zone),
-    toLower(info.abbreviation),
-    toLower(formatUtcOffset(timestamp, info.zone)),
+    info.zone.toLowerCase(),
+    info.abbreviation.toLowerCase(),
+    formatUtcOffset(timestamp, info.zone).toLowerCase(),
   ];
 
   if (label !== info.zone) {
-    parts.push(toLower(label));
+    parts.push(label.toLowerCase());
   }
 
   for (const country of info.countries) {
-    parts.push(toLower(country.name));
-    parts.push(toLower(country.code));
+    parts.push(country.name.toLowerCase());
+    parts.push(country.code.toLowerCase());
   }
 
   return parts.join('|');

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneOffset.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneOffset.tsx
@@ -1,5 +1,4 @@
 import { css, cx } from '@emotion/css';
-import { isString } from 'lodash';
 
 import { type GrafanaTheme2, type TimeZone, dateTimeFormat } from '@grafana/data';
 
@@ -15,7 +14,7 @@ export const TimeZoneOffset = (props: Props) => {
   const { timestamp, timeZone, className } = props;
   const styles = useStyles2(getStyles);
 
-  if (!isString(timeZone)) {
+  if (typeof timeZone !== 'string') {
     return null;
   }
 

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneOption.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneOption.tsx
@@ -1,5 +1,4 @@
 import { css, cx } from '@emotion/css';
-import { isString } from 'lodash';
 import { type PropsWithChildren, type RefCallback, type JSX } from 'react';
 import * as React from 'react';
 
@@ -33,7 +32,7 @@ export const WideTimeZoneOption = (props: PropsWithChildren<Props>) => {
   const timestamp = Date.now();
   const containerStyles = cx(styles.container, isFocused && styles.containerFocused);
 
-  if (!isString(data.value)) {
+  if (typeof data.value !== 'string') {
     return null;
   }
 
@@ -72,7 +71,7 @@ export const CompactTimeZoneOption = (props: React.PropsWithChildren<Props>) => 
   const timestamp = Date.now();
   const containerStyles = cx(styles.container, isFocused && styles.containerFocused);
 
-  if (!isString(data.value)) {
+  if (typeof data.value !== 'string') {
     return null;
   }
 

--- a/packages/grafana-ui/src/components/FileDropzone/FileDropzone.tsx
+++ b/packages/grafana-ui/src/components/FileDropzone/FileDropzone.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { isString, uniqueId } from 'lodash';
+import { uniqueId } from 'lodash';
 import { type ReactNode, useCallback, useState } from 'react';
 import {
   type Accept,
@@ -267,7 +267,7 @@ export function getMimeTypeByExtension(ext: string) {
 }
 
 export function transformAcceptToNewFormat(accept?: string | string[] | Accept): Accept | undefined {
-  if (isString(accept)) {
+  if (typeof accept === 'string') {
     return {
       [getMimeTypeByExtension(accept)]: [accept],
     };
@@ -307,7 +307,7 @@ function getPrimaryText(files: DropzoneFile[], options?: BackwardsCompatibleDrop
 }
 
 function getAcceptedFileTypeText(accept: string | string[] | Accept) {
-  if (isString(accept)) {
+  if (typeof accept === 'string') {
     return `Accepted file type: ${accept}`;
   }
 

--- a/packages/grafana-ui/src/components/JSONFormatter/json_explorer/json_explorer.ts
+++ b/packages/grafana-ui/src/components/JSONFormatter/json_explorer/json_explorer.ts
@@ -1,8 +1,6 @@
 // Based on work https://github.com/mohsen1/json-formatter-js
 // License MIT, Copyright (c) 2015 Mohsen Azimi
 
-import { isNumber } from 'lodash';
-
 import { isObject, getObjectName, getType, getValuePreview, cssClass, createElement } from './helpers';
 
 const DATE_STRING_REGEX =
@@ -223,7 +221,7 @@ export class JsonExplorer {
   }
 
   isNumberArray() {
-    return this.json.length > 0 && this.json.length < 4 && (isNumber(this.json[0]) || isNumber(this.json[1]));
+    return this.json.length > 0 && this.json.length < 4 && (typeof this.json[0] === 'number' || typeof this.json[1] === 'number');
   }
 
   renderArray() {

--- a/packages/grafana-ui/src/components/JSONFormatter/json_explorer/json_explorer.ts
+++ b/packages/grafana-ui/src/components/JSONFormatter/json_explorer/json_explorer.ts
@@ -221,7 +221,11 @@ export class JsonExplorer {
   }
 
   isNumberArray() {
-    return this.json.length > 0 && this.json.length < 4 && (typeof this.json[0] === 'number' || typeof this.json[1] === 'number');
+    return (
+      this.json.length > 0 &&
+      this.json.length < 4 &&
+      (typeof this.json[0] === 'number' || typeof this.json[1] === 'number')
+    );
   }
 
   renderArray() {

--- a/packages/grafana-ui/src/components/Segment/Segment.tsx
+++ b/packages/grafana-ui/src/components/Segment/Segment.tsx
@@ -72,7 +72,7 @@ export function Segment<T>({
   return (
     <SegmentSelect
       {...rest}
-      value={value && !(typeof value === 'object' && value !== null) ? { value } : value}
+      value={value && typeof value !== 'object' ? { value } : value}
       placeholder={inputPlaceholder}
       options={options}
       width={width}

--- a/packages/grafana-ui/src/components/Segment/Segment.tsx
+++ b/packages/grafana-ui/src/components/Segment/Segment.tsx
@@ -1,5 +1,4 @@
 import { cx } from '@emotion/css';
-import { isObject } from 'lodash';
 import { type HTMLProps } from 'react';
 import * as React from 'react';
 
@@ -44,7 +43,7 @@ export function Segment<T>({
   const styles = useStyles2(getSegmentStyles);
 
   if (!expanded) {
-    const label = isObject(value) ? value.label : value;
+    const label = typeof value === 'object' && value !== null ? value.label : value;
     const labelAsString = label != null ? String(label) : undefined;
 
     return (
@@ -73,7 +72,7 @@ export function Segment<T>({
   return (
     <SegmentSelect
       {...rest}
-      value={value && !isObject(value) ? { value } : value}
+      value={value && !(typeof value === 'object' && value !== null) ? { value } : value}
       placeholder={inputPlaceholder}
       options={options}
       width={width}

--- a/packages/grafana-ui/src/components/Segment/Segment.tsx
+++ b/packages/grafana-ui/src/components/Segment/Segment.tsx
@@ -6,6 +6,7 @@ import { type SelectableValue } from '@grafana/data';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { InlineLabel } from '../Forms/InlineLabel';
+import { getLabelFromValue } from '../Select/utils';
 
 import { SegmentSelect } from './SegmentSelect';
 import { getSegmentStyles } from './styles';
@@ -43,8 +44,7 @@ export function Segment<T>({
   const styles = useStyles2(getSegmentStyles);
 
   if (!expanded) {
-    const label = typeof value === 'object' && value !== null ? value.label : value;
-    const labelAsString = label != null ? String(label) : undefined;
+    const label = getLabelFromValue(value);
 
     return (
       <Label
@@ -61,7 +61,7 @@ export function Segment<T>({
                 className
               )}
             >
-              {labelAsString || placeholder}
+              {label || placeholder}
             </InlineLabel>
           )
         }

--- a/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
@@ -85,7 +85,7 @@ export function SegmentAsync<T>({
   return (
     <SegmentSelect
       {...rest}
-      value={value && !(typeof value === 'object' && value !== null) ? { value } : value}
+      value={value && typeof value !== 'object' ? { value } : value}
       placeholder={inputPlaceholder}
       options={state.value ?? []}
       loadOptions={reloadOptionsOnChange ? fetchOptions : undefined}

--- a/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
@@ -9,6 +9,7 @@ import { t } from '@grafana/i18n';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { InlineLabel } from '../Forms/InlineLabel';
+import { getLabelFromValue } from '../Select/utils';
 
 import { SegmentSelect } from './SegmentSelect';
 import { getSegmentStyles } from './styles';
@@ -55,8 +56,7 @@ export function SegmentAsync<T>({
   const styles = useStyles2(getSegmentStyles);
 
   if (!expanded) {
-    const label = typeof value === 'object' && value !== null ? value.label : value;
-    const labelAsString = label != null ? String(label) : undefined;
+    const label = getLabelFromValue(value);
 
     return (
       <Label
@@ -74,7 +74,7 @@ export function SegmentAsync<T>({
                 className
               )}
             >
-              {labelAsString || placeholder}
+              {label || placeholder}
             </InlineLabel>
           )
         }

--- a/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
@@ -1,5 +1,4 @@
 import { cx } from '@emotion/css';
-import { isObject } from 'lodash';
 import { type HTMLProps } from 'react';
 import * as React from 'react';
 import { useAsyncFn } from 'react-use';
@@ -56,7 +55,7 @@ export function SegmentAsync<T>({
   const styles = useStyles2(getSegmentStyles);
 
   if (!expanded) {
-    const label = isObject(value) ? value.label : value;
+    const label = typeof value === 'object' && value !== null ? value.label : value;
     const labelAsString = label != null ? String(label) : undefined;
 
     return (
@@ -86,7 +85,7 @@ export function SegmentAsync<T>({
   return (
     <SegmentSelect
       {...rest}
-      value={value && !isObject(value) ? { value } : value}
+      value={value && !(typeof value === 'object' && value !== null) ? { value } : value}
       placeholder={inputPlaceholder}
       options={state.value ?? []}
       loadOptions={reloadOptionsOnChange ? fetchOptions : undefined}

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -1,4 +1,3 @@
-import { isArray, negate } from 'lodash';
 import { type ComponentProps, useCallback, useEffect, useRef, useState, useImperativeHandle } from 'react';
 import * as React from 'react';
 import {
@@ -311,7 +310,7 @@ export function SelectBase<T, Rest = {}>({
   const SelectMenuComponent = virtualized ? VirtualizedSelectMenu : SelectMenu;
 
   let toggleAllState = ToggleAllState.noneSelected;
-  if (toggleAllOptions?.enabled && isArray(selectedValue)) {
+  if (toggleAllOptions?.enabled && Array.isArray(selectedValue)) {
     if (toggleAllOptions?.determineToggleAllState) {
       toggleAllState = toggleAllOptions.determineToggleAllState(selectedValue, options);
     } else {
@@ -325,7 +324,7 @@ export function SelectBase<T, Rest = {}>({
       toSelect =
         toggleAllState === ToggleAllState.noneSelected
           ? options.filter(toggleAllOptions.optionsFilter)
-          : options.filter(negate(toggleAllOptions.optionsFilter));
+          : options.filter((opt) => !toggleAllOptions.optionsFilter!(opt));
     }
 
     onChange(toSelect, {
@@ -402,7 +401,7 @@ export function SelectBase<T, Rest = {}>({
           toggleAllOptions?.enabled && {
             state: toggleAllState,
             selectAllClicked: toggleAll,
-            selectedCount: isArray(selectedValue) ? selectedValue.length : undefined,
+            selectedCount: Array.isArray(selectedValue) ? selectedValue.length : undefined,
           }
         }
         styles={selectStyles}

--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -169,7 +169,10 @@ export const VirtualizedSelectMenu = ({
     );
   }
 
-  let longestOption = Math.max(0, ...flattenedOptions.map((option) => option.label?.length ?? 0));
+  let longestOption = flattenedOptions.reduce((max, option) => {
+    const length = option.label?.length ?? 0;
+    return length > max ? length : max;
+  }, 0);
   if (toggleAllOptions && longestOption < 12) {
     longestOption = 12;
   }

--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -1,5 +1,4 @@
 import { css, cx } from '@emotion/css';
-import { max } from 'lodash';
 import { type RefCallback, useLayoutEffect, useMemo, useRef, type JSX } from 'react';
 import * as React from 'react';
 import { FixedSizeList as List } from 'react-window';
@@ -170,7 +169,7 @@ export const VirtualizedSelectMenu = ({
     );
   }
 
-  let longestOption = max(flattenedOptions.map((option) => option.label?.length)) ?? 0;
+  let longestOption = Math.max(0, ...flattenedOptions.map((option) => option.label?.length ?? 0));
   if (toggleAllOptions && longestOption < 12) {
     longestOption = 12;
   }

--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -171,7 +171,7 @@ export const VirtualizedSelectMenu = ({
 
   let longestOption = flattenedOptions.reduce((max, option) => {
     const length = option.label?.length ?? 0;
-    return length > max ? length : max;
+    return Math.max(max, length);
   }, 0);
   if (toggleAllOptions && longestOption < 12) {
     longestOption = 12;

--- a/packages/grafana-ui/src/components/Select/utils.ts
+++ b/packages/grafana-ui/src/components/Select/utils.ts
@@ -53,3 +53,8 @@ export const findSelectedValue = (
 export const omitDescriptions = (options: SelectableValue[]): SelectableValue[] => {
   return options.map(({ description, ...rest }) => rest);
 };
+
+export const getLabelFromValue = (value: unknown): string | undefined => {
+  const label = value !== null && typeof value === 'object' && 'label' in value ? value.label : value;
+  return label != null ? String(label) : undefined;
+};

--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, identity, isNumber, omit, pickBy } from 'lodash';
+import { cloneDeep, omit, pickBy } from 'lodash';
 
 import {
   convertOldAngularValueMappings,
@@ -101,7 +101,7 @@ function migrateFromGraphPanel(panel: PanelModel<Partial<SingleStatBaseOptions>>
       }
 
       if (legendConfig.values) {
-        const enabledLegendValues = pickBy(legendConfig, identity);
+        const enabledLegendValues = pickBy(legendConfig, (v) => v);
         options.legend.calcs = getReducersFromLegend(enabledLegendValues);
       }
 
@@ -288,17 +288,17 @@ export function sharedSingleStatMigrationHandler(panel: PanelModel<SingleStatBas
     const config = panel.fieldConfig?.defaults;
     let unit = config?.unit;
     if (unit === 'percent') {
-      if (!isNumber(config.min)) {
+      if (typeof config.min !== 'number') {
         config.min = 0;
       }
-      if (!isNumber(config.max)) {
+      if (typeof config.max !== 'number') {
         config.max = 100;
       }
     } else if (unit === 'percentunit') {
-      if (!isNumber(config.min)) {
+      if (typeof config.min !== 'number') {
         config.min = 0;
       }
-      if (!isNumber(config.max)) {
+      if (typeof config.max !== 'number') {
         config.max = 1;
       }
     }

--- a/packages/grafana-ui/src/components/Table/CellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/CellActions.tsx
@@ -67,7 +67,12 @@ export function CellActions({
                 let inspectValue = cell.value;
                 try {
                   const parsed = typeof inspectValue === 'string' ? JSON.parse(inspectValue) : inspectValue;
-                  if (Array.isArray(parsed) || (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed))) {
+                  const isPlainObj =
+                    typeof parsed === 'object' &&
+                    parsed !== null &&
+                    !Array.isArray(parsed) &&
+                    (Object.getPrototypeOf(parsed) === Object.prototype || Object.getPrototypeOf(parsed) === null);
+                  if (Array.isArray(parsed) || isPlainObj) {
                     inspectValue = JSON.stringify(parsed, null, 2);
                     mode = TableCellInspectorMode.code;
                   }

--- a/packages/grafana-ui/src/components/Table/CellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/CellActions.tsx
@@ -1,4 +1,3 @@
-import { isPlainObject } from 'lodash';
 import { useCallback } from 'react';
 import * as React from 'react';
 
@@ -68,7 +67,7 @@ export function CellActions({
                 let inspectValue = cell.value;
                 try {
                   const parsed = typeof inspectValue === 'string' ? JSON.parse(inspectValue) : inspectValue;
-                  if (Array.isArray(parsed) || isPlainObject(parsed)) {
+                  if (Array.isArray(parsed) || (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed))) {
                     inspectValue = JSON.stringify(parsed, null, 2);
                     mode = TableCellInspectorMode.code;
                   }

--- a/packages/grafana-ui/src/components/Table/Cells/BarGaugeCell.tsx
+++ b/packages/grafana-ui/src/components/Table/Cells/BarGaugeCell.tsx
@@ -1,4 +1,3 @@
-import { isFunction } from 'lodash';
 import { useState } from 'react';
 
 import { type ThresholdsConfig, ThresholdsMode, VizOrientation, getFieldConfigWithMinMax } from '@grafana/data';
@@ -53,7 +52,7 @@ export const BarGaugeCell = (props: TableCellProps) => {
   }
 
   const getLinks = () => {
-    if (!isFunction(field.getLinks)) {
+    if (typeof field.getLinks !== 'function') {
       return [];
     }
 

--- a/packages/grafana-ui/src/components/Table/Cells/JSONViewCell.tsx
+++ b/packages/grafana-ui/src/components/Table/Cells/JSONViewCell.tsx
@@ -1,5 +1,4 @@
 import { css, cx } from '@emotion/css';
-import { isString } from 'lodash';
 import { useState, type JSX } from 'react';
 
 import { getCellLinks } from '../../../utils/table';
@@ -20,7 +19,7 @@ export function JSONViewCell(props: TableCellProps): JSX.Element {
   let value = cell.value;
   let displayValue = value;
 
-  if (isString(value)) {
+  if (typeof value === 'string') {
     try {
       value = JSON.parse(value);
     } catch {} // ignore errors

--- a/packages/grafana-ui/src/graveyard/TimeSeries/utils.ts
+++ b/packages/grafana-ui/src/graveyard/TimeSeries/utils.ts
@@ -1,4 +1,3 @@
-import { isNumber } from 'lodash';
 import uPlot from 'uplot';
 
 import {
@@ -455,7 +454,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{
 
         const t = indexByName.get(dispName);
         const b = indexByName.get(fillBelowDispName);
-        if (isNumber(b) && isNumber(t)) {
+        if (typeof b === 'number' && typeof t === 'number') {
           builder.addBand({
             series: [t, b],
             fill: undefined, // using null will have the band use fill options from `t`

--- a/packages/grafana-ui/src/utils/fuzzy.ts
+++ b/packages/grafana-ui/src/utils/fuzzy.ts
@@ -1,5 +1,3 @@
-import { last } from 'lodash';
-
 import { type HighlightPart } from '../types/completion';
 
 type FuzzyMatch = {
@@ -56,7 +54,7 @@ export function fuzzyMatch(stack: string, needle: string): FuzzyMatch {
     if (ranges.length === 0) {
       ranges.push({ start: letterIndex, end: letterIndex });
     } else {
-      const lastRange = last(ranges)!;
+      const lastRange = ranges.at(-1)!;
       if (letterIndex === lastRange.end + 1) {
         lastRange.end++;
       } else {


### PR DESCRIPTION
**What is this feature?**

Replace trivial lodash utility functions with native JavaScript/TypeScript equivalents in `@grafana/ui`. This is the first PR in an incremental effort to remove the `lodash` dependency from the package.

14 files are now fully free of lodash imports, and 2 additional files have their lodash imports reduced (non-trivial functions remain for future PRs).

Functions replaced: `isString`, `isNumber`, `isFunction`, `isArray`, `isObject`, `isPlainObject`, `negate`, `last`, `max`, `toLower`, `isEmpty`, `identity`.

**Why do we need this feature?**

Lodash adds unnecessary bundle weight for functions that have direct native equivalents in modern JS/TS. Removing these trivial usages is the lowest-risk first step toward eventually dropping the dependency entirely from `@grafana/ui`.

**Who is this feature for?**

Grafana developers and end users who benefit from a smaller bundle size. This is an internal code quality improvement with no user-facing behavior changes.

**Which issue(s) does this PR fix?**:


**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.