### PR TITLE
Provisioning: Allow HTTP URLs for Git repositories

### DIFF
--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -151,8 +151,8 @@ func isValidGitURL(gitURL string) bool {
 		return false
 	}
 
-	// Must be HTTPS
-	if parsed.Scheme != "https" {
+	// Must be HTTPS or HTTP (HTTP allowed for local development)
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
 		return false
 	}
 

--- a/apps/provisioning/pkg/repository/git/repository_test.go
+++ b/apps/provisioning/pkg/repository/git/repository_test.go
@@ -33,9 +33,9 @@ func TestIsValidGitURL(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "invalid HTTP URL",
+			name: "valid HTTP URL for local development",
 			url:  "http://git.example.com/owner/repo.git",
-			want: false,
+			want: true,
 		},
 		{
 			name: "missing scheme",

--- a/apps/provisioning/pkg/repository/github/validator.go
+++ b/apps/provisioning/pkg/repository/github/validator.go
@@ -38,9 +38,9 @@ func Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 		if err != nil {
 			list = append(list, field.Invalid(field.NewPath("spec", "github", "url"), gh.URL, err.Error()))
 		}
-		// Allow any HTTPS GitHub server (github.com, GitHub Enterprise, etc.)
-		if !strings.HasPrefix(gh.URL, "https://") {
-			list = append(list, field.Invalid(field.NewPath("spec", "github", "url"), gh.URL, "URL must start with https://"))
+		// Allow any HTTPS or HTTP GitHub server (github.com, GitHub Enterprise, local instances, etc.)
+		if !strings.HasPrefix(gh.URL, "https://") && !strings.HasPrefix(gh.URL, "http://") {
+			list = append(list, field.Invalid(field.NewPath("spec", "github", "url"), gh.URL, "URL must start with https:// or http://"))
 		}
 	}
 

--- a/apps/provisioning/pkg/repository/github/validator_test.go
+++ b/apps/provisioning/pkg/repository/github/validator_test.go
@@ -65,7 +65,7 @@ func TestValidate(t *testing.T) {
 			errorContains: []string{"url"},
 		},
 		{
-			name: "invalid URL format - non-HTTPS",
+			name: "valid HTTP URL for local development",
 			obj: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-repo",
@@ -77,9 +77,13 @@ func TestValidate(t *testing.T) {
 						Branch: "main",
 					},
 				},
+				Secure: provisioning.SecureValues{
+					Token: common.InlineSecureValue{
+						Create: common.NewSecretValue("test-token"),
+					},
+				},
 			},
-			expectedError: true,
-			errorContains: []string{"URL must start with https://"},
+			expectedError: false,
 		},
 		{
 			name: "valid github.com repository",

--- a/apps/provisioning/pkg/repository/tester.go
+++ b/apps/provisioning/pkg/repository/tester.go
@@ -33,12 +33,6 @@ func NewTester(validators ...Validator) Tester {
 func (t *Tester) Test(ctx context.Context, repo Repository) (*provisioning.TestResults, error) {
 	cfg := repo.Config()
 
-	// HACK: Set a default finalizer for test requests to bypass finalizer validation
-	// Test requests don't actually create resources, so finalizers aren't meaningful here
-	if len(cfg.Finalizers) == 0 {
-		cfg.Finalizers = []string{CleanFinalizer}
-	}
-
 	for _, validator := range t.validators {
 		list := validator.Validate(ctx, cfg)
 		if len(list) > 0 {

--- a/apps/provisioning/pkg/repository/tester.go
+++ b/apps/provisioning/pkg/repository/tester.go
@@ -33,6 +33,12 @@ func NewTester(validators ...Validator) Tester {
 func (t *Tester) Test(ctx context.Context, repo Repository) (*provisioning.TestResults, error) {
 	cfg := repo.Config()
 
+	// HACK: Set a default finalizer for test requests to bypass finalizer validation
+	// Test requests don't actually create resources, so finalizers aren't meaningful here
+	if len(cfg.Finalizers) == 0 {
+		cfg.Finalizers = []string{CleanFinalizer}
+	}
+
 	for _, validator := range t.validators {
 		list := validator.Validate(ctx, cfg)
 		if len(list) > 0 {


### PR DESCRIPTION
## What this PR does

Allows HTTP (non-HTTPS) URLs for Git repositories in the provisioning system to support local development scenarios.

## Changes

- Modified git repository URL validator to accept both `http://` and `https://`
- Modified GitHub repository URL validator to accept both protocols
- Updated test cases to validate HTTP URLs are accepted

## Why

Useful for:
- Local development with HTTP-only Git servers (e.g., Gitea on `http://localhost:3001`)
- Testing and demo environments
- Internal networks where HTTPS may not be configured

## Security Note

Production deployments should still use HTTPS for security. HTTP support is primarily intended for development and testing environments.

## Testing

- ✅ All unit tests pass (`go test ./apps/provisioning/pkg/repository/...`)
- ✅ Updated test cases for HTTP URL validation
- ✅ Manual testing with local Gitea instance

---
🤖 Generated with Claude Code