### PR TITLE
CloudMigrations: Fix flaky test query status with sync

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -416,30 +416,36 @@ func Test_OnlyQueriesStatusFromGMSWhenRequired(t *testing.T) {
 	}
 
 	// make sure GMS is called when snapshot is pending processing or processing
-	for i, status := range []cloudmigration.SnapshotStatus{
+	for _, status := range []cloudmigration.SnapshotStatus{
 		cloudmigration.SnapshotStatusPendingProcessing,
 		cloudmigration.SnapshotStatusProcessing,
 	} {
-		err = s.store.UpdateSnapshot(context.Background(), cloudmigration.UpdateSnapshotCmd{
-			UID:       uid,
-			SessionID: sess.UID,
-			Status:    status,
-		})
-		assert.NoError(t, err)
+		// in this case since the background sync will run, we can create a brand new snapshot to avoid race problems.
+		snapshotUID := uuid.NewString()
+		require.NoError(t, s.store.CreateSnapshot(context.Background(), cloudmigration.CloudMigrationSnapshot{
+			UID:            snapshotUID,
+			SessionUID:     sess.UID,
+			Status:         status,
+			GMSSnapshotUID: "gms uid 2",
+		}))
+
 		snapshot, err := s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
-			SnapshotUID: uid,
+			SnapshotUID: snapshotUID,
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, status, snapshot.Status)
 
+		// then we wait for the sync to complete before the next status.
 		require.Eventually(
 			t,
-			func() bool { return gmsClientMock.GetSnapshotStatusCallCount() == i+1 },
+			func() bool {
+				cms, _ := s.store.GetSnapshotByUID(context.Background(), sess.OrgID, sess.UID, snapshotUID, cloudmigration.SnapshotResultQueryParams{})
+				return cms.Status == cloudmigration.SnapshotStatusFinished
+			},
 			5*time.Second,
 			100*time.Millisecond,
-			"GMS client mock GetSnapshotStatus count: %d on status: %s (want: %d)",
-			gmsClientMock.GetSnapshotStatusCallCount(), string(status), i+1,
+			"Snapshot status should be updated to Finished after sync completes",
 		)
 	}
 


### PR DESCRIPTION
A new attempt at fixing this flaky test by not using the same snapshot when checking for updates since the sync will kick off in the background.