### PR TITLE
Provisioning wizard: Redirect to repository status page after creation

### DIFF
--- a/public/app/features/provisioning/Wizard/hooks/useWizardNavigation.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useWizardNavigation.ts
@@ -84,7 +84,13 @@ export function useWizardNavigation({
         workflowsEnabled: getWorkflows(formData.repository),
         ...(repoType === 'github' && { githubAuthType }),
       });
-      navigate(PROVISIONING_URL);
+      // Navigate to repository status page instead of listing page
+      const repoName = formData.repositoryName;
+      if (repoName) {
+        navigate(`${PROVISIONING_URL}/${repoName}`);
+      } else {
+        navigate(PROVISIONING_URL);
+      }
     } else {
       let nextStepIndex = currentStepIndex + 1;
 


### PR DESCRIPTION
## What this PR does

After completing the onboarding wizard, redirect users to the newly created repository's status page instead of the repository listing page.

## Changes

- Modified `useWizardNavigation` to navigate to `/admin/provisioning/{repoName}`
- Falls back to listing page if repository name is not available

## Why

Provides immediate feedback on:
- Repository state and health
- Sync progress and status
- Any errors or warnings

## User Experience

**Before:** Complete wizard → See list of all repositories  
**After:** Complete wizard → See your new repository's status and sync progress ✨

---
🤖 Generated with Claude Code