### PR TITLE
Provisioning: don't allow folders to be created through files

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/jobs.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/jobs.go
@@ -255,15 +255,22 @@ func (JobStatus) OpenAPIModelName() string {
 	return OpenAPIPrefix + "JobStatus"
 }
 
-// Convert a JOB to a
+// ToSyncStatus converts a job status to a sync status, which will be put in the repository status.
 func (in JobStatus) ToSyncStatus(jobId string) SyncStatus {
-	return SyncStatus{
+	s := SyncStatus{
 		JobID:    jobId,
 		State:    in.State,
 		Started:  in.Started,
 		Finished: in.Finished,
-		Message:  in.Errors,
 	}
+
+	if len(in.Errors) > 0 {
+		s.Message = in.Errors
+	} else if len(in.Warnings) > 0 {
+		s.Message = in.Warnings
+	}
+
+	return s
 }
 
 type JobResourceSummary struct {

--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/grafana/grafana-app-sdk/logging"
 
 	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	folder "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
@@ -155,6 +157,10 @@ func (r *parser) Parse(ctx context.Context, info *repository.FileInfo) (parsed *
 		if err != nil {
 			return nil, fmt.Errorf("load resource URLs: %w", err)
 		}
+	}
+
+	if parsed.GVK.Group == folder.GROUP && parsed.GVK.Kind == folder.FolderResourceInfo.GroupVersionKind().Kind {
+		return nil, NewResourceValidationError(errors.New("cannot declare folders within files"))
 	}
 
 	// Remove the internal dashboard UID,version and id if they exist

--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -160,7 +160,7 @@ func (r *parser) Parse(ctx context.Context, info *repository.FileInfo) (parsed *
 	}
 
 	if parsed.GVK.Group == folder.GROUP && parsed.GVK.Kind == folder.FolderResourceInfo.GroupVersionKind().Kind {
-		return nil, NewResourceValidationError(errors.New("cannot declare folders within files"))
+		return nil, NewResourceValidationError(errors.New("cannot declare folders through files"))
 	}
 
 	// Remove the internal dashboard UID,version and id if they exist

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -389,13 +389,15 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			_, err := helper.Repositories.Resource.Create(ctx, testCase.repo, metav1.CreateOptions{})
-			if testCase.expectedErr == "" {
-				assert.NoError(t, err)
-			} else {
-				assert.Error(t, err)
-				assert.ErrorContains(t, err, testCase.expectedErr)
-			}
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				_, err := helper.Repositories.Resource.Create(ctx, testCase.repo, metav1.CreateOptions{})
+				if testCase.expectedErr == "" {
+					require.NoError(collect, err)
+				} else {
+					require.Error(collect, err)
+					require.ErrorContains(collect, err, testCase.expectedErr)
+				}
+			}, waitTimeoutDefault, waitIntervalDefault)
 		})
 	}
 

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -992,6 +992,26 @@ spec:
 		name, _, _ := unstructured.NestedString(obj.Object, "resource", "upsert", "metadata", "name")
 		require.True(t, strings.HasPrefix(name, "prefix-"), "should generate name")
 	})
+
+	t.Run("folder not allowed", func(t *testing.T) {
+		code := 0
+
+		result := helper.AdminREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("files", "folder.json").
+			Body([]byte(`apiVersion: folder.grafana.app/v1beta1
+kind: Folder
+metadata:
+  name: someFolder
+spec:
+  title: Test Folder
+`)).Do(ctx).StatusCode(&code)
+		require.Error(t, result.Error(), "should return error")
+		require.Contains(t, result.Error().Error(), "cannot declare folders through files")
+		require.Equal(t, http.StatusBadRequest, code, "expect bad request result")
+	})
 }
 
 func TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Updating the resource parser in jobs controller to not allow the creation of `Folder` object through files. 
Instead, a warning will be produced when a sync job tries to reconcile an object formed like that:
<img width="920" height="324" alt="image" src="https://github.com/user-attachments/assets/69ca02bf-9e06-4161-8c93-4bf4370b72de" />

**Why do we need this feature?**

In provisioning jobs operator, the resource parses was allowing folders to be created through files - this currently breaks the way our jobs work, which takes for granted that folders are handled in the git repo through directories. 
Examples on how the flow break:
- When a managed folder gets deleted, and such resource is declared through a file, we get:
```
deleting file <folder_file>/: delete tree: object <id> has unexpected type OBJ_BLOB (expected OBJ_TREE)
```

**Who is this feature for?**

Users of GitSync

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/879

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
