### PR TITLE
zanzana: Fix batch check to split requests exceeding OpenFGA max checks limit

### DIFF
--- a/pkg/services/authz/zanzana/server/server_batch_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"testing"
 
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
@@ -223,5 +225,83 @@ func TestIntegrationServerBatchCheck(t *testing.T) {
 		// user:1 has both get and update access to dashboard 1
 		assert.True(t, res.GetResults()["check1"].GetAllowed())
 		assert.True(t, res.GetResults()["check2"].GetAllowed())
+	})
+}
+
+func TestIntegrationServerBatchCheck_SubBatching(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	server := setupOpenFGAServer(t)
+	setup(t, server)
+
+	// Set a low limit to force sub-batching within the test
+	server.cfg.OpenFgaServerSettings = setting.OpenFgaServerSettings{
+		MaxChecksPerBatchCheck: 3,
+	}
+
+	newBatchReq := func(subject string, items []*authzv1.BatchCheckItem) *authzv1.BatchCheckRequest {
+		return &authzv1.BatchCheckRequest{
+			Namespace: namespace,
+			Subject:   subject,
+			Checks:    items,
+		}
+	}
+
+	newItem := func(correlationID, verb, group, resource, subresource, folder, name string) *authzv1.BatchCheckItem {
+		return &authzv1.BatchCheckItem{
+			CorrelationId: correlationID,
+			Verb:          verb,
+			Group:         group,
+			Resource:      resource,
+			Subresource:   subresource,
+			Name:          name,
+			Folder:        folder,
+		}
+	}
+
+	t.Run("batch exceeding limit returns correct results for all items", func(t *testing.T) {
+		// user:2 has group_resource access to all dashboards, so all should be allowed.
+		// 7 items with MaxChecksPerBatchCheck=3 forces splitting into multiple sub-batches.
+		items := make([]*authzv1.BatchCheckItem, 7)
+		for i := range items {
+			items[i] = newItem(
+				fmt.Sprintf("check-%d", i),
+				utils.VerbGet, dashboardGroup, dashboardResource, "", "1", fmt.Sprintf("%d", i+1),
+			)
+		}
+
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:2", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 7)
+		for i := range items {
+			assert.True(t, res.GetResults()[fmt.Sprintf("check-%d", i)].GetAllowed(),
+				"check-%d should be allowed via group_resource access", i)
+		}
+	})
+
+	t.Run("batch exceeding limit preserves mixed allowed and denied results", func(t *testing.T) {
+		// user:4 has folder-based access to folders 1 and 3 but not folder 2.
+		// Generate items across folders to get a mix of allowed/denied across sub-batches.
+		items := []*authzv1.BatchCheckItem{
+			newItem("f1-a", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "100"), // allowed
+			newItem("f1-b", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "101"), // allowed
+			newItem("f2-a", utils.VerbGet, dashboardGroup, dashboardResource, "", "2", "200"), // denied
+			newItem("f3-a", utils.VerbGet, dashboardGroup, dashboardResource, "", "3", "300"), // allowed
+			newItem("f2-b", utils.VerbGet, dashboardGroup, dashboardResource, "", "2", "201"), // denied
+			newItem("f1-c", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "102"), // allowed
+			newItem("f3-b", utils.VerbGet, dashboardGroup, dashboardResource, "", "3", "301"), // allowed
+		}
+
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:4", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 7)
+
+		assert.True(t, res.GetResults()["f1-a"].GetAllowed())
+		assert.True(t, res.GetResults()["f1-b"].GetAllowed())
+		assert.False(t, res.GetResults()["f2-a"].GetAllowed())
+		assert.True(t, res.GetResults()["f3-a"].GetAllowed())
+		assert.False(t, res.GetResults()["f2-b"].GetAllowed())
+		assert.True(t, res.GetResults()["f1-c"].GetAllowed())
+		assert.True(t, res.GetResults()["f3-b"].GetAllowed())
 	})
 }


### PR DESCRIPTION
Ensure that doBatchCheck respects the OpenFGA MaxChecksPerBatchCheck limit by splitting oversized requests into smaller sub-batches. 