### PR TITLE
Dashboards: Log keyboard shortcuts to dashboard events

### DIFF
--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -52,7 +52,7 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
     key: 'v',
     onTrigger: withFocusedPanel(scene, (vizPanel: VizPanel) => {
       const panelId = getPanelIdForVizPanel(vizPanel);
-      DashboardInteractions.panelActionClicked('view', panelId, 'panel');
+      DashboardInteractions.panelActionClicked('view', panelId, 'keyboard');
       if (scene.state.viewPanel) {
         locationService.partial({ viewPanel: undefined });
       } else {
@@ -215,7 +215,7 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
       key: 'e',
       onTrigger: withFocusedPanel(scene, async (vizPanel: VizPanel) => {
         const panelId = getPanelIdForVizPanel(vizPanel);
-        DashboardInteractions.panelActionClicked('edit', panelId, 'panel');
+        DashboardInteractions.panelActionClicked('edit', panelId, 'keyboard');
         const sceneRoot = vizPanel.getRoot();
         if (sceneRoot instanceof DashboardScene) {
           if (scene.state.editPanel) {
@@ -250,7 +250,7 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
       onTrigger: withFocusedPanel(scene, (vizPanel: VizPanel) => {
         if (scene.state.isEditing) {
           const panelId = getPanelIdForVizPanel(vizPanel);
-          DashboardInteractions.panelActionClicked('delete', panelId, 'panel');
+          DashboardInteractions.panelActionClicked('delete', panelId, 'keyboard');
           onRemovePanel(scene, vizPanel);
         }
       }),
@@ -260,7 +260,7 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
     keybindings.addBinding({
       key: 'p d',
       onTrigger: withFocusedPanel(scene, (vizPanel: VizPanel) => {
-        DashboardInteractions.panelActionClicked('duplicate', getPanelIdForVizPanel(vizPanel), 'panel');
+        DashboardInteractions.panelActionClicked('duplicate', getPanelIdForVizPanel(vizPanel), 'keyboard');
         if (scene.state.isEditing) {
           scene.duplicatePanel(vizPanel);
         }

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -11,6 +11,7 @@ import { shareDashboardType } from '../../dashboard/components/ShareModal/utils'
 import { PanelInspectDrawer } from '../inspect/PanelInspectDrawer';
 import { ShareDrawer } from '../sharing/ShareDrawer/ShareDrawer';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
+import { DashboardInteractions } from '../utils/interactions';
 import { findVizPanelByPathId } from '../utils/pathId';
 import { getEditPanelUrl, tryGetExploreUrlForPanel } from '../utils/urlBuilders';
 import { getPanelIdForVizPanel } from '../utils/utils';
@@ -50,6 +51,8 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
   keybindings.addBinding({
     key: 'v',
     onTrigger: withFocusedPanel(scene, (vizPanel: VizPanel) => {
+      const panelId = getPanelIdForVizPanel(vizPanel);
+      DashboardInteractions.panelActionClicked('view', panelId, 'panel');
       if (scene.state.viewPanel) {
         locationService.partial({ viewPanel: undefined });
       } else {
@@ -211,9 +214,10 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
     keybindings.addBinding({
       key: 'e',
       onTrigger: withFocusedPanel(scene, async (vizPanel: VizPanel) => {
+        const panelId = getPanelIdForVizPanel(vizPanel);
+        DashboardInteractions.panelActionClicked('edit', panelId, 'panel');
         const sceneRoot = vizPanel.getRoot();
         if (sceneRoot instanceof DashboardScene) {
-          const panelId = getPanelIdForVizPanel(vizPanel);
           if (scene.state.editPanel) {
             locationService.push(
               locationUtil.getUrlForPartial(locationService.getLocation(), {
@@ -245,6 +249,8 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
       key: 'p r',
       onTrigger: withFocusedPanel(scene, (vizPanel: VizPanel) => {
         if (scene.state.isEditing) {
+          const panelId = getPanelIdForVizPanel(vizPanel);
+          DashboardInteractions.panelActionClicked('delete', panelId, 'panel');
           onRemovePanel(scene, vizPanel);
         }
       }),
@@ -254,6 +260,7 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
     keybindings.addBinding({
       key: 'p d',
       onTrigger: withFocusedPanel(scene, (vizPanel: VizPanel) => {
+        DashboardInteractions.panelActionClicked('duplicate', getPanelIdForVizPanel(vizPanel), 'panel');
         if (scene.state.isEditing) {
           scene.duplicatePanel(vizPanel);
         }

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -108,7 +108,7 @@ export const DashboardInteractions = {
   panelActionClicked(
     item: 'configure' | 'configure_dropdown' | 'edit' | 'copy' | 'duplicate' | 'delete' | 'view',
     id: number,
-    source: 'panel' | 'edit_pane'
+    source: 'panel' | 'edit_pane' | 'keyboard'
   ) {
     reportDashboardInteraction('panel_action_clicked', { item, id, source });
   },


### PR DESCRIPTION
Fixes #117764

This adds keyboards shortcuts to triggers for dashboard user events