### PR TITLE
Alerting/Triage: Fix group indentation

### DIFF
--- a/public/app/features/alerting/unified/triage/rows/GenericRow.tsx
+++ b/public/app/features/alerting/unified/triage/rows/GenericRow.tsx
@@ -121,7 +121,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       css({
         padding: 5,
         width: '100%',
-        addingLeft: depth ? `calc(${theme.spacing(depth)} + 5px)` : 5,
+        paddingLeft: depth ? `calc(${theme.spacing(depth)} + 5px)` : 5,
       }),
     groupItemWrapper: (width: number) =>
       css({


### PR DESCRIPTION
This seems to have been caused by a typo – I can investigate some linting rules later.