### PR TITLE
Logs Panel: Added support to show the field selector in Dashboards

### DIFF
--- a/public/app/plugins/panel/logs/module.tsx
+++ b/public/app/plugins/panel/logs/module.tsx
@@ -117,6 +117,19 @@ export const plugin = new PanelPlugin<Options>(LogsPanel)
       });
     }
 
+    if (config.featureToggles.newLogsPanel) {
+      builder.addBooleanSwitch({
+        path: 'showFieldSelector',
+        name: t('logs.name-enable-field-selector', 'Enable field selector'),
+        category,
+        description: t(
+          'logs.description-enable-infinite-scrolling',
+          'Experimental. Show a component to manage the displayed fields from the logs.'
+        ),
+        defaultValue: false,
+      });
+    }
+
     builder.addBooleanSwitch({
       path: 'enableInfiniteScrolling',
       name: t('logs.name-enable-infinite-scrolling', 'Enable infinite scrolling'),

--- a/public/app/plugins/panel/logs/module.tsx
+++ b/public/app/plugins/panel/logs/module.tsx
@@ -123,7 +123,7 @@ export const plugin = new PanelPlugin<Options>(LogsPanel)
         name: t('logs.name-enable-field-selector', 'Enable field selector'),
         category,
         description: t(
-          'logs.description-enable-infinite-scrolling',
+          'logs.description-enable-field-selector',
           'Experimental. Show a component to manage the displayed fields from the logs.'
         ),
         defaultValue: false,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10464,7 +10464,7 @@
       "label-numbers": "Numbers",
       "label-signature": "Signature"
     },
-    "description-enable-infinite-scrolling": "Experimental. Request more results by scrolling to the bottom of the logs list.",
+    "description-enable-infinite-scrolling": "Experimental. Show a component to manage the displayed fields from the logs.",
     "description-enable-logs-highlighting": "Use a predefined coloring scheme to highlight relevant parts of the log lines",
     "description-show-controls": "Display controls to jump to the last or first log line, and filters by log level",
     "description-show-log-attributes": "Experimental. When OTel logs are displayed, add an extra displayed field with relevant key-value pairs from labels and metadata.",
@@ -10756,6 +10756,7 @@
       "label-inline": "Inline",
       "label-sidebar": "Sidebar"
     },
+    "name-enable-field-selector": "Enable field selector",
     "name-enable-infinite-scrolling": "Enable infinite scrolling",
     "name-enable-log-details": "Enable log details",
     "name-enable-logs-highlighting": "Enable logs highlighting",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10464,7 +10464,8 @@
       "label-numbers": "Numbers",
       "label-signature": "Signature"
     },
-    "description-enable-infinite-scrolling": "Experimental. Show a component to manage the displayed fields from the logs.",
+    "description-enable-field-selector": "Experimental. Show a component to manage the displayed fields from the logs.",
+    "description-enable-infinite-scrolling": "Experimental. Request more results by scrolling to the bottom of the logs list.",
     "description-enable-logs-highlighting": "Use a predefined coloring scheme to highlight relevant parts of the log lines",
     "description-show-controls": "Display controls to jump to the last or first log line, and filters by log level",
     "description-show-log-attributes": "Experimental. When OTel logs are displayed, add an extra displayed field with relevant key-value pairs from labels and metadata.",


### PR DESCRIPTION
This PR adds a new Dashboard experimental option to control the display of the Field Selector component.

https://github.com/user-attachments/assets/8a5f7108-ea3f-4bf6-a2b7-e1e354c888aa

Part of https://github.com/grafana/grafana/issues/112372