### PR TITLE
IAM: Wire RoleBinding storage backend into MT IAM API server

### DIFF
--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -36,7 +36,6 @@ import (
 	iamauthorizer "github.com/grafana/grafana/pkg/registry/apis/iam/authorizer"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/externalgroupmapping"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
-	"github.com/grafana/grafana/pkg/registry/apis/iam/noopstorage"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/resourcepermission"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/serviceaccount"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/sso"
@@ -46,6 +45,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry/fieldselectors"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver"
+	gfauthorizer "github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer"
 	"github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer/storewrapper"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
@@ -148,6 +148,7 @@ func NewAPIService(
 	accessClient types.AccessClient,
 	dbProvider legacysql.LegacyDatabaseProvider,
 	coreRoleStorage CoreRoleStorageBackend,
+	roleBindingsStorage RoleBindingStorageBackend,
 	roleApiInstaller RoleApiInstaller,
 	globalRoleApiInstaller GlobalRoleApiInstaller,
 	teamLBACApiInstaller TeamLBACApiInstaller,
@@ -165,6 +166,7 @@ func NewAPIService(
 	globalRoleAuthorizer := globalRoleApiInstaller.GetAuthorizer()
 	roleAuthorizer := roleApiInstaller.GetAuthorizer()
 	teamLBACAuthorizer := teamLBACApiInstaller.GetAuthorizer()
+	resourceAuthorizer := gfauthorizer.NewResourceAuthorizer(accessClient)
 
 	resourceParentProvider := iamauthorizer.NewApiParentProvider(
 		iamauthorizer.NewRemoteConfigProvider(authorizerDialConfigs, tokenExchanger),
@@ -176,7 +178,7 @@ func NewAPIService(
 		display:                    user.NewLegacyDisplayREST(store),
 		resourcePermissionsStorage: resourcePermissionsStorage,
 		coreRolesStorage:           coreRoleStorage,
-		roleBindingsStorage:        noopstorage.ProvideStorageBackend(), // TODO: add a proper storage backend
+		roleBindingsStorage:        roleBindingsStorage,
 		logger:                     log.New("iam.apis"),
 		features:                   features,
 		accessClient:               accessClient,
@@ -223,6 +225,10 @@ func NewAPIService(
 						return authorizer.DecisionDeny, "only access policy identities have access for now", nil
 					}
 					return roleAuthorizer.Authorize(ctx, a)
+				}
+
+				if a.GetResource() == "rolebindings" {
+					return resourceAuthorizer.Authorize(ctx, a)
 				}
 
 				return authorizer.DecisionDeny, "access denied", nil


### PR DESCRIPTION
**What is this feature?**

Replaces the `noopstorage` placeholder for RoleBindings in the MT IAM API server (`NewAPIService`) with a real, injected storage backend and adds the corresponding `rolebindings` entry to the inline authorizer.

**Why do we need this feature?**

The MT IAM API server had a TODO placeholder (`noopstorage.ProvideStorageBackend()`) for the RoleBindings resource. This meant RoleBindings were silently non-functional — reads returned empty results, writes were dropped, and the authorizer denied all access. This PR wires in the enterprise SQL storage backend and grants access through `NewResourceAuthorizer`, bringing RoleBindings to parity with the embedded IAM API server.

**Who is this feature for?**

Engineers running Grafana in multi-tenant mode who need working RBAC role bindings.

**Special notes for your reviewer:**

This is step 1 of a series of PRs to bring the MT IAM API server to feature parity with the embedded one, one resource at a time.

Changes:
- `NewAPIService` now accepts a `roleBindingsStorage RoleBindingStorageBackend` parameter instead of hard-coding `noopstorage.ProvideStorageBackend()`
- Added a `"rolebindings"` case to the inline authorizer using `gfauthorizer.NewResourceAuthorizer(accessClient)` (same authorizer the embedded path uses)
- Removed the now-unused `noopstorage` import