### PR TITLE
Remove namespace from OFREP URL

### DIFF
--- a/pkg/registry/apis/ofrep/register.go
+++ b/pkg/registry/apis/ofrep/register.go
@@ -139,7 +139,7 @@ func (b *APIBuilder) GetAPIRoutes(gv schema.GroupVersion) *builder.APIRoutes {
 			}}}
 
 	return &builder.APIRoutes{
-		Namespace: []builder.APIRouteHandler{
+		Root: []builder.APIRouteHandler{
 			{
 				Path: "ofrep/v1/evaluate/flags",
 				Spec: &spec3.PathProps{
@@ -367,8 +367,6 @@ func (b *APIBuilder) validateNamespace(r *http.Request) (bool, string) {
 
 	if user.GetNamespace() != "" {
 		namespace = user.GetNamespace()
-	} else {
-		namespace = mux.Vars(r)["namespace"]
 	}
 
 	// Read request body for namespace validation and tracing

--- a/pkg/tests/apis/features/features_test.go
+++ b/pkg/tests/apis/features/features_test.go
@@ -35,7 +35,7 @@ func TestIntegrationFeatures(t *testing.T) {
 	t.Run("Test evaluate flags", func(t *testing.T) {
 		rsp := apis.DoRequest(helper, apis.RequestParams{
 			Method: http.MethodPost,
-			Path:   "/apis/features.grafana.app/v0alpha1/namespaces/default/ofrep/v1/evaluate/flags/" + flag,
+			Path:   "/apis/features.grafana.app/v0alpha1/ofrep/v1/evaluate/flags/" + flag,
 			User:   helper.Org1.Admin,
 		}, &map[string]any{})
 


### PR DESCRIPTION
Removing namespace from features service URL.

 Benefits:
  - **Simpler client configuration**: frontend and other clients can configure a static URL without knowing the namespace. The namespace is derived from the authenticated user's context.
  - **Aligns with OpenFeature patterns**: OpenFeature providers are singletons that should be configured once with a fixed endpoint URL, not dynamically per-namespace.

It looks like `user.GetNamespace()` is always populated: both authenticated users and anonymous users have namespace assigned from, making the URL fallback unnecessary.
Should be safe to remove as the comparison of URL namespace vs eval context namespace is a consistency check, not a security one. Actual security comes from authentication check (`isAuthenticatedRequest`) and public flags whitelist (`isPublicFlag`)

#### To do:
- [ ] Update all references to OFREP URL