### PR TITLE
Provisioning: return warning instead of error when deleting non-existing file

### DIFF
--- a/apps/provisioning/pkg/repository/local/local.go
+++ b/apps/provisioning/pkg/repository/local/local.go
@@ -335,12 +335,21 @@ func (r *localRepository) Delete(ctx context.Context, path string, ref string, c
 
 	fullPath := safepath.Join(r.path, path)
 
+	var err error
 	if safepath.IsDir(path) {
 		// if it is a folder, delete all of its contents
-		return os.RemoveAll(fullPath)
+		err = os.RemoveAll(fullPath)
+	} else {
+		err = os.Remove(fullPath)
+	}
+	if err != nil {
+		if os.IsNotExist(err) {
+			return repository.ErrFileNotFound
+		}
+		return err
 	}
 
-	return os.Remove(fullPath)
+	return nil
 }
 
 func (r *localRepository) Move(ctx context.Context, oldPath, newPath, ref, comment string) error {

--- a/apps/provisioning/pkg/repository/local/local_test.go
+++ b/apps/provisioning/pkg/repository/local/local_test.go
@@ -394,7 +394,7 @@ func TestLocalRepository_Delete(t *testing.T) {
 			path:        "non-existent-file.txt",
 			ref:         "",
 			comment:     "test delete non-existent",
-			expectedErr: os.ErrNotExist,
+			expectedErr: repository.ErrFileNotFound,
 		},
 		{
 			name: "delete with ref not supported",

--- a/pkg/registry/apis/provisioning/jobs/delete/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/delete/worker_test.go
@@ -266,7 +266,7 @@ func TestDeleteWorker_ProcessWithSyncWorker(t *testing.T) {
 		return result.Path() == "test/path" && result.Action() == repository.FileActionDeleted && result.Error() == nil
 	})).Return()
 
