### PR TITLE
Alerting: Enhance API for importing Alertmanager configuration

### DIFF
--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
 
+	"github.com/grafana/alerting/definition"
+
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -1930,9 +1932,9 @@ type mockAlertmanager struct {
 	mock.Mock
 }
 
-func (m *mockAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, extraConfig apimodels.ExtraConfiguration, replace bool, dryRun bool) error {
+func (m *mockAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, extraConfig apimodels.ExtraConfiguration, replace bool, dryRun bool) (definition.RenameResources, error) {
 	args := m.Called(ctx, org, extraConfig, replace, dryRun)
-	return args.Error(0)
+	return args.Get(0).(definition.RenameResources), args.Error(1)
 }
 
 func (m *mockAlertmanager) GetAlertmanagerConfiguration(ctx context.Context, org int64, withAutogen bool, withMergedExtraConfig bool) (apimodels.GettableUserConfig, error) {
@@ -1958,7 +1960,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 				len(extraConfig.MergeMatchers) == 2 &&
 				len(extraConfig.TemplateFiles) == 1 &&
 				extraConfig.TemplateFiles["test.tmpl"] == "{{ define \"test\" }}Hello{{ end }}"
-		}), false, false).Return(nil).Once()
+		}), false, false).Return(definition.RenameResources{}, nil).Once()
 
 		rc := createRequestCtx()
 		rc.Req.Header.Set(configIdentifierHeader, identifier)
@@ -1992,7 +1994,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		mockAM := &mockAlertmanager{}
 		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
 			return extraConfig.Identifier == defaultConfigIdentifier
-		}), false, false).Return(nil)
+		}), false, false).Return(definition.RenameResources{}, nil)
 
 		ft := featuremgmt.WithFeatures(featuremgmt.FlagAlertingImportAlertmanagerAPI)
 		srv, _, _ := createConvertPrometheusSrv(t, withAlertmanager(mockAM), withFeatureToggles(ft))
@@ -2021,7 +2023,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		mockAM := &mockAlertmanager{}
 		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
 			return extraConfig.Identifier == defaultConfigIdentifier
-		}), true, false).Return(nil)
+		}), true, false).Return(definition.RenameResources{}, nil)
 
 		ft := featuremgmt.WithFeatures(featuremgmt.FlagAlertingImportAlertmanagerAPI)
 		srv, _, _ := createConvertPrometheusSrv(t, withAlertmanager(mockAM), withFeatureToggles(ft))
@@ -2050,7 +2052,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		mockAM := &mockAlertmanager{}
 		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
 			return extraConfig.Identifier == defaultConfigIdentifier
-		}), false, true).Return(nil)
+		}), false, true).Return(definition.RenameResources{}, nil)
 
 		ft := featuremgmt.WithFeatures(featuremgmt.FlagAlertingImportAlertmanagerAPI)
 		srv, _, _ := createConvertPrometheusSrv(t, withAlertmanager(mockAM), withFeatureToggles(ft))
@@ -2070,6 +2072,46 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		response := srv.RouteConvertPrometheusPostAlertmanagerConfig(rc, amCfg)
 
 		require.Equal(t, http.StatusOK, response.Status(), "dry run should return 200 OK")
+		mockAM.AssertExpectations(t)
+	})
+
+	t.Run("should return rename information when resources are renamed", func(t *testing.T) {
+		rc := createRequestCtx()
+		rc.Req.Header.Set(configIdentifierHeader, identifier)
+		mockAM := &mockAlertmanager{}
+
+		expectedRenames := definition.RenameResources{
+			Receivers: map[string]string{
+				"default": "default-test-config",
+			},
+			TimeIntervals: map[string]string{
+				"weekdays": "weekdays-test-config",
+			},
+		}
+
+		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
+			return extraConfig.Identifier == identifier
+		}), false, false).Return(expectedRenames, nil)
+
+		ft := featuremgmt.WithFeatures(featuremgmt.FlagAlertingImportAlertmanagerAPI)
+		srv, _, _ := createConvertPrometheusSrv(t, withAlertmanager(mockAM), withFeatureToggles(ft))
+
+		amCfg := apimodels.AlertmanagerUserConfig{
+			AlertmanagerConfig: `{"route": {"receiver": "default"}, "receivers": [{"name": "default"}]}`,
+		}
+		response := srv.RouteConvertPrometheusPostAlertmanagerConfig(rc, amCfg)
+
+		require.Equal(t, http.StatusAccepted, response.Status())
+
+		// Parse response body
+		var resp apimodels.ConvertAlertmanagerResponse
+		err := json.Unmarshal(response.Body(), &resp)
+		require.NoError(t, err)
+		require.Equal(t, "success", resp.Status)
+		require.NotNil(t, resp.RenameResources)
+		require.Equal(t, "default-test-config", resp.RenameResources.Receivers["default"])
+		require.Equal(t, "weekdays-test-config", resp.RenameResources.TimeIntervals["weekdays"])
+
 		mockAM.AssertExpectations(t)
 	})
 

