### PR TITLE
Dashboards: Prioritize current datasource over auto-assigned when persisting

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -487,9 +487,9 @@ describe('transformSceneToSaveModelSchemaV2', () => {
       // Get a reference to the DS references mapping
       const dsReferencesMap = new Map<string, string | undefined>([['A', undefined]]);
 
-      // Test the query without DS originally - should return undefined
+      // Test the query without DS originally - should return panlel level datasource
       const resultA = getPersistedDSFor(queryWithoutDS, dsReferencesMap, 'query', queryRunner);
-      expect(resultA).toBeUndefined();
+      expect(resultA).toEqual({ uid: 'default-ds', type: 'default' });
 
       // Test the query with DS that differs from panel - same as PanelQueryRunner: use panel ref
       const resultB = getPersistedDSFor(queryWithDS, dsReferencesMap, 'query', queryRunner);
@@ -736,7 +736,7 @@ describe('getElementDatasource', () => {
 
     // Call the function with the panel and query without DS
     const resultWithoutDS = getElementDatasource(vizPanel, queryWithoutDS, 'panel', queryRunner, dsReferencesMapping);
-    expect(resultWithoutDS).toBeUndefined();
+    expect(resultWithoutDS).toEqual({ uid: 'default-ds', type: 'default' });
 
     // Query with only type differs from panel → use panel ref
     const resultWithOnlyType = getElementDatasource(
@@ -990,8 +990,8 @@ describe('getVizPanelQueries', () => {
     const result = getVizPanelQueries(vizPanel, dsReferencesMapping);
     expect(result.length).toBe(2);
     expect(result[0].spec.query.kind).toBe('DataQuery');
-    expect(result[0].spec.query.datasource).toBeUndefined(); // ignore datasource if it wasn't provided
-    expect(result[0].spec.query.group).toBe(defaultDataQueryKind().group); // this is a default query that contains only refId and therefore group should be the default group
+    expect(result[0].spec.query.datasource).toEqual({ name: 'default-ds' }); // picks up panel level when no datasource is provided
+    expect(result[0].spec.query.group).toBe('default'); // this is a default query that contains only refId and therefore group should be the default group
     expect(result[0].spec.query.version).toBe('v0');
 
     expect(result[1].spec.query.kind).toBe('DataQuery');

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -487,7 +487,7 @@ describe('transformSceneToSaveModelSchemaV2', () => {
       // Get a reference to the DS references mapping
       const dsReferencesMap = new Map<string, string | undefined>([['A', undefined]]);
 
-      // Test the query without DS originally - should return panlel level datasource
+      // Test the query without DS originally - should return panel level datasource
       const resultA = getPersistedDSFor(queryWithoutDS, dsReferencesMap, 'query', queryRunner);
       expect(resultA).toEqual({ uid: 'default-ds', type: 'default' });
 

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -18,6 +18,7 @@ import { DataSourceRef } from '@grafana/schema';
 import { sortedDeepCloneWithoutNulls } from 'app/core/utils/object';
 import { getPanelDataFrames } from 'app/features/dashboard/components/HelpWizard/utils';
 import { GrafanaQueryType } from 'app/plugins/datasource/grafana/types';
+import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
 import {
   Spec as DashboardV2Spec,
@@ -899,12 +900,15 @@ export function getPersistedDSFor<T extends SceneDataQuery | QueryVariable | Ann
       }
     }
 
-    const panel = context?.state?.datasource;
-    if (panel) {
-      const notExpr = !datasource || (datasource.uid !== ExpressionDatasourceRef.uid && datasource.type !== ExpressionDatasourceRef.type);
+    const panelDS = context?.state?.datasource;
+    if (panelDS?.uid) {
+      const notMixed = panelDS?.uid !== MIXED_DATASOURCE_NAME;
+      const notExpr =
+        !datasource ||
+        (datasource.uid !== ExpressionDatasourceRef.uid && datasource.type !== ExpressionDatasourceRef.type);
 
-      if (!datasource || (panel?.uid && panel?.uid !== datasource.uid && panel?.uid !== '-- Mixed --' && notExpr)) {
-        datasource = panel;
+      if (!datasource || (panelDS?.uid !== datasource.uid && notMixed && notExpr)) {
+        datasource = panelDS;
       }
     }
   }

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -907,7 +907,7 @@ export function getPersistedDSFor<T extends SceneDataQuery | QueryVariable | Ann
         !datasource ||
         (datasource.uid !== ExpressionDatasourceRef.uid && datasource.type !== ExpressionDatasourceRef.type);
 
-      if (!datasource || (panelDS?.uid !== datasource.uid && notMixed && notExpr)) {
+      if (notMixed && (!datasource || (panelDS?.uid !== datasource.uid && notExpr))) {
         datasource = panelDS;
       }
     }


### PR DESCRIPTION
**What is this feature?**

When a panel query, variable, or annotation has no datasource defined in the saved dashboard model, Grafana auto-assigns one at runtime. Previously, `getPersistedDSFor` checked this auto-assigned mapping first and returned immediately, ignoring any datasource the user may have explicitly selected since.

This change reorders the logic so that:
1. The element's current datasource is resolved first
2. If a datasource is found, it is persisted (user's explicit choice wins)
3. Only if no datasource is resolved does the function fall back to the auto-assigned value