### PR TITLE
Faro: Stop reporting query errors as exceptions

### DIFF
--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -24,8 +24,6 @@ import { queryIsEmpty } from 'app/core/utils/query';
 import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
 import { ExpressionQuery } from 'app/features/expressions/types';
 
-import { queryLogger } from '../utils';
-
 import { cancelNetworkRequestsOnUnsubscribe } from './processing/canceler';
 import { emitDataRequestEvent } from './queryAnalytics';
 
@@ -164,7 +162,6 @@ export function runRequest(
     // handle errors
     catchError((err) => {
       console.error('runRequest.catchError', err);
-      queryLogger.logError(err);
       return of({
         ...state.panelData,
         state: LoadingState.Error,

--- a/public/app/features/query/utils.ts
+++ b/public/app/features/query/utils.ts
@@ -1,3 +1,0 @@
-import { createMonitoringLogger } from '@grafana/runtime';
-
-export const queryLogger = createMonitoringLogger('features.query');


### PR DESCRIPTION
Query failures (bad queries, timeouts, datasource errors) are expected operational events, not application bugs. The `queryLogger.logError(err)` call in `runRequest` was pushing these to Faro as exceptions with context source `features.query`, creating noise that obscures real frontend errors.

This removes that call. Query errors are still logged to the browser console, surfaced in the panel UI, and tracked via query analytics.