### PR TITLE
Provisioning: Check Github App permissions in tester

### DIFF
--- a/apps/provisioning/pkg/connection/github/client.go
+++ b/apps/provisioning/pkg/connection/github/client.go
@@ -49,6 +49,8 @@ type App struct {
 	Slug string
 	// Owner represents the GH account/org owning the app
 	Owner string
+	// Permissions granted to the GitHub App
+	Permissions AppPermissions
 }
 type AppPermission int
 
@@ -72,8 +74,6 @@ type AppInstallation struct {
 	ID int64
 	// Whether the installation is enabled or not.
 	Enabled bool
-	// Permissions granted to the installation
-	Permissions AppPermissions
 }
 
 // InstallationToken represents a Github App Installation Access Token.
@@ -114,6 +114,12 @@ func (r *githubClient) GetApp(ctx context.Context) (App, error) {
 		ID:    app.GetID(),
 		Slug:  app.GetSlug(),
 		Owner: app.GetOwner().GetLogin(),
+		Permissions: AppPermissions{
+			Contents:     toAppPermission(app.GetPermissions().GetContents()),
+			Metadata:     toAppPermission(app.GetPermissions().GetMetadata()),
+			PullRequests: toAppPermission(app.GetPermissions().GetPullRequests()),
+			Webhooks:     toAppPermission(app.GetPermissions().GetRepositoryHooks()),
+		},
 	}, nil
 }
 
@@ -143,12 +149,6 @@ func (r *githubClient) GetAppInstallation(ctx context.Context, installationID st
 	return AppInstallation{
 		ID:      installation.GetID(),
 		Enabled: installation.GetSuspendedAt().IsZero(),
-		Permissions: AppPermissions{
-			Contents:     toAppPermission(installation.GetPermissions().GetContents()),
-			Metadata:     toAppPermission(installation.GetPermissions().GetMetadata()),
-			PullRequests: toAppPermission(installation.GetPermissions().GetPullRequests()),
-			Webhooks:     toAppPermission(installation.GetPermissions().GetRepositoryHooks()),
-		},
 	}, nil
 }
 

