### PR TITLE
[DOC] [HOLD] Add examples for false to Traces LBAC doc

### DIFF
--- a/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
+++ b/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure Team LBAC for Tempo or Cloud Traces"
-description: "Use label-based access control (LBAC) to restrict Cloud Traces data by team and attribute rules."
+description: "Use label-based access control (LBAC) to restrict Grafana Cloud Traces data by team and attribute rules."
 keywords:
   - tempo
   - datasource
@@ -19,17 +19,17 @@ noindex: true
 
 {{< docs/private-preview product="Label-based access control for traces" >}}
 
-Team label-based access control (LBAC) for Cloud Traces or Tempo lets you restrict which spans teams can access by defining rules using trace attributes. LBAC provides fine-grained, team-based access control within a single tenant and mirrors the experience used for logs and metrics LBAC in Grafana Cloud.
+Team label-based access control (LBAC) for Grafana Cloud Traces or Tempo lets you restrict which spans teams can access by defining rules using trace attributes. LBAC provides fine-grained, team-based access control within a single tenant and mirrors the experience used for metrics, logs, and traces LBAC in Grafana Cloud.
 
 Grafana uses the term LBAC as an umbrella term for label-based access control for all data sources.
 Traces use **attributes**, not labels, for access control, but the Grafana UI surfaces this functionality as LBAC for consistency.
 
-This feature only applies to Grafana Cloud Traces, specifically, the Cloud-provisioned tracing data source.
+This feature only applies to Grafana Cloud Traces, specifically, the Grafana Cloud-provisioned tracing data source.
 If you want to use this feature with a Tempo data source, contact Grafana Support to make sure that this is enabled in your organization.
 
 ## How LBAC works
 
-When a user queries tracing data source, Grafana evaluates the user’s team memberships and the LBAC rules assigned to those teams. These rules are added to the request so the Cloud Traces data source returns only permitted spans or attributes.
+When you query the tracing data source, Grafana evaluates the user’s team memberships and the LBAC rules assigned to those teams. These rules are added to the request so the Grafana Cloud Traces data source returns only permitted spans or attributes.
 
 LBAC rules use **attribute selectors**, such as:
 
@@ -41,33 +41,35 @@ Multiple conditions in the same rule use **AND** (`,`), while multiple rules acr
 
 ## Before you begin
 
-- Be sure that you have the permission setup to create a Tempo or Cloud Traces tenant in Grafana Cloud.
-- Be sure that you have administrator permissions for Grafana.
-- Be sure that you have a team setup in Grafana.
+- Ensure you have permission to create a Tempo or Grafana Cloud Traces tenant in Grafana Cloud.
+- Ensure you have administrator permissions for Grafana.
+- Ensure you have a team set up in Grafana.
 
 ### Known limitations
 
+LBAC for traces has these limitations:
+
 - Autocomplete in search is still under development.
-- LBAC is restricted to only contain resource scope attributes.
-- There is a slight performance degradation for users with multiple rules.
+- LBAC is restricted to resource scope attributes only.
+- There is a slight performance impact for users with multiple rules.
 
 ## Configure team LBAC for traces
 
-Follow this workflow when adding a new data source. The data source must be hosted by Grafana and not self-managed.
+Follow this workflow when adding a new data source. The data source must be hosted by Grafana, not self-managed.
 
 1. Start your Grafana Cloud instance.
