### PR TITLE
Transformations: Fix bug in "Config from query results"

### DIFF
--- a/public/app/features/transformers/configFromQuery/configFromQuery.test.ts
+++ b/public/app/features/transformers/configFromQuery/configFromQuery.test.ts
@@ -27,6 +27,16 @@ describe('config from data', () => {
     ],
   });
 
+  it('should return data unchanged when configRefId does not match any frame', () => {
+    const options: ConfigFromQueryTransformOptions = {
+      configRefId: 'missing',
+      mappings: [],
+    };
+
+    const results = extractConfigFromQuery(options, [config, seriesA]);
+    expect(results).toEqual([config, seriesA]);
+  });
+
   it('Select and apply with two frames and default mappings and reducer', () => {
     const options: ConfigFromQueryTransformOptions = {
       configRefId: 'A',

--- a/public/app/features/transformers/configFromQuery/configFromQuery.ts
+++ b/public/app/features/transformers/configFromQuery/configFromQuery.ts
@@ -65,9 +65,8 @@ export function extractConfigFromQuery(options: ConfigFromQueryTransformOptions,
     }
 
     const outputFrame: DataFrame = {
+      ...frame,
       fields: [],
-      length: frame.length,
-      refId: frame.refId,
     };
 
     for (const field of frame.fields) {


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->

This PR fixes #81240.

### RCA for #81240

Currently, the `configFromData` transformer constructs new output frames with only `fields`, `length`, and `refId`, dropping `frame.name` and `frame.meta`. An unintended consequence of this is that series names are lost when the datasource uses `frame.name` for series identity (as opposed to field names, labels, or `config.displayName`).

This manifests with datasources that (in some query configurations) return multiple frames with distinct `frame.name` values and generic field names (e.g. JSON, SNMP, some Prometheus response formats). In these cases, all series fall back to the generic field name (like "Value") in legends and tooltips, making them indistinguishable from each other.

## Changes
<!--- Describe your changes in detail -->
In `transformers/configFromQuery/configFromQuery.ts`, instead of just passing the `redId` and `length` to the output frame, we instead spread all properties of the frame (except for `fields`) to the output frame.
- This allows the `frame.name` to be set in the output frame, so that the panel doesn't fall back to using the field name ("Value") for the series legend.
- This is a pattern that's used in other transformations, for example:

https://github.com/grafana/grafana/blob/66bfe236687da04917df9c09eb8f743d1cddcf0a/packages/grafana-data/src/transformations/transformers/filter.ts#L70-L74

https://github.com/grafana/grafana/blob/66bfe236687da04917df9c09eb8f743d1cddcf0a/packages/grafana-data/src/transformations/transformers/reduce.ts#L156-L160

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->

None identified.

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->

### On `main`

Multiple series are improperly labeled as `Value` in the legend:

<img width="956" height="613" alt="repro main" src="https://github.com/user-attachments/assets/ff78b1ff-217a-4af7-b18b-9488575e4317" />

### On `81240/config-from-query-results-fix-missing-field-name`

The series have distinct names in the legend, that come from `frame` properties:

<img width="956" height="613" alt="fix on feature branch" src="https://github.com/user-attachments/assets/527cf62d-cb7b-48ac-b64d-703e602679ba" />

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->

Import this dashboard, which depends on the `gdev-testdata` datasource: [Config from query - frame name bug repro-1771039918566.json](https://github.com/user-attachments/files/25310241/Config.from.query.-.frame.name.bug.repro-1771039918566.json)

Next, check out the dashboard on `main` and notice that the legend matches the **Demo** > **On `main`** above.

Finally, check out the dashboard on `main` and notice that the legend matches the **Demo** > **On `81240/config-from-query-results-fix-missing-field-name`** above.

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable