### PR TITLE
SeriesIcon: Remove noMargin prop and make it default behaviour

### DIFF
--- a/packages/grafana-ui/src/components/VizLegend/SeriesIcon.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/SeriesIcon.tsx
@@ -11,11 +11,10 @@ export interface Props extends React.HTMLAttributes<HTMLDivElement> {
   color?: string;
   gradient?: string;
   lineStyle?: LineStyle;
-  noMargin?: boolean;
 }
 
 export const SeriesIcon = React.memo(
-  React.forwardRef<HTMLDivElement, Props>(({ color, className, gradient, lineStyle, noMargin, ...restProps }, ref) => {
+  React.forwardRef<HTMLDivElement, Props>(({ color, className, gradient, lineStyle, ...restProps }, ref) => {
     const theme = useTheme2();
     const styles = useStyles2(getStyles);
 
@@ -60,7 +59,7 @@ export const SeriesIcon = React.memo(
       <div
         data-testid="series-icon"
         ref={ref}
-        className={cx(className, styles.forcedColors, styles.container, noMargin ? null : styles.margin)}
+        className={cx(className, styles.forcedColors, styles.container)}
         style={customStyle}
         {...restProps}
       />
@@ -69,9 +68,6 @@ export const SeriesIcon = React.memo(
 );
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  margin: css({
-    marginRight: '8px',
-  }),
   container: css({
     display: 'inline-block',
     width: '14px',

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendListItem.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendListItem.tsx
@@ -117,6 +117,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: 'flex',
     whiteSpace: 'nowrap',
     alignItems: 'center',
+    gap: theme.spacing(1),
     flexGrow: 1,
   }),
   value: css({

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.tsx
@@ -148,6 +148,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       whiteSpace: 'nowrap',
       alignItems: 'center',
+      gap: theme.spacing(1),
     }),
     value: css({
       textAlign: 'right',

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipColorIndicator.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipColorIndicator.tsx
@@ -38,7 +38,6 @@ export const VizTooltipColorIndicator = ({
       <SeriesIcon
         color={color}
         lineStyle={lineStyle}
-        noMargin
         className={cx(
           position === ColorIndicatorPosition.Leading ? styles.leading : styles.trailing,
           styles.seriesIndicator

--- a/packages/grafana-ui/src/graveyard/Graph/GraphContextMenu.tsx
+++ b/packages/grafana-ui/src/graveyard/Graph/GraphContextMenu.tsx
@@ -19,6 +19,7 @@ import { SeriesIcon } from '../../components/VizLegend/SeriesIcon';
 import { useStyles2 } from '../../themes/ThemeContext';
 
 import { GraphDimensions } from './GraphTooltip/types';
+import { Stack } from '../../components/Layout/Stack/Stack';
 
 /** @deprecated */
 export type ContextDimensions<T extends Dimensions = any> = { [key in keyof T]: [number, number | undefined] | null };
@@ -121,10 +122,10 @@ export const GraphContextMenuHeader = ({
     <div className={styles.wrapper}>
       <strong>{timestamp}</strong>
       <HorizontalGroup>
-        <div>
+        <Stack alignItems="center" gap={1}>
           <SeriesIcon color={seriesColor} />
           <span className={styles.displayName}>{displayName}</span>
-        </div>
+        </Stack>
         {displayValue && <FormattedValueDisplay value={displayValue} />}
       </HorizontalGroup>
     </div>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- removes the margin from `SeriesIcon`
- removes the `noMargin` prop
- adjusts the rest of the app to match

**Why do we need this feature?**

- G13 seems like a good time to make a small breaking change like this
  - we shouldn't merge this until 12.4 has been cut
  - looking at https://ops.grafana-ops.net/d/dmb2o0xnz/imported-property-details?orgId=1&from=now-6h&to=now&timezone=Europe%2FBerlin&var-packageName=@grafana%2Fui&var-propertyName=SeriesIcon, there is only 1 external package that we know of using this component

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.


# Release notice breaking change

The margin on `SeriesIcon`, and the corresponding `noMargin` prop have been removed. If you were already using `noMargin`, there is nothing to do except remove the prop. Otherwise you'll need to handle the spacing in your consuming component. You can do this either by using a flex container with a `gap`, or passing a `className` with `margin` to `SeriesIcon`