### PR TITLE
Alerting: Use dry-run mode in the api for validating collisions

### DIFF
--- a/public/app/features/alerting/unified/api/convertToGMAApi.ts
+++ b/public/app/features/alerting/unified/api/convertToGMAApi.ts
@@ -76,6 +76,7 @@ export const convertToGMAApi = alertingApi.injectEndpoints({
           template_files: templateFiles,
         },
         headers: {
+          // The config identifier is the name of the extra configuration (policy tree name)
           'X-Grafana-Alerting-Config-Identifier': configIdentifier,
           // TODO: Remove this header once the backend no longer requires it
           'X-Grafana-Alerting-Merge-Matchers': `__grafana_managed_route__=${configIdentifier}`,

--- a/public/app/features/alerting/unified/api/convertToGMAApi.ts
+++ b/public/app/features/alerting/unified/api/convertToGMAApi.ts
@@ -1,6 +1,6 @@
 import { RulerRulesConfigDTO } from 'app/types/unified-alerting-dto';
 
-import type { DryRunValidationResult } from '../components/import-to-gma/types';
+import type { ConvertAlertmanagerResponse } from '../components/import-to-gma/types';
 
 import { alertingApi } from './alertingApi';
 
@@ -49,17 +49,58 @@ export const convertToGMAApi = alertingApi.injectEndpoints({
     }),
 
     /**
-     * Convert Alertmanager config (contact points, policies, templates, time intervals) to Grafana
+     * Import Alertmanager config (contact points, policies, templates, time intervals) to Grafana.
      * POST /api/convert/api/v1/alerts
+     *
+     * Supports force-replace via X-Grafana-Alerting-Config-Force-Replace header
+     * to overwrite an existing config with a different identifier.
      */
     convertAlertmanagerConfig: build.mutation<
-      void,
+      ConvertAlertmanagerResponse,
       {
         /** Alertmanager config as JSON string or YAML string */
         alertmanagerConfig: string;
         /** Template files map */
         templateFiles?: Record<string, string>;
         /** Configuration identifier - used as the extra config name (e.g., "prometheus-prod") */
+        configIdentifier: string;
+        /** If true, forcibly replace existing configuration regardless of identifier */
+        forceReplace?: boolean;
+      }
+    >({
+      query: ({ alertmanagerConfig, templateFiles = {}, configIdentifier, forceReplace }) => ({
+        url: `/api/convert/api/v1/alerts`,
+        method: 'POST',
+        body: {
+          alertmanager_config: alertmanagerConfig,
+          template_files: templateFiles,
+        },
+        headers: {
+          'X-Grafana-Alerting-Config-Identifier': configIdentifier,
+          // TODO: Remove this header once the backend no longer requires it
+          'X-Grafana-Alerting-Merge-Matchers': `__grafana_managed_route__=${configIdentifier}`,
+          ...(forceReplace ? { 'X-Grafana-Alerting-Config-Force-Replace': 'true' } : {}),
+        },
+      }),
+    }),
+
+    /**
+     * Dry-run validation for Alertmanager config import.
+     * Uses the same endpoint as the real import but with the X-Grafana-Alerting-Dry-Run header.
+     * Validates the config, checks for conflicts, and returns info about resources that would be renamed
+     * without actually saving anything.
+     *
+     * POST /api/convert/api/v1/alerts (with X-Grafana-Alerting-Dry-Run: true)
+     * Returns 200 OK on success (vs 202 Accepted for real imports)
+     */
+    dryRunAlertmanagerConfig: build.mutation<
+      ConvertAlertmanagerResponse,
+      {
+        /** Alertmanager config as JSON string or YAML string */
+        alertmanagerConfig: string;
+        /** Template files map */
+        templateFiles?: Record<string, string>;
+        /** Configuration identifier - used as the extra config name */
         configIdentifier: string;
       }
     >({
@@ -71,52 +112,13 @@ export const convertToGMAApi = alertingApi.injectEndpoints({
           template_files: templateFiles,
         },
         headers: {
-          // The config identifier is the name of the extra configuration (policy tree name)
-          // This identifies the imported config and allows overwriting on subsequent imports
-          'X-Grafana-Alerting-Config-Identifier': configIdentifier,
-          // TODO: Remove this header once the backend no longer requires it
-          // For now, we send __grafana_managed_route__=<configIdentifier> to satisfy the backend validation
-          'X-Grafana-Alerting-Merge-Matchers': `__grafana_managed_route__=${configIdentifier}`,
-        },
-      }),
-    }),
-
-    /**
-     * Dry-run validation for Alertmanager config import.
-     * Validates the config, checks for conflicts, and returns info about resources that would be renamed.
-     *
-     * TODO: This endpoint doesn't exist yet. See https://github.com/grafana/alerting-squad/issues/1378
-     * When implemented, it should:
-     * - Validate the Alertmanager config
-     * - Merge into current config (without persisting)
-     * - Check for conflicts
-     * - Return list of receivers/time intervals that would be renamed
-     *
-     * POST /api/convert/api/v1/alerts/dry-run (proposed endpoint)
-     */
-    dryRunAlertmanagerConfig: build.mutation<
-      DryRunValidationResult,
-      {
-        /** Alertmanager config as JSON string or YAML string */
-        alertmanagerConfig: string;
-        /** Template files map */
-        templateFiles?: Record<string, string>;
-        /** Configuration identifier - used as the extra config name */
-        configIdentifier: string;
-      }
-    >({
-      query: ({ alertmanagerConfig, templateFiles = {}, configIdentifier }) => ({
-        // TODO: Update URL once the backend endpoint is implemented
-        url: `/api/convert/api/v1/alerts/dry-run`,
-        method: 'POST',
-        body: {
-          alertmanager_config: alertmanagerConfig,
-          template_files: templateFiles,
-        },
-        headers: {
           'X-Grafana-Alerting-Config-Identifier': configIdentifier,
           // TODO: Remove this header once the backend no longer requires it
           'X-Grafana-Alerting-Merge-Matchers': `__grafana_managed_route__=${configIdentifier}`,
+          'X-Grafana-Alerting-Dry-Run': 'true',
+          // Always force-replace during dry-run to avoid 409 conflicts —
+          // we want to validate the config regardless of existing identifiers
+          'X-Grafana-Alerting-Config-Force-Replace': 'true',
         },
       }),
     }),

--- a/public/app/features/alerting/unified/components/import-to-gma/CollapsibleRenameList.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/CollapsibleRenameList.tsx
@@ -1,0 +1,95 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { CollapsableSection, Icon, Stack, Text, useStyles2 } from '@grafana/ui';
+
+interface RenameEntry {
+  originalName: string;
+  newName: string;
+}
+
+interface CollapsibleRenameListProps {
+  /** Label summarizing the list, e.g. "Receivers renamed: 3" */
+  label: string;
+  /** Items that will be renamed */
+  items: RenameEntry[];
+}
+
+/**
+ * Collapsible list showing resources that will be renamed during import.
+ */
+function CollapsibleRenameList({ label, items }: CollapsibleRenameListProps) {
+  const styles = useStyles2(getStyles);
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <CollapsableSection
+      label={
+        <Text variant="bodySmall" weight="medium">
+          {label}
+        </Text>
+      }
+      isOpen={false}
+      className={styles.header}
+      contentClassName={styles.content}
+    >
+      <Stack direction="column" gap={0.5}>
+        {items.map(({ originalName, newName }) => (
+          <Stack key={originalName} direction="row" gap={1} alignItems="center">
+            <Text variant="bodySmall" color="secondary">
+              {originalName}
+            </Text>
+            <Icon name="arrow-right" size="sm" />
+            <Text variant="bodySmall">{newName}</Text>
+          </Stack>
+        ))}
+      </Stack>
+    </CollapsableSection>
+  );
+}
+
+interface RenamedResourcesListProps {
+  renamedReceivers: RenameEntry[];
+  renamedTimeIntervals: RenameEntry[];
+}
+
+/**
+ * Renders collapsible lists for both renamed receivers and time intervals.
+ * Returns null if there are no renames.
+ */
+export function RenamedResourcesList({ renamedReceivers, renamedTimeIntervals }: RenamedResourcesListProps) {
+  if (renamedReceivers.length === 0 && renamedTimeIntervals.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack direction="column" gap={1}>
+      <CollapsibleRenameList
+        label={t('alerting.import-to-gma.renamed-receivers', '{{count}} contact points will be renamed', {
+          count: renamedReceivers.length,
+        })}
+        items={renamedReceivers}
+      />
+      <CollapsibleRenameList
+        label={t('alerting.import-to-gma.renamed-intervals', '{{count}} time intervals will be renamed', {
+          count: renamedTimeIntervals.length,
+        })}
+        items={renamedTimeIntervals}
+      />
+    </Stack>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  header: css({
+    fontSize: theme.typography.bodySmall.fontSize,
+    padding: 0,
+  }),
+  content: css({
+    padding: `0 0 0 ${theme.spacing(2.5)}`,
+  }),
+});

