### PR TITLE
[release-12.3.4] App Platform: Add dry-run support to DualWriter

### DIFF
--- a/pkg/registry/apis/folders/folder_storage.go
+++ b/pkg/registry/apis/folders/folder_storage.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apiserver/pkg/util/dryrun"
 
 	claims "github.com/grafana/authlib/types"
 
@@ -84,6 +85,11 @@ func (s *folderStorage) Create(ctx context.Context,
 	if err != nil {
 		statusErr := apierrors.ToFolderStatusError(err)
 		return nil, &statusErr
+	}
+
+	// Skip permission side effects during dry-run
+	if dryrun.IsDryRun(options.DryRun) {
+		return obj, nil
 	}
 
 	// When cfg.RBAC.PermissionsOnCreation("folder") is not enabled

--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apiserver/pkg/util/dryrun"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 
@@ -177,6 +178,12 @@ func (d *dualWriter) List(ctx context.Context, options *metainternalversion.List
 
 // Create overrides the behavior of the generic DualWriter and writes to LegacyStorage and Storage.
 func (d *dualWriter) Create(ctx context.Context, in runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	// During dry-run, skip legacy storage and delegate directly to unified storage
+	// which already handles dry-run correctly via DryRunnableStorage.
+	if dryrun.IsDryRun(options.DryRun) {
+		return d.unified.Create(ctx, in, createValidation, options)
+	}
+
 	log := logging.FromContext(ctx).With("method", "Create")
 
 	accIn, err := meta.Accessor(in)
@@ -286,6 +293,13 @@ func (d *dualWriter) Delete(ctx context.Context, name string, deleteValidation r
 	// By setting RemovePermissions to false in the context, we will skip the deletion of permissions
 	// in the legacy store. This is needed as otherwise the permissions would be missing when executing
 	// the delete operation in the unified storage store.
+
+	// During dry-run, skip legacy storage and delegate directly to unified storage
+	// which already handles dry-run correctly via DryRunnableStorage.
+	if dryrun.IsDryRun(options.DryRun) {
+		return d.unified.Delete(ctx, name, deleteValidation, options)
+	}
+
 	log := logging.FromContext(ctx).With("method", "Delete", "name", name)
 	ctx = utils.SetFolderRemovePermissions(ctx, false)
 
@@ -327,6 +341,18 @@ func (d *dualWriter) Delete(ctx context.Context, name string, deleteValidation r
 
 // Update overrides the behavior of the generic DualWriter and writes first to Storage and then to LegacyStorage.
 func (d *dualWriter) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	// During dry-run, skip legacy storage and delegate directly to unified storage
+	// which already handles dry-run correctly via DryRunnableStorage.
+	if dryrun.IsDryRun(options.DryRun) {
+		dryRunInfo := objInfo
+		dryRunForceCreate := forceAllowCreate
+		if !d.readUnified {
+			dryRunInfo = &wrappedUpdateInfo{objInfo: objInfo}
+			dryRunForceCreate = true
+		}
+		return d.unified.Update(ctx, name, dryRunInfo, createValidation, updateValidation, dryRunForceCreate, options)
+	}
+
 	log := logging.FromContext(ctx).With("method", "Update", "name", name, "objInfo", objInfo)
 
 	// update in legacy first, and then unistore. Will return a failure if either fails.
@@ -388,8 +414,15 @@ func (d *dualWriter) Update(ctx context.Context, name string, objInfo rest.Updat
 	return objFromLegacy, createdLegacy, nil
 }
 
+
 // DeleteCollection overrides the behavior of the generic DualWriter and deletes from both LegacyStorage and Storage.
 func (d *dualWriter) DeleteCollection(ctx context.Context, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions, listOptions *metainternalversion.ListOptions) (runtime.Object, error) {
+	// During dry-run, skip legacy storage and delegate directly to unified storage
+	// which already handles dry-run correctly via DryRunnableStorage.
+	if dryrun.IsDryRun(options.DryRun) {
+		return d.unified.DeleteCollection(ctx, deleteValidation, options, listOptions)
+	}
+
 	log := logging.FromContext(ctx).With("method", "DeleteCollection", "resourceVersion", listOptions.ResourceVersion)
 
 	// delete from legacy first, and anything that is successful can be deleted in unistore too.

--- a/pkg/storage/legacysql/dualwrite/dualwriter_dryrun_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_dryrun_test.go
@@ -1,0 +1,251 @@
+package dualwrite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/grafana/grafana/pkg/apiserver/rest"
+)
+
+// dryRunOptions contains the standard DryRun field value used in k8s dry-run requests.
+var dryRunAll = []string{metav1.DryRunAll}
+
+func TestDryRun_Create(t *testing.T) {
+	modes := []struct {
+		name string
+		mode rest.DualWriterMode
+	}{
+		{"Mode1", rest.Mode1},
+		{"Mode2", rest.Mode2},
+		{"Mode3", rest.Mode3},
+	}
+
+	for _, m := range modes {
+		t.Run(m.name+" should not create in legacy storage when dry-run is set", func(t *testing.T) {
+			l := (rest.Storage)(nil)
+			s := (rest.Storage)(nil)
+
+			ls := storageMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
+
+			// Only unified storage should be called
+			us.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, nil)
+
+			dw, err := NewStaticStorage(kind, m.mode, ls, us)
+			require.NoError(t, err)
+
+			obj, err := dw.Create(context.Background(), exampleObj, createFn, &metav1.CreateOptions{DryRun: dryRunAll})
+			require.NoError(t, err)
+			require.Equal(t, exampleObj, obj)
+
+			// Legacy storage should NOT have been called
+			ls.AssertNotCalled(t, "Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			// Unified storage should have been called
+			us.AssertCalled(t, "Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		})
+	}
+}
+
+func TestDryRun_Delete(t *testing.T) {
+	modes := []struct {
+		name string
+		mode rest.DualWriterMode
+	}{
+		{"Mode1", rest.Mode1},
+		{"Mode2", rest.Mode2},
+		{"Mode3", rest.Mode3},
+	}
+
+	for _, m := range modes {
+		t.Run(m.name+" should not delete in legacy storage when dry-run is set", func(t *testing.T) {
+			l := (rest.Storage)(nil)
+			s := (rest.Storage)(nil)
+
+			ls := storageMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
+
+			// Only unified storage should be called
+			us.On("Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+
+			dw, err := NewStaticStorage(kind, m.mode, ls, us)
+			require.NoError(t, err)
+
+			obj, _, err := dw.Delete(context.Background(), "foo", func(context.Context, runtime.Object) error { return nil }, &metav1.DeleteOptions{DryRun: dryRunAll})
+			require.NoError(t, err)
+			require.Equal(t, exampleObj, obj)
+
+			// Legacy storage should NOT have been called
+			ls.AssertNotCalled(t, "Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			// Unified storage should have been called
+			us.AssertCalled(t, "Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		})
+	}
+}
+
+func TestDryRun_Update(t *testing.T) {
+	modes := []struct {
+		name string
+		mode rest.DualWriterMode
+	}{
+		{"Mode1", rest.Mode1},
+		{"Mode2", rest.Mode2},
+		{"Mode3", rest.Mode3},
+	}
+
+	for _, m := range modes {
+		t.Run(m.name+" should not update in legacy storage when dry-run is set", func(t *testing.T) {
+			l := (rest.Storage)(nil)
+			s := (rest.Storage)(nil)
+
+			ls := storageMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
+
+			// Only unified storage should be called
+			us.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+
+			dw, err := NewStaticStorage(kind, m.mode, ls, us)
+			require.NoError(t, err)
+
+			obj, _, err := dw.Update(context.Background(), "foo", updatedObjInfoObj{},
+				func(ctx context.Context, obj runtime.Object) error { return nil },
+				func(ctx context.Context, obj, old runtime.Object) error { return nil },
+				false, &metav1.UpdateOptions{DryRun: dryRunAll})
+			require.NoError(t, err)
+			require.Equal(t, exampleObj, obj)
+
+			// Legacy storage should NOT have been called
+			ls.AssertNotCalled(t, "Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			// Unified storage should have been called
+			us.AssertCalled(t, "Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		})
+	}
+}
+
+func TestDryRun_Update_WrapsObjInfoForLegacyReadModes(t *testing.T) {
+	t.Run("Mode1 should wrap objInfo and set forceAllowCreate=true", func(t *testing.T) {
+		l := (rest.Storage)(nil)
+		s := (rest.Storage)(nil)
+
+		ls := storageMock{&mock.Mock{}, l}
+		us := storageMock{&mock.Mock{}, s}
+
+		us.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+
+		dw, err := NewStaticStorage(kind, rest.Mode1, ls, us)
+		require.NoError(t, err)
+
+		_, _, err = dw.Update(context.Background(), "foo", updatedObjInfoObj{},
+			func(ctx context.Context, obj runtime.Object) error { return nil },
+			func(ctx context.Context, obj, old runtime.Object) error { return nil },
+			false, &metav1.UpdateOptions{DryRun: dryRunAll})
+		require.NoError(t, err)
+
+		// Verify unified was called with wrappedUpdateInfo and forceAllowCreate=true
+		require.Len(t, us.Calls, 1)
+		call := us.Calls[0]
+		_, isWrapped := call.Arguments[2].(*wrappedUpdateInfo)
+		require.True(t, isWrapped, "Mode1 dry-run should wrap objInfo with wrappedUpdateInfo")
+		forceCreate := call.Arguments[5].(bool)
+		require.True(t, forceCreate, "Mode1 dry-run should set forceAllowCreate=true")
+	})
+
+	t.Run("Mode2 should wrap objInfo and set forceAllowCreate=true", func(t *testing.T) {
+		l := (rest.Storage)(nil)
+		s := (rest.Storage)(nil)
+
+		ls := storageMock{&mock.Mock{}, l}
+		us := storageMock{&mock.Mock{}, s}
+
+		us.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+
+		dw, err := NewStaticStorage(kind, rest.Mode2, ls, us)
+		require.NoError(t, err)
+
+		_, _, err = dw.Update(context.Background(), "foo", updatedObjInfoObj{},
+			func(ctx context.Context, obj runtime.Object) error { return nil },
+			func(ctx context.Context, obj, old runtime.Object) error { return nil },
+			false, &metav1.UpdateOptions{DryRun: dryRunAll})
+		require.NoError(t, err)
+
+		// Verify unified was called with wrappedUpdateInfo and forceAllowCreate=true
+		require.Len(t, us.Calls, 1)
+		call := us.Calls[0]
+		_, isWrapped := call.Arguments[2].(*wrappedUpdateInfo)
+		require.True(t, isWrapped, "Mode2 dry-run should wrap objInfo with wrappedUpdateInfo")
+		forceCreate := call.Arguments[5].(bool)
+		require.True(t, forceCreate, "Mode2 dry-run should set forceAllowCreate=true")
+	})
+
+	t.Run("Mode3 should pass original objInfo unchanged", func(t *testing.T) {
+		l := (rest.Storage)(nil)
+		s := (rest.Storage)(nil)
+
+		ls := storageMock{&mock.Mock{}, l}
+		us := storageMock{&mock.Mock{}, s}
+
+		us.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+
+		dw, err := NewStaticStorage(kind, rest.Mode3, ls, us)
+		require.NoError(t, err)
+
+		originalInfo := updatedObjInfoObj{}
+		_, _, err = dw.Update(context.Background(), "foo", originalInfo,
+			func(ctx context.Context, obj runtime.Object) error { return nil },
+			func(ctx context.Context, obj, old runtime.Object) error { return nil },
+			false, &metav1.UpdateOptions{DryRun: dryRunAll})
+		require.NoError(t, err)
+
+		// Verify unified was called with original objInfo (not wrapped)
+		require.Len(t, us.Calls, 1)
+		call := us.Calls[0]
+		_, isWrapped := call.Arguments[2].(*wrappedUpdateInfo)
+		require.False(t, isWrapped, "Mode3 dry-run should NOT wrap objInfo")
+		forceCreate := call.Arguments[5].(bool)
+		require.False(t, forceCreate, "Mode3 dry-run should preserve original forceAllowCreate=false")
+	})
+}
+
+func TestDryRun_DeleteCollection(t *testing.T) {
+	modes := []struct {
+		name string
+		mode rest.DualWriterMode
+	}{
+		{"Mode1", rest.Mode1},
+		{"Mode2", rest.Mode2},
+		{"Mode3", rest.Mode3},
+	}
+
+	for _, m := range modes {
+		t.Run(m.name+" should not delete collection in legacy storage when dry-run is set", func(t *testing.T) {
+			l := (rest.Storage)(nil)
+			s := (rest.Storage)(nil)
+
+			ls := storageMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
+
+			// Only unified storage should be called
+			us.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleList, nil)
+
+			dw, err := NewStaticStorage(kind, m.mode, ls, us)
+			require.NoError(t, err)
+
+			obj, err := dw.DeleteCollection(context.Background(),
+				func(ctx context.Context, obj runtime.Object) error { return nil },
+				&metav1.DeleteOptions{DryRun: dryRunAll},
+				&metainternalversion.ListOptions{})
+			require.NoError(t, err)
+			require.Equal(t, exampleList, obj)
+
+			// Legacy storage should NOT have been called
+			ls.AssertNotCalled(t, "DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			// Unified storage should have been called
+			us.AssertCalled(t, "DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		})
+	}
+}

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -1501,3 +1501,114 @@ func TestIntegrationMoveNestedFolderToRootK8S(t *testing.T) {
 	require.Equal(t, "f2", get.Result.UID)
 	require.Equal(t, "", get.Result.ParentUID)
 }
+
+func TestIntegrationFolderDryRun(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	if !db.IsTestDbSQLite() {
+		t.Skip("test only on sqlite for now")
+	}
+
+	// Test dry-run on dual-writer modes 1-4.
+	// Mode 0 (legacy-only) does not use the dualWriter, so dry-run is not intercepted.
+	for mode := 1; mode <= 4; mode++ {
+		modeDw := grafanarest.DualWriterMode(mode)
+		t.Run(fmt.Sprintf("dry-run mode %v", modeDw), func(t *testing.T) {
+			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+				DisableDataMigrations: true,
+				AppModeProduction:     true,
+				DisableAnonymous:      true,
+				APIServerStorageType:  "unified",
+				UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
+					folders.RESOURCEGROUP: {
+						DualWriterMode: modeDw,
+					},
+				},
+				EnableFeatureToggles: []string{},
+			})
+
+			client := helper.GetResourceClient(apis.ResourceClientArgs{
+				User: helper.Org1.Admin,
+				GVR:  gvr,
+			})
+
+			// Create a real folder first
+			folderObj := &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"title": "DryRun Test Folder",
+					},
+				},
+			}
+			folderObj.SetGenerateName("dryrun-test-")
+			created, err := client.Resource.Create(context.Background(), folderObj, metav1.CreateOptions{})
+			require.NoError(t, err)
+			createdName := created.GetName()
+			require.NotEmpty(t, createdName)
+
+			t.Run("delete with dry-run should not actually delete", func(t *testing.T) {
+				err := client.Resource.Delete(context.Background(), createdName, metav1.DeleteOptions{
+					DryRun: []string{metav1.DryRunAll},
+				})
+				require.NoError(t, err)
+
+				// Folder should still exist
+				got, err := client.Resource.Get(context.Background(), createdName, metav1.GetOptions{})
+				require.NoError(t, err, "folder should still exist after dry-run delete")
+				require.Equal(t, createdName, got.GetName())
+			})
+
+			t.Run("create with dry-run should not actually create", func(t *testing.T) {
+				dryRunFolder := &unstructured.Unstructured{
+					Object: map[string]any{
+						"spec": map[string]any{
+							"title": "DryRun Create Folder",
+						},
+					},
+				}
+				dryRunFolder.SetName("dryrun-create-test")
+				_, err := client.Resource.Create(context.Background(), dryRunFolder, metav1.CreateOptions{
+					DryRun: []string{metav1.DryRunAll},
+				})
+				require.NoError(t, err)
+
+				// Folder should NOT exist
+				_, err = client.Resource.Get(context.Background(), "dryrun-create-test", metav1.GetOptions{})
+				require.Error(t, err, "folder should not exist after dry-run create")
+			})
+
+			// Update dry-run only works reliably in modes 3+ where unified storage is
+			// the primary read source, so the client-sent UID matches the unified store.
+			// In modes 1/2, the client reads from legacy (which has a different UID than
+			// unified), causing a UID precondition mismatch on dry-run update.
+			if mode >= 3 {
+				t.Run("update with dry-run should not actually update", func(t *testing.T) {
+					// Get the current folder
+					current, err := client.Resource.Get(context.Background(), createdName, metav1.GetOptions{})
+					require.NoError(t, err)
+
+					// Modify the title
+					spec := current.Object["spec"].(map[string]any)
+					originalTitle := spec["title"]
+					spec["title"] = "DryRun Updated Title"
+					current.Object["spec"] = spec
+
+					_, err = client.Resource.Update(context.Background(), current, metav1.UpdateOptions{
+						DryRun: []string{metav1.DryRunAll},
+					})
+					require.NoError(t, err)
+
+					// Title should be unchanged
+					got, err := client.Resource.Get(context.Background(), createdName, metav1.GetOptions{})
+					require.NoError(t, err)
+					gotSpec := got.Object["spec"].(map[string]any)
+					require.Equal(t, originalTitle, gotSpec["title"], "title should not change after dry-run update")
+				})
+			}
+
+			// Clean up
+			err = client.Resource.Delete(context.Background(), createdName, metav1.DeleteOptions{})
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Backport ccaf8685b47 from #118217

## Conflicts resolved

Only `pkg/storage/legacysql/dualwrite/dualwriter.go` had conflicts. The release branch is missing tracing infrastructure (added in fd14d4a5ed3), so dry-run guards were inserted at the start of method bodies instead of after `defer span.End()`.

The following files auto-merged cleanly:
- `pkg/tests/apis/folder/folders_test.go` - new `TestIntegrationFolderDryRun` test appended
- `pkg/registry/apis/folders/folder_storage.go` - dry-run check in Create method
- `pkg/storage/legacysql/dualwrite/dualwriter_dryrun_test.go` - new unit test file