### PR TITLE
Schema: Remove duplicate definition

### DIFF
--- a/packages/grafana-schema/src/raw/composable/table/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/table/panelcfg/x/types.gen.ts
@@ -17,53 +17,6 @@ export const pluginVersion = "12.4.0-pre";
 /**
  * @deprecated - use common in /packages/grafana-schema/src/common/table.cue instead i.e. `import { TableOptions } from '@grafana/schema';`
  */
-export interface Options {
-  /**
-   * Controls the height of the rows
-   */
-  cellHeight?: ui.TableCellHeight;
-  /**
-   * If true, disables all keyboard events in the table. this is used when previewing a table (i.e. suggestions)
-   */
-  disableKeyboardEvents?: boolean;
-  /**
-   * Enable pagination on the table
-   */
-  enablePagination?: boolean;
-  /**
-   * Represents the index of the selected frame
-   */
-  frameIndex: number;
-  /**
-   * Defines the number of columns to freeze on the left side of the table
-   */
-  frozenColumns?: {
-    left?: number;
-  };
-  /**
-   * limits the maximum height of a row, if text wrapping or dynamic height is enabled
-   */
-  maxRowHeight?: number;
-  /**
-   * Controls whether the panel should show the header
-   */
-  showHeader: boolean;
-  /**
-   * Controls whether the header should show icons for the column types
-   */
-  showTypeIcons?: boolean;
-  /**
-   * Used to control row sorting
-   */
-  sortBy?: Array<ui.TableSortByFieldState>;
-}
-
-export const defaultOptions: Partial<Options> = {
-  cellHeight: ui.TableCellHeight.Sm,
-  frameIndex: 0,
-  showHeader: true,
-  showTypeIcons: false,
-  sortBy: [],
-};
+export interface Options extends ui.TableOptions {}
 
 export interface FieldConfig extends ui.TableFieldOptions {}

--- a/public/app/plugins/panel/table/panelcfg.cue
+++ b/public/app/plugins/panel/table/panelcfg.cue
@@ -25,28 +25,7 @@ composableKinds: PanelCfg: {
 			version: [0, 0]
 			schema: {
 				// @deprecated - use common in /packages/grafana-schema/src/common/table.cue instead i.e. `import { TableOptions } from '@grafana/schema';`
-				Options: {
-					// Represents the index of the selected frame
-					frameIndex: number | *0
-					// Controls whether the panel should show the header
-					showHeader: bool | *true
-					// Controls whether the header should show icons for the column types
-					showTypeIcons?: bool | *false
-					// Used to control row sorting
-					sortBy?: [...ui.TableSortByFieldState]
-					// Enable pagination on the table
-					enablePagination?: bool
-					// Controls the height of the rows
-					cellHeight?: ui.TableCellHeight & (*"sm" | _)
-					// limits the maximum height of a row, if text wrapping or dynamic height is enabled
-					maxRowHeight?: number
-					// Defines the number of columns to freeze on the left side of the table
-					frozenColumns?: {
-						left?: number | *0
-					}
-					// If true, disables all keyboard events in the table. this is used when previewing a table (i.e. suggestions)
-					disableKeyboardEvents?: bool
-				} @cuetsy(kind="interface")
+				Options: {ui.TableOptions} @cuetsy(kind="interface")
 				FieldConfig: {ui.TableFieldOptions} @cuetsy(kind="interface")
 			}
 		}]

--- a/public/app/plugins/panel/table/panelcfg.gen.ts
+++ b/public/app/plugins/panel/table/panelcfg.gen.ts
@@ -15,53 +15,6 @@ import * as ui from '@grafana/schema';
 /**
  * @deprecated - use common in /packages/grafana-schema/src/common/table.cue instead i.e. `import { TableOptions } from '@grafana/schema';`
  */
-export interface Options {
-  /**
-   * Controls the height of the rows
-   */
-  cellHeight?: ui.TableCellHeight;
-  /**
-   * If true, disables all keyboard events in the table. this is used when previewing a table (i.e. suggestions)
-   */
-  disableKeyboardEvents?: boolean;
-  /**
-   * Enable pagination on the table
-   */
-  enablePagination?: boolean;
-  /**
-   * Represents the index of the selected frame
-   */
-  frameIndex: number;
-  /**
-   * Defines the number of columns to freeze on the left side of the table
-   */
-  frozenColumns?: {
-    left?: number;
-  };
-  /**
-   * limits the maximum height of a row, if text wrapping or dynamic height is enabled
-   */
-  maxRowHeight?: number;
-  /**
-   * Controls whether the panel should show the header
-   */
-  showHeader: boolean;
-  /**
-   * Controls whether the header should show icons for the column types
-   */
-  showTypeIcons?: boolean;
-  /**
-   * Used to control row sorting
-   */
-  sortBy?: Array<ui.TableSortByFieldState>;
-}
-
-export const defaultOptions: Partial<Options> = {
-  cellHeight: ui.TableCellHeight.Sm,
-  frameIndex: 0,
-  showHeader: true,
-  showTypeIcons: false,
-  sortBy: [],
-};
+export interface Options extends ui.TableOptions {}
 
 export interface FieldConfig extends ui.TableFieldOptions {}


### PR DESCRIPTION
**What is this feature?**

Follow up on https://github.com/grafana/grafana/pull/118084, removing the duplicate options def

**Why do we need this feature?**

Keep things DRY, prevent future bugs

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
