### PR TITLE
GCM: Ensure the SLO name is human readable

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/CloudMonitoringMetricFindQuery.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/CloudMonitoringMetricFindQuery.ts
@@ -1,7 +1,7 @@
 import { isString } from 'lodash';
 
 import { ALIGNMENT_PERIODS, SELECTORS } from './constants';
-import { ValueTypes, MetricFindQueryTypes } from './dataquery.gen';
+import { MetricFindQueryTypes, ValueTypes } from './dataquery.gen';
 import CloudMonitoringDatasource from './datasource';
 import {
   extractServicesFromMetricDescriptors,
@@ -174,6 +174,6 @@ export default class CloudMonitoringMetricFindQuery {
   }
 
   toFindQueryResult(x: any) {
-    return isString(x) ? { text: x, expandable: true } : { ...x, expandable: true };
+    return isString(x) ? { text: x, expandable: true } : { ...x, text: x.label || x.value, expandable: true };
   }
 }


### PR DESCRIPTION
The `text` property was not being set for SLO Service variable queries, causing the UID of the SLO to be displayed instead which is confusing for users.

This PR correctly sets the text property, ensuring that the display name is human readable if a `label` property is present on the variable value.

Fixes #110129