### PR TITLE
CloudWatch: add pagination and sorting to log group selector

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/styles.ts
+++ b/public/app/plugins/datasource/cloudwatch/components/styles.ts
@@ -85,6 +85,15 @@ const getStyles = (theme: GrafanaTheme2) => ({
     marginRight: theme.spacing(1),
   }),
 
+  sortField: css({
+    minWidth: '220px',
+  }),
+
+  pagination: css({
+    marginTop: theme.spacing(1),
+    overflow: 'auto',
+  }),
+
   resultLimit: css({
     margin: '4px 0',
     fontStyle: 'italic',


### PR DESCRIPTION
CloudWatch: add pagination and sorting to log group selector

This PR updates the CloudWatch Logs log group selector to - fetch all matching log groups across AWS pages,

It preserves the existing CloudWatch query constraint that only up to 50 log groups can be queried at once.

Fix #118097