### PR TITLE
RefreshPicker: Update aria labels to match visible labels

### DIFF
--- a/e2e-playwright/dashboard-cujs/dashboard-view.spec.ts
+++ b/e2e-playwright/dashboard-cujs/dashboard-view.spec.ts
@@ -189,7 +189,7 @@ test.describe(
         const refreshedPanelContents = await panelContent.textContent();
 
         await intervalRefreshBtn.click();
-        const offBtn = page.locator('button[aria-label="Turn off auto refresh"]');
+        const offBtn = page.locator('button[aria-label="Off"]');
         await offBtn.click();
 
         await expect(panelContent).toHaveText(refreshedPanelContents!, {

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.test.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.test.tsx
@@ -11,7 +11,7 @@ describe('RefreshPicker', () => {
         const result = intervalsToOptions();
 
         expect(result).toEqual([
-          { value: '', label: 'Off', ariaLabel: 'Off' },
+          { value: '', label: 'Off' },
           { value: '5s', label: '5s', ariaLabel: '5 seconds' },
           { value: '10s', label: '10s', ariaLabel: '10 seconds' },
           { value: '30s', label: '30s', ariaLabel: '30 seconds' },
@@ -33,7 +33,7 @@ describe('RefreshPicker', () => {
         const result = intervalsToOptions({ intervals });
 
         expect(result).toEqual([
-          { value: '', label: 'Off', ariaLabel: 'Off' },
+          { value: '', label: 'Off' },
           { value: '5s', label: '5s', ariaLabel: '5 seconds' },
           { value: '10s', label: '10s', ariaLabel: '10 seconds' },
         ]);
@@ -45,7 +45,7 @@ describe('RefreshPicker', () => {
 
       const result = intervalsToOptions({ intervals });
       expect(result).toEqual([
-        { value: '', label: 'Off', ariaLabel: 'Off' },
+        { value: '', label: 'Off' },
         { value: '10s', label: '10s', ariaLabel: '10 seconds' },
         { value: '1m 30s', label: '1m 30s', ariaLabel: '1 minute 30 seconds' },
       ]);
@@ -54,13 +54,13 @@ describe('RefreshPicker', () => {
   describe('translateOption', () => {
     it('returns LIVE, Off, auto, and custom options correctly', () => {
       const live = translateOption(RefreshPicker.liveOption.value);
-      expect(live).toMatchObject({ value: 'LIVE', label: expect.any(String), ariaLabel: expect.any(String) });
+      expect(live).toMatchObject({ value: 'LIVE', label: expect.any(String) });
 
       const off = translateOption(RefreshPicker.offOption.value);
-      expect(off).toMatchObject({ value: '', label: expect.any(String), ariaLabel: expect.any(String) });
+      expect(off).toMatchObject({ value: '', label: expect.any(String) });
 
       const auto = translateOption(RefreshPicker.autoOption.value);
-      expect(auto).toMatchObject({ value: 'auto', label: expect.any(String), ariaLabel: expect.any(String) });
+      expect(auto).toMatchObject({ value: 'auto', label: expect.any(String) });
 
       const custom = translateOption('7s');
       expect(custom).toMatchObject({ value: '7s', label: '7s' });

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.test.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.test.tsx
@@ -11,7 +11,7 @@ describe('RefreshPicker', () => {
         const result = intervalsToOptions();
 
         expect(result).toEqual([
-          { value: '', label: 'Off', ariaLabel: 'Turn off auto refresh' },
+          { value: '', label: 'Off', ariaLabel: 'Off' },
           { value: '5s', label: '5s', ariaLabel: '5 seconds' },
           { value: '10s', label: '10s', ariaLabel: '10 seconds' },
           { value: '30s', label: '30s', ariaLabel: '30 seconds' },
@@ -33,7 +33,7 @@ describe('RefreshPicker', () => {
         const result = intervalsToOptions({ intervals });
 
         expect(result).toEqual([
-          { value: '', label: 'Off', ariaLabel: 'Turn off auto refresh' },
+          { value: '', label: 'Off', ariaLabel: 'Off' },
           { value: '5s', label: '5s', ariaLabel: '5 seconds' },
           { value: '10s', label: '10s', ariaLabel: '10 seconds' },
         ]);
@@ -45,7 +45,7 @@ describe('RefreshPicker', () => {
 
       const result = intervalsToOptions({ intervals });
       expect(result).toEqual([
-        { value: '', label: 'Off', ariaLabel: 'Turn off auto refresh' },
+        { value: '', label: 'Off', ariaLabel: 'Off' },
         { value: '10s', label: '10s', ariaLabel: '10 seconds' },
         { value: '1m 30s', label: '1m 30s', ariaLabel: '1 minute 30 seconds' },
       ]);
@@ -74,12 +74,12 @@ describe('RefreshPicker', () => {
       expect(RefreshPicker.isLive(undefined)).toBe(false);
     });
     it('offOption, liveOption and autoOption', () => {
-      expect(RefreshPicker.offOption).toEqual({ value: '', label: 'Off', ariaLabel: 'Turn off auto refresh' });
-      expect(RefreshPicker.liveOption).toEqual({ value: 'LIVE', label: 'Live', ariaLabel: 'Turn on live streaming' });
+      expect(RefreshPicker.offOption).toEqual({ value: '', label: 'Off', ariaLabel: 'Off' });
+      expect(RefreshPicker.liveOption).toEqual({ value: 'LIVE', label: 'Live', ariaLabel: 'Live' });
       expect(RefreshPicker.autoOption).toEqual({
         value: 'auto',
         label: 'Auto',
-        ariaLabel: 'Select refresh from the query range',
+        ariaLabel: 'Auto',
       });
     });
   });

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -94,7 +94,7 @@ const RefreshPickerComponent = memo((props: Props) => {
     selectedValue = { value: '' };
   }
 
-  const durationAriaLabel = selectedValue.ariaLabel;
+  const durationAriaLabel = selectedValue.ariaLabel ?? selectedValue.label;
   const ariaLabelDurationSelectedMessage = t(
     'refresh-picker.aria-label.duration-selected',
     'Choose refresh time interval with current interval {{durationAriaLabel}} selected',
@@ -151,25 +151,22 @@ export const RefreshPicker = Object.assign(RefreshPickerComponent, {
   autoOption,
 });
 
-export const translateOption = (option: string) => {
+export const translateOption = (option: string): SelectableValue<string> => {
   switch (option) {
     case liveOption.value:
       return {
         label: t('refresh-picker.live-option.label', 'Live'),
         value: option,
-        ariaLabel: t('refresh-picker.live-option.aria-label', 'Live'),
       };
     case offOption.value:
       return {
         label: t('refresh-picker.off-option.label', 'Off'),
         value: option,
-        ariaLabel: t('refresh-picker.off-option.aria-label', 'Off'),
       };
     case autoOption.value:
       return {
         label: t('refresh-picker.auto-option.label', 'Auto'),
         value: option,
-        ariaLabel: t('refresh-picker.auto-option.aria-label', 'Auto'),
       };
   }
   return {

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -32,17 +32,17 @@ export interface Props {
 const offOption = {
   label: 'Off',
   value: '',
-  ariaLabel: 'Turn off auto refresh',
+  ariaLabel: 'Off',
 };
 const liveOption = {
   label: 'Live',
   value: 'LIVE',
-  ariaLabel: 'Turn on live streaming',
+  ariaLabel: 'Live',
 };
 const autoOption = {
   label: 'Auto',
   value: 'auto',
-  ariaLabel: 'Select refresh from the query range',
+  ariaLabel: 'Auto',
 };
 
 /**
@@ -157,19 +157,19 @@ export const translateOption = (option: string) => {
       return {
         label: t('refresh-picker.live-option.label', 'Live'),
         value: option,
-        ariaLabel: t('refresh-picker.live-option.aria-label', 'Turn on live streaming'),
+        ariaLabel: t('refresh-picker.live-option.aria-label', 'Live'),
       };
     case offOption.value:
       return {
         label: t('refresh-picker.off-option.label', 'Off'),
         value: option,
-        ariaLabel: t('refresh-picker.off-option.aria-label', 'Turn off auto refresh'),
+        ariaLabel: t('refresh-picker.off-option.aria-label', 'Off'),
       };
     case autoOption.value:
       return {
-        label: t('refresh-picker.auto-option.label', autoOption.label),
+        label: t('refresh-picker.auto-option.label', 'Auto'),
         value: option,
-        ariaLabel: t('refresh-picker.auto-option.aria-label', autoOption.ariaLabel),
+        ariaLabel: t('refresh-picker.auto-option.aria-label', 'Auto'),
       };
   }
   return {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13358,15 +13358,15 @@
       "duration-selected": "Choose refresh time interval with current interval {{durationAriaLabel}} selected"
     },
     "auto-option": {
-      "aria-label": "",
-      "label": ""
+      "aria-label": "Auto",
+      "label": "Auto"
     },
     "live-option": {
-      "aria-label": "Turn on live streaming",
+      "aria-label": "Live",
       "label": "Live"
     },
     "off-option": {
-      "aria-label": "Turn off auto refresh",
+      "aria-label": "Off",
       "label": "Off"
     },
     "tooltip": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13358,15 +13358,12 @@
       "duration-selected": "Choose refresh time interval with current interval {{durationAriaLabel}} selected"
     },
     "auto-option": {
-      "aria-label": "Auto",
       "label": "Auto"
     },
     "live-option": {
-      "aria-label": "Live",
       "label": "Live"
     },
     "off-option": {
-      "aria-label": "Off",
       "label": "Off"
     },
     "tooltip": {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- updates `aria-label`s to match visible labels

**Why do we need this feature?**

- so people using a screenreader have the same experience

**Who is this feature for?**

- anyone using a screenreader

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/116511

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
