### PR TITLE
Docs: add gnupg to prerequisite packages for Debian install

### DIFF
--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -46,7 +46,7 @@ Complete the following steps to install Grafana from the APT repository:
 1. Install the prerequisite packages:
 
    ```bash
-   sudo apt-get install -y apt-transport-https wget
+   sudo apt-get install -y apt-transport-https wget gnupg
    ```
 
 1. Import the GPG key:


### PR DESCRIPTION
This PR adds `gnupg` to the prerequisite packages, as it is missing in minimal environments like Docker or Incus.
Without this, the installation fails on the `gpg` command while importing the repository key.

incus
```
bumpsoo@debian-server:~$ incus launch images:debian/13 debian13-test
Launching debian13-test
bumpsoo@debian-server:~$ incus exec debian13-test bash
root@debian13-test:~# apt-get install -y apt-transport-https wget
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  ca-certificates libgnutls30t64 libp11-kit0 libpsl5t64 libtasn1-6 openssl publicsuffix
Suggested packages:
  gnutls-bin
The following NEW packages will be installed:
  apt-transport-https ca-certificates libgnutls30t64 libp11-kit0 libpsl5t64 libtasn1-6 openssl publicsuffix wget
0 upgraded, 9 newly installed, 0 to remove and 0 not upgraded.
Need to get 4975 kB of archives.
After this operation, 13.2 MB of additional disk space will be used.
Get:1 http://deb.debian.org/debian-security trixie-security/main amd64 openssl amd64 3.5.4-1~deb13u2 [1495 kB]
Get:2 http://deb.debian.org/debian trixie/main amd64 ca-certificates all 20250419 [162 kB]
Get:3 http://deb.debian.org/debian trixie/main amd64 libp11-kit0 amd64 0.25.5-3 [425 kB]
Get:4 http://deb.debian.org/debian trixie/main amd64 libtasn1-6 amd64 4.20.0-2 [49.9 kB]
Get:5 http://deb.debian.org/debian trixie/main amd64 libgnutls30t64 amd64 3.8.9-3+deb13u1 [1466 kB]
Get:6 http://deb.debian.org/debian trixie/main amd64 libpsl5t64 amd64 0.21.2-1.1+b1 [57.2 kB]
Get:7 http://deb.debian.org/debian trixie/main amd64 wget amd64 1.25.0-2 [984 kB]
Get:8 http://deb.debian.org/debian trixie/main amd64 apt-transport-https all 3.0.3 [38.6 kB]
Get:9 http://deb.debian.org/debian trixie/main amd64 publicsuffix all 20250328.1952-0.1 [296 kB]
Fetched 4975 kB in 0s (33.4 MB/s)
Preconfiguring packages ...
Selecting previously unselected package openssl.
(Reading database ... 11460 files and directories currently installed.)
Preparing to unpack .../0-openssl_3.5.4-1~deb13u2_amd64.deb ...
Unpacking openssl (3.5.4-1~deb13u2) ...
Selecting previously unselected package ca-certificates.
Preparing to unpack .../1-ca-certificates_20250419_all.deb ...
Unpacking ca-certificates (20250419) ...
Selecting previously unselected package libp11-kit0:amd64.
Preparing to unpack .../2-libp11-kit0_0.25.5-3_amd64.deb ...
Unpacking libp11-kit0:amd64 (0.25.5-3) ...
Selecting previously unselected package libtasn1-6:amd64.
Preparing to unpack .../3-libtasn1-6_4.20.0-2_amd64.deb ...
Unpacking libtasn1-6:amd64 (4.20.0-2) ...
Selecting previously unselected package libgnutls30t64:amd64.
Preparing to unpack .../4-libgnutls30t64_3.8.9-3+deb13u1_amd64.deb ...
Unpacking libgnutls30t64:amd64 (3.8.9-3+deb13u1) ...
Selecting previously unselected package libpsl5t64:amd64.
Preparing to unpack .../5-libpsl5t64_0.21.2-1.1+b1_amd64.deb ...
Unpacking libpsl5t64:amd64 (0.21.2-1.1+b1) ...
Selecting previously unselected package wget.
Preparing to unpack .../6-wget_1.25.0-2_amd64.deb ...
Unpacking wget (1.25.0-2) ...
Selecting previously unselected package apt-transport-https.
Preparing to unpack .../7-apt-transport-https_3.0.3_all.deb ...
Unpacking apt-transport-https (3.0.3) ...
Selecting previously unselected package publicsuffix.
Preparing to unpack .../8-publicsuffix_20250328.1952-0.1_all.deb ...
Unpacking publicsuffix (20250328.1952-0.1) ...
Setting up apt-transport-https (3.0.3) ...
Setting up libpsl5t64:amd64 (0.21.2-1.1+b1) ...
Setting up libp11-kit0:amd64 (0.25.5-3) ...
Setting up libtasn1-6:amd64 (4.20.0-2) ...
Setting up openssl (3.5.4-1~deb13u2) ...
Setting up publicsuffix (20250328.1952-0.1) ...
Setting up libgnutls30t64:amd64 (3.8.9-3+deb13u1) ...
Setting up wget (1.25.0-2) ...
Setting up ca-certificates (20250419) ...
Updating certificates in /etc/ssl/certs...
150 added, 0 removed; done.
Processing triggers for libc-bin (2.41-12+deb13u1) ...
Processing triggers for ca-certificates (20250419) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
root@debian13-test:~# mkdir -p /etc/apt/keyrings/
root@debian13-test:~# wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/grafana.gpg > /dev/null
bash: gpg: command not found
```

