### PR TITLE
feat(setting): add LRU cache to List to reduce load from burst requests

### DIFF
--- a/pkg/services/setting/service.go
+++ b/pkg/services/setting/service.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
@@ -48,6 +50,8 @@ const LogPrefix = "setting.service"
 const DefaultPageSize = int64(500)
 const DefaultQPS = float32(15)
 const DefaultBurst = 40
+const DefaultCacheTTL = 1 * time.Second
+const DefaultCacheMaxEntries = 1000
 
 const (
 	ApiGroup   = "setting.grafana.app"
@@ -71,8 +75,9 @@ var settingGroupVersion = schema.GroupVersion{
 
 type clientMetrics struct {
 	listDuration             *prometheus.HistogramVec
-	listResultSize           *prometheus.HistogramVec
+	listResultSize           prometheus.Histogram
 	rateLimiterThrottleTotal prometheus.Counter
+	cacheHitTotal            prometheus.Counter
 }
 
 // Service retrieves configuration settings from a remote settings service.
@@ -124,10 +129,13 @@ type Service interface {
 }
 
 type remoteSettingService struct {
-	restClient *rest.RESTClient
-	log        logging.Logger
-	pageSize   int64
-	metrics    clientMetrics
+	restClient   *rest.RESTClient
+	log          logging.Logger
+	pageSize     int64
+	metrics      clientMetrics
+	cache        *expirable.LRU[string, []*Setting]  // nil when caching disabled
+	fetchMutexes *expirable.LRU[string, *sync.Mutex] // per-cache-key fetch locks
+	fetchMu      sync.Mutex                          // guards fetchMutexes get-or-create
 }
 
 var _ Service = (*remoteSettingService)(nil)
@@ -155,6 +163,11 @@ type Config struct {
 	// The UserAgent format is "settings-client <version> (<service_name>)".
 	// Falls back to the OTEL_SERVICE_NAME environment variable, then to "grafana".
 	ServiceName string
+	// CacheTTL sets the TTL for cached List results. Defaults to DefaultCacheTTL (1s).
+	// Set to -1 to disable caching.
+	CacheTTL time.Duration
+	// CacheMaxEntries sets the max LRU cache entries. Defaults to DefaultCacheMaxEntries (1000).
+	CacheMaxEntries int
 }
 
 // Setting represents the parsed spec of a Setting resource.
@@ -200,11 +213,29 @@ func New(config Config) (Service, error) {
 		pageSize = config.PageSize
 	}
 
+	cacheTTL := DefaultCacheTTL
+	if config.CacheTTL > 0 {
+		cacheTTL = config.CacheTTL
+	}
+	cacheMaxEntries := DefaultCacheMaxEntries
+	if config.CacheMaxEntries > 0 {
+		cacheMaxEntries = config.CacheMaxEntries
+	}
+
+	var cache *expirable.LRU[string, []*Setting]
+	var fetchMutexes *expirable.LRU[string, *sync.Mutex]
+	if config.CacheTTL >= 0 {
+		cache = expirable.NewLRU[string, []*Setting](cacheMaxEntries, nil, cacheTTL)
+		fetchMutexes = expirable.NewLRU[string, *sync.Mutex](cacheMaxEntries, nil, 2*cacheTTL)
+	}
+
 	return &remoteSettingService{
-		restClient: restClient,
-		log:        log,
-		pageSize:   pageSize,
-		metrics:    metrics,
+		restClient:   restClient,
+		log:          log,
+		pageSize:     pageSize,
+		metrics:      metrics,
+		cache:        cache,
+		fetchMutexes: fetchMutexes,
 	}, nil
 }
 
@@ -230,7 +261,7 @@ func (s *remoteSettingService) ListAsIni(ctx context.Context, labelSelector meta
 	return iniFile, nil
 }
 
-func (s *remoteSettingService) List(ctx context.Context, labelSelector metav1.LabelSelector) ([]*Setting, error) {
+func (s *remoteSettingService) List(ctx context.Context, labelSelector metav1.LabelSelector) (settings []*Setting, oErr error) {
 	namespace, ok := request.NamespaceFrom(ctx)
 	ns := semconv.GrafanaNamespaceName(namespace)
 	ctx, span := tracer.Start(ctx, "remoteSettingService.List",
@@ -243,21 +274,77 @@ func (s *remoteSettingService) List(ctx context.Context, labelSelector metav1.La
 	log := s.log.FromContext(ctx).New(ns.Key, ns.Value, "function", "remoteSettingService.List", "traceId", span.SpanContext().TraceID())
 
 	startTime := time.Now()
-	var status string
+	var cacheHit bool
+	// Uses the named return oErr to determine success/error status.
+	// Cache-hit returns set cacheHit=true to skip duration observation,
+	// since sub-millisecond cache lookups would skew the remote-call histogram.
 	defer func() {
-		duration := time.Since(startTime).Seconds()
-		s.metrics.listDuration.WithLabelValues(status).Observe(duration)
+		if cacheHit {
+			return
+		}
+		status := "success"
+		if oErr != nil {
+			status = "error"
+		}
+		s.metrics.listDuration.WithLabelValues(status).Observe(time.Since(startTime).Seconds())
 	}()
 
 	selector, err := metav1.LabelSelectorAsSelector(&labelSelector)
 	if err != nil {
-		status = "error"
 		return nil, tracing.Error(span, err)
 	}
 	if selector.Empty() {
 		log.Debug("empty selector. Fetching all settings")
 	}
 
+	lSelector := selector.String()
+	cacheKey := namespace + "|" + lSelector
+
+	if s.cache != nil {
+		if cached, ok := s.cache.Get(cacheKey); ok {
+			cacheHit = true
+			s.metrics.cacheHitTotal.Inc()
+			return cached, nil
+		}
+	}
+
+	if s.cache != nil {
+		fetchMutex := s.getOrCreateFetchMutex(cacheKey)
+		fetchMutex.Lock()
+		defer fetchMutex.Unlock()
+
+		if cached, ok := s.cache.Get(cacheKey); ok {
+			cacheHit = true
+			s.metrics.cacheHitTotal.Inc()
+			return cached, nil
+		}
+	}
+
+	allSettings, err := s.fetch(ctx, namespace, lSelector, span)
+	if err != nil {
+		return nil, err
+	}
+
+	if s.cache != nil {
+		s.cache.Add(cacheKey, allSettings)
+	}
+
+	return allSettings, nil
+}
+
+func (s *remoteSettingService) getOrCreateFetchMutex(key string) *sync.Mutex {
+	s.fetchMu.Lock()
+	defer s.fetchMu.Unlock()
+	if mu, ok := s.fetchMutexes.Get(key); ok {
+		return mu
+	}
+	mu := &sync.Mutex{}
+	s.fetchMutexes.Add(key, mu)
+	return mu
+}
+
+// fetch retrieves all settings from the remote service using paginated requests.
+func (s *remoteSettingService) fetch(ctx context.Context, namespace string, lSelector string, span trace.Span) ([]*Setting, error) {
 	// Pre-allocate with estimated capacity
 	allSettings := make([]*Setting, 0, s.pageSize*8)
 	var continueToken string
@@ -267,9 +354,8 @@ func (s *remoteSettingService) List(ctx context.Context, labelSelector metav1.La
 	for hasNext && totalPages < 1000 {
 		totalPages++
 
-		settings, nextToken, lErr := s.fetchPage(ctx, namespace, selector.String(), continueToken)
+		settings, nextToken, lErr := s.fetchPage(ctx, namespace, lSelector, continueToken)
 		if lErr != nil {
-			status = "error"
 			return nil, tracing.Error(span, lErr)
 		}
 
@@ -279,10 +365,7 @@ func (s *remoteSettingService) List(ctx context.Context, labelSelector metav1.La
 			hasNext = false
 		}
 	}
-
-	status = "success"
-	s.metrics.listResultSize.WithLabelValues(status).Observe(float64(len(allSettings)))
-
+	s.metrics.listResultSize.Observe(float64(len(allSettings)))
 	return allSettings, nil
 }
 
@@ -540,7 +623,7 @@ func initMetrics() clientMetrics {
 			},
 			[]string{"status"}, // status: "success" or "error"
 		),
-		listResultSize: prometheus.NewHistogramVec(
+		listResultSize: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
 				Namespace:                   "settings",
 				Subsystem:                   "service",
@@ -548,13 +631,18 @@ func initMetrics() clientMetrics {
 				Help:                        "Number of settings returned by remote settings service List operations",
 				NativeHistogramBucketFactor: 1.1,
 			},
-			[]string{"status"}, // status: "success" or "error"
 		),
 		rateLimiterThrottleTotal: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: "settings",
 			Subsystem: "service",
 			Name:      "rate_limiter_throttle_total",
 			Help:      "Total number of requests that waited more than 50ms due to client-side rate limiting",
+		}),
+		cacheHitTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "settings",
+			Subsystem: "service",
+			Name:      "list_settings_cache_hit_total",
+			Help:      "Total number of List cache hits",
 		}),
 	}
 	return metrics
