### PR TITLE
Alerting: Bring back alert.notifications.receivers:test role

### DIFF
--- a/pkg/services/ngalert/accesscontrol.go
+++ b/pkg/services/ngalert/accesscontrol.go
@@ -135,6 +135,7 @@ var (
 			Group:       models.AlertRolesGroup,
 			Permissions: []accesscontrol.Permission{
 				{Action: accesscontrol.ActionAlertingReceiversCreate},
+				{Action: accesscontrol.ActionAlertingReceiversTest}, // deprecated, kept for backward compatibility
 				{Action: accesscontrol.ActionAlertingReceiversTestCreate, Scope: models.ScopeReceiversProvider.GetResourceScopeType(alertingac.NewReceiverType)},
 			},
 		},


### PR DESCRIPTION
### Description

Bringing back the `alert.notifications.receivers:test`, removed [here](https://github.com/grafana/grafana/pull/116563/changes#diff-95b8e7bc951344dfe3eca537915a86e5119023d26fed0b810c81c864cda876aeL137-R138), for backward compatibility.

### Testing

Attempting to start Grafana and provision a custom role using `alert.notifications.receivers:test` fails with the following error:

> Error: ✗ could not provision role [OrgId:1 RoleUID:test]: [permreg.unknown-action] unknown action: alert.notifications.receivers:test, was not found in the list of valid actions

After the change in this PR, there's no error and Grafana starts normally.