### PR TITLE
Alerting: Use semantic theme colors for Alert Activity

### DIFF
--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -15,7 +15,7 @@ import {
   SceneVariableSet,
   VariableValueSelectors,
 } from '@grafana/scenes';
-import { Icon, Text, Tooltip, useTheme2 } from '@grafana/ui';
+import { Icon, Text, Tooltip } from '@grafana/ui';
 
 import { getAPINamespace } from '../../../../api/utils';
 import { SectionFooter } from '../insights/SectionFooter';

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -1,6 +1,6 @@
 import { DataSourceInstanceSettings, DataSourceJsonData } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { config, getDataSourceSrv } from '@grafana/runtime';
 import {
   EmbeddedScene,
   NestedScene,
@@ -71,26 +71,28 @@ const grafanaCloudPromDs: DataSourceInformation = {
   settings: undefined,
 };
 
-const SERIES_COLORS = {
-  alerting: 'red',
-  firing: 'red',
-  active: 'red',
-  missed: 'red',
-  failed: 'red',
-  // we'll use a specific "yellow" that works for both dark and light theme with sufficient contrast
-  pending: 'rgb(255, 153, 0)',
-  recovering: 'rgb(255, 153, 0)',
-  nodata: 'blue',
-  'active evaluation': 'blue',
-  normal: 'green',
-  success: 'green',
-  error: 'orange',
+const themeColors = config.theme2.colors;
+
+const SERIES_COLOR_MAPPING = {
+  alerting: themeColors.error.main,
+  firing: themeColors.error.main,
+  active: themeColors.error.main,
+  missed: themeColors.error.main,
+  failed: themeColors.error.main,
+  pending: themeColors.warning.main,
+  recovering: themeColors.warning.main,
+  nodata: themeColors.info.main,
+  'active evaluation': themeColors.info.main,
+  normal: themeColors.success.main,
+  success: themeColors.success.main,
+  error: themeColors.warning.text,
 };
 
-export function overrideToFixedColor(key: keyof typeof SERIES_COLORS) {
+// ⚠️ these colors will _not_ update if user changes their theme without refreshing
+export function overrideToFixedColor(key: keyof typeof SERIES_COLOR_MAPPING) {
   return {
     mode: 'fixed',
-    fixedColor: SERIES_COLORS[key],
+    fixedColor: SERIES_COLOR_MAPPING[key],
   };
 }
 

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -15,7 +15,7 @@ import {
   SceneVariableSet,
   VariableValueSelectors,
 } from '@grafana/scenes';
-import { Icon, Text, Tooltip } from '@grafana/ui';
+import { Icon, Text, Tooltip, useTheme2 } from '@grafana/ui';
 
 import { getAPINamespace } from '../../../../api/utils';
 import { SectionFooter } from '../insights/SectionFooter';
@@ -77,8 +77,9 @@ const SERIES_COLORS = {
   active: 'red',
   missed: 'red',
   failed: 'red',
-  pending: 'yellow',
-  recovering: 'yellow',
+  // we'll use a specific "yellow" that works for both dark and light theme with sufficient contrast
+  pending: 'rgb(255, 153, 0)',
+  recovering: 'rgb(255, 153, 0)',
   nodata: 'blue',
   'active evaluation': 'blue',
   normal: 'green',


### PR DESCRIPTION
**What is this feature?**

Uses a slightly darker shade of yellow for the light theme following user feedback.