### PR TITLE
Alerting: Add silence view page

### DIFF
--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -152,6 +152,20 @@ export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
       ),
     },
     {
+      path: '/alerting/silence/:id/view',
+      roles: evaluateAccess([
+        AccessControlAction.AlertingInstanceRead,
+        AccessControlAction.AlertingInstancesExternalRead,
+        AccessControlAction.AlertingSilenceRead,
+      ]),
+      component: importAlertingComponent(
+        () =>
+          import(
+            /* webpackChunkName: "SilenceViewPage" */ 'app/features/alerting/unified/components/silences/SilenceViewPage'
+          )
+      ),
+    },
+    {
       path: '/alerting/notifications',
       roles: evaluateAccess([
         AccessControlAction.AlertingNotificationsRead,

--- a/public/app/features/alerting/unified/components/silences/SilenceDetails.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilenceDetails.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2, dateMath, intervalToAbbreviatedDurationString } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { useStyles2 } from '@grafana/ui';
+import { Stack, useStyles2 } from '@grafana/ui';
 
+import { SilenceMetadataGrid } from './SilenceMetadataGrid';
 import SilencedAlertsTable from './SilencedAlertsTable';
 import { SilenceTableItem } from './SilencesTable';
 
@@ -15,28 +16,9 @@ export const SilenceDetails = ({ silence }: Props) => {
   const { startsAt, endsAt, comment, createdBy, silencedAlerts } = silence;
   const styles = useStyles2(getStyles);
 
-  const dateDisplayFormat = 'YYYY-MM-DD HH:mm';
-  const startsAtDate = dateMath.parse(startsAt);
-  const endsAtDate = dateMath.parse(endsAt);
-  const duration = intervalToAbbreviatedDurationString({ start: new Date(startsAt), end: new Date(endsAt) });
   return (
-    <div className={styles.container}>
-      <div className={styles.title}>
-        <Trans i18nKey="alerting.silence-details.comment">Comment</Trans>
-      </div>
-      <div>{comment}</div>
-      <div className={styles.title}>
-        <Trans i18nKey="alerting.silence-details.schedule">Schedule</Trans>
-      </div>
-      <div>{`${startsAtDate?.format(dateDisplayFormat)} - ${endsAtDate?.format(dateDisplayFormat)}`}</div>
-      <div className={styles.title}>
-        <Trans i18nKey="alerting.silence-details.duration">Duration</Trans>
-      </div>
-      <div>{duration}</div>
-      <div className={styles.title}>
-        <Trans i18nKey="alerting.silence-details.created-by">Created by</Trans>
-      </div>
-      <div>{createdBy}</div>
+    <Stack direction="column" gap={2}>
+      <SilenceMetadataGrid {...{ startsAt, endsAt, comment, createdBy }} />
       {Array.isArray(silencedAlerts) && (
         <>
           <div className={styles.title}>
@@ -45,21 +27,12 @@ export const SilenceDetails = ({ silence }: Props) => {
           <SilencedAlertsTable silencedAlerts={silencedAlerts} />
         </>
       )}
-    </div>
+    </Stack>
   );
 };
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  container: css({
-    display: 'grid',
-    gridTemplateColumns: '1fr 9fr',
-    gridRowGap: '1rem',
-    paddingBottom: theme.spacing(2),
-  }),
   title: css({
     color: theme.colors.text.primary,
-  }),
-  row: css({
-    margin: theme.spacing(1, 0),
   }),
 });

--- a/public/app/features/alerting/unified/components/silences/SilenceMetadataGrid.test.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilenceMetadataGrid.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from 'test/test-utils';
+
+import { SilenceMetadataGrid } from './SilenceMetadataGrid';
+
+describe('SilenceMetadataGrid', () => {
+  const defaultProps = {
+    startsAt: '2024-01-15T10:00:00.000Z',
+    endsAt: '2024-01-15T12:00:00.000Z',
+    comment: 'Test silence comment',
+    createdBy: 'admin',
+  };
+
+  it('should render comment', () => {
+    render(<SilenceMetadataGrid {...defaultProps} />);
+    expect(screen.getByText('Test silence comment')).toBeInTheDocument();
+  });
+
+  it('should render created by', () => {
+    render(<SilenceMetadataGrid {...defaultProps} />);
+    expect(screen.getByText('admin')).toBeInTheDocument();
+  });
+
+  it('should render schedule dates', () => {
+    render(<SilenceMetadataGrid {...defaultProps} />);
+    expect(screen.getByText(/2024-01-15/)).toBeInTheDocument();
+  });
+
+  it('should render duration', () => {
+    render(<SilenceMetadataGrid {...defaultProps} />);
+    expect(screen.getByText('2h')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/components/silences/SilenceMetadataGrid.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilenceMetadataGrid.tsx
@@ -1,0 +1,56 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2, dateTimeFormat, intervalToAbbreviatedDurationString } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+import { useStyles2 } from '@grafana/ui';
+
+interface SilenceMetadataGridProps {
+  startsAt: string;
+  endsAt: string;
+  comment: string;
+  createdBy: string;
+}
+
+export function SilenceMetadataGrid({ startsAt, endsAt, comment, createdBy }: SilenceMetadataGridProps) {
+  const styles = useStyles2(getStyles);
+  const dateDisplayFormat = 'YYYY-MM-DD HH:mm';
+  const startsAtDate = dateTimeFormat(startsAt, { format: dateDisplayFormat });
+  const endsAtDate = dateTimeFormat(endsAt, { format: dateDisplayFormat });
+  const duration = intervalToAbbreviatedDurationString({
+    start: new Date(startsAt),
+    end: new Date(endsAt),
+  });
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.label}>
+        <Trans i18nKey="alerting.silence-details.comment">Comment</Trans>
+      </div>
+      <div>{comment}</div>
+      <div className={styles.label}>
+        <Trans i18nKey="alerting.silence-details.schedule">Schedule</Trans>
+      </div>
+      <div>{`${startsAtDate} - ${endsAtDate}`}</div>
+      <div className={styles.label}>
+        <Trans i18nKey="alerting.silence-details.duration">Duration</Trans>
+      </div>
+      <div>{duration}</div>
+      <div className={styles.label}>
+        <Trans i18nKey="alerting.silence-details.created-by">Created by</Trans>
+      </div>
+      <div>{createdBy}</div>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    display: 'grid',
+    gridTemplateColumns: '1fr 9fr',
+    gridRowGap: '1rem',
+    paddingBottom: theme.spacing(2),
+  }),
+  label: css({
+    color: theme.colors.text.primary,
+  }),
+});

--- a/public/app/features/alerting/unified/components/silences/SilenceViewContent.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilenceViewContent.tsx
@@ -2,6 +2,7 @@ import { Trans } from '@grafana/i18n';
 import { Stack, Text, TextLink } from '@grafana/ui';
 import { AlertmanagerAlert, Silence } from 'app/plugins/datasource/alertmanager/types';
 
+import { createReturnTo } from '../../hooks/useReturnTo';
 import { MATCHER_ALERT_RULE_UID } from '../../utils/constants';
 
 import { Matchers } from './Matchers';
@@ -16,6 +17,11 @@ interface SilenceViewContentProps {
 export function SilenceViewContent({ silence, silencedAlerts }: SilenceViewContentProps) {
   const { matchers = [], comment, createdBy, startsAt, endsAt, metadata } = silence;
   const filteredMatchers = matchers.filter((m) => m.name !== MATCHER_ALERT_RULE_UID);
+  const returnTo = createReturnTo();
+
+  const alertRuleHref = metadata?.rule_uid
+    ? `/alerting/grafana/${metadata.rule_uid}/view?${new URLSearchParams({ returnTo }).toString()}`
+    : '';
 
   return (
     <Stack direction="column" gap={2}>
@@ -24,7 +30,7 @@ export function SilenceViewContent({ silence, silencedAlerts }: SilenceViewConte
           <Text variant="bodySmall" color="secondary">
             <Trans i18nKey="alerting.silence-view.alert-rule">Alert rule</Trans>
           </Text>
-          <TextLink href={`/alerting/grafana/${metadata.rule_uid}/view`}>{metadata.rule_title}</TextLink>
+          <TextLink href={alertRuleHref}>{metadata.rule_title}</TextLink>
         </Stack>
       )}
 

--- a/public/app/features/alerting/unified/components/silences/SilenceViewContent.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilenceViewContent.tsx
@@ -20,7 +20,7 @@ export function SilenceViewContent({ silence, silencedAlerts }: SilenceViewConte
   const returnTo = createReturnTo();
 
   const alertRuleHref = metadata?.rule_uid
-    ? `/alerting/grafana/${metadata.rule_uid}/view?${new URLSearchParams({ returnTo }).toString()}`
+    ? `/alerting/grafana/${encodeURIComponent(metadata.rule_uid)}/view?${new URLSearchParams({ returnTo }).toString()}`
     : '';
 
   return (

--- a/public/app/features/alerting/unified/components/silences/SilenceViewContent.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilenceViewContent.tsx
@@ -1,0 +1,52 @@
+import { Trans } from '@grafana/i18n';
+import { Stack, Text, TextLink } from '@grafana/ui';
+import { AlertmanagerAlert, Silence } from 'app/plugins/datasource/alertmanager/types';
+
+import { MATCHER_ALERT_RULE_UID } from '../../utils/constants';
+
+import { Matchers } from './Matchers';
+import { SilenceMetadataGrid } from './SilenceMetadataGrid';
+import SilencedAlertsTable from './SilencedAlertsTable';
+
+interface SilenceViewContentProps {
+  silence: Silence;
+  silencedAlerts: AlertmanagerAlert[];
+}
+
+export function SilenceViewContent({ silence, silencedAlerts }: SilenceViewContentProps) {
+  const { matchers = [], comment, createdBy, startsAt, endsAt, metadata } = silence;
+  const filteredMatchers = matchers.filter((m) => m.name !== MATCHER_ALERT_RULE_UID);
+
+  return (
+    <Stack direction="column" gap={2}>
+      {metadata?.rule_title && metadata?.rule_uid && (
+        <Stack direction="column" gap={0.5}>
+          <Text variant="bodySmall" color="secondary">
+            <Trans i18nKey="alerting.silence-view.alert-rule">Alert rule</Trans>
+          </Text>
+          <TextLink href={`/alerting/grafana/${metadata.rule_uid}/view`}>{metadata.rule_title}</TextLink>
+        </Stack>
+      )}
+
+      {filteredMatchers.length > 0 && (
+        <Stack direction="column" gap={0.5}>
+          <Text variant="bodySmall" color="secondary">
+            <Trans i18nKey="alerting.silence-view.matchers">Matching labels</Trans>
+          </Text>
+          <Matchers matchers={filteredMatchers} />
+        </Stack>
+      )}
+
+      <SilenceMetadataGrid startsAt={startsAt} endsAt={endsAt} comment={comment} createdBy={createdBy} />
+
+      {silencedAlerts.length > 0 && (
+        <Stack direction="column" gap={0.5}>
+          <Text variant="bodySmall" color="secondary">
+            <Trans i18nKey="alerting.silence-view.affected-alerts">Affected alerts</Trans>
+          </Text>
+          <SilencedAlertsTable silencedAlerts={silencedAlerts} />
+        </Stack>
+      )}
+    </Stack>
+  );
+}

--- a/public/app/features/alerting/unified/components/silences/SilenceViewPage.test.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilenceViewPage.test.tsx
@@ -1,0 +1,117 @@
+import { HttpResponse } from 'msw';
+import { Route, Routes } from 'react-router-dom-v5-compat';
+import { render, screen } from 'test/test-utils';
+
+import { AlertState } from 'app/plugins/datasource/alertmanager/types';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { setupMswServer } from '../../mockApi';
+import { MOCK_SILENCE_ID_EXISTING, grantUserPermissions, mockAlertmanagerAlert, mockSilence } from '../../mocks';
+import { setAlertmanagerAlertsHandler, setSilenceGetResolver } from '../../mocks/server/configure';
+import { MOCK_GRAFANA_ALERT_RULE_TITLE } from '../../mocks/server/handlers/grafanaRuler';
+
+import SilenceViewPage from './SilenceViewPage';
+
+const MOCK_RULE_UID = 'abc-rule-uid-123';
+
+setupMswServer();
+
+function renderSilenceViewPage(silenceId: string) {
+  return render(
+    <Routes>
+      <Route path="/alerting/silence/:id/view" element={<SilenceViewPage />} />
+    </Routes>,
+    {
+      historyOptions: {
+        initialEntries: [`/alerting/silence/${silenceId}/view`],
+      },
+    }
+  );
+}
+
+describe('SilenceViewPage', () => {
+  beforeEach(() => {
+    grantUserPermissions([AccessControlAction.AlertingInstanceRead, AccessControlAction.AlertingSilenceRead]);
+
+    // Return no alerts by default to avoid duplicate key warnings from mock data
+    setAlertmanagerAlertsHandler([]);
+  });
+
+  it('should show loading state initially', () => {
+    renderSilenceViewPage(MOCK_SILENCE_ID_EXISTING);
+    expect(screen.getByText(/Loading silence/)).toBeInTheDocument();
+  });
+
+  it('should render silence details for an existing silence', async () => {
+    renderSilenceViewPage(MOCK_SILENCE_ID_EXISTING);
+
+    expect(await screen.findByText('Happy path silence')).toBeInTheDocument();
+    expect(screen.getByText('active')).toBeInTheDocument();
+  });
+
+  it('should render matchers for an existing silence', async () => {
+    renderSilenceViewPage(MOCK_SILENCE_ID_EXISTING);
+
+    expect(await screen.findByText('Happy path silence')).toBeInTheDocument();
+    expect(screen.getByText(/foo=bar/)).toBeInTheDocument();
+  });
+
+  it('should show not found for non-existent silence', async () => {
+    renderSilenceViewPage('non-existent-id');
+
+    expect(await screen.findByText(/not found/i)).toBeInTheDocument();
+  });
+
+  it('should show error state on API failure', async () => {
+    setSilenceGetResolver(() => {
+      return HttpResponse.json({ message: 'Internal server error' }, { status: 500 });
+    });
+
+    renderSilenceViewPage(MOCK_SILENCE_ID_EXISTING);
+
+    expect(await screen.findByText(/Error loading silence/)).toBeInTheDocument();
+  });
+
+  it('should display affected alerts when present', async () => {
+    const silenceId = MOCK_SILENCE_ID_EXISTING;
+    setAlertmanagerAlertsHandler([
+      mockAlertmanagerAlert({
+        fingerprint: 'unique-fingerprint-1',
+        status: { state: AlertState.Suppressed, silencedBy: [silenceId], inhibitedBy: [] },
+        labels: { alertname: 'TestAlert', severity: 'warning' },
+      }),
+    ]);
+
+    renderSilenceViewPage(silenceId);
+
+    expect(await screen.findByText('Happy path silence')).toBeInTheDocument();
+    expect(await screen.findByText('TestAlert')).toBeInTheDocument();
+  });
+
+  it('should show alert rule link when metadata is present', async () => {
+    const silenceId = 'silence-with-rule-metadata';
+    const silenceWithRule = mockSilence({
+      id: silenceId,
+      comment: 'Silence targeting a specific rule',
+      metadata: {
+        rule_title: MOCK_GRAFANA_ALERT_RULE_TITLE,
+        rule_uid: MOCK_RULE_UID,
+      },
+    });
+
+    setSilenceGetResolver(({ request }) => {
+      const ruleMetadataQueryParam = new URL(request.url).searchParams.get('ruleMetadata');
+      const { metadata, ...silence } = silenceWithRule;
+      return HttpResponse.json({
+        ...silence,
+        ...(ruleMetadataQueryParam && { metadata }),
+      });
+    });
+
+    renderSilenceViewPage(silenceId);
+
+    const ruleLink = await screen.findByRole('link', { name: MOCK_GRAFANA_ALERT_RULE_TITLE });
+    expect(ruleLink).toBeInTheDocument();
+    expect(ruleLink).toHaveAttribute('href', `/alerting/grafana/${MOCK_RULE_UID}/view`);
+  });
+});

--- a/public/app/features/alerting/unified/components/silences/SilenceViewPage.test.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilenceViewPage.test.tsx
@@ -113,7 +113,7 @@ describe('SilenceViewPage', () => {
     const ruleLink = await screen.findByRole('link', { name: MOCK_GRAFANA_ALERT_RULE_TITLE });
     expect(ruleLink).toBeInTheDocument();
     const parsedRuleLink = new URL(ruleLink.getAttribute('href') ?? '', 'http://localhost');
-    expect(parsedRuleLink.pathname).toBe(`/alerting/grafana/${MOCK_RULE_UID}/view`);
+    expect(parsedRuleLink.pathname).toBe(`/alerting/grafana/${encodeURIComponent(MOCK_RULE_UID)}/view`);
     expect(parsedRuleLink.searchParams.get('returnTo')).toBe(`/alerting/silence/${silenceId}/view`);
   });
 });

--- a/public/app/features/alerting/unified/components/silences/SilenceViewPage.test.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilenceViewPage.test.tsx
@@ -112,6 +112,8 @@ describe('SilenceViewPage', () => {
 
     const ruleLink = await screen.findByRole('link', { name: MOCK_GRAFANA_ALERT_RULE_TITLE });
     expect(ruleLink).toBeInTheDocument();
-    expect(ruleLink).toHaveAttribute('href', `/alerting/grafana/${MOCK_RULE_UID}/view`);
+    const parsedRuleLink = new URL(ruleLink.getAttribute('href') ?? '', 'http://localhost');
+    expect(parsedRuleLink.pathname).toBe(`/alerting/grafana/${MOCK_RULE_UID}/view`);
+    expect(parsedRuleLink.searchParams.get('returnTo')).toBe(`/alerting/silence/${silenceId}/view`);
   });
 });

--- a/public/app/features/alerting/unified/components/silences/SilenceViewPage.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilenceViewPage.tsx
@@ -1,4 +1,5 @@
 import { t } from '@grafana/i18n';
+import { isFetchError } from '@grafana/runtime';
 import { Alert, LoadingPlaceholder, Stack, Text } from '@grafana/ui';
 import { EntityNotFound } from 'app/core/components/PageNotFound/EntityNotFound';
 
@@ -23,7 +24,8 @@ function Title({ title }: { title: string }) {
 }
 
 function SilenceView() {
-  const { silence, silencedAlerts, isLoading, error, isNotFound } = useSilenceViewData();
+  const { silence, silencedAlerts, isLoading, error } = useSilenceViewData();
+  const isNotFound = isFetchError(error) && error.status === 404;
 
   if (isLoading) {
     return <LoadingPlaceholder text={t('alerting.silence-view.loading', 'Loading silence...')} />;

--- a/public/app/features/alerting/unified/components/silences/SilenceViewPage.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilenceViewPage.tsx
@@ -1,0 +1,73 @@
+import { t } from '@grafana/i18n';
+import { Alert, LoadingPlaceholder, Stack, Text } from '@grafana/ui';
+import { EntityNotFound } from 'app/core/components/PageNotFound/EntityNotFound';
+
+import { useSilenceViewData } from '../../hooks/useSilenceViewData';
+import { stringifyErrorLike } from '../../utils/misc';
+import { withPageErrorBoundary } from '../../withPageErrorBoundary';
+import { AlertmanagerPageWrapper } from '../AlertingPageWrapper';
+
+import { SilenceStateTag } from './SilenceStateTag';
+import { SilenceViewContent } from './SilenceViewContent';
+
+function Title({ title }: { title: string }) {
+  const { silence } = useSilenceViewData();
+  const silenceState = silence?.status.state;
+
+  return (
+    <Stack direction="row" gap={1} alignItems="center">
+      <Text variant="h1">{title}</Text>
+      {silenceState && <SilenceStateTag state={silenceState} />}
+    </Stack>
+  );
+}
+
+function SilenceView() {
+  const { silence, silencedAlerts, isLoading, error, isNotFound } = useSilenceViewData();
+
+  if (isLoading) {
+    return <LoadingPlaceholder text={t('alerting.silence-view.loading', 'Loading silence...')} />;
+  }
+
+  if (isNotFound) {
+    return <EntityNotFound entity="Silence" />;
+  }
+
+  if (error) {
+    return (
+      <Alert severity="error" title={t('alerting.silence-view.error', 'Error loading silence')}>
+        {stringifyErrorLike(error)}
+      </Alert>
+    );
+  }
+
+  if (!silence) {
+    return <EntityNotFound entity="Silence" />;
+  }
+
+  return <SilenceViewContent silence={silence} silencedAlerts={silencedAlerts} />;
+}
+
+function SilenceViewPage() {
+  const pageNav = {
+    id: 'silence-view',
+    text: t('alerting.silence-view.page-nav.text', 'Silence'),
+    parentItem: {
+      text: t('alerting.silence-view.page-nav.parent', 'Silences'),
+      url: '/alerting/silences',
+    },
+  };
+
+  return (
+    <AlertmanagerPageWrapper
+      navId="silences"
+      pageNav={pageNav}
+      accessType="instance"
+      renderTitle={(title) => <Title title={title} />}
+    >
+      <SilenceView />
+    </AlertmanagerPageWrapper>
+  );
+}
+
+export default withPageErrorBoundary(SilenceViewPage);

--- a/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
@@ -350,60 +350,67 @@ function useColumns(alertManagerSourceName: string) {
         size: 7,
       },
     ];
-    if (updateSupported) {
-      columns.push({
-        id: 'actions',
-        label: t('alerting.use-columns.label.actions', 'Actions'),
-        renderCell: function renderActions({ data: silence }) {
-          const isExpired = silence.status.state === SilenceState.Expired;
+    columns.push({
+      id: 'actions',
+      label: t('alerting.use-columns.label.actions', 'Actions'),
+      renderCell: function renderActions({ data: silence }) {
+        const isExpired = silence.status.state === SilenceState.Expired;
 
-          const canCreate = silence?.accessControl?.create;
-          const canWrite = silence?.accessControl?.write;
+        const canCreate = silence?.accessControl?.create;
+        const canWrite = silence?.accessControl?.write;
 
-          const canRecreate = isExpired && (isGrafanaFlavoredAlertmanager ? canCreate : updateAllowed);
-          const canEdit = !isExpired && (isGrafanaFlavoredAlertmanager ? canWrite : updateAllowed);
+        const canRecreate = updateSupported && isExpired && (isGrafanaFlavoredAlertmanager ? canCreate : updateAllowed);
+        const canEdit = updateSupported && !isExpired && (isGrafanaFlavoredAlertmanager ? canWrite : updateAllowed);
 
-          return (
-            <Stack gap={0.5} wrap="wrap">
-              {canRecreate && (
+        return (
+          <Stack gap={0.5} wrap="wrap">
+            <LinkButton
+              title={t('alerting.use-columns.title-view', 'View')}
+              size="sm"
+              variant="secondary"
+              icon="eye"
+              href={makeAMLink(`/alerting/silence/${silence.id}/view`, alertManagerSourceName)}
+            >
+              <Trans i18nKey="silences.table.view-button">View</Trans>
+            </LinkButton>
+            {canRecreate && (
+              <LinkButton
+                title={t('alerting.use-columns.title-recreate', 'Recreate')}
+                size="sm"
+                variant="secondary"
+                icon="sync"
+                href={makeAMLink(`/alerting/silence/${silence.id}/edit`, alertManagerSourceName)}
+              >
+                <Trans i18nKey="silences.table.recreate-button">Recreate</Trans>
+              </LinkButton>
+            )}
+            {canEdit && (
+              <>
                 <LinkButton
-                  title={t('alerting.use-columns.title-recreate', 'Recreate')}
+                  title={t('alerting.use-columns.title-unsilence', 'Unsilence')}
                   size="sm"
                   variant="secondary"
-                  icon="sync"
+                  icon="bell"
+                  onClick={() => handleExpireSilenceClick(silence.id)}
+                >
+                  <Trans i18nKey="silences.table.unsilence-button">Unsilence</Trans>
+                </LinkButton>
+                <LinkButton
+                  title={t('alerting.use-columns.title-edit', 'Edit')}
+                  size="sm"
+                  variant="secondary"
+                  icon="pen"
                   href={makeAMLink(`/alerting/silence/${silence.id}/edit`, alertManagerSourceName)}
                 >
-                  <Trans i18nKey="silences.table.recreate-button">Recreate</Trans>
+                  <Trans i18nKey="silences.table.edit-button">Edit</Trans>
                 </LinkButton>
-              )}
-              {canEdit && (
-                <>
-                  <LinkButton
-                    title={t('alerting.use-columns.title-unsilence', 'Unsilence')}
-                    size="sm"
-                    variant="secondary"
-                    icon="bell"
-                    onClick={() => handleExpireSilenceClick(silence.id)}
-                  >
-                    <Trans i18nKey="silences.table.unsilence-button">Unsilence</Trans>
-                  </LinkButton>
-                  <LinkButton
-                    title={t('alerting.use-columns.title-edit', 'Edit')}
-                    size="sm"
-                    variant="secondary"
-                    icon="pen"
-                    href={makeAMLink(`/alerting/silence/${silence.id}/edit`, alertManagerSourceName)}
-                  >
-                    <Trans i18nKey="silences.table.edit-button">Edit</Trans>
-                  </LinkButton>
-                </>
-              )}
-            </Stack>
-          );
-        },
-        size: 5,
-      });
-    }
+              </>
+            )}
+          </Stack>
+        );
+      },
+      size: 5,
+    });
     return columns;
   }, [alertManagerSourceName, expireSilence, isGrafanaFlavoredAlertmanager, updateAllowed, updateSupported]);
 }