docker
```
bumpsoo@code-ssh:~$ docker run --rm -it debian:13 bash
root@45442545b16f:/# apt-get update && apt-get install -y apt-transport-https wget
Get:1 http://deb.debian.org/debian trixie InRelease [140 kB]
Get:2 http://deb.debian.org/debian trixie-updates InRelease [47.3 kB]
Get:3 http://deb.debian.org/debian-security trixie-security InRelease [43.4 kB]
Get:4 http://deb.debian.org/debian trixie/main amd64 Packages [9670 kB]
Get:5 http://deb.debian.org/debian trixie-updates/main amd64 Packages [5412 B]
Get:6 http://deb.debian.org/debian-security trixie-security/main amd64 Packages [104 kB]
Fetched 10.0 MB in 1s (13.4 MB/s)
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  ca-certificates libffi8 libgnutls30t64 libidn2-0 libp11-kit0 libpsl5t64 libtasn1-6 libunistring5 openssl publicsuffix
Suggested packages:
  gnutls-bin
The following NEW packages will be installed:
  apt-transport-https ca-certificates libffi8 libgnutls30t64 libidn2-0 libp11-kit0 libpsl5t64 libtasn1-6 libunistring5 openssl publicsuffix wget
0 upgraded, 12 newly installed, 0 to remove and 0 not upgraded.
Need to get 5585 kB of archives.
After this operation, 15.9 MB of additional disk space will be used.
Get:1 http://deb.debian.org/debian-security trixie-security/main amd64 openssl amd64 3.5.4-1~deb13u2 [1495 kB]
Get:2 http://deb.debian.org/debian trixie/main amd64 ca-certificates all 20250419 [162 kB]
Get:3 http://deb.debian.org/debian trixie/main amd64 libunistring5 amd64 1.3-2 [477 kB]
Get:4 http://deb.debian.org/debian trixie/main amd64 libidn2-0 amd64 2.3.8-2 [109 kB]
Get:5 http://deb.debian.org/debian trixie/main amd64 libffi8 amd64 3.4.8-2 [24.1 kB]
Get:6 http://deb.debian.org/debian trixie/main amd64 libp11-kit0 amd64 0.25.5-3 [425 kB]
Get:7 http://deb.debian.org/debian trixie/main amd64 libtasn1-6 amd64 4.20.0-2 [49.9 kB]
Get:8 http://deb.debian.org/debian trixie/main amd64 libgnutls30t64 amd64 3.8.9-3+deb13u1 [1466 kB]
Get:9 http://deb.debian.org/debian trixie/main amd64 libpsl5t64 amd64 0.21.2-1.1+b1 [57.2 kB]
Get:10 http://deb.debian.org/debian trixie/main amd64 wget amd64 1.25.0-2 [984 kB]
Get:11 http://deb.debian.org/debian trixie/main amd64 apt-transport-https all 3.0.3 [38.6 kB]
Get:12 http://deb.debian.org/debian trixie/main amd64 publicsuffix all 20250328.1952-0.1 [296 kB]
Fetched 5585 kB in 0s (45.4 MB/s)
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 79, <STDIN> line 12.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC entries checked: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.40.1 /usr/local/share/perl/5.40.1 /usr/lib/x86_64-linux-gnu/perl5/5.40 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.40 /usr/share/perl/5.40 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 8, <STDIN> line 12.)
debconf: falling back to frontend: Teletype
Preconfiguring packages ...
Selecting previously unselected package openssl.
(Reading database ... 4936 files and directories currently installed.)
Preparing to unpack .../00-openssl_3.5.4-1~deb13u2_amd64.deb ...
Unpacking openssl (3.5.4-1~deb13u2) ...
Selecting previously unselected package ca-certificates.
Preparing to unpack .../01-ca-certificates_20250419_all.deb ...
Unpacking ca-certificates (20250419) ...
Selecting previously unselected package libunistring5:amd64.
Preparing to unpack .../02-libunistring5_1.3-2_amd64.deb ...
Unpacking libunistring5:amd64 (1.3-2) ...
Selecting previously unselected package libidn2-0:amd64.
Preparing to unpack .../03-libidn2-0_2.3.8-2_amd64.deb ...
Unpacking libidn2-0:amd64 (2.3.8-2) ...
Selecting previously unselected package libffi8:amd64.
Preparing to unpack .../04-libffi8_3.4.8-2_amd64.deb ...
Unpacking libffi8:amd64 (3.4.8-2) ...
Selecting previously unselected package libp11-kit0:amd64.
Preparing to unpack .../05-libp11-kit0_0.25.5-3_amd64.deb ...
Unpacking libp11-kit0:amd64 (0.25.5-3) ...
Selecting previously unselected package libtasn1-6:amd64.
Preparing to unpack .../06-libtasn1-6_4.20.0-2_amd64.deb ...
Unpacking libtasn1-6:amd64 (4.20.0-2) ...
Selecting previously unselected package libgnutls30t64:amd64.
Preparing to unpack .../07-libgnutls30t64_3.8.9-3+deb13u1_amd64.deb ...
Unpacking libgnutls30t64:amd64 (3.8.9-3+deb13u1) ...
Selecting previously unselected package libpsl5t64:amd64.
Preparing to unpack .../08-libpsl5t64_0.21.2-1.1+b1_amd64.deb ...
Unpacking libpsl5t64:amd64 (0.21.2-1.1+b1) ...
Selecting previously unselected package wget.
Preparing to unpack .../09-wget_1.25.0-2_amd64.deb ...
Unpacking wget (1.25.0-2) ...
Selecting previously unselected package apt-transport-https.
Preparing to unpack .../10-apt-transport-https_3.0.3_all.deb ...
Unpacking apt-transport-https (3.0.3) ...
Selecting previously unselected package publicsuffix.
Preparing to unpack .../11-publicsuffix_20250328.1952-0.1_all.deb ...
Unpacking publicsuffix (20250328.1952-0.1) ...
Setting up apt-transport-https (3.0.3) ...
Setting up libunistring5:amd64 (1.3-2) ...
Setting up libffi8:amd64 (3.4.8-2) ...
Setting up libtasn1-6:amd64 (4.20.0-2) ...
Setting up openssl (3.5.4-1~deb13u2) ...
Setting up publicsuffix (20250328.1952-0.1) ...
Setting up libidn2-0:amd64 (2.3.8-2) ...
Setting up ca-certificates (20250419) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 79.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC entries checked: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.40.1 /usr/local/share/perl/5.40.1 /usr/lib/x86_64-linux-gnu/perl5/5.40 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.40 /usr/share/perl/5.40 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 8.)
debconf: falling back to frontend: Teletype
Updating certificates in /etc/ssl/certs...
150 added, 0 removed; done.
Setting up libp11-kit0:amd64 (0.25.5-3) ...
Setting up libgnutls30t64:amd64 (3.8.9-3+deb13u1) ...
Setting up libpsl5t64:amd64 (0.21.2-1.1+b1) ...
Setting up wget (1.25.0-2) ...
Processing triggers for libc-bin (2.41-12+deb13u1) ...
Processing triggers for ca-certificates (20250419) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
root@45442545b16f:/# mkdir -p /etc/apt/keyrings/
root@45442545b16f:/# wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/grafana.gpg > /dev/null
bash: gpg: command not found
```
