### PR TITLE
AppInstaller: Allow custom auth registration

### DIFF
--- a/pkg/services/apiserver/appinstaller/installer.go
+++ b/pkg/services/apiserver/appinstaller/installer.go
@@ -50,6 +50,13 @@ type ClusterScopedStorageAuthorizerProvider interface {
 	GetClusterScopedStorageAuthorizer(gr schema.GroupResource) storewrapper.ResourceStorageAuthorizer
 }
 
+// NamespaceScopedStorageAuthorizerProvider allows apps to provide custom authorizers for namespace-scoped resources.
+// Apps can optionally implement this interface to add storage-level authorization.
+type NamespaceScopedStorageAuthorizerProvider interface {
+	// return nil to skip
+	GetNamespaceScopedStorageAuthorizer(gr schema.GroupResource) storewrapper.ResourceStorageAuthorizer
+}
+
 type AppInstallerConfig struct {
 	CustomConfig             any
 	AllowedV0Alpha1Resources []string

--- a/pkg/services/apiserver/appinstaller/installer.go
+++ b/pkg/services/apiserver/appinstaller/installer.go
@@ -50,8 +50,10 @@ type ClusterScopedStorageAuthorizerProvider interface {
 	GetClusterScopedStorageAuthorizer(gr schema.GroupResource) storewrapper.ResourceStorageAuthorizer
 }
 
-// NamespaceScopedStorageAuthorizerProvider allows apps to provide custom authorizers for namespace-scoped resources.
-// Apps can optionally implement this interface to add storage-level authorization.
+// NamespaceScopedStorageAuthorizerProvider allows apps to provide custom authorizers on the storage layer,
+// specifically when they are needing to authorize based on the name of the resource (and need to filter lists accordingly)
+// or if they need the spec of the object.
+// Optional to implement.
 type NamespaceScopedStorageAuthorizerProvider interface {
 	// return nil to skip
 	GetNamespaceScopedStorageAuthorizer(gr schema.GroupResource) storewrapper.ResourceStorageAuthorizer

--- a/pkg/services/apiserver/appinstaller/server.go
+++ b/pkg/services/apiserver/appinstaller/server.go
@@ -119,6 +119,15 @@ func (s *serverWrapper) configureStorage(gr schema.GroupResource, dualWriteSuppo
 		if isNamespaced {
 			gs.KeyFunc = grafanaregistry.NamespaceKeyFunc(gr)
 			gs.KeyRootFunc = grafanaregistry.KeyRootFunc(gr)
+
+			// check if the app provides a custom storage authorizer for namespace-scoped resources
+			if provider, ok := s.installer.(NamespaceScopedStorageAuthorizerProvider); ok {
+				authz := provider.GetNamespaceScopedStorageAuthorizer(gr)
+				if authz != nil {
+					return storewrapper.New(gs, authz)
+				}
+			}
+
 			return gs
 		}
 


### PR DESCRIPTION
This PR allows us to wrap the storage layer with proper auth for apps. This is needed for resources that are using the `name` to store information like dsUID, and need to filter listing on them. The `Authorize()` function isn't sufficient there.

Needed for https://github.com/grafana/grafana-enterprise/pull/10875