--- a/public/app/features/alerting/unified/hooks/useSilenceViewData.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useSilenceViewData.test.tsx
@@ -73,7 +73,6 @@ describe('useSilenceViewData', () => {
     });
 
     expect(result.current.error).toBeUndefined();
-    expect(result.current.isNotFound).toBeFalsy();
     expect(result.current.silence).toBeDefined();
     expect(result.current.silencedAlerts).toHaveLength(1);
     expect(result.current.silencedAlerts[0].labels.alertname).toBe('MatchingAlert');
@@ -90,7 +89,6 @@ describe('useSilenceViewData', () => {
 
     expect(result.current.error).toBeDefined();
     expect(result.current.silence).toBeUndefined();
-    expect(result.current.isNotFound).toBeFalsy();
     expect(result.current.silencedAlerts).toEqual([]);
   });
 
@@ -105,7 +103,6 @@ describe('useSilenceViewData', () => {
 
     expect(result.current.error).toBeDefined();
     expect(result.current.silence).toBeUndefined();
-    expect(result.current.isNotFound).toBeTruthy();
     expect(result.current.silencedAlerts).toEqual([]);
   });
 });

--- a/public/app/features/alerting/unified/hooks/useSilenceViewData.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useSilenceViewData.test.tsx
@@ -1,0 +1,111 @@
+import { HttpResponse } from 'msw';
+import { PropsWithChildren } from 'react';
+import { Route, Routes } from 'react-router-dom-v5-compat';
+import { getWrapper, renderHook, waitFor } from 'test/test-utils';
+
+import { AlertState } from 'app/plugins/datasource/alertmanager/types';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { setupMswServer } from '../mockApi';
+import { MOCK_SILENCE_ID_EXISTING, grantUserPermissions, mockAlertmanagerAlert } from '../mocks';
+import { setAlertmanagerAlertsHandler, setSilenceGetResolver } from '../mocks/server/configure';
+import { AlertmanagerProvider } from '../state/AlertmanagerContext';
+
+import { useSilenceViewData } from './useSilenceViewData';
+
+setupMswServer();
+
+function createWrapper(silenceId: string) {
+  const ProviderWrapper = getWrapper({
+    renderWithRouter: true,
+    historyOptions: {
+      initialEntries: [`/alerting/silence/${silenceId}/view`],
+    },
+  });
+
+  return function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <ProviderWrapper>
+        <Routes>
+          <Route
+            path="/alerting/silence/:id/view"
+            element={<AlertmanagerProvider accessType="instance">{children}</AlertmanagerProvider>}
+          />
+        </Routes>
+      </ProviderWrapper>
+    );
+  };
+}
+
+describe('useSilenceViewData', () => {
+  beforeEach(() => {
+    grantUserPermissions([AccessControlAction.AlertingInstanceRead, AccessControlAction.AlertingSilenceRead]);
+    setAlertmanagerAlertsHandler([]);
+  });
+
+  it('returns loading state initially', () => {
+    const { result } = renderHook(() => useSilenceViewData(), { wrapper: createWrapper(MOCK_SILENCE_ID_EXISTING) });
+
+    expect(result.current.isLoading).toBeTruthy();
+    expect(result.current.silence).toBeUndefined();
+    expect(result.current.silencedAlerts).toEqual([]);
+  });
+
+  it('returns silence and filtered silenced alerts on success', async () => {
+    const silenceId = MOCK_SILENCE_ID_EXISTING;
+    setAlertmanagerAlertsHandler([
+      mockAlertmanagerAlert({
+        fingerprint: 'matching-alert',
+        status: { state: AlertState.Suppressed, silencedBy: [silenceId], inhibitedBy: [] },
+        labels: { alertname: 'MatchingAlert' },
+      }),
+      mockAlertmanagerAlert({
+        fingerprint: 'non-matching-alert',
+        status: { state: AlertState.Suppressed, silencedBy: ['another-silence-id'], inhibitedBy: [] },
+        labels: { alertname: 'NonMatchingAlert' },
+      }),
+    ]);
+
+    const { result } = renderHook(() => useSilenceViewData(), { wrapper: createWrapper(silenceId) });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBeFalsy();
+    });
+
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isNotFound).toBeFalsy();
+    expect(result.current.silence).toBeDefined();
+    expect(result.current.silencedAlerts).toHaveLength(1);
+    expect(result.current.silencedAlerts[0].labels.alertname).toBe('MatchingAlert');
+  });
+
+  it('returns error state on silence API failure', async () => {
+    setSilenceGetResolver(() => HttpResponse.json({ message: 'Internal server error' }, { status: 500 }));
+
+    const { result } = renderHook(() => useSilenceViewData(), { wrapper: createWrapper(MOCK_SILENCE_ID_EXISTING) });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBeFalsy();
+    });
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.silence).toBeUndefined();
+    expect(result.current.isNotFound).toBeFalsy();
+    expect(result.current.silencedAlerts).toEqual([]);
+  });
+
+  it('returns not found state on 404 silence response', async () => {
+    setSilenceGetResolver(() => HttpResponse.json({ message: 'Not found' }, { status: 404 }));
+
+    const { result } = renderHook(() => useSilenceViewData(), { wrapper: createWrapper('non-existent-id') });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBeFalsy();
+    });
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.silence).toBeUndefined();
+    expect(result.current.isNotFound).toBeTruthy();
+    expect(result.current.silencedAlerts).toEqual([]);
+  });
+});

