### PR TITLE
Alerting: Support matching alert labels in notification history views.

### DIFF
--- a/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
+++ b/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
@@ -84,10 +84,10 @@ export const NotificationsList = React.memo(function NotificationsList({
       const toDate = timeRange.to.toISOString();
 
       // Convert label filter to API matchers
-      let groupLabels: CreateNotificationqueryMatcher[] = [];
+      let labels: CreateNotificationqueryMatcher[] = [];
       if (labelFilter && labelFilter.trim()) {
         const matchers = parsePromQLStyleMatcherLooseSafe(labelFilter);
-        groupLabels = matchers.map(matcherToAPIFormat);
+        labels = matchers.map(matcherToAPIFormat);
       }
 
       createNotificationQuery({
@@ -98,7 +98,7 @@ export const NotificationsList = React.memo(function NotificationsList({
           status: isNotificationStatus(statusFilter) ? statusFilter : undefined,
           outcome: isNotificationOutcome(outcomeFilter) ? outcomeFilter : undefined,
           receiver: receiverFilter && receiverFilter !== 'all' ? receiverFilter : undefined,
-          groupLabels,
+          labels,
         },
       });
     } catch {
@@ -258,7 +258,7 @@ function NotificationRow({ record, onLabelClick }: NotificationRowProps) {
       </div>
       {!isCollapsed && (
         <div className={styles.expandedRow}>
-          <NotificationDetails record={record} />
+          <NotificationDetails record={record} onLabelClick={onLabelClick} />
         </div>
       )}
     </Stack>
@@ -280,9 +280,10 @@ function NotificationState({ status }: NotificationStateProps) {
 
 interface NotificationDetailsProps {
   record: NotificationEntry;
+  onLabelClick: ([value, key]: [string | undefined, string | undefined]) => void;
 }
 
-function NotificationDetails({ record }: NotificationDetailsProps) {
+function NotificationDetails({ record, onLabelClick }: NotificationDetailsProps) {
   const styles = useStyles2(getStyles);
 
   // Split alerts into firing and resolved
@@ -344,7 +345,7 @@ function NotificationDetails({ record }: NotificationDetailsProps) {
                   <Trans i18nKey="alerting.notifications-scene.labels">Labels:</Trans>
                 </strong>
               </Text>
-              <AlertLabels labels={filteredLabels} size="sm" />
+              <AlertLabels labels={filteredLabels} size="sm" onClick={onLabelClick} />
             </Stack>
           )}
           {hasOtherAnnotations && (

--- a/public/app/features/alerting/unified/notifications/NotificationsRuntimeDataSource.ts
+++ b/public/app/features/alerting/unified/notifications/NotificationsRuntimeDataSource.ts
@@ -110,10 +110,10 @@ class NotificationsAPIDatasource extends RuntimeDataSource<NotificationsAPIQuery
     const labelFilter = templateSrv.replace(query.labelFilter ?? '', request.scopedVars);
 
     // Convert label filter to API matchers
-    let groupLabels: CreateNotificationqueryMatcher[] = [];
+    let labels: CreateNotificationqueryMatcher[] = [];
     if (labelFilter && labelFilter.trim()) {
       const matchers = parsePromQLStyleMatcherLooseSafe(labelFilter);
-      groupLabels = matchers.map(matcherToAPIFormat);
+      labels = matchers.map(matcherToAPIFormat);
     }
 
     const notificationResult = await getNotifications(
@@ -122,7 +122,7 @@ class NotificationsAPIDatasource extends RuntimeDataSource<NotificationsAPIQuery
       isNotificationStatus(statusFilter) ? statusFilter : undefined,
       isNotificationOutcome(outcomeFilter) ? outcomeFilter : undefined,
       receiverFilter && receiverFilter !== 'all' ? receiverFilter : undefined,
-      groupLabels
+      labels
     );
 
     const dataFrame = notificationsToDataFrame(notificationResult);
@@ -192,7 +192,7 @@ export const getNotifications = async (
   status?: CreateNotificationqueryNotificationStatus,
   outcome?: CreateNotificationqueryNotificationOutcome,
   receiver?: string,
-  groupLabels?: CreateNotificationqueryMatcher[]
+  labels?: CreateNotificationqueryMatcher[]
 ): Promise<CreateNotificationqueryResponse> => {
   const result = await dispatch(
     notificationsApi.endpoints.createNotificationquery.initiate(
@@ -204,7 +204,7 @@ export const getNotifications = async (
           status: status,
           outcome: outcome,
           receiver: receiver,
-          groupLabels: groupLabels || [],
+          labels: labels || [],
         },
       },
       // @ts-expect-error forceRefetch is a valid RTK Query initiate option but not included in generated types


### PR DESCRIPTION
Support for matching alert labels was added in here: https://github.com/grafana/grafana/pull/118081

This change does two things:
- Uses the new API for filtering labels instead of group labels
- Makes labels in the alert display clickable

The existing ability to search on group labels is somewhat redundant now, it may be removed.

[Screencast from 2026-02-16 14-52-37.webm](https://github.com/user-attachments/assets/76d1b130-479a-496d-b05c-1614475be7f3)