-	mockProgress.On("ResetResults").Return()
+	mockProgress.On("ResetResults", true).Return()
 	mockProgress.On("SetMessage", mock.Anything, "pull resources").Return()
 
 	mockSyncWorker.On("Process", mock.Anything, mockRepo, mock.MatchedBy(func(syncJob v0alpha1.Job) bool {
@@ -307,7 +307,7 @@ func TestDeleteWorker_ProcessSyncWorkerError(t *testing.T) {
 	mockRepo.On("Delete", mock.Anything, "test/path", "", "Delete test/path").Return(nil)
 
 	mockProgress.On("Record", mock.Anything, mock.Anything).Return()
-	mockProgress.On("ResetResults").Return()
+	mockProgress.On("ResetResults", true).Return()
 	mockProgress.On("SetMessage", mock.Anything, "pull resources").Return()
 
 	syncError := errors.New("sync failed")
@@ -601,7 +601,7 @@ func TestDeleteWorker_ProcessResourceResolutionError(t *testing.T) {
 	mockProgress.On("TooManyErrors").Return(nil)
 
 	// Mock sync worker behavior that happens when no ref is specified
-	mockProgress.On("ResetResults").Return()
+	mockProgress.On("ResetResults", true).Return()
 	mockProgress.On("SetMessage", mock.Anything, "pull resources").Return()
 
 	mockSyncWorker := jobs.NewMockWorker(t)
@@ -1154,7 +1154,7 @@ func TestDeleteWorker_RefURLsNotSetWithoutRef(t *testing.T) {
 	mockProgress.On("SetMessage", mock.Anything, "Deleting test.json").Once()
 	mockProgress.On("Record", mock.Anything, mock.Anything).Once()
 	mockProgress.On("TooManyErrors").Return(nil).Once()
-	mockProgress.On("ResetResults").Once()
+	mockProgress.On("ResetResults", true).Once()
 	mockProgress.On("SetMessage", mock.Anything, "pull resources").Once()
 	mockProgress.On("Complete", mock.Anything, mock.Anything).Return(v0alpha1.JobStatus{})
 	// SetRefURLs should NOT be called since no ref is specified

--- a/pkg/registry/apis/provisioning/jobs/job_progress_recorder_mock.go
+++ b/pkg/registry/apis/provisioning/jobs/job_progress_recorder_mock.go
@@ -71,52 +71,6 @@ func (_c *MockJobProgressRecorder_Complete_Call) RunAndReturn(run func(context.C
 	return _c
 }
 
-// HasDirPathFailedDeletion provides a mock function with given fields: folderPath
-func (_m *MockJobProgressRecorder) HasDirPathFailedDeletion(folderPath string) bool {
-	ret := _m.Called(folderPath)
-
-	if len(ret) == 0 {
-		panic("no return value specified for HasDirPathFailedDeletion")
-	}
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = rf(folderPath)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-// MockJobProgressRecorder_HasDirPathFailedDeletion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HasDirPathFailedDeletion'
-type MockJobProgressRecorder_HasDirPathFailedDeletion_Call struct {
-	*mock.Call
-}
-
-// HasDirPathFailedDeletion is a helper method to define mock.On call
-//   - folderPath string
-func (_e *MockJobProgressRecorder_Expecter) HasDirPathFailedDeletion(folderPath interface{}) *MockJobProgressRecorder_HasDirPathFailedDeletion_Call {
-	return &MockJobProgressRecorder_HasDirPathFailedDeletion_Call{Call: _e.mock.On("HasDirPathFailedDeletion", folderPath)}
-}
-
-func (_c *MockJobProgressRecorder_HasDirPathFailedDeletion_Call) Run(run func(folderPath string)) *MockJobProgressRecorder_HasDirPathFailedDeletion_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
-	})
-	return _c
-}
-
-func (_c *MockJobProgressRecorder_HasDirPathFailedDeletion_Call) Return(_a0 bool) *MockJobProgressRecorder_HasDirPathFailedDeletion_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockJobProgressRecorder_HasDirPathFailedDeletion_Call) RunAndReturn(run func(string) bool) *MockJobProgressRecorder_HasDirPathFailedDeletion_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // HasDirPathFailedCreation provides a mock function with given fields: path
 func (_m *MockJobProgressRecorder) HasDirPathFailedCreation(path string) bool {
 	ret := _m.Called(path)
@@ -163,6 +117,52 @@ func (_c *MockJobProgressRecorder_HasDirPathFailedCreation_Call) RunAndReturn(ru
 	return _c
 }
 
+// HasDirPathFailedDeletion provides a mock function with given fields: folderPath
+func (_m *MockJobProgressRecorder) HasDirPathFailedDeletion(folderPath string) bool {
+	ret := _m.Called(folderPath)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasDirPathFailedDeletion")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(folderPath)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockJobProgressRecorder_HasDirPathFailedDeletion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HasDirPathFailedDeletion'
+type MockJobProgressRecorder_HasDirPathFailedDeletion_Call struct {
+	*mock.Call
+}
+
+// HasDirPathFailedDeletion is a helper method to define mock.On call
+//   - folderPath string
+func (_e *MockJobProgressRecorder_Expecter) HasDirPathFailedDeletion(folderPath interface{}) *MockJobProgressRecorder_HasDirPathFailedDeletion_Call {
+	return &MockJobProgressRecorder_HasDirPathFailedDeletion_Call{Call: _e.mock.On("HasDirPathFailedDeletion", folderPath)}
+}
+
+func (_c *MockJobProgressRecorder_HasDirPathFailedDeletion_Call) Run(run func(folderPath string)) *MockJobProgressRecorder_HasDirPathFailedDeletion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockJobProgressRecorder_HasDirPathFailedDeletion_Call) Return(_a0 bool) *MockJobProgressRecorder_HasDirPathFailedDeletion_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockJobProgressRecorder_HasDirPathFailedDeletion_Call) RunAndReturn(run func(string) bool) *MockJobProgressRecorder_HasDirPathFailedDeletion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Record provides a mock function with given fields: ctx, result
 func (_m *MockJobProgressRecorder) Record(ctx context.Context, result JobResourceResult) {
 	_m.Called(ctx, result)
@@ -197,9 +197,9 @@ func (_c *MockJobProgressRecorder_Record_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
-// ResetResults provides a mock function with no fields
-func (_m *MockJobProgressRecorder) ResetResults() {
-	_m.Called()
+// ResetResults provides a mock function with given fields: keepWarnings
+func (_m *MockJobProgressRecorder) ResetResults(keepWarnings bool) {
+	_m.Called(keepWarnings)
 }
 
 // MockJobProgressRecorder_ResetResults_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResetResults'
@@ -208,13 +208,14 @@ type MockJobProgressRecorder_ResetResults_Call struct {
 }
 
 // ResetResults is a helper method to define mock.On call
-func (_e *MockJobProgressRecorder_Expecter) ResetResults() *MockJobProgressRecorder_ResetResults_Call {
-	return &MockJobProgressRecorder_ResetResults_Call{Call: _e.mock.On("ResetResults")}
+//   - keepWarnings bool
+func (_e *MockJobProgressRecorder_Expecter) ResetResults(keepWarnings interface{}) *MockJobProgressRecorder_ResetResults_Call {
+	return &MockJobProgressRecorder_ResetResults_Call{Call: _e.mock.On("ResetResults", keepWarnings)}
 }
 
-func (_c *MockJobProgressRecorder_ResetResults_Call) Run(run func()) *MockJobProgressRecorder_ResetResults_Call {
+func (_c *MockJobProgressRecorder_ResetResults_Call) Run(run func(keepWarnings bool)) *MockJobProgressRecorder_ResetResults_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(bool))
 	})
 	return _c
 }
@@ -224,7 +225,7 @@ func (_c *MockJobProgressRecorder_ResetResults_Call) Return() *MockJobProgressRe
 	return _c
 }
 
-func (_c *MockJobProgressRecorder_ResetResults_Call) RunAndReturn(run func()) *MockJobProgressRecorder_ResetResults_Call {
+func (_c *MockJobProgressRecorder_ResetResults_Call) RunAndReturn(run func(bool)) *MockJobProgressRecorder_ResetResults_Call {
 	_c.Run(run)
 	return _c
 }

--- a/pkg/registry/apis/provisioning/jobs/job_resource_result.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result.go
@@ -129,6 +129,8 @@ func (b *jobResourceResultBuilder) WithAction(action repository.FileAction) *job
 
 // WithError sets the error associated with the resource operation.
 // If the error is classified as a warning error, it will be set as a warning instead of an error.
+// TODO: we should probably move the warning checks to the caller,
+// and have a clear separation between WithError and WithWarning
 func (b *jobResourceResultBuilder) WithError(err error) *jobResourceResultBuilder {
 	if err != nil && isWarningError(err) {
 		b.result.warning = err
@@ -137,6 +139,15 @@ func (b *jobResourceResultBuilder) WithError(err error) *jobResourceResultBuilde
 		b.result.err = err
 		b.result.warning = nil
 	}
+	return b
+}
+
+// WithWarning explicitly sets the error associated with the resource operation as a warning.
+func (b *jobResourceResultBuilder) WithWarning(err error) *jobResourceResultBuilder {
+	if err != nil {
+		b.result.warning = err
+	}
+
 	return b
 }
 

--- a/pkg/registry/apis/provisioning/jobs/job_resource_result_test.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result_test.go
@@ -62,6 +62,35 @@ func TestNewJobResourceResult_WithError(t *testing.T) {
 	assert.Equal(t, err, result.Error())
 }
 
+func TestNewJobResourceResult_WithWarning(t *testing.T) {
+	name := "test-resource"
+	group := "test-group"
+	kind := "test-kind"
+	path := "/test/path"
+	action := repository.FileActionCreated
+
+	warningErr := errors.New("some warning error")
+
+	// Test with ParseError directly (a warning error)
+	result := NewResourceResult().
+		WithName(name).
+		WithGroup(group).
+		WithKind(kind).
+		WithPath(path).
+		WithAction(action).
+		WithWarning(warningErr).
+		Build()
+
+	assert.Equal(t, name, result.Name())
+	assert.Equal(t, group, result.Group())
+	assert.Equal(t, kind, result.Kind())
+	assert.Equal(t, path, result.Path())
+	assert.Equal(t, action, result.Action())
+	assert.Nil(t, result.Error(), "error should be stored as warning, not error")
+	assert.NotNil(t, result.Warning(), "error should be stored as warning")
+	assert.Equal(t, warningErr, result.Warning())
+}
+
 func TestNewJobResourceResult_WithoutError(t *testing.T) {
 	name := "test-resource"
 	group := "test-group"

--- a/pkg/registry/apis/provisioning/jobs/migrate/unifiedstorage.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/unifiedstorage.go
@@ -49,7 +49,7 @@ func (m *UnifiedStorageMigrator) Migrate(ctx context.Context, repo repository.Re
 	}
 
 	// Reset the results after the export as pull will operate on the same resources
-	progress.ResetResults()
+	progress.ResetResults(false)
 
 	// Pull resources from the repository
 	progress.SetMessage(ctx, "pull resources")

--- a/pkg/registry/apis/provisioning/jobs/migrate/unifiedstorage_test.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/unifiedstorage_test.go
@@ -61,7 +61,7 @@ func TestUnifiedStorageMigrator_Migrate(t *testing.T) {
 				ew.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
 					return job.Spec.Push != nil
 				}), pr).Return(nil)
-				pr.On("ResetResults").Return()
+				pr.On("ResetResults", false).Return()
 				pr.On("SetMessage", mock.Anything, "pull resources").Return()
 				sw.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
 					return job.Spec.Pull != nil && !job.Spec.Pull.Incremental
@@ -91,7 +91,7 @@ func TestUnifiedStorageMigrator_Migrate(t *testing.T) {
 				ew.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
 					return job.Spec.Push != nil
 				}), pr).Return(nil)
-				pr.On("ResetResults").Return()
+				pr.On("ResetResults", false).Return()
 				pr.On("SetMessage", mock.Anything, "pull resources").Return()
 				sw.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
 					return job.Spec.Pull != nil && !job.Spec.Pull.Incremental
@@ -123,7 +123,7 @@ func TestUnifiedStorageMigrator_Migrate(t *testing.T) {
 
 				nc.On("Clean", mock.Anything, "test-namespace", pr).Return(nil)
 				// Reset progress and sync job succeeds
-				pr.On("ResetResults").Return()
+				pr.On("ResetResults", false).Return()
 				pr.On("SetMessage", mock.Anything, "pull resources").Return()
 				sw.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
 					return job.Spec.Pull != nil && !job.Spec.Pull.Incremental
@@ -153,7 +153,7 @@ func TestUnifiedStorageMigrator_Migrate(t *testing.T) {
 				ew.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
 					return job.Spec.Push != nil
 				}), pr).Return(nil)
-				pr.On("ResetResults").Return()
+				pr.On("ResetResults", false).Return()
 				// Cleaner should be skipped - no cleaner-related mocks
 				// Sync job should run
 				pr.On("SetMessage", mock.Anything, "pull resources").Return()
@@ -183,7 +183,7 @@ func TestUnifiedStorageMigrator_Migrate(t *testing.T) {
 				ew.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
 					return job.Spec.Push != nil
 				}), pr).Return(nil)
