### PR TITLE
Alerting: Add alertingSyncNotifiersApiMigration feature flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -609,6 +609,11 @@ export interface FeatureToggles {
   */
   alertingDisableSendAlertsExternal?: boolean;
   /**
+  * Use the new k8s API for fetching integration type schemas
+  * @default false
+  */
+  alertingSyncNotifiersApiMigration?: boolean;
+  /**
   * Enables possibility to preserve dashboard variables and time range when navigating between dashboards
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -952,6 +952,14 @@ var (
 			Expression:   "false",
 		},
 		{
+			Name:         "alertingSyncNotifiersApiMigration",
+			Description:  "Use the new k8s API for fetching integration type schemas",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaAlertingSquad,
+			FrontendOnly: true,
+			Expression:   "false",
+		},
+		{
 			Name:         "preserveDashboardStateWhenNavigating",
 			Description:  "Enables possibility to preserve dashboard variables and time range when navigating between dashboards",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -117,6 +117,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-01-14,alertingNavigationV2,experimental,@grafana/alerting-squad,false,false,false
 2025-12-19,alertingSavedSearches,experimental,@grafana/alerting-squad,false,false,true
 2024-05-23,alertingDisableSendAlertsExternal,experimental,@grafana/alerting-squad,false,false,false
+2026-02-06,alertingSyncNotifiersApiMigration,experimental,@grafana/alerting-squad,false,false,true
 2024-05-27,preserveDashboardStateWhenNavigating,experimental,@grafana/dashboards-squad,false,false,false
 2024-05-29,alertingCentralAlertHistory,experimental,@grafana/alerting-squad,false,false,false
 2024-06-05,pluginProxyPreserveTrailingSlash,GA,@grafana/plugins-platform-backend,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -22,7 +22,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2023-04-12,disableSSEDataplane,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2023-04-03,renderAuthJWT,preview,@grafana/grafana-operator-experience-squad,false,false,false
 2023-06-06,refactorVariablesTimeRange,preview,@grafana/dashboards-squad,false,false,false
-2023-05-05,faroDatasourceSelector,preview,@grafana/app-o11y,false,false,true
+2023-05-04,faroDatasourceSelector,preview,@grafana/app-o11y,false,false,true
 2023-04-24,enableDatagridEditing,preview,@grafana/dataviz-squad,false,false,false
 2026-02-10,faroSessionReplay,experimental,@grafana/session-replay,false,false,true
 2023-07-12,logsExploreTableVisualisation,GA,@grafana/observability-logs,false,false,true
@@ -117,7 +117,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-01-14,alertingNavigationV2,experimental,@grafana/alerting-squad,false,false,false
 2025-12-19,alertingSavedSearches,experimental,@grafana/alerting-squad,false,false,true
 2024-05-23,alertingDisableSendAlertsExternal,experimental,@grafana/alerting-squad,false,false,false
-2026-02-06,alertingSyncNotifiersApiMigration,experimental,@grafana/alerting-squad,false,false,true
+2026-02-05,alertingSyncNotifiersApiMigration,experimental,@grafana/alerting-squad,false,false,true
 2024-05-27,preserveDashboardStateWhenNavigating,experimental,@grafana/dashboards-squad,false,false,false
 2024-05-29,alertingCentralAlertHistory,experimental,@grafana/alerting-squad,false,false,false
 2024-06-05,pluginProxyPreserveTrailingSlash,GA,@grafana/plugins-platform-backend,false,false,false
@@ -146,10 +146,10 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-10-04,pluginsSriChecks,GA,@grafana/plugins-platform-backend,false,false,false
 2024-10-17,unifiedStorageBigObjectsSupport,experimental,@grafana/search-and-storage,false,false,false
 2024-10-22,timeRangeProvider,experimental,@grafana/grafana-frontend-platform,false,false,false
-2025-11-05,timeRangePan,GA,@grafana/dataviz-squad,false,false,true
+2025-11-04,timeRangePan,GA,@grafana/dataviz-squad,false,false,true
 2025-11-20,newTimeRangeZoomShortcuts,GA,@grafana/dataviz-squad,false,false,true
 2024-10-24,azureMonitorDisableLogLimit,GA,@grafana/partner-datasources,false,false,false
-2024-12-20,playlistsReconciler,experimental,@grafana/grafana-app-platform-squad,false,true,false
+2024-12-19,playlistsReconciler,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2024-11-14,passwordlessMagicLinkAuthentication,experimental,@grafana/identity-access-team,false,false,false
 2024-12-18,prometheusSpecialCharsInLabelValues,experimental,@grafana/oss-big-tent,false,false,true
 2024-11-05,enableExtensionsAdminPage,experimental,@grafana/plugins-platform-backend,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -355,10 +355,6 @@ const (
 	// Disables the ability to send alerts to an external Alertmanager datasource.
 	FlagAlertingDisableSendAlertsExternal = "alertingDisableSendAlertsExternal"
 
-	// FlagAlertingSyncNotifiersApiMigration
-	// Use the new k8s API for fetching integration type schemas
-	FlagAlertingSyncNotifiersApiMigration = "alertingSyncNotifiersApiMigration"
-
 	// FlagPreserveDashboardStateWhenNavigating
 	// Enables possibility to preserve dashboard variables and time range when navigating between dashboards
 	FlagPreserveDashboardStateWhenNavigating = "preserveDashboardStateWhenNavigating"

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -355,6 +355,10 @@ const (
 	// Disables the ability to send alerts to an external Alertmanager datasource.
 	FlagAlertingDisableSendAlertsExternal = "alertingDisableSendAlertsExternal"
 
+	// FlagAlertingSyncNotifiersApiMigration
+	// Use the new k8s API for fetching integration type schemas
+	FlagAlertingSyncNotifiersApiMigration = "alertingSyncNotifiersApiMigration"
+
 	// FlagPreserveDashboardStateWhenNavigating
 	// Enables possibility to preserve dashboard variables and time range when navigating between dashboards
 	FlagPreserveDashboardStateWhenNavigating = "preserveDashboardStateWhenNavigating"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -240,6 +240,20 @@
     },
     {
       "metadata": {
+        "name": "alertingSyncNotifiersApiMigration",
+        "resourceVersion": "0",
+        "creationTimestamp": "2026-02-06T00:00:00Z"
+      },
+      "spec": {
+        "description": "Use the new k8s API for fetching integration type schemas",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingEnrichmentAssistantInvestigations",
         "resourceVersion": "1764664939750",
         "creationTimestamp": "2025-08-29T14:46:39Z",

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -240,20 +240,6 @@
     },
     {
       "metadata": {
-        "name": "alertingSyncNotifiersApiMigration",
-        "resourceVersion": "0",
-        "creationTimestamp": "2026-02-06T00:00:00Z"
-      },
-      "spec": {
-        "description": "Use the new k8s API for fetching integration type schemas",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad",
-        "frontend": true,
-        "expression": "false"
-      }
-    },
-    {
-      "metadata": {
         "name": "alertingEnrichmentAssistantInvestigations",
         "resourceVersion": "1764664939750",
         "creationTimestamp": "2025-08-29T14:46:39Z",
@@ -646,6 +632,20 @@
         "codeowner": "@grafana/alerting-squad",
         "requiresRestart": true,
         "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingSyncNotifiersApiMigration",
+        "resourceVersion": "0",
+        "creationTimestamp": "2026-02-06T00:00:00Z"
+      },
+      "spec": {
+        "description": "Use the new k8s API for fetching integration type schemas",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
         "expression": "false"
       }
     },


### PR DESCRIPTION
**What is this feature?**
This PR adds the `alertingSyncNotifiersApiMigration`, which will be used to hide the frontend changes for https://github.com/grafana/alerting-squad/issues/1396

**Why do we need this feature?**

We cannot include backend and frontend changes in a single PR anymore, so we have to add these before the frontend changes

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/alerting-squad/issues/1396