### PR TITLE
Team Folders: Use search endpoint for teams instead of list, for managing team owners

### DIFF
--- a/packages/grafana-test-utils/src/handlers/apis/iam.grafana.app/v0alpha1/handlers.ts
+++ b/packages/grafana-test-utils/src/handlers/apis/iam.grafana.app/v0alpha1/handlers.ts
@@ -43,6 +43,21 @@ const getTeamHandler = () =>
     }
   );
 
+const searchTeamsHandler = () =>
+  http.get<{ namespace: string }>('/apis/iam.grafana.app/v0alpha1/namespaces/:namespace/searchTeams', ({ request }) => {
+    const url = new URL(request.url);
+    const searchQuery = url.searchParams.get('query') || '';
+
+    const items = Array.from(mockTeamsMap.values()).map(({ team }) => team);
+    const filteredItems = items
+      .filter((item) => item.spec.title.toLowerCase().includes(searchQuery.toLowerCase()))
+      .map((team) => ({ name: team.metadata.name, title: team.spec.title }));
+    return HttpResponse.json({
+      totalHits: filteredItems.length,
+      hits: filteredItems,
+    });
+  });
+
 const listTeamsHandler = () =>
   http.get<{ namespace: string }, never>('/apis/iam.grafana.app/v0alpha1/namespaces/:namespace/teams', () => {
     const items = Array.from(mockTeamsMap.values()).map(({ team }) => team);
@@ -54,4 +69,4 @@ const listTeamsHandler = () =>
     });
   });
 
-export default [getDisplayMapping(), getTeamHandler(), listTeamsHandler()];
+export default [getDisplayMapping(), getTeamHandler(), listTeamsHandler(), searchTeamsHandler()];

--- a/public/app/core/components/OwnerReferences/OwnerReferenceSelector.tsx
+++ b/public/app/core/components/OwnerReferences/OwnerReferenceSelector.tsx
@@ -1,12 +1,13 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { t, Trans } from '@grafana/i18n';
 import { Box, Combobox, ComboboxOption, Label } from '@grafana/ui';
 import { OwnerReference } from 'app/api/clients/folder/v1beta1';
 import {
-  useListTeamQuery,
   API_GROUP as IAM_API_GROUP,
   API_VERSION as IAM_API_VERSION,
+  useLazyGetTeamQuery,
+  useLazyGetSearchTeamsQuery,
 } from 'app/api/clients/iam/v0alpha1';
 
 const OWNER_REFERENCE_API_VERSION = `${IAM_API_GROUP}/${IAM_API_VERSION}` as const;
@@ -25,11 +26,33 @@ export const OwnerReferenceSelector = ({
   defaultTeamUid?: string;
 }) => {
   const [selectedTeam, setSelectedTeam] = useState<ComboboxOption<string> | string | null>(defaultTeamUid || null);
-  const { data: teams, isLoading } = useListTeamQuery({});
-  const teamsOptions = (teams?.items || []).map((team) => ({
-    label: team.spec.title,
-    value: team.metadata.name!,
-  }));
+  const [searchTeams, { isLoading }] = useLazyGetSearchTeamsQuery();
+  const [getTeam, { isLoading: isSelectedTeamLoading }] = useLazyGetTeamQuery();
+
+  useEffect(() => {
+    if (defaultTeamUid) {
+      getTeam({ name: defaultTeamUid }, true)
+        .unwrap()
+        .then((team) => {
+          setSelectedTeam({
+            label: team.spec.title,
+            value: team.metadata.name!,
+          });
+        });
+    }
+  }, [defaultTeamUid, getTeam]);
+
+  const loadOptions = async (inputValue: string): Promise<Array<ComboboxOption<string>>> => {
+    const result = await searchTeams({ query: inputValue }, true).unwrap();
+
+    const mappedResults = result.hits.map((team: { title: string; name: string }) => ({
+      label: team.title,
+      value: team.name,
+    }));
+
+    return mappedResults;
+  };
+
   return (
     <Box>
       <Label htmlFor="owner-reference-selector">
@@ -39,9 +62,11 @@ export const OwnerReferenceSelector = ({
       <Combobox
         id="owner-reference-selector"
         isClearable
+        prefixIcon="users-alt"
         value={selectedTeam}
-        loading={isLoading}
-        options={teamsOptions}
+        loading={isLoading || isSelectedTeamLoading}
+        disabled={isLoading || isSelectedTeamLoading}
+        options={loadOptions}
         placeholder={t('manage-owner-references.select-owner', 'Select an owner')}
         onChange={(team) => {
           setSelectedTeam(team);

--- a/public/app/core/components/OwnerReferences/OwnerReferenceSelector.tsx
+++ b/public/app/core/components/OwnerReferences/OwnerReferenceSelector.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { t, Trans } from '@grafana/i18n';
-import { Box, Combobox, ComboboxOption, Label } from '@grafana/ui';
+import { Alert, Box, Combobox, ComboboxOption, Label } from '@grafana/ui';
 import { OwnerReference } from 'app/api/clients/folder/v1beta1';
 import {
   API_GROUP as IAM_API_GROUP,
@@ -9,6 +9,7 @@ import {
   useLazyGetTeamQuery,
   useLazyGetSearchTeamsQuery,
 } from 'app/api/clients/iam/v0alpha1';
+import { extractErrorMessage } from 'app/api/utils';
 
 const OWNER_REFERENCE_API_VERSION = `${IAM_API_GROUP}/${IAM_API_VERSION}` as const;
 const OWNER_REFERENCE_KIND = 'Team' as const;
@@ -27,7 +28,7 @@ export const OwnerReferenceSelector = ({
 }) => {
   const [selectedTeam, setSelectedTeam] = useState<ComboboxOption<string> | string | null>(defaultTeamUid || null);
   const [searchTeams, { isLoading }] = useLazyGetSearchTeamsQuery();
-  const [getTeam, { isLoading: isSelectedTeamLoading }] = useLazyGetTeamQuery();
+  const [getTeam, { isLoading: isSelectedTeamLoading, error: selectedTeamError }] = useLazyGetTeamQuery();
 
   useEffect(() => {
     if (defaultTeamUid) {
@@ -52,6 +53,16 @@ export const OwnerReferenceSelector = ({
 
     return mappedResults;
   };
+  if (Boolean(selectedTeamError)) {
+    return (
+      <Alert
+        severity="error"
+        title={t('manage-owner-references.error-load-team-details', 'Could not load team details')}
+      >
+        {extractErrorMessage(selectedTeamError)}
+      </Alert>
+    );
+  }
 
   return (
     <Box>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10698,6 +10698,7 @@
     }
   },
   "manage-owner-references": {
+    "error-load-team-details": "Could not load team details",
     "folder-owner-error": "Error updating folder owner",
     "folder-owner-removed": "Folder owner removed",
     "folder-owner-updated": "Folder owner updated",


### PR DESCRIPTION
**What is this feature?**
Uses search endpoint in the team selector for choosing a folder owner

**Why do we need this feature?**
So we can actually find all teams when selecting an owner

**Who is this feature for?**
Team folders users/people assigning folder owners
