### PR TITLE
Alerting: Improve import wizard validation and UX

### DIFF
--- a/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.tsx
@@ -201,10 +201,14 @@ export function Step1Content({
 }
 
 /**
- * Hook to check if Step 1 form is valid
+ * Hook to check if Step 1 form is valid.
+ * Checks both that required fields are filled AND that there are no validation errors.
  */
 export function useStep1Validation(canImport: boolean): boolean {
-  const { watch } = useFormContext<ImportFormValues>();
+  const {
+    watch,
+    formState: { errors },
+  } = useFormContext<ImportFormValues>();
   const [notificationsSource, policyTreeName, notificationsDatasourceUID, notificationsYamlFile] = watch([
     'notificationsSource',
     'policyTreeName',
@@ -212,15 +216,22 @@ export function useStep1Validation(canImport: boolean): boolean {
     'notificationsYamlFile',
   ]);
 
-  return useMemo(() => {
-    return isStep1Valid({
-      canImport,
-      policyTreeName,
-      notificationsSource,
-      notificationsYamlFile,
-      notificationsDatasourceUID,
-    });
-  }, [canImport, policyTreeName, notificationsSource, notificationsYamlFile, notificationsDatasourceUID]);
+  const hasStep1Errors =
+    !!errors.notificationsSource ||
+    !!errors.policyTreeName ||
+    !!errors.notificationsDatasourceUID ||
+    !!errors.notificationsYamlFile;
+
+  if (!canImport || hasStep1Errors) {
+    return false;
+  }
+
+  return isStep1Valid({
+    policyTreeName,
+    notificationsSource,
+    notificationsYamlFile,
+    notificationsDatasourceUID,
+  });
 }
 
 /**

--- a/public/app/features/alerting/unified/components/import-to-gma/steps/utils.ts
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/utils.ts
@@ -41,7 +41,6 @@ export function hasValidSourceSelection(
 }
 
 export interface Step1ValidationParams {
-  canImport: boolean;
   policyTreeName: string | null;
   notificationsSource: 'yaml' | 'datasource';
   notificationsYamlFile: File | null;
@@ -52,16 +51,15 @@ export interface Step1ValidationParams {
  * Validates that Step 1 form is complete and valid
  */
 export function isStep1Valid(params: Step1ValidationParams): boolean {
-  const { canImport, policyTreeName, notificationsSource, notificationsYamlFile, notificationsDatasourceUID } = params;
+  const { policyTreeName, notificationsSource, notificationsYamlFile, notificationsDatasourceUID } = params;
 
-  if (!canImport || !policyTreeName) {
+  if (!policyTreeName) {
     return false;
   }
   return hasValidSourceSelection(notificationsSource, notificationsYamlFile, notificationsDatasourceUID);
 }
 
 export interface Step2ValidationParams {
-  canImport: boolean;
   rulesSource: 'yaml' | 'datasource';
   rulesYamlFile: File | null;
   rulesDatasourceUID: string | null | undefined;
@@ -74,16 +72,11 @@ export interface Step2ValidationParams {
  * Validates that Step 2 form is complete and valid
  */
 export function isStep2Valid(params: Step2ValidationParams): boolean {
-  const { canImport, rulesSource, rulesYamlFile, rulesDatasourceUID, selectedRoutingTree, targetDatasourceUID } =
-    params;
+  const { rulesSource, rulesYamlFile, rulesDatasourceUID, selectedRoutingTree, targetDatasourceUID } = params;
 
-  if (!canImport) {
-    return false;
-  }
   if (!hasValidSourceSelection(rulesSource, rulesYamlFile, rulesDatasourceUID)) {
     return false;
   }
-  // A routing tree must be selected
   if (!selectedRoutingTree) {
     return false;
   }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1772,7 +1772,9 @@
         "target-folder": "Target folder",
         "target-folder-desc": "Folder where imported rules will be stored",
         "upload": "Upload YAML file",
-        "yaml-file": "Rules YAML file"
+        "yaml-error": "Failed to parse YAML file: {{error}}",
+        "yaml-file": "Rules YAML file",
+        "yaml-required": "Please select a file"
       },
       "success": "Successfully imported resources to Grafana Alerting.",
       "target-folder": {


### PR DESCRIPTION
**What is this feature?**

This PR improves validation and UX in the import-to-GMA wizard:

- **Block step navigation on validation errors**: Steps 1 and 2 now check `formState.errors` in their validation hooks, preventing the user from proceeding to the next step when there are validation errors (they can still skip).
- **YAML file validation on upload (Step 2)**: When uploading a rules YAML file, it is now parsed with `parseYamlFileToRulerRulesConfigDTO` to validate its structure before allowing the user to proceed, matching the behavior already present in `ImportToGMARules`.
- **Auto-populate target datasource (Step 2)**: When the user selects a datasource in "Import Source", the "Target data source" field is automatically populated if it's empty and the selected datasource is a valid recording rules target.

### Code cleanup

- Moved the `canImport` permission check from `isStep1Valid`/`isStep2Valid` utility functions into the `useStep1Validation`/`useStep2Validation` hooks, separating permission logic from form field validation.
- Removed unnecessary `useMemo` wrapping trivial synchronous validation calls in both hooks.

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:
Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
