### PR TITLE
docs(saml): add Okta-specific role sync configuration example

### DIFF
--- a/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-team-role-mapping/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-team-role-mapping/_index.md
@@ -108,3 +108,64 @@ Example configuration:
 [auth.saml]
 skip_org_role_sync = true
 ```
+
+## Configure role sync with Okta
+
+This section shows how to configure Okta to send group memberships in the SAML assertion, then use those groups to assign roles in Grafana.
+
+### Step 1: Configure Okta to send groups
+
+1. In Okta Admin, go to **Applications** > **Applications** and open your Grafana SAML app.
+1. Open the **Sign On** tab, then click **Edit** in the SAML 2.0 section.
+1. Scroll to **GROUP ATTRIBUTE STATEMENTS**.
+1. Add a group attribute with the following settings:
+
+   | Field      | Value           |
+   | ---------- | --------------- |
+   | **Name**   | `Group`         |
+   | **Filter** | Matches regex   |
+   | **Value**  | `.*`            |
+
+1. Click **Save**.
+
+This configuration sends all Okta groups the user belongs to in the SAML assertion under the `Group` attribute.
+
+{{< admonition type="note" >}}
+To send only specific groups, change the regex filter. For example, `grafana-.*` sends only groups starting with "grafana-".
+{{< /admonition >}}
+
+### Step 2: Configure Grafana to map groups to roles
+
+Use the group attribute for role assignment by setting `assertion_attribute_role` to your groups attribute name:
+
+```ini
+[auth.saml]
+# Use the Group attribute (sent from Okta) for role assignment
+assertion_attribute_groups = Group
+assertion_attribute_role = Group
+
+# Map Okta group names to Grafana roles
+role_values_admin = grafana-admins
+role_values_editor = grafana-editors
+role_values_viewer = grafana-viewers
+```
+
+With this configuration:
+
+- Users in the `grafana-admins` Okta group receive the Admin role
+- Users in the `grafana-editors` Okta group receive the Editor role
+- Users in the `grafana-viewers` Okta group receive the Viewer role
+- Users not matching any group receive the role specified by `auto_assign_org_role` (defaults to Viewer)
+
+{{< admonition type="note" >}}
+Group names are case-sensitive. Ensure the group names in Grafana configuration match exactly with the Okta group names.
+{{< /admonition >}}
+
+For Grafana Cloud users configuring SAML through the UI:
+
+1. Go to **Administration** > **Authentication** > **Configure SAML**.
+1. In the **User mapping** section, set:
+   - **Groups attribute**: `Group`
+   - **Role attribute**: `Group`
+1. In the **Role mapping** section, enter your Okta group names for each role.
+1. Click **Save**.

--- a/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-team-role-mapping/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-team-role-mapping/_index.md
@@ -120,18 +120,18 @@ This section shows how to configure Okta to send group memberships in the SAML a
 1. Scroll to **GROUP ATTRIBUTE STATEMENTS**.
 1. Add a group attribute with the following settings:
 
-   | Field      | Value           |
-   | ---------- | --------------- |
-   | **Name**   | `Group`         |
-   | **Filter** | Matches regex   |
-   | **Value**  | `.*`            |
+   | Field      | Value         |
+   | ---------- | ------------- |
+   | **Name**   | `Group`       |
+   | **Filter** | Matches regular expression |
+   | **Value**  | `.*`          |
 
 1. Click **Save**.
 
 This configuration sends all Okta groups the user belongs to in the SAML assertion under the `Group` attribute.
 
 {{< admonition type="note" >}}
-To send only specific groups, change the regex filter. For example, `grafana-.*` sends only groups starting with "grafana-".
+To send only specific groups, change the regular expression filter. For example, `grafana-.*` sends only groups starting with `grafana-`.
 {{< /admonition >}}
 
 ### Step 2: Configure Grafana to map groups to roles

--- a/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-team-role-mapping/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-team-role-mapping/_index.md
@@ -161,7 +161,7 @@ With this configuration:
 Group names are case-sensitive. Ensure the group names in Grafana configuration match exactly with the Okta group names.
 {{< /admonition >}}
 
-For Grafana Cloud users configuring SAML through the UI:
+If you're a Grafana Cloud user and want to configure SAML through the UI:
 
 1. Go to **Administration** > **Authentication** > **Configure SAML**.
 1. In the **User mapping** section, set:

--- a/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-team-role-mapping/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-team-role-mapping/_index.md
@@ -136,7 +136,7 @@ To send only specific groups, change the regular expression filter. For example,
 
 ### Step 2: Configure Grafana to map groups to roles
 
-Use the group attribute for role assignment by setting `assertion_attribute_role` to your groups attribute name:
+Use the group attribute for role assignment by setting `assertion_attribute_role` to your group attribute's name:
 
 ```ini
 [auth.saml]

