### PR TITLE
Tempo: Fix query editor breaking when invalid query used

### DIFF
--- a/public/app/plugins/datasource/tempo/traceql/highlighting.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/highlighting.test.ts
@@ -1,6 +1,6 @@
 import { monacoTypes } from '@grafana/ui';
 
-import { computeErrorMessage, getErrorNodes, getWarningMarkers } from './highlighting';
+import { computeErrorMessage, getErrorMarkers, getErrorNodes, getMarker, getWarningMarkers } from './highlighting';
 
 describe('Highlighting', () => {
   describe('gets correct warning markers for', () => {
@@ -81,6 +81,42 @@ describe('Highlighting', () => {
           },
         ])
       );
+    });
+  });
+
+  describe('getMarker', () => {
+    it('returns valid 1-based marker when from and to are 0 (invalid query at position 0)', () => {
+      const { model } = setup('{ .foo = 1 }');
+      const marker = getMarker(8, 'Invalid query.', model, 0, 0);
+      expect(marker).toEqual({
+        message: 'Invalid query.',
+        severity: 8,
+        startLineNumber: 1,
+        endLineNumber: 1,
+        startColumn: 1,
+        endColumn: 1,
+      });
+    });
+
+    it('returns correct marker for valid from/to on single line', () => {
+      const { model } = setup('hello');
+      const marker = getMarker(8, 'Test error', model, 1, 4);
+      expect(marker).toMatchObject({
+        message: 'Test error',
+        severity: 8,
+        startLineNumber: 1,
+        endLineNumber: 1,
+        startColumn: 2,
+        endColumn: 5,
+      });
+    });
+  });
+
+  describe('getErrorMarkers', () => {
+    it('does not throw for invalid query that produces error nodes', () => {
+      const { model } = setup('Root=1-698b7d11-6e5020e45727f8fe3724ce4f');
+      const errorNodes = getErrorNodes('Root=1-698b7d11-6e5020e45727f8fe3724ce4f');
+      expect(() => getErrorMarkers(8, model, errorNodes)).not.toThrow();
     });
   });
 

--- a/public/app/plugins/datasource/tempo/traceql/highlighting.ts
+++ b/public/app/plugins/datasource/tempo/traceql/highlighting.ts
@@ -199,15 +199,19 @@ export const getMarker = (
     end -= model.getLineLength(endLine) + 1;
   }
 
+  // Monaco uses 1-based line numbers; avoid getLineLength(0) and invalid line 0 (fixes editor break on invalid query at position 0)
+  const startLineNumber = startLine > 0 ? startLine : 1;
+  const endLineNumber = endLine > 0 ? endLine : 1;
+  const startColumn =
+    startLine > 0 ? start + model.getLineLength(startLine) + 2 : 1;
+  const endColumn = endLine > 0 ? end + model.getLineLength(endLine) + 2 : 1;
+
   return {
     message,
     severity,
-
-    startLineNumber: startLine,
-    endLineNumber: endLine,
-
-    // `+ 2` because of the above computations
-    startColumn: start + model.getLineLength(startLine) + 2,
-    endColumn: end + model.getLineLength(endLine) + 2,
+    startLineNumber,
+    endLineNumber,
+    startColumn,
+    endColumn,
   };
 };

--- a/public/app/plugins/datasource/tempo/traceql/highlighting.ts
+++ b/public/app/plugins/datasource/tempo/traceql/highlighting.ts
@@ -202,8 +202,7 @@ export const getMarker = (
   // Monaco uses 1-based line numbers; avoid getLineLength(0) and invalid line 0 (fixes editor break on invalid query at position 0)
   const startLineNumber = startLine > 0 ? startLine : 1;
   const endLineNumber = endLine > 0 ? endLine : 1;
-  const startColumn =
-    startLine > 0 ? start + model.getLineLength(startLine) + 2 : 1;
+  const startColumn = startLine > 0 ? start + model.getLineLength(startLine) + 2 : 1;
   const endColumn = endLine > 0 ? end + model.getLineLength(endLine) + 2 : 1;
 
   return {


### PR DESCRIPTION
**What is this feature?**

Bug fix for the Tempo datasource TraceQL query editor. The editor could break (white screen / crash) when an invalid query was entered and the page was refreshed.

**Why do we need this feature?**

Invalid input (e.g. `Root=1-698b7d11-6e5020e45727f8fe3724ce4f`) is parsed as TraceQL and can produce syntax error nodes at position 0. The marker logic used 0-based line numbers and called `getLineLength(0)`, which is invalid for Monaco (1-based). That led to invalid markers and could break the editor. Additionally, any thrown error in the parse/marker path was uncaught and could crash the editor.

**Who is this feature for?**

Users of the Tempo datasource in Explore or dashboards who might paste invalid or malformed queries (e.g. trace IDs with a prefix) and then refresh the page.

**Which issue(s) does this PR fix?**

Fixes #117985

**What changed?**

- **highlighting.ts:** `getMarker()` now uses 1-based line/column when the error spans position 0 (start of query). It no longer passes line 0 to Monaco or calls `getLineLength(0)`, avoiding invalid markers.
- **TraceQLEditor.tsx:** Wrapped `getErrorNodes` / `setMarkers` in try/catch (on mount and on content change). On failure, errors are logged with `console.warn` and the editor stays usable instead of crashing.

**Special notes for your reviewer:**

- [ ] It works as expected from a user's perspective (invalid query + refresh no longer breaks the editor).
- [ ] No new tests added (per request); existing Tempo plugin tests can be run from `public/app/plugins/datasource/tempo` with `npx jest traceql/highlighting.test.ts --watchAll=false --config=jest.config.js`.