### PR TITLE
Alerting: Alias for structs from Alertmanager config

### DIFF
--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	amconfig "github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	prommodel "github.com/prometheus/common/model"
 	"go.yaml.in/yaml/v3"
@@ -894,7 +893,7 @@ func parseKeyValuePairs(input string, headerName string) (map[string]string, err
 
 // parseMergeMatchersHeader parses the merge matchers header value.
 // Expected format: "key1=value1,key2=value2"
-func parseMergeMatchersHeader(c *contextmodel.ReqContext) (amconfig.Matchers, error) {
+func parseMergeMatchersHeader(c *contextmodel.ReqContext) (apimodels.Matchers, error) {
 	matchersStr := strings.TrimSpace(c.Req.Header.Get(mergeMatchersHeader))
 
 	if matchersStr == "" {
@@ -906,7 +905,7 @@ func parseMergeMatchersHeader(c *contextmodel.ReqContext) (amconfig.Matchers, er
 		return nil, err
 	}
 
-	matchers := amconfig.Matchers{}
+	matchers := apimodels.Matchers{}
 	for key, value := range kvPairs {
 		matchers = append(matchers, &labels.Matcher{
 			Type:  labels.MatchEqual,
@@ -935,7 +934,7 @@ func parseVersionMessageHeader(c *contextmodel.ReqContext) (string, error) {
 	return str, nil
 }
 
-func formatMergeMatchers(matchers amconfig.Matchers) string {
+func formatMergeMatchers(matchers apimodels.Matchers) string {
 	var pairs []string
 	for _, matcher := range matchers {
 		if matcher.Type == labels.MatchEqual {

--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	amconfig "github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	prommodel "github.com/prometheus/common/model"
 	"github.com/stretchr/testify/mock"
@@ -2334,7 +2333,7 @@ func TestParseMergeMatchersHeader(t *testing.T) {
 		name             string
 		headerValue      string
 		expectedError    bool
-		expectedMatchers amconfig.Matchers
+		expectedMatchers apimodels.Matchers
 	}{
 		{
 			name:          "empty header should not return error",
@@ -2345,7 +2344,7 @@ func TestParseMergeMatchersHeader(t *testing.T) {
 			name:          "single matcher should parse correctly",
 			headerValue:   "env=prod",
 			expectedError: false,
-			expectedMatchers: amconfig.Matchers{
+			expectedMatchers: apimodels.Matchers{
 				{Type: labels.MatchEqual, Name: "env", Value: "prod"},
 			},
 		},
@@ -2353,7 +2352,7 @@ func TestParseMergeMatchersHeader(t *testing.T) {
 			name:          "multiple matchers should be parsed correctly",
 			headerValue:   "env=prod,team=alerting",
 			expectedError: false,
-			expectedMatchers: amconfig.Matchers{
+			expectedMatchers: apimodels.Matchers{
 				{Type: labels.MatchEqual, Name: "env", Value: "prod"},
 				{Type: labels.MatchEqual, Name: "team", Value: "alerting"},
 			},
@@ -2362,7 +2361,7 @@ func TestParseMergeMatchersHeader(t *testing.T) {
 			name:          "matchers with spaces should be parsed correctly",
 			headerValue:   " env = prod , team = alerting ",
 			expectedError: false,
-			expectedMatchers: amconfig.Matchers{
+			expectedMatchers: apimodels.Matchers{
 				{Type: labels.MatchEqual, Name: "env", Value: "prod"},
 				{Type: labels.MatchEqual, Name: "team", Value: "alerting"},
 			},
@@ -2465,7 +2464,7 @@ func TestFormatMergeMatchers(t *testing.T) {
 	})
 
 	t.Run("single matcher should format correctly", func(t *testing.T) {
-		matchers := amconfig.Matchers{
+		matchers := apimodels.Matchers{
 			&labels.Matcher{
 				Type:  labels.MatchEqual,
 				Name:  "env",
@@ -2477,7 +2476,7 @@ func TestFormatMergeMatchers(t *testing.T) {
 	})
 
 	t.Run("multiple matchers should format correctly", func(t *testing.T) {
-		matchers := amconfig.Matchers{
+		matchers := apimodels.Matchers{
 			&labels.Matcher{
 				Type:  labels.MatchEqual,
 				Name:  "env",

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -8,8 +8,6 @@ import (
 	"regexp"
 	"strings"
 
-	alertmanager_config "github.com/prometheus/alertmanager/config"
-
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -631,7 +629,7 @@ func escapeRouteExport(r *definitions.RouteExport) {
 		// convert regex to string, escape then covert back to regex
 		stringRepr := addEscapeCharactersToString(v.String())
 		mutated := regexp.MustCompile(stringRepr)
-		r.MatchRE[k] = alertmanager_config.Regexp{Regexp: mutated}
+		r.MatchRE[k] = definitions.Regexp{Regexp: mutated}
 	}
 	if r.MuteTimeIntervals != nil {
 		muteTimeIntervals := make([]string, len(*r.MuteTimeIntervals))

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -267,6 +267,13 @@ type (
 	ObjectMatchers            = definition.ObjectMatchers
 	PostableApiReceiver       = definition.PostableApiReceiver
 	PostableGrafanaReceivers  = definition.PostableGrafanaReceivers
+	Receiver                  = config.Receiver
+	Regexp                    = config.Regexp
+	Matchers                  = config.Matchers
+	MatchRegexps              = config.MatchRegexps
+	AmMuteTimeInterval        = config.MuteTimeInterval
+	TimeInterval              = config.TimeInterval
+	InhibitRule               = config.InhibitRule
 )
 
 type MergeResult struct {

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -14,7 +14,6 @@ import (
 	alertingNotify "github.com/grafana/alerting/notify"
 	"github.com/grafana/alerting/notify/nfstatus"
 	alertingTemplates "github.com/grafana/alerting/templates"
-	"github.com/prometheus/alertmanager/config"
 
 	amv2 "github.com/prometheus/alertmanager/api/v2/models"
 
@@ -357,7 +356,7 @@ func (am *alertmanager) aggregateRouteMatchers(r *apimodels.Route, amu *Aggregat
 	}
 }
 
-func (am *alertmanager) aggregateInhibitMatchers(rules []config.InhibitRule, amu *AggregateMatchersUsage) {
+func (am *alertmanager) aggregateInhibitMatchers(rules []apimodels.InhibitRule, amu *AggregateMatchersUsage) {
 	for _, r := range rules {
 		amu.Matchers += len(r.SourceMatchers)
 		amu.Matchers += len(r.TargetMatchers)

--- a/pkg/services/ngalert/notifier/alertmanager_config_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	amconfig "github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/stretchr/testify/require"
 
@@ -37,7 +36,7 @@ func TestMultiOrgAlertmanager_SaveAndApplyExtraConfiguration(t *testing.T) {
 
 		extraConfig := definitions.ExtraConfiguration{
 			Identifier:    "test-alertmanager-config",
-			MergeMatchers: amconfig.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "prod"}},
+			MergeMatchers: definitions.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "prod"}},
 			TemplateFiles: map[string]string{"test.tmpl": "{{ define \"test\" }}Test{{ end }}"},
 			AlertmanagerConfig: `route:
   receiver: test-receiver
@@ -72,7 +71,7 @@ receivers:
 
 		extraConfig := definitions.ExtraConfiguration{
 			Identifier:    "dry-run-config",
-			MergeMatchers: amconfig.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "test"}},
+			MergeMatchers: definitions.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "test"}},
 			TemplateFiles: map[string]string{"test.tmpl": "{{ define \"test\" }}Test{{ end }}"},
 			AlertmanagerConfig: `route:
   receiver: test-receiver
@@ -100,7 +99,7 @@ receivers:
 		// First add a configuration
 		originalConfig := definitions.ExtraConfiguration{
 			Identifier:    identifier,
-			MergeMatchers: amconfig.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "original"}},
+			MergeMatchers: definitions.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "original"}},
 			AlertmanagerConfig: `route:
   receiver: original-receiver
 receivers:
@@ -113,7 +112,7 @@ receivers:
 		// Now replace it
 		updatedConfig := definitions.ExtraConfiguration{
 			Identifier:    identifier,
-			MergeMatchers: amconfig.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "updated"}},
+			MergeMatchers: definitions.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "updated"}},
 			TemplateFiles: map[string]string{"updated.tmpl": "{{ define \"updated\" }}Updated{{ end }}"},
 			AlertmanagerConfig: `route:
   receiver: updated-receiver
@@ -139,7 +138,7 @@ receivers:
 
 		firstConfig := definitions.ExtraConfiguration{
 			Identifier:    "first-config",
-			MergeMatchers: amconfig.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "first"}},
+			MergeMatchers: definitions.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "first"}},
 			AlertmanagerConfig: `{
 				"route": {
 					"receiver": "first-receiver"
@@ -157,7 +156,7 @@ receivers:
 
 		secondConfig := definitions.ExtraConfiguration{
 			Identifier:    "second-config",
-			MergeMatchers: amconfig.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "second"}},
+			MergeMatchers: definitions.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "second"}},
 			AlertmanagerConfig: `{
 				"route": {
 					"receiver": "second-receiver"
@@ -205,7 +204,7 @@ receivers:
 				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
-						Receiver: amconfig.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "initial-receiver",
 						},
 					},
@@ -215,7 +214,7 @@ receivers:
 
 		originalConfig := definitions.ExtraConfiguration{
 			Identifier:    identifier,
-			MergeMatchers: amconfig.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "original"}},
+			MergeMatchers: definitions.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "original"}},
 			AlertmanagerConfig: `route:
   receiver: original-receiver
 receivers:
@@ -237,7 +236,7 @@ func TestMultiOrgAlertmanager_SaveAndApplyAlertmanagerConfiguration(t *testing.T
 
 		extraConfig := definitions.ExtraConfiguration{
 			Identifier:    "test-extra-config",
-			MergeMatchers: amconfig.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "test"}},
+			MergeMatchers: definitions.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "test"}},
 			TemplateFiles: map[string]string{"test.tmpl": "{{ define \"test\" }}Test{{ end }}"},
 			AlertmanagerConfig: `route:
   receiver: extra-receiver
@@ -266,7 +265,7 @@ receivers:
 				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
-						Receiver: amconfig.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "main-receiver",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -313,7 +312,7 @@ receivers:
 				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
-						Receiver: amconfig.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "initial-receiver",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -343,7 +342,7 @@ receivers:
 				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
-						Receiver: amconfig.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "main-receiver",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -384,7 +383,7 @@ receivers:
 				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
-						Receiver: amconfig.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "initial-receiver",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -415,7 +414,7 @@ receivers:
 				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
-						Receiver: amconfig.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "main-receiver",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -499,7 +498,7 @@ func TestMultiOrgAlertmanager_DeleteExtraConfiguration(t *testing.T) {
 
 		extraConfig := definitions.ExtraConfiguration{
 			Identifier:    identifier,
-			MergeMatchers: amconfig.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "delete"}},
+			MergeMatchers: definitions.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "delete"}},
 			AlertmanagerConfig: `route:
   receiver: test-receiver
 receivers:

--- a/pkg/services/ngalert/notifier/autogen_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/autogen_alertmanager_test.go
@@ -38,7 +38,7 @@ func TestAddAutogenConfig(t *testing.T) {
 			})
 		}
 		for _, muteInterval := range muteIntervals {
-			cfg.MuteTimeIntervals = append(cfg.MuteTimeIntervals, config.MuteTimeInterval{
+			cfg.MuteTimeIntervals = append(cfg.MuteTimeIntervals, definitions.AmMuteTimeInterval{
 				Name: muteInterval,
 			})
 		}

--- a/pkg/services/ngalert/notifier/legacy_storage/imported.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported.go
@@ -5,7 +5,6 @@ import (
 	"slices"
 
 	"github.com/grafana/alerting/definition"
-	"github.com/prometheus/alertmanager/config"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -72,7 +71,7 @@ func (e ImportedConfigRevision) GetReceivers(uids []string) ([]*models.Receiver,
 	return result, nil
 }
 
-func (e ImportedConfigRevision) GetMuteTimeIntervals() ([]config.MuteTimeInterval, error) {
+func (e ImportedConfigRevision) GetMuteTimeIntervals() ([]definitions.AmMuteTimeInterval, error) {
 	if e.importedConfig == nil {
 		return nil, nil
 	}
@@ -99,9 +98,9 @@ func (e ImportedConfigRevision) GetMuteTimeIntervals() ([]config.MuteTimeInterva
 	)
 
 	// Apply renames to imported intervals
-	result := make([]config.MuteTimeInterval, 0, len(importedTime)+len(importedMute))
+	result := make([]definitions.AmMuteTimeInterval, 0, len(importedTime)+len(importedMute))
 
-	pushRenamed := func(mt config.MuteTimeInterval) {
+	pushRenamed := func(mt definitions.AmMuteTimeInterval) {
 		if newName, renamed := renames[mt.Name]; renamed {
 			mt.Name = newName
 		}
@@ -109,7 +108,7 @@ func (e ImportedConfigRevision) GetMuteTimeIntervals() ([]config.MuteTimeInterva
 	}
 
 	for _, ti := range importedTime {
-		pushRenamed(config.MuteTimeInterval(ti))
+		pushRenamed(definitions.AmMuteTimeInterval(ti))
 	}
 
 	for _, mti := range importedMute {

--- a/pkg/services/ngalert/notifier/legacy_storage/receivers_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/receivers_test.go
@@ -538,10 +538,10 @@ func getConfigRevisionForTest(opts ...opt) *ConfigRevision {
 			AlertmanagerConfig: definitions.PostableApiAlertingConfig{
 				Config: definitions.Config{
 					Route: &definitions.Route{Receiver: "receiver1"},
-					TimeIntervals: []config.TimeInterval{
+					TimeIntervals: []definitions.TimeInterval{
 						{Name: "time-interval-1"},
 					},
-					MuteTimeIntervals: []config.MuteTimeInterval{
+					MuteTimeIntervals: []definitions.AmMuteTimeInterval{
 						{Name: "mute-interval-1"},
 					},
 				},

--- a/pkg/services/ngalert/notifier/validation.go
+++ b/pkg/services/ngalert/notifier/validation.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/prometheus/alertmanager/config"
-
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -57,8 +55,8 @@ type staticContactPointValidator struct {
 // apiAlertingConfig contains the methods required to validate NotificationSettings and create autogen routes.
 type apiAlertingConfig[R receiver] interface {
 	GetReceivers() []R
-	GetMuteTimeIntervals() []config.MuteTimeInterval
-	GetTimeIntervals() []config.TimeInterval
+	GetMuteTimeIntervals() []definitions.AmMuteTimeInterval
+	GetTimeIntervals() []definitions.TimeInterval
 	GetRoute() *definitions.Route
 }
 

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -10,7 +10,6 @@ import (
 
 	alertingNotify "github.com/grafana/alerting/notify"
 	"github.com/grafana/alerting/receivers/schema"
-	"github.com/prometheus/alertmanager/config"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -210,7 +209,7 @@ func (ecp *ContactPointService) CreateContactPoint(
 
 	if !receiverFound {
 		revision.Config.AlertmanagerConfig.Receivers = append(revision.Config.AlertmanagerConfig.Receivers, &apimodels.PostableApiReceiver{
-			Receiver: config.Receiver{
+			Receiver: apimodels.Receiver{
 				Name: grafanaReceiver.Name,
 			},
 			PostableGrafanaReceivers: apimodels.PostableGrafanaReceivers{
@@ -501,7 +500,7 @@ groupLoop:
 
 				// Doesn't exist? Create a new group just for the receiver.
 				newGroup := &apimodels.PostableApiReceiver{
-					Receiver: config.Receiver{
+					Receiver: apimodels.Receiver{
 						Name: target.Name,
 					},
 					PostableGrafanaReceivers: apimodels.PostableGrafanaReceivers{

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/alerting/notify/notifytest"
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/grafana/alerting/receivers/slack"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
@@ -663,7 +662,7 @@ func TestStitchReceivers(t *testing.T) {
 				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "receiver-1",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -677,7 +676,7 @@ func TestStitchReceivers(t *testing.T) {
 						},
 					},
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "receiver-2",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -726,7 +725,7 @@ func TestStitchReceivers(t *testing.T) {
 				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "new-receiver",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -740,7 +739,7 @@ func TestStitchReceivers(t *testing.T) {
 						},
 					},
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "receiver-2",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -788,7 +787,7 @@ func TestStitchReceivers(t *testing.T) {
 				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "receiver-1",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -807,7 +806,7 @@ func TestStitchReceivers(t *testing.T) {
 						},
 					},
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "receiver-2",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -844,7 +843,7 @@ func TestStitchReceivers(t *testing.T) {
 					},
 					Receivers: []*definitions.PostableApiReceiver{
 						{
-							Receiver: config.Receiver{
+							Receiver: definitions.Receiver{
 								Name: "receiver-1",
 							},
 							PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -863,7 +862,7 @@ func TestStitchReceivers(t *testing.T) {
 							},
 						},
 						{
-							Receiver: config.Receiver{
+							Receiver: definitions.Receiver{
 								Name: "receiver-2",
 							},
 							PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -909,7 +908,7 @@ func TestStitchReceivers(t *testing.T) {
 				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "receiver-1",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -923,7 +922,7 @@ func TestStitchReceivers(t *testing.T) {
 						},
 					},
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "receiver-2",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -970,7 +969,7 @@ func TestStitchReceivers(t *testing.T) {
 					},
 					Receivers: []*definitions.PostableApiReceiver{
 						{
-							Receiver: config.Receiver{
+							Receiver: definitions.Receiver{
 								Name: "receiver-1",
 							},
 							PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -989,7 +988,7 @@ func TestStitchReceivers(t *testing.T) {
 							},
 						},
 						{
-							Receiver: config.Receiver{
+							Receiver: definitions.Receiver{
 								Name: "receiver-2",
 							},
 							PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1003,7 +1002,7 @@ func TestStitchReceivers(t *testing.T) {
 							},
 						},
 						{
-							Receiver: config.Receiver{
+							Receiver: definitions.Receiver{
 								Name: "receiver-3",
 							},
 							PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1017,7 +1016,7 @@ func TestStitchReceivers(t *testing.T) {
 							},
 						},
 						{
-							Receiver: config.Receiver{
+							Receiver: definitions.Receiver{
 								Name: "receiver-4",
 							},
 							PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1053,7 +1052,7 @@ func TestStitchReceivers(t *testing.T) {
 				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "receiver-1",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1067,7 +1066,7 @@ func TestStitchReceivers(t *testing.T) {
 						},
 					},
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "receiver-2",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1081,7 +1080,7 @@ func TestStitchReceivers(t *testing.T) {
 						},
 					},
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "receiver-3",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1095,7 +1094,7 @@ func TestStitchReceivers(t *testing.T) {
 						},
 					},
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "receiver-4",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1138,7 +1137,7 @@ func TestStitchReceivers(t *testing.T) {
 				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "receiver-1",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1152,7 +1151,7 @@ func TestStitchReceivers(t *testing.T) {
 						},
 					},
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "receiver-2",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1171,7 +1170,7 @@ func TestStitchReceivers(t *testing.T) {
 						},
 					},
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "brand-new-group",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1210,7 +1209,7 @@ func TestStitchReceivers(t *testing.T) {
 				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "receiver-1",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1224,7 +1223,7 @@ func TestStitchReceivers(t *testing.T) {
 						},
 					},
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "receiver-2",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1243,7 +1242,7 @@ func TestStitchReceivers(t *testing.T) {
 						},
 					},
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "brand-new-group",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1278,7 +1277,7 @@ func TestStitchReceivers(t *testing.T) {
 					},
 					Receivers: []*definitions.PostableApiReceiver{
 						{
-							Receiver: config.Receiver{
+							Receiver: definitions.Receiver{
 								Name: "receiver-1",
 							},
 							PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1297,7 +1296,7 @@ func TestStitchReceivers(t *testing.T) {
 							},
 						},
 						{
-							Receiver: config.Receiver{
+							Receiver: definitions.Receiver{
 								Name: "receiver-2",
 							},
 							PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1337,7 +1336,7 @@ func TestStitchReceivers(t *testing.T) {
 				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
-						Receiver: config.Receiver{
+						Receiver: definitions.Receiver{
 							Name: "receiver-1",
 						},
 						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1396,7 +1395,7 @@ func createTestConfigWithReceivers() *definitions.PostableUserConfig {
 			},
 			Receivers: []*definitions.PostableApiReceiver{
 				{
-					Receiver: config.Receiver{
+					Receiver: definitions.Receiver{
 						Name: "receiver-1",
 					},
 					PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1410,7 +1409,7 @@ func createTestConfigWithReceivers() *definitions.PostableUserConfig {
 					},
 				},
 				{
-					Receiver: config.Receiver{
+					Receiver: definitions.Receiver{
 						Name: "receiver-2",
 					},
 					PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1454,7 +1453,7 @@ func createInconsistentTestConfigWithReceivers() *definitions.PostableUserConfig
 			},
 			Receivers: []*definitions.PostableApiReceiver{
 				{
-					Receiver: config.Receiver{
+					Receiver: definitions.Receiver{
 						Name: "receiver-1",
 					},
 					PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
@@ -1468,7 +1467,7 @@ func createInconsistentTestConfigWithReceivers() *definitions.PostableUserConfig
 					},
 				},
 				{
-					Receiver: config.Receiver{
+					Receiver: definitions.Receiver{
 						Name: "receiver-2",
 					},
 					PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -27,7 +27,7 @@ func TestGetMuteTimings(t *testing.T) {
 		Config: &definitions.PostableUserConfig{
 			AlertmanagerConfig: definitions.PostableApiAlertingConfig{
 				Config: definitions.Config{
-					MuteTimeIntervals: []config.MuteTimeInterval{
+					MuteTimeIntervals: []definitions.AmMuteTimeInterval{
 						{
 							Name:          "Test1",
 							TimeIntervals: nil,
@@ -37,7 +37,7 @@ func TestGetMuteTimings(t *testing.T) {
 							TimeIntervals: nil,
 						},
 					},
-					TimeIntervals: []config.TimeInterval{
+					TimeIntervals: []definitions.TimeInterval{
 						{
 							Name:          "Test3",
 							TimeIntervals: nil,
@@ -127,10 +127,10 @@ func TestGetMuteTimings(t *testing.T) {
 	})
 
 	t.Run("with imported intervals", func(t *testing.T) {
-		grafanaIntervals := []config.MuteTimeInterval{
+		grafanaIntervals := []definitions.AmMuteTimeInterval{
 			{Name: "grafana-interval"},
 		}
-		importedIntervals := []config.MuteTimeInterval{
+		importedIntervals := []definitions.AmMuteTimeInterval{
 			{Name: "imported-interval"},
 		}
 		revision := createConfigWithImportedIntervals(grafanaIntervals, importedIntervals)
@@ -219,13 +219,13 @@ func TestGetMuteTimingByName(t *testing.T) {
 		Config: &definitions.PostableUserConfig{
 			AlertmanagerConfig: definitions.PostableApiAlertingConfig{
 				Config: definitions.Config{
-					MuteTimeIntervals: []config.MuteTimeInterval{
+					MuteTimeIntervals: []definitions.AmMuteTimeInterval{
 						{
 							Name:          "Test1",
 							TimeIntervals: nil,
 						},
 					},
-					TimeIntervals: []config.TimeInterval{
+					TimeIntervals: []definitions.TimeInterval{
 						{
 							Name:          "Test2",
 							TimeIntervals: nil,
@@ -306,13 +306,13 @@ func TestGetMuteTimingByUID(t *testing.T) {
 		Config: &definitions.PostableUserConfig{
 			AlertmanagerConfig: definitions.PostableApiAlertingConfig{
 				Config: definitions.Config{
-					MuteTimeIntervals: []config.MuteTimeInterval{
+					MuteTimeIntervals: []definitions.AmMuteTimeInterval{
 						{
 							Name:          "Test1",
 							TimeIntervals: nil,
 						},
 					},
-					TimeIntervals: []config.TimeInterval{
+					TimeIntervals: []definitions.TimeInterval{
 						{
 							Name:          "Test2",
 							TimeIntervals: nil,
@@ -383,12 +383,12 @@ func TestCreateMuteTimings(t *testing.T) {
 			TemplateFiles: nil,
 			AlertmanagerConfig: definitions.PostableApiAlertingConfig{
 				Config: definitions.Config{
-					MuteTimeIntervals: []config.MuteTimeInterval{
+					MuteTimeIntervals: []definitions.AmMuteTimeInterval{
 						{
 							Name: "TEST",
 						},
 					},
-					TimeIntervals: []config.TimeInterval{
+					TimeIntervals: []definitions.TimeInterval{
 						{
 							Name: "TEST2",
 						},
@@ -399,7 +399,7 @@ func TestCreateMuteTimings(t *testing.T) {
 		}
 	}
 
-	expected := config.MuteTimeInterval{
+	expected := definitions.AmMuteTimeInterval{
 		Name: "Test",
 		TimeIntervals: []timeinterval.TimeInterval{
 			{
@@ -420,7 +420,7 @@ func TestCreateMuteTimings(t *testing.T) {
 	t.Run("returns ErrTimeIntervalInvalid if mute timings fail validation", func(t *testing.T) {
 		sut, _, _ := createMuteTimingSvcSut()
 		timing := definitions.MuteTimeInterval{
-			MuteTimeInterval: config.MuteTimeInterval{
+			MuteTimeInterval: definitions.AmMuteTimeInterval{
 				Name: "",
 			},
 			Provenance: definitions.Provenance(models.ProvenanceFile),
@@ -448,7 +448,7 @@ func TestCreateMuteTimings(t *testing.T) {
 
 		require.Truef(t, ErrTimeIntervalExists.Is(err), "expected ErrTimeIntervalExists but got %s", err)
 
-		existing = config.MuteTimeInterval(initialConfig().AlertmanagerConfig.TimeIntervals[0])
+		existing = definitions.AmMuteTimeInterval(initialConfig().AlertmanagerConfig.TimeIntervals[0])
 		timing = definitions.MuteTimeInterval{
 			MuteTimeInterval: existing,
 			Provenance:       definitions.Provenance(models.ProvenanceFile),
@@ -490,7 +490,7 @@ func TestCreateMuteTimings(t *testing.T) {
 		require.Equal(t, orgID, store.Calls[1].Args[2])
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-		expectedTimings := append(initialConfig().AlertmanagerConfig.TimeIntervals, config.TimeInterval(expected))
+		expectedTimings := append(initialConfig().AlertmanagerConfig.TimeIntervals, definitions.TimeInterval(expected))
 		require.EqualValues(t, expectedTimings, revision.Config.AlertmanagerConfig.TimeIntervals)
 
 		prov.AssertCalled(t, "SetProvenance", mock.Anything, &timing, orgID, expectedProvenance)
@@ -554,7 +554,7 @@ func TestCreateMuteTimings(t *testing.T) {
 func TestUpdateMuteTimings(t *testing.T) {
 	orgID := int64(1)
 
-	original := config.MuteTimeInterval{
+	original := definitions.AmMuteTimeInterval{
 		Name: "Test",
 	}
 	originalVersion := calculateMuteTimeIntervalFingerprint(original)
@@ -563,10 +563,10 @@ func TestUpdateMuteTimings(t *testing.T) {
 			TemplateFiles: nil,
 			AlertmanagerConfig: definitions.PostableApiAlertingConfig{
 				Config: definitions.Config{
-					MuteTimeIntervals: []config.MuteTimeInterval{
+					MuteTimeIntervals: []definitions.AmMuteTimeInterval{
 						original,
 					},
-					TimeIntervals: []config.TimeInterval{
+					TimeIntervals: []definitions.TimeInterval{
 						{
 							Name: "Test2",
 						},
@@ -584,7 +584,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 		}
 	}
 
-	expected := config.MuteTimeInterval{
+	expected := definitions.AmMuteTimeInterval{
 		Name: "Test",
 		TimeIntervals: []timeinterval.TimeInterval{
 			{
@@ -608,7 +608,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 	t.Run("rejects mute timings that fail validation", func(t *testing.T) {
 		sut, _, _ := createMuteTimingSvcSut()
 		timing := definitions.MuteTimeInterval{
-			MuteTimeInterval: config.MuteTimeInterval{
+			MuteTimeInterval: definitions.AmMuteTimeInterval{
 				Name: "",
 			},
 			Provenance: definitions.Provenance(models.ProvenanceFile),
@@ -650,7 +650,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 		}
 		timing := definitions.MuteTimeInterval{
 			UID: legacy_storage.NameToUid("Test2"),
-			MuteTimeInterval: config.MuteTimeInterval{
+			MuteTimeInterval: definitions.AmMuteTimeInterval{
 				Name: "Test",
 				TimeIntervals: []timeinterval.TimeInterval{
 					{
@@ -711,7 +711,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 
 		t.Run("when only Name is specified", func(t *testing.T) {
 			timing := definitions.MuteTimeInterval{
-				MuteTimeInterval: config.MuteTimeInterval{
+				MuteTimeInterval: definitions.AmMuteTimeInterval{
 					Name: "not-found",
 				},
 				Provenance: definitions.Provenance(expectedProvenance),
@@ -755,14 +755,14 @@ func TestUpdateMuteTimings(t *testing.T) {
 		require.Equal(t, orgID, store.Calls[1].Args[2])
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-		require.EqualValues(t, []config.MuteTimeInterval{expected}, revision.Config.AlertmanagerConfig.MuteTimeIntervals)
+		require.EqualValues(t, []definitions.AmMuteTimeInterval{expected}, revision.Config.AlertmanagerConfig.MuteTimeIntervals)
 
 		prov.AssertCalled(t, "SetProvenance", mock.Anything, &timing, orgID, expectedProvenance)
 
 		t.Run("bypass optimistic concurrency check if version is empty", func(t *testing.T) {
 			store.Calls = nil
 			timing := definitions.MuteTimeInterval{
-				MuteTimeInterval: config.MuteTimeInterval{
+				MuteTimeInterval: definitions.AmMuteTimeInterval{
 					Name: expected.Name,
 					TimeIntervals: []timeinterval.TimeInterval{
 						{Months: []timeinterval.MonthRange{
@@ -791,7 +791,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 			require.Equal(t, orgID, store.Calls[1].Args[2])
 			revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-			require.EqualValues(t, []config.MuteTimeInterval{timing.MuteTimeInterval}, revision.Config.AlertmanagerConfig.MuteTimeIntervals)
+			require.EqualValues(t, []definitions.AmMuteTimeInterval{timing.MuteTimeInterval}, revision.Config.AlertmanagerConfig.MuteTimeIntervals)
 		})
 	})
 
@@ -811,7 +811,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 				return nil
 			})
 
-		original := config.MuteTimeInterval(initialConfig().AlertmanagerConfig.TimeIntervals[0])
+		original := definitions.AmMuteTimeInterval(initialConfig().AlertmanagerConfig.TimeIntervals[0])
 
 		expected := expected
 		expected.Name = original.Name
@@ -836,7 +836,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 		require.Equal(t, orgID, store.Calls[1].Args[2])
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-		require.EqualValues(t, []config.TimeInterval{config.TimeInterval(expected)}, revision.Config.AlertmanagerConfig.TimeIntervals)
+		require.EqualValues(t, []definitions.TimeInterval{definitions.TimeInterval(expected)}, revision.Config.AlertmanagerConfig.TimeIntervals)
 
 		prov.AssertCalled(t, "SetProvenance", mock.Anything, &timing, orgID, expectedProvenance)
 	})
@@ -911,7 +911,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 		assert.Equal(t, orgID, store.Calls[1].Args[2])
 
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
-		assert.EqualValues(t, append(initialConfig().AlertmanagerConfig.TimeIntervals, config.TimeInterval(interval)), revision.Config.AlertmanagerConfig.TimeIntervals)
+		assert.EqualValues(t, append(initialConfig().AlertmanagerConfig.TimeIntervals, definitions.TimeInterval(interval)), revision.Config.AlertmanagerConfig.TimeIntervals)
 		assert.Falsef(t, isTimeIntervalInUseInRoutes(expected.Name, revision.Config.AlertmanagerConfig.Route), "There are still references to the old time interval")
 		assert.Truef(t, isTimeIntervalInUseInRoutes(interval.Name, revision.Config.AlertmanagerConfig.Route), "There are no references to the new time interval")
 	})
@@ -1087,7 +1087,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 func TestDeleteMuteTimings(t *testing.T) {
 	orgID := int64(1)
 
-	timingToDelete := config.MuteTimeInterval{Name: "unused-timing"}
+	timingToDelete := definitions.AmMuteTimeInterval{Name: "unused-timing"}
 	correctVersion := calculateMuteTimeIntervalFingerprint(timingToDelete)
 	usedMuteTiming := "used-timing"
 	usedActiveTiming := "used-active-timing"
@@ -1100,13 +1100,13 @@ func TestDeleteMuteTimings(t *testing.T) {
 						MuteTimeIntervals:   []string{usedMuteTiming},
 						ActiveTimeIntervals: []string{usedActiveTiming},
 					},
-					MuteTimeIntervals: []config.MuteTimeInterval{
+					MuteTimeIntervals: []definitions.AmMuteTimeInterval{
 						{
 							Name: usedMuteTiming,
 						},
 						timingToDelete,
 					},
-					TimeIntervals: []config.TimeInterval{
+					TimeIntervals: []definitions.TimeInterval{
 						{
 							Name: usedActiveTiming,
 						},
@@ -1236,7 +1236,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 		require.Equal(t, orgID, store.Calls[1].Args[2])
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-		expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.MuteTimeIntervals, func(interval config.MuteTimeInterval) bool {
+		expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.MuteTimeIntervals, func(interval definitions.AmMuteTimeInterval) bool {
 			return interval.Name == timingToDelete.Name
 		})
 		require.EqualValues(t, expectedMuteTimings, revision.Config.AlertmanagerConfig.MuteTimeIntervals)
@@ -1252,7 +1252,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 			require.Equal(t, orgID, store.Calls[1].Args[2])
 			revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-			expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.MuteTimeIntervals, func(interval config.MuteTimeInterval) bool {
+			expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.MuteTimeIntervals, func(interval definitions.AmMuteTimeInterval) bool {
 				return interval.Name == timingToDelete.Name
 			})
 			require.EqualValues(t, expectedMuteTimings, revision.Config.AlertmanagerConfig.MuteTimeIntervals)
@@ -1278,7 +1278,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 			})
 
 		timingToDelete := initialConfig().AlertmanagerConfig.TimeIntervals[1]
-		correctVersion := calculateMuteTimeIntervalFingerprint(config.MuteTimeInterval(timingToDelete))
+		correctVersion := calculateMuteTimeIntervalFingerprint(definitions.AmMuteTimeInterval(timingToDelete))
 
 		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Name, orgID, "", correctVersion)
 		require.NoError(t, err)
@@ -1291,13 +1291,13 @@ func TestDeleteMuteTimings(t *testing.T) {
 		require.Equal(t, orgID, store.Calls[1].Args[2])
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-		expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.TimeIntervals, func(interval config.TimeInterval) bool {
+		expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.TimeIntervals, func(interval definitions.TimeInterval) bool {
 			return interval.Name == timingToDelete.Name
 		})
 		require.EqualValues(t, expectedMuteTimings, revision.Config.AlertmanagerConfig.TimeIntervals)
 		require.EqualValues(t, initialConfig().AlertmanagerConfig.MuteTimeIntervals, revision.Config.AlertmanagerConfig.MuteTimeIntervals)
 
-		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, &definitions.MuteTimeInterval{MuteTimeInterval: config.MuteTimeInterval(timingToDelete)}, orgID)
+		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, &definitions.MuteTimeInterval{MuteTimeInterval: definitions.AmMuteTimeInterval(timingToDelete)}, orgID)
 	})
 
 	t.Run("deletes mute timing and provenance by UID", func(t *testing.T) {
@@ -1329,7 +1329,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 		require.Equal(t, orgID, store.Calls[1].Args[2])
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-		expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.MuteTimeIntervals, func(interval config.MuteTimeInterval) bool {
+		expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.MuteTimeIntervals, func(interval definitions.AmMuteTimeInterval) bool {
 			return interval.Name == timingToDelete.Name
 		})
 		require.EqualValues(t, expectedMuteTimings, revision.Config.AlertmanagerConfig.MuteTimeIntervals)
@@ -1414,7 +1414,7 @@ func createMuteTimingSvcSut() (*MuteTimingService, *legacy_storage.AlertmanagerC
 // buildMimirAMConfigWithTimeIntervals creates a Mimir alertmanager config YAML string
 // containing the provided time intervals for use in ExtraConfigs.
 // This generates a minimal but valid Prometheus alertmanager config with a route and receiver.
-func buildMimirAMConfigWithTimeIntervals(intervals []config.MuteTimeInterval) string {
+func buildMimirAMConfigWithTimeIntervals(intervals []definitions.AmMuteTimeInterval) string {
 	if len(intervals) == 0 {
 		return ""
 	}
@@ -1459,7 +1459,7 @@ func buildMimirAMConfigWithTimeIntervals(intervals []config.MuteTimeInterval) st
 
 // createConfigWithImportedIntervals creates a ConfigRevision with both Grafana and imported
 // Mimir time intervals for testing.
-func createConfigWithImportedIntervals(grafanaIntervals []config.MuteTimeInterval, importedIntervals []config.MuteTimeInterval) *legacy_storage.ConfigRevision {
+func createConfigWithImportedIntervals(grafanaIntervals []definitions.AmMuteTimeInterval, importedIntervals []definitions.AmMuteTimeInterval) *legacy_storage.ConfigRevision {
 	cfg := &definitions.PostableUserConfig{
 		AlertmanagerConfig: definitions.PostableApiAlertingConfig{
 			Config: definitions.Config{

--- a/pkg/services/ngalert/provisioning/notification_policies_test.go
+++ b/pkg/services/ngalert/provisioning/notification_policies_test.go
@@ -348,7 +348,7 @@ func TestResetPolicyTree(t *testing.T) {
 	currentRevision.Config.TemplateFiles = map[string]string{
 		"test": "test",
 	}
-	currentRevision.Config.AlertmanagerConfig.TimeIntervals = []config.TimeInterval{
+	currentRevision.Config.AlertmanagerConfig.TimeIntervals = []definitions.TimeInterval{
 		{
 			Name: "test",
 		},
@@ -442,8 +442,8 @@ func TestResetPolicyTree(t *testing.T) {
 
 func TestRoute_Fingerprint(t *testing.T) {
 	// Test that the fingerprint is stable.
-	mustRegex := func(rg string) config.Regexp {
-		var regex config.Regexp
+	mustRegex := func(rg string) definitions.Regexp {
+		var regex definitions.Regexp
 		require.NoError(t, json.Unmarshal([]byte(rg), &regex))
 		return regex
 	}
@@ -461,7 +461,7 @@ func TestRoute_Fingerprint(t *testing.T) {
 			},
 			GroupByAll: true,
 			Match:      map[string]string{"Match1": "MatchValue1", "Match2": "MatchValue2"},
-			MatchRE: map[string]config.Regexp{
+			MatchRE: map[string]definitions.Regexp{
 				"MatchRE": mustRegex(`".*"`),
 			},
 			Matchers: config.Matchers{
@@ -492,7 +492,7 @@ func TestRoute_Fingerprint(t *testing.T) {
 		},
 		GroupByAll: false,
 		Match:      map[string]string{"Match1_2": "MatchValue1", "Match2": "MatchValue2_2"},
-		MatchRE: map[string]config.Regexp{
+		MatchRE: map[string]definitions.Regexp{
 			"MatchRE": mustRegex(`".+"`),
 		},
 		Matchers: config.Matchers{
@@ -585,7 +585,7 @@ func getDefaultConfigRevision() legacy_storage.ConfigRevision {
 						Receiver: "test-receiver",
 					},
 					InhibitRules: nil,
-					TimeIntervals: []config.TimeInterval{
+					TimeIntervals: []definitions.TimeInterval{
 						{
 							Name: "test-mute-interval",
 						},


### PR DESCRIPTION
This PR consolidates all references in production code to "github.com/prometheus/alertmanager/config" in one place - defitions package. 

This will let us gradually switch to alerting repository without massive refactorrre