### PR TITLE
Elasticsearch: Ensure SigV4 is displayed correctly

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
@@ -12,7 +12,7 @@ import {
   DataSourceDescription,
 } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
-import { Alert, SecureSocksProxySettings, Divider, Stack } from '@grafana/ui';
+import { Alert, Divider, SecureSocksProxySettings, Stack } from '@grafana/ui';
 
 import { ElasticsearchOptions, ElasticsearchSecureJsonData } from '../types';
 
@@ -37,18 +37,6 @@ export const ConfigEditor = (props: Props) => {
     config: options,
     onChange: onOptionsChange,
   });
-  if (config.sigV4AuthEnabled) {
-    authProps.customMethods = [
-      {
-        id: 'custom-sigv4',
-        label: 'SigV4 auth',
-        description: 'AWS Signature Version 4 authentication',
-        component: <SIGV4ConnectionConfig inExperimentalAuthComponent={true} {...props} />,
-      },
-    ];
-    authProps.selectedMethod = options.jsonData.sigV4Auth ? 'custom-sigv4' : authProps.selectedMethod;
-  }
-
   authProps.customMethods = [
     {
       id: 'custom-api-key',
@@ -58,6 +46,19 @@ export const ConfigEditor = (props: Props) => {
     },
   ];
   authProps.selectedMethod = options.jsonData.apiKeyAuth ? 'custom-api-key' : authProps.selectedMethod;
+
+  if (config.sigV4AuthEnabled) {
+    authProps.customMethods = [
+      ...authProps.customMethods,
+      {
+        id: 'custom-sigv4',
+        label: 'SigV4 auth',
+        description: 'AWS Signature Version 4 authentication',
+        component: <SIGV4ConnectionConfig inExperimentalAuthComponent={true} {...props} />,
+      },
+    ];
+    authProps.selectedMethod = options.jsonData.sigV4Auth ? 'custom-sigv4' : authProps.selectedMethod;
+  }
 
   return (
     <>


### PR DESCRIPTION
#114855 introduced an issue that would cause the SigV4 auth option to not be displayed. This change fixes that and adds tests to ensure we catch this if it were to happen again in the future.

Fixes #117661