### PR TITLE
[SPIKE] Git Sync: folder metadata warnings & fix actions in UI

### DIFF
--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -15,6 +15,7 @@ import { FolderRepo } from '../../core/components/NestedFolderPicker/FolderRepo'
 import { ManagerKind } from '../apiserver/types';
 import { TemplateDashboardModal } from '../dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal';
 import { buildNavModel, getDashboardsTabID } from '../folders/state/navModel';
+import { MissingFolderMetadataBanner } from '../provisioning/components/Folders/MissingFolderMetadataBanner';
 import { ProvisionedFolderPreviewBanner } from '../provisioning/components/Folders/ProvisionedFolderPreviewBanner';
 import { useGetResourceRepositoryView } from '../provisioning/hooks/useGetResourceRepositoryView';
 import { useSearchStateManager } from '../search/state/SearchStateManager';
@@ -160,6 +161,7 @@ const BrowseDashboardsPage = memo(({ queryParams }: { queryParams: Record<string
     >
       <Page.Contents className={styles.pageContents}>
         <ProvisionedFolderPreviewBanner queryParams={queryParams} />
+        {isProvisionedFolder && <MissingFolderMetadataBanner folderUID={folderUID} />}
         {/* only show recently viewed dashboards when in root and flag is enabled */}
         {isRecentlyViewedEnabled && <RecentlyViewedDashboards />}
         <div>

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
@@ -54,8 +54,8 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
   const canMoveFolder = canEditFolders && !isProvisionedRootFolder && !isReadOnlyRepo;
   // Can only delete folders when the folder has the right permission and is not provisioned root folder
   const canDeleteFolders = canDeleteFoldersPermissions && !isProvisionedRootFolder && !isReadOnlyRepo;
-  // Show permissions only if the folder is not provisioned
-  const canShowPermissions = canViewPermissions && !isProvisionedFolder;
+  // SPIKE: Permissions are now allowed for provisioned folders (folder UID is stable)
+  const canShowPermissions = canViewPermissions;
 
   const onMove = async (destinationUID: string) => {
     await moveFolder({ folderUID: folder.uid, destinationUID: destinationUID });
@@ -148,7 +148,8 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
 
   const menu = (
     <Menu>
-      {canViewPermissions && !isProvisionedFolder && (
+      {/* SPIKE: Permissions now shown for provisioned folders too */}
+      {canViewPermissions && (
         <MenuItem onClick={() => setShowPermissionsDrawer(true)} label={managePermissionsLabel} />
       )}
       {showManageOwners && (

--- a/public/app/features/provisioning/Job/RecentJobs.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.tsx
@@ -75,7 +75,21 @@ const getJobColumns = () => [
   {
     id: 'message',
     header: t('provisioning.recent-jobs.column-message', 'Message'),
-    cell: ({ row: { original: job } }: JobCell) => <span>{job.status?.message}</span>,
+    cell: ({ row: { original: job } }: JobCell) => {
+      const message = job.status?.message;
+      const hasMetadataWarning = message?.includes('missing .folder.json');
+      if (hasMetadataWarning && job.spec?.repository) {
+        return (
+          <Stack direction="row" gap={1} alignItems="center">
+            <span>{message}</span>
+            <a href={`/provisioning/${job.spec.repository}?tab=resources`}>
+              <Badge text="Fix" color="orange" icon="wrench" />
+            </a>
+          </Stack>
+        );
+      }
+      return <span>{message}</span>;
+    },
   },
 ];
 

--- a/public/app/features/provisioning/Repository/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.tsx
@@ -1,9 +1,21 @@
 import { css, cx } from '@emotion/css';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Alert, Box, Card, CellProps, Grid, InteractiveTable, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CellProps,
+  Grid,
+  InteractiveTable,
+  LinkButton,
+  Stack,
+  Text,
+  useStyles2,
+} from '@grafana/ui';
 import {
   Repository,
   ResourceCount,
@@ -75,19 +87,7 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
     <Box padding={2}>
       <Stack direction="column" gap={2}>
         {missingMetadataCount > 0 && (
-          <Alert
-            severity="warning"
-            title={t(
-              'provisioning.repository-overview.missing-metadata-title',
-              '{{count}} folder(s) missing metadata',
-              { count: missingMetadataCount }
-            )}
-          >
-            <Trans i18nKey="provisioning.repository-overview.missing-metadata-body">
-              Some folders in this repository are missing .folder.json metadata files. Go to the Resources tab to review
-              and fix them.
-            </Trans>
-          </Alert>
+          <MissingMetadataAlert count={missingMetadataCount} repoName={repoName} />
         )}
         <Grid columns={{ xs: 1, sm: 2, lg: lgColumn, xxl: xxlColumn }} gap={2} alignItems={'flex-start'}>
           <div className={styles.cardContainer}>
@@ -183,6 +183,44 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
         </div>
       </Stack>
     </Box>
+  );
+}
+
+// SPIKE: alert with "Fix folder IDs" button for missing metadata
+function MissingMetadataAlert({ count, repoName }: { count: number; repoName: string }) {
+  const [isFixing, setIsFixing] = useState(false);
+
+  const handleFix = () => {
+    setIsFixing(true);
+    // SPIKE: Simulate creating a PR job to fix folder metadata
+    setTimeout(() => setIsFixing(false), 2000);
+  };
+
+  return (
+    <Alert
+      severity="warning"
+      title={t(
+        'provisioning.repository-overview.missing-metadata-title',
+        '{{count}} folder(s) missing metadata',
+        { count }
+      )}
+    >
+      <Stack direction="row" alignItems="center" gap={2}>
+        <span>
+          <Trans i18nKey="provisioning.repository-overview.missing-metadata-body">
+            Some folders in this repository are missing .folder.json metadata files. Go to the Resources tab to review
+            and fix them.
+          </Trans>
+        </span>
+        <Button variant="secondary" icon="wrench" onClick={handleFix} disabled={isFixing}>
+          {isFixing ? (
+            <Trans i18nKey="provisioning.repository-overview.fixing">Fixing...</Trans>
+          ) : (
+            <Trans i18nKey="provisioning.repository-overview.fix-all">Fix folder IDs</Trans>
+          )}
+        </Button>
+      </Stack>
+    </Alert>
   );
 }
 

--- a/public/app/features/provisioning/Shared/StatusBadge.tsx
+++ b/public/app/features/provisioning/Shared/StatusBadge.tsx
@@ -14,7 +14,7 @@ interface BadgeConfig {
   tooltip?: string;
 }
 
-function getBadgeConfig(repo: Repository): BadgeConfig {
+function getBadgeConfig(repo: Repository, hasMissingMetadata?: boolean): BadgeConfig {
   if (repo.metadata?.deletionTimestamp) {
     return {
       color: 'red',
@@ -37,6 +37,19 @@ function getBadgeConfig(repo: Repository): BadgeConfig {
       text: t('provisioning.status-badge.pending', 'Pending'),
       icon: 'spinner',
       tooltip: t('provisioning.status-badge.waiting-for-health-check', 'Waiting for health check to run'),
+    };
+  }
+
+  // SPIKE: if metadata is missing, show warning regardless of sync state
+  if (hasMissingMetadata) {
+    return {
+      color: 'orange',
+      text: t('provisioning.status-badge.missing-metadata', 'Missing metadata'),
+      icon: 'exclamation-triangle',
+      tooltip: t(
+        'provisioning.status-badge.missing-metadata-tooltip',
+        'Some folders are missing .folder.json metadata files'
+      ),
     };
   }
 
@@ -79,9 +92,11 @@ function getBadgeConfig(repo: Repository): BadgeConfig {
 interface StatusBadgeProps {
   repo?: Repository;
   displayOnly?: boolean; // if true, disable click action and cursor will be default
+  /** SPIKE: whether the repo has folders with missing metadata */
+  hasMissingMetadata?: boolean;
 }
 
-export function StatusBadge({ repo, displayOnly = false }: StatusBadgeProps) {
+export function StatusBadge({ repo, displayOnly = false, hasMissingMetadata }: StatusBadgeProps) {
   const handleClick = useCallback(() => {
     if (displayOnly || !repo?.metadata?.name) {
       return;
@@ -93,7 +108,7 @@ export function StatusBadge({ repo, displayOnly = false }: StatusBadgeProps) {
     return null;
   }
 
-  const { color, text, icon, tooltip } = getBadgeConfig(repo);
+  const { color, text, icon, tooltip } = getBadgeConfig(repo, hasMissingMetadata);
 
   return (
     <Badge

--- a/public/app/features/provisioning/components/Folders/MissingFolderMetadataBanner.tsx
+++ b/public/app/features/provisioning/components/Folders/MissingFolderMetadataBanner.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+
+import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
+import { Alert, Button, Stack } from '@grafana/ui';
+
+import { PROVISIONING_URL } from '../../constants';
+
+interface MissingFolderMetadataBannerProps {
+  folderUID?: string;
+}
+
+/**
+ * SPIKE: Banner shown on provisioned folder pages when the folder is missing
+ * a .folder.json metadata file. Provides a direct "Fix" action and a link
+ * to the repository status page.
+ */
+export function MissingFolderMetadataBanner({ folderUID }: MissingFolderMetadataBannerProps) {
+  const [isFixing, setIsFixing] = useState(false);
+  const provisioningEnabled = config.featureToggles.provisioning;
+
+  if (!provisioningEnabled || !folderUID) {
+    return null;
+  }
+
+  // SPIKE: In a real implementation this would check the API for missing metadata.
+  // For the spike, we show the banner on all provisioned folders to demonstrate the UI.
+  const hasMissingMetadata = true;
+
+  if (!hasMissingMetadata) {
+    return null;
+  }
+
+  const handleFix = () => {
+    setIsFixing(true);
+    // SPIKE: Simulate creating a PR job
+    setTimeout(() => setIsFixing(false), 2000);
+  };
+
+  return (
+    <Alert
+      severity="warning"
+      title={t(
+        'provisioning.folder-metadata-banner.title',
+        'This folder is missing a .folder.json metadata file'
+      )}
+    >
+      <Stack direction="row" alignItems="center" gap={2}>
+        <span>
+          <Trans i18nKey="provisioning.folder-metadata-banner.description">
+            Without a metadata file, this folder may lose its identity (UID and permissions) when re-synced. Fix this by
+            creating a PR that adds the missing metadata file.
+          </Trans>
+        </span>
+        <Stack direction="row" gap={1}>
+          <Button variant="secondary" icon="wrench" onClick={handleFix} disabled={isFixing} size="sm">
+            {isFixing ? (
+              <Trans i18nKey="provisioning.folder-metadata-banner.fixing">Fixing...</Trans>
+            ) : (
+              <Trans i18nKey="provisioning.folder-metadata-banner.fix">Fix folder ID</Trans>
+            )}
+          </Button>
+          <Button
+            variant="secondary"
+            icon="external-link-alt"
+            size="sm"
+            onClick={() => {
+              window.location.href = `${PROVISIONING_URL}/${folderUID}?tab=resources`;
+            }}
+          >
+            <Trans i18nKey="provisioning.folder-metadata-banner.view-resources">View in Resources</Trans>
+          </Button>
+        </Stack>
+      </Stack>
+    </Alert>
+  );
+}

--- a/public/app/features/provisioning/hooks/useRepositoryAllJobs.ts
+++ b/public/app/features/provisioning/hooks/useRepositoryAllJobs.ts
@@ -11,6 +11,60 @@ function labelSelectorActive(repositoryName?: string): string | undefined {
   return repositoryName ? `provisioning.grafana.app/repository=${repositoryName}` : undefined;
 }
 
+// SPIKE: fake warning job to simulate a pull that found missing folder metadata
+function createFakeWarningJob(repositoryName: string): Job {
+  const now = Date.now();
+  return {
+    metadata: {
+      name: 'fake-warning-job-metadata',
+      uid: 'spike-fake-warning-job',
+      creationTimestamp: new Date(now - 60000).toISOString(),
+    },
+    spec: {
+      action: 'pull',
+      repository: repositoryName,
+      pull: { incremental: true },
+    },
+    status: {
+      state: 'warning',
+      started: now - 60000,
+      finished: now - 55000,
+      message: 'Completed with warnings: 2 folders missing .folder.json metadata files',
+      warnings: [
+        'Folder "dashboards/team-a" is missing .folder.json — folder UID will be auto-generated and may change on next sync',
+        'Folder "dashboards/team-b" is missing .folder.json — permissions set on this folder may be lost',
+      ],
+      summary: [
+        {
+          group: 'folder.grafana.app',
+          kind: 'Folder',
+          total: 5,
+          create: 0,
+          update: 3,
+          noop: 0,
+          warning: 2,
+          warnings: [
+            'dashboards/team-a: missing .folder.json metadata file. Fix: /provisioning/' +
+              repositoryName +
+              '?tab=resources',
+            'dashboards/team-b: missing .folder.json metadata file. Fix: /provisioning/' +
+              repositoryName +
+              '?tab=resources',
+          ],
+        },
+        {
+          group: 'dashboard.grafana.app',
+          kind: 'Dashboard',
+          total: 12,
+          create: 2,
+          update: 10,
+          noop: 0,
+        },
+      ],
+    },
+  };
+}
+
 export function useRepositoryAllJobs({
   repositoryName,
 }: RepositoryHistoricalJobsArgs): [
@@ -32,6 +86,10 @@ export function useRepositoryAllJobs({
   );
 
   const concatedItems = [...(activeQuery.data?.items ?? []), ...(historicQuery.data?.items ?? [])];
+
+  // SPIKE: inject fake warning job
+  concatedItems.push(createFakeWarningJob(repositoryName));
+
   const collator = new Intl.Collator(undefined, { numeric: true });
   const sortedItems = concatedItems.slice().sort((a, b) => {
     const aTime = a.metadata?.creationTimestamp ?? '';

--- a/public/app/features/provisioning/types.ts
+++ b/public/app/features/provisioning/types.ts
@@ -97,6 +97,8 @@ export interface TreeItem {
   hash?: string;
   status?: SyncStatus;
   hasFile?: boolean;
+  /** SPIKE: folder is missing .folder.json metadata file */
+  missingMetadata?: boolean;
 }
 
 export interface FlatTreeItem {

--- a/public/app/features/provisioning/utils/treeUtils.ts
+++ b/public/app/features/provisioning/utils/treeUtils.ts
@@ -179,6 +179,20 @@ export function buildTree(mergedItems: MergedItem[]): TreeItem[] {
   };
 
   updateFolderStatus(roots);
+
+  // SPIKE: detect folders missing .folder.json metadata files
+  const filePaths = new Set(mergedItems.map((item) => item.path));
+  const markMissingMetadata = (nodes: TreeItem[]) => {
+    for (const node of nodes) {
+      if (node.type === 'Folder') {
+        const metadataPath = node.path ? `${node.path}/.folder.json` : '.folder.json';
+        node.missingMetadata = !filePaths.has(metadataPath);
+        markMissingMetadata(node.children);
+      }
+    }
+  };
+  markMissingMetadata(roots);
+
   return roots;
 }
 
@@ -197,6 +211,20 @@ export function flattenTree(items: TreeItem[], level = 0): FlatTreeItem[] {
   }
 
   return result;
+}
+
+/**
+ * SPIKE: Count folders with missing .folder.json metadata in a tree.
+ */
+export function countMissingMetadata(items: TreeItem[]): number {
+  let count = 0;
+  for (const item of items) {
+    if (item.missingMetadata) {
+      count++;
+    }
+    count += countMissingMetadata(item.children);
+  }
+  return count;
 }
 
 /**


### PR DESCRIPTION
## Summary

UI spike to visualize missing folder metadata warnings and fix-me job flows across the Git Sync UI. **Not production code** — all changes are marked with `SPIKE:` comments for easy cleanup. No backend changes; data is faked in the frontend.

### What this covers

- **Resources Tab**: Warning icons + global alert banner + per-row "Fix" buttons for folders missing `.folder.json`
- **Repository Overview**: Alert banner showing count of folders with missing metadata, linking to Resources tab
- **Repository List (StatusBadge)**: Repos with missing metadata show an orange "Missing metadata" badge
- **Folder Page**: Warning banner on provisioned folders with "Fix folder ID" + "View in Resources" actions
- **Job History**: Fake warning pull job injected to demonstrate how metadata warnings appear in job history, including a clickable "Fix" badge in the message column
- **Permissions**: Unlocked "Manage permissions" for provisioned folders (folder UID is stable)

### Files changed (11)

| Area | File | Change |
|------|------|--------|
| Types | `provisioning/types.ts` | Added `missingMetadata` flag to `TreeItem` |
| Detection | `provisioning/utils/treeUtils.ts` | Detects folders without `.folder.json` + `countMissingMetadata()` |
| Resources Tab | `provisioning/Repository/ResourceTreeView.tsx` | Warning alert, per-row icons + Fix buttons |
| Repo Overview | `provisioning/Repository/RepositoryOverview.tsx` | Missing metadata alert banner |
| Repo List | `provisioning/Repository/RepositoryListItem.tsx` | Passes `hasMissingMetadata` to StatusBadge |
| Status Badge | `provisioning/Shared/StatusBadge.tsx` | New "Missing metadata" badge state |
| Folder Page | `provisioning/components/Folders/MissingFolderMetadataBanner.tsx` | **New** - warning banner component |
| Folder Page | `browse-dashboards/BrowseDashboardsPage.tsx` | Integrates metadata banner |
| Job History | `provisioning/hooks/useRepositoryAllJobs.ts` | Injects fake warning job |
| Job History | `provisioning/Job/RecentJobs.tsx` | "Fix" badge link in warning messages |
| Permissions | `browse-dashboards/components/FolderActionsButton.tsx` | Removed `!isProvisionedFolder` gate |

## Test plan

- [ ] Navigate to Provisioning > Repositories — repos should show "Missing metadata" badge if any folder lacks `.folder.json`
- [ ] Click into a repository > Overview tab — should see warning alert if folders are missing metadata
- [ ] Switch to Resources tab — folders without `.folder.json` show warning icon + Fix button; global "Fix folder IDs" banner at top
- [ ] Navigate to a provisioned folder in Dashboards — should see the "Missing metadata" warning banner
- [ ] On provisioned folder, click Folder actions > "Manage permissions" should now be visible
- [ ] In repository Overview > Jobs section — fake warning job should appear with expandable warnings and "Fix" link


Made with [Cursor](https://cursor.com)