### PR TITLE
Fix: Don't reuse go-plugin config

### DIFF
--- a/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
+++ b/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
@@ -65,7 +65,7 @@ func (p *grpcPlugin) Logger() log.Logger {
 	return p.logger
 }
 
-func (p *grpcPlugin) Start(_ context.Context) (retErr error) {
+func (p *grpcPlugin) Start(_ context.Context) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 


### PR DESCRIPTION

**What is this feature?**

This fixes a bug introduced by #115936. As a side effect of handling for a new category of error, that PR led to the `goplugin.ClientConfig` being reused if the backend plugin failed and needed to be restarted, but the reused config's `Cmd` member already has configured stdin and stdout, leading ultimately to an error from `os/exec` [here](https://github.com/golang/go/blob/eaf3bc799a221cc375f188e8699c9330c1caf40a/src/os/exec/exec.go#L1074-L1080).

Many thanks to @kevinwcyu for pinpointing the problem here!

**Why do we need this feature?**

In Grafana Cloud when backend plugin processes fail they aren't getting restarted, leading all subsequent queries for that plugin to fail.