--- a/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
+++ b/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
@@ -324,9 +324,10 @@ type RouteConvertPrometheusPostAlertmanagerConfigParams struct {
 	// configuration to alerts matching both environment=production AND team=backend.
 	// in: header
 	MergeMatchers string `json:"x-grafana-alerting-merge-matchers"`
-	// Alertmanager configuration including routing rules, receivers, and template files
-	// in:body
-	Body AlertmanagerUserConfig
+	// If true, the configuration will replace an existing configuration regardless of its identifier
+	// in:query
+	Replace bool `json:"x-grafana-alerting-config-force-replace"`
+	Body    AlertmanagerUserConfig
 }
 
 // swagger:parameters RouteConvertPrometheusGetAlertmanagerConfig

--- a/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
+++ b/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
@@ -325,9 +325,14 @@ type RouteConvertPrometheusPostAlertmanagerConfigParams struct {
 	// in: header
 	MergeMatchers string `json:"x-grafana-alerting-merge-matchers"`
 	// If true, the configuration will replace an existing configuration regardless of its identifier
-	// in:query
+	// in: header
 	Replace bool `json:"x-grafana-alerting-config-force-replace"`
-	Body    AlertmanagerUserConfig
+	// If true, validates the configuration without saving it
+	// in: header
+	DryRun bool `json:"x-grafana-alerting-dry-run"`
+	// Alertmanager configuration including routing rules, receivers, and template files
+	// in:body
+	Body AlertmanagerUserConfig
 }
 
 // swagger:parameters RouteConvertPrometheusGetAlertmanagerConfig

--- a/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
+++ b/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
@@ -312,6 +312,22 @@ type ConvertPrometheusResponse struct {
 	Error     string `json:"error"`
 }
 
