### PR TITLE
chore: replace `config.panels` usage in codeLoader

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2822,11 +2822,6 @@
       "count": 2
     }
   },
-  "public/app/features/plugins/sandbox/codeLoader.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "public/app/features/plugins/sandbox/distortions.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1

--- a/public/app/features/plugins/sandbox/codeLoader.ts
+++ b/public/app/features/plugins/sandbox/codeLoader.ts
@@ -1,6 +1,6 @@
 import { PluginType, patchArrayVectorProrotypeMethods } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { getAppPluginMetas } from '@grafana/runtime/internal';
+import { getAppPluginMetas, getPanelPluginMetas } from '@grafana/runtime/internal';
 
 import { transformPluginSourceForCDN } from '../cdn/utils';
 import { resolvePluginUrlWithCache } from '../loader/pluginInfoCache';
@@ -131,7 +131,8 @@ export async function getPluginLoadData(pluginId: string): Promise<SandboxPlugin
   }
 
   //find it in panels
-  for (const panel of Object.values(config.panels)) {
+  const panels = await getPanelPluginMetas();
+  for (const panel of panels) {
     if (panel.id === pluginId) {
       return panel;
     }


### PR DESCRIPTION
**What is this feature?**

This pull request updates how panel plugin metadata is retrieved in the `codeLoader.ts` file. The main change is switching from accessing panels directly from the `config` object to using the asynchronous `getPanelPluginMetas` function. 

**Why do we need this feature?**

So we can remove `config.panels`

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates #117467

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
