### PR TITLE
RestoreDashboardVersion: Add folderUid to restoreDashboardVersion

### DIFF
--- a/public/app/features/dashboard/api/v1.test.ts
+++ b/public/app/features/dashboard/api/v1.test.ts
@@ -563,5 +563,33 @@ describe('v1 dashboard API', () => {
       expect(dashboardToRestore.metadata.resourceVersion).toBe('');
       expect(mockPost).toHaveBeenCalled();
     });
+
+    it('should preserve dashboard folder metadata', async () => {
+      const dashboardToRestore = {
+        ...mockDashboardDto,
+        metadata: {
+          ...mockDashboardDto.metadata,
+          annotations: {
+            ...(mockDashboardDto.metadata.annotations || {}),
+            [AnnoKeyFolder]: 'randomFolderUid',
+          },
+        },
+      };
+
+      const api = new K8sDashboardAPI();
+      await api.restoreDashboard(dashboardToRestore);
+
+      expect(mockPost).toHaveBeenCalledWith(
+        expect.stringContaining('/apis/dashboard.grafana.app/v1beta1/'),
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            annotations: expect.objectContaining({
+              [AnnoKeyFolder]: 'randomFolderUid',
+            }),
+          }),
+        }),
+        expect.anything()
+      );
+    });
   });
 });

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -272,6 +272,7 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
         name: uid,
       },
       message: `Restored from version ${version}`,
+      folderUid: historicalVersion.metadata?.annotations?.[AnnoKeyFolder],
     });
   }
 

--- a/public/app/features/dashboard/api/v2.test.ts
+++ b/public/app/features/dashboard/api/v2.test.ts
@@ -484,5 +484,33 @@ describe('v2 dashboard API', () => {
       expect(dashboardToRestore.metadata.resourceVersion).toBe('');
       expect(mockPost).toHaveBeenCalled();
     });
+
+    it('should preserve dashboard folder metadata', async () => {
+      const dashboardToRestore = {
+        ...mockDashboardDto,
+        metadata: {
+          ...mockDashboardDto.metadata,
+          annotations: {
+            ...(mockDashboardDto.metadata.annotations || {}),
+            [AnnoKeyFolder]: 'randomFolderUid',
+          },
+        },
+      };
+
+      const api = new K8sDashboardV2API();
+      await api.restoreDashboard(dashboardToRestore);
+
+      expect(mockPost).toHaveBeenCalledWith(
+        expect.stringContaining('/apis/dashboard.grafana.app/v2beta1/'),
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            annotations: expect.objectContaining({
+              [AnnoKeyFolder]: 'randomFolderUid',
+            }),
+          }),
+        }),
+        expect.anything()
+      );
+    });
   });
 });

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -220,6 +220,7 @@ export class K8sDashboardV2API
         name: uid,
       },
       message: `Restored from version ${version}`,
+      folderUid: historicalVersion.metadata?.annotations?.[AnnoKeyFolder],
     });
   }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/117677

Issue: folderUid was ignored when restoring a dashboard