### PR TITLE
A11y: Add distinguishing context to bookmark button labels

### DIFF
--- a/e2e-playwright/various-suite/bookmarks.spec.ts
+++ b/e2e-playwright/various-suite/bookmarks.spec.ts
@@ -34,7 +34,7 @@ test.describe(
       await expect(adminItem).toContainText('Administration');
 
       // Click the "Add to Bookmarks" button in the Administration section
-      const addToBookmarksButton = adminItem.getByLabel('Add to Bookmarks');
+      const addToBookmarksButton = adminItem.getByLabel('Add Administration to Bookmarks');
       await addToBookmarksButton.click({ force: true });
 
       // Check if the Administration menu item is visible in the Bookmarks section
@@ -83,7 +83,7 @@ test.describe(
       await expect(administrationLink).toBeVisible();
 
       // Click the "Remove from Bookmarks" button
-      const removeFromBookmarksButton = bookmarksItem.getByLabel('Remove from Bookmarks');
+      const removeFromBookmarksButton = bookmarksItem.getByLabel('Remove Administration from Bookmarks');
       await removeFromBookmarksButton.click({ force: true });
 
       // Check that Administration is no longer in bookmarks

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
@@ -93,6 +93,7 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick, onPin, isPi
             url={link.url}
             onPin={() => onPin(link)}
             isPinned={isPinned(link.url)}
+            itemName={link.text}
           >
             <div
               className={cx(styles.labelWrapper, {

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItemText.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItemText.tsx
@@ -15,9 +15,10 @@ export interface Props {
   url: string;
   onPin: (id?: string) => void;
   isPinned?: boolean;
+  itemName: string;
 }
 
-export function MegaMenuItemText({ children, isActive, onClick, target, url, onPin, isPinned }: Props) {
+export function MegaMenuItemText({ children, isActive, onClick, target, url, onPin, isPinned, itemName }: Props) {
   const theme = useTheme2();
 
   const styles = getStyles(theme, isActive);
@@ -54,8 +55,8 @@ export function MegaMenuItemText({ children, isActive, onClick, target, url, onP
           onClick={() => onPin(url)}
           aria-label={
             isPinned
-              ? t('navigation.item.remove-bookmark', 'Remove from Bookmarks')
-              : t('navigation.item.add-bookmark', 'Add to Bookmarks')
+              ? t('navigation.item.remove-bookmark', 'Remove {{itemName}} from Bookmarks', { itemName })
+              : t('navigation.item.add-bookmark', 'Add {{itemName}} to Bookmarks', { itemName })
           }
         />
       )}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11327,8 +11327,8 @@
       "upgrade-tooltip": "Upgrade to add more users"
     },
     "item": {
-      "add-bookmark": "Add to Bookmarks",
-      "remove-bookmark": "Remove from Bookmarks"
+      "add-bookmark": "Add {{itemName}} to Bookmarks",
+      "remove-bookmark": "Remove {{itemName}} from Bookmarks"
     },
     "kiosk": {
       "tv-alert": "Press ESC to exit kiosk mode"


### PR DESCRIPTION
**What is this feature?**

This fix updates bookmark button aria-labels in the navigation mega menu to include the associated item name, making them descriptive and contextual.

**Why do we need this feature?**

All bookmark buttons previously shared an identical aria-label ("Add to Bookmarks" or "Remove from Bookmarks"), preventing screen reader users from distinguishing which item each button belonged to. This violates WCAG 4.1.2 (Name, Role, Value).

**Who is this feature for?**

Screen reader users and anyone relying on assistive technologies to navigate Grafana.

**Which issue(s) does this PR fix?**:

Fixes #117829