--- a/public/app/features/alerting/unified/hooks/useSilenceViewData.ts
+++ b/public/app/features/alerting/unified/hooks/useSilenceViewData.ts
@@ -1,0 +1,51 @@
+import { useMemo } from 'react';
+import { useParams } from 'react-router-dom-v5-compat';
+
+import { isFetchError } from '@grafana/runtime';
+import { AlertmanagerAlert, Silence } from 'app/plugins/datasource/alertmanager/types';
+
+import { alertSilencesApi } from '../api/alertSilencesApi';
+import { alertmanagerApi } from '../api/alertmanagerApi';
+import { useAlertmanager } from '../state/AlertmanagerContext';
+import { getDatasourceAPIUid } from '../utils/datasource';
+
+interface UseSilenceViewDataResult {
+  silence?: Silence;
+  silencedAlerts: AlertmanagerAlert[];
+  isLoading: boolean;
+  error: unknown;
+  isNotFound: boolean;
+}
+
+export function useSilenceViewData(): UseSilenceViewDataResult {
+  const { id: silenceId = '' } = useParams();
+  const { selectedAlertmanager: alertManagerSourceName = '' } = useAlertmanager();
+
+  const {
+    data: silence,
+    isLoading,
+    error,
+  } = alertSilencesApi.endpoints.getSilence.useQuery({
+    id: silenceId,
+    datasourceUid: getDatasourceAPIUid(alertManagerSourceName),
+    ruleMetadata: true,
+    accessControl: true,
+  });
+
+  const { data: alertManagerAlerts = [] } = alertmanagerApi.endpoints.getAlertmanagerAlerts.useQuery({
+    amSourceName: alertManagerSourceName,
+    filter: { silenced: true, active: false, inhibited: false },
+  });
+
+  const silencedAlerts = useMemo(() => {
+    return alertManagerAlerts.filter((alert) => alert.status.silencedBy.includes(silenceId));
+  }, [alertManagerAlerts, silenceId]);
+
+  return {
+    silence,
+    silencedAlerts,
+    isLoading,
+    error,
+    isNotFound: isFetchError(error) && error.status === 404,
+  };
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3140,6 +3140,17 @@
       "label-silence-start-and-end": "Silence start and end",
       "placeholder-select-time-range": "Select time range"
     },
