### PR TITLE
Alerting: Fix alert rule last evaluation duration units

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/Details.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/Details.tsx
@@ -10,6 +10,7 @@ import { useDatasource } from 'app/features/datasources/hooks';
 import { CombinedRule } from 'app/types/unified-alerting';
 import { GrafanaAlertingRuleDefinition, RulerGrafanaRuleDTO } from 'app/types/unified-alerting-dto';
 
+import { Time } from '../../../../../explore/Time';
 import { usePendingPeriod } from '../../../hooks/rules/usePendingPeriod';
 import { makeEditTimeIntervalLink } from '../../../utils/misc';
 import { getAnnotations, isPausedRule, prometheusRuleType, rulerRuleType } from '../../../utils/rules';
@@ -160,7 +161,8 @@ export const Details = ({ rule }: DetailsProps) => {
               <DetailText
                 id="last-evaluation-duration"
                 label={t('alerting.alert.last-evaluation-duration', 'Last evaluation duration')}
-                value={`${evaluationDuration} ms`}
+                value={Time({ timeInMs: evaluationDuration! * 1000, humanize: true })}
+                tooltipValue={`${evaluationDuration}s`}
               />
             )}
             {missingSeriesEvalsToResolve && (

--- a/public/app/features/alerting/unified/components/rules/RuleDetails.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetails.tsx
@@ -142,7 +142,7 @@ const EvaluationBehaviorSummary = ({ rule }: EvaluationBehaviorSummaryProps) => 
             content={`${lastEvaluationDuration}s`}
             theme="info"
           >
-            <span>{Time({ timeInMs: lastEvaluationDuration, humanize: true })}</span>
+            <span>{Time({ timeInMs: lastEvaluationDuration * 1000, humanize: true })}</span>
           </Tooltip>
         </DetailsField>
       )}


### PR DESCRIPTION
`api/v1/rules` returns `evaluationTime` in seconds, but the UI was treating it as milliseconds in Rule View page.

### Screenshots

<details><summary>Rule with 15s query</summary>
<p>

<img width="1233" height="363" alt="Screenshot 2026-02-10 at 19-26-16 Edit alert rule - Alert rules - Alerting - Alerts   IRM - Grafana" src="https://github.com/user-attachments/assets/2f4a87dc-776a-43d0-9e42-b79df78cf014" />

</p>
</details> 

<details><summary>Before displayed as 15ms</summary>
<p>

<img width="1335" height="617" alt="Screenshot 2026-02-10 at 19-01-37 Details - Slow Rule - 1m - test - Alerting - Alerts   IRM - Grafana" src="https://github.com/user-attachments/assets/f6f9d9f9-3755-4277-a185-473c501dbf20" />


</p>
</details> 

<details><summary>After</summary>
<p>

<img width="1335" height="617" alt="Screenshot 2026-02-10 at 19-29-32 Details - Slow Rule - 1m - test - Alerting - Alerts   IRM - Grafana" src="https://github.com/user-attachments/assets/6079281a-5478-414c-a4a2-82ae01d302c0" />

</p>
</details> 