### PR TITLE
UI: Use TextLink for home links consistently

### DIFF
--- a/packages/grafana-ui/src/components/Link/TextLink.tsx
+++ b/packages/grafana-ui/src/components/Link/TextLink.tsx
@@ -25,8 +25,8 @@ interface TextLinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 't
   variant?: TextLinkVariants;
   /** Override the default weight for the used variant */
   weight?: 'light' | 'regular' | 'medium' | 'bold';
-  /** Set the icon to be shown. An external link will show the 'external-link-alt' icon as default.*/
-  icon?: IconName;
+  /** Set the icon to be shown. An external link will show the 'external-link-alt' icon as default but can be hidden with `null`.*/
+  icon?: IconName | null;
   children: React.ReactNode;
 }
 
@@ -57,13 +57,13 @@ export const TextLink = forwardRef<HTMLAnchorElement, TextLinkProps>(
 
     const theme = useTheme2();
     const styles = getLinkStyles(theme, inline, variant, weight, color);
-    const externalIcon = icon || 'external-link-alt';
+    const externalIcon = icon === undefined ? 'external-link-alt' : icon;
 
     if (external) {
       return (
         <a href={validUrl} ref={ref} {...rest} target="_blank" rel="noreferrer" className={styles.wrapper}>
           {children}
-          <Icon className={styles.icon} size={svgSizes[variant] || 'md'} name={externalIcon} />
+          {externalIcon && <Icon className={styles.icon} size={svgSizes[variant] || 'md'} name={externalIcon} />}
         </a>
       );
     }

--- a/packages/grafana-ui/src/components/Link/TextLink.tsx
+++ b/packages/grafana-ui/src/components/Link/TextLink.tsx
@@ -25,8 +25,8 @@ interface TextLinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 't
   variant?: TextLinkVariants;
   /** Override the default weight for the used variant */
   weight?: 'light' | 'regular' | 'medium' | 'bold';
-  /** Set the icon to be shown. An external link will show the 'external-link-alt' icon as default but can be hidden with `null`.*/
-  icon?: IconName | null;
+  /** Set the icon to be shown. An external link will show the 'external-link-alt' icon as default.*/
+  icon?: IconName;
   children: React.ReactNode;
 }
 