-				pr.On("ResetResults").Return()
+				pr.On("ResetResults", false).Return()
 				// Sync job should run and fail
 				pr.On("SetMessage", mock.Anything, "pull resources").Return()
 				sw.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
@@ -212,7 +212,7 @@ func TestUnifiedStorageMigrator_Migrate(t *testing.T) {
 				ew.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
 					return job.Spec.Push != nil
 				}), pr).Return(nil)
-				pr.On("ResetResults").Return()
+				pr.On("ResetResults", false).Return()
 
 				// Sync job and cleanup should also run
 				pr.On("SetMessage", mock.Anything, "pull resources").Return()
@@ -244,7 +244,7 @@ func TestUnifiedStorageMigrator_Migrate(t *testing.T) {
 				ew.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
 					return job.Spec.Push != nil
 				}), pr).Return(nil)
-				pr.On("ResetResults").Return()
+				pr.On("ResetResults", false).Return()
 				pr.On("SetMessage", mock.Anything, "pull resources").Return()
 				sw.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
 					return job.Spec.Pull != nil && !job.Spec.Pull.Incremental
@@ -274,7 +274,7 @@ func TestUnifiedStorageMigrator_Migrate(t *testing.T) {
 				ew.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
 					return job.Spec.Push != nil && job.Spec.Push.Message == "test migration message"
 				}), pr).Return(nil)
