### PR TITLE
Scopes: Fix runtime type error

### DIFF
--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -341,7 +341,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
     // something selected without knowing the parent so we default to assuming it's not the same parent.
     const sameParent =
       this.state.selectedScopes[0]?.scopeNodeId &&
-      this.state.nodes[this.state.selectedScopes[0].scopeNodeId].spec.parentName === scopeNode.spec.parentName;
+      this.state.nodes[this.state.selectedScopes[0].scopeNodeId]?.spec.parentName === scopeNode.spec.parentName;
 
     if (
       !sameParent ||


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Checks if the currently selected node is in the cache. This will not happen if it uses fetches the single nodes from an endpoint.

**Why do we need this feature?**

To prevent a runtime error if it is not there.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to https://github.com/grafana/hyperion-planning/issues/513. It will fix the error, but I am fairly certain some other issue will appear.

**Special notes for your reviewer:**

We could go into the root cause of why it doesn't appear in the cache, but given that we want to do a refactor and that this can be prevented by enabling `useScopeSingleNodeEndpoint `, we can hold off on that