--- a/apps/provisioning/pkg/connection/github/client_test.go
+++ b/apps/provisioning/pkg/connection/github/client_test.go
@@ -215,6 +215,104 @@ func TestGithubClient_GetAppInstallation(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "get installation with all permissions",
+			mockHandler: mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetAppInstallationsByInstallationId,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						installation := &github.Installation{
+							ID:          github.Ptr(int64(67890)),
+							SuspendedAt: nil,
+							Permissions: &github.InstallationPermissions{
+								Contents:        github.Ptr("write"),
+								Metadata:        github.Ptr("read"),
+								PullRequests:    github.Ptr("write"),
+								RepositoryHooks: github.Ptr("write"),
+							},
+						}
+						w.WriteHeader(http.StatusOK)
+						require.NoError(t, json.NewEncoder(w).Encode(installation))
+					}),
+				),
+			),
+			appToken:       "test-app-token",
+			installationID: "67890",
+			wantInstallation: conngh.AppInstallation{
+				ID:      67890,
+				Enabled: true,
+				Permissions: conngh.AppPermissions{
+					Contents:     conngh.AppPermissionWrite,
+					Metadata:     conngh.AppPermissionRead,
+					PullRequests: conngh.AppPermissionWrite,
+					Webhooks:     conngh.AppPermissionWrite,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "get installation with nil permissions",
+			mockHandler: mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetAppInstallationsByInstallationId,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						installation := &github.Installation{
+							ID:          github.Ptr(int64(67890)),
+							SuspendedAt: nil,
+							Permissions: nil,
+						}
+						w.WriteHeader(http.StatusOK)
+						require.NoError(t, json.NewEncoder(w).Encode(installation))
+					}),
+				),
+			),
+			appToken:       "test-app-token",
+			installationID: "67890",
+			wantInstallation: conngh.AppInstallation{
+				ID:      67890,
+				Enabled: true,
+				Permissions: conngh.AppPermissions{
+					Contents:     conngh.AppPermissionNone,
+					Metadata:     conngh.AppPermissionNone,
+					PullRequests: conngh.AppPermissionNone,
+					Webhooks:     conngh.AppPermissionNone,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "get installation with partial permissions",
+			mockHandler: mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetAppInstallationsByInstallationId,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						installation := &github.Installation{
+							ID:          github.Ptr(int64(67890)),
+							SuspendedAt: nil,
+							Permissions: &github.InstallationPermissions{
+								Contents: github.Ptr("read"),
+								Metadata: nil,
+							},
+						}
+						w.WriteHeader(http.StatusOK)
+						require.NoError(t, json.NewEncoder(w).Encode(installation))
+					}),
+				),
+			),
+			appToken:       "test-app-token",
+			installationID: "67890",
+			wantInstallation: conngh.AppInstallation{
+				ID:      67890,
+				Enabled: true,
+				Permissions: conngh.AppPermissions{
+					Contents:     conngh.AppPermissionRead,
+					Metadata:     conngh.AppPermissionNone,
+					PullRequests: conngh.AppPermissionNone,
+					Webhooks:     conngh.AppPermissionNone,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name:             "invalid installation ID",
 			mockHandler:      mockhub.NewMockedHTTPClient(),
 			appToken:         "test-app-token",

--- a/apps/provisioning/pkg/connection/github/client_test.go
+++ b/apps/provisioning/pkg/connection/github/client_test.go
@@ -36,6 +36,12 @@ func TestGithubClient_GetApp(t *testing.T) {
 							Owner: &github.User{
 								Login: github.Ptr("grafana"),
 							},
+							Permissions: &github.InstallationPermissions{
+								Contents:        github.Ptr("write"),
+								Metadata:        github.Ptr("read"),
+								PullRequests:    github.Ptr("write"),
+								RepositoryHooks: github.Ptr("write"),
+							},
 						}
 						w.WriteHeader(http.StatusOK)
 						require.NoError(t, json.NewEncoder(w).Encode(app))
@@ -47,6 +53,12 @@ func TestGithubClient_GetApp(t *testing.T) {
 				ID:    12345,
 				Slug:  "my-test-app",
 				Owner: "grafana",
+				Permissions: conngh.AppPermissions{
+					Contents:     conngh.AppPermissionWrite,
+					Metadata:     conngh.AppPermissionRead,
+					PullRequests: conngh.AppPermissionWrite,
+					Webhooks:     conngh.AppPermissionWrite,
+				},
 			},
 			wantErr: nil,
 		},
@@ -240,12 +252,6 @@ func TestGithubClient_GetAppInstallation(t *testing.T) {
 			wantInstallation: conngh.AppInstallation{
 				ID:      67890,
 				Enabled: true,
-				Permissions: conngh.AppPermissions{
-					Contents:     conngh.AppPermissionWrite,
-					Metadata:     conngh.AppPermissionRead,
-					PullRequests: conngh.AppPermissionWrite,
-					Webhooks:     conngh.AppPermissionWrite,
-				},
 			},
 			wantErr: false,
 		},
@@ -270,12 +276,6 @@ func TestGithubClient_GetAppInstallation(t *testing.T) {
 			wantInstallation: conngh.AppInstallation{
 				ID:      67890,
 				Enabled: true,
-				Permissions: conngh.AppPermissions{
-					Contents:     conngh.AppPermissionNone,
-					Metadata:     conngh.AppPermissionNone,
-					PullRequests: conngh.AppPermissionNone,
-					Webhooks:     conngh.AppPermissionNone,
-				},
 			},
 			wantErr: false,
 		},
@@ -303,12 +303,6 @@ func TestGithubClient_GetAppInstallation(t *testing.T) {
 			wantInstallation: conngh.AppInstallation{
 				ID:      67890,
 				Enabled: true,
-				Permissions: conngh.AppPermissions{
-					Contents:     conngh.AppPermissionRead,
-					Metadata:     conngh.AppPermissionNone,
-					PullRequests: conngh.AppPermissionNone,
-					Webhooks:     conngh.AppPermissionNone,
-				},
 			},
 			wantErr: false,
 		},

--- a/apps/provisioning/pkg/connection/github/connection_test.go
+++ b/apps/provisioning/pkg/connection/github/connection_test.go
@@ -795,7 +795,8 @@ func TestConnection_Test(t *testing.T) {
 			expectSuccess: false,
 			expectedErrors: []provisioning.ErrorDetails{
 				{
-					Type:   metav1.CauseTypeInternal,
+					Type:   metav1.CauseTypeFieldValueInvalid,
+					Field:  "spec.github.installationID",
 					Detail: github.ErrServiceUnavailable.Error(),
 				},
 			},
@@ -836,50 +837,7 @@ func TestConnection_Test(t *testing.T) {
 				{
 					Type:   metav1.CauseTypeFieldValueInvalid,
 					Field:  "spec.github.installationID",
-					Detail: "failed to validate installation",
-				},
-			},
-		},
-		{
-			name: "failure - installation is suspended",
-			connection: &provisioning.Connection{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-connection"},
-				Spec: provisioning.ConnectionSpec{
-					Type: provisioning.GithubConnectionType,
-					GitHub: &provisioning.GitHubConnectionConfig{
-						AppID:          appID,
-						InstallationID: "456",
-					},
-				},
-			},
-			secrets: github.ConnectionSecrets{
-				PrivateKey: common.RawSecureValue(privateKeyBase64),
-				Token:      token,
-			},
-			setupMock: func(mockFactory *github.MockGithubFactory, mockClient *github.MockClient) {
-				mockFactory.EXPECT().New(mock.Anything, mock.Anything).Return(mockClient)
-				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
-					ID:   123,
-					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
-					},
-				}, nil)
-				mockClient.EXPECT().GetAppInstallation(mock.Anything, "456").Return(github.AppInstallation{
-					ID:      456,
-					Enabled: false,
-				}, nil)
-			},
-			expectedCode:  http.StatusForbidden,
-			expectSuccess: false,
-			expectedErrors: []provisioning.ErrorDetails{
-				{
-					Type:   metav1.CauseTypeFieldValueInvalid,
-					Field:  "spec.github.installationID",
-					Detail: "installation is suspended",
+					Detail: "invalid installation ID: 456",
 				},
 			},
 		},

