### PR TITLE
unistore: use FilterAuthorized instead of Compile in resource.List

### DIFF
--- a/apps/quotas/go.mod
+++ b/apps/quotas/go.mod
@@ -188,6 +188,7 @@ require (
 	github.com/google/flatbuffers v25.12.19+incompatible // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/google/wire v0.7.0 // indirect

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
+	"github.com/bwmarrin/snowflake"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
@@ -1166,12 +1167,13 @@ func (s *server) listAuthorized(ctx context.Context, req *resourcepb.ListRequest
 
 		extractFn := func(c candidateItem) authz.BatchCheckItem {
 			return authz.BatchCheckItem{
-				Name:      c.name,
-				Folder:    c.folder,
-				Verb:      utils.VerbGet,
-				Group:     key.Group,
-				Resource:  key.Resource,
-				Namespace: key.Namespace,
+				Name:               c.name,
+				Folder:             c.folder,
+				Verb:               utils.VerbGet,
+				Group:              key.Group,
+				Resource:           key.Resource,
+				Namespace:          key.Namespace,
+				FreshnessTimestamp: resourceVersionTime(c.resourceVersion),
 			}
 		}
 
@@ -1781,4 +1783,25 @@ func (s *server) checkQuota(ctx context.Context, nsr NamespacedResource) error {
 	}
 
 	return nil
+}
+
+// resourceVersionTime extracts the timestamp embedded in a resource version.
+// Resource versions can be either snowflake IDs (KV backend) or microsecond
+// Unix timestamps (SQL backend). The function distinguishes them by magnitude:
+//   - Snowflake IDs for recent dates are > 1e17
+//   - Microsecond timestamps for recent dates are in the 1e14–1e16 range
+//
+// Returns the zero time if the value doesn't match either format.
+func resourceVersionTime(rv int64) time.Time {
+	switch {
+	case rv > 1e17:
+		ms := snowflake.ID(rv).Time()
+		return time.Unix(0, ms*int64(time.Millisecond))
+
+	case rv > 1e14:
+		return time.UnixMicro(rv)
+
+	default:
+		return time.Time{}
+	}
 }

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/grafana/authlib/authz"
 	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/dskit/backoff"
 
@@ -1114,69 +1115,103 @@ func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (*resour
 	}
 
 	key := req.Options.Key
-	//nolint:staticcheck // SA1019: Compile is deprecated but BatchCheck is not yet fully implemented
-	checker, _, err := s.access.Compile(ctx, user, claims.ListRequest{
-		Group:     key.Group,
-		Resource:  key.Resource,
-		Namespace: key.Namespace,
-		Verb:      utils.VerbGet,
-	})
-	var trashChecker claims.ItemChecker // only for trash
+
+	// Determine the verb for authorization
+	verb := utils.VerbGet
 	if req.Source == resourcepb.ListRequest_TRASH {
-		//nolint:staticcheck // SA1019: Compile is deprecated but BatchCheck is not yet fully implemented
-		trashChecker, _, err = s.access.Compile(ctx, user, claims.ListRequest{
+		verb = utils.VerbSetPermissions // Basically Admin for trash
+	}
+
+	// For trash, also determine if user is admin upfront so we can combine
+	// with "user deleted the object" check per item.
+	var isTrashAdmin bool
+	if req.Source == resourcepb.ListRequest_TRASH {
+		adminResp, err := s.access.Check(ctx, user, claims.CheckRequest{
+			Verb:      utils.VerbSetPermissions,
 			Group:     key.Group,
 			Resource:  key.Resource,
 			Namespace: key.Namespace,
-			Verb:      utils.VerbSetPermissions, // Basically Admin
-		})
+		}, "")
 		if err != nil {
 			return &resourcepb.ListResponse{Error: AsErrorResult(err)}, nil
 		}
-	}
-	if err != nil {
-		return &resourcepb.ListResponse{Error: AsErrorResult(err)}, nil
-	}
-	if checker == nil {
-		return &resourcepb.ListResponse{Error: &resourcepb.ErrorResult{
-			Code: http.StatusForbidden,
-		}}, nil
+		isTrashAdmin = adminResp.Allowed
 	}
 
+	// candidateItem holds metadata from the ListIterator for batch authorization.
+	type candidateItem struct {
+		name            string
+		folder          string
+		resourceVersion int64
+		value           []byte
+		continueToken   string
+	}
+
+	var nextToken string
+	maxPageBytes := s.maxPageSizeBytes
+
 	iterFunc := func(iter ListIterator) error {
-		for iter.Next() {
-			if err := iter.Error(); err != nil {
+		// Convert ListIterator to iter.Seq for FilterAuthorized
+		candidates := func(yield func(candidateItem) bool) {
+			for iter.Next() {
+				if err := iter.Error(); err != nil {
+					return
+				}
+				if !yield(candidateItem{
+					name:            iter.Name(),
+					folder:          iter.Folder(),
+					resourceVersion: iter.ResourceVersion(),
+					value:           iter.Value(),
+					continueToken:   iter.ContinueToken(),
+				}) {
+					return
+				}
+			}
+		}
+
+		extractFn := func(c candidateItem) authz.BatchCheckItem {
+			return authz.BatchCheckItem{
+				Name:      c.name,
+				Folder:    c.folder,
+				Verb:      verb,
+				Group:     key.Group,
+				Resource:  key.Resource,
+				Namespace: key.Namespace,
+			}
+		}
+
+		for item, err := range authz.FilterAuthorized(ctx, s.access, candidates, extractFn, authz.WithTracer(tracer)) {
+			if err != nil {
 				return err
 			}
 
-			// Trash is only accessible to admins or the user who deleted the object
+			// Trash items need an additional check: provisioned objects excluded,
+			// and either the user deleted the object or the user is admin.
 			if req.Source == resourcepb.ListRequest_TRASH {
-				if !s.isTrashItemAuthorized(ctx, iter, trashChecker) {
+				if !s.isTrashItemAuthorizedByValue(ctx, item.value, isTrashAdmin) {
 					continue
 				}
-			} else if !checker(iter.Name(), iter.Folder()) {
-				continue
 			}
 
-			item := &resourcepb.ResourceWrapper{
-				ResourceVersion: iter.ResourceVersion(),
-				Value:           iter.Value(),
-			}
+			rsp.Items = append(rsp.Items, &resourcepb.ResourceWrapper{
+				ResourceVersion: item.resourceVersion,
+				Value:           item.value,
+			})
+			pageBytes += len(item.value)
 
-			pageBytes += len(item.Value)
-			rsp.Items = append(rsp.Items, item)
-			if (req.Limit > 0 && len(rsp.Items) >= int(req.Limit)) || pageBytes >= s.maxPageSizeBytes {
-				t := iter.ContinueToken()
-				if iter.Next() {
-					rsp.NextPageToken = t
-				}
-				return iter.Error()
+			if (req.Limit > 0 && len(rsp.Items) >= int(req.Limit)) || pageBytes >= maxPageBytes {
+				nextToken = item.continueToken
+				break
 			}
 		}
+
 		return iter.Error()
 	}
 
-	var rv int64
+	var (
+		rv  int64
+		err error
+	)
 	switch req.Source {
 	case resourcepb.ListRequest_STORE:
 		rv, err = s.backend.ListIterator(ctx, req, iterFunc)
@@ -1199,22 +1234,24 @@ func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (*resour
 		return rsp, nil
 	}
 	rsp.ResourceVersion = rv
+	rsp.NextPageToken = nextToken
 	gr := req.Options.Key.Group + "/" + req.Options.Key.Resource
 	if s.storageMetrics != nil {
 		s.storageMetrics.ListWithFieldSelectors.WithLabelValues(gr, "storage").Inc()
 	}
-	return rsp, err
+	return rsp, nil
 }
 
-// isTrashItemAuthorized checks if the user has access to the trash item.
-func (s *server) isTrashItemAuthorized(ctx context.Context, iter ListIterator, trashChecker claims.ItemChecker) bool {
+// isTrashItemAuthorizedByValue checks if the user has access to the trash item using the raw value.
+// hasAdminPermission indicates whether the user has admin permission (from a Check call).
+func (s *server) isTrashItemAuthorizedByValue(ctx context.Context, value []byte, hasAdminPermission bool) bool {
 	user, ok := claims.AuthInfoFrom(ctx)
 	if !ok || user == nil {
 		return false
 	}
 
 	partial := &metav1.PartialObjectMetadata{}
-	err := json.Unmarshal(iter.Value(), partial)
+	err := json.Unmarshal(value, partial)
 	if err != nil {
 		return false
 	}
@@ -1230,7 +1267,7 @@ func (s *server) isTrashItemAuthorized(ctx context.Context, iter ListIterator, t
 	}
 
 	// Trash is only accessible to admins or the user who deleted the object
-	return obj.GetUpdatedBy() == user.GetUID() || trashChecker(iter.Name(), iter.Folder())
+	return obj.GetUpdatedBy() == user.GetUID() || hasAdminPermission
 }
 
 // Start the server.broadcaster (requires that the backend storage services are enabled)

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -769,8 +769,7 @@ func Test_resourceVersionTime(t *testing.T) {
 	tests := []struct {
 		name      string
 		rv        int64
-		wantZero  bool
-		wantClose time.Time // if not zero, must be within 1s of this
+		wantClose time.Time
 	}{
 		{
 			name:      "snowflake ID",
@@ -783,35 +782,30 @@ func Test_resourceVersionTime(t *testing.T) {
 			wantClose: refTime,
 		},
 		{
-			name:     "zero",
-			rv:       0,
-			wantZero: true,
+			name:      "zero",
+			rv:        0,
+			wantClose: time.UnixMicro(0),
 		},
 		{
-			name:     "negative",
-			rv:       -1,
-			wantZero: true,
+			name:      "negative",
+			rv:        -1,
+			wantClose: time.UnixMicro(-1),
 		},
 		{
-			name:     "small positive (not a timestamp)",
-			rv:       12345,
-			wantZero: true,
+			name:      "small positive",
+			rv:        12345,
+			wantClose: time.UnixMicro(12345),
 		},
 		{
-			name:     "sequential counter (too small for microseconds)",
-			rv:       1000000,
-			wantZero: true,
+			name:      "sequential counter",
+			rv:        1000000,
+			wantClose: time.UnixMicro(1000000),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := resourceVersionTime(tt.rv)
-			if tt.wantZero {
-				require.True(t, got.IsZero(), "expected zero time, got %v", got)
-				return
-			}
-			require.False(t, got.IsZero(), "expected non-zero time")
 			diff := got.Sub(tt.wantClose).Abs()
 			require.Less(t, diff, time.Second,
 				"expected time close to %v, got %v (diff %v)", tt.wantClose, got, diff)

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -194,7 +194,7 @@ func TestIntegrationDashboardAPIZanzanaList(t *testing.T) {
 		AppModeProduction:     true,
 		DisableAnonymous:      true,
 		APIServerStorageType:  "unified",
-		DBMaxConns:            4,
+		DBMaxConns:            50,
 		UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
 			"dashboards.dashboard.grafana.app": {
 				DualWriterMode: rest.Mode5,


### PR DESCRIPTION
Start using BatchCheck (via https://github.com/grafana/authlib/blob/main/authz/filter.go#L49)  instead of Compile in unistore List.