### PR TITLE
Dashboard: datasource prioritization rules

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v33.panel_ds_name_to_ref.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v33.panel_ds_name_to_ref.v42.v2alpha1.json
@@ -92,14 +92,14 @@
                   "kind": "PanelQuery",
                   "spec": {
                     "query": {
-                      "kind": "prometheus",
+                      "kind": "loki",
                       "spec": {
                         "description": "Nested target should also migrate from string to object"
                       }
                     },
                     "datasource": {
-                      "type": "prometheus",
-                      "uid": "default-ds-uid"
+                      "type": "loki",
+                      "uid": "non-default-test-ds-uid"
                     },
                     "refId": "A",
                     "hidden": false
@@ -138,14 +138,14 @@
                   "kind": "PanelQuery",
                   "spec": {
                     "query": {
-                      "kind": "elasticsearch",
+                      "kind": "prometheus",
                       "spec": {
                         "description": "Target with existing object should remain unchanged"
                       }
                     },
                     "datasource": {
-                      "type": "elasticsearch",
-                      "uid": "existing-target-uid"
+                      "type": "prometheus",
+                      "uid": "existing-ref-uid"
                     },
                     "refId": "A",
                     "hidden": false
@@ -289,14 +289,14 @@
                   "kind": "PanelQuery",
                   "spec": {
                     "query": {
-                      "kind": "prometheus",
+                      "kind": "loki",
                       "spec": {
                         "description": "Valid string should migrate to object"
                       }
                     },
                     "datasource": {
-                      "type": "prometheus",
-                      "uid": "default-ds-uid"
+                      "type": "loki",
+                      "uid": "non-default-test-ds-uid"
                     },
                     "refId": "B",
                     "hidden": false
@@ -306,14 +306,14 @@
                   "kind": "PanelQuery",
                   "spec": {
                     "query": {
-                      "kind": "prometheus",
+                      "kind": "loki",
                       "spec": {
                         "description": "Non-existing datasource should be preserved as-is (migration returns nil)"
                       }
                     },
                     "datasource": {
-                      "type": "prometheus",
-                      "uid": "non-existing-ds"
+                      "type": "loki",
+                      "uid": "non-default-test-ds-uid"
                     },
                     "refId": "C",
                     "hidden": false
@@ -381,7 +381,7 @@
                     },
                     "datasource": {
                       "type": "prometheus",
-                      "uid": "existing-ref"
+                      "uid": "default-ds-uid"
                     },
                     "refId": "A",
                     "hidden": false
@@ -391,14 +391,14 @@
                   "kind": "PanelQuery",
                   "spec": {
                     "query": {
-                      "kind": "loki",
+                      "kind": "prometheus",
                       "spec": {
                         "description": "String target should migrate to object"
                       }
                     },
                     "datasource": {
-                      "type": "loki",
-                      "uid": "non-default-test-ds-uid"
+                      "type": "prometheus",
+                      "uid": "default-ds-uid"
                     },
                     "refId": "B",
                     "hidden": false
@@ -503,7 +503,7 @@
                     },
                     "datasource": {
                       "type": "prometheus",
-                      "uid": "also-missing-ds"
+                      "uid": "completely-missing-ds"
                     },
                     "refId": "A",
                     "hidden": false

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v33.panel_ds_name_to_ref.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v33.panel_ds_name_to_ref.v42.v2beta1.json
@@ -96,10 +96,10 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "prometheus",
+                      "group": "loki",
                       "version": "v0",
                       "datasource": {
-                        "name": "default-ds-uid"
+                        "name": "non-default-test-ds-uid"
                       },
                       "spec": {
                         "description": "Nested target should also migrate from string to object"
@@ -144,10 +144,10 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "elasticsearch",
+                      "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "existing-target-uid"
+                        "name": "existing-ref-uid"
                       },
                       "spec": {
                         "description": "Target with existing object should remain unchanged"
@@ -302,10 +302,10 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "prometheus",
+                      "group": "loki",
                       "version": "v0",
                       "datasource": {
-                        "name": "default-ds-uid"
+                        "name": "non-default-test-ds-uid"
                       },
                       "spec": {
                         "description": "Valid string should migrate to object"
@@ -320,10 +320,10 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "prometheus",
+                      "group": "loki",
                       "version": "v0",
                       "datasource": {
-                        "name": "non-existing-ds"
+                        "name": "non-default-test-ds-uid"
                       },
                       "spec": {
                         "description": "Non-existing datasource should be preserved as-is (migration returns nil)"
@@ -394,7 +394,7 @@
                       "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "existing-ref"
+                        "name": "default-ds-uid"
                       },
                       "spec": {
                         "description": "Existing object target should remain unchanged"
@@ -409,10 +409,10 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "loki",
+                      "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "non-default-test-ds-uid"
+                        "name": "default-ds-uid"
                       },
                       "spec": {
                         "description": "String target should migrate to object"
@@ -523,7 +523,7 @@
                       "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "also-missing-ds"
+                        "name": "completely-missing-ds"
                       },
                       "spec": {
                         "description": "Unknown target datasource should remain unchanged (migration returns nil)"

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v34.multiple_stats_cloudwatch.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v34.multiple_stats_cloudwatch.v42.v2alpha1.json
@@ -1172,7 +1172,7 @@
                     },
                     "datasource": {
                       "type": "prometheus",
-                      "uid": "default-ds-uid"
+                      "uid": "prometheus"
                     },
                     "refId": "A",
                     "hidden": false
@@ -1214,7 +1214,7 @@
                     },
                     "datasource": {
                       "type": "prometheus",
-                      "uid": "default-ds-uid"
+                      "uid": "prometheus"
                     },
                     "refId": "C",
                     "hidden": false
@@ -1239,7 +1239,7 @@
                     },
                     "datasource": {
                       "type": "prometheus",
-                      "uid": "default-ds-uid"
+                      "uid": "prometheus"
                     },
                     "refId": "D",
                     "hidden": false

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v34.multiple_stats_cloudwatch.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v34.multiple_stats_cloudwatch.v42.v2beta1.json
@@ -1205,7 +1205,7 @@
                       "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "default-ds-uid"
+                        "name": "prometheus"
                       },
                       "spec": {
                         "dimensions": {
@@ -1249,7 +1249,7 @@
                       "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "default-ds-uid"
+                        "name": "prometheus"
                       },
                       "spec": {
                         "dimensions": {
@@ -1275,7 +1275,7 @@
                       "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "default-ds-uid"
+                        "name": "prometheus"
                       },
                       "spec": {
                         "dimensions": {

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v36.ds_name_to_ref.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v36.ds_name_to_ref.v42.v2alpha1.json
@@ -263,12 +263,12 @@
                   "kind": "PanelQuery",
                   "spec": {
                     "query": {
-                      "kind": "elasticsearch",
+                      "kind": "prometheus",
                       "spec": {}
                     },
                     "datasource": {
-                      "type": "elasticsearch",
-                      "uid": "existing-target-uid"
+                      "type": "prometheus",
+                      "uid": "unknown-nested-datasource"
                     },
                     "refId": "A",
                     "hidden": false
@@ -454,12 +454,12 @@
                   "kind": "PanelQuery",
                   "spec": {
                     "query": {
-                      "kind": "elasticsearch",
+                      "kind": "prometheus",
                       "spec": {}
                     },
                     "datasource": {
-                      "type": "elasticsearch",
-                      "uid": "existing-target-uid"
+                      "type": "prometheus",
+                      "uid": "existing-ref-uid"
                     },
                     "refId": "A",
                     "hidden": false
@@ -503,7 +503,7 @@
                     },
                     "datasource": {
                       "type": "prometheus",
-                      "uid": "unknown-target-datasource"
+                      "uid": "unknown-panel-datasource"
                     },
                     "refId": "A",
                     "hidden": false

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v36.ds_name_to_ref.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v36.ds_name_to_ref.v42.v2beta1.json
@@ -276,10 +276,10 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "elasticsearch",
+                      "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "existing-target-uid"
+                        "name": "unknown-nested-datasource"
                       },
                       "spec": {}
                     },
@@ -476,10 +476,10 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "elasticsearch",
+                      "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "existing-target-uid"
+                        "name": "existing-ref-uid"
                       },
                       "spec": {}
                     },
@@ -525,7 +525,7 @@
                       "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "unknown-target-datasource"
+                        "name": "unknown-panel-datasource"
                       },
                       "spec": {}
                     },

--- a/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1_test.go
+++ b/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1_test.go
@@ -132,7 +132,6 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 			},
 		},
 		{
-			// Same condition as frontend (SceneQueryRunner): use panel when query has no ref, or when
 			// query ref != panel ref and panel is not mixed and query is not expression.
 			name: "panel ref used when query ref differs from panel ref (panel not mixed, query not expression)",
 			createV1beta1: func() *dashv1.Dashboard {
@@ -470,7 +469,7 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 						totalQueries += len(element.PanelKind.Spec.Data.Spec.Queries)
 					}
 				}