@@ -564,10 +652,12 @@ func (s *remoteSettingService) Describe(descs chan<- *prometheus.Desc) {
 	s.metrics.listDuration.Describe(descs)
 	s.metrics.listResultSize.Describe(descs)
 	s.metrics.rateLimiterThrottleTotal.Describe(descs)
+	s.metrics.cacheHitTotal.Describe(descs)
 }
 
 func (s *remoteSettingService) Collect(metrics chan<- prometheus.Metric) {
 	s.metrics.listDuration.Collect(metrics)
 	s.metrics.listResultSize.Collect(metrics)
 	s.metrics.rateLimiterThrottleTotal.Collect(metrics)
+	s.metrics.cacheHitTotal.Collect(metrics)
 }

--- a/pkg/services/setting/service_test.go
+++ b/pkg/services/setting/service_test.go
@@ -8,8 +8,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -662,6 +664,207 @@ func TestNew(t *testing.T) {
 	})
 }
 
+func TestListCache(t *testing.T) {
+	t.Run("should return cached result on second call with same namespace and selector", func(t *testing.T) {
+		var requestCount atomic.Int32
+		settings := []Setting{
+			{Section: "server", Key: "port", Value: "3000"},
+		}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(generateSettingsJSON(settings, "")))
+		}))
+		defer server.Close()
+
+		client := newTestClientWithCache(t, server.URL, 500, 5*time.Second)
+		ctx := request.WithNamespace(context.Background(), "test-namespace")
+		selector := metav1.LabelSelector{}
+
+		result1, err := client.List(ctx, selector)
+		require.NoError(t, err)
+		assert.Len(t, result1, 1)
+		assert.Equal(t, int32(1), requestCount.Load())
+
+		result2, err := client.List(ctx, selector)
+		require.NoError(t, err)
+		assert.Len(t, result2, 1)
+		assert.Equal(t, int32(1), requestCount.Load(), "second call should hit cache, not the server")
+
+		remoteClient := client.(*remoteSettingService)
+		assert.Equal(t, float64(1), testutil.ToFloat64(remoteClient.metrics.cacheHitTotal))
+	})
+
+	t.Run("should miss cache for different selectors", func(t *testing.T) {
+		var requestCount atomic.Int32
+		settings := []Setting{
+			{Section: "server", Key: "port", Value: "3000"},
+			{Section: "database", Key: "host", Value: "localhost"},
+		}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(generateSettingsJSON(settings, "")))
+		}))
+		defer server.Close()
+
+		client := newTestClientWithCache(t, server.URL, 500, 5*time.Second)
+		ctx := request.WithNamespace(context.Background(), "test-namespace")
+
+		_, err := client.List(ctx, metav1.LabelSelector{})
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), requestCount.Load())
+
+		_, err = client.List(ctx, metav1.LabelSelector{
+			MatchLabels: map[string]string{"section": "server"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), requestCount.Load(), "different selector should miss cache")
+	})
+
+	t.Run("should miss cache for different namespaces", func(t *testing.T) {
+		var requestCount atomic.Int32
+		settings := []Setting{
+			{Section: "server", Key: "port", Value: "3000"},
+		}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(generateSettingsJSON(settings, "")))
+		}))
+		defer server.Close()
+
+		client := newTestClientWithCache(t, server.URL, 500, 5*time.Second)
+		selector := metav1.LabelSelector{}
+
+		ctx1 := request.WithNamespace(context.Background(), "namespace-a")
+		_, err := client.List(ctx1, selector)
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), requestCount.Load())
+
+		ctx2 := request.WithNamespace(context.Background(), "namespace-b")
+		_, err = client.List(ctx2, selector)
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), requestCount.Load(), "different namespace should miss cache")
+	})
+
+	t.Run("should not cache when cache is disabled", func(t *testing.T) {
+		var requestCount atomic.Int32
+		settings := []Setting{
+			{Section: "server", Key: "port", Value: "3000"},
+		}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(generateSettingsJSON(settings, "")))
+		}))
+		defer server.Close()
+
+		config := Config{
+			URL:           server.URL,
+			WrapTransport: func(rt http.RoundTripper) http.RoundTripper { return rt },
+			PageSize:      500,
+			CacheTTL:      -1,
+		}
+		client, err := New(config)
+		require.NoError(t, err)
+
+		remoteClient := client.(*remoteSettingService)
+		assert.Nil(t, remoteClient.cache, "cache should be nil when disabled")
+
+		ctx := request.WithNamespace(context.Background(), "test-namespace")
+		selector := metav1.LabelSelector{}
+
+		_, err = client.List(ctx, selector)
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), requestCount.Load())
+
+		_, err = client.List(ctx, selector)
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), requestCount.Load(), "every call should hit server when cache disabled")
+	})
+
+	t.Run("should use default cache TTL when CacheTTL is zero", func(t *testing.T) {
+		config := Config{
+			URL:           "https://example.com",
+			WrapTransport: func(rt http.RoundTripper) http.RoundTripper { return rt },
+		}
+		client, err := New(config)
+		require.NoError(t, err)
+
+		remoteClient := client.(*remoteSettingService)
+		assert.NotNil(t, remoteClient.cache, "cache should be enabled by default")
+		assert.NotNil(t, remoteClient.metrics.cacheHitTotal, "cacheHitTotal should be set when cache enabled")
+	})
+
+	t.Run("should not observe listResultSize on cache hit", func(t *testing.T) {
+		settings := []Setting{
+			{Section: "server", Key: "port", Value: "3000"},
+		}
+		server := newTestServer(t, settings, "")
+		defer server.Close()
+
+		client := newTestClientWithCache(t, server.URL, 500, 5*time.Second)
+		ctx := request.WithNamespace(context.Background(), "test-namespace")
+		selector := metav1.LabelSelector{}
+
+		remoteClient := client.(*remoteSettingService)
+
+		// First call: actual fetch — expect 1 sample in histogram
+		_, err := client.List(ctx, selector)
+		require.NoError(t, err)
+		countAfterFirst := testutil.CollectAndCount(remoteClient.metrics.listResultSize)
+
+		// Second call: cache hit — sample count must not increase
+		_, err = client.List(ctx, selector)
+		require.NoError(t, err)
+		countAfterSecond := testutil.CollectAndCount(remoteClient.metrics.listResultSize)
+
+		assert.Equal(t, countAfterFirst, countAfterSecond, "listResultSize should not be observed on cache hit")
+	})
+
+	t.Run("should serialize concurrent fetches for the same cache key", func(t *testing.T) {
+		var concurrentMax atomic.Int32
+		var concurrent atomic.Int32
+		settings := []Setting{
+			{Section: "server", Key: "port", Value: "3000"},
+		}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			cur := concurrent.Add(1)
+			for {
+				old := concurrentMax.Load()
+				if cur <= old || concurrentMax.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			concurrent.Add(-1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(generateSettingsJSON(settings, "")))
+		}))
+		defer server.Close()
+
+		// Use very short TTL so the cache expires between requests
+		client := newTestClientWithCache(t, server.URL, 500, 10*time.Millisecond)
+
+		done := make(chan struct{})
+		selector := metav1.LabelSelector{}
+		count := 5
+		for range count {
+			go func() {
+				ctx := request.WithNamespace(context.Background(), "same-namespace")
+				_, _ = client.List(ctx, selector)
+				done <- struct{}{}
+			}()
+		}
+		for range count {
+			<-done
+		}
+
+		assert.Equal(t, int32(1), concurrentMax.Load(), "only one concurrent request per cache key should be allowed")
+	})
+}
+
 // Helper functions
 
 func newTestServer(t *testing.T, settings []Setting, continueToken string) *httptest.Server {
@@ -678,6 +881,20 @@ func newTestClient(t *testing.T, serverURL string, pageSize int64) Service {
 		URL:           serverURL,
 		WrapTransport: func(rt http.RoundTripper) http.RoundTripper { return rt },
 		PageSize:      pageSize,
+		CacheTTL:      -1, // disable cache for existing tests
+	}
+	client, err := New(config)
+	require.NoError(t, err)
+	return client
+}
+
+func newTestClientWithCache(t *testing.T, serverURL string, pageSize int64, cacheTTL time.Duration) Service {
+	t.Helper()
+	config := Config{
+		URL:           serverURL,
+		WrapTransport: func(rt http.RoundTripper) http.RoundTripper { return rt },
+		PageSize:      pageSize,
+		CacheTTL:      cacheTTL,
 	}
 	client, err := New(config)
 	require.NoError(t, err)
@@ -746,7 +963,7 @@ func TestInstrumentedRateLimiter(t *testing.T) {
 			}
 
 			ctx := t.Context()
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				require.NoError(t, rl.Wait(ctx))
 			}
 			assert.Equal(t, float64(0), testutil.ToFloat64(counter))
@@ -762,7 +979,8 @@ func BenchmarkParseSettingList(b *testing.B) {
 
 	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		reader := bytes.NewReader(jsonBytes)
 		_, _, _ = parseSettingList(context.Background(), reader)
 	}
@@ -774,7 +992,7 @@ func BenchmarkParseSettingList_SinglePage(b *testing.B) {
 
 	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		reader := bytes.NewReader(jsonBytes)
 		_, _, _ = parseSettingList(context.Background(), reader)
 	}


### PR DESCRIPTION
**What is this feature?**

It adds a TTL-based expirable LRU cache around the paginated List fetch, keyed by namespace + label selector. Configurable via `Config.CacheTTL` (default `1s`, negative to disable) and `Config.CacheMaxEntries` (default 1000).

**Why do we need this feature?**

Reduces load on the remote settings service caused by burst requests by caching List results in a TTL-based LRU with per-namespace mutex

**Which issue(s) does this PR fix?**:

Part of: https://github.com/grafana/grafana-org/issues/829

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
