### PR TITLE
Revert "OpenFeature: Add `Content-Type` header to OFREP requests"

### DIFF
--- a/pkg/services/featuremgmt/ofrep_provider.go
+++ b/pkg/services/featuremgmt/ofrep_provider.go
@@ -7,27 +7,9 @@ import (
 	"github.com/open-feature/go-sdk/openfeature"
 )
 
-// contentTypeTransport ensures Content-Type header is set for OFREP requests
-type contentTypeTransport struct {
-	base http.RoundTripper
-}
-
-func (t *contentTypeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// OFREP requires Content-Type: application/json, but the SDK doesn't set it
-	if req.Body != nil && req.Header.Get("Content-Type") == "" {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return t.base.RoundTrip(req)
-}
-
 func newOFREPProvider(url string, client *http.Client) (openfeature.FeatureProvider, error) {
 	options := []ofrep.Option{}
 	if client != nil {
-		// Wrap transport to add Content-Type header
-		if client.Transport == nil {
-			client.Transport = http.DefaultTransport
-		}
-		client.Transport = &contentTypeTransport{base: client.Transport}
 		options = append(options, ofrep.WithClient(client))
 	}
 


### PR DESCRIPTION
Reverts grafana/grafana#117884 as the issue has been fixed upstream