### PR TITLE
feat(query): add Fix with Assistant button to query error alerts

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -550,7 +550,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
             )}
             {editor}
           </ErrorBoundaryAlert>
-          {error && <QueryErrorAlert error={error} />}
+          {error && <QueryErrorAlert error={error} query={query} />}
           {visualization}
         </div>
       </QueryOperationRow>

--- a/public/app/features/query/components/QueryErrorAlert.test.tsx
+++ b/public/app/features/query/components/QueryErrorAlert.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import { DataQueryError, DataQueryErrorType } from '@grafana/data';
+import { DataQueryError } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
 
 import { QueryErrorAlert } from './QueryErrorAlert';
@@ -46,12 +46,12 @@ describe('QueryErrorAlert', () => {
     expect(screen.getByText(/abc123/)).toBeInTheDocument();
   });
 
-  it('should render the Explain in Assistant button', () => {
+  it('should render the Fix with Assistant button', () => {
     const error: DataQueryError = { message: 'Some error' };
 
     render(<QueryErrorAlert error={error} />);
 
-    expect(screen.getByRole('button', { name: 'Explain in Assistant' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Fix with Assistant' })).toBeInTheDocument();
   });
 
   it('should pass original query to assistant context when provided', () => {

--- a/public/app/features/query/components/QueryErrorAlert.test.tsx
+++ b/public/app/features/query/components/QueryErrorAlert.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+
+import { DataQueryError, DataQueryErrorType } from '@grafana/data';
+import { DataQuery } from '@grafana/schema';
+
+import { QueryErrorAlert } from './QueryErrorAlert';
+
+jest.mock('@grafana/assistant', () => ({
+  OpenAssistantButton: ({ title }: { title: string }) => <button>{title}</button>,
+  createAssistantContextItem: jest.fn((type: string, params: { title: string; data: unknown }) => ({
+    type,
+    ...params,
+  })),
+}));
+
+describe('QueryErrorAlert', () => {
+  it('should render the error message', () => {
+    const error: DataQueryError = { message: 'Something went wrong' };
+
+    render(<QueryErrorAlert error={error} />);
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('should fall back to data.message when message is not set', () => {
+    const error: DataQueryError = { data: { message: 'Data level error' } };
+
+    render(<QueryErrorAlert error={error} />);
+
+    expect(screen.getByText('Data level error')).toBeInTheDocument();
+  });
+
+  it('should show default message when no message is available', () => {
+    const error: DataQueryError = {};
+
+    render(<QueryErrorAlert error={error} />);
+
+    expect(screen.getByText('Query error')).toBeInTheDocument();
+  });
+
+  it('should render the trace ID when present', () => {
+    const error: DataQueryError = { message: 'Error', traceId: 'abc123' };
+
+    render(<QueryErrorAlert error={error} />);
+
+    expect(screen.getByText(/abc123/)).toBeInTheDocument();
+  });
+
+  it('should render the Explain in Assistant button', () => {
+    const error: DataQueryError = { message: 'Some error' };
+
+    render(<QueryErrorAlert error={error} />);
+
+    expect(screen.getByRole('button', { name: 'Explain in Assistant' })).toBeInTheDocument();
+  });
+
+  it('should pass original query to assistant context when provided', () => {
+    const { createAssistantContextItem } = jest.requireMock('@grafana/assistant');
+    createAssistantContextItem.mockClear();
+
+    const error: DataQueryError = { message: 'Error' };
+    const query: DataQuery = { refId: 'A' };
+
+    render(<QueryErrorAlert error={error} query={query} />);
+
+    expect(createAssistantContextItem).toHaveBeenCalledWith('structured', {
+      title: 'Original query',
+      data: query,
+    });
+  });
+
+  it('should not pass query context when query is not provided', () => {
+    const { createAssistantContextItem } = jest.requireMock('@grafana/assistant');
+    createAssistantContextItem.mockClear();
+
+    const error: DataQueryError = { message: 'Error' };
+
+    render(<QueryErrorAlert error={error} />);
+
+    // Should only be called once for the error details, not for the query
+    expect(createAssistantContextItem).toHaveBeenCalledTimes(1);
+    expect(createAssistantContextItem).toHaveBeenCalledWith(
+      'structured',
+      expect.objectContaining({ title: 'Query error details' })
+    );
+  });
+});

--- a/public/app/features/query/components/QueryErrorAlert.test.tsx
+++ b/public/app/features/query/components/QueryErrorAlert.test.tsx
@@ -5,7 +5,10 @@ import { DataQuery } from '@grafana/schema';
 
 import { QueryErrorAlert } from './QueryErrorAlert';
 
+const mockUseAssistant = jest.fn().mockReturnValue({ isAvailable: true });
+
 jest.mock('@grafana/assistant', () => ({
+  useAssistant: () => mockUseAssistant(),
   OpenAssistantButton: ({ title }: { title: string }) => <button>{title}</button>,
   createAssistantContextItem: jest.fn((type: string, params: { title: string; data: unknown }) => ({
     type,
@@ -14,6 +17,21 @@ jest.mock('@grafana/assistant', () => ({
 }));
 
 describe('QueryErrorAlert', () => {
+  beforeEach(() => {
+    mockUseAssistant.mockReturnValue({ isAvailable: true });
+  });
+
+  it('should not render the assistant button when assistant is not available', () => {
+    mockUseAssistant.mockReturnValue({ isAvailable: false });
+
+    const error: DataQueryError = { message: 'Some error' };
+
+    render(<QueryErrorAlert error={error} />);
+
+    expect(screen.getByText('Some error')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Fix with Assistant' })).not.toBeInTheDocument();
+  });
+
   it('should render the error message', () => {
     const error: DataQueryError = { message: 'Something went wrong' };
 

--- a/public/app/features/query/components/QueryErrorAlert.tsx
+++ b/public/app/features/query/components/QueryErrorAlert.tsx
@@ -37,12 +37,12 @@ export function QueryErrorAlert({ error, query }: Props) {
       </div>
       {isAvailable && (
         <div className={styles.assistantButton}>
-        <OpenAssistantButton
-          origin="grafana/query-editor-error"
-          prompt={`Help me analyze and fix the following ${error.type ? `\`${error.type}\`` : ''} query error: \`\`\`${message}\`\`\``}
-          context={buildAssistantContext(error, message, query)}
-          title={t('query.query-error-alert.fix-with-assistant', 'Fix with Assistant')}
-          size="sm"
+          <OpenAssistantButton
+            origin="grafana/query-editor-error"
+            prompt={`Help me analyze and fix the following ${error.type ? `\`${error.type}\`` : ''} query error: \`\`\`${message}\`\`\``}
+            context={buildAssistantContext(error, message, query)}
+            title={t('query.query-error-alert.fix-with-assistant', 'Fix with Assistant')}
+            size="sm"
           />
         </div>
       )}

--- a/public/app/features/query/components/QueryErrorAlert.tsx
+++ b/public/app/features/query/components/QueryErrorAlert.tsx
@@ -1,17 +1,39 @@
 import { css } from '@emotion/css';
 
+import { OpenAssistantButton, createAssistantContextItem } from '@grafana/assistant';
 import { DataQueryError, GrafanaTheme2 } from '@grafana/data';
-import { Trans } from '@grafana/i18n';
+import { Trans, t } from '@grafana/i18n';
+import { DataQuery } from '@grafana/schema';
 import { Icon, useStyles2 } from '@grafana/ui';
 
 export interface Props {
   error: DataQueryError;
+  query?: DataQuery;
 }
 
-export function QueryErrorAlert({ error }: Props) {
+export function QueryErrorAlert({ error, query }: Props) {
   const styles = useStyles2(getStyles);
 
   const message = error?.message ?? error?.data?.message ?? 'Query error';
+
+  const context = [
+    createAssistantContextItem('structured', {
+      title: t('query.query-error-alert.error-details', 'Query error details'),
+      data: {
+        type: error.type,
+        message,
+      },
+    }),
+  ];
+
+  if (query) {
+    context.push(
+      createAssistantContextItem('structured', {
+        title: t('query.query-error-alert.original-query', 'Original query'),
+        data: query,
+      })
+    );
+  }
 
   return (
     <div className={styles.wrapper}>
@@ -31,6 +53,15 @@ export function QueryErrorAlert({ error }: Props) {
           </>
         )}
       </div>
+      <div className={styles.assistantButton}>
+        <OpenAssistantButton
+          origin="grafana/query-editor-error"
+          prompt={`Explain the following query error and help me fix it.\n\nError: ${message}${error.type ? `\nError type: \`${error.type}\`` : ''}`}
+          context={context}
+          title={t('query.query-error-alert.explain-in-assistant', 'Explain in Assistant')}
+          size="sm"
+        />
+      </div>
     </div>
   );
 }
@@ -40,6 +71,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     marginTop: theme.spacing(0.5),
     background: theme.colors.background.secondary,
     display: 'flex',
+    alignItems: 'center',
   }),
   icon: css({
     background: theme.colors.error.main,
@@ -50,5 +82,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     fontSize: theme.typography.bodySmall.fontSize,
     fontFamily: theme.typography.fontFamilyMonospace,
     padding: theme.spacing(1),
+    flex: 1,
+  }),
+  assistantButton: css({
+    padding: theme.spacing(0, 1),
   }),
 });

--- a/public/app/features/query/components/QueryErrorAlert.tsx
+++ b/public/app/features/query/components/QueryErrorAlert.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { OpenAssistantButton, createAssistantContextItem } from '@grafana/assistant';
+import { OpenAssistantButton, createAssistantContextItem, useAssistant } from '@grafana/assistant';
 import { DataQueryError, GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { DataQuery } from '@grafana/schema';
@@ -13,9 +13,9 @@ export interface Props {
 
 export function QueryErrorAlert({ error, query }: Props) {
   const styles = useStyles2(getStyles);
+  const { isAvailable } = useAssistant();
 
   const message = error?.message ?? error?.data?.message ?? 'Query error';
-  const context = buildAssistantContext(error, message, query);
 
   return (
     <div className={styles.wrapper}>
@@ -35,15 +35,17 @@ export function QueryErrorAlert({ error, query }: Props) {
           </>
         )}
       </div>
-      <div className={styles.assistantButton}>
+      {isAvailable && (
+        <div className={styles.assistantButton}>
         <OpenAssistantButton
           origin="grafana/query-editor-error"
-          prompt={`Help me fix the following query error.\n\nError: ${message}${error.type ? `\nError type: \`${error.type}\`` : ''}`}
-          context={context}
+          prompt={`Help me analyze and fix the following ${error.type ? `\`${error.type}\`` : ''} query error: \`\`\`${message}\`\`\``}
+          context={buildAssistantContext(error, message, query)}
           title={t('query.query-error-alert.fix-with-assistant', 'Fix with Assistant')}
           size="sm"
-        />
-      </div>
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12922,6 +12922,9 @@
       "query-name-div-title-edit-query-name": "Edit query name"
     },
     "query-error-alert": {
+      "error-details": "Query error details",
+      "fix-with-assistant": "Fix with Assistant",
+      "original-query": "Original query",
       "trace-id": "(Trace ID: {{traceId}})"
     },
     "query-group": {


### PR DESCRIPTION
Add an "Fix iwithAssistant" button to `QueryErrorAlert` so users can quickly get AI-powered help when a query fails. The button opens the Grafana Assistant with the error details (type, message) and the original query as context.

**Key changes:**
- Added `OpenAssistantButton` to `QueryErrorAlert` with error type, message, and original query as structured context
- Added optional `query` prop to `QueryErrorAlert` and passed it from `QueryEditorRow`
- Added tests for the new assistant integration

The button is visible only when Assistant plugin is enabled in Grafana instance.


https://github.com/user-attachments/assets/2c5bc27b-4e96-494b-a96c-114e7adfaa47


This is consistent with what we do with health check errors:

<img width="1215" height="363" alt="image" src="https://github.com/user-attachments/assets/a381708e-165c-48f5-9a32-2d27f9b17328" />

