### PR TITLE
BrowseDashboardsPage: flaky tests

### DIFF
--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.test.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.test.tsx
@@ -223,7 +223,9 @@ describe('browse-dashboards BrowseDashboardsPage', () => {
         await user.click(await screen.findByText(/test team/i));
 
         await user.click(screen.getByRole('button', { name: 'Save owner' }));
-        expect(screen.queryByRole('dialog', { name: 'Manage folder owner' })).not.toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog', { name: 'Manage folder owner' })).not.toBeInTheDocument();
+        });
       });
 
       it('allows removing the team that owns the folder', async () => {
@@ -240,7 +242,9 @@ describe('browse-dashboards BrowseDashboardsPage', () => {
         await user.click(await screen.findByTitle(/clear value/i));
 
         await user.click(screen.getByRole('button', { name: 'Save owner' }));
-        expect(screen.queryByRole('dialog', { name: 'Manage folder owner' })).not.toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog', { name: 'Manage folder owner' })).not.toBeInTheDocument();
+        });
       });
     });
   });


### PR DESCRIPTION
Trying to address the flakyness which is blocking some PRs. E.g. https://github.com/grafana/grafana-enterprise/actions/runs/21906518499/job/63248160943?pr=10877

Feel free to close if this is already fixed somewhere else.