### PR TITLE
I18n: Add LANG override to make command

### DIFF
--- a/.github/workflows/i18n-verify.yml
+++ b/.github/workflows/i18n-verify.yml
@@ -14,4 +14,7 @@ jobs:
   verify-i18n:
     # Run on `grafana/grafana` main branch, or on pull requests to prevent double-running on mirrors
     if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
+    strategy:
+      matrix:
+        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     uses: grafana/grafana-github-actions/.github/workflows/verify-i18n.yml@main

--- a/.github/workflows/i18n-verify.yml
+++ b/.github/workflows/i18n-verify.yml
@@ -14,7 +14,4 @@ jobs:
   verify-i18n:
     # Run on `grafana/grafana` main branch, or on pull requests to prevent double-running on mirrors
     if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
-    strategy:
-      matrix:
-        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     uses: grafana/grafana-github-actions/.github/workflows/verify-i18n.yml@main

--- a/Makefile
+++ b/Makefile
@@ -136,17 +136,17 @@ i18n-extract-enterprise:
 else
 i18n-extract-enterprise:
 	@echo "Extracting i18n strings for Enterprise"
-	cd public/locales/enterprise && yarn run i18next-cli extract --sync-primary
+	cd public/locales/enterprise && LANG=en_US.UTF-8 yarn run i18next-cli extract --sync-primary
 endif
 
 .PHONY: i18n-extract
 i18n-extract: i18n-extract-enterprise
 	@echo "Extracting i18n strings for OSS"
-	yarn run i18next-cli extract --sync-primary
+	LANG=en_US.UTF-8 yarn run i18next-cli extract --sync-primary
 	@echo "Extracting i18n strings for packages"
-	yarn run packages:i18n-extract
+	LANG=en_US.UTF-8 yarn run packages:i18n-extract
 	@echo "Extracting i18n strings for plugins"
-	yarn run plugin:i18n-extract
+	LANG=en_US.UTF-8 yarn run plugin:i18n-extract
 
 ##@ Building
 .PHONY: gen-cue

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "plugins:build-bundled": "echo 'bundled plugins are no longer supported'",
     "watch": "yarn start -d watch,start core:start --watchTheme",
     "i18n:stats": "node ./scripts/cli/reportI18nStats.mjs",
-    "i18n-extract": "make i18n-extract",
+    "i18n-extract": "LANG=en_US.UTF-8 make i18n-extract",
     "plugin:build": "nx run-many -t build --projects='tag:scope:plugin'",
     "plugin:build:commit": "nx run-many -t build:commit --projects='tag:scope:plugin'",
     "plugin:build:dev": "nx run-many -t dev --projects='tag:scope:plugin' --maxParallel=100",


### PR DESCRIPTION
After some (unsuccessful) tries of making the i18n extraction more robust by using custom sort function we abandoned that https://github.com/grafana/grafana/pull/118178 due to flakiness. The reliance on a specific locale for the sort is still there though and this should ensure that everybody running the extraction will get the same results no matter what their locale is.