### PR TITLE
Provisioning: Add tooltip for disabled automatic pulling

### DIFF
--- a/public/app/features/provisioning/Repository/RepositoryListItem.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryListItem.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 
+import { dateTimeFormatTimeAgo } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { Badge, Card, LinkButton, Stack, Text, TextLink } from '@grafana/ui';
@@ -43,6 +44,16 @@ export function RepositoryListItem({ repository }: Props) {
       );
     }
 
+    if (status?.sync?.finished) {
+      meta.push(
+        <Text variant="bodySmall" color="secondary" key="last-sync">
+          {t('provisioning.repository-card.last-sync', 'Last sync: {{date}}', {
+            date: dateTimeFormatTimeAgo(status.sync.finished),
+          })}
+        </Text>
+      );
+    }
+
     return meta;
   };
 
@@ -82,11 +93,7 @@ export function RepositoryListItem({ repository }: Props) {
         </Stack>
       </Card.Description>
 
-      <Card.Meta>
-        <Stack gap={2} direction="row" wrap>
-          {getRepositoryMeta()}
-        </Stack>
-      </Card.Meta>
+      <Card.Meta>{getRepositoryMeta()}</Card.Meta>
 
       <Card.Actions>
         <Stack gap={1} direction="row">

--- a/public/app/features/provisioning/Shared/StatusBadge.tsx
+++ b/public/app/features/provisioning/Shared/StatusBadge.tsx
@@ -23,57 +23,70 @@ function getBadgeConfig(repo: Repository): BadgeConfig {
     };
   }
 
-  if (!repo.spec?.sync?.enabled) {
+  const pullingDisabledTooltip = !repo.spec?.sync?.enabled
+    ? t(
+        'provisioning.status-badge.automatic-pulling-disabled-tooltip',
+        'Automatic pulling disabled. Review your connection configuration to enable pulling.'
+      )
+    : undefined;
+
+  // Sync state takes precedence over disabled state
+  if (repo.status?.sync?.state?.length) {
+    switch (repo.status.sync.state) {
+      case 'success':
+        return {
+          icon: 'check',
+          text: t('provisioning.status-badge.up-to-date', 'Up-to-date'),
+          color: 'green',
+          tooltip: pullingDisabledTooltip,
+        };
+      case 'warning':
+        return {
+          color: 'orange',
+          text: t('provisioning.status-badge.warning', 'Warning'),
+          icon: 'exclamation-triangle',
+          tooltip: pullingDisabledTooltip,
+        };
+      case 'working':
+      case 'pending':
+        return {
+          color: 'darkgrey',
+          text: t('provisioning.status-badge.pulling', 'Pulling'),
+          icon: 'spinner',
+          tooltip: pullingDisabledTooltip,
+        };
+      case 'error':
+        return {
+          color: 'red',
+          text: t('provisioning.status-badge.error', 'Error'),
+          icon: 'exclamation-triangle',
+          tooltip: pullingDisabledTooltip,
+        };
+      default:
+        return {
+          color: 'purple',
+          text: t('provisioning.status-badge.unknown', 'Unknown'),
+          icon: 'exclamation-triangle',
+          tooltip: pullingDisabledTooltip,
+        };
+    }
+  }
+
+  if (pullingDisabledTooltip) {
     return {
       color: 'orange',
-      text: t('provisioning.status-badge.automatic-pulling-disabled', 'Automatic pulling disabled'),
+      text: t('provisioning.status-badge.disabled', 'Disabled'),
       icon: 'info-circle',
+      tooltip: pullingDisabledTooltip,
     };
   }
 
-  if (!repo.status?.sync?.state?.length) {
-    return {
-      color: 'darkgrey',
-      text: t('provisioning.status-badge.pending', 'Pending'),
-      icon: 'spinner',
-      tooltip: t('provisioning.status-badge.waiting-for-health-check', 'Waiting for health check to run'),
-    };
-  }
-
-  // Sync state
-  switch (repo.status?.sync?.state) {
-    case 'success':
-      return {
-        icon: 'check',
-        text: t('provisioning.status-badge.up-to-date', 'Up-to-date'),
-        color: 'green',
-      };
-    case 'warning':
-      return {
-        color: 'orange',
-        text: t('provisioning.status-badge.warning', 'Warning'),
-        icon: 'exclamation-triangle',
-      };
-    case 'working':
-    case 'pending':
-      return {
-        color: 'darkgrey',
-        text: t('provisioning.status-badge.pulling', 'Pulling'),
-        icon: 'spinner',
-      };
-    case 'error':
-      return {
-        color: 'red',
-        text: t('provisioning.status-badge.error', 'Error'),
-        icon: 'exclamation-triangle',
-      };
-    default:
-      return {
-        color: 'purple',
-        text: t('provisioning.status-badge.unknown', 'Unknown'),
-        icon: 'exclamation-triangle',
-      };
-  }
+  return {
+    color: 'darkgrey',
+    text: t('provisioning.status-badge.pending', 'Pending'),
+    icon: 'spinner',
+    tooltip: t('provisioning.status-badge.waiting-for-health-check', 'Waiting for health check to run'),
+  };
 }
 
 interface StatusBadgeProps {

--- a/public/app/features/provisioning/Shared/StatusBadge.tsx
+++ b/public/app/features/provisioning/Shared/StatusBadge.tsx
@@ -23,70 +23,59 @@ function getBadgeConfig(repo: Repository): BadgeConfig {
     };
   }
 
