### PR TITLE
features: add an 1hour-poll-interval

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -21,7 +21,7 @@ export async function initOpenFeature() {
 
   const ofProvider = new OFREPWebProvider({
     baseUrl: baseUrl,
-    pollInterval: -1, // disable polling
+    pollInterval: 60 * 60 * 1000, // 1hour in milliseconds
     timeoutMs: 5_000,
   });
 


### PR DESCRIPTION
for openfeature flags, we enable a poll interval of 1hour.

(the value is specified [in milliseconds](https://github.com/open-feature/js-sdk-contrib/blob/a923c1617bbcbaae0d7663a4d353c170f3ce9f96/libs/providers/ofrep-web/src/lib/model/ofrep-web-provider-options.ts#L5))