### PR TITLE
Provisioning: Default to creating new GitHub App when none exist

### DIFF
--- a/public/app/features/provisioning/Wizard/GitHubAppFields.tsx
+++ b/public/app/features/provisioning/Wizard/GitHubAppFields.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Controller, FormProvider, useForm, useFormContext } from 'react-hook-form';
 
 import { Trans, t } from '@grafana/i18n';
@@ -26,6 +27,7 @@ export function GitHubAppFields({ onGitHubAppSubmit }: GitHubAppFieldsProps) {
   const {
     control,
     watch,
+    setValue,
     formState: { errors },
   } = useFormContext<WizardFormData>();
 
@@ -50,6 +52,14 @@ export function GitHubAppFields({ onGitHubAppSubmit }: GitHubAppFieldsProps) {
     connections: githubConnections,
     error: connectionListError,
   } = useConnectionOptions(true);
+
+  const hasNoConnections = !isLoading && !connectionListError && githubConnections.length === 0;
+
+  useEffect(() => {
+    if (hasNoConnections) {
+      setValue('githubAppMode', 'new');
+    }
+  }, [hasNoConnections, setValue]);
 
   const [githubAppMode, githubAppConnectionName] = watch(['githubAppMode', 'githubApp.connectionName']);
   const { connection: selectedConnection } = useConnectionStatus(githubAppConnectionName);


### PR DESCRIPTION
**What is this feature?**

When opening the GitHub App configuration step with no existing connections, automatically switch to "Connect to a new app" mode instead of showing an info alert. This provides better UX by showing the creation form directly.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/811
