### PR TITLE
fix: add retry for SQLITE_BUSY errors encountered in ci tests

### DIFF
--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -2,9 +2,12 @@ package migrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/grafana/dskit/backoff"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang-migrate/migrate/v4/database"
@@ -328,19 +331,6 @@ func (mg *Migrator) doMigration(ctx context.Context, m Migration) error {
 		sess = sess.Context(ctx)
 
 		err := mg.exec(ctx, m, sess)
-		// if we get an sqlite busy/locked error, sleep 100ms and try again
-		cnt := 0
-		for cnt < 3 && sqlite.IsBusyOrLocked(err) {
-			cnt++
-			logger.Debug("Database locked, sleeping then retrying", "error", err, "sql", sql)
-			span.AddEvent("Database locked, sleeping then retrying",
-				trace.WithAttributes(attribute.String("error", err.Error())),
-				trace.WithAttributes(attribute.String("sql", sql)),
-			)
-			time.Sleep(100 * time.Millisecond)
-			err = mg.exec(ctx, m, sess)
-		}
-
 		if err != nil {
 			logger.Error("Exec failed", "error", err, "sql", sql)
 			record.Error = err.Error()
@@ -418,10 +408,25 @@ func (mg *Migrator) exec(ctx context.Context, m Migration, sess *xorm.Session) e
 type dbTransactionFunc func(sess *xorm.Session) error
 
 func (mg *Migrator) InTransaction(callback dbTransactionFunc) error {
-	return mg.inTransactionWithRetry(callback, 0)
+	b := backoff.New(context.Background(), backoff.Config{
+		MinBackoff: 100 * time.Millisecond,
+		MaxBackoff: time.Second,
+		MaxRetries: 10,
+	})
+
+	var lastErr error
+	for b.Ongoing() {
+		lastErr = mg.inTransaction(callback)
+		if !sqlite.IsBusyOrLocked(lastErr) {
+			break
+		}
+		mg.Logger.Info("Database locked on migration, retrying transaction", "error", lastErr)
+		b.Wait()
+	}
+	return errors.Join(lastErr, b.Err())
 }
 
-func (mg *Migrator) inTransactionWithRetry(callback dbTransactionFunc, retry int) error {
+func (mg *Migrator) inTransaction(callback dbTransactionFunc) error {
 	sess := mg.DBEngine.NewSession()
 	defer sess.Close()
 
@@ -433,14 +438,6 @@ func (mg *Migrator) inTransactionWithRetry(callback dbTransactionFunc, retry int
 		if rollErr := sess.Rollback(); rollErr != nil {
 			return fmt.Errorf("failed to roll back transaction due to error: %s: %w", rollErr, err)
 		}
-
-		// Retry on SQLite busy/locked errors with a new session.
-		if retry < 5 && sqlite.IsBusyOrLocked(err) {
-			time.Sleep(time.Millisecond * 100)
-			mg.Logger.Info("Database locked on migration, retrying transaction", "error", err, "retry", retry)
-			return mg.inTransactionWithRetry(callback, retry+1)
-		}
-
 		return err
 	}
 

--- a/pkg/storage/secret/database/database.go
+++ b/pkg/storage/secret/database/database.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"time"
 
 	"github.com/jmoiron/sqlx"
 	"go.opentelemetry.io/otel/codes"
@@ -12,7 +11,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
-	"github.com/grafana/grafana/pkg/util/sqlite"
 	"github.com/grafana/grafana/pkg/util/xorm"
 )
 
@@ -54,10 +52,6 @@ func (db *Database) DriverName() string {
 	return db.dbType
 }
 
-// maxTransactionRetries is the maximum number of times a transaction will be retried
-// when a SQLite busy/locked error is encountered.
-const maxTransactionRetries = 5
-
 func (db *Database) Transaction(ctx context.Context, callback func(context.Context) error) (err error) {
 	// If another transaction is already open, we just use that one instead of nesting.
 	sqlxTx, ok := ctx.Value(contextSessionTxKey{}).(*sqlx.Tx)
@@ -76,30 +70,13 @@ func (db *Database) Transaction(ctx context.Context, callback func(context.Conte
 		}
 	}()
 
-	for retry := 0; ; retry++ {
-		err = db.doTransaction(spanCtx, callback)
-		if err == nil {
-			return nil
-		}
-
-		// Retry on SQLite busy/locked errors, up to the maximum number of retries.
-		if retry < maxTransactionRetries && sqlite.IsBusyOrLocked(err) {
-			time.Sleep(time.Millisecond * 10)
-			continue
-		}
-
-		return err
-	}
-}
-
-func (db *Database) doTransaction(ctx context.Context, callback func(context.Context) error) error {
-	sqlxTx, err := db.sqlx.BeginTxx(ctx, nil)
+	sqlxTx, err = db.sqlx.BeginTxx(spanCtx, nil)
 	if err != nil {
 		return err
 	}
 
 	// Save it in the context so the transaction can be reused in case it is nested.
-	txCtx := context.WithValue(ctx, contextSessionTxKey{}, sqlxTx)
+	txCtx := context.WithValue(spanCtx, contextSessionTxKey{}, sqlxTx)
 
 	if err := callback(txCtx); err != nil {
 		if rbErr := sqlxTx.Rollback(); rbErr != nil {

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -722,6 +722,8 @@ func CreateGrafDir(t *testing.T, opts GrafanaOpts) (string, string) {
 	require.NoError(t, err)
 	_, err = dbSection.NewKey("max_idle_conn", fmt.Sprintf("%d", maxConns))
 	require.NoError(t, err)
+	_, err = dbSection.NewKey("wal", "true")
+	require.NoError(t, err)
 
 	cfgPath := filepath.Join(cfgDir, "test.ini")
 	err = cfg.SaveTo(cfgPath)


### PR DESCRIPTION
The 2 failure cases we were reported related to main sql store and migrations particularly:
- https://github.com/grafana/grafana/actions/runs/21908943693/job/63256977109?pr=117024
- https://github.com/grafana/grafana/actions/runs/21826810428/job/62973827261?pr=117680

In this PR, I increase the retry count with backoff support now.