### PR TITLE
Provisioning: Allow non-admin users to receive watch events

### DIFF
--- a/pkg/services/live/features/watch.go
+++ b/pkg/services/live/features/watch.go
@@ -59,11 +59,6 @@ func (b *WatchRunner) OnSubscribe(_ context.Context, u identity.Requester, e mod
 		return model.SubscribeReply{}, backend.SubscribeStreamStatusPermissionDenied, fmt.Errorf("path must end with user uid (%s)", userID)
 	}
 
-	// While testing with provisioning repositories, we will limit this to admin only
-	if !u.HasRole(identity.RoleAdmin) {
-		return model.SubscribeReply{}, backend.SubscribeStreamStatusPermissionDenied, fmt.Errorf("only admin users for now")
-	}
-
 	b.watchingMu.Lock()
 	defer b.watchingMu.Unlock()
 


### PR DESCRIPTION
**What is this feature?**

Remove the temporary admin-only restriction on watch subscriptions in Grafana Live channels that was preventing non-admin users from receiving real-time updates on provisioning resources.

**Why do we need this feature?**

Non-admin users (Editors) can perform bulk operations on provisioned resources (delete/move via browse dashboards), but they were unable to receive watch events. This caused the UI to get stuck in "progress" mode indefinitely because the watch subscription failed with `PermissionDenied`.

**Who is this feature for?**

Non-admin users (Editors and above) who perform bulk operations on provisioned resources.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/876
