### PR TITLE
Explore: AI-powered visualization suggestions

### DIFF
--- a/public/app/features/panel/components/VizTypePicker/VisualizationSuggestionCard.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationSuggestionCard.tsx
@@ -58,6 +58,10 @@ export function VisualizationSuggestionCard({
       suggestion.cardOptions.previewModifier(preview);
     }
 
+    // Clone so PanelRenderer can mutate (fixThresholds etc); plugin suggestions may be frozen
+    const options = preview.options ? cloneDeep(preview.options) : undefined;
+    const fieldConfig = preview.fieldConfig ? cloneDeep(preview.fieldConfig) : undefined;
+
     content = (
       <button {...commonButtonProps}>
         {/* to use inert in React 18, we have to do this hacky object spread thing. https://stackoverflow.com/questions/72720469/error-when-using-inert-attribute-with-typescript */}
@@ -72,8 +76,8 @@ export function VisualizationSuggestionCard({
             pluginId={suggestion.pluginId}
             width={renderWidth}
             height={renderHeight}
-            options={preview.options}
-            fieldConfig={preview.fieldConfig}
+            options={options}
+            fieldConfig={fieldConfig}
           />
         </div>
       </button>

--- a/public/app/features/panel/suggestions/ai/buildAIContext.ts
+++ b/public/app/features/panel/suggestions/ai/buildAIContext.ts
@@ -1,0 +1,231 @@
+import { DataFrame, FieldType, PanelData, PanelPluginMeta, PluginState } from '@grafana/data';
+import { DataSourceRef } from '@grafana/schema';
+import { config } from '@grafana/runtime';
+
+import {
+  AISuggestionContext,
+  DataSummary,
+  DatasourceInfo,
+  FieldInfo,
+  QueryMetadata,
+  VisualizationInfo,
+} from './types';
+
+const MAX_FRAMES = 3;
+const MAX_SAMPLE_VALUES = 3;
+
+/**
+ * Build the data summary from series
+ */
+function buildDataSummary(series: DataFrame[]): DataSummary {
+  let rowCountTotal = 0;
+  let rowCountMax = 0;
+  let fieldCount = 0;
+
+  for (const frame of series) {
+    rowCountTotal += frame.length;
+    rowCountMax = Math.max(rowCountMax, frame.length);
+    fieldCount += frame.fields.length;
+  }
+
+  // Determine if this is instant data (single row per frame)
+  const isInstant = series.length > 0 && series.every((frame) => frame.length <= 1);
+
+  return {
+    rowCountTotal,
+    rowCountMax,
+    fieldCount,
+    frameCount: series.length,
+    isInstant,
+  };
+}
+
+/**
+ * Extract field information with sample values from series
+ */
+function extractFieldInfo(series: DataFrame[]): FieldInfo[] {
+  const fields: FieldInfo[] = [];
+  const framesToProcess = series.slice(0, MAX_FRAMES);
+
+  for (const frame of framesToProcess) {
+    for (const field of frame.fields) {
+      // Get sample values (first 3)
+      const sampleValues: unknown[] = [];
+      for (let i = 0; i < Math.min(field.values.length, MAX_SAMPLE_VALUES); i++) {
+        sampleValues.push(field.values[i]);
+      }
+
+      fields.push({
+        name: field.name,
+        type: FieldType[field.type] ?? field.type,
+        sampleValues,
+      });
+    }
+  }
+
+  return fields;
+}
+
+/**
+ * Extract datasource information from panel data
+ */
+function getDatasourceInfo(data: PanelData): DatasourceInfo[] {
+  const targets = data.request?.targets ?? [];
+  const dsMap = new Map<string, DatasourceInfo>();
+
+  for (const target of targets) {
+    const ds = target.datasource as DataSourceRef | undefined;
+    if (ds?.type && !dsMap.has(ds.type)) {
+      dsMap.set(ds.type, { type: ds.type });
+    }
+  }
+
+  // If no datasources found, return unknown
+  if (dsMap.size === 0) {
+    return [{ type: 'unknown' }];
+  }
+
+  return Array.from(dsMap.values());
+}
+
+/**
+ * Extract query metadata from panel data
+ */
+function getQueryMetadata(data: PanelData): QueryMetadata {
+  const targets = data.request?.targets ?? [];
+
+  // Extract query types from targets
+  const queryTypes = [...new Set(targets.map((t) => t.queryType).filter((qt): qt is string => Boolean(qt)))];
+
+  // Extract preferred visualization types from series metadata
+  const preferredVizTypes = [
+    ...new Set(
+      data.series
+        .map((s) => s.meta?.preferredVisualisationType)
+        .filter((vt): vt is string => Boolean(vt))
+    ),
+  ];
+
+  // Extract data frame types from series metadata
+  const dataFrameTypes = [
+    ...new Set(data.series.map((s) => s.meta?.type).filter((t): t is string => Boolean(t))),
+  ];
+
+  return {
+    queryTypes,
+    preferredVizTypes,
+    dataFrameTypes,
+  };
+}
+
+/**
+ * Get filtered list of available panel plugins for AI context
+ */
+export function getFilteredPanelPlugins(): PanelPluginMeta[] {
+  const allPanels = config.panels;
+
+  return Object.values(allPanels).filter(
+    (panel) =>
+      !panel.hideFromList && // Not hidden
+      panel.state !== PluginState.deprecated && // Not deprecated
+      !panel.skipDataQuery // Data visualization (not widget)
+  );
+}
+
+/**
+ * Map panel plugins to visualization info for AI context
+ */
+function mapToVisualizationInfo(plugins: PanelPluginMeta[]): VisualizationInfo[] {
+  return plugins.map((panel) => ({
+    id: panel.id,
+    name: panel.name,
+    description: panel.info?.description ?? '',
+  }));
+}
+
+/**
+ * Build the complete AI suggestion context
+ */
+export function buildAIContext(
+  data: PanelData,
+  panelState: 'new' | 'editing',
+  currentVisualization?: string
+): AISuggestionContext {
+  const series = data.series ?? [];
+  const plugins = getFilteredPanelPlugins();
+
+  return {
+    dataSummary: buildDataSummary(series),
+    fields: extractFieldInfo(series),
+    datasources: getDatasourceInfo(data),
+    queryMetadata: getQueryMetadata(data),
+    panelState,
+    currentVisualization,
+    availableVisualizations: mapToVisualizationInfo(plugins),
+  };
+}
+
+/**
+ * Build a user prompt string from the AI context
+ */
+export function buildUserPrompt(context: AISuggestionContext): string {
+  const parts: string[] = [];
+
+  // Data summary
+  parts.push('## Data Summary');
+  parts.push(`- Frames: ${context.dataSummary.frameCount}`);
+  parts.push(`- Total rows: ${context.dataSummary.rowCountTotal}`);
+  parts.push(`- Max rows per frame: ${context.dataSummary.rowCountMax}`);
+  parts.push(`- Total fields: ${context.dataSummary.fieldCount}`);
+  parts.push(`- Instant query: ${context.dataSummary.isInstant}`);
+  parts.push('');
+
+  // Fields
+  if (context.fields.length > 0) {
+    parts.push('## Fields');
+    for (const field of context.fields) {
+      const samples = field.sampleValues.map((v) => JSON.stringify(v)).join(', ');
+      parts.push(`- ${field.name} (${field.type}): [${samples}]`);
+    }
+    parts.push('');
+  }
+
+  // Datasources
+  parts.push('## Datasources');
+  for (const ds of context.datasources) {
+    parts.push(`- ${ds.type}`);
+  }
+  parts.push('');
+
+  // Query metadata
+  if (context.queryMetadata.queryTypes.length > 0 || context.queryMetadata.preferredVizTypes.length > 0) {
+    parts.push('## Query Hints');
+    if (context.queryMetadata.queryTypes.length > 0) {
+      parts.push(`- Query types: ${context.queryMetadata.queryTypes.join(', ')}`);
+    }
+    if (context.queryMetadata.preferredVizTypes.length > 0) {
+      parts.push(`- Preferred viz types: ${context.queryMetadata.preferredVizTypes.join(', ')}`);
+    }
+    if (context.queryMetadata.dataFrameTypes.length > 0) {
+      parts.push(`- Data frame types: ${context.queryMetadata.dataFrameTypes.join(', ')}`);
+    }
+    parts.push('');
+  }
+
+  // Panel state
+  parts.push('## Panel State');
+  parts.push(`- State: ${context.panelState}`);
+  if (context.currentVisualization) {
+    parts.push(`- Current visualization: ${context.currentVisualization}`);
+  }
+  parts.push('');
+
+  // Available visualizations
+  parts.push('## Available Visualizations');
+  for (const viz of context.availableVisualizations) {
+    const desc = viz.description ? ` - ${viz.description}` : '';
+    parts.push(`- ${viz.id}: ${viz.name}${desc}`);
+  }
+
+  return parts.join('\n');
+}

--- a/public/app/features/panel/suggestions/ai/getAISuggestions.ts
+++ b/public/app/features/panel/suggestions/ai/getAISuggestions.ts
@@ -1,0 +1,129 @@
+import { useInlineAssistant, isAssistantAvailable, type InlineToolRunnable } from '@grafana/assistant';
+import { PanelData, PanelPluginVisualizationSuggestion } from '@grafana/data';
+
+import { getAllSuggestions } from '../getAllSuggestions';
+
+import { buildAIContext, buildUserPrompt, getFilteredPanelPlugins } from './buildAIContext';
+import { SYSTEM_PROMPT, AI_SUGGESTIONS_ORIGIN } from './prompts';
+import { createGetFieldDetailsTool } from './tools/getFieldDetails';
+import { createGetVisualizationCapabilitiesTool } from './tools/getVisualizationCapabilities';
+import { createSuggestVisualizationsTool } from './tools/suggestVisualizations';
+import { EnrichedAISuggestion } from './types';
+
+const AI_TIMEOUT_MS = 5000;
+
+/**
+ * Check if AI suggestions are available (Assistant plugin is loaded and available)
+ */
+export function useAISuggestionsAvailable(): boolean {
+  try {
+    // isAssistantAvailable returns an observable, but we can check current state
+    let available = false;
+    const subscription = isAssistantAvailable().subscribe((value) => {
+      available = value;
+    });
+    subscription.unsubscribe();
+    return available;
+  } catch {
+    return false;
+  }
+}
+
+export interface AISuggestionsResult {
+  aiSuggestions: EnrichedAISuggestion[];
+  ruleBasedSuggestions: PanelPluginVisualizationSuggestion[];
+  hasErrors: boolean;
+}
+
+/**
+ * Hook to get AI-powered visualization suggestions.
+ *
+ * This combines AI suggestions with rule-based suggestions, using rule-based
+ * as fallback and for enriching AI suggestions with options/fieldConfig.
+ */
+export function useAISuggestions() {
+  const { generate } = useInlineAssistant();
+
+  const getAISuggestions = async (
+    data: PanelData,
+    panelState: 'new' | 'editing',
+    currentVisualization?: string
+  ): Promise<AISuggestionsResult> => {
+    // 1. Get rule-based suggestions first (always available as fallback)
+    const ruleBasedResult = await getAllSuggestions(data.series);
+
+    // 2. Build AI context
+    const context = buildAIContext(data, panelState, currentVisualization);
+    const validPluginIds = new Set(context.availableVisualizations.map((v) => v.id));
+    const plugins = getFilteredPanelPlugins();
+
+    // 3. Create a promise to receive the tool result
+    let resolveWithSuggestions: (suggestions: EnrichedAISuggestion[]) => void;
+    const suggestionsPromise = new Promise<EnrichedAISuggestion[]>((resolve) => {
+      resolveWithSuggestions = resolve;
+    });
+
+    // 4. Create tools
+    const tools: InlineToolRunnable[] = [
+      createSuggestVisualizationsTool(validPluginIds, ruleBasedResult.suggestions, (suggestions) =>
+        resolveWithSuggestions(suggestions)
+      ),
+      createGetFieldDetailsTool(data.series),
+      createGetVisualizationCapabilitiesTool(plugins),
+    ];
+
+    // 5. Call the AI with tools
+    try {
+      await generate({
+        origin: AI_SUGGESTIONS_ORIGIN,
+        prompt: buildUserPrompt(context),
+        systemPrompt: SYSTEM_PROMPT,
+        tools,
+        onComplete: () => {
+          // If AI completes without calling the tool, resolve with empty
+          resolveWithSuggestions([]);
+        },
+        onError: (error) => {
+          console.warn('AI suggestions error:', error);
+          resolveWithSuggestions([]);
+        },
+      });
+    } catch (error) {
+      console.warn('AI suggestions generation failed:', error);
+      resolveWithSuggestions([]);
+    }
+
+    // 6. Wait for tool result (with timeout)
+    const timeout = new Promise<EnrichedAISuggestion[]>((resolve) => setTimeout(() => resolve([]), AI_TIMEOUT_MS));
+
+    const aiSuggestions = await Promise.race([suggestionsPromise, timeout]);
+
+    return {
+      aiSuggestions,
+      ruleBasedSuggestions: ruleBasedResult.suggestions,
+      hasErrors: ruleBasedResult.hasErrors,
+    };
+  };
+
+  return { getAISuggestions };
+}
+
+/**
+ * Merge AI suggestions with rule-based suggestions.
+ *
+ * AI suggestions come first (with isAISuggestion flag), followed by
+ * rule-based suggestions that weren't already suggested by AI.
+ */
+export function mergeSuggestions(
+  aiSuggestions: EnrichedAISuggestion[],
+  ruleBasedSuggestions: PanelPluginVisualizationSuggestion[]
+): PanelPluginVisualizationSuggestion[] {
+  // Get plugin IDs that AI already suggested
+  const aiPluginIds = new Set(aiSuggestions.map((s) => s.pluginId));
+
+  // Filter out rule-based suggestions that duplicate AI suggestions (by pluginId)
+  const uniqueRuleBased = ruleBasedSuggestions.filter((s) => !aiPluginIds.has(s.pluginId));
+
+  // AI suggestions first, then unique rule-based
+  return [...aiSuggestions, ...uniqueRuleBased];
+}

--- a/public/app/features/panel/suggestions/ai/index.ts
+++ b/public/app/features/panel/suggestions/ai/index.ts
@@ -1,0 +1,13 @@
+export { useAISuggestions, useAISuggestionsAvailable, mergeSuggestions } from './getAISuggestions';
+export { buildAIContext, buildUserPrompt, getFilteredPanelPlugins } from './buildAIContext';
+export { SYSTEM_PROMPT, AI_SUGGESTIONS_ORIGIN } from './prompts';
+export type {
+  AISuggestionContext,
+  AIVisualizationSuggestion,
+  DataSummary,
+  DatasourceInfo,
+  EnrichedAISuggestion,
+  FieldInfo,
+  QueryMetadata,
+  VisualizationInfo,
+} from './types';

--- a/public/app/features/panel/suggestions/ai/prompts.ts
+++ b/public/app/features/panel/suggestions/ai/prompts.ts
@@ -1,0 +1,27 @@
+/**
+ * System prompt for AI visualization suggestions.
+ *
+ * This prompt instructs the AI to analyze data context and suggest appropriate visualizations.
+ */
+export const SYSTEM_PROMPT = `You are a visualization expert for Grafana dashboards. Analyze the provided data context and suggest the best visualizations.
+
+You have access to these tools:
+- suggest_visualizations: REQUIRED. Call this to submit your final recommendations.
+- get_field_details: Optional. Get more details about a specific data frame.
+- get_visualization_capabilities: Optional. Get details about a visualization type.
+
+Guidelines:
+- Consider the datasource type (Prometheus metrics vs Loki logs vs tracing data)
+- Consider the data shape (time series, table, single values)
+- Consider query type hints (instant vs range, logs vs metrics)
+- Match preferredVisualisationType if present
+- Suggest 3-5 visualizations, best first
+- Keep names short (2-4 words)
+- Provide clear, concise reasons
+
+You MUST call suggest_visualizations with your recommendations. Do not respond with plain text.`;
+
+/**
+ * Origin identifier for analytics tracking
+ */
+export const AI_SUGGESTIONS_ORIGIN = 'grafana/panel-editor/visualization-suggestions';

--- a/public/app/features/panel/suggestions/ai/tools/getFieldDetails.ts
+++ b/public/app/features/panel/suggestions/ai/tools/getFieldDetails.ts
@@ -1,0 +1,48 @@
+import { DataFrame } from '@grafana/data';
+import { createTool, type InlineToolRunnable, type ToolOutput } from '@grafana/assistant';
+
+import { GetFieldDetailsInput } from '../types';
+
+const MAX_SAMPLE_VALUES = 5;
+
+/**
+ * Creates the get_field_details tool that allows AI to query more details about a specific data frame.
+ */
+export function createGetFieldDetailsTool(series: DataFrame[]): InlineToolRunnable {
+  return createTool(
+    async (input: GetFieldDetailsInput): Promise<ToolOutput> => {
+      const frame = series[input.frameIndex];
+      if (!frame) {
+        return `Frame ${input.frameIndex} not found. Available frames: 0-${series.length - 1}`;
+      }
+
+      const details = frame.fields.map((f) => ({
+        name: f.name,
+        type: f.type,
+        labels: f.labels,
+        config: {
+          unit: f.config?.unit,
+          displayName: f.config?.displayName,
+        },
+        sampleValues: f.values.slice(0, MAX_SAMPLE_VALUES),
+      }));
+
+      return [JSON.stringify(details, null, 2), details];
+    },
+    {
+      name: 'get_field_details',
+      description: 'Get detailed field information for a specific data frame including sample values',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          frameIndex: {
+            type: 'number',
+            description: 'Index of the data frame (0-based)',
+          },
+        },
+        required: ['frameIndex'],
+      },
+      validate: (input) => input as GetFieldDetailsInput,
+    }
+  );
+}

--- a/public/app/features/panel/suggestions/ai/tools/getVisualizationCapabilities.ts
+++ b/public/app/features/panel/suggestions/ai/tools/getVisualizationCapabilities.ts
@@ -1,0 +1,43 @@
+import { PanelPluginMeta } from '@grafana/data';
+import { createTool, type InlineToolRunnable, type ToolOutput } from '@grafana/assistant';
+
+import { GetVisualizationCapabilitiesInput } from '../types';
+
+/**
+ * Creates the get_visualization_capabilities tool that allows AI to query details about a specific visualization type.
+ */
+export function createGetVisualizationCapabilitiesTool(plugins: PanelPluginMeta[]): InlineToolRunnable {
+  return createTool(
+    async (input: GetVisualizationCapabilitiesInput): Promise<ToolOutput> => {
+      const plugin = plugins.find((p) => p.id === input.pluginId);
+      if (!plugin) {
+        return `Plugin ${input.pluginId} not found.`;
+      }
+
+      const info = {
+        id: plugin.id,
+        name: plugin.name,
+        description: plugin.info?.description,
+        skipDataQuery: plugin.skipDataQuery,
+        supportsSuggestions: plugin.suggestions,
+      };
+
+      return [JSON.stringify(info, null, 2), info];
+    },
+    {
+      name: 'get_visualization_capabilities',
+      description: 'Get detailed information about a specific visualization type',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          pluginId: {
+            type: 'string',
+            description: 'The visualization plugin ID',
+          },
+        },
+        required: ['pluginId'],
+      },
+      validate: (input) => input as GetVisualizationCapabilitiesInput,
+    }
+  );
+}

