### PR TITLE
Provisioning: retrieve default branch for Git repos in Test endpoint

### DIFF
--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -175,6 +175,16 @@ func (r *gitRepository) Test(ctx context.Context) (*provisioning.TestResults, er
 
 	t := string(r.config.Spec.Type)
 
+	// In case the branch is empty
+	if r.GetCurrentBranch() == "" {
+		branch, err := r.GetDefaultBranch(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		r.SetBranch(branch)
+	}
+
 	if ok, err := r.client.IsAuthorized(ctx); err != nil || !ok {
 		detail := "not authorized"
 		if err != nil {

--- a/apps/provisioning/pkg/repository/git/validator.go
+++ b/apps/provisioning/pkg/repository/git/validator.go
@@ -57,12 +57,6 @@ func ValidateGitConfigFields(repo *provisioning.Repository, url, branch, path st
 		}
 	}
 
-	// Require branch for non-GitHub repositories
-	// (GitHub repositories allow empty branches - they can retrieve the default branch)
-	if branch == "" && repo.Spec.Type != provisioning.GitHubRepositoryType {
-		list = append(list, field.Required(field.NewPath("spec", t, "branch"), "a git branch is required"))
-	}
-
 	// Validate branch name format if a branch is provided (applies to all repository types)
 	if branch != "" && !IsValidGitBranchName(branch) {
 		list = append(list, field.Invalid(field.NewPath("spec", t, "branch"), branch, "invalid branch name"))

--- a/apps/provisioning/pkg/repository/git/validator_test.go
+++ b/apps/provisioning/pkg/repository/git/validator_test.go
@@ -82,7 +82,7 @@ func TestValidate(t *testing.T) {
 			errorContains: []string{"invalid git URL format"},
 		},
 		{
-			name: "empty branch not allowed for git repositories",
+			name: "empty branch allowed for a pure git repository",
 			obj: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-repo",
@@ -91,15 +91,14 @@ func TestValidate(t *testing.T) {
 					Type: provisioning.GitRepositoryType,
 					Git: &provisioning.GitRepositoryConfig{
 						URL:    "https://github.com/grafana/grafana.git",
-						Branch: "", // Empty branch is not allowed for generic git repositories
+						Branch: "", // Empty branch should be valid for Git repositories
 					},
 				},
 			},
-			expectedError: true,
-			errorContains: []string{"branch is required"},
+			expectedError: false,
 		},
 		{
-			name: "empty branch allowed for github repositories",
+			name: "empty branch allowed for a github repository",
 			obj: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-repo",


### PR DESCRIPTION
**What is this feature?**

Adding the possibility to gather the default branch in `Test` function for pure git repository implementation.

Other than that, it also removes the check on the branch emptiness, as it's not needed anymore. 

**Why do we need this feature?**

The new UI flow needs to call `/test` endpoint (and in the future creation with dryRun) with an empty branch for pure git repositories. This PR allows it.

**Who is this feature for?**

Users of GitSync

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/873

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
