### PR TITLE
MSSQL: Fix connection when password  contains semicolon

### DIFF
--- a/pkg/tsdb/mssql/sqleng/connection.go
+++ b/pkg/tsdb/mssql/sqleng/connection.go
@@ -151,7 +151,7 @@ func generateConnectionString(dsInfo DataSourceInfo, azureCredentials azcredenti
 		if odbcNeedsEscape(pass) || odbcNeedsEscape(user) {
 			user = escapeOdbcValue(user)
 			pass = escapeOdbcValue(pass)
-			connStr = "odbc:" + connStr + fmt.Sprintf("user id=%s;password=%s;", user, pass)
+			connStr = "odbc:" + strings.TrimPrefix(connStr, "odbc:") + fmt.Sprintf("user id=%s;password=%s;", user, pass)
 		} else {
 			connStr += fmt.Sprintf("user id=%s;password=%s;", user, pass)
 		}

--- a/pkg/tsdb/mssql/sqleng/connection.go
+++ b/pkg/tsdb/mssql/sqleng/connection.go
@@ -21,7 +21,7 @@ import (
 // odbcNeedsEscape returns true if the value contains semicolon or closing brace,
 // which would break connection string parsing (semicolon is the key=value delimiter).
 func odbcNeedsEscape(s string) bool {
-	return strings.ContainsAny(s, ";}")
+    return strings.ContainsAny(s, ";}") || s != strings.TrimSpace(s)
 }
 
 // escapeOdbcValue wraps a connection string value in ODBC braces so that semicolons

--- a/pkg/tsdb/mssql/sqleng/connection.go
+++ b/pkg/tsdb/mssql/sqleng/connection.go
@@ -138,12 +138,15 @@ func generateConnectionString(dsInfo DataSourceInfo, azureCredentials azcredenti
 	case kerberosRaw, kerberosKeytab, kerberosCredentialCacheFile, kerberosCredentialCache:
 		user := dsInfo.User
 		pass := dsInfo.DecryptedSecureJSONData["password"]
-		if odbcNeedsEscape(pass) || odbcNeedsEscape(user) {
+		useOdbc := odbcNeedsEscape(pass) || odbcNeedsEscape(user)
+		if useOdbc {
 			user = escapeOdbcValue(user)
 			pass = escapeOdbcValue(pass)
-			connStr = "odbc:" + kerberos.Krb5ParseAuthCredentials(addr.Host, addr.Port, dsInfo.Database, user, pass, kerberosAuth)
-		} else {
-			connStr = kerberos.Krb5ParseAuthCredentials(addr.Host, addr.Port, dsInfo.Database, user, pass, kerberosAuth)
+		}
+		
+		connStr = kerberos.Krb5ParseAuthCredentials(addr.Host, addr.Port, dsInfo.Database, user, pass, kerberosAuth)
+		if useOdbc {
+			connStr = "odbc:" + strings.TrimPrefix(connStr, "odbc:")
 		}
 	default:
 		user := dsInfo.User

--- a/pkg/tsdb/mssql/sqleng/connection.go
+++ b/pkg/tsdb/mssql/sqleng/connection.go
@@ -21,7 +21,7 @@ import (
 // odbcNeedsEscape returns true if the value contains semicolon or closing brace,
 // which would break connection string parsing (semicolon is the key=value delimiter).
 func odbcNeedsEscape(s string) bool {
-    return strings.ContainsAny(s, ";}") || s != strings.TrimSpace(s)
+	return strings.ContainsAny(s, ";}") || s != strings.TrimSpace(s)
 }
 
 // escapeOdbcValue wraps a connection string value in ODBC braces so that semicolons
@@ -143,7 +143,7 @@ func generateConnectionString(dsInfo DataSourceInfo, azureCredentials azcredenti
 			user = escapeOdbcValue(user)
 			pass = escapeOdbcValue(pass)
 		}
-		
+
 		connStr = kerberos.Krb5ParseAuthCredentials(addr.Host, addr.Port, dsInfo.Database, user, pass, kerberosAuth)
 		if useOdbc {
 			connStr = "odbc:" + strings.TrimPrefix(connStr, "odbc:")

--- a/pkg/tsdb/mssql/sqleng/sql_engine_test.go
+++ b/pkg/tsdb/mssql/sqleng/sql_engine_test.go
@@ -691,6 +691,19 @@ func TestGenerateConnectionString(t *testing.T) {
 			},
 			expConnStr: "server=localhost;database=database;user id=user;password=;",
 		},
+		{
+			desc: "Password with semicolon (ODBC escaping)",
+			dataSource: DataSourceInfo{
+				URL:      "localhost",
+				Database: "database",
+				User:     "myuser",
+				DecryptedSecureJSONData: map[string]string{
+					"password": "StrongPass;123",
+				},
+				JsonData: JsonData{},
+			},
+			expConnStr: "odbc:server=localhost;database=database;user id={myuser};password={StrongPass;123};",
+		},
 	}
 
 	logger := backend.NewLoggerWith("logger", "mssql.test")


### PR DESCRIPTION
## Description

## What

Fix MSSQL datasource authentication failure when the username or password contains ';' or '}' by properly handling special characters in the connection string; other special characters work correctly.

Previously, the connection string was built by concatenating values directly (e.g. `password=StrongPass;123;`). The go-mssqldb driver treats semicolon as the key-value delimiter, so a password like `StrongPass;123` was parsed as `password=StrongPass` and `123` as a separate token, causing authentication to fail.

## Why

Passwords such as `StrongPass;123` are valid in SQL Server but broke the Grafana MSSQL datasource because they were embedded in the connection string without escaping.

## How

- When the password or username contains `;` or `}`, we now use ODBC-style escaping supported by the go-mssqldb driver:
  - Prefix the connection string with `odbc:` so the driver uses the ODBC parser.
  - Wrap values in braces and escape `}` as `}}` (e.g. `password={StrongPass;123};`).
- When the password and username do not contain these characters, behavior is unchanged (no `odbc:` prefix, no braces).




**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #17665