### PR TITLE
Dx: Require exact Node.js version from nvmrc

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -18,8 +18,12 @@ We recommend using [Homebrew](https://brew.sh/) for installing any missing depen
 ```
 brew install git
 brew install go
-brew install node@24
 ```
+
+If you're using `nvm`, or `fnm`, we recommend setting up your ZSH profile to automatically switch Node.js version when you change directory (or spawn a new shell):
+
+- https://github.com/nvm-sh/nvm#calling-nvm-use-automatically-in-a-directory-with-a-nvmrc-file
+- https://github.com/Schniz/fnm#shell-setup (specifically, the `--use-on-cd` flag)
 
 ### Windows
 

--- a/package.json
+++ b/package.json
@@ -477,7 +477,7 @@
     ]
   },
   "engines": {
-    "node": ">= 22 <25"
+    "node": "24.11.0"
   },
   "packageManager": "yarn@4.11.0",
   "dependenciesMeta": {

--- a/scripts/check-frontend-dev.sh
+++ b/scripts/check-frontend-dev.sh
@@ -28,11 +28,11 @@ CURRENT_VERSION=$(node --version | sed 's/v//')
 
 if [ "$CURRENT_VERSION" != "$REQUIRED_VERSION" ]; then
     printf "%b\n" ""
-    printf "%b\n" "${RED}⚠️  WARNING  ⚠️${NC}"
+    printf "%b\n" "${RED}⚠️  ERROR  ⚠️${NC}"
     printf "%b\n" "${YELLOW}${BOLD}Node.js version mismatch!${NC}"
     printf "%b\n" ""
-    printf "%b\n" "${BOLD}${CYAN}Recommended:${NC} ${GREEN}$REQUIRED_VERSION${NC} (from .nvmrc)"
-    printf "%b\n" "${BOLD}${CYAN}Current:${NC}     ${RED}$CURRENT_VERSION${NC}"
+    printf "%b\n" "${BOLD}${CYAN}Required:${NC} ${GREEN}$REQUIRED_VERSION${NC} (from .nvmrc)"
+    printf "%b\n" "${BOLD}${CYAN}Current:${NC}  ${RED}$CURRENT_VERSION${NC}"
     printf "%b\n" ""
     printf "%b\n" "${BOLD}${YELLOW}⚠️ We only test and support developing Grafana with the specific LTS Node.js release.${NC}"
     printf "%b\n" "   Using a different version may lead to unexpected build issues or runtime errors."
@@ -41,8 +41,7 @@ if [ "$CURRENT_VERSION" != "$REQUIRED_VERSION" ]; then
     printf "%b\n" "   • ${BLUE}nvm${NC} - Node Version Manager"
     printf "%b\n" "   • ${BLUE}fnm${NC} - Fast Node Manager"
     printf "%b\n" ""
-    printf "%b\n" "${BLUE}${BOLD}If you experience issues building Grafana, first switch to the recommended version of Node.js.${NC}"
+    printf "%b\n" "${BLUE}${BOLD}Set IGNORE_NODE_VERSION_CHECK if you need to bypass this check (not recommended).${NC}"
     printf "%b\n" ""
+    exit 1
 fi
-
-


### PR DESCRIPTION
**What is this feature?**

Updates `package.json#engines.node` to state that Grafana's Node.js compatibility for development + builds is exactly `24.11.0`, and updates the `check-frontend-dev.sh` script to require that the Node.js version is exactly `24.11.0`, both matching the version set in `.nvmrc`.

**Why do we need this feature?**

After internal discussion around #118041, it was concluded that the desire is actually that Grafana has one specific version of Node.js that it supports for development + builds, rather than supporting a wide range of compatible releases. This did not match up with reality, as `package.json#engines.node` stated Grafana had a much wider Node.js compatibility, and `check-frontend-dev.sh` allowed developers to use other versions, only warning them rather than requiring that they use the specific version desired.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

Closes #118041

**Special notes for your reviewer:**

Using an older Node.js release:
```
~/GitHub/grafana/grafana ❯ fnm use 24.10.0                
Using Node v24.10.0

~/GitHub/grafana/grafana ❯ ./scripts/check-frontend-dev.sh

⚠️  ERROR  ⚠️
Node.js version mismatch!

Required: 24.11.0 (from .nvmrc)
Current:  24.10.0

⚠️ We only test and support developing Grafana with the specific LTS Node.js release.
   Using a different version may lead to unexpected build issues or runtime errors.

💡 Consider using a node version manager and configuring it to auto-switch to the recommended version:
   • nvm - Node Version Manager
   • fnm - Fast Node Manager

Set IGNORE_NODE_VERSION_CHECK if you need to bypass this check (not recommended).

~/GitHub/grafana/grafana ❯ echo $?
1

~/GitHub/grafana/grafana ❯ IGNORE_NODE_VERSION_CHECK=1 ./scripts/check-frontend-dev.sh

~/GitHub/grafana/grafana ❯ echo $?                                                    
0
```

Using the Node.js release specified by `.nvmrc`:
```
~/GitHub/grafana/grafana ❯ fnm use
Using Node v24.11.0

~/GitHub/grafana/grafana ❯ ./scripts/check-frontend-dev.sh

~/GitHub/grafana/grafana ❯ echo $?                        
0
```

Using a newer Node.js release:
```
~/GitHub/grafana/grafana ❯ fnm use 24.13.0
Using Node v24.13.0

~/GitHub/grafana/grafana ❯ ./scripts/check-frontend-dev.sh

⚠️  ERROR  ⚠️
Node.js version mismatch!

Required: 24.11.0 (from .nvmrc)
Current:  24.13.0

⚠️ We only test and support developing Grafana with the specific LTS Node.js release.
   Using a different version may lead to unexpected build issues or runtime errors.

💡 Consider using a node version manager and configuring it to auto-switch to the recommended version:
   • nvm - Node Version Manager
   • fnm - Fast Node Manager

Set IGNORE_NODE_VERSION_CHECK if you need to bypass this check (not recommended).

~/GitHub/grafana/grafana ❯ echo $?                        
1

~/GitHub/grafana/grafana ❯ IGNORE_NODE_VERSION_CHECK=1 ./scripts/check-frontend-dev.sh

~/GitHub/grafana/grafana ❯ echo $?                                                    
0
```