### PR TITLE
provsioning: add quota checker to parser

### DIFF
--- a/apps/provisioning/pkg/quotas/checker.go
+++ b/apps/provisioning/pkg/quotas/checker.go
@@ -1,0 +1,157 @@
+package quotas
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+var ErrQuotaExceeded = errors.New("quota exceeded")
+
+// ResourceCounter provides resource counting for quota enforcement.
+// It is independent from any implemented resource lister to avoid dependency cycles.
+type ResourceCounter interface {
+	Count(ctx context.Context, namespace, repository string) (int64, error)
+}
+
+// QuotaChecker validates whether a resource operation is within quota.
+//
+//go:generate mockery --name QuotaChecker --structname MockQuotaChecker --inpackage --filename quota_checker_mock.go --with-expecter
+type QuotaChecker interface {
+	// GrantResourceCreation checks if a new resource can be created and executes the create function.
+	GrantResourceCreation(ctx context.Context, createFn func() error) error
+
+	// OnResourceDeleted updates the tracked quota when a resource is deleted.
+	OnResourceDeleted(ctx context.Context) error
+}
+
+// QuotaCheckerFactory creates QuotaCheckers scoped to a specific repository.
+//
+//go:generate mockery --name QuotaCheckerFactory --structname MockQuotaCheckerFactory --inpackage --filename quota_checker_factory_mock.go --with-expecter
+type QuotaCheckerFactory interface {
+	GetQuotaChecker(ctx context.Context, quotaStatus provisioning.QuotaStatus, namespace, repository string) (QuotaChecker, error)
+}
+
+type quotaCheckerFactory struct {
+	resourceCounter ResourceCounter
+}
+
+// NewQuotaCheckerFactory creates a new QuotaCheckerFactory using a resource counter.
+func NewQuotaCheckerFactory(counter ResourceCounter) QuotaCheckerFactory {
+	return &quotaCheckerFactory{
+		resourceCounter: counter,
+	}
+}
+
+// GetQuotaChecker creates a QuotaChecker for the given namespace and repository.
+// It uses the provided quota status and fetches current resource stats, returning a checker
+// that can evaluate whether the quota is exceeded.
+func (f *quotaCheckerFactory) GetQuotaChecker(ctx context.Context, quotaStatus provisioning.QuotaStatus, namespace, repository string) (QuotaChecker, error) {
+	// Fetch current resource count for this repo
+	count, err := f.resourceCounter.Count(ctx, namespace, repository)
+	if err != nil {
+		return nil, fmt.Errorf("get resource stats for quota check: %w", err)
+	}
+
+	return &resourcesQuotaChecker{
+		quotaStatus: quotaStatus,
+		quotaUsage:  Usage{TotalResources: count},
+		granted:     0,
+	}, nil
+}
+
+// resourcesQuotaChecker holds a snapshot of quota limits and current resource counts,
+// and evaluates whether the quota is exceeded. It tracks in-flight grants to prevent
+// race conditions when multiple resources are created concurrently.
+type resourcesQuotaChecker struct {
+	mu          sync.Mutex
+	quotaStatus provisioning.QuotaStatus
+	quotaUsage  Usage
+	granted     int64 // tracks in-flight grants (resources being created but not yet committed)
+}
+
+func (f *resourcesQuotaChecker) GrantResourceCreation(ctx context.Context, createFn func() error) error {
+	f.mu.Lock()
+	if !f.shouldGrant() {
+		f.mu.Unlock()
+		return ErrQuotaExceeded
+	}
+
+	f.granted++
+	resourceGranted := true
+
+	// Defer immediately (still holds separate resourceGranted per-call)
+	defer func() {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if resourceGranted {
+			f.granted--
+		}
+	}()
+
+	f.mu.Unlock()
+
+	if err := createFn(); err != nil {
+		return err
+	}
+
+	f.mu.Lock()
+	f.granted--
+	f.quotaUsage.TotalResources++
+	resourceGranted = false
+	f.mu.Unlock()
+
+	return nil
+}
+
+// shouldGrant calculates if a new resource can be created.
+func (f *resourcesQuotaChecker) shouldGrant() bool {
+	// If quota is unlimited (0), always allow
+	if f.quotaStatus.MaxResourcesPerRepository == 0 {
+		return true
+	}
+	return max(f.quotaStatus.MaxResourcesPerRepository-f.quotaUsage.TotalResources-f.granted, 0) > 0
+}
+
+// OnResourceDeleted frees up a resource when it's deleted.
+// It decrements the used resource count.
+func (f *resourcesQuotaChecker) OnResourceDeleted(ctx context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.quotaUsage.TotalResources > 0 {
+		f.quotaUsage.TotalResources--
+	}
+
+	return nil
+}
+
+// unlimitedQuotaChecker is a no-op quota checker that always allows operations.
+// It's used when quota checking is not needed or disabled.
+type unlimitedQuotaChecker struct{}
+
+// GrantResourceCreation always allows resource creation without checking quota.
+func (u *unlimitedQuotaChecker) GrantResourceCreation(ctx context.Context, createFn func() error) error {
+	return createFn()
+}
+
+// OnResourceDeleted is a no-op for unlimited quota checker.
+func (u *unlimitedQuotaChecker) OnResourceDeleted(ctx context.Context) error {
+	return nil
+}
+
+// unlimitedQuotaCheckerFactory creates unlimited quota checkers.
+type unlimitedQuotaCheckerFactory struct{}
+
+// NewUnlimitedQuotaCheckerFactory creates a factory that returns unlimited quota checkers.
+func NewUnlimitedQuotaCheckerFactory() QuotaCheckerFactory {
+	return &unlimitedQuotaCheckerFactory{}
+}
+
+// GetQuotaChecker returns an unlimited quota checker that always allows operations.
+func (f *unlimitedQuotaCheckerFactory) GetQuotaChecker(ctx context.Context, _ provisioning.QuotaStatus, _, _ string) (QuotaChecker, error) {
+	return &unlimitedQuotaChecker{}, nil
+}

