### PR TITLE
Cloudwatch: Rename X-Ray to Application Signals

### DIFF
--- a/docs/sources/datasources/aws-cloudwatch/configure/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/configure/index.md
@@ -95,15 +95,15 @@ You must use both an access key ID and a secret access key to authenticate.
 | **Query timeout result** | Grafana polls CloudWatch Logs every second until AWS returns a `Done` status or the timeout is reached. An error is returned if the timeout is exceeded. For alerting, the timeout defined in the Grafana configuration file takes precedence. Enter a valid duration string, such as `30m`, `30s` or `200ms`. The default is `30m`. |
 | **Default Log Groups**   | _Optional_. Specify the default log groups for CloudWatch Logs queries.                                                                                                                                                                                                                                                              |
 
-**X-Ray trace link:**
+**Application Signals trace link:**
 
 | Setting         | Description                                           |
 | --------------- | ----------------------------------------------------- |
-| **Data source** | Select the X-Ray data source from the drop-down menu. |
+| **Data source** | Select the Application Signals data source from the drop-down menu. |
 
-Grafana automatically creates a link to a trace in X-Ray data source if logs contain the `@xrayTraceId` field. To use this feature, you must already have an X-Ray data source configured. For details, see the [X-Ray data source docs](/grafana/plugins/grafana-X-Ray-datasource/). To view the X-Ray link, select the log row in either the Explore view or dashboard [Logs panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/logs/) to view the log details section.
+Grafana automatically creates a link to a trace in Application Signals data source if logs contain the `@xrayTraceId` field. To use this feature, you must already have an Application Signals data source configured. For details, see the [Application Signals data source docs](/docs/plugins/grafana-x-ray-datasource/). To view the Application Signals link, select the log row in either the Explore view or dashboard [Logs panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/logs/) to view the log details section.
 
