### PR TITLE
Table: Update ESLint rule to restrict certain imports and provide help on how to work around restrictions

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -87,6 +87,14 @@ function withBaseRestrictedImportsConfig(config = {}) {
   return finalConfig;
 }
 
+const datavizDefaultImportsRestrictions = [
+  {
+    group: ['@emotion/css'],
+    importNames: ['cx'],
+    message: 'Do not use "cx" from @emotion/css. Instead, use `clsx` and compose together only strings.',
+  },
+];
+
 /**
  * @type {Array<import('eslint').Linter.Config>}
  */
@@ -478,12 +486,40 @@ module.exports = [
 
   {
     // custom rule for Table to avoid performance regressions
+    files: ['packages/grafana-ui/src/components/Table/TableNG/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        withBaseRestrictedImportsConfig({
+          patterns: [
+            ...datavizDefaultImportsRestrictions,
+            {
+              group: ['@grafana/data'],
+              importNames: ['getFieldDisplayName'],
+              message:
+                'Using the method inside Table can have performance implications which are unnecessary. Instead, use the local `getDisplayName` from the table utils.',
+            },
+          ],
+        }),
+      ],
+    },
+  },
+
+  {
+    // custom rule for Table to avoid performance regressions
     files: ['packages/grafana-ui/src/components/Table/TableNG/Cells/**/*.{ts,tsx}'],
     rules: {
       'no-restricted-imports': [
         'error',
         withBaseRestrictedImportsConfig({
           patterns: [
+            ...datavizDefaultImportsRestrictions,
+            {
+              group: ['@grafana/data'],
+              importNames: ['getFieldDisplayName'],
+              message:
+                'Using the method inside Table can have performance implications which are unnecessary. Instead, use the local `getDisplayName` from the table utils.',
+            },
             {
               group: ['**/themes/ThemeContext'],
               importNames: ['useStyles2', 'useTheme2'],
@@ -496,20 +532,14 @@ module.exports = [
     },
   },
 
-  // dataviz prefers to use `clsx` over `cx` to compose classes as a rule for performance reasons
+  // other dataviz panels which should just get our default set of restrictions
   {
     files: ['public/app/plugins/panel/state-timeline/**/*.{ts,tsx}'],
     rules: {
       'no-restricted-imports': [
         'error',
         withBaseRestrictedImportsConfig({
-          patterns: [
-            {
-              group: ['@emotion/css'],
-              importNames: ['cx'],
-              message: 'Do not use "cx" from @emotion/css. Instead, use `clsx` and compose together only strings.',
-            },
-          ],
+          patterns: [...datavizDefaultImportsRestrictions],
         }),
       ],
     },

--- a/packages/grafana-ui/src/components/Table/TableNG/Filter/Filter.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Filter/Filter.tsx
@@ -1,7 +1,8 @@
-import { css, cx } from '@emotion/css';
+import { css } from '@emotion/css';
+import { clsx } from 'clsx';
 import { memo, useRef, useState } from 'react';
 
-import { Field, getFieldDisplayName, GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { Field, GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 
@@ -9,6 +10,7 @@ import { useStyles2 } from '../../../../themes/ThemeContext';
 import { Icon } from '../../../Icon/Icon';
 import { Popover } from '../../../Tooltip/Popover';
 import { FilterOperator, FilterType, TableRow } from '../types';
+import { getDisplayName } from '../utils';
 
 import { FilterPopup } from './FilterPopup';
 import { operatorSelectableValues } from './utils';
@@ -58,7 +60,7 @@ export const Filter = memo(
         ref={ref}
         type="button"
         aria-label={t('grafana-ui.table.filter.button', `Filter {{name}}`, {
-          name: field ? getFieldDisplayName(field) : '',
+          name: field ? getDisplayName(field) : '',
         })}
         data-testid={selectors.components.Panels.Visualization.TableNG.Filters.HeaderButton}
         tabIndex={0}
@@ -77,7 +79,7 @@ export const Filter = memo(
           }
         }}
       >
-        <Icon name="filter" className={cx(iconClassName, { [styles.filterIconEnabled]: filterEnabled })} />
+        <Icon name="filter" className={clsx(iconClassName, filterEnabled ? styles.filterIconEnabled : undefined)} />
         {isPopoverVisible && ref.current && (
           <Popover
             content={


### PR DESCRIPTION
Been meaning to do this for a while - https://github.com/grafana/grafana/pull/117641/changes#r2783035278 prompted me to finally do it.

We should make it very obvious to those working in Table certain hard-and-fast rules we have that can be applied with ESLint, such as this import rule. Also, I decided to generalize the cx rule up to a set of dataviz import exclusions, so we can continue extend it if there are other things we would generally forbid.