### PR TITLE
App Platform: Add dry-run support to DualWriter

### DIFF
--- a/pkg/registry/apis/folders/folder_storage.go
+++ b/pkg/registry/apis/folders/folder_storage.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apiserver/pkg/util/dryrun"
 
 	claims "github.com/grafana/authlib/types"
 
@@ -84,6 +85,11 @@ func (s *folderStorage) Create(ctx context.Context,
 	if err != nil {
 		statusErr := apierrors.ToFolderStatusError(err)
 		return nil, &statusErr
+	}
+
+	// Skip permission side effects during dry-run
+	if dryrun.IsDryRun(options.DryRun) {
+		return obj, nil
 	}
 
 	// When cfg.RBAC.PermissionsOnCreation("folder") is not enabled

--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apiserver/pkg/util/dryrun"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
@@ -202,6 +203,12 @@ func (d *dualWriter) Create(ctx context.Context, in runtime.Object, createValida
 			attribute.Bool("readUnified", d.readUnified)))
 	defer span.End()
 
+	// During dry-run, skip legacy storage and delegate directly to unified storage
+	// which already handles dry-run correctly via DryRunnableStorage.
+	if dryrun.IsDryRun(options.DryRun) {
+		return d.unified.Create(ctx, in, createValidation, options)
+	}
+
 	log := logging.FromContext(ctx).With("method", "Create")
 
 	accIn, err := utils.MetaAccessor(in)
@@ -333,6 +340,13 @@ func (d *dualWriter) Delete(ctx context.Context, name string, deleteValidation r
 			attribute.Bool("errorIsOK", d.errorIsOK),
 			attribute.Bool("readUnified", d.readUnified)))
 	defer span.End()
+
+	// During dry-run, skip legacy storage and delegate directly to unified storage
+	// which already handles dry-run correctly via DryRunnableStorage.
+	if dryrun.IsDryRun(options.DryRun) {
+		return d.unified.Delete(ctx, name, deleteValidation, options)
+	}
+
 	log := logging.FromContext(ctx).With("method", "Delete", "name", name)
 	ctx = utils.SetFolderRemovePermissions(ctx, false)
 
@@ -379,6 +393,13 @@ func (d *dualWriter) Update(ctx context.Context, name string, objInfo rest.Updat
 			attribute.Bool("errorIsOK", d.errorIsOK),
 			attribute.Bool("readUnified", d.readUnified)))
 	defer span.End()
+
+	// During dry-run, skip legacy storage and delegate directly to unified storage
+	// which already handles dry-run correctly via DryRunnableStorage.
+	if dryrun.IsDryRun(options.DryRun) {
+		return d.unified.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+	}
+
 	log := logging.FromContext(ctx).With("method", "Update", "name", name)
 	// update in legacy first, and then unistore. Will return a failure if either fails.
 	//
@@ -464,6 +485,12 @@ func (d *dualWriter) DeleteCollection(ctx context.Context, deleteValidation rest
 			attribute.Bool("errorIsOK", d.errorIsOK),
 			attribute.Bool("readUnified", d.readUnified)))
 	defer span.End()
+
+	// During dry-run, skip legacy storage and delegate directly to unified storage
+	// which already handles dry-run correctly via DryRunnableStorage.
+	if dryrun.IsDryRun(options.DryRun) {
+		return d.unified.DeleteCollection(ctx, deleteValidation, options, listOptions)
+	}
 
 	log := logging.FromContext(ctx).With("method", "DeleteCollection", "resourceVersion", listOptions.ResourceVersion)
 

