### PR TITLE
PanelChrome: Improve panel status design

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -595,7 +595,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       alignItems: 'center',
       // remove logic after newPanelPadding feature toggle is removed
-      padding: newPanelPadding ? theme.spacing(0, 1, 0, 1.5) : theme.spacing(0, 0.5, 0, 1),
+      padding: newPanelPadding ? theme.spacing(0, 1, 0, 1) : theme.spacing(0, 0.5, 0, 1),
       gap: theme.spacing(1),
     }),
     subHeader: css({
@@ -623,6 +623,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       label: 'panel-title',
       display: 'flex',
       minWidth: 0,
+      paddingLeft: theme.spacing.x0_5,
       '& > h2': {
         minWidth: 0,
       },

--- a/packages/grafana-ui/src/components/PanelChrome/PanelStatus.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelStatus.tsx
@@ -1,11 +1,8 @@
-import { css } from '@emotion/css';
 import * as React from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 
-import { useStyles2 } from '../../themes/ThemeContext';
-import { ToolbarButton } from '../ToolbarButton/ToolbarButton';
+import { Button } from '../Button/Button';
 
 export interface Props {
   message?: string;
@@ -14,33 +11,15 @@ export interface Props {
 }
 
 export function PanelStatus({ message, onClick, ariaLabel = 'status' }: Props) {
-  const styles = useStyles2(getStyles);
-
   return (
-    <ToolbarButton
-      className={styles.buttonStyles}
+    <Button
       onClick={onClick}
       variant={'destructive'}
       icon="exclamation-triangle"
-      iconSize="md"
+      size="sm"
       tooltip={message || ''}
       aria-label={ariaLabel}
       data-testid={selectors.components.Panels.Panel.status('error')}
     />
   );
 }
-
-const getStyles = (theme: GrafanaTheme2) => {
-  return {
-    buttonStyles: css({
-      label: 'panel-header-state-button',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      padding: theme.spacing(1),
-      width: theme.spacing(theme.components.height.md),
-      height: theme.spacing(theme.components.height.md),
-      borderRadius: theme.shape.radius.default,
-    }),
-  };
-};


### PR DESCRIPTION
The panel status looks a bit off, especially since the update to panel header padding we did a few months ago. 

Issues 

* md size button while other buttons in the header are small 
* left side padding makes left and top padding/spacing uneven 

Changes
* Change from md size button to sm button
* Change left side padding to 8px instead of 12px, add 4px left side padding to title text instead 

Before: 
<img width="1512" height="690" alt="Screenshot 2026-02-17 at 08 12 40" src="https://github.com/user-attachments/assets/60cfc529-e3b6-41bb-95db-ff9ee48dc012" />

After: 
<img width="1512" height="808" alt="Screenshot 2026-02-17 at 07 51 12" src="https://github.com/user-attachments/assets/b89bca47-d951-43c6-a907-db5dc21b0ec8" />