--- a/public/app/features/panel/suggestions/ai/tools/suggestVisualizations.ts
+++ b/public/app/features/panel/suggestions/ai/tools/suggestVisualizations.ts
@@ -1,0 +1,98 @@
+import { cloneDeep } from 'lodash';
+
+import { PanelPluginVisualizationSuggestion, VisualizationSuggestionScore } from '@grafana/data';
+import { createTool, type InlineToolRunnable, type ToolOutput } from '@grafana/assistant';
+
+import { EnrichedAISuggestion, SuggestVisualizationsInput } from '../types';
+
+/**
+ * Creates the suggest_visualizations tool that AI must call to submit recommendations.
+ *
+ * This tool validates plugin IDs and enriches suggestions with options/fieldConfig
+ * from rule-based suggestions when available.
+ */
+export function createSuggestVisualizationsTool(
+  validPluginIds: Set<string>,
+  ruleBasedSuggestions: PanelPluginVisualizationSuggestion[],
+  onSuggestionsReceived: (suggestions: EnrichedAISuggestion[]) => void
+): InlineToolRunnable {
+  return createTool(
+    async (input: SuggestVisualizationsInput): Promise<ToolOutput> => {
+      const enriched: EnrichedAISuggestion[] = [];
+      const errors: string[] = [];
+
+      for (const suggestion of input.suggestions) {
+        // Validate plugin ID
+        if (!validPluginIds.has(suggestion.pluginId)) {
+          errors.push(`Invalid pluginId: ${suggestion.pluginId}`);
+          continue;
+        }
+
+        // Find matching rule-based suggestion for options/fieldConfig
+        const ruleBased = ruleBasedSuggestions.find((r) => r.pluginId === suggestion.pluginId);
+
+        // Generate a unique hash for the suggestion
+        const hash = `ai-${suggestion.pluginId}-${suggestion.name.replace(/\s+/g, '-').toLowerCase()}`;
+
+        enriched.push({
+          pluginId: suggestion.pluginId,
+          name: suggestion.name,
+          hash,
+          description: suggestion.reason,
+          reason: suggestion.reason,
+          // Deep clone to avoid read-only errors when Grafana modifies these
+          options: ruleBased?.options ? cloneDeep(ruleBased.options) : undefined,
+          fieldConfig: ruleBased?.fieldConfig ? cloneDeep(ruleBased.fieldConfig) : undefined,
+          score: VisualizationSuggestionScore.Best, // AI suggestions get highest priority
+          isAISuggestion: true,
+        });
+      }
+
+      // Call the callback with enriched suggestions
+      onSuggestionsReceived(enriched);
+
+      const message =
+        errors.length > 0
+          ? `Accepted ${enriched.length} suggestions. Errors: ${errors.join(', ')}`
+          : `Accepted ${enriched.length} visualization suggestions.`;
+
+      return [message, enriched];
+    },
+    {
+      name: 'suggest_visualizations',
+      description: `Submit your visualization suggestions. You MUST call this tool to provide your recommendations. Each suggestion needs a pluginId (from the available list), a short name, and a reason explaining why it fits the data.`,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          suggestions: {
+            type: 'array',
+            description: 'List of visualization suggestions, ordered by relevance (best first)',
+            items: {
+              type: 'object',
+              properties: {
+                pluginId: {
+                  type: 'string',
+                  description: 'Plugin ID from the availableVisualizations list',
+                },
+                name: {
+                  type: 'string',
+                  description: 'Short display name (2-4 words)',
+                },
+                reason: {
+                  type: 'string',
+                  description: 'One sentence explaining why this visualization fits the data',
+                },
+              },
+              required: ['pluginId', 'name', 'reason'],
+            },
+            minItems: 1,
+            maxItems: 5,
+          },
+        },
+        required: ['suggestions'],
+      },
+      validate: (input) => input as SuggestVisualizationsInput,
+      responseFormat: 'content_and_artifact',
+    }
+  );
+}

