### PR TITLE
News, Canvas: Change heading tags to avoid nesting issues

### DIFF
--- a/public/app/features/canvas/elements/notFound.tsx
+++ b/public/app/features/canvas/elements/notFound.tsx
@@ -1,17 +1,21 @@
+import { css } from '@emotion/css';
 import { memo } from 'react';
 
+import { GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
+import { useStyles2 } from '@grafana/ui';
 
 import { CanvasElementItem, CanvasElementProps } from '../element';
 
 const NotFoundDisplay = memo(({ config }: CanvasElementProps) => {
+  const styles = useStyles2(getStyles);
   return (
-    <div>
+    <div className={styles.container}>
       <Trans
         i18nKey="canvas.not-found-display.not-found"
         components={{ config: <pre>{JSON.stringify(config, null, 2)}</pre> }}
       >
-        <h3>Not found: </h3>
+        <span className={styles.heading}>Not found: </span>
         {'<config />'}
       </Trans>
     </div>
@@ -36,3 +40,8 @@ export const notFoundItem: CanvasElementItem = {
     config: {},
   }),
 };
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({ background: theme.colors.background.canvas }),
+  heading: css({ ...theme.typography.h3 }),
+});

--- a/public/app/features/dimensions/editors/ResourceCards.tsx
+++ b/public/app/features/dimensions/editors/ResourceCards.tsx
@@ -49,7 +49,7 @@ const MemoizedCell = memo(function Cell(props: CellProps) {
           ) : (
             <img src={card.imgUrl} alt="" className={styles.img} />
           )}
-          <h6 className={styles.text}>{card.label.slice(0, -4)}</h6>
+          <span className={styles.text}>{card.label.slice(0, -4)}</span>
         </div>
       )}
     </div>
@@ -125,6 +125,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     fill: theme.colors.text.primary,
   }),
   text: css({
+    ...theme.typography.h6,
     color: theme.colors.text.primary,
     whiteSpace: 'nowrap',
     fontSize: '12px',

--- a/public/app/plugins/panel/news/component/News.tsx
+++ b/public/app/plugins/panel/news/component/News.tsx
@@ -39,10 +39,13 @@ function NewsComponent({ width, showImage, data, index }: NewsItemProps) {
         <time className={styles.date} dateTime={dateTimeFormat(newsItem.date, { format: 'MMM DD' })}>
           {dateTimeFormat(newsItem.date, { format: 'MMM DD' })}{' '}
         </time>
-        <a className={styles.link} href={textUtil.sanitizeUrl(newsItem.link)} target="_blank" rel="noopener noreferrer">
-          <h3 className={styles.title} id={titleId}>
-            {newsItem.title}
-          </h3>
+        <a
+          className={cx(styles.link, styles.title)}
+          href={textUtil.sanitizeUrl(newsItem.link)}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {newsItem.title}
         </a>
         <div className={styles.content} dangerouslySetInnerHTML={{ __html: textUtil.sanitize(newsItem.content) }} />
       </div>
@@ -128,6 +131,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     },
   }),
   title: css({
+    ...theme.typography.h3,
     fontSize: '16px',
     marginBottom: theme.spacing(0.5),
   }),

--- a/public/app/plugins/panel/news/component/News.tsx
+++ b/public/app/plugins/panel/news/component/News.tsx
@@ -40,6 +40,7 @@ function NewsComponent({ width, showImage, data, index }: NewsItemProps) {
           {dateTimeFormat(newsItem.date, { format: 'MMM DD' })}{' '}
         </time>
         <a
+          id={titleId}
           className={cx(styles.link, styles.title)}
           href={textUtil.sanitizeUrl(newsItem.link)}
           target="_blank"

--- a/public/app/plugins/panel/news/component/News.tsx
+++ b/public/app/plugins/panel/news/component/News.tsx
@@ -39,15 +39,17 @@ function NewsComponent({ width, showImage, data, index }: NewsItemProps) {
         <time className={styles.date} dateTime={dateTimeFormat(newsItem.date, { format: 'MMM DD' })}>
           {dateTimeFormat(newsItem.date, { format: 'MMM DD' })}{' '}
         </time>
-        <a
-          id={titleId}
-          className={cx(styles.link, styles.title)}
-          href={textUtil.sanitizeUrl(newsItem.link)}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {newsItem.title}
-        </a>
+
+        <h1 className={styles.title} id={titleId}>
+          <a
+            className={styles.link}
+            href={textUtil.sanitizeUrl(newsItem.link)}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {newsItem.title}
+          </a>
+        </h1>
         <div className={styles.content} dangerouslySetInnerHTML={{ __html: textUtil.sanitize(newsItem.content) }} />
       </div>
     </article>


### PR DESCRIPTION
Relates to https://github.com/grafana/grafana/issues/117836

In all of the cases in Dataviz's code, we can avoid using heading tags because they are not meaningful semantically to the flow of the content of the overall page.