### PR TITLE
Fix: truncated labels on datasource picker

### DIFF
--- a/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
@@ -37,8 +37,8 @@ describe('DataSourcePicker', () => {
           type: 'datasource',
           info: {
             logos: {
-              small: 'public/app/plugins/datasource/prometheus/img/prometheus_logo.svg',
-              large: 'public/app/plugins/datasource/prometheus/img/prometheus_logo.svg',
+              small: 'prometheus_logo.svg',
+              large: 'prometheus_logo.svg',
             },
             author: { name: 'Grafana Labs' },
             description: 'Prometheus data source',

--- a/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
@@ -1,17 +1,70 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { DataSourceInstanceSettings, DataSourcePluginMeta } from '@grafana/data';
+
 import { DataSourcePicker } from './DataSourcePicker';
+
+const mockGetInstanceSettings = jest.fn();
+const mockGetList = jest.fn();
 
 jest.mock('../services/dataSourceSrv', () => ({
   getDataSourceSrv: () => ({
-    getList: () => [],
-    getInstanceSettings: () => undefined,
+    getList: mockGetList,
+    getInstanceSettings: mockGetInstanceSettings,
     get: () => undefined,
   }),
 }));
 
 describe('DataSourcePicker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetList.mockReturnValue([]);
+    mockGetInstanceSettings.mockReturnValue(undefined);
+  });
+
+  describe('long datasource names', () => {
+    it('should display full datasource name without truncation when current is passed as UID', () => {
+      const longDatasourceName = 'grafanacloud-demokitcloudamersandbox-prom';
+      const currentUid = 'grafanacloud-prom';
+      const mockDs: DataSourceInstanceSettings = {
+        uid: currentUid,
+        name: longDatasourceName,
+        type: 'prometheus',
+        meta: {
+          id: 'prometheus',
+          name: 'Prometheus',
+          type: 'datasource',
+          info: {
+            logos: {
+              small: 'public/app/plugins/datasource/prometheus/img/prometheus_logo.svg',
+              large: 'public/app/plugins/datasource/prometheus/img/prometheus_logo.svg',
+            },
+            author: { name: 'Grafana Labs' },
+            description: 'Prometheus data source',
+            links: [],
+            screenshots: [],
+            updated: '2021-01-01',
+            version: '1.0.0',
+          },
+          module: 'core:plugin/prometheus',
+          baseUrl: '',
+        } as DataSourcePluginMeta,
+        readOnly: false,
+        jsonData: {},
+        access: 'proxy',
+      };
+
+      mockGetInstanceSettings.mockReturnValue(mockDs);
+      mockGetList.mockReturnValue([mockDs]);
+
+      render(<DataSourcePicker current={currentUid} onChange={jest.fn()} />);
+
+      // The full name should be visible in the select value
+      expect(screen.getByText(longDatasourceName)).toBeInTheDocument();
+    });
+  });
+
   describe('onClear', () => {
     it('should call onClear when function is passed', async () => {
       const onClear = jest.fn();

--- a/packages/grafana-runtime/src/components/DataSourcePicker.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.tsx
@@ -113,7 +113,7 @@ export class DataSourcePicker extends PureComponent<DataSourcePickerProps, DataS
 
     if (ds) {
       return {
-        label: ds.name.slice(0, 37),
+        label: ds.name,
         value: ds.uid,
         imgUrl: ds.meta.info.logos.small,
         hideText: hideTextValue,


### PR DESCRIPTION
## Description

There has been a recent UI issue with one of our GTM colleague. The datasource label in app-o11y configuration page seems to be truncated for long names [look the before image]

## Changes
Please refer to code as documentation here.

## Risks
This is low risk

## Demo

#### Before
<img width="983" height="612" alt="Screenshot 2026-02-11 at 14 29 20" src="https://github.com/user-attachments/assets/59652842-06b1-497a-8829-4993caacd7ae" />

#### After

<img width="1105" height="608" alt="Screenshot 2026-02-11 at 14 27 26" src="https://github.com/user-attachments/assets/4b5768e2-7552-45a4-ae47-9d5445b4c099" />

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
I have added a test case to support the fix but this can be verified locally easily by sym-linking app-o11y with grafana core and doing a one liner change in DataSourcePicker.tsx (getCurrentValue function)

`if (ds) {
      ds.name = 'grafanacloud-demokitcloudamersandbox-prom';
     ....
 }`

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable
