### PR TITLE
Dynamic dashboards: Add tracking for removing panel from sidebar

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/EditPaneHeader.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/EditPaneHeader.test.tsx
@@ -1,11 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { getPanelPlugin } from '@grafana/data/test';
 import { selectors } from '@grafana/e2e-selectors';
-import { SceneTimeRange } from '@grafana/scenes';
+import { setPluginImportUtils } from '@grafana/runtime';
+import { SceneGridItem, SceneGridLayout, SceneTimeRange, VizPanel } from '@grafana/scenes';
 import { Sidebar, useSidebar } from '@grafana/ui';
 
 import { DashboardScene } from '../scene/DashboardScene';
+import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
+import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 import { RowItem } from '../scene/layout-rows/RowItem';
 import { RowsLayoutManager } from '../scene/layout-rows/RowsLayoutManager';
 import { TabItem } from '../scene/layout-tabs/TabItem';
@@ -17,11 +21,15 @@ import { DashboardEditPane } from './DashboardEditPane';
 import { EditPaneHeader } from './EditPaneHeader';
 import { ElementSelection } from './ElementSelection';
 
+setPluginImportUtils({
+  importPanelPlugin: (id: string) => Promise.resolve(getPanelPlugin({})),
+  getPanelPluginFromCache: (id: string) => undefined,
+});
+
 // Mock DashboardInteractions
 jest.mock('../utils/interactions', () => ({
   DashboardInteractions: {
-    trackRemoveRowClick: jest.fn(),
-    trackRemoveTabClick: jest.fn(),
+    trackDeleteDashboardElement: jest.fn(),
   },
 }));
 
@@ -49,6 +57,22 @@ const sceneWithRow = new DashboardScene({
   }),
 });
 
+const panel = new VizPanel({
+  key: 'panel-test',
+  pluginId: 'text',
+  title: 'panel-test',
+});
+const gridItem = new DashboardGridItem({ body: panel });
+const sceneWithPanel = new DashboardScene({
+  $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+  isEditing: true,
+  body: new DefaultGridLayoutManager({
+    grid: new SceneGridLayout({
+      children: [gridItem],
+    }),
+  }),
+});
+
 const buildTestScene = (scene: DashboardScene) => {
   activateFullSceneTree(scene);
   return scene;
@@ -71,7 +95,7 @@ describe('EditPaneHeader', () => {
   });
 
   describe('tracking item deletion', () => {
-    it('should call DashboardActions.trackDeleteRow when deleting a row', async () => {
+    it('should call DashboardInteractions.trackDeleteDashboardElement when deleting a row', async () => {
       const user = userEvent.setup();
       const scene = buildTestScene(sceneWithRow);
       const row = (scene.state.body as RowsLayoutManager).state.rows[0];
@@ -85,10 +109,10 @@ describe('EditPaneHeader', () => {
       );
 
       await user.click(screen.getByTestId(selectors.components.EditPaneHeader.deleteButton));
-      expect(DashboardInteractions.trackRemoveRowClick).toHaveBeenCalled();
+      expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('row');
     });
 
-    it('should call DashboardActions.trackDeleteTab when deleting a tab', async () => {
+    it('should call DashboardInteractions.trackDeleteDashboardElement when deleting a tab', async () => {
       const user = userEvent.setup();
       const scene = buildTestScene(sceneWithTab);
       const tab = (scene.state.body as TabsLayoutManager).state.tabs[0];
@@ -102,7 +126,25 @@ describe('EditPaneHeader', () => {
       );
 
       await user.click(screen.getByTestId(selectors.components.EditPaneHeader.deleteButton));
-      expect(DashboardInteractions.trackRemoveTabClick).toHaveBeenCalled();
+      expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('tab');
+    });
+
+    it('should call DashboardInteractions.trackDeleteDashboardElement when deleting a panel', async () => {
+      const user = userEvent.setup();
+      const scene = buildTestScene(sceneWithPanel);
+      const panel = ((scene.state.body as DefaultGridLayoutManager).state.grid.state.children[0] as SceneGridItem).state
+        .body as VizPanel;
+      const elementSelection = new ElementSelection([['panel-test', panel.getRef()]]);
+      const editableElement = elementSelection.createSelectionElement()!;
+
+      render(
+        <WrapSidebar>
+          <EditPaneHeader element={editableElement} editPane={mockEditPane} />
+        </WrapSidebar>
+      );
+
+      await user.click(screen.getByTestId(selectors.components.EditPaneHeader.deleteButton));
+      expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('panel');
     });
   });
 });

--- a/public/app/features/dashboard-scene/edit-pane/EditPaneHeader.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/EditPaneHeader.test.tsx
@@ -4,10 +4,12 @@ import userEvent from '@testing-library/user-event';
 import { getPanelPlugin } from '@grafana/data/test';
 import { selectors } from '@grafana/e2e-selectors';
 import { setPluginImportUtils } from '@grafana/runtime';
-import { SceneTimeRange } from '@grafana/scenes';
+import { SceneGridItem, SceneGridLayout, SceneTimeRange, VizPanel } from '@grafana/scenes';
 import { Sidebar, useSidebar } from '@grafana/ui';
 
 import { DashboardScene } from '../scene/DashboardScene';
+import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
+import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 import { RowItem } from '../scene/layout-rows/RowItem';
 import { RowsLayoutManager } from '../scene/layout-rows/RowsLayoutManager';
 import { TabItem } from '../scene/layout-tabs/TabItem';
@@ -61,7 +63,25 @@ describe('EditPaneHeader', () => {
       expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('Tab');
     });
   });
+
+  it('should call DashboardInteractions.trackDeleteDashboardElement when deleting a panel', async () => {
+    const { panel, mockEditPane } = setup('panel');
+    const elementSelection = new ElementSelection([['panel-test', panel!.getRef()]]);
+    const editableElement = elementSelection.createSelectionElement()!;
+    renderEditPaneHeader(editableElement, mockEditPane);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId(selectors.components.EditPaneHeader.deleteButton));
+
+    expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('Panel');
+  });
 });
