### PR TITLE
FS: Gate settings service behind feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1517,4 +1517,9 @@ export interface FeatureToggles {
   * @default false
   */
   react19?: boolean;
+  /**
+  * Enables the frontend service to fetch tenant-specific settings overrides from the settings service
+  * @default false
+  */
+  frontendServiceUseSettingsService?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2400,6 +2400,14 @@ var (
 			Owner:        grafanaFrontendPlatformSquad,
 			Expression:   "false",
 		},
+		{
+			Name:         "frontendServiceUseSettingsService",
+			Description:  "Enables the frontend service to fetch tenant-specific settings overrides from the settings service",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaFrontendPlatformSquad,
+			Expression:   "false",
+			HideFromDocs: true,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -298,3 +298,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-02-11,alertingNotificationHistoryRuleViewer,experimental,@grafana/alerting-squad,false,false,false
 2026-02-13,alertingNotificationHistoryGlobal,experimental,@grafana/alerting-squad,false,false,false
 2026-02-18,react19,experimental,@grafana/grafana-frontend-platform,false,false,false
+2026-02-18,frontendServiceUseSettingsService,experimental,@grafana/grafana-frontend-platform,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -829,4 +829,8 @@ const (
 	// FlagReact19
 	// Whether to use the new React 19 runtime
 	FlagReact19 = "react19"
+
+	// FlagFrontendServiceUseSettingsService
+	// Enables the frontend service to fetch tenant-specific settings overrides from the settings service
+	FlagFrontendServiceUseSettingsService = "frontendServiceUseSettingsService"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2060,6 +2060,35 @@
     },
     {
       "metadata": {
+        "name": "frontendServiceSettingsOverrides",
+        "resourceVersion": "1771419300836",
+        "creationTimestamp": "2026-02-18T12:55:00Z",
+        "deletionTimestamp": "2026-02-18T16:12:18Z"
+      },
+      "spec": {
+        "description": "Enables the frontend service to fetch tenant-specific settings overrides from the settings service",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "frontendServiceUseSettingsService",
+        "resourceVersion": "1771431138536",
+        "creationTimestamp": "2026-02-18T16:12:18Z"
+      },
+      "spec": {
+        "description": "Enables the frontend service to fetch tenant-specific settings overrides from the settings service",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "grafanaAPIServerEnsureKubectlAccess",
         "resourceVersion": "1768498862515",
         "creationTimestamp": "2023-12-06T20:21:21Z",

--- a/pkg/services/frontend/context_middleware.go
+++ b/pkg/services/frontend/context_middleware.go
@@ -91,6 +91,7 @@ func setRequestContext(ctx context.Context, w http.ResponseWriter, r *http.Reque
 	}
 	evalCtx := openfeature.NewEvaluationContext(openFeatureNamespace, map[string]any{
 		"namespace": openFeatureNamespace,
+		"hostname":  hostname,
 	})
 	ctx = openfeature.MergeTransactionContext(ctx, evalCtx)
 

--- a/pkg/services/frontend/request_config_middleware.go
+++ b/pkg/services/frontend/request_config_middleware.go
@@ -3,11 +3,13 @@ package frontend
 import (
 	"net/http"
 
+	"github.com/open-feature/go-sdk/openfeature"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	settingservice "github.com/grafana/grafana/pkg/services/setting"
 	"github.com/grafana/grafana/pkg/setting"
@@ -35,32 +37,37 @@ func RequestConfigMiddleware(cfg *setting.Cfg, license licensing.Licensing, sett
 			// This is the default configuration that will be used for all requests
 			requestConfig := NewFSRequestConfig(cfg, license)
 
-			// Fetch tenant-specific configuration if namespace is present
-			if namespace, ok := request.NamespaceFrom(ctx); ok {
-				if namespace != "" && settingsService != nil {
-					// Fetch tenant overrides for relevant sections only
-					selector := metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{{
-							Key:      "section",
-							Operator: metav1.LabelSelectorOpIn,
-							Values:   []string{"security", "analytics"},
-						}, {
-							// don't return values from defaults.ini as they conflict with the services's own defaults
-							Key:      "source",
-							Operator: metav1.LabelSelectorOpNotIn,
-							Values:   []string{"defaults"},
-						}},
-					}
+			// Fetch tenant-specific configuration if the feature toggle is enabled and namespace is present
+			ofClient := openfeature.NewDefaultClient()
+			settingsEnabled, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagFrontendServiceUseSettingsService, false, openfeature.TransactionContext(ctx))
 
-					settings, err := settingsService.ListAsIni(ctx, selector)
-					if err != nil {
-						settingsFetchMetric.WithLabelValues("error").Inc()
-						logger.Error("failed to fetch tenant settings", "namespace", namespace, "err", err)
-						// Fall back to base config
-					} else {
-						settingsFetchMetric.WithLabelValues("success").Inc()
-						// Merge tenant overrides with base config
-						requestConfig.ApplyOverrides(settings, logger)
+			if settingsEnabled {
+				if namespace, ok := request.NamespaceFrom(ctx); ok {
+					if namespace != "" && settingsService != nil {
+						// Fetch tenant overrides for relevant sections only
+						selector := metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{{
+								Key:      "section",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"security", "analytics"},
+							}, {
+								// don't return values from defaults.ini as they conflict with the services's own defaults
+								Key:      "source",
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"defaults"},
+							}},
+						}
+
+						settings, err := settingsService.ListAsIni(ctx, selector)
+						if err != nil {
+							settingsFetchMetric.WithLabelValues("error").Inc()
+							logger.Error("failed to fetch tenant settings", "namespace", namespace, "err", err)
+							// Fall back to base config
+						} else {
+							settingsFetchMetric.WithLabelValues("success").Inc()
+							// Merge tenant overrides with base config
+							requestConfig.ApplyOverrides(settings, logger)
+						}
 					}
 				}
 			}

--- a/pkg/services/frontend/request_config_middleware_test.go
+++ b/pkg/services/frontend/request_config_middleware_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"gopkg.in/ini.v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/endpoints/request"
@@ -13,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	settingservice "github.com/grafana/grafana/pkg/services/setting"
 	"github.com/grafana/grafana/pkg/setting"
@@ -35,6 +39,32 @@ func setupTestContext(r *http.Request, namespace string) *http.Request {
 		ctx = request.WithNamespace(ctx, namespace)
 	}
 	return r.WithContext(ctx)
+}
+
+var openfeatureTestMutex sync.Mutex
+
+func enableSettingsOverridesToggle(t *testing.T) {
+	t.Helper()
+	openfeatureTestMutex.Lock()
+
+	flag := memprovider.InMemoryFlag{
+		Key:            featuremgmt.FlagFrontendServiceUseSettingsService,
+		DefaultVariant: "on",
+		Variants:       map[string]any{"on": true, "off": false},
+	}
+
+	err := featuremgmt.InitOpenFeature(featuremgmt.OpenFeatureConfig{
+		ProviderType: setting.StaticProviderType,
+		StaticFlags: map[string]memprovider.InMemoryFlag{
+			featuremgmt.FlagFrontendServiceUseSettingsService: flag,
+		},
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
+		openfeatureTestMutex.Unlock()
+	})
 }
 
 func TestRequestConfigMiddleware(t *testing.T) {
@@ -103,6 +133,8 @@ func TestRequestConfigMiddleware(t *testing.T) {
 	})
 
 	t.Run("should fetch and apply tenant overrides from settings service", func(t *testing.T) {
+		enableSettingsOverridesToggle(t)
+
 		// Create mock settings service that returns CSP overrides
 		mockSettingsService := &mockSettingsService{
 			settings: []*settingservice.Setting{
@@ -157,6 +189,8 @@ func TestRequestConfigMiddleware(t *testing.T) {
 	})
 
 	t.Run("should fallback to base config on settings service error", func(t *testing.T) {
+		enableSettingsOverridesToggle(t)
+
 		// Create mock that returns an error
 		mockSettingsService := &mockSettingsService{
 			err: assert.AnError,
@@ -206,6 +240,8 @@ func TestRequestConfigMiddleware(t *testing.T) {
 	})
 
 	t.Run("should not call settings service when no namespace is present", func(t *testing.T) {
+		enableSettingsOverridesToggle(t)
+
 		mockSettingsService := &mockSettingsService{}
 
 		license := &licensing.OSSLicensingService{}
@@ -232,6 +268,47 @@ func TestRequestConfigMiddleware(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, recorder.Code)
 		assert.False(t, mockSettingsService.called)
+	})
+
+	t.Run("should not call settings service when feature toggle is disabled", func(t *testing.T) {
+		// No call to enableSettingsOverridesToggle - toggle defaults to off
+		mockSettingsService := &mockSettingsService{}
+
+		license := &licensing.OSSLicensingService{}
+		cfg := &setting.Cfg{
+			Raw:         ini.Empty(),
+			HTTPPort:    "1234",
+			CSPEnabled:  true,
+			CSPTemplate: "default-src 'self'",
+			AppURL:      "https://grafana.example.com",
+		}
+
+		middleware := RequestConfigMiddleware(cfg, license, mockSettingsService)
+
+		var capturedConfig FSRequestConfig
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var err error
+			capturedConfig, err = FSRequestConfigFromContext(r.Context())
+			require.NoError(t, err)
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := middleware(testHandler)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req = setupTestContext(req, "stacks-123")
+		recorder := httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+
+		// Settings service should not be called when toggle is off
+		assert.False(t, mockSettingsService.called)
+
+		// Base config should be used unchanged
+		assert.True(t, capturedConfig.CSPEnabled)
+		assert.Equal(t, "default-src 'self'", capturedConfig.CSPTemplate)
 	})
 }
 


### PR DESCRIPTION
- Adds a new `frontendServiceUseSettingsService` OpenFeature feature toggle (off by default) that gates the frontend service's calls to the settings service for tenant-specific overrides
- Add the request hostname (`r.Host`) in the OpenFeature evaluation context so flag rules can target specific hostnames
