### PR TITLE
InfluxDB: Mark unauthenticated error as downstream for flightsql 

### DIFF
--- a/pkg/tsdb/influxdb/fsql/fsql.go
+++ b/pkg/tsdb/influxdb/fsql/fsql.go
@@ -65,6 +65,8 @@ func Query(ctx context.Context, dsInfo *models.DatasourceInfo, req backend.Query
 					tRes.Responses[q.RefID] = backend.ErrDataResponseWithSource(backend.StatusNotFound, backend.ErrorSourceDownstream, errStr)
 				case codes.Unavailable:
 					tRes.Responses[q.RefID] = backend.ErrDataResponseWithSource(http.StatusServiceUnavailable, backend.ErrorSourceDownstream, errStr)
+				case codes.Unauthenticated:
+  					tRes.Responses[q.RefID] = backend.ErrDataResponseWithSource(backend.StatusUnauthorized, backend.ErrorSourceDownstream, errStr,)
 				default:
 					tRes.Responses[q.RefID] = backend.ErrDataResponse(backend.StatusInternal, errStr)
 				}

--- a/pkg/tsdb/influxdb/fsql/fsql.go
+++ b/pkg/tsdb/influxdb/fsql/fsql.go
@@ -66,7 +66,7 @@ func Query(ctx context.Context, dsInfo *models.DatasourceInfo, req backend.Query
 				case codes.Unavailable:
 					tRes.Responses[q.RefID] = backend.ErrDataResponseWithSource(http.StatusServiceUnavailable, backend.ErrorSourceDownstream, errStr)
 				case codes.Unauthenticated:
-  					tRes.Responses[q.RefID] = backend.ErrDataResponseWithSource(backend.StatusUnauthorized, backend.ErrorSourceDownstream, errStr,)
+					tRes.Responses[q.RefID] = backend.ErrDataResponseWithSource(backend.StatusUnauthorized, backend.ErrorSourceDownstream, errStr)
 				default:
 					tRes.Responses[q.RefID] = backend.ErrDataResponse(backend.StatusInternal, errStr)
 				}


### PR DESCRIPTION
Mark gRPC `Unauthenticated` errors from FlightSQL to downstream errors instead of returning a generic 500 (plugin error).