### PR TITLE
MySQL: improve CheatSheet example for \$__timeGroupAlias

### DIFF
--- a/public/app/plugins/datasource/mysql/CheatSheet.tsx
+++ b/public/app/plugins/datasource/mysql/CheatSheet.tsx
@@ -52,15 +52,26 @@ export function CheatSheet() {
         <li>$__unixEpochGroup(column,&apos;5m&apos;) -&gt; column DIV 300 * 300</li>
         <li>$__unixEpochGroupAlias(column,&apos;5m&apos;) -&gt; column DIV 300 * 300 AS &quot;time&quot;</li>
       </ul>
-      <p>Example of group by and order by with $__timeGroup:</p>
+      <p>Example of group by and order by with $__timeGroupAlias:</p>
       <pre>
         <code>
-          $__timeGroupAlias(timestamp_col, &apos;1h&apos;), sum(value_double) as value
+          SELECT
           <br />
-          FROM yourtable
+          $__timeGroupAlias(time_date_time,&apos;5m&apos;),
           <br />
-          GROUP BY 1<br />
-          ORDER BY 1
+          min(value_double),
+          <br />
+          &apos;min&apos; as metric
+          <br />
+          FROM my_data
+          <br />
+          WHERE
+          <br />
+          $__timeFilter(time_date_time)
+          <br />
+          GROUP BY time
+          <br />
+          ORDER BY time
           <br />
         </code>
       </pre>


### PR DESCRIPTION
The MySQL cheat sheet example query missed the select part. I updated the query to be the same what we have in our docs.

Updated cheat sheet:
<img width="2032" height="1162" alt="Screenshot 2026-02-17 at 16 26 44" src="https://github.com/user-attachments/assets/96da6acf-d827-4d90-b1b9-bc38c9b96470" />
