### PR TITLE
Chore: Improve MT service compatibility check

### DIFF
--- a/.github/workflows/pr-mt-service-compatibility.yml
+++ b/.github/workflows/pr-mt-service-compatibility.yml
@@ -29,6 +29,8 @@ jobs:
             frontend_strict:
               - 'public/**'
               - 'packages/**'
+              - '!public/**/*.gen.ts'
+              - '!packages/**/*.gen.ts'
               - 'scripts/webpack/**'
               - '.eslintrc*'
               - '.prettierrc*'
@@ -81,7 +83,9 @@ jobs:
             echo "Exception process (if changes MUST be coupled):"
             echo "• Add the 'no-check-mt-service-compatibility' label to this PR"
             echo "• Explain in the PR description why these changes cannot be separated"
-            echo "• Get platform team approval"
+            echo ""
+            echo "For more details, see: https://enghub.grafana-ops.net/docs/default/component/deployment-tools/grafana-frontend-service/#guide-for-development-process-in-a-decoupled-deployment"
+            echo "If you need help or have feedback, reach us in #proj-mt-frontend"
             exit 1
           fi
         env:


### PR DESCRIPTION
**What is this feature?**

* Excludes `gen.ts` files from the check since some backend changes will trigger these updates and it make sense to merge them together. The goal is to skip this false positives: [PR1](https://github.com/grafana/grafana/pull/117427/changes#diff-1041a86bb28a135ab3234e0ff63059ae15c97ffe7b1ec49a9dbf2ec21fa17aa5) and [PR2](https://github.com/grafana/grafana/pull/116059/changes#diff-4a6871fb46d7f5f7defa7aa30debcaec5c92d6c85b73bf876df179c5f85a7d32)
* Improves failing message pointing to the docs and our slack channel
