### PR TITLE
chore: transfer Levitate alerts

### DIFF
--- a/.github/workflows/detect-breaking-changes-levitate.yml
+++ b/.github/workflows/detect-breaking-changes-levitate.yml
@@ -300,10 +300,10 @@ jobs:
         if: steps.levitate-run.outputs.exit_code == 1 && steps.does-label-exist.outputs.result == 0 && github.repository == 'grafana/grafana'
         uses: grafana/shared-workflows/actions/send-slack-message@7b628e7352c2dea057c565cc4fcd5564d5f396c0 #v1.0.0
         with:
-          channel-id: "C031SLFH6G0"
+          channel-id: "C08QATP6AE9"
           payload:  |
             {
-              "channel": "C031SLFH6G0",
+              "channel": "C08QATP6AE9",
               "text": ":warning: Possible breaking changes detected in *PR:* <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} :warning:",
               "icon_emoji": ":grot:",
               "username": "Levitate Bot",
@@ -366,7 +366,7 @@ jobs:
       # Add reviewers
       # This is very weird, the actual request goes through (comes back with a 201), but does not assign the team.
       # Related issue: https://github.com/renovatebot/renovate/issues/1908
-      - name: Add "grafana/plugins-platform-frontend" as a reviewer
+      - name: Add "grafana/grafana-frontend-platform" as a reviewer
         if: steps.levitate-run.outputs.exit_code == 1
         uses: actions/github-script@v8
         env:
@@ -379,11 +379,11 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               reviewers: [],
-              team_reviewers: ['plugins-platform-frontend']
+              team_reviewers: ['grafana-frontend-platform']
             });
 
       # Remove reviewers (no more breaking changes)
-      - name: Remove "grafana/plugins-platform-frontend" from the list of reviewers
+      - name: Remove "grafana/grafana-frontend-platform" from the list of reviewers
         if: steps.levitate-run.outputs.exit_code == 0
         uses: actions/github-script@v8
         env:
@@ -396,7 +396,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               reviewers: [],
-              team_reviewers: ['plugins-platform-frontend']
+              team_reviewers: ['grafana-frontend-platform']
             });
 
       - name: Exit

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -85,4 +85,4 @@ export {
   usePanelPluginInstalled,
   usePanelPluginVersion,
 } from './services/pluginMeta/hooks';
-export { getListedPanelPluginIds, getPanelPluginVersion, isPanelPluginInstalled } from './services/pluginMeta/panels';
+export { getPanelPluginVersion, isPanelPluginInstalled } from './services/pluginMeta/panels';

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -85,4 +85,4 @@ export {
   usePanelPluginInstalled,
   usePanelPluginVersion,
 } from './services/pluginMeta/hooks';
-export { getPanelPluginVersion, isPanelPluginInstalled } from './services/pluginMeta/panels';
+export { getListedPanelPluginIds, getPanelPluginVersion, isPanelPluginInstalled } from './services/pluginMeta/panels';


### PR DESCRIPTION
**What is this feature?**

This pull request updates workflow automation and refines the plugin exports in the codebase. The main changes include updating Slack notification channels, correcting reviewer team names in GitHub Actions.

**Why do we need this feature?**

So the Levitate alerts are posted in the correct channel and the correct team is assigned

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
