### PR TITLE
Provisioning: add quota tracker

### DIFF
--- a/apps/provisioning/pkg/quotas/tracker.go
+++ b/apps/provisioning/pkg/quotas/tracker.go
@@ -37,5 +37,7 @@ func (q *QuotaTracker) Release() {
 	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	q.current--
+	if q.current > 0 {
+		q.current--
+	}
 }

--- a/apps/provisioning/pkg/quotas/tracker.go
+++ b/apps/provisioning/pkg/quotas/tracker.go
@@ -1,0 +1,41 @@
+package quotas
+
+import "sync"
+
+// QuotaTracker provides best-effort, in-memory quota enforcement.
+type QuotaTracker struct {
+	mu      sync.Mutex
+	current int64
+	limit   int64 // 0 means unlimited
+}
+
+func NewQuotaTracker(currentUsage, limit int64) *QuotaTracker {
+	return &QuotaTracker{
+		current: currentUsage,
+		limit:   limit,
+	}
+}
+
+// TryAcquire checks if creating one more resource would stay within the quota.
+func (q *QuotaTracker) TryAcquire() bool {
+	if q.limit <= 0 {
+		return true
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.current >= q.limit {
+		return false
+	}
+	q.current++
+	return true
+}
+
+// Release decrements the resource counter, e.g. after a successful deletion.
+func (q *QuotaTracker) Release() {
+	if q.limit <= 0 {
+		return
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.current--
+}

--- a/apps/provisioning/pkg/quotas/tracker_test.go
+++ b/apps/provisioning/pkg/quotas/tracker_test.go
@@ -1,0 +1,145 @@
+package quotas
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuotaTracker_TryAcquire(t *testing.T) {
+	tests := []struct {
+		name         string
+		currentUsage int64
+		limit        int64
+		wantResult   bool
+	}{
+		{
+			name:         "unlimited quota always allows",
+			currentUsage: 999,
+			limit:        0,
+			wantResult:   true,
+		},
+		{
+			name:         "within quota allows",
+			currentUsage: 5,
+			limit:        10,
+			wantResult:   true,
+		},
+		{
+			name:         "at limit rejects",
+			currentUsage: 10,
+			limit:        10,
+			wantResult:   false,
+		},
+		{
+			name:         "over limit rejects",
+			currentUsage: 15,
+			limit:        10,
+			wantResult:   false,
+		},
+		{
+			name:         "one below limit allows",
+			currentUsage: 9,
+			limit:        10,
+			wantResult:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracker := NewQuotaTracker(tt.currentUsage, tt.limit)
+			got := tracker.TryAcquire()
+			assert.Equal(t, tt.wantResult, got)
+		})
+	}
+}
+
+func TestQuotaTracker_TryAcquireIncrementsCounter(t *testing.T) {
+	tracker := NewQuotaTracker(8, 10)
+
+	require.True(t, tracker.TryAcquire())  // 8 -> 9
+	require.True(t, tracker.TryAcquire())  // 9 -> 10
+	require.False(t, tracker.TryAcquire()) // 10 >= 10, rejected
+	require.False(t, tracker.TryAcquire()) // still at 10, rejected
+}
+
+func TestQuotaTracker_Release(t *testing.T) {
+	tracker := NewQuotaTracker(10, 10)
+
+	// At limit, acquire should fail
+	require.False(t, tracker.TryAcquire())
+
+	// Release one slot
+	tracker.Release()
+
+	// Now acquire should succeed
+	require.True(t, tracker.TryAcquire())
+
+	// And fail again at limit
+	require.False(t, tracker.TryAcquire())
+}
+
+func TestQuotaTracker_ReleaseUnlimited(t *testing.T) {
+	tracker := NewQuotaTracker(0, 0)
+
+	// Release on unlimited tracker should not panic
+	tracker.Release()
+	require.True(t, tracker.TryAcquire())
+}
+
+func TestQuotaTracker_ConcurrentAccess(t *testing.T) {
+	limit := int64(100)
+	tracker := NewQuotaTracker(0, limit)
+
+	var wg sync.WaitGroup
+	acquired := make(chan bool, 200)
+
+	// Launch 200 goroutines each trying to acquire
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			acquired <- tracker.TryAcquire()
+		}()
+	}
+
+	wg.Wait()
+	close(acquired)
+
+	successCount := 0
+	for result := range acquired {
+		if result {
+			successCount++
+		}
+	}
+
+	// Exactly 100 should succeed (limit)
+	assert.Equal(t, int(limit), successCount)
+}
+
+func TestQuotaTracker_ConcurrentAcquireAndRelease(t *testing.T) {
+	tracker := NewQuotaTracker(50, 50)
+
+	var wg sync.WaitGroup
+
+	// Release 10 slots concurrently
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tracker.Release()
+		}()
+	}
+	wg.Wait()
+
+	// Now we should be able to acquire exactly 10
+	acquired := 0
+	for i := 0; i < 20; i++ {
+		if tracker.TryAcquire() {
+			acquired++
+		}
+	}
+	assert.Equal(t, 10, acquired)
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add a quota tracker that will be used when syncing resources to make sure the quota is not breached in a sync.

**Why do we need this feature?**

Right now, a pre-check happens before the sync, but there is no ongoing tracking while the sync is running

**Who is this feature for?**

Provisioning feature

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/git-ui-sync-project/issues/917

**Special notes for your reviewer:**

Please check that:
- [ x ] It works as expected from a user's perspective.
- [ x ] If this is a pre-GA feature, it is behind a feature toggle.
- [ x ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
