### PR TITLE
Table: Improve a11y

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -109,7 +109,7 @@
     "react-calendar": "^6.0.0",
     "react-colorful": "5.6.1",
     "react-custom-scrollbars-2": "4.5.0",
-    "react-data-grid": "grafana/react-data-grid#a922856b5ede21d55db3fdffb6d38dc76bdc7c58",
+    "react-data-grid": "grafana/react-data-grid#8423a96e43129516ba6cd08cbae9f0f7a285cfa4",
     "react-dropzone": "14.3.8",
     "react-highlight-words": "0.21.0",
     "react-hook-form": "^7.49.2",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -109,7 +109,7 @@
     "react-calendar": "^6.0.0",
     "react-colorful": "5.6.1",
     "react-custom-scrollbars-2": "4.5.0",
-    "react-data-grid": "grafana/react-data-grid#8423a96e43129516ba6cd08cbae9f0f7a285cfa4",
+    "react-data-grid": "grafana/react-data-grid#a10c748f40edc538425b458af4e471a8262ec4ed",
     "react-dropzone": "14.3.8",
     "react-highlight-words": "0.21.0",
     "react-hook-form": "^7.49.2",

--- a/packages/grafana-ui/src/components/Table/TableNG/Filter/Filter.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Filter/Filter.tsx
@@ -59,6 +59,8 @@ export const Filter = memo(
         className={styles.headerFilter}
         ref={ref}
         type="button"
+        aria-haspopup="dialog"
+        aria-pressed={isPopoverVisible}
         aria-label={t('grafana-ui.table.filter.button', `Filter {{name}}`, {
           name: field ? getDisplayName(field) : '',
         })}

--- a/packages/grafana-ui/src/components/Table/TableNG/Filter/FilterPopup.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Filter/FilterPopup.tsx
@@ -160,6 +160,7 @@ export const FilterPopup = memo(
               tooltip={t('grafana-ui.table.filter-popup-aria-label-match-case', 'Match case')}
               variant={matchCase ? 'primary' : 'secondary'}
               onClick={() => setMatchCase((s) => !s)}
+              aria-pressed={matchCase}
               icon={'text-fields'}
             />
           </Stack>

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
@@ -556,7 +556,7 @@ describe('TableNG', () => {
       const grid = container.querySelector('[role="grid"]');
       expect(grid).toBeInTheDocument();
 
-      const expandIcons = container.querySelectorAll('svg[aria-label="Expand row"]');
+      const expandIcons = container.querySelectorAll('[aria-label="Expand row"]');
       expect(expandIcons.length).toBeGreaterThan(0);
     });
 
@@ -575,30 +575,29 @@ describe('TableNG', () => {
       });
 
       // Count initial rows
-      const initialRows = container.querySelectorAll('[role="row"]');
-      const initialRowCount = initialRows.length;
+      const nestedRows = container.querySelectorAll('[role="grid"] [role="row"]');
 
       // Find the expand button
-      const expandButton = container.querySelector('svg[aria-label="Expand row"]');
+      const expandButton = container.querySelector('[aria-label="Expand row"]');
       expect(expandButton).toBeInTheDocument();
 
       // Click the expand button
       if (expandButton) {
+        for (const row of nestedRows) {
+          expect(row).not.toBeVisible();
+        }
+        expect(nestedRows).toHaveLength(6);
+
         await user.click(expandButton);
 
         // After expansion, we should have more rows
-        const expandedRows = container.querySelectorAll('[role="row"]');
-        expect(expandedRows.length).toBeGreaterThan(initialRowCount);
+        expect(nestedRows[0]).toBeVisible(); // header
+        expect(nestedRows[1]).toBeVisible(); // first of two
+        expect(nestedRows[2]).toBeVisible(); // second of two
 
-        // Check for nested data by looking for specific cell content
-        const expectedExpandedContent = ['N1', 'N2'];
-        expectedExpandedContent.forEach((text) => {
-          expect(screen.getByText(text)).toBeInTheDocument();
-        });
-
-        // Hidden nested fields should stay hidden
-        expect(screen.queryByText('Nested hidden')).not.toBeInTheDocument();
-        expect(screen.queryByText('secret1')).not.toBeInTheDocument();
+        expect(nestedRows[3]).not.toBeVisible(); // header
+        expect(nestedRows[4]).not.toBeVisible(); // first of two
+        expect(nestedRows[5]).not.toBeVisible(); // second of two
 
         // Check if the expanded row has the aria-expanded attribute
         const expandedRow = container.querySelector('[aria-expanded="true"]');

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
@@ -553,7 +553,7 @@ describe('TableNG', () => {
         expect(screen.getByText(text)).toBeInTheDocument();
       });
 
-      const grid = container.querySelector('[role="grid"]');
+      const grid = container.querySelector('[role="treegrid"]');
       expect(grid).toBeInTheDocument();
 
       const expandIcons = container.querySelectorAll('[aria-label="Expand row"]');
@@ -575,7 +575,8 @@ describe('TableNG', () => {
       });
 
       // Count initial rows
-      const nestedRows = container.querySelectorAll('[role="grid"] [role="row"]');
+      const initialRows = container.querySelectorAll('[role="row"]');
+      const initialRowCount = initialRows.length;
 
       // Find the expand button
       const expandButton = container.querySelector('[aria-label="Expand row"]');
@@ -583,21 +584,21 @@ describe('TableNG', () => {
 
       // Click the expand button
       if (expandButton) {
-        for (const row of nestedRows) {
-          expect(row).not.toBeVisible();
-        }
-        expect(nestedRows).toHaveLength(6);
-
         await user.click(expandButton);
 
         // After expansion, we should have more rows
-        expect(nestedRows[0]).toBeVisible(); // header
-        expect(nestedRows[1]).toBeVisible(); // first of two
-        expect(nestedRows[2]).toBeVisible(); // second of two
+        const expandedRows = container.querySelectorAll('[role="row"]');
+        expect(expandedRows.length).toBeGreaterThan(initialRowCount);
 
-        expect(nestedRows[3]).not.toBeVisible(); // header
-        expect(nestedRows[4]).not.toBeVisible(); // first of two
-        expect(nestedRows[5]).not.toBeVisible(); // second of two
+        // Check for nested data by looking for specific cell content
+        const expectedExpandedContent = ['N1', 'N2'];
+        expectedExpandedContent.forEach((text) => {
+          expect(screen.getByText(text)).toBeInTheDocument();
+        });
+
+        // Hidden nested fields should stay hidden
+        expect(screen.queryByText('Nested hidden')).not.toBeInTheDocument();
+        expect(screen.queryByText('secret1')).not.toBeInTheDocument();
 
         // Check if the expanded row has the aria-expanded attribute
         const expandedRow = container.querySelector('[aria-expanded="true"]');

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -979,9 +979,7 @@ const renderRowFactory =
 
     // Don't render non expanded child rows
     if (row.__depth === 1 && !isExpanded) {
-      a11yProps['aria-level'] = 1;
-      a11yProps['aria-expanded'] = isExpanded;
-      return <Row key={key} {...props} {...a11yProps} style={{ display: 'none' }} />;
+      return null;
     }
 
     // Add aria-expanded to parent rows that have nested data

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -975,8 +975,6 @@ const renderRowFactory =
     const rowIdx = row.__index;
     const isExpanded = expandedRows.has(rowIdx);
 
-    const a11yProps: HTMLAttributes<HTMLDivElement> = {};
-
     // Don't render non expanded child rows
     if (row.__depth === 1 && !isExpanded) {
       return null;
@@ -984,9 +982,7 @@ const renderRowFactory =
 
     // Add aria-expanded to parent rows that have nested data
     if (row.data) {
-      a11yProps['aria-level'] = 1;
-      a11yProps['aria-expanded'] = isExpanded;
-      return <Row key={key} {...props} {...a11yProps} />;
+      return <Row key={key} aria-level={row.__index + 1} aria-expanded={isExpanded} {...props} />;
     }
 
     const handlers: Partial<typeof props> = {};
@@ -1008,5 +1004,5 @@ const renderRowFactory =
       }
     }
 
-    return <Row key={key} {...props} {...handlers} {...a11yProps} />;
+    return <Row key={key} {...props} {...handlers} />;
   };

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -4,7 +4,6 @@ import { clsx } from 'clsx';
 import memoize from 'micro-memoize';
 import {
   CSSProperties,
-  HTMLAttributes,
   type JSX,
   Key,
   ReactNode,
@@ -36,7 +35,7 @@ import {
   FieldType,
   getDisplayProcessor,
 } from '@grafana/data';
-import { Trans } from '@grafana/i18n';
+import { t, Trans } from '@grafana/i18n';
 import { FieldColorModeId, TableCellTooltipPlacement, TableFooterOptions } from '@grafana/schema';
 
 import { useStyles2, useTheme2 } from '../../../themes/ThemeContext';
@@ -374,7 +373,7 @@ export function TableNG(props: TableNGProps) {
       renderers: Renderers<TableRow, TableSummaryRow>
     ): TableColumn => ({
       key: EXPANDED_COLUMN_KEY,
-      name: '',
+      name: t('grafana-ui.table.nested-table.expander-column-name', 'Expand nested rows'),
       field: {
         name: '',
         type: FieldType.other,
@@ -444,6 +443,9 @@ export function TableNG(props: TableNGProps) {
             />
           </div>
         );
+      },
+      renderHeaderCell(props) {
+        return <div className="sr-only">{props.column.name}</div>;
       },
       width: COLUMN.EXPANDER_WIDTH,
       minWidth: COLUMN.EXPANDER_WIDTH,

--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
@@ -60,7 +60,6 @@ const HeaderCell: React.FC<HeaderCellProps> = ({
   return (
     <Stack
       ref={ref}
-      tabIndex={-1}
       direction="row"
       gap={0.5}
       alignItems="center"

--- a/packages/grafana-ui/src/components/Table/TableNG/components/RowExpander.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/RowExpander.tsx
@@ -8,7 +8,7 @@ import { useStyles2 } from '../../../../themes/ThemeContext';
 import { Icon } from '../../../Icon/Icon';
 import { RowExpanderNGProps } from '../types';
 
-export function RowExpander({ onCellExpand, isExpanded }: RowExpanderNGProps) {
+export function RowExpander({ onCellExpand, isExpanded, rowId }: RowExpanderNGProps) {
   const styles = useStyles2(getStyles);
   function handleKeyDown(e: React.KeyboardEvent<HTMLSpanElement>) {
     if (e.key === ' ' || e.key === 'Enter') {
@@ -16,6 +16,9 @@ export function RowExpander({ onCellExpand, isExpanded }: RowExpanderNGProps) {
       onCellExpand(e);
     }
   }
+  const label = isExpanded
+    ? t('grafana-ui.row-expander-ng.aria-label-collapse', 'Collapse row')
+    : t('grafana-ui.row-expander.aria-label-expand', 'Expand row');
   return (
     <div
       role="button"
@@ -23,18 +26,12 @@ export function RowExpander({ onCellExpand, isExpanded }: RowExpanderNGProps) {
       className={styles.expanderCell}
       onClick={onCellExpand}
       onKeyDown={handleKeyDown}
+      aria-label={label}
       data-testid={selectors.components.Panels.Visualization.TableNG.RowExpander}
+      aria-expanded={isExpanded}
+      aria-controls={rowId}
     >
-      <Icon
-        aria-label={
-          isExpanded
-            ? t('grafana-ui.row-expander-ng.aria-label-collapse', 'Collapse row')
-            : t('grafana-ui.row-expander.aria-label-expand', 'Expand row')
-        }
-        aria-expanded={isExpanded}
-        name={isExpanded ? 'angle-down' : 'angle-right'}
-        size="lg"
-      />
+      <Icon name={isExpanded ? 'angle-down' : 'angle-right'} size="lg" aria-hidden="true" />
     </div>
   );
 }

--- a/packages/grafana-ui/src/components/Table/TableNG/components/TableCellTooltip.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/TableCellTooltip.tsx
@@ -3,6 +3,7 @@ import { DataGridHandle } from 'react-data-grid';
 
 import { ActionModel, DataFrame, Field, GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
+import { t } from '@grafana/i18n';
 import { TableCellTooltipPlacement } from '@grafana/schema';
 
 import { Popover } from '../../../Tooltip/Popover';
@@ -153,16 +154,25 @@ export const TableCellTooltip = memo(
           />
         )}
 
-        {/* TODO: figure out an accessible way to trigger the tooltip. */}
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
         <div
           className={classes.tooltipCaret}
           ref={tooltipCaretRef}
           data-testid={selectors.components.Panels.Visualization.TableNG.Tooltip.Caret}
+          aria-label={t('grafana-ui.table.tooltip.trigger', 'Toggle tooltip')}
+          role="button"
+          aria-haspopup="true"
           aria-pressed={pinned}
+          tabIndex={0}
           onClick={() => setPinned((prev) => !prev)}
           onMouseLeave={onMouseLeave}
           onMouseEnter={onMouseEnter}
+          onKeyDown={(ev) => {
+            if (ev.key === 'Enter' || ev.key === ' ') {
+              ev.preventDefault();
+              ev.stopPropagation();
+              setPinned((prev) => !prev);
+            }
+          }}
           onBlur={onMouseLeave}
           onFocus={onMouseEnter}
         />

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -204,6 +204,7 @@ export interface TableCellActionsProps {
 /* ------------------------- Specialized Cell Props ------------------------- */
 export interface RowExpanderNGProps {
   onCellExpand: (e: SyntheticEvent) => void;
+  rowId: string;
   isExpanded?: boolean;
 }
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9731,6 +9731,7 @@
       },
       "inspect-drawer-title": "Inspect value",
       "nested-table": {
+        "expander-column-name": "Expand nested rows",
         "no-data": "No data"
       },
       "no-values-label": "No values",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9737,6 +9737,9 @@
       "pagination-summary": "{{itemsRangeStart}} - {{displayedEnd}} of {{numRows}} rows",
       "sparkline": {
         "no-data": "no data"
+      },
+      "tooltip": {
+        "trigger": "Toggle tooltip"
       }
     },
     "tags": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4215,7 +4215,7 @@ __metadata:
     react-calendar: "npm:^6.0.0"
     react-colorful: "npm:5.6.1"
     react-custom-scrollbars-2: "npm:4.5.0"
-    react-data-grid: "grafana/react-data-grid#a922856b5ede21d55db3fdffb6d38dc76bdc7c58"
+    react-data-grid: "grafana/react-data-grid#8423a96e43129516ba6cd08cbae9f0f7a285cfa4"
     react-dom: "npm:18.3.1"
     react-dropzone: "npm:14.3.8"
     react-highlight-words: "npm:0.21.0"
@@ -29868,15 +29868,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-data-grid@grafana/react-data-grid#a922856b5ede21d55db3fdffb6d38dc76bdc7c58":
+"react-data-grid@grafana/react-data-grid#8423a96e43129516ba6cd08cbae9f0f7a285cfa4":
   version: 7.0.0-beta.56
-  resolution: "react-data-grid@https://github.com/grafana/react-data-grid.git#commit=a922856b5ede21d55db3fdffb6d38dc76bdc7c58"
+  resolution: "react-data-grid@https://github.com/grafana/react-data-grid.git#commit=8423a96e43129516ba6cd08cbae9f0f7a285cfa4"
   dependencies:
     clsx: "npm:^2.0.0"
   peerDependencies:
     react: ^18.0 || ^19.0
     react-dom: ^18.0 || ^19.0
-  checksum: 10/18d368ff52151c1e7900819b0d92bb554b3d26135a5d4401a6e3c044fd62ca72a4177b63ba705b93901fa489458a965ce1d1deb2e4f98aa5fb39c276d2b12d38
+  checksum: 10/8a7a94ff1eed79dcf2d6f4c8643e6b05d3c2d22d045dc9a8f6d3e2cbf6d2b07e95b3c98c3e7fffe49c5e508a0a92e85c053112fa94b14aae63bb4685c8769581
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4215,7 +4215,7 @@ __metadata:
     react-calendar: "npm:^6.0.0"
     react-colorful: "npm:5.6.1"
     react-custom-scrollbars-2: "npm:4.5.0"
-    react-data-grid: "grafana/react-data-grid#8423a96e43129516ba6cd08cbae9f0f7a285cfa4"
+    react-data-grid: "grafana/react-data-grid#a10c748f40edc538425b458af4e471a8262ec4ed"
     react-dom: "npm:18.3.1"
     react-dropzone: "npm:14.3.8"
     react-highlight-words: "npm:0.21.0"
@@ -29868,15 +29868,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-data-grid@grafana/react-data-grid#8423a96e43129516ba6cd08cbae9f0f7a285cfa4":
+"react-data-grid@grafana/react-data-grid#a10c748f40edc538425b458af4e471a8262ec4ed":
   version: 7.0.0-beta.56
-  resolution: "react-data-grid@https://github.com/grafana/react-data-grid.git#commit=8423a96e43129516ba6cd08cbae9f0f7a285cfa4"
+  resolution: "react-data-grid@https://github.com/grafana/react-data-grid.git#commit=a10c748f40edc538425b458af4e471a8262ec4ed"
   dependencies:
     clsx: "npm:^2.0.0"
   peerDependencies:
     react: ^18.0 || ^19.0
     react-dom: ^18.0 || ^19.0
-  checksum: 10/8a7a94ff1eed79dcf2d6f4c8643e6b05d3c2d22d045dc9a8f6d3e2cbf6d2b07e95b3c98c3e7fffe49c5e508a0a92e85c053112fa94b14aae63bb4685c8769581
+  checksum: 10/ba5ae10da5a0b104a8dad11ad3ae6b0e624edf8ec3f48f56bb392fc08cc453233e9a47cf713cf8d6f133265cae690ee0ea81112f7594f1007893883f5409d0e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #117843, #117828, #84096

I've verified using Lighthouse, and in an upcoming PR I'll add a11y checks via Playwright to keep this working.

- added `treegrid` role when nesting is present, and added some other related `aria` props to help in the nested table scenario.
- adds `aria-hidden` to a number of non-interactive or non-relevant-to-screenreader elements in our react-data-grid fork.
  - need to open a PR to upstream that.
- removed an unnecessary tabIndex={-1}
- improve aria tags on tooltip trigger for Tooltip from Field
- improves aria tags on row collapsing element for nested tables