### PR TITLE
CI: Partial revert usage of self-hosted runners for FE E2E tests

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -44,7 +44,8 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.changed == 'true'
     name: Build & Package Grafana
-    runs-on: ubuntu-x64-xlarge
+    # We cannot use self-hosted runners currently as Docker and Dagger requests get rate limited frequently, but do not in GH hosted runners.
+    runs-on: ubuntu-latest-16-cores
     permissions:
       contents: read
       id-token: write
@@ -122,14 +123,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     outputs:
       artifact: ${{ steps.artifact.outputs.artifact }}
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@main
-        if: github.event.pull_request.head.repo.fork == false
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
-        if: github.event.pull_request.head.repo.fork == false
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
@@ -225,16 +221,12 @@ jobs:
             path: e2e/old-arch/panels-suite
             flags: --flags="--env dashboardScene=false"
     name: ${{ matrix.suite }}
-    runs-on: ubuntu-x64-large
+    # We cannot use self-hosted runners currently as Docker and Dagger requests get rate limited frequently, but do not in GH hosted runners.
+    runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read
-      id-token: write
 
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@main
-        if: github.event.pull_request.head.repo.fork == false
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
-        if: github.event.pull_request.head.repo.fork == false
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
@@ -276,14 +268,8 @@ jobs:
     if: needs.detect-changes.outputs.changed == 'true'
     permissions:
       contents: read
-      id-token: write
 
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@main
-        if: github.event.pull_request.head.repo.fork == false
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
-        if: github.event.pull_request.head.repo.fork == false
-
       - name: Checkout code
         uses: actions/checkout@v5
         with:
@@ -307,10 +293,10 @@ jobs:
     needs:
       - build-grafana
     name: Playwright E2E tests (${{ matrix.shard }}/${{ matrix.shardTotal }})
-    runs-on: ubuntu-x64-large
+    # We cannot use self-hosted runners currently as Docker and Dagger requests get rate limited frequently, but do not in GH hosted runners.
+    runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read
-      id-token: write
 
     strategy:
       fail-fast: false
@@ -319,10 +305,6 @@ jobs:
         shardTotal: [8]
 
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@main
-        if: github.event.pull_request.head.repo.fork == false
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
-        if: github.event.pull_request.head.repo.fork == false
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
@@ -423,15 +405,7 @@ jobs:
     if: ${{ !cancelled() }}
     name: All Playwright tests complete
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@main
-        if: github.event.pull_request.head.repo.fork == false
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
-        if: github.event.pull_request.head.repo.fork == false
-
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
@@ -512,16 +486,12 @@ jobs:
     needs:
       - build-grafana
     name: A11y test
-    runs-on: ubuntu-x64-large
+    # We cannot use self-hosted runners currently as Docker and Dagger requests get rate limited frequently, but do not in GH hosted runners.
+    runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read
-      id-token: write
 
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@main
-        if: github.event.pull_request.head.repo.fork == false
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
-        if: github.event.pull_request.head.repo.fork == false
       - uses: actions/checkout@v5
         with:
           persist-credentials: false


### PR DESCRIPTION
We are being rate limited by Dagger, but the assumption is that the GH hosted runners don't.