### PR TITLE
[release-11.6.11] CI: Disable verify pipeline in release-11.6.11

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -142,31 +142,31 @@ jobs:
         include:
           - name: linux-amd64 # publish-npm relies on this step building npm packages
             artifacts: targz:grafana:linux/amd64,deb:grafana:linux/amd64,rpm:grafana:linux/amd64,docker:grafana:linux/amd64,docker:grafana:linux/amd64:ubuntu,npm:grafana,storybook
-            verify: true
+            verify: false
           - name: linux-arm64
             artifacts: targz:grafana:linux/arm64,deb:grafana:linux/arm64,rpm:grafana:linux/arm64,docker:grafana:linux/arm64,docker:grafana:linux/arm64:ubuntu
             verify: false
           - name: linux-s390x
             artifacts: targz:grafana:linux/s390x,deb:grafana:linux/s390x,rpm:grafana:linux/s390x,docker:grafana:linux/s390x,docker:grafana:linux/s390x:ubuntu
-            verify: true
+            verify: false
           - name: linux-armv7
             artifacts: targz:grafana:linux/arm/v7,deb:grafana:linux/arm/v7,docker:grafana:linux/arm/v7,docker:grafana:linux/arm/v7:ubuntu
-            verify: true
+            verify: false
           - name: linux-armv6
             artifacts: targz:grafana:linux/arm/v6,deb:grafana:linux/arm/v6
-            verify: true
+            verify: false
           - name: windows-amd64
             artifacts: targz:grafana:windows/amd64,zip:grafana:windows/amd64,msi:grafana:windows/amd64
-            verify: true
+            verify: false
           - name: windows-arm64
             artifacts: targz:grafana:windows/arm64,zip:grafana:windows/arm64
-            verify: true
+            verify: false
           - name: darwin-amd64
             artifacts: targz:grafana:darwin/amd64
-            verify: true
+            verify: false
           - name: darwin-arm64
             artifacts: targz:grafana:darwin/arm64
-            verify: true
+            verify: false
     steps:
       - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2
       - uses: actions/checkout@v5


### PR DESCRIPTION
Currently, chrome fails to install due to a gpg issue.