### PR TITLE
Users: Offer external management on invite page + disable form

### DIFF
--- a/public/app/features/org/UserInviteForm.tsx
+++ b/public/app/features/org/UserInviteForm.tsx
@@ -16,6 +16,7 @@ import {
   Tooltip,
   Label,
   Stack,
+  Alert,
 } from '@grafana/ui';
 import { getConfig } from 'app/core/config';
 import { useDispatch } from 'app/types/store';
@@ -71,66 +72,83 @@ export const UserInviteForm = () => {
   };
 
   return (
-    <Form defaultValues={defaultValues} onSubmit={onSubmit}>
-      {({ register, control, errors }) => {
-        return (
-          <>
-            <FieldSet>
-              <Field
-                invalid={!!errors.loginOrEmail}
-                error={!!errors.loginOrEmail ? 'Email or username is required' : undefined}
-                label={t('org.user-invite-form.label-email-or-username', 'Email or username')}
-                disabled={disabled}
-              >
-                {/* eslint-disable-next-line @grafana/i18n/no-untranslated-strings */}
-                <Input {...register('loginOrEmail', { required: true })} placeholder="email@example.com" />
-              </Field>
-              <Field invalid={!!errors.name} label={t('org.user-invite-form.label-name', 'Name')} disabled={disabled}>
-                <Input
-                  {...register('name')}
-                  placeholder={t('org.user-invite-form.placeholder-optional', '(optional)')}
-                />
-              </Field>
-              <Field
-                invalid={!!errors.role}
-                label={
-                  <Label>
-                    <Stack gap={0.5}>
-                      <span>
-                        <Trans i18nKey="org.user-invite-form.role">Role</Trans>
-                      </span>
-                      {tooltipMessage && (
-                        <Tooltip placement="right-end" interactive={true} content={tooltipMessage}>
-                          <Icon name="info-circle" size="xs" />
-                        </Tooltip>
-                      )}
-                    </Stack>
-                  </Label>
-                }
-                disabled={disabled}
-              >
-                <Controller
-                  render={({ field: { ref, ...field } }) => <RadioButtonGroup {...field} options={roles} />}
-                  control={control}
-                  name="role"
-                />
-              </Field>
-              <Field label={t('org.user-invite-form.label-send-invite-email', 'Send invite email')} disabled={disabled}>
-                <Switch id="send-email-switch" {...register('sendEmail')} />
-              </Field>
-            </FieldSet>
-            <Stack>
-              <Button type="submit" disabled={disabled}>
-                <Trans i18nKey="org.user-invite-form.submit">Submit</Trans>
-              </Button>
-              <LinkButton href={locationUtil.assureBaseUrl(getConfig().appSubUrl + '/admin/users')} variant="secondary">
-                <Trans i18nKey="org.user-invite-form.back">Back</Trans>
-              </LinkButton>
-            </Stack>
-          </>
-        );
-      }}
-    </Form>
+    <>
+      {disabled && (
+        <Alert severity="warning" title={t('org.user-invite-form.disabled-title', 'Externally managed users')}>
+          <Trans i18nKey="org.user-invite-form.disabled-message">
+            This form is no longer in use. To invite a new user, please click the button to manage invitations
+            externally.
+          </Trans>
+        </Alert>
+      )}
+
+      <Form defaultValues={defaultValues} onSubmit={onSubmit}>
+        {({ register, control, errors }) => {
+          return (
+            <>
+              <FieldSet>
+                <Field
+                  invalid={!!errors.loginOrEmail}
+                  error={!!errors.loginOrEmail ? 'Email or username is required' : undefined}
+                  label={t('org.user-invite-form.label-email-or-username', 'Email or username')}
+                  disabled={disabled}
+                >
+                  {/* eslint-disable-next-line @grafana/i18n/no-untranslated-strings */}
+                  <Input {...register('loginOrEmail', { required: true })} placeholder="email@example.com" />
+                </Field>
+                <Field invalid={!!errors.name} label={t('org.user-invite-form.label-name', 'Name')} disabled={disabled}>
+                  <Input
+                    {...register('name')}
+                    placeholder={t('org.user-invite-form.placeholder-optional', '(optional)')}
+                  />
+                </Field>
+                <Field
+                  invalid={!!errors.role}
+                  label={
+                    <Label>
+                      <Stack gap={0.5}>
+                        <span>
+                          <Trans i18nKey="org.user-invite-form.role">Role</Trans>
+                        </span>
+                        {tooltipMessage && (
+                          <Tooltip placement="right-end" interactive={true} content={tooltipMessage}>
+                            <Icon name="info-circle" size="xs" />
+                          </Tooltip>
+                        )}
+                      </Stack>
+                    </Label>
+                  }
+                  disabled={disabled}
+                >
+                  <Controller
+                    render={({ field: { ref, ...field } }) => <RadioButtonGroup {...field} options={roles} />}
+                    control={control}
+                    name="role"
+                  />
+                </Field>
+                <Field
+                  label={t('org.user-invite-form.label-send-invite-email', 'Send invite email')}
+                  disabled={disabled}
+                >
+                  <Switch id="send-email-switch" {...register('sendEmail')} />
+                </Field>
+              </FieldSet>
+              <Stack>
+                <Button type="submit" disabled={disabled}>
+                  <Trans i18nKey="org.user-invite-form.submit">Submit</Trans>
+                </Button>
+                <LinkButton
+                  href={locationUtil.assureBaseUrl(getConfig().appSubUrl + '/admin/users')}
+                  variant="secondary"
+                >
+                  <Trans i18nKey="org.user-invite-form.back">Back</Trans>
+                </LinkButton>
+              </Stack>
+            </>
+          );
+        }}
+      </Form>
+    </>
   );
 };
 

