### PR TITLE
Provisioning: Pure git username value fix

### DIFF
--- a/public/app/features/provisioning/Wizard/fields.ts
+++ b/public/app/features/provisioning/Wizard/fields.ts
@@ -212,10 +212,7 @@ const getProviderConfigs = (): Record<RepoType, Record<string, FieldConfig>> => 
           'provisioning.git.token-user-description',
           'The username that will be used to access the repository with the access token'
         ),
-        required: true,
-        validation: {
-          required: t('provisioning.git.token-user-required', 'Username is required'),
-        },
+        required: false,
       },
       url: {
         ...shared.url,

--- a/public/app/features/provisioning/utils/data.test.ts
+++ b/public/app/features/provisioning/utils/data.test.ts
@@ -30,29 +30,171 @@ function makeFormData(type: RepositoryFormData['type']): RepositoryFormData {
 }
 
 describe('provisioning data mapping', () => {
-  it('adds tokenUser to bitbucket spec', () => {
-    const spec = dataToSpec(makeFormData('bitbucket'));
+  describe('bitbucket', () => {
+    it('adds tokenUser to bitbucket spec', () => {
+      const spec = dataToSpec(makeFormData('bitbucket'));
 
-    expect(spec.bitbucket?.tokenUser).toBe('test-user');
+      expect(spec.bitbucket?.tokenUser).toBe('test-user');
+      expect(spec.bitbucket?.url).toBe('https://example.com/repo.git');
+      expect(spec.bitbucket?.branch).toBe('main');
+    });
+
+    it('reads tokenUser from bitbucket spec', () => {
+      const spec: RepositorySpec = {
+        type: 'bitbucket',
+        title: 'repo',
+        description: '',
+        sync: baseSync,
+        workflows: [],
+        bitbucket: {
+          url: 'https://bitbucket.org/owner/repo',
+          branch: 'main',
+          path: '',
+          tokenUser: 'x-token-auth',
+        },
+      };
+
+      const data = specToData(spec);
+      expect(data.tokenUser).toBe('x-token-auth');
+    });
   });
 
-  it('reads tokenUser from bitbucket spec', () => {
-    const spec: RepositorySpec = {
-      type: 'bitbucket',
-      title: 'repo',
-      description: '',
-      sync: baseSync,
-      workflows: [],
-      bitbucket: {
-        url: 'https://bitbucket.org/owner/repo',
-        branch: 'main',
-        path: '',
-        tokenUser: 'x-token-auth',
-      },
-    };
+  describe('pure git', () => {
+    it('adds tokenUser to git spec', () => {
+      const spec = dataToSpec(makeFormData('git'));
 
-    const data = specToData(spec);
-    expect(data.tokenUser).toBe('x-token-auth');
+      expect(spec.git?.tokenUser).toBe('test-user');
+      expect(spec.git?.url).toBe('https://example.com/repo.git');
+      expect(spec.git?.branch).toBe('main');
+    });
+
+    it('reads git spec to form data', () => {
+      const spec: RepositorySpec = {
+        type: 'git',
+        title: 'repo',
+        description: '',
+        sync: baseSync,
+        workflows: [],
+        git: {
+          url: 'https://git.example.com/owner/repo.git',
+          branch: 'main',
+          path: 'grafana/',
+          tokenUser: 'git-user',
+        },
+      };
+
+      const data = specToData(spec);
+      expect(data.type).toBe('git');
+      expect(data.url).toBe('https://git.example.com/owner/repo.git');
+      expect(data.branch).toBe('main');
+      expect(data.path).toBe('grafana/');
+    });
+  });
+
+  describe('gitlab', () => {
+    it('maps form data to gitlab spec without tokenUser', () => {
+      const spec = dataToSpec(makeFormData('gitlab'));
+
+      expect(spec.gitlab?.url).toBe('https://example.com/repo.git');
+      expect(spec.gitlab?.branch).toBe('main');
+      expect(spec.gitlab?.path).toBe('');
+      expect(spec.gitlab).not.toHaveProperty('tokenUser');
+    });
+
+    it('reads gitlab spec to form data', () => {
+      const spec: RepositorySpec = {
+        type: 'gitlab',
+        title: 'repo',
+        description: '',
+        sync: baseSync,
+        workflows: [],
+        gitlab: {
+          url: 'https://gitlab.com/owner/repo',
+          branch: 'main',
+          path: '',
+        },
+      };
+
+      const data = specToData(spec);
+      expect(data.type).toBe('gitlab');
+      expect(data.url).toBe('https://gitlab.com/owner/repo');
+      expect(data.branch).toBe('main');
+    });
+  });
+
+  describe('github', () => {
+    it('maps form data to github spec with generateDashboardPreviews', () => {
+      const formData = makeFormData('github');
+      formData.generateDashboardPreviews = true;
+      const spec = dataToSpec(formData);
+
+      expect(spec.github?.url).toBe('https://example.com/repo.git');
+      expect(spec.github?.generateDashboardPreviews).toBe(true);
+    });
+
+    it('adds connection when connectionName is provided', () => {
+      const formData = makeFormData('github');
+      formData.connectionName = 'my-github-app';
+      const spec = dataToSpec(formData, 'param-connection');
+
+      expect(spec.connection?.name).toBe('my-github-app');
+    });
+
+    it('uses connectionName from parameter when not in form data', () => {
+      const spec = dataToSpec(makeFormData('github'), 'param-connection');
+
+      expect(spec.connection?.name).toBe('param-connection');
+    });
+
+    it('reads github spec to form data', () => {
+      const spec: RepositorySpec = {
+        type: 'github',
+        title: 'repo',
+        description: '',
+        sync: baseSync,
+        workflows: [],
+        github: {
+          url: 'https://github.com/owner/repo',
+          branch: 'main',
+          path: '',
+          generateDashboardPreviews: true,
+        },
+      };
+
+      const data = specToData(spec);
+      expect(data.type).toBe('github');
+      expect(data.url).toBe('https://github.com/owner/repo');
+      expect(data.generateDashboardPreviews).toBe(true);
+    });
+  });
+
+  describe('local', () => {
+    it('maps form data to local spec and filters branch from workflows', () => {
+      const formData = makeFormData('local');
+      formData.path = '/var/lib/grafana/repos/my-repo';
+      formData.prWorkflow = true;
+      const spec = dataToSpec(formData);
+
+      expect(spec.local?.path).toBe('/var/lib/grafana/repos/my-repo');
+      expect(spec.workflows).not.toContain('branch');
+    });
+
+    it('reads local spec to form data', () => {
+      const spec: RepositorySpec = {
+        type: 'local',
+        title: 'repo',
+        description: '',
+        sync: baseSync,
+        workflows: [],
+        local: {
+          path: '/path/to/repo',
+        },
+      };
+
+      const data = specToData(spec);
+      expect(data.type).toBe('local');
+      expect(data.path).toBe('/path/to/repo');
+    });
   });
 });
 

--- a/public/app/features/provisioning/utils/data.ts
+++ b/public/app/features/provisioning/utils/data.ts
@@ -53,7 +53,7 @@ export const dataToSpec = (data: RepositoryFormData, connectionName?: string): R
       };
       break;
     case 'git':
-      spec.git = baseConfig;
+      spec.git = { ...baseConfig, tokenUser: data.tokenUser };
       break;
     case 'local':
       spec.local = {
@@ -69,7 +69,8 @@ export const dataToSpec = (data: RepositoryFormData, connectionName?: string): R
 
 export const specToData = (spec: RepositorySpec): RepositoryFormData => {
   const remoteConfig = spec.github || spec.gitlab || spec.bitbucket || spec.git;
-  const tokenUser = spec.bitbucket?.tokenUser;
+  // tokenUser is only available for bitbucket and pure git
+  const tokenUser = spec.bitbucket?.tokenUser ?? spec.git?.tokenUser;
 
   return structuredClone({
     ...spec,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12415,7 +12415,6 @@
       "token-label": "Access Token",
       "token-required": "Git token is required",
       "token-user-description": "The username that will be used to access the repository with the access token",
-      "token-user-required": "Username is required",
       "url-description": "The Git repository URL",
       "url-pattern": "Must be a valid Git repository URL",
       "url-required": "Repository URL is required"


### PR DESCRIPTION
**What is this feature?**

- Bugfix FE is not passing username to BE while configuring repo
- Bugfix in repo setting page FE is not displaying username
- `ConfigForm`: for pure git, make userToken optional

**Why do we need this feature?**

- To properly display username

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/867

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