-2. Access Tempo or Cloud Traces data sources details for your stack.
-3. Copy Tempo or Cloud Traces details and create a Cloud Access Policy.
-   - Copy the [details of your Tempo or Cloud Traces setup](https://grafana.com/docs/grafana-cloud/send-data/traces/set-up/locate-url-user-password/).
+2. Access Tempo or Grafana Cloud Traces data source details for your stack.
+3. Copy Tempo or Grafana Cloud Traces details and create a Cloud Access Policy.
+   - Copy the [details of your Tempo or Grafana Cloud Traces setup](https://grafana.com/docs/grafana-cloud/send-data/traces/set-up/locate-url-user-password/).
 4. In Grafana Cloud, navigate to **Administration > Users and access > Cloud Access Policies**.
-   - Create an access policy for the Tempo or Cloud Traces data source.
+   - Create an access policy for the Tempo or Grafana Cloud Traces data source.
    - Ensure the access policy includes `traces:read` permissions.
    - Ensure the access policy doesn't include `labels` rules.
-5. In Grafana, select Tempo or Cloud Traces or create new data source.
-6. Navigate back to the Tempo or Cloud Traces data source.
-   - Set up the Tempo or Cloud Traces data source using basic authentication. Use the [userID/tenantID](https://grafana.com/docs/grafana-cloud/send-data/traces/set-up/locate-url-user-password/) as the username. Use the token from your access policy as the password.
+5. In Grafana, select Tempo or Grafana Cloud Traces, or create a new data source.
+6. Navigate back to the Tempo or Grafana Cloud Traces data source.
+   - Set up the Tempo or Grafana Cloud Traces data source using basic authentication. Use the [userID/tenantID](https://grafana.com/docs/grafana-cloud/send-data/traces/set-up/locate-url-user-password/) as the username. Use the token from your access policy as the password.
    - Select **Save and connect**.
-7. Go to the **Permissions** tab of the newly created Tempo or Cloud Traces data source. Here, you find the LBAC for data sources rules section.
+7. Go to the **Permissions** tab of the newly created Tempo or Grafana Cloud Traces data source to find the LBAC for data sources rules section.
 
 8. Choose a team from the **Team** dropdown.
 9. Enter attribute selectors such as:
@@ -76,7 +78,7 @@ Follow this workflow when adding a new data source. The data source must be host
    { resource.service.name="checkout", resource.env="prod" }
    ```
 
-   Refer to the Examples section below for more examples.
+   Refer to the example rules for more guidance.
 
 10. Select **Save**.
 
@@ -88,22 +90,21 @@ Each rule operates independently as its own filter, separate from other rules wi
 
 LBAC rules guidelines:
 
-- Use only resource scope attributes, for example `{ resource.env="prod" }`.
-- Use double quotes for string values, for example: `{ resource.env="prod" }`.
-- You can use regular expressions matching with `=~` operator, for example: `{ resource.team =~ "team-a|team-b" }`.
-- LBAC does not support `nil`; you cannot match spans where an attribute does not exist.
-- You can have up to two conditions in the same rule using a comma (`,`) as an `AND` operator, for example: `{ resource.env="prod", resource.team="frontend" }`.
+- Use only resource scope attributes, for example, `{ resource.env="prod" }`.
+- Use double quotes for string values, for example, `{ resource.env="prod" }`.
+- Use regular expressions with the `=~` operator, for example, `{ resource.team =~ "team-a|team-b" }`.
+- LBAC doesn't support `nil`; you can't match spans where an attribute doesn't exist.
+- Use a comma (`,`) as an `AND` operator for up to two conditions per rule, for example, `{ resource.env="prod", resource.team="frontend" }`.
 
 #### Attribute existence and missing attributes
 
 Attribute selectors use exact-match semantics.
 For example, a selector like `{ resource.restricted = false }` matches only spans where the attribute exists and equals that value.
-If the attributes referenced in a rule do not exist on a span, that span is skipped and does not appear in the results.
+If the attributes referenced in a rule do not exist on a span, that span is skipped and doesn't appear in the results.
 
-LBAC does not support `nil`, so you cannot match spans where an attribute is not set.
-If you want "allow when restricted=false or when attribute absent" semantics, you cannot achieve that with LBAC.
+LBAC doesn't support `nil`, so you can't match spans where an attribute isn't set. If you want "allow when restricted=false or when attribute absent" semantics, you can't achieve that with LBAC.
 To allow access only when an attribute is explicitly not restricted, use a single rule such as `{ resource.restricted = false }`.
-Note that this excludes spans that do not have the `restricted` attribute.
+Note that this example excludes spans that don't have the `restricted` attribute.
 
 Refer to [Create LBAC for data sources rules for a supported data source](https://grafana.com/docs/grafana/next/administration/data-source-management/teamlbac/create-teamlbac-rules/) for more information.
 
@@ -115,7 +116,7 @@ Limit users to only see spans from the `payments` API.
 { resource.service.name="payments-api" }
 ```
 
-This example matches spans with team A **or** team B. This single example is faster than using multiple rules with the same label.
+This example matches spans with team A or team B. A single rule is faster than multiple rules with the same attribute.
 
 ```
 { resource.team =~ "team-a|team-b" }
@@ -123,7 +124,7 @@ This example matches spans with team A **or** team B. This single example is fas
 
 #### Multiple rules
 
-Two rules combined to give user access to spans from `prod` environment or the `billing` team.
+Combine two rules to give users access to spans from the `prod` environment or the `billing` team:
 
 ```
 { resource.env="prod" }
@@ -139,18 +140,15 @@ This example gives users access to spans from the `frontend` team in the `prod` 
 
 #### User on multiple teams
 
-Users on multiple teams receive access based on all combined LBAC rules assigned to each team.
+If you're on multiple teams, you receive access based on all LBAC rules assigned to those teams combined.
 
 Team A → `{ resource.cluster="us-east-1" }`
 Team B → `{ resource.service.name="frontend" }`
 
 #### Restrict access by a boolean attribute
 
-A rule like `{ resource.restricted = false }` matches only spans that have the attribute explicitly set to `false`.
-Spans without the `restricted` attribute do not match and are excluded.
-
-Because LBAC does not support `nil`, you cannot match spans where the attribute is absent.
-If your instrumentation ensures the `restricted` attribute is always set (for example, `false` when not restricted), use:
+To allow access only when spans are not restricted (either explicitly `restricted = false` or when the attribute is absent), use two rules.
+For example, a single rule `{ resource.restricted = false }` would exclude spans that do not have the `restricted` attribute at all.
 
 ```
 { resource.restricted = false }
@@ -158,23 +156,23 @@ If your instrumentation ensures the `restricted` attribute is always set (for ex
 
 ## How LBAC affects returned data
 
-For Trace-by-ID endpoints, unauthorized spans show only minimal intrinsic fields:
+For Trace-by-ID endpoints, spans that don't match your LBAC rules show only minimal intrinsic fields:
 
 - `traceId`, `spanId`, `parentId`
 - `name`, `kind`
 - `timestamps`
 - `status`
 
-For Search, metrics, autocomplete, only spans matching LBAC rules appear.
+For search, metrics, and autocomplete, only spans that match your LBAC rules appear.
 
 ## Manage LBAC rules
 
 To edit an existing LBAC rule, follow these steps:
 
-1. Open your stack and select your **Tempo** or **Cloud Traces** data source.
+1. Open your stack and select your **Tempo** or **Grafana Cloud Traces** data source.
 2. Select **Permissions**.
 3. Scroll to **Data access**.
-4. Select the rule you want to edit and click the Pencil (Edit) icon.
+4. Select the rule you want to edit and select **Edit**.
 5. Modify **Attribute filters**.
 6. Select **Save**.
 
@@ -182,8 +180,9 @@ To delete an existing LBAC rule, follow these steps:
 
 Open your stack and select your **Tempo** or **Cloud Traces** data source.
 
-1. Select **Permissions**.
-2. Scroll to **Data access**.
-3. Select the rule you want to edit.
-4. Select the **X** (Delete) icon.
-5. Confirm deletion.
+1. Open your stack and select your **Tempo** or **Grafana Cloud Traces** data source.
+2. Select **Permissions**.
+3. Scroll to **Data access**.
+4. Select the rule you want to delete.
+5. Select **Delete**.
+6. Confirm deletion.

--- a/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
+++ b/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
@@ -91,6 +91,7 @@ Each rule operates independently as its own filter, separate from other rules wi
 LBAC rules guidelines:
 
 - Use only resource scope attributes, for example, `{ resource.env="prod" }`.
+- Only string values are supported.
 - Use double quotes for string values, for example, `{ resource.env="prod" }`.
 - Use regular expressions with the `=~` operator, for example, `{ resource.team =~ "team-a|team-b" }`.
 - LBAC doesn't support `nil`; you can't match spans where an attribute doesn't exist.


### PR DESCRIPTION
Adds an example of how to locate an attribute that doesn't exist in the Traces LBAC doc. 

Note that booleans aren't supported quite yet. 
@ie-pham is going to add this support soon. Once it's added, we can merge this PR. 

Fixes https://github.com/grafana/tempo-squad/issues/1055

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
