### PR TITLE
Docs: Document skipUrlSync variable property for URL syncing behavior

### DIFF
--- a/docs/sources/visualizations/dashboards/variables/_index.md
+++ b/docs/sources/visualizations/dashboards/variables/_index.md
@@ -81,10 +81,12 @@ https://play.grafana.org/d/HYaGDGIMk/templating-global-variables-and-interpolati
 
 In the preceding example, the variables and values are `var-Server=CCC` and `var-MyCustomDashboardVariable=Hello%20World%21`.
 
-You can prevent a variable from being synced to the URL by enabling the **Skip URL sync** option in the variable settings. When enabled, the variable value won't appear as a `var-` query parameter in the URL. This is useful when you want to keep URLs clean or prevent users from overriding a variable value through the URL. All variable types support this option.
+You can prevent a variable from being synced to the URL by setting `skipUrlSync` to `true` in the variable definition within the dashboard JSON model. When set, the variable value won't appear as a `var-` query parameter in the URL.
+
+This is useful when you want to keep URLs clean, prevent users from overriding a variable value through the URL, or avoid exposing sensitive values in shared links.
 
 {{< admonition type="note">}}
-Constant variables have **Skip URL sync** enabled by default, since their value is fixed and not intended to be changed through the URL.
+Constant variables have `skipUrlSync` set to `true` by default, since their value is fixed and not intended to be changed through the URL.
 {{< /admonition >}}
 
 ## Additional examples

--- a/docs/sources/visualizations/dashboards/variables/_index.md
+++ b/docs/sources/visualizations/dashboards/variables/_index.md
@@ -72,7 +72,7 @@ The following image shows a panel in edit mode using the query:
 
 ### Variables in URLs
 
-Variable values are always synced to the URL using [query parameter syntax](https://grafana.com/docs/grafana/latest/dashboards/variables/variable-syntax/#query-parameters), `var-<varname>=value`.
+By default, variable values are synced to the URL using [query parameter syntax](https://grafana.com/docs/grafana/latest/dashboards/variables/variable-syntax/#query-parameters), `var-<varname>=value`.
 For example:
 
 ```text
@@ -80,6 +80,12 @@ https://play.grafana.org/d/HYaGDGIMk/templating-global-variables-and-interpolati
 ```
 
 In the preceding example, the variables and values are `var-Server=CCC` and `var-MyCustomDashboardVariable=Hello%20World%21`.
+
+You can prevent a variable from being synced to the URL by enabling the **Skip URL sync** option in the variable settings. When enabled, the variable value won't appear as a `var-` query parameter in the URL. This is useful when you want to keep URLs clean or prevent users from overriding a variable value through the URL. All variable types support this option.
+
+{{< admonition type="note">}}
+Constant variables have **Skip URL sync** enabled by default, since their value is fixed and not intended to be changed through the URL.
+{{< /admonition >}}
 
 ## Additional examples
 


### PR DESCRIPTION
**What is this feature?**

Documents the `skipUrlSync` variable property in the Variables documentation page. The update explains how variable values are synced to URLs by default, how to disable this behavior by setting `skipUrlSync: true` in the dashboard JSON model, and notes that constant variables have this enabled by default.

before
<img width="781" height="297" alt="image" src="https://github.com/user-attachments/assets/deb8bb99-de05-47ba-bfb1-551593a606c3" />


after:
<img width="795" height="565" alt="image" src="https://github.com/user-attachments/assets/83412cce-9df5-4de9-9f66-2d0e18f8c98a" />

