### PR TITLE
Zanzana: Fix team subject type restriction for resource permission tuples

### DIFF
--- a/pkg/services/authz/zanzana/server/server_mutate_resourcepermissions.go
+++ b/pkg/services/authz/zanzana/server/server_mutate_resourcepermissions.go
@@ -139,7 +139,7 @@ func toZanzanaSubject(kind string, name string) (string, error) {
 	case iamv0.ResourcePermissionSpecPermissionKindServiceAccount:
 		return zanzana.NewTupleEntry(zanzana.TypeServiceAccount, name, ""), nil
 	case iamv0.ResourcePermissionSpecPermissionKindTeam:
-		return zanzana.NewTupleEntry(zanzana.TypeTeam, name, ""), nil
+		return zanzana.NewTupleEntry(zanzana.TypeTeam, name, zanzana.RelationTeamMember), nil
 	case iamv0.ResourcePermissionSpecPermissionKindBasicRole:
 		basicRole := zanzana.TranslateBasicRole(name)
 		if basicRole == "" {


### PR DESCRIPTION
## Summary
- Fix `toZanzanaSubject` to produce `team:<id>#member` instead of `team:<id>` when creating resource permission tuples for teams, matching the FGA schema's type restriction for `resource#view` (and all other resource relations).
- Without this fix, the reconciler fails with: `Invalid tuple 'resource:...#view@team:...'. Reason: type 'team' is not an allowed type restriction for 'resource#view'`

## Details
The FGA schema defines resource relations (view, edit, admin, etc.) with `team#member` as the allowed subject type -- meaning "all members of a team". The `toZanzanaSubject` function was producing a bare `team:<id>` subject (no `#member` relation), which OpenFGA rejected as an invalid type restriction.

This is consistent with how `GetRoleBindingTuple` in `server_mutate_rolebindings.go` already correctly sets the `#member` relation for team subjects.