--- a/pkg/tests/apis/provisioning/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection_test.go
@@ -1750,6 +1750,12 @@ func TestIntegrationConnectionController_FieldErrorsCleared(t *testing.T) {
 				ghmock.GetApp, github.App{
 					ID:   &appID,
 					Slug: &appSlug,
+					Permissions: &github.InstallationPermissions{
+						Contents:        github.Ptr("write"),
+						Metadata:        github.Ptr("read"),
+						PullRequests:    github.Ptr("write"),
+						RepositoryHooks: github.Ptr("write"),
+					},
 				},
 			),
 			ghmock.WithRequestMatchHandler(
@@ -1805,6 +1811,12 @@ func TestIntegrationConnectionController_FieldErrorsCleared(t *testing.T) {
 				ghmock.GetApp, github.App{
 					ID:   &appID,
 					Slug: &appSlug,
+					Permissions: &github.InstallationPermissions{
+						Contents:        github.Ptr("write"),
+						Metadata:        github.Ptr("read"),
+						PullRequests:    github.Ptr("write"),
+						RepositoryHooks: github.Ptr("write"),
+					},
 				},
 			),
 			ghmock.WithRequestMatch(

--- a/pkg/tests/apis/provisioning/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection_test.go
@@ -2275,9 +2275,13 @@ func verifyToken(t *testing.T, appID, token string) (bool, error) {
 }
 
 // createInstallationWithPermissions creates a GitHub installation with specific permissions
-func createInstallationWithPermissions(id int64, permissions map[string]string) *github.Installation {
-	installation := &github.Installation{
-		ID: github.Ptr(id),
+func createAppWithPermissions(id int64, permissions map[string]string) *github.App {
+	app := &github.App{
+		ID:   github.Ptr(id),
+		Slug: github.Ptr("test-app"),
+		Owner: &github.User{
+			Login: github.Ptr("test-owner"),
+		},
 	}
 
 	// Set permissions based on the map
@@ -2297,10 +2301,10 @@ func createInstallationWithPermissions(id int64, permissions map[string]string) 
 			installationPerms.RepositoryHooks = github.Ptr(hooks)
 		}
 
-		installation.Permissions = installationPerms
+		app.Permissions = installationPerms
 	}
 
-	return installation
+	return app
 }
 
 func TestIntegrationProvisioning_GithubPermissionValidation(t *testing.T) {
@@ -2399,15 +2403,10 @@ func TestIntegrationProvisioning_GithubPermissionValidation(t *testing.T) {
 			// Setup mock GitHub client
 			connectionFactory := helper.GetEnv().GithubConnectionFactory.(*githubConnection.Factory)
 
-			app := &github.App{
-				ID:   github.Ptr(int64(123456)),
-				Slug: github.Ptr("test-app"),
-				Owner: &github.User{
-					Login: github.Ptr("test-owner"),
-				},
+			app := createAppWithPermissions(123456, tc.permissions)
+			installation := &github.Installation{
+				ID: github.Ptr(int64(454545)),
 			}
-
-			installation := createInstallationWithPermissions(454545, tc.permissions)
 
 			connectionFactory.Client = ghmock.NewMockedHTTPClient(
 				ghmock.WithRequestMatchHandler(

--- a/pkg/tests/apis/provisioning/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection_test.go
@@ -1515,6 +1515,12 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 					_, _ = w.Write(ghmock.MustMarshal(github.App{
 						ID:   &appID,
 						Slug: &appSlug,
+						Permissions: &github.InstallationPermissions{
+							Contents:        github.Ptr("write"),
+							Metadata:        github.Ptr("read"),
+							PullRequests:    github.Ptr("write"),
+							RepositoryHooks: github.Ptr("write"),
+						},
 					}))
 				}),
 			),
@@ -1623,6 +1629,12 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 					_, _ = w.Write(ghmock.MustMarshal(github.App{
 						ID:   &appID,
 						Slug: &appSlug,
+						Permissions: &github.InstallationPermissions{
+							Contents:        github.Ptr("write"),
+							Metadata:        github.Ptr("read"),
+							PullRequests:    github.Ptr("write"),
+							RepositoryHooks: github.Ptr("write"),
+						},
 					}))
 				}),
 			),

--- a/pkg/tests/apis/provisioning/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection_test.go
@@ -2273,3 +2273,246 @@ func verifyToken(t *testing.T, appID, token string) (bool, error) {
 
 	return claims.VerifyIssuer(appID, true), nil
 }
+
+// createInstallationWithPermissions creates a GitHub installation with specific permissions
+func createInstallationWithPermissions(id int64, permissions map[string]string) *github.Installation {
+	installation := &github.Installation{
+		ID: github.Ptr(id),
+	}
+
+	// Set permissions based on the map
+	if len(permissions) > 0 {
+		installationPerms := &github.InstallationPermissions{}
+
+		if contents, ok := permissions["contents"]; ok {
+			installationPerms.Contents = github.Ptr(contents)
+		}
+		if metadata, ok := permissions["metadata"]; ok {
+			installationPerms.Metadata = github.Ptr(metadata)
+		}
+		if prs, ok := permissions["pull_requests"]; ok {
+			installationPerms.PullRequests = github.Ptr(prs)
+		}
+		if hooks, ok := permissions["webhooks"]; ok {
+			installationPerms.RepositoryHooks = github.Ptr(hooks)
+		}
+
+		installation.Permissions = installationPerms
+	}
+
+	return installation
+}
+
+func TestIntegrationProvisioning_GithubPermissionValidation(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafana(t)
+	ctx := context.Background()
+
+	// Base64 encoded test private key
+	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(testPrivateKeyPEM))
+
+	testCases := []struct {
+		name                string
+		permissions         map[string]string
+		expectHealthy       bool
+		expectedErrorCount  int
+		expectedErrorFields []string
+		expectedErrorDetail string // substring to check in error detail
+	}{
+		{
+			name: "success - all permissions present",
+			permissions: map[string]string{
+				"contents":      "write",
+				"metadata":      "read",
+				"pull_requests": "write",
+				"webhooks":      "write",
+			},
+			expectHealthy:      true,
+			expectedErrorCount: 0,
+		},
+		{
+			name: "failure - missing contents permission",
+			permissions: map[string]string{
+				"contents":      "", // missing
+				"metadata":      "read",
+				"pull_requests": "write",
+				"webhooks":      "write",
+			},
+			expectHealthy:       false,
+			expectedErrorCount:  1,
+			expectedErrorFields: []string{"spec.github.appID"},
+			expectedErrorDetail: "lacks required 'contents' permission",
+		},
+		{
+			name: "failure - insufficient contents permission",
+			permissions: map[string]string{
+				"contents":      "read", // insufficient
+				"metadata":      "read",
+				"pull_requests": "write",
+				"webhooks":      "write",
+			},
+			expectHealthy:       false,
+			expectedErrorCount:  1,
+			expectedErrorFields: []string{"spec.github.appID"},
+			expectedErrorDetail: "requires 'write', has 'read'",
+		},
+		{
+			name: "failure - missing metadata permission",
+			permissions: map[string]string{
+				"contents":      "write",
+				"metadata":      "", // missing
+				"pull_requests": "write",
+				"webhooks":      "write",
+			},
+			expectHealthy:       false,
+			expectedErrorCount:  1,
+			expectedErrorFields: []string{"spec.github.appID"},
+			expectedErrorDetail: "lacks required 'metadata' permission",
+		},
+		{
+			name: "failure - multiple missing permissions",
+			permissions: map[string]string{
+				"contents":      "read", // insufficient
+				"metadata":      "",     // missing
+				"pull_requests": "",     // missing
+				"webhooks":      "write",
+			},
+			expectHealthy:      false,
+			expectedErrorCount: 3, // all three failures
+		},
+		{
+			name: "success - write satisfies read requirement",
+			permissions: map[string]string{
+				"contents":      "write",
+				"metadata":      "write", // write satisfies read
+				"pull_requests": "write",
+				"webhooks":      "write",
+			},
+			expectHealthy:      true,
+			expectedErrorCount: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup mock GitHub client
+			connectionFactory := helper.GetEnv().GithubConnectionFactory.(*githubConnection.Factory)
+
+			app := &github.App{
+				ID:   github.Ptr(int64(123456)),
+				Slug: github.Ptr("test-app"),
+				Owner: &github.User{
+					Login: github.Ptr("test-owner"),
+				},
+			}
+
+			installation := createInstallationWithPermissions(454545, tc.permissions)
+
+			connectionFactory.Client = ghmock.NewMockedHTTPClient(
+				ghmock.WithRequestMatchHandler(
+					ghmock.GetApp,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write(ghmock.MustMarshal(app))
+					}),
+				),
+				ghmock.WithRequestMatchHandler(
+					ghmock.GetAppInstallationsByInstallationId,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write(ghmock.MustMarshal(installation))
+					}),
+				),
+			)
+			helper.SetGithubConnectionFactory(connectionFactory)
+
+			// Create connection
+			connection := &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "provisioning.grafana.app/v0alpha1",
+				"kind":       "Connection",
+				"metadata": map[string]any{
+					"name":      fmt.Sprintf("test-conn-%s", strings.ReplaceAll(tc.name, " ", "-")),
+					"namespace": "default",
+				},
+				"spec": map[string]any{
+					"title": "Test Connection",
+					"type":  "github",
+					"github": map[string]any{
+						"appID":          "123456",
+						"installationID": "454545",
+					},
+				},
+				"secure": map[string]any{
+					"privateKey": map[string]any{
+						"create": privateKeyBase64,
+					},
+				},
+			}}
+
+			c, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, c)
+			t.Cleanup(func() {
+				require.EventuallyWithT(t, func(collect *assert.CollectT) {
+					err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+					require.NoError(collect, err)
+				}, waitTimeoutDefault, waitIntervalDefault)
+			})
+
+			restConfig := helper.Org1.Admin.NewRestConfig()
+			provisioningClient, err := clientset.NewForConfig(restConfig)
+			require.NoError(t, err)
+			connClient := provisioningClient.ProvisioningV0alpha1().Connections("default")
+
+			// Wait for health check to complete
+			var conn *provisioning.Connection
+			require.Eventually(t, func() bool {
+				var err error
+				conn, err = connClient.Get(ctx, c.GetName(), metav1.GetOptions{})
+				if err != nil {
+					return false
+				}
+				// Health check should have run
+				return conn.Status.ObservedGeneration == conn.Generation &&
+					conn.Status.Health.Checked > 0
+			}, 15*time.Second, 500*time.Millisecond, "connection should be reconciled and health checked")
+
+			// Validate health status
+			if tc.expectHealthy {
+				assert.True(t, conn.Status.Health.Healthy, "connection should be healthy with valid permissions")
+				assert.Empty(t, conn.Status.FieldErrors, "should have no field errors when healthy")
+
+				readyCondition := meta.FindStatusCondition(conn.Status.Conditions, provisioning.ConditionTypeReady)
+				assert.Equal(t, metav1.ConditionTrue, readyCondition.Status, "Ready condition should be True")
+			} else {
+				assert.False(t, conn.Status.Health.Healthy, "connection should be unhealthy with invalid permissions")
+				assert.Len(t, conn.Status.FieldErrors, tc.expectedErrorCount,
+					"should have expected number of field errors")
+
+				// Validate error details
+				if tc.expectedErrorCount > 0 {
+					for _, fieldError := range conn.Status.FieldErrors {
+						assert.Equal(t, metav1.CauseTypeForbidden, fieldError.Type,
+							"error type should be Forbidden for permission issues")
+
+						if len(tc.expectedErrorFields) > 0 {
+							assert.Contains(t, tc.expectedErrorFields, fieldError.Field,
+								"error should reference expected field")
+						}
+
+						if tc.expectedErrorDetail != "" {
+							assert.Contains(t, fieldError.Detail, tc.expectedErrorDetail,
+								"error detail should contain expected message")
+						}
+					}
+				}
+
+				readyCondition := meta.FindStatusCondition(conn.Status.Conditions, provisioning.ConditionTypeReady)
+				assert.Equal(t, metav1.ConditionFalse, readyCondition.Status, "Ready condition should be False")
+				assert.Equal(t, provisioning.ReasonAuthenticationFailed, readyCondition.Reason,
+					"Ready condition should have InvalidSpec reason")
+			}
+		})
+	}
+}

