### PR TITLE
Annotations: add support for listing by tags and scopes

### DIFF
--- a/apps/annotation/kinds/annotation.cue
+++ b/apps/annotation/kinds/annotation.cue
@@ -11,6 +11,7 @@ annotationv0alpha1: {
       dashboardUID?: string
       panelID?: int64
       tags?: [...string]
+      scopes?: [...string]
 		}
 	}
   selectableFields: [

--- a/apps/annotation/kinds/manifest.cue
+++ b/apps/annotation/kinds/manifest.cue
@@ -23,6 +23,15 @@ v0alpha1: {
                     }
                 }
             }
+            "/search": {
+                "GET": {
+                    response: {
+                        apiVersion: string
+                        kind: string
+                        items: [..._]
+                    }
+                }
+            }
         }
     }
     codegen: {

--- a/apps/annotation/pkg/apis/annotation/v0alpha1/annotation_spec_gen.go
+++ b/apps/annotation/pkg/apis/annotation/v0alpha1/annotation_spec_gen.go
@@ -10,6 +10,7 @@ type AnnotationSpec struct {
 	DashboardUID *string  `json:"dashboardUID,omitempty"`
 	PanelID      *int64   `json:"panelID,omitempty"`
 	Tags         []string `json:"tags,omitempty"`
+	Scopes       []string `json:"scopes,omitempty"`
 }
 
 // NewAnnotationSpec creates a new AnnotationSpec object.

--- a/apps/annotation/pkg/apis/annotation/v0alpha1/getsearch_response_body_types_gen.go
+++ b/apps/annotation/pkg/apis/annotation/v0alpha1/getsearch_response_body_types_gen.go
@@ -1,0 +1,22 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+// +k8s:openapi-gen=true
+type GetSearchBody struct {
+	ApiVersion string        `json:"apiVersion"`
+	Kind       string        `json:"kind"`
+	Items      []interface{} `json:"items"`
+}
+
+// NewGetSearchBody creates a new GetSearchBody object.
+func NewGetSearchBody() *GetSearchBody {
+	return &GetSearchBody{
+		Items: []interface{}{},
+	}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchBody.
+func (GetSearchBody) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetSearchBody"
+}

--- a/apps/annotation/pkg/apis/annotation/v0alpha1/getsearch_response_object_types_gen.go
+++ b/apps/annotation/pkg/apis/annotation/v0alpha1/getsearch_response_object_types_gen.go
@@ -1,0 +1,41 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+import (
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// +k8s:openapi-gen=true
+type GetSearchResponse struct {
+	metav1.TypeMeta `json:",inline"`
+	GetSearchBody   `json:",inline"`
+}
+
+func NewGetSearchResponse() *GetSearchResponse {
+	return &GetSearchResponse{}
+}
+
+func (t *GetSearchBody) DeepCopyInto(dst *GetSearchBody) {
+	_ = resource.CopyObjectInto(dst, t)
+}
+
+func (o *GetSearchResponse) DeepCopyObject() runtime.Object {
+	dst := NewGetSearchResponse()
+	o.DeepCopyInto(dst)
+	return dst
+}
+
+func (o *GetSearchResponse) DeepCopyInto(dst *GetSearchResponse) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.GetSearchBody.DeepCopyInto(&dst.GetSearchBody)
+}
+
+func (GetSearchResponse) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetSearchResponse"
+}
+
+var _ runtime.Object = NewGetSearchResponse()

