### PR TITLE
Provisioning: Pass token to backend for non-GitHub providers

### DIFF
--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
@@ -53,7 +53,7 @@ export const ProvisioningWizard = memo(function ProvisioningWizard({
       migrate: {
         history: true,
       },
-      githubAuthType: 'github-app',
+      githubAuthType: type === 'github' ? 'github-app' : 'pat',
       githubAppMode: 'existing',
       githubApp: {},
     },


### PR DESCRIPTION
**What is this feature?**

This fixes a bug where tokens were not passed to the backend when creating repositories through the wizard for Pure Git, GitLab, and Bitbucket providers.

**Why do we need this feature?**

The provisioning wizard defaulted `githubAuthType` to `'github-app'` for all repo types. However, GitHub App auth is only supported for GitHub; other providers require PAT authentication. This caused the token to be stripped before sending to the backend, breaking token-based authentication for non-GitHub providers.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/861
