### PR TITLE
frontend changes

### DIFF
--- a/public/app/features/datasources/api.ts
+++ b/public/app/features/datasources/api.ts
@@ -176,7 +176,7 @@ export const getDataSourceFromK8sAPI = async (k8sName: string, namespace: string
 };
 
 export const getDataSourceByUid = async (uid: string) => {
-  if (config.featureToggles.queryServiceWithConnections) {
+  if (config.featureToggles.useNewAPIsForDatasourceCRUD) {
     return getDataSourceFromK8sAPI(uid, config.namespace);
   }
 


### PR DESCRIPTION
Part of https://github.com/grafana/grafana-enterprise/issues/8977

in https://github.com/grafana/grafana/pull/116120, we added logic in the frontend to use the new datasource apigroups based on the queryServiceWithConnections toggle. Unfortunately, with the MT frontend picking up changes really quickly, this broke stacks which were running on e.g. slow and hadn't received the updates that made sure the /access endpoint existed on those backends yet.

This PR puts the frontend logic behind its own toggle, so that we can re-enable queryServiceWithConnections for working on the backend, without breaking stacks on slower release channels.

backend changes in https://github.com/grafana/grafana/pull/118068