### PR TITLE
APIServer: Surface watch errors in the UI

### DIFF
--- a/pkg/services/live/features/watch.go
+++ b/pkg/services/live/features/watch.go
@@ -59,12 +59,6 @@ func (b *WatchRunner) OnSubscribe(_ context.Context, u identity.Requester, e mod
 		return model.SubscribeReply{}, backend.SubscribeStreamStatusPermissionDenied, fmt.Errorf("path must end with user uid (%s)", userID)
 	}
 
-	// TODO: This is only for testing and needs to be removed later.
-	// While testing with provisioning repositories, we will limit this to admin only
-	if !u.HasRole(identity.RoleAdmin) {
-		return model.SubscribeReply{}, backend.SubscribeStreamStatusPermissionDenied, fmt.Errorf("only admin users for now")
-	}
-
 	b.watchingMu.Lock()
 	defer b.watchingMu.Unlock()
 

--- a/pkg/services/live/features/watch.go
+++ b/pkg/services/live/features/watch.go
@@ -59,6 +59,12 @@ func (b *WatchRunner) OnSubscribe(_ context.Context, u identity.Requester, e mod
 		return model.SubscribeReply{}, backend.SubscribeStreamStatusPermissionDenied, fmt.Errorf("path must end with user uid (%s)", userID)
 	}
 
+	// TODO: This is only for testing and needs to be removed later.
+	// While testing with provisioning repositories, we will limit this to admin only
+	if !u.HasRole(identity.RoleAdmin) {
+		return model.SubscribeReply{}, backend.SubscribeStreamStatusPermissionDenied, fmt.Errorf("only admin users for now")
+	}
+
 	b.watchingMu.Lock()
 	defer b.watchingMu.Unlock()
 

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -883,7 +883,7 @@ func subscribeStatusToCentrifugeError(status backend.SubscribeStreamStatus) *cen
 	case backend.SubscribeStreamStatusNotFound:
 		return centrifuge.ErrorUnknownChannel
 	case backend.SubscribeStreamStatusPermissionDenied:
-		return centrifuge.ErrorUnauthorized
+		return centrifuge.ErrorPermissionDenied
 	default:
 		return centrifuge.ErrorInternal
 	}

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -747,6 +747,9 @@ func (g *GrafanaLive) handleOnSubscribe(clientContextWithSpan context.Context, c
 		})
 		if err != nil {
 			logger.Error("Error calling channel handler subscribe", "user", client.UserID(), "client", client.ID(), "channel", e.Channel, "error", err)
+			if status != backend.SubscribeStreamStatusOK {
+				return centrifuge.SubscribeReply{}, subscribeStatusToCentrifugeError(status)
+			}
 			return centrifuge.SubscribeReply{}, centrifuge.ErrorInternal
 		}
 	}
@@ -873,6 +876,17 @@ func (g *GrafanaLive) handleOnPublish(clientCtxWithSpan context.Context, client 
 	}
 	logger.Debug("Publication successful", "user", client.UserID(), "client", client.ID(), "channel", e.Channel)
 	return centrifugeReply, nil
