### PR TITLE
Provisioning: Fix repository URLs for generic git type

### DIFF
--- a/public/app/features/provisioning/components/utils/url.ts
+++ b/public/app/features/provisioning/components/utils/url.ts
@@ -15,6 +15,10 @@ export const getBranchUrl = (baseUrl: string, branch: string, repoType?: string)
       return `${cleanBaseUrl}/-/tree/${branch}`;
     case 'bitbucket':
       return `${cleanBaseUrl}/src/${branch}`;
+    case 'git':
+      // Generic git repositories don't have a standard URL pattern for branches
+      // Just return the base URL without branch segment
+      return cleanBaseUrl;
     default:
       return '';
   }

--- a/public/app/features/provisioning/utils/git.test.ts
+++ b/public/app/features/provisioning/utils/git.test.ts
@@ -127,7 +127,7 @@ describe('buildRepoUrl', () => {
       ).toBe('https://bitbucket.org/workspace/repo/src/main');
     });
 
-    it('builds generic git href with tree segment', () => {
+    it('builds generic git href without tree segment', () => {
       expect(
         getRepoHrefForProvider(
           spec({
@@ -135,7 +135,7 @@ describe('buildRepoUrl', () => {
             git: { url: 'https://git.example.com/owner/repo.git', branch: 'main' },
           })
         )
-      ).toBe('https://git.example.com/owner/repo/tree/main');
+      ).toBe('https://git.example.com/owner/repo');
     });
   });
 

--- a/public/app/features/provisioning/utils/git.ts
+++ b/public/app/features/provisioning/utils/git.ts
@@ -102,12 +102,9 @@ export const getRepoHrefForProvider = (spec?: RepositorySpec) => {
         path: spec.bitbucket?.path,
       });
     case 'git':
-      return buildRepoUrl({
-        baseUrl: spec.git?.url,
-        branch: spec.git?.branch,
-        providerSegments: ['tree'],
-        path: spec.git?.path,
-      });
+      // Generic git repositories don't have a standard URL pattern
+      // Just return the base URL without branch/path segments
+      return spec.git?.url ? buildCleanBaseUrl(spec.git.url) : undefined;
     default:
       return undefined;
   }


### PR DESCRIPTION
## What this PR does

For generic git repositories (non-GitHub/GitLab/Bitbucket), remove the `/tree/{branch}` segment from URLs.

## Changes

- `getRepoHrefForProvider`: Return clean base URL for 'git' type
- `getBranchUrl`: Return clean base URL for 'git' type
- Updated test to expect base URL without `/tree/` segment

## Why

Different git hosting platforms have different URL patterns. Since we can't predict the URL structure for generic git servers (Gitea, custom Git servers, etc.), we return just the base repository URL.

## URL Comparison

| Repository Type | URL Pattern |
|----------------|-------------|
| **GitHub** | `https://github.com/owner/repo/tree/main` |
| **GitLab** | `https://gitlab.com/owner/repo/-/tree/main` |
| **Bitbucket** | `https://bitbucket.org/owner/repo/src/main` |
| **Generic Git** | `http://localhost:3001/owner/repo` (base URL only) ✅ |

## Example

**Before:** `http://localhost:3001/owner/repo/tree/main`  
**After:** `http://localhost:3001/owner/repo` ✅

---
🤖 Generated with Claude Code