### PR TITLE
Histogram: Drop buckets from data which are too small

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/histogram.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.ts
@@ -196,8 +196,12 @@ export function getHistogramFields(frame: DataFrame): HistogramFields | undefine
     let yMaxField = frame.fields.find((f) => f.name === 'yMax')!;
     let countField = frame.fields.find((f) => f.name === 'count')!;
 
-    let uniqueMaxs = [...new Set(yMaxField.values)].sort((a, b) => a - b);
-    let uniqueMins = [...new Set(yMinField.values)].sort((a, b) => a - b);
+    let uniqueMaxs = [...new Set(yMaxField.values)]
+      .sort((a, b) => a - b)
+      .filter((val) => val >= histogramBucketSizes[0]);
+    let uniqueMins = [...new Set(yMinField.values)]
+      .sort((a, b) => a - b)
+      .filter((val) => val >= histogramBucketSizes[0]);
 
     // useLogScale is assumed for native histograms, we get the multiplier from first bucket's min/max bounds
     let bucketFactor = uniqueMaxs[0] / uniqueMins[0];


### PR DESCRIPTION
This issue was discovered when working on a customer escalation.

The key issue here is that, when we start from an absurdly small bucket size like `1e-128` and start scaling it up by multiplying it by 1.09 or whatever, we will end up with the max limit of buckets (1k) and they'll all be `1e-128`, `1.09e-128`, up to a max of like `1e-126` or something.

While the root cause is clearly something wonky with the data (potentially coming from the datasource), we can at least attempt to throw away obviously unusable data below the `1e-9` in the list of `histogramBucketSizes`. This change makes the panel in question render data again, although the biggest issue I see here is that if there is a `count` to render in that near-zero bucket, it will not be represented in the viz.