### PR TITLE
Watch: Add watcher lifecycle management for scalability

### DIFF
--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -174,7 +174,9 @@ func ProvideService(cfg *setting.Cfg, routeRegister routing.RouteRegister, plugC
 	}
 	g.GrafanaScope.Dashboards = dash
 	g.GrafanaScope.Features["dashboard"] = dash
-	g.GrafanaScope.Features["watch"] = features.NewWatchRunner(g.Publish, configProvider)
+	g.GrafanaScope.Features["watch"] = features.NewWatchRunner(g.Publish, configProvider, func(ns string, channel string) (int, error) {
+		return node.Hub().NumSubscribers(orgchannel.PrependK8sNamespace(ns, channel)), nil
+	})
 
 	g.surveyCaller = survey.NewCaller(managedStreamRunner, node)
 	err = g.surveyCaller.SetupHandlers()


### PR DESCRIPTION
**What is this feature?**

Adds subscriber tracking and context cancellation to watch channels to prevent resource exhaustion and goroutine leaks.

**Why do we need this feature?**

Watch channels currently never clean up watchers when subscribers disconnect. With multiple concurrent users, unused K8s watch connections and goroutines accumulate indefinitely, causing scalability issues. This implements automatic cleanup after 15 seconds of zero active subscribers.



