### PR TITLE
Don't return refs to empty datasource secrets

### DIFF
--- a/pkg/tests/apis/datasource/testdata_test.go
+++ b/pkg/tests/apis/datasource/testdata_test.go
@@ -112,9 +112,9 @@ func TestIntegrationTestDatasource(t *testing.T) {
 					},
 				},
 				"secure": map[string]any{
-					// "aaa": map[string]any{
-					// 	"remove": true, // remove does not really remove in legacy!
-					// },
+					"aaa": map[string]any{
+						"remove": true,
+					},
 					"ccc": map[string]any{
 						"create": "CCC", // add a third value
 					},
@@ -132,7 +132,7 @@ func TestIntegrationTestDatasource(t *testing.T) {
 		require.NoError(t, err)
 
 		keys := slices.Collect(maps.Keys(secure))
-		require.ElementsMatch(t, []string{"aaa", "bbb", "ccc"}, keys)
+		require.ElementsMatch(t, []string{"bbb", "ccc"}, keys)
 	})
 
 	t.Run("list", func(t *testing.T) {


### PR DESCRIPTION
The existing APIs store a value for empty secrets in the `data_source` table. When returning a datasource instance, the secrets are decrypted, and empty values are skipped.

This PR updates the new k8s style APIs to match that behavior.