### PR TITLE
Provisioning: Pure Git URL trim .git suffix

### DIFF
--- a/public/app/features/provisioning/utils/git.test.ts
+++ b/public/app/features/provisioning/utils/git.test.ts
@@ -1,0 +1,161 @@
+import { RepositorySpec } from 'app/api/clients/provisioning/v0alpha1';
+
+import { getRepoHrefForProvider } from './git';
+
+// Partial specs for testing; getRepoHrefForProvider only reads type and provider url/branch/path.
+function spec(s: Partial<RepositorySpec>): RepositorySpec {
+  return s as RepositorySpec;
+}
+
+describe('buildRepoUrl', () => {
+  describe('base URL normalization', () => {
+    it('strips trailing .git from GitHub URL', () => {
+      expect(
+        getRepoHrefForProvider(
+          spec({
+            type: 'github',
+            github: { url: 'https://github.com/owner/repo.git', branch: 'main' },
+          })
+        )
+      ).toBe('https://github.com/owner/repo/tree/main');
+    });
+
+    it('strips trailing .git/ from base URL', () => {
+      expect(
+        getRepoHrefForProvider(
+          spec({
+            type: 'github',
+            github: { url: 'https://github.com/owner/repo.git/', branch: 'main' },
+          })
+        )
+      ).toBe('https://github.com/owner/repo/tree/main');
+    });
+
+    it('leaves URL unchanged when it does not end with .git', () => {
+      expect(
+        getRepoHrefForProvider(
+          spec({
+            type: 'github',
+            github: { url: 'https://github.com/owner/repo', branch: 'main' },
+          })
+        )
+      ).toBe('https://github.com/owner/repo/tree/main');
+    });
+
+    it('trims whitespace from base URL', () => {
+      expect(
+        getRepoHrefForProvider(
+          spec({
+            type: 'github',
+            github: { url: '  https://github.com/owner/repo  ', branch: 'main' },
+          })
+        )
+      ).toBe('https://github.com/owner/repo/tree/main');
+    });
+  });
+
+  describe('branch and path', () => {
+    it('builds URL with branch only', () => {
+      expect(
+        getRepoHrefForProvider(
+          spec({
+            type: 'github',
+            github: { url: 'https://github.com/owner/repo', branch: 'develop' },
+          })
+        )
+      ).toBe('https://github.com/owner/repo/tree/develop');
+    });
+
+    it('builds URL with path segments encoded', () => {
+      expect(
+        getRepoHrefForProvider(
+          spec({
+            type: 'github',
+            github: {
+              url: 'https://github.com/owner/repo',
+              branch: 'main',
+              path: 'src/utils/index.ts',
+            },
+          })
+        )
+      ).toBe('https://github.com/owner/repo/tree/main/src/utils/index.ts');
+    });
+
+    it('builds URL without branch when branch is missing', () => {
+      expect(
+        getRepoHrefForProvider(
+          spec({
+            type: 'github',
+            github: { url: 'https://github.com/owner/repo' } as RepositorySpec['github'],
+          })
+        )
+      ).toBe('https://github.com/owner/repo/tree');
+    });
+  });
+
+  describe('providers', () => {
+    it('builds GitHub href with tree segment', () => {
+      expect(
+        getRepoHrefForProvider(
+          spec({
+            type: 'github',
+            github: { url: 'https://github.com/org/my-repo.git', branch: 'main' },
+          })
+        )
+      ).toBe('https://github.com/org/my-repo/tree/main');
+    });
+
+    it('builds GitLab href with -/tree segments', () => {
+      expect(
+        getRepoHrefForProvider(
+          spec({
+            type: 'gitlab',
+            gitlab: { url: 'https://gitlab.com/group/project.git', branch: 'main' },
+          })
+        )
+      ).toBe('https://gitlab.com/group/project/-/tree/main');
+    });
+
+    it('builds Bitbucket href with src segment', () => {
+      expect(
+        getRepoHrefForProvider(
+          spec({
+            type: 'bitbucket',
+            bitbucket: { url: 'https://bitbucket.org/workspace/repo.git', branch: 'main' },
+          })
+        )
+      ).toBe('https://bitbucket.org/workspace/repo/src/main');
+    });
+
+    it('builds generic git href with tree segment', () => {
+      expect(
+        getRepoHrefForProvider(
+          spec({
+            type: 'git',
+            git: { url: 'https://git.example.com/owner/repo.git', branch: 'main' },
+          })
+        )
+      ).toBe('https://git.example.com/owner/repo/tree/main');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns undefined when spec is undefined', () => {
+      expect(getRepoHrefForProvider(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined when type is missing', () => {
+      expect(getRepoHrefForProvider(spec({ type: undefined }))).toBeUndefined();
+    });
+
+    it('returns undefined when base URL is missing for provider', () => {
+      expect(
+        getRepoHrefForProvider(spec({ type: 'github', github: { url: undefined, branch: 'main' } }))
+      ).toBeUndefined();
+    });
+
+    it('returns undefined for unknown provider type', () => {
+      expect(getRepoHrefForProvider({ type: 'unknown' } as unknown as RepositorySpec)).toBeUndefined();
+    });
+  });
+});

--- a/public/app/features/provisioning/utils/git.ts
+++ b/public/app/features/provisioning/utils/git.ts
@@ -47,8 +47,9 @@ const buildRepoUrl = ({ baseUrl, branch, providerSegments, path }: BuildRepoUrlP
     return undefined;
   }
 
-  // Normalize base URL: trim whitespace + remove trailing slashes.
-  const cleanBase = stripSlashes(baseUrl.trim());
+  // Normalize base URL: trim whitespace + remove trailing slashes + remove .git suffix if present
+  const cleanBase = stripSlashes(baseUrl.trim()).replace(/\.git\/?$/i, '');
+
   const cleanBranch = branch?.trim() || undefined;
 
   // Start composing URL parts:


### PR DESCRIPTION
**What is this feature?**

Sometimes pure git repo url ends with `.git` which makes user land on 404 page when url are append with branch or folder path like `xxx.git/main/tree`

**Why do we need this feature?**

Make sure user navigate correctly

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/864

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
