### PR TITLE
Chore: Add plugin status change metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -645,7 +645,7 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.39.0 // indirect
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.39.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/multierr v1.11.0
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go4.org/netipx v0.0.0-20230125063823-8449b0a6169f // indirect
 	golang.org/x/sys v0.40.0 // indirect

--- a/pkg/plugins/go.mod
+++ b/pkg/plugins/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.7.0
 	github.com/hashicorp/go-secure-stdlib/plugincontainer v0.4.2
+	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.64.0
 	go.opentelemetry.io/otel v1.39.0
@@ -81,7 +82,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.23 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/pkg/plugins/manager/process/process_test.go
+++ b/pkg/plugins/manager/process/process_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/plugins"
@@ -68,8 +69,9 @@ func TestProcessManager_Start(t *testing.T) {
 					plugin.Error = tc.Error
 				})
 
-				m := ProvideService()
-				err := m.Start(context.Background(), p)
+				m, err := ProvideService(prometheus.NewRegistry())
+				require.NoError(t, err)
+				err = m.Start(context.Background(), p)
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedStartCount, bp.StartCount)
 
@@ -90,11 +92,12 @@ func TestProcessManager_Start(t *testing.T) {
 			plugin.Backend = true
 		})
 
-		m := ProvideService()
+		m, err := ProvideService(prometheus.NewRegistry())
+		require.NoError(t, err)
 		m.keepPluginAliveTickerDuration = 1
 		ctx := context.Background()
 		ctx, cancel := context.WithCancel(ctx)
-		err := m.Start(ctx, p)
+		err = m.Start(ctx, p)
 		require.NoError(t, err)
 		require.Equal(t, 1, bp.StartCount)
 		cancel()
@@ -119,8 +122,9 @@ func TestProcessManager_Stop(t *testing.T) {
 			plugin.Backend = true
 		})
 
-		m := ProvideService()
-		err := m.Stop(context.Background(), p)
+		m, err := ProvideService(prometheus.NewRegistry())
+		require.NoError(t, err)
+		err = m.Stop(context.Background(), p)
 		require.NoError(t, err)
 
 		require.True(t, p.IsDecommissioned())
@@ -139,9 +143,10 @@ func TestProcessManager_ManagedBackendPluginLifecycle(t *testing.T) {
 			plugin.Backend = true
 		})
 
-		m := ProvideService()
+		m, err := ProvideService(prometheus.NewRegistry())
+		require.NoError(t, err)
 
-		err := m.Start(context.Background(), p)
+		err = m.Start(context.Background(), p)
 		require.NoError(t, err)
 		require.Equal(t, 1, bp.StartCount)
 

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -428,7 +428,10 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	jaegerService := jaeger.ProvideService(httpclientProvider)
 	corepluginRegistry := coreplugin.ProvideCoreRegistry(tracer, azuremonitorService, cloudwatchService, cloudmonitoringService, elasticsearchService, graphiteService, influxdbService, lokiService, opentsdbService, prometheusService, tempoService, testdatasourceService, postgresService, mysqlService, mssqlService, grafanadsService, pyroscopeService, parcaService, zipkinService, jaegerService)
 	backendFactoryProvider := coreplugin.ProvideCoreProvider(corepluginRegistry)
-	processService := process.ProvideService()
+	processService, err := process.ProvideService(registerer)
+	if err != nil {
+		return nil, err
+	}
 	orgService, err := orgimpl.ProvideService(sqlStore, cfg, quotaService)
 	if err != nil {
 		return nil, err
@@ -1114,7 +1117,10 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	jaegerService := jaeger.ProvideService(httpclientProvider)
 	corepluginRegistry := coreplugin.ProvideCoreRegistry(tracer, azuremonitorService, cloudwatchService, cloudmonitoringService, elasticsearchService, graphiteService, influxdbService, lokiService, opentsdbService, prometheusService, tempoService, testdatasourceService, postgresService, mysqlService, mssqlService, grafanadsService, pyroscopeService, parcaService, zipkinService, jaegerService)
 	backendFactoryProvider := coreplugin.ProvideCoreProvider(corepluginRegistry)
-	processService := process.ProvideService()
+	processService, err := process.ProvideService(registerer)
+	if err != nil {
+		return nil, err
+	}
 	orgService, err := orgimpl.ProvideService(sqlStore, cfg, quotaService)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This adds metrics for backend plugin state changes - start, stop, decommission and restart, including the result (error / ok).

**Why do we need this feature?**

We currently have somewhat poor visibility into when plugins are restarted in Grafana Cloud - there's a log message, but the volume of logs makes it impractical to search casually. This will make it easy to monitor and potentially alert on restarts or restart failures. I decided to include the other events for completeness but am on the fence about their value.