+}
+
+func subscribeStatusToCentrifugeError(status backend.SubscribeStreamStatus) *centrifuge.Error {
+	switch status {
+	case backend.SubscribeStreamStatusNotFound:
+		return centrifuge.ErrorUnknownChannel
+	case backend.SubscribeStreamStatusPermissionDenied:
+		return centrifuge.ErrorUnauthorized
+	default:
+		return centrifuge.ErrorInternal
+	}
 }
 
 func subscribeStatusToHTTPError(status backend.SubscribeStreamStatus) (int, string) {

--- a/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
+++ b/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
@@ -1,23 +1,33 @@
 import { Subscription } from 'rxjs';
 
+import { createErrorNotification } from 'app/core/copy/appNotification';
+import { notifyApp } from 'app/core/reducers/appNotification';
 import { ScopedResourceClient } from 'app/features/apiserver/client';
 import { ListOptions, GeneratedResourceList as ResourceList } from 'app/features/apiserver/types';
+
+interface OnCacheEntryAddedOptions {
+  showErrorNotification?: boolean;
+}
 
 /**
  * Creates a cache entry handler for RTK Query that watches for changes to a resource
  * and updates the cache accordingly.
  */
-export function createOnCacheEntryAdded<Spec, Status>(resourceName: string) {
+export function createOnCacheEntryAdded<Spec, Status>(resourceName: string, options: OnCacheEntryAddedOptions = {}) {
+  const { showErrorNotification = true } = options;
+
   return async function onCacheEntryAdded<List extends ResourceList<Spec, Status>>(
     arg: ListOptions | undefined,
     {
       updateCachedData,
       cacheDataLoaded,
       cacheEntryRemoved,
+      dispatch,
     }: {
       updateCachedData: (fn: (draft: List) => void) => void;
       cacheDataLoaded: Promise<{ data: List }>;
       cacheEntryRemoved: Promise<void>;
+      dispatch: (action: unknown) => void;
     }
   ) {
     if (!arg?.watch) {
@@ -36,25 +46,32 @@ export function createOnCacheEntryAdded<Spec, Status>(resourceName: string) {
       const response = await cacheDataLoaded;
       const resourceVersion = response.data.metadata?.resourceVersion;
 
-      subscription = client.watch({ resourceVersion }).subscribe((event) => {
-        updateCachedData((draft) => {
-          if (!draft.items) {
-            draft.items = [];
-          }
-          // Find the item with the matching name
-          const existingIndex = draft.items.findIndex((item) => item.metadata?.name === event.object.metadata.name);
+      subscription = client.watch({ resourceVersion }).subscribe({
+        next: (event) => {
+          updateCachedData((draft) => {
+            if (!draft.items) {
+              draft.items = [];
+            }
+            // Find the item with the matching name
+            const existingIndex = draft.items.findIndex((item) => item.metadata?.name === event.object.metadata.name);
 
-          if (event.type === 'ADDED' && existingIndex === -1) {
-            draft.items.push(event.object);
-          } else if (event.type === 'DELETED' && existingIndex !== -1) {
-            // Remove the item if it exists
-            draft.items.splice(existingIndex, 1);
-          } else if (existingIndex !== -1) {
-            // Could be ADDED or MODIFIED
-            // Update the existing item if it exists
-            draft.items[existingIndex] = event.object;
+            if (event.type === 'ADDED' && existingIndex === -1) {
+              draft.items.push(event.object);
+            } else if (event.type === 'DELETED' && existingIndex !== -1) {
+              // Remove the item if it exists
+              draft.items.splice(existingIndex, 1);
+            } else if (existingIndex !== -1) {
+              // Could be ADDED or MODIFIED
+              // Update the existing item if it exists
+              draft.items[existingIndex] = event.object;
+            }
+          });
+        },
+        error: (error) => {
+          if (showErrorNotification) {
+            dispatch(notifyApp(createErrorNotification('Error watching for resource updates', error)));
           }
-        });
+        },
       });
     } catch (error) {
       console.error('Error in onCacheEntryAdded:', error);

--- a/public/app/api/clients/provisioning/v0alpha1/index.ts
+++ b/public/app/api/clients/provisioning/v0alpha1/index.ts
@@ -57,7 +57,7 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
         // cached job to update — activeJob is already undefined, so the existing
         // FinishedJobStatus fallback handles it. We only need to set the error
         // status when there IS a cached job that would otherwise appear stuck.
-        onError: (error, { updateCachedData }) => {
+        onError: (error, updateCachedData) => {
           updateCachedData((draft) => {
             if (draft.items?.[0]) {
               draft.items[0].status = {

--- a/public/app/api/clients/provisioning/v0alpha1/index.ts
+++ b/public/app/api/clients/provisioning/v0alpha1/index.ts
@@ -52,9 +52,15 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
         params: queryArg,
       }),
       onCacheEntryAdded: createOnCacheEntryAdded<JobSpec, JobStatus>('jobs', {
-        onError: (_error, { updateCachedData }) => {
+        onError: (error, { updateCachedData }) => {
           updateCachedData((draft) => {
-            draft.items = [];
+            if (draft.items?.[0]) {
+              draft.items[0].status = {
+                ...draft.items[0].status,
+                state: 'error',
+                message: String(error),
+              };
+            }
           });
         },
       }),

--- a/public/app/api/clients/provisioning/v0alpha1/index.ts
+++ b/public/app/api/clients/provisioning/v0alpha1/index.ts
@@ -52,6 +52,11 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
         params: queryArg,
       }),
       onCacheEntryAdded: createOnCacheEntryAdded<JobSpec, JobStatus>('jobs', {
+        // The listJob query is always scoped to a single job via fieldSelector,
+        // so items will contain at most one entry. If items is empty, there's no
+        // cached job to update — activeJob is already undefined, so the existing
+        // FinishedJobStatus fallback handles it. We only need to set the error
+        // status when there IS a cached job that would otherwise appear stuck.
         onError: (error, { updateCachedData }) => {
           updateCachedData((draft) => {
             if (draft.items?.[0]) {

--- a/public/app/api/clients/provisioning/v0alpha1/index.ts
+++ b/public/app/api/clients/provisioning/v0alpha1/index.ts
@@ -51,7 +51,13 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
         url: `/jobs`,
         params: queryArg,
       }),
-      onCacheEntryAdded: createOnCacheEntryAdded<JobSpec, JobStatus>('jobs'),
+      onCacheEntryAdded: createOnCacheEntryAdded<JobSpec, JobStatus>('jobs', {
+        onError: (_error, { updateCachedData }) => {
+          updateCachedData((draft) => {
+            draft.items = [];
+          });
+        },
+      }),
     },
     listRepository: {
       query: ({ watch, ...queryArg }) => ({

--- a/public/app/features/apiserver/client.ts
+++ b/public/app/features/apiserver/client.ts
@@ -70,7 +70,6 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
           }),
           filter((event) => isLiveChannelMessageEvent(event)),
           map((event) => event.message),
-          retry({ count: 3, delay: 1000 }),
           catchError((error) => {
             console.error('Live channel watch stream error:', error);
             throw error;

--- a/public/app/features/apiserver/client.ts
+++ b/public/app/features/apiserver/client.ts
@@ -1,6 +1,6 @@
 import { Observable, from, retry, catchError, filter, map, mergeMap } from 'rxjs';
 
-import { isLiveChannelMessageEvent, LiveChannelScope } from '@grafana/data';
+import { isLiveChannelMessageEvent, isLiveChannelStatusEvent, LiveChannelScope } from '@grafana/data';
 import { config, getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 
@@ -62,6 +62,12 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
           data: params?.resourceVersion ? { resourceVersion: params.resourceVersion } : undefined,
         })
         .pipe(
+          map((event) => {
+            if (isLiveChannelStatusEvent(event) && event.error) {
+              throw event.error;
+            }
+            return event;
+          }),
           filter((event) => isLiveChannelMessageEvent(event)),
           map((event) => event.message),
           retry({ count: 3, delay: 1000 }),
@@ -80,7 +86,13 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
         method: 'GET',
       })
       .pipe(
-        filter((response) => response.ok && response.data instanceof Uint8Array),
+        map((response) => {
+          if (!response.ok) {
+            throw new Error(`Watch request failed with status ${response.status}: ${response.statusText}`);
+          }
+          return response;
+        }),
+        filter((response) => response.data instanceof Uint8Array),
         map((response) => {
           const text = decoder.decode(response.data);
           return text.split('\n');

--- a/public/app/features/apiserver/client.ts
+++ b/public/app/features/apiserver/client.ts
@@ -70,6 +70,9 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
           }),
           filter((event) => isLiveChannelMessageEvent(event)),
           map((event) => event.message),
+          // No RxJS retry here — centrifuge handles transient reconnection
+          // at the protocol level. Non-temporary errors (e.g. permission denied)
+          // should surface immediately rather than being retried.
           catchError((error) => {
             console.error('Live channel watch stream error:', error);
             throw error;

--- a/public/app/features/live/centrifuge/channel.ts
+++ b/public/app/features/live/centrifuge/channel.ts
@@ -5,6 +5,7 @@ import {
   PublicationContext,
   SubscriptionErrorContext,
   SubscribedContext,
+  UnsubscribedContext,
 } from 'centrifuge';
 import { Subject, of, Observable } from 'rxjs';
 
@@ -101,9 +102,12 @@ export class CentrifugeLiveChannel<T = any> {
         }
         this.sendStatus(ctx.data);
       })
-      .on('unsubscribed', () => {
+      .on('unsubscribed', (ctx: UnsubscribedContext) => {
         this.currentStatus.timestamp = Date.now();
         this.currentStatus.state = LiveChannelConnectionState.Disconnected;
+        if (ctx.code >= 100) {
+          this.currentStatus.error = ctx.reason;
+        }
         this.sendStatus();
       })
       .on('subscribing', () => {


### PR DESCRIPTION
**What is this feature?**

When watch API calls fail (e.g., due to permission errors), errors are now propagated through the Observable pipeline and displayed as toast notifications to the user.

**Why do we need this feature?**

Previously, errors in watch calls were silently dropped by filters, causing the UI to appear stuck—particularly during bulk operations—since watch events never arrived and no error feedback was shown.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/877

**Special notes for your reviewer:**

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.