### PR TITLE
test: bump sqlite query retries to 10 for integration tests

### DIFF
--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -423,7 +423,7 @@ func CreateGrafDir(t *testing.T, opts GrafanaOpts) (string, string) {
 		return section, err
 	}
 
-	queryRetries := 3
+	queryRetries := 10
 	if opts.EnableCSP {
 		securitySect, err := cfg.NewSection("security")
 		require.NoError(t, err)


### PR DESCRIPTION
The `query_retries` is [only valid for sqlite](https://github.com/grafana/grafana/blob/main/pkg/services/sqlstore/database_config.go#L47-L48) and it only retries the `SQLITE_BUSY` errors ([here](https://github.com/grafana/grafana/blob/main/pkg/util/xorm/dialect_sqlite3.go#L478-L480)). So, I believe it is safe to bump this value for integration tests.

Encountered:
```

--- FAIL: TestIntegration_AdminApiReencrypt (80.15s)
    testinfra.go:52: Using test database type sqlite3 host  port  user  name  path /home/ubuntu/.cache/grafana-test/grafana-test-3035756499.db
    testinfra.go:52: Grafana is listening on 127.0.0.1:40347
    reencrypt_test.go:200: 
        	Error Trace:	/opt/actions-runner/_work/grafana/grafana/pkg/tests/api/admin/encryption/reencrypt_test.go:200
        	            				/opt/actions-runner/_work/grafana/grafana/pkg/tests/api/admin/encryption/reencrypt_test.go:78
        	            				/opt/actions-runner/_work/grafana/grafana/pkg/tests/api/admin/encryption/reencrypt_test.go:98
        	            				/opt/actions-runner/_work/grafana/grafana/pkg/tests/api/admin/encryption/reencrypt_test.go:81
        	Error:      	Received unexpected error:
        	            	failed to post process Alertmanager configuration: failed to get latest configuration: [sqlstore.max-retries-reached] retry 3: database is locked (5) (SQLITE_BUSY)
        	Test:       	TestIntegration_AdminApiReencrypt
FAIL

```