-  const pullingDisabledTooltip = !repo.spec?.sync?.enabled
-    ? t(
-        'provisioning.status-badge.automatic-pulling-disabled-tooltip',
-        'Automatic pulling disabled. Review your connection configuration to enable pulling.'
-      )
-    : undefined;
+  let config: BadgeConfig;
 
   // Sync state takes precedence over disabled state
   if (repo.status?.sync?.state?.length) {
     switch (repo.status.sync.state) {
       case 'success':
-        return {
-          icon: 'check',
-          text: t('provisioning.status-badge.up-to-date', 'Up-to-date'),
-          color: 'green',
-          tooltip: pullingDisabledTooltip,
-        };
+        config = { icon: 'check', text: t('provisioning.status-badge.up-to-date', 'Up-to-date'), color: 'green' };
+        break;
       case 'warning':
-        return {
+        config = {
           color: 'orange',
           text: t('provisioning.status-badge.warning', 'Warning'),
           icon: 'exclamation-triangle',
-          tooltip: pullingDisabledTooltip,
         };
+        break;
       case 'working':
       case 'pending':
-        return {
-          color: 'darkgrey',
-          text: t('provisioning.status-badge.pulling', 'Pulling'),
-          icon: 'spinner',
-          tooltip: pullingDisabledTooltip,
-        };
+        config = { color: 'darkgrey', text: t('provisioning.status-badge.pulling', 'Pulling'), icon: 'spinner' };
+        break;
       case 'error':
-        return {
+        config = {
           color: 'red',
           text: t('provisioning.status-badge.error', 'Error'),
           icon: 'exclamation-triangle',
-          tooltip: pullingDisabledTooltip,
         };
+        break;
       default:
-        return {
+        config = {
           color: 'purple',
           text: t('provisioning.status-badge.unknown', 'Unknown'),
           icon: 'exclamation-triangle',
-          tooltip: pullingDisabledTooltip,
         };
+        break;
     }
-  }
-
-  if (pullingDisabledTooltip) {
-    return {
-      color: 'orange',
-      text: t('provisioning.status-badge.disabled', 'Disabled'),
-      icon: 'info-circle',
-      tooltip: pullingDisabledTooltip,
+  } else if (!repo.spec?.sync?.enabled) {
+    config = { color: 'orange', text: t('provisioning.status-badge.disabled', 'Disabled'), icon: 'info-circle' };
+  } else {
+    config = {
+      color: 'darkgrey',
+      text: t('provisioning.status-badge.pending', 'Pending'),
+      icon: 'spinner',
+      tooltip: t('provisioning.status-badge.waiting-for-health-check', 'Waiting for health check to run'),
     };
   }
 
-  return {
-    color: 'darkgrey',
-    text: t('provisioning.status-badge.pending', 'Pending'),
-    icon: 'spinner',
-    tooltip: t('provisioning.status-badge.waiting-for-health-check', 'Waiting for health check to run'),
-  };
+  if (!repo.spec?.sync?.enabled) {
+    config.tooltip = t(
+      'provisioning.status-badge.automatic-pulling-disabled-tooltip',
+      'Automatic pulling disabled. Review your connection configuration to enable pulling.'
+    );
+  }
+
+  return config;
 }
 
 interface StatusBadgeProps {

--- a/public/app/features/provisioning/Shared/StatusBadge.tsx
+++ b/public/app/features/provisioning/Shared/StatusBadge.tsx
@@ -23,44 +23,20 @@ function getBadgeConfig(repo: Repository): BadgeConfig {
     };
   }
 
-  let config: BadgeConfig;
+  if (!repo.spec?.sync?.enabled) {
+    return {
+      color: 'orange',
+      text: t('provisioning.status-badge.disabled', 'Disabled'),
+      icon: 'info-circle',
+      tooltip: t(
+        'provisioning.status-badge.automatic-pulling-disabled-tooltip',
+        'Automatic pulling disabled. Review your connection configuration to enable pulling.'
+      ),
+    };
+  }
 
-  // Sync state takes precedence over disabled state
-  if (repo.status?.sync?.state?.length) {
-    switch (repo.status.sync.state) {
-      case 'success':
-        config = { icon: 'check', text: t('provisioning.status-badge.up-to-date', 'Up-to-date'), color: 'green' };
-        break;
-      case 'warning':
-        config = {
-          color: 'orange',
-          text: t('provisioning.status-badge.warning', 'Warning'),
-          icon: 'exclamation-triangle',
-        };
-        break;
-      case 'working':
-      case 'pending':
-        config = { color: 'darkgrey', text: t('provisioning.status-badge.pulling', 'Pulling'), icon: 'spinner' };
-        break;
-      case 'error':
-        config = {
-          color: 'red',
-          text: t('provisioning.status-badge.error', 'Error'),
-          icon: 'exclamation-triangle',
-        };
-        break;
-      default:
-        config = {
-          color: 'purple',
-          text: t('provisioning.status-badge.unknown', 'Unknown'),
-          icon: 'exclamation-triangle',
-        };
-        break;
-    }
-  } else if (!repo.spec?.sync?.enabled) {
-    config = { color: 'orange', text: t('provisioning.status-badge.disabled', 'Disabled'), icon: 'info-circle' };
-  } else {
-    config = {
+  if (!repo.status?.sync?.state?.length) {
+    return {
       color: 'darkgrey',
       text: t('provisioning.status-badge.pending', 'Pending'),
       icon: 'spinner',
@@ -68,14 +44,31 @@ function getBadgeConfig(repo: Repository): BadgeConfig {
     };
   }
 
-  if (!repo.spec?.sync?.enabled) {
-    config.tooltip = t(
-      'provisioning.status-badge.automatic-pulling-disabled-tooltip',
-      'Automatic pulling disabled. Review your connection configuration to enable pulling.'
-    );
+  switch (repo.status.sync.state) {
+    case 'success':
+      return { icon: 'check', text: t('provisioning.status-badge.up-to-date', 'Up-to-date'), color: 'green' };
+    case 'warning':
+      return {
+        color: 'orange',
+        text: t('provisioning.status-badge.warning', 'Warning'),
+        icon: 'exclamation-triangle',
+      };
+    case 'working':
+    case 'pending':
+      return { color: 'darkgrey', text: t('provisioning.status-badge.pulling', 'Pulling'), icon: 'spinner' };
+    case 'error':
+      return {
+        color: 'red',
+        text: t('provisioning.status-badge.error', 'Error'),
+        icon: 'exclamation-triangle',
+      };
+    default:
+      return {
+        color: 'purple',
+        text: t('provisioning.status-badge.unknown', 'Unknown'),
+        icon: 'exclamation-triangle',
+      };
   }
-
-  return config;
 }
 
 interface StatusBadgeProps {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12723,6 +12723,7 @@
       "source-code": "Source code"
     },
     "repository-card": {
+      "last-sync": "Last sync: {{date}}",
       "read-only-badge": "Read only",
       "settings": "Settings",
       "view": "View"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12851,7 +12851,6 @@
       "label-pending-step": "Pending step"
     },
     "status-badge": {
-      "automatic-pulling-disabled": "Automatic pulling disabled",
       "automatic-pulling-disabled-tooltip": "Automatic pulling disabled. Review your connection configuration to enable pulling.",
       "deleting": "Deleting",
       "disabled": "Disabled",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12852,7 +12852,9 @@
     },
     "status-badge": {
       "automatic-pulling-disabled": "Automatic pulling disabled",
+      "automatic-pulling-disabled-tooltip": "Automatic pulling disabled. Review your connection configuration to enable pulling.",
       "deleting": "Deleting",
+      "disabled": "Disabled",
       "error": "Error",
       "pending": "Pending",
       "pulling": "Pulling",


### PR DESCRIPTION
**What is this feature?**

Add a tooltip to repository status badges when automatic pulling is disabled, guiding users to review their connection configuration. The badge text simplifies from "Automatic pulling disabled" to "Disabled" for clarity, with the full explanatory message shown on hover.

**Fixes**: https://github.com/grafana/git-ui-sync-project/issues/829

Provisioning wizard abandoned: 
<img width="883" height="186" alt="Screenshot 2026-02-16 at 17 30 42" src="https://github.com/user-attachments/assets/367df095-5c80-44d0-be54-6109f245a04b" />


Healthy repository, but with a disabled sync:

<img width="678" height="183" alt="Screenshot 2026-02-16 at 17 31 12" src="https://github.com/user-attachments/assets/bd43e4c9-16b4-410b-8007-a163d5fad4f7" />
