### PR TITLE
Tests: update connection max time out

### DIFF
--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -736,6 +736,9 @@ func CreateGrafDir(t *testing.T, opts GrafanaOpts) (string, string) {
 	require.NoError(t, err)
 	_, err = dbSection.NewKey("max_idle_conn", fmt.Sprintf("%d", maxConns))
 	require.NoError(t, err)
+	// Use a short conn_max_lifetime to avoid leaking database connections.
+	_, err = dbSection.NewKey("conn_max_lifetime", "5")
+	require.NoError(t, err)
 	_, err = dbSection.NewKey("wal", "true")
 	require.NoError(t, err)
 


### PR DESCRIPTION
CI Integration tests are failing due to number of open connections. Adding a test config option to close idle connection.