### PR TITLE
MSSQL: Fix connection when password or username contains semicolon

### DIFF
--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -1,5 +1,5 @@
 {
- "basePath": "/api",
+ "basePath": "/api/v2/",
  "consumes": [
   "application/json"
  ],
@@ -2849,6 +2849,16 @@
   "PermissionDenied": {
    "type": "object"
   },
+  "PostSilencesOKBody": {
+   "description": "PostSilencesOKBody post silences o k body",
+   "properties": {
+    "silenceID": {
+     "description": "silence ID",
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
   "PostableApiAlertingConfig": {
    "description": "nolint:revive",
    "properties": {
@@ -4869,6 +4879,7 @@
    "type": "object"
   },
   "URL": {
+   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -4904,7 +4915,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "URL is a custom URL type that allows validation at configuration load time.",
+   "title": "A URL represents a parsed URL (technically, a URI reference).",
    "type": "object"
   },
   "UpdateNamespaceRulesRequest": {
@@ -5704,10 +5715,15 @@
    "type": "object"
   }
  },
+ "host": "localhost",
  "info": {
-  "description": "Package definitions includes the types required for generating or consuming an OpenAPI\nspec for the Grafana Alerting API.",
-  "title": "Grafana Alerting API.",
-  "version": "1.1.0"
+  "description": "API of the Prometheus Alertmanager (https://github.com/prometheus/alertmanager)\nSchemes:\nhttp",
+  "license": {
+   "name": "Apache 2.0",
+   "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+  },
+  "title": "Alertmanager API",
+  "version": "0.0.1"
  },
  "paths": {
   "/convert/api/prom/rules": {
@@ -7495,6 +7511,204 @@
      "$ref": "#/definitions/postableAlert"
     },
     "type": "array"
+   }
+  },
+  "deleteSilenceInternalServerError": {
+   "description": "DeleteSilenceInternalServerError Internal server error",
+   "headers": {
+    "body": {
+     "description": "In: Body",
+     "type": "string"
+    }
+   }
+  },
+  "deleteSilenceNotFound": {
+   "description": "DeleteSilenceNotFound A silence with the specified ID was not found"
+  },
+  "deleteSilenceOK": {
+   "description": "DeleteSilenceOK Delete silence response"
+  },
+  "getAlertGroupsBadRequest": {
+   "description": "GetAlertGroupsBadRequest Bad request",
+   "headers": {
+    "body": {
+     "description": "In: Body",
+     "type": "string"
+    }
+   }
+  },
+  "getAlertGroupsInternalServerError": {
+   "description": "GetAlertGroupsInternalServerError Internal server error",
+   "headers": {
+    "body": {
+     "description": "In: Body",
+     "type": "string"
+    }
+   }
+  },
+  "getAlertGroupsOK": {
+   "description": "GetAlertGroupsOK Get alert groups response",
+   "headers": {
+    "body": {
+     "description": "In: Body"
+    }
+   },
+   "schema": {
+    "$ref": "#/definitions/alertGroups"
+   }
+  },
+  "getAlertsBadRequest": {
+   "description": "GetAlertsBadRequest Bad request",
+   "headers": {
+    "body": {
+     "description": "In: Body",
+     "type": "string"
+    }
+   }
+  },
+  "getAlertsInternalServerError": {
+   "description": "GetAlertsInternalServerError Internal server error",
+   "headers": {
+    "body": {
+     "description": "In: Body",
+     "type": "string"
+    }
+   }
+  },
+  "getAlertsOK": {
+   "description": "GetAlertsOK Get alerts response",
+   "headers": {
+    "body": {
+     "description": "In: Body"
+    }
+   },
+   "schema": {
+    "$ref": "#/definitions/gettableAlerts"
+   }
+  },
+  "getReceiversOK": {
+   "description": "GetReceiversOK Get receivers response",
+   "headers": {
+    "body": {
+     "description": "In: Body",
+     "items": {
+      "$ref": "#/definitions/receiver"
+     },
+     "type": "array"
+    }
+   }
+  },
+  "getSilenceInternalServerError": {
+   "description": "GetSilenceInternalServerError Internal server error",
+   "headers": {
+    "body": {
+     "description": "In: Body",
+     "type": "string"
+    }
+   }
+  },
+  "getSilenceNotFound": {
+   "description": "GetSilenceNotFound A silence with the specified ID was not found"
+  },
+  "getSilenceOK": {
+   "description": "GetSilenceOK Get silence response",
+   "headers": {
+    "body": {
+     "description": "In: Body"
+    }
+   },
+   "schema": {
+    "$ref": "#/definitions/gettableSilence"
+   }
+  },
+  "getSilencesBadRequest": {
+   "description": "GetSilencesBadRequest Bad request",
+   "headers": {
+    "body": {
+     "description": "In: Body",
+     "type": "string"
+    }
+   }
+  },
+  "getSilencesInternalServerError": {
+   "description": "GetSilencesInternalServerError Internal server error",
+   "headers": {
+    "body": {
+     "description": "In: Body",
+     "type": "string"
+    }
+   }
+  },
+  "getSilencesOK": {
+   "description": "GetSilencesOK Get silences response",
+   "headers": {
+    "body": {
+     "description": "In: Body"
+    }
+   },
+   "schema": {
+    "$ref": "#/definitions/gettableSilences"
+   }
+  },
+  "getStatusOK": {
+   "description": "GetStatusOK Get status response",
+   "headers": {
+    "body": {
+     "description": "In: Body"
+    }
+   },
+   "schema": {
+    "$ref": "#/definitions/alertmanagerStatus"
+   }
+  },
+  "postAlertsBadRequest": {
+   "description": "PostAlertsBadRequest Bad request",
+   "headers": {
+    "body": {
+     "description": "In: Body",
+     "type": "string"
+    }
+   }
+  },
+  "postAlertsInternalServerError": {
+   "description": "PostAlertsInternalServerError Internal server error",
+   "headers": {
+    "body": {
+     "description": "In: Body",
+     "type": "string"
+    }
+   }
+  },
+  "postAlertsOK": {
+   "description": "PostAlertsOK Create alerts response"
+  },
+  "postSilencesBadRequest": {
+   "description": "PostSilencesBadRequest Bad request",
+   "headers": {
+    "body": {
+     "description": "In: Body",
+     "type": "string"
+    }
+   }
+  },
+  "postSilencesNotFound": {
+   "description": "PostSilencesNotFound A silence with the specified ID was not found",
+   "headers": {
+    "body": {
+     "description": "In: Body",
+     "type": "string"
+    }
+   }
+  },
+  "postSilencesOK": {
+   "description": "PostSilencesOK Create / update silence response",
+   "headers": {
+    "body": {
+     "description": "In: Body"
+    }
+   },
+   "schema": {
+    "$ref": "#/definitions/PostSilencesOKBody"
    }
   },
   "receiversResponse": {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -11,11 +11,16 @@
   ],
   "swagger": "2.0",
   "info": {
-    "description": "Package definitions includes the types required for generating or consuming an OpenAPI\nspec for the Grafana Alerting API.",
-    "title": "Grafana Alerting API.",
-    "version": "1.1.0"
+    "description": "API of the Prometheus Alertmanager (https://github.com/prometheus/alertmanager)\nSchemes:\nhttp",
+    "title": "Alertmanager API",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "0.0.1"
   },
-  "basePath": "/api",
+  "host": "localhost",
+  "basePath": "/api/v2/",
   "paths": {
     "/alertmanager/grafana/api/v2/alerts": {
       "get": {
@@ -1070,6 +1075,127 @@
         }
       }
     },
+    "/alerts": {
+      "get": {
+        "description": "Get a list of alerts",
+        "tags": [
+          "alert"
+        ],
+        "operationId": "getAlerts",
+        "parameters": [
+          {
+            "type": "boolean",
+            "default": true,
+            "description": "Show active alerts",
+            "name": "Active",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "A list of matchers to filter alerts by",
+            "name": "Filter",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "description": "Show inhibited alerts",
+            "name": "Inhibited",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "A regex matching receivers to filter alerts by",
+            "name": "Receiver",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "description": "Show silenced alerts",
+            "name": "Silenced",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "description": "Show unprocessed alerts",
+            "name": "Unprocessed",
+            "in": "query"
+          }
+        ]
+      },
+      "post": {
+        "description": "Create new Alerts",
+        "tags": [
+          "alert"
+        ],
+        "operationId": "postAlerts",
+        "parameters": [
+          {
+            "description": "The alerts to create",
+            "name": "Alerts",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/postableAlerts"
+            }
+          }
+        ]
+      }
+    },
+    "/alerts/groups": {
+      "get": {
+        "description": "Get a list of alert groups",
+        "tags": [
+          "alertgroup"
+        ],
+        "operationId": "getAlertGroups",
+        "parameters": [
+          {
+            "type": "boolean",
+            "default": true,
+            "description": "Show active alerts",
+            "name": "Active",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "A list of matchers to filter alerts by",
+            "name": "Filter",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "description": "Show inhibited alerts",
+            "name": "Inhibited",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "A regex matching receivers to filter alerts by",
+            "name": "Receiver",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "description": "Show silenced alerts",
+            "name": "Silenced",
+            "in": "query"
+          }
+        ]
+      }
+    },
     "/convert/api/prom/rules": {
       "get": {
         "produces": [
@@ -2032,6 +2158,15 @@
         }
       }
     },
+    "/receivers": {
+      "get": {
+        "description": "Get list of all receivers (name of notification integrations)",
+        "tags": [
+          "receiver"
+        ],
+        "operationId": "getReceivers"
+      }
+    },
     "/ruler/grafana/api/v1/export/rules": {
       "get": {
         "description": "List rules in provisioning format",
@@ -2858,6 +2993,90 @@
             }
           }
         }
+      }
+    },
+    "/silence/{silenceID}": {
+      "get": {
+        "description": "Get a silence by its ID",
+        "tags": [
+          "silence"
+        ],
+        "operationId": "getSilence",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the silence to get",
+            "name": "SilenceID",
+            "in": "path",
+            "required": true
+          }
+        ]
+      },
+      "delete": {
+        "description": "Delete a silence by its ID",
+        "tags": [
+          "silence"
+        ],
+        "operationId": "deleteSilence",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the silence to get",
+            "name": "SilenceID",
+            "in": "path",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/silences": {
+      "get": {
+        "description": "Get a list of silences",
+        "tags": [
+          "silence"
+        ],
+        "operationId": "getSilences",
+        "parameters": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "A list of matchers to filter silences by",
+            "name": "Filter",
+            "in": "query"
+          }
+        ]
+      },
+      "post": {
+        "description": "Post a new silence or update an existing one",
+        "tags": [
+          "silence"
+        ],
+        "operationId": "postSilences",
+        "parameters": [
+          {
+            "description": "The silence to create",
+            "name": "Silence",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/postableSilence"
+            }
+          }
+        ]
+      }
+    },
+    "/status": {
+      "get": {
+        "description": "Get current status of an Alertmanager instance and its cluster",
+        "tags": [
+          "general"
+        ],
+        "operationId": "getStatus"
       }
     },
     "/v1/eval": {
@@ -7275,6 +7494,16 @@
     "PermissionDenied": {
       "type": "object"
     },
+    "PostSilencesOKBody": {
+      "description": "PostSilencesOKBody post silences o k body",
+      "type": "object",
+      "properties": {
+        "silenceID": {
+          "description": "silence ID",
+          "type": "string"
+        }
+      }
+    },
     "PostableApiAlertingConfig": {
       "description": "nolint:revive",
       "type": "object",
@@ -9295,8 +9524,9 @@
       }
     },
     "URL": {
+      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
       "type": "object",
-      "title": "URL is a custom URL type that allows validation at configuration load time.",
+      "title": "A URL represents a parsed URL (technically, a URI reference).",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -10152,6 +10382,204 @@
         "type": "array",
         "items": {
           "$ref": "#/definitions/postableAlert"
+        }
+      }
+    },
+    "deleteSilenceInternalServerError": {
+      "description": "DeleteSilenceInternalServerError Internal server error",
+      "headers": {
+        "body": {
+          "type": "string",
+          "description": "In: Body"
+        }
+      }
+    },
+    "deleteSilenceNotFound": {
+      "description": "DeleteSilenceNotFound A silence with the specified ID was not found"
+    },
+    "deleteSilenceOK": {
+      "description": "DeleteSilenceOK Delete silence response"
+    },
+    "getAlertGroupsBadRequest": {
+      "description": "GetAlertGroupsBadRequest Bad request",
+      "headers": {
+        "body": {
+          "type": "string",
+          "description": "In: Body"
+        }
+      }
+    },
+    "getAlertGroupsInternalServerError": {
+      "description": "GetAlertGroupsInternalServerError Internal server error",
+      "headers": {
+        "body": {
+          "type": "string",
+          "description": "In: Body"
+        }
+      }
+    },
+    "getAlertGroupsOK": {
+      "description": "GetAlertGroupsOK Get alert groups response",
+      "schema": {
+        "$ref": "#/definitions/alertGroups"
+      },
+      "headers": {
+        "body": {
+          "description": "In: Body"
+        }
+      }
+    },
+    "getAlertsBadRequest": {
+      "description": "GetAlertsBadRequest Bad request",
+      "headers": {
+        "body": {
+          "type": "string",
+          "description": "In: Body"
+        }
+      }
+    },
+    "getAlertsInternalServerError": {
+      "description": "GetAlertsInternalServerError Internal server error",
+      "headers": {
+        "body": {
+          "type": "string",
+          "description": "In: Body"
+        }
+      }
+    },
+    "getAlertsOK": {
+      "description": "GetAlertsOK Get alerts response",
+      "schema": {
+        "$ref": "#/definitions/gettableAlerts"
+      },
+      "headers": {
+        "body": {
+          "description": "In: Body"
+        }
+      }
+    },
+    "getReceiversOK": {
+      "description": "GetReceiversOK Get receivers response",
+      "headers": {
+        "body": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/receiver"
+          },
+          "description": "In: Body"
+        }
+      }
+    },
+    "getSilenceInternalServerError": {
+      "description": "GetSilenceInternalServerError Internal server error",
+      "headers": {
+        "body": {
+          "type": "string",
+          "description": "In: Body"
+        }
+      }
+    },
+    "getSilenceNotFound": {
+      "description": "GetSilenceNotFound A silence with the specified ID was not found"
+    },
+    "getSilenceOK": {
+      "description": "GetSilenceOK Get silence response",
+      "schema": {
+        "$ref": "#/definitions/gettableSilence"
+      },
+      "headers": {
+        "body": {
+          "description": "In: Body"
+        }
+      }
+    },
+    "getSilencesBadRequest": {
+      "description": "GetSilencesBadRequest Bad request",
+      "headers": {
+        "body": {
+          "type": "string",
+          "description": "In: Body"
+        }
+      }
+    },
+    "getSilencesInternalServerError": {
+      "description": "GetSilencesInternalServerError Internal server error",
+      "headers": {
+        "body": {
+          "type": "string",
+          "description": "In: Body"
+        }
+      }
+    },
+    "getSilencesOK": {
+      "description": "GetSilencesOK Get silences response",
+      "schema": {
+        "$ref": "#/definitions/gettableSilences"
+      },
+      "headers": {
+        "body": {
+          "description": "In: Body"
+        }
+      }
+    },
+    "getStatusOK": {
+      "description": "GetStatusOK Get status response",
+      "schema": {
+        "$ref": "#/definitions/alertmanagerStatus"
+      },
+      "headers": {
+        "body": {
+          "description": "In: Body"
+        }
+      }
+    },
+    "postAlertsBadRequest": {
+      "description": "PostAlertsBadRequest Bad request",
+      "headers": {
+        "body": {
+          "type": "string",
+          "description": "In: Body"
+        }
+      }
+    },
+    "postAlertsInternalServerError": {
+      "description": "PostAlertsInternalServerError Internal server error",
+      "headers": {
+        "body": {
+          "type": "string",
+          "description": "In: Body"
+        }
+      }
+    },
+    "postAlertsOK": {
+      "description": "PostAlertsOK Create alerts response"
+    },
+    "postSilencesBadRequest": {
+      "description": "PostSilencesBadRequest Bad request",
+      "headers": {
+        "body": {
+          "type": "string",
+          "description": "In: Body"
+        }
+      }
+    },
+    "postSilencesNotFound": {
+      "description": "PostSilencesNotFound A silence with the specified ID was not found",
+      "headers": {
+        "body": {
+          "type": "string",
+          "description": "In: Body"
+        }
+      }
+    },
+    "postSilencesOK": {
+      "description": "PostSilencesOK Create / update silence response",
+      "schema": {
+        "$ref": "#/definitions/PostSilencesOKBody"
+      },
+      "headers": {
+        "body": {
+          "description": "In: Body"
         }
       }
     },