--- a/public/app/features/org/UserInviteForm.tsx
+++ b/public/app/features/org/UserInviteForm.tsx
@@ -22,6 +22,7 @@ import { useDispatch } from 'app/types/store';
 
 import { Form } from '../../core/components/Form/Form';
 import { addInvitee } from '../invites/state/actions';
+import { getCanInviteUsersToOrg } from '../users/utils';
 
 const tooltipMessage = (
   <>
@@ -62,6 +63,7 @@ const defaultValues: FormModel = {
 
 export const UserInviteForm = () => {
   const dispatch = useDispatch();
+  const disabled = !getCanInviteUsersToOrg();
 
   const onSubmit = async (formData: FormModel) => {
     await dispatch(addInvitee(formData)).unwrap();
@@ -78,11 +80,12 @@ export const UserInviteForm = () => {
                 invalid={!!errors.loginOrEmail}
                 error={!!errors.loginOrEmail ? 'Email or username is required' : undefined}
                 label={t('org.user-invite-form.label-email-or-username', 'Email or username')}
+                disabled={disabled}
               >
                 {/* eslint-disable-next-line @grafana/i18n/no-untranslated-strings */}
                 <Input {...register('loginOrEmail', { required: true })} placeholder="email@example.com" />
               </Field>
-              <Field invalid={!!errors.name} label={t('org.user-invite-form.label-name', 'Name')}>
+              <Field invalid={!!errors.name} label={t('org.user-invite-form.label-name', 'Name')} disabled={disabled}>
                 <Input
                   {...register('name')}
                   placeholder={t('org.user-invite-form.placeholder-optional', '(optional)')}
@@ -104,6 +107,7 @@ export const UserInviteForm = () => {
                     </Stack>
                   </Label>
                 }
+                disabled={disabled}
               >
                 <Controller
                   render={({ field: { ref, ...field } }) => <RadioButtonGroup {...field} options={roles} />}
@@ -111,12 +115,12 @@ export const UserInviteForm = () => {
                   name="role"
                 />
               </Field>
-              <Field label={t('org.user-invite-form.label-send-invite-email', 'Send invite email')}>
+              <Field label={t('org.user-invite-form.label-send-invite-email', 'Send invite email')} disabled={disabled}>
                 <Switch id="send-email-switch" {...register('sendEmail')} />
               </Field>
             </FieldSet>
             <Stack>
-              <Button type="submit">
+              <Button type="submit" disabled={disabled}>
                 <Trans i18nKey="org.user-invite-form.submit">Submit</Trans>
               </Button>
               <LinkButton href={locationUtil.assureBaseUrl(getConfig().appSubUrl + '/admin/users')} variant="secondary">

--- a/public/app/features/org/UserInvitePage.tsx
+++ b/public/app/features/org/UserInvitePage.tsx
@@ -1,6 +1,9 @@
 import { Trans, t } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
 import { Page } from 'app/core/components/Page/Page';
 import { contextSrv } from 'app/core/services/context_srv';
+
+import { UsersExternalButton } from '../users/UsersExternalButton';
 
 import UserInviteForm from './UserInviteForm';
 
@@ -12,11 +15,21 @@ export function UserInvitePage() {
     </Trans>
   );
 
+  const onExternalUserMngClick = () => {
+    reportInteraction('users_invite_actions_clicked', {
+      category: 'org_users',
+      item: 'manage_users_external',
+    });
+  };
+
+  const actions = <UsersExternalButton onExternalUserMngClick={onExternalUserMngClick} />;
+
   return (
     <Page
       navId="global-users"
       pageNav={{ text: t('org.user-invite-page.text.invite-user', 'Invite user') }}
       subTitle={subTitle}
+      actions={actions}
     >
       <Page.Contents>
         <UserInviteForm />

--- a/public/app/features/org/UserInvitePage.tsx
+++ b/public/app/features/org/UserInvitePage.tsx
@@ -16,10 +16,7 @@ export function UserInvitePage() {
   );
 
   const onExternalUserMngClick = () => {
-    reportInteraction('users_invite_actions_clicked', {
-      category: 'org_users',
-      item: 'manage_users_external',
-    });
+    reportInteraction('admin_manage_users_invite_form_action_clicked');
   };
 
   const actions = <UsersExternalButton onExternalUserMngClick={onExternalUserMngClick} />;

--- a/public/app/features/users/UsersActionBar.test.tsx
+++ b/public/app/features/users/UsersActionBar.test.tsx
@@ -1,30 +1,18 @@
 import { render, screen } from '@testing-library/react';
-import { Provider } from 'react-redux';
 import { mockToolkitActionCreator } from 'test/core/redux/mocks';
 
 import { config } from '@grafana/runtime';
-import { configureStore } from 'app/store/configureStore';
 
 import { Props, UsersActionBarUnconnected } from './UsersActionBar';
-import { initialState, searchQueryChanged } from './state/reducers';
+import { searchQueryChanged } from './state/reducers';
 
 jest.mock('app/core/services/context_srv', () => ({
   contextSrv: {
-    user: {},
     hasPermission: () => true,
   },
 }));
 
 const setup = (propOverrides?: object) => {
-  const store = configureStore({
-    users: {
-      ...initialState,
-      externalUserMngInfo: config.externalUserMngInfo,
-      externalUserMngLinkName: config.externalUserMngLinkName,
-      externalUserMngLinkUrl: config.externalUserMngLinkUrl,
-    },
-  });
-
   const props: Props = {
     searchQuery: '',
     changeSearchQuery: mockToolkitActionCreator(searchQueryChanged),
@@ -35,11 +23,7 @@ const setup = (propOverrides?: object) => {
 
   Object.assign(props, propOverrides);
 
-  const { rerender } = render(
-    <Provider store={store}>
-      <UsersActionBarUnconnected {...props} />
-    </Provider>
-  );
+  const { rerender } = render(<UsersActionBarUnconnected {...props} />);
 
   return { rerender, props };
 };

--- a/public/app/features/users/UsersActionBar.test.tsx
+++ b/public/app/features/users/UsersActionBar.test.tsx
@@ -1,39 +1,67 @@
 import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
 import { mockToolkitActionCreator } from 'test/core/redux/mocks';
 
 import { config } from '@grafana/runtime';
+import { configureStore } from 'app/store/configureStore';
 
 import { Props, UsersActionBarUnconnected } from './UsersActionBar';
-import { searchQueryChanged } from './state/reducers';
+import { initialState, searchQueryChanged } from './state/reducers';
 
 jest.mock('app/core/services/context_srv', () => ({
   contextSrv: {
+    user: {},
     hasPermission: () => true,
   },
 }));
 
 const setup = (propOverrides?: object) => {
+  const store = configureStore({
+    users: {
+      ...initialState,
+      externalUserMngInfo: config.externalUserMngInfo,
+      externalUserMngLinkName: config.externalUserMngLinkName,
+      externalUserMngLinkUrl: config.externalUserMngLinkUrl,
+    },
+  });
+
   const props: Props = {
     searchQuery: '',
     changeSearchQuery: mockToolkitActionCreator(searchQueryChanged),
     onShowInvites: jest.fn(),
     pendingInvitesCount: 0,
-    externalUserMngLinkUrl: '',
-    externalUserMngLinkName: '',
     showInvites: false,
   };
 
   Object.assign(props, propOverrides);
 
-  config.externalUserMngLinkUrl = props.externalUserMngLinkUrl;
-  config.externalUserMngLinkName = props.externalUserMngLinkName;
-
-  const { rerender } = render(<UsersActionBarUnconnected {...props} />);
+  const { rerender } = render(
+    <Provider store={store}>
+      <UsersActionBarUnconnected {...props} />
+    </Provider>
+  );
 
   return { rerender, props };
 };
 
 describe('Render', () => {
+  const originalExternalUserMngInfo = config.externalUserMngInfo;
+  const originalExternalUserMngLinkUrl = config.externalUserMngLinkUrl;
+  const originalExternalUserMngLinkName = config.externalUserMngLinkName;
+  const originalExternalUserMngAnalytics = config.externalUserMngAnalytics;
+  const originalExternalUserMngAnalyticsParams = config.externalUserMngAnalyticsParams;
+  const originalDisableLoginForm = config.disableLoginForm;
+
+  afterEach(() => {
+    // Restore original config after each test
+    config.externalUserMngInfo = originalExternalUserMngInfo;
+    config.externalUserMngLinkUrl = originalExternalUserMngLinkUrl;
+    config.externalUserMngLinkName = originalExternalUserMngLinkName;
+    config.externalUserMngAnalytics = originalExternalUserMngAnalytics;
+    config.externalUserMngAnalyticsParams = originalExternalUserMngAnalyticsParams;
+    config.disableLoginForm = originalDisableLoginForm;
+  });
+
   it('should render component', () => {
     setup();
 
@@ -55,10 +83,10 @@ describe('Render', () => {
   });
 
   it('should show external user management button', () => {
-    setup({
-      externalUserMngLinkUrl: 'http://some/url',
-      externalUserMngLinkName: 'someUrl',
-    });
+    config.externalUserMngLinkUrl = 'http://some/url';
+    config.externalUserMngLinkName = 'someUrl';
+
+    setup();
 
     expect(screen.getByRole('link', { name: 'someUrl' })).toHaveAttribute('href', 'http://some/url');
   });
@@ -66,11 +94,10 @@ describe('Render', () => {
   it('should show external user management button with analytics values when configured', () => {
     config.externalUserMngAnalytics = true;
     config.externalUserMngAnalyticsParams = 'src=grafananet&other=value1';
+    config.externalUserMngLinkUrl = 'http://some/url';
+    config.externalUserMngLinkName = 'someUrl';
 
-    setup({
-      externalUserMngLinkUrl: 'http://some/url',
-      externalUserMngLinkName: 'someUrl',
-    });
+    setup();
 
     expect(screen.getByRole('link', { name: 'someUrl' })).toHaveAttribute(
       'href',
@@ -81,25 +108,21 @@ describe('Render', () => {
   it('should show external user management button without analytics values when disabled', () => {
     config.externalUserMngAnalytics = false;
     config.externalUserMngAnalyticsParams = 'src=grafananet&other=value1';
+    config.externalUserMngLinkUrl = 'http://some/url';
+    config.externalUserMngLinkName = 'someUrl';
 
-    setup({
-      externalUserMngLinkUrl: 'http://some/url',
-      externalUserMngLinkName: 'someUrl',
-    });
+    setup();
 
     expect(screen.getByRole('link', { name: 'someUrl' })).toHaveAttribute('href', 'http://some/url');
   });
 
   it('should not show invite button when externalUserMngInfo is set and disableLoginForm is true', () => {
-    const originalExternalUserMngInfo = config.externalUserMngInfo;
     config.externalUserMngInfo = 'truthy';
     config.disableLoginForm = true;
 
     setup();
 
     expect(screen.queryByRole('link', { name: 'Invite' })).not.toBeInTheDocument();
-    // Reset the disableLoginForm mock to its original value
-    config.externalUserMngInfo = originalExternalUserMngInfo;
   });
 
   it('should show invite button when externalUserMngInfo is not set and disableLoginForm is true', () => {
@@ -109,18 +132,13 @@ describe('Render', () => {
     setup();
 
     expect(screen.getByRole('link', { name: 'Invite' })).toHaveAttribute('href', 'org/users/invite');
-    // Reset the disableLoginForm mock to its original value
-    config.disableLoginForm = false;
   });
 
   it('should show invite button when externalUserMngInfo is set and disableLoginForm is false', () => {
-    const originalExternalUserMngInfo = config.externalUserMngInfo;
     config.externalUserMngInfo = 'truthy';
 
     setup();
 
     expect(screen.getByRole('link', { name: 'Invite' })).toHaveAttribute('href', 'org/users/invite');
-    // Reset the disableLoginForm mock to its original value
-    config.externalUserMngInfo = originalExternalUserMngInfo;
   });
 });

--- a/public/app/features/users/UsersActionBar.tsx
+++ b/public/app/features/users/UsersActionBar.tsx
@@ -4,9 +4,6 @@ import { connect, ConnectedProps } from 'react-redux';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { RadioButtonGroup, LinkButton, FilterInput, InlineField } from '@grafana/ui';
-import config from 'app/core/config';
-import { contextSrv } from 'app/core/services/context_srv';
-import { AccessControlAction } from 'app/types/accessControl';
 import { StoreState } from 'app/types/store';
 
 import { selectTotal } from '../invites/state/selectors';
@@ -14,6 +11,7 @@ import { selectTotal } from '../invites/state/selectors';
 import { UsersExternalButton } from './UsersExternalButton';
 import { changeSearchQuery } from './state/actions';
 import { getUsersSearchQuery } from './state/selectors';
+import { getCanInviteUsersToOrg } from './utils';
 
 export interface OwnProps {
   showInvites: boolean;
@@ -46,11 +44,6 @@ export const UsersActionBarUnconnected = ({
     { label: t('users.users-action-bar-unconnected.options.label.users', 'Users'), value: 'users' },
     { label: `Pending Invites (${pendingInvitesCount})`, value: 'invites' },
   ];
-  const canAddToOrg: boolean = contextSrv.hasPermission(AccessControlAction.OrgUsersAdd);
-  // Show invite button in the following cases:
-  // 1) the instance is not a hosted Grafana instance (!config.externalUserMngInfo)
-  // 2) new basic auth users can be created for this instance (!config.disableLoginForm).
-  const showInviteButton: boolean = canAddToOrg && !(config.disableLoginForm && config.externalUserMngInfo);
 
   const onExternalUserMngClick = () => {
     reportInteraction('users_admin_actions_clicked', {
@@ -76,7 +69,7 @@ export const UsersActionBarUnconnected = ({
           <RadioButtonGroup value={showInvites ? 'invites' : 'users'} options={options} onChange={onShowInvites} />
         </div>
       )}
-      {showInviteButton && (
+      {getCanInviteUsersToOrg() && (
         <LinkButton href="org/users/invite">
           <Trans i18nKey="users.users-action-bar-unconnected.invite">Invite</Trans>
         </LinkButton>

--- a/public/app/features/users/UsersActionBar.tsx
+++ b/public/app/features/users/UsersActionBar.tsx
@@ -11,9 +11,9 @@ import { StoreState } from 'app/types/store';
 
 import { selectTotal } from '../invites/state/selectors';
 
+import { UsersExternalButton } from './UsersExternalButton';
 import { changeSearchQuery } from './state/actions';
 import { getUsersSearchQuery } from './state/selectors';
-import { getExternalUserMngLinkUrl } from './utils';
 
 export interface OwnProps {
   showInvites: boolean;
@@ -24,8 +24,6 @@ function mapStateToProps(state: StoreState) {
   return {
     searchQuery: getUsersSearchQuery(state.users),
     pendingInvitesCount: selectTotal(state.invites),
-    externalUserMngLinkName: state.users.externalUserMngLinkName,
-    externalUserMngLinkUrl: state.users.externalUserMngLinkUrl,
   };
 }
 
@@ -38,8 +36,6 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 export type Props = ConnectedProps<typeof connector> & OwnProps;
 
 export const UsersActionBarUnconnected = ({
-  externalUserMngLinkName,
-  externalUserMngLinkUrl,
   searchQuery,
   pendingInvitesCount,
   changeSearchQuery,
@@ -85,16 +81,7 @@ export const UsersActionBarUnconnected = ({
           <Trans i18nKey="users.users-action-bar-unconnected.invite">Invite</Trans>
         </LinkButton>
       )}
-      {externalUserMngLinkUrl && (
-        <LinkButton
-          onClick={onExternalUserMngClick}
-          href={getExternalUserMngLinkUrl('manage-users')}
-          target="_blank"
-          rel="noopener"
-        >
-          {externalUserMngLinkName}
-        </LinkButton>
-      )}
+      <UsersExternalButton onExternalUserMngClick={onExternalUserMngClick} />
     </div>
   );
 };

--- a/public/app/features/users/UsersExternalButton.tsx
+++ b/public/app/features/users/UsersExternalButton.tsx
@@ -1,40 +1,21 @@
-import { connect, ConnectedProps } from 'react-redux';
-
+import { config } from '@grafana/runtime';
 import { LinkButton } from '@grafana/ui';
-import { StoreState } from 'app/types/store';
 
 import { getExternalUserMngLinkUrl } from './utils';
 
-export interface OwnProps {
+export interface Props {
   onExternalUserMngClick: () => void;
 }
 
-function mapStateToProps(state: StoreState) {
-  return {
-    externalUserMngLinkName: state.users.externalUserMngLinkName,
-    externalUserMngLinkUrl: state.users.externalUserMngLinkUrl,
-  };
-}
-
-const connector = connect(mapStateToProps);
-
-export type Props = ConnectedProps<typeof connector> & OwnProps;
-
-export const UsersExternalButtonUnconnected = ({
-  externalUserMngLinkName,
-  externalUserMngLinkUrl,
-  onExternalUserMngClick,
-}: Props) => {
-  return externalUserMngLinkUrl ? (
+export const UsersExternalButton = ({ onExternalUserMngClick }: Props) => {
+  return config.externalUserMngLinkUrl ? (
     <LinkButton
       onClick={onExternalUserMngClick}
       href={getExternalUserMngLinkUrl('manage-users')}
       target="_blank"
       rel="noopener"
     >
-      {externalUserMngLinkName}
+      {config.externalUserMngLinkName}
     </LinkButton>
   ) : null;
 };
-
-export const UsersExternalButton = connector(UsersExternalButtonUnconnected);

--- a/public/app/features/users/UsersExternalButton.tsx
+++ b/public/app/features/users/UsersExternalButton.tsx
@@ -1,0 +1,40 @@
+import { connect, ConnectedProps } from 'react-redux';
+
+import { LinkButton } from '@grafana/ui';
+import { StoreState } from 'app/types/store';
+
+import { getExternalUserMngLinkUrl } from './utils';
+
+export interface OwnProps {
+  onExternalUserMngClick: () => void;
+}
+
+function mapStateToProps(state: StoreState) {
+  return {
+    externalUserMngLinkName: state.users.externalUserMngLinkName,
+    externalUserMngLinkUrl: state.users.externalUserMngLinkUrl,
+  };
+}
+
+const connector = connect(mapStateToProps);
+
+export type Props = ConnectedProps<typeof connector> & OwnProps;
+
+export const UsersExternalButtonUnconnected = ({
+  externalUserMngLinkName,
+  externalUserMngLinkUrl,
+  onExternalUserMngClick,
+}: Props) => {
+  return externalUserMngLinkUrl ? (
+    <LinkButton
+      onClick={onExternalUserMngClick}
+      href={getExternalUserMngLinkUrl('manage-users')}
+      target="_blank"
+      rel="noopener"
+    >
+      {externalUserMngLinkName}
+    </LinkButton>
+  ) : null;
+};
+
+export const UsersExternalButton = connector(UsersExternalButtonUnconnected);

--- a/public/app/features/users/UsersListPage.test.tsx
+++ b/public/app/features/users/UsersListPage.test.tsx
@@ -29,7 +29,6 @@ const setup = (propOverrides?: object) => {
     page: 1,
     totalPages: 1,
     perPage: 30,
-    externalUserMngInfo: '',
     fetchInvitees: jest.fn(),
     loadUsers: jest.fn(),
     updateUser: jest.fn(),

--- a/public/app/features/users/UsersListPage.tsx
+++ b/public/app/features/users/UsersListPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { OrgRole, renderMarkdown } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { Alert } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -26,7 +27,6 @@ function mapStateToProps(state: StoreState) {
     totalPages: state.users.totalPages,
     perPage: state.users.perPage,
     invitees: selectInvitesMatchingQuery(state.invites, searchQuery),
-    externalUserMngInfo: state.users.externalUserMngInfo,
     isLoading: state.users.isLoading,
     rolesLoading: state.users.rolesLoading,
   };
@@ -54,7 +54,6 @@ export const UsersListPageUnconnected = ({
   page,
   totalPages,
   invitees,
-  externalUserMngInfo,
   isLoading,
   rolesLoading,
   loadUsers,
@@ -65,7 +64,7 @@ export const UsersListPageUnconnected = ({
   changeSort,
 }: Props) => {
   const [showInvites, setShowInvites] = useState(false);
-  const externalUserMngInfoHtml = externalUserMngInfo ? renderMarkdown(externalUserMngInfo) : '';
+  const externalUserMngInfoHtml = config.externalUserMngInfo ? renderMarkdown(config.externalUserMngInfo) : '';
 
   useEffect(() => {
     loadUsers();

--- a/public/app/features/users/state/reducers.ts
+++ b/public/app/features/users/state/reducers.ts
@@ -1,6 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import config from 'app/core/config';
 import { UsersState, OrgUser } from 'app/types/user';
 
 export const initialState: UsersState = {
@@ -9,9 +8,6 @@ export const initialState: UsersState = {
   page: 0,
   perPage: 30,
   totalPages: 1,
-  externalUserMngInfo: config.externalUserMngInfo,
-  externalUserMngLinkName: config.externalUserMngLinkName,
-  externalUserMngLinkUrl: config.externalUserMngLinkUrl,
   isLoading: false,
   rolesLoading: false,
 };

--- a/public/app/features/users/utils.ts
+++ b/public/app/features/users/utils.ts
@@ -1,4 +1,15 @@
 import { config } from '@grafana/runtime';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+export function getCanInviteUsersToOrg(): boolean {
+  const canAddToOrg: boolean = contextSrv.hasPermission(AccessControlAction.OrgUsersAdd);
+
+  // Show invite button in the following cases:
+  // 1) the instance is not a hosted Grafana instance (!config.externalUserMngInfo)
+  // 2) new basic auth users can be created for this instance (!config.disableLoginForm).
+  return canAddToOrg && !(config.disableLoginForm && config.externalUserMngInfo);
+}
 
 export function getExternalUserMngLinkUrl(cnt: string) {
   const url = new URL(config.externalUserMngLinkUrl);

--- a/public/app/types/user.ts
+++ b/public/app/types/user.ts
@@ -82,9 +82,6 @@ export interface Invitee {
 export interface UsersState {
   users: OrgUser[];
   searchQuery: string;
-  externalUserMngLinkUrl: string;
-  externalUserMngLinkName: string;
-  externalUserMngInfo: string;
   isLoading: boolean;
   rolesLoading?: boolean;
   page: number;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11725,6 +11725,8 @@
     },
     "user-invite-form": {
       "back": "Back",
+      "disabled-message": "This form is no longer in use. To invite a new user, please click the button to manage invitations externally.",
+      "disabled-title": "Externally managed users",
       "label-email-or-username": "Email or username",
       "label-name": "Name",
       "label-send-invite-email": "Send invite email",


### PR DESCRIPTION
**What is this feature?**

Reuses the logic that already exists in `UsersActionBar`, updates `UserInvitePage` to offer an external user management button if available, and updates `UserInviteForm` to disable the form if basic user management is not available.

~~This might warrant some more explicit messaging being displayed on the `UserInvitePage` when `UserInviteForm` is disabled, though I suspect that would get complicated -- `externalUserMngInfo` is what is rendered on the `UsersListPage`, but the wording of that (at least in Grafana Cloud) is very specific to that page, referencing the table below the message, so I don't think this could be reused for the `UserInvitePage`. My current thinking is that given there shouldn't be a way to get to this page in the first place, and I'm just making this change for users who manage to get to it directly, a lack of additional copy is fine.~~

**Why do we need this feature?**

While the entry point for user management, `/admin/users`, already had logic in `UsersActionBar` to conditionally offer basic + external user management, it was still possible for a user to navigate directly to `/org/users/invite` and be presented with the basic user form when it wouldn't work (Grafana Cloud), getting back a `Cannot invite external user when logic is disabled.` error message if submitted.

**Who is this feature for?**

Grafana Cloud

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.