--- a/pkg/tests/apis/provisioning/health_test.go
+++ b/pkg/tests/apis/provisioning/health_test.go
@@ -244,38 +244,7 @@ func TestIntegrationProvisioning_ConnectionTestEndpointWithPermissions(t *testin
 	helper := runGrafana(t)
 	ctx := context.Background()
 
-	// Get the private key for GitHub connection
-	privateKeyBase64 := ""
-	// Read connection_test.go to get the test private key
-	// We'll use the same key that's defined there
-	privateKeyPEM := `-----BEGIN RSA PRIVATE KEY-----
-MIIEoQIBAAKCAQBn1MuM5hIfH6d3TNStI1ofWv/gcjQ4joi9cFijEwVLuPYkF1nD
-KkSbaMGFUWiOTaB/H9fxmd/V2u04NlBY3av6m5T/sHfVSiEWAEUblh3cA34HVCmD
-cqyyVty5HLGJJlSs2C7W2x7yUc9ImzyDBsyjpKOXuojJ9wN9a17D2cYU5WkXjoDC
-4BHid61jn9WBTtPZXSgOdirwahNzxZQSIP7DA9T8yiZwIWPp5YesgsAPyQLCFPgM
-s77xz/CEUnEYQ35zI/k/mQrwKdQ/ZP8xLwQohUID0BIxE7G5quL069RuuCZWZkoF
-oPiZbp7HSryz1+19jD3rFT7eHGUYvAyCnXmXAgMBAAECggEADSs4Bc7ITZo+Kytb
-bfol3AQ2n8jcRrANN7mgBE7NRSVYUouDnvUlbnCC2t3QXPwLdxQa11GkygLSQ2bg
-GeVDgq1o4GUJTcvxFlFCcpU/hEANI/DQsxNAQ/4wUGoLOlHaO3HPvwBblHA70gGe
-Ux/xpG+lMAFAiB0EHEwZ4M0mClBEOQv3NzaFTWuBHtIMS8eid7M1q5qz9+rCgZSL
-KBBHo0OvUbajG4CWl8SM6LUYapASGg+U17E+4xA3npwpIdsk+CbtX+vvX324n4kn
-0EkrJqCjv8M1KiCKAP+UxwP00ywxOg4PN+x+dHI/I7xBvEKe/x6BltVSdGA+PlUK
-02wagQKBgQDF7gdQLFIagPH7X7dBP6qEGxj/Ck9Qdz3S1gotPkVeq+1/UtQijYZ1
-j44up/0yB2B9P4kW091n+iWcyfoU5UwBua9dHvCZP3QH05LR1ZscUHxLGjDPBASt
-l2xSq0hqqNWBspb1M0eCY0Yxi65iDkj3xsI2iN35BEb1FlWdR5KGvwKBgQCGS0ce
-wASWbZIPU2UoKGOQkIJU6QmLy0KZbfYkpyfE8IxGttYVEQ8puNvDDNZWHNf+LP85
-c8iV6SfnWiLmu1XkG2YmJFBCCAWgJ8Mq2XQD8E+a/xcaW3NqlcC5+I2czX367j3r
-69wZSxRbzR+DCfOiIkrekJImwN183ZYy2cBbKQKBgFj86IrSMmO6H5Ft+j06u5ZD
-fJyF7Rz3T3NwSgkHWzbyQ4ggHEIgsRg/36P4YSzSBj6phyAdRwkNfUWdxXMJmH+a
-FU7frzqnPaqbJAJ1cBRt10QI1XLtkpDdaJVObvONTtjOC3LYiEkGCzQRYeiyFXpZ
-AU51gJ8JnkFotjtNR4KPAoGAehVREDlLcl0lnN0ZZspgyPk2Im6/iOA9KTH3xBZZ
-ZwWu4FIyiHA7spgk4Ep5R0ttZ9oMI3SIcw/EgONGOy8uw/HMiPwWIhEc3B2JpRiO
-CU6bb7JalFFyuQBudiHoyxVcY5PVovWF31CLr3DoJr4TR9+Y5H/U/XnzYCIo+w1N
-exECgYBFAGKYTIeGAvhIvD5TphLpbCyeVLBIq5hRyrdRY+6Iwqdr5PGvLPKwin5+
-+4CDhWPW4spq8MYPCRiMrvRSctKt/7FhVGL2vE/0VY3TcLk14qLC+2+0lnPVgnYn
-u5/wOyuHp1cIBnjeN41/pluOWFBHI9xLW3ExLtmYMiecJ8VdRA==
------END RSA PRIVATE KEY-----`
-	privateKeyBase64 = base64.StdEncoding.EncodeToString([]byte(privateKeyPEM))
+	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(testPrivateKeyPEM))
 
 	t.Run("test endpoint returns 403 for insufficient permissions", func(t *testing.T) {
 		// Setup mock with insufficient permissions

--- a/pkg/tests/apis/provisioning/health_test.go
+++ b/pkg/tests/apis/provisioning/health_test.go
@@ -366,7 +366,7 @@ u5/wOyuHp1cIBnjeN41/pluOWFBHI9xLW3ExLtmYMiecJ8VdRA==
 	t.Run("test endpoint succeeds with all permissions", func(t *testing.T) {
 		// Setup mock with all required permissions
 		connectionFactory := helper.GetEnv().GithubConnectionFactory.(*githubConnection.Factory)
-		
+
 		app := createAppWithPermissions(123456, map[string]string{
 			"contents":      "write",
 			"metadata":      "read",

--- a/pkg/tests/apis/provisioning/health_test.go
+++ b/pkg/tests/apis/provisioning/health_test.go
@@ -2,16 +2,24 @@ package provisioning
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"net/http"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/google/go-github/v82/github"
+	ghmock "github.com/migueleliasweb/go-github-mock/src/mock"
 	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	githubConnection "github.com/grafana/grafana/apps/provisioning/pkg/connection/github"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
@@ -228,4 +236,204 @@ func parseTestResults(t *testing.T, obj runtime.Object) *provisioning.TestResult
 	require.NoError(t, err)
 
 	return &testResults
+}
+
+func TestIntegrationProvisioning_ConnectionTestEndpointWithPermissions(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafana(t)
+	ctx := context.Background()
+
+	// Get the private key for GitHub connection
+	privateKeyBase64 := ""
+	// Read connection_test.go to get the test private key
+	// We'll use the same key that's defined there
+	privateKeyPEM := `-----BEGIN RSA PRIVATE KEY-----
+MIIEoQIBAAKCAQBn1MuM5hIfH6d3TNStI1ofWv/gcjQ4joi9cFijEwVLuPYkF1nD
+KkSbaMGFUWiOTaB/H9fxmd/V2u04NlBY3av6m5T/sHfVSiEWAEUblh3cA34HVCmD
+cqyyVty5HLGJJlSs2C7W2x7yUc9ImzyDBsyjpKOXuojJ9wN9a17D2cYU5WkXjoDC
+4BHid61jn9WBTtPZXSgOdirwahNzxZQSIP7DA9T8yiZwIWPp5YesgsAPyQLCFPgM
+s77xz/CEUnEYQ35zI/k/mQrwKdQ/ZP8xLwQohUID0BIxE7G5quL069RuuCZWZkoF
+oPiZbp7HSryz1+19jD3rFT7eHGUYvAyCnXmXAgMBAAECggEADSs4Bc7ITZo+Kytb
+bfol3AQ2n8jcRrANN7mgBE7NRSVYUouDnvUlbnCC2t3QXPwLdxQa11GkygLSQ2bg
+GeVDgq1o4GUJTcvxFlFCcpU/hEANI/DQsxNAQ/4wUGoLOlHaO3HPvwBblHA70gGe
+Ux/xpG+lMAFAiB0EHEwZ4M0mClBEOQv3NzaFTWuBHtIMS8eid7M1q5qz9+rCgZSL
+KBBHo0OvUbajG4CWl8SM6LUYapASGg+U17E+4xA3npwpIdsk+CbtX+vvX324n4kn
+0EkrJqCjv8M1KiCKAP+UxwP00ywxOg4PN+x+dHI/I7xBvEKe/x6BltVSdGA+PlUK
+02wagQKBgQDF7gdQLFIagPH7X7dBP6qEGxj/Ck9Qdz3S1gotPkVeq+1/UtQijYZ1
+j44up/0yB2B9P4kW091n+iWcyfoU5UwBua9dHvCZP3QH05LR1ZscUHxLGjDPBASt
+l2xSq0hqqNWBspb1M0eCY0Yxi65iDkj3xsI2iN35BEb1FlWdR5KGvwKBgQCGS0ce
+wASWbZIPU2UoKGOQkIJU6QmLy0KZbfYkpyfE8IxGttYVEQ8puNvDDNZWHNf+LP85
+c8iV6SfnWiLmu1XkG2YmJFBCCAWgJ8Mq2XQD8E+a/xcaW3NqlcC5+I2czX367j3r
+69wZSxRbzR+DCfOiIkrekJImwN183ZYy2cBbKQKBgFj86IrSMmO6H5Ft+j06u5ZD
+fJyF7Rz3T3NwSgkHWzbyQ4ggHEIgsRg/36P4YSzSBj6phyAdRwkNfUWdxXMJmH+a
+FU7frzqnPaqbJAJ1cBRt10QI1XLtkpDdaJVObvONTtjOC3LYiEkGCzQRYeiyFXpZ
+AU51gJ8JnkFotjtNR4KPAoGAehVREDlLcl0lnN0ZZspgyPk2Im6/iOA9KTH3xBZZ
+ZwWu4FIyiHA7spgk4Ep5R0ttZ9oMI3SIcw/EgONGOy8uw/HMiPwWIhEc3B2JpRiO
+CU6bb7JalFFyuQBudiHoyxVcY5PVovWF31CLr3DoJr4TR9+Y5H/U/XnzYCIo+w1N
+exECgYBFAGKYTIeGAvhIvD5TphLpbCyeVLBIq5hRyrdRY+6Iwqdr5PGvLPKwin5+
++4CDhWPW4spq8MYPCRiMrvRSctKt/7FhVGL2vE/0VY3TcLk14qLC+2+0lnPVgnYn
+u5/wOyuHp1cIBnjeN41/pluOWFBHI9xLW3ExLtmYMiecJ8VdRA==
+-----END RSA PRIVATE KEY-----`
+	privateKeyBase64 = base64.StdEncoding.EncodeToString([]byte(privateKeyPEM))
+
+	t.Run("test endpoint returns 403 for insufficient permissions", func(t *testing.T) {
+		// Setup mock with insufficient permissions
+		connectionFactory := helper.GetEnv().GithubConnectionFactory.(*githubConnection.Factory)
+
+		app := &github.App{
+			ID:   github.Ptr(int64(123456)),
+			Slug: github.Ptr("test-app"),
+			Owner: &github.User{
+				Login: github.Ptr("test-owner"),
+			},
+		}
+
+		// Installation with only read permissions (insufficient)
+		installation := createInstallationWithPermissions(454545, map[string]string{
+			"contents":      "read", // needs write
+			"metadata":      "read",
+			"pull_requests": "read", // needs write
+			"webhooks":      "read", // needs write
+		})
+
+		connectionFactory.Client = ghmock.NewMockedHTTPClient(
+			ghmock.WithRequestMatchHandler(
+				ghmock.GetApp,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(ghmock.MustMarshal(app))
+				}),
+			),
+			ghmock.WithRequestMatchHandler(
+				ghmock.GetAppInstallationsByInstallationId,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(ghmock.MustMarshal(installation))
+				}),
+			),
+		)
+		helper.SetGithubConnectionFactory(connectionFactory)
+
+		// Create connection config for test
+		config := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "provisioning.grafana.app/v0alpha1",
+				"kind":       "Connection",
+				"metadata": map[string]any{
+					"name": "test",
+				},
+				"spec": map[string]any{
+					"title": "Test Connection",
+					"type":  "github",
+					"github": map[string]any{
+						"appID":          "123456",
+						"installationID": "454545",
+					},
+				},
+				"secure": map[string]any{
+					"privateKey": map[string]any{
+						"create": privateKeyBase64,
+					},
+				},
+			},
+		}
+
+		// Create with dryRun - that would test the connection
+		c, err := helper.Connections.Resource.Create(ctx, config, metav1.CreateOptions{
+			DryRun: []string{"All"},
+		})
+		require.Error(t, err)
+		require.Nil(t, c)
+
+		var k8sErr *k8serrors.StatusError
+		require.True(t, errors.As(err, &k8sErr))
+
+		require.Equal(t, metav1.StatusReasonInvalid, k8sErr.Status().Reason)
+		require.NotNil(t, k8sErr.Status().Details)
+
+		for _, reason := range k8sErr.Status().Details.Causes {
+			require.Equal(t, metav1.CauseTypeFieldValueInvalid, reason.Type)
+			require.Equal(t, "spec.github.appID", reason.Field)
+
+			switch {
+			case strings.Contains(reason.Message, "pull_requests"):
+				require.Contains(t, reason.Message, "requires 'write', has 'read'")
+			case strings.Contains(reason.Message, "webhooks"):
+				require.Contains(t, reason.Message, "requires 'write', has 'read'")
+			case strings.Contains(reason.Message, "contents"):
+				require.Contains(t, reason.Message, "requires 'write', has 'read'")
+			case strings.Contains(reason.Message, "metadata"):
+				t.Fatalf("should not error on metadata")
+			}
+		}
+	})
+
+	t.Run("test endpoint succeeds with all permissions", func(t *testing.T) {
+		// Setup mock with all required permissions
+		connectionFactory := helper.GetEnv().GithubConnectionFactory.(*githubConnection.Factory)
+
+		app := &github.App{
+			ID:   github.Ptr(int64(123456)),
+			Slug: github.Ptr("test-app"),
+			Owner: &github.User{
+				Login: github.Ptr("test-owner"),
+			},
+		}
+
+		installation := createInstallationWithPermissions(454545, map[string]string{
+			"contents":      "write",
+			"metadata":      "read",
+			"pull_requests": "write",
+			"webhooks":      "write",
+		})
+
+		connectionFactory.Client = ghmock.NewMockedHTTPClient(
+			ghmock.WithRequestMatchHandler(
+				ghmock.GetApp,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(ghmock.MustMarshal(app))
+				}),
+			),
+			ghmock.WithRequestMatchHandler(
+				ghmock.GetAppInstallationsByInstallationId,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(ghmock.MustMarshal(installation))
+				}),
+			),
+		)
+		helper.SetGithubConnectionFactory(connectionFactory)
+
+		config := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "provisioning.grafana.app/v0alpha1",
+				"kind":       "Connection",
+				"metadata": map[string]any{
+					"name": "test",
+				},
+				"spec": map[string]any{
+					"title": "Test Connection",
+					"type":  "github",
+					"github": map[string]any{
+						"appID":          "123456",
+						"installationID": "454545",
+					},
+				},
+				"secure": map[string]any{
+					"privateKey": map[string]any{
+						"create": privateKeyBase64,
+					},
+				},
+			},
+		}
+
+		// Create with dryRun - that would test the connection
+		c, err := helper.Connections.Resource.Create(ctx, config, metav1.CreateOptions{
+			DryRun: []string{"All"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, c)
+	})
 }

