### PR TITLE
QueryEditor: Add new cards to the Query Stack

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
@@ -157,11 +157,18 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     }
 
     const updatedQueries = addQuery(currentQueries, newQuery);
-    const newItem = updatedQueries[updatedQueries.length - 1];
 
-    // If afterRefId is specified, move the new query (currently at end) to just after it
-    if (afterRefId) {
-      updatedQueries.pop();
+    // Identify the newly added query by refId rather than position, so this
+    // is resilient to future changes in how addQuery orders the array.
+    const existingRefIds = new Set(currentQueries.map((q) => q.refId));
+    const newItem = updatedQueries.find((q) => !existingRefIds.has(q.refId));
+
+    // If afterRefId is specified, move the new query to just after it
+    if (afterRefId && newItem) {
+      const newItemIndex = updatedQueries.indexOf(newItem);
+      if (newItemIndex !== -1) {
+        updatedQueries.splice(newItemIndex, 1);
+      }
       const afterIndex = updatedQueries.findIndex((q) => q.refId === afterRefId);
       if (afterIndex !== -1) {
         updatedQueries.splice(afterIndex + 1, 0, newItem);

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
@@ -138,7 +138,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
   public addQuery = (query?: Partial<DataQuery>, afterRefId?: string): string | undefined => {
     const queryRunner = getQueryRunnerFor(this.state.panelRef.resolve());
     if (!queryRunner) {
-      return undefined;
+      return;
     }
 
     const { datasource, dsSettings } = this.state;

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
@@ -61,7 +61,7 @@ export interface QueryEditorUIState {
 export interface QueryEditorActions {
   updateQueries: (queries: DataQuery[]) => void;
   updateSelectedQuery: (updatedQuery: DataQuery, originalRefId: string) => void;
-  addQuery: (query?: Partial<DataQuery>) => void;
+  addQuery: (query?: Partial<DataQuery>, afterRefId?: string) => string | undefined;
   deleteQuery: (refId: string) => void;
   duplicateQuery: (refId: string) => void;
   toggleQueryHide: (refId: string) => void;

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -168,7 +168,7 @@ function getStyles(theme: GrafanaTheme2) {
   return {
     button: css({
       position: 'absolute',
-      top: 'calc(100%)',
+      top: '100%',
       left: 0,
       transform: 'translate(-100%, 0)',
       zIndex: 1,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -22,7 +22,6 @@ function isExpressionType(
   return typeof item.value === 'string' && item.value in EXPRESSION_ICON_MAP;
 }
 
-/** The various menus when adding a card. */
 type MenuView = 'main' | 'expressionTypes';
 
 interface AddCardButtonProps {
@@ -30,10 +29,6 @@ interface AddCardButtonProps {
   afterRefId: string;
 }
 
-/**
- * A plus ("+") icon button with dropdown menu for adding queries, saved
- * queries, or expressions below a given card in the sidebar.
- */
 export const AddCardButton = ({ afterRefId }: AddCardButtonProps) => {
   const styles = useStyles2(getStyles);
   const theme = useTheme2();

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -44,8 +44,6 @@ export const AddCardButton = ({ afterRefId }: AddCardButtonProps) => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuView, setMenuView] = useState<MenuView>('main');
 
-  // Focuses the expressions submenu as soon as it mounts so keyboard
-  // navigation (arrow keys) works as expected.
   const focusOnMount = useCallback((el: HTMLDivElement | null) => el?.focus(), []);
 
   // When the savedQueriesRBAC feature toggle is enabled, access to the query
@@ -55,7 +53,6 @@ export const AddCardButton = ({ afterRefId }: AddCardButtonProps) => {
     ? contextSrv.hasPermission(AccessControlAction.QueriesRead)
     : contextSrv.isSignedIn;
 
-  /** Add a query after this card and auto-select it in the sidebar. */
   const addAndSelect = useCallback(
     (query?: Partial<DataQuery>) => {
       const newRefId = addQuery(query, afterRefId);
@@ -67,7 +64,6 @@ export const AddCardButton = ({ afterRefId }: AddCardButtonProps) => {
     [addQuery, afterRefId, setSelectedQuery]
   );
 
-  /** Create an expression of a certain type and add it. */
   const addExpressionOfType = useCallback(
     (type: ExpressionQueryType) => {
       const baseQuery = expressionDatasource.newQuery();
@@ -78,7 +74,6 @@ export const AddCardButton = ({ afterRefId }: AddCardButtonProps) => {
     [addAndSelect]
   );
 
-  /** Reset the menu to the main view when it closes. */
   const handleMenuVisibleChange = useCallback((visible: boolean) => {
     setMenuOpen(visible);
     if (!visible) {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -44,7 +44,7 @@ export const AddCardButton = ({ afterRefId }: AddCardButtonProps) => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuView, setMenuView] = useState<MenuView>('main');
 
-  // Fcuses the expressions submenu as soon as it mounts so keyboard
+  // Focuses the expressions submenu as soon as it mounts so keyboard
   // navigation (arrow keys) works as expected.
   const focusOnMount = useCallback((el: HTMLDivElement | null) => el?.focus(), []);
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -13,16 +13,8 @@ import { ExpressionQueryType, expressionTypes } from 'app/features/expressions/t
 import { getDefaults } from 'app/features/expressions/utils/expressionTypes';
 import { AccessControlAction } from 'app/types/accessControl';
 
+import { EXPRESSION_ICON_MAP } from '../../constants';
 import { useActionsContext, useQueryEditorUIContext } from '../QueryEditorContext';
-
-const EXPRESSION_ICON_MAP = {
-  [ExpressionQueryType.math]: 'calculator-alt',
-  [ExpressionQueryType.reduce]: 'compress-arrows',
-  [ExpressionQueryType.resample]: 'sync',
-  [ExpressionQueryType.classic]: 'cog',
-  [ExpressionQueryType.threshold]: 'sliders-v-alt',
-  [ExpressionQueryType.sql]: 'database',
-} as const satisfies Record<ExpressionQueryType, string>;
 
 function isExpressionType(
   item: SelectableValue<ExpressionQueryType>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -1,0 +1,215 @@
+import { css } from '@emotion/css';
+import { useCallback, useMemo, useState } from 'react';
+
+import { CoreApp, GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { config as grafanaConfig } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
+import { Dropdown, Icon, Menu, useStyles2, useTheme2 } from '@grafana/ui';
+import { contextSrv } from 'app/core/services/context_srv';
+import { useQueryLibraryContext } from 'app/features/explore/QueryLibrary/QueryLibraryContext';
+import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
+import { ExpressionQueryType, expressionTypes } from 'app/features/expressions/types';
+import { getDefaults } from 'app/features/expressions/utils/expressionTypes';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { useActionsContext, useQueryEditorUIContext } from '../QueryEditorContext';
+
+const EXPRESSION_ICON_MAP = {
+  [ExpressionQueryType.math]: 'calculator-alt',
+  [ExpressionQueryType.reduce]: 'compress-arrows',
+  [ExpressionQueryType.resample]: 'sync',
+  [ExpressionQueryType.classic]: 'cog',
+  [ExpressionQueryType.threshold]: 'sliders-v-alt',
+  [ExpressionQueryType.sql]: 'database',
+} as const satisfies Record<ExpressionQueryType, string>;
+
+function isExpressionType(
+  item: SelectableValue<ExpressionQueryType>
+): item is SelectableValue<ExpressionQueryType> & { value: ExpressionQueryType } {
+  return typeof item.value === 'string' && item.value in EXPRESSION_ICON_MAP;
+}
+
+/** The various menus when adding a card. */
+type MenuView = 'main' | 'expressionTypes';
+
+interface AddCardButtonProps {
+  /** The refId of the card this button belongs to; new items are inserted after it. */
+  afterRefId: string;
+}
+
+/**
+ * A plus ("+") icon button with dropdown menu for adding queries, saved
+ * queries, or expressions below a given card in the sidebar.
+ */
+export const AddCardButton = ({ afterRefId }: AddCardButtonProps) => {
+  const styles = useStyles2(getStyles);
+  const theme = useTheme2();
+  const { addQuery } = useActionsContext();
+  const { setSelectedQuery } = useQueryEditorUIContext();
+  const { openDrawer, queryLibraryEnabled } = useQueryLibraryContext();
+
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [menuView, setMenuView] = useState<MenuView>('main');
+
+  // Fcuses the expressions submenu as soon as it mounts so keyboard
+  // navigation (arrow keys) works as expected.
+  const focusOnMount = useCallback((el: HTMLDivElement | null) => el?.focus(), []);
+
+  // When the savedQueriesRBAC feature toggle is enabled, access to the query
+  // library is governed by fine-grained RBAC permissions. Otherwise, any
+  // signed-in user can read saved queries (the pre-RBAC default).
+  const canReadQueries = grafanaConfig.featureToggles.savedQueriesRBAC
+    ? contextSrv.hasPermission(AccessControlAction.QueriesRead)
+    : contextSrv.isSignedIn;
+
+  /** Add a query after this card and auto-select it in the sidebar. */
+  const addAndSelect = useCallback(
+    (query?: Partial<DataQuery>) => {
+      const newRefId = addQuery(query, afterRefId);
+      if (newRefId) {
+        const selectTarget: DataQuery = { refId: newRefId, hide: false };
+        setSelectedQuery(selectTarget);
+      }
+    },
+    [addQuery, afterRefId, setSelectedQuery]
+  );
+
+  /** Create an expression of a certain type and add it. */
+  const addExpressionOfType = useCallback(
+    (type: ExpressionQueryType) => {
+      const baseQuery = expressionDatasource.newQuery();
+      const queryWithType = { ...baseQuery, type };
+      const queryWithDefaults = getDefaults(queryWithType);
+      addAndSelect(queryWithDefaults);
+    },
+    [addAndSelect]
+  );
+
+  /** Reset the menu to the main view when it closes. */
+  const handleMenuVisibleChange = useCallback((visible: boolean) => {
+    setMenuOpen(visible);
+    if (!visible) {
+      setMenuView('main');
+    }
+  }, []);
+
+  const menus: Record<MenuView, React.ReactElement> = useMemo(
+    () => ({
+      main: (
+        <Menu key="main">
+          <Menu.Item
+            label={t('query-editor-next.sidebar.add-query', 'Add query')}
+            icon="question-circle"
+            onClick={() => addAndSelect()}
+          />
+          {queryLibraryEnabled && canReadQueries && (
+            <Menu.Item
+              label={t('query-editor-next.sidebar.add-saved-query', 'Add saved query')}
+              icon="book-open"
+              onClick={() =>
+                openDrawer({
+                  onSelectQuery: (query) => addAndSelect(query),
+                  options: { context: CoreApp.PanelEditor },
+                })
+              }
+            />
+          )}
+          <Menu.Item
+            label={t('query-editor-next.sidebar.add-expression', 'Add expression')}
+            icon="calculator-alt"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setMenuView('expressionTypes');
+            }}
+          />
+        </Menu>
+      ),
+      expressionTypes: (
+        <Menu key="expressionTypes" ref={focusOnMount}>
+          <Menu.Item
+            label={t('query-editor-next.sidebar.back', 'Back')}
+            icon="arrow-left"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setMenuView('main');
+            }}
+          />
+          <Menu.Divider />
+          {expressionTypes.filter(isExpressionType).map((item) => (
+            <Menu.Item
+              key={item.value}
+              label={item.label ?? ''}
+              icon={EXPRESSION_ICON_MAP[item.value]}
+              onClick={() => addExpressionOfType(item.value)}
+            />
+          ))}
+        </Menu>
+      ),
+    }),
+    [addAndSelect, addExpressionOfType, canReadQueries, focusOnMount, openDrawer, queryLibraryEnabled]
+  );
+
+  return (
+    <Dropdown
+      overlay={menus[menuView]}
+      placement="right-start"
+      offset={[theme.spacing.gridSize, 0]}
+      onVisibleChange={handleMenuVisibleChange}
+    >
+      <button
+        className={styles.button}
+        data-add-button
+        data-menu-open={menuOpen || undefined}
+        type="button"
+        aria-label={t('query-editor-next.sidebar.add-below', 'Add below {{id}}', { id: afterRefId })}
+      >
+        <Icon name="plus" size="md" />
+      </button>
+    </Dropdown>
+  );
+};
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    button: css({
+      position: 'absolute',
+      top: 'calc(100%)',
+      left: 0,
+      transform: 'translate(-100%, 0)',
+      zIndex: 1,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: theme.spacing(2),
+      height: theme.spacing(2),
+      borderRadius: theme.shape.radius.sm,
+      border: 'none',
+      background: theme.colors.primary.main,
+      color: theme.colors.primary.contrastText,
+      cursor: 'pointer',
+      padding: 0,
+      opacity: 0,
+      pointerEvents: 'none',
+
+      [theme.transitions.handleMotion('no-preference', 'reduce')]: {
+        transition: theme.transitions.create(['opacity', 'background-color'], {
+          duration: theme.transitions.duration.short,
+        }),
+      },
+
+      '&:hover': {
+        background: theme.colors.primary.shade,
+      },
+
+      '&:focus-visible': {
+        opacity: 1,
+        pointerEvents: 'auto',
+        outline: `2px solid ${theme.colors.primary.border}`,
+        outlineOffset: '2px',
+      },
+    }),
+  };
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/DraggableList.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/DraggableList.tsx
@@ -24,7 +24,7 @@ export function DraggableList<T>({
     <DragDropContext onDragStart={onDragStart} onDragEnd={onDragEnd}>
       <Droppable droppableId={droppableId} direction="vertical">
         {(provided) => (
-          <Stack ref={provided.innerRef} {...provided.droppableProps} direction="column" gap={1}>
+          <Stack ref={provided.innerRef} {...provided.droppableProps} direction="column" gap={2.5}>
             {items.map((item, index) => {
               const key = keyExtractor(item);
               return (

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryCard.tsx
@@ -26,6 +26,7 @@ export const QueryCard = ({ query }: { query: DataQuery }) => {
       onDelete={() => deleteQuery(query.refId)}
       onToggleHide={() => toggleQueryHide(query.refId)}
       isHidden={!!query.hide}
+      showAddButton={true}
     >
       <DataSourceLogo dataSource={queryDsSettings} />
       <Text weight="light" variant="code" color="secondary">

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.test.tsx
@@ -114,7 +114,8 @@ describe('QueryEditorSidebar', () => {
     expect(screen.getByRole('button', { name: /select card organize/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /select card reduce/i })).toBeInTheDocument();
 
-    // Count total transformation cards (should be 2)
+    // Count total transformation cards (should be 2).
+    // Filter to "Select card" buttons only, excluding the "Add below" ("+" icon) buttons.
     const transformCards = screen.getAllByRole('button').filter((button) => {
       const label = button.getAttribute('aria-label') || '';
       return label.startsWith('Select card') && (label.includes('organize') || label.includes('reduce'));
@@ -161,5 +162,44 @@ describe('QueryEditorSidebar', () => {
 
     // Should render transformation card
     expect(screen.getByRole('button', { name: /select card organize/i })).toBeInTheDocument();
+  });
+
+  it('should render an "Add below" button for every card', () => {
+    const queries: DataQuery[] = [
+      { refId: 'A', datasource: { type: 'test', uid: 'test' } },
+      { refId: 'B', datasource: { type: 'test', uid: 'test' } },
+    ];
+
+    const transformations: Transformation[] = [
+      { transformId: 'organize', registryItem: undefined, transformConfig: { id: 'organize', options: {} } },
+    ];
+
+    render(
+      <QueryEditorProvider
+        dsState={{ datasource: undefined, dsSettings: undefined, dsError: undefined }}
+        qrState={{ queries, data: undefined, isLoading: false }}
+        panelState={{ panel: new VizPanel({ key: 'panel-1' }), transformations }}
+        uiState={{
+          selectedQuery: queries[0],
+          selectedTransformation: null,
+          setSelectedQuery: jest.fn(),
+          setSelectedTransformation: jest.fn(),
+          queryOptions: mockQueryOptionsState,
+          selectedQueryDsData: null,
+          selectedQueryDsLoading: false,
+          showingDatasourceHelp: false,
+          toggleDatasourceHelp: jest.fn(),
+          cardType: QueryEditorType.Query,
+        }}
+        actions={mockActions}
+      >
+        <QueryEditorSidebar sidebarSize={SidebarSize.Full} setSidebarSize={jest.fn()} />
+      </QueryEditorProvider>
+    );
+
+    // Every card (2 queries + 1 transformation) should have an "Add below" button
+    expect(screen.getByRole('button', { name: /add below A/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add below B/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add below organize/i })).toBeInTheDocument();
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.test.tsx
@@ -164,7 +164,7 @@ describe('QueryEditorSidebar', () => {
     expect(screen.getByRole('button', { name: /select card organize/i })).toBeInTheDocument();
   });
 
-  it('should render an "Add below" button for every card', () => {
+  it('should render "Add below" buttons only for query/expression cards, not transformations', () => {
     const queries: DataQuery[] = [
       { refId: 'A', datasource: { type: 'test', uid: 'test' } },
       { refId: 'B', datasource: { type: 'test', uid: 'test' } },
@@ -197,9 +197,11 @@ describe('QueryEditorSidebar', () => {
       </QueryEditorProvider>
     );
 
-    // Every card (2 queries + 1 transformation) should have an "Add below" button
+    // Query cards should have an "Add below" button
     expect(screen.getByRole('button', { name: /add below A/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /add below B/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /add below organize/i })).toBeInTheDocument();
+
+    // Transformation cards should NOT have an "Add below" button
+    expect(screen.queryByRole('button', { name: /add below organize/i })).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.tsx
@@ -83,7 +83,6 @@ function getStyles(theme: GrafanaTheme2) {
       borderRadius: theme.shape.radius.default,
       padding: theme.spacing(1),
       background: theme.colors.background.primary,
-      overflowY: 'auto',
     }),
   };
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.tsx
@@ -83,6 +83,7 @@ function getStyles(theme: GrafanaTheme2) {
       borderRadius: theme.shape.radius.default,
       padding: theme.spacing(1),
       background: theme.colors.background.primary,
+      overflowY: 'auto',
     }),
   };
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QuerySidebarCollapsableHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QuerySidebarCollapsableHeader.tsx
@@ -1,10 +1,12 @@
 import { css } from '@emotion/css';
 import { useState } from 'react';
 
-import { CollapsableSection, Stack, Text } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { CollapsableSection, Stack, Text, useStyles2 } from '@grafana/ui';
 
 export const QuerySidebarCollapsableHeader = ({ label, children }: { label: string; children: React.ReactNode }) => {
   const [isOpen, setIsOpen] = useState(true);
+  const styles = useStyles2(getStyles);
 
   return (
     <CollapsableSection
@@ -15,11 +17,23 @@ export const QuerySidebarCollapsableHeader = ({ label, children }: { label: stri
       }
       isOpen={isOpen}
       onToggle={setIsOpen}
-      contentClassName={css({ padding: 0 })}
+      className={styles.collapsableSection}
     >
-      <Stack direction="column" gap={1}>
-        {children}
-      </Stack>
+      <div className={styles.queryStackCardsContainer}>
+        <Stack direction="column" gap={2.5}>
+          {children}
+        </Stack>
+      </div>
     </CollapsableSection>
   );
 };
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  collapsableSection: css({
+    padding: 0,
+    marginTop: theme.spacing(2),
+  }),
+  queryStackCardsContainer: css({
+    paddingTop: theme.spacing(0.5),
+  }),
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QuerySidebarCollapsableHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QuerySidebarCollapsableHeader.tsx
@@ -18,6 +18,7 @@ export const QuerySidebarCollapsableHeader = ({ label, children }: { label: stri
       isOpen={isOpen}
       onToggle={setIsOpen}
       className={styles.collapsableSection}
+      contentClassName={styles.contentArea}
     >
       <div className={styles.queryStackCardsContainer}>
         <Stack direction="column" gap={2.5}>
@@ -30,10 +31,12 @@ export const QuerySidebarCollapsableHeader = ({ label, children }: { label: stri
 
 const getStyles = (theme: GrafanaTheme2) => ({
   collapsableSection: css({
+    marginTop: theme.spacing(1),
+  }),
+  contentArea: css({
     padding: 0,
-    marginTop: theme.spacing(2),
   }),
   queryStackCardsContainer: css({
-    paddingTop: theme.spacing(0.5),
+    paddingTop: theme.spacing(1),
   }),
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QuerySidebarCollapsableHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QuerySidebarCollapsableHeader.tsx
@@ -38,5 +38,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   queryStackCardsContainer: css({
     paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(2.5), // Prevents clipping of the last card's absolutely-positioned AddCardButton
   }),
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.test.tsx
@@ -21,7 +21,6 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 const queryConfig = QUERY_EDITOR_TYPE_CONFIG[QueryEditorType.Query];
-const transformationConfig = QUERY_EDITOR_TYPE_CONFIG[QueryEditorType.Transformation];
 
 interface RenderSidebarCardProps {
   id?: string;
@@ -30,6 +29,7 @@ interface RenderSidebarCardProps {
   addQuery?: jest.Mock;
   setSelectedQuery?: jest.Mock;
   config?: typeof queryConfig;
+  showAddButton?: boolean;
 }
 
 function renderSidebarCard({
@@ -39,6 +39,7 @@ function renderSidebarCard({
   addQuery = jest.fn().mockReturnValue('B'),
   setSelectedQuery = jest.fn(),
   config = queryConfig,
+  showAddButton = true,
 }: RenderSidebarCardProps = {}) {
   // The add button starts with pointer-events: none (visible only on hover).
   // JSDOM can't simulate CSS :hover, so we skip the pointer-events check.
@@ -77,6 +78,7 @@ function renderSidebarCard({
         onToggleHide={jest.fn()}
         isHidden={false}
         onDuplicate={jest.fn()}
+        showAddButton={showAddButton}
       >
         <span>Card content</span>
       </SidebarCard>
@@ -182,8 +184,8 @@ describe('SidebarCard', () => {
       expect(screen.getByText('Card content')).toBeInTheDocument();
     });
 
-    it('does not render the add button for transformation cards', () => {
-      renderSidebarCard({ config: transformationConfig });
+    it('does not render the add button when showAddButton is false', () => {
+      renderSidebarCard({ showAddButton: false });
 
       expect(screen.getByRole('button', { name: /select card A/i })).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /add below A/i })).not.toBeInTheDocument();

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.test.tsx
@@ -21,6 +21,16 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 const queryConfig = QUERY_EDITOR_TYPE_CONFIG[QueryEditorType.Query];
+const transformationConfig = QUERY_EDITOR_TYPE_CONFIG[QueryEditorType.Transformation];
+
+interface RenderSidebarCardProps {
+  id?: string;
+  isSelected?: boolean;
+  onClick?: jest.Mock;
+  addQuery?: jest.Mock;
+  setSelectedQuery?: jest.Mock;
+  config?: typeof queryConfig;
+}
 
 function renderSidebarCard({
   id = 'A',
@@ -28,7 +38,8 @@ function renderSidebarCard({
   onClick = jest.fn(),
   addQuery = jest.fn().mockReturnValue('B'),
   setSelectedQuery = jest.fn(),
-} = {}) {
+  config = queryConfig,
+}: RenderSidebarCardProps = {}) {
   // The add button starts with pointer-events: none (visible only on hover).
   // JSDOM can't simulate CSS :hover, so we skip the pointer-events check.
   const user = userEvent.setup({ pointerEventsCheck: 0 });
@@ -57,7 +68,7 @@ function renderSidebarCard({
       }}
       actions={actions}
     >
-      <SidebarCard config={queryConfig} isSelected={isSelected} id={id} onClick={onClick}>
+      <SidebarCard config={config} isSelected={isSelected} id={id} onClick={onClick}>
         <span>Card content</span>
       </SidebarCard>
     </QueryEditorProvider>
@@ -160,6 +171,13 @@ describe('SidebarCard', () => {
       expect(screen.getByRole('button', { name: /select card A/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /add below A/i })).toBeInTheDocument();
       expect(screen.getByText('Card content')).toBeInTheDocument();
+    });
+
+    it('does not render the add button for transformation cards', () => {
+      renderSidebarCard({ config: transformationConfig });
+
+      expect(screen.getByRole('button', { name: /select card A/i })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /add below A/i })).not.toBeInTheDocument();
     });
 
     it('clicking "Add query" calls addQuery with the card refId as afterRefId', async () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.test.tsx
@@ -68,7 +68,16 @@ function renderSidebarCard({
       }}
       actions={actions}
     >
-      <SidebarCard config={config} isSelected={isSelected} id={id} onClick={onClick}>
+      <SidebarCard
+        config={config}
+        isSelected={isSelected}
+        id={id}
+        onClick={onClick}
+        onDelete={jest.fn()}
+        onToggleHide={jest.fn()}
+        isHidden={false}
+        onDuplicate={jest.fn()}
+      >
         <span>Card content</span>
       </SidebarCard>
     </QueryEditorProvider>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.test.tsx
@@ -40,7 +40,7 @@ function renderSidebarCard({
       dsState={{ datasource: undefined, dsSettings: undefined, dsError: undefined }}
       qrState={{ queries, data: undefined, isLoading: false }}
       panelState={{
-        panel: {} as never,
+        panel: new VizPanel({ key: 'panel-1' }),
         transformations: [],
       }}
       uiState={{

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
@@ -4,7 +4,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Icon, Stack, Text, useStyles2 } from '@grafana/ui';
 
-import { QUERY_EDITOR_TYPE_HAS_ADD_BUTTON, QueryEditorTypeConfig } from '../../constants';
+import { QueryEditorTypeConfig } from '../../constants';
 
 import { AddCardButton } from './AddCardButton';
 import { HoverActions } from './HoverActions';
@@ -19,6 +19,7 @@ interface SidebarCardProps {
   onDelete: () => void;
   onToggleHide: () => void;
   isHidden: boolean;
+  showAddButton: boolean;
 }
 
 export const SidebarCard = ({
@@ -31,8 +32,9 @@ export const SidebarCard = ({
   onDelete,
   onToggleHide,
   isHidden,
+  showAddButton = true,
 }: SidebarCardProps) => {
-  const hasAddButton = QUERY_EDITOR_TYPE_HAS_ADD_BUTTON[config.__type__];
+  const hasAddButton = showAddButton;
   const styles = useStyles2(getStyles, { config, isSelected, hasAddButton });
   const typeText = config.getLabel();
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
@@ -105,18 +105,17 @@ function getStyles(
 
       // Two slim pseudo-element strips extend the hover zone to the left and
       // below the card, covering the path to the <AddCardButton /> ("+" icon button)
-      // without overlapping the card's own clickable surface (which would interfere
-      // with selecting the query card).
+      // without overlapping the card's own clickable surface
 
       // Left strip: narrow gutter running along the card's left edge and below.
       '&::before': {
         content: '""',
         position: 'absolute',
-        top: '0%',
+        top: 0,
         left: `calc(-1 * ${theme.spacing(1.5)})`,
         width: theme.spacing(1.5),
         height: `calc(100% + ${theme.spacing(1.5)})`,
-        // background: 'hsla(333, 83%, 33%, 0.5)', // uncomment to debug hover zone to the left of the card
+        background: 'hsla(333, 83%, 33%, 0.5)', // uncomment to debug hover zone to the left of the card
       },
 
       // Bottom strip: runs along the card's bottom edge extending to the left.
@@ -127,7 +126,7 @@ function getStyles(
         left: `calc(-1 * ${theme.spacing(1.5)})`,
         width: `calc(100% + ${theme.spacing(1.5)})`,
         height: theme.spacing(1.5),
-        // background: 'hsla(333, 83%, 33%, 0.5)', // uncomment to debug hover zone below the card
+        background: 'hsla(333, 83%, 33%, 0.5)', // uncomment to debug hover zone below the card
       },
 
       '&:hover': {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
@@ -1,31 +1,13 @@
 import { css, cx } from '@emotion/css';
-import { useCallback, useMemo, useState } from 'react';
 
-import { CoreApp, GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config as grafanaConfig } from '@grafana/runtime';
-import { DataQuery } from '@grafana/schema';
-import { Dropdown, Icon, Menu, Stack, Text, useStyles2, useTheme2 } from '@grafana/ui';
-import { contextSrv } from 'app/core/services/context_srv';
-import { useQueryLibraryContext } from 'app/features/explore/QueryLibrary/QueryLibraryContext';
-import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
-import { ExpressionQueryType, expressionTypes } from 'app/features/expressions/types';
-import { getDefaults } from 'app/features/expressions/utils/expressionTypes';
-import { AccessControlAction } from 'app/types/accessControl';
+import { Icon, Stack, Text, useStyles2 } from '@grafana/ui';
 
 import { QueryEditorTypeConfig } from '../../constants';
-import { useActionsContext, useQueryEditorUIContext } from '../QueryEditorContext';
 
+import { AddCardButton } from './AddCardButton';
 import { HoverActions } from './HoverActions';
-
-const EXPRESSION_ICON_MAP = {
-  [ExpressionQueryType.math]: 'calculator-alt',
-  [ExpressionQueryType.reduce]: 'compress-arrows',
-  [ExpressionQueryType.resample]: 'sync',
-  [ExpressionQueryType.classic]: 'cog',
-  [ExpressionQueryType.threshold]: 'sliders-v-alt',
-  [ExpressionQueryType.sql]: 'database',
-} as const satisfies Record<ExpressionQueryType, string>;
 
 interface SidebarCardProps {
   config: QueryEditorTypeConfig;
@@ -37,12 +19,6 @@ interface SidebarCardProps {
   onDelete: () => void;
   onToggleHide: () => void;
   isHidden: boolean;
-}
-
-function isExpressionType(
-  item: SelectableValue<ExpressionQueryType>
-): item is SelectableValue<ExpressionQueryType> & { value: ExpressionQueryType } {
-  return typeof item.value === 'string' && item.value in EXPRESSION_ICON_MAP;
 }
 
 /**
@@ -62,118 +38,7 @@ export const SidebarCard = ({
   isHidden,
 }: SidebarCardProps) => {
   const styles = useStyles2(getStyles, { config, isSelected });
-  const theme = useTheme2();
   const typeText = config.getLabel();
-  const { addQuery } = useActionsContext();
-  const { setSelectedQuery } = useQueryEditorUIContext();
-  const { openDrawer, queryLibraryEnabled } = useQueryLibraryContext();
-  const [menuOpen, setMenuOpen] = useState(false);
-  const [menuView, setMenuView] = useState<MenuView>('main');
-
-  // Callback ref: focuses the submenu as soon as it mounts so keyboard
-  // navigation (arrow keys) works immediately. FloatingFocusManager only
-  // handles focus on the initial Dropdown open, not on content swaps.
-  const focusOnMount = useCallback((el: HTMLDivElement | null) => el?.focus(), []);
-
-  // When the savedQueriesRBAC feature toggle is enabled, access to the query
-  // library is governed by fine-grained RBAC permissions. Otherwise, any
-  // signed-in user can read saved queries (the pre-RBAC default).
-  const canReadQueries = grafanaConfig.featureToggles.savedQueriesRBAC
-    ? contextSrv.hasPermission(AccessControlAction.QueriesRead)
-    : contextSrv.isSignedIn;
-
-  /** Add a query after this card and auto-select it in the sidebar. */
-  const addAndSelect = useCallback(
-    (query?: Partial<DataQuery>) => {
-      const newRefId = addQuery(query, id);
-      if (newRefId) {
-        // `setSelectedQuery` only needs a `refId` to identify the query;
-        // the full `DataQuery` will be resolved from the queries array.
-        const selectTarget: DataQuery = { refId: newRefId, hide: false };
-        setSelectedQuery(selectTarget);
-      }
-    },
-    [addQuery, id, setSelectedQuery]
-  );
-
-  /** Create an expression of a certain type and add it. */
-  const addExpressionOfType = useCallback(
-    (type: ExpressionQueryType) => {
-      const baseQuery = expressionDatasource.newQuery();
-      const queryWithType = { ...baseQuery, type };
-      const queryWithDefaults = getDefaults(queryWithType);
-      addAndSelect(queryWithDefaults);
-    },
-    [addAndSelect]
-  );
-
-  /** Reset the menu to the main view when it closes. */
-  const handleMenuVisibleChange = useCallback((visible: boolean) => {
-    setMenuOpen(visible);
-    if (!visible) {
-      setMenuView('main');
-    }
-  }, []);
-
-  const menus: Record<MenuView, React.ReactElement> = useMemo(
-    () => ({
-      main: (
-        <Menu key="main">
-          <Menu.Item
-            label={t('query-editor-next.sidebar.add-query', 'Add query')}
-            icon="question-circle"
-            onClick={() => addAndSelect()}
-          />
-          {queryLibraryEnabled && canReadQueries && (
-            <Menu.Item
-              label={t('query-editor-next.sidebar.add-saved-query', 'Add saved query')}
-              icon="book-open"
-              onClick={() =>
-                openDrawer({
-                  onSelectQuery: (query) => addAndSelect(query),
-                  options: { context: CoreApp.PanelEditor },
-                })
-              }
-            />
-          )}
-          <Menu.Item
-            label={t('query-editor-next.sidebar.add-expression', 'Add expression')}
-            icon="calculator-alt"
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              setMenuView('expressionTypes');
-            }}
-          />
-        </Menu>
-      ),
-      expressionTypes: (
-        <Menu key="expressionTypes" ref={focusOnMount}>
-          <Menu.Item
-            label={t('query-editor-next.sidebar.back', 'Back')}
-            icon="arrow-left"
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              setMenuView('main');
-            }}
-          />
-          <Menu.Divider />
-          {expressionTypes.filter(isExpressionType).map((item) => (
-            <Menu.Item
-              key={item.value}
-              label={item.label ?? ''}
-              icon={EXPRESSION_ICON_MAP[item.value]}
-              onClick={() => addExpressionOfType(item.value)}
-            />
-          ))}
-        </Menu>
-      ),
-    }),
-    [addAndSelect, addExpressionOfType, canReadQueries, focusOnMount, openDrawer, queryLibraryEnabled]
-  );
-
-  const addMenu = menus[menuView];
 
   // Using a div with role="button" instead of a native button for @hello-pangea/dnd compatibility,
   // so we manually handle Enter and Space key activation.
@@ -210,25 +75,10 @@ export const SidebarCard = ({
               isHidden={isHidden}
             />
           </div>
-          <div className={styles.cardContent}>{children}</div>
         </div>
-        <Dropdown
-          overlay={addMenu}
-          placement="right-start"
-          offset={[theme.spacing.gridSize, 0]} // nudge the menu to the right, for a little space between the "+" button and the menu
-          onVisibleChange={handleMenuVisibleChange}
-        >
-          <button
-            className={styles.addButton}
-            data-add-button
-            data-menu-open={menuOpen || undefined}
-            type="button"
-            aria-label={t('query-editor-next.sidebar.add-below', 'Add below {{id}}', { id })}
-          >
-            <Icon name="plus" size="md" />
-          </button>
-        </Dropdown>
+        <div className={styles.cardContent}>{children}</div>
       </div>
+      <AddCardButton afterRefId={id} />
     </div>
   );
 };
@@ -254,9 +104,9 @@ function getStyles(
       marginInline: theme.spacing(2),
 
       // Two slim pseudo-element strips extend the hover zone to the left and
-      // below the card, covering the path to the "+" button without overlapping
-      // the card's own clickable surface (which would interfere with selecting
-      // the query card).
+      // below the card, covering the path to the <AddCardButton /> ("+" icon button)
+      // without overlapping the card's own clickable surface (which would interfere
+      // with selecting the query card).
 
       // Left strip: narrow gutter running along the card's left edge and below.
       '&::before': {
@@ -266,7 +116,7 @@ function getStyles(
         left: `calc(-1 * ${theme.spacing(1.5)})`,
         width: theme.spacing(1.5),
         height: `calc(100% + ${theme.spacing(1.5)})`,
-        // background: 'hsla(333, 83%, 33%, 0.5)', // uncomment to debug hover zone
+        // background: 'hsla(333, 83%, 33%, 0.5)', // uncomment to debug hover zone to the left of the card
       },
 
       // Bottom strip: runs along the card's bottom edge extending to the left.
@@ -277,7 +127,7 @@ function getStyles(
         left: `calc(-1 * ${theme.spacing(1.5)})`,
         width: `calc(100% + ${theme.spacing(1.5)})`,
         height: theme.spacing(1.5),
-        // background: 'hsla(333, 83%, 33%, 0.5)', // uncomment to debug hover zone
+        // background: 'hsla(333, 83%, 33%, 0.5)', // uncomment to debug hover zone below the card
       },
 
       '&:hover': {
@@ -319,43 +169,6 @@ function getStyles(
       },
 
       '&:focus-visible': {
-        outline: `2px solid ${theme.colors.primary.border}`,
-        outlineOffset: '2px',
-      },
-    }),
-    addButton: css({
-      position: 'absolute',
-      top: 'calc(100%)',
-      left: 0,
-      transform: 'translate(-100%, 0)',
-      zIndex: 1,
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      width: theme.spacing(2),
-      height: theme.spacing(2),
-      borderRadius: theme.shape.radius.sm,
-      border: 'none',
-      background: theme.colors.primary.main,
-      color: theme.colors.primary.contrastText,
-      cursor: 'pointer',
-      padding: 0,
-      opacity: 0,
-      pointerEvents: 'none',
-
-      [theme.transitions.handleMotion('no-preference', 'reduce')]: {
-        transition: theme.transitions.create(['opacity', 'background-color'], {
-          duration: theme.transitions.duration.short,
-        }),
-      },
-
-      '&:hover': {
-        background: theme.colors.primary.shade,
-      },
-
-      '&:focus-visible': {
-        opacity: 1,
-        pointerEvents: 'auto',
         outline: `2px solid ${theme.colors.primary.border}`,
         outlineOffset: '2px',
       },

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from '@emotion/css';
 import { useCallback, useRef, useState } from 'react';
 
-import { CoreApp, GrafanaTheme2 } from '@grafana/data';
+import { CoreApp, GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config as grafanaConfig } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
@@ -37,6 +37,12 @@ interface SidebarCardProps {
   onDelete: () => void;
   onToggleHide: () => void;
   isHidden: boolean;
+}
+
+function isExpressionType(
+  item: SelectableValue<ExpressionQueryType>
+): item is SelectableValue<ExpressionQueryType> & { value: ExpressionQueryType } {
+  return typeof item.value === 'string' && item.value in EXPRESSION_ICON_MAP;
 }
 
 /**
@@ -146,12 +152,12 @@ export const SidebarCard = ({
           }}
         />
         <Menu.Divider />
-        {expressionTypes.map((item) => (
+        {expressionTypes.filter(isExpressionType).map((item) => (
           <Menu.Item
             key={item.value}
             label={item.label ?? ''}
-            icon={EXPRESSION_ICON_MAP[item.value!]}
-            onClick={() => addExpressionOfType(item.value!)}
+            icon={EXPRESSION_ICON_MAP[item.value]}
+            onClick={() => addExpressionOfType(item.value)}
           />
         ))}
       </Menu>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
@@ -63,7 +63,6 @@ export const SidebarCard = ({
   const { openDrawer, queryLibraryEnabled } = useQueryLibraryContext();
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuView, setMenuView] = useState<MenuView>('main');
-  const addButtonRef = useRef<HTMLButtonElement>(null);
 
   // Callback ref: focuses the submenu as soon as it mounts so keyboard
   // navigation (arrow keys) works immediately. FloatingFocusManager only
@@ -205,7 +204,6 @@ export const SidebarCard = ({
           onVisibleChange={handleMenuVisibleChange}
         >
           <button
-            ref={addButtonRef}
             className={styles.addButton}
             data-add-button
             data-menu-open={menuOpen || undefined}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
@@ -253,15 +253,30 @@ function getStyles(
       position: 'relative',
       marginInline: theme.spacing(2),
 
-      // Invisible pseudo-element extends the hover zone to cover the "+" button
-      // which sits outside the card's bottom-left corner.
+      // Two slim pseudo-element strips extend the hover zone to the left and
+      // below the card, covering the path to the "+" button without overlapping
+      // the card's own clickable surface (which would interfere with selecting
+      // the query card).
+
+      // Left strip: narrow gutter running along the card's left edge and below.
+      '&::before': {
+        content: '""',
+        position: 'absolute',
+        top: '0%',
+        left: `calc(-1 * ${theme.spacing(1.5)})`,
+        width: theme.spacing(1.5),
+        height: `calc(100% + ${theme.spacing(1.5)})`,
+        // background: 'hsla(333, 83%, 33%, 0.5)', // uncomment to debug hover zone
+      },
+
+      // Bottom strip: runs along the card's bottom edge extending to the left.
       '&::after': {
         content: '""',
         position: 'absolute',
-        bottom: '-1em',
+        top: '100%',
         left: `calc(-1 * ${theme.spacing(1.5)})`,
         width: `calc(100% + ${theme.spacing(1.5)})`,
-        height: `calc(100% + 1em)`,
+        height: theme.spacing(1.5),
         // background: 'hsla(333, 83%, 33%, 0.5)', // uncomment to debug hover zone
       },
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
@@ -115,7 +115,7 @@ function getStyles(
         left: `calc(-1 * ${theme.spacing(1.5)})`,
         width: theme.spacing(1.5),
         height: `calc(100% + ${theme.spacing(1.5)})`,
-        background: 'hsla(333, 83%, 33%, 0.5)', // uncomment to debug hover zone to the left of the card
+        // background: 'hsla(333, 83%, 33%, 0.5)', // uncomment to debug hover zone to the left of the card
       },
 
       // Bottom strip: runs along the card's bottom edge extending to the left.
@@ -126,7 +126,7 @@ function getStyles(
         left: `calc(-1 * ${theme.spacing(1.5)})`,
         width: `calc(100% + ${theme.spacing(1.5)})`,
         height: theme.spacing(1.5),
-        background: 'hsla(333, 83%, 33%, 0.5)', // uncomment to debug hover zone below the card
+        // background: 'hsla(333, 83%, 33%, 0.5)', // uncomment to debug hover zone below the card
       },
 
       '&:hover': {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
@@ -65,6 +65,11 @@ export const SidebarCard = ({
   const [menuView, setMenuView] = useState<MenuView>('main');
   const addButtonRef = useRef<HTMLButtonElement>(null);
 
+  // Callback ref: focuses the submenu as soon as it mounts so keyboard
+  // navigation (arrow keys) works immediately. FloatingFocusManager only
+  // handles focus on the initial Dropdown open, not on content swaps.
+  const focusOnMount = useCallback((el: HTMLDivElement | null) => el?.focus(), []);
+
   // When the savedQueriesRBAC feature toggle is enabled, access to the query
   // library is governed by fine-grained RBAC permissions. Otherwise, any
   // signed-in user can read saved queries (the pre-RBAC default).
@@ -101,7 +106,7 @@ export const SidebarCard = ({
 
   const menus: Record<MenuView, React.ReactElement> = {
     main: (
-      <Menu>
+      <Menu key="main">
         <Menu.Item
           label={t('query-editor-next.sidebar.add-query', 'Add query')}
           icon="question-circle"
@@ -131,7 +136,7 @@ export const SidebarCard = ({
       </Menu>
     ),
     expressionTypes: (
-      <Menu>
+      <Menu key="expressionTypes" ref={focusOnMount}>
         <Menu.Item
           label={t('query-editor-next.sidebar.back', 'Back')}
           icon="arrow-left"

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
@@ -132,7 +132,7 @@ function getStyles(
           zIndex: 1,
         },
 
-        '&:hover [data-add-button], [data-menu-open]': {
+        '&:hover [data-add-button], & [data-menu-open]': {
           opacity: 1,
           pointerEvents: 'auto',
         },

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
@@ -4,7 +4,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Icon, Stack, Text, useStyles2 } from '@grafana/ui';
 
-import { QueryEditorTypeConfig } from '../../constants';
+import { QUERY_EDITOR_TYPE_HAS_ADD_BUTTON, QueryEditorTypeConfig } from '../../constants';
 
 import { AddCardButton } from './AddCardButton';
 import { HoverActions } from './HoverActions';
@@ -21,11 +21,6 @@ interface SidebarCardProps {
   isHidden: boolean;
 }
 
-/**
- * The various menu views for the sidebar card.
- */
-type MenuView = 'main' | 'expressionTypes';
-
 export const SidebarCard = ({
   config,
   isSelected,
@@ -37,7 +32,8 @@ export const SidebarCard = ({
   onToggleHide,
   isHidden,
 }: SidebarCardProps) => {
-  const styles = useStyles2(getStyles, { config, isSelected });
+  const hasAddButton = QUERY_EDITOR_TYPE_HAS_ADD_BUTTON[config.__type__];
+  const styles = useStyles2(getStyles, { config, isSelected, hasAddButton });
   const typeText = config.getLabel();
 
   // Using a div with role="button" instead of a native button for @hello-pangea/dnd compatibility,
@@ -78,14 +74,14 @@ export const SidebarCard = ({
         </div>
         <div className={styles.cardContent}>{children}</div>
       </div>
-      <AddCardButton afterRefId={id} />
+      {hasAddButton && <AddCardButton afterRefId={id} />}
     </div>
   );
 };
 
 function getStyles(
   theme: GrafanaTheme2,
-  { config, isSelected }: { config: QueryEditorTypeConfig; isSelected?: boolean }
+  { config, isSelected, hasAddButton }: { config: QueryEditorTypeConfig; isSelected?: boolean; hasAddButton?: boolean }
 ) {
   const hoverActions = css({
     opacity: 0,
@@ -103,41 +99,42 @@ function getStyles(
       position: 'relative',
       marginInline: theme.spacing(2),
 
-      // Two slim pseudo-element strips extend the hover zone to the left and
-      // below the card, covering the path to the <AddCardButton /> ("+" icon button)
-      // without overlapping the card's own clickable surface
+      // The hover-zone pseudo-elements and add-button visibility rules are
+      // only needed when the card has an AddCardButton.
+      ...(hasAddButton && {
+        // Two slim pseudo-element strips extend the hover zone to the left and
+        // below the card, covering the path to the "+" button without overlapping
+        // the card's clickable area.
 
-      // Left strip: narrow gutter running along the card's left edge and below.
-      '&::before': {
-        content: '""',
-        position: 'absolute',
-        top: 0,
-        left: `calc(-1 * ${theme.spacing(1.5)})`,
-        width: theme.spacing(1.5),
-        height: `calc(100% + ${theme.spacing(1.5)})`,
-        // background: 'hsla(333, 83%, 33%, 0.5)', // uncomment to debug hover zone to the left of the card
-      },
+        // Left strip: narrow gutter running along the card's left edge and below.
+        '&::before': {
+          content: '""',
+          position: 'absolute',
+          top: 0,
+          left: `calc(-1 * ${theme.spacing(1.5)})`,
+          width: theme.spacing(1.5),
+          height: `calc(100% + ${theme.spacing(1.5)})`,
+        },
 
-      // Bottom strip: runs along the card's bottom edge extending to the left.
-      '&::after': {
-        content: '""',
-        position: 'absolute',
-        top: '100%',
-        left: `calc(-1 * ${theme.spacing(1.5)})`,
-        width: `calc(100% + ${theme.spacing(1.5)})`,
-        height: theme.spacing(1.5),
-        // background: 'hsla(333, 83%, 33%, 0.5)', // uncomment to debug hover zone below the card
-      },
+        // Bottom strip: runs along the card's bottom edge extending to the left.
+        '&::after': {
+          content: '""',
+          position: 'absolute',
+          top: '100%',
+          left: `calc(-1 * ${theme.spacing(1.5)})`,
+          width: `calc(100% + ${theme.spacing(1.5)})`,
+          height: theme.spacing(1.5),
+        },
 
-      '&:hover': {
-        zIndex: 1,
-      },
+        '&:hover': {
+          zIndex: 1,
+        },
 
-      // Show add button on hover, or when its dropdown menu is open
-      '&:hover [data-add-button], [data-menu-open]': {
-        opacity: 1,
-        pointerEvents: 'auto',
-      },
+        '&:hover [data-add-button], [data-menu-open]': {
+          opacity: 1,
+          pointerEvents: 'auto',
+        },
+      }),
     }),
     card: css({
       display: 'flex',

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
@@ -192,7 +192,6 @@ function getStyles(
       gap: theme.spacing(1),
       padding: theme.spacing(1),
     }),
-
     hidden: css({
       opacity: 0.6,
     }),

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/TransformationCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/TransformationCard.tsx
@@ -21,6 +21,7 @@ export const TransformationCard = ({ transformation }: { transformation: Transfo
       onDelete={() => deleteTransformation(transformation.transformId)}
       onToggleHide={() => toggleTransformationDisabled(transformation.transformId)}
       isHidden={!!transformation.transformConfig.disabled}
+      showAddButton={false}
     >
       <Text weight="light" variant="code" color="secondary">
         {transformationName}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/VizAndDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/VizAndDataPaneNext.tsx
@@ -100,7 +100,7 @@ function getStyles(theme: GrafanaTheme2, sidebarSize: SidebarSize) {
     }),
     sidebar: css({
       gridArea: 'sidebar',
-      overflow: 'visible',
+      overflow: 'hidden',
       position: 'relative',
       boxSizing: 'border-box',
       paddingBottom: theme.spacing(2),

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
@@ -1,5 +1,6 @@
 import { IconName } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { ExpressionQueryType } from 'app/features/expressions/types';
 
 import { QueryOptionField } from './QueryEditor/types';
 
@@ -126,3 +127,12 @@ export const QUERY_OPTION_FIELD_CONFIG: Record<QueryOptionField, QueryOptionFiel
     inputType: 'number',
   },
 };
+
+export const EXPRESSION_ICON_MAP = {
+  [ExpressionQueryType.math]: 'calculator-alt',
+  [ExpressionQueryType.reduce]: 'compress-arrows',
+  [ExpressionQueryType.resample]: 'sync',
+  [ExpressionQueryType.classic]: 'cog',
+  [ExpressionQueryType.threshold]: 'sliders-v-alt',
+  [ExpressionQueryType.sql]: 'database',
+} as const satisfies Record<ExpressionQueryType, string>;

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
@@ -23,6 +23,7 @@ export const QUERY_EDITOR_COLORS = {
 };
 
 export interface QueryEditorTypeConfig {
+  __type__: QueryEditorType;
   icon: IconName;
   color: string;
   getLabel: () => string;
@@ -30,16 +31,19 @@ export interface QueryEditorTypeConfig {
 
 export const QUERY_EDITOR_TYPE_CONFIG: Record<QueryEditorType, QueryEditorTypeConfig> = {
   [QueryEditorType.Query]: {
+    __type__: QueryEditorType.Query,
     icon: 'database',
     color: QUERY_EDITOR_COLORS.query,
     getLabel: () => t('query-editor-next.labels.query', 'Query'),
   },
   [QueryEditorType.Expression]: {
+    __type__: QueryEditorType.Expression,
     icon: 'calculator-alt',
     color: QUERY_EDITOR_COLORS.expression,
     getLabel: () => t('query-editor-next.labels.expression', 'Expression'),
   },
   [QueryEditorType.Transformation]: {
+    __type__: QueryEditorType.Transformation,
     icon: 'process',
     color: QUERY_EDITOR_COLORS.transformation,
     getLabel: () => t('query-editor-next.labels.transformation', 'Transformation'),
@@ -136,3 +140,9 @@ export const EXPRESSION_ICON_MAP = {
   [ExpressionQueryType.threshold]: 'sliders-v-alt',
   [ExpressionQueryType.sql]: 'database',
 } as const satisfies Record<ExpressionQueryType, string>;
+
+export const QUERY_EDITOR_TYPE_HAS_ADD_BUTTON: Record<QueryEditorType, boolean> = {
+  [QueryEditorType.Query]: true,
+  [QueryEditorType.Expression]: true,
+  [QueryEditorType.Transformation]: false,
+};

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
@@ -23,7 +23,6 @@ export const QUERY_EDITOR_COLORS = {
 };
 
 export interface QueryEditorTypeConfig {
-  __type__: QueryEditorType;
   icon: IconName;
   color: string;
   getLabel: () => string;
@@ -31,19 +30,16 @@ export interface QueryEditorTypeConfig {
 
 export const QUERY_EDITOR_TYPE_CONFIG: Record<QueryEditorType, QueryEditorTypeConfig> = {
   [QueryEditorType.Query]: {
-    __type__: QueryEditorType.Query,
     icon: 'database',
     color: QUERY_EDITOR_COLORS.query,
     getLabel: () => t('query-editor-next.labels.query', 'Query'),
   },
   [QueryEditorType.Expression]: {
-    __type__: QueryEditorType.Expression,
     icon: 'calculator-alt',
     color: QUERY_EDITOR_COLORS.expression,
     getLabel: () => t('query-editor-next.labels.expression', 'Expression'),
   },
   [QueryEditorType.Transformation]: {
-    __type__: QueryEditorType.Transformation,
     icon: 'process',
     color: QUERY_EDITOR_COLORS.transformation,
     getLabel: () => t('query-editor-next.labels.transformation', 'Transformation'),
@@ -140,9 +136,3 @@ export const EXPRESSION_ICON_MAP = {
   [ExpressionQueryType.threshold]: 'sliders-v-alt',
   [ExpressionQueryType.sql]: 'database',
 } as const satisfies Record<ExpressionQueryType, string>;
-
-export const QUERY_EDITOR_TYPE_HAS_ADD_BUTTON: Record<QueryEditorType, boolean> = {
-  [QueryEditorType.Query]: true,
-  [QueryEditorType.Expression]: true,
-  [QueryEditorType.Transformation]: false,
-};

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.ts
@@ -140,8 +140,8 @@ export function usePanelEditorShell(model: PanelEditor) {
 
 export function useVizAndDataPaneLayout(model: PanelEditor, containerHeight: number) {
   const CONTROLS_ROW_HEIGHT_PX = 32;
-  const SIDEBAR_MIN_WIDTH = 285;
-  const SIDEBAR_MAX_WIDTH = 380;
+  const SIDEBAR_MIN_WIDTH = 320;
+  const SIDEBAR_MAX_WIDTH = 420;
   const VIZ_MIN_HEIGHT = 200;
   const VIZ_BOTTOM_GAP = 80;
   const SIDEBAR_EXPANDED_PADDING = 16;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13010,6 +13010,11 @@
       "transformation": "Transformation"
     },
     "sidebar": {
+      "add-below": "Add below {{id}}",
+      "add-expression": "Add expression",
+      "add-query": "Add query",
+      "add-saved-query": "Add saved query",
+      "back": "Back",
       "card-click": "Select card {{id}}",
       "queries-expressions": "Queries & Expressions",
       "query-stack": "Query Stack",


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->

This PR closes #116714. It enables adding new cards to the **Queries & Expressions** in the Query Stack.

## Changes
<!--- Describe your changes in detail -->
- Updates `PanelDataPaneNext.tsx` to ensure that expressions can be added without the panel-level datasource overriding the `ExpressionDatasourceRef`. This matches how expressions were handled in the original query editor.
- Updates `SidebarCard.tsx` and adds `AddCardButton.tsx` to add a ➕ icon to cards in the **Query Stack**, which opens a menu supporting addition of new queries, saved queries, and expressions.
- Adds tests.
- Other updates to styles, to more closely align with the [designs](https://www.figma.com/design/3H1r3q7pxqbxF8IH9nYVIz/Reimagining-Querying-Explorations?node-id=2362-9499&m=dev).

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->

~Should this PR be doing anything to support Transformations functionality? cc: @sgriff96~ 

UPDATE: Per design feedback, we'll wait on additional designs before enabling "add new card" functionality for Transformations. In the meantime, the ➕ icon button is disabled for Transformations.

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->

Queries, saved queries, and expressions can be added via the menu:

https://github.com/user-attachments/assets/5f957af0-e1fe-4062-b3c3-bb2e2925347c

The menu is also fully navigable via keyboard:

https://github.com/user-attachments/assets/1c39464e-c007-4d0d-8ace-00ec69327b73

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
- After checking out `116714/query-editor-add-new-card`, enable the `queryEditorNext` and `queryLibrary` feature toggles in `conf/custom/ini`.
- Run Grafana with enterprise features enabled.
- Open a dashboard and add various items to the **Query Stack**.
- Compare to the [designs](https://www.figma.com/design/3H1r3q7pxqbxF8IH9nYVIz/Reimagining-Querying-Explorations?node-id=2362-9499&m=dev).

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable