### PR TITLE
SQL Expressions: Quote table names with spaces to fix parsing errors

### DIFF
--- a/public/app/features/expressions/components/SqlExpressions/CompletionProvider/sqlCompletionProvider.ts
+++ b/public/app/features/expressions/components/SqlExpressions/CompletionProvider/sqlCompletionProvider.ts
@@ -6,6 +6,7 @@ import {
   type TableIdentifier,
 } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
+import { quoteIdentifierIfNecessary } from 'app/plugins/datasource/mysql/sqlUtil';
 
 import { ALLOWED_FUNCTIONS } from '../../../utils/metaSqlExpr';
 
@@ -21,9 +22,10 @@ export const getSqlCompletionProvider: (args: CompletionProviderGetterArgs) => L
     tables: {
       resolve: async () => {
         const refIdsToTableDefs = args.refIds.map((refId) => {
+          const name = refId.label || refId.value || '';
           const tableDef: TableDefinition = {
-            name: refId.label || refId.value || '',
-            completion: refId.label || refId.value || '',
+            name,
+            completion: quoteIdentifierIfNecessary(name),
           };
           return tableDef;
         });

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
@@ -118,6 +118,37 @@ describe('SqlExpr', () => {
       expect(updatedQuery.format).toBe('alerting');
     });
   });
+
+  it('quotes table names with spaces in the initial query', async () => {
+    const onChange = jest.fn();
+    const refIds = [{ value: 'gdp per capita' }];
+    const query = { refId: 'expr1', type: 'sql', expression: '' } as ExpressionQuery;
+
+    render(<SqlExpr onChange={onChange} refIds={refIds} query={query} queries={[]} />);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    const updatedQuery = onChange.mock.calls[0][0];
+    expect(updatedQuery.expression).toContain('`gdp per capita`');
+  });
+
+  it('does not quote simple table names without spaces', async () => {
+    const onChange = jest.fn();
+    const refIds = [{ value: 'A' }];
+    const query = { refId: 'expr1', type: 'sql', expression: '' } as ExpressionQuery;
+
+    render(<SqlExpr onChange={onChange} refIds={refIds} query={query} queries={[]} />);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    const updatedQuery = onChange.mock.calls[0][0];
+    expect(updatedQuery.expression).toContain('A');
+    expect(updatedQuery.expression).not.toContain('`A`');
+  });
 });
 
 describe('Schema Inspector feature toggle', () => {

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
@@ -11,6 +11,8 @@ import { type DataQuery } from '@grafana/schema';
 import { formatSQL } from '@grafana/sql';
 import { Button, Stack, useStyles2 } from '@grafana/ui';
 
+import { quoteIdentifierIfNecessary } from 'app/plugins/datasource/mysql/sqlUtil';
+
 import { type ExpressionQueryEditorProps } from '../../ExpressionQueryEditor';
 import { type SqlExpressionQuery } from '../../types';
 import { fetchSQLFields } from '../../utils/metaSqlExpr';
@@ -77,7 +79,7 @@ export const SqlExpr = ({ onChange, refIds, query, alerting = false, queries, me
   const initialQuery = `SELECT
   *
 FROM
-  ${vars[0]}
+  ${quoteIdentifierIfNecessary(vars[0])}
 LIMIT
   10`;
 

--- a/public/app/features/expressions/utils/metaSqlExpr.ts
+++ b/public/app/features/expressions/utils/metaSqlExpr.ts
@@ -12,7 +12,7 @@ export async function fetchSQLFields(query: Partial<SQLQuery>, queries: DataQuer
     return [];
   }
 
-  const queryString = `SELECT * FROM ${query.table} LIMIT 1`;
+  const queryString = `SELECT * FROM ${quoteIdentifierIfNecessary(query.table)} LIMIT 1`;
 
   const queryResponse = await datasource.runMetaSQLExprQuery(
     { rawSql: queryString, format: QueryFormat.Table, refId: `fields-${uuidv4()}` },


### PR DESCRIPTION
**What is this feature?**

Wraps table names in backticks when they contain spaces or other characters that require quoting. Uses the existing `quoteIdentifierIfNecessary` utility that was already being used for field names but wasn't applied to table names.

**Why do we need this feature?**

When a data source query has a refId containing spaces (e.g. "gdp per capita"), the SQL expression generates invalid SQL like `SELECT * FROM gdp per capita LIMIT 10` which fails to parse. The table name needs to be quoted as `` `gdp per capita` `` for the SQL to be valid.

**Who is this feature for?**

Users creating SQL Expressions where source queries have refIds with spaces.

**Which issue(s) does this PR fix?**:

Fixes #117497

**Special notes for your reviewer:**

The fix applies `quoteIdentifierIfNecessary` (already exists in `mysql/sqlUtil.ts`) to table names in three places:

1. **`SqlExpr.tsx`** - the initial query template that generates the default `SELECT * FROM <table> LIMIT 10`
2. **`sqlCompletionProvider.ts`** - autocomplete completions, so selecting a table from the dropdown inserts a quoted name
3. **`metaSqlExpr.ts`** - the schema fetch query used by the schema inspector

Simple identifiers like `A` are left unquoted since `quoteIdentifierIfNecessary` only adds backticks when needed.

Added two tests covering both cases (with and without spaces).

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.