### PR TITLE
Alerting: add sortBy template function

### DIFF
--- a/docs/sources/alerting/configure-notifications/template-notifications/reference.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/reference.md
@@ -224,6 +224,7 @@ In addition, the following functions are also available for templating notificat
 | `stringSlice`  | ...string                  | string        | Returns the passed strings as a slice of strings. auto-escaping.                                                                                                                                                 |
 | `date`         | string, [Time](#time)      | string        | Format a time in the specified format. For format options, refer to [Go's time format documentation](https://pkg.go.dev/time#pkg-constants).                                                                     |
 | `tz`           | string, [Time](#time)      | [Time](#time) | Returns the time in the specified timezone, such as `Europe/Paris`. For available timezone options, refer to the [list of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). |
+| `sortBy`       | field string, list         | list          | Sorts a list of objects by a field. Supports sorting by a field in a struct or a key in a map. Nested fields can be accessed using dot notation (e.g. `Labels.severity`).                                        |
 
 Here's an example using some functions to format text:
 

--- a/pkg/services/ngalert/state/template/funcs.go
+++ b/pkg/services/ngalert/state/template/funcs.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"reflect"
 	"regexp"
 	"slices"
+	"sort"
 	"strings"
 	"text/template"
 )
@@ -23,6 +25,8 @@ const (
 	RemoveLabelsReFuncName   = "removeLabelsRe"
 	TableLinkFuncName        = "tableLink"
 	MergeLabelValuesFuncName = "mergeLabelValues"
+	// SortByFuncName is the name of the function that sorts a list of objects by a field.
+	SortByFuncName = "sortBy"
 )
 
 var (
@@ -34,6 +38,7 @@ var (
 		RemoveLabelsReFuncName:   removeLabelsReFunc,
 		TableLinkFuncName:        tableLinkFunc,
 		MergeLabelValuesFuncName: mergeLabelValuesFunc,
+		SortByFuncName:           sortByFunc,
 	}
 )
 
@@ -130,4 +135,172 @@ func mergeLabelValuesFunc(values map[string]Value) Labels {
 		res[label] = strings.Join(keys, ", ")
 	}
 	return res
+}
+
+// sortByFunc sorts a list of objects by a field.
+// It supports sorting by a field in a struct or a key in a map.
+// Nested fields can be accessed using dot notation (e.g. "Labels.severity").
+func sortByFunc(field string, list interface{}) (interface{}, error) {
+	if list == nil {
+		return nil, nil
+	}
+
+	val := reflect.ValueOf(list)
+	if val.Kind() != reflect.Slice && val.Kind() != reflect.Array {
+		return nil, fmt.Errorf("sortBy: expected slice or array, got %T", list)
+	}
+
+	length := val.Len()
+	if length == 0 {
+		return list, nil
+	}
+
+	// Validate field existence on the first element to fail fast
+	if length > 0 {
+		_, err := getFieldResult(val.Index(0), field)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	newSlice := reflect.MakeSlice(val.Type(), length, length)
+	reflect.Copy(newSlice, val)
+
+	var err error
+
+	sort.Slice(newSlice.Interface(), func(i, j int) bool {
+		if err != nil {
+			return false
+		}
+
+		itemI := newSlice.Index(i)
+		itemJ := newSlice.Index(j)
+
+		valI, e1 := getFieldResult(itemI, field)
+		if e1 != nil {
+			err = e1
+			return false
+		}
+
+		valJ, e2 := getFieldResult(itemJ, field)
+		if e2 != nil {
+			err = e2
+			return false
+		}
+
+		return less(valI, valJ)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return newSlice.Interface(), nil
+}
+
+func getFieldResult(obj reflect.Value, fieldPath string) (reflect.Value, error) {
+	parts := strings.Split(fieldPath, ".")
+	curr := obj
+
+	for _, part := range parts {
+		if !curr.IsValid() {
+			return reflect.Value{}, fmt.Errorf("property %q is nil", part)
+		}
+
+		for curr.Kind() == reflect.Ptr || curr.Kind() == reflect.Interface {
+			if curr.IsNil() {
+				return reflect.Value{}, nil
+			}
+			curr = curr.Elem()
+		}
+
+		if curr.Kind() == reflect.Struct {
+			f := curr.FieldByName(part)
+			if !f.IsValid() {
+				return reflect.Value{}, fmt.Errorf("field %q not found in struct %s", part, curr.Type())
+			}
+			curr = f
+		} else if curr.Kind() == reflect.Map {
+			key := reflect.ValueOf(part)
+			val := curr.MapIndex(key)
+			if !val.IsValid() {
+				return reflect.Value{}, nil
+			}
+			curr = val
+		} else {
+			return reflect.Value{}, fmt.Errorf("cannot access field %q on type %s", part, curr.Kind())
+		}
+	}
+	return curr, nil
+}
+
+func less(v1, v2 reflect.Value) bool {
+	if !v1.IsValid() {
+		return true
+	}
+	if !v2.IsValid() {
+		return false
+	}
+
+	v1 = indirect(v1)
+	v2 = indirect(v2)
+
+	// After indirect, if we still have Ptr or Interface, it means it is nil.
+	// We treat nil as less than any value.
+	isNil1 := (v1.Kind() == reflect.Ptr || v1.Kind() == reflect.Interface) && v1.IsNil()
+	isNil2 := (v2.Kind() == reflect.Ptr || v2.Kind() == reflect.Interface) && v2.IsNil()
+	
+	if isNil1 {
+		return !isNil2 // nil < non-nil, nil !< nil
+	}
+	if isNil2 {
+		return false // non-nil > nil
+	}
+
+	switch v1.Kind() {
+	case reflect.String:
+		s1 := v1.String()
+		s2 := ""
+		if v2.Kind() == reflect.String {
+			s2 = v2.String()
+		} else {
+			s2 = fmt.Sprint(v2.Interface())
+		}
+		return s1 < s2
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		i1 := v1.Int()
+		var i2 int64
+		switch v2.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			i2 = v2.Int()
+		case reflect.Float32, reflect.Float64:
+			i2 = int64(v2.Float())
+		default:
+			return fmt.Sprint(v1.Interface()) < fmt.Sprint(v2.Interface())
+		}
+		return i1 < i2
+	case reflect.Float32, reflect.Float64:
+		f1 := v1.Float()
+		var f2 float64
+		switch v2.Kind() {
+		case reflect.Float32, reflect.Float64:
+			f2 = v2.Float()
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			f2 = float64(v2.Int())
+		default:
+			return fmt.Sprint(v1.Interface()) < fmt.Sprint(v2.Interface())
+		}
+		return f1 < f2
+	}
+
+	return fmt.Sprint(v1.Interface()) < fmt.Sprint(v2.Interface())
+}
+func indirect(v reflect.Value) reflect.Value {
+	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return v
+		}
+		v = v.Elem()
+	}
+	return v
 }

