### PR TITLE
fix(escape): escape all logs not only json

### DIFF
--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -245,6 +245,23 @@ Value"
 }`);
     });
 
+    test('Escapes literal \\n in non-JSON plain text logs (e.g. stack traces)', () => {
+      const entry =
+        'WARN c.n.l.BootstrapExecutor [main] - deployment failed. TimeoutException\\n at java.base/java.util.concurrent.CompletableFuture.wrapInCompletionException(CompletableFuture.java:323)';
+      const logListModel = createLogLine(
+        { entry, hasUnescapedContent: true },
+        {
+          escape: true,
+          order: LogsSortOrder.Descending,
+          timeZone: 'browser',
+          wrapLogMessage: true,
+          prettifyJSON: false,
+        }
+      );
+      expect(logListModel.body).toContain('TimeoutException\n at java.base');
+      expect(logListModel.body).not.toContain('TimeoutException\\n at');
+    });
+
     test('Uses lossless parsing', () => {
       const entry = '{"number": 90071992547409911}';
       const logListModel = createLogLine(

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -145,10 +145,12 @@ export class LogListModel implements LogRowModel {
         if (reStringified) {
           this.raw = reStringified;
         }
-        if (this._escapeUnescapedString) {
-          this.raw = escapeUnescapedString(this.raw);
-        }
       } catch (error) {}
+
+      // always escape for literal \n, \t, \r sequences so "Escape newlines" works for all log types.
+      if (this._escapeUnescapedString) {
+        this.raw = escapeUnescapedString(this.raw);
+      }
       const raw = this.raw;
       this._body = this.collapsed
         ? raw.substring(0, this._virtualization?.getTruncationLength(null) ?? TRUNCATION_DEFAULT_LENGTH)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
https://github.com/grafana/grafana/issues/118310

Escaping used to be applied in the constructor then escape was changed to be applied only inside the try block; when parse() throws for non-JSON logs, the catch block is empty and the escape was skipped. Updated escaping to run all the time again.

#### Testing
These logs already were json so they would have been escaped in the old logic as well.
service_name=nginx-json-mixed
<img width="1849" height="311" alt="Screenshot 2026-02-18 at 9 56 35 AM" src="https://github.com/user-attachments/assets/3260ca8f-13e7-4405-90a4-015d05d9ca60" />
<img width="1833" height="343" alt="Screenshot 2026-02-18 at 9 56 51 AM" src="https://github.com/user-attachments/assets/8dae2012-18df-46fe-b113-eed30ee92ae2" />


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/118310

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
