### PR TITLE
CI: Use fork of dagger action with binary cache for E2E tests

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -70,10 +70,11 @@ jobs:
       # If no cache hit, build Grafana
       - name: Build Grafana
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: dagger/dagger-for-github@d913e70051faf3b907d4dd96ef1161083c88c644
+        uses: kminehart/dagger-for-github@main
         env:
           CACHE_BUILDERS: ${{ github.event.pull_request.head.repo.fork == false }}
         with:
+          cache-binary: "true"
           version: 0.18.8
           verb: run
           args: go run ./pkg/build/cmd artifacts -a targz:grafana:linux/amd64 -a docker:grafana:linux/amd64 --grafana-dir="${PWD}" --cache-builders=${CACHE_BUILDERS} > out.txt
@@ -247,8 +248,9 @@ jobs:
       - name: chmod +x
         run: chmod +x ./e2e-runner
       - name: Run E2E tests
-        uses: dagger/dagger-for-github@d913e70051faf3b907d4dd96ef1161083c88c644
+        uses: kminehart/dagger-for-github@main
         with:
+          cache-binary: "true"
           version: 0.18.8
           verb: run
           args: go run ./pkg/build/e2e --package=grafana.tar.gz
@@ -330,8 +332,9 @@ jobs:
         with:
           name: grafana-tar-gz
       - name: Run E2E tests
-        uses: dagger/dagger-for-github@d913e70051faf3b907d4dd96ef1161083c88c644
+        uses: kminehart/dagger-for-github@main
         with:
+          cache-binary: "true"
           version: 0.18.8
           verb: run
           args: go run ./pkg/build/e2e-playwright --package=grafana.tar.gz --shard=${{ matrix.shard }}/${{ matrix.shardTotal }} --blob-dir=./blob-report
@@ -398,8 +401,9 @@ jobs:
           name: grafana-tar-gz
 
       - name: Run E2E tests
-        uses: dagger/dagger-for-github@d913e70051faf3b907d4dd96ef1161083c88c644
+        uses: kminehart/dagger-for-github@main
         with:
+          cache-binary: "true"
           version: 0.18.8
           verb: run
           args: go run ./pkg/build/e2e-playwright --package=grafana.tar.gz --playwright-command="yarn e2e:playwright:cloud-plugins" --cloud-plugin-creds=/tmp/outputs.json
@@ -530,15 +534,17 @@ jobs:
           name: grafana-tar-gz
       - name: Run PR a11y test
         if: github.event_name == 'pull_request'
-        uses: dagger/dagger-for-github@d913e70051faf3b907d4dd96ef1161083c88c644
+        uses: kminehart/dagger-for-github@main
         with:
+          cache-binary: "true"
           version: 0.18.8
           verb: run
           args: go run ./pkg/build/a11y --package=grafana.tar.gz
       - name: Run non-PR a11y test
         if: github.event_name != 'pull_request'
-        uses: dagger/dagger-for-github@d913e70051faf3b907d4dd96ef1161083c88c644
+        uses: kminehart/dagger-for-github@main
         with:
+          cache-binary: "true"
           version: 0.18.8
           verb: run
           args: go run ./pkg/build/a11y --package=grafana.tar.gz --no-threshold-fail --results=./pa11y-ci-results.json

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -70,7 +70,7 @@ jobs:
       # If no cache hit, build Grafana
       - name: Build Grafana
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: kminehart/dagger-for-github@main
+        uses: kminehart/dagger-for-github@590bdefcb7f0c1030fce068a2c041c36582262d6
         env:
           CACHE_BUILDERS: ${{ github.event.pull_request.head.repo.fork == false }}
         with:
@@ -248,7 +248,7 @@ jobs:
       - name: chmod +x
         run: chmod +x ./e2e-runner
       - name: Run E2E tests
-        uses: kminehart/dagger-for-github@main
+        uses: kminehart/dagger-for-github@590bdefcb7f0c1030fce068a2c041c36582262d6
         with:
           cache-binary: "true"
           version: 0.18.8
@@ -332,7 +332,7 @@ jobs:
         with:
           name: grafana-tar-gz
       - name: Run E2E tests
-        uses: kminehart/dagger-for-github@main
+        uses: kminehart/dagger-for-github@590bdefcb7f0c1030fce068a2c041c36582262d6
         with:
           cache-binary: "true"
           version: 0.18.8
@@ -401,7 +401,7 @@ jobs:
           name: grafana-tar-gz
 
       - name: Run E2E tests
-        uses: kminehart/dagger-for-github@main
+        uses: kminehart/dagger-for-github@590bdefcb7f0c1030fce068a2c041c36582262d6
         with:
           cache-binary: "true"
           version: 0.18.8
@@ -534,7 +534,7 @@ jobs:
           name: grafana-tar-gz
       - name: Run PR a11y test
         if: github.event_name == 'pull_request'
-        uses: kminehart/dagger-for-github@main
+        uses: kminehart/dagger-for-github@590bdefcb7f0c1030fce068a2c041c36582262d6
         with:
           cache-binary: "true"
           version: 0.18.8
@@ -542,7 +542,7 @@ jobs:
           args: go run ./pkg/build/a11y --package=grafana.tar.gz
       - name: Run non-PR a11y test
         if: github.event_name != 'pull_request'
-        uses: kminehart/dagger-for-github@main
+        uses: kminehart/dagger-for-github@590bdefcb7f0c1030fce068a2c041c36582262d6
         with:
           cache-binary: "true"
           version: 0.18.8


### PR DESCRIPTION
We can use this forked version of the action that enables binary caching so we can keep using our self-hosted runners!