--- a/pkg/services/ngalert/state/template/funcs.go
+++ b/pkg/services/ngalert/state/template/funcs.go
@@ -249,7 +249,7 @@ func less(v1, v2 reflect.Value) bool {
 	// We treat nil as less than any value.
 	isNil1 := (v1.Kind() == reflect.Ptr || v1.Kind() == reflect.Interface) && v1.IsNil()
 	isNil2 := (v2.Kind() == reflect.Ptr || v2.Kind() == reflect.Interface) && v2.IsNil()
-	
+
 	if isNil1 {
 		return !isNil2 // nil < non-nil, nil !< nil
 	}
@@ -291,9 +291,9 @@ func less(v1, v2 reflect.Value) bool {
 			return fmt.Sprint(v1.Interface()) < fmt.Sprint(v2.Interface())
 		}
 		return f1 < f2
+	default:
+		return fmt.Sprint(v1.Interface()) < fmt.Sprint(v2.Interface())
 	}
-
-	return fmt.Sprint(v1.Interface()) < fmt.Sprint(v2.Interface())
 }
 func indirect(v reflect.Value) reflect.Value {
 	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {

--- a/pkg/services/ngalert/state/template/sort_test.go
+++ b/pkg/services/ngalert/state/template/sort_test.go
@@ -1,0 +1,198 @@
+package template
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSortByFunc(t *testing.T) {
+	type TestStruct struct {
+		Name     string
+		Value    int
+		Nested   struct{ Field string }
+		PtrField *int
+	}
+
+	val1 := 10
+	val2 := 20
+	val3 := 5
+
+	tests := []struct {
+		name      string
+		field     string
+		input     interface{}
+		expected  interface{}
+		expectErr bool
+	}{
+		{
+			name:  "sort slice of structs by string field",
+			field: "Name",
+			input: []TestStruct{
+				{Name: "c"}, {Name: "a"}, {Name: "b"},
+			},
+			expected: []TestStruct{
+				{Name: "a"}, {Name: "b"}, {Name: "c"},
+			},
+		},
+		{
+			name:  "sort slice of structs by int field",
+			field: "Value",
+			input: []TestStruct{
+				{Value: 10}, {Value: 5}, {Value: 20},
+			},
+			expected: []TestStruct{
+				{Value: 5}, {Value: 10}, {Value: 20},
+			},
+		},
+		{
+			name:  "sort slice of structs by nested field",
+			field: "Nested.Field",
+			input: []TestStruct{
+				{Nested: struct{ Field string }{"z"}},
+				{Nested: struct{ Field string }{"x"}},
+				{Nested: struct{ Field string }{"y"}},
+			},
+			expected: []TestStruct{
+				{Nested: struct{ Field string }{"x"}},
+				{Nested: struct{ Field string }{"y"}},
+				{Nested: struct{ Field string }{"z"}},
+			},
+		},
+		{
+			name:  "sort slice of pointers to structs",
+			field: "Value",
+			input: []*TestStruct{
+				{Value: 10}, {Value: 2}, {Value: 5},
+			},
+			expected: []*TestStruct{
+				{Value: 2}, {Value: 5}, {Value: 10},
+			},
+		},
+		{
+			name:  "sort slice of structs with pointer field (nil check)",
+			field: "PtrField",
+			input: []TestStruct{
+				{Name: "nil", PtrField: nil},
+				{Name: "20", PtrField: &val2},
+				{Name: "10", PtrField: &val1},
+			},
+			expected: []TestStruct{
+				{Name: "nil", PtrField: nil},
+				{Name: "10", PtrField: &val1},
+				{Name: "20", PtrField: &val2},
+			},
+		},
+		{
+			name:  "sort slice of structures with pointer fields",
+			field: "PtrField",
+			input: []TestStruct{
+				{Name: "10", PtrField: &val1},
+				{Name: "20", PtrField: &val2},
+				{Name: "5", PtrField: &val3},
+			},
+			expected: []TestStruct{
+				{Name: "5", PtrField: &val3},
+				{Name: "10", PtrField: &val1},
+				{Name: "20", PtrField: &val2},
+			},
+		},
+		{
+			name:  "sort slice of maps by key",
+			field: "key",
+			input: []map[string]interface{}{
+				{"key": "c", "other": 1},
+				{"key": "a", "other": 2},
+				{"key": "b", "other": 3},
+			},
+			expected: []map[string]interface{}{
+				{"key": "a", "other": 2},
+				{"key": "b", "other": 3},
+				{"key": "c", "other": 1},
+			},
+		},
+		{
+			name:  "sort slice of maps by nested key does not work directly like this in tests easily but dot notation works",
+			field: "key",
+			input: []map[string]string{
+				{"key": "2"}, {"key": "1"},
+			},
+			expected: []map[string]string{
+				{"key": "1"}, {"key": "2"},
+			},
+		},
+		{
+			name:      "error on non-slice input",
+			field:     "Name",
+			input:     TestStruct{},
+			expectErr: true,
+		},
+		{
+			name:  "sort handles invalid field gracefully (returns unsorted or partial? implementation returns error)",
+			field: "NonExistent",
+			input: []TestStruct{{Name: "a"}},
+			expectErr: true,
+		},
+		{
+			name:  "nil input returns nil",
+			field: "any",
+			input: nil,
+			expected: nil,
+		},
+		{
+			name: "empty slice returns empty",
+			field: "any",
+			input: []TestStruct{},
+			expected: []TestStruct{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := sortByFunc(tc.field, tc.input)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, res)
+			}
+		})
+	}
+}
+
+func TestSortByFunc_InTemplate(t *testing.T) {
+	// Verify it works within the Expand function (integration test)
+	// We need to Mock Data or use simple data structure
+	
+	type Alert struct {
+		Labels map[string]string
+		Value  float64
+	}
+	
+	alerts := []Alert{
+		{Labels: map[string]string{"foo": "c"}, Value: 1},
+		{Labels: map[string]string{"foo": "a"}, Value: 2},
+		{Labels: map[string]string{"foo": "b"}, Value: 3},
+	}
+	
+	// Data struct from template.go has Labels, Values (map), Value. 
+	// Expand takes Data.
+	// We can cheat and pass our custom struct if usage allows, but Expand signature takes Data.
+	// However, Expand uses .Data as context. 
+	// Wait, internal Expand expects Data.
+	// But we can test just the sorting of a list variable inside the template.
+	
+	tmpl := `{{ range $a := .Value | sortBy "Labels.foo" }}{{ .Labels.foo }},{{ end }}`
+	
+	// Create Data where .Value is our list of Alerts (Expand allows .Value to be any)
+	d := Data{
+		Value: alerts,
+	}
+	
+	res, err := Expand(context.Background(), "test", tmpl, d, nil, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, "a,b,c,", res)
+}