-				assert.Equal(t, 3, totalQueries, "All 3 queries should be preserved")
+				assert.Equal(t, 3, totalQueries, "all 3 queries should be preserved")
 			},
 		},
 	}

--- a/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1_test.go
+++ b/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1_test.go
@@ -32,7 +32,7 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 		validateV2alpha1 func(t *testing.T, v2alpha1 *dashv2alpha1.Dashboard)
 	}{
 		{
-			name: "panel datasource type datasource with no UID - resolves to grafana UID",
+			name: "panel type datasource with no UID - use panel ref (query empty), resolve to grafana UID",
 			createV1beta1: func() *dashv1.Dashboard {
 				return &dashv1.Dashboard{
 					Spec: dashv1.DashboardSpec{
@@ -84,7 +84,7 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 			},
 		},
 		{
-			name: "empty target datasource objects inherit from panel datasource",
+			name: "targets with empty datasource {} - use panel ref (query has no ref), get panel DS",
 			createV1beta1: func() *dashv1.Dashboard {
 				return &dashv1.Dashboard{
 					Spec: dashv1.DashboardSpec{
@@ -94,7 +94,6 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 								map[string]interface{}{
 									"id":   1,
 									"type": "bargauge",
-									// Panel datasource is set
 									"datasource": map[string]interface{}{
 										"type": "prometheus",
 										"uid":  "prometheus-uid",
@@ -103,7 +102,6 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 										map[string]interface{}{
 											"refId":      "A",
 											"scenarioId": "random_walk",
-											// Target datasource is empty object {} - should inherit from panel
 											"datasource": map[string]interface{}{},
 										},
 										map[string]interface{}{
@@ -123,10 +121,10 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 				panel := v2alpha1.Spec.Elements["panel-1"].PanelKind
 				require.NotNil(t, panel)
 
-				// Verify queries inherit panel datasource
+				// Query has no ref (empty {}) → use panel ref; both queries get panel DS
 				require.Len(t, panel.Spec.Data.Spec.Queries, 2)
 				for _, query := range panel.Spec.Data.Spec.Queries {
-					require.NotNil(t, query.Spec.Datasource, "Query should inherit datasource from panel when target datasource is empty")
+					require.NotNil(t, query.Spec.Datasource)
 					assert.Equal(t, "prometheus", *query.Spec.Datasource.Type)
 					assert.Equal(t, "prometheus-uid", *query.Spec.Datasource.Uid)
 					assert.Equal(t, "prometheus", query.Spec.Query.Kind)
@@ -134,7 +132,171 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 			},
 		},
 		{
-			name: "panel datasource null without empty target datasource objects - no default set",
+			// Same condition as frontend (SceneQueryRunner): use panel when query has no ref, or when
+			// query ref != panel ref and panel is not mixed and query is not expression.
+			name: "panel ref used when query ref differs from panel ref (panel not mixed, query not expression)",
+			createV1beta1: func() *dashv1.Dashboard {
+				return &dashv1.Dashboard{
+					Spec: dashv1.DashboardSpec{
+						Object: map[string]interface{}{
+							"title": "Test Dashboard",
+							"panels": []interface{}{
+								map[string]interface{}{
+									"id":   1,
+									"type": "bargauge",
+									"datasource": map[string]interface{}{
+										"type": "prometheus",
+										"uid":  "prometheus-uid",
+									},
+									"targets": []interface{}{
+										map[string]interface{}{
+											"refId":      "A",
+											"scenarioId": "random_walk",
+											"datasource": map[string]interface{}{
+												"type": "loki",
+												"uid":  "loki-uid",
+											},
+										},
+										map[string]interface{}{
+											"refId":      "B",
+											"scenarioId": "random_walk",
+											"datasource": map[string]interface{}{
+												"type": "elasticsearch",
+												"uid":  "elasticsearch-uid",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			validateV2alpha1: func(t *testing.T, v2alpha1 *dashv2alpha1.Dashboard) {
+				require.NotNil(t, v2alpha1.Spec.Elements["panel-1"])
+				panel := v2alpha1.Spec.Elements["panel-1"].PanelKind
+				require.NotNil(t, panel)
+
+				// Query ref != panel ref and panel not mixed → use panel ref (matches frontend)
+				require.Len(t, panel.Spec.Data.Spec.Queries, 2)
+				for _, query := range panel.Spec.Data.Spec.Queries {
+					require.NotNil(t, query.Spec.Datasource)
+					assert.Equal(t, "prometheus", *query.Spec.Datasource.Type)
+					assert.Equal(t, "prometheus-uid", *query.Spec.Datasource.Uid)
+					assert.Equal(t, "prometheus", query.Spec.Query.Kind)
+				}
+			},
+		},
+		{
+			// Mixed is identified by panel uid "-- Mixed --". When panel is mixed we do not use panel ref.
+			name: "mixed panel (uid -- Mixed --) - each query keeps its target datasource",
+			createV1beta1: func() *dashv1.Dashboard {
+				return &dashv1.Dashboard{
+					Spec: dashv1.DashboardSpec{
+						Object: map[string]interface{}{
+							"title": "Test Dashboard",
+							"panels": []interface{}{
+								map[string]interface{}{
+									"id":   1,
+									"type": "bargauge",
+									"datasource": map[string]interface{}{
+										"type": "datasource",
+										"uid":  "-- Mixed --",
+									},
+									"targets": []interface{}{
+										map[string]interface{}{
+											"refId":      "A",
+											"scenarioId": "random_walk",
+											"datasource": map[string]interface{}{
+												"type": "prometheus",
+												"uid":  "prometheus-uid",
+											},
+										},
+										map[string]interface{}{
+											"refId":      "B",
+											"scenarioId": "random_walk",
+											"datasource": map[string]interface{}{
+												"type": "loki",
+												"uid":  "loki-uid",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			validateV2alpha1: func(t *testing.T, v2alpha1 *dashv2alpha1.Dashboard) {
+				require.NotNil(t, v2alpha1.Spec.Elements["panel-1"])
+				panel := v2alpha1.Spec.Elements["panel-1"].PanelKind
+				require.NotNil(t, panel)
+
+				require.Len(t, panel.Spec.Data.Spec.Queries, 2)
+				// Query A: prometheus
+				assert.Equal(t, "prometheus", *panel.Spec.Data.Spec.Queries[0].Spec.Datasource.Type)
+				assert.Equal(t, "prometheus-uid", *panel.Spec.Data.Spec.Queries[0].Spec.Datasource.Uid)
+				// Query B: loki
+				assert.Equal(t, "loki", *panel.Spec.Data.Spec.Queries[1].Spec.Datasource.Type)
+				assert.Equal(t, "loki-uid", *panel.Spec.Data.Spec.Queries[1].Spec.Datasource.Uid)
+			},
+		},
+		{
+			// Expression queries (__expr__) are never overwritten by panel ref (same as frontend).
+			name: "expression query (__expr__) keeps expression ref when panel has different datasource",
+			createV1beta1: func() *dashv1.Dashboard {
+				return &dashv1.Dashboard{
+					Spec: dashv1.DashboardSpec{
+						Object: map[string]interface{}{
+							"title": "Test Dashboard",
+							"panels": []interface{}{
+								map[string]interface{}{
+									"id":   1,
+									"type": "bargauge",
+									"datasource": map[string]interface{}{
+										"type": "prometheus",
+										"uid":  "prometheus-uid",
+									},
+									"targets": []interface{}{
+										map[string]interface{}{
+											"refId":      "A",
+											"scenarioId": "random_walk",
+											"datasource": map[string]interface{}{},
+										},
+										map[string]interface{}{
+											"refId":      "B",
+											"scenarioId": "random_walk",
+											"datasource": map[string]interface{}{
+												"type": "__expr__",
+												"uid":  "__expr__",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			validateV2alpha1: func(t *testing.T, v2alpha1 *dashv2alpha1.Dashboard) {
+				require.NotNil(t, v2alpha1.Spec.Elements["panel-1"])
+				panel := v2alpha1.Spec.Elements["panel-1"].PanelKind
+				require.NotNil(t, panel)
+
+				require.Len(t, panel.Spec.Data.Spec.Queries, 2)
+				// Query A: no ref → uses panel
+				require.NotNil(t, panel.Spec.Data.Spec.Queries[0].Spec.Datasource)
+				assert.Equal(t, "prometheus", *panel.Spec.Data.Spec.Queries[0].Spec.Datasource.Type)
+				assert.Equal(t, "prometheus-uid", *panel.Spec.Data.Spec.Queries[0].Spec.Datasource.Uid)
+				// Query B: expression → not overwritten by panel
+				require.NotNil(t, panel.Spec.Data.Spec.Queries[1].Spec.Datasource)
+				assert.Equal(t, "__expr__", *panel.Spec.Data.Spec.Queries[1].Spec.Datasource.Type)
+				assert.Equal(t, "__expr__", *panel.Spec.Data.Spec.Queries[1].Spec.Datasource.Uid)
+				assert.Equal(t, "__expr__", panel.Spec.Data.Spec.Queries[1].Spec.Query.Kind)
+			},
+		},
+		{
+			name: "panel datasource null and target has no datasource field - no default set",
 			createV1beta1: func() *dashv1.Dashboard {
 				return &dashv1.Dashboard{
 					Spec: dashv1.DashboardSpec{
@@ -164,15 +326,14 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 				panel := v2alpha1.Spec.Elements["panel-1"].PanelKind
 				require.NotNil(t, panel)
 
-				// Verify queries don't have datasource when panel is null and targets don't have empty datasource objects
+				// usePanelRef true (query empty) but hasPanelRef false (panel null) → query keeps no ref
 				require.Len(t, panel.Spec.Data.Spec.Queries, 1)
 				query := panel.Spec.Data.Spec.Queries[0]
-				// Query should not have datasource when panel datasource is null and target doesn't have empty datasource object
-				assert.Nil(t, query.Spec.Datasource, "Query should not have datasource when panel datasource is null and target has no empty datasource object")
+				assert.Nil(t, query.Spec.Datasource)
 			},
 		},
 		{
-			name: "empty panel datasource object preserved as empty",
+			name: "empty panel and target datasource {} - preserved as empty (no panel ref to apply)",
 			createV1beta1: func() *dashv1.Dashboard {
 				return &dashv1.Dashboard{
 					Spec: dashv1.DashboardSpec{
@@ -202,12 +363,11 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 				panel := v2alpha1.Spec.Elements["panel-1"].PanelKind
 				require.NotNil(t, panel)
 
-				// Verify queries don't have datasource when panel datasource is empty object {}
+				// usePanelRef true (query empty) but hasPanelRef false (panel {} → nil panelDatasource) → query stays empty
 				require.Len(t, panel.Spec.Data.Spec.Queries, 1)
 				query := panel.Spec.Data.Spec.Queries[0]
-				// Empty objects {} should be preserved as empty, not converted to defaults
-				assert.Nil(t, query.Spec.Datasource, "Query should not have datasource when panel datasource is empty object {}")
-				assert.Equal(t, "", query.Spec.Query.Kind, "Query kind should be empty when datasource is empty object {}")
+				assert.Nil(t, query.Spec.Datasource)
+				assert.Equal(t, "", query.Spec.Query.Kind)
 			},
 		},
 		{

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -491,13 +491,13 @@ describe('transformSceneToSaveModelSchemaV2', () => {
       const resultA = getPersistedDSFor(queryWithoutDS, dsReferencesMap, 'query', queryRunner);
       expect(resultA).toBeUndefined();
 
-      // Test the query with DS originally - should return the original datasource
+      // Test the query with DS that differs from panel - same as PanelQueryRunner: use panel ref
       const resultB = getPersistedDSFor(queryWithDS, dsReferencesMap, 'query', queryRunner);
-      expect(resultB).toEqual({ uid: 'prometheus', type: 'prometheus' });
+      expect(resultB).toEqual({ uid: 'default-ds', type: 'default' });
 
-      // Test the query with only type defined - should return the type
+      // Query with only type (no uid) differs from panel - use panel ref
       const resultC = getPersistedDSFor(queryWithOnlyDSType, dsReferencesMap, 'query', queryRunner);
-      expect(resultC).toEqual({ type: 'prometheus' });
+      expect(resultC).toEqual({ uid: 'default-ds', type: 'default' });
 
       // Test a query with no DS originally but not in the mapping - should get the runner's datasource
       const queryNotInMapping: SceneDataQuery = {
@@ -687,15 +687,15 @@ describe('getElementDatasource', () => {
       annotations: new Map<string, string>(),
     };
 
-    // Call the function with the panel and query with DS
+    // Query with DS that differs from panel → same as PanelQueryRunner: use panel ref
     const resultWithDS = getElementDatasource(vizPanel, queryWithDS, 'panel', queryRunner, dsReferencesMapping);
-    expect(resultWithDS).toEqual({ uid: 'prometheus', type: 'prometheus' });
+    expect(resultWithDS).toEqual({ uid: 'default-ds', type: 'default' });
 
     // Call the function with the panel and query without DS
     const resultWithoutDS = getElementDatasource(vizPanel, queryWithoutDS, 'panel', queryRunner, dsReferencesMapping);
     expect(resultWithoutDS).toBeUndefined();
 
-    // Call the function with the panel and query with only type
+    // Query with only type differs from panel → use panel ref
     const resultWithOnlyType = getElementDatasource(
       vizPanel,
       queryWithOnlyType,
@@ -703,7 +703,7 @@ describe('getElementDatasource', () => {
       queryRunner,
       dsReferencesMapping
     );
-    expect(resultWithOnlyType).toEqual({ type: 'prometheus' });
+    expect(resultWithOnlyType).toEqual({ uid: 'default-ds', type: 'default' });
   });
 
   it('should handle variable datasources correctly', () => {
@@ -952,7 +952,8 @@ describe('getVizPanelQueries', () => {
     expect(result[0].spec.query.version).toBe('v0');
 
     expect(result[1].spec.query.kind).toBe('DataQuery');
-    expect(result[1].spec.query.datasource?.name).toBe('prometheus-uid');
+    // Query ref differs from panel → persist panel ref (same as PanelQueryRunner); schema stores uid as .name
+    expect(result[1].spec.query.datasource?.name).toBe('default-ds');
     expect(result[1].spec.query.group).toBe('prometheus');
     expect(result[1].spec.query.version).toBe('v0');
   });

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -402,6 +402,11 @@ export function getDataQueryKind(query: SceneDataQuery | string | undefined, que
   // If query has a datasource UID (even without type), check if it matches the queryRunner's datasource
   // Only use queryRunner's type if the UIDs match or if query has no datasource at all
   if (queryRunner?.state.datasource?.type) {
+    // If query has a datasource UID that differs from queryRunner's, fall back to default
+    if (query.datasource?.uid && query.datasource.uid !== queryRunner.state.datasource.uid) {
+      const defaultDS = getDefaultDataSourceRef();
+      return defaultDS?.type || '';
+    }
     return queryRunner.state.datasource.type;
   }
 

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -911,7 +911,6 @@ export function getPersistedDSFor<T extends SceneDataQuery | QueryVariable | Ann
     }
 
     const panel = context?.state?.datasource;
-
     if (!panel) {
       return datasource;
     }
@@ -923,7 +922,6 @@ export function getPersistedDSFor<T extends SceneDataQuery | QueryVariable | Ann
       datasource = panel;
     }
 
-    console.log('returned', datasource);
     return datasource;
   }
 

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -359,7 +359,9 @@ export function getVizPanelQueries(
       const dataQuery: DataQueryKind = {
         kind: 'DataQuery',
         version: defaultDataQueryKind().version,
-        group: queryDatasource ? getDataQueryKind(query, queryRunner) : defaultDataQueryKind().group,
+        group: queryDatasource
+          ? queryDatasource.type || getDataQueryKind(query, queryRunner)
+          : defaultDataQueryKind().group,
         datasource: {
           name: queryDatasource?.uid,
         },
@@ -397,19 +399,9 @@ export function getDataQueryKind(query: SceneDataQuery | string | undefined, que
     return defaultDS?.type || '';
   }
 
-  // Query has explicit datasource with type
-  if (query.datasource?.type) {
-    return query.datasource.type;
-  }
-
   // If query has a datasource UID (even without type), check if it matches the queryRunner's datasource
   // Only use queryRunner's type if the UIDs match or if query has no datasource at all
   if (queryRunner?.state.datasource?.type) {
-    // If query has a datasource UID that differs from queryRunner's, fall back to default
-    if (query.datasource?.uid && query.datasource.uid !== queryRunner.state.datasource.uid) {
-      const defaultDS = getDefaultDataSourceRef();
-      return defaultDS?.type || '';
-    }
     return queryRunner.state.datasource.type;
   }
 


### PR DESCRIPTION
**What is this feature?**

Updates the v1 -> v2 dashboard migration so that, when converting panel queries, the panel-level datasource is used when it exists. Only when the panel has no datasource or has mixed or query is an expression do we use the target/query-level datasource


This approach will make sure we match current v1 behaviour and dont break existing dashboards [decision tree for v1](https://github.com/grafana/scenes/blob/main/packages/scenes/src/querying/SceneQueryRunner.ts#L572-L583)
