### PR TITLE
Provisioning wizard: Auto-select branch when refs are loaded

### DIFF
--- a/public/app/features/provisioning/Wizard/ConnectStep.tsx
+++ b/public/app/features/provisioning/Wizard/ConnectStep.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import { Combobox, Field, Input, Stack } from '@grafana/ui';
@@ -17,6 +17,7 @@ export const ConnectStep = memo(function ConnectStep() {
     formState: { errors },
     getValues,
     watch,
+    setValue,
   } = useFormContext<WizardFormData>();
 
   // We don't need to dynamically react on repo type changes, so we use getValues for it
@@ -35,6 +36,46 @@ export const ConnectStep = memo(function ConnectStep() {
 
   const gitFields = isGitBased ? getGitProviderFields(type) : null;
   const localFields = !isGitBased ? getLocalProviderFields(type) : null;
+
+  // Track if we've already auto-selected a branch
+  const hasAutoSelectedRef = useRef(false);
+
+  // Auto-select branch when refs are loaded for the first time
+  useEffect(() => {
+    // Only auto-select if:
+    // 1. We haven't already auto-selected
+    // 2. We have branch options
+    // 3. No branch is currently selected
+    // 4. Not loading
+    if (
+      hasAutoSelectedRef.current ||
+      !repositoryRefsOptions ||
+      repositoryRefsOptions.length === 0 ||
+      isRefsLoading ||
+      getValues('repository.branch')
+    ) {
+      return;
+    }
+
+    // Get all branch names
+    const branchNames = repositoryRefsOptions.map((opt) => opt.value);
+
+    // Priority: main > master > first alphabetically
+    let selectedBranch: string | undefined;
+    if (branchNames.includes('main')) {
+      selectedBranch = 'main';
+    } else if (branchNames.includes('master')) {
+      selectedBranch = 'master';
+    } else {
+      // Sort alphabetically and take the first
+      selectedBranch = [...branchNames].sort()[0];
+    }
+
+    if (selectedBranch) {
+      setValue('repository.branch', selectedBranch);
+      hasAutoSelectedRef.current = true;
+    }
+  }, [repositoryRefsOptions, isRefsLoading, getValues, setValue]);
 
   return (
     <Stack direction="column" gap={2}>

--- a/public/app/features/provisioning/Wizard/ConnectStep.tsx
+++ b/public/app/features/provisioning/Wizard/ConnectStep.tsx
@@ -29,6 +29,7 @@ export const ConnectStep = memo(function ConnectStep() {
     options: repositoryRefsOptions,
     loading: isRefsLoading,
     error: refsError,
+    defaultBranch,
   } = useGetRepositoryRefs({
     repositoryType: type,
     repositoryName: repositoryName,
@@ -37,45 +38,14 @@ export const ConnectStep = memo(function ConnectStep() {
   const gitFields = isGitBased ? getGitProviderFields(type) : null;
   const localFields = !isGitBased ? getLocalProviderFields(type) : null;
 
-  // Track if we've already auto-selected a branch
   const hasAutoSelectedRef = useRef(false);
 
-  // Auto-select branch when refs are loaded for the first time
   useEffect(() => {
-    // Only auto-select if:
-    // 1. We haven't already auto-selected
-    // 2. We have branch options
-    // 3. No branch is currently selected
-    // 4. Not loading
-    if (
-      hasAutoSelectedRef.current ||
-      !repositoryRefsOptions ||
-      repositoryRefsOptions.length === 0 ||
-      isRefsLoading ||
-      getValues('repository.branch')
-    ) {
-      return;
-    }
-
-    // Get all branch names
-    const branchNames = repositoryRefsOptions.map((opt) => opt.value);
-
-    // Priority: main > master > first alphabetically
-    let selectedBranch: string | undefined;
-    if (branchNames.includes('main')) {
-      selectedBranch = 'main';
-    } else if (branchNames.includes('master')) {
-      selectedBranch = 'master';
-    } else {
-      // Sort alphabetically and take the first
-      selectedBranch = [...branchNames].sort()[0];
-    }
-
-    if (selectedBranch) {
-      setValue('repository.branch', selectedBranch);
+    if (!hasAutoSelectedRef.current && defaultBranch && !getValues('repository.branch')) {
+      setValue('repository.branch', defaultBranch);
       hasAutoSelectedRef.current = true;
     }
-  }, [repositoryRefsOptions, isRefsLoading, getValues, setValue]);
+  }, [defaultBranch, getValues, setValue]);
 
   return (
     <Stack direction="column" gap={2}>

--- a/public/app/features/provisioning/constants.ts
+++ b/public/app/features/provisioning/constants.ts
@@ -9,3 +9,5 @@ export const DEFAULT_REPOSITORY_TYPES: Array<'github' | 'local'> = ['github', 'l
 
 // TODO: use the limits from the API when they are available
 export const FREE_TIER_CONNECTION_LIMIT = 1;
+
+export const DEFAULT_BRANCH_NAMES = ['main', 'master'] as const;

--- a/public/app/features/provisioning/hooks/useGetRepositoryRefs.ts
+++ b/public/app/features/provisioning/hooks/useGetRepositoryRefs.ts
@@ -3,6 +3,7 @@
  * Used to populate the branch dropdown in onboarding wizard
  */
 import { skipToken } from '@reduxjs/toolkit/query';
+import { useMemo } from 'react';
 
 import { useGetRepositoryRefsQuery } from '@grafana/api-clients/rtkq/provisioning/v0alpha1';
 import { t } from '@grafana/i18n';
@@ -10,6 +11,7 @@ import { getErrorMessage } from 'app/api/clients/provisioning/utils/httpUtils';
 
 import { useRepositoryStatus } from '../Wizard/hooks/useRepositoryStatus';
 import { RepoType } from '../Wizard/types';
+import { DEFAULT_BRANCH_NAMES } from '../constants';
 import { isGitProvider } from '../utils/repositoryTypes';
 
 export interface UseGetRepositoryRefsProps {
@@ -34,8 +36,18 @@ export function useGetRepositoryRefs({ repositoryType, repositoryName }: UseGetR
 
   const branchOptions = branchData?.items.map((item) => ({ label: item.name, value: item.name })) ?? [];
 
+  const defaultBranch = useMemo(() => {
+    if (!branchData?.items?.length) {
+      return undefined;
+    }
+    const names = branchData.items.map((item) => item.name);
+    const preferred = DEFAULT_BRANCH_NAMES.find((b) => names.includes(b));
+    return preferred ?? [...names].sort()[0];
+  }, [branchData]);
+
   return {
     options: branchOptions,
+    defaultBranch,
     loading: branchLoading || isRepositoryLoading || healthStatusNotReady,
     error: isRepoError
       ? t(


### PR DESCRIPTION
## What this PR does

Automatically select the default branch when repository refs are fetched for the first time in the onboarding wizard.

## Changes

- Added `useEffect` to auto-select branch when refs are loaded
- Added ref to track if auto-selection has already occurred
- Selection only happens if no branch is currently set

## Selection Priority

1. **'main'** (if exists)
2. **'master'** (if exists)  
3. **First branch alphabetically**

## Why

Improves UX by pre-selecting the most likely branch choice, reducing manual steps in the wizard.

## User Experience

**Before:** User must manually select branch from dropdown  
**After:** Branch auto-populated with 'main' or 'master' ✨

## Implementation

- Watches `repositoryRefsOptions` changes
- Prevents re-selection if user has already chosen a branch
- Only triggers when refs finish loading

---
🤖 Generated with Claude Code