### PR TITLE
Provisioning: Allow GitHub Enterprise URLs for repositories

### DIFF
--- a/apps/provisioning/pkg/repository/github/validator.go
+++ b/apps/provisioning/pkg/repository/github/validator.go
@@ -37,8 +37,10 @@ func Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 		_, _, err := ParseOwnerRepoGithub(gh.URL)
 		if err != nil {
 			list = append(list, field.Invalid(field.NewPath("spec", "github", "url"), gh.URL, err.Error()))
-		} else if !strings.HasPrefix(gh.URL, "https://github.com/") {
-			list = append(list, field.Invalid(field.NewPath("spec", "github", "url"), gh.URL, "URL must start with https://github.com/"))
+		}
+		// Allow any HTTPS GitHub server (github.com, GitHub Enterprise, etc.)
+		if !strings.HasPrefix(gh.URL, "https://") {
+			list = append(list, field.Invalid(field.NewPath("spec", "github", "url"), gh.URL, "URL must start with https://"))
 		}
 	}
 

--- a/apps/provisioning/pkg/repository/github/validator_test.go
+++ b/apps/provisioning/pkg/repository/github/validator_test.go
@@ -65,7 +65,7 @@ func TestValidate(t *testing.T) {
 			errorContains: []string{"url"},
 		},
 		{
-			name: "invalid URL format",
+			name: "invalid URL format - non-HTTPS",
 			obj: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-repo",
@@ -73,16 +73,16 @@ func TestValidate(t *testing.T) {
 				Spec: provisioning.RepositorySpec{
 					Type: provisioning.GitHubRepositoryType,
 					GitHub: &provisioning.GitHubRepositoryConfig{
-						URL:    "https://gitlab.com/grafana/grafana",
+						URL:    "http://github.com/grafana/grafana",
 						Branch: "main",
 					},
 				},
 			},
 			expectedError: true,
-			errorContains: []string{"URL must start with https://github.com/"},
+			errorContains: []string{"URL must start with https://"},
 		},
 		{
-			name: "valid github repository",
+			name: "valid github.com repository",
 			obj: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-repo",
@@ -93,6 +93,27 @@ func TestValidate(t *testing.T) {
 						URL:    "https://github.com/grafana/grafana",
 						Branch: "main",
 						Path:   "grafana",
+					},
+				},
+				Secure: provisioning.SecureValues{
+					Token: common.InlineSecureValue{
+						Create: common.NewSecretValue("test-token"),
+					},
+				},
+			},
+		},
+		{
+			name: "valid GitHub Enterprise repository",
+			obj: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-repo-enterprise",
+				},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:    "https://github.mycompany.com/engineering/backend",
+						Branch: "main",
+						Path:   "configs",
 					},
 				},
 				Secure: provisioning.SecureValues{

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -339,6 +339,35 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 				},
 			}},
 		},
+		{
+			name: "should accept GitHub Enterprise URL",
+			repo: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "provisioning.grafana.app/v0alpha1",
+				"kind":       "Repository",
+				"metadata": map[string]any{
+					"name":      "repo-github-enterprise",
+					"namespace": "default",
+				},
+				"spec": map[string]any{
+					"title": "GitHub Enterprise Repository",
+					"type":  "github",
+					"sync": map[string]any{
+						"enabled": false,
+						"target":  "folder",
+					},
+					"github": map[string]any{
+						"url":    "https://github.enterprise.example.com/org/repo",
+						"branch": "main",
+					},
+					"workflows": []string{},
+				},
+				"secure": map[string]any{
+					"token": map[string]any{
+						"create": "someToken",
+					},
+				},
+			}},
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			_, err := helper.Repositories.Resource.Create(ctx, testCase.repo, metav1.CreateOptions{})


### PR DESCRIPTION
Fixes https://github.com/grafana/git-ui-sync-project/issues/857

## Summary

Removed the restriction that limited GitHub repository URLs to `github.com` only. The provisioning backend now accepts any HTTPS GitHub server, enabling support for GitHub Enterprise deployments.

## Changes

- **Validator**: Modified `validator.go` to only require `https://` prefix instead of `https://github.com/`, allowing any GitHub server hostname
- **Unit tests**: Updated and added test cases in `validator_test.go`:
  - Updated "invalid URL format" test to check for non-HTTPS URLs
  - Added "valid GitHub Enterprise repository" test case validating enterprise URLs
- **Integration tests**: Added test case in `repository_test.go` to validate GitHub Enterprise URL acceptance

## Testing

- ✅ All unit tests pass including new GitHub Enterprise validation test
- ✅ Integration test file compiles successfully
- ✅ Existing github.com URLs continue to work as before

## Validation

Users can now configure GitHub repositories with enterprise URLs such as:
- `https://github.enterprise.example.com/org/repo`
- `https://github.mycompany.com/engineering/backend`

Standard github.com URLs remain fully supported:
- `https://github.com/grafana/grafana`

## Checklist

- [x] Tests added/updated
- [x] No breaking changes - backward compatible with existing github.com URLs
- [x] Documentation not needed - behavior is self-explanatory from validation

🤖 Generated with Claude Code