### PR TITLE
Provisioning: add finalizers if not present in repo test endpoint

### DIFF
--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -134,7 +134,7 @@ func (s *testConnector) Connect(ctx context.Context, name string, _ runtime.Obje
 
 						// Copying previous finalizers
 						if len(cfg.GetFinalizers()) == 0 {
-							cfg.Finalizers = oldCfg.GetFinalizers()
+							cfg.SetFinalizers(oldCfg.GetFinalizers())
 						}
 					}
 				}
@@ -147,10 +147,10 @@ func (s *testConnector) Connect(ctx context.Context, name string, _ runtime.Obje
 				// In case the given repo has no finalizers, set the default ones.
 				// This is because we now enforce their existence at validation time.
 				if len(cfg.GetFinalizers()) == 0 {
-					cfg.Finalizers = []string{
+					cfg.SetFinalizers([]string{
 						repository.RemoveOrphanResourcesFinalizer,
 						repository.CleanFinalizer,
-					}
+					})
 				}
 
 				// In case a connection is specified, we should try creating a new token with given info

--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -131,12 +131,26 @@ func (s *testConnector) Connect(ctx context.Context, name string, _ runtime.Obje
 					if old != nil {
 						oldCfg := old.Config()
 						repository.CopySecureValues(&cfg, oldCfg)
+
+						// Copying previous finalizers
+						if len(cfg.GetFinalizers()) == 0 {
+							cfg.Finalizers = oldCfg.GetFinalizers()
+						}
 					}
 				}
 
 				cfg.SetName(name)
 				if cfg.GetNamespace() == "" {
 					cfg.SetNamespace(ns)
+				}
+
+				// In case the given repo has no finalizers, set the default ones.
+				// This is because we now enforce their existence at validation time.
+				if len(cfg.GetFinalizers()) == 0 {
+					cfg.Finalizers = []string{
+						repository.RemoveOrphanResourcesFinalizer,
+						repository.CleanFinalizer,
+					}
 				}
 
 				// In case a connection is specified, we should try creating a new token with given info


### PR DESCRIPTION
**What is this feature?**

https://github.com/grafana/grafana/pull/118078 introduced a bug in repository test endpoint, as the `/test` doesn't enforce the presence of finalizers in given object.

**Why do we need this feature?**

To have a properly working test endpoint, and enforce finalizers presence.

**Who is this feature for?**

Users of GitSync

**Which issue(s) does this PR fix?**:

No issue - followup from https://github.com/grafana/grafana/pull/118078

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
