### PR TITLE
Navigation: Add subtitle text to the Service Center panel on the Alerts & IRM landing page

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -218,6 +218,7 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 			serviceLink := &navtree.NavLink{
 				Text:       "Service center",
 				Id:         "standalone-plugin-page-slo-services",
+				SubTitle:   "The Service Center provides a single pane of glass into key operational resources and the ability to run operational reviews.",
 				Url:        s.cfg.AppSubURL + "/a/grafana-slo-app/services",
 				SortWeight: 1,
 				IsNew:      true,

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -218,7 +218,7 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 			serviceLink := &navtree.NavLink{
 				Text:       "Service center",
 				Id:         "standalone-plugin-page-slo-services",
-				SubTitle:   "The Service Center provides a single pane of glass into key operational resources and the ability to run operational reviews.",
+				SubTitle:   "Centralizes service-level operational data including slos, alerts, and incidents by grouping resources through shared labels or tags",
 				Url:        s.cfg.AppSubURL + "/a/grafana-slo-app/services",
 				SortWeight: 1,
 				IsNew:      true,

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -218,7 +218,7 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 			serviceLink := &navtree.NavLink{
 				Text:       "Service center",
 				Id:         "standalone-plugin-page-slo-services",
-				SubTitle:   "Centralizes service-level operational data including slos, alerts, and incidents by grouping resources through shared labels or tags",
+				SubTitle:   "Centralizes service-level operational data including SLOs, alerts, and incidents by grouping resources through shared labels or tags",
 				Url:        s.cfg.AppSubURL + "/a/grafana-slo-app/services",
 				SortWeight: 1,
 				IsNew:      true,


### PR DESCRIPTION
**What is this feature?**

Adds a subtitle to the Service Center nav item in the Alerts & IRM section: "Centralizes service-level operational data including slos, alerts, and incidents by grouping resources through shared labels or tags".

**Why do we need this feature?**

The Service Center card previously had no subtitle, unlike Alerting, IRM, and SLO. This adds a short description so users understand what Service Center does before opening it.

<img width="1223" height="294" alt="Screenshot 2026-02-13 at 12 15 18 PM" src="https://github.com/user-attachments/assets/76692c30-4fcc-4c2d-b8c2-bd55a2e9f200" />

**Who is this feature for?**

Users who see the Alerts & IRM section (e.g. Grafana Cloud with SLO/IRM plugins) and want to quickly understand what Service Center offers.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. *(N/A – copy change only)*
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. *(N/A – UI copy only)*