### PR TITLE
LogListControls: Fix expanded copy for columns control

### DIFF
--- a/public/app/features/logs/components/panel/LogListControls.test.tsx
+++ b/public/app/features/logs/components/panel/LogListControls.test.tsx
@@ -21,7 +21,10 @@ const SHOW_TIMESTAMP_LABEL_COPY = 'Show timestamps';
 const WRAP_LINES_LABEL_COPY = 'Wrap lines';
 const ENABLE_UNWRAPPED_COLUMNS_COPY = 'Enable columns';
 const DISABLE_UNWRAPPED_COLUMNS_COPY = 'Disable columns';
-const COLUMNS_DISABLED_COPY = 'Columns are not supported with line wrapping enabled';
+const COLUMNS_NOT_SUPPORTED_COPY = 'Columns not supported';
+const COLUMNS_ENABLED_COPY = 'Columns enabled';
+const COLUMNS_DISABLED_COPY = 'Columns disabled';
+const COLUMNS_DISABLED_TOOLTIP_COPY = 'Columns are not supported with line wrapping enabled';
 const WRAP_JSON_TOOLTIP_COPY = 'Enable line wrapping and prettify JSON';
 const WRAP_JSON_LABEL_COPY = 'Wrap JSON';
 const WRAP_DISABLE_LABEL_COPY = 'Disable line wrapping';
@@ -361,6 +364,8 @@ describe('LogListControls', () => {
 
     expect(screen.getByLabelText(DISABLE_UNWRAPPED_COLUMNS_COPY)).toBeInTheDocument();
     expect(screen.getByLabelText(DISABLE_UNWRAPPED_COLUMNS_COPY)).toBeEnabled();
+    expect(screen.getByText(COLUMNS_ENABLED_COPY)).toBeInTheDocument();
+    expect(screen.queryByText(COLUMNS_DISABLED_COPY)).not.toBeInTheDocument();
 
     rerender(
       <LogListContextProvider {...contextProps} wrapLogMessage={false} unwrappedColumns={false}>
@@ -370,6 +375,8 @@ describe('LogListControls', () => {
 
     expect(screen.getByLabelText(ENABLE_UNWRAPPED_COLUMNS_COPY)).toBeInTheDocument();
     expect(screen.getByLabelText(ENABLE_UNWRAPPED_COLUMNS_COPY)).toBeEnabled();
+    expect(screen.getByText(COLUMNS_DISABLED_COPY)).toBeInTheDocument();
+    expect(screen.queryByText(COLUMNS_ENABLED_COPY)).not.toBeInTheDocument();
 
     config.featureToggles.newLogsPanel = originalFlagState;
   });
@@ -384,7 +391,8 @@ describe('LogListControls', () => {
       </LogListContextProvider>
     );
 
-    expect(screen.getByLabelText(COLUMNS_DISABLED_COPY)).toBeDisabled();
+    expect(screen.getByLabelText(COLUMNS_DISABLED_TOOLTIP_COPY)).toBeDisabled();
+    expect(screen.getByText(COLUMNS_NOT_SUPPORTED_COPY)).toBeInTheDocument();
 
     config.featureToggles.newLogsPanel = originalFlagState;
   });

--- a/public/app/features/logs/components/panel/LogListControls.tsx
+++ b/public/app/features/logs/components/panel/LogListControls.tsx
@@ -427,7 +427,13 @@ export const LogListControls = ({ eventBus, logLevels = FILTER_LEVELS, visualisa
                   aria-pressed={unwrappedColumns}
                   className={unwrappedColumns ? styles.controlButtonActive : styles.controlButton}
                   onClick={onSetUnwrappedColumnsClick}
-                  label={t('logs.logs-controls.unwrapped-columns.disabled-label', 'Columns not suported')}
+                  label={
+                    wrapLogMessage
+                      ? t('logs.logs-controls.unwrapped-columns.disabled-label', 'Columns not supported')
+                      : unwrappedColumns
+                        ? t('logs.logs-controls.unwrapped-columns.disabled', 'Columns enabled')
+                        : t('logs.logs-controls.unwrapped-columns.enabled', 'Columns disabled')
+                  }
                   tooltip={
                     wrapLogMessage
                       ? t(

--- a/public/app/features/logs/components/panel/LogListControls.tsx
+++ b/public/app/features/logs/components/panel/LogListControls.tsx
@@ -431,13 +431,13 @@ export const LogListControls = ({ eventBus, logLevels = FILTER_LEVELS, visualisa
                     wrapLogMessage
                       ? t('logs.logs-controls.unwrapped-columns.disabled-label', 'Columns not supported')
                       : unwrappedColumns
-                        ? t('logs.logs-controls.unwrapped-columns.disabled', 'Columns enabled')
-                        : t('logs.logs-controls.unwrapped-columns.enabled', 'Columns disabled')
+                        ? t('logs.logs-controls.unwrapped-columns.disabled-text', 'Columns enabled')
+                        : t('logs.logs-controls.unwrapped-columns.enabled-text', 'Columns disabled')
                   }
                   tooltip={
                     wrapLogMessage
                       ? t(
-                          'logs.logs-controls.unwrapped-columns.disabled',
+                          'logs.logs-controls.unwrapped-columns.not-supported',
                           'Columns are not supported with line wrapping enabled'
                         )
                       : unwrappedColumns

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10564,9 +10564,10 @@
       "unwrap-lines": "Unwrap lines",
       "unwrapped-columns": {
         "disable": "Disable columns",
-        "disabled": "Columns are not supported with line wrapping enabled",
-        "disabled-label": "Columns not suported",
-        "enable": "Enable columns"
+        "disabled": "Columns enabled",
+        "disabled-label": "Columns not supported",
+        "enable": "Enable columns",
+        "enabled": "Columns disabled"
       },
       "wrap-lines": "Wrap lines"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10564,10 +10564,11 @@
       "unwrap-lines": "Unwrap lines",
       "unwrapped-columns": {
         "disable": "Disable columns",
-        "disabled": "Columns enabled",
         "disabled-label": "Columns not supported",
+        "disabled-text": "Columns enabled",
         "enable": "Enable columns",
-        "enabled": "Columns disabled"
+        "enabled-text": "Columns disabled",
+        "not-supported": "Columns are not supported with line wrapping enabled"
       },
       "wrap-lines": "Wrap lines"
     },


### PR DESCRIPTION
It was mistakenly showing "Columns not supported" with wrapping disabled.

<img width="1006" height="618" alt="imagen" src="https://github.com/user-attachments/assets/cdc39f36-9c59-479b-a62c-6288f9ea36d1" />
