### PR TITLE
Alerting: Add alerts activity banner to rule list view

### DIFF
--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -444,14 +444,12 @@ export function trackAlertsActivityBannerDismiss(dismissedUntil: string) {
 // View Experience Toggle Telemetry (persistent control near page title)
 // ============================================================================
 
+// Payload for view experience toggle telemetry.
+
 export interface ViewExperienceToggleEventPayload {
-  source: 'title_control';
-  current_view: 'new' | 'old';
-  target_view: 'new' | 'old';
-  user_id?: number;
-  org_id?: number;
-  stack_type?: StackType;
-  plan?: UserPlan;
+  source: 'titleControl';
+  currentView: 'new' | 'old';
+  targetView: 'new' | 'old';
 }
 
 /**
@@ -460,10 +458,7 @@ export interface ViewExperienceToggleEventPayload {
 export function trackViewExperienceToggleClick(
   payload: ViewExperienceToggleEventPayload & { action: 'clicked' | 'canceled' | 'confirmed' }
 ) {
-  reportInteraction('grafana_alerting_view_experience_toggle', {
-    ...payload,
-    grafana_version: config.buildInfo.version,
-  });
+  reportInteraction('grafana_alerting_view_experience_toggle', payload);
 }
 
 /**
@@ -472,8 +467,5 @@ export function trackViewExperienceToggleClick(
 export function trackViewExperienceToggleConfirmed(
   payload: ViewExperienceToggleEventPayload & { preferenceSaved: boolean }
 ) {
-  reportInteraction('grafana_alerting_view_experience_confirmed', {
-    ...payload,
-    grafana_version: config.buildInfo.version,
-  });
+  reportInteraction('grafana_alerting_view_experience_confirmed', payload);
 }

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -379,30 +379,6 @@ export type AlertRuleTrackingProps = {
 // Alerts Activity Banner & View Experience Telemetry
 // ============================================================================
 
-export type UserPlan = 'Enterprise' | 'Advanced' | 'Free' | 'Unknown';
-
-/**
- * Determine the user's plan from license info
- */
-export function getUserPlan(): UserPlan {
-  const licenseInfo = config.licenseInfo;
-  if (!licenseInfo) {
-    return 'Unknown';
-  }
-
-  // Check edition from license info or build info
-  const edition = licenseInfo.edition || config.buildInfo?.edition;
-
-  if (edition === 'Enterprise') {
-    return 'Enterprise';
-  }
-  if (edition === 'Pro') {
-    return 'Advanced';
-  }
-  // Free/OSS edition
-  return 'Free';
-}
-
 /**
  * Track banner impression - fired once per session when banner is first shown.
  * Note: user_id, org_id, grafana_version, and other common properties are automatically
@@ -435,7 +411,6 @@ export function trackAlertsActivityBannerDismiss(dismissedUntil: string) {
 // Payload for view experience toggle telemetry.
 
 export interface ViewExperienceToggleEventPayload {
-  source: 'titleControl';
   currentView: 'v1' | 'v2';
   targetView: 'v1' | 'v2';
 }

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -458,7 +458,7 @@ export interface ViewExperienceToggleEventPayload {
 export function trackViewExperienceToggleClick(
   payload: ViewExperienceToggleEventPayload & { action: 'clicked' | 'canceled' | 'confirmed' }
 ) {
-  reportInteraction('grafana_alerting_view_experience_toggle', payload);
+  reportInteraction('grafana_alerting_view_experience_toggle', { ...payload });
 }
 
 /**
@@ -467,5 +467,5 @@ export function trackViewExperienceToggleClick(
 export function trackViewExperienceToggleConfirmed(
   payload: ViewExperienceToggleEventPayload & { preferenceSaved: boolean }
 ) {
-  reportInteraction('grafana_alerting_view_experience_confirmed', payload);
+  reportInteraction('grafana_alerting_view_experience_confirmed', { ...payload });
 }

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -415,45 +415,28 @@ export function getUserPlan(): UserPlan {
   return 'Free';
 }
 
-export interface AlertsActivityBannerEventPayload {
-  banner_id: string;
-  page: string;
-  user_id?: number;
-  org_id?: number;
-  stack_type?: StackType;
-  plan?: UserPlan;
-  variant_id?: string | null;
-}
-
 /**
- * Track banner impression - fired once per session when banner is first shown
+ * Track banner impression - fired once per session when banner is first shown.
+ * Note: user_id, org_id, grafana_version, and other common properties are automatically
+ * tracked by the analytics infrastructure.
  */
-export function trackAlertsActivityBannerImpression(payload: AlertsActivityBannerEventPayload) {
-  reportInteraction('grafana_alerting_banner_impression', {
-    ...payload,
-    grafana_version: config.buildInfo.version,
-  });
+export function trackAlertsActivityBannerImpression() {
+  reportInteraction('grafana_alerting_alerts_activity_banner_impression');
 }
 
 /**
  * Track when user clicks "Open Alerts Activity" CTA
  */
-export function trackAlertsActivityBannerClickTry(payload: AlertsActivityBannerEventPayload & { referrer?: string }) {
-  reportInteraction('grafana_alerting_banner_click_try', {
-    ...payload,
-    grafana_version: config.buildInfo.version,
-  });
+export function trackAlertsActivityBannerClickTry() {
+  reportInteraction('grafana_alerting_alerts_activity_banner_click');
 }
 
 /**
  * Track when user dismisses the banner
  */
-export function trackAlertsActivityBannerDismiss(
-  payload: AlertsActivityBannerEventPayload & { dismissed_until: string }
-) {
-  reportInteraction('grafana_alerting_banner_dismiss', {
-    ...payload,
-    grafana_version: config.buildInfo.version,
+export function trackAlertsActivityBannerDismiss(dismissedUntil: string) {
+  reportInteraction('grafana_alerting_alerts_activity_banner_dismiss', {
+    dismissed_until: dismissedUntil,
   });
 }
 

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -379,19 +379,7 @@ export type AlertRuleTrackingProps = {
 // Alerts Activity Banner & View Experience Telemetry
 // ============================================================================
 
-export type StackType = 'DMA' | 'GMA' | 'Unknown';
 export type UserPlan = 'Enterprise' | 'Advanced' | 'Free' | 'Unknown';
-
-/**
- * Determine the stack type based on feature toggles
- */
-export function getStackType(): StackType {
-  // alertingDisableDMAinUI === false means DMA is enabled
-  if (config.featureToggles.alertingDisableDMAinUI === false) {
-    return 'DMA';
-  }
-  return 'GMA';
-}
 
 /**
  * Determine the user's plan from license info
@@ -448,8 +436,8 @@ export function trackAlertsActivityBannerDismiss(dismissedUntil: string) {
 
 export interface ViewExperienceToggleEventPayload {
   source: 'titleControl';
-  currentView: 'new' | 'old';
-  targetView: 'new' | 'old';
+  currentView: 'v1' | 'v2';
+  targetView: 'v1' | 'v2';
 }
 
 /**

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -467,9 +467,11 @@ export function trackViewExperienceToggleClick(
 }
 
 /**
- * Track when view experience preference is successfully persisted
+ * Track when view experience preference is persisted (or fails to persist)
  */
-export function trackViewExperienceToggleConfirmed(payload: ViewExperienceToggleEventPayload & { success: boolean }) {
+export function trackViewExperienceToggleConfirmed(
+  payload: ViewExperienceToggleEventPayload & { preferenceSaved: boolean }
+) {
   reportInteraction('grafana_alerting_view_experience_confirmed', {
     ...payload,
     grafana_version: config.buildInfo.version,

--- a/public/app/features/alerting/unified/featureToggles.ts
+++ b/public/app/features/alerting/unified/featureToggles.ts
@@ -31,3 +31,21 @@ export const shouldUseFullyCompatibleBackendFilters = () =>
  * Saved searches feature - allows users to save and apply search queries on the Alert Rules page.
  */
 export const shouldUseSavedSearches = () => config.featureToggles.alertingSavedSearches ?? false;
+
+/**
+ * Alerts Activity Banner - shows a promotional banner on the Rule List page
+ * directing users to try the new Alerts Activity (triage) view.
+ *
+ * The banner is only shown if:
+ * 1. This feature toggle is enabled (alertingAlertsActivityBanner)
+ * 2. The Alerts Activity feature itself is enabled (alertingTriage)
+ *
+ * Note: alertingAlertsActivityBanner is not yet in the generated FeatureToggles type.
+ * Once the backend toggle is registered and featureToggles.gen.ts is regenerated,
+ * this type assertion can be removed.
+ */
+export const shouldShowAlertsActivityBanner = () => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const featureToggles = config.featureToggles as Record<string, boolean | undefined>;
+  return (featureToggles.alertingAlertsActivityBanner && featureToggles.alertingTriage) ?? false;
+};

--- a/public/app/features/alerting/unified/featureToggles.ts
+++ b/public/app/features/alerting/unified/featureToggles.ts
@@ -39,13 +39,6 @@ export const shouldUseSavedSearches = () => config.featureToggles.alertingSavedS
  * The banner is only shown if:
  * 1. This feature toggle is enabled (alertingAlertsActivityBanner)
  * 2. The Alerts Activity feature itself is enabled (alertingTriage)
- *
- * Note: alertingAlertsActivityBanner is not yet in the generated FeatureToggles type.
- * Once the backend toggle is registered and featureToggles.gen.ts is regenerated,
- * this type assertion can be removed.
  */
-export const shouldShowAlertsActivityBanner = () => {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  const featureToggles = config.featureToggles as Record<string, boolean | undefined>;
-  return (featureToggles.alertingAlertsActivityBanner && featureToggles.alertingTriage) ?? false;
-};
+export const shouldShowAlertsActivityBanner = () =>
+  (config.featureToggles.alertingAlertsActivityBanner && config.featureToggles.alertingTriage) ?? false;

--- a/public/app/features/alerting/unified/rule-list/AlertsActivityBanner.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/AlertsActivityBanner.test.tsx
@@ -25,18 +25,19 @@ describe('AlertsActivityBanner', () => {
     localStorage.clear();
   });
 
-  describe('when feature toggle is disabled', () => {
+  describe('when feature toggles are disabled', () => {
     testWithFeatureToggles({ enable: [] });
 
-    it('should not render when alertingTriage is disabled', () => {
+    it('should not render when feature toggles are disabled', () => {
       render(<AlertsActivityBanner />);
 
       expect(ui.banner.query()).not.toBeInTheDocument();
     });
   });
 
-  describe('when feature toggle is enabled', () => {
-    testWithFeatureToggles({ enable: ['alertingTriage'] });
+  describe('when feature toggles are enabled', () => {
+    // Both alertingAlertsActivityBanner and alertingTriage are required
+    testWithFeatureToggles({ enable: ['alertingAlertsActivityBanner', 'alertingTriage'] });
 
     it('should render the banner with correct content', () => {
       render(<AlertsActivityBanner />);

--- a/public/app/features/alerting/unified/rule-list/AlertsActivityBanner.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/AlertsActivityBanner.test.tsx
@@ -12,7 +12,6 @@ jest.mock('../Analytics', () => ({
   trackAlertsActivityBannerClickTry: jest.fn(),
   trackAlertsActivityBannerDismiss: jest.fn(),
   getStackType: jest.fn(() => 'GMA'),
-  getUserPlan: jest.fn(() => 'Free'),
 }));
 
 const ui = {
@@ -66,23 +65,7 @@ describe('AlertsActivityBanner', () => {
       render(<AlertsActivityBanner />);
 
       expect(Analytics.trackAlertsActivityBannerImpression).toHaveBeenCalledTimes(1);
-      expect(Analytics.trackAlertsActivityBannerImpression).toHaveBeenCalledWith(
-        expect.objectContaining({
-          banner_id: 'alerts-activity-v1',
-          page: 'rule_list',
-        })
-      );
-    });
-
-    it('should include plan and stack_type in telemetry', () => {
-      render(<AlertsActivityBanner />);
-
-      expect(Analytics.trackAlertsActivityBannerImpression).toHaveBeenCalledWith(
-        expect.objectContaining({
-          stack_type: 'GMA',
-          plan: 'Free',
-        })
-      );
+      expect(Analytics.trackAlertsActivityBannerImpression).toHaveBeenCalledWith();
     });
 
     it('should track impression only once across re-renders', () => {
@@ -109,12 +92,7 @@ describe('AlertsActivityBanner', () => {
       button.addEventListener('click', (e) => e.preventDefault(), { once: true });
       await user.click(button);
 
-      expect(Analytics.trackAlertsActivityBannerClickTry).toHaveBeenCalledWith(
-        expect.objectContaining({
-          banner_id: 'alerts-activity-v1',
-          page: 'rule_list',
-        })
-      );
+      expect(Analytics.trackAlertsActivityBannerClickTry).toHaveBeenCalledWith();
     });
 
     describe('dismiss functionality', () => {
@@ -125,12 +103,8 @@ describe('AlertsActivityBanner', () => {
         const closeButton = screen.getByRole('button', { name: /close/i });
         await user.click(closeButton);
 
-        expect(Analytics.trackAlertsActivityBannerDismiss).toHaveBeenCalledWith(
-          expect.objectContaining({
-            banner_id: 'alerts-activity-v1',
-            dismissed_until: expect.any(String),
-          })
-        );
+        // Dismiss tracking receives the dismissed_until date
+        expect(Analytics.trackAlertsActivityBannerDismiss).toHaveBeenCalledWith(expect.any(String));
 
         // Check localStorage was set
         const dismissedUntil = localStorage.getItem(STORAGE_KEY_DISMISSED_UNTIL);

--- a/public/app/features/alerting/unified/rule-list/AlertsActivityBanner.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/AlertsActivityBanner.test.tsx
@@ -1,0 +1,188 @@
+import { render, screen, testWithFeatureToggles } from 'test/test-utils';
+import { byRole, byText } from 'testing-library-selector';
+
+import * as Analytics from '../Analytics';
+
+import { AlertsActivityBanner } from './AlertsActivityBanner';
+
+// Mock the analytics functions
+jest.mock('../Analytics', () => ({
+  ...jest.requireActual('../Analytics'),
+  trackAlertsActivityBannerImpression: jest.fn(),
+  trackAlertsActivityBannerClickTry: jest.fn(),
+  trackAlertsActivityBannerDismiss: jest.fn(),
+  getStackType: jest.fn(() => 'GMA'),
+  getUserPlan: jest.fn(() => 'Free'),
+}));
+
+const ui = {
+  banner: byRole('region'),
+  title: byText(/alert activity is now available/i),
+  description: byText(/a brand new page is now available/i),
+  dmaNote: byText(/some triage features may be limited/i),
+  openButton: byRole('link', { name: /open alerts activity/i }),
+};
+
+const STORAGE_KEY_DISMISSED_UNTIL = 'grafana.alerting.alerts_activity_banner.dismissed_until';
+
+describe('AlertsActivityBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    // Reset stack type mock to GMA by default
+    (Analytics.getStackType as jest.Mock).mockReturnValue('GMA');
+  });
+
+  describe('when feature toggle is disabled', () => {
+    testWithFeatureToggles({ enable: [] });
+
+    it('should not render when alertingTriage is disabled', () => {
+      render(<AlertsActivityBanner />);
+
+      expect(ui.banner.query()).not.toBeInTheDocument();
+      expect(Analytics.trackAlertsActivityBannerImpression).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when feature toggle is enabled', () => {
+    testWithFeatureToggles({ enable: ['alertingTriage'] });
+
+    it('should render the banner with correct content', () => {
+      render(<AlertsActivityBanner />);
+
+      expect(ui.title.get()).toBeInTheDocument();
+      expect(ui.description.get()).toBeInTheDocument();
+      expect(ui.openButton.get()).toBeInTheDocument();
+    });
+
+    it('should not have an opt-out button (handled by page title)', () => {
+      render(<AlertsActivityBanner />);
+
+      // The opt-out button should NOT be in the banner - it's in the page title now
+      expect(screen.queryByRole('button', { name: /switch to old/i })).not.toBeInTheDocument();
+    });
+
+    it('should track impression on first render', () => {
+      render(<AlertsActivityBanner />);
+
+      expect(Analytics.trackAlertsActivityBannerImpression).toHaveBeenCalledTimes(1);
+      expect(Analytics.trackAlertsActivityBannerImpression).toHaveBeenCalledWith(
+        expect.objectContaining({
+          banner_id: 'alerts-activity-v1',
+          page: 'rule_list',
+        })
+      );
+    });
+
+    it('should include plan and stack_type in telemetry', () => {
+      render(<AlertsActivityBanner />);
+
+      expect(Analytics.trackAlertsActivityBannerImpression).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stack_type: 'GMA',
+          plan: 'Free',
+        })
+      );
+    });
+
+    it('should track impression only once across re-renders', () => {
+      const { rerender } = render(<AlertsActivityBanner />);
+
+      rerender(<AlertsActivityBanner />);
+      rerender(<AlertsActivityBanner />);
+
+      expect(Analytics.trackAlertsActivityBannerImpression).toHaveBeenCalledTimes(1);
+    });
+
+    it('should have correct href on Open Alerts Activity button', () => {
+      render(<AlertsActivityBanner />);
+
+      // LinkButton uses createRelativeUrl which adds the app subpath prefix
+      expect(ui.openButton.get()).toHaveAttribute('href', expect.stringContaining('/alerting/alerts'));
+    });
+
+    it('should track click when Open Alerts Activity is clicked', async () => {
+      const { user } = render(<AlertsActivityBanner />);
+
+      // Prevent the actual navigation which jsdom doesn't support
+      const button = ui.openButton.get();
+      button.addEventListener('click', (e) => e.preventDefault(), { once: true });
+      await user.click(button);
+
+      expect(Analytics.trackAlertsActivityBannerClickTry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          banner_id: 'alerts-activity-v1',
+          page: 'rule_list',
+        })
+      );
+    });
+
+    describe('dismiss functionality', () => {
+      it('should hide banner and persist dismissal when dismiss button is clicked', async () => {
+        const { user } = render(<AlertsActivityBanner />);
+
+        // Find and click the close button (the X icon on the Alert)
+        const closeButton = screen.getByRole('button', { name: /close/i });
+        await user.click(closeButton);
+
+        expect(Analytics.trackAlertsActivityBannerDismiss).toHaveBeenCalledWith(
+          expect.objectContaining({
+            banner_id: 'alerts-activity-v1',
+            dismissed_until: expect.any(String),
+          })
+        );
+
+        // Check localStorage was set
+        const dismissedUntil = localStorage.getItem(STORAGE_KEY_DISMISSED_UNTIL);
+        expect(dismissedUntil).toBeTruthy();
+
+        // Verify the dismissal date is ~30 days in the future
+        const dismissedDate = new Date(JSON.parse(dismissedUntil!));
+        const expectedDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+        expect(Math.abs(dismissedDate.getTime() - expectedDate.getTime())).toBeLessThan(5000);
+      });
+    });
+
+    describe('persistence', () => {
+      it('should not render when banner was recently dismissed', () => {
+        const futureDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+        localStorage.setItem(STORAGE_KEY_DISMISSED_UNTIL, JSON.stringify(futureDate));
+
+        render(<AlertsActivityBanner />);
+
+        expect(ui.banner.query()).not.toBeInTheDocument();
+        expect(Analytics.trackAlertsActivityBannerImpression).not.toHaveBeenCalled();
+      });
+
+      it('should render when dismissal has expired', () => {
+        const pastDate = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+        localStorage.setItem(STORAGE_KEY_DISMISSED_UNTIL, JSON.stringify(pastDate));
+
+        render(<AlertsActivityBanner />);
+
+        expect(ui.banner.query()).toBeInTheDocument();
+        expect(Analytics.trackAlertsActivityBannerImpression).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('DMA stack detection', () => {
+    testWithFeatureToggles({ enable: ['alertingTriage'] });
+
+    it('should not show DMA note for GMA stack', () => {
+      (Analytics.getStackType as jest.Mock).mockReturnValue('GMA');
+
+      render(<AlertsActivityBanner />);
+
+      expect(ui.dmaNote.query()).not.toBeInTheDocument();
+    });
+
+    it('should show DMA note when stack type is DMA', () => {
+      (Analytics.getStackType as jest.Mock).mockReturnValue('DMA');
+
+      render(<AlertsActivityBanner />);
+
+      expect(ui.dmaNote.get()).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/alerting/unified/rule-list/AlertsActivityBanner.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/AlertsActivityBanner.test.tsx
@@ -11,7 +11,7 @@ jest.mock('../Analytics', () => ({
 }));
 
 const ui = {
-  banner: byRole('region'),
+  banner: byRole('status'),
   title: byText(/alert activity is now available/i),
   description: byText(/a brand new page is now available/i),
   openButton: byRole('link', { name: /open alerts activity/i }),

--- a/public/app/features/alerting/unified/rule-list/AlertsActivityBanner.tsx
+++ b/public/app/features/alerting/unified/rule-list/AlertsActivityBanner.tsx
@@ -1,0 +1,142 @@
+import { css } from '@emotion/css';
+import { useCallback, useEffect, useRef } from 'react';
+
+import { GrafanaTheme2, createRelativeUrl } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
+import { Alert, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
+import { contextSrv } from 'app/core/services/context_srv';
+
+import {
+  getStackType,
+  getUserPlan,
+  trackAlertsActivityBannerClickTry,
+  trackAlertsActivityBannerDismiss,
+  trackAlertsActivityBannerImpression,
+} from '../Analytics';
+import { ALERTING_PATHS } from '../utils/navigation';
+
+import { useAlertsActivityBannerPrefs } from './hooks/useAlertsActivityBannerPrefs';
+
+const BANNER_ID = 'alerts-activity-v1';
+
+export interface AlertsActivityBannerProps {
+  /** Unique identifier for this banner instance (for A/B testing) */
+  variantId?: string | null;
+}
+
+/**
+ * Banner promoting Alerts Activity (triage view) to users on the Rule List page.
+ *
+ * Single responsibility: Promote Alerts Activity feature only.
+ * The opt-out control is handled separately in RuleListPageTitle.
+ *
+ * Features:
+ * - Dismissible for 30 days
+ * - DMA stack detection with limited functionality note
+ * - Full telemetry tracking for impressions, clicks, dismissals
+ */
+export function AlertsActivityBanner({ variantId = null }: AlertsActivityBannerProps) {
+  const styles = useStyles2(getStyles);
+  const { isDismissed, dismissBanner } = useAlertsActivityBannerPrefs();
+  const impressionTracked = useRef(false);
+
+  // Determine stack type for telemetry and UI
+  const stackType = getStackType();
+  const isDMAStack = stackType === 'DMA';
+  const plan = getUserPlan();
+
+  // Check if Alerts Activity feature is available
+  const isAlertsActivityEnabled = config.featureToggles.alertingTriage ?? false;
+
+  const getEventPayload = useCallback(
+    () => ({
+      banner_id: BANNER_ID,
+      page: 'rule_list',
+      user_id: contextSrv.user.id,
+      org_id: contextSrv.user.orgId,
+      stack_type: stackType,
+      plan,
+      variant_id: variantId,
+    }),
+    [stackType, plan, variantId]
+  );
+
+  // Track impression once per mount
+  useEffect(() => {
+    if (!impressionTracked.current && !isDismissed && isAlertsActivityEnabled) {
+      trackAlertsActivityBannerImpression(getEventPayload());
+      impressionTracked.current = true;
+    }
+  }, [isDismissed, isAlertsActivityEnabled, getEventPayload]);
+
+  // Don't render if:
+  // - Alerts Activity is not enabled
+  // - User has dismissed the banner (within 30 days)
+  if (!isAlertsActivityEnabled || isDismissed) {
+    return null;
+  }
+
+  const handleOpenAlertsActivity = () => {
+    trackAlertsActivityBannerClickTry({
+      ...getEventPayload(),
+      referrer: window.location.pathname,
+    });
+    // Navigation handled by LinkButton href
+  };
+
+  const handleDismiss = () => {
+    const dismissedUntil = dismissBanner();
+    trackAlertsActivityBannerDismiss({
+      ...getEventPayload(),
+      dismissed_until: dismissedUntil,
+    });
+  };
+
+  return (
+    <Alert
+      severity="info"
+      title={t('alerting.alerts-activity-banner.title', 'Alert Activity is now available!')}
+      onRemove={handleDismiss}
+      className={styles.banner}
+      role="region"
+      aria-labelledby="alerts-activity-banner-title"
+    >
+      <Stack direction="column" gap={2}>
+        <Text>
+          <Trans i18nKey="alerting.alerts-activity-banner.description">
+            A brand new page is now available to handle operational work for your Grafana-managed alert rules. Find out
+            what alerts are firing, explore historical information, filter and group to enhance your triage and root
+            cause analysis.
+          </Trans>
+        </Text>
+
+        {isDMAStack && (
+          <Text color="secondary" italic>
+            <Trans i18nKey="alerting.alerts-activity-banner.dma-note">
+              Some triage features may be limited on your stack.
+            </Trans>
+          </Text>
+        )}
+
+        <div>
+          <LinkButton
+            href={createRelativeUrl(ALERTING_PATHS.ALERTS_ACTIVITY)}
+            variant="primary"
+            size="sm"
+            onClick={handleOpenAlertsActivity}
+            aria-label={t('alerting.alerts-activity-banner.open-button-aria', 'Open Alerts Activity')}
+          >
+            <Trans i18nKey="alerting.alerts-activity-banner.open-button">See Alert Activity</Trans>
+          </LinkButton>
+        </div>
+      </Stack>
+    </Alert>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  banner: css({
+    marginBottom: theme.spacing(2),
+  }),
+});

--- a/public/app/features/alerting/unified/rule-list/AlertsActivityBanner.tsx
+++ b/public/app/features/alerting/unified/rule-list/AlertsActivityBanner.tsx
@@ -7,7 +7,6 @@ import { config } from '@grafana/runtime';
 import { Alert, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
 
 import {
-  getStackType,
   trackAlertsActivityBannerClickTry,
   trackAlertsActivityBannerDismiss,
   trackAlertsActivityBannerImpression,
@@ -25,17 +24,12 @@ import { useAlertsActivityBannerPrefs } from './hooks/useAlertsActivityBannerPre
  *
  * Features:
  * - Dismissible for 30 days
- * - DMA stack detection with limited functionality note
  * - Telemetry tracking for impressions, clicks, dismissals
  */
 export function AlertsActivityBanner() {
   const styles = useStyles2(getStyles);
   const { isDismissed, dismissBanner } = useAlertsActivityBannerPrefs();
   const impressionTracked = useRef(false);
-
-  // Determine stack type for UI (DMA has limited functionality)
-  const stackType = getStackType();
-  const isDMAStack = stackType === 'DMA';
 
   // Check if Alerts Activity feature is available
   const isAlertsActivityEnabled = config.featureToggles.alertingTriage ?? false;
@@ -82,14 +76,6 @@ export function AlertsActivityBanner() {
             cause analysis.
           </Trans>
         </Text>
-
-        {isDMAStack && (
-          <Text color="secondary" italic>
-            <Trans i18nKey="alerting.alerts-activity-banner.dma-note">
-              Some triage features may be limited on your stack.
-            </Trans>
-          </Text>
-        )}
 
         <div>
           <LinkButton

--- a/public/app/features/alerting/unified/rule-list/AlertsActivityBanner.tsx
+++ b/public/app/features/alerting/unified/rule-list/AlertsActivityBanner.tsx
@@ -65,8 +65,6 @@ export function AlertsActivityBanner() {
       title={t('alerting.alerts-activity-banner.title', 'Alert Activity is now available!')}
       onRemove={handleDismiss}
       className={styles.banner}
-      role="region"
-      aria-labelledby="alerts-activity-banner-title"
     >
       <Stack direction="column" gap={2}>
         <Text>

--- a/public/app/features/alerting/unified/rule-list/AlertsActivityOptOutModal.tsx
+++ b/public/app/features/alerting/unified/rule-list/AlertsActivityOptOutModal.tsx
@@ -1,0 +1,58 @@
+import { Trans, t } from '@grafana/i18n';
+import { Button, Modal, Stack, Text } from '@grafana/ui';
+
+export interface RevertToOldExperienceModalProps {
+  isOpen: boolean;
+  onRevert: () => void;
+  onSeeAlertActivity: () => void;
+  onDismiss: () => void;
+}
+
+/**
+ * Confirmation modal shown when user clicks "Revert to previous experience".
+ * Only shown when switching from NEW to OLD experience.
+ * Encourages users to try Alert Activity before reverting.
+ */
+export function RevertToOldExperienceModal({
+  isOpen,
+  onRevert,
+  onSeeAlertActivity,
+  onDismiss,
+}: RevertToOldExperienceModalProps) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      title={t('alerting.revert-experience-modal.title', 'Revert to previous experience')}
+      onDismiss={onDismiss}
+      closeOnBackdropClick={true}
+      closeOnEscape={true}
+    >
+      <Stack direction="column" gap={2}>
+        <Text>
+          <Trans i18nKey="alerting.revert-experience-modal.description-line1">
+            Considering going back to the previous experience because you&apos;re missing more information on alert
+            state?
+          </Trans>
+        </Text>
+        <Text>
+          <Trans i18nKey="alerting.revert-experience-modal.description-line2">
+            The Alert Activity page is now available to handle operational work for your Grafana-managed alert rules.
+            Find out what alerts are firing, explore historical information, filter and group to enhance your triage and
+            root cause analysis.
+          </Trans>
+        </Text>
+      </Stack>
+      <Modal.ButtonRow>
+        <Button variant="secondary" onClick={onRevert}>
+          <Trans i18nKey="alerting.revert-experience-modal.revert-button">Revert to previous experience</Trans>
+        </Button>
+        <Button variant="primary" onClick={onSeeAlertActivity}>
+          <Trans i18nKey="alerting.revert-experience-modal.see-activity-button">See Alert Activity</Trans>
+        </Button>
+      </Modal.ButtonRow>
+    </Modal>
+  );
+}
+
+// Legacy export for backwards compatibility
+export const ViewExperienceSwitchModal = RevertToOldExperienceModal;

--- a/public/app/features/alerting/unified/rule-list/AlertsActivityOptOutModal.tsx
+++ b/public/app/features/alerting/unified/rule-list/AlertsActivityOptOutModal.tsx
@@ -53,6 +53,3 @@ export function RevertToOldExperienceModal({
     </Modal>
   );
 }
-
-// Legacy export for backwards compatibility
-export const ViewExperienceSwitchModal = RevertToOldExperienceModal;

--- a/public/app/features/alerting/unified/rule-list/RuleList.v1.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v1.tsx
@@ -16,7 +16,7 @@ import { RuleListErrors } from '../components/rules/RuleListErrors';
 import { RuleListGroupView } from '../components/rules/RuleListGroupView';
 import { RuleListStateView } from '../components/rules/RuleListStateView';
 import { RuleStats } from '../components/rules/RuleStats';
-import { shouldShowAlertsActivityBanner, shouldUsePrometheusRulesPrimary } from '../featureToggles';
+import { shouldUsePrometheusRulesPrimary } from '../featureToggles';
 import { useCombinedRuleNamespaces } from '../hooks/useCombinedRuleNamespaces';
 import { useFilteredRules, useRulesFilter } from '../hooks/useFilteredRules';
 import { useUnifiedAlertingSelector } from '../hooks/useUnifiedAlertingSelector';
@@ -42,7 +42,6 @@ const prometheusRulesPrimary = shouldUsePrometheusRulesPrimary();
 const RuleListV1 = () => {
   const { navId, pageNav } = useAlertRulesNav();
   const dispatch = useDispatch();
-  const showBanner = shouldShowAlertsActivityBanner();
   const rulesDataSourceNames = useMemo(getAllRulesSourceNames, []);
   const [expandAll, setExpandAll] = useState(false);
 
@@ -130,7 +129,7 @@ const RuleListV1 = () => {
       actions={<RuleListActionButtons hasAlertRulesCreated={hasAlertRulesCreated} />}
     >
       <Stack direction="column">
-        {showBanner && <AlertsActivityBanner />}
+        <AlertsActivityBanner />
         <RuleListErrors />
         <RulesFilter onClear={onFilterCleared} />
         {hasAlertRulesCreated && (

--- a/public/app/features/alerting/unified/rule-list/RuleList.v1.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v1.tsx
@@ -16,7 +16,7 @@ import { RuleListErrors } from '../components/rules/RuleListErrors';
 import { RuleListGroupView } from '../components/rules/RuleListGroupView';
 import { RuleListStateView } from '../components/rules/RuleListStateView';
 import { RuleStats } from '../components/rules/RuleStats';
-import { shouldUsePrometheusRulesPrimary } from '../featureToggles';
+import { shouldShowAlertsActivityBanner, shouldUsePrometheusRulesPrimary } from '../featureToggles';
 import { useCombinedRuleNamespaces } from '../hooks/useCombinedRuleNamespaces';
 import { useFilteredRules, useRulesFilter } from '../hooks/useFilteredRules';
 import { useUnifiedAlertingSelector } from '../hooks/useUnifiedAlertingSelector';
@@ -25,6 +25,7 @@ import { fetchAllPromAndRulerRulesAction, fetchAllPromRulesAction, fetchRulerRul
 import { RULE_LIST_POLL_INTERVAL_MS } from '../utils/constants';
 import { GRAFANA_RULES_SOURCE_NAME, getAllRulesSourceNames } from '../utils/datasource';
 
+import { AlertsActivityBanner } from './AlertsActivityBanner';
 import { RuleListPageTitle } from './RuleListPageTitle';
 import { RuleListActionButtons } from './components/RuleListActionButtons';
 
@@ -41,6 +42,7 @@ const prometheusRulesPrimary = shouldUsePrometheusRulesPrimary();
 const RuleListV1 = () => {
   const { navId, pageNav } = useAlertRulesNav();
   const dispatch = useDispatch();
+  const showBanner = shouldShowAlertsActivityBanner();
   const rulesDataSourceNames = useMemo(getAllRulesSourceNames, []);
   const [expandAll, setExpandAll] = useState(false);
 
@@ -128,6 +130,7 @@ const RuleListV1 = () => {
       actions={<RuleListActionButtons hasAlertRulesCreated={hasAlertRulesCreated} />}
     >
       <Stack direction="column">
+        {showBanner && <AlertsActivityBanner />}
         <RuleListErrors />
         <RulesFilter onClear={onFilterCleared} />
         {hasAlertRulesCreated && (

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
@@ -11,7 +11,6 @@ import { AlertingPageWrapper } from '../components/AlertingPageWrapper';
 import { GrafanaRulesExporter } from '../components/export/GrafanaRulesExporter';
 import { useListViewMode } from '../components/rules/Filter/RulesViewModeSelector';
 import { AIAlertRuleButtonComponent } from '../enterprise-components/AI/AIGenAlertRuleButton/addAIAlertRuleButton';
-import { shouldShowAlertsActivityBanner } from '../featureToggles';
 import { AlertingAction, useAlertingAbility } from '../hooks/useAbilities';
 import { useRulesFilter } from '../hooks/useFilteredRules';
 import { useAlertRulesNav } from '../navigation/useAlertRulesNav';
@@ -28,11 +27,10 @@ import { useApplyDefaultSearch } from './filter/useApplyDefaultSearch';
 function RuleList() {
   const { filterState } = useRulesFilter();
   const { viewMode, handleViewChange } = useListViewMode();
-  const showBanner = shouldShowAlertsActivityBanner();
 
   return (
     <Stack direction="column">
-      {showBanner && <AlertsActivityBanner />}
+      <AlertsActivityBanner />
       <RulesFilter viewMode={viewMode} onViewModeChange={handleViewChange} />
       {viewMode === 'list' ? (
         <FilterView filterState={filterState} />

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
@@ -11,12 +11,14 @@ import { AlertingPageWrapper } from '../components/AlertingPageWrapper';
 import { GrafanaRulesExporter } from '../components/export/GrafanaRulesExporter';
 import { useListViewMode } from '../components/rules/Filter/RulesViewModeSelector';
 import { AIAlertRuleButtonComponent } from '../enterprise-components/AI/AIGenAlertRuleButton/addAIAlertRuleButton';
+import { shouldShowAlertsActivityBanner } from '../featureToggles';
 import { AlertingAction, useAlertingAbility } from '../hooks/useAbilities';
 import { useRulesFilter } from '../hooks/useFilteredRules';
 import { useAlertRulesNav } from '../navigation/useAlertRulesNav';
 import { getRulesDataSources } from '../utils/datasource';
 import { isAdmin } from '../utils/misc';
 
+import { AlertsActivityBanner } from './AlertsActivityBanner';
 import { FilterView } from './FilterView';
 import { GroupedView } from './GroupedView';
 import { RuleListPageTitle } from './RuleListPageTitle';
@@ -26,9 +28,11 @@ import { useApplyDefaultSearch } from './filter/useApplyDefaultSearch';
 function RuleList() {
   const { filterState } = useRulesFilter();
   const { viewMode, handleViewChange } = useListViewMode();
+  const showBanner = shouldShowAlertsActivityBanner();
 
   return (
     <Stack direction="column">
+      {showBanner && <AlertsActivityBanner />}
       <RulesFilter viewMode={viewMode} onViewModeChange={handleViewChange} />
       {viewMode === 'list' ? (
         <FilterView filterState={filterState} />

--- a/public/app/features/alerting/unified/rule-list/RuleListPageTitle.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleListPageTitle.test.tsx
@@ -1,17 +1,10 @@
-import { render, testWithFeatureToggles } from 'test/test-utils';
+import { render, screen, testWithFeatureToggles, waitFor, within } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
-
-import { reportInteraction } from '@grafana/runtime';
 
 import { mockLocalStorage } from '../mocks';
 import { getPreviewToggle, setPreviewToggle } from '../previewToggles';
 
 import { RuleListPageTitle } from './RuleListPageTitle';
-
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  reportInteraction: jest.fn(),
-}));
 
 // Mock window.location.reload
 const mockReload = jest.fn();
@@ -22,9 +15,26 @@ Object.defineProperty(window, 'location', {
 
 const ui = {
   title: byRole('heading', { name: 'Alert rules' }),
-  enableV2Button: byRole('button', { name: 'Try out the new look!' }),
-  disableV2Button: byRole('button', { name: 'Go back to the old look' }),
+  useNewExperienceButton: byRole('button', { name: /use new experience/i }),
+  revertButton: byRole('button', { name: /revert to previous experience/i }),
 };
+
+// Helper to get modal elements (modal uses dialog role)
+function getModal() {
+  return screen.getByRole('dialog');
+}
+
+function getModalRevertButton() {
+  return within(getModal()).getByRole('button', { name: /revert to previous experience/i });
+}
+
+function getModalSeeActivityButton() {
+  return within(getModal()).getByRole('button', { name: /see alert activity/i });
+}
+
+function queryModal() {
+  return screen.queryByRole('dialog');
+}
 
 const localStorageMock = mockLocalStorage();
 Object.defineProperty(window, 'localStorage', {
@@ -48,68 +58,108 @@ describe('RuleListPageTitle', () => {
     expect(ui.title.get()).toBeInTheDocument();
   });
 
-  it('should not show v2 toggle when alertingListViewV2PreviewToggle feature flag is disabled', () => {
+  it('should not show toggle button when alertingListViewV2PreviewToggle feature flag is disabled', () => {
     renderRuleListPageTitle();
-    expect(ui.enableV2Button.query()).not.toBeInTheDocument();
-    expect(ui.disableV2Button.query()).not.toBeInTheDocument();
+    expect(ui.useNewExperienceButton.query()).not.toBeInTheDocument();
+    expect(ui.revertButton.query()).not.toBeInTheDocument();
   });
 
-  describe('with alertingListViewV2PreviewToggle enabled and alertingListViewV2 disabled', () => {
+  describe('when on OLD view (alertingListViewV2PreviewToggle enabled, alertingListViewV2 disabled)', () => {
     testWithFeatureToggles({ enable: ['alertingListViewV2PreviewToggle'] });
 
-    it('should show enable v2 button', () => {
+    it('should show "Use new experience" button', () => {
       renderRuleListPageTitle();
-      expect(ui.enableV2Button.get()).toBeInTheDocument();
-      expect(ui.disableV2Button.query()).not.toBeInTheDocument();
-      expect(ui.enableV2Button.get()).toHaveAttribute('data-testid', 'alerting-list-view-toggle-v2');
+      expect(ui.useNewExperienceButton.get()).toBeInTheDocument();
+      expect(ui.revertButton.query()).not.toBeInTheDocument();
     });
 
-    it('should enable v2 and reload page when clicked on "Try out the new look!" button', async () => {
+    it('should switch directly to new experience without showing modal', async () => {
       const { user } = renderRuleListPageTitle();
 
-      await user.click(ui.enableV2Button.get());
+      await user.click(ui.useNewExperienceButton.get());
 
-      const previewToggle = getPreviewToggle('alertingListViewV2');
-      expect(previewToggle).toBe(true);
+      // Should NOT show the modal
+      expect(queryModal()).not.toBeInTheDocument();
+
+      // Should switch directly
+      expect(getPreviewToggle('alertingListViewV2')).toBe(true);
       expect(mockReload).toHaveBeenCalled();
-    });
-
-    it('should report interaction when enabling v2', async () => {
-      const { user } = renderRuleListPageTitle();
-
-      await user.click(ui.enableV2Button.get());
-
-      expect(reportInteraction).toHaveBeenCalledWith('alerting.list_view.v2.enabled');
     });
   });
 
-  describe('with alertingListViewV2PreviewToggle enabled and alertingListViewV2 enabled', () => {
+  describe('when on NEW view (alertingListViewV2PreviewToggle and alertingListViewV2 enabled)', () => {
     testWithFeatureToggles({ enable: ['alertingListViewV2PreviewToggle', 'alertingListViewV2'] });
 
-    it('should show disable v2 button', () => {
-      renderRuleListPageTitle();
-      expect(ui.disableV2Button.get()).toBeInTheDocument();
-      expect(ui.enableV2Button.query()).not.toBeInTheDocument();
-      expect(ui.disableV2Button.get()).toHaveAttribute('data-testid', 'alerting-list-view-toggle-v1');
+    beforeEach(() => {
+      setPreviewToggle('alertingListViewV2', true);
     });
 
-    it('should disable v2 and reload page when clicked on "Go back to the old look" button', async () => {
-      setPreviewToggle('alertingListViewV2', true);
+    it('should show "Revert to previous experience" button', () => {
+      renderRuleListPageTitle();
+      expect(ui.revertButton.get()).toBeInTheDocument();
+      expect(ui.useNewExperienceButton.query()).not.toBeInTheDocument();
+    });
+
+    it('should show confirmation modal when clicking revert button', async () => {
       const { user } = renderRuleListPageTitle();
 
-      await user.click(ui.disableV2Button.get());
+      await user.click(ui.revertButton.get());
+
+      // Modal should appear
+      await waitFor(() => {
+        expect(getModal()).toBeInTheDocument();
+      });
+      expect(getModalRevertButton()).toBeInTheDocument();
+      expect(getModalSeeActivityButton()).toBeInTheDocument();
+    });
+
+    it('should revert to old experience when confirming in modal', async () => {
+      const { user } = renderRuleListPageTitle();
+
+      await user.click(ui.revertButton.get());
+      await waitFor(() => {
+        expect(getModal()).toBeInTheDocument();
+      });
+
+      await user.click(getModalRevertButton());
 
       expect(getPreviewToggle('alertingListViewV2')).toBe(false);
       expect(mockReload).toHaveBeenCalled();
     });
 
-    it('should report interaction when disabling v2', async () => {
-      setPreviewToggle('alertingListViewV2', true);
+    it('should close modal when clicking "See Alert Activity"', async () => {
       const { user } = renderRuleListPageTitle();
 
-      await user.click(ui.disableV2Button.get());
+      await user.click(ui.revertButton.get());
+      await waitFor(() => {
+        expect(getModal()).toBeInTheDocument();
+      });
 
-      expect(reportInteraction).toHaveBeenCalledWith('alerting.list_view.v2.disabled');
+      await user.click(getModalSeeActivityButton());
+
+      // Modal should close
+      await waitFor(() => {
+        expect(queryModal()).not.toBeInTheDocument();
+      });
+
+      // Should NOT switch view
+      expect(mockReload).not.toHaveBeenCalled();
+    });
+
+    it('should close modal when dismissed via escape', async () => {
+      const { user } = renderRuleListPageTitle();
+
+      await user.click(ui.revertButton.get());
+      await waitFor(() => {
+        expect(getModal()).toBeInTheDocument();
+      });
+
+      // Press escape to close
+      await user.keyboard('{Escape}');
+
+      await waitFor(() => {
+        expect(queryModal()).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/public/app/features/alerting/unified/rule-list/RuleListPageTitle.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleListPageTitle.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, testWithFeatureToggles, waitFor, within } from 'test/test-utils';
+import { render, testWithFeatureToggles, waitFor, within } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
 import { mockLocalStorage } from '../mocks';
@@ -17,23 +17,14 @@ const ui = {
   title: byRole('heading', { name: 'Alert rules' }),
   useNewExperienceButton: byRole('button', { name: /use new experience/i }),
   revertButton: byRole('button', { name: /revert to previous experience/i }),
+  modal: {
+    dialog: byRole('dialog'),
+  },
 };
 
-// Helper to get modal elements (modal uses dialog role)
-function getModal() {
-  return screen.getByRole('dialog');
-}
-
-function getModalRevertButton() {
-  return within(getModal()).getByRole('button', { name: /revert to previous experience/i });
-}
-
-function getModalSeeActivityButton() {
-  return within(getModal()).getByRole('button', { name: /see alert activity/i });
-}
-
-function queryModal() {
-  return screen.queryByRole('dialog');
+// Helper to get elements scoped within the modal dialog
+function withinModal() {
+  return within(ui.modal.dialog.get());
 }
 
 const localStorageMock = mockLocalStorage();
@@ -79,7 +70,7 @@ describe('RuleListPageTitle', () => {
       await user.click(ui.useNewExperienceButton.get());
 
       // Should NOT show the modal
-      expect(queryModal()).not.toBeInTheDocument();
+      expect(ui.modal.dialog.query()).not.toBeInTheDocument();
 
       // Should switch directly
       expect(getPreviewToggle('alertingListViewV2')).toBe(true);
@@ -107,10 +98,10 @@ describe('RuleListPageTitle', () => {
 
       // Modal should appear
       await waitFor(() => {
-        expect(getModal()).toBeInTheDocument();
+        expect(ui.modal.dialog.get()).toBeInTheDocument();
       });
-      expect(getModalRevertButton()).toBeInTheDocument();
-      expect(getModalSeeActivityButton()).toBeInTheDocument();
+      expect(withinModal().getByRole('button', { name: /revert to previous experience/i })).toBeInTheDocument();
+      expect(withinModal().getByRole('button', { name: /see alert activity/i })).toBeInTheDocument();
     });
 
     it('should revert to old experience when confirming in modal', async () => {
@@ -118,10 +109,10 @@ describe('RuleListPageTitle', () => {
 
       await user.click(ui.revertButton.get());
       await waitFor(() => {
-        expect(getModal()).toBeInTheDocument();
+        expect(ui.modal.dialog.get()).toBeInTheDocument();
       });
 
-      await user.click(getModalRevertButton());
+      await user.click(withinModal().getByRole('button', { name: /revert to previous experience/i }));
 
       expect(getPreviewToggle('alertingListViewV2')).toBe(false);
       expect(mockReload).toHaveBeenCalled();
@@ -132,14 +123,14 @@ describe('RuleListPageTitle', () => {
 
       await user.click(ui.revertButton.get());
       await waitFor(() => {
-        expect(getModal()).toBeInTheDocument();
+        expect(ui.modal.dialog.get()).toBeInTheDocument();
       });
 
-      await user.click(getModalSeeActivityButton());
+      await user.click(withinModal().getByRole('button', { name: /see alert activity/i }));
 
       // Modal should close
       await waitFor(() => {
-        expect(queryModal()).not.toBeInTheDocument();
+        expect(ui.modal.dialog.query()).not.toBeInTheDocument();
       });
 
       // Should NOT switch view
@@ -151,14 +142,14 @@ describe('RuleListPageTitle', () => {
 
       await user.click(ui.revertButton.get());
       await waitFor(() => {
-        expect(getModal()).toBeInTheDocument();
+        expect(ui.modal.dialog.get()).toBeInTheDocument();
       });
 
       // Press escape to close
       await user.keyboard('{Escape}');
 
       await waitFor(() => {
-        expect(queryModal()).not.toBeInTheDocument();
+        expect(ui.modal.dialog.query()).not.toBeInTheDocument();
       });
     });
   });

--- a/public/app/features/alerting/unified/rule-list/RuleListPageTitle.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleListPageTitle.tsx
@@ -22,7 +22,6 @@ export function RuleListPageTitle({ title }: { title: string }) {
   const [showConfirmModal, setShowConfirmModal] = useState(false);
 
   const getEventPayload = (): ViewExperienceToggleEventPayload => ({
-    source: 'titleControl',
     currentView: listViewV2Enabled ? 'v2' : 'v1',
     targetView: listViewV2Enabled ? 'v1' : 'v2',
   });

--- a/public/app/features/alerting/unified/rule-list/RuleListPageTitle.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleListPageTitle.tsx
@@ -1,48 +1,145 @@
-import { t } from '@grafana/i18n';
-import { config, reportInteraction } from '@grafana/runtime';
-import { Button, ButtonProps, Stack } from '@grafana/ui';
+import { useState } from 'react';
 
+import { t } from '@grafana/i18n';
+import { config, locationService } from '@grafana/runtime';
+import { Button, ButtonProps, Stack } from '@grafana/ui';
+import { contextSrv } from 'app/core/services/context_srv';
+
+import {
+  getStackType,
+  getUserPlan,
+  trackViewExperienceToggleClick,
+  trackViewExperienceToggleConfirmed,
+} from '../Analytics';
 import { shouldUseAlertingListViewV2 } from '../featureToggles';
 import { setPreviewToggle } from '../previewToggles';
+import { ALERTING_PATHS } from '../utils/navigation';
+
+import { RevertToOldExperienceModal } from './AlertsActivityOptOutModal';
 
 export function RuleListPageTitle({ title }: { title: string }) {
   const shouldShowV2Toggle = config.featureToggles.alertingListViewV2PreviewToggle ?? false;
-
   const listViewV2Enabled = shouldUseAlertingListViewV2();
 
-  const toggleListView = () => {
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+
+  const stackType = getStackType();
+  const plan = getUserPlan();
+
+  const getEventPayload = () => ({
+    source: 'title_control' as const,
+    current_view: listViewV2Enabled ? ('new' as const) : ('old' as const),
+    target_view: listViewV2Enabled ? ('old' as const) : ('new' as const),
+    user_id: contextSrv.user.id,
+    org_id: contextSrv.user.orgId,
+    stack_type: stackType,
+    plan,
+  });
+
+  const handleToggleClick = () => {
+    trackViewExperienceToggleClick({
+      ...getEventPayload(),
+      action: 'clicked',
+    });
+
+    // Only show confirmation when switching from NEW to OLD
+    // When switching from OLD to NEW, just do it directly
     if (listViewV2Enabled) {
-      setPreviewToggle('alertingListViewV2', false);
-      reportInteraction('alerting.list_view.v2.disabled');
+      setShowConfirmModal(true);
     } else {
-      setPreviewToggle('alertingListViewV2', true);
-      reportInteraction('alerting.list_view.v2.enabled');
+      // Switching to new experience - no confirmation needed
+      switchToNewExperience();
     }
-    window.location.reload();
   };
 
+  const switchToNewExperience = () => {
+    try {
+      setPreviewToggle('alertingListViewV2', true);
+      trackViewExperienceToggleConfirmed({
+        ...getEventPayload(),
+        success: true,
+      });
+      window.location.reload();
+    } catch {
+      trackViewExperienceToggleConfirmed({
+        ...getEventPayload(),
+        success: false,
+      });
+    }
+  };
+
+  const handleRevert = () => {
+    trackViewExperienceToggleClick({
+      ...getEventPayload(),
+      action: 'confirmed',
+    });
+    setShowConfirmModal(false);
+
+    try {
+      setPreviewToggle('alertingListViewV2', false);
+      trackViewExperienceToggleConfirmed({
+        ...getEventPayload(),
+        success: true,
+      });
+      window.location.reload();
+    } catch {
+      trackViewExperienceToggleConfirmed({
+        ...getEventPayload(),
+        success: false,
+      });
+    }
+  };
+
+  const handleSeeAlertActivity = () => {
+    trackViewExperienceToggleClick({
+      ...getEventPayload(),
+      action: 'canceled',
+    });
+    setShowConfirmModal(false);
+    // Navigate to Alert Activity page (locationService auto-prefixes, no createRelativeUrl needed)
+    locationService.push(ALERTING_PATHS.ALERTS_ACTIVITY);
+  };
+
+  const handleDismiss = () => {
+    trackViewExperienceToggleClick({
+      ...getEventPayload(),
+      action: 'canceled',
+    });
+    setShowConfirmModal(false);
+  };
+
+  // Button configuration based on current view
   const configToUse: ButtonProps & { 'data-testid': string } = listViewV2Enabled
     ? {
         variant: 'secondary',
         icon: undefined,
-        children: t('alerting.rule-list.toggle.go-back-to-old-look', 'Go back to the old look'),
+        children: t('alerting.rule-list.toggle.view-previous-experience', 'Revert to previous experience'),
         'data-testid': 'alerting-list-view-toggle-v1',
       }
     : {
         variant: 'primary',
         icon: 'rocket',
-        children: t('alerting.rule-list.toggle.try-out-the-new-look', 'Try out the new look!'),
+        children: t('alerting.rule-list.toggle.use-new-experience', 'Use new experience'),
         'data-testid': 'alerting-list-view-toggle-v2',
       };
 
   return (
-    <Stack direction="row" alignItems="center" justifyContent="space-between" gap={2}>
-      <h1>{title}</h1>
-      {shouldShowV2Toggle && (
-        <div>
-          <Button size="sm" fill="outline" {...configToUse} onClick={toggleListView} className="fs-unmask" />
-        </div>
-      )}
-    </Stack>
+    <>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" gap={2}>
+        <h1>{title}</h1>
+        {shouldShowV2Toggle && (
+          <div>
+            <Button size="sm" fill="outline" {...configToUse} onClick={handleToggleClick} className="fs-unmask" />
+          </div>
+        )}
+      </Stack>
+
+      <RevertToOldExperienceModal
+        isOpen={showConfirmModal}
+        onRevert={handleRevert}
+        onSeeAlertActivity={handleSeeAlertActivity}
+        onDismiss={handleDismiss}
+      />
+    </>
   );
 }

--- a/public/app/features/alerting/unified/rule-list/RuleListPageTitle.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleListPageTitle.tsx
@@ -3,11 +3,9 @@ import { useState } from 'react';
 import { t } from '@grafana/i18n';
 import { config, locationService } from '@grafana/runtime';
 import { Button, ButtonProps, Stack } from '@grafana/ui';
-import { contextSrv } from 'app/core/services/context_srv';
 
 import {
-  getStackType,
-  getUserPlan,
+  ViewExperienceToggleEventPayload,
   trackViewExperienceToggleClick,
   trackViewExperienceToggleConfirmed,
 } from '../Analytics';
@@ -23,17 +21,10 @@ export function RuleListPageTitle({ title }: { title: string }) {
 
   const [showConfirmModal, setShowConfirmModal] = useState(false);
 
-  const stackType = getStackType();
-  const plan = getUserPlan();
-
-  const getEventPayload = () => ({
-    source: 'title_control' as const,
-    current_view: listViewV2Enabled ? ('new' as const) : ('old' as const),
-    target_view: listViewV2Enabled ? ('old' as const) : ('new' as const),
-    user_id: contextSrv.user.id,
-    org_id: contextSrv.user.orgId,
-    stack_type: stackType,
-    plan,
+  const getEventPayload = (): ViewExperienceToggleEventPayload => ({
+    source: 'titleControl',
+    currentView: listViewV2Enabled ? 'new' : 'old',
+    targetView: listViewV2Enabled ? 'old' : 'new',
   });
 
   const handleToggleClick = () => {

--- a/public/app/features/alerting/unified/rule-list/RuleListPageTitle.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleListPageTitle.tsx
@@ -57,13 +57,14 @@ export function RuleListPageTitle({ title }: { title: string }) {
       setPreviewToggle('alertingListViewV2', true);
       trackViewExperienceToggleConfirmed({
         ...getEventPayload(),
-        success: true,
+        preferenceSaved: true,
       });
       window.location.reload();
     } catch {
+      // preferenceSaved: false when localStorage write fails (e.g., private browsing, storage full)
       trackViewExperienceToggleConfirmed({
         ...getEventPayload(),
-        success: false,
+        preferenceSaved: false,
       });
     }
   };
@@ -79,13 +80,13 @@ export function RuleListPageTitle({ title }: { title: string }) {
       setPreviewToggle('alertingListViewV2', false);
       trackViewExperienceToggleConfirmed({
         ...getEventPayload(),
-        success: true,
+        preferenceSaved: true,
       });
       window.location.reload();
     } catch {
       trackViewExperienceToggleConfirmed({
         ...getEventPayload(),
-        success: false,
+        preferenceSaved: false,
       });
     }
   };

--- a/public/app/features/alerting/unified/rule-list/RuleListPageTitle.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleListPageTitle.tsx
@@ -23,8 +23,8 @@ export function RuleListPageTitle({ title }: { title: string }) {
 
   const getEventPayload = (): ViewExperienceToggleEventPayload => ({
     source: 'titleControl',
-    currentView: listViewV2Enabled ? 'new' : 'old',
-    targetView: listViewV2Enabled ? 'old' : 'new',
+    currentView: listViewV2Enabled ? 'v2' : 'v1',
+    targetView: listViewV2Enabled ? 'v1' : 'v2',
   });
 
   const handleToggleClick = () => {

--- a/public/app/features/alerting/unified/rule-list/hooks/useAlertsActivityBannerPrefs.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useAlertsActivityBannerPrefs.ts
@@ -1,0 +1,49 @@
+import { useCallback, useMemo } from 'react';
+import { useLocalStorage } from 'react-use';
+
+const STORAGE_KEY_DISMISSED_UNTIL = 'grafana.alerting.alerts_activity_banner.dismissed_until';
+
+// Default dismissal duration: 30 days
+const DISMISSAL_DURATION_MS = 30 * 24 * 60 * 60 * 1000;
+
+export interface AlertsActivityBannerPrefs {
+  /** Whether the banner is currently dismissed (within dismissal period) */
+  isDismissed: boolean;
+  /** Dismiss the banner for the default duration (30 days). Returns the dismissal expiry date. */
+  dismissBanner: () => string;
+}
+
+/**
+ * Hook to manage Alerts Activity banner dismissal preferences using localStorage.
+ *
+ * Note: The view experience toggle (new/old view) is handled separately by the
+ * preview toggle mechanism in RuleListPageTitle, not by this banner.
+ *
+ * TODO: Migrate to server-side API when /api/alerting/ui-preferences is available
+ */
+export function useAlertsActivityBannerPrefs(): AlertsActivityBannerPrefs {
+  const [dismissedUntilRaw, setDismissedUntil] = useLocalStorage<string | null>(STORAGE_KEY_DISMISSED_UNTIL, null);
+
+  const isDismissed = useMemo(() => {
+    if (!dismissedUntilRaw) {
+      return false;
+    }
+    try {
+      const dismissedUntilDate = new Date(dismissedUntilRaw);
+      return dismissedUntilDate > new Date();
+    } catch {
+      return false;
+    }
+  }, [dismissedUntilRaw]);
+
+  const dismissBanner = useCallback(() => {
+    const dismissedUntil = new Date(Date.now() + DISMISSAL_DURATION_MS).toISOString();
+    setDismissedUntil(dismissedUntil);
+    return dismissedUntil;
+  }, [setDismissedUntil]);
+
+  return {
+    isDismissed,
+    dismissBanner,
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/hooks/useAlertsActivityBannerPrefs.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useAlertsActivityBannerPrefs.ts
@@ -8,7 +8,7 @@ const STORAGE_KEY_DISMISSED_UNTIL = 'grafana.alerting.alerts_activity_banner.dis
 const DISMISSAL_DURATION_MS = 30 * 24 * 60 * 60 * 1000;
 
 export interface AlertsActivityBannerPrefs {
-  isDismissed: boolean;
+  bannerIsDismissed: boolean;
   dismissBanner: () => string;
 }
 
@@ -23,7 +23,7 @@ export function useAlertsActivityBannerPrefs(): AlertsActivityBannerPrefs {
     store.get(STORAGE_KEY_DISMISSED_UNTIL)
   );
 
-  const isDismissed = useMemo(() => {
+  const bannerIsDismissed = useMemo(() => {
     if (!dismissedUntilRaw) {
       return false;
     }
@@ -43,7 +43,7 @@ export function useAlertsActivityBannerPrefs(): AlertsActivityBannerPrefs {
   }, []);
 
   return {
-    isDismissed,
+    bannerIsDismissed,
     dismissBanner,
   };
 }

--- a/public/app/features/alerting/unified/rule-list/hooks/useAlertsActivityBannerPrefs.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useAlertsActivityBannerPrefs.ts
@@ -7,9 +7,7 @@ const STORAGE_KEY_DISMISSED_UNTIL = 'grafana.alerting.alerts_activity_banner.dis
 const DISMISSAL_DURATION_MS = 30 * 24 * 60 * 60 * 1000;
 
 export interface AlertsActivityBannerPrefs {
-  /** Whether the banner is currently dismissed (within dismissal period) */
   isDismissed: boolean;
-  /** Dismiss the banner for the default duration (30 days). Returns the dismissal expiry date. */
   dismissBanner: () => string;
 }
 

--- a/public/app/features/alerting/unified/rule-list/hooks/useAlertsActivityBannerPrefs.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useAlertsActivityBannerPrefs.ts
@@ -1,5 +1,6 @@
-import { useCallback, useMemo } from 'react';
-import { useLocalStorage } from 'react-use';
+import { useCallback, useMemo, useState } from 'react';
+
+import { store } from '@grafana/data';
 
 const STORAGE_KEY_DISMISSED_UNTIL = 'grafana.alerting.alerts_activity_banner.dismissed_until';
 
@@ -18,7 +19,9 @@ export interface AlertsActivityBannerPrefs {
  * preview toggle mechanism in RuleListPageTitle, not by this banner.
  */
 export function useAlertsActivityBannerPrefs(): AlertsActivityBannerPrefs {
-  const [dismissedUntilRaw, setDismissedUntil] = useLocalStorage<string | null>(STORAGE_KEY_DISMISSED_UNTIL, null);
+  const [dismissedUntilRaw, setDismissedUntilRaw] = useState<string | undefined>(() =>
+    store.get(STORAGE_KEY_DISMISSED_UNTIL)
+  );
 
   const isDismissed = useMemo(() => {
     if (!dismissedUntilRaw) {
@@ -34,9 +37,10 @@ export function useAlertsActivityBannerPrefs(): AlertsActivityBannerPrefs {
 
   const dismissBanner = useCallback(() => {
     const dismissedUntil = new Date(Date.now() + DISMISSAL_DURATION_MS).toISOString();
-    setDismissedUntil(dismissedUntil);
+    store.set(STORAGE_KEY_DISMISSED_UNTIL, dismissedUntil);
+    setDismissedUntilRaw(dismissedUntil);
     return dismissedUntil;
-  }, [setDismissedUntil]);
+  }, []);
 
   return {
     isDismissed,

--- a/public/app/features/alerting/unified/rule-list/hooks/useAlertsActivityBannerPrefs.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useAlertsActivityBannerPrefs.ts
@@ -18,8 +18,6 @@ export interface AlertsActivityBannerPrefs {
  *
  * Note: The view experience toggle (new/old view) is handled separately by the
  * preview toggle mechanism in RuleListPageTitle, not by this banner.
- *
- * TODO: Migrate to server-side API when /api/alerting/ui-preferences is available
  */
 export function useAlertsActivityBannerPrefs(): AlertsActivityBannerPrefs {
   const [dismissedUntilRaw, setDismissedUntil] = useLocalStorage<string | null>(STORAGE_KEY_DISMISSED_UNTIL, null);

--- a/public/app/features/alerting/unified/utils/navigation.ts
+++ b/public/app/features/alerting/unified/utils/navigation.ts
@@ -31,6 +31,7 @@ export const ALERTING_PATHS: Record<string, RelativeUrl> = {
   TEMPLATES: '/alerting/notifications/templates',
   TIME_INTERVALS: '/alerting/routes/mute-timing',
   ROUTES: '/alerting/routes',
+  ALERTS_ACTIVITY: '/alerting/alerts',
 };
 
 /**

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3155,11 +3155,6 @@
       "title-preview-not-available": "Preview not available",
       "valid-matcher-affected-alerts": "Add a valid matcher to see affected alerts"
     },
-    "silences": {
-      "affected-instances": "Affected alert instances",
-      "only-firing-instances": "Only alert instances in the firing state are displayed.",
-      "preview-affected-instances": "Preview the alert instances affected by this silence."
-    },
     "silences-editor": {
       "comment-placeholder-details-about-the-silence": "Details about the silence",
       "label-comment": "Comment",
@@ -3181,6 +3176,11 @@
       "text-loading-silences": "Loading silences...",
       "title-error-loading-silences": "Error loading silences",
       "title-the-selected-alertmanager-has-no-configuration": "The selected Alertmanager has no configuration"
+    },
+    "silences": {
+      "affected-instances": "Affected alert instances",
+      "only-firing-instances": "Only alert instances in the firing state are displayed.",
+      "preview-affected-instances": "Preview the alert instances affected by this silence."
     },
     "simple-condition-editor": {
       "label-of-query": "OF QUERY",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -601,7 +601,6 @@
     },
     "alerts-activity-banner": {
       "description": "A brand new page is now available to handle operational work for your Grafana-managed alert rules. Find out what alerts are firing, explore historical information, filter and group to enhance your triage and root cause analysis.",
-      "dma-note": "Some triage features may be limited on your stack.",
       "open-button": "See Alert Activity",
       "open-button-aria": "Open Alerts Activity",
       "title": "Alert Activity is now available!"
@@ -3155,6 +3154,11 @@
       "title-preview-not-available": "Preview not available",
       "valid-matcher-affected-alerts": "Add a valid matcher to see affected alerts"
     },
+    "silences": {
+      "affected-instances": "Affected alert instances",
+      "only-firing-instances": "Only alert instances in the firing state are displayed.",
+      "preview-affected-instances": "Preview the alert instances affected by this silence."
+    },
     "silences-editor": {
       "comment-placeholder-details-about-the-silence": "Details about the silence",
       "label-comment": "Comment",
@@ -3176,11 +3180,6 @@
       "text-loading-silences": "Loading silences...",
       "title-error-loading-silences": "Error loading silences",
       "title-the-selected-alertmanager-has-no-configuration": "The selected Alertmanager has no configuration"
-    },
-    "silences": {
-      "affected-instances": "Affected alert instances",
-      "only-firing-instances": "Only alert instances in the firing state are displayed.",
-      "preview-affected-instances": "Preview the alert instances affected by this silence."
     },
     "simple-condition-editor": {
       "label-of-query": "OF QUERY",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -599,6 +599,13 @@
       "title-restore-version": "Restore version",
       "title-restoring-alertmanager-configuration": "Restoring Alertmanager configuration"
     },
+    "alerts-activity-banner": {
+      "description": "A brand new page is now available to handle operational work for your Grafana-managed alert rules. Find out what alerts are firing, explore historical information, filter and group to enhance your triage and root cause analysis.",
+      "dma-note": "Some triage features may be limited on your stack.",
+      "open-button": "See Alert Activity",
+      "open-button-aria": "Open Alerts Activity",
+      "title": "Alert Activity is now available!"
+    },
     "alerts-folder-view": {
       "aria-label-sort": "Sort",
       "label-filter-placeholder-search-alerts-by-labels": "Search alerts by labels",
@@ -2649,6 +2656,13 @@
       "resample-to": "Resample to",
       "upsample": "Upsample"
     },
+    "revert-experience-modal": {
+      "description-line1": "Considering going back to the previous experience because you're missing more information on alert state?",
+      "description-line2": "The Alert Activity page is now available to handle operational work for your Grafana-managed alert rules. Find out what alerts are firing, explore historical information, filter and group to enhance your triage and root cause analysis.",
+      "revert-button": "Revert to previous experience",
+      "see-activity-button": "See Alert Activity",
+      "title": "Revert to previous experience"
+    },
     "routing": {
       "routing": "Routing"
     },
@@ -2877,8 +2891,8 @@
       },
       "rulerrule-loading-error": "Failed to load the rule",
       "toggle": {
-        "go-back-to-old-look": "Go back to the old look",
-        "try-out-the-new-look": "Try out the new look!"
+        "use-new-experience": "Use new experience",
+        "view-previous-experience": "Revert to previous experience"
       },
       "unknown-rule-type": "Unknown rule type"
     },


### PR DESCRIPTION
This PR adds a promotional banner for the new Alert Activity feature and improves the view-switching experience between the old and new Rule List pages.

<img width="1212" height="737" alt="image" src="https://github.com/user-attachments/assets/1e44d4f0-1c6c-44b7-81c4-c9943566af5d" />
<img width="1214" height="730" alt="image" src="https://github.com/user-attachments/assets/533fe40e-ed77-4f3f-ab4b-2d75e89c4d5a" />

https://github.com/user-attachments/assets/af000de8-1996-4c6b-afb0-47428d8b269d

