### PR TITLE
CI: Use self-hosted runners for FE workflows

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -44,7 +44,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.changed == 'true'
     name: Build & Package Grafana
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-x64-xlarge
     permissions:
       contents: read
       id-token: write
@@ -220,7 +220,7 @@ jobs:
             path: e2e/old-arch/panels-suite
             flags: --flags="--env dashboardScene=false"
     name: ${{ matrix.suite }}
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-x64-large
     permissions:
       contents: read
 
@@ -291,7 +291,7 @@ jobs:
     needs:
       - build-grafana
     name: Playwright E2E tests (${{ matrix.shard }}/${{ matrix.shardTotal }})
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-x64-large
     permissions:
       contents: read
 
@@ -478,7 +478,7 @@ jobs:
     needs:
       - build-grafana
     name: A11y test
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-x64-large
     permissions:
       contents: read
 

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -307,7 +307,7 @@ jobs:
     needs:
       - build-grafana
     name: Playwright E2E tests (${{ matrix.shard }}/${{ matrix.shardTotal }})
-    runs-on: ubuntu-x64-xlarge
+    runs-on: ubuntu-x64-large
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -125,6 +125,10 @@ jobs:
     outputs:
       artifact: ${{ steps.artifact.outputs.artifact }}
     steps:
+      - uses: grafana/shared-workflows/actions/dockerhub-login@main
+        if: github.event.pull_request.head.repo.fork == false
+      - uses: grafana/shared-workflows/actions/login-to-gar@main
+        if: github.event.pull_request.head.repo.fork == false
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
@@ -225,6 +229,10 @@ jobs:
       contents: read
 
     steps:
+      - uses: grafana/shared-workflows/actions/dockerhub-login@main
+        if: github.event.pull_request.head.repo.fork == false
+      - uses: grafana/shared-workflows/actions/login-to-gar@main
+        if: github.event.pull_request.head.repo.fork == false
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
@@ -268,6 +276,11 @@ jobs:
       contents: read
 
     steps:
+      - uses: grafana/shared-workflows/actions/dockerhub-login@main
+        if: github.event.pull_request.head.repo.fork == false
+      - uses: grafana/shared-workflows/actions/login-to-gar@main
+        if: github.event.pull_request.head.repo.fork == false
+
       - name: Checkout code
         uses: actions/checkout@v5
         with:
@@ -302,6 +315,10 @@ jobs:
         shardTotal: [8]
 
     steps:
+      - uses: grafana/shared-workflows/actions/dockerhub-login@main
+        if: github.event.pull_request.head.repo.fork == false
+      - uses: grafana/shared-workflows/actions/login-to-gar@main
+        if: github.event.pull_request.head.repo.fork == false
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
@@ -331,6 +348,11 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - uses: grafana/shared-workflows/actions/dockerhub-login@main
+        if: github.event.pull_request.head.repo.fork == false
+      - uses: grafana/shared-workflows/actions/login-to-gar@main
+        if: github.event.pull_request.head.repo.fork == false
+
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
@@ -398,6 +420,11 @@ jobs:
     name: All Playwright tests complete
     runs-on: ubuntu-latest
     steps:
+      - uses: grafana/shared-workflows/actions/dockerhub-login@main
+        if: github.event.pull_request.head.repo.fork == false
+      - uses: grafana/shared-workflows/actions/login-to-gar@main
+        if: github.event.pull_request.head.repo.fork == false
+
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
@@ -483,6 +510,10 @@ jobs:
       contents: read
 
     steps:
+      - uses: grafana/shared-workflows/actions/dockerhub-login@main
+        if: github.event.pull_request.head.repo.fork == false
+      - uses: grafana/shared-workflows/actions/login-to-gar@main
+        if: github.event.pull_request.head.repo.fork == false
       - uses: actions/checkout@v5
         with:
           persist-credentials: false

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -304,7 +304,7 @@ jobs:
     needs:
       - build-grafana
     name: Playwright E2E tests (${{ matrix.shard }}/${{ matrix.shardTotal }})
-    runs-on: ubuntu-x64-large
+    runs-on: ubuntu-x64-xlarge
     permissions:
       contents: read
 

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -122,6 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     outputs:
       artifact: ${{ steps.artifact.outputs.artifact }}
     steps:
@@ -227,6 +228,7 @@ jobs:
     runs-on: ubuntu-x64-large
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - uses: grafana/shared-workflows/actions/dockerhub-login@main
@@ -274,6 +276,7 @@ jobs:
     if: needs.detect-changes.outputs.changed == 'true'
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - uses: grafana/shared-workflows/actions/dockerhub-login@main
@@ -307,6 +310,7 @@ jobs:
     runs-on: ubuntu-x64-xlarge
     permissions:
       contents: read
+      id-token: write
 
     strategy:
       fail-fast: false
@@ -419,6 +423,9 @@ jobs:
     if: ${{ !cancelled() }}
     name: All Playwright tests complete
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: grafana/shared-workflows/actions/dockerhub-login@main
         if: github.event.pull_request.head.repo.fork == false
@@ -508,6 +515,7 @@ jobs:
     runs-on: ubuntu-x64-large
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - uses: grafana/shared-workflows/actions/dockerhub-login@main

--- a/.github/workflows/run-schema-v2-e2e.yml
+++ b/.github/workflows/run-schema-v2-e2e.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   dashboard-schema-v2-e2e:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-x64-large
     continue-on-error: true
     if: github.event.pull_request.draft == false
     steps:

--- a/.github/workflows/storybook-a11y.yml
+++ b/.github/workflows/storybook-a11y.yml
@@ -28,7 +28,7 @@ jobs:
           self: .github/workflows/storybook-a11y.yml
 
   test-storybook-a11y-light:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-x64-large
     permissions:
       contents: read
       id-token: write
@@ -58,7 +58,7 @@ jobs:
       run: npx wait-on --timeout 120000 http://localhost:9001 && yarn test:storybook
 
   test-storybook-a11y-dark:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-x64-large
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Switching for our self-hosted runners - time spent on the CI should be the same!