### PR TITLE
Alerting: Fix policy tab broken

### DIFF
--- a/public/app/features/alerting/unified/NotificationPoliciesPage.tsx
+++ b/public/app/features/alerting/unified/NotificationPoliciesPage.tsx
@@ -60,7 +60,7 @@ const NotificationPoliciesTabs = () => {
       <>
         <GrafanaAlertmanagerWarning currentAlertmanager={selectedAlertmanager} />
         <InhibitionRulesAlert alertmanagerSourceName={selectedAlertmanager} />
-        <PoliciesList />
+        <PolicyTreeTab />
       </>
     );
   }


### PR DESCRIPTION
**What is this feature?**

- Fix regression introduced in #116749 where the V2 navigation path (`alertingNavigationV2`) always rendered `<PoliciesList />`, ignoring the `alertingMultiplePolicies` feature toggle
- When `alertingMultiplePolicies` is not enabled (undefined or false), the V2 nav path now correctly renders `<PoliciesTree />` instead of `<PoliciesList />`
- Add tests covering the interaction between `alertingNavigationV2` and `alertingMultiplePolicies`

## Context

When `alertingNavigationV2` was enabled in an environment (e.g. ops), users saw the multiple policies list view (`PoliciesList`) even though `alertingMultiplePolicies` was not enabled. This happened because the V2 nav code path returned `<PoliciesList />` directly, bypassing the `PolicyTreeTab` component where the feature toggle check lives.

The fix replaces `<PoliciesList />` with `<PolicyTreeTab />` in the V2 nav path, ensuring both code paths respect the `alertingMultiplePolicies` toggle consistently.

## Test plan

- [x] Test: V2 nav enabled + `alertingMultiplePolicies` undefined -> renders `PoliciesTree`
- [x] Test: V2 nav enabled + `alertingMultiplePolicies` disabled -> renders `PoliciesTree`
- [x] Test: V2 nav enabled + `alertingMultiplePolicies` enabled -> renders `PoliciesList`

**Why do we need this feature?**

It's a bug.

**Who is this feature for?**

Alerting users.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