+    "silence-view": {
+      "affected-alerts": "Affected alerts",
+      "alert-rule": "Alert rule",
+      "error": "Error loading silence",
+      "loading": "Loading silence...",
+      "matchers": "Matching labels",
+      "page-nav": {
+        "parent": "Silences",
+        "text": "Silence"
+      }
+    },
     "silenced-alerts-table-row": {
       "silenced-for": "for {{duration}}"
     },
@@ -3448,7 +3459,8 @@
       },
       "title-edit": "Edit",
       "title-recreate": "Recreate",
-      "title-unsilence": "Unsilence"
+      "title-unsilence": "Unsilence",
+      "title-view": "View"
     },
     "use-combined-labels": {
       "grouped-options": {
@@ -13926,7 +13938,8 @@
       "no-matching-silences": "No matching silences found;",
       "noConfig": "Create a new contact point to create a configuration using the default values or contact your administrator to set up the Alertmanager.",
       "recreate-button": "Recreate",
-      "unsilence-button": "Unsilence"
+      "unsilence-button": "Unsilence",
+      "view-button": "View"
     }
   },
   "silences-table": {


### PR DESCRIPTION
**What is this feature?**

This PR adds a new view page for silences. The page is view only and does not expose any edit controls.

<img width="3405" height="2045" alt="image" src="https://github.com/user-attachments/assets/05745f6b-4589-4e88-b098-f576b181ac84" />

**Why do we need this feature?**

Currently, there is no way to link directly to a specific silence in Grafana Managed Alerts. This makes it difficult to share silence details with teammates, for example in Slack during on-call rotations.

**Who is this feature for?**

Alerting users 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/117977

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