+type ConvertAlertmanagerResponse struct {
+	Status    string `json:"status"`
+	ErrorType string `json:"errorType"`
+	Error     string `json:"error"`
+	// RenameResources contains information about renamed resources during configuration merge
+	RenameResources *RenameResources `json:"rename_resources,omitempty"`
+}
+
+// RenameResources describes which resources were renamed to avoid conflicts
+type RenameResources struct {
+	// Receivers maps old receiver names to new receiver names
+	Receivers map[string]string `json:"receivers,omitempty"`
+	// TimeIntervals maps old time interval names to new time interval names
+	TimeIntervals map[string]string `json:"time_intervals,omitempty"`
+}
+
 // swagger:parameters RouteConvertPrometheusPostAlertmanagerConfig
 type RouteConvertPrometheusPostAlertmanagerConfigParams struct {
 	// Unique identifier for this Alertmanager configuration.

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -433,15 +433,16 @@ func (moa *MultiOrgAlertmanager) modifyAndApplyExtraConfiguration(
 }
 
 // SaveAndApplyExtraConfiguration adds or replaces an ExtraConfiguration while preserving the main AlertmanagerConfig.
-func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, extraConfig definitions.ExtraConfiguration) error {
+func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, extraConfig definitions.ExtraConfiguration, replace bool) error {
 	modifyFunc := func(configs []definitions.ExtraConfiguration) ([]definitions.ExtraConfiguration, error) {
-		// for now we validate that after the update there will be just one extra config.
-		for _, c := range configs {
-			if c.Identifier != extraConfig.Identifier {
-				return nil, ErrAlertmanagerMultipleExtraConfigsUnsupported.Build(errutil.TemplateData{Public: map[string]interface{}{"Identifier": c.Identifier}})
+		if !replace {
+			// for now we validate that after the update there will be just one extra config.
+			for _, c := range configs {
+				if c.Identifier != extraConfig.Identifier {
+					return nil, ErrAlertmanagerMultipleExtraConfigsUnsupported.Build(errutil.TemplateData{Public: map[string]interface{}{"Identifier": c.Identifier}})
+				}
 			}
 		}
-
 		return []definitions.ExtraConfiguration{extraConfig}, nil
 	}
 

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/grafana/alerting/definition"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
@@ -392,54 +393,59 @@ func (moa *MultiOrgAlertmanager) modifyAndApplyExtraConfiguration(
 	org int64,
 	modifyFn func([]definitions.ExtraConfiguration) ([]definitions.ExtraConfiguration, error),
 	dryRun bool,
-) error {
+) (definition.RenameResources, error) {
 	currentCfg, err := moa.configStore.GetLatestAlertmanagerConfiguration(ctx, org)
 	if err != nil {
-		return fmt.Errorf("failed to get current configuration: %w", err)
+		return definition.RenameResources{}, fmt.Errorf("failed to get current configuration: %w", err)
 	}
 
 	cfg, err := Load([]byte(currentCfg.AlertmanagerConfiguration))
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal current alertmanager configuration: %w", err)
+		return definition.RenameResources{}, fmt.Errorf("failed to unmarshal current alertmanager configuration: %w", err)
 	}
 
 	cfg.ExtraConfigs, err = modifyFn(cfg.ExtraConfigs)
 	if err != nil {
-		return fmt.Errorf("failed to apply extra configuration: %w", err)
+		return definition.RenameResources{}, fmt.Errorf("failed to apply extra configuration: %w", err)
 	}
 
 	if len(cfg.ManagedRoutes) > 0 {
 		for _, c := range cfg.ExtraConfigs {
 			if _, ok := cfg.ManagedRoutes[c.Identifier]; ok {
-				return ErrIdentifierAlreadyExists.Build(errutil.TemplateData{Public: map[string]interface{}{"Identifier": c.Identifier}})
+				return definition.RenameResources{}, ErrIdentifierAlreadyExists.Build(errutil.TemplateData{Public: map[string]interface{}{"Identifier": c.Identifier}})
 			}
 		}
 	}
 
+	merge, err := cfg.GetMergedAlertmanagerConfig()
+	if err != nil {
+		return definition.RenameResources{}, fmt.Errorf("cannot merge imported configuration into Grafana: %w", err)
+	}
+
 	if dryRun {
 		moa.logger.Debug("Dry run: extra configuration validated successfully", "org", org)
-		return nil
+		return merge.RenameResources, nil
 	}
 
 	am, err := moa.AlertmanagerFor(org)
 	if err != nil {
 		// It's okay if the alertmanager isn't ready yet, we're changing its config anyway.
 		if !errors.Is(err, ErrAlertmanagerNotReady) {
-			return err
+			return definition.RenameResources{}, err
 		}
 	}
 
 	if err := am.SaveAndApplyConfig(ctx, cfg); err != nil {
 		moa.logger.Error("Unable to save and apply alertmanager configuration with extra config", "error", err, "org", org)
-		return AlertmanagerConfigRejectedError{err}
+		return definition.RenameResources{}, AlertmanagerConfigRejectedError{err}
 	}
 
 	moa.logger.Info("Applied alertmanager configuration with extra config", "org", org)
-	return nil
+	return merge.RenameResources, nil
 }
 
 // SaveAndApplyExtraConfiguration adds or replaces an ExtraConfiguration while preserving the main AlertmanagerConfig.
-func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, extraConfig definitions.ExtraConfiguration, replace bool, dryRun bool) error {
+func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, extraConfig definitions.ExtraConfiguration, replace bool, dryRun bool) (definition.RenameResources, error) {
 	modifyFunc := func(configs []definitions.ExtraConfiguration) ([]definitions.ExtraConfiguration, error) {
 		if !replace {
 			// for now we validate that after the update there will be just one extra config.
@@ -452,9 +458,9 @@ func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Cont
 		return []definitions.ExtraConfiguration{extraConfig}, nil
 	}
 
-	err := moa.modifyAndApplyExtraConfiguration(ctx, org, modifyFunc, dryRun)
+	renamed, err := moa.modifyAndApplyExtraConfiguration(ctx, org, modifyFunc, dryRun)
 	if err != nil {
-		return err
+		return definition.RenameResources{}, err
 	}
 
 	if dryRun {
@@ -462,7 +468,7 @@ func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Cont
 	} else {
 		moa.logger.Info("Applied alertmanager configuration with extra config", "org", org, "identifier", extraConfig.Identifier)
 	}
-	return nil
+	return renamed, nil
 }
 
 // DeleteExtraConfiguration deletes an ExtraConfiguration by its identifier while preserving the main AlertmanagerConfig.
@@ -477,7 +483,8 @@ func (moa *MultiOrgAlertmanager) DeleteExtraConfiguration(ctx context.Context, o
 		return filtered, nil
 	}
 
-	return moa.modifyAndApplyExtraConfiguration(ctx, org, modifyFunc, false)
+	_, err := moa.modifyAndApplyExtraConfiguration(ctx, org, modifyFunc, false)
+	return err
 }
 
 // assignReceiverConfigsUIDs assigns missing UUIDs to receiver configs.

--- a/pkg/services/ngalert/notifier/alertmanager_config_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config_test.go
@@ -25,7 +25,7 @@ func TestMultiOrgAlertmanager_SaveAndApplyExtraConfiguration(t *testing.T) {
   receiver: test-receiver`,
 		}
 
-		err := mam.SaveAndApplyExtraConfiguration(ctx, 999, extraConfig, false, false)
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, 999, extraConfig, false, false)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "failed to get current configuration")
 	})
@@ -45,8 +45,10 @@ receivers:
   - name: test-receiver`,
 		}
 
-		err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, extraConfig, false, false)
+		renamed, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, extraConfig, false, false)
 		require.NoError(t, err)
