### PR TITLE
Combobox: Migrate to isItemDisabled API

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -261,6 +261,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     items: filteredOptions,
     itemToString,
     selectedItem,
+    isItemDisabled: (item) => !!item?.infoOption,
 
     // Don't change downshift state in the onBlahChange handlers. Instead, use the stateReducer to make changes.
     // Downshift calls change handlers on the render after so you can get sync/flickering issues if you change its state

--- a/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
+++ b/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
@@ -130,7 +130,6 @@ export const ComboboxList = <T extends string | number>({
                   index: virtualRow.index,
                   id: itemId,
                   'aria-describedby': groupHeaderId,
-                  disabled: item.infoOption,
                 })}
               >
                 {isMultiSelect && (

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
@@ -160,6 +160,7 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
     inputId: id,
     inputValue,
     selectedItem: null,
+    isItemDisabled: (item) => !!item?.infoOption,
     stateReducer: (state, actionAndChanges) => {
       const { type } = actionAndChanges;
       let { changes } = actionAndChanges;


### PR DESCRIPTION
**What is this feature?**

Migrates the Combobox and MultiCombobox components to use the `isItemDisabled` callback API instead of the deprecated `disabled` prop in `getItemProps()`.

**Why do we need this feature?**

 This fixes the console warning:

<img width="720" height="82" alt="Screenshot 2026-02-12 at 13 02 43" src="https://github.com/user-attachments/assets/a5f46f63-d94b-4992-8a1a-4404181a7353" />