--- a/public/app/features/panel/suggestions/ai/types.ts
+++ b/public/app/features/panel/suggestions/ai/types.ts
@@ -1,0 +1,97 @@
+import { FieldConfigSource, PanelPluginVisualizationSuggestion } from '@grafana/data';
+
+/**
+ * Summary of the data shape for AI context
+ */
+export interface DataSummary {
+  rowCountTotal: number;
+  rowCountMax: number;
+  fieldCount: number;
+  frameCount: number;
+  isInstant: boolean;
+}
+
+/**
+ * Field information with sample values for AI context
+ */
+export interface FieldInfo {
+  name: string;
+  type: string; // 'time', 'number', 'string', etc.
+  sampleValues: unknown[]; // First 3 values
+}
+
+/**
+ * Datasource information for AI context
+ */
+export interface DatasourceInfo {
+  type: string; // 'prometheus', 'loki', 'mysql', etc.
+}
+
+/**
+ * Query metadata for AI context
+ */
+export interface QueryMetadata {
+  queryTypes: string[]; // ['range'], ['instant'], ['logs']
+  preferredVizTypes: string[]; // from datasource meta
+  dataFrameTypes: string[]; // TimeSeriesWide, etc.
+}
+
+/**
+ * Visualization info for AI context
+ */
+export interface VisualizationInfo {
+  id: string;
+  name: string;
+  description: string;
+}
+
+/**
+ * Complete context sent to AI for visualization suggestions
+ */
+export interface AISuggestionContext {
+  dataSummary: DataSummary;
+  fields: FieldInfo[];
+  datasources: DatasourceInfo[];
+  queryMetadata: QueryMetadata;
+  panelState: 'new' | 'editing';
+  currentVisualization?: string;
+  availableVisualizations: VisualizationInfo[];
+}
+
+/**
+ * Single visualization suggestion from AI
+ */
+export interface AIVisualizationSuggestion {
+  pluginId: string;
+  name: string;
+  reason: string;
+}
+
+/**
+ * Input for the suggest_visualizations tool
+ */
+export interface SuggestVisualizationsInput {
+  suggestions: AIVisualizationSuggestion[];
+}
+
+/**
+ * Enriched suggestion with options/fieldConfig from rule-based suggestions
+ */
+export interface EnrichedAISuggestion extends PanelPluginVisualizationSuggestion {
+  reason?: string;
+  isAISuggestion: true;
+}
+
+/**
+ * Input for get_field_details tool
+ */
+export interface GetFieldDetailsInput {
+  frameIndex: number;
+}
+
+/**
+ * Input for get_visualization_capabilities tool
+ */
+export interface GetVisualizationCapabilitiesInput {
+  pluginId: string;
+}