+		require.Empty(t, renamed.Receivers, "no renaming should occur")
+		require.Empty(t, renamed.TimeIntervals, "no renaming should occur")
 
 		gettableConfig, err := mam.GetAlertmanagerConfiguration(ctx, orgID, false, false)
 		require.NoError(t, err)
@@ -79,7 +81,7 @@ receivers:
 		}
 
 		// Call with dryRun=true
-		err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, extraConfig, false, true)
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, extraConfig, false, true)
 		require.NoError(t, err)
 
 		// Verify configuration was NOT saved
@@ -105,7 +107,7 @@ receivers:
   - name: original-receiver`,
 		}
 
-		err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, originalConfig, false, false)
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, originalConfig, false, false)
 		require.NoError(t, err)
 
 		// Now replace it
@@ -119,7 +121,7 @@ receivers:
   - name: updated-receiver`,
 		}
 
-		err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, updatedConfig, false, false)
+		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, updatedConfig, false, false)
 		require.NoError(t, err)
 
 		// Verify only one config exists with updated content
@@ -150,7 +152,7 @@ receivers:
 			}`,
 		}
 
-		err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, firstConfig, false, false)
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, firstConfig, false, false)
 		require.NoError(t, err)
 
 		secondConfig := definitions.ExtraConfiguration{
@@ -168,13 +170,13 @@ receivers:
 			}`,
 		}
 
-		err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, secondConfig, false, false)
+		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, secondConfig, false, false)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "multiple extra configurations are not supported")
 		require.ErrorContains(t, err, "first-config")
 
 		t.Run("replaces if replace=true", func(t *testing.T) {
-			err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, secondConfig, true, false)
+			_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, secondConfig, true, false)
 			require.NoError(t, err)
 
 			gettableConfig, err := mam.GetAlertmanagerConfiguration(ctx, orgID, false, false)
