### PR TITLE
feat (query editor v2): Wire up the query editors

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
@@ -1,6 +1,20 @@
-import { CoreApp, DataSourceApi, DataSourceInstanceSettings, getDataSourceRef, getNextRefId } from '@grafana/data';
+import {
+  CoreApp,
+  DataSourceApi,
+  DataSourceInstanceSettings,
+  DataTransformerConfig,
+  getDataSourceRef,
+  getNextRefId,
+} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
-import { SceneObjectBase, SceneObjectRef, SceneObjectState, SceneQueryRunner, VizPanel } from '@grafana/scenes';
+import {
+  SceneDataTransformer,
+  SceneObjectBase,
+  SceneObjectRef,
+  SceneObjectState,
+  SceneQueryRunner,
+  VizPanel,
+} from '@grafana/scenes';
 import { DataQuery, DataSourceRef } from '@grafana/schema';
 import { addQuery } from 'app/core/utils/query';
 import { QueryGroupOptions } from 'app/types/query';
@@ -256,6 +270,33 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
 
     panel.setState(panelStateUpdate);
     queryRunner.setState(dataObjStateUpdate);
+    queryRunner.runQueries();
+  };
+
+  public updateTransformation = (oldConfig: DataTransformerConfig, newConfig: DataTransformerConfig) => {
+    const panel = this.state.panelRef.resolve();
+    const queryRunner = getQueryRunnerFor(panel);
+    const dataTransformer = panel.state.$data;
+
+    if (!(dataTransformer instanceof SceneDataTransformer)) {
+      return;
+    }
+
+    const transformations = [...dataTransformer.state.transformations];
+    // Find by object reference - same reference from useTransformations hook
+    const index = transformations.findIndex((t) => t === oldConfig);
+
+    if (index === -1) {
+      return;
+    }
+
+    transformations[index] = newConfig;
+    dataTransformer.setState({ transformations });
+
+    if (!queryRunner) {
+      return;
+    }
+
     queryRunner.runQueries();
   };
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorBody.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorBody.tsx
@@ -1,51 +1,38 @@
 import { css } from '@emotion/css';
-import { ReactNode } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
+import { CardEditorRenderer } from '../CardEditorRenderer';
 import { useQueryEditorUIContext } from '../QueryEditorContext';
 
 import { QueryEditorDetailsSidebar } from './QueryEditorDetailsSidebar';
 
