### PR TITLE
Dashboard version history: Show use name instead of UID

### DIFF
--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -7,7 +7,7 @@ import { SceneComponentProps, SceneObjectBase, sceneGraph } from '@grafana/scene
 import { Spinner, Stack } from '@grafana/ui';
 import { useGetDisplayMappingQuery } from 'app/api/clients/iam/v0alpha1';
 import { Page } from 'app/core/components/Page/Page';
-import { Resource } from 'app/features/apiserver/types';
+import { AnnoKeyMessage, AnnoKeyUpdatedBy, AnnoKeyUpdatedTimestamp, Resource } from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import {
   DecoratedRevisionModel,
@@ -122,9 +122,12 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
         checked: false,
         uid: item.metadata.name,
         version: item.metadata.generation ?? 0,
-        created: item.metadata.creationTimestamp ?? new Date().toISOString(),
-        createdBy: item.metadata.annotations?.['grafana.app/updatedBy'] ?? '',
-        message: item.metadata.annotations?.['grafana.app/message'] ?? '',
+        created:
+          item.metadata.annotations?.[AnnoKeyUpdatedTimestamp] ??
+          item.metadata.creationTimestamp ??
+          new Date().toISOString(),
+        createdBy: item.metadata.annotations?.[AnnoKeyUpdatedBy] ?? '',
+        message: item.metadata.annotations?.[AnnoKeyMessage] ?? '',
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         data: item.spec as object,
       })

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -1,8 +1,11 @@
+import { skipToken } from '@reduxjs/toolkit/query/react';
 import * as React from 'react';
+import { useMemo } from 'react';
 
 import { PageLayoutType, dateTimeFormat, dateTimeFormatTimeAgo } from '@grafana/data';
 import { SceneComponentProps, SceneObjectBase, sceneGraph } from '@grafana/scenes';
 import { Spinner, Stack } from '@grafana/ui';
+import { useGetDisplayMappingQuery } from 'app/api/clients/iam/v0alpha1';
 import { Page } from 'app/core/components/Page/Page';
 import { Resource } from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
@@ -182,6 +185,26 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
   const dashboard = model.getDashboard();
   const { isLoading, isAppending, viewMode, baseInfo, newInfo, isNewLatest } = model.useState();
   const { navModel, pageNav } = useDashboardEditPageNav(dashboard, model.getUrlKey());
+
+  const userKeys = useMemo(
+    () => [...new Set(model.versions.map((v) => v.createdBy).filter(Boolean))],
+    [model.versions]
+  );
+  const { data: displayData } = useGetDisplayMappingQuery(userKeys.length > 0 ? { key: userKeys } : skipToken);
+  const isLoadingUserDisplayNames = userKeys.length > 0 && !displayData;
+
+  // Here replacing raw user ids with human readable names
+  const versionsWithDisplayNames = useMemo(() => {
+    if (!displayData) {
+      return model.versions;
+    }
+    return model.versions.map((version) => {
+      const idx = version.createdBy ? displayData.keys.indexOf(version.createdBy) : -1;
+      const displayName = idx >= 0 ? displayData.display[idx]?.displayName : undefined;
+      return displayName ? { ...version, createdBy: displayName } : version;
+    });
+  }, [model.versions, displayData]);
+
   const canCompare = model.versions.filter((version) => version.checked).length === 2;
   const showButtons = model.versions.length > 1;
   const hasMore = model.versions.length >= model.limit;
@@ -219,10 +242,11 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
         <VersionsHistorySpinner msg="Fetching history list&hellip;" />
       ) : (
         <VersionHistoryTable
-          versions={model.versions}
+          versions={versionsWithDisplayNames}
           onCheck={model.onCheck}
           canCompare={canCompare}
           onRestore={dashboard.onRestore}
+          isLoadingUserDisplayNames={isLoadingUserDisplayNames}
         />
       )}
       {isAppending && <VersionsHistorySpinner msg="Fetching more entries&hellip;" />}

--- a/public/app/features/dashboard-scene/settings/version-history/VersionHistoryTable.tsx
+++ b/public/app/features/dashboard-scene/settings/version-history/VersionHistoryTable.tsx
@@ -1,5 +1,6 @@
 import { css, cx } from '@emotion/css';
 import * as React from 'react';
+import Skeleton from 'react-loading-skeleton';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -14,9 +15,16 @@ type VersionsTableProps = {
   canCompare: boolean;
   onCheck: (ev: React.FormEvent<HTMLInputElement>, versionId: number) => void;
   onRestore: (version: DecoratedRevisionModel) => Promise<boolean>;
+  isLoadingUserDisplayNames?: boolean;
 };
 
-export const VersionHistoryTable = ({ versions, canCompare, onCheck, onRestore }: VersionsTableProps) => {
+export const VersionHistoryTable = ({
+  versions,
+  canCompare,
+  onCheck,
+  onRestore,
+  isLoadingUserDisplayNames,
+}: VersionsTableProps) => {
   const styles = useStyles2(getStyles);
 
   return (
@@ -60,7 +68,7 @@ export const VersionHistoryTable = ({ versions, canCompare, onCheck, onRestore }
               </td>
               <td>{version.version}</td>
               <td>{version.createdDateString}</td>
-              <td>{version.createdBy}</td>
+              <td>{isLoadingUserDisplayNames ? <Skeleton width={100} /> : version.createdBy}</td>
               <td>{version.message}</td>
               <td className="text-right">
                 {idx === 0 ? (


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/grafana/grafana/pull/114686. Before this PR, user would see user uid in the dashboard version history list, instead of actual user names. See before/after:

<img width="1389" height="589" alt="Screenshot 2026-02-09 at 12 39 36" src="https://github.com/user-attachments/assets/156bbc6c-0e36-4d34-a391-519d84a1af45" />


<img width="1389" height="589" alt="Screenshot 2026-02-09 at 12 39 03" src="https://github.com/user-attachments/assets/e5d7a16d-bb6b-4ffc-94e6-fa2d310946b5" />

Since user names are loaded async now, i've added skeleton for rendering the user name to avoid uid/username flick.
