### PR TITLE
Auditing: Disable logging of data sources request and response bodies by default

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
@@ -220,11 +220,11 @@ Keep dashboard content in the logs (request or response fields). This can signif
 
 ### log_datasource_query_request_body
 
-Whether to record data source queries' request body. This can significantly increase the size of your logs. Enabled by default.
+Whether to record data source queries' request body. This can significantly increase the size of your logs. Disabled by default.
 
 ### log_datasource_query_response_body
 
-Whether to record data source queries' response body. This can significantly increase the size of your logs. Enabled by default.
+Whether to record data source queries' response body. This can significantly increase the size of your logs. Disabled by default.
 
 ### verbose
 

--- a/docs/sources/setup-grafana/configure-security/audit-grafana.md
+++ b/docs/sources/setup-grafana/configure-security/audit-grafana.md
@@ -371,10 +371,10 @@ enabled = false
 loggers = file
 # Keep dashboard content in the logs (request or response fields); this can significantly increase the size of your logs.
 log_dashboard_content = false
-# Whether to record data source queries' request body. This can significantly increase the size of your logs. Enabled by default.
-log_datasource_query_request_body = true
-# Whether to record data source queries' response body. This can significantly increase the size of your logs. Enabled by default.
-log_datasource_query_response_body = true
+# Whether to record data source queries' request body. This can significantly increase the size of your logs. Disabled by default.
+log_datasource_query_request_body = false
+# Whether to record data source queries' response body. This can significantly increase the size of your logs. Disabled by default.
+log_datasource_query_response_body = false
 # Keep requests and responses body; this can significantly increase the size of your logs.
 verbose = false
 # Write an audit log for every status code.


### PR DESCRIPTION
We've added this setting and to preserve behavior we made the default `true`, but we'd want the default to be `false` instead. 