-interface QueryEditorBodyProps {
-  children?: ReactNode;
-}
-
-export function QueryEditorBody({ children }: QueryEditorBodyProps) {
+export function QueryEditorBody() {
   const styles = useStyles2(getStyles);
   const { queryOptions } = useQueryEditorUIContext();
-  const { isQueryOptionsOpen } = queryOptions;
 
   return (
     <div className={styles.container}>
-      <div className={styles.content}>{children}</div>
-      {isQueryOptionsOpen && (
-        <div className={styles.sidebarWrapper}>
-          <QueryEditorDetailsSidebar />
-        </div>
-      )}
+      <div className={styles.scrollableContent}>
+        <CardEditorRenderer />
+      </div>
+      {queryOptions.isQueryOptionsOpen && <QueryEditorDetailsSidebar />}
     </div>
   );
 }
 
-function getStyles(theme: GrafanaTheme2) {
-  return {
-    container: css({
-      display: 'flex',
-      flex: 1,
-      minHeight: 0,
-      overflow: 'hidden',
-    }),
-    sidebarWrapper: css({
-      flexShrink: 0,
-      borderLeft: `1px solid ${theme.colors.border.weak}`,
-    }),
-    content: css({
-      flex: 1,
-      minWidth: 0,
-      overflow: 'auto',
-      padding: theme.spacing(2),
-    }),
-  };
-}
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    position: 'relative',
+    flex: 1,
+    minHeight: 0,
+    display: 'flex',
+  }),
+  scrollableContent: css({
+    flex: 1,
+    minWidth: 0,
+    overflow: 'auto',
+    padding: theme.spacing(2),
+  }),
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorDetailsSidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorDetailsSidebar.tsx
@@ -273,12 +273,16 @@ export function QueryEditorDetailsSidebar() {
 function getStyles(theme: GrafanaTheme2) {
   return {
     container: css({
-      height: '100%',
-      minHeight: '100vh',
+      position: 'absolute',
+      top: 0,
+      right: 0,
+      bottom: 0,
       display: 'flex',
       flexDirection: 'column',
       width: CONTENT_SIDE_BAR.width,
       backgroundColor: theme.colors.background.primary,
+      borderLeft: `1px solid ${theme.colors.border.weak}`,
+      zIndex: 20,
     }),
     header: css({
       width: '100%',

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/CardEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/CardEditorRenderer.tsx
@@ -1,0 +1,15 @@
+import { QueryEditorType } from '../constants';
+
+import { useQueryEditorUIContext } from './QueryEditorContext';
+import { QueryEditorRenderer } from './QueryEditorRenderer';
+import { TransformationEditorRenderer } from './TransformationEditorRenderer';
+
+export function CardEditorRenderer() {
+  const { cardType } = useQueryEditorUIContext();
+
+  if (cardType === QueryEditorType.Transformation) {
+    return <TransformationEditorRenderer />;
+  }
+
+  return <QueryEditorRenderer />;
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Footer/QueryEditorFooter.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Footer/QueryEditorFooter.tsx
@@ -126,7 +126,7 @@ function getStyles(theme: GrafanaTheme2) {
       borderBottomLeftRadius: theme.shape.radius.default,
       borderBottomRightRadius: theme.shape.radius.default,
       padding: theme.spacing(0.5, 0.5, 0.5, 1.5),
-      zIndex: 1,
+      zIndex: theme.zIndex.modal,
       minHeight: 26,
     }),
     itemsList: css({

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContent.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContent.tsx
@@ -2,17 +2,15 @@ import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
-import { QueryErrorAlert } from 'app/features/query/components/QueryErrorAlert';
 
 import { QueryEditorBody } from './Body/QueryEditorBody';
 import { QueryEditorFooter } from './Footer/QueryEditorFooter';
 import { ContentHeaderSceneWrapper } from './Header/ContentHeader';
 import { DatasourceHelpPanel } from './Header/DatasourceHelpPanel';
-import { useQueryEditorUIContext, useQueryRunnerContext } from './QueryEditorContext';
+import { useQueryEditorUIContext } from './QueryEditorContext';
 
 export function QueryEditorContent() {
   const styles = useStyles2(getStyles);
-  const { queryError } = useQueryRunnerContext();
   const { queryOptions, showingDatasourceHelp } = useQueryEditorUIContext();
   const { isQueryOptionsOpen } = queryOptions;
 
@@ -20,7 +18,7 @@ export function QueryEditorContent() {
     <div className={styles.container}>
       <ContentHeaderSceneWrapper />
       {showingDatasourceHelp && <DatasourceHelpPanel />}
-      <QueryEditorBody>{queryError && <QueryErrorAlert error={queryError} />}</QueryEditorBody>
+      <QueryEditorBody />
       {!isQueryOptionsOpen && <QueryEditorFooter />}
     </div>
   );
@@ -35,11 +33,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     borderRadius: theme.shape.radius.default,
     height: '100%',
     width: '100%',
-  }),
-  contentBody: css({
-    padding: theme.spacing(2),
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.spacing(2),
+    overflow: 'hidden',
   }),
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
@@ -1,6 +1,12 @@
 import { createContext, ReactNode, useContext } from 'react';
 
-import { DataQueryError, DataSourceApi, DataSourceInstanceSettings, PanelData } from '@grafana/data';
+import {
+  DataQueryError,
+  DataSourceApi,
+  DataSourceInstanceSettings,
+  DataTransformerConfig,
+  PanelData,
+} from '@grafana/data';
 import { VizPanel } from '@grafana/scenes';
 import { DataQuery } from '@grafana/schema';
 import { ExpressionQuery } from 'app/features/expressions/types';
@@ -62,6 +68,7 @@ export interface QueryEditorActions {
   runQueries: () => void;
   changeDataSource: (settings: DataSourceInstanceSettings, queryRefId: string) => void;
   onQueryOptionsChange: (options: QueryGroupOptions) => void;
+  updateTransformation: (oldConfig: DataTransformerConfig, newConfig: DataTransformerConfig) => void;
 }
 
 const DatasourceContext = createContext<DatasourceState | null>(null);

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
@@ -1,0 +1,92 @@
+import { useCallback, useMemo } from 'react';
+
+import { CoreApp, DataSourcePluginContextProvider } from '@grafana/data';
+import { t, Trans } from '@grafana/i18n';
+import { DataQuery } from '@grafana/schema';
+import { Alert, Spinner, Stack, Text } from '@grafana/ui';
+import { filterPanelDataToQuery } from 'app/features/query/components/QueryEditorRow';
+import { QueryErrorAlert } from 'app/features/query/components/QueryErrorAlert';
+
+import { useActionsContext, useQueryEditorUIContext, useQueryRunnerContext } from './QueryEditorContext';
+
+export function QueryEditorRenderer() {
+  const { queries, data, queryError } = useQueryRunnerContext();
+  const { selectedQuery, selectedQueryDsData, selectedQueryDsLoading } = useQueryEditorUIContext();
+  const { updateSelectedQuery, addQuery, runQueries } = useActionsContext();
+
+  const selectedRefId = selectedQuery?.refId;
+
+  // Filter panel data to only include data for this specific query
+  const filteredData = useMemo(() => {
+    return selectedRefId && data ? filterPanelDataToQuery(data, selectedRefId) : undefined;
+  }, [data, selectedRefId]);
+
+  const handleChange = useCallback(
+    (updatedQuery: DataQuery) => {
+      if (!selectedRefId) {
+        return;
+      }
+      updateSelectedQuery(updatedQuery, selectedRefId);
+    },
+    [updateSelectedQuery, selectedRefId]
+  );
+
+  if (!selectedQuery) {
+    return null;
+  }
+
+  if (selectedQueryDsLoading) {
+    return (
+      <Stack gap={1}>
+        <Spinner />
+        <Text>
+          <Trans i18nKey="query-editor-renderer.loading-datasource">Loading datasource</Trans>
+        </Text>
+      </Stack>
+    );
+  }
+
+  if (!selectedQueryDsData?.datasource || !selectedQueryDsData?.dsSettings) {
+    return (
+      <Alert
+        severity="error"
+        title={t('query-editor-renderer.datasource-load-error-title', 'Failed to load datasource for this query')}
+      />
+    );
+  }
+
+  const QueryEditorComponent = selectedQueryDsData.datasource.components?.QueryEditor;
+
+  if (!QueryEditorComponent) {
+    return (
+      <Alert
+        severity="warning"
+        title={t(
+          'query-editor-renderer.no-query-editor-component',
+          'Data source plugin does not export any query editor component'
+        )}
+      />
+    );
+  }
+
+  const { datasource, dsSettings } = selectedQueryDsData;
+
+  return (
+    <>
+      <DataSourcePluginContextProvider instanceSettings={dsSettings}>
+        <QueryEditorComponent
+          app={CoreApp.Dashboard}
+          data={filteredData}
+          datasource={datasource}
+          onAddQuery={addQuery}
+          onChange={handleChange}
+          onRunQuery={runQueries}
+          queries={queries}
+          query={selectedQuery}
+          range={filteredData?.timeRange}
+        />
+      </DataSourcePluginContextProvider>
+      {queryError && <QueryErrorAlert error={queryError} />}
+    </>
+  );
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditor.tsx
@@ -1,4 +1,4 @@
-import { createElement, useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 
 import { DataTransformerConfig, DataFrame } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -22,17 +22,15 @@ export function TransformationEditor({ transformation, inputData, onUpdate }: Tr
     [transformConfig, onUpdate]
   );
 
-  const editor = useMemo(
-    () =>
-      createElement(registryItem!.editor!, {
-        options: { ...registryItem!.transformation.defaultOptions, ...transformConfig.options },
-        input: inputData,
-        onChange: handleChange,
-      }),
-    [registryItem, transformConfig.options, inputData, handleChange]
-  );
+  const Editor = registryItem!.editor!;
 
   return (
-    <div data-testid={selectors.components.TransformTab.transformationEditor(registryItem?.name || '')}>{editor}</div>
+    <div data-testid={selectors.components.TransformTab.transformationEditor(registryItem?.name || '')}>
+      <Editor
+        input={inputData}
+        onChange={handleChange}
+        options={{ ...registryItem!.transformation.defaultOptions, ...transformConfig.options }}
+      />
+    </div>
   );
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditor.tsx
@@ -1,0 +1,38 @@
+import { createElement, useCallback, useMemo } from 'react';
+
+import { DataTransformerConfig, DataFrame } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+
+import { Transformation } from './types';
+
+interface TransformationEditorProps {
+  transformation: Transformation;
+  inputData: DataFrame[];
+  onUpdate: (oldConfig: DataTransformerConfig, newConfig: DataTransformerConfig) => void;
+}
+
+export function TransformationEditor({ transformation, inputData, onUpdate }: TransformationEditorProps) {
+  const { registryItem, transformConfig } = transformation;
+
+  const handleChange = useCallback(
+    (opts: Record<string, unknown>) => {
+      const updatedConfig = { ...transformConfig, options: opts };
+      onUpdate(transformConfig, updatedConfig);
+    },
+    [transformConfig, onUpdate]
+  );
+
+  const editor = useMemo(
+    () =>
+      createElement(registryItem!.editor!, {
+        options: { ...registryItem!.transformation.defaultOptions, ...transformConfig.options },
+        input: inputData,
+        onChange: handleChange,
+      }),
+    [registryItem, transformConfig.options, inputData, handleChange]
+  );
+
+  return (
+    <div data-testid={selectors.components.TransformTab.transformationEditor(registryItem?.name || '')}>{editor}</div>
+  );
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditorRenderer.tsx
@@ -11,7 +11,9 @@ export function TransformationEditorRenderer() {
   const { selectedTransformation } = useQueryEditorUIContext();
   const { updateTransformation } = useActionsContext();
 
-  const inputData = useMemo(() => data?.series || [], [data?.series]);
+  // Memoize to avoid recreating potentially large data.series array reference on every render.
+  // This prevents unnecessary re-renders and processing in TransformationEditor.
+  const inputData = useMemo(() => data?.series ?? [], [data?.series]);
 
   if (!selectedTransformation) {
     return null;

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditorRenderer.tsx
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+
+import { t } from '@grafana/i18n';
+import { Alert } from '@grafana/ui';
+
+import { useActionsContext, useQueryEditorUIContext, useQueryRunnerContext } from './QueryEditorContext';
+import { TransformationEditor } from './TransformationEditor';
+
+export function TransformationEditorRenderer() {
+  const { data } = useQueryRunnerContext();
+  const { selectedTransformation } = useQueryEditorUIContext();
+  const { updateTransformation } = useActionsContext();
+
+  const inputData = useMemo(() => data?.series || [], [data?.series]);
+
+  if (!selectedTransformation) {
+    return null;
+  }
+
+  if (!selectedTransformation.registryItem?.editor) {
+    return (
+      <Alert
+        severity="error"
+        title={t(
+          'transformation-editor-renderer.no-transformation-editor-title',
+          'Transformation does not have an editor component'
+        )}
+      />
+    );
+  }
+
+  return (
+    <TransformationEditor
+      inputData={inputData}
+      onUpdate={updateTransformation}
+      transformation={selectedTransformation}
+    />
+  );
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedCard.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedCard.ts
@@ -1,0 +1,48 @@
+import { useMemo } from 'react';
+
+import { DataQuery } from '@grafana/schema';
+
+import { Transformation } from '../types';
+
+/**
+ * Hook to resolve the currently selected query or transformation.
+ * They are mutually exclusive - if a transformation is selected, no query is selected.
+ */
+export function useSelectedCard(
+  selectedQueryRefId: string | null,
+  selectedTransformationId: string | null,
+  queries: DataQuery[],
+  transformations: Transformation[]
+) {
+  const selectedQuery = useMemo(() => {
+    // If we have a selected query refId, try to find that query
+    if (selectedQueryRefId) {
+      const query = queries.find((q) => q.refId === selectedQueryRefId);
+      if (query) {
+        return query;
+      }
+    }
+
+    // If a transformation is selected, don't select any query
+    if (selectedTransformationId) {
+      return null;
+    }
+
+    // Otherwise, default to the first query if available
+    return queries.length > 0 ? queries[0] : null;
+  }, [queries, selectedQueryRefId, selectedTransformationId]);
+
+  const selectedTransformation = useMemo(() => {
+    // If we have a selected transformation id, try to find that transformation
+    if (selectedTransformationId) {
+      const transformation = transformations.find((t) => t.transformId === selectedTransformationId);
+      if (transformation) {
+        return transformation;
+      }
+    }
+
+    return null;
+  }, [transformations, selectedTransformationId]);
+
+  return { selectedQuery, selectedTransformation };
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.ts
@@ -1,0 +1,46 @@
+import { useAsync } from 'react-use';
+
+import { DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
+import { getDataSourceSrv } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
+
+/**
+ * Hook to load the datasource for the currently selected query.
+ * Falls back to the panel's datasource if the query doesn't specify one.
+ */
+export function useSelectedQueryDatasource(
+  selectedQuery: DataQuery | null,
+  panelDsSettings: DataSourceInstanceSettings | undefined
+) {
+  const { value: selectedQueryDsData, loading: selectedQueryDsLoading } = useAsync(async () => {
+    if (!selectedQuery) {
+      return undefined;
+    }
+
+    try {
+      // If query has datasource, use it; otherwise fall back to panel datasource
+      const dsRef = selectedQuery.datasource || (panelDsSettings ? getDataSourceRef(panelDsSettings) : undefined);
+
+      if (!dsRef) {
+        return undefined;
+      }
+
+      const queryDsSettings = getDataSourceSrv().getInstanceSettings(dsRef);
+      if (!queryDsSettings) {
+        console.error('Datasource settings not found for', dsRef);
+        return undefined;
+      }
+
+      const queryDatasource = await getDataSourceSrv().get(dsRef);
+      return { datasource: queryDatasource, dsSettings: queryDsSettings };
+    } catch (err) {
+      console.error('Failed to load datasource for selected query:', err);
+      return undefined;
+    }
+  }, [selectedQuery?.datasource?.uid, selectedQuery?.datasource?.type, panelDsSettings?.uid]);
+
+  return {
+    selectedQueryDsData: selectedQueryDsData ?? null,
+    selectedQueryDsLoading,
+  };
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformations.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformations.ts
@@ -2,10 +2,9 @@ import { useMemo } from 'react';
 
 import { standardTransformersRegistry } from '@grafana/data';
 import { SceneDataTransformer } from '@grafana/scenes';
-import { DataTransformerConfig } from '@grafana/schema';
 
 import { Transformation } from '../types';
-import { isDataTransformerConfig } from '../utils';
+import { filterDataTransformerConfigs } from '../utils';
 
 /**
  * Hook to subscribe to transformations from a SceneDataTransformer.
@@ -15,14 +14,12 @@ export function useTransformations(dataTransformer: SceneDataTransformer | null)
   const transformerState = dataTransformer?.useState();
 
   return useMemo(() => {
-    if (!dataTransformer) {
+    if (!dataTransformer || !transformerState) {
       return [];
     }
 
     // Filter to only include DataTransformerConfig items (exclude CustomTransformerDefinition)
-    const transformationList = (transformerState?.transformations || []).filter((t): t is DataTransformerConfig =>
-      isDataTransformerConfig(t)
-    );
+    const transformationList = filterDataTransformerConfigs(transformerState.transformations || []);
 
     // Use the transformation's id + index as a stable key for React
     // transformConfig holds the actual object reference from Scene state
@@ -31,5 +28,5 @@ export function useTransformations(dataTransformer: SceneDataTransformer | null)
       registryItem: standardTransformersRegistry.getIfExists(t.id),
       transformId: `${t.id}-${index}`,
     }));
-  }, [dataTransformer, transformerState?.transformations]);
+  }, [dataTransformer, transformerState]);
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformations.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformations.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+
+import { standardTransformersRegistry } from '@grafana/data';
+import { SceneDataTransformer } from '@grafana/scenes';
+import { DataTransformerConfig } from '@grafana/schema';
+
+import { Transformation } from '../types';
+import { isDataTransformerConfig } from '../utils';
+
+/**
+ * Hook to subscribe to transformations from a SceneDataTransformer.
+ * Returns a reactive array of Transformation objects.
+ */
+export function useTransformations(dataTransformer: SceneDataTransformer | null): Transformation[] {
+  const transformerState = dataTransformer?.useState();
+
+  return useMemo(() => {
+    if (!dataTransformer) {
+      return [];
+    }
+
+    // Filter to only include DataTransformerConfig items (exclude CustomTransformerDefinition)
+    const transformationList = (transformerState?.transformations || []).filter((t): t is DataTransformerConfig =>
+      isDataTransformerConfig(t)
+    );
+
+    // Use the transformation's id + index as a stable key for React
+    // transformConfig holds the actual object reference from Scene state
+    return transformationList.map((t, index) => ({
+      transformConfig: t,
+      registryItem: standardTransformersRegistry.getIfExists(t.id),
+      transformId: `${t.id}-${index}`,
+    }));
+  }, [dataTransformer, transformerState?.transformations]);
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/testUtils.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/testUtils.tsx
@@ -51,6 +51,7 @@ export const mockActions: QueryEditorActions = {
   changeDataSource: jest.fn(),
   toggleQueryHide: jest.fn(),
   onQueryOptionsChange: jest.fn(),
+  updateTransformation: jest.fn(),
 };
 
 export const mockOptions: QueryGroupOptions = {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
@@ -29,3 +29,9 @@ export function isDataTransformerConfig(
 ): transformation is DataTransformerConfig {
   return transformation !== null && 'id' in transformation && !('refId' in transformation);
 }
+
+export const filterDataTransformerConfigs = (
+  transformations: Array<DataTransformerConfig | CustomTransformerDefinition>
+): DataTransformerConfig[] => {
+  return transformations.filter((t): t is DataTransformerConfig => isDataTransformerConfig(t));
+};

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
@@ -30,6 +30,12 @@ export function isDataTransformerConfig(
   return transformation !== null && 'id' in transformation && !('refId' in transformation);
 }
 
+/**
+ * Filters an array of transformations to only include DataTransformerConfig items since
+ * the UI does not support CustomTransformerDefinition items.
+ * @param transformations - The array of transformations to filter.
+ * @returns An array of DataTransformerConfig items.
+ */
 export const filterDataTransformerConfigs = (
   transformations: Array<DataTransformerConfig | CustomTransformerDefinition>
 ): DataTransformerConfig[] => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
@@ -45,4 +45,4 @@ export const TIME_OPTION_PLACEHOLDER = '1h';
 export const CONTENT_SIDE_BAR = {
   width: 300,
   labelWidth: 80,
-};
+} as const;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13034,6 +13034,11 @@
       "transformations": "Transformations"
     }
   },
+  "query-editor-renderer": {
+    "datasource-load-error-title": "Failed to load datasource for this query",
+    "loading-datasource": "Loading datasource",
+    "no-query-editor-component": "Data source plugin does not export any query editor component"
+  },
   "query-library": {
     "exposed-compoment": {
       "tooltip": "Open Query Library"
@@ -14241,6 +14246,9 @@
     "traces-panel": {
       "no-data-found-in-response": "No data found in response"
     }
+  },
+  "transformation-editor-renderer": {
+    "no-transformation-editor-title": "Transformation does not have an editor component"
   },
   "transformations": {
     "empty": {


### PR DESCRIPTION
## Description
This PR wires up the actual query, expression, and transformation editor renderers. 

## Changes
<!--- Describe your changes in detail -->
* Reworked how we get and store transformations so that the transformation editor works as expected. 
* Added `updateTransformation` method to `PanelDataPaneNext`
* Made some CSS changes so that the QueryEditorSidebar component renders correctly with the editors within the content body. 
* Updated some datasource fetching logic in the wrapper component

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->
* I'm not aware of too many risks at this time.

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->
<img width="1387" height="577" alt="image" src="https://github.com/user-attachments/assets/939daf66-3a5e-46cc-9d04-92353720e1f6" />

<img width="1385" height="572" alt="image" src="https://github.com/user-attachments/assets/0ac55315-bdb9-4ed9-96e1-26de518371c9" />

<img width="1385" height="568" alt="image" src="https://github.com/user-attachments/assets/a03f0038-3685-4d98-a55b-898965486732" />

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* Pull down the branch, open a panel with each type of card (transformation, query, expression), and basically make sure I didn't super bork something?

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable