### PR TITLE
QueryEditor: Clean up query content header icon and padding

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
@@ -112,7 +112,7 @@ export function ContentHeader({
   return (
     <div className={styles.container} ref={containerRef}>
       <div className={styles.leftSection}>
-        <Icon name={QUERY_EDITOR_TYPE_CONFIG[cardType].icon} size="sm" />
+        {cardType !== QueryEditorType.Query && <Icon name={QUERY_EDITOR_TYPE_CONFIG[cardType].icon} size="sm" />}
 
         {cardType === QueryEditorType.Query && selectedQuery && (
           <>
@@ -234,6 +234,10 @@ const getDatasourceSectionStyles = (theme: GrafanaTheme2) => ({
     // Remove borders from all nested divs
     '& > div, & div': {
       border: 'none',
+    },
+    // Remove left padding from the prefix icon
+    '[class*="input-prefix"]': {
+      paddingLeft: 0,
     },
   }),
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
@@ -224,20 +224,22 @@ const getStyles = (theme: GrafanaTheme2, { cardType }: { cardType: QueryEditorTy
 };
 
 // TODO: This is a hacky solution to create an inline datasource picker.
+// We override internal Input component styles to make it appear borderless and compact.
 const getDatasourceSectionStyles = (theme: GrafanaTheme2) => ({
   dataSourcePickerWrapper: css({
-    // Target the Input component inside the picker
-    input: {
-      border: 'none',
-      backgroundColor: theme.colors.background.secondary,
-    },
-    // Remove borders from all nested divs
     '& > div, & div': {
       border: 'none',
     },
-    // Remove left padding from the prefix icon
+    input: {
+      border: 'none',
+      backgroundColor: theme.colors.background.secondary,
+      // Override the inline paddingLeft set by the Input component's prefix measurement logic
+      paddingLeft: `${theme.spacing(3.5)} !important`,
+    },
     '[class*="input-prefix"]': {
       paddingLeft: 0,
+      paddingRight: 0,
+      minWidth: 'auto',
     },
   }),
 });


### PR DESCRIPTION
## Summary
Align query header with existing design:
![header](https://github.com/user-attachments/assets/31fa21c5-6ee0-4b51-ad8e-71d1cf7c3429)


- Remove the generic icon for query type in the content header - it's redundant since the datasource logo is already shown via the picker
- Remove extra left padding on the datasource logo caused by the Input prefix wrapper

## Demo
Before:
<img width="830" height="249" alt="Screenshot 2026-02-16 at 17 42 43" src="https://github.com/user-attachments/assets/ba3beb2d-9aea-4955-9c52-72df67574301" />

After:
<img width="830" height="249" alt="Screenshot 2026-02-16 at 18 03 24" src="https://github.com/user-attachments/assets/551342d0-1269-41b5-bfc9-28b007745e43" />


