### PR TITLE
Logs Panel: Added support to persist displayed fields as panel options in Dashboards

### DIFF
--- a/public/app/plugins/panel/logs/LogsPanel.test.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.test.tsx
@@ -895,12 +895,101 @@ describe.each([false, true])('LogsPanel with controls = %s', (showControls: bool
 
       expect(onClickShowFieldMock).toHaveBeenCalledTimes(1);
     });
+
+    it('calls onOptionsChange with updated displayedFields when showing a field', async () => {
+      const onOptionsChangeMock = jest.fn();
+
+      setup(
+        {
+          data: {
+            ...defaultProps.data,
+            series,
+          },
+          options: {
+            ...defaultProps.options,
+            showLabels: false,
+            showTime: false,
+            wrapLogMessage: false,
+            showCommonLabels: false,
+            prettifyLogMessage: false,
+            sortOrder: LogsSortOrder.Descending,
+            dedupStrategy: LogsDedupStrategy.none,
+            enableLogDetails: true,
+            displayedFields: [],
+            onClickHideField: undefined,
+            onClickShowField: undefined,
+          },
+          onOptionsChange: onOptionsChangeMock,
+        },
+        showControls
+      );
+
+      expect(await screen.findByRole('row')).toBeInTheDocument();
+      expect(screen.getByText('logline text')).toBeInTheDocument();
+
+      // Click to open log details
+      await userEvent.click(screen.getByText('logline text'));
+      // Click to show the 'app' field
+      await userEvent.click(screen.getByLabelText('Show this field instead of the message'));
+
+      // Verify onOptionsChange was called with the field shown
+      expect(onOptionsChangeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          displayedFields: ['app'],
+        })
+      );
+    });
+
+    it('calls onOptionsChange with updated displayedFields when hiding a field', async () => {
+      const onOptionsChangeMock = jest.fn();
+
+      setup(
+        {
+          data: {
+            ...defaultProps.data,
+            series,
+          },
+          options: {
+            ...defaultProps.options,
+            showLabels: false,
+            showTime: false,
+            wrapLogMessage: false,
+            showCommonLabels: false,
+            prettifyLogMessage: false,
+            sortOrder: LogsSortOrder.Descending,
+            dedupStrategy: LogsDedupStrategy.none,
+            enableLogDetails: true,
+            displayedFields: ['app'],
+            onClickHideField: undefined,
+            onClickShowField: undefined,
+          },
+          onOptionsChange: onOptionsChangeMock,
+        },
+        showControls
+      );
+
+      expect(await screen.findByRole('row')).toBeInTheDocument();
+      expect(screen.getByText('app=common_app')).toBeInTheDocument();
+
+      // Click to open log details
+      await userEvent.click(screen.getByText('app=common_app'));
+      // Click to hide the 'app' field
+      await userEvent.click(screen.getByLabelText('Hide this field'));
+
+      // Verify onOptionsChange was called with the field hidden
+      expect(onOptionsChangeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          displayedFields: [],
+        })
+      );
+    });
   });
 });
 
 const setup = (propsOverrides?: Partial<LogsPanelProps>, showControls = false) => {
   const props: LogsPanelProps = {
     ...defaultProps,
+    ...propsOverrides,
     data: {
       ...(propsOverrides?.data || defaultProps.data),
     },

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -139,11 +139,8 @@ interface LogsPanelProps extends PanelProps<Options> {
 }
 const noCommonLabels: Labels = {};
 
-export const LogsPanel = ({
-  data,
-  timeZone,
-  fieldConfig,
-  options: {
+export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChange, height, id }: LogsPanelProps) => {
+  const {
     showControls,
     showFieldSelector,
     controlsStorageKey,
@@ -174,11 +171,7 @@ export const LogsPanel = ({
     timestampResolution,
     showLogAttributes,
     unwrappedColumns,
-    ...options
-  },
-  height,
-  id,
-}: LogsPanelProps) => {
+  } = options;
   const isAscending = sortOrder === LogsSortOrder.Ascending;
   const style = useStyles2(getStyles);
   const logsContainerRef = useRef<HTMLDivElement>(null);
@@ -413,20 +406,30 @@ export const LogsPanel = ({
     (key: string) => {
       const index = displayedFields?.indexOf(key);
       if (index === -1) {
-        setDisplayedFields(displayedFields?.concat(key));
+        const newDisplayedFields = displayedFields?.concat(key);
+        setDisplayedFields(newDisplayedFields);
+        onOptionsChange({
+          ...options,
+          displayedFields: newDisplayedFields,
+        });
       }
     },
-    [displayedFields]
+    [displayedFields, onOptionsChange, options]
   );
 
   const hideField = useCallback(
     (key: string) => {
       const index = displayedFields?.indexOf(key);
       if (index !== undefined && index > -1) {
-        setDisplayedFields(displayedFields?.filter((k) => key !== k));
+        const newDisplayedFields = displayedFields?.filter((k) => key !== k);
+        setDisplayedFields(newDisplayedFields);
+        onOptionsChange({
+          ...options,
+          displayedFields: newDisplayedFields,
+        });
       }
     },
-    [displayedFields]
+    [displayedFields, onOptionsChange, options]
   );
 
   useEffect(() => {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/95553

This PR adds support to persist displayed fields selected in the Panel Editor, to be persisted and reused in the Dashboard.

Demo:

https://github.com/user-attachments/assets/548ce61f-b056-470a-a0fe-f586b010dcd0

> [!IMPORTANT]
> You need to be in EDIT mode in order to persist the selection. Checkout the diff before saving to make sure you're changes are there.