### PR TITLE
Secrets Keeper: Add backend routes for keeper pages

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -132,6 +132,14 @@ func (hs *HTTPServer) registerRoutes() {
 			ac.EvalPermission(secret.ActionSecretSecureValuesCreate),
 			ac.EvalPermission(secret.ActionSecretSecureValuesRead),
 		)), hs.Index)
+		r.Get("/admin/secrets/keepers", authorize(ac.EvalAny(
+			ac.EvalPermission(secret.ActionSecretKeepersCreate),
+			ac.EvalPermission(secret.ActionSecretKeepersRead),
+		)), hs.Index)
+		r.Get("/admin/secrets/keepers/*", authorize(ac.EvalAny(
+			ac.EvalPermission(secret.ActionSecretKeepersCreate),
+			ac.EvalPermission(secret.ActionSecretKeepersRead),
+		)), hs.Index)
 	}
 
 	r.Get("/styleguide", reqSignedIn, hs.Index)


### PR DESCRIPTION
## Summary
- Register GET routes for `/admin/secrets/keepers` and `/admin/secrets/keepers/*` in `pkg/api/api.go`
- Gated behind `secretsManagementAppPlatformUI` feature flag
- Uses keepers-specific RBAC permissions (`secret.keepers:create`, `secret.keepers:read`), separate from secure values permissions

Without these routes, direct navigation to keeper pages (e.g. bookmarks, page refresh) returns a 404 because the Go router has no handler to serve the SPA entry point.

## Test plan
- [x] Navigate to `/admin/secrets/keepers` directly — page loads (no 404)
- [x] Navigate to `/admin/secrets/keepers/new` directly — page loads (no 404)
- [ ] User without keeper permissions gets 403 on keeper routes
- [x] Existing `/admin/secrets` route still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>