--- a/pkg/tests/apis/provisioning/health_test.go
+++ b/pkg/tests/apis/provisioning/health_test.go
@@ -281,21 +281,15 @@ u5/wOyuHp1cIBnjeN41/pluOWFBHI9xLW3ExLtmYMiecJ8VdRA==
 		// Setup mock with insufficient permissions
 		connectionFactory := helper.GetEnv().GithubConnectionFactory.(*githubConnection.Factory)
 
-		app := &github.App{
-			ID:   github.Ptr(int64(123456)),
-			Slug: github.Ptr("test-app"),
-			Owner: &github.User{
-				Login: github.Ptr("test-owner"),
-			},
-		}
-
-		// Installation with only read permissions (insufficient)
-		installation := createInstallationWithPermissions(454545, map[string]string{
+		app := createAppWithPermissions(123456, map[string]string{
 			"contents":      "read", // needs write
 			"metadata":      "read",
 			"pull_requests": "read", // needs write
 			"webhooks":      "read", // needs write
 		})
+		installation := &github.Installation{
+			ID: github.Ptr(int64(454545)),
+		}
 
 		connectionFactory.Client = ghmock.NewMockedHTTPClient(
 			ghmock.WithRequestMatchHandler(
@@ -372,21 +366,16 @@ u5/wOyuHp1cIBnjeN41/pluOWFBHI9xLW3ExLtmYMiecJ8VdRA==
 	t.Run("test endpoint succeeds with all permissions", func(t *testing.T) {
 		// Setup mock with all required permissions
 		connectionFactory := helper.GetEnv().GithubConnectionFactory.(*githubConnection.Factory)
-
-		app := &github.App{
-			ID:   github.Ptr(int64(123456)),
-			Slug: github.Ptr("test-app"),
-			Owner: &github.User{
-				Login: github.Ptr("test-owner"),
-			},
-		}
-
-		installation := createInstallationWithPermissions(454545, map[string]string{
+		
+		app := createAppWithPermissions(123456, map[string]string{
 			"contents":      "write",
 			"metadata":      "read",
 			"pull_requests": "write",
 			"webhooks":      "write",
 		})
+		installation := &github.Installation{
+			ID: github.Ptr(int64(454545)),
+		}
 
 		connectionFactory.Client = ghmock.NewMockedHTTPClient(
 			ghmock.WithRequestMatchHandler(

--- a/pkg/tests/apis/provisioning/helper_test.go
+++ b/pkg/tests/apis/provisioning/helper_test.go
@@ -1080,6 +1080,12 @@ func (h *provisioningTestHelper) setGithubClient(t *testing.T, connection *unstr
 				app := github.App{
 					ID:   &id,
 					Slug: &appSlug,
+					Permissions: &github.InstallationPermissions{
+						Contents:        github.Ptr("write"),
+						Metadata:        github.Ptr("read"),
+						PullRequests:    github.Ptr("write"),
+						RepositoryHooks: github.Ptr("write"),
+					},
 				}
 				_, _ = w.Write(ghmock.MustMarshal(app))
 			}),


### PR DESCRIPTION
**What is this feature?**

Retrieving additional app information, related to the app permissions, and use that to check if the Github app has enough permissions to make the provisioning feature work as expacted.
Such permissions are:
- Metadata: readonly
- Contents: read/write
- Pull Requests: read/write
- Webhooks: read/write

The failure will be shown in both the API, when `POST` is called with `dryRun` and the controller, which will perform periodic healthchecks. 

**Why do we need this feature?**

With this we'll let the user know if they have setup their app without enough information, so that they can act upon it and fix their app.

**Who is this feature for?**

Users of GitSync

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/808

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
