### PR TITLE
Graphite: Do not set frame names

### DIFF
--- a/pkg/tsdb/graphite/query.go
+++ b/pkg/tsdb/graphite/query.go
@@ -226,7 +226,7 @@ func (s *Service) toDataFrames(response *http.Response, refId string) (frames da
 			}
 		}
 
-		frames = append(frames, data.NewFrame(refId,
+		frames = append(frames, data.NewFrame("",
 			data.NewField("time", nil, timeVector),
 			data.NewField("value", tags, values).SetConfig(&data.FieldConfig{DisplayNameFromDS: series.Target})).SetMeta(
 			&data.FrameMeta{Type: data.FrameTypeTimeSeriesMulti}))

--- a/pkg/tsdb/graphite/query_test.go
+++ b/pkg/tsdb/graphite/query_test.go
@@ -175,7 +175,7 @@ func TestConvertResponses(t *testing.T) {
 		a := 50.0
 		b := 100.0
 		refId := "A"
-		expectedFrame := data.NewFrame("A",
+		expectedFrame := data.NewFrame("",
 			data.NewField("time", nil, []time.Time{time.Unix(1, 0).UTC(), time.Unix(2, 0).UTC(), time.Unix(3, 0).UTC()}),
 			data.NewField("value", data.Labels{}, []*float64{&a, nil, &b}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "target"}),
 		).SetMeta(&data.FrameMeta{Type: data.FrameTypeTimeSeriesMulti})
@@ -204,7 +204,7 @@ func TestConvertResponses(t *testing.T) {
 		a := 50.0
 		b := 100.0
 		refId := "A"
-		expectedFrame := data.NewFrame("A",
+		expectedFrame := data.NewFrame("",
 			data.NewField("time", nil, []time.Time{time.Unix(1, 0).UTC(), time.Unix(2, 0).UTC(), time.Unix(3, 0).UTC()}),
 			data.NewField("value", data.Labels{
 				"fooTag": "fooValue",
@@ -269,7 +269,7 @@ func TestConvertResponses(t *testing.T) {
 		refId := "A"
 		a := 50.0
 		b := 100.0
-		expectedFrame := data.NewFrame("A",
+		expectedFrame := data.NewFrame("",
 			data.NewField("time", nil, []time.Time{time.Unix(1, 0).UTC(), time.Unix(2, 0).UTC(), time.Unix(3, 0).UTC()}),
 			data.NewField("value", data.Labels{
 				"fooTag": "fooValue",
@@ -303,7 +303,7 @@ func TestConvertResponses(t *testing.T) {
 		a := 50.0
 		b := 100.0
 		refId := "A"
-		expectedFrame := data.NewFrame("A",
+		expectedFrame := data.NewFrame("",
 			data.NewField("time", nil, []time.Time{time.Unix(1, 0).UTC(), time.Unix(2, 0).UTC(), time.Unix(3, 0).UTC()}),
 			data.NewField("value", data.Labels{
 				"fooTag": "fooValue",
@@ -730,8 +730,8 @@ Error: Target not found
 				assert.NoError(t, err)
 				require.NotNil(t, result)
 
-				for refID, resp := range result.Responses {
-					experimental.CheckGoldenJSONResponse(t, "testdata", fmt.Sprintf("%s-RefID-%s.golden", testName, refID), &resp, false)
+				for _, resp := range result.Responses {
+					experimental.CheckGoldenJSONResponse(t, "testdata", fmt.Sprintf("%s.golden", testName), &resp, false)
 				}
 			}
 		})

--- a/pkg/tsdb/graphite/testdata/interval_format_transformation-RefID-.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/interval_format_transformation-RefID-.golden.jsonc
@@ -1,0 +1,71 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: 
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100              |
+//  | 2021-01-01 00:01:00 +0000 UTC | 150              |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "hitcount(stats.counters.web.hits, '1min')"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000
+          ],
+          [
+            100,
+            150
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/graphite/testdata/interval_format_transformation.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/interval_format_transformation.golden.jsonc
@@ -1,0 +1,71 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: 
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100              |
+//  | 2021-01-01 00:01:00 +0000 UTC | 150              |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "hitcount(stats.counters.web.hits, '1min')"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000
+          ],
+          [
+            100,
+            150
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/graphite/testdata/mixed_queries_-_some_empty,_some_valid-RefID-.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/mixed_queries_-_some_empty,_some_valid-RefID-.golden.jsonc
@@ -1,0 +1,71 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: 
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100              |
+//  | 2021-01-01 00:01:00 +0000 UTC | 150              |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "stats.counters.web.hits"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000
+          ],
+          [
+            100,
+            150
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/graphite/testdata/mixed_queries_-_some_empty,_some_valid.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/mixed_queries_-_some_empty,_some_valid.golden.jsonc
@@ -1,0 +1,71 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: 
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100              |
+//  | 2021-01-01 00:01:00 +0000 UTC | 150              |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "stats.counters.web.hits"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000
+          ],
+          [
+            100,
+            150
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/graphite/testdata/successful_multiple_queries-RefID-.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/successful_multiple_queries-RefID-.golden.jsonc
@@ -1,0 +1,135 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: 
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100              |
+//  | 2021-01-01 00:01:00 +0000 UTC | 150              |
+//  +-------------------------------+------------------+
+//  
+//  
+//  
+//  Frame[1] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: 
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 50               |
+//  | 2021-01-01 00:01:00 +0000 UTC | 75               |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "stats.counters.web.hits"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000
+          ],
+          [
+            100,
+            150
+          ]
+        ]
+      }
+    },
+    {
+      "schema": {
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "stats.counters.api.calls"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000
+          ],
+          [
+            50,
+            75
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/graphite/testdata/successful_multiple_queries.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/successful_multiple_queries.golden.jsonc
@@ -1,0 +1,135 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: 
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100              |
+//  | 2021-01-01 00:01:00 +0000 UTC | 150              |
+//  +-------------------------------+------------------+
+//  
+//  
+//  
+//  Frame[1] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: 
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 50               |
+//  | 2021-01-01 00:01:00 +0000 UTC | 75               |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "stats.counters.web.hits"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000
+          ],
+          [
+            100,
+            150
+          ]
+        ]
+      }
+    },
+    {
+      "schema": {
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "stats.counters.api.calls"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000
+          ],
+          [
+            50,
+            75
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/graphite/testdata/successful_single_query_with_data-RefID-.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/successful_single_query_with_data-RefID-.golden.jsonc
@@ -1,0 +1,74 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: 
+//  Dimensions: 2 Fields by 3 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100              |
+//  | 2021-01-01 00:01:00 +0000 UTC | 150              |
+//  | 2021-01-01 00:02:00 +0000 UTC | 120              |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "stats.counters.web.hits"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000,
+            1609459320000
+          ],
+          [
+            100,
+            150,
+            120
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/graphite/testdata/successful_single_query_with_data.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/successful_single_query_with_data.golden.jsonc
@@ -1,0 +1,74 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: 
+//  Dimensions: 2 Fields by 3 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100              |
+//  | 2021-01-01 00:01:00 +0000 UTC | 150              |
+//  | 2021-01-01 00:02:00 +0000 UTC | 120              |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "stats.counters.web.hits"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000,
+            1609459320000
+          ],
+          [
+            100,
+            150,
+            120
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/graphite/testdata/successful_single_query_with_null_values-RefID-.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/successful_single_query_with_null_values-RefID-.golden.jsonc
@@ -1,0 +1,74 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: 
+//  Dimensions: 2 Fields by 3 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100              |
+//  | 2021-01-01 00:01:00 +0000 UTC | null             |
+//  | 2021-01-01 00:02:00 +0000 UTC | 120              |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "stats.counters.web.hits"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000,
+            1609459320000
+          ],
+          [
+            100,
+            null,
+            120
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/graphite/testdata/successful_single_query_with_null_values.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/successful_single_query_with_null_values.golden.jsonc
@@ -1,0 +1,74 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: 
+//  Dimensions: 2 Fields by 3 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100              |
+//  | 2021-01-01 00:01:00 +0000 UTC | null             |
+//  | 2021-01-01 00:02:00 +0000 UTC | 120              |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "stats.counters.web.hits"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000,
+            1609459320000
+          ],
+          [
+            100,
+            null,
+            120
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/graphite/testdata/successful_single_query_with_tags-RefID-.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/successful_single_query_with_tags-RefID-.golden.jsonc
@@ -1,0 +1,76 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: 
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------+--------------------------------------------------------------------+
+//  | Name: time                    | Name: value                                                        |
+//  | Labels:                       | Labels: environment=production, host=server1, port=8080, rate=99.5 |
+//  | Type: []time.Time             | Type: []*float64                                                   |
+//  +-------------------------------+--------------------------------------------------------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100                                                                |
+//  | 2021-01-01 00:01:00 +0000 UTC | 150                                                                |
+//  +-------------------------------+--------------------------------------------------------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {
+              "environment": "production",
+              "host": "server1",
+              "port": "8080",
+              "rate": "99.5"
+            },
+            "config": {
+              "displayNameFromDS": "stats.counters.web.hits"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000
+          ],
+          [
+            100,
+            150
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/graphite/testdata/successful_single_query_with_tags.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/successful_single_query_with_tags.golden.jsonc
@@ -1,0 +1,76 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: 
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------+--------------------------------------------------------------------+
+//  | Name: time                    | Name: value                                                        |
+//  | Labels:                       | Labels: environment=production, host=server1, port=8080, rate=99.5 |
+//  | Type: []time.Time             | Type: []*float64                                                   |
+//  +-------------------------------+--------------------------------------------------------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100                                                                |
+//  | 2021-01-01 00:01:00 +0000 UTC | 150                                                                |
+//  +-------------------------------+--------------------------------------------------------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {
+              "environment": "production",
+              "host": "server1",
+              "port": "8080",
+              "rate": "99.5"
+            },
+            "config": {
+              "displayNameFromDS": "stats.counters.web.hits"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000
+          ],
+          [
+            100,
+            150
+          ]
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Frame names aren't required and they can break transformations on queries for Graphite when moving from frontend to backend mode as, historically, we overrode Grafana's series naming logic for Graphite.

This is a little frustrating as we'd prefer to stick to Grafana's naming conventions but to avoid breaking changes we revert to our historical implementation.