### PR TITLE
Provisioning: enforce finalizers on resources not marked for deletion

### DIFF
--- a/apps/provisioning/pkg/repository/mutator.go
+++ b/apps/provisioning/pkg/repository/mutator.go
@@ -39,11 +39,13 @@ func (m *AdmissionMutator) Mutate(ctx context.Context, a admission.Attributes, o
 		return fmt.Errorf("expected repository configuration, got %T", obj)
 	}
 
-	// This is called on every update, so be careful to only add the finalizer for create
-	if len(r.Finalizers) == 0 && a.GetOperation() == admission.Create {
-		r.Finalizers = []string{
-			RemoveOrphanResourcesFinalizer,
-			CleanFinalizer,
+	// Enforcing the presence of finalizers in resources not marked for deletion.
+	if r.DeletionTimestamp == nil || r.DeletionTimestamp.IsZero() {
+		if len(r.Finalizers) == 0 {
+			r.Finalizers = []string{
+				RemoveOrphanResourcesFinalizer,
+				CleanFinalizer,
+			}
 		}
 	}
 

--- a/apps/provisioning/pkg/repository/mutator_test.go
+++ b/apps/provisioning/pkg/repository/mutator_test.go
@@ -183,6 +183,38 @@ func TestAdmissionMutator_Mutate(t *testing.T) {
 			wantErr:         true,
 			wantErrContains: "failed to mutate repository",
 		},
+		{
+			name: "does not add finalizers when resource is marked for deletion",
+			obj: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+				Spec: provisioning.RepositorySpec{},
+			},
+			operation:       admission.Update,
+			minSyncInterval: 60 * time.Second,
+			wantFinalizers:  nil,
+			wantInterval:    60,
+			wantWorkflows:   []provisioning.Workflow{},
+			wantErr:         false,
+		},
+		{
+			name: "does not add finalizers when DeletionTimestamp is zero",
+			obj: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test",
+					DeletionTimestamp: &metav1.Time{},
+				},
+				Spec: provisioning.RepositorySpec{},
+			},
+			operation:       admission.Create,
+			minSyncInterval: 60 * time.Second,
+			wantFinalizers:  nil,
+			wantInterval:    60,
+			wantWorkflows:   []provisioning.Workflow{},
+			wantErr:         false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/apps/provisioning/pkg/repository/tester_test.go
+++ b/apps/provisioning/pkg/repository/tester_test.go
@@ -27,6 +27,9 @@ func TestTester_Test_Cases(t *testing.T) {
 			repository: func() *MockRepository {
 				m := NewMockRepository(t)
 				m.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
 					Spec: provisioning.RepositorySpec{
 						// Missing required title
 					},
@@ -45,6 +48,9 @@ func TestTester_Test_Cases(t *testing.T) {
 			repository: func() *MockRepository {
 				m := NewMockRepository(t)
 				m.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
 					Spec: provisioning.RepositorySpec{
 						Title: "Test Repo",
 					},
@@ -63,6 +69,9 @@ func TestTester_Test_Cases(t *testing.T) {
 			repository: func() *MockRepository {
 				m := NewMockRepository(t)
 				m.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
 					Spec: provisioning.RepositorySpec{
 						Title: "Test Repo",
 					},
@@ -77,6 +86,9 @@ func TestTester_Test_Cases(t *testing.T) {
 			repository: func() *MockRepository {
 				m := NewMockRepository(t)
 				m.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
 					Spec: provisioning.RepositorySpec{
 						Title: "Test Repo",
 					},
@@ -132,6 +144,9 @@ func TestTester_Test_Cases(t *testing.T) {
 func TestTester_Test(t *testing.T) {
 	repository := NewMockRepository(t)
 	repository.On("Config").Return(&provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Finalizers: []string{CleanFinalizer},
+		},
 		Spec: provisioning.RepositorySpec{
 			Title: "Test Repo",
 		},

--- a/apps/provisioning/pkg/repository/validator.go
+++ b/apps/provisioning/pkg/repository/validator.go
@@ -90,6 +90,19 @@ func (v *RepositoryValidator) Validate(ctx context.Context, cfg *provisioning.Re
 		}
 	}
 
+	// Validating the presence of finalizers in resources not marked for deletion.
+	if cfg.DeletionTimestamp != nil || cfg.DeletionTimestamp.IsZero() {
+		if len(cfg.Finalizers) == 0 {
+			list = append(list,
+				field.Invalid(
+					field.NewPath("medatada", "finalizers"),
+					cfg.Finalizers,
+					"cannot have no finalizers set on resources not marked for deletion",
+				),
+			)
+		}
+	}
+
 	if slices.Contains(cfg.Finalizers, RemoveOrphanResourcesFinalizer) &&
 		slices.Contains(cfg.Finalizers, ReleaseOrphanResourcesFinalizer) {
 		list = append(list,

--- a/apps/provisioning/pkg/repository/validator_test.go
+++ b/apps/provisioning/pkg/repository/validator_test.go
@@ -43,6 +43,9 @@ func TestValidator_Validate(t *testing.T) {
 			name: "missing title",
 			repository: func() *provisioning.Repository {
 				return &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
 					Spec: provisioning.RepositorySpec{},
 				}
 			}(),
@@ -55,6 +58,9 @@ func TestValidator_Validate(t *testing.T) {
 			name: "sync enabled without target",
 			repository: func() *provisioning.Repository {
 				return &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
 					Spec: provisioning.RepositorySpec{
 						Title: "Test Repo",
 						Sync: provisioning.SyncOptions{
@@ -73,7 +79,8 @@ func TestValidator_Validate(t *testing.T) {
 			repository: func() *provisioning.Repository {
 				return &provisioning.Repository{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "sql",
+						Name:       "sql",
+						Finalizers: []string{CleanFinalizer},
 					},
 					Spec: provisioning.RepositorySpec{
 						Title: "Test Repo",
@@ -93,6 +100,9 @@ func TestValidator_Validate(t *testing.T) {
 			name: "mismatched local config",
 			repository: func() *provisioning.Repository {
 				return &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
 					Spec: provisioning.RepositorySpec{
 						Title: "Test Repo",
 						Type:  provisioning.GitHubRepositoryType,
@@ -109,6 +119,9 @@ func TestValidator_Validate(t *testing.T) {
 			name: "mismatched github config",
 			repository: func() *provisioning.Repository {
 				return &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
 					Spec: provisioning.RepositorySpec{
 						Title:  "Test Repo",
 						Type:   provisioning.LocalRepositoryType,
@@ -125,6 +138,9 @@ func TestValidator_Validate(t *testing.T) {
 			name: "github enabled when image rendering is not allowed",
 			repository: func() *provisioning.Repository {
 				return &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
 					Spec: provisioning.RepositorySpec{
 						Title:  "Test Repo",
 						Type:   provisioning.GitHubRepositoryType,
@@ -141,6 +157,9 @@ func TestValidator_Validate(t *testing.T) {
 			name: "mismatched git config",
 			repository: func() *provisioning.Repository {
 				return &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
 					Spec: provisioning.RepositorySpec{
 						Title: "Test Repo",
 						Type:  provisioning.LocalRepositoryType,
@@ -158,7 +177,8 @@ func TestValidator_Validate(t *testing.T) {
 			repository: func() *provisioning.Repository {
 				return &provisioning.Repository{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "sql",
+						Name:       "sql",
+						Finalizers: []string{CleanFinalizer},
 					},
 					Spec: provisioning.RepositorySpec{
 						Title: "Test Repo",
@@ -179,6 +199,9 @@ func TestValidator_Validate(t *testing.T) {
 			name: "branch workflow for non-github repository",
 			repository: func() *provisioning.Repository {
 				return &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
 					Spec: provisioning.RepositorySpec{
 						Title:     "Test Repo",
 						Type:      provisioning.LocalRepositoryType,
@@ -195,6 +218,9 @@ func TestValidator_Validate(t *testing.T) {
 			name: "invalid workflow in the list",
 			repository: func() *provisioning.Repository {
 				return &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
 					Spec: provisioning.RepositorySpec{
 						Title:     "Test Repo",
 						Type:      provisioning.GitHubRepositoryType,
@@ -245,6 +271,25 @@ func TestValidator_Validate(t *testing.T) {
 				require.Contains(t, errors.ToAggregate().Error(), "unknown finalizer: invalid-finalizer")
 			},
 		},
+		{
+			name: "no finalizers on resource not marked for deletion",
+			repository: func() *provisioning.Repository {
+				return &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{},
+					},
+					Spec: provisioning.RepositorySpec{
+						Title:     "Test Repo",
+						Type:      provisioning.GitHubRepositoryType,
+						Workflows: []provisioning.Workflow{provisioning.WriteWorkflow},
+					},
+				}
+			}(),
+			expectedErrs: 1,
+			validateError: func(t *testing.T, errors field.ErrorList) {
+				require.Contains(t, errors.ToAggregate().Error(), "cannot have no finalizers set on resources not marked for deletion")
+			},
+		},
 	}
 
 	mockFactory := NewMockFactory(t)
@@ -290,7 +335,10 @@ func TestAdmissionValidator_Validate(t *testing.T) {
 		{
 			name: "valid repository passes validation",
 			obj: &provisioning.Repository{
-				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test",
+					Finalizers: []string{CleanFinalizer},
+				},
 				Spec: provisioning.RepositorySpec{
 					Title: "Test Repo",
 					Type:  provisioning.GitHubRepositoryType,
@@ -303,7 +351,10 @@ func TestAdmissionValidator_Validate(t *testing.T) {
 		{
 			name: "invalid repository fails validation",
 			obj: &provisioning.Repository{
-				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test",
+					Finalizers: []string{CleanFinalizer},
+				},
 				Spec: provisioning.RepositorySpec{
 					// Missing title
 					Type: provisioning.GitHubRepositoryType,
@@ -354,7 +405,10 @@ func TestAdmissionValidator_Validate(t *testing.T) {
 		{
 			name: "forbids changing repository type on update",
 			obj: &provisioning.Repository{
-				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test",
+					Finalizers: []string{CleanFinalizer},
+				},
 				Spec: provisioning.RepositorySpec{
 					Title: "Test Repo",
 					Type:  provisioning.GitRepositoryType, // Changed from github
@@ -362,7 +416,10 @@ func TestAdmissionValidator_Validate(t *testing.T) {
 				},
 			},
 			old: &provisioning.Repository{
-				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test",
+					Finalizers: []string{CleanFinalizer},
+				},
 				Spec: provisioning.RepositorySpec{
 					Title: "Test Repo",
 					Type:  provisioning.GitHubRepositoryType,
@@ -376,7 +433,10 @@ func TestAdmissionValidator_Validate(t *testing.T) {
 		{
 			name: "forbids changing sync target after sync",
 			obj: &provisioning.Repository{
-				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test",
+					Finalizers: []string{CleanFinalizer},
+				},
 				Spec: provisioning.RepositorySpec{
 					Title: "Test Repo",
 					Type:  provisioning.GitHubRepositoryType,
@@ -384,7 +444,10 @@ func TestAdmissionValidator_Validate(t *testing.T) {
 				},
 			},
 			old: &provisioning.Repository{
-				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test",
+					Finalizers: []string{CleanFinalizer},
+				},
 				Spec: provisioning.RepositorySpec{
 					Title: "Test Repo",
 					Type:  provisioning.GitHubRepositoryType,
@@ -443,7 +506,10 @@ func TestAdmissionValidator_CopiesSecureValuesOnUpdate(t *testing.T) {
 	)
 
 	oldRepo := &provisioning.Repository{
-		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test",
+			Finalizers: []string{CleanFinalizer},
+		},
 		Spec: provisioning.RepositorySpec{
 			Title: "Test Repo",
 			Type:  provisioning.GitHubRepositoryType,
@@ -456,7 +522,10 @@ func TestAdmissionValidator_CopiesSecureValuesOnUpdate(t *testing.T) {
 	}
 
 	newRepo := &provisioning.Repository{
-		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test",
+			Finalizers: []string{CleanFinalizer},
+		},
 		Spec: provisioning.RepositorySpec{
 			Title: "Test Repo",
 			Type:  provisioning.GitHubRepositoryType,
@@ -500,7 +569,10 @@ func TestAdmissionValidator_CallsMultipleValidators(t *testing.T) {
 	)
 
 	repo := &provisioning.Repository{
-		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test",
+			Finalizers: []string{CleanFinalizer},
+		},
 		Spec: provisioning.RepositorySpec{
 			Title: "Test Repo",
 			Type:  provisioning.GitHubRepositoryType,
@@ -531,7 +603,10 @@ func TestAdmissionValidator_ValidatorError(t *testing.T) {
 	)
 
 	repo := &provisioning.Repository{
-		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test",
+			Finalizers: []string{CleanFinalizer},
+		},
 		Spec: provisioning.RepositorySpec{
 			Title: "Test Repo",
 			Type:  provisioning.GitHubRepositoryType,

--- a/pkg/registry/apis/provisioning/controller/health_test.go
+++ b/pkg/registry/apis/provisioning/controller/health_test.go
@@ -495,6 +495,9 @@ func TestRefreshHealth(t *testing.T) {
 			mockPatcher := mocks.NewStatusPatcher(t)
 			mockRepo := &mockRepository{
 				config: &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{repository.CleanFinalizer},
+					},
 					Spec: provisioning.RepositorySpec{
 						Title: "Test Repository",
 						Type:  provisioning.LocalRepositoryType,
@@ -644,6 +647,7 @@ func TestRefreshHealthWithPatchOps(t *testing.T) {
 				config: &provisioning.Repository{
 					ObjectMeta: metav1.ObjectMeta{
 						Generation: 1,
+						Finalizers: []string{repository.CleanFinalizer},
 					},
 					Spec: provisioning.RepositorySpec{
 						Title: "Test Repository",

--- a/pkg/tests/apis/provisioning/health_test.go
+++ b/pkg/tests/apis/provisioning/health_test.go
@@ -55,6 +55,12 @@ func TestIntegrationHealth(t *testing.T) {
 		newRepoConfig := map[string]any{
 			"apiVersion": "provisioning.grafana.app/v0alpha1",
 			"kind":       "Repository",
+			"metadata": map[string]any{
+				"finalizers": []string{
+					"remove-orphan-resources",
+					"cleanup",
+				},
+			},
 			"spec": map[string]any{
 				"title": "Test New Configuration",
 				"type":  "local",

--- a/pkg/tests/apis/provisioning/repository_subresources_auth_test.go
+++ b/pkg/tests/apis/provisioning/repository_subresources_auth_test.go
@@ -32,6 +32,12 @@ func TestIntegrationProvisioning_RepositorySubresourcesAuthorization(t *testing.
 		newRepoConfig := map[string]any{
 			"apiVersion": "provisioning.grafana.app/v0alpha1",
 			"kind":       "Repository",
+			"metadata": map[string]any{
+				"finalizers": []string{
+					"remove-orphan-resources",
+					"cleanup",
+				},
+			},
 			"spec": map[string]any{
 				"title": "Test Configuration",
 				"type":  "local",


### PR DESCRIPTION
**What is this feature?**

- If the resource is not marked for deletion, and has no finalisers, enforce the default ones in both validation and mutation.
- Covering that in unit tests and integration tests

**Why do we need this feature?**

When a `Repository` gets updated with empty finalizers, i.e. they get removed, it causes an issue when the resource gets deleted later: the absence of finalizers causes the resource to be immediately deleted, w/o letting the controller handle such operation.

**Who is this feature for?**

Users of GitSync

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/754

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