@@ -220,7 +222,7 @@ receivers:
   - name: original-receiver`,
 		}
 
-		err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, originalConfig, false, false)
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, originalConfig, false, false)
 		require.ErrorIs(t, err, ErrIdentifierAlreadyExists)
 	})
 }
@@ -243,8 +245,10 @@ receivers:
   - name: extra-receiver`,
 		}
 
-		err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, extraConfig, false, false)
+		renamed, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, extraConfig, false, false)
 		require.NoError(t, err)
+		require.Empty(t, renamed.Receivers, "no renaming should occur")
+		require.Empty(t, renamed.TimeIntervals, "no renaming should occur")
 
 		// Verify extra config was saved
 		gettableConfig, err := mam.GetAlertmanagerConfiguration(ctx, orgID, false, false)
@@ -502,8 +506,10 @@ receivers:
   - name: test-receiver`,
 		}
 
-		err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, extraConfig, false, false)
+		renamed, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, extraConfig, false, false)
 		require.NoError(t, err)
+		require.Empty(t, renamed.Receivers, "no renaming should occur")
+		require.Empty(t, renamed.TimeIntervals, "no renaming should occur")
 
 		gettableConfig, err := mam.GetAlertmanagerConfiguration(ctx, orgID, false, false)
 		require.NoError(t, err)

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -1293,7 +1293,7 @@ func (a apiClient) ConvertPrometheusDeleteNamespace(t *testing.T, namespaceTitle
 	requireStatusCode(t, http.StatusAccepted, status, raw)
 }
 
-func (a apiClient) ConvertPrometheusPostAlertmanagerConfig(t *testing.T, amCfg apimodels.AlertmanagerUserConfig, headers map[string]string) apimodels.ConvertPrometheusResponse {
+func (a apiClient) ConvertPrometheusPostAlertmanagerConfig(t *testing.T, amCfg apimodels.AlertmanagerUserConfig, headers map[string]string) apimodels.ConvertAlertmanagerResponse {
 	t.Helper()
 
 	resp, status, body := a.RawConvertPrometheusPostAlertmanagerConfig(t, amCfg, headers)
@@ -1302,7 +1302,7 @@ func (a apiClient) ConvertPrometheusPostAlertmanagerConfig(t *testing.T, amCfg a
 	return resp
 }
 
-func (a apiClient) RawConvertPrometheusPostAlertmanagerConfig(t *testing.T, amCfg apimodels.AlertmanagerUserConfig, headers map[string]string) (apimodels.ConvertPrometheusResponse, int, string) {
+func (a apiClient) RawConvertPrometheusPostAlertmanagerConfig(t *testing.T, amCfg apimodels.AlertmanagerUserConfig, headers map[string]string) (apimodels.ConvertAlertmanagerResponse, int, string) {
 	t.Helper()
 
 	path := "%s/api/convert/api/v1/alerts"
@@ -1328,7 +1328,7 @@ func (a apiClient) RawConvertPrometheusPostAlertmanagerConfig(t *testing.T, amCf
 		req.Header.Set(key, value)
 	}
 
-	return sendRequestJSON[apimodels.ConvertPrometheusResponse](t, req, http.StatusAccepted)
+	return sendRequestJSON[apimodels.ConvertAlertmanagerResponse](t, req, http.StatusAccepted)
 }
 
 func (a apiClient) ConvertPrometheusGetAlertmanagerConfig(t *testing.T, headers map[string]string) apimodels.AlertmanagerUserConfig {


### PR DESCRIPTION
**What is this feature?**

This update introduces enhanced configuration management for Alertmanager. Key changes include:
- Added support for a `dryRun` flag in `SaveAndApplyExtraConfiguration` to validate configurations without saving them. A new API header, `X-Grafana-Alerting-Dry-Run`, enables this functionality.
- Introduced a `replace` flag in `SaveAndApplyExtraConfiguration` to allow replacing existing configurations. The new API header, `X-Grafana-Alerting-Config-Force-Replace`, facilitates forced replacements.
- Updated integration tests to ensure functionality and reliability of the new features.

**Which issue(s) does this PR fix?**:

Related https://github.com/grafana/alerting-squad/issues/1393