### PR TITLE
fix: status n subresource keyfunc

### DIFF
--- a/pkg/services/apiserver/appinstaller/server.go
+++ b/pkg/services/apiserver/appinstaller/server.go
@@ -160,11 +160,11 @@ func (s *serverWrapper) configureStorage(gr schema.GroupResource, dualWriteSuppo
 
 	// if the storage is a status store, we need to extract the underlying generic registry store
 	if statusStore, ok := storage.(*appsdkapiserver.StatusREST); ok {
-		isNamespaced := statusStore.Store.CreateStrategy != nil && statusStore.Store.CreateStrategy.NamespaceScoped()
-		if isNamespaced {
-			statusStore.Store.KeyFunc = grafanaregistry.NamespaceKeyFunc(gr)
-			statusStore.Store.KeyRootFunc = grafanaregistry.KeyRootFunc(gr)
-		} else {
+		isClusterScoped := statusStore.Store.CreateStrategy != nil && !statusStore.Store.CreateStrategy.NamespaceScoped()
+
+		statusStore.Store.KeyFunc = grafanaregistry.NamespaceKeyFunc(gr)
+		statusStore.Store.KeyRootFunc = grafanaregistry.KeyRootFunc(gr)
+		if isClusterScoped {
 			statusStore.Store.KeyFunc = grafanaregistry.ClusterScopedKeyFunc(gr)
 			statusStore.Store.KeyRootFunc = grafanaregistry.ClusterKeyRootFunc(gr)
 			// Note: StatusREST for cluster-scoped resources relies on API-level authorization.
@@ -182,11 +182,11 @@ func (s *serverWrapper) configureStorage(gr schema.GroupResource, dualWriteSuppo
 
 	// if the storage is a subresource store, we need to extract the underlying generic registry store
 	if subresourceStore, ok := storage.(*appsdkapiserver.SubresourceREST); ok {
-		isNamespaced := subresourceStore.Store.CreateStrategy != nil && subresourceStore.Store.CreateStrategy.NamespaceScoped()
-		if isNamespaced {
-			subresourceStore.Store.KeyFunc = grafanaregistry.NamespaceKeyFunc(gr)
-			subresourceStore.Store.KeyRootFunc = grafanaregistry.KeyRootFunc(gr)
-		} else {
+		isClusterScoped := subresourceStore.Store.CreateStrategy != nil && !subresourceStore.Store.CreateStrategy.NamespaceScoped()
+
+		subresourceStore.Store.KeyFunc = grafanaregistry.NamespaceKeyFunc(gr)
+		subresourceStore.Store.KeyRootFunc = grafanaregistry.KeyRootFunc(gr)
+		if isClusterScoped {
 			subresourceStore.Store.KeyFunc = grafanaregistry.ClusterScopedKeyFunc(gr)
 			subresourceStore.Store.KeyRootFunc = grafanaregistry.ClusterKeyRootFunc(gr)
 			// Note: SubresourceREST for cluster-scoped resources relies on API-level authorization.


### PR DESCRIPTION
Based on convo:
https://raintank-corp.slack.com/archives/C04RVCAG9B5/p1771240830572519

To test enable `grafanaAdvisor = true` and then:
```
# Create check
curl 'http://localhost:3000/apis/advisor.grafana.app/v0alpha1/namespaces/default/checks' \
  -u "admin:admin" \
  -H 'content-type: application/json' \
  --data-raw '{"kind":"Check","apiVersion":"advisor.grafana.app/v0alpha1","spec":{"data":{}},"metadata":{"name":"check-test","labels":{"advisor.grafana.app/type":"config"},"namespace":"default"},"status":{"report":{"count":0,"failures":[]}}}'

# Validate that check exists
curl -u 'admin:admin' http://localhost:3000/apis/advisor.grafana.app/v0alpha1/namespaces/default/checks/check-test

# Patch it
curl -X PATCH \
  'http://localhost:3000/apis/advisor.grafana.app/v0alpha1/namespaces/default/checks/check-test/status' \
  -H 'Content-Type: application/json-patch+json' \
  -u 'admin:admin' \
  -d '[{"op": "add", "path": "/status", "value": {"report": {"count":1,"failures":[]}}}]'
```