### PR TITLE
Provisioning: Add retry option for failed sync jobs

### DIFF
--- a/public/app/features/provisioning/Job/FinishedJobStatus.tsx
+++ b/public/app/features/provisioning/Job/FinishedJobStatus.tsx
@@ -14,9 +14,10 @@ export interface FinishedJobProps {
   repositoryName: string;
   jobType: 'sync' | 'delete' | 'move';
   onStatusChange?: (statusInfo: StepStatusInfo) => void;
+  onRetry?: () => void;
 }
 
-export function FinishedJobStatus({ jobUid, repositoryName, jobType, onStatusChange }: FinishedJobProps) {
+export function FinishedJobStatus({ jobUid, repositoryName, jobType, onStatusChange, onRetry }: FinishedJobProps) {
   const hasRetried = useRef(false);
   const finishedQuery = useGetRepositoryJobsWithPathQuery({
     name: repositoryName,
@@ -69,6 +70,10 @@ export function FinishedJobStatus({ jobUid, repositoryName, jobType, onStatusCha
             message: messages.error,
           },
           warning: warningInfo,
+          action: onRetry && {
+            label: t('provisioning.job-status.retry-action', 'Retry'),
+            onClick: onRetry,
+          },
         });
       } else if (state === 'success') {
         onStatusChange?.({
@@ -93,7 +98,7 @@ export function FinishedJobStatus({ jobUid, repositoryName, jobType, onStatusCha
         clearTimeout(timeoutId);
       }
     };
-  }, [finishedQuery, job, onStatusChange, retryFailed]);
+  }, [finishedQuery, job, onStatusChange, onRetry, retryFailed]);
 
   // If retry failed, return null - parent handles the error via onStatusChange
   if (retryFailed) {
@@ -111,5 +116,7 @@ export function FinishedJobStatus({ jobUid, repositoryName, jobType, onStatusCha
     );
   }
 
-  return <JobContent job={job} isFinishedJob={true} onStatusChange={onStatusChange} jobType={jobType} />;
+  return (
+    <JobContent job={job} isFinishedJob={true} onStatusChange={onStatusChange} jobType={jobType} onRetry={onRetry} />
+  );
 }

--- a/public/app/features/provisioning/Job/JobContent.tsx
+++ b/public/app/features/provisioning/Job/JobContent.tsx
@@ -17,9 +17,10 @@ export interface JobContentProps {
   job?: Job;
   isFinishedJob?: boolean;
   onStatusChange?: (statusInfo: StepStatusInfo) => void;
+  onRetry?: () => void;
 }
 
-export function JobContent({ jobType, job, isFinishedJob = false, onStatusChange }: JobContentProps) {
+export function JobContent({ jobType, job, isFinishedJob = false, onStatusChange, onRetry }: JobContentProps) {
   const errorSetRef = useRef(false);
 
   const { state, message, progress, summary } = job?.status || {};
@@ -66,6 +67,10 @@ export function JobContent({ jobType, job, isFinishedJob = false, onStatusChange
               message: messages.error,
             },
             warning: warningInfo,
+            action: onRetry && {
+              label: t('provisioning.job-status.retry-action', 'Retry'),
+              onClick: onRetry,
+            },
           });
           errorSetRef.current = true;
         }
@@ -78,7 +83,7 @@ export function JobContent({ jobType, job, isFinishedJob = false, onStatusChange
       default:
         break;
     }
-  }, [state, message, job, onStatusChange]);
+  }, [state, message, job, onStatusChange, onRetry]);
 
   if (!job?.status) {
     return null;

--- a/public/app/features/provisioning/Job/JobStatus.tsx
+++ b/public/app/features/provisioning/Job/JobStatus.tsx
@@ -14,9 +14,10 @@ export interface JobStatusProps {
   watch: Job;
   jobType: 'sync' | 'delete' | 'move';
   onStatusChange?: (statusInfo: StepStatusInfo) => void;
+  onRetry?: () => void;
 }
 
-export function JobStatus({ jobType, watch, onStatusChange }: JobStatusProps) {
+export function JobStatus({ jobType, watch, onStatusChange, onRetry }: JobStatusProps) {
   const activeQuery = useListJobQuery({
     fieldSelector: `metadata.name=${watch.metadata?.name}`,
     watch: true,
@@ -56,7 +57,15 @@ export function JobStatus({ jobType, watch, onStatusChange }: JobStatusProps) {
   }
 
   if (activeJob) {
-    return <JobContent job={activeJob} isFinishedJob={false} onStatusChange={onStatusChange} jobType={jobType} />;
+    return (
+      <JobContent
+        job={activeJob}
+        isFinishedJob={false}
+        onStatusChange={onStatusChange}
+        jobType={jobType}
+        onRetry={onRetry}
+      />
+    );
   }
 
   if (shouldCheckFinishedJobs) {
@@ -66,6 +75,7 @@ export function JobStatus({ jobType, watch, onStatusChange }: JobStatusProps) {
         repositoryName={repoLabel}
         onStatusChange={onStatusChange}
         jobType={jobType}
+        onRetry={onRetry}
       />
     );
   }

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -86,6 +86,11 @@ export const SynchronizeStep = memo(function SynchronizeStep({ onCancel, isCance
     }
   };
 
+  const retryJob = () => {
+    setJob(undefined);
+    startSynchronization();
+  };
+
   if (isLoading || healthStatusNotReady) {
     return (
       <Box padding={4}>
@@ -112,7 +117,7 @@ export const SynchronizeStep = memo(function SynchronizeStep({ onCancel, isCance
     );
   }
   if (job) {
-    return <JobStatus watch={job} onStatusChange={setStepStatusInfo} jobType="sync" />;
+    return <JobStatus watch={job} onStatusChange={setStepStatusInfo} jobType="sync" onRetry={retryJob} />;
   }
 
   return (

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12669,6 +12669,7 @@
       "loading-finished-job": "Loading finished job...",
       "no-job-found": "No job found",
       "no-job-found-message": "The job may have been deleted or could not be retrieved. Cancel the current process and start again.",
+      "retry-action": "Retry",
       "starting": "Starting...",
       "status": {
         "title-error-running-job": "Error running job",


### PR DESCRIPTION
**What is this feature?**

When a sync job fails during the provisioning wizard (e.g., due to a network issue), users can now click a "Retry" button in the error alert to re-attempt the job without restarting the entire provisioning flow.

**Why do we need this feature?**

Currently, if a sync job fails, users must cancel and restart the entire provisioning flow, losing all their progress. This feature allows users to retry the failed job immediately, improving the user experience during transient failures.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/850

**Special notes for your reviewer:**

<img width="971" height="375" alt="Screenshot 2026-02-17 at 13 02 18" src="https://github.com/user-attachments/assets/38d8978e-23da-428e-8f9f-80c0a2877446" />