-To log the `@xrayTraceId`, refer to the [AWS X-Ray documentation](https://docs.aws.amazon.com/xray/latest/devguide/xray-services.html). To provide the field to Grafana, your log queries must also contain the `@xrayTraceId` field, for example by using the query `fields @message, @xrayTraceId`.
+To log the `@xrayTraceId`, refer to the [AWS Application Signals documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html). To provide the field to Grafana, your log queries must also contain the `@xrayTraceId` field, for example by using the query `fields @message, @xrayTraceId`.
 
 **Private data source connect** - _Only for Grafana Cloud users._
 

--- a/docs/sources/datasources/aws-cloudwatch/configure/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/configure/index.md
@@ -97,8 +97,8 @@ You must use both an access key ID and a secret access key to authenticate.
 
 **Application Signals trace link:**
 
-| Setting         | Description                                           |
-| --------------- | ----------------------------------------------------- |
+| Setting         | Description                                                         |
+| --------------- | ------------------------------------------------------------------- |
 | **Data source** | Select the Application Signals data source from the drop-down menu. |
 
 Grafana automatically creates a link to a trace in Application Signals data source if logs contain the `@xrayTraceId` field. To use this feature, you must already have an Application Signals data source configured. For details, see the [Application Signals data source docs](/docs/plugins/grafana-x-ray-datasource/). To view the Application Signals link, select the log row in either the Explore view or dashboard [Logs panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/logs/) to view the log details section.

--- a/docs/sources/datasources/aws-cloudwatch/troubleshooting/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/troubleshooting/index.md
@@ -448,19 +448,19 @@ These issues don't produce specific error messages but are commonly encountered.
 1. Ensure the IAM policy grants access to the required services (EC2, Lambda, RDS, etc.).
 1. Verify resources exist and are emitting metrics in the selected region.
 
-### X-Ray trace links not appearing
+### Application Signals trace links not appearing
 
 **Symptoms:**
 
-- Log entries don't show X-Ray trace links
+- Log entries don't show Application Signals trace links
 - `@xrayTraceId` field not appearing
 
 **Solutions:**
 
-1. Verify an X-Ray data source is configured and linked in the CloudWatch data source settings.
+1. Verify an Application Signals data source is configured and linked in the CloudWatch data source settings.
 1. Ensure your logs contain the `@xrayTraceId` field.
 1. Update log queries to include `@xrayTraceId` in the fields, for example: `fields @message, @xrayTraceId`.
-1. Configure your application to log X-Ray trace IDs. Refer to the [AWS X-Ray documentation](https://docs.aws.amazon.com/xray/latest/devguide/xray-services.html).
+1. Configure your application to log Application Signals trace IDs. Refer to the [AWS Application Signals documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html).
 
 ## Enable debug logging
 

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/XrayLinkConfig.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/XrayLinkConfig.tsx
@@ -38,7 +38,11 @@ export function XrayLinkConfig({ newFormStyling, datasourceUid, onChange }: Prop
           severity="info"
         />
       )}
-      <Field htmlFor="data-source-picker" label="Data source" description="Application Signals data source containing traces">
+      <Field
+        htmlFor="data-source-picker"
+        label="Data source"
+        description="Application Signals data source containing traces"
+      >
         <DataSourcePicker
           pluginId={xRayDsId}
           onChange={(ds: DataSourceInstanceSettings) => onChange(ds.uid)}
@@ -52,7 +56,8 @@ export function XrayLinkConfig({ newFormStyling, datasourceUid, onChange }: Prop
       <h3 className="page-heading">Application Signals trace link</h3>
 
       <div className={styles.infoText}>
-        Grafana will automatically create a link to a trace in Application Signals data source if logs contain @xrayTraceId field
+        Grafana will automatically create a link to a trace in Application Signals data source if logs contain
+        @xrayTraceId field
       </div>
 
       {!hasXrayDatasource && (

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/XrayLinkConfig.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/XrayLinkConfig.tsx
@@ -27,18 +27,18 @@ export function XrayLinkConfig({ newFormStyling, datasourceUid, onChange }: Prop
 
   return newFormStyling ? (
     <ConfigSection
-      title="X-ray trace link"
-      description="Grafana will automatically create a link to a trace in X-ray data source if logs contain @xrayTraceId field"
+      title="Application Signals trace link"
+      description="Grafana will automatically create a link to a trace in Application Signals data source if logs contain @xrayTraceId field"
     >
       {!hasXrayDatasource && (
         <Alert
           title={
-            'There is no X-ray datasource to link to. First add an X-ray data source and then link it to Cloud Watch. '
+            'There is no Application Signals datasource to link to. First add an Application Signals data source and then link it to Cloud Watch. '
           }
           severity="info"
         />
       )}
-      <Field htmlFor="data-source-picker" label="Data source" description="X-ray data source containing traces">
+      <Field htmlFor="data-source-picker" label="Data source" description="Application Signals data source containing traces">
         <DataSourcePicker
           pluginId={xRayDsId}
           onChange={(ds: DataSourceInstanceSettings) => onChange(ds.uid)}
@@ -49,16 +49,16 @@ export function XrayLinkConfig({ newFormStyling, datasourceUid, onChange }: Prop
     </ConfigSection>
   ) : (
     <>
-      <h3 className="page-heading">X-ray trace link</h3>
+      <h3 className="page-heading">Application Signals trace link</h3>
 
       <div className={styles.infoText}>
-        Grafana will automatically create a link to a trace in X-ray data source if logs contain @xrayTraceId field
+        Grafana will automatically create a link to a trace in Application Signals data source if logs contain @xrayTraceId field
       </div>
 
       {!hasXrayDatasource && (
         <Alert
           title={
-            'There is no X-ray datasource to link to. First add an X-ray data source and then link it to Cloud Watch. '
+            'There is no Application Signals datasource to link to. First add an Application Signals data source and then link it to Cloud Watch. '
           }
           severity="info"
         />
@@ -69,7 +69,7 @@ export function XrayLinkConfig({ newFormStyling, datasourceUid, onChange }: Prop
           htmlFor="data-source-picker"
           label="Data source"
           labelWidth={28}
-          tooltip="X-ray data source containing traces"
+          tooltip="Application Signals data source containing traces"
         >
           <DataSourcePicker
             pluginId={xRayDsId}


### PR DESCRIPTION
AWS has renamed the X-Ray service to Application Signals and we should too.
This pr ports:
- https://github.com/grafana/grafana-cloudwatch-datasource/pull/335
- https://github.com/grafana/grafana-cloudwatch-datasource/pull/284

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