--- a/apps/annotation/pkg/apis/annotation_manifest.go
+++ b/apps/annotation/pkg/apis/annotation_manifest.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	rawSchemaAnnotationv0alpha1     = []byte(`{"Annotation":{"properties":{"spec":{"$ref":"#/components/schemas/spec"},"status":{"$ref":"#/components/schemas/status"}},"required":["spec"]},"OperatorState":{"additionalProperties":false,"properties":{"descriptiveState":{"description":"descriptiveState is an optional more descriptive state field which has no requirements on format","type":"string"},"details":{"additionalProperties":true,"description":"details contains any extra information that is operator-specific","type":"object"},"lastEvaluation":{"description":"lastEvaluation is the ResourceVersion last evaluated","type":"string"},"state":{"description":"state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.","enum":["success","in_progress","failed"],"type":"string"}},"required":["lastEvaluation","state"],"type":"object"},"spec":{"additionalProperties":false,"properties":{"dashboardUID":{"type":"string"},"panelID":{"type":"integer"},"tags":{"items":{"type":"string"},"type":"array"},"text":{"type":"string"},"time":{"type":"integer"},"timeEnd":{"type":"integer"}},"required":["text","time"],"type":"object"},"status":{"additionalProperties":false,"properties":{"additionalFields":{"additionalProperties":true,"description":"additionalFields is reserved for future use","type":"object"},"operatorStates":{"additionalProperties":{"$ref":"#/components/schemas/OperatorState"},"description":"operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.","type":"object"}},"type":"object"}}`)
+	rawSchemaAnnotationv0alpha1     = []byte(`{"Annotation":{"properties":{"spec":{"$ref":"#/components/schemas/spec"},"status":{"$ref":"#/components/schemas/status"}},"required":["spec"]},"OperatorState":{"additionalProperties":false,"properties":{"descriptiveState":{"description":"descriptiveState is an optional more descriptive state field which has no requirements on format","type":"string"},"details":{"additionalProperties":true,"description":"details contains any extra information that is operator-specific","type":"object"},"lastEvaluation":{"description":"lastEvaluation is the ResourceVersion last evaluated","type":"string"},"state":{"description":"state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.","enum":["success","in_progress","failed"],"type":"string"}},"required":["lastEvaluation","state"],"type":"object"},"spec":{"additionalProperties":false,"properties":{"dashboardUID":{"type":"string"},"panelID":{"type":"integer"},"scopes":{"items":{"type":"string"},"type":"array"},"tags":{"items":{"type":"string"},"type":"array"},"text":{"type":"string"},"time":{"type":"integer"},"timeEnd":{"type":"integer"}},"required":["text","time"],"type":"object"},"status":{"additionalProperties":false,"properties":{"additionalFields":{"additionalProperties":true,"description":"additionalFields is reserved for future use","type":"object"},"operatorStates":{"additionalProperties":{"$ref":"#/components/schemas/OperatorState"},"description":"operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.","type":"object"}},"type":"object"}}`)
 	versionSchemaAnnotationv0alpha1 app.VersionSchema
 	_                               = json.Unmarshal(rawSchemaAnnotationv0alpha1, &versionSchemaAnnotationv0alpha1)
 )
