### PR TITLE
Expressions: quote SQL table identifiers when refIds contain spaces

### DIFF
--- a/public/app/features/expressions/components/SqlExpressions/CompletionProvider/sqlCompletionProvider.test.ts
+++ b/public/app/features/expressions/components/SqlExpressions/CompletionProvider/sqlCompletionProvider.test.ts
@@ -1,0 +1,20 @@
+import { getSqlCompletionProvider } from './sqlCompletionProvider';
+
+describe('getSqlCompletionProvider', () => {
+  it('quotes completion value when refId has spaces', async () => {
+    const provider = getSqlCompletionProvider({
+      getFields: jest.fn().mockResolvedValue([]),
+      refIds: [{ value: 'A B' }],
+    });
+
+    const resolvedProvider = provider({}, {} as never);
+    const tables = await resolvedProvider.tables.resolve();
+
+    expect(tables).toEqual([
+      {
+        name: 'A B',
+        completion: '`A B`',
+      },
+    ]);
+  });
+});

--- a/public/app/features/expressions/components/SqlExpressions/CompletionProvider/sqlCompletionProvider.ts
+++ b/public/app/features/expressions/components/SqlExpressions/CompletionProvider/sqlCompletionProvider.ts
@@ -3,6 +3,7 @@ import { ColumnDefinition, LanguageCompletionProvider, TableDefinition, TableIde
 import { config } from '@grafana/runtime';
 
 import { ALLOWED_FUNCTIONS } from '../../../utils/metaSqlExpr';
+import { quoteTableIdentifierIfNecessary } from '../../../utils/sqlIdentifier';
 
 interface CompletionProviderGetterArgs {
   getFields: (t: TableIdentifier) => Promise<ColumnDefinition[]>;
@@ -18,7 +19,7 @@ export const getSqlCompletionProvider: (args: CompletionProviderGetterArgs) => L
         const refIdsToTableDefs = args.refIds.map((refId) => {
           const tableDef: TableDefinition = {
             name: refId.label || refId.value || '',
-            completion: refId.label || refId.value || '',
+            completion: quoteTableIdentifierIfNecessary(refId.label || refId.value || ''),
           };
           return tableDef;
         });

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
@@ -14,6 +14,7 @@ import { Button, Stack, useStyles2 } from '@grafana/ui';
 import { ExpressionQueryEditorProps } from '../../ExpressionQueryEditor';
 import { SqlExpressionQuery } from '../../types';
 import { fetchSQLFields } from '../../utils/metaSqlExpr';
+import { quoteTableIdentifierIfNecessary } from '../../utils/sqlIdentifier';
 import { QueryToolbox } from '../QueryToolbox';
 
 import { getSqlCompletionProvider } from './CompletionProvider/sqlCompletionProvider';
@@ -71,7 +72,7 @@ export const SqlExpr = ({ onChange, refIds, query, alerting = false, queries, me
   const initialQuery = `SELECT
   *
 FROM
-  ${vars[0]}
+  ${quoteTableIdentifierIfNecessary(vars[0])}
 LIMIT
   10`;
 

--- a/public/app/features/expressions/utils/metaSqlExpr.test.ts
+++ b/public/app/features/expressions/utils/metaSqlExpr.test.ts
@@ -1,0 +1,30 @@
+import { QueryFormat } from '@grafana/plugin-ui';
+
+import { fetchSQLFields } from './metaSqlExpr';
+
+const runMetaSQLExprQuery = jest.fn();
+
+jest.mock('../ExpressionDatasource', () => ({
+  dataSource: {
+    runMetaSQLExprQuery: (...args: unknown[]) => runMetaSQLExprQuery(...args),
+  },
+}));
+
+describe('fetchSQLFields', () => {
+  beforeEach(() => {
+    runMetaSQLExprQuery.mockResolvedValue({ fields: [] });
+  });
+
+  it('quotes table names with spaces when building metadata query', async () => {
+    await fetchSQLFields({ table: 'gdp per capita' }, [{ refId: 'gdp per capita' }] as never);
+
+    expect(runMetaSQLExprQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rawSql: 'SELECT * FROM `gdp per capita` LIMIT 1',
+        format: QueryFormat.Table,
+      }),
+      expect.anything(),
+      [{ refId: 'gdp per capita' }]
+    );
+  });
+});

--- a/public/app/features/expressions/utils/metaSqlExpr.ts
+++ b/public/app/features/expressions/utils/metaSqlExpr.ts
@@ -7,6 +7,7 @@ import { mapFieldsToTypes } from 'app/plugins/datasource/mysql/fields';
 import { quoteIdentifierIfNecessary } from 'app/plugins/datasource/mysql/sqlUtil';
 
 import { dataSource } from '../ExpressionDatasource';
+import { quoteTableIdentifierIfNecessary } from './sqlIdentifier';
 
 export async function fetchSQLFields(query: Partial<SQLQuery>, queries: DataQuery[]): Promise<SQLSelectableValue[]> {
   const datasource = dataSource;
@@ -14,7 +15,7 @@ export async function fetchSQLFields(query: Partial<SQLQuery>, queries: DataQuer
     return [];
   }
 
-  const queryString = `SELECT * FROM ${query.table} LIMIT 1`;
+  const queryString = `SELECT * FROM ${quoteTableIdentifierIfNecessary(query.table)} LIMIT 1`;
 
   const queryResponse = await datasource.runMetaSQLExprQuery(
     { rawSql: queryString, format: QueryFormat.Table, refId: `fields-${uuidv4()}` },

--- a/public/app/features/expressions/utils/sqlIdentifier.test.ts
+++ b/public/app/features/expressions/utils/sqlIdentifier.test.ts
@@ -1,0 +1,11 @@
+import { quoteTableIdentifierIfNecessary } from './sqlIdentifier';
+
+describe('quoteTableIdentifierIfNecessary', () => {
+  it('quotes table identifiers with spaces', () => {
+    expect(quoteTableIdentifierIfNecessary('gdp per capita')).toBe('`gdp per capita`');
+  });
+
+  it('does not double quote already quoted table identifiers', () => {
+    expect(quoteTableIdentifierIfNecessary('`gdp per capita`')).toBe('`gdp per capita`');
+  });
+});

--- a/public/app/features/expressions/utils/sqlIdentifier.ts
+++ b/public/app/features/expressions/utils/sqlIdentifier.ts
@@ -1,0 +1,5 @@
+import { quoteIdentifierIfNecessary, unquoteIdentifier } from 'app/plugins/datasource/mysql/sqlUtil';
+
+export function quoteTableIdentifierIfNecessary(value: string) {
+  return quoteIdentifierIfNecessary(unquoteIdentifier(value));
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This update fixes SQL Expressions table identifier handling for query refIds that include spaces or other non-identifier characters.  
It ensures table names are quoted consistently in:
- The initial SQL template in the SQL Expressions editor.
- SQL table autocomplete insertion.
- The metadata schema query used for field discovery.

**Why do we need this feature?**

Without quoting, refIds such as `gdp per capita` generate invalid SQL (for example, `FROM gdp per capita`) and fail with SQL parse errors.  
This causes SQL Expressions to break for valid user-configured refIds that contain spaces.

**Who is this feature for?**

This is for Grafana users who build panels and SQL Expressions, especially users who use descriptive refIds with spaces in query names.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #117497

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