-				pr.On("ResetResults").Return()
+				pr.On("ResetResults", false).Return()
 				pr.On("SetMessage", mock.Anything, "pull resources").Return()
 				sw.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
 					return job.Spec.Pull != nil && !job.Spec.Pull.Incremental

--- a/pkg/registry/apis/provisioning/jobs/move/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/move/worker.go
@@ -112,7 +112,7 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 	}
 
 	if opts.Ref == "" {
-		progress.ResetResults()
+		progress.ResetResults(false)
 		progress.SetMessage(ctx, "pull resources")
 
 		syncJob := provisioning.Job{

--- a/pkg/registry/apis/provisioning/jobs/move/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/move/worker_test.go
@@ -303,7 +303,7 @@ func TestMoveWorker_ProcessWithSyncWorker(t *testing.T) {
 		return result.Path() == "test/path" && result.Action() == repository.FileActionRenamed && result.Error() == nil
 	})).Return()
 
-	mockProgress.On("ResetResults").Return()
+	mockProgress.On("ResetResults", false).Return()
 	mockProgress.On("SetMessage", mock.Anything, "pull resources").Return()
 	mockProgress.On("Complete", mock.Anything, mock.Anything).Return(provisioning.JobStatus{})
 
@@ -346,7 +346,7 @@ func TestMoveWorker_ProcessSyncWorkerError(t *testing.T) {
 	mockRepo.On("Move", mock.Anything, "test/path", "new/location/path", "", "Move test/path to new/location/path").Return(nil)
 
 	mockProgress.On("Record", mock.Anything, mock.Anything).Return()
-	mockProgress.On("ResetResults").Return()
+	mockProgress.On("ResetResults", false).Return()
 	mockProgress.On("SetMessage", mock.Anything, "pull resources").Return()
 
 	syncError := errors.New("sync failed")
@@ -552,7 +552,7 @@ func TestMoveWorker_ProcessWithResourceReferences(t *testing.T) {
 	})).Return()
 
 	// Add expectations for sync worker (called when ref is empty)
