### PR TITLE
FS: Add prometheus metric for settings service fetch failures

### DIFF
--- a/pkg/services/frontend/frontend_service.go
+++ b/pkg/services/frontend/frontend_service.go
@@ -37,6 +37,13 @@ var bootErrorMetric = promauto.NewCounter(prometheus.CounterOpts{
 	Help:      "Total number of frontend boot errors",
 })
 
+var settingsFetchMetric = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "grafana",
+	Subsystem: "frontend",
+	Name:      "settings_fetch_total",
+	Help:      "Total number of settings service fetch attempts from the request config middleware",
+}, []string{"status"}) // status: "success" or "error"
+
 type frontendService struct {
 	*services.BasicService
 	cfg          *setting.Cfg

--- a/pkg/services/frontend/request_config_middleware.go
+++ b/pkg/services/frontend/request_config_middleware.go
@@ -54,9 +54,11 @@ func RequestConfigMiddleware(cfg *setting.Cfg, license licensing.Licensing, sett
 
 					settings, err := settingsService.ListAsIni(ctx, selector)
 					if err != nil {
+						settingsFetchMetric.WithLabelValues("error").Inc()
 						logger.Error("failed to fetch tenant settings", "namespace", namespace, "err", err)
 						// Fall back to base config
 					} else {
+						settingsFetchMetric.WithLabelValues("success").Inc()
 						// Merge tenant overrides with base config
 						requestConfig.ApplyOverrides(settings, logger)
 					}


### PR DESCRIPTION
**What is this feature?**

A new Prometheus counter metric `grafana_frontend_settings_fetch_total` with `status` label to track success/failure rates of settings service fetch attempts. The metric increments with `status="success"` when settings are successfully fetched and applied, and `status="error"` when the fetch fails and the middleware falls back to base configuration.

**Why do we need this feature?**

Previously, failures to fetch settings from the settings service were only logged but not tracked in metrics. This makes it difficult to monitor and alert on degradation in the settings service availability. The new metric enables operators to track error rates and set up alerts for critical failures.

**Who is this feature for?**

Operators and SREs running the multi-tenant frontend service who need visibility into settings service health.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.