--- a/pkg/tsdb/mssql/sqleng/sql_engine_test.go
+++ b/pkg/tsdb/mssql/sqleng/sql_engine_test.go
@@ -691,6 +691,19 @@ func TestGenerateConnectionString(t *testing.T) {
 			},
 			expConnStr: "server=localhost;database=database;user id=user;password=;",
 		},
+		{
+			desc: "Password with semicolon (ODBC escaping)",
+			dataSource: DataSourceInfo{
+				URL:      "localhost",
+				Database: "database",
+				User:     "myuser",
+				DecryptedSecureJSONData: map[string]string{
+					"password": "StrongPass;123",
+				},
+				JsonData: JsonData{},
+			},
+			expConnStr: "odbc:server=localhost;database=database;user id={myuser};password={StrongPass;123};",
+		},
 	}
 
 	logger := backend.NewLoggerWith("logger", "mssql.test")


### PR DESCRIPTION

## Description

## What

Fix MSSQL datasource authentication failure when the username or password contains ';' or '}' by properly handling special characters in the connection string; other special characters work correctly.

Previously, the connection string was built by concatenating values directly (e.g. `password=StrongPass;123;`). The go-mssqldb driver treats semicolon as the key-value delimiter, so a password like `StrongPass;123` was parsed as `password=StrongPass` and `123` as a separate token, causing authentication to fail.

## Why

Passwords such as `StrongPass;123` are valid in SQL Server but broke the Grafana MSSQL datasource because they were embedded in the connection string without escaping.

## How

- When the password or username contains `;` or `}`, we now use ODBC-style escaping supported by the go-mssqldb driver:
  - Prefix the connection string with `odbc:` so the driver uses the ODBC parser.
  - Wrap values in braces and escape `}` as `}}` (e.g. `password={StrongPass;123};`).
- When the password and username do not contain these characters, behavior is unchanged (no `odbc:` prefix, no braces).




**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #17665