### PR TITLE
Alerting: Historian: Support matching notification history by labels.

### DIFF
--- a/apps/alerting/historian/kinds/v0alpha1/notification.cue
+++ b/apps/alerting/historian/kinds/v0alpha1/notification.cue
@@ -25,6 +25,8 @@ import (
     ruleUID?: string
     // GroupLabels optionally filters the entries by matching group labels.
     groupLabels?: #Matchers
+    // Labels optionally filters the entries by matching alert labels.
+    labels?: #Matchers
 }
 
 #NotificationQueryResult: {

--- a/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationquery_request_body_types_gen.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationquery_request_body_types_gen.go
@@ -65,6 +65,8 @@ type CreateNotificationqueryRequestBody struct {
 	RuleUID *string `json:"ruleUID,omitempty"`
 	// GroupLabels optionally filters the entries by matching group labels.
 	GroupLabels *CreateNotificationqueryRequestMatchers `json:"groupLabels,omitempty"`
+	// Labels optionally filters the entries by matching alert labels.
+	Labels *CreateNotificationqueryRequestMatchers `json:"labels,omitempty"`
 }
 
 // NewCreateNotificationqueryRequestBody creates a new CreateNotificationqueryRequestBody object.

--- a/apps/alerting/historian/pkg/apis/alertinghistorian_manifest.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian_manifest.go
@@ -113,6 +113,13 @@ var appManifestData = app.ManifestData{
 																		Ref:         spec.MustCreateRef("#/components/schemas/createNotificationqueryMatchers"),
 																	},
 																},
+																"labels": {
+																	SchemaProps: spec.SchemaProps{
+
+																		Description: "Labels optionally filters the entries by matching alert labels.",
+																		Ref:         spec.MustCreateRef("#/components/schemas/createNotificationqueryMatchers"),
+																	},
+																},
 																"limit": {
 																	SchemaProps: spec.SchemaProps{
 																		Type:        []string{"integer"},


### PR DESCRIPTION
The updated log format (one alert per line) makes this much simpler. This does
make groupLabel matching somewhat redundant, so we may remove that before marking
the API stable. It can stay for now in case we find a use for it.
