### PR TITLE
TeamFolders: Block team deletion

### DIFF
--- a/packages/grafana-test-utils/src/handlers/apis/folder.grafana.app/v1beta1/handlers.ts
+++ b/packages/grafana-test-utils/src/handlers/apis/folder.grafana.app/v1beta1/handlers.ts
@@ -283,7 +283,21 @@ const folderCountsHandler = () =>
     }
   );
 
+const getFolderListHandler = () =>
+  http.get<{ namespace: string }>('/apis/folder.grafana.app/v1beta1/namespaces/:namespace/folders', ({ params }) => {
+    const { namespace } = params;
+    const folders = mockTree.map(({ item }, index) => folderToAppPlatform(item, index + 1, namespace));
+
+    return HttpResponse.json({
+      kind: 'FolderList',
+      apiVersion: 'folder.grafana.app/v1beta1',
+      metadata: {},
+      items: folders,
+    });
+  });
+
 export default [
+  getFolderListHandler(),
   getFolderHandler(),
   getFolderParentsHandler(),
   createFolderHandler(),

--- a/public/app/api/clients/dashboard/v0alpha1/index.ts
+++ b/public/app/api/clients/dashboard/v0alpha1/index.ts
@@ -2,4 +2,4 @@ import { generatedAPI } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
 
 export const dashboardAPIv0alpha1 = generatedAPI.enhanceEndpoints({});
 
-export const { useSearchDashboardsAndFoldersQuery } = dashboardAPIv0alpha1;
+export const { useSearchDashboardsAndFoldersQuery, useLazySearchDashboardsAndFoldersQuery } = dashboardAPIv0alpha1;

--- a/public/app/features/teams/TeamDeleteModal.test.tsx
+++ b/public/app/features/teams/TeamDeleteModal.test.tsx
@@ -1,6 +1,8 @@
 import { screen } from '@testing-library/react';
 import { render } from 'test/test-utils';
 
+import { MOCK_TEAMS } from '@grafana/test-utils/unstable';
+
 import { TeamDeleteModal, Props } from './TeamDeleteModal';
 
 describe('TeamDeleteModal', () => {
@@ -15,10 +17,12 @@ describe('TeamDeleteModal', () => {
     ownedFolder: false,
   };
 
-  it('renders a dialog with the correct title', async () => {
+  it('renders a dialog with the correct title and text', async () => {
+    const mockTeam = MOCK_TEAMS[0];
     render(<TeamDeleteModal {...defaultProps} />);
 
     expect(await screen.findByRole('dialog', { name: 'Delete' })).toBeInTheDocument();
+    expect(await screen.findByText(`This action will delete the team ${mockTeam.spec.title}`)).toBeInTheDocument();
   });
 
   it('displays a `Cancel` and a `Delete` button', async () => {
@@ -34,8 +38,11 @@ describe('TeamDeleteModal', () => {
     expect(await screen.findByRole('button', { name: 'Delete' })).toBeEnabled();
   });
 
-  it('disables the `Delete` button when ownedFolder is true', async () => {
+  it('shows the alert and disables the `Delete` button when ownedFolder is true', async () => {
     render(<TeamDeleteModal {...defaultProps} ownedFolder={true} />);
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(await screen.findByText('Cannot delete team')).toBeInTheDocument();
 
     expect(await screen.findByRole('button', { name: 'Delete' })).toBeDisabled();
   });

--- a/public/app/features/teams/TeamDeleteModal.test.tsx
+++ b/public/app/features/teams/TeamDeleteModal.test.tsx
@@ -22,7 +22,8 @@ describe('TeamDeleteModal', () => {
     render(<TeamDeleteModal {...defaultProps} />);
 
     expect(await screen.findByRole('dialog', { name: 'Delete' })).toBeInTheDocument();
-    expect(await screen.findByText(`This action will delete the team ${mockTeam.spec.title}`)).toBeInTheDocument();
+    expect(await screen.findByText(/This action will delete the team/)).toBeInTheDocument();
+    expect(await screen.findByText(`${mockTeam.spec.title}`)).toBeInTheDocument();
   });
 
   it('displays a `Cancel` and a `Delete` button', async () => {

--- a/public/app/features/teams/TeamDeleteModal.test.tsx
+++ b/public/app/features/teams/TeamDeleteModal.test.tsx
@@ -1,12 +1,7 @@
-import { render as rtlRender, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { TestProvider } from 'test/helpers/TestProvider';
+import { screen } from '@testing-library/react';
+import { render } from 'test/test-utils';
 
 import { TeamDeleteModal, Props } from './TeamDeleteModal';
-
-function render(...[ui, options]: Parameters<typeof rtlRender>) {
-  rtlRender(<TestProvider>{ui}</TestProvider>, options);
-}
 
 describe('TeamDeleteModal', () => {
   const mockOnDismiss = jest.fn();
@@ -46,16 +41,16 @@ describe('TeamDeleteModal', () => {
   });
 
   it('calls onConfirm when clicking the `Delete` button', async () => {
-    render(<TeamDeleteModal {...defaultProps} />);
+    const { user } = render(<TeamDeleteModal {...defaultProps} />);
 
-    await userEvent.click(await screen.findByRole('button', { name: 'Delete' }));
+    await user.click(await screen.findByRole('button', { name: 'Delete' }));
     expect(mockOnConfirm).toHaveBeenCalled();
   });
 
   it('calls onDismiss when clicking the `Cancel` button', async () => {
-    render(<TeamDeleteModal {...defaultProps} />);
+    const { user } = render(<TeamDeleteModal {...defaultProps} />);
 
-    await userEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+    await user.click(await screen.findByRole('button', { name: 'Cancel' }));
     expect(mockOnDismiss).toHaveBeenCalled();
   });
 });

--- a/public/app/features/teams/TeamDeleteModal.test.tsx
+++ b/public/app/features/teams/TeamDeleteModal.test.tsx
@@ -1,0 +1,61 @@
+import { render as rtlRender, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TestProvider } from 'test/helpers/TestProvider';
+
+import { TeamDeleteModal, Props } from './TeamDeleteModal';
+
+function render(...[ui, options]: Parameters<typeof rtlRender>) {
+  rtlRender(<TestProvider>{ui}</TestProvider>, options);
+}
+
+describe('TeamDeleteModal', () => {
+  const mockOnDismiss = jest.fn();
+  const mockOnConfirm = jest.fn();
+
+  const defaultProps: Props = {
+    isOpen: true,
+    onConfirm: mockOnConfirm,
+    onDismiss: mockOnDismiss,
+    teamName: 'Test Team',
+    ownedFolder: false,
+  };
+
+  it('renders a dialog with the correct title', async () => {
+    render(<TeamDeleteModal {...defaultProps} />);
+
+    expect(await screen.findByRole('dialog', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('displays a `Cancel` and a `Delete` button', async () => {
+    render(<TeamDeleteModal {...defaultProps} />);
+
+    expect(await screen.findByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('enables the `Delete` button when ownedFolder is false', async () => {
+    render(<TeamDeleteModal {...defaultProps} />);
+
+    expect(await screen.findByRole('button', { name: 'Delete' })).toBeEnabled();
+  });
+
+  it('disables the `Delete` button when ownedFolder is true', async () => {
+    render(<TeamDeleteModal {...defaultProps} ownedFolder={true} />);
+
+    expect(await screen.findByRole('button', { name: 'Delete' })).toBeDisabled();
+  });
+
+  it('calls onConfirm when clicking the `Delete` button', async () => {
+    render(<TeamDeleteModal {...defaultProps} />);
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Delete' }));
+    expect(mockOnConfirm).toHaveBeenCalled();
+  });
+
+  it('calls onDismiss when clicking the `Cancel` button', async () => {
+    render(<TeamDeleteModal {...defaultProps} />);
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+    expect(mockOnDismiss).toHaveBeenCalled();
+  });
+});

--- a/public/app/features/teams/TeamDeleteModal.tsx
+++ b/public/app/features/teams/TeamDeleteModal.tsx
@@ -1,28 +1,51 @@
 import { t, Trans } from '@grafana/i18n';
-import { ConfirmModal, Space, Text } from '@grafana/ui';
+import { Alert, ConfirmModal, Space, Text } from '@grafana/ui';
 
 export interface Props {
   isOpen: boolean;
   onConfirm: () => Promise<void>;
   onDismiss: () => void;
+  teamName: string;
+  ownedFolder: boolean;
 }
 
-export const TeamDeleteModal = ({ isOpen, onConfirm, onDismiss }: Props) => {
+export const TeamDeleteModal = ({ isOpen, onConfirm, onDismiss, teamName, ownedFolder }: Props) => {
   return (
     <ConfirmModal
       isOpen={isOpen}
+      title={t('teams.team-list.columns.delete-modal.title', 'Delete')}
       body={
         <>
           <Text element="p">
-            <Trans i18nKey="teams.team-list.columns.delete-modal.text">This action will delete the team</Trans>
+            <Trans i18nKey="teams.team-list.columns.delete-modal-text" values={{ teamName: teamName }}>
+              This action will delete the team &quot;
+              <Text variant="code" weight="bold">
+                {'{{ teamName }}'}
+              </Text>
+              &quot;.
+            </Trans>
           </Text>
           <Space v={2} />
         </>
       }
-      title={t('teams.team-list.columns.delete-modal.title', 'Delete')}
+      description={
+        <>
+          {ownedFolder ? (
+            <Alert
+              severity="warning"
+              title={t('teams.team-list.columns.delete-modal-invalid-title', 'Cannot delete team')}
+            >
+              <Trans i18nKey="teams.team-list.columns.delete-modal-invalid-text">
+                This team is owner of one or more folders. Remove ownership first in order to proceed.
+              </Trans>
+            </Alert>
+          ) : null}
+        </>
+      }
       onDismiss={onDismiss}
       onConfirm={onConfirm}
       confirmText={t('teams.team-list.columns.delete-modal.confirm-button', 'Delete')}
+      disabled={ownedFolder}
     />
   );
 };

--- a/public/app/features/teams/TeamDeleteModal.tsx
+++ b/public/app/features/teams/TeamDeleteModal.tsx
@@ -7,19 +7,22 @@ export interface Props {
   onDismiss: () => void;
 }
 
-export const TeamDeleteModal = ({ onConfirm, onDismiss, ...props }: Props) => {
-  <ConfirmModal
-    body={
-      <>
-        <Text element="p">
-          <Trans i18nKey="team-list.action.delete-modal-text">This action will delete the team</Trans>
-        </Text>
-        <Space v={2} />
-      </>
-    }
-    title={t('team-list.action.delete-modal-title', 'Delete')}
-    onDismiss={onDismiss}
-    onConfirm={onConfirm}
-    confirmText={t('team-list.action.confirmation-text', 'Delete')}
-  />;
+export const TeamDeleteModal = ({ isOpen, onConfirm, onDismiss }: Props) => {
+  return (
+    <ConfirmModal
+      isOpen={isOpen}
+      body={
+        <>
+          <Text element="p">
+            <Trans i18nKey="team-list.action.delete-modal-text">This action will delete the team</Trans>
+          </Text>
+          <Space v={2} />
+        </>
+      }
+      title={t('team-list.action.delete-modal-title', 'Delete')}
+      onDismiss={onDismiss}
+      onConfirm={onConfirm}
+      confirmText={t('team-list.action.confirmation-text', 'Delete')}
+    />
+  );
 };

--- a/public/app/features/teams/TeamDeleteModal.tsx
+++ b/public/app/features/teams/TeamDeleteModal.tsx
@@ -14,15 +14,15 @@ export const TeamDeleteModal = ({ isOpen, onConfirm, onDismiss }: Props) => {
       body={
         <>
           <Text element="p">
-            <Trans i18nKey="team-list.action.delete-modal-text">This action will delete the team</Trans>
+            <Trans i18nKey="teams.team-list.columns.delete-modal.text">This action will delete the team</Trans>
           </Text>
           <Space v={2} />
         </>
       }
-      title={t('team-list.action.delete-modal-title', 'Delete')}
+      title={t('teams.team-list.columns.delete-modal.title', 'Delete')}
       onDismiss={onDismiss}
       onConfirm={onConfirm}
-      confirmText={t('team-list.action.confirmation-text', 'Delete')}
+      confirmText={t('teams.team-list.columns.delete-modal.confirm-button', 'Delete')}
     />
   );
 };

--- a/public/app/features/teams/TeamDeleteModal.tsx
+++ b/public/app/features/teams/TeamDeleteModal.tsx
@@ -36,7 +36,7 @@ export const TeamDeleteModal = ({ isOpen, onConfirm, onDismiss, teamName, ownedF
               title={t('teams.team-list.columns.delete-modal-invalid-title', 'Cannot delete team')}
             >
               <Trans i18nKey="teams.team-list.columns.delete-modal-invalid-text">
-                This team is owner of one or more folders. Remove ownership first in order to proceed.
+                This team is the owner of one or more folders. Remove ownership first in order to proceed.
               </Trans>
             </Alert>
           ) : null}

--- a/public/app/features/teams/TeamDeleteModal.tsx
+++ b/public/app/features/teams/TeamDeleteModal.tsx
@@ -1,0 +1,25 @@
+import { t, Trans } from '@grafana/i18n';
+import { ConfirmModal, Space, Text } from '@grafana/ui';
+
+export interface Props {
+  isOpen: boolean;
+  onConfirm: () => Promise<void>;
+  onDismiss: () => void;
+}
+
+export const TeamDeleteModal = ({ onConfirm, onDismiss, ...props }: Props) => {
+  <ConfirmModal
+    body={
+      <>
+        <Text element="p">
+          <Trans i18nKey="team-list.action.delete-modal-text">This action will delete the team</Trans>
+        </Text>
+        <Space v={2} />
+      </>
+    }
+    title={t('team-list.action.delete-modal-title', 'Delete')}
+    onDismiss={onDismiss}
+    onConfirm={onConfirm}
+    confirmText={t('team-list.action.confirmation-text', 'Delete')}
+  />;
+};

--- a/public/app/features/teams/TeamList.test.tsx
+++ b/public/app/features/teams/TeamList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from 'test/test-utils';
+import { render, screen, userEvent, waitFor } from 'test/test-utils';
 
 import { setBackendSrv } from '@grafana/runtime';
 import { setupMockServer } from '@grafana/test-utils/server';
@@ -6,6 +6,11 @@ import { MOCK_TEAMS } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
 
+import { appEvents } from '../../core/app_events';
+import { ShowModalReactEvent } from '../../types/events';
+import { MoveModal } from '../browse-dashboards/components/BrowseActions/MoveModal';
+
+import { TeamDeleteModal } from './TeamDeleteModal';
 import TeamList from './TeamList';
 
 setBackendSrv(backendSrv);
@@ -27,10 +32,19 @@ describe('TeamList', () => {
     );
   });
 
-  it('shows the delete button', async () => {
+  it('clicks the delete button and opens the TeamDeleteModal', async () => {
     const mockTeam = MOCK_TEAMS[0];
+    jest.spyOn(appEvents, 'publish');
     render(<TeamList />);
-    expect(await screen.findByRole('button', { name: `Delete ${mockTeam.spec.title}` }));
+    await userEvent.click(await screen.findByRole('button', { name: `Delete ${mockTeam.spec.title}` }));
+
+    expect(appEvents.publish).toHaveBeenCalledWith(
+      new ShowModalReactEvent(
+        expect.objectContaining({
+          component: TeamDeleteModal,
+        })
+      )
+    );
   });
 
   describe('when user has access to create a team', () => {

--- a/public/app/features/teams/TeamList.test.tsx
+++ b/public/app/features/teams/TeamList.test.tsx
@@ -27,13 +27,10 @@ describe('TeamList', () => {
     );
   });
 
-  it('deletes a team', async () => {
+  it('shows the delete button', async () => {
     const mockTeam = MOCK_TEAMS[0];
-    const { user } = render(<TeamList />);
-    await user.click(await screen.findByRole('button', { name: `Delete team ${mockTeam.spec.title}` }));
-    await user.click(screen.getByRole('button', { name: 'Delete' }));
-
-    await waitFor(() => expect(screen.queryByText(mockTeam.spec.title)).not.toBeInTheDocument());
+    render(<TeamList />);
+    expect(await screen.findByRole('button', { name: `Delete ${mockTeam.spec.title}` }));
   });
 
   describe('when user has access to create a team', () => {

--- a/public/app/features/teams/TeamList.test.tsx
+++ b/public/app/features/teams/TeamList.test.tsx
@@ -8,7 +8,6 @@ import { contextSrv } from 'app/core/services/context_srv';
 
 import { appEvents } from '../../core/app_events';
 import { ShowModalReactEvent } from '../../types/events';
-import { MoveModal } from '../browse-dashboards/components/BrowseActions/MoveModal';
 
 import { TeamDeleteModal } from './TeamDeleteModal';
 import TeamList from './TeamList';

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -6,12 +6,11 @@ import { SortingRule } from 'react-table';
 import { Trans, t } from '@grafana/i18n';
 import {
   Avatar,
-  Button,
   CellProps,
   Column,
   EmptyState,
   FilterInput,
-  Icon,
+  IconButton,
   InlineField,
   InteractiveTable,
   LinkButton,
@@ -226,17 +225,19 @@ const TeamList = () => {
                   tooltip={t('teams.team-list.columns.tooltip-edit-team', 'Edit team')}
                 />
               )}
-              {/*<DeleteButton*/}
-              {/*  aria-label={t('teams.team-list.columns.aria-label-delete-button', 'Delete team {{teamName}}', {*/}
-              {/*    teamName: original.name,*/}
-              {/*  })}*/}
-              {/*  size="sm"*/}
-              {/*  disabled={!canDelete}*/}
-              {/*  onConfirm={() => deleteTeam({ uid: original.uid })}*/}
-              {/*/>*/}
-              <Button onClick={showDeleteModal} variant="destructive" disabled={!canDelete}>
-                <Icon name="times" size="sm" />
-              </Button>
+              <IconButton
+                onClick={showDeleteModal}
+                variant="destructive"
+                disabled={!canDelete}
+                name="times"
+                size="md"
+                tooltip={t('teams.team-list.columns.tooltip-delete-button', 'Delete {{teamName}}', {
+                  teamName: original.name,
+                })}
+                aria-label={t('teams.team-list.columns.aria-label-delete-button', 'Delete team {{teamName}}', {
+                  teamName: original.name,
+                })}
+              />
             </Stack>
           );
         },

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -223,16 +223,17 @@ const TeamList = () => {
           return (
             <Stack direction="row" justifyContent="flex-end" gap={2}>
               {canReadTeam && (
-                <LinkButton
-                  href={`org/teams/edit/${original.uid}`}
-                  aria-label={t('teams.team-list.columns.aria-label-edit-team', 'Edit team {{teamName}}', {
-                    teamName: original.name,
-                  })}
-                  icon="pen"
-                  size="sm"
-                  variant="secondary"
-                  tooltip={t('teams.team-list.columns.tooltip-edit-team', 'Edit team')}
-                />
+                <a href={`org/teams/edit/${original.uid}`} style={{ display: 'inline-flex' }}>
+                  <IconButton
+                    name="pen"
+                    size="md"
+                    variant="secondary"
+                    aria-label={t('teams.team-list.columns.aria-label-edit-team', 'Edit team {{teamName}}', {
+                      teamName: original.name,
+                    })}
+                    tooltip={t('teams.team-list.columns.tooltip-edit-team', 'Edit team')}
+                  />
+                </a>
               )}
               <IconButton
                 onClick={showDeleteModal}

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -11,7 +11,7 @@ import {
   Column,
   DeleteButton,
   EmptyState,
-  FilterInput,
+  FilterInput, Icon,
   InlineField,
   InteractiveTable,
   LinkButton,
@@ -32,8 +32,8 @@ import { appEvents } from '../../core/app_events';
 import { TeamRolePicker } from '../../core/components/RolePicker/TeamRolePicker';
 import { ShowModalReactEvent } from '../../types/events';
 import { EnterpriseAuthFeaturesCard } from '../admin/EnterpriseAuthFeaturesCard';
-import { DeleteModal } from '../browse-dashboards/components/BrowseActions/DeleteModal';
 
+import { TeamDeleteModal } from './TeamDeleteModal';
 import { useDeleteTeam, useGetTeams } from './hooks';
 
 type Cell<T extends keyof TeamWithRoles = keyof TeamWithRoles> = CellProps<TeamWithRoles, TeamWithRoles[T]>;
@@ -205,10 +205,9 @@ const TeamList = () => {
           const showDeleteModal = () => {
             appEvents.publish(
               new ShowModalReactEvent({
-                component: DeleteModal,
+                component: TeamDeleteModal,
                 props: {
-                  selectedItems,
-                  onConfirm: onDelete,
+                  onConfirm: () => deleteTeam({ uid: original.uid }),
                 },
               })
             );
@@ -227,16 +226,16 @@ const TeamList = () => {
                   tooltip={t('teams.team-list.columns.tooltip-edit-team', 'Edit team')}
                 />
               )}
-              <DeleteButton
-                aria-label={t('teams.team-list.columns.aria-label-delete-button', 'Delete team {{teamName}}', {
-                  teamName: original.name,
-                })}
-                size="sm"
-                disabled={!canDelete}
-                onConfirm={() => deleteTeam({ uid: original.uid })}
-              />
+              {/*<DeleteButton*/}
+              {/*  aria-label={t('teams.team-list.columns.aria-label-delete-button', 'Delete team {{teamName}}', {*/}
+              {/*    teamName: original.name,*/}
+              {/*  })}*/}
+              {/*  size="sm"*/}
+              {/*  disabled={!canDelete}*/}
+              {/*  onConfirm={() => deleteTeam({ uid: original.uid })}*/}
+              {/*/>*/}
               <Button onClick={showDeleteModal} variant="destructive">
-                <Trans i18nKey="browse-dashboards.action.delete-button">Delete</Trans>
+                <Icon name="times" size="sm" />
               </Button>
             </Stack>
           );

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -6,6 +6,7 @@ import { SortingRule } from 'react-table';
 import { Trans, t } from '@grafana/i18n';
 import {
   Avatar,
+  Button,
   CellProps,
   Column,
   DeleteButton,
@@ -27,8 +28,11 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { Role, AccessControlAction } from 'app/types/accessControl';
 import { TeamWithRoles } from 'app/types/teams';
 
+import { appEvents } from '../../core/app_events';
 import { TeamRolePicker } from '../../core/components/RolePicker/TeamRolePicker';
+import { ShowModalReactEvent } from '../../types/events';
 import { EnterpriseAuthFeaturesCard } from '../admin/EnterpriseAuthFeaturesCard';
+import { DeleteModal } from '../browse-dashboards/components/BrowseActions/DeleteModal';
 
 import { useDeleteTeam, useGetTeams } from './hooks';
 
@@ -197,6 +201,18 @@ const TeamList = () => {
 
           const canReadTeam = contextSrv.hasPermissionInMetadata(AccessControlAction.ActionTeamsRead, original);
           const canDelete = contextSrv.hasPermissionInMetadata(AccessControlAction.ActionTeamsDelete, original);
+
+          const showDeleteModal = () => {
+            appEvents.publish(
+              new ShowModalReactEvent({
+                component: DeleteModal,
+                props: {
+                  selectedItems,
+                  onConfirm: onDelete,
+                },
+              })
+            );
+          };
           return (
             <Stack direction="row" justifyContent="flex-end" gap={2}>
               {canReadTeam && (
@@ -219,6 +235,9 @@ const TeamList = () => {
                 disabled={!canDelete}
                 onConfirm={() => deleteTeam({ uid: original.uid })}
               />
+              <Button onClick={showDeleteModal} variant="destructive">
+                <Trans i18nKey="browse-dashboards.action.delete-button">Delete</Trans>
+              </Button>
             </Stack>
           );
         },

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -69,12 +69,7 @@ const TeamList = () => {
   const [sort, setSort] = useState<string>();
   const { data: teamData, isLoading } = useGetTeams({ query, pageSize, page, sort });
   const [deleteTeam] = useDeleteTeam();
-  const { data: singleFolderCheck } = useSearchDashboardsAndFoldersQuery(
-    { type: 'folder', limit: 1 },
-    { skip: !config.featureToggles.teamFolders }
-  );
-
-  const [triggerFullFoldersQuery] = useLazySearchDashboardsAndFoldersQuery();
+  const [triggerFoldersQuery] = useLazySearchDashboardsAndFoldersQuery();
 
   const teams = teamData?.teams || [];
   const totalPages = Math.ceil((teamData?.totalCount || 0) / pageSize) || 0;
@@ -215,10 +210,11 @@ const TeamList = () => {
 
           const showDeleteModal = async () => {
             let ownedFolders: DashboardHit[] = [];
-            if (singleFolderCheck?.hits) {
-              const { data: foldersData } = await triggerFullFoldersQuery({
+            if (config.featureToggles.teamFolders) {
+              const { data: foldersData } = await triggerFoldersQuery({
                 type: 'folder',
                 ownerReference: [`iam.grafana.app/Team/${original.uid}`],
+                limit: 1,
               });
               if (foldersData?.hits) {
                 ownedFolders = foldersData.hits;
@@ -275,15 +271,7 @@ const TeamList = () => {
         },
       },
     ],
-    [
-      displayRolePicker,
-      isLoading,
-      styles.blockSkeleton,
-      roleOptions,
-      deleteTeam,
-      singleFolderCheck,
-      triggerFullFoldersQuery,
-    ]
+    [displayRolePicker, isLoading, styles.blockSkeleton, roleOptions, deleteTeam, triggerFoldersQuery]
   );
 
   return (

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -5,6 +5,7 @@ import { SortingRule } from 'react-table';
 
 import { useListFolderQuery } from '@grafana/api-clients/rtkq/folder/v1beta1';
 import { Trans, t } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
 import {
   Avatar,
   CellProps,
@@ -209,11 +210,17 @@ const TeamList = () => {
           );
 
           const showDeleteModal = () => {
+            reportInteraction('grafana_teams_list_delete_button_clicked', {
+              ownedFolder: ownedFolders && ownedFolders.length > 0,
+            });
             appEvents.publish(
               new ShowModalReactEvent({
                 component: TeamDeleteModal,
                 props: {
-                  onConfirm: () => deleteTeam({ uid: original.uid }),
+                  onConfirm: () => {
+                    reportInteraction('grafana_teams_list_delete_modal_confirm_clicked');
+                    deleteTeam({ uid: original.uid });
+                  },
                   teamName: original.name,
                   ownedFolder: ownedFolders && ownedFolders.length > 0,
                 },

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -23,7 +23,10 @@ import {
   TextLink,
   useStyles2,
 } from '@grafana/ui';
-import { useSearchDashboardsAndFoldersQuery, useLazySearchDashboardsAndFoldersQuery } from 'app/api/clients/dashboard/v0alpha1';
+import {
+  useSearchDashboardsAndFoldersQuery,
+  useLazySearchDashboardsAndFoldersQuery,
+} from 'app/api/clients/dashboard/v0alpha1';
 import { Page } from 'app/core/components/Page/Page';
 import { fetchRoleOptions } from 'app/core/components/RolePicker/api';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -210,12 +213,16 @@ const TeamList = () => {
           const canReadTeam = contextSrv.hasPermissionInMetadata(AccessControlAction.ActionTeamsRead, original);
           const canDelete = contextSrv.hasPermissionInMetadata(AccessControlAction.ActionTeamsDelete, original);
 
-          const showDeleteModal = () => {
+          const showDeleteModal = async () => {
             let ownedFolders: DashboardHit[] = [];
-            if (foldersData?.hits) {
-              ownedFolders = foldersData.hits.filter((folder) =>
-                folder.ownerReferences?.includes(`iam.grafana.app/Team/${original.uid}`)
-              );
+            if (singleFolderCheck?.hits) {
+              const { data: foldersData } = await triggerFullFoldersQuery({
+                type: 'folder',
+                ownerReference: [`iam.grafana.app/Team/${original.uid}`],
+              });
+              if (foldersData?.hits) {
+                ownedFolders = foldersData.hits;
+              }
             }
 
             reportInteraction('grafana_teams_list_delete_button_clicked', {
@@ -268,7 +275,15 @@ const TeamList = () => {
         },
       },
     ],
-    [displayRolePicker, isLoading, styles.blockSkeleton, roleOptions, deleteTeam, foldersData]
+    [
+      displayRolePicker,
+      isLoading,
+      styles.blockSkeleton,
+      roleOptions,
+      deleteTeam,
+      singleFolderCheck,
+      triggerFullFoldersQuery,
+    ]
   );
 
   return (

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -9,9 +9,9 @@ import {
   Button,
   CellProps,
   Column,
-  DeleteButton,
   EmptyState,
-  FilterInput, Icon,
+  FilterInput,
+  Icon,
   InlineField,
   InteractiveTable,
   LinkButton,
@@ -234,7 +234,7 @@ const TeamList = () => {
               {/*  disabled={!canDelete}*/}
               {/*  onConfirm={() => deleteTeam({ uid: original.uid })}*/}
               {/*/>*/}
-              <Button onClick={showDeleteModal} variant="destructive">
+              <Button onClick={showDeleteModal} variant="destructive" disabled={!canDelete}>
                 <Icon name="times" size="sm" />
               </Button>
             </Stack>

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Skeleton from 'react-loading-skeleton';
 import { SortingRule } from 'react-table';
 
@@ -23,10 +23,7 @@ import {
   TextLink,
   useStyles2,
 } from '@grafana/ui';
-import {
-  useSearchDashboardsAndFoldersQuery,
-  useLazySearchDashboardsAndFoldersQuery,
-} from 'app/api/clients/dashboard/v0alpha1';
+import { useLazySearchDashboardsAndFoldersQuery } from 'app/api/clients/dashboard/v0alpha1';
 import { Page } from 'app/core/components/Page/Page';
 import { fetchRoleOptions } from 'app/core/components/RolePicker/api';
 import { useAppNotification } from 'app/core/copy/appNotification';
@@ -72,6 +69,7 @@ const TeamList = () => {
   const [deleteTeam] = useDeleteTeam();
   const [triggerFoldersQuery] = useLazySearchDashboardsAndFoldersQuery();
   const notifyApp = useAppNotification();
+  const foldersQueryRef = useRef<ReturnType<typeof triggerFoldersQuery> | null>(null);
 
   const teams = teamData?.teams || [];
   const totalPages = Math.ceil((teamData?.totalCount || 0) / pageSize) || 0;
@@ -90,6 +88,14 @@ const TeamList = () => {
     if (contextSrv.licensedAccessControlEnabled() && contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
       fetchRoleOptions().then((roles) => setRoleOptions(roles));
     }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (foldersQueryRef.current) {
+        foldersQueryRef.current.abort();
+      }
+    };
   }, []);
 
   const columns: Array<Column<TeamWithRoles>> = useMemo(
@@ -213,11 +219,13 @@ const TeamList = () => {
           const showDeleteModal = async () => {
             let ownedFolders: DashboardHit[] = [];
             if (config.featureToggles.teamFolders) {
-              const { data: foldersData, isError } = await triggerFoldersQuery({
+              foldersQueryRef.current = triggerFoldersQuery({
                 type: 'folder',
                 ownerReference: [`iam.grafana.app/Team/${original.uid}`],
                 limit: 1,
               });
+
+              const { data: foldersData, isError } = await foldersQueryRef.current;
 
               if (isError) {
                 notifyApp.error(

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -23,7 +23,7 @@ import {
   TextLink,
   useStyles2,
 } from '@grafana/ui';
-import { useSearchDashboardsAndFoldersQuery } from 'app/api/clients/dashboard/v0alpha1';
+import { useSearchDashboardsAndFoldersQuery, useLazySearchDashboardsAndFoldersQuery } from 'app/api/clients/dashboard/v0alpha1';
 import { Page } from 'app/core/components/Page/Page';
 import { fetchRoleOptions } from 'app/core/components/RolePicker/api';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -66,10 +66,12 @@ const TeamList = () => {
   const [sort, setSort] = useState<string>();
   const { data: teamData, isLoading } = useGetTeams({ query, pageSize, page, sort });
   const [deleteTeam] = useDeleteTeam();
-  const { data: foldersData } = useSearchDashboardsAndFoldersQuery(
-    { type: 'folder' },
+  const { data: singleFolderCheck } = useSearchDashboardsAndFoldersQuery(
+    { type: 'folder', limit: 1 },
     { skip: !config.featureToggles.teamFolders }
   );
+
+  const [triggerFullFoldersQuery] = useLazySearchDashboardsAndFoldersQuery();
 
   const teams = teamData?.teams || [];
   const totalPages = Math.ceil((teamData?.totalCount || 0) / pageSize) || 0;

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -227,10 +227,9 @@ const TeamList = () => {
 
               const { data: foldersData, isError, error } = await foldersQueryRef.current;
 
-              if (isError) {
-                if (error && error.name === 'AbortError') {
-                  return;
-                }
+              const isAbortError = error && typeof error === 'object' && 'name' in error && error.name === 'AbortError';
+
+              if (isError && !isAbortError) {
                 notifyApp.error(
                   t(
                     'teams.team-list.failed-to-check-folders',
@@ -238,6 +237,10 @@ const TeamList = () => {
                   )
                 );
                 console.error(error);
+                return;
+              }
+
+              if (isAbortError) {
                 return;
               }
 

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -225,15 +225,19 @@ const TeamList = () => {
                 limit: 1,
               });
 
-              const { data: foldersData, isError } = await foldersQueryRef.current;
+              const { data: foldersData, isError, error } = await foldersQueryRef.current;
 
               if (isError) {
+                if (error && error.name === 'AbortError') {
+                  return;
+                }
                 notifyApp.error(
                   t(
                     'teams.team-list.failed-to-check-folders',
                     'Failed to check if the team owns folders. Please try again.'
                   )
                 );
+                console.error(error);
                 return;
               }
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14293,7 +14293,15 @@
       "columns": {
         "aria-label-delete-button": "Delete team {{teamName}}",
         "aria-label-edit-team": "Edit team {{teamName}}",
+        "delete-modal": {
+          "confirm-button": "Delete",
+          "title": "Delete"
+        },
+        "delete-modal-invalid-text": "This team is owner of one or more folders. Remove ownership first in order to proceed.",
+        "delete-modal-invalid-title": "Cannot delete team",
+        "delete-modal-text": "This action will delete the team \"<1>{{ teamName }}</1> \".",
         "title-edit-team": "Edit team",
+        "tooltip-delete-button": "Delete {{teamName}}",
         "tooltip-edit-team": "Edit team"
       },
       "loading-teams": "Loading teams...",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14297,7 +14297,7 @@
           "confirm-button": "Delete",
           "title": "Delete"
         },
-        "delete-modal-invalid-text": "This team is owner of one or more folders. Remove ownership first in order to proceed.",
+        "delete-modal-invalid-text": "This team is the owner of one or more folders. Remove ownership first in order to proceed.",
         "delete-modal-invalid-title": "Cannot delete team",
         "delete-modal-text": "This action will delete the team \"<1>{{ teamName }}</1> \".",
         "title-edit-team": "Edit team",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14304,6 +14304,7 @@
         "tooltip-delete-button": "Delete {{teamName}}",
         "tooltip-edit-team": "Edit team"
       },
+      "failed-to-check-folders": "Failed to check if the team owns folders. Please try again.",
       "loading-teams": "Loading teams...",
       "new-team": "New Team",
       "placeholder-search-teams": "Search teams"


### PR DESCRIPTION
**What is this feature?**
Block deletion of teams when they are the owner of a folder:
- change deletion workflow => added a modal to confirm deletion and show if deletion is blocked
- replace edit button to fit styling with new delete button
- adjust test for TeamList
- add test for TeamDeleteModal
- add handler for folder list

**Which issue(s) does this PR fix?**:

Fixes #116926

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
