### PR TITLE
Docs: GS - New Git providers

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/_index.md
@@ -38,15 +38,17 @@ Git Sync is available in [public preview](https://grafana.com/docs/release-life-
 
 {{< /admonition >}}
 
-Git Sync in Grafana lets you synchronize your resources so you can store your dashboards as JSON files stored in GitHub and manage them as code. You and your team can version control, collaborate, and automate deployments efficiently.
+Git Sync in Grafana lets you synchronize your resources so you can store your dashboards as JSON files in any Git provider and manage them as code. You and your team can version control, collaborate, and automate deployments efficiently.
 
 ## How it works
 
-Git Sync allows you to connect external resources with your Grafana instance. After setup, all synchronized resources live under the `provisioned` folder. You can continue to have unprovisioned resources outside that folder.
+Git Sync allows you to connect external resources with your Grafana instance. After setup, all synchronized resources live in Git under the `provisioned` folder. You can continue to have unprovisioned resources outside that folder.
 
 Git Sync is bidirectional. You can modify provisioned resources both from the Grafana UI or from the synced repository, and changes will be reflected in both places.
 
-Refer to [key concepts](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/key-concepts) and [Usage and performance limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits) for further details.
+Git Sync is available for any Git provider through a Pure Git repository type, and has specific enhanced integrations for GitHub, GitLab and Bitbucket. Refer to [Usage and performance limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits) for further details, including usage tiers.
+
+Refer to [key concepts](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/key-concepts) for more information on how Git Sync works.
 
 ### Make changes in the Grafana UI
 
@@ -58,19 +60,6 @@ Your Grafana instance polls the provisioned GitHub resources to synchronize. If 
 
 - Without webhooks, Grafana polls for changes at the specified interval. The default polling interval is 60 seconds, and you can change this setting in the Grafana UI.
 - If you enable the [webhooks feature](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/#configure-webhooks-and-image-rendering), repository notifications appear almost immediately.
-
-## Resource support and compatibility
-
-Git Sync only supports dashboards and folders. Alerts, panels, and other resources are not supported yet.
-
-If you're using Git Sync in Grafana OSS or Grafana Enterprise, some supported resources might be in an incompatible data format. If this happens, syncing will be blocked. Compatibility issues will be fixed with an upcoming migration tool.
-
-A resource can be:
-
-| Is the resource? | **Compatible**                                                             | **Incompatible**                                                                                |
-| ---------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| **Supported**    | The resource can be managed with Git Sync.                                 | The resource is supported but has compatibility issues. It **cannot** be managed with Git Sync. |
-| **Unsupported**  | The resource is **not** supported and **cannot** be managed with Git Sync. | Not applicable.                                                                                 |
 
 ## Common use cases
 

--- a/docs/sources/as-code/observability-as-code/git-sync/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/_index.md
@@ -1,10 +1,13 @@
 ---
-description: Learn about Git Sync, the Grafana feature for storing and managing dashboards within GitHub repositories.
+description: Learn about Git Sync, the Grafana feature for storing and managing dashboards within Git repositories.
 keywords:
   - dashboards
   - git integration
   - git sync
+  - git
   - github
+  - gitlab
+  - bitbucket
   - observability
   - configuration
   - as code
@@ -32,7 +35,7 @@ aliases:
 
 {{< admonition type="caution" >}}
 
-Git Sync is available in [public preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud, and is an [experimental feature](https://grafana.com/docs/release-life-cycle/) in Grafana v12 for open source and Enterprise editions. Documentation and support is available **based on the different tiers** but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided.
+Git Sync is available in [public preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud, and is an [experimental feature](https://grafana.com/docs/release-life-cycle/) in Grafana v12 for open source and Enterprise editions. Documentation and support is available based on the different tiers but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided.
 
 **Git Sync is under development.** Refer to [Usage and performance limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits) for more information. [Contact Grafana](https://grafana.com/help/) for support or to report any issues you encounter and help us improve this feature.
 
@@ -42,7 +45,7 @@ Git Sync in Grafana lets you synchronize your resources so you can store your da
 
 ## How it works
 
-Git Sync allows you to connect external resources with your Grafana instance. After setup, all synchronized resources live in Git under the `provisioned` folder. You can continue to have unprovisioned resources outside that folder.
+Git Sync allows you to connect external resources with your Grafana instance. After setup, all synchronized resources live in Git under the provisioned folder, and you can continue to have non-provisioned resources outside that folder.
 
 Git Sync is bidirectional. You can modify provisioned resources both from the Grafana UI or from the synced repository, and changes will be reflected in both places.
 
@@ -52,11 +55,11 @@ Refer to [key concepts](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-co
 
 ### Make changes in the Grafana UI
 
-Whenever you modify a dashboard directly from the UI, you can also commit those changes to Git upon saving. You can configure settings to either enforce PR approvals before merging in your repository, or allow direct commits.
+Whenever you modify a dashboard directly from the UI, you can also commit those changes to your synchronized Git repositories upon saving. You can configure settings to either enforce PR approvals before merging in your repository, or allow direct commits.
 
-### Make changes in your GitHub repositories
+### Make changes in your Git repositories
 
-Your Grafana instance polls the provisioned GitHub resources to synchronize. If you made any changes in GitHub, they will be updated in the Grafana database as well. The Grafana UI reads from the database and updates the UI to reflect these changes.
+Your Grafana instance polls the provisioned Git resources to synchronize. If you made any changes in your syncronized Git repositories, they will be updated in the Grafana database as well. The Grafana UI reads from the database and updates the UI to reflect these changes.
 
 - Without webhooks, Grafana polls for changes at the specified interval. The default polling interval is 60 seconds, and you can change this setting in the Grafana UI.
 - If you enable the [webhooks feature](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/#configure-webhooks-and-image-rendering), repository notifications appear almost immediately.

--- a/docs/sources/as-code/observability-as-code/git-sync/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/_index.md
@@ -59,7 +59,7 @@ Whenever you modify a dashboard directly from the UI, you can also commit those 
 
 ### Make changes in your Git repositories
 
-Your Grafana instance polls the provisioned Git resources to synchronize. If you made any changes in your syncronized Git repositories, they will be updated in the Grafana database as well. The Grafana UI reads from the database and updates the UI to reflect these changes.
+Your Grafana instance polls the provisioned Git resources to synchronize. If you made any changes in your synchronized Git repositories, they will be updated in the Grafana database as well. The Grafana UI reads from the database and updates the UI to reflect these changes.
 
 - Without webhooks, Grafana polls for changes at the specified interval. The default polling interval is 60 seconds, and you can change this setting in the Grafana UI.
 - If you enable the [webhooks feature](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/#configure-webhooks-and-image-rendering), repository notifications appear almost immediately.

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
@@ -31,135 +31,47 @@ Git Sync is available in [public preview](https://grafana.com/docs/release-life-
 
 To set up Git Sync and synchronize your Grafana dashboards and folders with a GitHub repository, follow these steps:
 
-1. Read [Before you begin](#before-you-begin) carefully
+1. Read [Before you begin](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before/) carefully
 1. Set up Git Sync [using the UI](#set-up-git-sync-using-the-ui) or [as code](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code/)
 1. After setup, [verify your dashboards](#verify-your-dashboards-in-grafana)
-1. Optionally, you can also [extend Git Sync with webhooks and image rendering](#extend-git-sync-for-real-time-notification-and-image-rendering)
-
-{{< admonition type="note" >}}
-
-You can configure a local file system instead of using GitHub. Refer to [Set up file provisioning](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/provision-resources/file-path-setup/) for more information.
-
-{{< /admonition >}}
-
-## Before you begin
-
-Before you begin, ensure you have the following:
-
-- A Grafana instance (Cloud, OSS, or Enterprise)
-- If you're [using webhooks or image rendering](#extend-git-sync-for-real-time-notification-and-image-rendering), a public instance with external access
-- Administration rights in your Grafana organization
-- An **authentication method** for your connection: either a [GitHub private access token](#create-a-github-access-token) or a [GitHub App](#create-a-github-app)
-- A GitHub repository to store your dashboards in
-- Optional: The [Image Renderer service](https://github.com/grafana/grafana-image-renderer) to save image previews with your PRs
-
-Get acquainted with the following topics:
-
-- [Supported resources](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/provision-resources/intro-git-sync#supported-resources)
-- [Usage and performance limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits)
-
-For further details on how Git Sync operates refer to [key concepts](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/key-concepts).
-
-### Enable required feature toggles
-
-In Grafana Cloud, Git Sync is being rolled out gradually. For more details refer to [Rolling release channels for Grafana Cloud](https://grafana.com/docs/rolling-release/).
-
-To activate Git Sync in Grafana OSS/Enterprise, set the `provisioning` feature toggle to `true`:
-
-1. Open your Grafana configuration file, either `grafana.ini` or `custom.ini`.
-1. Add this value:
-
-   ```ini
-   [feature_toggles]
-   provisioning = true
-   ```
-
-1. Save the changes to the file and restart Grafana.
-
-For more information about feature toggles, refer to [Configure feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#experimental-feature-toggles).
-
-### Create a GitHub access token
-
-If you chose to authenticate with a GitHub Personal Access Token, create one with the repository permissions described below, and add it to your Git Sync configuration to enable read and write permissions between Grafana and GitHub repository.
-
-To create a GitHub access token:
-
-1. [Create a new fine-grained personal access token](https://github.com/settings/personal-access-tokens/new). Refer to [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) for instructions.
-1. Under **Permissions**, click **Select permissions** and select the following:
-   - **Contents**: Read and write permission
-   - **Metadata**: Read-only permission
-   - **Pull requests**: Read and write permission
-   - **Webhooks**: Read and write permission
-1. Select any additional options and then press **Generate token**.
-1. Copy the access token. Leave the browser window available with the token until you've completed configuration.
-
-### Create a GitHub App
-
-GitHub Apps are tools that extend GitHub functionality. They use fine-grained permissions and short-lived tokens, giving you more control over which repositories are being accessed. Find out more in the [GitHub Apps official documentation](https://docs.github.com/en/apps/overview).
-
-If you chose to authenticate with a newly created GitHub App, you'll need the following parameters:
-
-- GitHub App ID
-- GitHub App Private Key
-- GitHub App Installation ID
-
-There are many ways to create a GitHub App. The following instructions are orientative, always refer to official GitHub documentation for more details.
-
-To create the GitHub App, follow these steps:
-
-1. Go to https://github.com/settings/apps and click on **New Github App**, or navigate directly to https://github.com/settings/apps/new
-1. Fill in the following fields:
-   - Name: Must be unique
-   - Homepage URL: For example, your Grafana Cloud instance URL
-1. Scroll down to the **Webhook** section and uncheck the **Active** box
-1. In the **Permissions** section, go to **Repository permissions** and set these parameters:
-   - **Contents**: Read and write permission
-   - **Metadata**: Read-only permission
-   - **Pull requests**: Read and write permission
-   - **Webhooks**: Read and write permission
-1. Finally, under **Where can this GitHub App be installed?**, select **Only on this account**
-1. Click on **Create Github App** to complete the process.
-
-On the app page:
-
-1. Copy the **AppID** from the **About** section
-1. Select the **Generate private key** from the banner or scroll down to to the **Private Keys** section to generate a key
-1. A PEM file containing your private key will be downloaded to your computer
-
-Finally, install the app:
-
-1. At the top left of the App page, click on **Install App**
-1. Choose for which user you need to install it, you’ll be redirected to the repository selection screen
-1. Choose for which repositories you want to install the app
-1. Click **Install**.
-1. On the installation page, copy **`installationID`** from the page URL https://github.com/settings/installations/installationID
+1. Optionally, you can also [extend Git Sync with webhooks and image rendering](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend/)
 
 ## Set up Git Sync using the UI
 
 To set up Git Sync from the Grafana UI, follow these steps:
 
 1. Log in to your Grafana server with an account that has the Grafana Admin flag set.
-1. Select **Administration > General > Provisioning** in the left-side menu to access the Git Sync configuration screen. If you already have an active Git Sync connection, go to the **Getting Started** tab.
-1. Select **Configure with GitHub**.
-1. [Choose the connection type](#choose-the-connection-type). There's two methods to connect Git Sync: with a Personal Access Token or via GitHub App
-1. [Configure the provisioning repository](#configure-repository)
-1. [Choose what content to sync with Grafana](#choose-what-to-synchronize)
-1. [Synchronize with external storage](#synchronize-with-external-storage)
-1. [Choose additional settings](#choose-additional-settings)
+1. Select **Administration > General > Provisioning** in the left-side menu to access the Git Sync configuration screen. If you already have an active Git Sync connection, go to the **Get started** tab.
+1. [Select your provider](#select-your-provider) to start a new Git Sync setup: GitHub, GitLab, Bitbucket, or Pure Git.
+1. [Configure the provisioning repository](#configure-the-provisioning-repository).
+1. [Choose what content to sync with Grafana](#choose-what-to-synchronize).
+1. [Synchronize with external storage](#synchronize-with-external-storage).
+1. [Choose additional settings](#choose-additional-settings).
 
-### Choose the connection type
+## Select your provider
 
-On this screen you will configure your Git Sync connection, either using a **Personal Access Token** or with **GitHub App**.
+Git Sync is available for any Git provider through a Pure Git repository type, and has specific enhanced integrations for GitHub, GitLab and Bitbucket. Refer to [Compatible providers](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits#compatible-providers) for more details.
 
-#### Connect with a Personal Access Token
+Alternatively, on-prem file provisioning in Grafana lets you include resources, including folders and dashboard JSON files, that are stored in a local file system. Refer to [Provision resources on-prem](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/provision-resources/) for more details.
 
-{{< admonition type="note" >}}
+Select any of the following options to proceed:
 
-Refer to [Create a GitHub access token](#create-a-github-access-token) for instructions for instructions on how to create a Personal Access Token.
+### Configure with GitHub
 
-{{< /admonition >}}
+If you want to configure Git Sync for GitHub, you can connect using a **Personal Access Token** or with **GitHub App**.
 
-If you want to configure your connection with a Personal Access Token, select the option and follow these steps:
+#### Connect with a GitHub Personal Access Token
+
+If you want to configure Git Sync for GitHub and authenticate with a Personal Access Token, sign in to GitHub and [create a new fine-grained personal access token](https://github.com/settings/personal-access-tokens/new) with these permissions:
+
+- **Contents**: Read and write permission
+- **Metadata**: Read-only permission
+- **Pull requests**: Read and write permission
+- **Webhooks**: Read and write permission
+
+Refer to [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) for instructions.
+
+Return to Grafana and fill in the following fields:
 
 1. Paste your GitHub personal access token into **Enter your access token**.
 1. Paste the **Repository URL** for your GitHub repository into the text box.
@@ -170,40 +82,82 @@ Select **Configure repository** to set up your provisioning folder.
 
 {{< admonition type="note" >}}
 
-Refer to [Create a GitHub App](#create-a-github-app) for instructions on how to create a GitHub App.
+Refer to [Create a GitHub App](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/set-up-before#create-a-github-app) for instructions on how to create a GitHub App.
 
 {{< /admonition >}}
 
-If you already have an existing GitHub App connected:
+If you want to configure Git Sync for GitHub and authenticate with GitHub App:
 
-1. Select **Choose an existing app**.
-1. Click on the existing connection you want to use, and click on **Configure repository** to proceed.
-1. Paste the **Repository URL** for your GitHub repository into the text box.
+- If you already have an existing GitHub App connected:
 
-If you want to connect using a new GitHub App:
+  1. Select **Choose an existing app**.
+  1. Click on the existing connection you want to use, and click on **Configure repository** to proceed.
+  1. Paste the **Repository URL** for your GitHub repository into the text box.
 
-1. Select **Connect to a new app**.
-1. Type in the following fields:
-   - The ID of the GitHub App you want to use
-   - The GitHub Installation ID
-   - The Private Key
-1. Click on **Configure repository** to proceed.
-1. Paste the **Repository URL** for your GitHub repository into the text box.
+- If you want to connect using a new GitHub App:
+
+  1. Select **Connect to a new app**.
+  1. Type in the following fields:
+     - The ID of the GitHub App you want to use
+     - The GitHub Installation ID
+     - The Private Key
+  1. Click on **Configure repository** to proceed.
+  1. Paste the **Repository URL** for your GitHub repository into the text box.
 
 Select **Configure repository** to set up your provisioning folder.
 
-### Configure repository
+### Configure with GitLab
 
-Configure the repository you want to use for provisioning:
+If you want to configure Git Sync for GitLab, you need a GitLab Personal Access Token. To create one, [sign in to GitLab](https://gitlab.com/users/sign_in) and create a token with these permissions:
 
-1. Enter a branch to use for provisioning. The default value is `main`.
+- **Repository**: Read and write permission
+- **User**: Read only permission
+- **API**: Read and write permission
+
+Return to Grafana and fill in the following fields:
+
+1. Paste the token into the **Project Access Token** text box.
+1. Paste the **Repository URL** for your GitLab repository into the text box.
+
+Select **Configure repository** to set up your provisioning folder.
+
+### Configure with Bitbucket
+
+If you want to configure Git Sync for Bitbucket, you need a Bitbucket Personal Access Token. To create one, [sign in to Bitbucket](https://id.atlassian.com/login?application=bitbucket), go to **Create App passwords** and create a token with these permissions:
+
+- **Repositories**: Read and write permission
+- **Pull requests**: Read and write permission
+- **Webhooks**: Read and write permission
+
+Return to Grafana and fill in the following fields:
+
+1. Paste the token into the **Project Access Token** text box.
+1. Paste the **Repository URL** for your GitLab repository into the text box.
+
+Select **Configure repository** to set up your provisioning folder.
+
+### Configure with Pure Git
+
+If you're using another Git provider, you need to use the Pure Git option to configure your connection with a Personal Access Token:
+
+1. Paste the access token or password of the Git repository you want to sync in **Access Token**.
+1. Enter a **Username**. Git Sync will use this name to access the Git repository.
+1. Paste the **Repository URL** of your Git repository into the text box.
+
+Select **Configure repository** to set up your provisioning folder.
+
+## Configure the provisioning repository
+
+After configuring your connection authentication, continue to enter the details of the repository you want to use for provisioning:
+
+1. Enter a **Branch** to use for provisioning. The default value is `main`.
 1. Optionally, you can add a **Path** to a subdirectory where your dashboards are stored.
 
 Select **Choose what to synchronize** to have the connection to your repository verified and continue setup.
 
-### Choose what to synchronize
+## Choose what to synchronize
 
-On this screen, you will sync your selected external resources with Grafana. These provisioned resources will be stored in a new folder in Grafana without affecting the rest of your instance.
+On this screen, you will sync the external resources you specified in the previous step with your Grafana instance. These provisioned resources will be stored in a new folder in Grafana without affecting the rest of your instance.
 
 To set up synchronization:
 
@@ -220,7 +174,7 @@ Optionally, you can export any unmanaged resources into the provisioned folder. 
 
 Select **Choose additional settings** to continue setup.
 
-### Synchronize with external storage
+## Synchronize with external storage
 
 In this screen:
 
@@ -228,9 +182,11 @@ In this screen:
 1. Check the **Migrate existing resources** box to migrate your unmanaged dashboards to the provisioned folder. If you select this option, all future updates are automatically saved to the synced Git repository and provisioned back to the instance.
 1. Click **Begin synchronization** to create the Git Sync connection.
 
-### Choose additional settings
+After the process is completed, you will see a summary of the synced resources.
 
-You connection is complete!
+Click **Choose additional settings** for the final configuration steps.
+
+## Choose additional settings
 
 In this last step, you can configure the **Sync interval (seconds)** to indicate how often you want your Grafana instance to pull updates from GitHub. The default value is 300 seconds in Grafana Cloud, and 60 seconds in Grafana OSS/Enterprise.
 
@@ -247,59 +203,6 @@ Select **Finish** to complete the setup.
 To verify that your dashboards are available at the location that you specified, go to **Dashboards**. The name of the dashboard is listed in the **Name** column.
 
 Now that your dashboards have been synced from a repository, you can customize the name, change the branch, and create a pull request (PR) for it. Refer to [Manage provisioned repositories with Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/provision-resources/use-git-sync/) for more information.
-
-## Extend Git Sync for real-time notification and image rendering
-
-Optionally, you can extend Git Sync by enabling pull request notifications and image previews of dashboard changes.
-
-| Capability                                       | Benefit                                                           | Requires                               |
-| ------------------------------------------------ | ----------------------------------------------------------------- | -------------------------------------- |
-| A table summarizing changes to your pull request | A convenient way to save changes back to GitHub                   | Webhooks configured                    |
-| A dashboard preview image to a PR                | A snapshot of dashboard changes to a pull request outside Grafana | Image renderer and webhooks configured |
-
-### Set up webhooks for real-time notification and pull request integration
-
-Real-time notifications (or automatic pulling) is enabled and configured by default in Grafana Cloud.
-
-In Grafana OSS/Enterprise, Git Sync uses webhooks to enable real-time updates from GitHub public repositories, or to enable pull request integrations. Without webhooks the polling interval is set during configuration, and is 60 seconds by default. You can set up webhooks with whichever service or tooling you prefer: Cloudflare Tunnels with a Cloudflare-managed domain, port-forwarding and DNS options, or a tool such as `ngrok`.
-
-To set up webhooks:
-
-1. Expose your Grafana instance to the public Internet.
-
-- Use port forwarding and DNS, a tool such as `ngrok`, or any other method you prefer.
-- The permissions set in your GitHub access token provide the authorization for this communication.
-
-1. After you have the public URL, add it to your Grafana configuration file:
-
-```ini
-[server]
-root_url = https://<PUBLIC_DOMAIN>
-```
-
-1. Replace _`<PUBLIC_DOMAIN>`_ with your public domain.
-
-To check the configured webhooks, go to **Administration > General > Provisioning** and click the **View** link for your GitHub repository.
-
-#### Expose necessary paths only
-
-If your security setup doesn't permit publicly exposing the Grafana instance, you can either choose to allowlist the GitHub IP addresses, or expose only the necessary paths.
-
-The necessary paths required to be exposed are, in RegExp:
-
-- `/apis/provisioning\.grafana\.app/v0(alpha1)?/namespaces/[^/]+/repositories/[^/]+/(webhook|render/.*)$`
-
-### Set up image rendering for dashboard previews
-
-{{< admonition type="caution" >}}
-
-Only available in Grafana OSS and Grafana Enterprise.
-
-{{< /admonition >}}
-
-Set up image rendering to add visual previews of dashboard updates directly in pull requests. Image rendering also requires webhooks.
-
-To enable this capability, install the Grafana Image Renderer in your Grafana instance. For more information and installation instructions, refer to the [Image Renderer service](https://github.com/grafana/grafana-image-renderer).
 
 ## Update or delete your synced resources
 
@@ -319,7 +222,8 @@ You've successfully set up Git Sync to manage your Grafana dashboards through ve
 
 To learn more about using Git Sync refer to the following documents:
 
-- [Manage provisioned repositories with Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/provision-resources/use-git-sync/)
+- [Set up instantaneous pulling and dashboard previews in Pull Requests](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend)
+- [Work with provisioned repositories with Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/provision-resources/use-git-sync/)
 - [Work with provisioned dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/provision-resources/provisioned-dashboards/)
 - [Git Sync deployment scenarios](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/provision-resources/git-sync-deployment-scenarios)
 - [Export resources](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/provision-resources/export-resources/)

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
@@ -89,13 +89,11 @@ Refer to [Create a GitHub App](https://grafana.com/docs/grafana/<GRAFANA_VERSION
 If you want to configure Git Sync for GitHub and authenticate with GitHub App:
 
 - If you already have an existing GitHub App connected:
-
   1. Select **Choose an existing app**.
   1. Click on the existing connection you want to use, and click on **Configure repository** to proceed.
   1. Paste the **Repository URL** for your GitHub repository into the text box.
 
 - If you want to connect using a new GitHub App:
-
   1. Select **Connect to a new app**.
   1. Type in the following fields:
      - The ID of the GitHub App you want to use

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
@@ -102,6 +102,13 @@ If you want to configure Git Sync for GitHub and authenticate with GitHub App:
   1. Click on **Configure repository** to proceed.
   1. Paste the **Repository URL** for your GitHub repository into the text box.
 
+Note that your GitHub App must have the following permissions:
+
+- **Contents**: Read and write permission
+- **Metadata**: Read-only permission
+- **Pull requests**: Read and write permission
+- **Webhooks**: Read and write permission
+
 Select **Configure repository** to set up your provisioning folder.
 
 ### Configure with GitLab
@@ -121,7 +128,7 @@ Select **Configure repository** to set up your provisioning folder.
 
 ### Configure with Bitbucket
 
-If you want to configure Git Sync for Bitbucket, you need a Bitbucket Personal Access Token. To create one, [sign in to Bitbucket](https://id.atlassian.com/login?application=bitbucket), go to **Create App passwords** and create a token with these permissions:
+If you want to configure Git Sync for Bitbucket, you need a Bitbucket API token with scopes. To create one, [sign in to Bitbucket](https://id.atlassian.com/login?application=bitbucket) and create an API token with these permissions:
 
 - **Repositories**: Read and write permission
 - **Pull requests**: Read and write permission
@@ -129,7 +136,7 @@ If you want to configure Git Sync for Bitbucket, you need a Bitbucket Personal A
 
 Return to Grafana and fill in the following fields:
 
-1. Paste the token into the **Project Access Token** text box.
+1. Paste the token into the **API Token** text box.
 1. Paste the **Repository URL** for your GitLab repository into the text box.
 
 Select **Configure repository** to set up your provisioning folder.

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
@@ -1,0 +1,104 @@
+---
+description: Prerequisites for Git Sync, so you can provision GitHub repositories for use with Grafana.
+keywords:
+  - set up
+  - git integration
+  - git sync
+  - github
+  - prerequisites
+labels:
+  products:
+    - enterprise
+    - oss
+    - cloud
+title: Setup prerequisites
+weight: 120
+canonical: https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before/
+aliases:
+---
+
+# Before you begin
+
+{{< admonition type="caution" >}}
+
+Git Sync is available in [public preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud, and is an [experimental feature](https://grafana.com/docs/release-life-cycle/) in Grafana v12 for open source and Enterprise editions. Documentation and support is available **based on the different tiers** but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided.
+
+**Git Sync is under development.** Refer to [Usage and performance limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits) for more information. [Contact Grafana](https://grafana.com/help/) for support or to report any issues you encounter and help us improve this feature.
+
+{{< /admonition >}}
+
+Before you begin to set up Git Sync, ensure you have the following:
+
+- A Grafana instance (Cloud, OSS, or Enterprise)
+- Administration rights in your Grafana organization
+- A [Git provider](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits#compatible-providers)
+- If you're [using webhooks or image rendering](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend), a public instance with external access
+  - Optional: The [Image Renderer service](https://github.com/grafana/grafana-image-renderer) to save image previews with your PRs
+
+Get acquainted with the following topics:
+
+- [Supported resources](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/#supported-resources)
+- [Usage and performance limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits)
+
+For further details on how Git Sync operates refer to [key concepts](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/key-concepts).
+
+## Enable required feature toggles
+
+In Grafana Cloud, Git Sync is being rolled out gradually. For more details refer to [Rolling release channels for Grafana Cloud](https://grafana.com/docs/rolling-release/).
+
+To activate Git Sync in Grafana OSS/Enterprise, set the `provisioning` feature toggle to `true`:
+
+1. Open your Grafana configuration file, either `grafana.ini` or `custom.ini`.
+1. Add this value:
+
+   ```ini
+   [feature_toggles]
+   provisioning = true
+   ```
+
+1. Save the changes to the file and restart Grafana.
+
+For more information about feature toggles, refer to [Configure feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#experimental-feature-toggles).
+
+## Create a GitHub App
+
+GitHub Apps are tools that extend GitHub functionality. They use fine-grained permissions and short-lived tokens, giving you more control over which repositories are being accessed. Find out more in the [GitHub Apps official documentation](https://docs.github.com/en/apps/overview).
+
+If you chose to authenticate with a newly created GitHub App, you'll need the following parameters:
+
+- GitHub App ID
+- GitHub App Private Key
+- GitHub App Installation ID
+
+There are many ways to create a GitHub App. The following instructions are informative only, always refer to official GitHub documentation for more details.
+
+To create the GitHub App, follow these steps:
+
+1. Go to https://github.com/settings/apps and click on **New Github App**, or navigate directly to https://github.com/settings/apps/new
+1. Fill in the following fields:
+   - Name: Must be unique
+   - Homepage URL: For example, your Grafana Cloud instance URL
+1. Scroll down to the **Webhook** section and uncheck the **Active** box
+1. In the **Permissions** section, go to **Repository permissions** and set these parameters:
+   - **Contents**: Read and write permission
+   - **Metadata**: Read-only permission
+   - **Pull requests**: Read and write permission
+   - **Webhooks**: Read and write permission
+1. Finally, under **Where can this GitHub App be installed?**, select **Only on this account**
+1. Click on **Create Github App** to complete the process.
+
+On the app page:
+
+1. Copy the **AppID** from the **About** section
+1. Select the **Generate private key** from the banner or scroll down to to the **Private Keys** section to generate a key
+1. A PEM file containing your private key will be downloaded to your computer
+
+Finally, install the app:
+
+1. At the top left of the App page, click on **Install App**
+1. Choose for which user you need to install it, you’ll be redirected to the repository selection screen
+1. Choose for which repositories you want to install the app
+1. Click **Install**.
+1. On the installation page, copy **`installationID`** from the page URL https://github.com/settings/installations/installationID
+
+You can now proceed to [Set up Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/)!

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
@@ -12,7 +12,7 @@ labels:
     - oss
     - cloud
 title: Setup prerequisites
-weight: 120
+weight: 110
 canonical: https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before/
 aliases:
 ---

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code.md
@@ -1,5 +1,5 @@
 ---
-description: Instructions for setting up Git Sync as code, so you can provision GitHub repositories for use with Grafana.
+description: Instructions for setting up Git Sync as code, so you can provision Git repositories for use with Grafana.
 keywords:
   - set up
   - git integration
@@ -11,7 +11,7 @@ labels:
     - enterprise
     - oss
     - cloud
-title: Set up Git Sync for GitHub as code
+title: Set up Git Sync as code
 weight: 110
 canonical: https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/git-sync-setup/
 aliases:
@@ -29,7 +29,7 @@ Git Sync is available in [public preview](https://grafana.com/docs/release-life-
 
 {{< /admonition >}}
 
-You can also configure Git Sync using `grafanactl`. Since Git Sync configuration is managed as code using Custom Resource Definitions (CRDs), you can create your required resources in YAML files and push them to Grafana using `grafanactl`. This approach enables automated, GitOps-style workflows for managing Git Sync configuration instead of using the Grafana UI.
+You can also configure Git Sync using `grafanactl`, the Grafana CLI. Since Git Sync configuration is managed as code using Custom Resource Definitions (CRDs), you can create your required resources in YAML files and push them to Grafana using `grafanactl`. This approach enables automated, GitOps-style workflows for managing Git Sync configuration instead of using the Grafana UI.
 
 For more information, refer to the following documents:
 
@@ -37,9 +37,9 @@ For more information, refer to the following documents:
 - [Dashboard CRD Format](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/export-resources/)
 - [`grafanactl` documentation](https://grafana.github.io/grafanactl/)
 
-## Set up Git Sync for GitHub as code
+## Set up Git Sync as code with the Grafana CLI
 
-To set up Git Sync with `grafanactl`, follow these steps:
+To set up Git Sync as code with `grafanactl`, follow these steps:
 
 1. Understand [Usage and performance limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits)
 1. [Create the connection and repository CRDs](#create-the-resources-crds)
@@ -49,7 +49,9 @@ To set up Git Sync with `grafanactl`, follow these steps:
 
 ## Create the resources CRDs
 
-You need to create a repository resource and, if you're connecting to Git Sync with GitHub App, a connection resource as well.
+If you're connecting with any of the [supported Git providers](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits#compatible-git-providers) using a Personal Access Token, you need to create a repository resource to define the connection between your repositories and your Grafana instance.
+  
+If you're connecting to Git Sync with GitHub App, in addition to the repository resource you need to create a connection resource as well.
 
 ### Create the connection resource
 
@@ -83,7 +85,7 @@ Replace the placeholders with your values:
 
 ### Create the repository resource
 
-Next, create a `repository.yaml` file defining your Git Sync configuration. Depending on your authentication method, add your Personal Access Token information or the connection name.
+Next, create a `repository.yaml` file defining your Git Sync configuration. Depending on your Git provider and authentication method, add your Personal Access Token information or the connection name.
 
 ```yaml
 apiVersion: provisioning.grafana.app/v0alpha1
@@ -108,10 +110,19 @@ sync:
   workflows:
     - write
     - branch
-# Personal Access Token connection only:
+# GitHub Personal Access Token only:
 secure:
   token:
     create: <GITHUB_PAT>
+# GitLab Personal Access Token only:
+secure:
+  token: { create: "SECRET" }
+# Pure Git only:
+secure:
+  token:
+    {
+      create: "SECRET",
+    }  
 ```
 
 Replace the placeholders with your values:

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code.md
@@ -93,46 +93,68 @@ kind: Repository
 metadata:
   name: <REPOSITORY_NAME>
 spec:
-  title: <REPOSITORY_TITLE>
-  type: github
-  github:
-    url: <GITHUB_REPO_URL>
-    branch: <BRANCH>
-    path: grafana/
-    generateDashboardPreviews: true
-  # GitHub App connection only:
-  connection:
-    name: <GITHUB_CONNECTION_NAME>
-sync:
+  sync:
     enabled: true
     intervalSeconds: 60
     target: folder
   workflows:
     - write
     - branch
+  title: <REPOSITORY_TITLE>
+
+# Git Sync for GitHub:
+spec:
+  type: github
+  github:
+    url: <GIT_REPO_URL>
+    branch: <BRANCH>
+    path: grafana/
+# GitHub App connection only:
+  connection:
+    name: <GITHUB_CONNECTION_NAME>
 # GitHub Personal Access Token only:
 secure:
-  token:
-    create: <GITHUB_PAT>
+  token: { create: "GIT_PAT" }
+
 # GitLab Personal Access Token only:
+spec:
+  type: gitlab
+  gitlab:
+    url: <GIT_REPO_URL>
+    branch: <BRANCH>
 secure:
-  token: { create: "SECRET" }
+  token: { create: "GIT_PAT" }
+
+# Bitbucket Personal Access Token only:
+spec:
+  type: bitbucket
+  bitbucket:
+    url: <GIT_REPO_URL>
+    branch: <BRANCH>
+    tokenUser: nanogit-test-admin
+secure:
+  token: { create: "GIT_PAT" }
+
 # Pure Git only:
+spec:
+  type: git
+  git:
+    url: <GIT_REPO_URL>
+    branch: <BRANCH>
+    path: "grafana/"
+    tokenUser: git
 secure:
-  token:
-    {
-      create: "SECRET",
-    }  
+  token: { create: "GIT_PAT" }
 ```
 
 Replace the placeholders with your values:
 
 - _`<REPOSITORY_NAME>`_: Unique identifier for this repository resource
 - _`<REPOSITORY_TITLE>`_: Human-readable name displayed in Grafana UI
-- _`<GITHUB_REPO_URL>`_: GitHub repository URL
+- _`<GIT_REPO_URL>`_: GitHub repository URL
 - _`<BRANCH>`_: Branch to sync
 - _`<GITHUB_CONNECTION_NAME>`_: The name of your GitHub connection
-- _`<GITHUB_PAT>`_: GitHub Personal Access Token
+- _`<GIT_PAT>`_: Git provider Personal Access Token
 
 {{< admonition type="note" >}}
 

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code.md
@@ -50,7 +50,7 @@ To set up Git Sync as code with `grafanactl`, follow these steps:
 ## Create the resources CRDs
 
 If you're connecting with any of the [supported Git providers](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits#compatible-git-providers) using a Personal Access Token, you need to create a repository resource to define the connection between your repositories and your Grafana instance.
-  
+
 If you're connecting to Git Sync with GitHub App, in addition to the repository resource you need to create a connection resource as well.
 
 ### Create the connection resource

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code.md
@@ -12,7 +12,7 @@ labels:
     - oss
     - cloud
 title: Set up Git Sync as code
-weight: 110
+weight: 200
 canonical: https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/git-sync-setup/
 aliases:
   - ../../../observability-as-code/provision-resources/git-sync-setup/ # /docs/grafana/next/observability-as-code/provision-resources/git-sync-setup/
@@ -64,7 +64,7 @@ metadata:
   name: '<GITHUB_CONNECTION_NAME>'
   namespace: default
 spec:
-  title: <REPOSITORY_TITLE>
+  title: '<REPOSITORY_TITLE>'
   type: github
   url: https://github.com
   github:
@@ -91,7 +91,7 @@ Next, create a `repository.yaml` file defining your Git Sync configuration. Depe
 apiVersion: provisioning.grafana.app/v0alpha1
 kind: Repository
 metadata:
-  name: <REPOSITORY_NAME>
+  name: '<REPOSITORY_NAME>'
 spec:
   sync:
     enabled: true
@@ -100,18 +100,18 @@ spec:
   workflows:
     - write
     - branch
-  title: <REPOSITORY_TITLE>
+  title: '<REPOSITORY_TITLE>'
 
 # Git Sync for GitHub:
 spec:
   type: github
   github:
-    url: <GIT_REPO_URL>
-    branch: <BRANCH>
+    url: '<GIT_REPO_URL>'
+    branch: '<BRANCH>'
     path: grafana/
 # GitHub App connection only:
   connection:
-    name: <GITHUB_CONNECTION_NAME>
+    name: '<GITHUB_CONNECTION_NAME>'
 # GitHub Personal Access Token only:
 secure:
   token: { create: "GIT_PAT" }
@@ -120,8 +120,8 @@ secure:
 spec:
   type: gitlab
   gitlab:
-    url: <GIT_REPO_URL>
-    branch: <BRANCH>
+    url: '<GIT_REPO_URL>'
+    branch: '<BRANCH>'
 secure:
   token: { create: "GIT_PAT" }
 
@@ -129,9 +129,9 @@ secure:
 spec:
   type: bitbucket
   bitbucket:
-    url: <GIT_REPO_URL>
-    branch: <BRANCH>
-    tokenUser: nanogit-test-admin
+    url: '<GIT_REPO_URL>'
+    branch: '<BRANCH>'
+    tokenUser: tokenuser
 secure:
   token: { create: "GIT_PAT" }
 
@@ -139,10 +139,10 @@ secure:
 spec:
   type: git
   git:
-    url: <GIT_REPO_URL>
-    branch: <BRANCH>
+    url: '<GIT_REPO_URL>'
+    branch: '<BRANCH>'
     path: "grafana/"
-    tokenUser: git
+    tokenUser: tokenuser
 secure:
   token: { create: "GIT_PAT" }
 ```

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code.md
@@ -72,7 +72,7 @@ spec:
     installationID: '<GITHUB_INSTALL_ID>'
 secure:
   privateKey:
-    create: '<GITHUB_PRIVATE_KEY'
+    create: '<GITHUB_PRIVATE_KEY>'
 ```
 
 Replace the placeholders with your values:

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend.md
@@ -1,0 +1,91 @@
+---
+description: Instructions for extending Git Sync for real-time notification and image rendering.
+keywords:
+  - set up
+  - git integration
+  - git sync
+  - github
+  - extend
+  - image rendering
+  - real-time notifications
+labels:
+  products:
+    - enterprise
+    - oss
+    - cloud
+title: Instantaneous pulling and dashboard previews
+weight: 300
+canonical: https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend/
+aliases:
+---
+
+# Set up instantaneous pulling and dashboard previews in Pull Requests
+
+{{< admonition type="caution" >}}
+
+Git Sync is available in [public preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud, and is an [experimental feature](https://grafana.com/docs/release-life-cycle/) in Grafana v12 for open source and Enterprise editions. Documentation and support is available **based on the different tiers** but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided.
+
+**Git Sync is under development.** Refer to [Usage and performance limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits) for more information. [Contact Grafana](https://grafana.com/help/) for support or to report any issues you encounter and help us improve this feature.
+
+{{< /admonition >}}
+
+After [setup](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/), you can optionally extend Git Sync by enabling pull request notifications and image previews of dashboard changes.
+
+| Capability                                       | Benefit                                                           | Requires                               |
+| ------------------------------------------------ | ----------------------------------------------------------------- | -------------------------------------- |
+| A table summarizing changes to your pull request | A convenient way to save changes back to GitHub                   | Webhooks configured                    |
+| A dashboard preview image to a PR                | A snapshot of dashboard changes to a pull request outside Grafana | Image renderer and webhooks configured |
+
+## Set up webhooks for real-time notification and pull request integration
+
+Real-time notifications (or automatic pulling) is enabled and configured by default in Grafana Cloud.
+
+In Grafana OSS/Enterprise, Git Sync uses webhooks to enable real-time updates from GitHub public repositories, or to enable pull request integrations. Without webhooks the polling interval is set during configuration, and is 60 seconds by default. You can set up webhooks with whichever service or tooling you prefer: Cloudflare Tunnels with a Cloudflare-managed domain, port-forwarding and DNS options, or a tool such as `ngrok`.
+
+To set up webhooks:
+
+1. Expose your Grafana instance to the public Internet.
+
+- Use port forwarding and DNS, a tool such as `ngrok`, or any other method you prefer.
+- The permissions set in your GitHub access token provide the authorization for this communication.
+
+1. After you have the public URL, add it to your Grafana configuration file:
+
+```ini
+[server]
+root_url = https://<PUBLIC_DOMAIN>
+```
+
+1. Replace _`<PUBLIC_DOMAIN>`_ with your public domain.
+
+To check the configured webhooks, go to **Administration > General > Provisioning** and click the **View** link for your GitHub repository.
+
+### Expose necessary paths only
+
+If your security setup doesn't permit publicly exposing the Grafana instance, you can either choose to allowlist the GitHub IP addresses, or expose only the necessary paths.
+
+The necessary paths required to be exposed are, in RegExp:
+
+- `/apis/provisioning\.grafana\.app/v0(alpha1)?/namespaces/[^/]+/repositories/[^/]+/(webhook|render/.*)$`
+
+## Set up image rendering for dashboard previews
+
+{{< admonition type="caution" >}}
+
+Only available in Grafana OSS and Grafana Enterprise.
+
+{{< /admonition >}}
+
+Set up image rendering to add visual previews of dashboard updates directly in pull requests. Image rendering also requires webhooks.
+
+To enable this capability, install the Grafana Image Renderer in your Grafana instance. For more information and installation instructions, refer to the [Image Renderer service](https://github.com/grafana/grafana-image-renderer).
+
+## Next steps
+
+To learn more about using Git Sync refer to the following documents:
+
+- [Set up Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/)
+- [Export resources](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/export-resources/)
+- [Work with provisioned repositories](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/use-git-sync/)
+- [Work with provisioned dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/provisioned-dashboards/)
+- [Git Sync deployment scenarios](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-deployment-scenarios)

--- a/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
@@ -1,5 +1,5 @@
 ---
-description: Key concepts to understand how Git Sync works.
+description: Git Sync usage tiers, compatible providers, and known limitations.
 keywords:
   - as code
   - as-code
@@ -31,17 +31,13 @@ aliases:
 
 Git Sync is available in [public preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud, and is an [experimental feature](https://grafana.com/docs/release-life-cycle/) in Grafana v12 for open source and Enterprise editions. Documentation and support is available **based on the different tiers** but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided.
 
-**Git Sync is under development.** [Contact Grafana](https://grafana.com/help/) for support or to report any issues you encounter and help us improve this feature.
+**Git Sync is under development.** Refer to [Usage and performance limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits) for more information. [Contact Grafana](https://grafana.com/help/) for support or to report any issues you encounter and help us improve this feature.
 
 {{< /admonition >}}
 
 ## Performance considerations
 
 When Git Sync is enabled, the database load might increase, especially if your Grafana instance has many folders and nested folders. Evaluate the performance impact, if any, in a non-production environment.
-
-## Compatible services and providers
-
-At the moment Git Sync is available for GitHub only. Support for native Git and other providers, such as GitLab or Bitbucket, is on the roadmap.
 
 ## Usage tiers
 
@@ -52,11 +48,45 @@ The following Git Sync per-tier limits apply:
 | Amount of repositories                    | 1                | 10                | 10              | 10                     |
 | Amount of synced resources per repository | 20               | Grafana limit     | No limit        | No limit               |
 
-## Authentication
+## Compatible Git providers
 
-You can authenticate in GitHub using a Personal Access Token token or GitHub App. Refer to [Set up Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup) for more details.
+Git Sync is available for any Git provider through a Pure Git repository type, and has specific enhanced integrations for GitHub, GitLab and Bitbucket.
 
-## Known issues
+| **Provider** | **Available in**       | **Authentication**                  |
+| ------------ | ---------------------- | ----------------------------------- |
+| Pure Git     | Cloud, OSS, Enterprise | Personal Access Token               |
+| GitHub       | Cloud, OSS, Enterprise | Personal Access Token or GitHub App |
+| GitLab       | Cloud, Enterprise      | Personal Access Token               |
+| Bitbucket    | Cloud, Enterprise      | Personal Access Token               |
+
+### The Pure Git repository type
+
+The Pure Git repository type uses the standard Git over HTTP protocol, with no provider-specific logic. Pure Git delivers the core Git Sync workflow: your repository is the source of truth, you may edit dashboards in the UI, and Grafana stays in sync.
+
+However, Pure Git doesn't include any features that require provider APIs, such as webhook-driven instant sync, automated PR comments, or deep links to source files.
+
+### Enhanced integrations: GitHub, GitLab, Bitbucket
+
+If your Git provider is GitHub, GitLab, or Bitbucket, use the enhanced integration. Enhanced integrations understand the platform you're using, allowing workflows that feel native: automated pull request comments with dashboard previews, instant webhook-based sync, or direct navigation from Grafana to source files in your provider's UI.
+
+The GitHub enhanced integration is the most feature-complete experience today. It enables richer pull request workflows, deeper linking between Grafana and GitHub, and tighter integration into review processes. It is available in Grafana OSS, Enterprise, and Cloud.
+
+The GitLab and Bitbucket integrations have limited functionality for the moment, and are only available in Grafana Enterprise and Grafana Cloud. Expect continued improvements around pull request workflows, linking, and sync behavior in upcoming releases.
+
+## Resource support and compatibility
+
+Git Sync only supports dashboards and folders. Alerts, panels, and other resources are not supported yet.
+
+If you're using Git Sync in Grafana OSS or Grafana Enterprise, some supported resources might be in an incompatible data format. If this happens, syncing will be blocked. Compatibility issues will be fixed with an upcoming migration tool.
+
+A resource can be:
+
+| Is the resource? | **Compatible**                                                             | **Incompatible**                                                                                |
+| ---------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Supported**    | The resource can be managed with Git Sync.                                 | The resource is supported but has compatibility issues. It **cannot** be managed with Git Sync. |
+| **Unsupported**  | The resource is **not** supported and **cannot** be managed with Git Sync. | Not applicable.                                                                                 |
+
+## Known limitations
 
 ### Synced resources
 

--- a/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
@@ -1,5 +1,5 @@
 ---
-description: Git Sync usage tiers, compatible providers, and known limitations.
+description: Git Sync usage tiers, compatible Git providers, and known limitations.
 keywords:
   - as code
   - as-code

--- a/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
@@ -57,7 +57,7 @@ Git Sync is available for any Git provider through a Pure Git repository type, a
 | Pure Git     | Cloud, OSS, Enterprise | Personal Access Token               |
 | GitHub       | Cloud, OSS, Enterprise | Personal Access Token or GitHub App |
 | GitLab       | Cloud, Enterprise      | Personal Access Token               |
-| Bitbucket    | Cloud, Enterprise      | Personal Access Token               |
+| Bitbucket    | Cloud, Enterprise      | API token with scopes              |
 
 ### The Pure Git repository type
 

--- a/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
@@ -57,7 +57,7 @@ Git Sync is available for any Git provider through a Pure Git repository type, a
 | Pure Git     | Cloud, OSS, Enterprise | Personal Access Token               |
 | GitHub       | Cloud, OSS, Enterprise | Personal Access Token or GitHub App |
 | GitLab       | Cloud, Enterprise      | Personal Access Token               |
-| Bitbucket    | Cloud, Enterprise      | API token with scopes              |
+| Bitbucket    | Cloud, Enterprise      | API token with scopes               |
 
 ### The Pure Git repository type
 


### PR DESCRIPTION
Takes care of https://github.com/grafana/git-ui-sync-project/issues/858.
Replaces https://github.com/grafana/grafana/pull/117868.

Previews:

* https://deploy-preview-grafana-118354-zb444pucvq-vp.a.run.app/docs/grafana/latest/as-code/observability-as-code/git-sync/usage-limits/#compatible-git-providers
* https://deploy-preview-grafana-118354-zb444pucvq-vp.a.run.app/docs/grafana/latest/as-code/observability-as-code/git-sync/git-sync-setup/
* https://deploy-preview-grafana-118354-zb444pucvq-vp.a.run.app/docs/grafana/latest/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code/
* https://deploy-preview-grafana-118354-zb444pucvq-vp.a.run.app/docs/grafana/latest/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before/
* https://deploy-preview-grafana-118354-zb444pucvq-vp.a.run.app/docs/grafana/latest/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend/

Related PRs:

* https://github.com/grafana/git-ui-sync-project/issues/438
* https://github.com/grafana/grafana/pull/118266