### PR TITLE
testinfra: Add GlobalUserQuota option to GrafanaOpts

### DIFF
--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -489,6 +489,10 @@ func CreateGrafDir(t *testing.T, opts GrafanaOpts) (string, string) {
 		}
 		_, err = quotaSection.NewKey("org_dashboard", strconv.FormatInt(dashboardQuota, 10))
 		require.NoError(t, err)
+		if opts.GlobalUserQuota != nil {
+			_, err = quotaSection.NewKey("global_user", strconv.FormatInt(*opts.GlobalUserQuota, 10))
+			require.NoError(t, err)
+		}
 	}
 	if opts.DisableAnonymous {
 		anonSect, err := cfg.GetSection("auth.anonymous")
@@ -768,6 +772,7 @@ type GrafanaOpts struct {
 	AnonymousUserRole                     org.RoleType
 	EnableQuota                           bool
 	DashboardOrgQuota                     *int64
+	GlobalUserQuota                       *int64
 	DisableAnonymous                      bool
 	CatalogAppEnabled                     bool
 	ViewersCanEdit                        bool


### PR DESCRIPTION
**What is this feature?**

Allow integration tests to configure the global_user quota limit when starting a test Grafana instance. This enables testing behavior that depends on user quota enforcement, such as verifying transaction rollback when provisioning exceeds the quota.

**Why do we need this feature?**

N/A

**Who is this feature for?**

Folks that wish to customize `global_user` quota in integration tests.

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/support-escalations/issues/20684.