### PR TITLE
Table: pass keyLabel when adding ad hoc filter from cell actions

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react';
+
+import { Field, FieldType } from '@grafana/data';
+
+import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR } from '../types';
+
+import { TableCellActions } from './TableCellActions';
+
+describe('TableCellActions', () => {
+  const setInspectCell = jest.fn();
+
+  beforeEach(() => {
+    setInspectCell.mockClear();
+  });
+
+  describe('filter actions', () => {
+    it('calls onCellFilterAdded with key, value, operator and keyLabel when "Filter for value" is clicked', () => {
+      const onCellFilterAdded = jest.fn();
+      const field: Field = {
+        name: 'Account.Owner.Name',
+        type: FieldType.string,
+        values: [],
+        config: {
+          displayNameFromDS: 'Account Owner Name',
+        },
+      };
+      const value = 'CA';
+
+      render(
+        <TableCellActions
+          field={field}
+          value={value}
+          displayName={field.config.displayNameFromDS ?? field.name}
+          cellInspect={false}
+          showFilters={true}
+          setInspectCell={setInspectCell}
+          onCellFilterAdded={onCellFilterAdded}
+        />
+      );
+
+      screen.getByRole('button', { name: 'Filter for value' }).click();
+
+      expect(onCellFilterAdded).toHaveBeenCalledTimes(1);
+      expect(onCellFilterAdded).toHaveBeenCalledWith({
+        key: 'Account.Owner.Name',
+        operator: FILTER_FOR_OPERATOR,
+        value: 'CA',
+        keyLabel: 'Account Owner Name',
+      });
+    });
+
+    it('calls onCellFilterAdded with keyLabel from field.name when displayNameFromDS is not set', () => {
+      const onCellFilterAdded = jest.fn();
+      const field: Field = {
+        name: 'orders.status',
+        type: FieldType.string,
+        values: [],
+        config: {},
+      };
+
+      render(
+        <TableCellActions
+          field={field}
+          value="completed"
+          displayName={field.name}
+          cellInspect={false}
+          showFilters={true}
+          setInspectCell={setInspectCell}
+          onCellFilterAdded={onCellFilterAdded}
+        />
+      );
+
+      screen.getByRole('button', { name: 'Filter for value' }).click();
+
+      expect(onCellFilterAdded).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'orders.status',
+          value: 'completed',
+          operator: FILTER_FOR_OPERATOR,
+          keyLabel: 'orders.status',
+        })
+      );
+    });
+
+    it('calls onCellFilterAdded with key, value, operator and keyLabel when "Filter out value" is clicked', () => {
+      const onCellFilterAdded = jest.fn();
+      const field: Field = {
+        name: 'status',
+        type: FieldType.string,
+        values: [],
+        config: { displayNameFromDS: 'Status' },
+      };
+
+      render(
+        <TableCellActions
+          field={field}
+          value="pending"
+          displayName={field.config.displayNameFromDS ?? field.name}
+          cellInspect={false}
+          showFilters={true}
+          setInspectCell={setInspectCell}
+          onCellFilterAdded={onCellFilterAdded}
+        />
+      );
+
+      screen.getByRole('button', { name: 'Filter out value' }).click();
+
+      expect(onCellFilterAdded).toHaveBeenCalledTimes(1);
+      expect(onCellFilterAdded).toHaveBeenCalledWith({
+        key: 'status',
+        operator: FILTER_OUT_OPERATOR,
+        value: 'pending',
+        keyLabel: 'Status',
+      });
+    });
+  });
+});

