### PR TITLE
FS: Add QPS and Burst configuration for settings service

### DIFF
--- a/pkg/services/frontend/settings_service.go
+++ b/pkg/services/frontend/settings_service.go
@@ -24,12 +24,16 @@ import (
 //
 // [settings_service]
 // url =
+// qps =
+// burst =
 //
 // Returns nil if not configured (this is not an error condition). Errors returned should
 // be considered critical.
 func setupSettingsService(cfg *setting.Cfg, promRegister prometheus.Registerer) (settingservice.Service, error) {
 	settingsSec := cfg.SectionWithEnvOverrides("settings_service")
 	settingsServiceURL := settingsSec.Key("url").String()
+	settingsServiceQPS := float32(settingsSec.Key("qps").MustFloat64(0))
+	settingsServiceBurst := settingsSec.Key("burst").MustInt(0)
 	if settingsServiceURL == "" {
 		// If settings service URL is not configured, return nil *without* error
 		return nil, nil
@@ -63,6 +67,8 @@ func setupSettingsService(cfg *setting.Cfg, promRegister prometheus.Registerer) 
 		URL:                 settingsServiceURL,
 		TokenExchangeClient: tokenClient,
 		TLSClientConfig:     tlsConfig,
+		QPS:                 settingsServiceQPS,
+		Burst:               settingsServiceBurst,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create settings service client: %w", err)


### PR DESCRIPTION
**What is this feature?**

The settings service client now supports configurable QPS (queries per second) and Burst rate limiting parameters via INI configuration or environment variables.

**Why do we need this feature?**

Previously, the settings service client always used hardcoded defaults (QPS=10, Burst=25). This change allows operators to tune rate limiting based on their deployment requirements without code changes.

**Who is this feature for?**

Grafana operators who need to adjust rate limiting for the settings service client to match their performance and availability requirements.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] The implementation follows existing configuration patterns in the codebase.