### PR TITLE
Rendering: Fix single panel render with variable references

### DIFF
--- a/public/app/features/dashboard-scene/solo/SoloPanelPage.tsx
+++ b/public/app/features/dashboard-scene/solo/SoloPanelPage.tsx
@@ -54,7 +54,7 @@ export function SoloPanelPage({ queryParams }: Props) {
   }
 
   return (
-    <UrlSyncContextProvider scene={dashboard}>
+    <UrlSyncContextProvider scene={dashboard} updateUrlOnInit={true}>
       <SoloPanelRenderer dashboard={dashboard} panelId={queryParams.panelId} hideLogo={queryParams.hideLogo} />
     </UrlSyncContextProvider>
   );


### PR DESCRIPTION
This fixes a racy 🐎 issue where requests to (`/render/d-solo/`) render single panel screenshots would intermittently fail with a timeout for dashboards that had query variables.

The panel would never complete rendering, that is the `window.__querySceneRunningCount` would never become `0`.
  
I tried to reduce the issue as much as possible, and was able to consistently reproduce it with the following setup:
- Two query variables, where one depended (`action`) on the value of the other (`app`);
- The variables do not have a value (this I couldn't confirm 100% is needed);
- Use the example URL, and make sure to _disable caching_: http://localhost:3000/render/d-solo/asu2d2ax?orgId=1&from=2026-02-16T09:32:26.265Z&to=2026-02-16T10:02:26.265Z&timezone=browser&panelId=panel-1&__feature.dashboardSceneSolo=true&width=1000&height=50
  
The problem is that `var-action=` is not present in the URL, and causes the rendering to fail sometimes.

By setting `updateUrlOnInit={true}` in the `UrlSyncContextProvider` component, we make sure to load all these variables before we start rendering the panels. After setting this prop, I could no longer reproduce the issue.
  
I suspect this will also resolve other Image Renderer issues related to rendering panels for alerts, and other plugins (like Icinga), which use a similar approach.

We aren't seeing this issue usually because if you click on the panel, `Share > Share link > Copy image link`, it will generate a URL with *all* variables, which avoids the issue altogether. In our example: http://localhost:3000/render/d-solo/asu2d2ax?orgId=1&from=2026-02-16T14:58:03.529Z&to=2026-02-16T15:28:03.529Z&timezone=browser&var-app=&var-query1=bfdeqr4itbtoge&var-action=&panelId=panel-1&__feature.dashboardScene=true&hideLogo=true&width=1000&height=500&scale=1&tz=Europe%2FMadrid

In order to disable caching hints from the server, edit the line in: 
https://github.com/grafana/grafana/blob/main/pkg/api/render.go#L121 and replace it with:
```go
c.Resp.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
c.Resp.Header().Set("Pragma", "no-cache")
```

<details>
<summary>Here is the dashboard json you can import to reproduce the issue</summary>
  
```json
{
  "__inputs": [
    {
      "name": "DS_PROMETHEUS",
      "label": "prometheus",
      "description": "",
      "type": "datasource",
      "pluginId": "prometheus",
      "pluginName": "Prometheus"
    }
  ],
  "__elements": {},
  "__requires": [
    {
      "type": "grafana",
      "id": "grafana",
      "name": "Grafana",
      "version": "12.3.3"
    },
    {
      "type": "datasource",
      "id": "prometheus",
      "name": "Prometheus",
      "version": "1.0.0"
    },
    {
      "type": "panel",
      "id": "timeseries",
      "name": "Time series",
      "version": ""
    }
  ],
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "prometheus",
        "uid": "${query1}"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "barWidthFactor": 0.6,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "showValues": false,
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": 0
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "hideZeros": false,
          "mode": "single",
          "sort": "none"
        }
      },
      "pluginVersion": "12.3.3",
      "targets": [
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${query1}"
          },
          "editorMode": "code",
          "expr": "rate(process_cpu_seconds_total{}[$__rate_interval])",
          "legendFormat": "__auto",
          "range": true,
          "refId": "A"
        }
      ],
      "title": "New panel",
      "type": "timeseries"
    }
  ],
  "preload": false,
  "schemaVersion": 42,
  "tags": [],
  "templating": {
    "list": [
      {
        "current": {},
        "datasource": {
          "type": "prometheus",
          "uid": "${DS_PROMETHEUS}"
        },
        "definition": "label_values(application_status, app) ",
        "includeAll": false,
        "name": "app",
        "options": [],
        "query": {
          "query": "label_values(application_status, app) ",
          "refId": "StandardVariableQuery"
        },
        "refresh": 1,
        "regex": "(.*)-$environment",
        "sort": 1,
        "type": "query"
      },
      {
        "current": {
          "text": "",
          "value": "${DS_PROMETHEUS}",
          "selected": true
        },
        "name": "query1",
        "options": [],
        "query": "prometheus",
        "refresh": 1,
        "regex": "",
        "type": "datasource"
      },
      {
        "allowCustomValue": false,
        "current": {},
        "datasource": {
          "type": "prometheus",
          "uid": "${DS_PROMETHEUS}"
        },
        "definition": "label_values(http_requests_total{service=\"$app\"},action)",
        "hide": 2,
        "name": "action",
        "options": [],
        "query": {
          "qryType": 1,
          "query": "label_values(http_requests_total{service=\"$app\"},action)",
          "refId": "PrometheusVariableQueryEditor-VariableQuery"
        },
        "refresh": 1,
        "regex": "",
        "type": "query"
      }
    ]
  },
  "time": {
    "from": "now-30m",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "New dashboard2",
  "uid": "asu2d2ax",
  "version": 2,
  "weekStart": "",
  "id": null
}
```
</details>