@@ -57,13 +57,13 @@ export const TextLink = forwardRef<HTMLAnchorElement, TextLinkProps>(
 
     const theme = useTheme2();
     const styles = getLinkStyles(theme, inline, variant, weight, color);
-    const externalIcon = icon === undefined ? 'external-link-alt' : icon;
+    const externalIcon = icon || 'external-link-alt';
 
     if (external) {
       return (
         <a href={validUrl} ref={ref} {...rest} target="_blank" rel="noreferrer" className={styles.wrapper}>
           {children}
-          {externalIcon && <Icon className={styles.icon} size={svgSizes[variant] || 'md'} name={externalIcon} />}
+          <Icon className={styles.icon} size={svgSizes[variant] || 'md'} name={externalIcon} />
         </a>
       );
     }

--- a/public/app/plugins/panel/gettingstarted/GettingStarted.tsx
+++ b/public/app/plugins/panel/gettingstarted/GettingStarted.tsx
@@ -99,7 +99,7 @@ export class GettingStarted extends PureComponent<PanelProps, State> {
           </div>
         ) : (
           <>
-            <Button variant="secondary" fill="text" className={styles.dismiss} onClick={this.dismiss}>
+            <Button size="sm" fill="text" className={styles.dismiss} onClick={this.dismiss}>
               <Trans i18nKey="gettingstarted.getting-started.remove-this-panel">Remove this panel</Trans>
             </Button>
             {currentStep === steps.length - 1 && (
@@ -202,7 +202,6 @@ const getStyles = stylesFactory(() => {
     }),
     dismiss: css({
       alignSelf: 'flex-end',
-      textDecoration: 'underline',
       marginBottom: theme.spacing(1),
     }),
     loading: css({

--- a/public/app/plugins/panel/gettingstarted/components/DocsCard.tsx
+++ b/public/app/plugins/panel/gettingstarted/components/DocsCard.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { Icon, useStyles2 } from '@grafana/ui';
+import { TextLink, useStyles2 } from '@grafana/ui';
 
 import { Card } from '../types';
 
@@ -30,16 +30,16 @@ export const DocsCard = ({ card }: Props) => {
           <h4 className={styles.title}>{card.title}</h4>
         </a>
       </div>
-      <a
-        href={`${card.learnHref}?utm_source=grafana_gettingstarted`}
-        className={styles.learnUrl}
-        target="_blank"
-        rel="noreferrer"
-        onClick={() => reportInteraction('grafana_getting_started_docs', { title: card.title, link: card.learnHref })}
-      >
-        <Trans i18nKey="gettingstarted.docs-card.learn-how">Learn how in the docs</Trans>{' '}
-        <Icon name="external-link-alt" />
-      </a>
+      <div className={styles.learnUrl}>
+        <TextLink
+          href={`${card.learnHref}?utm_source=grafana_gettingstarted`}
+          external
+          inline={false}
+          onClick={() => reportInteraction('grafana_getting_started_docs', { title: card.title, link: card.learnHref })}
+        >
+          <Trans i18nKey="gettingstarted.docs-card.learn-how">Learn how in the docs</Trans>
+        </TextLink>
+      </div>
     </div>
   );
 };
@@ -67,11 +67,13 @@ const getStyles = (theme: GrafanaTheme2, complete: boolean) => {
       display: 'inline-block',
     }),
     learnUrl: css({
-      borderTop: `1px solid ${theme.colors.border.weak}`,
-      position: 'absolute',
-      bottom: 0,
-      padding: theme.spacing(1, 2),
-      width: '100%',
+      a: {
+        borderTop: `1px solid ${theme.colors.border.weak}`,
+        position: 'absolute',
+        bottom: 0,
+        padding: theme.spacing(1, 2),
+        width: '100%',
+      },
     }),
   };
 };

--- a/public/app/plugins/panel/gettingstarted/components/DocsCard.tsx
+++ b/public/app/plugins/panel/gettingstarted/components/DocsCard.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -18,7 +18,7 @@ export const DocsCard = ({ card }: Props) => {
 
   return (
     <div className={styles.card}>
-      <div className={cardContent}>
+      <div className={cx(cardContent, styles.content)}>
         <a
           href={`${card.href}?utm_source=grafana_gettingstarted`}
           className={styles.url}
@@ -49,10 +49,19 @@ const getStyles = (theme: GrafanaTheme2, complete: boolean) => {
     card: css({
       ...cardStyle(theme, complete),
 
+      display: 'flex',
+      flexDirection: 'column',
       minWidth: '230px',
 
       [theme.breakpoints.down('md')]: {
         minWidth: '192px',
+      },
+    }),
+    content: css({
+      flexGrow: 1,
+
+      '&:has(> a:hover)': {
+        backgroundColor: theme.colors.emphasize(theme.colors.background.secondary, 0.03),
       },
     }),
     heading: css({
@@ -65,12 +74,12 @@ const getStyles = (theme: GrafanaTheme2, complete: boolean) => {
     }),
     url: css({
       display: 'inline-block',
+      height: '100%',
     }),
     learnUrl: css({
       a: {
         borderTop: `1px solid ${theme.colors.border.weak}`,
-        position: 'absolute',
-        bottom: 0,
+        display: 'inline-block',
         padding: theme.spacing(1, 2),
         width: '100%',
       },

--- a/public/app/plugins/panel/gettingstarted/components/TutorialCard.tsx
+++ b/public/app/plugins/panel/gettingstarted/components/TutorialCard.tsx
@@ -52,6 +52,10 @@ const getStyles = (theme: GrafanaTheme2, complete: boolean) => {
       width: '460px',
       minWidth: '460px',
 
+      '&:hover': {
+        backgroundColor: theme.colors.emphasize(theme.colors.background.secondary, 0.03),
+      },
+
       [theme.breakpoints.down('xl')]: {
         minWidth: '368px',
       },

--- a/public/app/plugins/panel/news/component/News.tsx
+++ b/public/app/plugins/panel/news/component/News.tsx
@@ -41,7 +41,7 @@ function NewsComponent({ width, showImage, data, index }: NewsItemProps) {
         </time>
 
         <h1 className={styles.title} id={titleId}>
-          <TextLink href={textUtil.sanitizeUrl(newsItem.link)} external icon={null} inline={false}>
+          <TextLink href={textUtil.sanitizeUrl(newsItem.link)} external inline={false}>
             {newsItem.title}
           </TextLink>
         </h1>

--- a/public/app/plugins/panel/news/component/News.tsx
+++ b/public/app/plugins/panel/news/component/News.tsx
@@ -3,7 +3,7 @@ import { useId } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
 import { DataFrameView, GrafanaTheme2, textUtil, dateTimeFormat } from '@grafana/data';
-import { useStyles2 } from '@grafana/ui';
+import { TextLink, useStyles2 } from '@grafana/ui';
 import { attachSkeleton, SkeletonComponent } from '@grafana/ui/unstable';
 
 import { NewsItem } from '../types';
@@ -41,14 +41,9 @@ function NewsComponent({ width, showImage, data, index }: NewsItemProps) {
         </time>
 
         <h1 className={styles.title} id={titleId}>
-          <a
-            className={styles.link}
-            href={textUtil.sanitizeUrl(newsItem.link)}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <TextLink href={textUtil.sanitizeUrl(newsItem.link)} external icon={null} inline={false}>
             {newsItem.title}
-          </a>
+          </TextLink>
         </h1>
         <div className={styles.content} dangerouslySetInnerHTML={{ __html: textUtil.sanitize(newsItem.content) }} />
       </div>
@@ -122,15 +117,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     '> img': {
       width: '250px',
       borderRadius: theme.shape.radius.default,
-    },
-  }),
-  link: css({
-    color: theme.colors.text.link,
-    display: 'inline-block',
-
-    '&:hover': {
-      color: theme.colors.text.link,
-      textDecoration: 'underline',
     },
   }),
   title: css({

--- a/public/app/plugins/panel/welcome/Welcome.tsx
+++ b/public/app/plugins/panel/welcome/Welcome.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { useStyles2 } from '@grafana/ui';
+import { TextLink, useStyles2 } from '@grafana/ui';
 
 const helpOptions = [
   { value: 0, label: 'Documentation', href: 'https://grafana.com/docs/grafana/latest' },
@@ -24,17 +24,17 @@ export const WelcomeBanner = () => {
           <Trans i18nKey="welcome.welcome-banner.need-help">Need help?</Trans>
         </h3>
         <div className={styles.helpLinks}>
-          {helpOptions.map((option, index) => {
-            return (
-              <a
-                key={`${option.label}-${index}`}
-                className={styles.helpLink}
-                href={`${option.href}?utm_source=grafana_gettingstarted`}
-              >
-                {option.label}
-              </a>
-            );
-          })}
+          {helpOptions.map((option, index) => (
+            <TextLink
+              key={`${option.label}-${index}`}
+              href={`${option.href}?utm_source=grafana_gettingstarted`}
+              external
+              icon={null}
+              inline={false}
+            >
+              {option.label}
+            </TextLink>
+          ))}
         </div>
       </div>
     </div>
@@ -95,14 +95,11 @@ const getStyles = (theme: GrafanaTheme2) => {
     helpLinks: css({
       display: 'flex',
       flexWrap: 'wrap',
-    }),
-    helpLink: css({
-      marginRight: theme.spacing(2),
-      textDecoration: 'underline',
+      gap: theme.spacing(2),
       textWrap: 'nowrap',
 
       [theme.breakpoints.down('sm')]: {
-        marginRight: theme.spacing(1),
+        gap: theme.spacing(1),
       },
     }),
   };

--- a/public/app/plugins/panel/welcome/Welcome.tsx
+++ b/public/app/plugins/panel/welcome/Welcome.tsx
@@ -29,7 +29,6 @@ export const WelcomeBanner = () => {
               key={`${option.label}-${index}`}
               href={`${option.href}?utm_source=grafana_gettingstarted`}
               external
-              icon={null}
               inline={false}
             >
               {option.label}


### PR DESCRIPTION
**What is this feature?**

Updates all the panels that we display on the OSS homepage to consistently use `TextLink`. 

Updates the cards in the getting started panel to have a hover affect on them, visually indicating they are clickable.

**Why do we need this feature?**

Visual consistency with all the links presented on the OSS homepage, making it much clearer to the user what actually is a link, and having a more unified style.

**Who is this feature for?**

OSS

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

| Before | After |
|-|-|
| <img width="1905" height="1008" alt="image" src="https://github.com/user-attachments/assets/f96e87cf-e041-4922-be32-a80ec12ce8e2" /> | <img width="1905" height="1008" alt="image" src="https://github.com/user-attachments/assets/081cbfa7-c337-4cd4-a75a-67801692e871" /> |