### PR TITLE
Watch: Handle resourceVersion

### DIFF
--- a/pkg/services/live/features/watch.go
+++ b/pkg/services/live/features/watch.go
@@ -2,6 +2,7 @@ package features
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -105,6 +106,17 @@ func (b *WatchRunner) OnSubscribe(_ context.Context, u identity.Requester, e mod
 	if len(name) > 1 {
 		opts.FieldSelector = "metadata.name=" + name
 	}
+
+	// Support resourceVersion from subscription data.
+	if len(e.Data) > 0 {
+		var subData struct {
+			ResourceVersion string `json:"resourceVersion,omitempty"`
+		}
+		if err := json.Unmarshal(e.Data, &subData); err == nil && subData.ResourceVersion != "" {
+			opts.ResourceVersion = subData.ResourceVersion
+		}
+	}
+
 	watch, err := client.Watch(ctx, opts)
 	if err != nil {
 		return model.SubscribeReply{}, backend.SubscribeStreamStatusNotFound, err
@@ -188,24 +200,13 @@ func (b *watcher) run(ctx context.Context) {
 				return
 			}
 
-			cfg := jsoniter.ConfigCompatibleWithStandardLibrary
-			stream := cfg.BorrowStream(nil)
-			defer cfg.ReturnStream(stream)
+			data, err := marshalWatchEvent(event)
+			if err != nil {
+				logger.Error("marshal error", "channel", b.channel, "err", err)
+				continue
+			}
 
-			// regular json.Marshal() uses upper case
-			stream.WriteObjectStart()
-			stream.WriteObjectField("type")
-			stream.WriteString(string(event.Type))
-			stream.WriteMore()
-			stream.WriteObjectField("object")
-			stream.WriteVal(event.Object)
-			stream.WriteObjectEnd()
-
-			buf := stream.Buffer()
-			data := make([]byte, len(buf))
-			copy(data, buf)
-
-			err := b.publisher(b.ns, b.channel, data)
+			err = b.publisher(b.ns, b.channel, data)
 			if err != nil {
 				logger.Error("publish error", "channel", b.channel, "err", err)
 				b.watch.Stop()
@@ -214,4 +215,29 @@ func (b *watcher) run(ctx context.Context) {
 			}
 		}
 	}
+}
+
+// marshalWatchEvent serializes a watch event to JSON. This is extracted from the
+// run loop so that defer correctly returns the borrowed jsoniter stream each call.
+func marshalWatchEvent(event watch.Event) ([]byte, error) {
+	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
+	stream := cfg.BorrowStream(nil)
+	defer cfg.ReturnStream(stream)
+
+	stream.WriteObjectStart()
+	stream.WriteObjectField("type")
+	stream.WriteString(string(event.Type))
+	stream.WriteMore()
+	stream.WriteObjectField("object")
+	stream.WriteVal(event.Object)
+	stream.WriteObjectEnd()
+
+	if stream.Error != nil {
+		return nil, stream.Error
+	}
+
+	buf := stream.Buffer()
+	data := make([]byte, len(buf))
+	copy(data, buf)
+	return data, nil
 }

--- a/public/app/features/apiserver/client.ts
+++ b/public/app/features/apiserver/client.ts
@@ -59,10 +59,16 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
           scope: LiveChannelScope.Watch,
           stream: this.gvr.group,
           path: `${this.gvr.version}/${this.gvr.resource}${query}/${contextSrv.user.uid}`,
+          data: params?.resourceVersion ? { resourceVersion: params.resourceVersion } : undefined,
         })
         .pipe(
           filter((event) => isLiveChannelMessageEvent(event)),
-          map((event) => event.message)
+          map((event) => event.message),
+          retry({ count: 3, delay: 1000 }),
+          catchError((error) => {
+            console.error('Live channel watch stream error:', error);
+            throw error;
+          })
         );
     }
 


### PR DESCRIPTION
**What is this feature?**

This fixes the watch/websocket flow to properly track resource events from the initial list operation through to continuous watching, eliminating missed events during the subscription gap.

**Why do we need this feature?**

When deleting a Git Sync repository or connection via UI, the "Deleting" badge sometimes got stuck indefinitely. The root cause was a gap between the initial HTTP list query and websocket watch start - events during this gap were permanently lost, causing the frontend to never see the DELETED event.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/786
