### PR TITLE
Alerting: Change feature flags required for notifications tab in rule viewer.

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -498,10 +498,7 @@ function usePageNav(rule: CombinedRule) {
           setActiveTab(ActiveTab.Notifications);
         },
         // notification history is only available for Grafana managed alert rules and requires feature toggles
-        hideFromTabs:
-          !isGrafanaAlertRule ||
-          !config.featureToggles.alertingNotificationHistoryRuleViewer ||
-          !config.featureToggles.kubernetesAlertingHistorian,
+        hideFromTabs: !isGrafanaAlertRule || !config.featureToggles.alertingNotificationHistoryRuleViewer,
       },
       {
         text: t('alerting.use-page-nav.page-nav.text.details', 'Details'),


### PR DESCRIPTION
Don't require kubernetesAlertingHistorian be enabled for the tab to be visible.
