### PR TITLE
QueryEditor: Add transformations to query stack

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.test.tsx
@@ -301,6 +301,44 @@ describe('PanelDataPaneNext', () => {
       mockPanel.state.$data = mockTransformer;
     });
 
+    describe('addTransformation', () => {
+      it('should append a transformation to the end by default', () => {
+        jest.spyOn(mockTransformer, 'reprocessTransformations').mockImplementation(() => {});
+
+        dataPane.addTransformation('seriesToColumns');
+
+        expect(mockTransformer.setState).toHaveBeenCalledWith({
+          transformations: [
+            { id: 'organize', options: {} },
+            { id: 'reduce', options: {} },
+            { id: 'filter', options: {} },
+            { id: 'seriesToColumns', options: {} },
+          ],
+        });
+        expect(mockTransformer.reprocessTransformations).toHaveBeenCalled();
+      });
+
+      it('should insert a transformation after a specific index', () => {
+        jest.spyOn(mockTransformer, 'reprocessTransformations').mockImplementation(() => {});
+
+        dataPane.addTransformation('seriesToColumns', 0);
+
+        expect(mockTransformer.setState).toHaveBeenCalledWith({
+          transformations: [
+            { id: 'organize', options: {} },
+            { id: 'seriesToColumns', options: {} },
+            { id: 'reduce', options: {} },
+            { id: 'filter', options: {} },
+          ],
+        });
+      });
+
+      it('should not throw when $data is not SceneDataTransformer', () => {
+        mockPanel.state.$data = undefined;
+        expect(() => dataPane.addTransformation('seriesToColumns')).not.toThrow();
+      });
+    });
+
     describe('reorderTransformations', () => {
       it('should update transformations and reprocess when $data is SceneDataTransformer', () => {
         jest.spyOn(mockTransformer, 'reprocessTransformations').mockImplementation(() => {});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
@@ -303,6 +303,20 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     return { transformations: undefined, transformer: undefined };
   }
 
+  public addTransformation = (transformationId: string, afterIndex?: number) => {
+    const transformer = this.getSceneDataTransformer();
+    if (!transformer) {
+      return;
+    }
+
+    const transformations = filterDataTransformerConfigs([...transformer.state.transformations]);
+    const newConfig: DataTransformerConfig = { id: transformationId, options: {} };
+    const insertAt = afterIndex !== undefined ? afterIndex + 1 : transformations.length;
+    transformations.splice(insertAt, 0, newConfig);
+    transformer.setState({ transformations });
+    transformer.reprocessTransformations();
+  };
+
   public reorderTransformations = (transformations: DataTransformerConfig[]) => {
     const transformer = this.getSceneDataTransformer();
     if (transformer) {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
@@ -303,7 +303,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     return { transformations: undefined, transformer: undefined };
   }
 
-  public addTransformation = (transformationId: string, afterIndex?: number) => {
+  public addTransformation = (transformationId: string, afterIndex?: number): number | undefined => {
     const transformer = this.getSceneDataTransformer();
     if (!transformer) {
       return;
@@ -315,6 +315,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     transformations.splice(insertAt, 0, newConfig);
     transformer.setState({ transformations });
     transformer.reprocessTransformations();
+    return insertAt;
   };
 
   public reorderTransformations = (transformations: DataTransformerConfig[]) => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/ExpressionTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/ExpressionTypePicker.tsx
@@ -42,7 +42,7 @@ export function ExpressionTypePicker() {
 const getStyles = (theme: GrafanaTheme2) => ({
   grid: css({
     display: 'grid',
-    gridGap: theme.spacing(1),
+    gap: theme.spacing(1),
     gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
   }),
   image: css({

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
@@ -1,0 +1,55 @@
+import { css } from '@emotion/css';
+import { useMemo } from 'react';
+
+import { GrafanaTheme2, standardTransformersRegistry } from '@grafana/data';
+import { Card, Stack, Text, useStyles2, useTheme2 } from '@grafana/ui';
+import { PluginStateInfo } from 'app/features/plugins/components/PluginStateInfo';
+
+import { useQueryEditorUIContext } from '../QueryEditorContext';
+
+export function TransformationTypePicker() {
+  const styles = useStyles2(getStyles);
+  const theme = useTheme2();
+  const { finalizePendingTransformation } = useQueryEditorUIContext();
+
+  const allTransformations = useMemo(() => {
+    const collator = new Intl.Collator();
+    return standardTransformersRegistry.list().sort((a, b) => collator.compare(a.name, b.name));
+  }, []);
+
+  return (
+    <div className={styles.grid}>
+      {allTransformations.map((item) => {
+        const imageUrl = theme.isDark ? item.imageDark : item.imageLight;
+
+        return (
+          <Card key={item.id} onClick={() => finalizePendingTransformation(item.id)} noMargin>
+            <Card.Heading>
+              <Stack alignItems="center" justifyContent="space-between">
+                {item.name}
+                <PluginStateInfo state={item.state} />
+              </Stack>
+            </Card.Heading>
+            <Card.Description>
+              <Text variant="bodySmall">{item.description ?? ''}</Text>
+              {imageUrl && <img className={styles.image} src={imageUrl} alt={item.name} />}
+            </Card.Description>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  grid: css({
+    display: 'grid',
+    gridGap: theme.spacing(1),
+    gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+  }),
+  image: css({
+    display: 'block',
+    maxWidth: '100%',
+    marginTop: theme.spacing(2),
+  }),
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
@@ -44,7 +44,7 @@ export function TransformationTypePicker() {
 const getStyles = (theme: GrafanaTheme2) => ({
   grid: css({
     display: 'grid',
-    gridGap: theme.spacing(1),
+    gap: theme.spacing(1),
     gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
   }),
   image: css({

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
@@ -2,15 +2,15 @@ import { css } from '@emotion/css';
 import { useMemo } from 'react';
 
 import { GrafanaTheme2, standardTransformersRegistry } from '@grafana/data';
-import { Card, Stack, Text, useStyles2, useTheme2 } from '@grafana/ui';
-import { PluginStateInfo } from 'app/features/plugins/components/PluginStateInfo';
+import { useStyles2 } from '@grafana/ui';
+import { TransformationCard } from 'app/features/dashboard/components/TransformationsEditor/TransformationCard';
 
-import { useQueryEditorUIContext } from '../QueryEditorContext';
+import { useQueryEditorUIContext, useQueryRunnerContext } from '../QueryEditorContext';
 
 export function TransformationTypePicker() {
   const styles = useStyles2(getStyles);
-  const theme = useTheme2();
   const { finalizePendingTransformation } = useQueryEditorUIContext();
+  const { data } = useQueryRunnerContext();
 
   const allTransformations = useMemo(() => {
     const collator = new Intl.Collator();
@@ -19,24 +19,16 @@ export function TransformationTypePicker() {
 
   return (
     <div className={styles.grid}>
-      {allTransformations.map((item) => {
-        const imageUrl = theme.isDark ? item.imageDark : item.imageLight;
-
-        return (
-          <Card key={item.id} onClick={() => finalizePendingTransformation(item.id)} noMargin>
-            <Card.Heading>
-              <Stack alignItems="center" justifyContent="space-between">
-                {item.name}
-                <PluginStateInfo state={item.state} />
-              </Stack>
-            </Card.Heading>
-            <Card.Description>
-              <Text variant="bodySmall">{item.description ?? ''}</Text>
-              {imageUrl && <img className={styles.image} src={imageUrl} alt={item.name} />}
-            </Card.Description>
-          </Card>
-        );
-      })}
+      {allTransformations.map((item) => (
+        <TransformationCard
+          key={item.id}
+          transform={item}
+          data={data?.series}
+          onClick={finalizePendingTransformation}
+          showIllustrations
+          fullWidth
+        />
+      ))}
     </div>
   );
 }
@@ -46,10 +38,5 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: 'grid',
     gap: theme.spacing(1),
     gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
-  }),
-  image: css({
-    display: 'block',
-    maxWidth: '100%',
-    marginTop: theme.spacing(2),
   }),
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/CardEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/CardEditorRenderer.tsx
@@ -1,15 +1,20 @@
 import { QueryEditorType } from '../constants';
 
 import { ExpressionTypePicker } from './Body/ExpressionTypePicker';
+import { TransformationTypePicker } from './Body/TransformationTypePicker';
 import { useQueryEditorUIContext } from './QueryEditorContext';
 import { QueryEditorRenderer } from './QueryEditorRenderer';
 import { TransformationEditorRenderer } from './TransformationEditorRenderer';
 
 export function CardEditorRenderer() {
-  const { cardType, pendingExpression } = useQueryEditorUIContext();
+  const { cardType, pendingExpression, pendingTransformation } = useQueryEditorUIContext();
 
   if (pendingExpression) {
     return <ExpressionTypePicker />;
+  }
+
+  if (pendingTransformation) {
+    return <TransformationTypePicker />;
   }
 
   if (cardType === QueryEditorType.Transformation) {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
@@ -43,6 +43,8 @@ export interface ContentHeaderProps {
   cardType: QueryEditorType;
   pendingExpression?: boolean;
   onCancelPendingExpression?: () => void;
+  pendingTransformation?: boolean;
+  onCancelPendingTransformation?: () => void;
   onChangeDataSource: (ds: DataSourceInstanceSettings, refId: string) => void;
   onUpdateQuery: (updatedQuery: DataQuery, originalRefId: string) => void;
   /**
@@ -78,6 +80,8 @@ export function ContentHeader({
   cardType,
   pendingExpression,
   onCancelPendingExpression,
+  pendingTransformation,
+  onCancelPendingTransformation,
   onChangeDataSource,
   onUpdateQuery,
   renderHeaderExtras,
@@ -100,6 +104,22 @@ export function ContentHeader({
         </div>
         <Button variant="secondary" fill="text" size="sm" icon="times" onClick={onCancelPendingExpression}>
           <Trans i18nKey="query-editor-next.header.pending-expression-cancel">Cancel</Trans>
+        </Button>
+      </div>
+    );
+  }
+
+  if (pendingTransformation) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.leftSection}>
+          <Icon name={QUERY_EDITOR_TYPE_CONFIG[QueryEditorType.Transformation].icon} size="sm" />
+          <Text weight="light" variant="body" color="secondary">
+            <Trans i18nKey="query-editor-next.header.pending-transformation">Select a Transformation</Trans>
+          </Text>
+        </div>
+        <Button variant="secondary" fill="text" size="sm" icon="times" onClick={onCancelPendingTransformation}>
+          <Trans i18nKey="query-editor-next.header.pending-transformation-cancel">Cancel</Trans>
         </Button>
       </div>
     );
@@ -170,8 +190,15 @@ export function ContentHeaderSceneWrapper({
 }: {
   renderHeaderExtras?: () => React.ReactNode;
 } = {}) {
-  const { selectedQuery, selectedTransformation, cardType, pendingExpression, setPendingExpression } =
-    useQueryEditorUIContext();
+  const {
+    selectedQuery,
+    selectedTransformation,
+    cardType,
+    pendingExpression,
+    setPendingExpression,
+    pendingTransformation,
+    setPendingTransformation,
+  } = useQueryEditorUIContext();
   const { queries } = useQueryRunnerContext();
   const { changeDataSource, updateSelectedQuery } = useActionsContext();
 
@@ -183,6 +210,8 @@ export function ContentHeaderSceneWrapper({
       cardType={cardType}
       pendingExpression={!!pendingExpression}
       onCancelPendingExpression={() => setPendingExpression(null)}
+      pendingTransformation={!!pendingTransformation}
+      onCancelPendingTransformation={() => setPendingTransformation(null)}
       onChangeDataSource={changeDataSource}
       onUpdateQuery={updateSelectedQuery}
       renderHeaderExtras={renderHeaderExtras}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
@@ -32,6 +32,30 @@ const Separator = () => (
   </Text>
 );
 
+interface PendingPickerHeaderProps {
+  editorType: QueryEditorType;
+  label: NonNullable<React.ReactNode>;
+  onCancel?: () => void;
+  cancelLabel: React.ReactNode;
+  styles: ReturnType<typeof getStyles>;
+}
+
+function PendingPickerHeader({ editorType, label, onCancel, cancelLabel, styles }: PendingPickerHeaderProps) {
+  return (
+    <div className={styles.container}>
+      <div className={styles.leftSection}>
+        <Icon name={QUERY_EDITOR_TYPE_CONFIG[editorType].icon} size="sm" />
+        <Text weight="light" variant="body" color="secondary">
+          {label}
+        </Text>
+      </div>
+      <Button variant="secondary" fill="text" size="sm" icon="times" onClick={onCancel}>
+        {cancelLabel}
+      </Button>
+    </div>
+  );
+}
+
 /**
  * Props for the standalone ContentHeader component.
  * This interface defines everything needed to render the header without Scene coupling.
@@ -95,33 +119,25 @@ export function ContentHeader({
 
   if (pendingExpression) {
     return (
-      <div className={styles.container}>
-        <div className={styles.leftSection}>
-          <Icon name={QUERY_EDITOR_TYPE_CONFIG[QueryEditorType.Expression].icon} size="sm" />
-          <Text weight="light" variant="body" color="secondary">
-            <Trans i18nKey="query-editor-next.header.pending-expression">Select an Expression</Trans>
-          </Text>
-        </div>
-        <Button variant="secondary" fill="text" size="sm" icon="times" onClick={onCancelPendingExpression}>
-          <Trans i18nKey="query-editor-next.header.pending-expression-cancel">Cancel</Trans>
-        </Button>
-      </div>
+      <PendingPickerHeader
+        editorType={QueryEditorType.Expression}
+        label={<Trans i18nKey="query-editor-next.header.pending-expression">Select an Expression</Trans>}
+        onCancel={onCancelPendingExpression}
+        cancelLabel={<Trans i18nKey="query-editor-next.header.pending-expression-cancel">Cancel</Trans>}
+        styles={styles}
+      />
     );
   }
 
   if (pendingTransformation) {
     return (
-      <div className={styles.container}>
-        <div className={styles.leftSection}>
-          <Icon name={QUERY_EDITOR_TYPE_CONFIG[QueryEditorType.Transformation].icon} size="sm" />
-          <Text weight="light" variant="body" color="secondary">
-            <Trans i18nKey="query-editor-next.header.pending-transformation">Select a Transformation</Trans>
-          </Text>
-        </div>
-        <Button variant="secondary" fill="text" size="sm" icon="times" onClick={onCancelPendingTransformation}>
-          <Trans i18nKey="query-editor-next.header.pending-transformation-cancel">Cancel</Trans>
-        </Button>
-      </div>
+      <PendingPickerHeader
+        editorType={QueryEditorType.Transformation}
+        label={<Trans i18nKey="query-editor-next.header.pending-transformation">Select a Transformation</Trans>}
+        onCancel={onCancelPendingTransformation}
+        cancelLabel={<Trans i18nKey="query-editor-next.header.pending-transformation-cancel">Cancel</Trans>}
+        styles={styles}
+      />
     );
   }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContent.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContent.tsx
@@ -11,15 +11,16 @@ import { useQueryEditorUIContext } from './QueryEditorContext';
 
 export function QueryEditorContent() {
   const styles = useStyles2(getStyles);
-  const { queryOptions, showingDatasourceHelp, pendingExpression } = useQueryEditorUIContext();
+  const { queryOptions, showingDatasourceHelp, pendingExpression, pendingTransformation } = useQueryEditorUIContext();
   const { isQueryOptionsOpen } = queryOptions;
+  const hasPendingPicker = !!pendingExpression || !!pendingTransformation;
 
   return (
     <div className={styles.container}>
       <ContentHeaderSceneWrapper />
-      {!pendingExpression && showingDatasourceHelp && <DatasourceHelpPanel />}
+      {!hasPendingPicker && showingDatasourceHelp && <DatasourceHelpPanel />}
       <QueryEditorBody />
-      {!pendingExpression && !isQueryOptionsOpen && <QueryEditorFooter />}
+      {!hasPendingPicker && !isQueryOptionsOpen && <QueryEditorFooter />}
     </div>
   );
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
@@ -90,6 +90,7 @@ export interface QueryEditorActions {
   runQueries: () => void;
   changeDataSource: (settings: DataSourceInstanceSettings, queryRefId: string) => void;
   onQueryOptionsChange: (options: QueryGroupOptions) => void;
+  addTransformation: (transformationId: string, afterTransformId?: string) => void;
   deleteTransformation: (transformId: string) => void;
   toggleTransformationDisabled: (transformId: string) => void;
   updateTransformation: (oldConfig: DataTransformerConfig, newConfig: DataTransformerConfig) => void;

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
@@ -20,6 +20,10 @@ export interface PendingExpression {
   insertAfter: string;
 }
 
+export interface PendingTransformation {
+  insertAfter?: string;
+}
+
 export interface DatasourceState {
   datasource?: DataSourceApi;
   dsSettings?: DataSourceInstanceSettings;
@@ -78,6 +82,9 @@ export interface QueryEditorUIState {
   pendingExpression: PendingExpression | null;
   setPendingExpression: (pending: PendingExpression | null) => void;
   finalizePendingExpression: (type: ExpressionQueryType) => void;
+  pendingTransformation: PendingTransformation | null;
+  setPendingTransformation: (pending: PendingTransformation | null) => void;
+  finalizePendingTransformation: (transformationId: string) => void;
 }
 
 export interface QueryEditorActions {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
@@ -97,7 +97,7 @@ export interface QueryEditorActions {
   runQueries: () => void;
   changeDataSource: (settings: DataSourceInstanceSettings, queryRefId: string) => void;
   onQueryOptionsChange: (options: QueryGroupOptions) => void;
-  addTransformation: (transformationId: string, afterTransformId?: string) => void;
+  addTransformation: (transformationId: string, afterTransformId?: string) => string | undefined;
   deleteTransformation: (transformId: string) => void;
   toggleTransformationDisabled: (transformId: string) => void;
   updateTransformation: (oldConfig: DataTransformerConfig, newConfig: DataTransformerConfig) => void;

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
@@ -230,6 +230,10 @@ export function QueryEditorContextWrapper({
         dataPane.changeDataSource(getDataSourceRef(settings), queryRefId);
       },
       onQueryOptionsChange: (options: QueryGroupOptions) => dataPane.onQueryOptionsChange(options),
+      addTransformation: (transformationId: string, afterTransformId?: string) => {
+        const index = afterTransformId ? findTransformationIndex(afterTransformId) : -1;
+        dataPane.addTransformation(transformationId, index !== -1 ? index : undefined);
+      },
       deleteTransformation: (transformId: string) => {
         const index = findTransformationIndex(transformId);
         if (index !== -1) {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
@@ -9,7 +9,7 @@ import { QueryGroupOptions } from 'app/types/query';
 import { getQueryRunnerFor } from '../../../utils/utils';
 import { PanelDataPaneNext } from '../PanelDataPaneNext';
 
-import { QueryEditorProvider } from './QueryEditorContext';
+import { PendingExpression, PendingTransformation, QueryEditorProvider } from './QueryEditorContext';
 import { useAlertRulesForPanel } from './hooks/useAlertRulesForPanel';
 import { usePendingExpression } from './hooks/usePendingExpression';
 import { usePendingTransformation } from './hooks/usePendingTransformation';
@@ -217,10 +217,20 @@ export function QueryEditorContextWrapper({
         toggleDebug,
       },
       pendingExpression,
-      setPendingExpression,
+      setPendingExpression: (pending: PendingExpression | null) => {
+        if (pending) {
+          clearPendingTransformation();
+        }
+        setPendingExpression(pending);
+      },
       finalizePendingExpression,
       pendingTransformation,
-      setPendingTransformation,
+      setPendingTransformation: (pending: PendingTransformation | null) => {
+        if (pending) {
+          clearPendingExpression();
+        }
+        setPendingTransformation(pending);
+      },
       finalizePendingTransformation,
     }),
     [

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
@@ -96,17 +96,6 @@ export function QueryEditorContextWrapper({
     setFocusedField(null);
   }, []);
 
-  const { selectedQuery, selectedTransformation, selectedAlert } = useSelectedCard(
-    selectedQueryRefId,
-    selectedTransformationId,
-    selectedAlertId,
-    queryRunnerState?.queries ?? [],
-    transformations,
-    alertingState.alertRules
-  );
-
-  const { selectedQueryDsData, selectedQueryDsLoading } = useSelectedQueryDatasource(selectedQuery, dsSettings);
-
   // Transformation UI toggles
   const toggleHelp = useCallback(() => {
     setTransformTogglesState((prev) => ({ ...prev, showHelp: !prev.showHelp }));
@@ -152,6 +141,18 @@ export function QueryEditorContextWrapper({
       addTransformation: addTransformationAction,
       onCardSelectionChange,
     });
+
+  const { selectedQuery, selectedTransformation, selectedAlert } = useSelectedCard(
+    selectedQueryRefId,
+    selectedTransformationId,
+    selectedAlertId,
+    queryRunnerState?.queries ?? [],
+    transformations,
+    alertingState.alertRules,
+    Boolean(pendingExpression) || Boolean(pendingTransformation)
+  );
+
+  const { selectedQueryDsData, selectedQueryDsLoading } = useSelectedQueryDatasource(selectedQuery, dsSettings);
 
   const uiState = useMemo(
     () => ({

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -93,15 +93,9 @@ export const AddCardButton = ({ variant, afterId, alwaysVisible = false }: AddCa
     [addAndSelectQuery, canReadQueries, openDrawer, queryLibraryEnabled, setPendingExpression, afterId]
   );
 
-  const handleTransformationClick = useCallback(
-    (e: React.MouseEvent) => {
-      if (alwaysVisible) {
-        e.stopPropagation();
-      }
-      setPendingTransformation({ insertAfter: afterId });
-    },
-    [afterId, alwaysVisible, setPendingTransformation]
-  );
+  const handleTransformationClick = useCallback(() => {
+    setPendingTransformation({ insertAfter: afterId });
+  }, [afterId, setPendingTransformation]);
 
   const ariaLabel = getButtonAriaLabel(variant, afterId);
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -132,7 +132,6 @@ export const AddCardButton = ({ variant, afterId, alwaysVisible = false }: AddCa
         data-menu-open={menuOpen || undefined}
         type="button"
         aria-label={ariaLabel}
-        onClick={alwaysVisible ? (e) => e.stopPropagation() : undefined}
       >
         <Icon name="plus" size={alwaysVisible ? 'sm' : 'md'} />
       </button>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryCard.tsx
@@ -35,7 +35,6 @@ export const QueryCard = ({ query }: { query: DataQuery }) => {
       onDelete={() => deleteQuery(query.refId)}
       onDuplicate={() => duplicateQuery(query.refId)}
       onToggleHide={() => toggleQueryHide(query.refId)}
-      showAddButton={true}
     >
       {editorType === QueryEditorType.Query && <DataSourceLogo dataSource={queryDsSettings} size={14} />}
       {editorType === QueryEditorType.Expression && (

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.test.tsx
@@ -20,7 +20,7 @@ describe('QueryEditorSidebar', () => {
     jest.clearAllMocks();
   });
 
-  it('should not render transformations section when no transformations exist', () => {
+  it('should always render transformations section even when no transformations exist', () => {
     const queries: DataQuery[] = [{ refId: 'A', datasource: { type: 'test', uid: 'test' } }];
 
     renderWithQueryEditorProvider(<QueryEditorSidebar sidebarSize={SidebarSize.Full} setSidebarSize={jest.fn()} />, {
@@ -28,7 +28,7 @@ describe('QueryEditorSidebar', () => {
       selectedQuery: queries[0],
     });
 
-    expect(screen.queryByText(/transformations/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/transformations/i)).toBeInTheDocument();
   });
 
   it('should render queries section even when no queries exist', () => {
@@ -89,7 +89,7 @@ describe('QueryEditorSidebar', () => {
     expect(screen.getByRole('button', { name: /select card organize/i })).toBeInTheDocument();
   });
 
-  it('should render "Add below" buttons only for query/expression cards, not transformations', () => {
+  it('should render "Add below" buttons for both query/expression and transformation cards', () => {
     const queries: DataQuery[] = [
       { refId: 'A', datasource: { type: 'test', uid: 'test' } },
       { refId: 'B', datasource: { type: 'test', uid: 'test' } },
@@ -109,7 +109,7 @@ describe('QueryEditorSidebar', () => {
     expect(screen.getByRole('button', { name: /add below A/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /add below B/i })).toBeInTheDocument();
 
-    // Transformation cards should NOT have an "Add below" button
-    expect(screen.queryByRole('button', { name: /add below organize/i })).not.toBeInTheDocument();
+    // Transformation cards should also have an add button
+    expect(screen.getByRole('button', { name: /add transformation below organize/i })).toBeInTheDocument();
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.tsx
@@ -8,6 +8,7 @@ import { IconButton, ScrollContainer, Stack, Text, useStyles2 } from '@grafana/u
 import { QUERY_EDITOR_COLORS, SidebarSize } from '../../constants';
 import { usePanelContext, useQueryRunnerContext } from '../QueryEditorContext';
 
+import { AddCardButton } from './AddCardButton';
 import { AlertIndicator } from './AlertIndicator';
 import { DraggableList } from './DraggableList';
 import { QueryCard } from './QueryCard';
@@ -58,6 +59,7 @@ export const QueryEditorSidebar = memo(function QueryEditorSidebar({
         <div className={styles.content}>
           <QuerySidebarCollapsableHeader
             label={t('query-editor-next.sidebar.queries-expressions', 'Queries & Expressions')}
+            headerAction={<AddCardButton alwaysVisible />}
           >
             <DraggableList
               droppableId="query-sidebar-queries"
@@ -67,8 +69,11 @@ export const QueryEditorSidebar = memo(function QueryEditorSidebar({
               onDragEnd={onQueryDragEnd}
             />
           </QuerySidebarCollapsableHeader>
-          {transformations.length > 0 && (
-            <QuerySidebarCollapsableHeader label={t('query-editor-next.sidebar.transformations', 'Transformations')}>
+          <QuerySidebarCollapsableHeader
+            label={t('query-editor-next.sidebar.transformations', 'Transformations')}
+            headerAction={<AddCardButton variant="transformation" alwaysVisible />}
+          >
+            {transformations.length > 0 && (
               <DraggableList
                 droppableId="query-sidebar-transformations"
                 items={transformations}
@@ -76,8 +81,8 @@ export const QueryEditorSidebar = memo(function QueryEditorSidebar({
                 renderItem={(t) => <TransformationCard transformation={t} />}
                 onDragEnd={onTransformationDragEnd}
               />
-            </QuerySidebarCollapsableHeader>
-          )}
+            )}
+          </QuerySidebarCollapsableHeader>
         </div>
       </ScrollContainer>
       <div className={styles.footer}>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.tsx
@@ -59,7 +59,7 @@ export const QueryEditorSidebar = memo(function QueryEditorSidebar({
         <div className={styles.content}>
           <QuerySidebarCollapsableHeader
             label={t('query-editor-next.sidebar.queries-expressions', 'Queries & Expressions')}
-            headerAction={<AddCardButton alwaysVisible />}
+            headerAction={<AddCardButton variant="query" alwaysVisible />}
           >
             <DraggableList
               droppableId="query-sidebar-queries"

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QuerySidebarCollapsableHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QuerySidebarCollapsableHeader.tsx
@@ -25,7 +25,11 @@ export const QuerySidebarCollapsableHeader = ({
           <Text color="maxContrast" variant="bodySmall" weight="light">
             {label}
           </Text>
-          {headerAction}
+          {headerAction && (
+            // Prevent the header action from triggering the collapsable section collapse
+            // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+            <div onClick={(e) => e.stopPropagation()}>{headerAction}</div>
+          )}
         </Stack>
       }
       isOpen={isOpen}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QuerySidebarCollapsableHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QuerySidebarCollapsableHeader.tsx
@@ -4,16 +4,27 @@ import { useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { CollapsableSection, Stack, Text, useStyles2 } from '@grafana/ui';
 
-export const QuerySidebarCollapsableHeader = ({ label, children }: { label: string; children: React.ReactNode }) => {
+export const QuerySidebarCollapsableHeader = ({
+  label,
+  children,
+  headerAction,
+}: {
+  label: string;
+  children: React.ReactNode;
+  headerAction?: React.ReactNode;
+}) => {
   const [isOpen, setIsOpen] = useState(true);
   const styles = useStyles2(getStyles);
 
   return (
     <CollapsableSection
       label={
-        <Text color="maxContrast" variant="bodySmall" weight="light">
-          {label}
-        </Text>
+        <Stack direction="row" alignItems="center" gap={0.5}>
+          <Text color="maxContrast" variant="bodySmall" weight="light">
+            {label}
+          </Text>
+          {headerAction}
+        </Stack>
       }
       isOpen={isOpen}
       onToggle={setIsOpen}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QuerySidebarCollapsableHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QuerySidebarCollapsableHeader.tsx
@@ -26,9 +26,10 @@ export const QuerySidebarCollapsableHeader = ({
             {label}
           </Text>
           {headerAction && (
-            // Prevent the header action from triggering the collapsable section collapse
-            // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-            <div onClick={(e) => e.stopPropagation()}>{headerAction}</div>
+            // `stopPropagation` to prevent the header action from triggering the collapsable section collapse
+            <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="button" tabIndex={0}>
+              {headerAction}
+            </div>
           )}
         </Stack>
       }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QuerySidebarCollapsableHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QuerySidebarCollapsableHeader.tsx
@@ -4,15 +4,17 @@ import { useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { CollapsableSection, Stack, Text, useStyles2 } from '@grafana/ui';
 
+interface QuerySidebarCollapsableHeaderProps {
+  label: string;
+  children: React.ReactNode;
+  headerAction?: React.ReactNode;
+}
+
 export const QuerySidebarCollapsableHeader = ({
   label,
   children,
   headerAction,
-}: {
-  label: string;
-  children: React.ReactNode;
-  headerAction?: React.ReactNode;
-}) => {
+}: QuerySidebarCollapsableHeaderProps) => {
   const [isOpen, setIsOpen] = useState(true);
   const styles = useStyles2(getStyles);
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.test.tsx
@@ -28,7 +28,6 @@ interface RenderSidebarCardProps {
   setSelectedQuery?: jest.Mock;
   setPendingExpression?: jest.Mock;
   config?: typeof queryConfig;
-  showAddButton?: boolean;
 }
 
 function renderSidebarCard({
@@ -39,7 +38,6 @@ function renderSidebarCard({
   setSelectedQuery = jest.fn(),
   setPendingExpression = jest.fn(),
   config = queryConfig,
-  showAddButton = true,
 }: RenderSidebarCardProps = {}) {
   const queries: DataQuery[] = [{ refId: id, datasource: { type: 'test', uid: 'test' } }];
   const item = {
@@ -57,7 +55,6 @@ function renderSidebarCard({
       onDelete={jest.fn()}
       onToggleHide={jest.fn()}
       onDuplicate={jest.fn()}
-      showAddButton={showAddButton}
       item={item}
     >
       <span>Card content</span>
@@ -139,13 +136,6 @@ describe('SidebarCard', () => {
       expect(screen.getByRole('button', { name: /select card A/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /add below A/i })).toBeInTheDocument();
       expect(screen.getByText('Card content')).toBeInTheDocument();
-    });
-
-    it('does not render the add button when showAddButton is false', () => {
-      renderSidebarCard({ showAddButton: false });
-
-      expect(screen.getByRole('button', { name: /select card A/i })).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: /add below A/i })).not.toBeInTheDocument();
     });
 
     it('clicking "Add query" calls addQuery with the card refId as afterRefId', async () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
@@ -6,7 +6,7 @@ import { t } from '@grafana/i18n';
 import { useStyles2 } from '@grafana/ui';
 
 import { ActionItem, Actions } from '../../Actions';
-import { QueryEditorTypeConfig, QUERY_EDITOR_COLORS } from '../../constants';
+import { QueryEditorType, QueryEditorTypeConfig, QUERY_EDITOR_COLORS } from '../../constants';
 
 import { AddCardButton } from './AddCardButton';
 
@@ -19,7 +19,6 @@ interface SidebarCardProps {
   onDuplicate?: () => void;
   onDelete: () => void;
   onToggleHide: () => void;
-  showAddButton: boolean;
   item: ActionItem;
 }
 
@@ -32,11 +31,10 @@ export const SidebarCard = ({
   onDuplicate,
   onDelete,
   onToggleHide,
-  showAddButton = true,
   item,
 }: SidebarCardProps) => {
-  const hasAddButton = showAddButton;
-  const styles = useStyles2(getStyles, { config, isSelected, hasAddButton });
+  const addVariant = item.type === QueryEditorType.Transformation ? 'transformation' : 'query';
+  const styles = useStyles2(getStyles, { config, isSelected });
   const [hasFocusWithin, setHasFocusWithin] = useState(false);
 
   const handleFocus = useCallback(() => {
@@ -91,14 +89,14 @@ export const SidebarCard = ({
           />
         </div>
       </div>
-      {hasAddButton && <AddCardButton afterRefId={id} />}
+      <AddCardButton variant={addVariant} afterId={id} />
     </div>
   );
 };
 
 function getStyles(
   theme: GrafanaTheme2,
-  { config, isSelected, hasAddButton }: { config: QueryEditorTypeConfig; isSelected?: boolean; hasAddButton?: boolean }
+  { config, isSelected }: { config: QueryEditorTypeConfig; isSelected?: boolean }
 ) {
   const backgroundColor = isSelected ? QUERY_EDITOR_COLORS.card.activeBg : QUERY_EDITOR_COLORS.card.hoverBg;
   const hoverActions = css({
@@ -128,42 +126,38 @@ function getStyles(
       position: 'relative',
       marginInlineStart: theme.spacing(2),
 
-      // The hover-zone pseudo-elements and add-button visibility rules are
-      // only needed when the card has an AddCardButton.
-      ...(hasAddButton && {
-        // Two slim pseudo-element strips extend the hover zone to the left and
-        // below the card, covering the path to the "+" button without overlapping
-        // the card's clickable area.
+      // Two slim pseudo-element strips extend the hover zone to the left and
+      // below the card, covering the path to the "+" button without overlapping
+      // the card's clickable area.
 
-        // Left strip: narrow gutter running along the card's left edge and below.
-        '&::before': {
-          content: '""',
-          position: 'absolute',
-          top: 0,
-          left: `calc(-1 * ${theme.spacing(3.5)})`,
-          width: theme.spacing(3.5),
-          height: `calc(100% + ${theme.spacing(1.5)})`,
-        },
+      // Left strip: narrow gutter running along the card's left edge and below.
+      '&::before': {
+        content: '""',
+        position: 'absolute',
+        top: 0,
+        left: `calc(-1 * ${theme.spacing(3.5)})`,
+        width: theme.spacing(3.5),
+        height: `calc(100% + ${theme.spacing(1.5)})`,
+      },
 
-        // Bottom strip: runs along the card's bottom edge extending to the left.
-        '&::after': {
-          content: '""',
-          position: 'absolute',
-          top: '100%',
-          left: `calc(-1 * ${theme.spacing(3.5)})`,
-          width: `calc(100% + ${theme.spacing(3.5)})`,
-          height: theme.spacing(1.5),
-        },
+      // Bottom strip: runs along the card's bottom edge extending to the left.
+      '&::after': {
+        content: '""',
+        position: 'absolute',
+        top: '100%',
+        left: `calc(-1 * ${theme.spacing(3.5)})`,
+        width: `calc(100% + ${theme.spacing(3.5)})`,
+        height: theme.spacing(1.5),
+      },
 
-        '&:hover': {
-          zIndex: 1,
-        },
+      '&:hover': {
+        zIndex: 1,
+      },
 
-        '&:hover [data-add-button], & [data-menu-open]': {
-          opacity: 1,
-          pointerEvents: 'auto',
-        },
-      }),
+      '&:hover [data-add-button], & [data-menu-open]': {
+        opacity: 1,
+        pointerEvents: 'auto',
+      },
     }),
 
     card: css({

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/TransformationCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/TransformationCard.tsx
@@ -29,7 +29,6 @@ export const TransformationCard = ({ transformation }: { transformation: Transfo
       onClick={() => setSelectedTransformation(transformation)}
       onDelete={() => deleteTransformation(transformation.transformId)}
       onToggleHide={() => toggleTransformationDisabled(transformation.transformId)}
-      showAddButton={false}
     >
       <Icon
         name={QUERY_EDITOR_TYPE_CONFIG[QueryEditorType.Transformation].icon}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/usePendingTransformation.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/usePendingTransformation.test.ts
@@ -1,0 +1,144 @@
+import { renderHook, act } from '@testing-library/react';
+
+import { usePendingTransformation } from './usePendingTransformation';
+
+interface MockOptions {
+  addTransformation: jest.Mock;
+  onCardSelectionChange: jest.Mock;
+}
+
+function setup(overrides?: Partial<MockOptions>) {
+  const options: MockOptions = {
+    addTransformation: jest.fn().mockReturnValue('seriesToColumns-0'),
+    onCardSelectionChange: jest.fn(),
+    ...overrides,
+  };
+
+  const hookResult = renderHook(() => usePendingTransformation(options));
+
+  return { ...hookResult, options };
+}
+
+describe('usePendingTransformation', () => {
+  it('should initialize with null pending transformation', () => {
+    const { result } = setup();
+
+    expect(result.current.pendingTransformation).toBeNull();
+  });
+
+  describe('setPendingTransformation', () => {
+    it('should set pending transformation and deselect cards', () => {
+      const { result, options } = setup();
+
+      act(() => {
+        result.current.setPendingTransformation({ insertAfter: 'reduce-0' });
+      });
+
+      expect(result.current.pendingTransformation).toEqual({ insertAfter: 'reduce-0' });
+      expect(options.onCardSelectionChange).toHaveBeenCalledWith(null, null);
+    });
+
+    it('should not deselect cards when clearing pending transformation', () => {
+      const { result, options } = setup();
+
+      act(() => {
+        result.current.setPendingTransformation({ insertAfter: 'reduce-0' });
+      });
+
+      options.onCardSelectionChange.mockClear();
+
+      act(() => {
+        result.current.setPendingTransformation(null);
+      });
+
+      expect(result.current.pendingTransformation).toBeNull();
+      expect(options.onCardSelectionChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('finalizePendingTransformation', () => {
+    it('should add transformation and select the new card', () => {
+      const { result, options } = setup();
+
+      act(() => {
+        result.current.setPendingTransformation({ insertAfter: 'reduce-0' });
+      });
+
+      options.onCardSelectionChange.mockClear();
+
+      act(() => {
+        result.current.finalizePendingTransformation('seriesToColumns');
+      });
+
+      expect(options.addTransformation).toHaveBeenCalledWith('seriesToColumns', 'reduce-0');
+      expect(options.onCardSelectionChange).toHaveBeenCalledWith(null, 'seriesToColumns-0');
+      expect(result.current.pendingTransformation).toBeNull();
+    });
+
+    it('should not select a card if addTransformation returns undefined', () => {
+      const { result, options } = setup({
+        addTransformation: jest.fn().mockReturnValue(undefined),
+      });
+
+      act(() => {
+        result.current.setPendingTransformation({ insertAfter: 'reduce-0' });
+      });
+
+      options.onCardSelectionChange.mockClear();
+
+      act(() => {
+        result.current.finalizePendingTransformation('seriesToColumns');
+      });
+
+      expect(options.addTransformation).toHaveBeenCalled();
+      expect(options.onCardSelectionChange).not.toHaveBeenCalled();
+      expect(result.current.pendingTransformation).toBeNull();
+    });
+
+    it('should handle finalize when no pending transformation exists', () => {
+      const { result, options } = setup();
+
+      act(() => {
+        result.current.finalizePendingTransformation('seriesToColumns');
+      });
+
+      // Should still attempt to add transformation with undefined insertAfter
+      expect(options.addTransformation).toHaveBeenCalledWith('seriesToColumns', undefined);
+    });
+
+    it('should append to end when insertAfter is undefined', () => {
+      const { result, options } = setup();
+
+      act(() => {
+        result.current.setPendingTransformation({});
+      });
+
+      options.onCardSelectionChange.mockClear();
+
+      act(() => {
+        result.current.finalizePendingTransformation('reduce');
+      });
+
+      expect(options.addTransformation).toHaveBeenCalledWith('reduce', undefined);
+    });
+  });
+
+  describe('clearPendingTransformation', () => {
+    it('should clear the pending transformation without side effects', () => {
+      const { result, options } = setup();
+
+      act(() => {
+        result.current.setPendingTransformation({ insertAfter: 'reduce-0' });
+      });
+
+      options.onCardSelectionChange.mockClear();
+
+      act(() => {
+        result.current.clearPendingTransformation();
+      });
+
+      expect(result.current.pendingTransformation).toBeNull();
+      expect(options.onCardSelectionChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/usePendingTransformation.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/usePendingTransformation.ts
@@ -1,0 +1,49 @@
+import { useCallback, useState } from 'react';
+
+import { PendingTransformation } from '../QueryEditorContext';
+
+interface UsePendingTransformationOptions {
+  addTransformation: (transformationId: string, afterTransformId?: string) => string | undefined;
+  onCardSelectionChange: (queryRefId: string | null, transformationId: string | null) => void;
+}
+
+export function usePendingTransformation({
+  addTransformation,
+  onCardSelectionChange,
+}: UsePendingTransformationOptions) {
+  const [pendingTransformation, setPendingTransformationState] = useState<PendingTransformation | null>(null);
+
+  const setPendingTransformation = useCallback(
+    (pending: PendingTransformation | null) => {
+      setPendingTransformationState(pending);
+      if (pending) {
+        onCardSelectionChange(null, null);
+      }
+    },
+    [onCardSelectionChange]
+  );
+
+  const finalizePendingTransformation = useCallback(
+    (transformationId: string) => {
+      const insertAfterTransformId = pendingTransformation?.insertAfter;
+      setPendingTransformationState(null);
+
+      const newTransformId = addTransformation(transformationId, insertAfterTransformId);
+      if (newTransformId) {
+        onCardSelectionChange(null, newTransformId);
+      }
+    },
+    [pendingTransformation, addTransformation, onCardSelectionChange]
+  );
+
+  const clearPendingTransformation = useCallback(() => {
+    setPendingTransformationState(null);
+  }, []);
+
+  return {
+    pendingTransformation,
+    setPendingTransformation,
+    finalizePendingTransformation,
+    clearPendingTransformation,
+  };
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedCard.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedCard.ts
@@ -7,6 +7,10 @@ import { AlertRule, Transformation } from '../types';
 /**
  * Hook to resolve the currently selected query, transformation, or alert.
  * They are mutually exclusive - only one type can be selected at a time.
+ *
+ * @param hasPendingPicker - When true, suppresses the default fallback to the
+ *   first query so no card appears selected while a picker (expression or
+ *   transformation) is active.
  */
 export function useSelectedCard(
   selectedQueryRefId: string | null,
@@ -14,7 +18,8 @@ export function useSelectedCard(
   selectedAlertId: string | null,
   queries: DataQuery[],
   transformations: Transformation[],
-  alerts: AlertRule[]
+  alerts: AlertRule[],
+  hasPendingPicker = false
 ) {
   const selectedQuery = useMemo(() => {
     // If we have a selected query refId, try to find that query
@@ -25,14 +30,14 @@ export function useSelectedCard(
       }
     }
 
-    // If a transformation or alert is selected, don't select any query
-    if (selectedTransformationId || selectedAlertId) {
+    // If a transformation, alert, or picker is active, don't select any query
+    if (selectedTransformationId || selectedAlertId || hasPendingPicker) {
       return null;
     }
 
     // Otherwise, default to the first query if available
     return queries.length > 0 ? queries[0] : null;
-  }, [queries, selectedQueryRefId, selectedTransformationId, selectedAlertId]);
+  }, [queries, selectedQueryRefId, selectedTransformationId, selectedAlertId, hasPendingPicker]);
 
   const selectedTransformation = useMemo(() => {
     // If we have a selected transformation id, try to find that transformation

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/testUtils.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/testUtils.tsx
@@ -101,6 +101,9 @@ export const mockUIStateBase = {
   pendingExpression: null,
   setPendingExpression: jest.fn(),
   finalizePendingExpression: jest.fn(),
+  pendingTransformation: null,
+  setPendingTransformation: jest.fn(),
+  finalizePendingTransformation: jest.fn(),
 };
 
 export const mockTransformToggles = {
@@ -181,6 +184,9 @@ export function renderWithQueryEditorProvider(children: ReactElement, options: C
     pendingExpression: null,
     setPendingExpression: jest.fn(),
     finalizePendingExpression: jest.fn(),
+    pendingTransformation: null,
+    setPendingTransformation: jest.fn(),
+    finalizePendingTransformation: jest.fn(),
     selectedAlert: null,
     setSelectedAlert: jest.fn(),
     ...uiStateOverrides,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/testUtils.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/testUtils.tsx
@@ -64,6 +64,7 @@ export const mockActions: QueryEditorActions = {
   changeDataSource: jest.fn(),
   toggleQueryHide: jest.fn(),
   onQueryOptionsChange: jest.fn(),
+  addTransformation: jest.fn(),
   deleteTransformation: jest.fn(),
   toggleTransformationDisabled: jest.fn(),
   updateTransformation: jest.fn(),

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
@@ -5,15 +5,20 @@ import { isExpressionQuery } from 'app/features/expressions/guards';
 
 import { QueryEditorType } from '../constants';
 
-import { PendingExpression } from './QueryEditorContext';
+import { PendingExpression, PendingTransformation } from './QueryEditorContext';
 import { AlertRule, Transformation } from './types';
 
 export function getEditorType(
   card: DataQuery | Transformation | AlertRule | null,
-  pendingExpression?: PendingExpression | null
+  pendingExpression?: PendingExpression | null,
+  pendingTransformation?: PendingTransformation | null
 ): QueryEditorType {
   if (pendingExpression) {
     return QueryEditorType.Expression;
+  }
+
+  if (pendingTransformation) {
+    return QueryEditorType.Transformation;
   }
 
   if (!card) {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13254,6 +13254,8 @@
       "expression": "Expression",
       "pending-expression": "Select an Expression",
       "pending-expression-cancel": "Cancel",
+      "pending-transformation": "Select a Transformation",
+      "pending-transformation-cancel": "Cancel",
       "transformation": "Transformation"
     },
     "help": {
@@ -13270,7 +13272,10 @@
       "add-below": "Add below {{id}}",
       "add-expression": "Add expression",
       "add-query": "Add query",
+      "add-query-or-expression": "Add query or expression",
       "add-saved-query": "Add saved query",
+      "add-transformation": "Add transformation",
+      "add-transformation-below": "Add transformation below {{id}}",
       "alert-indicator": {
         "button-label": "View alert rules",
         "tooltip": "View alert rules"


### PR DESCRIPTION
## Description

This PR resolves #117962. It allows users to add new transformations to the Query Stack. It aims to match the **3.1 Adding Transformation** [designs](https://www.figma.com/design/3H1r3q7pxqbxF8IH9nYVIz/Reimagining-Querying-Explorations?node-id=2362-9499&m=dev).

## Changes
<!--- Describe your changes in detail -->
- Adds the `<AddCardButton />` next to each section in the Query Stack. Clicking this will add a new item to the bottom of its section.
- Leverages a new `addTransformation` method to add transformation cards to the query stack. When adding a transformation, we show a gallery of available transforms, following the v1 pattern.
- Gets rid of the `showAddButton` concept, as all types of cards (queries, expressions, transformations) are now capable of being added to the query stack.
- Small refactors to unify concepts, now that transformations are handled more closely to queries & expressions.

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->

None identified.

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->

https://github.com/user-attachments/assets/a4625355-fd7e-436e-957a-09285668a4de

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
- After checking out `117962/add-transformation-cards`, enable the `queryEditorNext` and `queryLibrary` feature toggles in `conf/custom/ini`.
- Run Grafana with enterprise features enabled.
- Open a dashboard and add transformations to the **Query Stack** using both section-level and card-level `+` icon buttons.
- Compare to the [designs](https://www.figma.com/design/3H1r3q7pxqbxF8IH9nYVIz/Reimagining-Querying-Explorations?node-id=2362-9499&m=dev).

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable

