### PR TITLE
Provisioning: Suppress success alert when pushing to a different branch

### DIFF
--- a/public/app/features/provisioning/hooks/useProvisionedRequestHandler.test.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedRequestHandler.test.ts
@@ -97,7 +97,7 @@ describe('useProvisionedRequestHandler', () => {
     });
 
     it('should call onBranchSuccess for branch workflow', () => {
-      const { request, handlers } = setup({
+      const { request, handlers, mockPublish } = setup({
         requestOverrides: {
           isError: false,
           isSuccess: true,
@@ -132,6 +132,10 @@ describe('useProvisionedRequestHandler', () => {
         expect.any(Object)
       );
       expect(handlers.onWriteSuccess).not.toHaveBeenCalled();
+      // Branch workflow should not show success alert (PR banner handles it)
+      expect(mockPublish).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: AppEvents.alertSuccess.name })
+      );
     });
 
     it('should call onWriteSuccess for write workflow', () => {

--- a/public/app/features/provisioning/hooks/useProvisionedRequestHandler.test.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedRequestHandler.test.ts
@@ -133,9 +133,7 @@ describe('useProvisionedRequestHandler', () => {
       );
       expect(handlers.onWriteSuccess).not.toHaveBeenCalled();
       // Branch workflow should not show success alert (PR banner handles it)
-      expect(mockPublish).not.toHaveBeenCalledWith(
-        expect.objectContaining({ type: AppEvents.alertSuccess.name })
-      );
+      expect(mockPublish).not.toHaveBeenCalledWith(expect.objectContaining({ type: AppEvents.alertSuccess.name }));
     });
 
     it('should call onWriteSuccess for write workflow', () => {

--- a/public/app/features/provisioning/hooks/useProvisionedRequestHandler.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedRequestHandler.ts
@@ -116,12 +116,15 @@ export function useProvisionedRequestHandler<T>({
         setLastBranch(repository?.name, selectedBranch || repository?.branch);
       }
 
-      // Success message
-      const message = successMessage || getContextualSuccessMessage(info);
-      getAppEvents().publish({
-        type: AppEvents.alertSuccess.name,
-        payload: [message],
-      });
+      // Only show success alert for write workflow (not branch workflow,
+      // which navigates to a preview page with its own PR banner)
+      if (workflow !== 'branch') {
+        const message = successMessage || getContextualSuccessMessage(info);
+        getAppEvents().publish({
+          type: AppEvents.alertSuccess.name,
+          payload: [message],
+        });
+      }
 
       // Branch workflow
       if (workflow === 'branch' && handlers.onBranchSuccess && ref && path) {


### PR DESCRIPTION
**What is this feature?**

Suppresses the success toast notification when pushing/saving provisioned resources to a non-configured branch. The preview page already displays a PR banner that communicates success.

**Why do we need this feature?**

The success toast was overlapping with the "Open pull request" banner, forcing users to dismiss the notification before they could interact with the PR banner.

**Who is this feature for?**

Users provisioning dashboards, folders, and other resources through Git branches.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/822

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.