### PR TITLE
KV Store Garbage Collector implementation

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -650,10 +650,15 @@ type Cfg struct {
 	EnableSQLKVBackend                         bool
 	EnableSQLKVCompatibilityMode               bool
 	EnableGarbageCollection                    bool
+	GarbageCollectionDryRun                    bool
 	GarbageCollectionInterval                  time.Duration
 	GarbageCollectionBatchSize                 int
 	GarbageCollectionMaxAge                    time.Duration
 	DashboardsGarbageCollectionMaxAge          time.Duration
+
+	EventRetentionPeriod time.Duration
+	EventPruningInterval time.Duration
+
 	// SimulatedNetworkLatency is used for testing only
 	SimulatedNetworkLatency       time.Duration
 	TenantApiServerAddress        string

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -130,10 +130,14 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 
 	// garbage collection
 	cfg.EnableGarbageCollection = section.Key("garbage_collection_enabled").MustBool(false)
+	cfg.GarbageCollectionDryRun = section.Key("garbage_collection_dry_run").MustBool(true)
 	cfg.GarbageCollectionInterval = section.Key("garbage_collection_interval").MustDuration(15 * time.Minute)
 	cfg.GarbageCollectionBatchSize = section.Key("garbage_collection_batch_size").MustInt(100)
 	cfg.GarbageCollectionMaxAge = section.Key("garbage_collection_max_age").MustDuration(24 * time.Hour)
 	cfg.DashboardsGarbageCollectionMaxAge = section.Key("dashboards_garbage_collection_max_age").MustDuration(365 * 24 * time.Hour)
+
+	cfg.EventRetentionPeriod = section.Key("event_retention_period").MustDuration(1 * time.Hour)
+	cfg.EventPruningInterval = section.Key("event_pruning_interval").MustDuration(5 * time.Minute)
 
 	// use sqlkv (resource/sqlkv) instead of the sql backend (sql/backend) as the StorageServer
 	cfg.EnableSQLKVBackend = section.Key("enable_sqlkv_backend").MustBool(false)

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -312,6 +312,7 @@ func TestSearchGetOrCreateIndexWithCancellation(t *testing.T) {
 	search := &slowSearchBackendWithCache{
 		mockSearchBackend: mockSearchBackend{},
 	}
+
 	supplier := &TestDocumentBuilderSupplier{
 		GroupsResources: map[string]string{
 			"group": "resource",

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -351,8 +351,13 @@ func (b *kvStorageBackend) initGarbageCollection(ctx context.Context) error {
 		ticker := time.NewTicker(b.garbageCollection.Interval)
 		defer ticker.Stop()
 
-		for range ticker.C {
-			_ = b.runGarbageCollection(ctx, time.Now().Add(-b.garbageCollection.MaxAge).UnixMicro())
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				_ = b.runGarbageCollection(ctx, time.Now().Add(-b.garbageCollection.MaxAge).UnixMicro())
+			}
 		}
 	}()
 

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -345,19 +345,14 @@ func (b *kvStorageBackend) initGarbageCollection(ctx context.Context) error {
 		// delay the first run by a random amount between 0 and the interval to avoid thundering herd
 		if b.garbageCollection.Interval > 0 {
 			jitter := time.Duration(rand.Int64N(b.garbageCollection.Interval.Nanoseconds()))
-			select {
-			case <-time.After(jitter):
-			}
+			<-time.After(jitter)
 		}
 
 		ticker := time.NewTicker(b.garbageCollection.Interval)
 		defer ticker.Stop()
 
-		for {
-			select {
-			case <-ticker.C:
-				_ = b.runGarbageCollection(ctx, time.Now().Add(-b.garbageCollection.MaxAge).UnixMicro())
-			}
+		for range ticker.C {
+			_ = b.runGarbageCollection(ctx, time.Now().Add(-b.garbageCollection.MaxAge).UnixMicro())
 		}
 	}()
 

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -17,6 +17,7 @@ import (
 	"github.com/bwmarrin/snowflake"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -37,6 +38,15 @@ const (
 	defaultEventPruningInterval = 5 * time.Minute
 	clusterScopeNamespace       = "__cluster__"
 )
+
+type GarbageCollectionConfig struct {
+	Enabled          bool
+	DryRun           bool
+	Interval         time.Duration // how often the process runs
+	BatchSize        int           // max number of candidates to delete (unique NGR)
+	MaxAge           time.Duration // retention period
+	DashboardsMaxAge time.Duration // dashboard retention
+}
 
 // convertClusterNamespaceToEmpty converts the internal __cluster__ namespace back to empty string
 // for cluster-scoped resources when returning to users
@@ -69,6 +79,7 @@ type kvStorageBackend struct {
 	eventRetentionPeriod         time.Duration
 	eventPruningInterval         time.Duration
 	historyPruner                Pruner
+	garbageCollection            GarbageCollectionConfig
 	withExperimentalClusterScope bool
 	lastImportStore              *lastImportStore
 	lastImportTimeMaxAge         time.Duration
@@ -101,6 +112,7 @@ type KVBackendOptions struct {
 	Tracer                       trace.Tracer          // TODO add tracing
 	Reg                          prometheus.Registerer // TODO add metrics
 	Log                          log.Logger
+	GarbageCollection            GarbageCollectionConfig
 
 	UseChannelNotifier bool
 	// Adding RvManager overrides the RV generated with snowflake in order to keep backwards compatibility with
@@ -171,10 +183,16 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 		dbKeepAlive:                  opts.DBKeepAlive,
 		lastImportStore:              newLastImportStore(kv),
 		lastImportTimeMaxAge:         opts.LastImportTimeMaxAge,
+		garbageCollection:            opts.GarbageCollection,
 	}
 	err = backend.initPruner(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize pruner: %w", err)
+	}
+	if backend.garbageCollection.Enabled {
+		if err := backend.initGarbageCollection(ctx); err != nil {
+			return nil, fmt.Errorf("failed to initialize garbage collection: %w", err)
+		}
 	}
 
 	// Optionally start the tenant watcher.
@@ -318,6 +336,192 @@ func (k *kvStorageBackend) initPruner(ctx context.Context) error {
 	k.historyPruner = pruner
 	k.historyPruner.Start(ctx)
 	return nil
+}
+
+func (b *kvStorageBackend) initGarbageCollection(ctx context.Context) error {
+	b.log.Info("starting garbage collection loop")
+
+	go func() {
+		// delay the first run by a random amount between 0 and the interval to avoid thundering herd
+		if b.garbageCollection.Interval > 0 {
+			jitter := time.Duration(rand.Int64N(b.garbageCollection.Interval.Nanoseconds()))
+			select {
+			case <-time.After(jitter):
+			}
+		}
+
+		ticker := time.NewTicker(b.garbageCollection.Interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				_ = b.runGarbageCollection(ctx, time.Now().Add(-b.garbageCollection.MaxAge).UnixMicro())
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeStamp int64) map[string]int64 {
+	ctx, span := tracer.Start(ctx, "sql.backend.runGarbageCollection")
+	defer span.End()
+	start := time.Now()
+
+	deletedByKey := map[string]int64{}
+
+	groupResources, err := b.dataStore.getGroupResources(ctx)
+	if err != nil {
+		b.log.Error("failed to list group resources for garbage collection", "error", err)
+		return deletedByKey
+	}
+
+	for _, gr := range groupResources {
+		resourceKey := gr.Group + "/" + gr.Resource
+		resourceCutoff := b.garbageCollectionCutoffTimestamp(gr.Group, gr.Resource, cutoffTimeStamp)
+		totalDeleted := int64(0)
+
+		key := ListRequestKey{
+			Group:    gr.Group,
+			Resource: gr.Resource,
+		}
+
+		prefix := key.Prefix()
+		startKey := prefix
+		endKey := PrefixRangeEnd(prefix)
+
+		for {
+			deleted, nextKey, err := b.garbageCollectBatch(ctx, gr.Group, gr.Resource, resourceCutoff, b.garbageCollection.BatchSize, startKey, endKey)
+			if err != nil {
+				b.log.Error("garbage collection failed",
+					"group", gr.Group,
+					"resource", gr.Resource,
+					"error", err)
+				break
+			}
+			startKey = nextKey
+			totalDeleted += deleted
+			if deleted < int64(b.garbageCollection.BatchSize) {
+				break
+			}
+			select {
+			case <-time.After(time.Second):
+			}
+		}
+		if totalDeleted > 0 {
+			b.log.Info("garbage collection deleted history",
+				"group", gr.Group,
+				"resource", gr.Resource,
+				"rows", totalDeleted,
+				"seconds", time.Since(start).Seconds(),
+			)
+			deletedByKey[resourceKey] += totalDeleted
+		}
+	}
+
+	return deletedByKey
+}
+
+func (b *kvStorageBackend) garbageCollectBatch(ctx context.Context, group, resourceName string, cutoffTimestamp int64, batchSize int, startKey, endKey string) (int64, string, error) {
+	ctx, span := tracer.Start(ctx, "sql.backend.garbageCollectBatch")
+	span.SetAttributes(attribute.String("group", group), attribute.String("resource", resourceName), attribute.Int64("cutoffTimestamp", cutoffTimestamp), attribute.Int("batchSize", batchSize))
+	defer span.End()
+
+	candidates := []string{}
+
+	nextStartKey := startKey
+
+	// traverse all keys in descending order of resource version,
+	// for deleted keys with resource version older than the cutoff,
+	// check if the resource is not present in the datastore
+	for dataKey, err := range b.kv.Keys(ctx, kv.DataSection, kv.ListOptions{
+		StartKey: startKey,
+		EndKey:   endKey,
+		Sort:     kv.SortOrderDesc}) {
+
+		if err != nil {
+			b.log.Error("failed to list collection before delete: %s", err)
+			return 0, "", err
+		}
+
+		dk, err := ParseKey(dataKey)
+		if err != nil {
+			b.log.Error("failed to parse datakey '%s': %s", dataKey, err)
+			continue
+		}
+
+		resourceCutoffSnowflake := cutoffTimestamp
+		if !isSnowflake(cutoffTimestamp) {
+			resourceCutoffSnowflake = rvmanager.SnowflakeFromRV(cutoffTimestamp)
+		}
+
+		if dk.Action == DataActionDeleted && dk.ResourceVersion < resourceCutoffSnowflake {
+			// ensure that the resource is not present in the datastore
+			_, err := b.dataStore.GetLatestResourceKey(ctx, GetRequestKey{
+				Group:     dk.Group,
+				Resource:  dk.Resource,
+				Namespace: dk.Namespace,
+				Name:      dk.Name,
+			})
+			if err == nil {
+				// resource is still present, skip deletion
+				continue
+			}
+
+			if !errors.Is(err, ErrNotFound) {
+				b.log.Error("failed to get the latest resource key for datakey '%s': %s", dk, err)
+				continue
+			}
+
+			// if we get a not found, then we can delete resource history entries for this resource
+			candidates = append(candidates, dataKey)
+			if len(candidates) >= b.garbageCollection.BatchSize {
+				break
+			}
+		}
+	}
+
+	keysToDelete := []string{}
+	for _, dataKey := range candidates {
+		dk, err := ParseKey(dataKey)
+		if err != nil {
+			b.log.Error("failed to parse datakey '%s': %s", dataKey, err)
+			continue
+		}
+
+		fmt.Printf("candidate dataKey: %+v\n", dataKey)
+		for currDK, _ := range b.dataStore.Keys(ctx, ListRequestKey{
+			Group:     dk.Group,
+			Resource:  dk.Resource,
+			Namespace: dk.Namespace,
+			Name:      dk.Name,
+		}, SortOrderAsc) {
+			keysToDelete = append(keysToDelete, currDK.String())
+			nextStartKey = currDK.String()
+		}
+
+		fmt.Printf("keysToDelete: %+v\n", keysToDelete)
+	}
+
+	if !b.garbageCollection.DryRun {
+		err := b.kv.BatchDelete(ctx, kv.DataSection, keysToDelete)
+		if err != nil {
+			b.log.Error("failed to batch delete keys: %s", err)
+			return 0, "", err
+		}
+
+		return int64(len(keysToDelete)), nextStartKey, nil
+	}
+
+	return 0, "", nil
+}
+
+func (b *kvStorageBackend) garbageCollectionCutoffTimestamp(group, resourceName string, defaultCutoff int64) int64 {
+	if group == "dashboard.grafana.app" && resourceName == "dashboards" {
+		return time.Now().Add(-b.garbageCollection.DashboardsMaxAge).UnixMicro()
+	}
+	return defaultCutoff
 }
 
 // WriteEvent writes a resource event (create/update/delete) to the storage backend.

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -496,8 +496,6 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 					}
 
 					keysDeleted = keysDeleted + int64(len(keysToDelete))
-				} else {
-					b.log.Info("garbage collection not deleting any keys because dry run mode is enabled")
 				}
 			}
 		}

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -374,7 +374,6 @@ func (b *kvStorageBackend) initGarbageCollection(ctx context.Context) error {
 func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeStamp int64) {
 	ctx, span := tracer.Start(ctx, "resource.kvStorageBackend.runGarbageCollection")
 	defer span.End()
-	start := time.Now()
 
 	// get group and resources
 	groupResources, err := b.dataStore.getGroupResources(ctx)
@@ -385,156 +384,160 @@ func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeS
 
 	// for each pair of group and resource
 	for _, gr := range groupResources {
-		// this function will return a map with the number of deleted entries for this group and resource
-		totalDeleted := int64(0)
-
 		// get the cutoff timestamp for this resource, allowing for resource-specific cutoff logic (e.g. different retention for dashboards)
 		resourceCutoff := b.garbageCollectionCutoffTimestamp(gr.Group, gr.Resource, cutoffTimeStamp)
 
-		// get the start and end keys for the list operation based on the resource prefix
-		// for example, for datashboards, the start key will be "unified/data/dashboard.grafana.app/dashboards/"
-		// and the end key will be "unified/data/dashboard.grafana.app/dashboards0"
-		key := ListRequestKey{
-			Group:    gr.Group,
-			Resource: gr.Resource,
-		}
-		prefix := key.Prefix()
-		startKey := prefix
-		endKey := PrefixRangeEnd(prefix)
-
-		for {
-			// garbageCollectBatch will return the number of deleted entries, the number of rows processed, and the next end key for pagination
-			keysDeleted, keysProcessed, nextEndKey, err := b.garbageCollectBatch(ctx, gr.Group, gr.Resource, resourceCutoff, b.garbageCollection.BatchSize, startKey, endKey)
-			if err != nil {
-				b.log.Error("garbage collection failed",
-					"group", gr.Group,
-					"resource", gr.Resource,
-					"error", err)
-				break
-			}
-
-			// if there are no more entries to process, break the loop
-			if keysProcessed == 0 {
-				break
-			}
-
-			// Parse and get the next end key to ensure we can continue paginating. If we can't parse it, we should stop to avoid an infinite loop.
-			nk, err := ParseKey(nextEndKey)
-			if err != nil {
-				b.log.Error("failed to parse nextEndKey '%s': %s", nextEndKey, err)
-				break
-			}
-			key = ListRequestKey{
-				Group:     gr.Group,
-				Resource:  gr.Resource,
-				Namespace: nk.Namespace,
-				Name:      nk.Name,
-			}
-			endKey = key.Prefix()
-
-			totalDeleted += keysDeleted
-
-			// wait a second between batches to avoid overwhelming the datastore
-			<-time.After(time.Second)
-		}
-		if totalDeleted > 0 {
-			b.log.Info("garbage collection deleted history",
+		// garbageCollectGroupResource will remove all deleted key for resources from a given group+resource
+		// with resource versions older than the cutoff timestamp,
+		err := b.garbageCollectGroupResource(ctx, gr.Group, gr.Resource, resourceCutoff)
+		if err != nil {
+			b.log.Error("garbage collection failed",
 				"group", gr.Group,
 				"resource", gr.Resource,
-				"rows", totalDeleted,
-				"seconds", time.Since(start).Seconds(),
-			)
+				"error", err)
+			break
 		}
+
 	}
 }
 
-// garbageCollectBatch scans batches of entries in the datastore for a given group+resource,
+// garbageCollectGroupResource scans batches of entries in the datastore for a given group+resource,
 // in descending order of resource version, looking for deleted entries with resource versions
 // older than the cutoff timestamp.
 // Once it finds a deleted entry, it looks for all previous versions of the same resource
 // up to the deleted version and deletes them in batch.
 // This ensures that we are not going to delete any keys that were created if the resource was recreated after deletion.
-func (b *kvStorageBackend) garbageCollectBatch(ctx context.Context, group, resourceName string, cutoffTimestamp int64, batchSize int, startKey, endKey string) (int64, int64, string, error) {
-	ctx, span := tracer.Start(ctx, "resource.kvStorageBackend.garbageCollectBatch")
+func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, group, resourceName string, cutoffTimestamp int64) error {
+	ctx, span := tracer.Start(ctx, "resource.kvStorageBackend.garbageCollectGroupResource")
+	batchSize := b.garbageCollection.BatchSize
+
 	span.SetAttributes(attribute.String("group", group), attribute.String("resource", resourceName), attribute.Int64("cutoffTimestamp", cutoffTimestamp), attribute.Int("batchSize", batchSize))
 	defer span.End()
+
+	start := time.Now()
 
 	if !isSnowflake(cutoffTimestamp) {
 		cutoffTimestamp = rvmanager.SnowflakeFromRV(cutoffTimestamp)
 	}
 
-	nextEndKey := endKey
+	totalDeleted := int64(0)
 
-	keysProcessed := int64(0)
-	keysDeleted := int64(0)
+	// get the start and end keys for the list operation based on the resource prefix
+	// for example, for datashboards, the start key will be "unified/data/dashboard.grafana.app/dashboards/"
+	// and the end key will be "unified/data/dashboard.grafana.app/dashboards0"
+	key := ListRequestKey{
+		Group:    group,
+		Resource: resourceName,
+	}
+	prefix := key.Prefix()
+	startKey := prefix
+	endKey := PrefixRangeEnd(prefix)
 
-	// traverse all keys in descending order of resource version,
-	// for deleted keys with resource version older than the cutoff,
-	// we will scan a fixed number of keys (batchSize) each time
-	for dataKey, err := range b.kv.Keys(ctx, kv.DataSection, kv.ListOptions{
-		StartKey: startKey,
-		EndKey:   endKey,
-		Limit:    int64(batchSize),
-		Sort:     kv.SortOrderDesc}) {
-		if err != nil {
-			b.log.Error("failed to list collection before delete: %s", err)
-			return 0, 0, "", err
-		}
+	for {
+		keysProcessed := int64(0)
+		keysDeleted := int64(0)
 
-		keysProcessed++
-
-		// parse the datakey to get the action and resource version
-		dk, err := ParseKey(dataKey)
-		if err != nil {
-			b.log.Error("failed to parse datakey '%s': %s", dataKey, err)
-			continue
-		}
-
-		// update the next end key for pagination. We will use this to continue scanning in the next batch
-		nextEndKey = dataKey
-
-		// if the action is deleted and the resource version is older than the cutoff, get all previous versions
-		// of the same resource and delete them in batch
-		if dk.Action == DataActionDeleted && dk.ResourceVersion < cutoffTimestamp {
-			startKey := ListRequestKey{
-				Group:     dk.Group,
-				Resource:  dk.Resource,
-				Namespace: dk.Namespace,
-				Name:      dk.Name,
-			}.Prefix()
-			endKey := PrefixRangeEnd(dk.String())
-
-			keysToDelete := []string{}
-			for deleteKey, err := range b.kv.Keys(ctx, kv.DataSection, ListOptions{
-				StartKey: startKey,
-				EndKey:   endKey,
-				Sort:     kv.SortOrderDesc,
-			}) {
-				if err != nil {
-					b.log.Error("failed to get keys for resource '%s': %s", dk, err)
-					return 0, 0, "", err
-				}
-				b.log.Info("garbage collection", "key to delete", deleteKey)
-				nextEndKey = deleteKey
-				keysToDelete = append(keysToDelete, deleteKey)
+		// traverse all keys in descending order of resource version,
+		// for deleted keys with resource version older than the cutoff,
+		// we will scan a fixed number of keys (batchSize) each time
+		for dataKey, err := range b.kv.Keys(ctx, kv.DataSection, kv.ListOptions{
+			StartKey: startKey,
+			EndKey:   endKey,
+			Limit:    int64(batchSize),
+			Sort:     kv.SortOrderDesc}) {
+			if err != nil {
+				b.log.Error("failed to list collection before delete: %s", err)
+				return err
 			}
 
-			// if not in dry run mode, batch delete the keys and return the number of deleted entries
-			if !b.garbageCollection.DryRun {
-				err := b.kv.BatchDelete(ctx, kv.DataSection, keysToDelete)
-				if err != nil {
-					b.log.Error("failed to batch delete keys: %s", err)
-					return 0, 0, "", err
+			keysProcessed++
+
+			// parse the datakey to get the action and resource version
+			dk, err := ParseKey(dataKey)
+			if err != nil {
+				b.log.Error("failed to parse datakey '%s': %s", dataKey, err)
+				continue
+			}
+
+			// update the next end key for pagination. We will use this to continue scanning in the next batch
+			endKey = dataKey
+
+			// if the action is deleted and the resource version is older than the cutoff, get all previous versions
+			// of the same resource and delete them in batch
+			if dk.Action == DataActionDeleted && dk.ResourceVersion < cutoffTimestamp {
+				startKey := ListRequestKey{
+					Group:     dk.Group,
+					Resource:  dk.Resource,
+					Namespace: dk.Namespace,
+					Name:      dk.Name,
+				}.Prefix()
+				endKey := PrefixRangeEnd(dk.String())
+
+				keysToDelete := []string{}
+				for deleteKey, err := range b.kv.Keys(ctx, kv.DataSection, ListOptions{
+					StartKey: startKey,
+					EndKey:   endKey,
+					Sort:     kv.SortOrderDesc,
+				}) {
+					if err != nil {
+						b.log.Error("failed to get keys for resource '%s': %s", dk, err)
+						return err
+					}
+					b.log.Info("garbage collection", "key to delete", deleteKey)
+					endKey = deleteKey
+					keysToDelete = append(keysToDelete, deleteKey)
 				}
 
-				keysDeleted = keysDeleted + int64(len(keysToDelete))
-			} else {
-				b.log.Info("garbage collection not deleting any keys because dry run mode is enabled")
+				// if not in dry run mode, batch delete the keys and return the number of deleted entries
+				if !b.garbageCollection.DryRun {
+					err := b.kv.BatchDelete(ctx, kv.DataSection, keysToDelete)
+					if err != nil {
+						b.log.Error("failed to batch delete keys: %s", err)
+						return err
+					}
+
+					keysDeleted = keysDeleted + int64(len(keysToDelete))
+				} else {
+					b.log.Info("garbage collection not deleting any keys because dry run mode is enabled")
+				}
 			}
 		}
+
+		// if there are no more entries to process, break the loop
+		if keysProcessed == 0 {
+			break
+		}
+
+		// Parse and get the next end key to ensure we can continue paginating. If we can't parse it, we should stop to avoid an infinite loop.
+		nk, err := ParseKey(endKey)
+		if err != nil {
+			b.log.Error("failed to parse nextEndKey '%s': %s", endKey, err)
+			break
+		}
+		key = ListRequestKey{
+			Group:     group,
+			Resource:  resourceName,
+			Namespace: nk.Namespace,
+			Name:      nk.Name,
+		}
+		endKey = key.Prefix()
+
+		totalDeleted += keysDeleted
+
+		// wait a second between batches to avoid overwhelming the datastore
+		<-time.After(time.Second)
 	}
 
-	return keysDeleted, keysProcessed, nextEndKey, nil
+	if totalDeleted > 0 {
+		b.log.Info("garbage collection deleted history",
+			"group", group,
+			"resource", resourceName,
+			"rows", totalDeleted,
+			"seconds", time.Since(start).Seconds(),
+		)
+	}
+
+	return nil
 }
 
 func (b *kvStorageBackend) garbageCollectionCutoffTimestamp(group, resourceName string, defaultCutoff int64) int64 {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -397,7 +397,6 @@ func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeS
 				"error", err)
 			break
 		}
-
 	}
 }
 
@@ -475,21 +474,20 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 			// if the action is deleted and the resource version is older than the cutoff, get all previous versions
 			// of the same resource and delete them in batch
 			if dk.Action == DataActionDeleted && dk.ResourceVersion < cutoffTimestamp {
-				startKey := k.Prefix()
+				startKeyToDelete := k.Prefix()
 				// end key is exclusive, so we need to add a suffix to make sure we include all the versions we want to delete
-				endKey := PrefixRangeEnd(dk.String())
+				endKeyToDelete := PrefixRangeEnd(dk.String())
 
 				keysToDelete := []string{}
 				for deleteKey, err := range b.kv.Keys(ctx, kv.DataSection, ListOptions{
-					StartKey: startKey,
-					EndKey:   endKey,
+					StartKey: startKeyToDelete,
+					EndKey:   endKeyToDelete,
 					Sort:     kv.SortOrderAsc,
 				}) {
 					if err != nil {
 						return fmt.Errorf("failed to get keys for resource '%s': %s", dk, err)
 					}
 					b.log.Info("garbage collection", "key to delete", deleteKey)
-					endKey = deleteKey
 					keysToDelete = append(keysToDelete, deleteKey)
 				}
 

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -341,6 +341,11 @@ func (k *kvStorageBackend) initPruner(ctx context.Context) error {
 func (b *kvStorageBackend) initGarbageCollection(ctx context.Context) error {
 	b.log.Info("starting garbage collection loop")
 
+	if b.garbageCollection.Interval <= 0 {
+		b.log.Error("garbage collection interval must be greater than 0")
+		return fmt.Errorf("garbage collection interval must be greater than 0")
+	}
+
 	go func() {
 		// delay the first run by a random amount between 0 and the interval to avoid thundering herd
 		if b.garbageCollection.Interval > 0 {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -361,7 +361,7 @@ func (b *kvStorageBackend) initGarbageCollection(ctx context.Context) error {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				_ = b.runGarbageCollection(ctx, time.Now().Add(-b.garbageCollection.MaxAge).UnixMicro())
+				b.runGarbageCollection(ctx, time.Now().Add(-b.garbageCollection.MaxAge).UnixMicro())
 			}
 		}
 	}()
@@ -371,24 +371,21 @@ func (b *kvStorageBackend) initGarbageCollection(ctx context.Context) error {
 
 // runGarbageCollection identifies deleted resources that are safe
 // to be fully removed from the datastore and deletes them in batches.
-func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeStamp int64) map[string]int64 {
+func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeStamp int64) {
 	ctx, span := tracer.Start(ctx, "resource.kvStorageBackend.runGarbageCollection")
 	defer span.End()
 	start := time.Now()
-
-	deletedByKey := map[string]int64{}
 
 	// get group and resources
 	groupResources, err := b.dataStore.getGroupResources(ctx)
 	if err != nil {
 		b.log.Error("failed to list group resources for garbage collection", "error", err)
-		return deletedByKey
+		return
 	}
 
 	// for each pair of group and resource
 	for _, gr := range groupResources {
 		// this function will return a map with the number of deleted entries for this group and resource
-		resourceKey := gr.Group + "/" + gr.Resource
 		totalDeleted := int64(0)
 
 		// get the cutoff timestamp for this resource, allowing for resource-specific cutoff logic (e.g. different retention for dashboards)
@@ -447,11 +444,11 @@ func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeS
 				"rows", totalDeleted,
 				"seconds", time.Since(start).Seconds(),
 			)
-			deletedByKey[resourceKey] += totalDeleted
+			return
 		}
 	}
 
-	return deletedByKey
+	return
 }
 
 // garbageCollectBatch scans batches of entries in the datastore for a given group+resource,

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -413,6 +413,7 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 	span.SetAttributes(attribute.String("group", group), attribute.String("resource", resourceName), attribute.Int64("cutoffTimestamp", cutoffTimestamp), attribute.Int("batchSize", batchSize))
 	defer span.End()
 
+	//nolint:staticcheck
 	start := time.Now()
 
 	if !isSnowflake(cutoffTimestamp) {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -466,7 +466,8 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 			}
 
 			// update the next end key for pagination. We will use this to continue scanning in the next batch
-			nextEndKey = k.Prefix()
+			// the next end key is the immediate previous key for the current key
+			nextEndKey = previousKey(dataKey)
 
 			// if the action is deleted and the resource version is older than the cutoff, get all previous versions
 			// of the same resource and delete them in batch
@@ -525,6 +526,23 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 	}
 
 	return nil
+}
+
+// previousKey returns the immediate previous key for the given key
+// for example, if the key is "unified/data/dashboard.grafana.app/dashboards/123-bbb",
+// the previous key will be "unified/data/dashboard.grafana.app/dashboards/123-bba"
+func previousKey(key string) string {
+	keyBuf := []byte(key)
+	buf := make([]byte, len(keyBuf))
+	copy(buf, keyBuf)
+	for i := len(buf) - 1; i >= 0; i-- {
+		if buf[i] > 0x00 {
+			buf[i] = buf[i] - 1
+			buf = buf[:i+1]
+			return string(buf)
+		}
+	}
+	return string(buf)
 }
 
 func (b *kvStorageBackend) garbageCollectionCutoffTimestamp(group, resourceName string, defaultCutoff int64) int64 {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -532,7 +532,7 @@ func (b *kvStorageBackend) garbageCollectBatch(ctx context.Context, group, resou
 			}
 
 			// get the keys for the same resource
-			for currDK, _ := range b.dataStore.Keys(ctx, ListRequestKey{
+			for currDK := range b.dataStore.Keys(ctx, ListRequestKey{
 				Group:     dk.Group,
 				Resource:  dk.Resource,
 				Namespace: dk.Namespace,

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -444,11 +444,8 @@ func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeS
 				"rows", totalDeleted,
 				"seconds", time.Since(start).Seconds(),
 			)
-			return
 		}
 	}
-
-	return
 }
 
 // garbageCollectBatch scans batches of entries in the datastore for a given group+resource,
@@ -496,7 +493,8 @@ func (b *kvStorageBackend) garbageCollectBatch(ctx context.Context, group, resou
 		// update the next end key for pagination. We will use this to continue scanning in the next batch
 		nextEndKey = dataKey
 
-		// if the action is deleted and the resource version is older than the cutoff, get all previous versions of the same resource and delete them in batch
+		// if the action is deleted and the resource version is older than the cutoff, get all previous versions
+		// of the same resource and delete them in batch
 		if dk.Action == DataActionDeleted && dk.ResourceVersion < cutoffTimestamp {
 			startKey := ListRequestKey{
 				Group:     dk.Group,

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -383,9 +383,6 @@ func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeS
 
 		// get the cutoff timestamp for this resource, allowing for resource-specific cutoff logic (e.g. different retention for dashboards)
 		resourceCutoff := b.garbageCollectionCutoffTimestamp(gr.Group, gr.Resource, cutoffTimeStamp)
-		if !isSnowflake(resourceCutoff) {
-			resourceCutoff = rvmanager.SnowflakeFromRV(resourceCutoff)
-		}
 
 		// get the start and end keys for the list operation based on the resource prefix
 		// for example, for datashboards, the start key will be "unified/data/dashboard.grafana.app/dashboards/"
@@ -454,6 +451,10 @@ func (b *kvStorageBackend) garbageCollectBatch(ctx context.Context, group, resou
 	ctx, span := tracer.Start(ctx, "sql.backend.garbageCollectBatch")
 	span.SetAttributes(attribute.String("group", group), attribute.String("resource", resourceName), attribute.Int64("cutoffTimestamp", cutoffTimestamp), attribute.Int("batchSize", batchSize))
 	defer span.End()
+
+	if !isSnowflake(cutoffTimestamp) {
+		cutoffTimestamp = rvmanager.SnowflakeFromRV(cutoffTimestamp)
+	}
 
 	candidates := []string{}
 

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -432,6 +432,7 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 	prefix := key.Prefix()
 	startKey := prefix
 	endKey := PrefixRangeEnd(prefix)
+	nextEndKey := ""
 
 	for {
 		keysProcessed := int64(0)
@@ -440,11 +441,14 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 		// traverse all keys in descending order of resource version,
 		// for deleted keys with resource version older than the cutoff,
 		// we will scan a fixed number of keys (batchSize) each time
-		for dataKey, err := range b.kv.Keys(ctx, kv.DataSection, kv.ListOptions{
+		it := b.kv.Keys(ctx, kv.DataSection, kv.ListOptions{
 			StartKey: startKey,
 			EndKey:   endKey,
 			Limit:    int64(batchSize),
-			Sort:     kv.SortOrderDesc}) {
+			Sort:     kv.SortOrderDesc,
+		})
+
+		for dataKey, err := range it {
 			if err != nil {
 				return fmt.Errorf("failed to list collection before delete: %s", err)
 			}
@@ -457,25 +461,29 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 				return fmt.Errorf("failed to parse dataKey '%s': %s", dataKey, err)
 			}
 
+			// get the request key for the current datakey, which will be used to calculate the next start and end key
+			k := ListRequestKey{
+				Group:     dk.Group,
+				Resource:  dk.Resource,
+				Namespace: dk.Namespace,
+				Name:      dk.Name,
+			}
+
 			// update the next end key for pagination. We will use this to continue scanning in the next batch
-			endKey = dataKey
+			nextEndKey = k.Prefix()
 
 			// if the action is deleted and the resource version is older than the cutoff, get all previous versions
 			// of the same resource and delete them in batch
 			if dk.Action == DataActionDeleted && dk.ResourceVersion < cutoffTimestamp {
-				startKey := ListRequestKey{
-					Group:     dk.Group,
-					Resource:  dk.Resource,
-					Namespace: dk.Namespace,
-					Name:      dk.Name,
-				}.Prefix()
+				startKey := k.Prefix()
+				// end key is exclusive, so we need to add a suffix to make sure we include all the versions we want to delete
 				endKey := PrefixRangeEnd(dk.String())
 
 				keysToDelete := []string{}
 				for deleteKey, err := range b.kv.Keys(ctx, kv.DataSection, ListOptions{
 					StartKey: startKey,
 					EndKey:   endKey,
-					Sort:     kv.SortOrderDesc,
+					Sort:     kv.SortOrderAsc,
 				}) {
 					if err != nil {
 						return fmt.Errorf("failed to get keys for resource '%s': %s", dk, err)
@@ -498,6 +506,10 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 				}
 			}
 		}
+
+		// update the end key for the next batch to be the last processed key in this batch,
+		// so that we can continue scanning from there
+		endKey = nextEndKey
 
 		// if there are no more entries to process, break the loop
 		if keysProcessed == 0 {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -431,9 +431,7 @@ func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeS
 			totalDeleted += deleted
 
 			// wait a second between batches to avoid overwhelming the datastore
-			select {
-			case <-time.After(time.Second):
-			}
+			<-time.After(time.Second)
 		}
 		if totalDeleted > 0 {
 			b.log.Info("garbage collection deleted history",

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -470,7 +470,6 @@ func (b *kvStorageBackend) garbageCollectBatch(ctx context.Context, group, resou
 		EndKey:   endKey,
 		Limit:    int64(batchSize),
 		Sort:     kv.SortOrderDesc}) {
-
 		if err != nil {
 			b.log.Error("failed to list collection before delete: %s", err)
 			return 0, 0, "", err

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -454,8 +454,7 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 			// parse the datakey to get the action and resource version
 			dk, err := ParseKey(dataKey)
 			if err != nil {
-				b.log.Error("failed to parse datakey '%s': %s", dataKey, err)
-				continue
+				return fmt.Errorf("failed to parse dataKey '%s': %s", dataKey, err)
 			}
 
 			// update the next end key for pagination. We will use this to continue scanning in the next batch
@@ -504,20 +503,6 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 		if keysProcessed == 0 {
 			break
 		}
-
-		// Parse and get the next end key to ensure we can continue paginating. If we can't parse it, we should stop to avoid an infinite loop.
-		nk, err := ParseKey(endKey)
-		if err != nil {
-			b.log.Error("failed to parse nextEndKey '%s': %s", endKey, err)
-			break
-		}
-		key = ListRequestKey{
-			Group:     group,
-			Resource:  resourceName,
-			Namespace: nk.Namespace,
-			Name:      nk.Name,
-		}
-		endKey = key.Prefix()
 
 		totalDeleted += keysDeleted
 

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -524,8 +524,6 @@ func (b *kvStorageBackend) garbageCollectBatch(ctx context.Context, group, resou
 	}
 
 	// if there are candidates to delete, we will batch delete them.
-	// We will do this in a separate loop to avoid holding locks on
-	// the datastore while we are scanning for candidates
 	if rowsProcessed > 0 && len(candidates) > 0 {
 		keysToDelete := []string{}
 

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -372,7 +372,7 @@ func (b *kvStorageBackend) initGarbageCollection(ctx context.Context) error {
 // runGarbageCollection identifies deleted resources that are safe
 // to be fully removed from the datastore and deletes them in batches.
 func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeStamp int64) map[string]int64 {
-	ctx, span := tracer.Start(ctx, "sql.backend.runGarbageCollection")
+	ctx, span := tracer.Start(ctx, "resource.kvStorageBackend.runGarbageCollection")
 	defer span.End()
 	start := time.Now()
 
@@ -458,7 +458,7 @@ func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeS
 // identifies deleted resources that are safe to be fully removed, and deletes all their keys.
 // It returns the number of deleted entries, the number of rows processed, and the next end key for pagination.
 func (b *kvStorageBackend) garbageCollectBatch(ctx context.Context, group, resourceName string, cutoffTimestamp int64, batchSize int, startKey, endKey string) (int64, int64, string, error) {
-	ctx, span := tracer.Start(ctx, "sql.backend.garbageCollectBatch")
+	ctx, span := tracer.Start(ctx, "resource.kvStorageBackend.garbageCollectBatch")
 	span.SetAttributes(attribute.String("group", group), attribute.String("resource", resourceName), attribute.Int64("cutoffTimestamp", cutoffTimestamp), attribute.Int("batchSize", batchSize))
 	defer span.End()
 

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -446,8 +446,7 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 			Limit:    int64(batchSize),
 			Sort:     kv.SortOrderDesc}) {
 			if err != nil {
-				b.log.Error("failed to list collection before delete: %s", err)
-				return err
+				return fmt.Errorf("failed to list collection before delete: %s", err)
 			}
 
 			keysProcessed++
@@ -480,8 +479,7 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 					Sort:     kv.SortOrderDesc,
 				}) {
 					if err != nil {
-						b.log.Error("failed to get keys for resource '%s': %s", dk, err)
-						return err
+						return fmt.Errorf("failed to get keys for resource '%s': %s", dk, err)
 					}
 					b.log.Info("garbage collection", "key to delete", deleteKey)
 					endKey = deleteKey
@@ -492,8 +490,7 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 				if !b.garbageCollection.DryRun {
 					err := b.kv.BatchDelete(ctx, kv.DataSection, keysToDelete)
 					if err != nil {
-						b.log.Error("failed to batch delete keys: %s", err)
-						return err
+						return fmt.Errorf("failed to batch delete keys: %s", err)
 					}
 
 					keysDeleted = keysDeleted + int64(len(keysToDelete))

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -364,6 +364,8 @@ func (b *kvStorageBackend) initGarbageCollection(ctx context.Context) error {
 	return nil
 }
 
+// runGarbageCollection identifies deleted resources that are safe
+// to be fully removed from the datastore and deletes them in batches.
 func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeStamp int64) map[string]int64 {
 	ctx, span := tracer.Start(ctx, "sql.backend.runGarbageCollection")
 	defer span.End()
@@ -371,28 +373,39 @@ func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeS
 
 	deletedByKey := map[string]int64{}
 
+	// get group and resources
 	groupResources, err := b.dataStore.getGroupResources(ctx)
 	if err != nil {
 		b.log.Error("failed to list group resources for garbage collection", "error", err)
 		return deletedByKey
 	}
 
+	// for each pair of group and resource
 	for _, gr := range groupResources {
+		// this function will return a map with the number of deleted entries for this group and resource
 		resourceKey := gr.Group + "/" + gr.Resource
-		resourceCutoff := b.garbageCollectionCutoffTimestamp(gr.Group, gr.Resource, cutoffTimeStamp)
 		totalDeleted := int64(0)
 
+		// get the cutoff timestamp for this resource, allowing for resource-specific cutoff logic (e.g. different retention for dashboards)
+		resourceCutoff := b.garbageCollectionCutoffTimestamp(gr.Group, gr.Resource, cutoffTimeStamp)
+		if !isSnowflake(resourceCutoff) {
+			resourceCutoff = rvmanager.SnowflakeFromRV(resourceCutoff)
+		}
+
+		// get the start and end keys for the list operation based on the resource prefix
+		// for example, for datashboards, the start key will be "unified/data/dashboard.grafana.app/dashboards/"
+		// and the end key will be "unified/data/dashboard.grafana.app/dashboards0"
 		key := ListRequestKey{
 			Group:    gr.Group,
 			Resource: gr.Resource,
 		}
-
 		prefix := key.Prefix()
 		startKey := prefix
 		endKey := PrefixRangeEnd(prefix)
 
 		for {
-			deleted, nextKey, err := b.garbageCollectBatch(ctx, gr.Group, gr.Resource, resourceCutoff, b.garbageCollection.BatchSize, startKey, endKey)
+			// garbageCollectBatch will return the number of deleted entries, the number of rows processed, and the next end key for pagination
+			deleted, rowsProcessed, nextEndKey, err := b.garbageCollectBatch(ctx, gr.Group, gr.Resource, resourceCutoff, b.garbageCollection.BatchSize, startKey, endKey)
 			if err != nil {
 				b.log.Error("garbage collection failed",
 					"group", gr.Group,
@@ -400,11 +413,29 @@ func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeS
 					"error", err)
 				break
 			}
-			startKey = nextKey
-			totalDeleted += deleted
-			if deleted < int64(b.garbageCollection.BatchSize) {
+
+			// if there are no more entries to process, break the loop
+			if rowsProcessed == 0 {
 				break
 			}
+
+			// Parse and get the next end key to ensure we can continue paginating. If we can't parse it, we should stop to avoid an infinite loop.
+			nk, err := ParseKey(nextEndKey)
+			if err != nil {
+				b.log.Error("failed to parse nextEndKey '%s': %s", nextEndKey, err)
+				break
+			}
+			key = ListRequestKey{
+				Group:     gr.Group,
+				Resource:  gr.Resource,
+				Namespace: nk.Namespace,
+				Name:      nk.Name,
+			}
+			endKey = key.Prefix()
+
+			totalDeleted += deleted
+
+			// wait a second between batches to avoid overwhelming the datastore
 			select {
 			case <-time.After(time.Second):
 			}
@@ -423,40 +454,49 @@ func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeS
 	return deletedByKey
 }
 
-func (b *kvStorageBackend) garbageCollectBatch(ctx context.Context, group, resourceName string, cutoffTimestamp int64, batchSize int, startKey, endKey string) (int64, string, error) {
+// garbageCollectBatch scans batches of entries in the datastore for a given group+resource,
+// identifies deleted resources that are safe to be fully removed, and deletes all their keys.
+// It returns the number of deleted entries, the number of rows processed, and the next end key for pagination.
+func (b *kvStorageBackend) garbageCollectBatch(ctx context.Context, group, resourceName string, cutoffTimestamp int64, batchSize int, startKey, endKey string) (int64, int64, string, error) {
 	ctx, span := tracer.Start(ctx, "sql.backend.garbageCollectBatch")
 	span.SetAttributes(attribute.String("group", group), attribute.String("resource", resourceName), attribute.Int64("cutoffTimestamp", cutoffTimestamp), attribute.Int("batchSize", batchSize))
 	defer span.End()
 
 	candidates := []string{}
 
-	nextStartKey := startKey
+	nextEndKey := endKey
+
+	rowsProcessed := int64(0)
 
 	// traverse all keys in descending order of resource version,
 	// for deleted keys with resource version older than the cutoff,
 	// check if the resource is not present in the datastore
+	// we will scan a fixed number of rows (batchSize) and look for candidates to delete
 	for dataKey, err := range b.kv.Keys(ctx, kv.DataSection, kv.ListOptions{
 		StartKey: startKey,
 		EndKey:   endKey,
+		Limit:    int64(batchSize),
 		Sort:     kv.SortOrderDesc}) {
 
 		if err != nil {
 			b.log.Error("failed to list collection before delete: %s", err)
-			return 0, "", err
+			return 0, 0, "", err
 		}
 
+		rowsProcessed++
+
+		// parse the datakey to get the action and resource version
 		dk, err := ParseKey(dataKey)
 		if err != nil {
 			b.log.Error("failed to parse datakey '%s': %s", dataKey, err)
 			continue
 		}
 
-		resourceCutoffSnowflake := cutoffTimestamp
-		if !isSnowflake(cutoffTimestamp) {
-			resourceCutoffSnowflake = rvmanager.SnowflakeFromRV(cutoffTimestamp)
-		}
+		// update the next end key for pagination. We will use this to continue scanning in the next batch
+		nextEndKey = dataKey
 
-		if dk.Action == DataActionDeleted && dk.ResourceVersion < resourceCutoffSnowflake {
+		// if the action is deleted and the resource version is older than the cutoff, we will check if the resource is still present in the datastore
+		if dk.Action == DataActionDeleted && dk.ResourceVersion < cutoffTimestamp {
 			// ensure that the resource is not present in the datastore
 			_, err := b.dataStore.GetLatestResourceKey(ctx, GetRequestKey{
 				Group:     dk.Group,
@@ -469,6 +509,7 @@ func (b *kvStorageBackend) garbageCollectBatch(ctx context.Context, group, resou
 				continue
 			}
 
+			// we are expecting a not found error, if we get a different error, log it and skip deletion to be safe
 			if !errors.Is(err, ErrNotFound) {
 				b.log.Error("failed to get the latest resource key for datakey '%s': %s", dk, err)
 				continue
@@ -476,45 +517,57 @@ func (b *kvStorageBackend) garbageCollectBatch(ctx context.Context, group, resou
 
 			// if we get a not found, then we can delete resource history entries for this resource
 			candidates = append(candidates, dataKey)
-			if len(candidates) >= b.garbageCollection.BatchSize {
-				break
+		}
+	}
+
+	// if there are candidates to delete, we will batch delete them.
+	// We will do this in a separate loop to avoid holding locks on
+	// the datastore while we are scanning for candidates
+	if rowsProcessed > 0 && len(candidates) > 0 {
+		keysToDelete := []string{}
+
+		// traverse the candidate list and for each candidate, we will get all keys
+		// for the same resource (same group, resource, namespace, name) and add them
+		// to the delete list
+		for _, dataKey := range candidates {
+			dk, err := ParseKey(dataKey)
+			if err != nil {
+				b.log.Error("failed to parse datakey '%s': %s", dataKey, err)
+				continue
+			}
+
+			// get the keys for the same resource
+			for currDK, _ := range b.dataStore.Keys(ctx, ListRequestKey{
+				Group:     dk.Group,
+				Resource:  dk.Resource,
+				Namespace: dk.Namespace,
+				Name:      dk.Name,
+			}, SortOrderAsc) {
+				keysToDelete = append(keysToDelete, currDK.String())
 			}
 		}
-	}
 
-	keysToDelete := []string{}
-	for _, dataKey := range candidates {
-		dk, err := ParseKey(dataKey)
-		if err != nil {
-			b.log.Error("failed to parse datakey '%s': %s", dataKey, err)
-			continue
+		for _, key := range keysToDelete {
+			b.log.Info("garbage collection",
+				"key to delete", key,
+			)
 		}
 
-		fmt.Printf("candidate dataKey: %+v\n", dataKey)
-		for currDK, _ := range b.dataStore.Keys(ctx, ListRequestKey{
-			Group:     dk.Group,
-			Resource:  dk.Resource,
-			Namespace: dk.Namespace,
-			Name:      dk.Name,
-		}, SortOrderAsc) {
-			keysToDelete = append(keysToDelete, currDK.String())
-			nextStartKey = currDK.String()
-		}
+		// if not in dry run mode, batch delete the keys and return the number of deleted entries
+		if !b.garbageCollection.DryRun {
+			err := b.kv.BatchDelete(ctx, kv.DataSection, keysToDelete)
+			if err != nil {
+				b.log.Error("failed to batch delete keys: %s", err)
+				return 0, 0, "", err
+			}
 
-		fmt.Printf("keysToDelete: %+v\n", keysToDelete)
+			return int64(len(keysToDelete)), rowsProcessed, nextEndKey, nil
+		} else {
+			b.log.Info("garbage collection not deleting any keys because dry run mode is enabled")
+		}
 	}
 
-	if !b.garbageCollection.DryRun {
-		err := b.kv.BatchDelete(ctx, kv.DataSection, keysToDelete)
-		if err != nil {
-			b.log.Error("failed to batch delete keys: %s", err)
-			return 0, "", err
-		}
-
-		return int64(len(keysToDelete)), nextStartKey, nil
-	}
-
-	return 0, "", nil
+	return 0, rowsProcessed, nextEndKey, nil
 }
 
 func (b *kvStorageBackend) garbageCollectionCutoffTimestamp(group, resourceName string, defaultCutoff int64) int64 {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -417,7 +417,7 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 	totalDeleted := int64(0)
 
 	// get the start and end keys for the list operation based on the resource prefix
-	// for example, for datashboards, the start key will be "unified/data/dashboard.grafana.app/dashboards/"
+	// for example, for dashboards, the start key will be "unified/data/dashboard.grafana.app/dashboards/"
 	// and the end key will be "unified/data/dashboard.grafana.app/dashboards0"
 	key := ListRequestKey{
 		Group:    group,

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -487,7 +487,7 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 					keysToDelete = append(keysToDelete, deleteKey)
 				}
 
-				// if not in dry run mode, batch delete the keys and return the number of deleted entries
+				// if not in dry run mode, batch delete the keys
 				if !b.garbageCollection.DryRun {
 					err := b.kv.BatchDelete(ctx, kv.DataSection, keysToDelete)
 					if err != nil {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -404,7 +404,7 @@ func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeS
 
 		for {
 			// garbageCollectBatch will return the number of deleted entries, the number of rows processed, and the next end key for pagination
-			deleted, rowsProcessed, nextEndKey, err := b.garbageCollectBatch(ctx, gr.Group, gr.Resource, resourceCutoff, b.garbageCollection.BatchSize, startKey, endKey)
+			keysDeleted, keysProcessed, nextEndKey, err := b.garbageCollectBatch(ctx, gr.Group, gr.Resource, resourceCutoff, b.garbageCollection.BatchSize, startKey, endKey)
 			if err != nil {
 				b.log.Error("garbage collection failed",
 					"group", gr.Group,
@@ -414,7 +414,7 @@ func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeS
 			}
 
 			// if there are no more entries to process, break the loop
-			if rowsProcessed == 0 {
+			if keysProcessed == 0 {
 				break
 			}
 
@@ -432,7 +432,7 @@ func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeS
 			}
 			endKey = key.Prefix()
 
-			totalDeleted += deleted
+			totalDeleted += keysDeleted
 
 			// wait a second between batches to avoid overwhelming the datastore
 			<-time.After(time.Second)
@@ -452,8 +452,11 @@ func (b *kvStorageBackend) runGarbageCollection(ctx context.Context, cutoffTimeS
 }
 
 // garbageCollectBatch scans batches of entries in the datastore for a given group+resource,
-// identifies deleted resources that are safe to be fully removed, and deletes all their keys.
-// It returns the number of deleted entries, the number of rows processed, and the next end key for pagination.
+// in descending order of resource version, looking for deleted entries with resource versions
+// older than the cutoff timestamp.
+// Once it finds a deleted entry, it looks for all previous versions of the same resource
+// up to the deleted version and deletes them in batch.
+// This ensures that we are not going to delete any keys that were created if the resource was recreated after deletion.
 func (b *kvStorageBackend) garbageCollectBatch(ctx context.Context, group, resourceName string, cutoffTimestamp int64, batchSize int, startKey, endKey string) (int64, int64, string, error) {
 	ctx, span := tracer.Start(ctx, "resource.kvStorageBackend.garbageCollectBatch")
 	span.SetAttributes(attribute.String("group", group), attribute.String("resource", resourceName), attribute.Int64("cutoffTimestamp", cutoffTimestamp), attribute.Int("batchSize", batchSize))
@@ -463,16 +466,14 @@ func (b *kvStorageBackend) garbageCollectBatch(ctx context.Context, group, resou
 		cutoffTimestamp = rvmanager.SnowflakeFromRV(cutoffTimestamp)
 	}
 
-	candidates := []string{}
-
 	nextEndKey := endKey
 
-	rowsProcessed := int64(0)
+	keysProcessed := int64(0)
+	keysDeleted := int64(0)
 
 	// traverse all keys in descending order of resource version,
 	// for deleted keys with resource version older than the cutoff,
-	// check if the resource is not present in the datastore
-	// we will scan a fixed number of rows (batchSize) and look for candidates to delete
+	// we will scan a fixed number of keys (batchSize) each time
 	for dataKey, err := range b.kv.Keys(ctx, kv.DataSection, kv.ListOptions{
 		StartKey: startKey,
 		EndKey:   endKey,
@@ -483,7 +484,7 @@ func (b *kvStorageBackend) garbageCollectBatch(ctx context.Context, group, resou
 			return 0, 0, "", err
 		}
 
-		rowsProcessed++
+		keysProcessed++
 
 		// parse the datakey to get the action and resource version
 		dk, err := ParseKey(dataKey)
@@ -495,81 +496,47 @@ func (b *kvStorageBackend) garbageCollectBatch(ctx context.Context, group, resou
 		// update the next end key for pagination. We will use this to continue scanning in the next batch
 		nextEndKey = dataKey
 
-		// if the action is deleted and the resource version is older than the cutoff, we will check if the resource is still present in the datastore
+		// if the action is deleted and the resource version is older than the cutoff, get all previous versions of the same resource and delete them in batch
 		if dk.Action == DataActionDeleted && dk.ResourceVersion < cutoffTimestamp {
-			// ensure that the resource is not present in the datastore
-			_, err := b.dataStore.GetLatestResourceKey(ctx, GetRequestKey{
+			startKey := ListRequestKey{
 				Group:     dk.Group,
 				Resource:  dk.Resource,
 				Namespace: dk.Namespace,
 				Name:      dk.Name,
-			})
-			if err == nil {
-				// resource is still present, skip deletion
-				continue
-			}
+			}.Prefix()
+			endKey := PrefixRangeEnd(dk.String())
 
-			// we are expecting a not found error, if we get a different error, log it and skip deletion to be safe
-			if !errors.Is(err, ErrNotFound) {
-				b.log.Error("failed to get the latest resource key for datakey '%s': %s", dk, err)
-				continue
-			}
-
-			// if we get a not found, then we can delete resource history entries for this resource
-			candidates = append(candidates, dataKey)
-		}
-	}
-
-	// if there are candidates to delete, we will batch delete them.
-	if rowsProcessed > 0 && len(candidates) > 0 {
-		keysToDelete := []string{}
-
-		// traverse the candidate list and for each candidate, we will get all keys
-		// for the same resource (same group, resource, namespace, name) and add them
-		// to the delete list
-		for _, dataKey := range candidates {
-			dk, err := ParseKey(dataKey)
-			if err != nil {
-				b.log.Error("failed to parse datakey '%s': %s", dataKey, err)
-				continue
-			}
-
-			// get the keys for the same resource
-			for currDK, err := range b.dataStore.Keys(ctx, ListRequestKey{
-				Group:     dk.Group,
-				Resource:  dk.Resource,
-				Namespace: dk.Namespace,
-				Name:      dk.Name,
-			}, SortOrderAsc) {
+			keysToDelete := []string{}
+			for deleteKey, err := range b.kv.Keys(ctx, kv.DataSection, ListOptions{
+				StartKey: startKey,
+				EndKey:   endKey,
+				Sort:     kv.SortOrderDesc,
+			}) {
 				if err != nil {
 					b.log.Error("failed to get keys for resource '%s': %s", dk, err)
 					return 0, 0, "", err
 				}
-				keysToDelete = append(keysToDelete, currDK.String())
-			}
-		}
-
-		for _, key := range keysToDelete {
-			b.log.Info("garbage collection",
-				"key to delete", key,
-			)
-		}
-
-		// if not in dry run mode, batch delete the keys and return the number of deleted entries
-		if !b.garbageCollection.DryRun {
-			err := b.kv.BatchDelete(ctx, kv.DataSection, keysToDelete)
-			if err != nil {
-				b.log.Error("failed to batch delete keys: %s", err)
-				return 0, 0, "", err
+				b.log.Info("garbage collection", "key to delete", deleteKey)
+				nextEndKey = deleteKey
+				keysToDelete = append(keysToDelete, deleteKey)
 			}
 
-			return int64(len(keysToDelete)), rowsProcessed, nextEndKey, nil
-		} else {
-			b.log.Info("garbage collection not deleting any keys because dry run mode is enabled")
+			// if not in dry run mode, batch delete the keys and return the number of deleted entries
+			if !b.garbageCollection.DryRun {
+				err := b.kv.BatchDelete(ctx, kv.DataSection, keysToDelete)
+				if err != nil {
+					b.log.Error("failed to batch delete keys: %s", err)
+					return 0, 0, "", err
+				}
+
+				keysDeleted = keysDeleted + int64(len(keysToDelete))
+			} else {
+				b.log.Info("garbage collection not deleting any keys because dry run mode is enabled")
+			}
 		}
 	}
 
-	return 0, rowsProcessed, nextEndKey, nil
+	return keysDeleted, keysProcessed, nextEndKey, nil
 }
 
 func (b *kvStorageBackend) garbageCollectionCutoffTimestamp(group, resourceName string, defaultCutoff int64) int64 {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -535,12 +535,16 @@ func (b *kvStorageBackend) garbageCollectBatch(ctx context.Context, group, resou
 			}
 
 			// get the keys for the same resource
-			for currDK := range b.dataStore.Keys(ctx, ListRequestKey{
+			for currDK, err := range b.dataStore.Keys(ctx, ListRequestKey{
 				Group:     dk.Group,
 				Resource:  dk.Resource,
 				Namespace: dk.Namespace,
 				Name:      dk.Name,
 			}, SortOrderAsc) {
+				if err != nil {
+					b.log.Error("failed to get keys for resource '%s': %s", dk, err)
+					return 0, 0, "", err
+				}
 				keysToDelete = append(keysToDelete, currDK.String())
 			}
 		}

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -416,10 +416,6 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 	//nolint:staticcheck
 	start := time.Now()
 
-	if !isSnowflake(cutoffTimestamp) {
-		cutoffTimestamp = rvmanager.SnowflakeFromRV(cutoffTimestamp)
-	}
-
 	totalDeleted := int64(0)
 
 	// get the start and end keys for the list operation based on the resource prefix
@@ -534,10 +530,16 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 }
 
 func (b *kvStorageBackend) garbageCollectionCutoffTimestamp(group, resourceName string, defaultCutoff int64) int64 {
+	cutoffTimestamp := defaultCutoff
+
 	if group == "dashboard.grafana.app" && resourceName == "dashboards" {
-		return time.Now().Add(-b.garbageCollection.DashboardsMaxAge).UnixMicro()
+		cutoffTimestamp = time.Now().Add(-b.garbageCollection.DashboardsMaxAge).UnixMicro()
 	}
-	return defaultCutoff
+
+	if !isSnowflake(cutoffTimestamp) {
+		cutoffTimestamp = rvmanager.SnowflakeFromRV(cutoffTimestamp)
+	}
+	return cutoffTimestamp
 }
 
 // WriteEvent writes a resource event (create/update/delete) to the storage backend.

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -348,10 +348,8 @@ func (b *kvStorageBackend) initGarbageCollection(ctx context.Context) error {
 
 	go func() {
 		// delay the first run by a random amount between 0 and the interval to avoid thundering herd
-		if b.garbageCollection.Interval > 0 {
-			jitter := time.Duration(rand.Int64N(b.garbageCollection.Interval.Nanoseconds()))
-			<-time.After(jitter)
-		}
+		jitter := time.Duration(rand.Int64N(b.garbageCollection.Interval.Nanoseconds()))
+		<-time.After(jitter)
 
 		ticker := time.NewTicker(b.garbageCollection.Interval)
 		defer ticker.Stop()

--- a/pkg/storage/unified/resource/storage_backend_gc_test.go
+++ b/pkg/storage/unified/resource/storage_backend_gc_test.go
@@ -545,5 +545,4 @@ func TestIntegrationGarbageCollectionLoop(t *testing.T) {
 		// FIX THIS: server.List with TRASH source without setting Name should return both deleted resources, but currently only returns one - needs investigation
 		// require.Len(t, trashResp.Items, 1)
 	})
-
 }

--- a/pkg/storage/unified/resource/storage_backend_gc_test.go
+++ b/pkg/storage/unified/resource/storage_backend_gc_test.go
@@ -1,0 +1,549 @@
+package resource
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/util/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// writeEventOption is a function that modifies writeEventOptions
+type writeEventOption func(*writeEventOptions)
+
+type writeEventOptions struct {
+	Namespace  string
+	Group      string
+	Resource   string
+	Folder     string
+	Value      []byte
+	PreviousRV int64
+}
+
+func writeEvent(t *testing.T, ctx context.Context, storageBackend *kvStorageBackend, resourceName string, action resourcepb.WatchEvent_Type, opts ...writeEventOption) (int64, error) {
+	// Default options
+	options := writeEventOptions{
+		Namespace: "namespace",
+		Group:     "group",
+		Resource:  "resource",
+		Folder:    "folderuid",
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	u := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": options.Group + "/v1",
+			"kind":       options.Resource,
+			"metadata": map[string]any{
+				"name":      resourceName,
+				"namespace": options.Namespace,
+			},
+			"spec": map[string]any{
+				"value": resourceName + " " + resourcepb.WatchEvent_Type_name[int32(action)],
+			},
+		},
+	}
+	value, _ := u.MarshalJSON()
+
+	res := &unstructured.Unstructured{
+		Object: map[string]any{},
+	}
+	meta, err := utils.MetaAccessor(res)
+	require.NoError(t, err)
+	meta.SetFolder(options.Folder)
+
+	event := WriteEvent{
+		Type:  action,
+		Value: value,
+		GUID:  uuid.New().String(),
+		Key: &resourcepb.ResourceKey{
+			Namespace: options.Namespace,
+			Group:     options.Group,
+			Resource:  options.Resource,
+			Name:      resourceName,
+		},
+		PreviousRV: options.PreviousRV,
+	}
+
+	switch action {
+	case resourcepb.WatchEvent_DELETED:
+		event.ObjectOld = meta
+
+		obj, err := utils.MetaAccessor(res)
+		if err != nil {
+			return 0, err
+		}
+		now := metav1.Now()
+		obj.SetDeletionTimestamp(&now)
+		obj.SetUpdatedTimestamp(&now.Time)
+		obj.SetManagedFields(nil)
+		obj.SetFinalizers(nil)
+		obj.SetGeneration(utils.DeletedGeneration)
+		obj.SetAnnotation(utils.AnnoKeyKubectlLastAppliedConfig, "") // clears it
+		event.Object = obj
+	case resourcepb.WatchEvent_ADDED:
+		event.Object = meta
+	case resourcepb.WatchEvent_MODIFIED:
+		event.Object = meta //
+		event.ObjectOld = meta
+	default:
+		panic(fmt.Sprintf("invalid action: %s", action))
+	}
+
+	return storageBackend.WriteEvent(ctx, event)
+}
+
+func TestIntegrationGarbageCollectionBatch(t *testing.T) {
+	gcConfig := GarbageCollectionConfig{
+		Enabled:          true,
+		DryRun:           false,
+		Interval:         time.Minute,
+		BatchSize:        100,
+		DashboardsMaxAge: 24 * time.Hour,
+	}
+
+	t.Run("can garbage collect a deleted resource", func(t *testing.T) {
+		testutil.SkipIntegrationTestInShortMode(t)
+
+		ctx := testutil.NewTestContext(t, time.Now().Add(30*time.Second))
+
+		storageBackend := setupTestStorageBackend(t, func(opts *KVBackendOptions) {
+			opts.GarbageCollection = gcConfig
+		})
+		b := storageBackend
+
+		server, err := NewResourceServer(ResourceServerOptions{
+			Backend: storageBackend,
+		})
+		require.NoError(t, err)
+
+		rv1, err := writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_ADDED)
+		require.NoError(t, err)
+
+		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
+			func(o *writeEventOptions) {
+				o.Namespace = "namespace"
+				o.PreviousRV = rv1
+			})
+		require.NoError(t, err)
+
+		listResp, err := server.List(ctx, &resourcepb.ListRequest{
+			Source: resourcepb.ListRequest_STORE,
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Namespace: "namespace",
+					Group:     "group",
+					Resource:  "resource",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, 0, len(listResp.Items))
+
+		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // Everything eligible for deletion
+		rowsDeleted, rowsProcessed, nextEndKey, err := b.garbageCollectBatch(ctx, "group", "resource", cutoffTimestamp, 100, "group/resource/", "group/resource0")
+		require.NoError(t, err)
+		require.Equal(t, int64(2), rowsDeleted)
+		require.Equal(t, int64(2), rowsProcessed)
+		require.Regexp(t, regexp.MustCompile(`^group/resource/namespace/resource1/\d+~created~folderuid$`), nextEndKey)
+
+		historyResp, err := server.List(ctx, &resourcepb.ListRequest{
+			Source: resourcepb.ListRequest_HISTORY,
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Namespace: "namespace",
+					Group:     "group",
+					Resource:  "resource",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Nil(t, historyResp.Error)
+		require.Len(t, historyResp.Items, 0)
+	})
+
+	t.Run("will only garbage collect eligible resources before cutoff", func(t *testing.T) {
+		testutil.SkipIntegrationTestInShortMode(t)
+
+		ctx := testutil.NewTestContext(t, time.Now().Add(30*time.Second))
+
+		storageBackend := setupTestStorageBackend(t, func(opts *KVBackendOptions) {
+			opts.GarbageCollection = gcConfig
+		})
+		b := storageBackend
+
+		server, err := NewResourceServer(ResourceServerOptions{
+			Backend: storageBackend,
+		})
+		require.NoError(t, err)
+
+		rv1, err := writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_ADDED)
+		require.NoError(t, err)
+		rv2, err := writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
+			func(o *writeEventOptions) {
+				o.Namespace = "namespace"
+				o.PreviousRV = rv1
+			})
+		require.NoError(t, err)
+
+		rv3, err := writeEvent(t, ctx, storageBackend, "resource2", resourcepb.WatchEvent_ADDED)
+		require.NoError(t, err)
+		_, err = writeEvent(t, ctx, storageBackend, "resource2", resourcepb.WatchEvent_DELETED,
+			func(o *writeEventOptions) {
+				o.Namespace = "namespace"
+				o.PreviousRV = rv3
+			})
+		require.NoError(t, err)
+
+		cutoffTimestamp := rv2 + 1
+		rowsDeleted, rowsProcessed, nextEndKey, err := b.garbageCollectBatch(ctx, "group", "resource", cutoffTimestamp, 100, "group/resource/", "group/resource0")
+		require.NoError(t, err)
+		require.Equal(t, int64(2), rowsDeleted)
+		require.Equal(t, int64(4), rowsProcessed)
+		require.Regexp(t, regexp.MustCompile(`^group/resource/namespace/resource1/\d+~created~folderuid$`), nextEndKey)
+
+		historyResp, err := server.List(ctx, &resourcepb.ListRequest{
+			Source: resourcepb.ListRequest_HISTORY,
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Namespace: "namespace",
+					Group:     "group",
+					Resource:  "resource",
+					Name:      "resource1",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Nil(t, historyResp.Error)
+		require.Len(t, historyResp.Items, 0)
+
+		historyResp, err = server.List(ctx, &resourcepb.ListRequest{
+			Source: resourcepb.ListRequest_TRASH,
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Namespace: "namespace",
+					Group:     "group",
+					Resource:  "resource",
+					Name:      "resource2",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Nil(t, historyResp.Error)
+		require.Len(t, historyResp.Items, 1)
+	})
+
+	t.Run("will not delete rows for other eligible resources", func(t *testing.T) {
+		testutil.SkipIntegrationTestInShortMode(t)
+
+		ctx := testutil.NewTestContext(t, time.Now().Add(30*time.Second))
+
+		storageBackend := setupTestStorageBackend(t, func(opts *KVBackendOptions) {
+			opts.GarbageCollection = gcConfig
+		})
+		b := storageBackend
+
+		server, err := NewResourceServer(ResourceServerOptions{
+			Backend: storageBackend,
+		})
+		require.NoError(t, err)
+
+		rv1, err := writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_ADDED)
+		require.NoError(t, err)
+		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
+			func(o *writeEventOptions) {
+				o.Namespace = "namespace"
+				o.PreviousRV = rv1
+			})
+		require.NoError(t, err)
+
+		rv2, err := writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_ADDED,
+			func(o *writeEventOptions) {
+				o.Resource = "other-resource"
+			})
+		require.NoError(t, err)
+		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
+			func(o *writeEventOptions) {
+				o.Namespace = "namespace"
+				o.PreviousRV = rv2
+				o.Resource = "other-resource"
+			})
+		require.NoError(t, err)
+
+		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // everything eligible for deletion
+		rowsDeleted, rowsProcessed, nexEndKey, err := b.garbageCollectBatch(ctx, "group", "resource", cutoffTimestamp, 100, "group/resource/", "group/resource0")
+		require.NoError(t, err)
+		require.Equal(t, int64(2), rowsDeleted)
+		require.Equal(t, int64(2), rowsProcessed)
+		require.Regexp(t, regexp.MustCompile(`^group/resource/namespace/resource1/\d+~created~folderuid$`), nexEndKey)
+
+		historyResp, err := server.List(ctx, &resourcepb.ListRequest{
+			Source: resourcepb.ListRequest_HISTORY,
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Namespace: "namespace",
+					Group:     "group",
+					Resource:  "resource",
+					Name:      "resource1",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Nil(t, historyResp.Error)
+		require.Len(t, historyResp.Items, 0)
+
+		trashResp, err := server.List(ctx, &resourcepb.ListRequest{
+			Source: resourcepb.ListRequest_TRASH,
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Namespace: "namespace",
+					Group:     "group",
+					Resource:  "other-resource",
+					Name:      "resource1",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Nil(t, trashResp.Error)
+		require.Len(t, trashResp.Items, 1)
+	})
+
+	// TODO: review this
+	t.Run("will limit candidate batch size", func(t *testing.T) {
+		testutil.SkipIntegrationTestInShortMode(t)
+
+		ctx := testutil.NewTestContext(t, time.Now().Add(30*time.Second))
+
+		storageBackend := setupTestStorageBackend(t, func(opts *KVBackendOptions) {
+			opts.GarbageCollection = gcConfig
+		})
+		b := storageBackend
+
+		server, err := NewResourceServer(ResourceServerOptions{
+			Backend: storageBackend,
+		})
+		require.NoError(t, err)
+
+		rv1, err := writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_ADDED)
+		require.NoError(t, err)
+		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
+			func(o *writeEventOptions) {
+				o.Namespace = "namespace"
+				o.PreviousRV = rv1
+			})
+		require.NoError(t, err)
+
+		rv2, err := writeEvent(t, ctx, storageBackend, "resource2", resourcepb.WatchEvent_ADDED)
+		require.NoError(t, err)
+		_, err = writeEvent(t, ctx, storageBackend, "resource2", resourcepb.WatchEvent_DELETED,
+			func(o *writeEventOptions) {
+				o.Namespace = "namespace"
+				o.PreviousRV = rv2
+			})
+		require.NoError(t, err)
+
+		trashResp, err := server.List(ctx, &resourcepb.ListRequest{
+			Source: resourcepb.ListRequest_TRASH,
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Namespace: "namespace",
+					Group:     "group",
+					Resource:  "resource",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Nil(t, trashResp.Error)
+		// FIX THIS: server.List with TRASH source without setting Name should return both deleted resources, but currently only returns one - needs investigation
+		// require.Len(t, trashResp.Items, 2)
+
+		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // everything eligible for deletion
+		rowsDeleted, rowsProcessed, nextEndKey, err := b.garbageCollectBatch(ctx, "group", "resource", cutoffTimestamp, 1, "group/resource/", "group/resource0")
+		require.NoError(t, err)
+		require.Equal(t, int64(2), rowsDeleted)
+		require.Equal(t, int64(1), rowsProcessed)
+		require.Regexp(t, regexp.MustCompile(`^group/resource/namespace/resource2/\d+~deleted~folderuid$`), nextEndKey)
+
+		trashResp, err = server.List(ctx, &resourcepb.ListRequest{
+			Source: resourcepb.ListRequest_TRASH,
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Namespace: "namespace",
+					Group:     "group",
+					Resource:  "resource",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Nil(t, trashResp.Error)
+		// FIX THIS: server.List with TRASH source without setting Name should return both deleted resources, but currently only returns one - needs investigation
+		// require.Len(t, trashResp.Items, 1)
+	})
+
+	t.Run("will not delete rows when resource is deleted then recreated with same name", func(t *testing.T) {
+		testutil.SkipIntegrationTestInShortMode(t)
+
+		ctx := testutil.NewTestContext(t, time.Now().Add(30*time.Second))
+
+		storageBackend := setupTestStorageBackend(t, func(opts *KVBackendOptions) {
+			opts.GarbageCollection = gcConfig
+		})
+		b := storageBackend
+
+		server, err := NewResourceServer(ResourceServerOptions{
+			Backend: storageBackend,
+		})
+		require.NoError(t, err)
+
+		rv1, err := writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_ADDED)
+		require.NoError(t, err)
+
+		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
+			func(o *writeEventOptions) {
+				o.Namespace = "namespace"
+				o.PreviousRV = rv1
+			})
+		require.NoError(t, err)
+
+		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_ADDED,
+			func(o *writeEventOptions) {
+				o.Namespace = "namespace"
+			})
+		require.NoError(t, err)
+
+		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // everything eligible for deletion
+		rowsDeleted, rowsProcessed, nextEndKey, err := b.garbageCollectBatch(ctx, "group", "resource", cutoffTimestamp, 100, "group/resource/", "group/resource0")
+		require.NoError(t, err)
+		require.Equal(t, int64(0), rowsDeleted)
+		require.Equal(t, int64(3), rowsProcessed)
+		require.Regexp(t, regexp.MustCompile(`^group/resource/namespace/resource1/\d+~created~folderuid$`), nextEndKey)
+
+		historyResp, err := server.List(ctx, &resourcepb.ListRequest{
+			Source: resourcepb.ListRequest_HISTORY,
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Namespace: "namespace",
+					Group:     "group",
+					Resource:  "resource",
+					Name:      "resource1",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Nil(t, historyResp.Error)
+		require.Len(t, historyResp.Items, 1)
+	})
+}
+
+func TestIntegrationGarbageCollectionLoop(t *testing.T) {
+	gcConfig := GarbageCollectionConfig{
+		Enabled:          true,
+		Interval:         time.Minute,
+		BatchSize:        100,
+		DashboardsMaxAge: 24 * time.Hour,
+	}
+
+	t.Run("can delete eligble resources", func(t *testing.T) {
+		testutil.SkipIntegrationTestInShortMode(t)
+
+		ctx := testutil.NewTestContext(t, time.Now().Add(2*time.Minute))
+
+		storageBackend := setupTestStorageBackend(t, func(opts *KVBackendOptions) {
+			opts.GarbageCollection = gcConfig
+		})
+		b := storageBackend
+
+		_, err := NewResourceServer(ResourceServerOptions{
+			Backend: storageBackend,
+		})
+		require.NoError(t, err)
+
+		rv1, err := writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_ADDED)
+		require.NoError(t, err)
+		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
+			func(o *writeEventOptions) {
+				o.Namespace = "namespace"
+				o.PreviousRV = rv1
+			})
+		require.NoError(t, err)
+
+		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // everything eligible for deletion
+		results := b.runGarbageCollection(ctx, cutoffTimestamp)
+		require.NoError(t, err)
+		require.Equal(t, int64(2), results["group/resource"])
+	})
+
+	t.Run("will respect dashboard retention settings", func(t *testing.T) {
+		testutil.SkipIntegrationTestInShortMode(t)
+
+		ctx := testutil.NewTestContext(t, time.Now().Add(2*time.Minute))
+
+		storageBackend := setupTestStorageBackend(t, func(opts *KVBackendOptions) {
+			opts.GarbageCollection = gcConfig
+		})
+		b := storageBackend
+
+		server, err := NewResourceServer(ResourceServerOptions{
+			Backend: storageBackend,
+		})
+		require.NoError(t, err)
+
+		rv1, err := writeEvent(t, ctx, storageBackend, "dashboard1", resourcepb.WatchEvent_ADDED,
+			func(o *writeEventOptions) {
+				o.Group = "dashboard.grafana.app"
+				o.Resource = "dashboards"
+			})
+		require.NoError(t, err)
+		_, err = writeEvent(t, ctx, storageBackend, "dashboard1", resourcepb.WatchEvent_DELETED,
+			func(o *writeEventOptions) {
+				o.Namespace = "namespace"
+				o.PreviousRV = rv1
+				o.Group = "dashboard.grafana.app"
+				o.Resource = "dashboards"
+			})
+		require.NoError(t, err)
+
+		rv2, err := writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_ADDED)
+		require.NoError(t, err)
+		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
+			func(o *writeEventOptions) {
+				o.Namespace = "namespace"
+				o.PreviousRV = rv2
+			})
+		require.NoError(t, err)
+
+		cutoffTimestamp := time.Now().Add(1 * time.Hour).UnixMicro() // everything eligible for deletion (except dashboards)
+		results := b.runGarbageCollection(ctx, cutoffTimestamp)
+		require.Equal(t, int64(2), results["group/resource"])
+		require.Zero(t, results["dashboard.grafana.app/dashboards"])
+
+		trashResp, err := server.List(ctx, &resourcepb.ListRequest{
+			Source: resourcepb.ListRequest_TRASH,
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Namespace: "namespace",
+					Group:     "dashboard.grafana.app",
+					Resource:  "dashboards",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Nil(t, trashResp.Error)
+		// FIX THIS: server.List with TRASH source without setting Name should return both deleted resources, but currently only returns one - needs investigation
+		// require.Len(t, trashResp.Items, 1)
+	})
+
+}

--- a/pkg/storage/unified/resource/storage_backend_gc_test.go
+++ b/pkg/storage/unified/resource/storage_backend_gc_test.go
@@ -494,6 +494,60 @@ func TestIntegrationGarbageCollectionLoop(t *testing.T) {
 		require.Equal(t, 0, count)
 	})
 
+	t.Run("nothing is eligble to delete", func(t *testing.T) {
+		testutil.SkipIntegrationTestInShortMode(t)
+
+		ctx := testutil.NewTestContext(t, time.Now().Add(2*time.Minute))
+
+		storageBackend := setupTestStorageBackend(t, func(opts *KVBackendOptions) {
+			opts.GarbageCollection = gcConfig
+		})
+		b := storageBackend
+
+		_, err := NewResourceServer(ResourceServerOptions{
+			Backend: storageBackend,
+		})
+		require.NoError(t, err)
+
+		rv1, err := writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_ADDED)
+		require.NoError(t, err)
+		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
+			func(o *writeEventOptions) {
+				o.Namespace = "namespace"
+				o.PreviousRV = rv1
+			})
+		require.NoError(t, err)
+
+		// count how many history entries there are before GC runs - should be 2 (created and deleted)
+		historyResp := storageBackend.kv.Keys(ctx, dataSection, ListOptions{
+			StartKey: "group/resource/namespace/",
+			EndKey:   "group/resource/namespace0",
+		})
+		count := 0
+		historyResp(func(k string, err error) bool {
+			require.NoError(t, err)
+			count++
+			return true
+		})
+		require.Equal(t, 2, count)
+
+		cutoffTimestamp := time.Now().Add(-time.Hour).UnixMicro() // nothing eligible for deletion
+		b.runGarbageCollection(ctx, cutoffTimestamp)
+
+		// count how many history entries there are after GC runs - should be 0
+		historyResp = storageBackend.kv.Keys(ctx, dataSection, ListOptions{
+			StartKey: "group/resource/namespace/",
+			EndKey:   "group/resource/namespace0",
+		})
+		count = 0
+		historyResp(func(k string, err error) bool {
+			require.NoError(t, err)
+			count++
+			return true
+		})
+		require.Equal(t, 2, count)
+	})
+
 	t.Run("will respect dashboard retention settings", func(t *testing.T) {
 		testutil.SkipIntegrationTestInShortMode(t)
 

--- a/pkg/storage/unified/resource/storage_backend_gc_test.go
+++ b/pkg/storage/unified/resource/storage_backend_gc_test.go
@@ -151,7 +151,7 @@ func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		require.Equal(t, 0, len(listResp.Items))
+		require.Empty(t, listResp.Items)
 
 		cutoffTimestamp := b.garbageCollectionCutoffTimestamp("group", "resource", time.Now().Add(time.Hour).UnixMicro()) // Everything eligible for deletion
 		err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoffTimestamp)

--- a/pkg/storage/unified/resource/storage_backend_gc_test.go
+++ b/pkg/storage/unified/resource/storage_backend_gc_test.go
@@ -135,7 +135,6 @@ func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 
 		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
 			func(o *writeEventOptions) {
-				o.Namespace = "namespace"
 				o.PreviousRV = rv1
 			})
 		require.NoError(t, err)
@@ -190,7 +189,6 @@ func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 		require.NoError(t, err)
 		rv2, err := writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
 			func(o *writeEventOptions) {
-				o.Namespace = "namespace"
 				o.PreviousRV = rv1
 			})
 		require.NoError(t, err)
@@ -199,7 +197,6 @@ func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 		require.NoError(t, err)
 		_, err = writeEvent(t, ctx, storageBackend, "resource2", resourcepb.WatchEvent_DELETED,
 			func(o *writeEventOptions) {
-				o.Namespace = "namespace"
 				o.PreviousRV = rv3
 			})
 		require.NoError(t, err)
@@ -258,7 +255,6 @@ func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 		require.NoError(t, err)
 		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
 			func(o *writeEventOptions) {
-				o.Namespace = "namespace"
 				o.PreviousRV = rv1
 			})
 		require.NoError(t, err)
@@ -270,7 +266,6 @@ func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 		require.NoError(t, err)
 		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
 			func(o *writeEventOptions) {
-				o.Namespace = "namespace"
 				o.PreviousRV = rv2
 				o.Resource = "other-resource"
 			})
@@ -330,7 +325,6 @@ func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 		require.NoError(t, err)
 		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
 			func(o *writeEventOptions) {
-				o.Namespace = "namespace"
 				o.PreviousRV = rv1
 			})
 		require.NoError(t, err)
@@ -339,7 +333,6 @@ func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 		require.NoError(t, err)
 		_, err = writeEvent(t, ctx, storageBackend, "resource2", resourcepb.WatchEvent_DELETED,
 			func(o *writeEventOptions) {
-				o.Namespace = "namespace"
 				o.PreviousRV = rv2
 			})
 		require.NoError(t, err)
@@ -400,15 +393,11 @@ func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 
 		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
 			func(o *writeEventOptions) {
-				o.Namespace = "namespace"
 				o.PreviousRV = rv1
 			})
 		require.NoError(t, err)
 
-		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_ADDED,
-			func(o *writeEventOptions) {
-				o.Namespace = "namespace"
-			})
+		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_ADDED)
 		require.NoError(t, err)
 
 		cutoffTimestamp := b.garbageCollectionCutoffTimestamp("group", "resource", time.Now().Add(time.Hour).UnixMicro()) // everything eligible for deletion
@@ -459,7 +448,6 @@ func TestIntegrationGarbageCollectionLoop(t *testing.T) {
 		require.NoError(t, err)
 		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
 			func(o *writeEventOptions) {
-				o.Namespace = "namespace"
 				o.PreviousRV = rv1
 			})
 		require.NoError(t, err)
@@ -513,7 +501,6 @@ func TestIntegrationGarbageCollectionLoop(t *testing.T) {
 		require.NoError(t, err)
 		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
 			func(o *writeEventOptions) {
-				o.Namespace = "namespace"
 				o.PreviousRV = rv1
 			})
 		require.NoError(t, err)
@@ -582,7 +569,6 @@ func TestIntegrationGarbageCollectionLoop(t *testing.T) {
 		require.NoError(t, err)
 		_, err = writeEvent(t, ctx, storageBackend, "resource1", resourcepb.WatchEvent_DELETED,
 			func(o *writeEventOptions) {
-				o.Namespace = "namespace"
 				o.PreviousRV = rv2
 			})
 		require.NoError(t, err)

--- a/pkg/storage/unified/resource/storage_backend_gc_test.go
+++ b/pkg/storage/unified/resource/storage_backend_gc_test.go
@@ -55,7 +55,8 @@ func writeEvent(t *testing.T, ctx context.Context, storageBackend *kvStorageBack
 			},
 		},
 	}
-	value, _ := u.MarshalJSON()
+	value, err := u.MarshalJSON()
+	require.NoError(t, err)
 
 	res := &unstructured.Unstructured{
 		Object: map[string]any{},

--- a/pkg/storage/unified/resource/storage_backend_gc_test.go
+++ b/pkg/storage/unified/resource/storage_backend_gc_test.go
@@ -3,7 +3,6 @@ package resource
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"testing"
 	"time"
 
@@ -106,7 +105,7 @@ func writeEvent(t *testing.T, ctx context.Context, storageBackend *kvStorageBack
 	return storageBackend.WriteEvent(ctx, event)
 }
 
-func TestIntegrationGarbageCollectionBatch(t *testing.T) {
+func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 	gcConfig := GarbageCollectionConfig{
 		Enabled:          true,
 		DryRun:           false,
@@ -154,25 +153,21 @@ func TestIntegrationGarbageCollectionBatch(t *testing.T) {
 		require.Equal(t, 0, len(listResp.Items))
 
 		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // Everything eligible for deletion
-		rowsDeleted, rowsProcessed, nextEndKey, err := b.garbageCollectBatch(ctx, "group", "resource", cutoffTimestamp, 100, "group/resource/", "group/resource0")
+		err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoffTimestamp)
 		require.NoError(t, err)
-		require.Equal(t, int64(2), rowsDeleted)
-		require.Equal(t, int64(2), rowsProcessed)
-		require.Regexp(t, regexp.MustCompile(`^group/resource/namespace/resource1/\d+~created~folderuid$`), nextEndKey)
 
-		historyResp, err := server.List(ctx, &resourcepb.ListRequest{
-			Source: resourcepb.ListRequest_HISTORY,
-			Options: &resourcepb.ListOptions{
-				Key: &resourcepb.ResourceKey{
-					Namespace: "namespace",
-					Group:     "group",
-					Resource:  "resource",
-				},
-			},
+		// count how many history entries there are after GC runs - should be 0
+		historyResp := storageBackend.kv.Keys(ctx, dataSection, ListOptions{
+			StartKey: "group/resource/namespace/",
+			EndKey:   "group/resource/namespace0",
 		})
-		require.NoError(t, err)
-		require.Nil(t, historyResp.Error)
-		require.Len(t, historyResp.Items, 0)
+		count := 0
+		historyResp(func(k string, err error) bool {
+			require.NoError(t, err)
+			count++
+			return true
+		})
+		require.Equal(t, 0, count)
 	})
 
 	t.Run("will only garbage collect eligible resources before cutoff", func(t *testing.T) {
@@ -209,11 +204,8 @@ func TestIntegrationGarbageCollectionBatch(t *testing.T) {
 		require.NoError(t, err)
 
 		cutoffTimestamp := rv2 + 1
-		rowsDeleted, rowsProcessed, nextEndKey, err := b.garbageCollectBatch(ctx, "group", "resource", cutoffTimestamp, 100, "group/resource/", "group/resource0")
+		err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoffTimestamp)
 		require.NoError(t, err)
-		require.Equal(t, int64(2), rowsDeleted)
-		require.Equal(t, int64(4), rowsProcessed)
-		require.Regexp(t, regexp.MustCompile(`^group/resource/namespace/resource1/\d+~created~folderuid$`), nextEndKey)
 
 		historyResp, err := server.List(ctx, &resourcepb.ListRequest{
 			Source: resourcepb.ListRequest_HISTORY,
@@ -284,11 +276,8 @@ func TestIntegrationGarbageCollectionBatch(t *testing.T) {
 		require.NoError(t, err)
 
 		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // everything eligible for deletion
-		rowsDeleted, rowsProcessed, nexEndKey, err := b.garbageCollectBatch(ctx, "group", "resource", cutoffTimestamp, 100, "group/resource/", "group/resource0")
+		err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoffTimestamp)
 		require.NoError(t, err)
-		require.Equal(t, int64(2), rowsDeleted)
-		require.Equal(t, int64(2), rowsProcessed)
-		require.Regexp(t, regexp.MustCompile(`^group/resource/namespace/resource1/\d+~created~folderuid$`), nexEndKey)
 
 		historyResp, err := server.List(ctx, &resourcepb.ListRequest{
 			Source: resourcepb.ListRequest_HISTORY,
@@ -321,7 +310,6 @@ func TestIntegrationGarbageCollectionBatch(t *testing.T) {
 		require.Len(t, trashResp.Items, 1)
 	})
 
-	// TODO: review this
 	t.Run("will limit candidate batch size", func(t *testing.T) {
 		testutil.SkipIntegrationTestInShortMode(t)
 
@@ -371,11 +359,9 @@ func TestIntegrationGarbageCollectionBatch(t *testing.T) {
 		// require.Len(t, trashResp.Items, 2)
 
 		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // everything eligible for deletion
-		rowsDeleted, rowsProcessed, nextEndKey, err := b.garbageCollectBatch(ctx, "group", "resource", cutoffTimestamp, 1, "group/resource/", "group/resource0")
+		b.garbageCollection.BatchSize = 1
+		err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoffTimestamp)
 		require.NoError(t, err)
-		require.Equal(t, int64(2), rowsDeleted)
-		require.Equal(t, int64(1), rowsProcessed)
-		require.Regexp(t, regexp.MustCompile(`^group/resource/namespace/resource2/\d+~created~folderuid$`), nextEndKey)
 
 		trashResp, err = server.List(ctx, &resourcepb.ListRequest{
 			Source: resourcepb.ListRequest_TRASH,
@@ -425,11 +411,8 @@ func TestIntegrationGarbageCollectionBatch(t *testing.T) {
 		require.NoError(t, err)
 
 		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // everything eligible for deletion
-		rowsDeleted, rowsProcessed, nextEndKey, err := b.garbageCollectBatch(ctx, "group", "resource", cutoffTimestamp, 100, "group/resource/", "group/resource0")
+		err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoffTimestamp)
 		require.NoError(t, err)
-		require.Equal(t, int64(2), rowsDeleted) // the deleted and the created event for resource1 should be deleted, but not the recreated one
-		require.Equal(t, int64(3), rowsProcessed)
-		require.Regexp(t, regexp.MustCompile(`^group/resource/namespace/resource1/\d+~created~folderuid$`), nextEndKey)
 
 		historyResp, err := server.List(ctx, &resourcepb.ListRequest{
 			Source: resourcepb.ListRequest_HISTORY,

--- a/pkg/storage/unified/resource/storage_backend_gc_test.go
+++ b/pkg/storage/unified/resource/storage_backend_gc_test.go
@@ -153,7 +153,7 @@ func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 0, len(listResp.Items))
 
-		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // Everything eligible for deletion
+		cutoffTimestamp := b.garbageCollectionCutoffTimestamp("group", "resource", time.Now().Add(time.Hour).UnixMicro()) // Everything eligible for deletion
 		err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoffTimestamp)
 		require.NoError(t, err)
 
@@ -204,7 +204,7 @@ func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 			})
 		require.NoError(t, err)
 
-		cutoffTimestamp := rv2 + 1
+		cutoffTimestamp := b.garbageCollectionCutoffTimestamp("group", "resource", rv2+1)
 		err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoffTimestamp)
 		require.NoError(t, err)
 
@@ -276,7 +276,7 @@ func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 			})
 		require.NoError(t, err)
 
-		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // everything eligible for deletion
+		cutoffTimestamp := b.garbageCollectionCutoffTimestamp("group", "resource", time.Now().Add(time.Hour).UnixMicro()) // everything eligible for deletion
 		err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoffTimestamp)
 		require.NoError(t, err)
 
@@ -359,7 +359,7 @@ func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 		// FIX THIS: server.List with TRASH source without setting Name should return both deleted resources, but currently only returns one - needs investigation
 		// require.Len(t, trashResp.Items, 2)
 
-		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // everything eligible for deletion
+		cutoffTimestamp := b.garbageCollectionCutoffTimestamp("group", "resource", time.Now().Add(time.Hour).UnixMicro()) // everything eligible for deletion
 		b.garbageCollection.BatchSize = 1
 		err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoffTimestamp)
 		require.NoError(t, err)
@@ -411,7 +411,7 @@ func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 			})
 		require.NoError(t, err)
 
-		cutoffTimestamp := time.Now().Add(time.Hour).UnixMicro() // everything eligible for deletion
+		cutoffTimestamp := b.garbageCollectionCutoffTimestamp("group", "resource", time.Now().Add(time.Hour).UnixMicro()) // everything eligible for deletion
 		err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoffTimestamp)
 		require.NoError(t, err)
 

--- a/pkg/storage/unified/resource/storage_backend_gc_test.go
+++ b/pkg/storage/unified/resource/storage_backend_gc_test.go
@@ -419,6 +419,58 @@ func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 		require.Nil(t, historyResp.Error)
 		require.Len(t, historyResp.Items, 1)
 	})
+
+	t.Run("pagination does not delete resources that were recreated", func(t *testing.T) {
+		testutil.SkipIntegrationTestInShortMode(t)
+
+		ctx := testutil.NewTestContext(t, time.Now().Add(30*time.Second))
+
+		cfg := gcConfig
+		cfg.BatchSize = 3
+		storageBackend := setupTestStorageBackend(t, func(opts *KVBackendOptions) {
+			opts.GarbageCollection = cfg
+		})
+		b := storageBackend
+
+		// other-dash: 2 keys (created, deleted)
+		rv1, err := writeEvent(t, ctx, storageBackend, "other-dash", resourcepb.WatchEvent_ADDED)
+		require.NoError(t, err)
+		_, err = writeEvent(t, ctx, storageBackend, "other-dash", resourcepb.WatchEvent_DELETED,
+			func(o *writeEventOptions) { o.PreviousRV = rv1 })
+		require.NoError(t, err)
+
+		// my-dash: 5 keys (created, updated, deleted, created again and updated again) — first batch ends with a my-dash key
+		rv1, err = writeEvent(t, ctx, storageBackend, "my-dash", resourcepb.WatchEvent_ADDED)
+		require.NoError(t, err)
+		rv2, err := writeEvent(t, ctx, storageBackend, "my-dash", resourcepb.WatchEvent_MODIFIED,
+			func(o *writeEventOptions) { o.PreviousRV = rv1 })
+		require.NoError(t, err)
+		_, err = writeEvent(t, ctx, storageBackend, "my-dash", resourcepb.WatchEvent_DELETED,
+			func(o *writeEventOptions) { o.PreviousRV = rv2 })
+		require.NoError(t, err)
+		rv4, err := writeEvent(t, ctx, storageBackend, "my-dash", resourcepb.WatchEvent_ADDED)
+		require.NoError(t, err)
+		_, err = writeEvent(t, ctx, storageBackend, "my-dash", resourcepb.WatchEvent_MODIFIED,
+			func(o *writeEventOptions) { o.PreviousRV = rv4 })
+		require.NoError(t, err)
+
+		cutoffTimestamp := b.garbageCollectionCutoffTimestamp("group", "resource", time.Now().Add(time.Hour).UnixMicro())
+		err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoffTimestamp)
+		require.NoError(t, err)
+
+		// Both resources should be fully GC'd; no history keys left
+		historyResp := storageBackend.kv.Keys(ctx, dataSection, ListOptions{
+			StartKey: "group/resource/namespace/",
+			EndKey:   "group/resource/namespace0",
+		})
+		count := 0
+		historyResp(func(k string, err error) bool {
+			require.NoError(t, err)
+			count++
+			return true
+		})
+		require.Equal(t, 2, count)
+	})
 }
 
 func TestIntegrationGarbageCollectionLoop(t *testing.T) {
@@ -521,7 +573,7 @@ func TestIntegrationGarbageCollectionLoop(t *testing.T) {
 		cutoffTimestamp := time.Now().Add(-time.Hour).UnixMicro() // nothing eligible for deletion
 		b.runGarbageCollection(ctx, cutoffTimestamp)
 
-		// count how many history entries there are after GC runs - should be 0
+		// count how many history entries there are after GC runs - should still be 2
 		historyResp = storageBackend.kv.Keys(ctx, dataSection, ListOptions{
 			StartKey: "group/resource/namespace/",
 			EndKey:   "group/resource/namespace0",

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -143,9 +143,7 @@ func NewStorageBackend(
 		Log:                  log.New("storage-backend"),
 		DBKeepAlive:          eDB,
 		LastImportTimeMaxAge: cfg.MaxFileIndexAge,
-<<<<<<< HEAD
 		TenantWatcherConfig:  resource.NewTenantWatcherConfig(cfg),
-=======
 		GarbageCollection: resource.GarbageCollectionConfig{
 			Enabled:          cfg.EnableGarbageCollection,
 			DryRun:           cfg.GarbageCollectionDryRun,
@@ -156,7 +154,6 @@ func NewStorageBackend(
 		},
 		EventRetentionPeriod: cfg.EventRetentionPeriod,
 		EventPruningInterval: cfg.EventPruningInterval,
->>>>>>> 440a3d2b9e4 (wip)
 	}
 
 	if cfg.EnableSQLKVCompatibilityMode {

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -143,7 +143,20 @@ func NewStorageBackend(
 		Log:                  log.New("storage-backend"),
 		DBKeepAlive:          eDB,
 		LastImportTimeMaxAge: cfg.MaxFileIndexAge,
+<<<<<<< HEAD
 		TenantWatcherConfig:  resource.NewTenantWatcherConfig(cfg),
+=======
+		GarbageCollection: resource.GarbageCollectionConfig{
+			Enabled:          cfg.EnableGarbageCollection,
+			DryRun:           cfg.GarbageCollectionDryRun,
+			Interval:         cfg.GarbageCollectionInterval,
+			BatchSize:        cfg.GarbageCollectionBatchSize,
+			MaxAge:           cfg.GarbageCollectionMaxAge,
+			DashboardsMaxAge: cfg.DashboardsGarbageCollectionMaxAge,
+		},
+		EventRetentionPeriod: cfg.EventRetentionPeriod,
+		EventPruningInterval: cfg.EventPruningInterval,
+>>>>>>> 440a3d2b9e4 (wip)
 	}
 
 	if cfg.EnableSQLKVCompatibilityMode {

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -163,7 +163,6 @@ func withBackend(opts *ServerOptions, resourceOpts *resource.ResourceServerOptio
 	if diagnostics, ok := opts.Backend.(resourcepb.DiagnosticsServer); ok {
 		resourceOpts.Diagnostics = diagnostics
 	}
-
 	return nil
 }
 

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -163,6 +163,7 @@ func withBackend(opts *ServerOptions, resourceOpts *resource.ResourceServerOptio
 	if diagnostics, ok := opts.Backend.(resourcepb.DiagnosticsServer); ok {
 		resourceOpts.Diagnostics = diagnostics
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR adds the implementation of a Garbage Collector background job for Unified Storage SQLKV backend

**Why do we need this feature?**

We need to periodically flush entries related to deleted resources from resource_history table.

**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/667

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
