### PR TITLE
Data Sources: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -229,8 +229,8 @@
 /devenv/create_docker_compose.sh @grafana/grafana-backend-services-squad
 /devenv/alert_rules.yaml @grafana/alerting-backend
 /devenv/dashboards.yaml @grafana/dashboards-squad
-/devenv/datasources.yaml @grafana/grafana-backend-group
-/devenv/datasources_docker.yaml @grafana/grafana-backend-group
+/devenv/datasources.yaml @grafana/data-sources
+/devenv/datasources_docker.yaml @grafana/data-sources
 /devenv/dev-dashboards-without-uid/ @grafana/dashboards-squad
 /devenv/dev-dashboards/panel-logstable/logs-table.json @grafana/observability-logs
 /devenv/scopes/ @grafana/grafana-operator-experience-squad

--- a/pkg/services/featuremgmt/codeowners.go
+++ b/pkg/services/featuremgmt/codeowners.go
@@ -29,4 +29,5 @@ const (
 	grafanaDatasourcesCoreServicesSquad         codeowner = "@grafana/grafana-datasources-core-services"
 	grafanaBackendGroup                         codeowner = "@grafana/grafana-backend-group"
 	grafanaPathfinderSquad                      codeowner = "@grafana/pathfinder"
+	grafanaDataSources                          codeowner = "@grafana/data-sources"
 )


### PR DESCRIPTION
Moves ownership in CODEOWNERS of `/devenv/datasources.yaml` and `/devenv/datasources_docker.yaml` to @grafana/data-sources.