### PR TITLE
Fix: Add optional chaining to prevent error when faro.api is accessed before initialized

### DIFF
--- a/packages/grafana-runtime/src/utils/logging.ts
+++ b/packages/grafana-runtime/src/utils/logging.ts
@@ -10,7 +10,7 @@ export { LogLevel };
  */
 export function logInfo(message: string, contexts?: LogContext) {
   if (config.grafanaJavascriptAgent.enabled) {
-    faro.api.pushLog([message], {
+    faro.api?.pushLog([message], {
       level: LogLevel.INFO,
       context: contexts,
     });
@@ -24,7 +24,7 @@ export function logInfo(message: string, contexts?: LogContext) {
  */
 export function logWarning(message: string, contexts?: LogContext) {
   if (config.grafanaJavascriptAgent.enabled) {
-    faro.api.pushLog([message], {
+    faro.api?.pushLog([message], {
       level: LogLevel.WARN,
       context: contexts,
     });
@@ -38,7 +38,7 @@ export function logWarning(message: string, contexts?: LogContext) {
  */
 export function logDebug(message: string, contexts?: LogContext) {
   if (config.grafanaJavascriptAgent.enabled) {
-    faro.api.pushLog([message], {
+    faro.api?.pushLog([message], {
       level: LogLevel.DEBUG,
       context: contexts,
     });
@@ -52,7 +52,7 @@ export function logDebug(message: string, contexts?: LogContext) {
  */
 export function logError(err: Error, contexts?: LogContext) {
   if (config.grafanaJavascriptAgent.enabled) {
-    faro.api.pushError(err, {
+    faro.api?.pushError(err, {
       context: contexts,
     });
   }
@@ -66,7 +66,7 @@ export function logError(err: Error, contexts?: LogContext) {
 export type MeasurementValues = Record<string, number>;
 export function logMeasurement(type: string, values: MeasurementValues, context?: LogContext) {
   if (config.grafanaJavascriptAgent.enabled) {
-    faro.api.pushMeasurement(
+    faro.api?.pushMeasurement(
       {
         type,
         values,

--- a/public/app/features/dashboard/dashgrid/PanelLoadTimeMonitor.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelLoadTimeMonitor.tsx
@@ -23,7 +23,7 @@ export const PanelLoadTimeMonitor = (props: Props) => {
     // https://firefox-source-docs.mozilla.org/performance/bestpractices.html
     requestAnimationFrame(() => {
       setTimeout(() => {
-        faro.api.pushMeasurement(
+        faro.api?.pushMeasurement(
           {
             type: PanelLogEvents.MEASURE_PANEL_LOAD_TIME_EVENT,
             values: {

--- a/public/app/features/dashboard/dashgrid/panelOptionsLogger.ts
+++ b/public/app/features/dashboard/dashgrid/panelOptionsLogger.ts
@@ -42,7 +42,7 @@ export class PanelOptionsLogger {
       panelType: this.panelLogInfo.panelType,
     };
 
-    faro.api.pushEvent(eventName, logObj);
+    faro.api?.pushEvent(eventName, logObj);
   };
 
   logPanelOptionChanges = (panelOptions: unknown, oldPanelOptions: unknown) => {


### PR DESCRIPTION
**What is this feature?**

Adds optional chaining to all call sites that access the Faro API directly (faro.api?.), matching the pattern already used in ErrorBoundary.tsx and EchoSrv.ts.

**Why do we need this feature?**

After upgrading to Faro v2, we noticed this error in the UI.

<img width="2296" height="968" alt="image" src="https://github.com/user-attachments/assets/cc8b6bf0-ae20-4842-aec6-886c9975758f" />



The faro singleton starts as an empty object {} and faro.api is only set when initializeFaro() runs asynchronously. Any logging call made before initialization results in `undefined.pushLog`.

I have not been able to determine the root cause. This is intended as a quick fix, which matches the precedent in other parts of the codebase.

**Who is this feature for?**

n/a

**Which issue(s) does this PR fix?**:

 Fixes the `TypeError: Cannot read properties of undefined (reading 'pushLog')` error

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