+
+function WrapSidebar({ children }: { children: React.ReactElement }) {
+  const sidebarContext = useSidebar({});
+
+  return <Sidebar contextValue={sidebarContext}>{children}</Sidebar>;
+}
 
 const renderEditPaneHeader = (editableElement: EditableDashboardElement, mockEditPane: DashboardEditPane) => {
   render(
@@ -71,44 +91,67 @@ const renderEditPaneHeader = (editableElement: EditableDashboardElement, mockEdi
   );
 };
 
-const setup = (layout: 'row' | 'tab'): { row?: RowItem; tab?: TabItem; mockEditPane: DashboardEditPane } => {
+const setup = (
+  layout: 'row' | 'tab' | 'panel'
+): { row?: RowItem; tab?: TabItem; panel?: VizPanel; mockEditPane: DashboardEditPane } => {
   const mockEditPane = {
     state: { selection: null },
     clearSelection: jest.fn(),
   } as unknown as DashboardEditPane;
 
-  if (layout === 'row') {
-    const sceneWithRow = new DashboardScene({
-      $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
-      isEditing: true,
-      body: new RowsLayoutManager({
-        rows: [
-          new RowItem({
-            title: 'test row',
-          }),
-        ],
-      }),
-    });
-    activateFullSceneTree(sceneWithRow);
-    return { row: (sceneWithRow.state.body as RowsLayoutManager).state.rows[0], mockEditPane };
-  }
-  const sceneWithTab = new DashboardScene({
-    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
-    isEditing: true,
-    body: new TabsLayoutManager({
-      tabs: [
-        new TabItem({
-          title: 'test tab',
+  switch (layout) {
+    case 'row': {
+      const sceneWithRow = new DashboardScene({
+        $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+        isEditing: true,
+        body: new RowsLayoutManager({
+          rows: [
+            new RowItem({
+              title: 'test row',
+            }),
+          ],
         }),
-      ],
-    }),
-  });
-  activateFullSceneTree(sceneWithTab);
-  return { tab: (sceneWithTab.state.body as TabsLayoutManager).state.tabs[0], mockEditPane };
+      });
+      activateFullSceneTree(sceneWithRow);
+      return { row: (sceneWithRow.state.body as RowsLayoutManager).state.rows[0], mockEditPane };
+    }
+    case 'tab': {
+      const sceneWithTab = new DashboardScene({
+        $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+        isEditing: true,
+        body: new TabsLayoutManager({
+          tabs: [
+            new TabItem({
+              title: 'test tab',
+            }),
+          ],
+        }),
+      });
+      activateFullSceneTree(sceneWithTab);
+      return { tab: (sceneWithTab.state.body as TabsLayoutManager).state.tabs[0], mockEditPane };
+    }
+    default: {
+      const panel = new VizPanel({
+        key: 'panel-test',
+        pluginId: 'text',
+        title: 'panel-test',
+      });
+      const gridItem = new DashboardGridItem({ body: panel });
+      const sceneWithPanel = new DashboardScene({
+        $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+        isEditing: true,
+        body: new DefaultGridLayoutManager({
+          grid: new SceneGridLayout({
+            children: [gridItem],
+          }),
+        }),
+      });
+      activateFullSceneTree(sceneWithPanel);
+      return {
+        panel: ((sceneWithPanel.state.body as DefaultGridLayoutManager).state.grid.state.children[0] as SceneGridItem)
+          .state.body as VizPanel,
+        mockEditPane,
+      };
+    }
+  }
 };
-
-function WrapSidebar({ children }: { children: React.ReactElement }) {
-  const sidebarContext = useSidebar({});
-
-  return <Sidebar contextValue={sidebarContext}>{children}</Sidebar>;
-}

--- a/public/app/features/dashboard-scene/edit-pane/EditPaneHeader.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/EditPaneHeader.test.tsx
@@ -4,16 +4,15 @@ import userEvent from '@testing-library/user-event';
 import { getPanelPlugin } from '@grafana/data/test';
 import { selectors } from '@grafana/e2e-selectors';
 import { setPluginImportUtils } from '@grafana/runtime';
-import { SceneGridItem, SceneGridLayout, SceneTimeRange, VizPanel } from '@grafana/scenes';
+import { SceneTimeRange } from '@grafana/scenes';
 import { Sidebar, useSidebar } from '@grafana/ui';
 
 import { DashboardScene } from '../scene/DashboardScene';
-import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
-import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 import { RowItem } from '../scene/layout-rows/RowItem';
 import { RowsLayoutManager } from '../scene/layout-rows/RowsLayoutManager';
 import { TabItem } from '../scene/layout-tabs/TabItem';
 import { TabsLayoutManager } from '../scene/layout-tabs/TabsLayoutManager';
+import { EditableDashboardElement } from '../scene/types/EditableDashboardElement';
 import { DashboardInteractions } from '../utils/interactions';
 import { activateFullSceneTree } from '../utils/test-utils';
 
@@ -33,49 +32,79 @@ jest.mock('../utils/interactions', () => ({
   },
 }));
 
-const sceneWithTab = new DashboardScene({
-  $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
-  isEditing: true,
-  body: new TabsLayoutManager({
-    tabs: [
-      new TabItem({
-        title: 'test tab',
-      }),
-    ],
-  }),
+describe('EditPaneHeader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  describe('tracking item deletion', () => {
+    it('should call DashboardInteractions.trackDeleteDashboardElement when deleting a row', async () => {
+      const { row, mockEditPane } = setup('row');
+      const elementSelection = new ElementSelection([['row-test', row!.getRef()]]);
+      const editableElement = elementSelection.createSelectionElement()!;
+      renderEditPaneHeader(editableElement, mockEditPane);
+
+      const user = userEvent.setup();
+      await user.click(screen.getByTestId(selectors.components.EditPaneHeader.deleteButton));
+
+      expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('Row');
+    });
+
+    it('should call DashboardInteractions.trackDeleteDashboardElement when deleting a tab', async () => {
+      const { tab, mockEditPane } = setup('tab');
+      const elementSelection = new ElementSelection([['tab-test', tab!.getRef()]]);
+      const editableElement = elementSelection.createSelectionElement()!;
+      renderEditPaneHeader(editableElement, mockEditPane);
+
+      const user = userEvent.setup();
+      await user.click(screen.getByTestId(selectors.components.EditPaneHeader.deleteButton));
+
+      expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('Tab');
+    });
+  });
 });
 
-const sceneWithRow = new DashboardScene({
-  $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
-  isEditing: true,
-  body: new RowsLayoutManager({
-    rows: [
-      new RowItem({
-        title: 'test row',
-      }),
-    ],
-  }),
-});
+const renderEditPaneHeader = (editableElement: EditableDashboardElement, mockEditPane: DashboardEditPane) => {
+  render(
+    <WrapSidebar>
+      <EditPaneHeader element={editableElement} editPane={mockEditPane} />
+    </WrapSidebar>
+  );
+};
 
-const panel = new VizPanel({
-  key: 'panel-test',
-  pluginId: 'text',
-  title: 'panel-test',
-});
-const gridItem = new DashboardGridItem({ body: panel });
-const sceneWithPanel = new DashboardScene({
-  $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
-  isEditing: true,
-  body: new DefaultGridLayoutManager({
-    grid: new SceneGridLayout({
-      children: [gridItem],
+const setup = (layout: 'row' | 'tab'): { row?: RowItem; tab?: TabItem; mockEditPane: DashboardEditPane } => {
+  const mockEditPane = {
+    state: { selection: null },
+    clearSelection: jest.fn(),
+  } as unknown as DashboardEditPane;
+
+  if (layout === 'row') {
+    const sceneWithRow = new DashboardScene({
+      $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+      isEditing: true,
+      body: new RowsLayoutManager({
+        rows: [
+          new RowItem({
+            title: 'test row',
+          }),
+        ],
+      }),
+    });
+    activateFullSceneTree(sceneWithRow);
+    return { row: (sceneWithRow.state.body as RowsLayoutManager).state.rows[0], mockEditPane };
+  }
+  const sceneWithTab = new DashboardScene({
+    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+    isEditing: true,
+    body: new TabsLayoutManager({
+      tabs: [
+        new TabItem({
+          title: 'test tab',
+        }),
+      ],
     }),
-  }),
-});
-
-const buildTestScene = (scene: DashboardScene) => {
-  activateFullSceneTree(scene);
-  return scene;
+  });
+  activateFullSceneTree(sceneWithTab);
+  return { tab: (sceneWithTab.state.body as TabsLayoutManager).state.tabs[0], mockEditPane };
 };
 
 function WrapSidebar({ children }: { children: React.ReactElement }) {
@@ -83,68 +112,3 @@ function WrapSidebar({ children }: { children: React.ReactElement }) {
 
   return <Sidebar contextValue={sidebarContext}>{children}</Sidebar>;
 }
-
-describe('EditPaneHeader', () => {
-  const mockEditPane = {
-    state: { selection: null },
-    clearSelection: jest.fn(),
-  } as unknown as DashboardEditPane;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  describe('tracking item deletion', () => {
-    it('should call DashboardInteractions.trackDeleteDashboardElement when deleting a row', async () => {
-      const user = userEvent.setup();
-      const scene = buildTestScene(sceneWithRow);
-      const row = (scene.state.body as RowsLayoutManager).state.rows[0];
-      const elementSelection = new ElementSelection([['row-test', row.getRef()]]);
-      const editableElement = elementSelection.createSelectionElement()!;
-
-      render(
-        <WrapSidebar>
-          <EditPaneHeader element={editableElement} editPane={mockEditPane} />
-        </WrapSidebar>
-      );
-
-      await user.click(screen.getByTestId(selectors.components.EditPaneHeader.deleteButton));
-      expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('row');
-    });
-
-    it('should call DashboardInteractions.trackDeleteDashboardElement when deleting a tab', async () => {
-      const user = userEvent.setup();
-      const scene = buildTestScene(sceneWithTab);
-      const tab = (scene.state.body as TabsLayoutManager).state.tabs[0];
-      const elementSelection = new ElementSelection([['tab-test', tab.getRef()]]);
-      const editableElement = elementSelection.createSelectionElement()!;
-
-      render(
-        <WrapSidebar>
-          <EditPaneHeader element={editableElement} editPane={mockEditPane} />
-        </WrapSidebar>
-      );
-
-      await user.click(screen.getByTestId(selectors.components.EditPaneHeader.deleteButton));
-      expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('tab');
-    });
-
-    it('should call DashboardInteractions.trackDeleteDashboardElement when deleting a panel', async () => {
-      const user = userEvent.setup();
-      const scene = buildTestScene(sceneWithPanel);
-      const panel = ((scene.state.body as DefaultGridLayoutManager).state.grid.state.children[0] as SceneGridItem).state
-        .body as VizPanel;
-      const elementSelection = new ElementSelection([['panel-test', panel.getRef()]]);
-      const editableElement = elementSelection.createSelectionElement()!;
-
-      render(
-        <WrapSidebar>
-          <EditPaneHeader element={editableElement} editPane={mockEditPane} />
-        </WrapSidebar>
-      );
-
-      await user.click(screen.getByTestId(selectors.components.EditPaneHeader.deleteButton));
-      expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('panel');
-    });
-  });
-});

--- a/public/app/features/dashboard-scene/edit-pane/EditPaneHeader.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/EditPaneHeader.tsx
@@ -1,9 +1,9 @@
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { Button, Menu, Stack, Dropdown, Icon, Sidebar } from '@grafana/ui';
-import { trackDeleteDashboardElement } from 'app/features/dashboard-scene/utils/tracking';
 
 import { EditableDashboardElement } from '../scene/types/EditableDashboardElement';
+import { DashboardInteractions } from '../utils/interactions';
 
 import { DashboardEditPane } from './DashboardEditPane';
 
@@ -26,7 +26,7 @@ export function EditPaneHeader({ element, editPane }: EditPaneHeaderProps) {
     } else if (onDelete) {
       onDelete();
     }
-    trackDeleteDashboardElement(elementInfo);
+    DashboardInteractions.trackDeleteDashboardElement(elementInfo.typeName);
   };
 
   return (

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -140,13 +140,9 @@ export const DashboardInteractions = {
   trackPastePanelClick() {
     reportDashboardInteraction('edit_action_clicked', { item: 'paste_panel' });
   },
-  trackRemoveRowClick() {
-    reportDashboardInteraction('edit_action_clicked', { item: 'remove_row' });
+  trackDeleteDashboardElement(elementType: string) {
+    reportDashboardInteraction('edit_action_clicked', { item: `remove_${elementType.toLowerCase()}` });
   },
-  trackRemoveTabClick() {
-    reportDashboardInteraction('edit_action_clicked', { item: 'remove_tab' });
-  },
-
   panelLinkClicked: (properties?: Record<string, unknown>) => {
     reportDashboardInteraction('panelheader_datalink_clicked', properties);
   },

--- a/public/app/features/dashboard-scene/utils/tracking.ts
+++ b/public/app/features/dashboard-scene/utils/tracking.ts
@@ -34,19 +34,6 @@ export function trackDashboardSceneLoaded(dashboard: DashboardScene, duration?: 
   });
 }
 
-export const trackDeleteDashboardElement = (element: EditableDashboardElementInfo) => {
-  switch (element?.typeName) {
-    case 'Row':
-      DashboardInteractions.trackRemoveRowClick();
-      break;
-    case 'Tab':
-      DashboardInteractions.trackRemoveTabClick();
-      break;
-    default:
-      break;
-  }
-};
-
 export const trackDashboardSceneEditButtonClicked = (dashboardUid?: string) => {
   DashboardInteractions.editButtonClicked({
     outlineExpanded: !store.getBool('grafana.dashboard.edit-pane.outline.collapsed', false),

--- a/public/app/features/dashboard-scene/utils/tracking.ts
+++ b/public/app/features/dashboard-scene/utils/tracking.ts
@@ -6,7 +6,6 @@ import { getDatasourceTypes } from 'app/features/dashboard/dashgrid/DashboardLib
 import { DashboardScene } from '../scene/DashboardScene';
 import { AutoGridItem } from '../scene/layout-auto-grid/AutoGridItem';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
-import { EditableDashboardElementInfo } from '../scene/types/EditableDashboardElement';
 
 import { DashboardInteractions } from './interactions';
 

--- a/public/app/features/dashboard/components/DashboardRow/DashboardRow.test.tsx
+++ b/public/app/features/dashboard/components/DashboardRow/DashboardRow.test.tsx
@@ -13,7 +13,7 @@ import { DashboardRow, UnthemedDashboardRow } from './DashboardRow';
 // mock DashboardInteractions
 jest.mock('app/features/dashboard-scene/utils/interactions', () => ({
   DashboardInteractions: {
-    trackRemoveRowClick: jest.fn(),
+    trackDeleteDashboardElement: jest.fn(),
   },
 }));
 
@@ -104,10 +104,10 @@ describe('DashboardRow', () => {
     expect(dashboardRow.getWarning()).not.toBeDefined();
   });
 
-  it('should call DashboardInteractions.trackRemoveRowClick when clicking on delete row button', async () => {
+  it('should call DashboardInteractions.trackDeleteDashboardElement when clicking on delete row button', async () => {
     const user = userEvent.setup();
     render(<DashboardRow panel={panel} dashboard={dashboardMock} />);
     await user.click(screen.getByRole('button', { name: 'Delete row' }));
-    expect(DashboardInteractions.trackRemoveRowClick).toHaveBeenCalled();
+    expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('row');
   });
 });

--- a/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
+++ b/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
@@ -143,7 +143,7 @@ export class UnthemedDashboardRow extends Component<DashboardRowProps> {
               type="button"
               className="pointer"
               onClick={() => {
-                DashboardInteractions.trackRemoveRowClick();
+                DashboardInteractions.trackDeleteDashboardElement('row');
                 this.onDelete();
               }}
               aria-label={t('dashboard.unthemed-dashboard-row.aria-label-delete-row', 'Delete row')}


### PR DESCRIPTION
Realized we were only tracking row and tab deletion, we should do it for panels too.