### PR TITLE
VariableEditor: Fix values not showing in preview table

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/components/VariableValuesPreview.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/VariableValuesPreview.test.tsx
@@ -1,0 +1,101 @@
+import { render, within } from '@testing-library/react';
+
+import { selectors } from '@grafana/e2e-selectors';
+import { VariableValueOption } from '@grafana/scenes';
+
+import { VariableValuesPreview, VariableValuesPreviewProps } from './VariableValuesPreview';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  config: {
+    ...jest.requireActual('@grafana/runtime').config,
+    featureToggles: {
+      multiPropsVariables: true,
+    },
+  },
+}));
+
+function renderPreview(props: VariableValuesPreviewProps) {
+  const renderResult = render(<VariableValuesPreview options={props.options} staticOptions={props.staticOptions} />);
+
+  return {
+    ...renderResult,
+    elements: {
+      multiPropsPreviewTable: () =>
+        // the <InteractiveTable /> is wrapped in a div because it does not allow a data-testid attribute
+        within(
+          renderResult.getByTestId(selectors.pages.Dashboard.Settings.Variables.Edit.CustomVariable.previewTable)
+        ).getByRole('table') as HTMLTableElement,
+    },
+  };
+}
+
+describe('VariableValuesPreview', () => {
+  describe('multiple properties preview', () => {
+    test('renders the options in a table', () => {
+      const options: VariableValueOption[] = [
+        { label: 'Development', value: 'dev', properties: { region: 'eu' } },
+        { label: 'Production', value: 'prod', properties: { region: 'us' } },
+        { label: 'Staging', value: 'stag', properties: { region: 'apac' } },
+      ];
+      const { elements } = renderPreview({ options, staticOptions: [] });
+
+      const table = elements.multiPropsPreviewTable();
+
+      const expectedHeaders = ['text', 'value', 'region'];
+      const headerCells = within(table).getAllByRole('columnheader');
+      expect(headerCells).toHaveLength(expectedHeaders.length);
+      expect(headerCells.map((cell) => cell.textContent)).toEqual(expectedHeaders);
+
+      const expectedRows = [
+        ['Development', 'dev', 'eu'],
+        ['Production', 'prod', 'us'],
+        ['Staging', 'stag', 'apac'],
+      ];
+
+      const rows = Array.from(table.tBodies[0].rows);
+      expect(rows).toHaveLength(expectedRows.length);
+      expectedRows.forEach((expectedCells, index) => {
+        expect(
+          within(rows[index])
+            .getAllByRole('cell')
+            .map((cell) => cell.textContent)
+        ).toEqual(expectedCells);
+      });
+    });
+
+    describe('if several options have the same value', () => {
+      test('renders properly all the options in a table', () => {
+        const options: VariableValueOption[] = [
+          { label: 'Development', value: 'env', properties: { region: 'eu' } },
+          { label: 'Production', value: 'env', properties: { region: 'us' } },
+          { label: 'Staging', value: 'env', properties: { region: 'apac' } },
+        ];
+        const { elements } = renderPreview({ options, staticOptions: [] });
+
+        const table = elements.multiPropsPreviewTable();
+
+        const expectedHeaders = ['text', 'value', 'region'];
+        const headerCells = within(table).getAllByRole('columnheader');
+        expect(headerCells).toHaveLength(expectedHeaders.length);
+        expect(headerCells.map((cell) => cell.textContent)).toEqual(expectedHeaders);
+
+        const expectedRows = [
+          ['Development', 'env', 'eu'],
+          ['Production', 'env', 'us'],
+          ['Staging', 'env', 'apac'],
+        ];
+
+        const rows = Array.from(table.tBodies[0].rows);
+        expect(rows).toHaveLength(expectedRows.length);
+        expectedRows.forEach((expectedCells, index) => {
+          expect(
+            within(rows[index])
+              .getAllByRole('cell')
+              .map((cell) => cell.textContent)
+          ).toEqual(expectedCells);
+        });
+      });
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/settings/variables/components/VariableValuesPreview.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/VariableValuesPreview.tsx
@@ -9,7 +9,7 @@ import { SceneVariable, VariableValueOption, VariableValueOptionProperties } fro
 import { Button, InlineFieldRow, InlineLabel, InteractiveTable, Text, useStyles2 } from '@grafana/ui';
 import { ALL_VARIABLE_VALUE } from 'app/features/variables/constants';
 
-interface VariableValuesPreviewProps {
+export interface VariableValuesPreviewProps {
   options: VariableValueOption[];
   staticOptions: VariableValueOption[];
 }
@@ -115,7 +115,7 @@ function VariableValuesWithPropsPreview({
         className={styles.table}
         columns={columns}
         data={data}
-        getRowId={(r) => String(r.value)}
+        getRowId={(r) => JSON.stringify(r)}
         pageSize={8}
       />
     </div>


### PR DESCRIPTION
This PR fixes a bug in the variable values preview table when several options share the same value.
The issue was limited to preview rendering in the UI.
Variable creation was correct, and options were still created as expected.

| Before | After |
|  ---   |  ---  |
| <img width="724" height="414" alt="image" src="https://github.com/user-attachments/assets/d7384694-9a96-4a2c-a433-00afb98185f1" /> | <img width="732" height="459" alt="image" src="https://github.com/user-attachments/assets/70940257-28a9-4d60-beaa-fcad7a6684e8" /> |

Related (but not a fix for): https://github.com/grafana/grafana/issues/118153