### PR TITLE
Provisioning: Surface sync warning details in UI

### DIFF
--- a/public/app/features/provisioning/Job/FinishedJobStatus.tsx
+++ b/public/app/features/provisioning/Job/FinishedJobStatus.tsx
@@ -7,6 +7,7 @@ import { useGetRepositoryJobsWithPathQuery } from 'app/api/clients/provisioning/
 import { StepStatusInfo } from '../Wizard/types';
 
 import { JobContent } from './JobContent';
+import { getJobMessages } from './getJobMessage';
 
 export interface FinishedJobProps {
   jobUid: string;
@@ -51,15 +52,23 @@ export function FinishedJobStatus({ jobUid, repositoryName, jobType, onStatusCha
     }
 
     if (finishedQuery.isSuccess && job?.status) {
-      const { state, message, errors } = job.status;
+      const { state } = job.status;
+      const messages = getJobMessages(job.status);
 
       if (state === 'error') {
+        const warningInfo = messages.warning
+          ? {
+              title: t('provisioning.job-status.status.title-warning-running-job', 'Job completed with warnings'),
+              message: messages.warning,
+            }
+          : undefined;
         onStatusChange?.({
           status: 'error',
           error: {
             title: t('provisioning.job-status.status.title-error-running-job', 'Error running job'),
-            message: errors?.length ? errors : message,
+            message: messages.error,
           },
+          warning: warningInfo,
         });
       } else if (state === 'success') {
         onStatusChange?.({
@@ -73,7 +82,7 @@ export function FinishedJobStatus({ jobUid, repositoryName, jobType, onStatusCha
           status: 'warning',
           warning: {
             title: t('provisioning.job-status.status.title-warning-running-job', 'Job completed with warnings'),
-            message: errors?.length ? errors : message,
+            message: messages.warning,
           },
         });
       }

--- a/public/app/features/provisioning/Job/JobAlerts.tsx
+++ b/public/app/features/provisioning/Job/JobAlerts.tsx
@@ -1,0 +1,25 @@
+import { JobStatus } from 'app/api/clients/provisioning/v0alpha1';
+
+import { ProvisioningAlert } from '../Shared/ProvisioningAlert';
+
+import { getJobMessages } from './getJobMessage';
+
+export function JobAlerts({ status }: { status: JobStatus }) {
+  const { state } = status;
+  const messages = getJobMessages(status);
+
+  if (state === 'success') {
+    return <ProvisioningAlert success={{ message: status.message }} />;
+  }
+
+  if (state === 'error' || state === 'warning') {
+    return (
+      <>
+        {messages.error && <ProvisioningAlert error={{ message: messages.error }} />}
+        {messages.warning && <ProvisioningAlert warning={{ message: messages.warning }} />}
+      </>
+    );
+  }
+
+  return null;
+}

--- a/public/app/features/provisioning/Job/JobContent.tsx
+++ b/public/app/features/provisioning/Job/JobContent.tsx
@@ -10,6 +10,7 @@ import ProgressBar from '../Shared/ProgressBar';
 import { StepStatusInfo } from '../Wizard/types';
 
 import { JobSummary } from './JobSummary';
+import { getJobMessages } from './getJobMessage';
 
 export interface JobContentProps {
   jobType: 'sync' | 'delete' | 'move';
@@ -21,7 +22,7 @@ export interface JobContentProps {
 export function JobContent({ jobType, job, isFinishedJob = false, onStatusChange }: JobContentProps) {
   const errorSetRef = useRef(false);
 
-  const { state, message, progress, summary, errors } = job?.status || {};
+  const { state, message, progress, summary } = job?.status || {};
   const repoName = job?.metadata?.labels?.['provisioning.grafana.app/repository'];
   const pullRequestURL = job?.status?.url?.newPullRequestURL;
 
@@ -35,30 +36,41 @@ export function JobContent({ jobType, job, isFinishedJob = false, onStatusChange
       case 'success':
         onStatusChange?.({ status: 'success' });
         break;
-      case 'warning':
+      case 'warning': {
         if (!errorSetRef.current) {
+          const messages = getJobMessages(job?.status ?? {});
           onStatusChange?.({
             status: 'warning',
             warning: {
               title: t('provisioning.job-status.status.title-warning-running-job', 'Job completed with warnings'),
-              message: errors?.length ? errors : message,
+              message: messages.warning,
             },
           });
           errorSetRef.current = true;
         }
         break;
-      case 'error':
+      }
+      case 'error': {
         if (!errorSetRef.current) {
+          const messages = getJobMessages(job?.status ?? {});
+          const warningInfo = messages.warning
+            ? {
+                title: t('provisioning.job-status.status.title-warning-running-job', 'Job completed with warnings'),
+                message: messages.warning,
+              }
+            : undefined;
           onStatusChange?.({
             status: 'error',
             error: {
               title: t('provisioning.job-status.status.title-error-running-job', 'Error running job'),
-              message: errors?.length ? errors : message,
+              message: messages.error,
             },
+            warning: warningInfo,
           });
           errorSetRef.current = true;
         }
         break;
+      }
       case 'working':
       case 'pending':
         onStatusChange?.({ status: 'running' });
@@ -66,7 +78,7 @@ export function JobContent({ jobType, job, isFinishedJob = false, onStatusChange
       default:
         break;
     }
-  }, [state, message, errors, onStatusChange]);
+  }, [state, message, job, onStatusChange]);
 
   if (!job?.status) {
     return null;

--- a/public/app/features/provisioning/Job/RecentJobs.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.tsx
@@ -12,6 +12,7 @@ import { useRepositoryAllJobs } from '../hooks/useRepositoryAllJobs';
 import { getStatusColor } from '../utils/repositoryStatus';
 import { formatTimestamp } from '../utils/time';
 
+import { JobAlerts } from './JobAlerts';
 import { JobSummary } from './JobSummary';
 
 interface Props {
@@ -85,6 +86,7 @@ interface ExpandedRowProps {
 function ExpandedRow({ row }: ExpandedRowProps) {
   const hasSummary = Boolean(row.status?.summary?.length);
   const hasErrors = Boolean(row.status?.errors?.length);
+  const hasWarnings = Boolean(row.status?.warnings?.length);
   const hasSpec = Boolean(row.spec);
 
   // the action is already showing
@@ -104,17 +106,9 @@ function ExpandedRow({ row }: ExpandedRowProps) {
     return v;
   }, [row.spec]);
 
-  if (!hasSummary && !hasErrors && !hasSpec) {
+  if (!hasSummary && !hasErrors && !hasWarnings && !hasSpec) {
     return null;
   }
-
-  const state = row.status?.state;
-  const isValidState = state && ['success', 'warning', 'error'].includes(state);
-  const alertProps = isValidState
-    ? {
-        [state]: { message: row.status?.message },
-      }
-    : null;
 
   return (
     <Box padding={2}>
@@ -127,7 +121,7 @@ function ExpandedRow({ row }: ExpandedRowProps) {
             <KeyValuesTable data={data} />
           </Stack>
         )}
-        {alertProps && <ProvisioningAlert {...alertProps} />}
+        {row.status && <JobAlerts status={row.status} />}
         {hasSummary && row.status?.summary && (
           <Stack direction="column" gap={2}>
             <Text variant="body" color="secondary">

--- a/public/app/features/provisioning/Job/getJobMessage.ts
+++ b/public/app/features/provisioning/Job/getJobMessage.ts
@@ -1,0 +1,30 @@
+import { JobStatus } from 'app/api/clients/provisioning/v0alpha1';
+
+export interface JobMessages {
+  error?: string[];
+  warning?: string[];
+}
+
+/**
+ * Extracts error and warning message arrays from a job status.
+ * Returns both separately so callers can render them as distinct alerts.
+ * Falls back to the generic `message` field based on state.
+ */
+export function getJobMessages(status: Partial<JobStatus>): JobMessages {
+  const { state, errors, warnings, message } = status;
+  const result: JobMessages = {};
+
+  if (errors?.length) {
+    result.error = errors;
+  } else if (state === 'error' && message) {
+    result.error = [message];
+  }
+
+  if (warnings?.length) {
+    result.warning = warnings;
+  } else if (state === 'warning' && message) {
+    result.warning = [message];
+  }
+
+  return result;
+}

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
@@ -214,7 +214,9 @@ export const ProvisioningWizard = memo(function ProvisioningWizard({
             {hasStepError && 'error' in stepStatusInfo && (
               <ProvisioningAlert error={stepStatusInfo.error} action={stepStatusInfo.action} />
             )}
-            {hasStepWarning && 'warning' in stepStatusInfo && <ProvisioningAlert warning={stepStatusInfo.warning} />}
+            {'warning' in stepStatusInfo && stepStatusInfo.warning && (
+              <ProvisioningAlert warning={stepStatusInfo.warning} />
+            )}
             {isStepSuccess && 'success' in stepStatusInfo && <ProvisioningAlert success={stepStatusInfo.success} />}
 
             <div className={styles.content}>

--- a/public/app/features/provisioning/Wizard/types.ts
+++ b/public/app/features/provisioning/Wizard/types.ts
@@ -50,7 +50,7 @@ export const RepoTypeDisplay: { [key in RepoType]: string } = {
 export type StepStatusInfo =
   | { status: 'idle' | 'running' }
   | { status: 'success'; success?: string | StatusInfo }
-  | { status: 'error'; error: string | StatusInfo; action?: AlertAction }
+  | { status: 'error'; error: string | StatusInfo; warning?: string | StatusInfo; action?: AlertAction }
   | { status: 'warning'; warning: string | StatusInfo };
 
 export type ConnectionCreationResult = { success: true; connectionName: string } | { success: false; error: string };


### PR DESCRIPTION
**What is this feature?**

When a sync job finishes with warnings (validation errors, ownership conflicts, etc.), the UI now displays the individual warning messages instead of only showing a generic "Job completed with warnings" message.

**Why do we need this feature?**

Previously, users had no way to diagnose warning issues after a sync completed. Warning details were collected by the backend but never surfaced to the UI, making it hard for users to fix problems.

**Who is this feature for?**

Git sync users who encounter warnings during sync operations and need to understand what went wrong to resolve the issue.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/874

**Special notes for your reviewer:**

<img width="990" height="529" alt="Screenshot 2026-02-16 at 9 48 27" src="https://github.com/user-attachments/assets/2d5fe142-0d71-45ec-b789-a41d389e73ae" />
<img width="1293" height="639" alt="Screenshot 2026-02-16 at 9 48 48" src="https://github.com/user-attachments/assets/9a3d2e0c-2a70-41bd-af1d-84371d71e9df" />
