### PR TITLE
Histogram: filter NaN and Infinity from bucket size calculation

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/histogram.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.ts
@@ -390,7 +390,7 @@ export function buildHistogram(
           if (!Number.isNaN(noValue)) {
             field = nullToValueField(field, noValue);
           } else {
-            field = { ...field, values: field.values.filter((v) => v != null) };
+            field = { ...field, values: field.values.filter((v) => Number.isFinite(v)) };
           }
         }
 

--- a/packages/grafana-data/src/transformations/transformers/histogram.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.ts
@@ -389,7 +389,7 @@ export function buildHistogram(
           if (!Number.isNaN(noValue)) {
             field = nullToValueField(field, noValue);
           } else {
-            field = { ...field, values: field.values.filter((v) => v != null) };
+            field = { ...field, values: field.values.filter((v) => Number.isFinite(v)) };
           }
         }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog, describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Filter NaN and Infinity values from numeric fields in buildHistogram() before auto bucket size detection. Replaces v != null with Number.isFinite(v) in the value preprocessing step.

**Why do we need this feature?**

When a Prometheus/Thanos query produces NaN values (e.g. from division by zero in rate(sum)/rate(count) when a service has zero requests in a given interval), the histogram panel silently renders an empty panel with no error message.

The root cause is that NaN != null evaluates to true in JavaScript, so NaN values pass through the null filter at histogram.ts:393. A single NaN then propagates through Array.sort() (undefined sort order), Math.min() (returns NaN), and the bucket size selection loop (NaN < x is always false), causing the auto bucket size detection to fail entirely.

**Who is this feature for?**

Users visualizing Prometheus/Thanos query results with the histogram panel, particularly when queries involve rate divisions over low-traffic services where rate(count) can be zero at some evaluation steps.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
