### PR TITLE
QueryEditor: fix callback ref warning in resize hooks

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.ts
@@ -39,6 +39,7 @@ export function useHorizontalRatioResize({
   const containerWidthRef = useRef(containerWidth);
   const minRatioRef = useRef(minRatio);
   const maxRatioRef = useRef(maxRatio);
+  const cleanupRef = useRef<(() => void) | null>(null);
 
   ratioRef.current = ratio;
   containerWidthRef.current = containerWidth;
@@ -46,6 +47,13 @@ export function useHorizontalRatioResize({
   maxRatioRef.current = maxRatio;
 
   const handleRef = useCallback((handle: HTMLElement | null) => {
+    cleanupRef.current?.();
+    cleanupRef.current = null;
+
+    if (!handle) {
+      return;
+    }
+
     let startX = 0;
     let startRatio = 0;
     let totalWidth = 0;
@@ -71,14 +79,9 @@ export function useHorizontalRatioResize({
       document.addEventListener('mouseup', onMouseUp);
     };
 
-    if (handle?.nodeType === Node.ELEMENT_NODE) {
-      handle.addEventListener('mousedown', onMouseDown);
-    }
-
-    return () => {
-      if (handle?.nodeType === Node.ELEMENT_NODE) {
-        handle.removeEventListener('mousedown', onMouseDown);
-      }
+    handle.addEventListener('mousedown', onMouseDown);
+    cleanupRef.current = () => {
+      handle.removeEventListener('mousedown', onMouseDown);
     };
   }, []);
 
@@ -109,6 +112,7 @@ export function useVerticalRatioResize({
   const containerHeightRef = useRef(containerHeight);
   const minRatioRef = useRef(minRatio);
   const maxRatioRef = useRef(maxRatio);
+  const cleanupRef = useRef<(() => void) | null>(null);
 
   ratioRef.current = ratio;
   containerHeightRef.current = containerHeight;
@@ -116,6 +120,13 @@ export function useVerticalRatioResize({
   maxRatioRef.current = maxRatio;
 
   const handleRef = useCallback((handle: HTMLElement | null) => {
+    cleanupRef.current?.();
+    cleanupRef.current = null;
+
+    if (!handle) {
+      return;
+    }
+
     let startY = 0;
     let startRatio = 0;
     let totalHeight = 0;
@@ -141,14 +152,9 @@ export function useVerticalRatioResize({
       document.addEventListener('mouseup', onMouseUp);
     };
 
-    if (handle?.nodeType === Node.ELEMENT_NODE) {
-      handle.addEventListener('mousedown', onMouseDown);
-    }
-
-    return () => {
-      if (handle?.nodeType === Node.ELEMENT_NODE) {
-        handle.removeEventListener('mousedown', onMouseDown);
-      }
+    handle.addEventListener('mousedown', onMouseDown);
+    cleanupRef.current = () => {
+      handle.removeEventListener('mousedown', onMouseDown);
     };
   }, []);
 


### PR DESCRIPTION
## Description
- The resize hooks in the panel editor used callback refs that returned  cleanup functions — a pattern only supported in React 19. This produced  a console warning on every render of the panel editor.
- Replaced with a ref-based cleanup pattern that is idiomatic in React 18:  the previous cleanup is stored in a ref and invoked when the element  changes or unmounts.

The goal is to avoid those two huge errors in the browser console.
<img width="1756" height="2334" alt="image" src="https://github.com/user-attachments/assets/55b1b23d-f451-4859-afdb-c6dd0148d152" />
