### PR TITLE
Team Folders: Allow users to see folder owners, if they can retrieve the details

### DIFF
--- a/public/app/core/components/OwnerReferences/OwnerReference.tsx
+++ b/public/app/core/components/OwnerReferences/OwnerReference.tsx
@@ -1,22 +1,20 @@
-import { OwnerReference as OwnerReferenceType } from '@grafana/api-clients/rtkq/folder/v1beta1';
-import { useGetTeamQuery } from '@grafana/api-clients/rtkq/iam/v0alpha1';
+import { Team } from '@grafana/api-clients/rtkq/iam/v0alpha1';
 import { reportInteraction } from '@grafana/runtime';
 import { Text, Link } from '@grafana/ui';
+import { contextSrv } from 'app/core/services/context_srv';
 
 /**
  * Display a team owner reference as a link to team details page
  */
-export const OwnerReference = ({ ownerReference }: { ownerReference: OwnerReferenceType }) => {
-  const { data: team, isLoading: isLoadingTeam } = useGetTeamQuery({ name: ownerReference.uid });
-
-  if (isLoadingTeam || !team) {
-    return null;
+export const OwnerReference = ({ team }: { team: Team }) => {
+  const isAdmin = contextSrv.hasRole('Admin') || contextSrv.isGrafanaAdmin;
+  if (!isAdmin) {
+    return <Text>{team.spec.title}</Text>;
   }
-
   return (
     <Link
-      href={`/org/teams/edit/${ownerReference.uid}/members`}
-      key={ownerReference.uid}
+      href={`/org/teams/edit/${team.metadata.name}/members`}
+      key={team.metadata.name}
       onClick={() => reportInteraction('grafana_owner_reference_link_clicked')}
     >
       <Text>{team.spec.title}</Text>

--- a/public/app/core/components/OwnerReferences/OwnerReference.tsx
+++ b/public/app/core/components/OwnerReferences/OwnerReference.tsx
@@ -7,6 +7,9 @@ import { contextSrv } from 'app/core/services/context_srv';
  * Display a team owner reference as a link to team details page
  */
 export const OwnerReference = ({ team }: { team: Team }) => {
+  // Check if the user is admin, because this is the quickest way (for now)
+  // to be sure that they'll definitely be able to view the team details page in question
+  // In the future, we'll check the access control permissions for the specific team in question
   const isAdmin = contextSrv.hasRole('Admin') || contextSrv.isGrafanaAdmin;
   if (!isAdmin) {
     return <Text>{team.spec.title}</Text>;

--- a/public/app/features/browse-dashboards/components/FolderDetailsActions/FolderDetailsActions.tsx
+++ b/public/app/features/browse-dashboards/components/FolderDetailsActions/FolderDetailsActions.tsx
@@ -29,11 +29,11 @@ export const FolderDetailsActions = ({ folderDTO }: { folderDTO?: CombinedFolder
     });
   };
 
-  const canReadTeamFolders = contextSrv.hasPermission(AccessControlAction.ActionTeamsRead);
+  const canReadTeams = contextSrv.hasPermission(AccessControlAction.ActionTeamsRead);
 
   return (
     <Stack alignItems="center">
-      {canReadTeamFolders && config.featureToggles.teamFolders && folderDTO && 'ownerReferences' in folderDTO && (
+      {canReadTeams && config.featureToggles.teamFolders && folderDTO && 'ownerReferences' in folderDTO && (
         <FolderOwners ownerReferences={folderDTO.ownerReferences} />
       )}
       {config.featureToggles.restoreDashboards && (

--- a/public/app/features/browse-dashboards/components/FolderDetailsActions/FolderDetailsActions.tsx
+++ b/public/app/features/browse-dashboards/components/FolderDetailsActions/FolderDetailsActions.tsx
@@ -1,6 +1,8 @@
 import { css } from '@emotion/css';
+import { skipToken } from '@reduxjs/toolkit/query';
 
 import { OwnerReference as OwnerReferenceType } from '@grafana/api-clients/rtkq/folder/v1beta1';
+import { useGetTeamQuery } from '@grafana/api-clients/rtkq/iam/v0alpha1';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
@@ -9,6 +11,7 @@ import { CombinedFolder, useGetFolderQueryFacade } from 'app/api/clients/folder/
 import { OwnerReference } from 'app/core/components/OwnerReferences/OwnerReference';
 import { contextSrv } from 'app/core/services/context_srv';
 import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
+import { AccessControlAction } from 'app/types/accessControl';
 
 import { getFolderPermissions } from '../../permissions';
 import CreateNewButton from '../CreateNewButton';
@@ -26,12 +29,11 @@ export const FolderDetailsActions = ({ folderDTO }: { folderDTO?: CombinedFolder
     });
   };
 
-  // For now, only admins can see folder owners
-  const isAdmin = contextSrv.hasRole('Admin') || contextSrv.isGrafanaAdmin;
+  const canReadTeamFolders = contextSrv.hasPermission(AccessControlAction.ActionTeamsRead);
 
   return (
     <Stack alignItems="center">
-      {isAdmin && config.featureToggles.teamFolders && folderDTO && 'ownerReferences' in folderDTO && (
+      {canReadTeamFolders && config.featureToggles.teamFolders && folderDTO && 'ownerReferences' in folderDTO && (
         <FolderOwners ownerReferences={folderDTO.ownerReferences} />
       )}
       {config.featureToggles.restoreDashboards && (
@@ -60,8 +62,10 @@ export const FolderDetailsActions = ({ folderDTO }: { folderDTO?: CombinedFolder
 const FolderOwners = ({ ownerReferences }: { ownerReferences?: OwnerReferenceType[] }) => {
   const styles = useStyles2(getStyles);
   const teamOwnerReferences = ownerReferences?.filter((ref) => ref.kind === 'Team');
+  const teamUid = teamOwnerReferences?.at(0)?.uid;
+  const { data: team, isLoading: isLoadingTeam } = useGetTeamQuery(teamUid ? { name: teamUid } : skipToken);
 
-  if (!teamOwnerReferences || teamOwnerReferences.length === 0) {
+  if (!teamOwnerReferences || teamOwnerReferences.length === 0 || isLoadingTeam || !team) {
     return null;
   }
 
@@ -70,7 +74,7 @@ const FolderOwners = ({ ownerReferences }: { ownerReferences?: OwnerReferenceTyp
       <Text>
         <Trans i18nKey="browse-dashboards.folder-owners.owned-by">Owned by:</Trans>
       </Text>
-      <OwnerReference ownerReference={teamOwnerReferences[0]!} />
+      <OwnerReference team={team} />
     </div>
   );
 };


### PR DESCRIPTION
**What is this feature?**
Instead of only allowing admins to see the folder owners, try and show the details of owners if the user has the `teams:read` permission

**Why do we need this feature?**
So users can see when they are the owner of a given folder, if an owner reference has been defined
