### PR TITLE
Table: Handle undefined overrides in fieldConfig

### DIFF
--- a/public/app/plugins/panel/table/migrations.test.ts
+++ b/public/app/plugins/panel/table/migrations.test.ts
@@ -6,6 +6,7 @@ import {
   migrateFromParentRowIndexToNestedFrames,
   migrateHiddenFields,
   migrateTextWrapToFieldLevel,
+  tableMigrationHandler,
   tablePanelChangedHandler,
 } from './migrations';
 
@@ -307,6 +308,27 @@ describe('Table Migrations', () => {
         ],
       },
     ]);
+  });
+
+  it('does not throw if overrides are undefined', () => {
+    const panel = {
+      fieldConfig: {
+        defaults: {
+          custom: {},
+        },
+      },
+    } as unknown as PanelModel;
+
+    tableMigrationHandler(panel);
+
+    expect(panel).toEqual({
+      fieldConfig: {
+        defaults: {
+          custom: {},
+        },
+        overrides: [],
+      },
+    });
   });
 
   it('migrates DataFrame[] from format using meta.custom.parentRowIndex to format using FieldType.nestedFrames', () => {

--- a/public/app/plugins/panel/table/migrations.ts
+++ b/public/app/plugins/panel/table/migrations.ts
@@ -26,11 +26,13 @@ export const tableMigrationHandler = (panel: PanelModel<Options>): Partial<Optio
     console.log('Was angular table', panel);
   }
 
+  // ensure overrides array exists before applying rest of overrides
+  panel.fieldConfig.overrides = panel.fieldConfig.overrides ?? [];
+
   migrateTextWrapToFieldLevel(panel);
   migrateHiddenFields(panel);
   migrateFooterV2(panel);
 
-  // Nothing changed
   return panel.options;
 };
 


### PR DESCRIPTION
Relates to https://github.com/grafana/support-escalations/issues/20740

Ensures that panel configs which do not contain an overrides array for some reason (despite the TypeScript's type's assurance that it exists) will not throw during migration.