### PR TITLE
FS: Add per-tenant RudderStack configuration support

### DIFF
--- a/pkg/services/frontend/request_config.go
+++ b/pkg/services/frontend/request_config.go
@@ -123,6 +123,13 @@ func (c *FSRequestConfig) ApplyOverrides(settings *ini.File, logger log.Logger) 
 	applyString(settings, "security", "content_security_policy_template", &c.CSPTemplate, logger)
 	applyBool(settings, "security", "content_security_policy_report_only", &c.CSPReportOnlyEnabled, logger)
 	applyString(settings, "security", "content_security_policy_report_only_template", &c.CSPReportOnlyTemplate, logger)
+
+	applyString(settings, "analytics", "rudderstack_write_key", &c.RudderstackWriteKey, logger)
+	applyString(settings, "analytics", "rudderstack_data_plane_url", &c.RudderstackDataPlaneUrl, logger)
+	applyString(settings, "analytics", "rudderstack_sdk_url", &c.RudderstackSdkUrl, logger)
+	applyString(settings, "analytics", "rudderstack_v3_sdk_url", &c.RudderstackV3SdkUrl, logger)
+	applyString(settings, "analytics", "rudderstack_config_url", &c.RudderstackConfigUrl, logger)
+	applyString(settings, "analytics", "rudderstack_integrations_url", &c.RudderstackIntegrationsUrl, logger)
 }
 
 func getValue(settings *ini.File, section, key string) *ini.Key {

--- a/pkg/services/frontend/request_config_middleware.go
+++ b/pkg/services/frontend/request_config_middleware.go
@@ -43,7 +43,7 @@ func RequestConfigMiddleware(cfg *setting.Cfg, license licensing.Licensing, sett
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
 							Key:      "section",
 							Operator: metav1.LabelSelectorOpIn,
-							Values:   []string{"security"}, // TODO: get correct list
+							Values:   []string{"security", "analytics"},
 						}, {
 							// don't return values from defaults.ini as they conflict with the services's own defaults
 							Key:      "source",

--- a/pkg/services/frontend/request_config_test.go
+++ b/pkg/services/frontend/request_config_test.go
@@ -56,6 +56,25 @@ func TestFSRequestConfig_ApplyOverrides(t *testing.T) {
 		assert.Equal(t, "10.3.0", config.BuildInfo.Version)
 	})
 
+	t.Run("should override FSFrontendSettings fields from settings service", func(t *testing.T) {
+		config := FSRequestConfig{
+			FSFrontendSettings: FSFrontendSettings{
+				RudderstackWriteKey:     "base-write-key",
+				RudderstackDataPlaneUrl: "https://base-dataplane.example.com",
+			},
+		}
+
+		iniFile := ini.Empty()
+		analyticsSection, _ := iniFile.NewSection("analytics")
+		_, _ = analyticsSection.NewKey("rudderstack_write_key", "tenant-write-key")
+		_, _ = analyticsSection.NewKey("rudderstack_data_plane_url", "https://tenant-dataplane.example.com")
+
+		config.ApplyOverrides(iniFile, log.New("test"))
+
+		assert.Equal(t, "tenant-write-key", config.RudderstackWriteKey)
+		assert.Equal(t, "https://tenant-dataplane.example.com", config.RudderstackDataPlaneUrl)
+	})
+
 	t.Run("should apply multiple CSP overrides at once", func(t *testing.T) {
 		config := FSRequestConfig{
 			FSFrontendSettings: FSFrontendSettings{


### PR DESCRIPTION
**What is this feature?**

Extends the frontend service request config to allow per-tenant RudderStack settings from the settings service. Each tenant can now have independent analytics configuration (write key, data plane URL, SDK URLs, etc.) by setting values in the settings service.


**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.