### PR TITLE
Dashboard: Backport datasource fixes

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v33.panel_ds_name_to_ref.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v33.panel_ds_name_to_ref.v42.v2alpha1.json
@@ -92,14 +92,14 @@
                   "kind": "PanelQuery",
                   "spec": {
                     "query": {
-                      "kind": "prometheus",
+                      "kind": "loki",
                       "spec": {
                         "description": "Nested target should also migrate from string to object"
                       }
                     },
                     "datasource": {
-                      "type": "prometheus",
-                      "uid": "default-ds-uid"
+                      "type": "loki",
+                      "uid": "non-default-test-ds-uid"
                     },
                     "refId": "A",
                     "hidden": false
@@ -138,14 +138,14 @@
                   "kind": "PanelQuery",
                   "spec": {
                     "query": {
-                      "kind": "elasticsearch",
+                      "kind": "prometheus",
                       "spec": {
                         "description": "Target with existing object should remain unchanged"
                       }
                     },
                     "datasource": {
-                      "type": "elasticsearch",
-                      "uid": "existing-target-uid"
+                      "type": "prometheus",
+                      "uid": "existing-ref-uid"
                     },
                     "refId": "A",
                     "hidden": false
@@ -289,14 +289,14 @@
                   "kind": "PanelQuery",
                   "spec": {
                     "query": {
-                      "kind": "prometheus",
+                      "kind": "loki",
                       "spec": {
                         "description": "Valid string should migrate to object"
                       }
                     },
                     "datasource": {
-                      "type": "prometheus",
-                      "uid": "default-ds-uid"
+                      "type": "loki",
+                      "uid": "non-default-test-ds-uid"
                     },
                     "refId": "B",
                     "hidden": false
@@ -306,14 +306,14 @@
                   "kind": "PanelQuery",
                   "spec": {
                     "query": {
-                      "kind": "prometheus",
+                      "kind": "loki",
                       "spec": {
                         "description": "Non-existing datasource should be preserved as-is (migration returns nil)"
                       }
                     },
                     "datasource": {
-                      "type": "prometheus",
-                      "uid": "non-existing-ds"
+                      "type": "loki",
+                      "uid": "non-default-test-ds-uid"
                     },
                     "refId": "C",
                     "hidden": false
@@ -381,7 +381,7 @@
                     },
                     "datasource": {
                       "type": "prometheus",
-                      "uid": "existing-ref"
+                      "uid": "default-ds-uid"
                     },
                     "refId": "A",
                     "hidden": false
@@ -391,14 +391,14 @@
                   "kind": "PanelQuery",
                   "spec": {
                     "query": {
-                      "kind": "loki",
+                      "kind": "prometheus",
                       "spec": {
                         "description": "String target should migrate to object"
                       }
                     },
                     "datasource": {
-                      "type": "loki",
-                      "uid": "non-default-test-ds-uid"
+                      "type": "prometheus",
+                      "uid": "default-ds-uid"
                     },
                     "refId": "B",
                     "hidden": false
@@ -503,7 +503,7 @@
                     },
                     "datasource": {
                       "type": "prometheus",
-                      "uid": "also-missing-ds"
+                      "uid": "completely-missing-ds"
                     },
                     "refId": "A",
                     "hidden": false

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v33.panel_ds_name_to_ref.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v33.panel_ds_name_to_ref.v42.v2beta1.json
@@ -96,10 +96,10 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "prometheus",
+                      "group": "loki",
                       "version": "v0",
                       "datasource": {
-                        "name": "default-ds-uid"
+                        "name": "non-default-test-ds-uid"
                       },
                       "spec": {
                         "description": "Nested target should also migrate from string to object"
@@ -144,10 +144,10 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "elasticsearch",
+                      "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "existing-target-uid"
+                        "name": "existing-ref-uid"
                       },
                       "spec": {
                         "description": "Target with existing object should remain unchanged"
@@ -302,10 +302,10 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "prometheus",
+                      "group": "loki",
                       "version": "v0",
                       "datasource": {
-                        "name": "default-ds-uid"
+                        "name": "non-default-test-ds-uid"
                       },
                       "spec": {
                         "description": "Valid string should migrate to object"
@@ -320,10 +320,10 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "prometheus",
+                      "group": "loki",
                       "version": "v0",
                       "datasource": {
-                        "name": "non-existing-ds"
+                        "name": "non-default-test-ds-uid"
                       },
                       "spec": {
                         "description": "Non-existing datasource should be preserved as-is (migration returns nil)"
@@ -394,7 +394,7 @@
                       "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "existing-ref"
+                        "name": "default-ds-uid"
                       },
                       "spec": {
                         "description": "Existing object target should remain unchanged"
@@ -409,10 +409,10 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "loki",
+                      "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "non-default-test-ds-uid"
+                        "name": "default-ds-uid"
                       },
                       "spec": {
                         "description": "String target should migrate to object"
@@ -523,7 +523,7 @@
                       "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "also-missing-ds"
+                        "name": "completely-missing-ds"
                       },
                       "spec": {
                         "description": "Unknown target datasource should remain unchanged (migration returns nil)"

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v34.multiple_stats_cloudwatch.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v34.multiple_stats_cloudwatch.v42.v2alpha1.json
@@ -1172,7 +1172,7 @@
                     },
                     "datasource": {
                       "type": "prometheus",
-                      "uid": "default-ds-uid"
+                      "uid": "prometheus"
                     },
                     "refId": "A",
                     "hidden": false
@@ -1214,7 +1214,7 @@
                     },
                     "datasource": {
                       "type": "prometheus",
-                      "uid": "default-ds-uid"
+                      "uid": "prometheus"
                     },
                     "refId": "C",
                     "hidden": false
@@ -1239,7 +1239,7 @@
                     },
                     "datasource": {
                       "type": "prometheus",
-                      "uid": "default-ds-uid"
+                      "uid": "prometheus"
                     },
                     "refId": "D",
                     "hidden": false

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v34.multiple_stats_cloudwatch.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v34.multiple_stats_cloudwatch.v42.v2beta1.json
@@ -1205,7 +1205,7 @@
                       "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "default-ds-uid"
+                        "name": "prometheus"
                       },
                       "spec": {
                         "dimensions": {
@@ -1249,7 +1249,7 @@
                       "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "default-ds-uid"
+                        "name": "prometheus"
                       },
                       "spec": {
                         "dimensions": {
@@ -1275,7 +1275,7 @@
                       "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "default-ds-uid"
+                        "name": "prometheus"
                       },
                       "spec": {
                         "dimensions": {

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v36.ds_name_to_ref.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v36.ds_name_to_ref.v42.v2alpha1.json
@@ -263,12 +263,12 @@
                   "kind": "PanelQuery",
                   "spec": {
                     "query": {
-                      "kind": "elasticsearch",
+                      "kind": "prometheus",
                       "spec": {}
                     },
                     "datasource": {
-                      "type": "elasticsearch",
-                      "uid": "existing-target-uid"
+                      "type": "prometheus",
+                      "uid": "unknown-nested-datasource"
                     },
                     "refId": "A",
                     "hidden": false
@@ -454,12 +454,12 @@
                   "kind": "PanelQuery",
                   "spec": {
                     "query": {
-                      "kind": "elasticsearch",
+                      "kind": "prometheus",
                       "spec": {}
                     },
                     "datasource": {
-                      "type": "elasticsearch",
-                      "uid": "existing-target-uid"
+                      "type": "prometheus",
+                      "uid": "existing-ref-uid"
                     },
                     "refId": "A",
                     "hidden": false
@@ -503,7 +503,7 @@
                     },
                     "datasource": {
                       "type": "prometheus",
-                      "uid": "unknown-target-datasource"
+                      "uid": "unknown-panel-datasource"
                     },
                     "refId": "A",
                     "hidden": false

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v36.ds_name_to_ref.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v36.ds_name_to_ref.v42.v2beta1.json
@@ -276,10 +276,10 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "elasticsearch",
+                      "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "existing-target-uid"
+                        "name": "unknown-nested-datasource"
                       },
                       "spec": {}
                     },
@@ -476,10 +476,10 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "elasticsearch",
+                      "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "existing-target-uid"
+                        "name": "existing-ref-uid"
                       },
                       "spec": {}
                     },
@@ -525,7 +525,7 @@
                       "group": "prometheus",
                       "version": "v0",
                       "datasource": {
-                        "name": "unknown-target-datasource"
+                        "name": "unknown-panel-datasource"
                       },
                       "spec": {}
                     },

--- a/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1_test.go
+++ b/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1_test.go
@@ -32,7 +32,7 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 		validateV2alpha1 func(t *testing.T, v2alpha1 *dashv2alpha1.Dashboard)
 	}{
 		{
-			name: "panel datasource type datasource with no UID - resolves to grafana UID",
+			name: "panel type datasource with no UID - use panel ref (query empty), resolve to grafana UID",
 			createV1beta1: func() *dashv1.Dashboard {
 				return &dashv1.Dashboard{
 					Spec: dashv1.DashboardSpec{
@@ -84,7 +84,7 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 			},
 		},
 		{
-			name: "empty target datasource objects inherit from panel datasource",
+			name: "targets with empty datasource {} - use panel ref (query has no ref), get panel DS",
 			createV1beta1: func() *dashv1.Dashboard {
 				return &dashv1.Dashboard{
 					Spec: dashv1.DashboardSpec{
@@ -94,7 +94,6 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 								map[string]interface{}{
 									"id":   1,
 									"type": "bargauge",
-									// Panel datasource is set
 									"datasource": map[string]interface{}{
 										"type": "prometheus",
 										"uid":  "prometheus-uid",
@@ -103,7 +102,6 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 										map[string]interface{}{
 											"refId":      "A",
 											"scenarioId": "random_walk",
-											// Target datasource is empty object {} - should inherit from panel
 											"datasource": map[string]interface{}{},
 										},
 										map[string]interface{}{
@@ -123,10 +121,10 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 				panel := v2alpha1.Spec.Elements["panel-1"].PanelKind
 				require.NotNil(t, panel)
 
-				// Verify queries inherit panel datasource
+				// Query has no ref (empty {}) → use panel ref; both queries get panel DS
 				require.Len(t, panel.Spec.Data.Spec.Queries, 2)
 				for _, query := range panel.Spec.Data.Spec.Queries {
-					require.NotNil(t, query.Spec.Datasource, "Query should inherit datasource from panel when target datasource is empty")
+					require.NotNil(t, query.Spec.Datasource)
 					assert.Equal(t, "prometheus", *query.Spec.Datasource.Type)
 					assert.Equal(t, "prometheus-uid", *query.Spec.Datasource.Uid)
 					assert.Equal(t, "prometheus", query.Spec.Query.Kind)
@@ -134,7 +132,170 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 			},
 		},
 		{
-			name: "panel datasource null without empty target datasource objects - no default set",
+			// query ref != panel ref and panel is not mixed and query is not expression.
+			name: "panel ref used when query ref differs from panel ref (panel not mixed, query not expression)",
+			createV1beta1: func() *dashv1.Dashboard {
+				return &dashv1.Dashboard{
+					Spec: dashv1.DashboardSpec{
+						Object: map[string]interface{}{
+							"title": "Test Dashboard",
+							"panels": []interface{}{
+								map[string]interface{}{
+									"id":   1,
+									"type": "bargauge",
+									"datasource": map[string]interface{}{
+										"type": "prometheus",
+										"uid":  "prometheus-uid",
+									},
+									"targets": []interface{}{
+										map[string]interface{}{
+											"refId":      "A",
+											"scenarioId": "random_walk",
+											"datasource": map[string]interface{}{
+												"type": "loki",
+												"uid":  "loki-uid",
+											},
+										},
+										map[string]interface{}{
+											"refId":      "B",
+											"scenarioId": "random_walk",
+											"datasource": map[string]interface{}{
+												"type": "elasticsearch",
+												"uid":  "elasticsearch-uid",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			validateV2alpha1: func(t *testing.T, v2alpha1 *dashv2alpha1.Dashboard) {
+				require.NotNil(t, v2alpha1.Spec.Elements["panel-1"])
+				panel := v2alpha1.Spec.Elements["panel-1"].PanelKind
+				require.NotNil(t, panel)
+
+				// Query ref != panel ref and panel not mixed → use panel ref (matches frontend)
+				require.Len(t, panel.Spec.Data.Spec.Queries, 2)
+				for _, query := range panel.Spec.Data.Spec.Queries {
+					require.NotNil(t, query.Spec.Datasource)
+					assert.Equal(t, "prometheus", *query.Spec.Datasource.Type)
+					assert.Equal(t, "prometheus-uid", *query.Spec.Datasource.Uid)
+					assert.Equal(t, "prometheus", query.Spec.Query.Kind)
+				}
+			},
+		},
+		{
+			// Mixed is identified by panel uid "-- Mixed --". When panel is mixed we do not use panel ref.
+			name: "mixed panel (uid -- Mixed --) - each query keeps its target datasource",
+			createV1beta1: func() *dashv1.Dashboard {
+				return &dashv1.Dashboard{
+					Spec: dashv1.DashboardSpec{
+						Object: map[string]interface{}{
+							"title": "Test Dashboard",
+							"panels": []interface{}{
+								map[string]interface{}{
+									"id":   1,
+									"type": "bargauge",
+									"datasource": map[string]interface{}{
+										"type": "datasource",
+										"uid":  "-- Mixed --",
+									},
+									"targets": []interface{}{
+										map[string]interface{}{
+											"refId":      "A",
+											"scenarioId": "random_walk",
+											"datasource": map[string]interface{}{
+												"type": "prometheus",
+												"uid":  "prometheus-uid",
+											},
+										},
+										map[string]interface{}{
+											"refId":      "B",
+											"scenarioId": "random_walk",
+											"datasource": map[string]interface{}{
+												"type": "loki",
+												"uid":  "loki-uid",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			validateV2alpha1: func(t *testing.T, v2alpha1 *dashv2alpha1.Dashboard) {
+				require.NotNil(t, v2alpha1.Spec.Elements["panel-1"])
+				panel := v2alpha1.Spec.Elements["panel-1"].PanelKind
+				require.NotNil(t, panel)
+
+				require.Len(t, panel.Spec.Data.Spec.Queries, 2)
+				// Query A: prometheus
+				assert.Equal(t, "prometheus", *panel.Spec.Data.Spec.Queries[0].Spec.Datasource.Type)
+				assert.Equal(t, "prometheus-uid", *panel.Spec.Data.Spec.Queries[0].Spec.Datasource.Uid)
+				// Query B: loki
+				assert.Equal(t, "loki", *panel.Spec.Data.Spec.Queries[1].Spec.Datasource.Type)
+				assert.Equal(t, "loki-uid", *panel.Spec.Data.Spec.Queries[1].Spec.Datasource.Uid)
+			},
+		},
+		{
+			// Expression queries (__expr__) are never overwritten by panel ref (same as frontend).
+			name: "expression query (__expr__) keeps expression ref when panel has different datasource",
+			createV1beta1: func() *dashv1.Dashboard {
+				return &dashv1.Dashboard{
+					Spec: dashv1.DashboardSpec{
+						Object: map[string]interface{}{
+							"title": "Test Dashboard",
+							"panels": []interface{}{
+								map[string]interface{}{
+									"id":   1,
+									"type": "bargauge",
+									"datasource": map[string]interface{}{
+										"type": "prometheus",
+										"uid":  "prometheus-uid",
+									},
+									"targets": []interface{}{
+										map[string]interface{}{
+											"refId":      "A",
+											"scenarioId": "random_walk",
+											"datasource": map[string]interface{}{},
+										},
+										map[string]interface{}{
+											"refId":      "B",
+											"scenarioId": "random_walk",
+											"datasource": map[string]interface{}{
+												"type": "__expr__",
+												"uid":  "__expr__",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			validateV2alpha1: func(t *testing.T, v2alpha1 *dashv2alpha1.Dashboard) {
+				require.NotNil(t, v2alpha1.Spec.Elements["panel-1"])
+				panel := v2alpha1.Spec.Elements["panel-1"].PanelKind
+				require.NotNil(t, panel)
+
+				require.Len(t, panel.Spec.Data.Spec.Queries, 2)
+				// Query A: no ref → uses panel
+				require.NotNil(t, panel.Spec.Data.Spec.Queries[0].Spec.Datasource)
+				assert.Equal(t, "prometheus", *panel.Spec.Data.Spec.Queries[0].Spec.Datasource.Type)
+				assert.Equal(t, "prometheus-uid", *panel.Spec.Data.Spec.Queries[0].Spec.Datasource.Uid)
+				// Query B: expression → not overwritten by panel
+				require.NotNil(t, panel.Spec.Data.Spec.Queries[1].Spec.Datasource)
+				assert.Equal(t, "__expr__", *panel.Spec.Data.Spec.Queries[1].Spec.Datasource.Type)
+				assert.Equal(t, "__expr__", *panel.Spec.Data.Spec.Queries[1].Spec.Datasource.Uid)
+				assert.Equal(t, "__expr__", panel.Spec.Data.Spec.Queries[1].Spec.Query.Kind)
+			},
+		},
+		{
+			name: "panel datasource null and target has no datasource field - no default set",
 			createV1beta1: func() *dashv1.Dashboard {
 				return &dashv1.Dashboard{
 					Spec: dashv1.DashboardSpec{
@@ -164,15 +325,14 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 				panel := v2alpha1.Spec.Elements["panel-1"].PanelKind
 				require.NotNil(t, panel)
 
-				// Verify queries don't have datasource when panel is null and targets don't have empty datasource objects
+				// usePanelRef true (query empty) but hasPanelRef false (panel null) → query keeps no ref
 				require.Len(t, panel.Spec.Data.Spec.Queries, 1)
 				query := panel.Spec.Data.Spec.Queries[0]
-				// Query should not have datasource when panel datasource is null and target doesn't have empty datasource object
-				assert.Nil(t, query.Spec.Datasource, "Query should not have datasource when panel datasource is null and target has no empty datasource object")
+				assert.Nil(t, query.Spec.Datasource)
 			},
 		},
 		{
-			name: "empty panel datasource object preserved as empty",
+			name: "empty panel and target datasource {} - preserved as empty (no panel ref to apply)",
 			createV1beta1: func() *dashv1.Dashboard {
 				return &dashv1.Dashboard{
 					Spec: dashv1.DashboardSpec{
@@ -202,12 +362,11 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 				panel := v2alpha1.Spec.Elements["panel-1"].PanelKind
 				require.NotNil(t, panel)
 
-				// Verify queries don't have datasource when panel datasource is empty object {}
+				// usePanelRef true (query empty) but hasPanelRef false (panel {} → nil panelDatasource) → query stays empty
 				require.Len(t, panel.Spec.Data.Spec.Queries, 1)
 				query := panel.Spec.Data.Spec.Queries[0]
-				// Empty objects {} should be preserved as empty, not converted to defaults
-				assert.Nil(t, query.Spec.Datasource, "Query should not have datasource when panel datasource is empty object {}")
-				assert.Equal(t, "", query.Spec.Query.Kind, "Query kind should be empty when datasource is empty object {}")
+				assert.Nil(t, query.Spec.Datasource)
+				assert.Equal(t, "", query.Spec.Query.Kind)
 			},
 		},
 		{
@@ -310,7 +469,7 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 						totalQueries += len(element.PanelKind.Spec.Data.Spec.Queries)
 					}
 				}
-				assert.Equal(t, 3, totalQueries, "All 3 queries should be preserved")
+				assert.Equal(t, 3, totalQueries, "all 3 queries should be preserved")
 			},
 		},
 	}

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -491,13 +491,13 @@ describe('transformSceneToSaveModelSchemaV2', () => {
       const resultA = getPersistedDSFor(queryWithoutDS, dsReferencesMap, 'query', queryRunner);
       expect(resultA).toBeUndefined();
 
-      // Test the query with DS originally - should return the original datasource
+      // Test the query with DS that differs from panel - same as PanelQueryRunner: use panel ref
       const resultB = getPersistedDSFor(queryWithDS, dsReferencesMap, 'query', queryRunner);
-      expect(resultB).toEqual({ uid: 'prometheus', type: 'prometheus' });
+      expect(resultB).toEqual({ uid: 'default-ds', type: 'default' });
 
-      // Test the query with only type defined - should return the type
+      // Query with only type (no uid) differs from panel - use panel ref
       const resultC = getPersistedDSFor(queryWithOnlyDSType, dsReferencesMap, 'query', queryRunner);
-      expect(resultC).toEqual({ type: 'prometheus' });
+      expect(resultC).toEqual({ uid: 'default-ds', type: 'default' });
 
       // Test a query with no DS originally but not in the mapping - should get the runner's datasource
       const queryNotInMapping: SceneDataQuery = {
@@ -555,21 +555,21 @@ describe('transformSceneToSaveModelSchemaV2', () => {
   });
 
   describe('getDataQueryKind', () => {
-    it('should preserve original query datasource type when available', () => {
-      // 1. Test with a query that has its own datasource type
-      const queryWithDS: SceneDataQuery = {
+    it('should use panel datasource type when panel UID differs from query UID (panel ref applied)', () => {
+      // Query-level datasource (original target) — will be overridden by panel ref
+      const query: SceneDataQuery = {
         refId: 'A',
         datasource: { uid: 'prometheus-1', type: 'prometheus' },
       };
 
-      // Create a query runner with a different datasource type
+      // Panel-level datasource — different UID means panel ref was applied
       const queryRunner = new SceneQueryRunner({
         datasource: { uid: 'default-ds', type: 'loki' },
         queries: [],
       });
 
-      // Should use the query's own datasource type (prometheus)
-      expect(getDataQueryKind(queryWithDS, queryRunner)).toBe('prometheus');
+      // Panel ref takes precedence over stale query datasource (matches backend behavior)
+      expect(getDataQueryKind(query, queryRunner)).toBe('loki');
     });
 
     it('should use queryRunner datasource type as fallback when query has no datasource', () => {
@@ -589,21 +589,64 @@ describe('transformSceneToSaveModelSchemaV2', () => {
     });
 
     it('should fall back to default datasource when neither query nor queryRunner has datasource type', () => {
-      // 3. Test with neither query nor queryRunner having a datasource type
       const queryWithoutDS: SceneDataQuery = {
         refId: 'A',
       };
 
-      // Create a query runner with no datasource
       const queryRunner = new SceneQueryRunner({
         queries: [],
       });
 
       expect(getDataQueryKind(queryWithoutDS, queryRunner)).toBe('loki');
+      expect(queryWithoutDS.datasource?.type).toBeUndefined();
+      expect(queryRunner.state.datasource?.type).toBeUndefined();
+    });
 
-      // Also verify the function's behavior by checking the args
-      expect(queryWithoutDS.datasource?.type).toBeUndefined(); // No query datasource
-      expect(queryRunner.state.datasource?.type).toBeUndefined(); // No queryRunner datasource
+    it('should fall back to default when panel ref applied but queryRunner has no type', () => {
+      // Query has type, but panel overrides with unknown datasource (no type)
+      const query: SceneDataQuery = {
+        refId: 'A',
+        datasource: { uid: 'prometheus-1', type: 'prometheus' },
+      };
+
+      // Panel has UID but no type (unknown datasource)
+      const queryRunner = new SceneQueryRunner({
+        datasource: { uid: 'unknown-ds' },
+        queries: [],
+      });
+
+      // queryRunner has no type → fall back to default
+      expect(getDataQueryKind(query, queryRunner)).toBe('loki');
+    });
+
+    it('should use queryRunner type when query and queryRunner have the same UID', () => {
+      const query: SceneDataQuery = {
+        refId: 'A',
+        datasource: { uid: 'prometheus-1' }, // same UID, no type
+      };
+
+      const queryRunner = new SceneQueryRunner({
+        datasource: { uid: 'prometheus-1', type: 'prometheus' },
+        queries: [],
+      });
+
+      // Same UID — use queryRunner's type
+      expect(getDataQueryKind(query, queryRunner)).toBe('prometheus');
+    });
+
+    it('should fall back to default when no queryRunner is provided', () => {
+      const query: SceneDataQuery = {
+        refId: 'A',
+        datasource: { uid: 'prometheus-1', type: 'prometheus' },
+      };
+
+      // No queryRunner — fall back to default
+      expect(getDataQueryKind(query, undefined)).toBe('loki');
+    });
+
+    it('should return default datasource type for undefined or string queries', () => {
+      expect(getDataQueryKind(undefined)).toBe('loki');
+      expect(getDataQueryKind('some-string')).toBe('loki');
     });
   });
 
@@ -687,15 +730,15 @@ describe('getElementDatasource', () => {
       annotations: new Map<string, string>(),
     };
 
-    // Call the function with the panel and query with DS
+    // Query with DS that differs from panel → same as PanelQueryRunner: use panel ref
     const resultWithDS = getElementDatasource(vizPanel, queryWithDS, 'panel', queryRunner, dsReferencesMapping);
-    expect(resultWithDS).toEqual({ uid: 'prometheus', type: 'prometheus' });
+    expect(resultWithDS).toEqual({ uid: 'default-ds', type: 'default' });
 
     // Call the function with the panel and query without DS
     const resultWithoutDS = getElementDatasource(vizPanel, queryWithoutDS, 'panel', queryRunner, dsReferencesMapping);
     expect(resultWithoutDS).toBeUndefined();
 
-    // Call the function with the panel and query with only type
+    // Query with only type differs from panel → use panel ref
     const resultWithOnlyType = getElementDatasource(
       vizPanel,
       queryWithOnlyType,
@@ -703,7 +746,7 @@ describe('getElementDatasource', () => {
       queryRunner,
       dsReferencesMapping
     );
-    expect(resultWithOnlyType).toEqual({ type: 'prometheus' });
+    expect(resultWithOnlyType).toEqual({ uid: 'default-ds', type: 'default' });
   });
 
   it('should handle variable datasources correctly', () => {
@@ -952,8 +995,9 @@ describe('getVizPanelQueries', () => {
     expect(result[0].spec.query.version).toBe('v0');
 
     expect(result[1].spec.query.kind).toBe('DataQuery');
-    expect(result[1].spec.query.datasource?.name).toBe('prometheus-uid');
-    expect(result[1].spec.query.group).toBe('prometheus');
+    // Query ref differs from panel → persist panel ref (same as PanelQueryRunner); schema stores uid as .name
+    expect(result[1].spec.query.datasource?.name).toBe('default-ds');
+    expect(result[1].spec.query.group).toBe('default');
     expect(result[1].spec.query.version).toBe('v0');
   });
 

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -1,5 +1,6 @@
 import { VariableRefresh, PanelData, LoadingState, toDataFrame, FieldType, getDefaultTimeRange } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
 import {
   AdHocFiltersVariable,
   behaviors,
@@ -36,6 +37,7 @@ import {
   defaultDataQueryKind,
 } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { GrafanaQueryType } from 'app/plugins/datasource/grafana/types';
+import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
 import { DashboardEditPane } from '../edit-pane/DashboardEditPane';
 import { DashboardAnnotationsDataLayer } from '../scene/DashboardAnnotationsDataLayer';
@@ -470,7 +472,7 @@ describe('transformSceneToSaveModelSchemaV2', () => {
       };
       const queryWithDS: SceneDataQuery = {
         refId: 'B',
-        datasource: { uid: 'prometheus', type: 'prometheus' },
+        datasource: { uid: 'panel-level-d', type: 'prometheus' },
       };
 
       const queryWithOnlyDSType: SceneDataQuery = {
@@ -481,23 +483,23 @@ describe('transformSceneToSaveModelSchemaV2', () => {
       // Mock query runner with runtime-resolved datasource
       const queryRunner = new SceneQueryRunner({
         queries: [queryWithoutDS, queryWithDS],
-        datasource: { uid: 'default-ds', type: 'default' },
+        datasource: { uid: 'panel-level-d', type: 'prometheus' },
       });
 
       // Get a reference to the DS references mapping
       const dsReferencesMap = new Map<string, string | undefined>([['A', undefined]]);
 
-      // Test the query without DS originally - should return undefined
+      // Test the query without DS originally - should return panel level datasource
       const resultA = getPersistedDSFor(queryWithoutDS, dsReferencesMap, 'query', queryRunner);
-      expect(resultA).toBeUndefined();
+      expect(resultA).toEqual({ uid: 'panel-level-d', type: 'prometheus' });
 
       // Test the query with DS that differs from panel - same as PanelQueryRunner: use panel ref
       const resultB = getPersistedDSFor(queryWithDS, dsReferencesMap, 'query', queryRunner);
-      expect(resultB).toEqual({ uid: 'default-ds', type: 'default' });
+      expect(resultB).toEqual({ uid: 'panel-level-d', type: 'prometheus' });
 
       // Query with only type (no uid) differs from panel - use panel ref
       const resultC = getPersistedDSFor(queryWithOnlyDSType, dsReferencesMap, 'query', queryRunner);
-      expect(resultC).toEqual({ uid: 'default-ds', type: 'default' });
+      expect(resultC).toEqual({ uid: 'panel-level-d', type: 'prometheus' });
 
       // Test a query with no DS originally but not in the mapping - should get the runner's datasource
       const queryNotInMapping: SceneDataQuery = {
@@ -505,7 +507,41 @@ describe('transformSceneToSaveModelSchemaV2', () => {
         // No datasource, but not in mapping
       };
       const resultD = getPersistedDSFor(queryNotInMapping, dsReferencesMap, 'query', queryRunner);
-      expect(resultD).toEqual({ uid: 'default-ds', type: 'default' });
+      expect(resultD).toEqual({ uid: 'panel-level-d', type: 'prometheus' });
+    });
+
+    it('should not override expression queries with panel datasource', () => {
+      const expressionQuery: SceneDataQuery = {
+        refId: 'E',
+        datasource: { uid: ExpressionDatasourceRef.uid, type: ExpressionDatasourceRef.type },
+      };
+
+      const queryRunner = new SceneQueryRunner({
+        queries: [expressionQuery],
+        datasource: { uid: 'prometheus-uid', type: 'prometheus' },
+      });
+
+      const dsReferencesMap = new Map<string, string | undefined>();
+
+      const result = getPersistedDSFor(expressionQuery, dsReferencesMap, 'query', queryRunner);
+      expect(result).toEqual({ uid: ExpressionDatasourceRef.uid, type: ExpressionDatasourceRef.type });
+    });
+
+    it('should not override queries when panel datasource is mixed', () => {
+      const queryWithDS: SceneDataQuery = {
+        refId: 'A',
+        datasource: { uid: 'prometheus-uid', type: 'prometheus' },
+      };
+
+      const queryRunner = new SceneQueryRunner({
+        queries: [queryWithDS],
+        datasource: { uid: MIXED_DATASOURCE_NAME, type: 'mixed' },
+      });
+
+      const dsReferencesMap = new Map<string, string | undefined>();
+
+      const result = getPersistedDSFor(queryWithDS, dsReferencesMap, 'query', queryRunner);
+      expect(result).toEqual({ uid: 'prometheus-uid', type: 'prometheus' });
     });
   });
 
@@ -564,7 +600,7 @@ describe('transformSceneToSaveModelSchemaV2', () => {
 
       // Panel-level datasource — different UID means panel ref was applied
       const queryRunner = new SceneQueryRunner({
-        datasource: { uid: 'default-ds', type: 'loki' },
+        datasource: { uid: 'panel-level-d', type: 'loki' },
         queries: [],
       });
 
@@ -736,7 +772,7 @@ describe('getElementDatasource', () => {
 
     // Call the function with the panel and query without DS
     const resultWithoutDS = getElementDatasource(vizPanel, queryWithoutDS, 'panel', queryRunner, dsReferencesMapping);
-    expect(resultWithoutDS).toBeUndefined();
+    expect(resultWithoutDS).toEqual({ uid: 'default-ds', type: 'default' });
 
     // Query with only type differs from panel → use panel ref
     const resultWithOnlyType = getElementDatasource(
@@ -990,8 +1026,8 @@ describe('getVizPanelQueries', () => {
     const result = getVizPanelQueries(vizPanel, dsReferencesMapping);
     expect(result.length).toBe(2);
     expect(result[0].spec.query.kind).toBe('DataQuery');
-    expect(result[0].spec.query.datasource).toBeUndefined(); // ignore datasource if it wasn't provided
-    expect(result[0].spec.query.group).toBe(defaultDataQueryKind().group); // this is a default query that contains only refId and therefore group should be the default group
+    expect(result[0].spec.query.datasource).toEqual({ name: 'default-ds' }); // picks up panel level when no datasource is provided
+    expect(result[0].spec.query.group).toBe('default'); // this is a default query that contains only refId and therefore group should be the default group
     expect(result[0].spec.query.version).toBe('v0');
 
     expect(result[1].spec.query.kind).toBe('DataQuery');

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -18,6 +18,7 @@ import { DataSourceRef } from '@grafana/schema';
 import { sortedDeepCloneWithoutNulls } from 'app/core/utils/object';
 import { getPanelDataFrames } from 'app/features/dashboard/components/HelpWizard/utils';
 import { GrafanaQueryType } from 'app/plugins/datasource/grafana/types';
+import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
 import {
   Spec as DashboardV2Spec,
@@ -887,18 +888,10 @@ export function getPersistedDSFor<T extends SceneDataQuery | QueryVariable | Ann
   type: 'query' | 'variable' | 'annotation',
   context?: SceneQueryRunner
 ): DataSourceRef | undefined {
-  // Get the element identifier - refId for queries, name for variables
-  const elementId = getElementIdentifier(element, type);
+  let datasource: DataSourceRef | undefined;
 
-  // If the ds was autossigned, return the datasource initial ds value.
-  if (autoAssignedDsRef?.has(elementId)) {
-    const dsType = autoAssignedDsRef.get(elementId);
-    // If the ds type was not undefined means the datasource was autossigned, so return the datasource with only the type
-    return dsType ? { type: dsType } : undefined;
-  }
-
+  // First, try to resolve from the element's current datasource if it has one
   if (type === 'query') {
-    let datasource: DataSourceRef | undefined;
     if ('datasource' in element && element.datasource) {
       const isEmptyDatasourceObject =
         typeof element.datasource === 'object' && Object.keys(element.datasource).length === 0;
@@ -907,27 +900,37 @@ export function getPersistedDSFor<T extends SceneDataQuery | QueryVariable | Ann
       }
     }
 
-    const panel = context?.state?.datasource;
-    if (!panel) {
-      return datasource;
-    }
+    const panelDS = context?.state?.datasource;
+    if (panelDS?.uid) {
+      const notMixed = panelDS?.uid !== MIXED_DATASOURCE_NAME;
+      const notExpr =
+        !datasource ||
+        (datasource.uid !== ExpressionDatasourceRef.uid && datasource.type !== ExpressionDatasourceRef.type);
 
-    const notExpr =
-      !datasource ||
-      (datasource.uid !== ExpressionDatasourceRef.uid && datasource.type !== ExpressionDatasourceRef.type);
-    if (!datasource || (panel?.uid && panel?.uid !== datasource.uid && panel?.uid !== '-- Mixed --' && notExpr)) {
-      datasource = panel;
+      if (notMixed && (!datasource || (panelDS?.uid !== datasource.uid && notExpr))) {
+        datasource = panelDS;
+      }
     }
-
-    return datasource;
   }
 
   if (type === 'variable' && 'state' in element && 'datasource' in element.state) {
-    return element.state.datasource || undefined;
+    datasource = element.state.datasource || undefined;
   }
 
   if (type === 'annotation' && 'datasource' in element) {
-    return element.datasource || undefined;
+    datasource = element.datasource || undefined;
+  }
+
+  // If a datasource was resolved from the element, use it
+  if (datasource) {
+    return datasource;
+  }
+
+  const elementId = getElementIdentifier(element, type);
+  if (autoAssignedDsRef?.has(elementId)) {
+    const dsType = autoAssignedDsRef.get(elementId);
+    // If the ds type was defined, return datasource with only the type; otherwise undefined
+    return dsType ? { type: dsType } : undefined;
   }
 
   return undefined;

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -2,6 +2,7 @@ import { omit } from 'lodash';
 
 import { AnnotationQuery, isEmptyObject, TimeRange } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
 import {
   behaviors,
   dataLayers,
@@ -358,7 +359,9 @@ export function getVizPanelQueries(
       const dataQuery: DataQueryKind = {
         kind: 'DataQuery',
         version: defaultDataQueryKind().version,
-        group: queryDatasource ? getDataQueryKind(query, queryRunner) : defaultDataQueryKind().group,
+        group: queryDatasource
+          ? queryDatasource.type || getDataQueryKind(query, queryRunner)
+          : defaultDataQueryKind().group,
         datasource: {
           name: queryDatasource?.uid,
         },
@@ -394,11 +397,6 @@ export function getDataQueryKind(query: SceneDataQuery | string | undefined, que
   if (typeof query === 'string') {
     const defaultDS = getDefaultDataSourceRef();
     return defaultDS?.type || '';
-  }
-
-  // Query has explicit datasource with type
-  if (query.datasource?.type) {
-    return query.datasource.type;
   }
 
   // If query has a datasource UID (even without type), check if it matches the queryRunner's datasource
@@ -899,22 +897,29 @@ export function getPersistedDSFor<T extends SceneDataQuery | QueryVariable | Ann
     return dsType ? { type: dsType } : undefined;
   }
 
-  // Return appropriate datasource reference based on element type
   if (type === 'query') {
+    let datasource: DataSourceRef | undefined;
     if ('datasource' in element && element.datasource) {
-      // Check if datasource is empty object {} (no keys), treat it as missing
-      // and fall through to use panel datasource (matches backend behavior)
       const isEmptyDatasourceObject =
         typeof element.datasource === 'object' && Object.keys(element.datasource).length === 0;
-
       if (!isEmptyDatasourceObject) {
-        // If element has its own datasource (and it's not empty), use that
-        return element.datasource;
+        datasource = element.datasource;
       }
     }
 
-    // For queries missing a datasource or with empty datasource object, use datasource from context (queryRunner)
-    return context?.state?.datasource;
+    const panel = context?.state?.datasource;
+    if (!panel) {
+      return datasource;
+    }
+
+    const notExpr =
+      !datasource ||
+      (datasource.uid !== ExpressionDatasourceRef.uid && datasource.type !== ExpressionDatasourceRef.type);
+    if (!datasource || (panel?.uid && panel?.uid !== datasource.uid && panel?.uid !== '-- Mixed --' && notExpr)) {
+      datasource = panel;
+    }
+
+    return datasource;
   }
 
   if (type === 'variable' && 'state' in element && 'datasource' in element.state) {


### PR DESCRIPTION
**What is this feature?**

Backport #117717 and #117998 to `steady`.

**Why do we need this feature?**

Backport datasource fixes to current `steady`/

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
