### PR TITLE
docs(alerting): Document `alertRuleUseFiredAtForStartsAt` experimental feature toggle

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -104,7 +104,8 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 
 The following toggles require explicitly setting Grafana's [app mode](../#app_mode) to 'development' before you can enable this feature toggle. These features tend to be experimental.
 
-| Feature toggle name                    | Description                                                                   |
-| -------------------------------------- | ----------------------------------------------------------------------------- |
-| `grafanaAPIServerWithExperimentalAPIs` | Register experimental APIs with the k8s API server, including all datasources |
-| `grafanaAPIServerEnsureKubectlAccess`  | Start an additional https handler and write kubectl options                   |
+| Feature toggle name                    | Description                                                                                                                                  |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `alertRuleUseFiredAtForStartsAt`       | Enables setting the `Alert.StartsAt` value used for notifications to the moment the alert first fired, fixing incorrect values in edge cases |
+| `grafanaAPIServerWithExperimentalAPIs` | Register experimental APIs with the k8s API server, including all datasources                                                                |
+| `grafanaAPIServerEnsureKubectlAccess`  | Start an additional https handler and write kubectl options                                                                                  |


### PR DESCRIPTION
This PR adds docs for experimental feature toggle introduced in https://github.com/grafana/grafana/pull/104046

