### PR TITLE
Alerting: Migrate alert notifiers api to the new app platform api

### DIFF
--- a/public/app/features/alerting/state/reducers.ts
+++ b/public/app/features/alerting/state/reducers.ts
@@ -85,7 +85,7 @@ const notificationChannelSlice = createSlice({
     notificationChannelLoaded: (state, action: PayloadAction<any>): NotificationChannelState => {
       const notificationChannel = action.payload;
       const selectedType: NotifierDTO = state.notifiers.find((t) => t.type === notificationChannel.type)!;
-      const secureChannelOptions = selectedType.options.filter((o: NotificationChannelOption) => o.secure);
+      const secureChannelOptions = (selectedType.options ?? []).filter((o: NotificationChannelOption) => o.secure);
       /*
         If any secure field is in plain text we need to migrate it to use secure field instead.
        */
@@ -157,6 +157,7 @@ function transformNotifiers(notifiers: NotifierDTO[]) {
         label: option.name,
         ...option,
         typeName: option.type,
+        options: option.options ?? [],
       };
     })
     .sort((o1, o2) => {

--- a/public/app/features/alerting/unified/api/integrationSchemasApi.test.ts
+++ b/public/app/features/alerting/unified/api/integrationSchemasApi.test.ts
@@ -12,12 +12,12 @@ const wrapper = () => getWrapper({ renderWithRouter: true });
 
 describe('useIntegrationTypeSchemas', () => {
   afterEach(() => {
-    config.featureToggles.alertingNotifiersApiMigration = false;
+    config.featureToggles.alertingSyncNotifiersApiMigration = false;
   });
 
-  describe('with alertingNotifiersApiMigration flag disabled', () => {
+  describe('with alertingSyncNotifiersApiMigration flag disabled', () => {
     beforeEach(() => {
-      config.featureToggles.alertingNotifiersApiMigration = false;
+      config.featureToggles.alertingSyncNotifiersApiMigration = false;
     });
 
     it('should return data from legacy API', async () => {
@@ -34,9 +34,9 @@ describe('useIntegrationTypeSchemas', () => {
     });
   });
 
-  describe('with alertingNotifiersApiMigration flag enabled', () => {
+  describe('with alertingSyncNotifiersApiMigration flag enabled', () => {
     beforeEach(() => {
-      config.featureToggles.alertingNotifiersApiMigration = true;
+      config.featureToggles.alertingSyncNotifiersApiMigration = true;
     });
 
     it('should return data from new k8s API', async () => {

--- a/public/app/features/alerting/unified/api/integrationSchemasApi.test.ts
+++ b/public/app/features/alerting/unified/api/integrationSchemasApi.test.ts
@@ -1,0 +1,123 @@
+import { getWrapper, renderHook, waitFor } from 'test/test-utils';
+
+import { config } from '@grafana/runtime';
+
+import { setupMswServer } from '../mockApi';
+
+import { useIntegrationTypeSchemas } from './integrationSchemasApi';
+
+setupMswServer();
+
+const wrapper = () => getWrapper({ renderWithRouter: true });
+
+describe('useIntegrationTypeSchemas', () => {
+  afterEach(() => {
+    config.featureToggles.alertingNotifiersApiMigration = false;
+  });
+
+  describe('with alertingNotifiersApiMigration flag disabled', () => {
+    beforeEach(() => {
+      config.featureToggles.alertingNotifiersApiMigration = false;
+    });
+
+    it('should return data from legacy API', async () => {
+      const { result } = renderHook(() => useIntegrationTypeSchemas(), { wrapper: wrapper() });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.data).toBeDefined();
+      expect(result.current.data?.length).toBeGreaterThan(0);
+      // Legacy API returns notifiers with top-level options
+      expect(result.current.data?.[0].options).toBeDefined();
+    });
+  });
+
+  describe('with alertingNotifiersApiMigration flag enabled', () => {
+    beforeEach(() => {
+      config.featureToggles.alertingNotifiersApiMigration = true;
+    });
+
+    it('should return data from new k8s API', async () => {
+      const { result } = renderHook(() => useIntegrationTypeSchemas(), { wrapper: wrapper() });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.data).toBeDefined();
+      expect(result.current.data?.length).toBeGreaterThan(0);
+    });
+
+    it('should transform response to NotifierDTO format with versions', async () => {
+      const { result } = renderHook(() => useIntegrationTypeSchemas(), { wrapper: wrapper() });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      const notifier = result.current.data?.[0];
+      expect(notifier).toBeDefined();
+      expect(notifier?.type).toBeDefined();
+      expect(notifier?.name).toBeDefined();
+      expect(notifier?.versions).toBeDefined();
+      expect(notifier?.versions?.length).toBeGreaterThan(0);
+    });
+
+    it('should populate secureFieldKey on secure options', async () => {
+      const { result } = renderHook(() => useIntegrationTypeSchemas(), { wrapper: wrapper() });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Find a notifier with secure options
+      const notifierWithSecure = result.current.data?.find((n) =>
+        n.versions?.some((v) => v.options.some((o) => o.secure))
+      );
+
+      if (notifierWithSecure) {
+        const secureOption = notifierWithSecure.versions?.flatMap((v) => v.options).find((o) => o.secure);
+
+        expect(secureOption?.secureFieldKey).toBe(secureOption?.propertyName);
+      }
+    });
+
+    it('should handle nested subformOptions with correct secureFieldKey paths', async () => {
+      const { result } = renderHook(() => useIntegrationTypeSchemas(), { wrapper: wrapper() });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Find a notifier with subformOptions
+      const notifierWithSubform = result.current.data?.find((n) =>
+        n.versions?.some((v) => v.options.some((o) => o.subformOptions?.length))
+      );
+
+      if (notifierWithSubform) {
+        const optionWithSubform = notifierWithSubform.versions
+          ?.flatMap((v) => v.options)
+          .find((o) => o.subformOptions?.length);
+
+        const secureSubOption = optionWithSubform?.subformOptions?.find((o) => o.secure);
+        if (secureSubOption) {
+          // secureFieldKey should include parent path
+          expect(secureSubOption.secureFieldKey).toContain(optionWithSubform?.propertyName);
+        }
+      }
+    });
+  });
+
+  describe('skip option', () => {
+    it('should not fetch when skip is true', async () => {
+      const { result } = renderHook(() => useIntegrationTypeSchemas({ skip: true }), {
+        wrapper: wrapper(),
+      });
+
+      // Should remain in initial state
+      expect(result.current.data).toBeUndefined();
+    });
+  });
+});

--- a/public/app/features/alerting/unified/api/integrationSchemasApi.test.ts
+++ b/public/app/features/alerting/unified/api/integrationSchemasApi.test.ts
@@ -76,12 +76,10 @@ describe('useIntegrationTypeSchemas', () => {
       const notifierWithSecure = result.current.data?.find((n) =>
         n.versions?.some((v) => v.options.some((o) => o.secure))
       );
+      expect(notifierWithSecure).toBeDefined();
 
-      if (notifierWithSecure) {
-        const secureOption = notifierWithSecure.versions?.flatMap((v) => v.options).find((o) => o.secure);
-
-        expect(secureOption?.secureFieldKey).toBe(secureOption?.propertyName);
-      }
+      const secureOption = notifierWithSecure!.versions?.flatMap((v) => v.options).find((o) => o.secure);
+      expect(secureOption?.secureFieldKey).toBe(secureOption?.propertyName);
     });
 
     it('should handle nested subformOptions with correct secureFieldKey paths', async () => {
@@ -91,22 +89,22 @@ describe('useIntegrationTypeSchemas', () => {
         expect(result.current.isLoading).toBe(false);
       });
 
-      // Find a notifier with subformOptions
-      const notifierWithSubform = result.current.data?.find((n) =>
-        n.versions?.some((v) => v.options.some((o) => o.subformOptions?.length))
+      // Find a notifier with subformOptions that contain a secure option
+      const notifierWithSecureSubform = result.current.data?.find((n) =>
+        n.versions?.some((v) => v.options.some((o) => o.subformOptions?.some((sub) => sub.secure)))
       );
+      expect(notifierWithSecureSubform).toBeDefined();
 
-      if (notifierWithSubform) {
-        const optionWithSubform = notifierWithSubform.versions
-          ?.flatMap((v) => v.options)
-          .find((o) => o.subformOptions?.length);
+      const optionWithSubform = notifierWithSecureSubform!.versions
+        ?.flatMap((v) => v.options)
+        .find((o) => o.subformOptions?.some((sub) => sub.secure));
+      expect(optionWithSubform).toBeDefined();
 
-        const secureSubOption = optionWithSubform?.subformOptions?.find((o) => o.secure);
-        if (secureSubOption) {
-          // secureFieldKey should include parent path
-          expect(secureSubOption.secureFieldKey).toContain(optionWithSubform?.propertyName);
-        }
-      }
+      const secureSubOption = optionWithSubform!.subformOptions?.find((o) => o.secure);
+      expect(secureSubOption).toBeDefined();
+
+      // secureFieldKey should include parent path
+      expect(secureSubOption!.secureFieldKey).toContain(optionWithSubform!.propertyName);
     });
   });
 

--- a/public/app/features/alerting/unified/api/integrationSchemasApi.test.ts
+++ b/public/app/features/alerting/unified/api/integrationSchemasApi.test.ts
@@ -1,6 +1,4 @@
-import { getWrapper, renderHook, waitFor } from 'test/test-utils';
-
-import { config } from '@grafana/runtime';
+import { getWrapper, renderHook, testWithFeatureToggles, waitFor } from 'test/test-utils';
 
 import { setupMswServer } from '../mockApi';
 
@@ -11,14 +9,8 @@ setupMswServer();
 const wrapper = () => getWrapper({ renderWithRouter: true });
 
 describe('useIntegrationTypeSchemas', () => {
-  afterEach(() => {
-    config.featureToggles.alertingSyncNotifiersApiMigration = false;
-  });
-
   describe('with alertingSyncNotifiersApiMigration flag disabled', () => {
-    beforeEach(() => {
-      config.featureToggles.alertingSyncNotifiersApiMigration = false;
-    });
+    testWithFeatureToggles({ disable: ['alertingSyncNotifiersApiMigration'] });
 
     it('should return data from legacy API', async () => {
       const { result } = renderHook(() => useIntegrationTypeSchemas(), { wrapper: wrapper() });
@@ -35,9 +27,7 @@ describe('useIntegrationTypeSchemas', () => {
   });
 
   describe('with alertingSyncNotifiersApiMigration flag enabled', () => {
-    beforeEach(() => {
-      config.featureToggles.alertingSyncNotifiersApiMigration = true;
-    });
+    testWithFeatureToggles({ enable: ['alertingSyncNotifiersApiMigration'] });
 
     it('should return data from new k8s API', async () => {
       const { result } = renderHook(() => useIntegrationTypeSchemas(), { wrapper: wrapper() });

--- a/public/app/features/alerting/unified/api/integrationSchemasApi.ts
+++ b/public/app/features/alerting/unified/api/integrationSchemasApi.ts
@@ -1,0 +1,113 @@
+import { useMemo } from 'react';
+
+import {
+  GetIntegrationtypeschemasField,
+  GetIntegrationtypeschemasIntegrationTypeSchema,
+  GetIntegrationtypeschemasIntegrationTypeSchemaVersion,
+  useGetIntegrationtypeschemasQuery,
+} from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
+import { config } from '@grafana/runtime';
+
+import { NotificationChannelOption, NotifierDTO, NotifierVersion } from '../types/alerting';
+
+import { alertmanagerApi } from './alertmanagerApi';
+
+const { useGrafanaNotifiersQuery } = alertmanagerApi;
+
+/**
+ * Transforms a k8s API field to NotificationChannelOption.
+ * Explicitly maps all fields to ensure type safety without assertions.
+ */
+function transformField(field: GetIntegrationtypeschemasField, prefix = ''): NotificationChannelOption {
+  const secureFieldKey = field.secure ? `${prefix}${field.propertyName}` : undefined;
+
+  return {
+    // Generated k8s API types use `string` for element; the backend returns valid element types
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    element: field.element as NotificationChannelOption['element'],
+    inputType: field.inputType,
+    label: field.label,
+    description: field.description,
+    placeholder: field.placeholder,
+    propertyName: field.propertyName,
+    required: field.required,
+    secure: field.secure,
+    secureFieldKey,
+    protected: field.protected,
+    selectOptions:
+      field.selectOptions?.map((opt) => ({
+        label: opt.label,
+        value: opt.value,
+        description: opt.description,
+      })) ?? null,
+    showWhen: {
+      field: field.showWhen.field,
+      is: field.showWhen.is,
+    },
+    validationRule: field.validationRule,
+    subformOptions: field.subformOptions?.map((subfield) =>
+      transformField(subfield, `${prefix}${field.propertyName}.`)
+    ),
+    dependsOn: field.dependsOn,
+  };
+}
+
+/**
+ * Transforms a k8s API version to NotifierVersion.
+ */
+function transformVersion(version: GetIntegrationtypeschemasIntegrationTypeSchemaVersion): NotifierVersion {
+  return {
+    version: version.version,
+    label: version.version,
+    description: '',
+    options: version.options.map((field) => transformField(field)),
+    canCreate: version.canCreate,
+    deprecated: version.deprecated,
+  };
+}
+
+/**
+ * Transforms a k8s API schema to NotifierDTO format.
+ * This is a type-safe transformation that explicitly maps all fields.
+ */
+function transformSchemaToNotifierDTO(schema: GetIntegrationtypeschemasIntegrationTypeSchema): NotifierDTO {
+  return {
+    // Generated k8s API types use `string` for type; the backend returns valid notifier types
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    type: schema.type as NotifierDTO['type'],
+    name: schema.name,
+    heading: schema.heading ?? '',
+    description: schema.description ?? '',
+    info: schema.info,
+    currentVersion: schema.currentVersion,
+    deprecated: schema.deprecated,
+    // No top-level options - they come from versions in the new API
+    versions: schema.versions.map(transformVersion),
+  };
+}
+
+/**
+ * Hook to fetch integration type schemas.
+ * Uses new k8s API when feature flag is enabled, falls back to legacy API.
+ */
+export function useIntegrationTypeSchemas(options?: { skip?: boolean }) {
+  const useNewApi = config.featureToggles.alertingNotifiersApiMigration;
+  const skip = options?.skip ?? false;
+
+  const newApiResult = useGetIntegrationtypeschemasQuery(undefined, {
+    skip: skip || !useNewApi,
+  });
+  const legacyResult = useGrafanaNotifiersQuery(undefined, {
+    skip: skip || !!useNewApi,
+  });
+
+  return useMemo(() => {
+    if (useNewApi) {
+      return {
+        ...newApiResult,
+        data: newApiResult.data?.items.map((item) => transformSchemaToNotifierDTO(item.spec)),
+      };
+    }
+    return legacyResult;
+  }, [useNewApi, newApiResult, legacyResult]);
+}

--- a/public/app/features/alerting/unified/api/integrationSchemasApi.ts
+++ b/public/app/features/alerting/unified/api/integrationSchemasApi.ts
@@ -86,11 +86,17 @@ function transformSchemaToNotifierDTO(schema: GetIntegrationtypeschemasIntegrati
   };
 }
 
+interface UseIntegrationTypeSchemasResult {
+  data?: NotifierDTO[];
+  isLoading: boolean;
+  error?: unknown;
+}
+
 /**
  * Hook to fetch integration type schemas.
  * Uses new k8s API when feature flag is enabled, falls back to legacy API.
  */
-export function useIntegrationTypeSchemas(options?: { skip?: boolean }) {
+export function useIntegrationTypeSchemas(options?: { skip?: boolean }): UseIntegrationTypeSchemasResult {
   const useNewApi = config.featureToggles.alertingSyncNotifiersApiMigration;
   const skip = options?.skip ?? false;
 
@@ -101,7 +107,7 @@ export function useIntegrationTypeSchemas(options?: { skip?: boolean }) {
     skip: skip || !!useNewApi,
   });
 
-  return useMemo(() => {
+  return useMemo((): UseIntegrationTypeSchemasResult => {
     if (useNewApi) {
       return {
         ...newApiResult,

--- a/public/app/features/alerting/unified/api/integrationSchemasApi.ts
+++ b/public/app/features/alerting/unified/api/integrationSchemasApi.ts
@@ -91,7 +91,7 @@ function transformSchemaToNotifierDTO(schema: GetIntegrationtypeschemasIntegrati
  * Uses new k8s API when feature flag is enabled, falls back to legacy API.
  */
 export function useIntegrationTypeSchemas(options?: { skip?: boolean }) {
-  const useNewApi = config.featureToggles.alertingNotifiersApiMigration;
+  const useNewApi = config.featureToggles.alertingSyncNotifiersApiMigration;
   const skip = options?.skip ?? false;
 
   const newApiResult = useGetIntegrationtypeschemasQuery(undefined, {

--- a/public/app/features/alerting/unified/api/integrationSchemasApi.ts
+++ b/public/app/features/alerting/unified/api/integrationSchemasApi.ts
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 import {
   GetIntegrationtypeschemasField,
   GetIntegrationtypeschemasIntegrationTypeSchema,
@@ -102,18 +100,15 @@ export function useIntegrationTypeSchemas(options?: { skip?: boolean }): UseInte
 
   const newApiResult = useGetIntegrationtypeschemasQuery(undefined, {
     skip: skip || !useNewApi,
+    selectFromResult: (result) => ({
+      ...result,
+      data: result.data?.items.map((item) => transformSchemaToNotifierDTO(item.spec)),
+    }),
   });
+
   const legacyResult = useGrafanaNotifiersQuery(undefined, {
     skip: skip || !!useNewApi,
   });
 
-  return useMemo((): UseIntegrationTypeSchemasResult => {
-    if (useNewApi) {
-      return {
-        ...newApiResult,
-        data: newApiResult.data?.items.map((item) => transformSchemaToNotifierDTO(item.spec)),
-      };
-    }
-    return legacyResult;
-  }, [useNewApi, newApiResult, legacyResult]);
+  return useNewApi ? newApiResult : legacyResult;
 }

--- a/public/app/features/alerting/unified/components/contact-points/useContactPoints.ts
+++ b/public/app/features/alerting/unified/components/contact-points/useContactPoints.ts
@@ -16,6 +16,7 @@ import { GrafanaManagedContactPoint, Receiver } from 'app/plugins/datasource/ale
 
 import { getAPINamespace } from '../../../../../api/utils';
 import { alertmanagerApi } from '../../api/alertmanagerApi';
+import { useIntegrationTypeSchemas } from '../../api/integrationSchemasApi';
 import { onCallApi } from '../../api/onCallApi';
 import { useAsync } from '../../hooks/useAsync';
 import { useIrmPlugin } from '../../hooks/usePluginBridge';
@@ -40,7 +41,6 @@ const RECEIVER_STATUS_POLLING_INTERVAL = 10 * 1000; // 10 seconds
 const {
   useGetAlertmanagerConfigurationQuery,
   useGetContactPointsStatusQuery,
-  useGrafanaNotifiersQuery,
   useLazyGetAlertmanagerConfigurationQuery,
 } = alertmanagerApi;
 const { useGrafanaOnCallIntegrationsQuery } = onCallApi;
@@ -136,7 +136,7 @@ export const useGrafanaContactPoints = ({
   const irmOrOnCallPlugin = useIrmPlugin(SupportedPlugin.OnCall);
 
   const onCallResponse = useOnCallIntegrations(potentiallySkip);
-  const alertNotifiers = useGrafanaNotifiersQuery(undefined, potentiallySkip);
+  const alertNotifiers = useIntegrationTypeSchemas(potentiallySkip);
   const contactPointsListResponse = useK8sContactPoints({ namespace }, potentiallySkip);
 
   const contactPointsStatusResponse = useGetContactPointsStatusQuery(undefined, {

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.test.tsx
@@ -290,7 +290,7 @@ describe('ChannelSubForm', () => {
           label: 'Webhook',
           description: 'Sends HTTP POST request',
           canCreate: true,
-          options: grafanaAlertNotifiers.webhook.options,
+          options: grafanaAlertNotifiers.webhook.options ?? [],
         },
       ],
     };

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
@@ -386,7 +386,7 @@ export function ChannelSubForm<R extends ChannelValues>({
 
 function getDefaultNotifierSettings(notifier: Notifier): Record<string, string> {
   const defaultSettings: Record<string, string> = {};
-  notifier.dto.options.forEach((option) => {
+  getOptionsForVersion(notifier.dto).forEach((option) => {
     if (option.defaultValue?.value) {
       defaultSettings[option.propertyName] = option.defaultValue?.value;
     }

--- a/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.test.tsx
@@ -999,6 +999,41 @@ describe('GrafanaReceiverForm', () => {
       });
     });
   });
+
+  describe('with alertingNotifiersApiMigration flag enabled', () => {
+    beforeEach(() => {
+      config.featureToggles.alertingNotifiersApiMigration = true;
+    });
+
+    afterEach(() => {
+      config.featureToggles.alertingNotifiersApiMigration = false;
+    });
+
+    it('should load notifiers from k8s API and render form correctly', async () => {
+      renderWithProvider(<GrafanaReceiverForm />);
+
+      await waitFor(() => {
+        expect(ui.loadingIndicator.query()).not.toBeInTheDocument();
+      });
+
+      // Verify integration type selector is populated
+      expect(ui.integrationType.get()).toBeInTheDocument();
+    });
+
+    it('should render options correctly when selecting an integration type', async () => {
+      renderWithProvider(<GrafanaReceiverForm />);
+
+      await waitFor(() => {
+        expect(ui.loadingIndicator.query()).not.toBeInTheDocument();
+      });
+
+      // Select Slack notifier type and verify options from versions are rendered
+      await clickSelectOption(ui.typeSelector.get(), 'Slack');
+
+      // Verify that options from the version are displayed
+      expect(ui.slack.recipient.get()).toBeInTheDocument();
+    });
+  });
 });
 
 function getAmCortexConfig(configure: (builder: AlertmanagerConfigBuilder) => void): AlertManagerCortexConfig {

--- a/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.test.tsx
@@ -1000,13 +1000,13 @@ describe('GrafanaReceiverForm', () => {
     });
   });
 
-  describe('with alertingNotifiersApiMigration flag enabled', () => {
+  describe('with alertingSyncNotifiersApiMigration flag enabled', () => {
     beforeEach(() => {
-      config.featureToggles.alertingNotifiersApiMigration = true;
+      config.featureToggles.alertingSyncNotifiersApiMigration = true;
     });
 
     afterEach(() => {
-      config.featureToggles.alertingNotifiersApiMigration = false;
+      config.featureToggles.alertingSyncNotifiersApiMigration = false;
     });
 
     it('should load notifiers from k8s API and render form correctly', async () => {

--- a/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
@@ -16,7 +16,7 @@ import {
 } from 'app/features/alerting/unified/utils/k8s/utils';
 import { GrafanaManagedContactPoint, GrafanaManagedReceiverConfig } from 'app/plugins/datasource/alertmanager/types';
 
-import { alertmanagerApi } from '../../../api/alertmanagerApi';
+import { useIntegrationTypeSchemas } from '../../../api/integrationSchemasApi';
 import { useTestContactPoint } from '../../../hooks/useTestContactPoint';
 import { GrafanaChannelValues, ReceiverFormValues } from '../../../types/receiver-form';
 import { hasLegacyIntegrations } from '../../../utils/notifier-versions';
@@ -47,8 +47,6 @@ interface Props {
   editMode?: boolean;
 }
 
-const { useGrafanaNotifiersQuery } = alertmanagerApi;
-
 export const GrafanaReceiverForm = ({ contactPoint, readOnly = false, editMode }: Props) => {
   const [createContactPoint] = useCreateContactPoint({
     alertmanager: GRAFANA_RULES_SOURCE_NAME,
@@ -66,7 +64,7 @@ export const GrafanaReceiverForm = ({ contactPoint, readOnly = false, editMode }
     hasOnCallError,
   } = useOnCallIntegration();
 
-  const { data: grafanaNotifiers = [], isLoading: isLoadingNotifiers } = useGrafanaNotifiersQuery();
+  const { data: grafanaNotifiers = [], isLoading: isLoadingNotifiers } = useIntegrationTypeSchemas();
   const [testChannelData, setTestChannelData] = useState<{
     channelValues: GrafanaChannelValues;
     existingIntegration?: GrafanaManagedReceiverConfig;

--- a/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/onCall/useOnCallIntegration.test.ts
+++ b/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/onCall/useOnCallIntegration.test.ts
@@ -108,16 +108,17 @@ describe('useOnCallIntegration', () => {
       });
 
       // Verify options are enhanced
-      expect(notifier.options).toHaveLength(3);
-      expect(notifier.options[0].propertyName).toBe(OnCallIntegrationSetting.IntegrationType);
-      expect(notifier.options[1].propertyName).toBe(OnCallIntegrationSetting.IntegrationName);
-      expect(notifier.options[2].propertyName).toBe('url');
+      const options = notifier.options ?? [];
+      expect(options).toHaveLength(3);
+      expect(options[0].propertyName).toBe(OnCallIntegrationSetting.IntegrationType);
+      expect(options[1].propertyName).toBe(OnCallIntegrationSetting.IntegrationName);
+      expect(options[2].propertyName).toBe('url');
 
-      expect(notifier.options[0].element).toBe('radio');
-      expect(notifier.options[2].element).toBe('select');
+      expect(options[0].element).toBe('radio');
+      expect(options[2].element).toBe('select');
 
-      expect(notifier.options[2].selectOptions).toHaveLength(1);
-      expect(notifier.options[2].selectOptions![0]).toMatchObject({
+      expect(options[2].selectOptions).toHaveLength(1);
+      expect(options[2].selectOptions![0]).toMatchObject({
         label: 'grafana-integration',
         value: 'https://oncall.com/grafana-integration',
       });
@@ -217,8 +218,9 @@ describe('useOnCallIntegration', () => {
         heading: '',
       });
 
-      expect(notifier.options).toHaveLength(1);
-      expect(notifier.options[0].propertyName).toBe('url');
+      const options = notifier.options ?? [];
+      expect(options).toHaveLength(1);
+      expect(options[0].propertyName).toBe('url');
     });
   });
 
@@ -269,8 +271,9 @@ describe('useOnCallIntegration', () => {
         heading: '',
       });
 
-      expect(notifier.options).toHaveLength(1);
-      expect(notifier.options[0].propertyName).toBe('url');
+      const options = notifier.options ?? [];
+      expect(options).toHaveLength(1);
+      expect(options[0].propertyName).toBe('url');
     });
   });
 });

--- a/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/onCall/useOnCallIntegration.test.ts
+++ b/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/onCall/useOnCallIntegration.test.ts
@@ -132,6 +132,41 @@ describe('useOnCallIntegration', () => {
       expect(notifier.versions![0].options[0].element).toBe('radio');
       expect(notifier.versions![0].options[2].element).toBe('select');
     });
+
+    it('should enhance only versions[].options when notifier has no top-level options', async () => {
+      const { result } = renderHook(() => useOnCallIntegration(), { wrapper: wrapper() });
+
+      await waitFor(() => expect(result.current.isLoadingOnCallIntegration).toBe(false));
+
+      const { extendOnCallNotifierFeatures } = result.current;
+
+      const notifier = extendOnCallNotifierFeatures({
+        name: 'Grafana OnCall',
+        type: 'oncall',
+        // No top-level options (new k8s API shape)
+        versions: [
+          {
+            version: 'v1',
+            label: 'v1',
+            description: 'Version 1',
+            options: [option('url', 'Grafana OnCall', 'Grafana OnCall', { element: 'input' })],
+          },
+        ],
+        currentVersion: 'v1',
+        description: '',
+        heading: '',
+      });
+
+      // Top-level options should remain undefined
+      expect(notifier.options).toBeUndefined();
+
+      // Versions[].options should still be enhanced
+      expect(notifier.versions).toHaveLength(1);
+      expect(notifier.versions![0].options).toHaveLength(3);
+      expect(notifier.versions![0].options[0].propertyName).toBe(OnCallIntegrationSetting.IntegrationType);
+      expect(notifier.versions![0].options[1].propertyName).toBe(OnCallIntegrationSetting.IntegrationName);
+      expect(notifier.versions![0].options[2].propertyName).toBe('url');
+    });
   });
 
   describe('When OnCall Alerting V2 integration disabled', () => {

--- a/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/onCall/useOnCallIntegration.tsx
+++ b/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/onCall/useOnCallIntegration.tsx
@@ -263,7 +263,8 @@ export function useOnCallIntegration() {
 
         return {
           ...notifier,
-          options: enhanceOptions(notifier.options),
+          // Only spread options if they exist (legacy API has them, new API doesn't)
+          ...(notifier.options && { options: enhanceOptions(notifier.options) }),
           // Also enhance versions[].options so getOptionsForVersion() returns the enhanced options
           versions: notifier.versions?.map((version) => ({
             ...version,

--- a/public/app/features/alerting/unified/mocks/server/all-handlers.ts
+++ b/public/app/features/alerting/unified/mocks/server/all-handlers.ts
@@ -9,6 +9,7 @@ import datasourcesHandlers from 'app/features/alerting/unified/mocks/server/hand
 import evalHandlers from 'app/features/alerting/unified/mocks/server/handlers/eval';
 import folderHandlers from 'app/features/alerting/unified/mocks/server/handlers/folders';
 import grafanaRulerHandlers from 'app/features/alerting/unified/mocks/server/handlers/grafanaRuler';
+import integrationTypeSchemasK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/integrationTypeSchemas.k8s';
 import receiverK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/receivers.k8s';
 import routingTreeK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/routingtrees.k8s';
 import templatesK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/templates.k8s';
@@ -35,6 +36,7 @@ export const alertingHandlers = [
   ...provisioningHandlers,
 
   // Kubernetes-style handlers
+  ...integrationTypeSchemasK8sHandlers,
   ...timeIntervalK8sHandlers,
   ...receiverK8sHandlers,
   ...receiverTestK8sHandlers,

--- a/public/app/features/alerting/unified/mocks/server/handlers/k8s/integrationTypeSchemas.k8s.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/k8s/integrationTypeSchemas.k8s.ts
@@ -1,0 +1,43 @@
+import { HttpResponse, http } from 'msw';
+
+import { grafanaAlertNotifiersMock } from 'app/features/alerting/unified/mockGrafanaNotifiers';
+import { NotifierDTO } from 'app/features/alerting/unified/types/alerting';
+
+import { ALERTING_API_SERVER_BASE_URL, getK8sResponse } from '../../utils';
+
+function transformToK8sSchema(notifier: NotifierDTO) {
+  return {
+    metadata: {
+      name: notifier.type,
+      namespace: 'default',
+    },
+    spec: {
+      type: notifier.type,
+      name: notifier.name,
+      heading: notifier.heading,
+      description: notifier.description,
+      info: notifier.info,
+      currentVersion: notifier.currentVersion ?? 'v1',
+      deprecated: notifier.deprecated,
+      versions: notifier.versions ?? [
+        {
+          version: 'v1',
+          canCreate: true,
+          options: notifier.options ?? [],
+        },
+      ],
+    },
+  };
+}
+
+export const getIntegrationTypeSchemasHandler = () =>
+  http.get<{ namespace: string }>(
+    `${ALERTING_API_SERVER_BASE_URL}/namespaces/:namespace/integrationtypeschemas`,
+    () => {
+      const items = grafanaAlertNotifiersMock.map(transformToK8sSchema);
+      return HttpResponse.json(getK8sResponse('IntegrationTypeSchemaList', items));
+    }
+  );
+
+const handlers = [getIntegrationTypeSchemasHandler()];
+export default handlers;

--- a/public/app/features/alerting/unified/types/alerting.ts
+++ b/public/app/features/alerting/unified/types/alerting.ts
@@ -101,7 +101,7 @@ export interface NotifierDTO<T = NotifierType> {
   description: string;
   type: T;
   heading: string;
-  options: NotificationChannelOption[];
+  options?: NotificationChannelOption[];
   info?: string;
   secure?: boolean;
   /**

--- a/public/app/features/alerting/unified/utils/notifier-versions.ts
+++ b/public/app/features/alerting/unified/utils/notifier-versions.ts
@@ -87,19 +87,19 @@ export function isDeprecated(notifier: NotifierDTO, version?: string): boolean {
 export function getOptionsForVersion(notifier: NotifierDTO, version?: string): NotificationChannelOption[] {
   // If no versions array, use default options
   if (!notifier.versions || notifier.versions.length === 0) {
-    return notifier.options;
+    return notifier.options ?? [];
   }
 
   // If version is specified, find the matching version
   if (version) {
     const versionData = notifier.versions.find((v) => v.version === version);
     // Return version-specific options if found, otherwise fall back to default
-    return versionData?.options ?? notifier.options;
+    return versionData?.options ?? notifier.options ?? [];
   }
 
   // If no version specified, find the default creatable version (canCreate !== false)
   const defaultVersion = notifier.versions.find((v) => v.canCreate !== false);
-  return defaultVersion?.options ?? notifier.options;
+  return defaultVersion?.options ?? notifier.options ?? [];
 }
 
 /**

--- a/public/app/features/alerting/unified/utils/receiver-form.ts
+++ b/public/app/features/alerting/unified/utils/receiver-form.ts
@@ -6,6 +6,7 @@ import {
   NotifierDTO,
   NotifierType,
 } from 'app/features/alerting/unified/types/alerting';
+import { getOptionsForVersion } from 'app/features/alerting/unified/utils/notifier-versions';
 import {
   AlertmanagerReceiver,
   GrafanaManagedContactPoint,
@@ -220,7 +221,7 @@ export function getSecureFieldNames(notifier: NotifierDTO): string[] {
     }
   }
 
-  findSecureOptions(notifier.options);
+  findSecureOptions(getOptionsForVersion(notifier));
 
   return secureFieldPaths;
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3039,6 +3039,11 @@
       "title-preview-not-available": "Preview not available",
       "valid-matcher-affected-alerts": "Add a valid matcher to see affected alerts"
     },
+    "silences": {
+      "affected-instances": "Affected alert instances",
+      "only-firing-instances": "Only alert instances in the firing state are displayed.",
+      "preview-affected-instances": "Preview the alert instances affected by this silence."
+    },
     "silences-editor": {
       "comment-placeholder-details-about-the-silence": "Details about the silence",
       "label-comment": "Comment",
@@ -3060,11 +3065,6 @@
       "text-loading-silences": "Loading silences...",
       "title-error-loading-silences": "Error loading silences",
       "title-the-selected-alertmanager-has-no-configuration": "The selected Alertmanager has no configuration"
-    },
-    "silences": {
-      "affected-instances": "Affected alert instances",
-      "only-firing-instances": "Only alert instances in the firing state are displayed.",
-      "preview-affected-instances": "Preview the alert instances affected by this silence."
     },
     "simple-condition-editor": {
       "label-of-query": "OF QUERY",


### PR DESCRIPTION
**What is this feature?**

This PR migrates the alerting frontend alert notifiers api from `/api/alert-notifiers` to the app platform API (`/apis/notifications.alerting.grafana.app/v0alpha1/namespaces/{{namespace}}/integrationtypeschemas`). No visual changes should be observable to the user. The changes are hidden behind the frontend only feature flag `alertingSyncNotifiersApiMigration`. 

**Why do we need this feature?**

As part of the migration to the single alert manager we need to migrate our existing endpoints to the k8s api

**Who is this feature for?**

Alerting users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1396

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

**How to test these changes**
1. Enable the `alertingNotifiersApiMigration` feature flag
2. Test Contact Points Page
  - Open browser DevTools → Network tab
  - Filter by XHR or Fetch requests
  - Navigate to: `/alerting/notifications`
  - Verify the API call:
    - With flag enabled: You should see a request to: `/apis/notifications.alerting.grafana.app/v0alpha1/namespaces/default/integrationtypeschemas`
    - With flag disabled: You should see a request to: `/api/alert-notifiers`
3. Test Create / Edit Contact Point 
  - Click "Add contact point" button or the "Edit" button in one of the existing contact points
  - Verify the form loads correctly:
    - The "Integration" dropdown should be populated with notifier types (Slack, Email, Webhook, etc.)
    - No console errors related to undefined options
  - Select different integration types and verify:
    - Form fields render correctly for each type
    - Required fields are marked appropriately
    - Secure fields (like API keys, tokens) show the correct input type
  - Submit the form and verify that it works as expected