--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -397,7 +397,13 @@ func (d *dualWriter) Update(ctx context.Context, name string, objInfo rest.Updat
 	// During dry-run, skip legacy storage and delegate directly to unified storage
 	// which already handles dry-run correctly via DryRunnableStorage.
 	if dryrun.IsDryRun(options.DryRun) {
-		return d.unified.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+		dryRunInfo := objInfo
+		dryRunForceCreate := forceAllowCreate
+		if !d.readUnified {
+			dryRunInfo = &wrappedUpdateInfo{objInfo: objInfo}
+			dryRunForceCreate = true
+		}
+		return d.unified.Update(ctx, name, dryRunInfo, createValidation, updateValidation, dryRunForceCreate, options)
 	}
 
 	log := logging.FromContext(ctx).With("method", "Update", "name", name)

--- a/pkg/storage/legacysql/dualwrite/dualwriter_dryrun_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_dryrun_test.go
@@ -1,0 +1,167 @@
+package dualwrite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/grafana/grafana/pkg/apiserver/rest"
+)
+
+// dryRunOptions contains the standard DryRun field value used in k8s dry-run requests.
+var dryRunAll = []string{metav1.DryRunAll}
+
+func TestDryRun_Create(t *testing.T) {
+	modes := []struct {
+		name string
+		mode rest.DualWriterMode
+	}{
+		{"Mode1", rest.Mode1},
+		{"Mode2", rest.Mode2},
+		{"Mode3", rest.Mode3},
+	}
+
+	for _, m := range modes {
+		t.Run(m.name+" should not create in legacy storage when dry-run is set", func(t *testing.T) {
+			l := (rest.Storage)(nil)
+			s := (rest.Storage)(nil)
+
+			ls := storageMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
+
+			// Only unified storage should be called
+			us.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, nil)
+
+			dw, err := NewStaticStorage(kind, m.mode, ls, us)
+			require.NoError(t, err)
+
+			obj, err := dw.Create(context.Background(), exampleObj, createFn, &metav1.CreateOptions{DryRun: dryRunAll})
+			require.NoError(t, err)
+			require.Equal(t, exampleObj, obj)
+
+			// Legacy storage should NOT have been called
+			ls.AssertNotCalled(t, "Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			// Unified storage should have been called
+			us.AssertCalled(t, "Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		})
+	}
+}
+
+func TestDryRun_Delete(t *testing.T) {
+	modes := []struct {
+		name string
+		mode rest.DualWriterMode
+	}{
+		{"Mode1", rest.Mode1},
+		{"Mode2", rest.Mode2},
+		{"Mode3", rest.Mode3},
+	}
+
+	for _, m := range modes {
+		t.Run(m.name+" should not delete in legacy storage when dry-run is set", func(t *testing.T) {
+			l := (rest.Storage)(nil)
+			s := (rest.Storage)(nil)
+
+			ls := storageMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
+
+			// Only unified storage should be called
+			us.On("Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+
+			dw, err := NewStaticStorage(kind, m.mode, ls, us)
+			require.NoError(t, err)
+
+			obj, _, err := dw.Delete(context.Background(), "foo", func(context.Context, runtime.Object) error { return nil }, &metav1.DeleteOptions{DryRun: dryRunAll})
+			require.NoError(t, err)
+			require.Equal(t, exampleObj, obj)
+
+			// Legacy storage should NOT have been called
+			ls.AssertNotCalled(t, "Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			// Unified storage should have been called
+			us.AssertCalled(t, "Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		})
+	}
+}
+
+func TestDryRun_Update(t *testing.T) {
+	modes := []struct {
+		name string
+		mode rest.DualWriterMode
+	}{
+		{"Mode1", rest.Mode1},
+		{"Mode2", rest.Mode2},
+		{"Mode3", rest.Mode3},
+	}
+
+	for _, m := range modes {
+		t.Run(m.name+" should not update in legacy storage when dry-run is set", func(t *testing.T) {
+			l := (rest.Storage)(nil)
+			s := (rest.Storage)(nil)
+
+			ls := storageMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
+
+			// Only unified storage should be called
+			us.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+
+			dw, err := NewStaticStorage(kind, m.mode, ls, us)
+			require.NoError(t, err)
+
+			obj, _, err := dw.Update(context.Background(), "foo", updatedObjInfoObj{},
+				func(ctx context.Context, obj runtime.Object) error { return nil },
+				func(ctx context.Context, obj, old runtime.Object) error { return nil },
+				false, &metav1.UpdateOptions{DryRun: dryRunAll})
+			require.NoError(t, err)
+			require.Equal(t, exampleObj, obj)
+
+			// Legacy storage should NOT have been called
+			ls.AssertNotCalled(t, "Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			// Unified storage should have been called
+			us.AssertCalled(t, "Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		})
+	}
+}
+
+func TestDryRun_DeleteCollection(t *testing.T) {
+	modes := []struct {
+		name string
+		mode rest.DualWriterMode
+	}{
+		{"Mode1", rest.Mode1},
+		{"Mode2", rest.Mode2},
+		{"Mode3", rest.Mode3},
+	}
+
+	for _, m := range modes {
+		t.Run(m.name+" should not delete collection in legacy storage when dry-run is set", func(t *testing.T) {
+			l := (rest.Storage)(nil)
+			s := (rest.Storage)(nil)
+
+			ls := storageMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
+
+			// Only unified storage should be called
+			us.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleList, nil)
+
+			dw, err := NewStaticStorage(kind, m.mode, ls, us)
+			require.NoError(t, err)
+
+			obj, err := dw.DeleteCollection(context.Background(),
+				func(ctx context.Context, obj runtime.Object) error { return nil },
+				&metav1.DeleteOptions{DryRun: dryRunAll},
+				&metainternalversion.ListOptions{})
+			require.NoError(t, err)
+			require.Equal(t, exampleList, obj)
+
+			// Legacy storage should NOT have been called
+			ls.AssertNotCalled(t, "DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			// Unified storage should have been called
+			us.AssertCalled(t, "DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		})
+	}
+}


### PR DESCRIPTION
**What is this feature?**

This PR adds comprehensive dry-run support to app platform storage operations, ensuring dry-run requests don't create side effects like permissions or actually modify data in the database.

**Why do we need this feature?**

Dry-run operations must be validated without side effects. When the dualwriter coordinates between legacy and unified storage, it must bypass legacy storage during dry-run since legacy storage doesn't properly implement Kubernetes dry-run semantics. The unified storage already handles dry-run correctly via DryRunnableStorage, so delegating to it during dry-run ensures correctness.

**Who is this feature for?**

This is for API users who rely on dry-run requests to validate operations before actually executing them, and for the app platform to meet Kubernetes API semantics.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafanactl/issues/183

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

**Test Coverage:**
- Added unit tests for dry-run in all dual-writer modes (1-3) covering Create, Delete, Update, and DeleteCollection
- Added integration test validating end-to-end dry-run semantics for folder resources