### PR TITLE
Provisioning: Only dual write when sync is enabled

### DIFF
--- a/pkg/registry/apis/provisioning/resources/dualwriter.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter.go
@@ -632,5 +632,10 @@ func (r *DualReadWriter) shouldUpdateGrafanaDB(opts DualWriteOptions, parsed *Pa
 		return false
 	}
 
+	// Only dual write if sync is enabled
+	if !r.repo.Config().Spec.Sync.Enabled {
+		return false
+	}
+
 	return r.isConfiguredBranch(opts)
 }


### PR DESCRIPTION
While prototyping running a repository that is entirely external (`sync.enabled = false`) -- everythign works great until you save a file and it fails because the root folder does not exist in grafana.

This PR makes sure sync is enabled before dual writing