### PR TITLE
Datasources: Fix active tab detection for custom config pages                  

### DIFF
--- a/public/app/features/datasources/state/navModel.test.ts
+++ b/public/app/features/datasources/state/navModel.test.ts
@@ -1,0 +1,53 @@
+import { NavModelItem } from '@grafana/data';
+
+import { getDataSourceNav } from './navModel';
+
+describe('getDataSourceNav', () => {
+  it('marks a custom config page as active with exact id matching', () => {
+    const settingsTab: NavModelItem = {
+      id: 'datasource-settings-uid-1',
+      text: 'Settings',
+      active: false,
+    };
+    const customTab: NavModelItem = {
+      id: 'datasource-page-custom-settings',
+      text: 'Custom settings',
+      active: false,
+    };
+
+    const main: NavModelItem = {
+      text: 'Datasource',
+      children: [settingsTab, customTab],
+    };
+
+    const nav = getDataSourceNav(main, 'custom-settings');
+
+    expect(nav.node.id).toBe('datasource-page-custom-settings');
+    expect(settingsTab.active).toBe(false);
+    expect(customTab.active).toBe(true);
+  });
+
+  it('marks built-in settings tab as active', () => {
+    const settingsTab: NavModelItem = {
+      id: 'datasource-settings-uid-1',
+      text: 'Settings',
+      active: false,
+    };
+    const dashboardsTab: NavModelItem = {
+      id: 'datasource-dashboards-uid-1',
+      text: 'Dashboards',
+      active: false,
+    };
+
+    const main: NavModelItem = {
+      text: 'Datasource',
+      children: [settingsTab, dashboardsTab],
+    };
+
+    const nav = getDataSourceNav(main, 'settings');
+
+    expect(nav.node.id).toBe('datasource-settings-uid-1');
+    expect(settingsTab.active).toBe(true);
+    expect(dashboardsTab.active).toBe(false);
+  });
+});

--- a/public/app/features/datasources/state/navModel.ts
+++ b/public/app/features/datasources/state/navModel.ts
@@ -151,7 +151,12 @@ export function getDataSourceNav(main: NavModelItem, pageName: string): NavModel
 
   // find active page
   for (const child of main.children!) {
-    if (child.id!.indexOf(pageName) > 0) {
+    const childId = child.id ?? '';
+    const isConfigPage = childId.startsWith('datasource-page-');
+    const isMatchingConfigPage = isConfigPage && childId === `datasource-page-${pageName}`;
+    const isMatchingBuiltInPage = !isConfigPage && childId.startsWith(`datasource-${pageName}-`);
+
+    if (isMatchingConfigPage || isMatchingBuiltInPage) {
       child.active = true;
       node = child;
       break;


### PR DESCRIPTION
  Fixes #118105 by replacing substring-based datasource tab matching with exact  
  ID matching, so custom config pages are marked active correctly