### PR TITLE
Provisioning: Fetch default branch for Pure Git repositories

### DIFF
--- a/apps/provisioning/pkg/repository/git/git.go
+++ b/apps/provisioning/pkg/repository/git/git.go
@@ -12,7 +12,7 @@ type GitRepository interface {
 	repository.Writer
 	repository.Reader
 	repository.StageableRepository
+	repository.BranchHandler
 	URL() string
 	Branch() string
-	SetBranch(branch string)
 }

--- a/apps/provisioning/pkg/repository/git/git_repository_mock.go
+++ b/apps/provisioning/pkg/repository/git/git_repository_mock.go
@@ -275,6 +275,107 @@ func (_c *MockGitRepository_Delete_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
+// GetCurrentBranch provides a mock function with no fields
+func (_m *MockGitRepository) GetCurrentBranch() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCurrentBranch")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// MockGitRepository_GetCurrentBranch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCurrentBranch'
+type MockGitRepository_GetCurrentBranch_Call struct {
+	*mock.Call
+}
+
+// GetCurrentBranch is a helper method to define mock.On call
+func (_e *MockGitRepository_Expecter) GetCurrentBranch() *MockGitRepository_GetCurrentBranch_Call {
+	return &MockGitRepository_GetCurrentBranch_Call{Call: _e.mock.On("GetCurrentBranch")}
+}
+
+func (_c *MockGitRepository_GetCurrentBranch_Call) Run(run func()) *MockGitRepository_GetCurrentBranch_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockGitRepository_GetCurrentBranch_Call) Return(_a0 string) *MockGitRepository_GetCurrentBranch_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockGitRepository_GetCurrentBranch_Call) RunAndReturn(run func() string) *MockGitRepository_GetCurrentBranch_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetDefaultBranch provides a mock function with given fields: ctx
+func (_m *MockGitRepository) GetDefaultBranch(ctx context.Context) (string, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDefaultBranch")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockGitRepository_GetDefaultBranch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDefaultBranch'
+type MockGitRepository_GetDefaultBranch_Call struct {
+	*mock.Call
+}
+
+// GetDefaultBranch is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockGitRepository_Expecter) GetDefaultBranch(ctx interface{}) *MockGitRepository_GetDefaultBranch_Call {
+	return &MockGitRepository_GetDefaultBranch_Call{Call: _e.mock.On("GetDefaultBranch", ctx)}
+}
+
+func (_c *MockGitRepository_GetDefaultBranch_Call) Run(run func(ctx context.Context)) *MockGitRepository_GetDefaultBranch_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockGitRepository_GetDefaultBranch_Call) Return(_a0 string, _a1 error) *MockGitRepository_GetDefaultBranch_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockGitRepository_GetDefaultBranch_Call) RunAndReturn(run func(context.Context) (string, error)) *MockGitRepository_GetDefaultBranch_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // History provides a mock function with given fields: ctx, path, ref
 func (_m *MockGitRepository) History(ctx context.Context, path string, ref string) ([]v0alpha1.HistoryItem, error) {
 	ret := _m.Called(ctx, path, ref)

--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -107,9 +107,10 @@ func (r *gitRepository) GetDefaultBranch(ctx context.Context) (string, error) {
 		branchName := strings.TrimPrefix(ref.Name, "refs/heads/")
 
 		// Check for main or master
-		if branchName == "main" {
+		switch branchName {
+		case "main":
 			hasMain = true
-		} else if branchName == "master" {
+		case "master":
 			hasMaster = true
 		}
 

--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -82,6 +82,63 @@ func (r *gitRepository) SetBranch(branch string) {
 	r.gitConfig.Branch = branch
 }
 
+func (r *gitRepository) GetCurrentBranch() string {
+	return r.gitConfig.Branch
+}
+
+func (r *gitRepository) GetDefaultBranch(ctx context.Context) (string, error) {
+	ctx, _ = r.withGitContext(ctx, "")
+
+	// Get all refs to find the default branch
+	refs, err := r.client.ListRefs(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list refs: %w", err)
+	}
+
+	var hasMain, hasMaster bool
+	var firstBranch string
+
+	// Single pass through refs to find main, master, or first branch alphabetically
+	for _, ref := range refs {
+		if !strings.HasPrefix(ref.Name, "refs/heads/") {
+			continue
+		}
+
+		branchName := strings.TrimPrefix(ref.Name, "refs/heads/")
+
+		// Check for main or master
+		if branchName == "main" {
+			hasMain = true
+		} else if branchName == "master" {
+			hasMaster = true
+		}
+
+		// Track first branch alphabetically as fallback
+		if firstBranch == "" || branchName < firstBranch {
+			firstBranch = branchName
+		}
+	}
+
+	// No branches found
+	if firstBranch == "" {
+		return "", fmt.Errorf("no branches found in repository")
+	}
+
+	// Prefer main, then master, then first branch alphabetically
+	if hasMain {
+		return "main", nil
+	}
+	if hasMaster {
+		return "master", nil
+	}
+
+	// If neither main nor master exists, return the first branch alphabetically.
+	// This provides deterministic behavior when working with repositories that use
+	// non-standard default branch names (e.g., "develop", "trunk", custom names).
+	// Users can always change the branch afterward or specify it directly in the repository configuration.
+	return firstBranch, nil
+}
+
 func (r *gitRepository) Config() *provisioning.Repository {
 	return r.config
 }

--- a/apps/provisioning/pkg/repository/git/repository_test.go
+++ b/apps/provisioning/pkg/repository/git/repository_test.go
@@ -3921,11 +3921,11 @@ func TestGitRepository_Move_ErrorConditions(t *testing.T) {
 
 func TestGitRepository_GetDefaultBranch(t *testing.T) {
 	tests := []struct {
-		name          string
-		setupMock     func(*mocks.FakeClient)
+		name           string
+		setupMock      func(*mocks.FakeClient)
 		expectedBranch string
-		wantError     bool
-		errorContains string
+		wantError      bool
+		errorContains  string
 	}{
 		{
 			name: "returns main when main branch exists",
@@ -3982,8 +3982,8 @@ func TestGitRepository_GetDefaultBranch(t *testing.T) {
 					{Name: "refs/tags/v1.0", Hash: hash.MustFromHex("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")},
 				}, nil)
 			},
-			wantError:      true,
-			errorContains:  "no branches found",
+			wantError:     true,
+			errorContains: "no branches found",
 		},
 		{
 			name: "returns error when ListRefs fails",

--- a/apps/provisioning/pkg/repository/git/repository_test.go
+++ b/apps/provisioning/pkg/repository/git/repository_test.go
@@ -3918,3 +3918,154 @@ func TestGitRepository_Move_ErrorConditions(t *testing.T) {
 		})
 	}
 }
+
+func TestGitRepository_GetDefaultBranch(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMock     func(*mocks.FakeClient)
+		expectedBranch string
+		wantError     bool
+		errorContains string
+	}{
+		{
+			name: "returns main when main branch exists",
+			setupMock: func(mockClient *mocks.FakeClient) {
+				mockClient.ListRefsReturns([]nanogit.Ref{
+					{Name: "refs/heads/main", Hash: hash.MustFromHex("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")},
+					{Name: "refs/heads/develop", Hash: hash.MustFromHex("b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3")},
+					{Name: "refs/heads/feature", Hash: hash.MustFromHex("c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4")},
+				}, nil)
+			},
+			expectedBranch: "main",
+			wantError:      false,
+		},
+		{
+			name: "returns master when master exists but main does not",
+			setupMock: func(mockClient *mocks.FakeClient) {
+				mockClient.ListRefsReturns([]nanogit.Ref{
+					{Name: "refs/heads/master", Hash: hash.MustFromHex("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")},
+					{Name: "refs/heads/develop", Hash: hash.MustFromHex("b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3")},
+					{Name: "refs/heads/feature", Hash: hash.MustFromHex("c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4")},
+				}, nil)
+			},
+			expectedBranch: "master",
+			wantError:      false,
+		},
+		{
+			name: "prefers main over master when both exist",
+			setupMock: func(mockClient *mocks.FakeClient) {
+				mockClient.ListRefsReturns([]nanogit.Ref{
+					{Name: "refs/heads/master", Hash: hash.MustFromHex("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")},
+					{Name: "refs/heads/main", Hash: hash.MustFromHex("b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3")},
+					{Name: "refs/heads/develop", Hash: hash.MustFromHex("c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4")},
+				}, nil)
+			},
+			expectedBranch: "main",
+			wantError:      false,
+		},
+		{
+			name: "returns first branch alphabetically when neither main nor master exists",
+			setupMock: func(mockClient *mocks.FakeClient) {
+				mockClient.ListRefsReturns([]nanogit.Ref{
+					{Name: "refs/heads/feature", Hash: hash.MustFromHex("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")},
+					{Name: "refs/heads/develop", Hash: hash.MustFromHex("b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3")},
+					{Name: "refs/heads/alpha", Hash: hash.MustFromHex("c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4")},
+				}, nil)
+			},
+			expectedBranch: "alpha",
+			wantError:      false,
+		},
+		{
+			name: "returns error when no branches exist",
+			setupMock: func(mockClient *mocks.FakeClient) {
+				mockClient.ListRefsReturns([]nanogit.Ref{
+					{Name: "refs/tags/v1.0", Hash: hash.MustFromHex("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")},
+				}, nil)
+			},
+			wantError:      true,
+			errorContains:  "no branches found",
+		},
+		{
+			name: "returns error when ListRefs fails",
+			setupMock: func(mockClient *mocks.FakeClient) {
+				mockClient.ListRefsReturns(nil, errors.New("network error"))
+			},
+			wantError:     true,
+			errorContains: "list refs",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mocks.FakeClient{}
+			tt.setupMock(mockClient)
+
+			gitRepo := &gitRepository{
+				client: mockClient,
+				gitConfig: RepositoryConfig{
+					URL: "https://git.example.com/owner/repo.git",
+				},
+				config: &provisioning.Repository{
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitRepositoryType,
+						Git: &provisioning.GitRepositoryConfig{
+							URL: "https://git.example.com/owner/repo.git",
+						},
+					},
+				},
+			}
+
+			branch, err := gitRepo.GetDefaultBranch(context.Background())
+
+			if tt.wantError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorContains)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedBranch, branch)
+			}
+		})
+	}
+}
+
+func TestGitRepository_GetCurrentBranch(t *testing.T) {
+	tests := []struct {
+		name           string
+		branchInConfig string
+		expectedBranch string
+	}{
+		{
+			name:           "returns current branch from config",
+			branchInConfig: "feature-branch",
+			expectedBranch: "feature-branch",
+		},
+		{
+			name:           "returns empty string when branch not set",
+			branchInConfig: "",
+			expectedBranch: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gitRepo := &gitRepository{
+				gitConfig: RepositoryConfig{
+					URL:    "https://git.example.com/owner/repo.git",
+					Branch: tt.branchInConfig,
+				},
+				config: &provisioning.Repository{
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitRepositoryType,
+						Git: &provisioning.GitRepositoryConfig{
+							URL:    "https://git.example.com/owner/repo.git",
+							Branch: tt.branchInConfig,
+						},
+					},
+				},
+			}
+
+			branch := gitRepo.GetCurrentBranch()
+			require.Equal(t, tt.expectedBranch, branch)
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/grafana/git-ui-sync-project/issues/862

## Summary

Implements the `BranchHandler` interface for Pure Git repositories to enable automatic default branch detection, similar to how it works for GitHub repositories.

## Changes

### Implementation (`apps/provisioning/pkg/repository/git/repository.go`)

Added two new methods to fulfill the `BranchHandler` interface:

1. **`GetCurrentBranch() string`** - Returns the currently configured branch
2. **`GetDefaultBranch(ctx context.Context) (string, error)`** - Intelligently determines the default branch by:
   - First checking for `main` branch
   - Falling back to `master` if main doesn't exist
   - Using the first branch alphabetically as a deterministic fallback
   - Returning an error if no branches exist

The implementation uses a **single loop** through refs for efficiency, tracking main/master and the alphabetically first branch in one pass.

### Interface Update (`apps/provisioning/pkg/repository/git/git.go`)

- Added `repository.BranchHandler` to the `GitRepository` interface
- Removed explicit `SetBranch(branch string)` declaration (now inherited from BranchHandler)

### Tests (`apps/provisioning/pkg/repository/git/repository_test.go`)

Added comprehensive unit tests covering:
- ✅ Returns `main` when it exists
- ✅ Returns `master` when main doesn't exist  
- ✅ Prefers `main` over `master` when both exist
- ✅ Returns first branch alphabetically as fallback
- ✅ Handles error when no branches exist
- ✅ Handles error when ListRefs fails
- ✅ Tests `GetCurrentBranch()` with various configurations

## Why This Matters

This change allows repositories using Pure Git to have empty branch configurations, with the system automatically detecting and using the repository's default branch. This provides:

- **Better UX**: Users don't need to know the default branch name upfront
- **Consistency**: Matches GitHub repository behavior
- **Flexibility**: Users can still override by specifying a branch explicitly

## Testing

All unit tests pass:
```bash
go test -v -run "TestGitRepository_GetDefaultBranch|TestGitRepository_GetCurrentBranch" ./apps/provisioning/pkg/repository/git/...
```

**Note**: Integration tests are not included as Pure Git functionality is not part of OSS yet.

## Checklist

- [x] Unit tests added and passing
- [x] Code follows existing patterns
- [x] No breaking changes
- [x] Documentation in code comments

---

@copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)