### PR TITLE
TableNG: Export `MaybeWrapWithLink` from @grafana/ui/internal

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/components/MaybeWrapWithLink.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/MaybeWrapWithLink.tsx
@@ -12,6 +12,9 @@ interface MaybeWrapWithLinkProps {
   children: ReactNode;
 }
 
+/**
+ * @internal
+ */
 export const MaybeWrapWithLink = memo(({ field, rowIdx, children }: MaybeWrapWithLinkProps): ReactNode => {
   const linksCount = field.config.links?.length ?? 0;
   const actionsCount = field.config.actions?.length ?? 0;

--- a/packages/grafana-ui/src/internal/index.ts
+++ b/packages/grafana-ui/src/internal/index.ts
@@ -109,3 +109,5 @@ export { closePopover } from '../utils/closePopover';
 
 export { flattenTokens } from '../slate-plugins/slate-prism';
 export { RadialGauge } from '../components/RadialGauge/RadialGauge';
+
+export { MaybeWrapWithLink } from '../components/Table/TableNG/components/MaybeWrapWithLink';


### PR DESCRIPTION
**What is this feature?**

Exporting MaybeWrapWithLink component.

**Why do we need this feature?**
So we don't have to maintain multiple copies of the same code in different plugins.

**Who is this feature for?**

Core developers using Table.

**Special notes for your reviewer:**
Doesn't help external app plugin developers, but we're in progress working on a better long term solution to export components in another package that isn't grafana/ui.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
