### PR TITLE
Alerting: Return 409 when attempting to delete a contact point that's in use (provisioning)

### DIFF
--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -364,7 +364,7 @@ func (ecp *ContactPointService) DeleteContactPoint(ctx context.Context, orgID in
 	for i, receiver := range revision.Config.AlertmanagerConfig.Receivers {
 		for j, grafanaReceiver := range receiver.GrafanaManagedReceivers {
 			if grafanaReceiver.UID == uid {
-				name = grafanaReceiver.Name
+				name = receiver.Name
 				receiver.GrafanaManagedReceivers = append(receiver.GrafanaManagedReceivers[:j], receiver.GrafanaManagedReceivers[j+1:]...)
 				// if this was the last receiver we removed, we remove the whole receiver
 				if len(receiver.GrafanaManagedReceivers) == 0 {

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -429,6 +429,15 @@ func TestIntegrationContactPointService(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("deleting a contact point referenced by a route returns ErrContactPointReferenced", func(t *testing.T) {
+		sut := createContactPointServiceSut(t, secretsService)
+
+		// UID1 is the sole integration in receiver "grafana-default-email",
+		// which is referenced in a route. Deleting it should fail with a conflict error.
+		err := sut.DeleteContactPoint(context.Background(), 1, "UID1")
+		require.ErrorIs(t, err, ErrContactPointReferenced)
+	})
 }
 
 func TestIntegrationContactPointServiceDecryptRedact(t *testing.T) {


### PR DESCRIPTION
### Description

Grafana returns a 500 status code when a user attempts to use provisioning to delete a contact point that's being used by an alert rule. 409 is a more appropriate status code.

### Testing

1. Create a contact point
2. Create an alert rule using that contact point (simplified routing)
3. Try to delete the contact point via `/v1/provisioning/contact-points/<uid>`
4. The status code should be 409, not 500