-	mockProgress.On("ResetResults").Return()
+	mockProgress.On("ResetResults", false).Return()
 	mockProgress.On("SetMessage", mock.Anything, "pull resources").Return()
 	mockSyncWorker.On("Process", mock.Anything, mockRepo, mock.MatchedBy(func(syncJob provisioning.Job) bool {
 		return syncJob.Spec.Pull != nil && !syncJob.Spec.Pull.Incremental
@@ -614,7 +614,7 @@ func TestMoveWorker_ProcessResourceReferencesError(t *testing.T) {
 
 	// Add expectations for sync worker (called when ref is empty)
 	mockSyncWorker := jobs.NewMockWorker(t)
-	mockProgress.On("ResetResults").Return()
+	mockProgress.On("ResetResults", false).Return()
 	mockProgress.On("SetMessage", mock.Anything, "pull resources").Return()
 	mockSyncWorker.On("Process", mock.Anything, mockRepo, mock.MatchedBy(func(syncJob provisioning.Job) bool {
 		return syncJob.Spec.Pull != nil && !syncJob.Spec.Pull.Incremental
@@ -918,7 +918,7 @@ func TestMoveWorker_RefURLsNotSetWithoutRef(t *testing.T) {
 	mockProgress.On("SetMessage", mock.Anything, "Moving test.json to target/test.json").Once()
 	mockProgress.On("Record", mock.Anything, mock.Anything).Once()
 	mockProgress.On("TooManyErrors").Return(nil).Once()
-	mockProgress.On("ResetResults").Once()
+	mockProgress.On("ResetResults", false).Once()
 	mockProgress.On("SetMessage", mock.Anything, "pull resources").Once()
 	mockProgress.On("Complete", mock.Anything, mock.Anything).Return(provisioning.JobStatus{})
 	// SetRefURLs should NOT be called since no ref is specified

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -105,6 +105,11 @@ func (r *jobProgressRecorder) Record(ctx context.Context, result JobResourceResu
 			r.failedDeletions = append(r.failedDeletions, result.Path())
 		}
 	} else if result.Warning() != nil {
+		// Still track failed deletions in case we get a warning
+		if result.Action() == repository.FileActionDeleted {
+			r.failedDeletions = append(r.failedDeletions, result.Path())
+		}
+
 		shouldLogWarning = true
 		logWarning = result.Warning()
 	}
@@ -124,17 +129,25 @@ func (r *jobProgressRecorder) Record(ctx context.Context, result JobResourceResu
 	r.maybeNotify(ctx)
 }
 
-// ResetResults will reset the results of the job
-func (r *jobProgressRecorder) ResetResults() {
+// ResetResults will reset the results of the job.
+// If the keepWarnings flag is set to true, the summary will preserve the warnings in it.
+func (r *jobProgressRecorder) ResetResults(keepWarnings bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	r.resultCount = 0
 	r.errorCount = 0
 	r.errors = nil
-	r.summaries = make(map[string]*provisioning.JobResourceSummary)
 	r.failedCreations = nil
 	r.failedDeletions = nil
+
+	summaries := make(map[string]*provisioning.JobResourceSummary)
+	for k, summary := range r.summaries {
+		if len(summary.Warnings) > 0 && keepWarnings {
+			summaries[k] = summary
+		}
+	}
+	r.summaries = summaries
 }
 
 func (r *jobProgressRecorder) SetMessage(ctx context.Context, msg string) {

--- a/pkg/registry/apis/provisioning/jobs/progress_test.go
+++ b/pkg/registry/apis/provisioning/jobs/progress_test.go
@@ -526,7 +526,7 @@ func TestJobProgressRecorderResetResults(t *testing.T) {
 	recorder.mu.RUnlock()
 
 	// Reset results
-	recorder.ResetResults()
+	recorder.ResetResults(false)
 
 	// Verify data is cleared
 	recorder.mu.RLock()

--- a/pkg/registry/apis/provisioning/jobs/queue.go
+++ b/pkg/registry/apis/provisioning/jobs/queue.go
@@ -21,7 +21,7 @@ type RepoGetter interface {
 type JobProgressRecorder interface {
 	Started() time.Time
 	Record(ctx context.Context, result JobResourceResult)
-	ResetResults()
+	ResetResults(keepWarnings bool)
 	SetFinalMessage(ctx context.Context, msg string)
 	SetMessage(ctx context.Context, msg string)
 	SetTotal(ctx context.Context, total int)


### PR DESCRIPTION
**What is this feature?**

- Return warning, not errors, when user try to delete an object which is not present in the repo;
- Bubble up these warnings into job state;
- Add integration tests for this.

_Result of deletion in Dashboard UI_
<img width="920" height="258" alt="Screenshot 2026-02-17 at 15 08 17" src="https://github.com/user-attachments/assets/8e2abaab-a277-40d2-88ea-7fb66114e140" />

_Job Details in Dashboard UI_
<img width="920" height="727" alt="Screenshot 2026-02-17 at 15 08 52" src="https://github.com/user-attachments/assets/91fd57d7-70b2-46ff-be4e-ec2fc046ac3e" />

_Job Details in Provisioning UI_
<img width="1561" height="436" alt="Screenshot 2026-02-17 at 15 09 30" src="https://github.com/user-attachments/assets/69520be0-ca61-4a74-95e1-7cd8d26817cb" />

**Why do we need this feature?**

After deleting a file from a repository, in Grafana UI is still possible to try and delete the same file if:
- Automatic sync is disabled;
- Webhook is not present;
- Automatic sync is enabled, but we're in-between syncs.

When trying to delete a non-existing file, the operation would error with:
```
deleting file <name>: file not found
```

since this operation is not a blocking one (as the resulting object is not there), we're updating the delete operation to return a warning instead.

**Who is this feature for?**

Users of GitSync

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/881

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
