### PR TITLE
Search: Normalize managedBy from unified search

### DIFF
--- a/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
+++ b/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
@@ -49,6 +49,7 @@ export const FolderRepo = memo(function FolderRepo({ folder }: Props) {
 
 // Check conditions that don't require the useIsProvisionedInstance hook
 function getCanSkipEarly(folder: FolderDTO | DashboardViewItem | undefined): boolean {
+  console.log('folder', folder);
   if (!folder) {
     return true;
   }

--- a/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
+++ b/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
@@ -49,7 +49,6 @@ export const FolderRepo = memo(function FolderRepo({ folder }: Props) {
 
 // Check conditions that don't require the useIsProvisionedInstance hook
 function getCanSkipEarly(folder: FolderDTO | DashboardViewItem | undefined): boolean {
-  console.log('folder', folder);
   if (!folder) {
     return true;
   }

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -1,6 +1,7 @@
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
+import { ManagerKind } from 'app/features/apiserver/types';
 import { GENERAL_FOLDER_UID } from 'app/features/search/constants';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { DashboardQueryResult, NestedFolderDTO } from 'app/features/search/service/types';
@@ -50,7 +51,7 @@ async function searchNewAPI(parentUID?: string, page = 1, pageSize = PAGE_SIZE) 
       explain: {},
     });
   }
-
+  console.log('-------------------------------', folders);
   return folders.map<NestedFolderDTO>((item) => {
     return {
       uid: item.uid,
@@ -81,7 +82,7 @@ export async function listFolders(
     title: item.title,
     parentTitle,
     parentUID,
-    managedBy: item.managedBy,
+    managedBy: typeof item.managedBy === 'string' ? item.managedBy : item.managedBy?.kind,
 
     // URLs from the backend come with subUrlPrefix already included, so match that behaviour here
     url: isSharedWithMe(item.uid) ? undefined : getFolderURL(item.uid),

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -82,7 +82,8 @@ export async function listFolders(
     title: item.title,
     parentTitle,
     parentUID,
-    managedBy: typeof item.managedBy === 'string' ? item.managedBy : item.managedBy?.kind,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    managedBy: typeof item.managedBy === 'string' ? item.managedBy : (item.managedBy?.kind as ManagerKind),
 
     // URLs from the backend come with subUrlPrefix already included, so match that behaviour here
     url: isSharedWithMe(item.uid) ? undefined : getFolderURL(item.uid),

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -51,7 +51,7 @@ async function searchNewAPI(parentUID?: string, page = 1, pageSize = PAGE_SIZE) 
       explain: {},
     });
   }
-  console.log('-------------------------------', folders);
+
   return folders.map<NestedFolderDTO>((item) => {
     return {
       uid: item.uid,

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -1,11 +1,10 @@
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
-import { ManagerKind } from 'app/features/apiserver/types';
 import { GENERAL_FOLDER_UID } from 'app/features/search/constants';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { DashboardQueryResult, NestedFolderDTO } from 'app/features/search/service/types';
-import { queryResultToViewItem } from 'app/features/search/service/utils';
+import { extractManagerKind, queryResultToViewItem } from 'app/features/search/service/utils';
 import { DashboardViewItem } from 'app/features/search/types';
 import { AccessControlAction } from 'app/types/accessControl';
 
@@ -82,9 +81,7 @@ export async function listFolders(
     title: item.title,
     parentTitle,
     parentUID,
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    managedBy: typeof item.managedBy === 'string' ? item.managedBy : (item.managedBy?.kind as ManagerKind),
-
+    managedBy: extractManagerKind(item.managedBy),
     // URLs from the backend come with subUrlPrefix already included, so match that behaviour here
     url: isSharedWithMe(item.uid) ? undefined : getFolderURL(item.uid),
   }));

--- a/public/app/features/search/service/types.ts
+++ b/public/app/features/search/service/types.ts
@@ -1,3 +1,4 @@
+import { ManagedBy } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
 import { DataFrameView, SelectableValue } from '@grafana/data';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 import { PermissionLevel } from 'app/types/acl';
@@ -58,7 +59,13 @@ export interface DashboardQueryResult {
   // debugging fields
   score: number;
   explain: {};
-  managedBy?: { kind: ManagerKind; id: number } | ManagerKind;
+  /**
+   * Who manages this resource (e.g. provisioning). From unified search this is
+   * the full object { kind, id }; from legacy or other paths it may be just the
+   * kind string (ManagerKind). Use typeof item.managedBy === 'string' or
+   * item.managedBy?.kind when normalizing.
+   */
+  managedBy?: ManagedBy | ManagerKind;
 
   // enterprise sends extra properties through for sorting (views, errors, etc)
   [key: string]: unknown;
@@ -105,5 +112,11 @@ export interface GrafanaSearcher {
 export interface NestedFolderDTO {
   uid: string;
   title: string;
-  managedBy?: ManagerKind | { kind: ManagerKind; id: number };
+  /**
+   * Who manages this resource (e.g. provisioning). From unified search this is
+   * the full object { kind, id }; from legacy or other paths it may be just the
+   * kind string (ManagerKind). Use typeof item.managedBy === 'string' or
+   * item.managedBy?.kind when normalizing.
+   */
+  managedBy?: ManagedBy | ManagerKind;
 }

--- a/public/app/features/search/service/types.ts
+++ b/public/app/features/search/service/types.ts
@@ -58,7 +58,7 @@ export interface DashboardQueryResult {
   // debugging fields
   score: number;
   explain: {};
-  managedBy?: ManagerKind;
+  managedBy?: { kind: ManagerKind; id: number } | ManagerKind;
 
   // enterprise sends extra properties through for sorting (views, errors, etc)
   [key: string]: unknown;
@@ -105,5 +105,5 @@ export interface GrafanaSearcher {
 export interface NestedFolderDTO {
   uid: string;
   title: string;
-  managedBy?: ManagerKind;
+  managedBy?: ManagerKind | { kind: ManagerKind; id: number };
 }

--- a/public/app/features/search/service/unified.test.ts
+++ b/public/app/features/search/service/unified.test.ts
@@ -168,9 +168,10 @@ describe('Unified Storage Searcher', () => {
     const results = toDashboardResults(mockResponse, 'errors_today');
 
     expect(results.length).toBe(2);
-    const sprinklesField = results.fields[10];
-    expect(sprinklesField.name).toBe('errors_today');
-    expect(sprinklesField.values).toEqual([1, 2]); // this also tests the hits original order is preserved
+    const sprinklesField = results.fields.find((f) => f.name === 'errors_today');
+    expect(sprinklesField).toBeDefined();
+    expect(sprinklesField!.name).toBe('errors_today');
+    expect(sprinklesField!.values).toEqual([1, 2]); // this also tests the hits original order is preserved
     expect(results.meta?.custom?.sortBy).toBe('errors_today');
   });
 

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -154,7 +154,7 @@ export class UnifiedSearcher implements GrafanaSearcher {
     } else {
       rsp = await this.fetchResponse(uri);
     }
-    console.log('unified search response', rsp);
+
     const first = toDashboardResults(rsp, query.sort ?? '');
     if (first.name === loadingFrameName) {
       return this.fallbackSearcher.search(query);

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -15,6 +15,8 @@ import { contextSrv } from 'app/core/services/context_srv';
 import kbn from 'app/core/utils/kbn';
 import { dispatch } from 'app/store/store';
 
+import { ManagerKind } from '../../apiserver/types';
+
 import { deletedDashboardsCache } from './deletedDashboardsCache';
 import {
   DashboardQueryResult,
@@ -44,6 +46,7 @@ export type SearchHit = {
 
   // calculated in the frontend
   url: string;
+  managedBy?: { kind: ManagerKind; id: string };
 };
 
 export type SearchAPIResponse = {
@@ -151,6 +154,7 @@ export class UnifiedSearcher implements GrafanaSearcher {
     } else {
       rsp = await this.fetchResponse(uri);
     }
+    console.log('unified search response', rsp);
     const first = toDashboardResults(rsp, query.sort ?? '');
     if (first.name === loadingFrameName) {
       return this.fallbackSearcher.search(query);
@@ -409,6 +413,7 @@ export function toDashboardResults(rsp: SearchAPIResponse, sort: string): DataFr
       location,
       name: hit.title, // 🤯 FIXME hit.name is k8s name, eg grafana dashboards UID
       kind: hit.resource.substring(0, hit.resource.length - 1), // dashboard "kind" is not plural
+      managedBy: hit.managedBy,
       ...field,
     };
   });

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -3,6 +3,7 @@ import { isEmpty } from 'lodash';
 import {
   API_GROUP as DASHBOARD_API_GROUP,
   BASE_URL as v0alphaBaseURL,
+  ManagedBy,
 } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
 import { generatedAPI as legacyUserAPI } from '@grafana/api-clients/rtkq/legacy/user';
 import { DataFrame, DataFrameView, getDisplayProcessor, SelectableValue, toDataFrame } from '@grafana/data';
@@ -14,8 +15,6 @@ import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 import { contextSrv } from 'app/core/services/context_srv';
 import kbn from 'app/core/utils/kbn';
 import { dispatch } from 'app/store/store';
-
-import { ManagerKind } from '../../apiserver/types';
 
 import { deletedDashboardsCache } from './deletedDashboardsCache';
 import {
@@ -46,7 +45,7 @@ export type SearchHit = {
 
   // calculated in the frontend
   url: string;
-  managedBy?: { kind: ManagerKind; id: string };
+  managedBy?: ManagedBy;
 };
 
 export type SearchAPIResponse = {

--- a/public/app/features/search/service/utils.ts
+++ b/public/app/features/search/service/utils.ts
@@ -1,3 +1,4 @@
+import { ManagedBy } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
 import { DataFrameView, IconName, fuzzySearch } from '@grafana/data';
 import { DashboardViewItemWithUIItems } from 'app/features/browse-dashboards/types';
 import { isSharedWithMe } from 'app/features/browse-dashboards/utils/dashboards';
@@ -82,14 +83,18 @@ function isSearchResultMeta(obj: unknown): obj is SearchResultMeta {
   return obj !== null && typeof obj === 'object' && 'locationInfo' in obj;
 }
 
+export function extractManagerKind(managedBy?: ManagedBy | ManagerKind): ManagerKind | undefined {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return typeof managedBy === 'string' ? managedBy : (managedBy?.kind as ManagerKind);
+}
+
 export function queryResultToViewItem(
   item: DashboardQueryResult,
   view?: DataFrameView<DashboardQueryResult>
 ): DashboardViewItem {
   const customMeta = view?.dataFrame.meta?.custom;
   const meta: SearchResultMeta | undefined = isSearchResultMeta(customMeta) ? customMeta : undefined;
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  const managedByStr = typeof item.managedBy === 'string' ? item.managedBy : (item.managedBy?.kind as ManagerKind);
+  const managedByStr = extractManagerKind(item.managedBy);
 
   const viewItem: DashboardViewItem = {
     kind: parseKindString(item.kind),

--- a/public/app/features/search/service/utils.ts
+++ b/public/app/features/search/service/utils.ts
@@ -4,7 +4,7 @@ import { isSharedWithMe } from 'app/features/browse-dashboards/utils/dashboards'
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { DashboardDataDTO } from 'app/types/dashboard';
 
-import { AnnoKeyFolder, ResourceList } from '../../apiserver/types';
+import { AnnoKeyFolder, ManagerKind, ResourceList } from '../../apiserver/types';
 import { DashboardSearchHit, DashboardSearchItemType, DashboardViewItem, DashboardViewItemKind } from '../types';
 
 import { DashboardQueryResult, SearchQuery, SearchResultMeta } from './types';
@@ -88,7 +88,8 @@ export function queryResultToViewItem(
 ): DashboardViewItem {
   const customMeta = view?.dataFrame.meta?.custom;
   const meta: SearchResultMeta | undefined = isSearchResultMeta(customMeta) ? customMeta : undefined;
-  const managedByStr = typeof item.managedBy === 'string' ? item.managedBy : item.managedBy?.kind;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const managedByStr = typeof item.managedBy === 'string' ? item.managedBy : (item.managedBy?.kind as ManagerKind);
 
   const viewItem: DashboardViewItem = {
     kind: parseKindString(item.kind),

--- a/public/app/features/search/service/utils.ts
+++ b/public/app/features/search/service/utils.ts
@@ -88,6 +88,7 @@ export function queryResultToViewItem(
 ): DashboardViewItem {
   const customMeta = view?.dataFrame.meta?.custom;
   const meta: SearchResultMeta | undefined = isSearchResultMeta(customMeta) ? customMeta : undefined;
+  const managedByStr = typeof item.managedBy === 'string' ? item.managedBy : item.managedBy?.kind;
 
   const viewItem: DashboardViewItem = {
     kind: parseKindString(item.kind),
@@ -95,7 +96,7 @@ export function queryResultToViewItem(
     title: item.name,
     url: item.url,
     tags: item.tags ?? [],
-    managedBy: item.managedBy,
+    managedBy: managedByStr,
   };
 
   // Set enterprise sort value property


### PR DESCRIPTION
**What is this feature?**

- Normalize `managedBy` values that can be either `{ kind, id }` or `ManagerKind` string, since BE is actually passing back object ([code here](https://github.com/grafana/grafana/blob/main/apps/dashboard/pkg/apis/dashboard/v0alpha1/search.go#L90)
- Update folder/dashboard mapping paths to consistently pass `ManagerKind` as string to UI
- Prevent `managedBy` object values from leaking into components that expect a string

**Why do we need this feature?**

- FE is expecting managedBy to be string and its currently broken for git sync folder badge display

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/885

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
