### PR TITLE
DataSourceTabPage: Fix active tab indicator for custom config pages

### DIFF
--- a/public/app/features/datasources/components/DataSourceTabPage.tsx
+++ b/public/app/features/datasources/components/DataSourceTabPage.tsx
@@ -13,7 +13,7 @@ export interface Props {
 }
 
 export function DataSourceTabPage({ uid, pageId }: Props) {
-  const { navId, pageNav, dataSourceHeader } = useDataSourceSettingsNav('settings');
+  const { navId, pageNav, dataSourceHeader } = useDataSourceSettingsNav(pageId ?? undefined);
 
   const info = useDataSourceInfo({
     dataSourcePluginName: pageNav.dataSourcePluginName,


### PR DESCRIPTION
**What is this pull request about?**

Fixes the active tab indicator for data source plugin custom config pages. When a plugin registers additional configuration tabs via `addConfigPage()`, clicking on a custom tab navigates to the correct page and renders the correct content, but the tab indicator (underline) stays on "Settings" instead of moving to the selected tab.

Fixes #118105

**How to test**

1. Use a data source plugin that registers custom config pages via `addConfigPage()` (e.g., TestData data source has a "Setup" tab)
2. Navigate to the data source settings page
3. Click on the custom tab
4. Verify the tab indicator moves to the selected tab
5. Click back to "Settings" — verify the indicator returns

**Root cause**

`DataSourceTabPage` receives `pageId` as a prop from `EditDataSourcePage`, but hardcodes `'settings'` when calling the `useDataSourceSettingsNav` hook. This causes `getDataSourceNav()` to always mark the "Settings" tab as active regardless of the current page.

**Fix**

Pass `pageId` through to the hook instead of hardcoding `'settings'`. The `?? undefined` coercion converts `string | null` to `string | undefined` to match the hook parameter type. When `pageId` is `null` (default settings page), the hook's existing fallback logic correctly defaults to `'settings'`.