--- a/public/test/mocks/assistant.ts
+++ b/public/test/mocks/assistant.ts
@@ -2,6 +2,8 @@
 // The real module tries to call getObservablePluginLinks() during initialization
 // which fails because Grafana hasn't started. This mock prevents that.
 
+import { of } from 'rxjs';
+
 export const useAssistant = jest.fn().mockReturnValue({
   isAvailable: false,
   openAssistant: undefined,
@@ -13,7 +15,23 @@ export const createAssistantContextItem = jest.fn();
 
 // Additional exports that may be used
 export const toggleAssistant = jest.fn();
-export const isAssistantAvailable = jest.fn().mockReturnValue(false);
+export const isAssistantAvailable = jest.fn().mockReturnValue(of(false));
 
-// Type exports (if needed
+// Inline assistant mock for AI suggestions
+export const useInlineAssistant = jest.fn().mockReturnValue({
+  generate: jest.fn().mockResolvedValue(undefined),
+  isGenerating: false,
+  cancel: jest.fn(),
+});
+
+// Tool creation mock
+export const createTool = jest.fn().mockImplementation((handler, config) => ({
+  handler,
+  ...config,
+}));
+
+// Type exports (if needed)
 export type AssistantHook = ReturnType<typeof useAssistant>;
+export type InlineAssistantHook = ReturnType<typeof useInlineAssistant>;
+export type InlineToolRunnable = ReturnType<typeof createTool>;
+export type ToolOutput = [string, unknown] | string;


### PR DESCRIPTION
NO NEED TO REVIEW

**What is this feature?**

Experimental feature that uses the @grafana/assistant SDK to provide intelligent visualization suggestions based on data context.

- Integrates useInlineAssistant for AI suggestion generation
- Falls back to rule-based suggestions when AI unavailable or fails
- Caches suggestions by requestId to avoid regeneration on tab switches
- Shows pulsing loading indicator during AI generation
- Only generates suggestions for valid query data (not error/loading states)

**Why do we need this feature?**

I was hoping for a better user experience - especially for new users that don't necessarily know much about panel options and visualizations - regarding panel suggestions but turns out it doesn't really improve it IMO

**Who is this feature for?**

Users new to Grafana

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