--- a/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.tsx
@@ -28,10 +28,13 @@ export const TableCellActions = memo(
             name={'filter-plus'}
             aria-label={t('grafana-ui.table.cell-filter-on', 'Filter for value')}
             onClick={() => {
+              const val = String(value ?? '');
               onCellFilterAdded?.({
                 key: field.name,
                 operator: FILTER_FOR_OPERATOR,
-                value: String(value ?? ''),
+                value: val,
+                keyLabel: field.config.displayNameFromDS ?? field.state?.displayName ?? field.name,
+                valueLabel: val,
               });
             }}
           />
@@ -39,10 +42,13 @@ export const TableCellActions = memo(
             name={'filter-minus'}
             aria-label={t('grafana-ui.table.cell-filter-out', 'Filter out value')}
             onClick={() => {
+              const val = String(value ?? '');
               onCellFilterAdded?.({
                 key: field.name,
                 operator: FILTER_OUT_OPERATOR,
-                value: String(value ?? ''),
+                value: val,
+                keyLabel: field.config.displayNameFromDS ?? field.state?.displayName ?? field.name,
+                valueLabel: val,
               });
             }}
           />

--- a/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.tsx
@@ -34,7 +34,6 @@ export const TableCellActions = memo(
                 operator: FILTER_FOR_OPERATOR,
                 value: val,
                 keyLabel: field.config.displayNameFromDS ?? field.state?.displayName ?? field.name,
-                valueLabel: val,
               });
             }}
           />
@@ -48,7 +47,6 @@ export const TableCellActions = memo(
                 operator: FILTER_OUT_OPERATOR,
                 value: val,
                 keyLabel: field.config.displayNameFromDS ?? field.state?.displayName ?? field.name,
-                valueLabel: val,
               });
             }}
           />


### PR DESCRIPTION
## Summary

This PR adds the same human-readable **key** label support for **Table panel** cell actions that PR #117640 added for the BarChart tooltip. When a user clicks "Filter for value" or "Filter out value" on a table cell, the filter is now passed to the ad hoc variable with optional **`keyLabel`**, so the filter chip (and variable UI) can show a friendly key name (e.g. "Account Owner Name") when the datasource provides it via `DisplayNameFromDS` or `field.state.displayName`, instead of only the technical key. Scope is **keyLabel only** (no value labels from panels).

**Target branch:** `sj/adhoc-filter-labels-3` — merge after #117640.

Ref: #117639

Fixes: #117639

---

## Context (from the issue)

The panel → ad hoc variable path previously only supported `AdHocFilterItem` as `{ key, value, operator }`. Panels that add filters (BarChart tooltip, Table cell actions, etc.) could not pass `keyLabel`, so any display names set by the datasource (e.g. `DisplayNameFromDS`) were never sent to the variable. #117640 extended the type and variable layer and wired BarChart; this PR completes the same behaviour for the Table panel (keyLabel only).

---

## What this PR does

- In **`packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.tsx`**:
  - For both the "Filter for value" and "Filter out value" actions, the object passed to `onCellFilterAdded` now includes **`keyLabel`**: `field.config.displayNameFromDS ?? field.state?.displayName ?? field.name` (same fallback pattern as BarChart).
  - The existing `key`, `value`, and `operator` are unchanged; keyLabel is optional and backward compatible with the contract from #117640.

---

## Why

- **Consistency:** Table and BarChart now both pass keyLabel when adding ad hoc filters from panel data, so behaviour is aligned across panels.
- **Better UX:** Datasources that set `DisplayNameFromDS` (or equivalent) on table columns get human-readable key names in filter chips when users use the cell filter actions, matching the BarChart tooltip behaviour.

---

## How to review

- **TableCellActions.tsx:** Confirm both filter actions (filter-plus and filter-minus) pass `keyLabel` in the object to `onCellFilterAdded`, with the same fallback logic as in the BarChart PR. No other behaviour (e.g. which rows/columns show the actions) is changed.

---

## Testing

- **Manual:** Use a datasource that sets `DisplayNameFromDS` (or field display names) on table columns, add a Table panel with a filterable column, use "Filter for value" or "Filter out value" on a cell, and confirm the ad hoc filter chip shows the human-readable column name when available. Without display names, the label falls back to the field name (unchanged behaviour).
- **Regression:** Existing Table panels and Explore tables that use `onCellFilterAdded` / `onAddAdHocFilter` continue to work; keyLabel is optional and the variable layer (from #117640) already handles its persistence.
