### PR TITLE
Alerting: Fix "Page not found" shown in the page header for some notifications pages

### DIFF
--- a/public/app/features/alerting/unified/components/contact-points/EditContactPoint.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/EditContactPoint.tsx
@@ -5,6 +5,7 @@ import { Alert, LoadingPlaceholder } from '@grafana/ui';
 import { useGetContactPoint } from 'app/features/alerting/unified/components/contact-points/useContactPoints';
 import { stringifyErrorLike } from 'app/features/alerting/unified/utils/misc';
 
+import { useContactPointsNav } from '../../navigation/useNotificationConfigNav';
 import { useAlertmanager } from '../../state/AlertmanagerContext';
 import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { AlertmanagerPageWrapper } from '../AlertingPageWrapper';
@@ -48,8 +49,10 @@ const EditContactPoint = () => {
 };
 
 function EditContactPointPage() {
+  const { navId, pageNav } = useContactPointsNav();
+
   return (
-    <AlertmanagerPageWrapper navId="receivers" accessType="notification">
+    <AlertmanagerPageWrapper navId={navId} pageNav={pageNav} accessType="notification">
       <EditContactPoint />
     </AlertmanagerPageWrapper>
   );

--- a/public/app/features/alerting/unified/components/contact-points/components/GlobalConfig.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/components/GlobalConfig.tsx
@@ -2,6 +2,7 @@ import { t } from '@grafana/i18n';
 import { Alert } from '@grafana/ui';
 
 import { useAlertmanagerConfig } from '../../../hooks/useAlertmanagerConfig';
+import { useContactPointsNav } from '../../../navigation/useNotificationConfigNav';
 import { useAlertmanager } from '../../../state/AlertmanagerContext';
 import { withPageErrorBoundary } from '../../../withPageErrorBoundary';
 import { AlertmanagerPageWrapper } from '../../AlertingPageWrapper';
@@ -37,8 +38,10 @@ const GlobalConfig = () => {
 };
 
 function GlobalConfigPage() {
+  const { navId, pageNav } = useContactPointsNav();
+
   return (
-    <AlertmanagerPageWrapper navId="receivers" accessType="notification">
+    <AlertmanagerPageWrapper navId={navId} pageNav={pageNav} accessType="notification">
       <GlobalConfig />
     </AlertmanagerPageWrapper>
   );

--- a/public/app/features/alerting/unified/components/notification-policies/PolicyPage.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/PolicyPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom-v5-compat';
 import { Trans, t } from '@grafana/i18n';
 import { Alert } from '@grafana/ui';
 
+import { useNotificationPoliciesNav } from '../../navigation/useNotificationConfigNav';
 import { ROOT_ROUTE_NAME } from '../../utils/k8s/constants';
 import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { AlertmanagerPageWrapper } from '../AlertingPageWrapper';
@@ -34,12 +35,14 @@ const PoliciesTreeWrapper = () => {
 function PolicyPage() {
   const { name = '' } = useParams();
   const routeName = name === ROOT_ROUTE_NAME ? 'Default Policy' : decodeURIComponent(name);
+  const { navId, pageNav } = useNotificationPoliciesNav();
 
   return (
     <AlertmanagerPageWrapper
-      navId="am-routes"
+      navId={navId}
       accessType="notification"
       pageNav={{
+        ...pageNav,
         text: routeName,
       }}
       renderTitle={(title) => <Title name={title} returnToFallback={'/alerting/routes'} />}

--- a/public/app/features/alerting/unified/components/receivers/NewReceiverView.tsx
+++ b/public/app/features/alerting/unified/components/receivers/NewReceiverView.tsx
@@ -1,5 +1,6 @@
 import { useAlertmanager } from 'app/features/alerting/unified/state/AlertmanagerContext';
 
+import { useContactPointsNav } from '../../navigation/useNotificationConfigNav';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { AlertmanagerPageWrapper } from '../AlertingPageWrapper';
@@ -17,8 +18,10 @@ const NewReceiverView = () => {
 };
 
 function NewReceiverViewPage() {
+  const { navId, pageNav } = useContactPointsNav();
+
   return (
-    <AlertmanagerPageWrapper navId="receivers" accessType="notification">
+    <AlertmanagerPageWrapper navId={navId} pageNav={pageNav} accessType="notification">
       <NewReceiverView />
     </AlertmanagerPageWrapper>
   );


### PR DESCRIPTION
**What is this feature?**

This PR fixes a regression introduced in #116749 (Alerting: Notification configuration tabs) where several notification config sub-pages show a "Page not found" 404 error in the page header when `alertingNavigationV2` is enabled.

The issue was caused by hardcoded legacy `navId` values (`"receivers"`, `"am-routes"`) that no longer exist in the nav tree when V2 navigation is active. These pages were missed during the migration in #116749. Replaced them with the dynamic navigation hooks (`useContactPointsNav`, `useNotificationPoliciesNav`) already used by the list pages.

### Affected pages
| Page | File | Old navId | Fix |
|---|---|---|---|
| Edit Contact Point | `EditContactPoint.tsx` | `"receivers"` | `useContactPointsNav()` |
| New Contact Point | `NewReceiverView.tsx` | `"receivers"` | `useContactPointsNav()` |
| Global Config | `GlobalConfig.tsx` | `"receivers"` | `useContactPointsNav()` |
| Policy Detail | `PolicyPage.tsx` | `"am-routes"` | `useNotificationPoliciesNav()` |

**Who is this feature for?**

Alerting users

**Special notes for your reviewer:**

Example before the change: 

<img width="1262" height="779" alt="Screenshot 2026-02-17 at 17 09 48" src="https://github.com/user-attachments/assets/93837e1a-7f22-4fcc-b024-774c141e796c" />


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
