### PR TITLE
Fix reading secure values from k8s -> legacy format

### DIFF
--- a/public/app/features/datasources/api.test.ts
+++ b/public/app/features/datasources/api.test.ts
@@ -59,7 +59,9 @@ describe('Datasources / API', () => {
         basicAuthUser: 'zaphod',
         isDefault: true,
         jsonData: { authType: 'bar' },
-        secureJsonFields: {},
+        secureJsonFields: {
+          basicAuthPassword: true,
+        },
         readOnly: false,
         withCredentials: false,
       };
@@ -88,6 +90,7 @@ describe('Datasources / API', () => {
         metadata: k8sMetadata,
         spec: k8sSpec,
         apiVersion: 'marvin.datasource.grafana.app/v0alpha1',
+        secure: { basicAuthPassword: { foo: 'bar' } },
       };
       expect(convertK8sDatasourceSettingsToLegacyDatasourceSettings(dsK8sSettings)).toEqual(dsLegacySettings);
     });

--- a/public/app/features/datasources/api.ts
+++ b/public/app/features/datasources/api.ts
@@ -41,6 +41,7 @@ export interface DataSourceSettingsK8s {
   apiVersion: string;
   metadata: K8sMetadata;
   spec: DatasourceInstanceK8sSpec;
+  secure?: Record<string, Record<string, string>>;
 }
 
 export const getDataSourceK8sGroup = (uid: string): string => {
@@ -81,6 +82,11 @@ export const convertK8sDatasourceSettingsToLegacyDatasourceSettings = (
     readOnly: false,
     withCredentials: false,
   };
+  if (dsK8sSettings.secure) {
+    for (let k of Object.keys(dsK8sSettings.secure)) {
+      dsSettings.secureJsonFields[k] = true;
+    }
+  }
   return dsSettings;
 };
 


### PR DESCRIPTION
Secure values were not being rendered in the UI because the conversion function wasn't handling them.