--- a/apps/provisioning/pkg/quotas/checker_test.go
+++ b/apps/provisioning/pkg/quotas/checker_test.go
@@ -1,0 +1,316 @@
+package quotas
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+// fakeResourceCounter is a test double for the ResourceCounter interface.
+type fakeResourceCounter struct {
+	count int64
+	err   error
+}
+
+func (f *fakeResourceCounter) Count(_ context.Context, _, _ string) (int64, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	return f.count, nil
+}
+
+func TestQuotaCheckerFactory_GetQuotaChecker(t *testing.T) {
+	tests := []struct {
+		name         string
+		maxResources int64
+		count        int64
+		countErr     error
+		expectErr    bool
+		expectErrMsg string
+	}{
+		{
+			name:         "within quota returns checker",
+			maxResources: 100,
+			count:        50,
+		},
+		{
+			name:         "unlimited quota returns checker",
+			maxResources: 0,
+			count:        9999,
+		},
+		{
+			name:         "stats error propagates",
+			maxResources: 100,
+			countErr:     fmt.Errorf("storage unavailable"),
+			expectErr:    true,
+			expectErrMsg: "get resource stats for quota check",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			counter := &fakeResourceCounter{count: tt.count, err: tt.countErr}
+			factory := NewQuotaCheckerFactory(counter)
+			quotaStatus := provisioning.QuotaStatus{MaxResourcesPerRepository: tt.maxResources}
+
+			checker, err := factory.GetQuotaChecker(ctx, quotaStatus, "test-ns", "my-repo")
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErrMsg)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, checker)
+		})
+	}
+}
+
+func TestGrantResourceCreation(t *testing.T) {
+	tests := []struct {
+		name          string
+		maxResources  int64
+		currentCount  int64
+		expectErr     error
+		expectCreated bool
+	}{
+		{
+			name:          "within quota allows creation",
+			maxResources:  100,
+			currentCount:  50,
+			expectCreated: true,
+		},
+		{
+			name:         "at quota limit denies creation",
+			maxResources: 100,
+			currentCount: 100,
+			expectErr:    ErrQuotaExceeded,
+		},
+		{
+			name:         "over quota denies creation",
+			maxResources: 100,
+			currentCount: 150,
+			expectErr:    ErrQuotaExceeded,
+		},
+		{
+			name:          "unlimited quota (0) allows creation",
+			maxResources:  0,
+			currentCount:  9999,
+			expectCreated: true,
+		},
+		{
+			name:          "empty stats allows creation",
+			maxResources:  100,
+			currentCount:  0,
+			expectCreated: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			counter := &fakeResourceCounter{count: tt.currentCount}
+			factory := NewQuotaCheckerFactory(counter)
+			quotaStatus := provisioning.QuotaStatus{MaxResourcesPerRepository: tt.maxResources}
+
+			checker, err := factory.GetQuotaChecker(ctx, quotaStatus, "test-ns", "my-repo")
+			require.NoError(t, err)
+
+			created := false
+			err = checker.GrantResourceCreation(ctx, func() error {
+				created = true
+				return nil
+			})
+
+			if tt.expectErr != nil {
+				require.ErrorIs(t, err, tt.expectErr)
+				assert.False(t, created, "createFn should not be called when quota is exceeded")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectCreated, created)
+			}
+		})
+	}
+}
+
+func TestGrantResourceCreation_FailedCreation(t *testing.T) {
+	ctx := context.Background()
+	counter := &fakeResourceCounter{count: 98}
+	factory := NewQuotaCheckerFactory(counter)
+	quotaStatus := provisioning.QuotaStatus{MaxResourcesPerRepository: 100}
+
+	checker, err := factory.GetQuotaChecker(ctx, quotaStatus, "test-ns", "my-repo")
+	require.NoError(t, err)
+
+	createErr := errors.New("create failed")
+
+	// First call: createFn fails — grant should be released, usage NOT incremented
+	err = checker.GrantResourceCreation(ctx, func() error {
+		return createErr
+	})
+	require.ErrorIs(t, err, createErr)
+
+	// Second call: should still succeed since the failed grant was released
+	created := false
+	err = checker.GrantResourceCreation(ctx, func() error {
+		created = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, created, "grant should be available after a failed creation")
+
+	// Third call: also succeeds (usage was 98 → 99 after second call)
+	created = false
+	err = checker.GrantResourceCreation(ctx, func() error {
+		created = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, created)
+
+	// Fourth call: should fail (usage is now 100, at the limit)
+	err = checker.GrantResourceCreation(ctx, func() error {
+		return nil
+	})
+	require.ErrorIs(t, err, ErrQuotaExceeded)
+}
+
+func TestGrantResourceCreation_FailedCreationAtLimit(t *testing.T) {
+	ctx := context.Background()
+	counter := &fakeResourceCounter{count: 99}
+	factory := NewQuotaCheckerFactory(counter)
+	quotaStatus := provisioning.QuotaStatus{MaxResourcesPerRepository: 100}
+
+	checker, err := factory.GetQuotaChecker(ctx, quotaStatus, "test-ns", "my-repo")
+	require.NoError(t, err)
+
+	createErr := errors.New("create failed")
+
+	// At 99/100 — grant is available, but createFn fails
+	err = checker.GrantResourceCreation(ctx, func() error {
+		return createErr
+	})
+	require.ErrorIs(t, err, createErr)
+
+	// The grant should have been released, so the slot is still free
+	created := false
+	err = checker.GrantResourceCreation(ctx, func() error {
+		created = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, created, "slot should still be available after failed creation")
+}
+
+func TestGrantResourceCreation_SequentialGrants(t *testing.T) {
+	ctx := context.Background()
+	counter := &fakeResourceCounter{count: 99}
+	factory := NewQuotaCheckerFactory(counter)
+	quotaStatus := provisioning.QuotaStatus{MaxResourcesPerRepository: 100}
+
+	checker, err := factory.GetQuotaChecker(ctx, quotaStatus, "test-ns", "my-repo")
+	require.NoError(t, err)
+
+	// First grant should succeed (99/100 → 100/100)
+	err = checker.GrantResourceCreation(ctx, func() error {
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Second grant should fail (100/100, at the limit)
+	err = checker.GrantResourceCreation(ctx, func() error {
+		return nil
+	})
+	require.ErrorIs(t, err, ErrQuotaExceeded)
+}
+
+func TestOnResourceDeleted(t *testing.T) {
+	ctx := context.Background()
+	counter := &fakeResourceCounter{count: 100}
+	factory := NewQuotaCheckerFactory(counter)
+	quotaStatus := provisioning.QuotaStatus{MaxResourcesPerRepository: 100}
+
+	checker, err := factory.GetQuotaChecker(ctx, quotaStatus, "test-ns", "my-repo")
+	require.NoError(t, err)
+
+	// At limit — creation should be denied
+	err = checker.GrantResourceCreation(ctx, func() error {
+		return nil
+	})
+	require.ErrorIs(t, err, ErrQuotaExceeded)
+
+	// Delete one resource
+	err = checker.OnResourceDeleted(ctx)
+	require.NoError(t, err)
+
+	// Now creation should succeed (99/100)
+	created := false
+	err = checker.GrantResourceCreation(ctx, func() error {
+		created = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, created)
+}
+
+func TestOnResourceDeleted_NeverNegative(t *testing.T) {
+	ctx := context.Background()
+	counter := &fakeResourceCounter{count: 0}
+	factory := NewQuotaCheckerFactory(counter)
+	quotaStatus := provisioning.QuotaStatus{MaxResourcesPerRepository: 100}
+
+	checker, err := factory.GetQuotaChecker(ctx, quotaStatus, "test-ns", "my-repo")
+	require.NoError(t, err)
+
+	// Delete when already at 0 should not go negative
+	err = checker.OnResourceDeleted(ctx)
+	require.NoError(t, err)
+
+	// Should still be able to create
+	err = checker.GrantResourceCreation(ctx, func() error {
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestUnlimitedQuotaChecker(t *testing.T) {
+	ctx := context.Background()
+	factory := NewUnlimitedQuotaCheckerFactory()
+
+	checker, err := factory.GetQuotaChecker(ctx, provisioning.QuotaStatus{}, "test-ns", "my-repo")
+	require.NoError(t, err)
+	require.NotNil(t, checker)
+
+	// Always allows creation
+	created := false
+	err = checker.GrantResourceCreation(ctx, func() error {
+		created = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, created)
+
+	// Propagates createFn errors
+	createErr := errors.New("create failed")
+	err = checker.GrantResourceCreation(ctx, func() error {
+		return createErr
+	})
+	require.ErrorIs(t, err, createErr)
+
+	// OnResourceDeleted is a no-op
+	err = checker.OnResourceDeleted(ctx)
+	require.NoError(t, err)
+}
+
+func TestQuotaCheckerFactory_ImplementsInterface(t *testing.T) {
+	counter := &fakeResourceCounter{count: 0}
+
+	var factory QuotaCheckerFactory = NewQuotaCheckerFactory(counter)
+	require.NotNil(t, factory)
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add a quota checker to low-level resource creation through parser.

**Why do we need this feature?**

In order to honor quota limits from different parts of provisioning (API calls, job executions...)


**Who is this feature for?**

Customers of provisioning feature.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/git-ui-sync-project/issues/560

**Special notes for your reviewer:**

Please check that:
- [ X ] It works as expected from a user's perspective.
- [ X ] If this is a pre-GA feature, it is behind a feature toggle.
- [ X ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
