### PR TITLE
Log Details: Use getLabelTypeFromRow when DataSourceWithLogsLabelTypesSupport is not supported

### DIFF
--- a/public/app/features/logs/components/panel/LogLine.test.tsx
+++ b/public/app/features/logs/components/panel/LogLine.test.tsx
@@ -610,7 +610,7 @@ describe.each(fontSizes)('LogLine', (fontSize: LogListFontSize) => {
       expect(screen.queryByPlaceholderText('Search field names and values')).not.toBeInTheDocument();
     });
 
-    test('Details are rendered if details mode is inline', () => {
+    test('Details are rendered if details mode is inline', async () => {
       render(
         <LogDetailsContext.Provider
           value={{
@@ -623,7 +623,7 @@ describe.each(fontSizes)('LogLine', (fontSize: LogListFontSize) => {
           <LogLine {...defaultProps} />
         </LogDetailsContext.Provider>
       );
-      expect(screen.getByPlaceholderText('Search field names and values')).toBeInTheDocument();
+      expect(await screen.findByPlaceholderText('Search field names and values')).toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -16,8 +16,8 @@ import {
   ScopedVars,
   toDataFrame,
 } from '@grafana/data';
-import { setPluginLinksHook } from '@grafana/runtime';
-import { TempoDatasource } from '@grafana-plugins/tempo/datasource';
+import { DataSourceSrv, getDataSourceSrv, setPluginLinksHook, usePluginLinks } from '@grafana/runtime';
+import { createLokiDatasource } from 'app/plugins/datasource/loki/mocks/datasource';
 import { createTempoDatasource } from 'app/plugins/datasource/tempo/test/mocks';
 
 import { DATAPLANE_LABEL_TYPES_NAME, DATAPLANE_LABELS_NAME } from '../../logsFrame';
@@ -45,28 +45,12 @@ jest.mock('@grafana/assistant', () => {
   };
 });
 
-const FIELDS_LABEL = 'TestLabelType';
-const tempoDS: TempoDatasource & {
-  getLabelDisplayTypeFromFrame?: (key: string, frame: DataFrame | undefined, index: number | null) => string | null;
-} = createTempoDatasource(undefined, { uid: 'abc-123' });
-const getMockTempoDS = jest.fn().mockImplementation((getLabelDisplayTypeFromFrame) => {
-  tempoDS.getLabelDisplayTypeFromFrame = jest
-    .fn()
-    .mockImplementation((key: string, frame: DataFrame | undefined, index: number | null) => {
-      return getLabelDisplayTypeFromFrame(key, frame, index) ?? FIELDS_LABEL;
-    });
-  return tempoDS;
-});
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getDataSourceSrv: jest.fn(),
+  usePluginLinks: jest.fn(),
+}));
 
-jest.mock('@grafana/runtime', () => {
-  return {
-    ...jest.requireActual('@grafana/runtime'),
-    usePluginLinks: jest.fn().mockReturnValue({ links: [] }),
-    getDataSourceSrv: () => ({
-      get: (uid: string) => Promise.resolve(getMockTempoDS(() => FIELDS_LABEL)),
-    }),
-  };
-});
 jest.mock('./LogListContext');
 jest.mock('app/features/explore/TraceView/TraceView', () => ({
   TraceView: () => <div>Trace view</div>,
@@ -76,18 +60,21 @@ afterAll(() => {
   jest.unmock('app/features/explore/TraceView/TraceView');
 });
 
+let lokiDS = createLokiDatasource(undefined, { uid: 'loki-ds' });
+let tempoDS = createTempoDatasource(undefined, { uid: 'tempo-ds' });
+
 const setup = async (
   propOverrides?: Partial<Props>,
   rowOverrides?: Partial<LogRowModel>,
   logListcontextOverrides?: Partial<LogListContextData>,
   logDetailsContextOverrides?: Partial<LogDetailsContextData>,
-  renderCompleteText = FIELDS_LABEL
+  renderCompleteText: string | RegExp = 'Fields'
 ) => {
   const logs = [
     createLogLine({
       logLevel: LogLevel.error,
       timeEpochMs: 1546297200000,
-      datasourceUid: tempoDS.uid,
+      datasourceUid: lokiDS.uid,
       ...rowOverrides,
     }),
   ];
@@ -142,8 +129,29 @@ const setup = async (
 };
 
 describe('LogLineDetails', () => {
+  beforeEach(() => {
+    lokiDS = createLokiDatasource(undefined, { uid: 'loki-ds' });
+    tempoDS = createTempoDatasource(undefined, { uid: 'tempo-ds' });
+    jest.mocked(usePluginLinks).mockReturnValue({
+      links: [],
+      isLoading: false,
+    });
+    jest.mocked(getDataSourceSrv).mockImplementation(
+      () =>
+        ({
+          get: (uid: string) => {
+            if (uid === 'loki-ds') {
+              return Promise.resolve(lokiDS);
+            } else if (uid === 'tempo-ds') {
+              return Promise.resolve(tempoDS);
+            }
+            return Promise.resolve(null);
+          },
+        }) as unknown as DataSourceSrv
+    );
+  });
+
   describe('Toggleable filters', () => {
-    // @todo leaking - this test will fail if ran at the end.
     test('should pass the log row to Explore filter functions', async () => {
       const onClickFilterLabelMock = jest.fn();
       const onClickFilterOutLabelMock = jest.fn();
@@ -152,6 +160,7 @@ describe('LogLineDetails', () => {
         logLevel: LogLevel.error,
         timeEpochMs: 1546297200000,
         labels: { key1: 'label1' },
+        datasourceUid: lokiDS.uid,
       });
 
       await setup(
@@ -208,7 +217,7 @@ describe('LogLineDetails', () => {
     test('should render the fields and the log line', async () => {
       await setup(undefined, { labels: { key1: 'label1', key2: 'label2' } });
       expect(screen.getByText('Log line')).toBeInTheDocument();
-      expect(screen.getByText(FIELDS_LABEL)).toBeInTheDocument();
+      expect(screen.getByText('Fields')).toBeInTheDocument();
     });
 
     test('fields should be visible by default', async () => {
@@ -404,7 +413,7 @@ describe('LogLineDetails', () => {
     await setup({ logs: [log] }, undefined, undefined, { showDetails: [log], currentLog: log });
 
     expect(screen.getByText('Log line')).toBeInTheDocument();
-    expect(screen.getByText(FIELDS_LABEL)).toBeInTheDocument();
+    expect(screen.getByText('Fields')).toBeInTheDocument();
     expect(screen.getByText('Links')).toBeInTheDocument();
 
     // Don't show additional fields for DataFrameType.LogLines
@@ -481,38 +490,58 @@ describe('LogLineDetails', () => {
         },
       });
 
-      beforeEach(() => {
-        jest.requireMock('@grafana/runtime').getDataSourceSrv = jest.fn().mockImplementation(() => ({
-          get: (uid: string) =>
-            Promise.resolve(
-              getMockTempoDS((key: string) => {
-                if (key === 'label1') {
-                  return 'Indexed label';
-                }
-                if (key === 'label2') {
-                  return 'Structured metadata';
-                }
-                if (key === 'label3') {
-                  return 'Parsed field';
-                }
-                return null;
-              })
-            ),
-        }));
-      });
+      test('should show label types if they are available and supported by the data source', async () => {
+        lokiDS.getLabelDisplayTypeFromFrame = jest
+          .fn()
+          .mockImplementation((key: string, frame: DataFrame | undefined, index: number | null) => {
+            if (key === 'label1') {
+              return 'Indexed label';
+            }
+            if (key === 'label2') {
+              return 'Structured metadata';
+            }
+            if (key === 'label3') {
+              return 'Parsed field';
+            }
+            return null;
+          });
 
-      afterAll(() => {
-        jest.requireMock('@grafana/runtime').getDataSourceSrv = jest.fn().mockImplementation(() => ({
-          get: (uid: string) => Promise.resolve(getMockTempoDS(() => FIELDS_LABEL)),
-        }));
-      });
-
-      test('should show label types if they are available and supported', async () => {
         await setup(
           undefined,
           {
             entry,
             dataFrame,
+            entryFieldIndex: 0,
+            datasourceUid: 'loki-ds',
+            rowIndex: 0,
+            labels,
+            rowId: '1',
+          },
+          undefined,
+          undefined,
+          'Indexed label'
+        );
+
+        // Show labels and links
+        expect(screen.getByText('label1')).toBeInTheDocument();
+        expect(screen.getByText('value1')).toBeInTheDocument();
+        expect(screen.getByText('label2')).toBeInTheDocument();
+        expect(screen.getByText('value2')).toBeInTheDocument();
+        expect(screen.getByText('label3')).toBeInTheDocument();
+        expect(screen.getByText('value3')).toBeInTheDocument();
+        expect(screen.getByText(/Indexed label/)).toBeInTheDocument();
+        expect(screen.getByText(/Parsed field/)).toBeInTheDocument();
+        expect(screen.getByText('Structured metadata')).toBeInTheDocument();
+      });
+
+      test('should fall back to the data plane labelType field if present', async () => {
+        await setup(
+          undefined,
+          {
+            entry,
+            dataFrame,
+            datasourceUid: 'tempo-ds',
+            datasourceType: 'loki',
             entryFieldIndex: 0,
             rowIndex: 0,
             labels,
@@ -545,6 +574,7 @@ describe('LogLineDetails', () => {
           {
             entry,
             dataFrame,
+            datasourceUid: 'loki-ds',
             entryFieldIndex: 0,
             rowIndex: 0,
             labels,
@@ -577,12 +607,13 @@ describe('LogLineDetails', () => {
             entryFieldIndex: 0,
             rowIndex: 0,
             labels,
+            datasourceUid: 'loki-ds',
             datasourceType: 'loki',
             rowId: '1',
           },
           undefined,
           undefined,
-          'Indexed label'
+          /Indexed label/
         );
 
         expect(screen.getByText('label1')).toBeInTheDocument();
@@ -728,7 +759,7 @@ describe('LogLineDetails', () => {
       ],
     });
     const log = createLogLine(
-      { entry, dataFrame, entryFieldIndex: 0, rowIndex: 0 },
+      { entry, dataFrame, entryFieldIndex: 0, rowIndex: 0, datasourceUid: lokiDS.uid },
       {
         escape: false,
         order: LogsSortOrder.Descending,
@@ -742,6 +773,9 @@ describe('LogLineDetails', () => {
                 href: '/explore',
                 interpolatedParams: {
                   query: {
+                    datasource: {
+                      uid: tempoDS.uid,
+                    },
                     refId: 'A',
                     query: 'abcd1234',
                     queryType: 'traceql',
@@ -771,14 +805,14 @@ describe('LogLineDetails', () => {
       })
     );
 
-    setup({ logs: [log] }, undefined, undefined, { showDetails: [log], currentLog: log });
+    await setup({ logs: [log] }, undefined, undefined, { showDetails: [log], currentLog: log });
 
     expect(screen.getByText('Links')).toBeInTheDocument();
     expect(screen.getByText('Trace')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Trace'));
 
-    expect(screen.getByText('Trace view')).toBeInTheDocument();
+    expect(await screen.findByText('Trace view')).toBeInTheDocument();
   });
 
   test('Shows a message if the trace cannot be retrieved', async () => {
@@ -811,6 +845,9 @@ describe('LogLineDetails', () => {
                 href: '/explore',
                 interpolatedParams: {
                   query: {
+                    datasource: {
+                      uid: tempoDS.uid,
+                    },
                     refId: 'A',
                     query: 'abcd1234',
                     queryType: 'traceql',

--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -68,7 +68,7 @@ const setup = async (
   rowOverrides?: Partial<LogRowModel>,
   logListcontextOverrides?: Partial<LogListContextData>,
   logDetailsContextOverrides?: Partial<LogDetailsContextData>,
-  renderCompleteText: string | RegExp = 'Fields'
+  renderCompleteText: string | RegExp = 'Log line'
 ) => {
   const logs = [
     createLogLine({
@@ -289,8 +289,8 @@ describe('LogLineDetails', () => {
     });
   });
   describe('when the log has no fields to display', () => {
-    test('should render no details available message', () => {
-      setup(undefined, { entry: '' });
+    test('should render no details available message', async () => {
+      await setup(undefined, { entry: '' });
       expect(screen.getByText('No fields to display.')).toBeInTheDocument();
     });
     test('should not render headings', () => {
@@ -341,7 +341,7 @@ describe('LogLineDetails', () => {
       }
     );
 
-    setup({ logs: [log] }, undefined, undefined, { showDetails: [log], currentLog: log });
+    await setup({ logs: [log] }, undefined, undefined, { showDetails: [log], currentLog: log });
 
     expect(screen.getByText('Fields')).toBeInTheDocument();
     expect(screen.getByText('Links')).toBeInTheDocument();
@@ -566,7 +566,7 @@ describe('LogLineDetails', () => {
 
       test('should fallback to a single group of Fields if not supported', async () => {
         jest.requireMock('@grafana/runtime').getDataSourceSrv = jest.fn().mockImplementation(() => ({
-          get: (uid: string) => Promise.resolve(undefined),
+          get: (uid: string) => Promise.reject(null),
         }));
 
         await setup(
@@ -870,7 +870,7 @@ describe('LogLineDetails', () => {
       })
     );
 
-    setup({ logs: [log] }, undefined, undefined, { showDetails: [log], currentLog: log });
+    await setup({ logs: [log] }, undefined, undefined, { showDetails: [log], currentLog: log });
 
     expect(screen.getByText('Links')).toBeInTheDocument();
     expect(screen.getByText('Trace')).toBeInTheDocument();

--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -549,7 +549,7 @@ describe('LogLineDetails', () => {
           },
           undefined,
           undefined,
-          'Indexed label'
+          /Indexed label/
         );
 
         // Show labels and links

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -2,18 +2,12 @@ import { css } from '@emotion/css';
 import { camelCase, groupBy } from 'lodash';
 import { memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import {
-  DataFrameType,
-  DataSourceWithLogsLabelTypesSupport,
-  GrafanaTheme2,
-  hasLogsLabelTypesSupport,
-  store,
-  TimeRange,
-} from '@grafana/data';
+import { DataFrameType, DataSourceApi, GrafanaTheme2, hasLogsLabelTypesSupport, store, TimeRange } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import { Box, ControlledCollapse, useStyles2 } from '@grafana/ui';
 
+import { getLabelTypeFromRow } from '../../utils';
 import { useAttributesExtensionLinks } from '../LogDetails';
 import { createLogLineLinks } from '../logParser';
 
@@ -41,7 +35,7 @@ export const LogLineDetailsComponent = memo(
     const { displayedFields, noInteractions, logOptionsStorageKey, setDisplayedFields, syntaxHighlighting } =
       useLogListContext();
     const [search, setSearch] = useState('');
-    const [ds, setDs] = useState<DataSourceWithLogsLabelTypesSupport | null>(null);
+    const [ds, setDs] = useState<DataSourceApi | null>(null);
     const inputRef = useRef('');
     const styles = useStyles2(getStyles);
 
@@ -90,11 +84,13 @@ export const LogLineDetailsComponent = memo(
             }
           : {};
       }
-      return groupBy(
-        labelsWithLinks,
-        (label) => ds.getLabelDisplayTypeFromFrame(label.key, log.dataFrame, log.rowIndex) ?? ''
-      );
-    }, [ds, labelsWithLinks, log.dataFrame, log.rowIndex]);
+      return groupBy(labelsWithLinks, (label) => {
+        if (hasLogsLabelTypesSupport(ds)) {
+          return ds.getLabelDisplayTypeFromFrame(label.key, log.dataFrame, log.rowIndex) ?? '';
+        }
+        return getLabelTypeFromRow(label.key, log, true) ?? '';
+      });
+    }, [ds, labelsWithLinks, log]);
 
     const labelGroups = useMemo(() => Object.keys(groupedLabels), [groupedLabels]);
 
@@ -163,7 +159,7 @@ export const LogLineDetailsComponent = memo(
     useEffect(() => {
       const setDatasource = async () => {
         const datasource = await getDataSourceSrv().get(log.datasourceUid);
-        if (datasource && hasLogsLabelTypesSupport(datasource)) {
+        if (datasource) {
           setDs(datasource);
         }
       };

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -35,7 +35,7 @@ export const LogLineDetailsComponent = memo(
     const { displayedFields, noInteractions, logOptionsStorageKey, setDisplayedFields, syntaxHighlighting } =
       useLogListContext();
     const [search, setSearch] = useState('');
-    const [ds, setDs] = useState<DataSourceApi | null>(null);
+    const [ds, setDs] = useState<DataSourceApi | null | undefined>(undefined);
     const inputRef = useRef('');
     const styles = useStyles2(getStyles);
 
@@ -157,15 +157,16 @@ export const LogLineDetailsComponent = memo(
     }, []);
 
     useEffect(() => {
-      const setDatasource = async () => {
-        const datasource = await getDataSourceSrv().get(log.datasourceUid);
-        if (datasource) {
-          setDs(datasource);
-        }
-      };
-
-      setDatasource();
+      getDataSourceSrv()
+        .get(log.datasourceUid)
+        .then(setDs)
+        .catch(() => setDs(null));
     }, [log.datasourceUid]);
+
+    // Wait for ds to be resolved to DataSourceApi or null on error
+    if (ds === undefined) {
+      return null;
+    }
 
     return (
       <>

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -402,11 +402,11 @@ function getLabelDisplayTypeFromFrame(labelKey: string, frame: DataFrame, index:
 }
 
 /**
+ * @deprecated Implement DataSourceWithLogsLabelTypesSupport and use ds.getLabelDisplayTypeFromFrame
+ * to support label types.
+ * 
  * Look for a `labelTypes` field. If found, use it to resolve the type for the
  * provided label.
- *
- * Implement DataSourceWithLogsLabelTypesSupport and use ds.getLabelDisplayTypeFromFrame to support
- * a different label types implementation.
  *
  * @param label
  * @param row
@@ -421,6 +421,7 @@ export function getLabelTypeFromRow(label: string, row: LogRowModel, plural = fa
 }
 
 /**
+ * @deprecated
  * @param labelType
  * @param datasourceType
  * @param plural
@@ -430,11 +431,11 @@ function getDataSourceLabelType(labelType: string, datasourceType: string | unde
     case 'loki':
       switch (labelType) {
         case 'I':
-          return t('logs.fields.type.loki.indexed-label', 'Indexed label', { count: plural ? 2 : 1 });
+          return t('logs.fields.type.loki.indexed-label', 'Indexed labels', { count: plural ? 2 : 1 });
         case 'S':
           return t('logs.fields.type.loki.structured-metadata', 'Structured metadata', { count: plural ? 2 : 1 });
         case 'P':
-          return t('logs.fields.type.loki.parsedl-label', 'Parsed field', { count: plural ? 2 : 1 });
+          return t('logs.fields.type.loki.parsedl-label', 'Parsed fields', { count: plural ? 2 : 1 });
         default:
           return null;
       }

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -404,7 +404,7 @@ function getLabelDisplayTypeFromFrame(labelKey: string, frame: DataFrame, index:
 /**
  * @deprecated Implement DataSourceWithLogsLabelTypesSupport and use ds.getLabelDisplayTypeFromFrame
  * to support label types.
- * 
+ *
  * Look for a `labelTypes` field. If found, use it to resolve the type for the
  * provided label.
  *
@@ -440,7 +440,7 @@ function getDataSourceLabelType(labelType: string, datasourceType: string | unde
           return null;
       }
     default:
-      return labelType;
+      return null;
   }
 }
 

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -402,15 +402,17 @@ function getLabelDisplayTypeFromFrame(labelKey: string, frame: DataFrame, index:
 }
 
 /**
- * @deprecated, use datasource.getLabelDisplayTypeFromFrame instead
+ * Look for a `labelTypes` field. If found, use it to resolve the type for the
+ * provided label.
+ *
+ * Implement DataSourceWithLogsLabelTypesSupport and use ds.getLabelDisplayTypeFromFrame to support
+ * a different label types implementation.
+ *
  * @param label
  * @param row
  * @param plural
  */
 export function getLabelTypeFromRow(label: string, row: LogRowModel, plural = false) {
-  if (!row.datasourceType) {
-    return null;
-  }
   const labelType = getLabelDisplayTypeFromFrame(label, row.dataFrame, row.rowIndex);
   if (!labelType) {
     return null;
@@ -419,12 +421,11 @@ export function getLabelTypeFromRow(label: string, row: LogRowModel, plural = fa
 }
 
 /**
- * @deprecated
  * @param labelType
  * @param datasourceType
  * @param plural
  */
-function getDataSourceLabelType(labelType: string, datasourceType: string, plural: boolean) {
+function getDataSourceLabelType(labelType: string, datasourceType: string | undefined, plural: boolean) {
   switch (datasourceType) {
     case 'loki':
       switch (labelType) {
@@ -438,7 +439,7 @@ function getDataSourceLabelType(labelType: string, datasourceType: string, plura
           return null;
       }
     default:
-      return null;
+      return labelType;
   }
 }
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10286,10 +10286,10 @@
     "fields": {
       "type": {
         "loki": {
-          "indexed-label_one": "Indexed label",
-          "indexed-label_other": "Indexed label",
-          "parsedl-label_one": "Parsed field",
-          "parsedl-label_other": "Parsed field",
+          "indexed-label_one": "Indexed labels",
+          "indexed-label_other": "Indexed labels",
+          "parsedl-label_one": "Parsed fields",
+          "parsedl-label_other": "Parsed fields",
           "structured-metadata_one": "Structured metadata",
           "structured-metadata_other": "Structured metadata"
         }


### PR DESCRIPTION
Follow up to https://github.com/grafana/grafana/pull/117025, where the label types implementation was deprecated and moved to a data source optional method.

We are keeping the deprecated core implementation for backwards compatibility when the available Loki data source doesn't support the new interface.

Additional changes:
- Unit test clean up
- Plurals for translations