--- a/pkg/services/ngalert/state/template/sort_test.go
+++ b/pkg/services/ngalert/state/template/sort_test.go
@@ -131,21 +131,21 @@ func TestSortByFunc(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:  "sort handles invalid field gracefully (returns unsorted or partial? implementation returns error)",
-			field: "NonExistent",
-			input: []TestStruct{{Name: "a"}},
+			name:      "sort handles invalid field gracefully (returns unsorted or partial? implementation returns error)",
+			field:     "NonExistent",
+			input:     []TestStruct{{Name: "a"}},
 			expectErr: true,
 		},
 		{
-			name:  "nil input returns nil",
-			field: "any",
-			input: nil,
+			name:     "nil input returns nil",
+			field:    "any",
+			input:    nil,
 			expected: nil,
 		},
 		{
-			name: "empty slice returns empty",
-			field: "any",
-			input: []TestStruct{},
+			name:     "empty slice returns empty",
+			field:    "any",
+			input:    []TestStruct{},
 			expected: []TestStruct{},
 		},
 	}
@@ -166,32 +166,32 @@ func TestSortByFunc(t *testing.T) {
 func TestSortByFunc_InTemplate(t *testing.T) {
 	// Verify it works within the Expand function (integration test)
 	// We need to Mock Data or use simple data structure
-	
+
 	type Alert struct {
 		Labels map[string]string
 		Value  float64
 	}
-	
+
 	alerts := []Alert{
 		{Labels: map[string]string{"foo": "c"}, Value: 1},
 		{Labels: map[string]string{"foo": "a"}, Value: 2},
 		{Labels: map[string]string{"foo": "b"}, Value: 3},
 	}
-	
-	// Data struct from template.go has Labels, Values (map), Value. 
+
+	// Data struct from template.go has Labels, Values (map), Value.
 	// Expand takes Data.
 	// We can cheat and pass our custom struct if usage allows, but Expand signature takes Data.
-	// However, Expand uses .Data as context. 
+	// However, Expand uses .Data as context.
 	// Wait, internal Expand expects Data.
 	// But we can test just the sorting of a list variable inside the template.
-	
+
 	tmpl := `{{ range $a := .Value | sortBy "Labels.foo" }}{{ .Labels.foo }},{{ end }}`
-	
+
 	// Create Data where .Value is our list of Alerts (Expand allows .Value to be any)
 	d := Data{
 		Value: alerts,
 	}
-	
+
 	res, err := Expand(context.Background(), "test", tmpl, d, nil, time.Now())
 	require.NoError(t, err)
 	assert.Equal(t, "a,b,c,", res)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR adds a `sortBy` template function to the alerting template engine. This function allows users to sort a list of alerts in their notification templates by any field, including nested fields (e.g., `.Labels.severity`, `.Value`) and map keys.

Example usage in a template:

```
{{ range .Alerts | sortBy "Labels.severity" }}
  {{ .Labels.alertname }}: {{ .Labels.severity }}
{{ end }}
```

**Why do we need this feature?**

Currently, alerts are processed in an arbitrary order or the order they are received. Users often need to present alerts in notifications sorted by severity, time, or other custom labels to prioritize critical information. This feature addresses this need by providing a flexible sorting mechanism directly within the template language.

**Who is this feature for?**

This feature is for Grafana Alerting users who customize their notification templates and want to control the order in which alerts are displayed.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #118147

**Special notes for your reviewer:**

- The implementation is located in `pkg/services/ngalert/state/template/funcs.go`.
- It uses Go's `reflect` package to dynamically access fields and sort slices of structs or maps.
- Comprehensive unit tests have been added in `pkg/services/ngalert/state/template/sort_test.go` covering:
  - Sorting by string and int fields.
  - Sorting by nested fields (dot notation).
  - Sorting slices of pointers and maps.
  - Handling `nil` values (treated as smaller than non-nil).
  - Error handling for invalid fields (fail-fast on the first element).
- An integration test ensures the function works correctly within the `Expand` template execution context.

Please check that:

- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
