### PR TITLE
DrilldownVariables: Keep hidden drilldown variables visible in edit mode

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -148,7 +148,7 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
     hideDashboardControls,
   } = model.useState();
   const dashboard = getDashboardSceneFor(model);
-  const { links, editPanel } = dashboard.useState();
+  const { links, editPanel, isEditing } = dashboard.useState();
   const isQueryEditorNext = Boolean(editPanel?.state.useQueryExperienceNext);
   const styles = useStyles2(getStyles, isQueryEditorNext);
   const showDebugger = window.location.search.includes('scene-debugger');
@@ -179,7 +179,7 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
           )}
           {!hideVariableControls && (
             <div className={styles.drilldownControlsContainer}>
-              <DrilldownControls adHocVar={adHocVar} groupByVar={groupByVar} />
+              <DrilldownControls adHocVar={adHocVar} groupByVar={groupByVar} isEditing={isEditing} />
             </div>
           )}
           <div className={cx(styles.rightControlsNewLayout, editPanel && styles.rightControlsWrap)}>

--- a/public/app/features/dashboard-scene/scene/DrilldownControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DrilldownControls.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { AdHocFiltersVariable, GroupByVariable } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
 
@@ -9,21 +10,23 @@ import { VariableValueSelectWrapper } from './VariableControls';
 interface DrilldownControlsProps {
   adHocVar: AdHocFiltersVariable;
   groupByVar: GroupByVariable;
+  isEditing?: boolean;
 }
 
 /**
  * DrilldownControls renders the AdHoc and GroupBy variables in a single row above the other variables.
  */
-export function DrilldownControls({ adHocVar, groupByVar }: DrilldownControlsProps) {
+export function DrilldownControls({ adHocVar, groupByVar, isEditing }: DrilldownControlsProps) {
   const styles = useStyles2(getStyles);
+  const isEditingNewLayouts = isEditing && config.featureToggles.dashboardNewLayouts;
 
   return (
     <div className={styles.drilldownRow}>
       <div className={styles.adHocContainer}>
-        <VariableValueSelectWrapper variable={adHocVar} />
+        <VariableValueSelectWrapper variable={adHocVar} isEditingNewLayouts={isEditingNewLayouts} />
       </div>
       <div className={styles.groupByContainer}>
-        <VariableValueSelectWrapper variable={groupByVar} />
+        <VariableValueSelectWrapper variable={groupByVar} isEditingNewLayouts={isEditingNewLayouts} />
       </div>
     </div>
   );


### PR DESCRIPTION
This PR fixes a dashboard-scene bug where setting a drilldown GroupBy variable to Hidden made it disappear even in edit mode.

Issue reported [in Slack](https://raintank-corp.slack.com/archives/C081AF3S814/p1771243825339649)