--- a/public/app/features/alerting/unified/components/import-to-gma/ExtraConfigWarning.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ExtraConfigWarning.tsx
@@ -1,0 +1,24 @@
+import { t } from '@grafana/i18n';
+import { Alert } from '@grafana/ui';
+
+interface ExtraConfigWarningProps {
+  existingIdentifier: string;
+}
+
+/**
+ * Warning alert shown when an existing imported configuration will be replaced.
+ */
+export function ExtraConfigWarning({ existingIdentifier }: ExtraConfigWarningProps) {
+  return (
+    <Alert
+      severity="warning"
+      title={t('alerting.import-to-gma.step1.extra-config-overwrite-title', 'Existing configuration will be replaced')}
+    >
+      {t(
+        'alerting.import-to-gma.step1.extra-config-overwrite-desc',
+        'An imported configuration named "{{identifier}}" already exists. Importing will replace it with the new configuration.',
+        { identifier: existingIdentifier }
+      )}
+    </Alert>
+  );
+}

--- a/public/app/features/alerting/unified/components/import-to-gma/ValidationStatus.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ValidationStatus.tsx
@@ -1,0 +1,74 @@
+import { Trans, t } from '@grafana/i18n';
+import { Alert, Box, Spinner, Stack, Text } from '@grafana/ui';
+
+import { RenamedResourcesList } from './CollapsibleRenameList';
+import { DryRunValidationResult } from './types';
+
+interface ValidationStatusProps {
+  state: 'loading' | 'success' | 'warning' | 'error';
+  result?: DryRunValidationResult;
+}
+
+/**
+ * Displays the current state of a dry-run validation:
+ * loading spinner, success alert, rename warnings, or error details.
+ */
+export function ValidationStatus({ state, result }: ValidationStatusProps) {
+  if (state === 'loading') {
+    return (
+      <Box padding={2} backgroundColor="secondary" borderRadius="default" borderColor="weak" borderStyle="solid">
+        <Stack direction="row" gap={1} alignItems="center">
+          <Spinner size="sm" />
+          <Text color="secondary">{t('alerting.import-to-gma.step1.validating', 'Validating configuration...')}</Text>
+        </Stack>
+      </Box>
+    );
+  }
+
+  if (state === 'success') {
+    return (
+      <Alert severity="success" title={t('alerting.import-to-gma.step1.validation-success', 'Validation successful')}>
+        <Trans i18nKey="alerting.import-to-gma.step1.validation-success-desc">
+          No conflicts found. The configuration is ready to import.
+        </Trans>
+      </Alert>
+    );
+  }
+
+  if (state === 'warning' && result) {
+    return <RenameWarning result={result} />;
+  }
+
+  if (state === 'error' && result) {
+    return (
+      <Alert severity="error" title={t('alerting.import-to-gma.step1.validation-error', 'Validation failed')}>
+        <Text>
+          {result.error ||
+            t('alerting.import-to-gma.step1.validation-error-desc', 'Failed to validate the configuration.')}
+        </Text>
+      </Alert>
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Shows a collapsible list of resources that will be renamed during import.
+ */
+function RenameWarning({ result }: { result: DryRunValidationResult }) {
+  return (
+    <Alert
+      severity="warning"
+      title={t(
+        'alerting.import-to-gma.step1.validation-warning',
+        'Some resources will be renamed to avoid conflicts with existing ones'
+      )}
+    >
+      <RenamedResourcesList
+        renamedReceivers={result.renamedReceivers}
+        renamedTimeIntervals={result.renamedTimeIntervals}
+      />
+    </Alert>
+  );
+}

--- a/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.test.tsx
@@ -71,6 +71,12 @@ const alertmanagerDataSource = mockDataSource<AlertManagerDataSourceJsonData>({
   },
 });
 
+const defaultStep1Props = {
+  canImport: true,
+  dryRunState: 'idle' as const,
+  onTriggerDryRun: jest.fn(),
+};
+
 describe('Step1AlertmanagerResources', () => {
   beforeEach(() => {
     setupDataSources(alertmanagerDataSource);
@@ -81,7 +87,7 @@ describe('Step1AlertmanagerResources', () => {
     it('should render permission warning when canImport=false', () => {
       render(
         <TestWrapper>
-          <Step1Content canImport={false} />
+          <Step1Content {...defaultStep1Props} canImport={false} />
         </TestWrapper>
       );
 
@@ -92,7 +98,7 @@ describe('Step1AlertmanagerResources', () => {
     it('should render Policy Tree Name field', () => {
       render(
         <TestWrapper>
-          <Step1Content canImport={true} />
+          <Step1Content {...defaultStep1Props} />
         </TestWrapper>
       );
 
@@ -103,7 +109,7 @@ describe('Step1AlertmanagerResources', () => {
     it('should render source selection (YAML/datasource)', () => {
       render(
         <TestWrapper>
-          <Step1Content canImport={true} />
+          <Step1Content {...defaultStep1Props} />
         </TestWrapper>
       );
 
@@ -121,7 +127,7 @@ describe('Step1AlertmanagerResources', () => {
     it('should render YAML file upload field when YAML source selected', () => {
       render(
         <TestWrapper defaultValues={{ notificationsSource: 'yaml' }}>
-          <Step1Content canImport={true} />
+          <Step1Content {...defaultStep1Props} />
         </TestWrapper>
       );
 
@@ -132,7 +138,7 @@ describe('Step1AlertmanagerResources', () => {
     it('should render datasource picker when datasource source selected', () => {
       render(
         <TestWrapper defaultValues={{ notificationsSource: 'datasource' }}>
-          <Step1Content canImport={true} />
+          <Step1Content {...defaultStep1Props} />
         </TestWrapper>
       );
 
@@ -241,7 +247,7 @@ describe('Step1AlertmanagerResources', () => {
       const user = userEvent.setup();
       render(
         <TestWrapper defaultValues={{ notificationsSource: 'datasource', policyTreeName: '' }}>
-          <Step1Content canImport={true} />
+          <Step1Content {...defaultStep1Props} />
         </TestWrapper>
       );
 
@@ -259,7 +265,7 @@ describe('Step1AlertmanagerResources', () => {
       const user = userEvent.setup();
       render(
         <TestWrapper defaultValues={{ notificationsSource: 'datasource', policyTreeName: 'my-custom-name' }}>
-          <Step1Content canImport={true} />
+          <Step1Content {...defaultStep1Props} />
         </TestWrapper>
       );
 
@@ -289,7 +295,7 @@ describe('Step1AlertmanagerResources', () => {
       const user = userEvent.setup();
       render(
         <TestWrapper defaultValues={{ notificationsSource: 'datasource', policyTreeName: '' }}>
-          <Step1Content canImport={true} />
+          <Step1Content {...defaultStep1Props} />
         </TestWrapper>
       );
 

--- a/public/app/features/alerting/unified/components/import-to-gma/steps/Step2AlertRules.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/Step2AlertRules.tsx
@@ -1,8 +1,7 @@
-import { css } from '@emotion/css';
 import { useEffect, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
-import { DataSourceInstanceSettings, GrafanaTheme2 } from '@grafana/data';
+import { DataSourceInstanceSettings } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import {
@@ -10,6 +9,7 @@ import {
   Box,
   Combobox,
   ComboboxOption,
+  Divider,
   Field,
   FileUpload,
   InlineField,
@@ -17,7 +17,6 @@ import {
   RadioButtonList,
   Stack,
   Text,
-  useStyles2,
 } from '@grafana/ui';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
 import { ProvisioningAwareFolderPicker } from 'app/features/provisioning/components/Shared/ProvisioningAwareFolderPicker';
@@ -40,8 +39,6 @@ interface Step2ContentProps {
   step1Skipped: boolean;
   /** Whether the user has permission to import rules */
   canImport: boolean;
-  /** Callback to report validation state changes */
-  onValidationChange?: (isValid: boolean) => void;
 }
 
 const supportedImportTypes: string[] = [DataSourceType.Prometheus, DataSourceType.Loki];
@@ -51,8 +48,7 @@ const supportedImportTypes: string[] = [DataSourceType.Prometheus, DataSourceTyp
  * This component contains only the form fields, without the header or action buttons
  * The WizardStep wrapper provides those
  */
-export function Step2Content({ step1Completed, step1Skipped, canImport, onValidationChange }: Step2ContentProps) {
-  const styles = useStyles2(getStyles);
+export function Step2Content({ step1Completed, step1Skipped, canImport }: Step2ContentProps) {
   const {
     control,
     register,
@@ -61,24 +57,13 @@ export function Step2Content({ step1Completed, step1Skipped, canImport, onValida
     formState: { errors },
   } = useFormContext<ImportFormValues>();
 
-  const [
-    rulesSource,
-    rulesDatasourceUID,
-    rulesDatasourceName,
-    rulesYamlFile,
-    selectedRoutingTree,
-    policyTreeName,
-    namespace,
-    targetDatasourceUID,
-  ] = watch([
+  const [rulesSource, rulesDatasourceUID, rulesDatasourceName, rulesYamlFile, policyTreeName, namespace] = watch([
     'rulesSource',
     'rulesDatasourceUID',
     'rulesDatasourceName',
     'rulesYamlFile',
-    'selectedRoutingTree',
     'policyTreeName',
     'namespace',
-    'targetDatasourceUID',
   ]);
 
   // Get namespaces and groups for filtering
@@ -139,23 +124,6 @@ export function Step2Content({ step1Completed, step1Skipped, canImport, onValida
     return options;
   }, [step1Completed, policyTreeName, routingTrees]);
 
-  // Validation logic
-  const isValid = useMemo(() => {
-    return isStep2Valid({
-      canImport,
-      rulesSource,
-      rulesYamlFile,
-      rulesDatasourceUID,
-      selectedRoutingTree,
-      targetDatasourceUID,
-    });
-  }, [canImport, rulesSource, rulesYamlFile, rulesDatasourceUID, selectedRoutingTree, targetDatasourceUID]);
-
-  // Report validation changes to parent
-  useEffect(() => {
-    onValidationChange?.(isValid);
-  }, [isValid, onValidationChange]);
-
   return (
     <Stack direction="column" gap={3}>
       {step1Skipped && (
@@ -181,13 +149,14 @@ export function Step2Content({ step1Completed, step1Skipped, canImport, onValida
       )}
 
       {/* Notification Routing Card */}
-      <div className={styles.card}>
-        <div className={styles.cardHeader}>
+      <Box backgroundColor="secondary" borderRadius="default" borderColor="weak" borderStyle="solid">
+        <Box display="flex" alignItems="center" justifyContent="space-between" padding={2}>
           <Text variant="h5" element="h3">
             {t('alerting.import-to-gma.step2.policy-title', 'Notification Routing')}
           </Text>
-        </div>
-        <div className={styles.cardContent}>
+        </Box>
+        <Divider spacing={0} />
+        <Box padding={2}>
           <Text color="secondary" variant="bodySmall">
             <Trans i18nKey="alerting.import-to-gma.step2.policy-desc">
               Choose how imported alerts should be routed to contact points.
@@ -218,17 +187,18 @@ export function Step2Content({ step1Completed, step1Skipped, canImport, onValida
               />
             </Field>
           </Box>
-        </div>
-      </div>
+        </Box>
+      </Box>
 
       {/* Import Source Card */}
-      <div className={styles.card}>
-        <div className={styles.cardHeader}>
+      <Box backgroundColor="secondary" borderRadius="default" borderColor="weak" borderStyle="solid">
+        <Box display="flex" alignItems="center" justifyContent="space-between" padding={2}>
           <Text variant="h5" element="h3">
             {t('alerting.import-to-gma.step2.source-title', 'Import Source')}
           </Text>
-        </div>
-        <div className={styles.cardContent}>
+        </Box>
+        <Divider spacing={0} />
+        <Box padding={2}>
           <Field noMargin>
             <Controller
               render={({ field: { onChange, ref, ...field } }) => (
@@ -362,17 +332,18 @@ export function Step2Content({ step1Completed, step1Skipped, canImport, onValida
               </Field>
             )}
           </Box>
-        </div>
-      </div>
+        </Box>
+      </Box>
 
       {/* Additional Settings Card */}
-      <div className={styles.card}>
-        <div className={styles.cardHeader}>
+      <Box backgroundColor="secondary" borderRadius="default" borderColor="weak" borderStyle="solid">
+        <Box display="flex" alignItems="center" justifyContent="space-between" padding={2}>
           <Text variant="h5" element="h3">
             {t('alerting.import-to-gma.step2.settings-title', 'Additional Settings')}
           </Text>
-        </div>
-        <div className={styles.cardContent}>
+        </Box>
+        <Divider spacing={0} />
+        <Box padding={2}>
           <Stack direction="column" gap={2}>
             <Field
               label={t('alerting.import-to-gma.step2.target-folder', 'Target folder')}
@@ -465,8 +436,8 @@ export function Step2Content({ step1Completed, step1Skipped, canImport, onValida
               </InlineField>
             </Box>
           </Stack>
-        </div>
-      </div>
+        </Box>
+      </Box>
     </Stack>
   );
 }
@@ -495,22 +466,3 @@ export function useStep2Validation(canImport: boolean): boolean {
     });
   }, [canImport, rulesSource, rulesYamlFile, rulesDatasourceUID, selectedRoutingTree, targetDatasourceUID]);
 }
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  card: css({
-    backgroundColor: theme.colors.background.secondary,
-    borderRadius: theme.shape.radius.default,
-    border: `1px solid ${theme.colors.border.weak}`,
-    overflow: 'hidden',
-  }),
-  cardHeader: css({
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    padding: theme.spacing(2),
-    borderBottom: `1px solid ${theme.colors.border.weak}`,
-  }),
-  cardContent: css({
-    padding: theme.spacing(2),
-  }),
-});

--- a/public/app/features/alerting/unified/components/import-to-gma/steps/utils.test.ts
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/utils.test.ts
@@ -1,0 +1,44 @@
+import { validatePolicyTreeName } from './utils';
+
+describe('validatePolicyTreeName', () => {
+  it.each(['prometheus-prod', 'my-alertmanager', 'a', 'abc123', 'my.config.name', 'a-b.c-d', '0', '1abc2'])(
+    'accepts valid name: "%s"',
+    (name) => {
+      expect(validatePolicyTreeName(name)).toBe(true);
+    }
+  );
+
+  it.each([
+    { name: '', reason: 'empty string' },
+    { name: 'Uppercase', reason: 'contains uppercase letters' },
+    { name: '-starts-with-dash', reason: 'starts with dash' },
+    { name: 'ends-with-dash-', reason: 'ends with dash' },
+    { name: '.starts-with-dot', reason: 'starts with dot' },
+    { name: 'ends-with-dot.', reason: 'ends with dot' },
+    { name: 'has spaces', reason: 'contains spaces' },
+    { name: 'has_underscore', reason: 'contains underscore' },
+    { name: 'special!char', reason: 'contains special characters' },
+  ])('rejects invalid format ($reason): "$name"', ({ name }) => {
+    const result = validatePolicyTreeName(name);
+    expect(result).not.toBe(true);
+    expect(result).toContain('lowercase alphanumeric');
+  });
+
+  it('rejects names exceeding 40 characters', () => {
+    const longName = 'a'.repeat(41);
+    const result = validatePolicyTreeName(longName);
+    expect(result).not.toBe(true);
+    expect(result).toContain('at most 40');
+  });
+
+  it('accepts names exactly 40 characters long', () => {
+    const maxName = 'a'.repeat(40);
+    expect(validatePolicyTreeName(maxName)).toBe(true);
+  });
+
+  it('checks length before format', () => {
+    const longInvalid = 'A'.repeat(41);
+    const result = validatePolicyTreeName(longInvalid);
+    expect(result).toContain('at most 40');
+  });
+});

--- a/public/app/features/alerting/unified/components/import-to-gma/steps/utils.ts
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/utils.ts
@@ -2,6 +2,27 @@
  * Shared validation utilities for import-to-gma steps
  */
 
+/** RFC 1123 subdomain pattern — must match the backend's identifier validation */
+const POLICY_TREE_NAME_PATTERN = /^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/;
+
+/** Maximum length for a policy tree name, enforced by the backend (k8s DNS-1123 subdomain) */
+export const POLICY_TREE_NAME_MAX_LENGTH = 40;
+
+/**
+ * Validates a policy tree name against RFC 1123 subdomain rules.
+ * Returns an error message string if invalid, or `true` if valid.
+ * Compatible with react-hook-form's `validate` option.
+ */
+export function validatePolicyTreeName(value: string): string | true {
+  if (value.length > POLICY_TREE_NAME_MAX_LENGTH) {
+    return `Must be at most ${POLICY_TREE_NAME_MAX_LENGTH} characters`;
+  }
+  if (!POLICY_TREE_NAME_PATTERN.test(value)) {
+    return 'Must be lowercase alphanumeric, dashes or dots, and start/end with an alphanumeric character (e.g. "prometheus-prod")';
+  }
+  return true;
+}
+
 /**
  * Validates that a source selection has the required data based on the source type
  */

--- a/public/app/features/alerting/unified/components/import-to-gma/types.ts
+++ b/public/app/features/alerting/unified/components/import-to-gma/types.ts
@@ -3,27 +3,41 @@
  */
 
 /**
- * Represents a resource that was renamed during dry-run validation.
- * When importing Alertmanager config, receivers/time intervals with conflicting names
- * get renamed with a suffix (e.g., "my-receiver" → "my-receiver <imported>").
+ * Describes which resources were renamed to avoid conflicts during import/dry-run.
+ * Maps old resource names to new resource names.
+ * Matches the backend type: definitions.RenameResources
  */
-export interface RenamedResource {
-  originalName: string;
-  newName: string;
+export interface RenameResources {
+  /** Receivers maps old receiver names to new receiver names */
+  receivers?: Record<string, string>;
+  /** TimeIntervals maps old time interval names to new time interval names */
+  time_intervals?: Record<string, string>;
 }
 
 /**
- * Response from the dry-run validation endpoint.
- * TODO: Update this interface once the backend API is implemented.
- * See: https://github.com/grafana/alerting-squad/issues/1378
+ * Response from the Alertmanager config import endpoint (POST /api/convert/api/v1/alerts).
+ * Used for both real imports and dry-run validation (with X-Grafana-Alerting-Dry-Run header).
+ * Matches the backend type: definitions.ConvertAlertmanagerResponse
+ */
+export interface ConvertAlertmanagerResponse {
+  status: string;
+  errorType?: string;
+  error?: string;
+  /** Contains information about renamed resources during configuration merge */
+  rename_resources?: RenameResources;
+}
+
+/**
+ * Parsed dry-run validation result for UI consumption.
+ * Derived from ConvertAlertmanagerResponse.
  */
 export interface DryRunValidationResult {
   /** Whether the validation passed (config is valid and can be merged) */
   valid: boolean;
   /** Error message if validation failed */
   error?: string;
-  /** Receivers that will be renamed due to conflicts with existing receivers */
-  renamedReceivers: RenamedResource[];
-  /** Time intervals that will be renamed due to conflicts with existing time intervals */
-  renamedTimeIntervals: RenamedResource[];
+  /** Receivers that will be renamed: old name → new name */
+  renamedReceivers: Array<{ originalName: string; newName: string }>;
+  /** Time intervals that will be renamed: old name → new name */
+  renamedTimeIntervals: Array<{ originalName: string; newName: string }>;
 }

--- a/public/app/features/alerting/unified/components/import-to-gma/useExtraConfigState.ts
+++ b/public/app/features/alerting/unified/components/import-to-gma/useExtraConfigState.ts
@@ -1,47 +1,25 @@
-import { useMemo } from 'react';
-
 import { useAlertmanagerConfig } from '../../hooks/useAlertmanagerConfig';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 
-export type ExtraConfigState = 'none' | 'same' | 'different';
-
 interface UseExtraConfigStateResult {
-  /** State of existing extra config relative to the provided identifier */
-  extraConfigState: ExtraConfigState;
-  /** Identifier of the existing extra config, if any */
+  /** Identifier of the existing extra config that will be replaced, if any */
   existingIdentifier?: string;
   /** Whether data is still loading */
   isLoading: boolean;
 }
 
 /**
- * Hook to determine the state of existing extra Alertmanager configurations.
+ * Hook to check if there is an existing imported Alertmanager configuration.
  *
- * Returns the relationship between any existing extra config and the provided identifier:
- * - 'none': No existing extra config, can import freely
- * - 'same': Existing config with same identifier, will overwrite (warning)
- * - 'different': Existing config with different identifier, cannot import (blocked)
- *
- * @param policyTreeName - The identifier to compare against existing extra configs
+ * If an extra config already exists, `existingIdentifier` will be set to its name,
+ * signalling that importing will replace it.
  */
-export function useExtraConfigState(policyTreeName: string): UseExtraConfigStateResult {
+export function useExtraConfigState(): UseExtraConfigStateResult {
   const { data: grafanaConfig, isLoading } = useAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);
 
-  const existingExtraConfig = grafanaConfig?.extra_config?.[0];
-  const existingIdentifier = existingExtraConfig?.identifier;
-
-  const extraConfigState = useMemo((): ExtraConfigState => {
-    if (!existingIdentifier) {
-      return 'none';
-    }
-    if (existingIdentifier === policyTreeName) {
-      return 'same';
-    }
-    return 'different';
-  }, [existingIdentifier, policyTreeName]);
+  const existingIdentifier = grafanaConfig?.extra_config?.[0]?.identifier;
 
   return {
-    extraConfigState,
     existingIdentifier,
     isLoading,
   };

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1652,6 +1652,10 @@
         "rules-title": "Alert Rules Preview"
       },
       "recording-rules": "Recording rules",
+      "renamed-intervals_one": "{{count}} time intervals will be renamed",
+      "renamed-intervals_other": "{{count}} time intervals will be renamed",
+      "renamed-receivers_one": "{{count}} contact points will be renamed",
+      "renamed-receivers_other": "{{count}} contact points will be renamed",
       "review": {
         "back": "Alert rules",
         "filter": "Filter",
@@ -1668,10 +1672,6 @@
         "pause-none": "No rules paused",
         "pause-recording": "Recording rules paused",
         "policy-tree": "Policy tree",
-        "renamed-intervals_one": "Time intervals renamed: {{count}}",
-        "renamed-intervals_other": "Time intervals renamed: {{count}}",
-        "renamed-receivers_one": "Receivers renamed: {{count}}",
-        "renamed-receivers_other": "Receivers renamed: {{count}}",
         "routing": "Notification routing",
         "routing-none": "No policy tree selected",
         "routing-tree": "Policy tree: {{name}}",
@@ -1700,8 +1700,6 @@
       },
       "step1": {
         "datasource": "Alertmanager data source",
-        "extra-config-conflict-desc": "There is already an uncommitted imported configuration named \"{{identifier}}\". To proceed, either use \"{{identifier}}\" as your policy tree name to replace it, or commit/discard the existing configuration first.",
-        "extra-config-conflict-title": "Cannot import notification resources",
         "extra-config-overwrite-desc": "An imported configuration named \"{{identifier}}\" already exists. Importing will replace it with the new configuration.",
         "extra-config-overwrite-title": "Existing configuration will be replaced",
         "heading": "Import Notification Resources",
@@ -1711,11 +1709,8 @@
         "policy-tree-desc": "Name for the imported notification policy tree. Alerts with the label <2>__grafana_managed_route__</2> matching this name will be routed through this policy tree.",
         "policy-tree-name": "Policy tree name",
         "policy-tree-placeholder": "prometheus-prod",
+        "policy-tree-required": "Policy tree name is required",
         "policy-tree-title": "Policy Tree Name",
-        "renamed-intervals_one": "{{count}} time intervals will be renamed",
-        "renamed-intervals_other": "{{count}} time intervals will be renamed",
-        "renamed-receivers_one": "{{count}} contact points will be renamed",
-        "renamed-receivers_other": "{{count}} contact points will be renamed",
         "select-datasource": "Select data source",
         "skip": "Skip this step",
         "source": {
@@ -1732,8 +1727,7 @@
         "validation-error-desc": "Failed to validate the configuration.",
         "validation-success": "Validation successful",
         "validation-success-desc": "No conflicts found. The configuration is ready to import.",
-        "validation-warning": "Some resources will be renamed",
-        "validation-warning-desc": "Some resources will be renamed to avoid conflicts with existing resources.",
+        "validation-warning": "Some resources will be renamed to avoid conflicts with existing ones",
         "yaml-file": "Alertmanager config YAML"
       },
       "step2": {


### PR DESCRIPTION
**What is this feature?**

Use the backend's dry-run mode (`X-Grafana-Alerting-Dry-Run: true`) for validating Alertmanager config imports instead of mock responses. This also adds support for force-replacing existing configurations via `X-Grafana-Alerting-Config-Force-Replace`.

### What changed

**API layer (`convertToGMAApi.ts`, `useImport.ts`)**
- Dry-run now hits the real import endpoint with the `X-Grafana-Alerting-Dry-Run` header instead of a non-existent `/dry-run` path
- Removed all mock dry-run logic (simulated delays, hardcoded success responses, TODO comments)
- Import endpoint now supports `forceReplace` option to overwrite configs with a different identifier
- New `ConvertAlertmanagerResponse` type matching the backend (`definitions.ConvertAlertmanagerResponse`)
- New `parseAlertmanagerYaml` helper to separate `template_files` from config (shared between import and dry-run)
- `resolveAlertmanagerConfig` extracts common config resolution logic used by both flows

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1394

**Special notes for your reviewer:**


https://github.com/user-attachments/assets/daa73fe4-cf59-4f2a-8d0d-51be24dfbcd6



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