--- a/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-team-role-mapping/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-team-role-mapping/_index.md
@@ -120,11 +120,11 @@ This section shows how to configure Okta to send group memberships in the SAML a
 1. Scroll to **GROUP ATTRIBUTE STATEMENTS**.
 1. Add a group attribute with the following settings:
 
-   | Field      | Value         |
-   | ---------- | ------------- |
-   | **Name**   | `Group`       |
+   | Field      | Value                      |
+   | ---------- | -------------------------- |
+   | **Name**   | `Group`                    |
    | **Filter** | Matches regular expression |
-   | **Value**  | `.*`          |
+   | **Value**  | `.*`                       |
 
 1. Click **Save**.
 

--- a/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-team-role-mapping/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-team-role-mapping/_index.md
@@ -161,7 +161,13 @@ With this configuration:
 Group names are case-sensitive. Ensure the group names in Grafana configuration match exactly with the Okta group names.
 {{< /admonition >}}
 
-For Grafana Cloud users configuring SAML through the UI:
+### Grafana Cloud UI configuration
+
+{{< admonition type="note" >}}
+The following steps apply only to Grafana Cloud. For self-hosted Grafana, use the configuration file settings shown above.
+{{< /admonition >}}
+
+To configure role sync through the Grafana Cloud UI:
 
 1. Go to **Administration** > **Authentication** > **Configure SAML**.
 1. In the **User mapping** section, set:

--- a/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-team-role-mapping/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-team-role-mapping/_index.md
@@ -161,13 +161,7 @@ With this configuration:
 Group names are case-sensitive. Ensure the group names in Grafana configuration match exactly with the Okta group names.
 {{< /admonition >}}
 
-### Grafana Cloud UI configuration
-
-{{< admonition type="note" >}}
-The following steps apply only to Grafana Cloud. For self-hosted Grafana, use the configuration file settings shown above.
-{{< /admonition >}}
-
-To configure role sync through the Grafana Cloud UI:
+For Grafana Cloud users configuring SAML through the UI:
 
 1. Go to **Administration** > **Authentication** > **Configure SAML**.
 1. In the **User mapping** section, set:

--- a/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-with-okta/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-with-okta/_index.md
@@ -45,7 +45,7 @@ Grafana supports user authentication through Okta, which is useful when you want
      | Email                       | Email - `user.email`                                 | `assertion_attribute_email = Email`       |
      | DisplayName                 | DisplayName - `user.firstName + " " + user.lastName` | `assertion_attribute_name = DisplayName`  |
 
-   - In the **GROUP ATTRIBUTE STATEMENTS (OPTIONAL)** section, enter a group attribute name (for example, `Group`, ensure it matches the `asssertion_attribute_groups` setting in Grafana) and set filter to `Matches regex .*` to return all user groups.
+   - In the **GROUP ATTRIBUTE STATEMENTS (OPTIONAL)** section, enter a group attribute name (for example, `Group`, ensure it matches the `assertion_attribute_groups` setting in Grafana) and set filter to `Matches regex .*` to return all user groups. To use these groups for role assignment, refer to [Configure role sync with Okta](/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-access/configure-authentication/saml/configure-saml-team-role-mapping/#configure-role-sync-with-okta).
 
 1. Click **Next**.
 1. On the final Feedback tab, fill out the form and then click **Finish**.


### PR DESCRIPTION
Replaces https://github.com/grafana/grafana/pull/117758.