@@ -50,6 +50,69 @@ var appManifestData = app.ManifestData{
 			},
 			Routes: app.ManifestVersionRoutes{
 				Namespaced: map[string]spec3.PathProps{
+					"/search": {
+						Get: &spec3.Operation{
+							OperationProps: spec3.OperationProps{
+
+								OperationId: "getSearch",
+
+								Responses: &spec3.Responses{
+									ResponsesProps: spec3.ResponsesProps{
+										Default: &spec3.Response{
+											ResponseProps: spec3.ResponseProps{
+												Description: "Default OK response",
+												Content: map[string]*spec3.MediaType{
+													"application/json": {
+														MediaTypeProps: spec3.MediaTypeProps{
+															Schema: &spec.Schema{
+																SchemaProps: spec.SchemaProps{
+																	Type: []string{"object"},
+																	Properties: map[string]spec.Schema{
+																		"apiVersion": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+																			},
+																		},
+																		"items": {
+																			SchemaProps: spec.SchemaProps{
+																				Type: []string{"array"},
+																				Items: &spec.SchemaOrArray{
+																					Schema: &spec.Schema{
+																						SchemaProps: spec.SchemaProps{
+																							Type: []string{"object"},
+																							AdditionalProperties: &spec.SchemaOrBool{
+																								Schema: &spec.Schema{
+																									SchemaProps: spec.SchemaProps{},
+																								},
+																							},
+																						}},
+																				},
+																			},
+																		},
+																		"kind": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+																			},
+																		},
+																	},
+																	Required: []string{
+																		"apiVersion",
+																		"kind",
+																		"items",
+																		"apiVersion",
+																		"kind",
+																	},
+																}},
+														}},
+												},
+											},
+										},
+									}},
+							},
+						},
+					},
 					"/tags": {
 						Get: &spec3.Operation{
 							OperationProps: spec3.OperationProps{
@@ -150,7 +213,8 @@ func ManifestGoTypeAssociator(kind, version string) (goType resource.Kind, exist
 }
 
 var customRouteToGoResponseType = map[string]any{
-	"v0alpha1||<namespace>/tags|GET": v0alpha1.GetTagsResponse{},
+	"v0alpha1||<namespace>/search|GET": v0alpha1.GetSearchResponse{},
+	"v0alpha1||<namespace>/tags|GET":   v0alpha1.GetTagsResponse{},
 }
 
 // ManifestCustomRouteResponsesAssociator returns the associated response go type for a given kind, version, custom route path, and method, if one exists.

--- a/apps/annotation/pkg/app/app.go
+++ b/apps/annotation/pkg/app/app.go
@@ -30,19 +30,33 @@ func New(cfg app.Config) (app.App, error) {
 		},
 	}
 
-	// Add custom route handlers if a TagHandler is provided in SpecificConfig.
-	// The handler is created/owned by the registry layer and passed in via
+	// Add custom route handlers if provided in SpecificConfig.
+	// The handlers are created/owned by the registry layer and passed in via
 	// SpecificConfig to avoid the apps package depending on the registry.
 	if cfg.SpecificConfig != nil {
-		if annotationConfig, ok := cfg.SpecificConfig.(*AnnotationConfig); ok && annotationConfig.TagHandler != nil {
-			simpleConfig.VersionedCustomRoutes = map[string]simple.AppVersionRouteHandlers{
-				"v0alpha1": {
-					{
-						Namespaced: true,
-						Path:       "tags",
-						Method:     "GET",
-					}: annotationConfig.TagHandler,
-				},
+		if annotationConfig, ok := cfg.SpecificConfig.(*AnnotationConfig); ok {
+			routes := make(simple.AppVersionRouteHandlers)
+
+			if annotationConfig.TagHandler != nil {
+				routes[simple.AppVersionRoute{
+					Namespaced: true,
+					Path:       "tags",
+					Method:     "GET",
+				}] = annotationConfig.TagHandler
+			}
+
+			if annotationConfig.SearchHandler != nil {
+				routes[simple.AppVersionRoute{
+					Namespaced: true,
+					Path:       "search",
+					Method:     "GET",
+				}] = annotationConfig.SearchHandler
+			}
+
+			if len(routes) > 0 {
+				simpleConfig.VersionedCustomRoutes = map[string]simple.AppVersionRouteHandlers{
+					"v0alpha1": routes,
+				}
 			}
 		}
 	}

--- a/apps/annotation/pkg/app/config.go
+++ b/apps/annotation/pkg/app/config.go
@@ -7,10 +7,12 @@ import (
 )
 
 // AnnotationConfig is the app-specific config for the annotation app. The
-// registry can pass a TagHandler implementation here to wire the /tags
-// resource route into the app without importing registry types.
+// registry can pass handler implementations here to wire custom resource
+// routes into the app without importing registry types.
+// Function signatures must match app.CustomRouteHandler from the app-sdk.
 type AnnotationConfig struct {
 	// TagHandler is the handler function for the GET /tags custom route.
-	// The function signature matches app.CustomRouteHandler from the app-sdk.
 	TagHandler func(ctx context.Context, writer app.CustomRouteResponseWriter, request *app.CustomRouteRequest) error
+	// SearchHandler is the handler function for the GET /search custom route.
+	SearchHandler func(ctx context.Context, writer app.CustomRouteResponseWriter, request *app.CustomRouteRequest) error
 }

--- a/apps/annotation/plugin/src/generated/annotation/v0alpha1/types.spec.gen.ts
+++ b/apps/annotation/plugin/src/generated/annotation/v0alpha1/types.spec.gen.ts
@@ -7,6 +7,7 @@ export interface Spec {
 	dashboardUID?: string;
 	panelID?: number;
 	tags?: string[];
+	scopes?: string[];
 }
 
 export const defaultSpec = (): Spec => ({

--- a/pkg/registry/apps/annotation/memory_store.go
+++ b/pkg/registry/apps/annotation/memory_store.go
@@ -64,6 +64,18 @@ func (m *memoryStore) List(ctx context.Context, namespace string, opts ListOptio
 			continue
 		}
 
+		if len(opts.Tags) > 0 {
+			if !matchTags(anno.Spec.Tags, opts.Tags, opts.TagsMatchAny) {
+				continue
+			}
+		}
+
+		if len(opts.Scopes) > 0 {
+			if !matchScopes(anno.Spec.Scopes, opts.Scopes, opts.ScopesMatchAny) {
+				continue
+			}
+		}
+
 		result = append(result, *anno.DeepCopy())
 
 		if opts.Limit > 0 && int64(len(result)) >= opts.Limit {
@@ -72,6 +84,60 @@ func (m *memoryStore) List(ctx context.Context, namespace string, opts ListOptio
 	}
 
 	return &AnnotationList{Items: result}, nil
+}
+
+func matchTags(annoTags []string, filterTags []string, matchAny bool) bool {
+	if matchAny {
+		for _, filterTag := range filterTags {
+			for _, annoTag := range annoTags {
+				if annoTag == filterTag {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	for _, filterTag := range filterTags {
+		found := false
+		for _, annoTag := range annoTags {
+			if annoTag == filterTag {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func matchScopes(annoScopes []string, filterScopes []string, matchAny bool) bool {
+	if matchAny {
+		for _, filterScope := range filterScopes {
+			for _, annoScope := range annoScopes {
+				if annoScope == filterScope {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	for _, filterScope := range filterScopes {
+		found := false
+		for _, annoScope := range annoScopes {
+			if annoScope == filterScope {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 func (m *memoryStore) Create(ctx context.Context, anno *annotationV0.Annotation) (*annotationV0.Annotation, error) {

--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -55,6 +55,7 @@ func RegisterAppInstaller(
 	}
 
 	var tagHandler func(context.Context, app.CustomRouteResponseWriter, *app.CustomRouteRequest) error
+	var searchHandler func(context.Context, app.CustomRouteResponseWriter, *app.CustomRouteRequest) error
 	if service != nil {
 		mapper := grafrequest.GetNamespaceMapper(cfg)
 
@@ -69,6 +70,9 @@ func RegisterAppInstaller(
 
 		// Create the tags handler using the sqlAdapter (which implements TagProvider)
 		tagHandler = newTagsHandler(sqlAdapter)
+
+		// Create the search handler
+		searchHandler = newSearchHandler(sqlAdapter)
 	}
 
 	provider := simple.NewAppProvider(apis.LocalManifest(), nil, annotationapp.New)
@@ -77,7 +81,8 @@ func RegisterAppInstaller(
 		KubeConfig:   restclient.Config{},
 		ManifestData: *apis.LocalManifest().ManifestData,
 		SpecificConfig: &annotationapp.AnnotationConfig{
-			TagHandler: tagHandler,
+			TagHandler:    tagHandler,
+			SearchHandler: searchHandler,
 		},
 	}
 	i, err := appsdkapiserver.NewDefaultAppInstaller(provider, appConfig, apis.NewGoTypeAssociator())

--- a/pkg/registry/apps/annotation/search_handler.go
+++ b/pkg/registry/apps/annotation/search_handler.go
@@ -1,0 +1,93 @@
+package annotation
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strconv"
+
+	"github.com/grafana/grafana-app-sdk/app"
+	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newSearchHandler(store Store) func(ctx context.Context, writer app.CustomRouteResponseWriter, request *app.CustomRouteRequest) error {
+	return func(ctx context.Context, writer app.CustomRouteResponseWriter, request *app.CustomRouteRequest) error {
+		namespace := request.ResourceIdentifier.Namespace
+
+		queryParams := request.URL.Query()
+		opts := listOptionsFromQueryParams(queryParams)
+
+		result, err := store.List(ctx, namespace, opts)
+		if err != nil {
+			return err
+		}
+
+		response := &annotationV0.AnnotationList{
+			Items:    result.Items,
+			ListMeta: metav1.ListMeta{Continue: result.Continue},
+		}
+
+		writer.Header().Set("Content-Type", "application/json")
+		return json.NewEncoder(writer).Encode(response)
+	}
+}
+
+func listOptionsFromQueryParams(queryParams url.Values) ListOptions {
+	opts := ListOptions{}
+
+	if v := queryParams.Get("dashboardUID"); v != "" {
+		opts.DashboardUID = v
+	}
+
+	if v := queryParams.Get("panelID"); v != "" {
+		if panelID, err := strconv.ParseInt(v, 10, 64); err == nil {
+			opts.PanelID = panelID
+		}
+	}
+
+	if v := queryParams.Get("from"); v != "" {
+		if from, err := strconv.ParseInt(v, 10, 64); err == nil {
+			opts.From = from
+		}
+	}
+
+	if v := queryParams.Get("to"); v != "" {
+		if to, err := strconv.ParseInt(v, 10, 64); err == nil {
+			opts.To = to
+		}
+	}
+
+	opts.Limit = 100
+	if v := queryParams.Get("limit"); v != "" {
+		if limit, err := strconv.ParseInt(v, 10, 64); err == nil && limit > 0 {
+			opts.Limit = limit
+		}
+	}
+
+	if v := queryParams.Get("continue"); v != "" {
+		opts.Continue = v
+	}
+
+	if tags, ok := queryParams["tag"]; ok {
+		opts.Tags = tags
+	}
+
+	if v := queryParams.Get("tagsMatchAny"); v != "" {
+		if matchAny, err := strconv.ParseBool(v); err == nil {
+			opts.TagsMatchAny = matchAny
+		}
+	}
+
+	if scopes, ok := queryParams["scope"]; ok {
+		opts.Scopes = scopes
+	}
+
+	if v := queryParams.Get("scopesMatchAny"); v != "" {
+		if matchAny, err := strconv.ParseBool(v); err == nil {
+			opts.ScopesMatchAny = matchAny
+		}
+	}
+
+	return opts
+}

--- a/pkg/registry/apps/annotation/search_handler_test.go
+++ b/pkg/registry/apps/annotation/search_handler_test.go
@@ -1,0 +1,206 @@
+package annotation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/grafana/grafana-app-sdk/resource"
+	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSearchHandler(t *testing.T) {
+	ctx := context.Background()
+
+	// create several test annotations with different tags and scopes
+	store := NewMemoryStore()
+	annotations := []*annotationV0.Annotation{
+		createTestAnnotation("a-1", "test", []string{"tag1"}, []string{"scope1"}),
+		createTestAnnotation("a-2", "test", []string{"tag2"}, []string{"scope2"}),
+		createTestAnnotation("a-3", "test", []string{"tag3"}, []string{"scope3"}),
+		createTestAnnotation("a-4", "test", []string{"tag1", "tag2"}, []string{"scope1", "scope2"}),
+		createTestAnnotation("a-5", "test", []string{}, []string{}),
+	}
+	for _, anno := range annotations {
+		_, err := store.Create(ctx, anno)
+		require.NoError(t, err)
+	}
+
+	handler := newSearchHandler(store)
+
+	tests := []struct {
+		name          string
+		queryParams   url.Values
+		expectedNames []string
+	}{
+		{
+			name: "Filter by single tag",
+			queryParams: url.Values{
+				"tag": []string{"tag1"},
+			},
+			expectedNames: []string{"a-1", "a-4"},
+		},
+		{
+			name: "Filter by multiple tags with matchAny=true (OR)",
+			queryParams: url.Values{
+				"tag":          []string{"tag1", "tag2"},
+				"tagsMatchAny": []string{"true"},
+			},
+			expectedNames: []string{"a-1", "a-2", "a-4"},
+		},
+		{
+			name: "Filter by multiple tags without matchAny (AND - default)",
+			queryParams: url.Values{
+				"tag": []string{"tag1", "tag2"},
+			},
+			expectedNames: []string{"a-4"},
+		},
+		{
+			name: "Filter by three tags with matchAny=true",
+			queryParams: url.Values{
+				"tag":          []string{"tag1", "tag2", "tag3"},
+				"tagsMatchAny": []string{"true"},
+			},
+			expectedNames: []string{"a-1", "a-2", "a-3", "a-4"},
+		},
+		{
+			name: "Filter by single scope",
+			queryParams: url.Values{
+				"scope": []string{"scope1"},
+			},
+			expectedNames: []string{"a-1", "a-4"},
+		},
+		{
+			name: "Filter by multiple scopes with matchAny=true (OR)",
+			queryParams: url.Values{
+				"scope":          []string{"scope1", "scope2"},
+				"scopesMatchAny": []string{"true"},
+			},
+			expectedNames: []string{"a-1", "a-2", "a-4"},
+		},
+		{
+			name: "Filter by multiple scopes without matchAny (AND - default)",
+			queryParams: url.Values{
+				"scope": []string{"scope1", "scope2"},
+			},
+			expectedNames: []string{"a-4"},
+		},
+		{
+			name: "Filter by both tags and scopes",
+			queryParams: url.Values{
+				"tag":   []string{"tag1"},
+				"scope": []string{"scope1"},
+			},
+			expectedNames: []string{"a-1", "a-4"},
+		},
+		{
+			name: "Filter by tags (OR) and scopes (AND)",
+			queryParams: url.Values{
+				"tag":          []string{"tag1", "tag2"},
+				"tagsMatchAny": []string{"true"},
+				"scope":        []string{"scope1", "scope2"},
+			},
+			expectedNames: []string{"a-4"},
+		},
+		{
+			name: "Invalid tagsMatchAny value (should be ignored, defaults to false)",
+			queryParams: url.Values{
+				"tag":          []string{"tag1"},
+				"tagsMatchAny": []string{"not-valid"},
+			},
+			expectedNames: []string{"a-1", "a-4"},
+		},
+		{
+			name: "Invalid scopesMatchAny value (should be ignored, defaults to false)",
+			queryParams: url.Values{
+				"scope":          []string{"scope1"},
+				"scopesMatchAny": []string{"not-valid"},
+			},
+			expectedNames: []string{"a-1", "a-4"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := &url.URL{
+				Scheme:   "http",
+				Host:     "localhost",
+				Path:     "/apis/annotation.grafana.app/v0alpha1/namespaces/default/search",
+				RawQuery: tt.queryParams.Encode(),
+			}
+
+			mockRequest := &app.CustomRouteRequest{
+				ResourceIdentifier: resource.FullIdentifier{
+					Namespace: metav1.NamespaceDefault,
+				},
+				URL:    u,
+				Method: "GET",
+			}
+
+			writer := &mockResponseWriter{
+				header: make(http.Header),
+				body:   &bytes.Buffer{},
+			}
+
+			err := handler(ctx, writer, mockRequest)
+			require.NoError(t, err)
+
+			var result annotationV0.AnnotationList
+			err = json.Unmarshal(writer.body.Bytes(), &result)
+			require.NoError(t, err)
+
+			// verify that the expected annotations were returned
+			if len(tt.expectedNames) > 0 {
+				resultNames := make([]string, len(result.Items))
+				for i, item := range result.Items {
+					resultNames[i] = item.Name
+				}
+				assert.ElementsMatch(t, tt.expectedNames, resultNames, "Result names should match expected names")
+			} else if tt.expectedNames != nil {
+				assert.Empty(t, result.Items, "Expected no results")
+			}
+		})
+	}
+}
+
+func createTestAnnotation(name, text string, tags []string, scopes []string) *annotationV0.Annotation {
+	return &annotationV0.Annotation{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: annotationV0.AnnotationSpec{
+			Text:   text,
+			Time:   1000,
+			Tags:   tags,
+			Scopes: scopes,
+		},
+	}
+}
+
+// mockResponseWriter implements app.CustomRouteResponseWriter for testing
+type mockResponseWriter struct {
+	header http.Header
+	body   *bytes.Buffer
+	code   int
+}
+
+func (m *mockResponseWriter) Header() http.Header {
+	return m.header
+}
+
+func (m *mockResponseWriter) Write(b []byte) (int, error) {
+	return m.body.Write(b)
+}
+
+func (m *mockResponseWriter) WriteHeader(statusCode int) {
+	m.code = statusCode
+}

--- a/pkg/registry/apps/annotation/sql_adapter.go
+++ b/pkg/registry/apps/annotation/sql_adapter.go
@@ -102,6 +102,8 @@ func (a *sqlAdapter) List(ctx context.Context, namespace string, opts ListOption
 		Limit:        queryLimit,
 		Offset:       offset,
 		AlertID:      -1,
+		Tags:         opts.Tags,
+		MatchAny:     opts.TagsMatchAny,
 	}
 
 	items, err := a.repo.Find(ctx, query)

--- a/pkg/registry/apps/annotation/storage.go
+++ b/pkg/registry/apps/annotation/storage.go
@@ -15,12 +15,16 @@ type Store interface {
 }
 
 type ListOptions struct {
-	DashboardUID string
-	PanelID      int64
-	From         int64
-	To           int64
-	Limit        int64
-	Continue     string
+	DashboardUID   string
+	PanelID        int64
+	From           int64
+	To             int64
+	Limit          int64
+	Continue       string
+	Tags           []string
+	TagsMatchAny   bool
+	Scopes         []string
+	ScopesMatchAny bool
 }
 
 type AnnotationList struct {


### PR DESCRIPTION
This PR updates the new Annotations App Platform storage interface to add support for listing by `tags` and `scopes` and allows the caller to specify matching behavior (all or any). We currently allow the user to filter annotations by tag as well as allow them to choose if they want to match by all or any of the tags, so this change will enable us to maintain support for that functionality in the new API.

This PR also adds a new `/search` custom route to provide these filtering capabilities in the API. K8s field selectors do not natively support slice types, so this custom route provides us with the flexibility to support listing annotations by tag/scope while also specifying matching behavior.

_NOTE: The existing SQL store does not support scopes. We're adding them to the storage interface as we plan to support them in future storage implementations._