### PR TITLE
Dashboards: Improve variable editor forms spacing

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1857,16 +1857,6 @@
       "count": 4
     }
   },
-  "public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "public/app/features/dashboard-scene/settings/variables/components/VariableSelectField.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1

--- a/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx
@@ -5,7 +5,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { EditorField } from '@grafana/plugin-ui';
 import { DataSourceRef } from '@grafana/schema';
-import { Alert, CodeEditor, Field, Switch, Box } from '@grafana/ui';
+import { Alert, CodeEditor, Field, Switch, Stack } from '@grafana/ui';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
 
 import { VariableCheckboxField } from './VariableCheckboxField';
@@ -48,29 +48,27 @@ export function AdHocVariableForm({
   );
 
   return (
-    <>
+    <Stack direction="column" gap={2}>
       {!inline && (
         <VariableLegend>
           <Trans i18nKey="dashboard-scene.ad-hoc-variable-form.adhoc-options">Ad-hoc options</Trans>
         </VariableLegend>
       )}
 
-      <Box marginBottom={2}>
-        <EditorField
-          label={t('dashboard-scene.ad-hoc-variable-form.label-data-source', 'Data source')}
-          htmlFor="data-source-picker"
-          tooltip={infoText}
-        >
-          <DataSourcePicker
-            current={datasource}
-            onChange={onDataSourceChange}
-            width={30}
-            variables={true}
-            dashboard={true}
-            noDefault
-          />
-        </EditorField>
-      </Box>
+      <EditorField
+        label={t('dashboard-scene.ad-hoc-variable-form.label-data-source', 'Data source')}
+        htmlFor="data-source-picker"
+        tooltip={infoText}
+      >
+        <DataSourcePicker
+          current={datasource}
+          onChange={onDataSourceChange}
+          width={30}
+          variables={true}
+          dashboard={true}
+          noDefault
+        />
+      </EditorField>
 
       {datasourceSupported === false ? (
         <Alert
@@ -79,6 +77,7 @@ export function AdHocVariableForm({
             'This data source does not support ad hoc filters'
           )}
           severity="warning"
+          bottomSpacing={0}
           data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.AdHocFiltersVariable.infoText}
         />
       ) : null}
@@ -95,6 +94,7 @@ export function AdHocVariableForm({
               'Provide dimensions as CSV: {{name}}, {{value}}',
               { name: 'dimensionName', value: 'dimensionId' }
             )}
+            noMargin
           >
             <Switch
               data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.AdHocFiltersVariable.modeToggle}
@@ -135,6 +135,6 @@ export function AdHocVariableForm({
           testId={selectors.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsAllowCustomValueSwitch}
         />
       )}
-    </>
+    </Stack>
   );
 }

--- a/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.tsx
@@ -5,7 +5,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { EditorField } from '@grafana/plugin-ui';
 import { DataSourceRef } from '@grafana/schema';
-import { Alert, Box, CodeEditor, Field, Switch } from '@grafana/ui';
+import { Alert, Stack, CodeEditor, Field, Switch } from '@grafana/ui';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
 
 import { VariableCheckboxField } from './VariableCheckboxField';
@@ -48,22 +48,20 @@ export function GroupByVariableForm({
   );
 
   return (
-    <>
+    <Stack direction="column" gap={2}>
       {!inline && (
         <VariableLegend>
           <Trans i18nKey="dashboard-scene.group-by-variable-form.group-by-options">Group by options</Trans>
         </VariableLegend>
       )}
 
-      <Box marginBottom={2}>
-        <EditorField
-          label={t('dashboard-scene.group-by-variable-form.label-data-source', 'Data source')}
-          htmlFor="data-source-picker"
-          tooltip={infoText}
-        >
-          <DataSourcePicker current={datasource} onChange={onDataSourceChange} width={30} variables={true} noDefault />
-        </EditorField>
-      </Box>
+      <EditorField
+        label={t('dashboard-scene.group-by-variable-form.label-data-source', 'Data source')}
+        htmlFor="data-source-picker"
+        tooltip={infoText}
+      >
+        <DataSourcePicker current={datasource} onChange={onDataSourceChange} width={30} variables={true} noDefault />
+      </EditorField>
 
       {!datasourceSupported ? (
         <Alert
@@ -72,6 +70,7 @@ export function GroupByVariableForm({
             'This data source does not support group by variables'
           )}
           severity="warning"
+          bottomSpacing={0}
           data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.GroupByVariable.infoText}
         />
       ) : null}
@@ -88,6 +87,7 @@ export function GroupByVariableForm({
               'Provide dimensions as CSV: {{name}}, {{value}}',
               { name: 'dimensionName', value: 'dimensionId' }
             )}
+            noMargin
           >
             <Switch
               data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.GroupByVariable.modeToggle}
@@ -128,6 +128,6 @@ export function GroupByVariableForm({
           testId={selectors.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsAllowCustomValueSwitch}
         />
       )}
-    </>
+    </Stack>
   );
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3079,11 +3079,6 @@
       "title-preview-not-available": "Preview not available",
       "valid-matcher-affected-alerts": "Add a valid matcher to see affected alerts"
     },
-    "silences": {
-      "affected-instances": "Affected alert instances",
-      "only-firing-instances": "Only alert instances in the firing state are displayed.",
-      "preview-affected-instances": "Preview the alert instances affected by this silence."
-    },
     "silences-editor": {
       "comment-placeholder-details-about-the-silence": "Details about the silence",
       "label-comment": "Comment",
@@ -3105,6 +3100,11 @@
       "text-loading-silences": "Loading silences...",
       "title-error-loading-silences": "Error loading silences",
       "title-the-selected-alertmanager-has-no-configuration": "The selected Alertmanager has no configuration"
+    },
+    "silences": {
+      "affected-instances": "Affected alert instances",
+      "only-firing-instances": "Only alert instances in the firing state are displayed.",
+      "preview-affected-instances": "Preview the alert instances affected by this silence."
     },
     "simple-condition-editor": {
       "label-of-query": "OF QUERY",


### PR DESCRIPTION
**What is this feature?**

Use `Stack` and `noMargin` for consistent spacing in `AdHoc` and `GroupBy` variable editor forms.