### PR TITLE
fix: plugin meta call works with sub paths

### DIFF
--- a/packages/grafana-runtime/src/services/pluginMeta/plugins.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/plugins.test.ts
@@ -49,7 +49,7 @@ describe('when useMTPlugins toggle is enabled and cache is not initialized', () 
     expect(response.items).toHaveLength(1);
     expect(response.items[0]).toBe(v0alpha1Meta);
     expect(global.fetch).toHaveBeenCalledTimes(1);
-    expect(global.fetch).toHaveBeenCalledWith('/apis/plugins.grafana.app/v0alpha1/namespaces/default/metas');
+    expect(global.fetch).toHaveBeenCalledWith('apis/plugins.grafana.app/v0alpha1/namespaces/default/metas');
   });
 });
 
@@ -77,7 +77,7 @@ describe('when useMTPlugins toggle is enabled and errors occur', () => {
     await initPluginMetas();
 
     expect(global.fetch).toHaveBeenCalledTimes(2); // first + second (because first throws), third is cached
-    expect(global.fetch).toHaveBeenCalledWith('/apis/plugins.grafana.app/v0alpha1/namespaces/default/metas');
+    expect(global.fetch).toHaveBeenCalledWith('apis/plugins.grafana.app/v0alpha1/namespaces/default/metas');
     expect(loggerMock.logError).toHaveBeenCalledTimes(1);
     expect(loggerMock.logError).toHaveBeenCalledWith(new Error(`Something failed while resolving a cached promise`), {
       message: 'Failed to load plugin metas 500:Internal Server Error',
@@ -101,7 +101,7 @@ describe('when useMTPlugins toggle is enabled and errors occur', () => {
     await initPluginMetas();
 
     expect(global.fetch).toHaveBeenCalledTimes(2); // first + second (because first throws), third is cached
-    expect(global.fetch).toHaveBeenCalledWith('/apis/plugins.grafana.app/v0alpha1/namespaces/default/metas');
+    expect(global.fetch).toHaveBeenCalledWith('apis/plugins.grafana.app/v0alpha1/namespaces/default/metas');
     expect(loggerMock.logError).toHaveBeenCalledTimes(1);
     expect(loggerMock.logError).toHaveBeenCalledWith(new Error(`Something failed while resolving a cached promise`), {
       message: 'Network Error',

--- a/packages/grafana-runtime/src/services/pluginMeta/plugins.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/plugins.ts
@@ -14,7 +14,7 @@ async function loadPluginMetas(): Promise<PluginMetasResponse> {
     return result;
   }
 
-  const metas = await fetch(`/apis/plugins.grafana.app/${getApiVersion()}/namespaces/${config.namespace}/metas`);
+  const metas = await fetch(`apis/plugins.grafana.app/${getApiVersion()}/namespaces/${config.namespace}/metas`);
   if (!metas.ok) {
     throw new Error(`Failed to load plugin metas ${metas.status}:${metas.statusText}`);
   }


### PR DESCRIPTION
**What is this feature?**

This pull request updates the way plugin meta data is fetched by removing the leading slash from the API endpoint URL.

I've configured the [ephemeral instance ](https://ephemeral15111821117737hugoha.grafana-dev.net/a/grafana-setupguide-app/home)with the correct feature toggles so it should call out to `metas` endpoint

**Why do we need this feature?**

So plugin meta requests work with configured sub paths

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

https://grafana.com/tutorials/run-grafana-behind-a-proxy/#introduction

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
