### PR TITLE
BarGauge: Fix incorrect value width in basic and gradient modes

### DIFF
--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -152,8 +152,9 @@ export class BarGauge extends PureComponent<Props> {
       valueDisplayMode,
       isOverflow,
     } = this.props;
-    const { valueHeight, valueWidth, maxBarHeight, maxBarWidth, wrapperWidth, wrapperHeight } =
-      calculateBarAndValueDimensions(this.props);
+    const { valueHeight, valueWidth, maxBarHeight, maxBarWidth, wrapperHeight } = calculateBarAndValueDimensions(
+      this.props
+    );
     const minValue = field.min ?? GAUGE_DEFAULT_MINIMUM;
     const maxValue = field.max ?? GAUGE_DEFAULT_MAXIMUM;
 
@@ -177,18 +178,23 @@ export class BarGauge extends PureComponent<Props> {
     );
 
     const containerStyles: CSSProperties = {
-      width: `${wrapperWidth}px`,
       height: `${wrapperHeight}px`,
+      display: 'flex',
+    };
+
+    const cellsContainerStyles: CSSProperties = {
       display: 'flex',
     };
 
     if (isVert) {
       containerStyles.flexDirection = 'column-reverse';
       containerStyles.alignItems = 'center';
+      cellsContainerStyles.flexDirection = 'column-reverse';
     } else {
       containerStyles.flexDirection = 'row';
       containerStyles.alignItems = 'center';
       valueStyles.justifyContent = 'flex-end';
+      cellsContainerStyles.flexDirection = 'row';
     }
 
     const cells: JSX.Element[] = [];
@@ -221,7 +227,7 @@ export class BarGauge extends PureComponent<Props> {
 
     return (
       <div style={containerStyles}>
-        {cells}
+        <div style={cellsContainerStyles}>{cells}</div>
         {valueDisplayMode !== BarGaugeValueMode.Hidden && (
           <FormattedValueDisplay
             data-testid={selectors.components.Panels.Visualization.BarGauge.valueV2}
@@ -690,7 +696,7 @@ function getValueStyles(
   const styles: CSSProperties = {
     color,
     height: `${height}px`,
-    maxWidth: `${width}px`,
+    width: `${width}px`,
     display: 'flex',
     alignItems: 'center',
     textWrap: 'nowrap',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**Why do we need this feature?**

To restore the correct appearance of horizontal bar gauges in basic and gradient modes as well as fixing the overflow of retro LCD horizontal bar gauges in table cells.

**Who is this feature for?**

Everyone

**What is this feature?**

Hi,

This PR aims to fix a regression that was introduced in Grafana 12.1.0 in PR #103755 in commit dd32cb32ac53995b9127cf61e2857e55352bf902. This commit was supposed to fix a visual overflow bug that affected retro LCD horizontal bar gauges when inside a table, as described in #106750, but ended up breaking the appearance of basic and gradient horizontal bar gauges as described in #111467.

**Versions prior to 12.1.x (in this example, Grafana 12.0.10):**
<img width="1916" height="513" alt="DONE-grafana-12 0 10" src="https://github.com/user-attachments/assets/34a37837-e68d-4f1d-85d1-f8ed2b53330b" />
Everything is displayed correctly (this was *before* PR #103755)

**During the development of 12.1.0 (PR #103755)**:
<img width="1916" height="513" alt="DONE-grafana-during-12 1 x-devel" src="https://github.com/user-attachments/assets/c9589c8e-8de9-413f-a731-998e036963df" />

I tried to reproduce the bug described in #106750 despite not having access to the linked video and managed to create a table in which the retro LCD bar gauge value overflows the table cell.

As visible below, in current versions of Grafana, horizontal bar gauges in basic and gradient modes are not displayed correctly.

**Versions 12.1.x and later (in this example, Grafana 12.3.2):**
<img width="1916" height="513" alt="DONE-grafana-12 1 x-and-later" src="https://github.com/user-attachments/assets/c00c1dfb-9a92-4a35-baa6-ffe2a2b0f9c4" />


Because the change in dd32cb32ac53995b9127cf61e2857e55352bf902 replaced the fixed `width` property of the bar gauge value with `maxWidth`, it caused:

- The "gray" (empty) part of the basic/gradient bar gauges to extend up to the value (as it has a `flex-grow: 1` property), which also causes the bars to have different lengths based on the length of the value itself (clearly visible on the screenshot above)
- The value container of retro LCD bar gauges to shift to the left due to its `justify-content: flex-end` property (the value should "stick" to the right of the panel)

Although it correctly fixed the table cell overflow shown in the previous screenshot.

### Fixing both problems

Restoring the correct appearance of basic/gradient bar gauges is simple as it consists in reverting commit dd32cb32ac53995b9127cf61e2857e55352bf902. 

However, doing so reintroduces the bug described in #106750 (which, after testing around, seems to only affect retro LCD bar gauges inside table cells).

In order to fix that issue, I wrapped all the "cells" that make up the retro LCD bar gauge into a flex `div` and removed the fixed `width` property of the parent `div` as it is already part of a flex container that has a width of 100%. The reason I did this is because simply removing the fixed `width` property would cause the flex container to shrink the individual "cells" that make up the retro LCD bar gauge unevenly (some being wider than others).

This then correctly prevents the bar gauge value from overflowing of the table cell, as shown below:

**Using the fix implemented in this PR:**
<img width="1916" height="513" alt="DONE-grafana-after-fix" src="https://github.com/user-attachments/assets/70cd5c7c-8148-48ab-960b-a5621df7ce90" />

Please keep in mind that I am not familiar with Grafana's codebase nor React so I have no idea if this fix breaks some other functionality.

I have been reproducing the aforementioned issues and testing potentials fixes using the dashboard below:

<details>
<summary>JSON Dashboard</summary>

```json
{
  "__inputs": [
    {
      "name": "DS_PROMETHEUS",
      "label": "Prometheus",
      "description": "",
      "type": "datasource",
      "pluginId": "prometheus",
      "pluginName": "Prometheus"
    }
  ],
  "__elements": {},
  "__requires": [
    {
      "type": "panel",
      "id": "bargauge",
      "name": "Bar gauge",
      "version": ""
    },
    {
      "type": "grafana",
      "id": "grafana",
      "name": "Grafana",
      "version": "12.4.0-pre"
    },
    {
      "type": "datasource",
      "id": "prometheus",
      "name": "Prometheus",
      "version": "1.0.0"
    },
    {
      "type": "panel",
      "id": "table",
      "name": "Table",
      "version": ""
    }
  ],
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "prometheus",
        "uid": "${DS_PROMETHEUS}"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "mappings": [],
          "max": 100,
          "min": 0,
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": 0
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          },
          "unit": "percent"
        },
        "overrides": []
      },
      "gridPos": {
        "h": 6,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "displayMode": "gradient",
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": false
        },
        "maxVizHeight": 300,
        "minVizHeight": 16,
        "minVizWidth": 8,
        "namePlacement": "auto",
        "orientation": "horizontal",
        "reduceOptions": {
          "calcs": [
            "lastNotNull"
          ],
          "fields": "",
          "values": false
        },
        "showUnfilled": true,
        "sizing": "auto",
        "valueMode": "color"
      },
      "pluginVersion": "12.4.0-pre",
      "targets": [
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${DS_PROMETHEUS}"
          },
          "editorMode": "code",
          "expr": "100",
          "legendFormat": "__auto",
          "range": true,
          "refId": "A"
        },
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${DS_PROMETHEUS}"
          },
          "editorMode": "code",
          "expr": "99",
          "instant": false,
          "legendFormat": "__auto",
          "range": true,
          "refId": "B"
        },
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${DS_PROMETHEUS}"
          },
          "editorMode": "code",
          "expr": "87",
          "instant": false,
          "legendFormat": "__auto",
          "range": true,
          "refId": "C"
        },
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${DS_PROMETHEUS}"
          },
          "editorMode": "code",
          "expr": "9",
          "instant": false,
          "legendFormat": "__auto",
          "range": true,
          "refId": "D"
        }
      ],
      "title": "Min = 0, Max = 100",
      "type": "bargauge"
    },
    {
      "datasource": {
        "type": "prometheus",
        "uid": "${DS_PROMETHEUS}"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "custom": {
            "align": "left",
            "cellOptions": {
              "mode": "lcd",
              "type": "gauge"
            },
            "filterable": false,
            "footer": {
              "reducers": []
            },
            "inspect": false
          },
          "mappings": [],
          "max": 1000000,
          "min": 0,
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": 0
              }
            ]
          }
        },
        "overrides": [
          {
            "matcher": {
              "id": "byName",
              "options": "9547 * 1"
            },
            "properties": [
              {
                "id": "custom.cellOptions",
                "value": {
                  "applyToRow": false,
                  "mode": "basic",
                  "type": "color-background"
                }
              },
              {
                "id": "custom.width",
                "value": 20
              }
            ]
          },
          {
            "matcher": {
              "id": "byName",
              "options": "453462"
            },
            "properties": [
              {
                "id": "custom.width",
                "value": 410
              }
            ]
          },
          {
            "matcher": {
              "id": "byName",
              "options": "Time"
            },
            "properties": [
              {
                "id": "custom.width",
                "value": 382
              }
            ]
          }
        ]
      },
      "gridPos": {
        "h": 6,
        "w": 12,
        "x": 12,
        "y": 0
      },
      "id": 3,
      "options": {
        "cellHeight": "sm",
        "enablePagination": false,
        "frameIndex": 0,
        "showHeader": true,
        "sortBy": [
          {
            "desc": false,
            "displayName": "453462"
          }
        ]
      },
      "pluginVersion": "12.4.0-pre",
      "targets": [
        {
          "editorMode": "code",
          "exemplar": false,
          "expr": "453462",
          "instant": true,
          "legendFormat": "__auto",
          "range": false,
          "refId": "A",
          "datasource": {
            "type": "prometheus",
            "uid": "${DS_PROMETHEUS}"
          }
        }
      ],
      "title": "New panel",
      "transformations": [
        {
          "id": "calculateField",
          "options": {
            "binary": {
              "left": {
                "matcher": {
                  "id": "byName",
                  "options": "9547"
                }
              },
              "operator": "*",
              "right": {
                "fixed": "1"
              }
            },
            "mode": "binary",
            "reduce": {
              "reducer": "sum"
            },
            "replaceFields": false
          }
        }
      ],
      "type": "table"
    },
    {
      "datasource": {
        "type": "prometheus",
        "uid": "${DS_PROMETHEUS}"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "mappings": [],
          "max": 100,
          "min": 0,
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": 0
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          },
          "unit": "percent"
        },
        "overrides": []
      },
      "gridPos": {
        "h": 6,
        "w": 12,
        "x": 0,
        "y": 6
      },
      "id": 5,
      "options": {
        "displayMode": "lcd",
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": false
        },
        "maxVizHeight": 300,
        "minVizHeight": 16,
        "minVizWidth": 8,
        "namePlacement": "auto",
        "orientation": "horizontal",
        "reduceOptions": {
          "calcs": [
            "lastNotNull"
          ],
          "fields": "",
          "values": false
        },
        "showUnfilled": true,
        "sizing": "auto",
        "valueMode": "color"
      },
      "pluginVersion": "12.4.0-pre",
      "targets": [
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${DS_PROMETHEUS}"
          },
          "editorMode": "code",
          "expr": "100",
          "legendFormat": "__auto",
          "range": true,
          "refId": "A"
        },
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${DS_PROMETHEUS}"
          },
          "editorMode": "code",
          "expr": "99",
          "instant": false,
          "legendFormat": "__auto",
          "range": true,
          "refId": "B"
        },
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${DS_PROMETHEUS}"
          },
          "editorMode": "code",
          "expr": "87",
          "instant": false,
          "legendFormat": "__auto",
          "range": true,
          "refId": "C"
        },
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${DS_PROMETHEUS}"
          },
          "editorMode": "code",
          "expr": "9",
          "instant": false,
          "legendFormat": "__auto",
          "range": true,
          "refId": "D"
        }
      ],
      "title": "Min = 0, Max = 100",
      "type": "bargauge"
    },
    {
      "datasource": {
        "type": "prometheus",
        "uid": "${DS_PROMETHEUS}"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "custom": {
            "align": "left",
            "cellOptions": {
              "mode": "gradient",
              "type": "gauge"
            },
            "filterable": false,
            "footer": {
              "reducers": []
            },
            "inspect": false
          },
          "mappings": [],
          "max": 100,
          "min": 0,
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": 0
              }
            ]
          },
          "unit": "percent"
        },
        "overrides": [
          {
            "matcher": {
              "id": "byName",
              "options": "9547 * 1"
            },
            "properties": [
              {
                "id": "custom.cellOptions",
                "value": {
                  "applyToRow": false,
                  "mode": "basic",
                  "type": "color-background"
                }
              },
              {
                "id": "custom.width",
                "value": 20
              }
            ]
          },
          {
            "matcher": {
              "id": "byName",
              "options": "453462"
            },
            "properties": [
              {
                "id": "custom.width",
                "value": 410
              }
            ]
          },
          {
            "matcher": {
              "id": "byName",
              "options": "Time"
            },
            "properties": [
              {
                "id": "custom.width",
                "value": 382
              }
            ]
          },
          {
            "matcher": {
              "id": "byName",
              "options": "100"
            },
            "properties": [
              {
                "id": "custom.width",
                "value": 413
              }
            ]
          }
        ]
      },
      "gridPos": {
        "h": 6,
        "w": 12,
        "x": 12,
        "y": 6
      },
      "id": 4,
      "options": {
        "cellHeight": "sm",
        "enablePagination": false,
        "frameIndex": 0,
        "showHeader": true,
        "sortBy": [
          {
            "desc": false,
            "displayName": "453462"
          }
        ]
      },
      "pluginVersion": "12.4.0-pre",
      "targets": [
        {
          "editorMode": "code",
          "exemplar": false,
          "expr": "100",
          "instant": true,
          "legendFormat": "__auto",
          "range": false,
          "refId": "A",
          "datasource": {
            "type": "prometheus",
            "uid": "${DS_PROMETHEUS}"
          }
        }
      ],
      "title": "New panel",
      "transformations": [
        {
          "id": "calculateField",
          "options": {
            "binary": {
              "left": {
                "matcher": {
                  "id": "byName",
                  "options": "9547"
                }
              },
              "operator": "*",
              "right": {
                "fixed": "1"
              }
            },
            "mode": "binary",
            "reduce": {
              "reducer": "sum"
            },
            "replaceFields": false
          }
        }
      ],
      "type": "table"
    },
    {
      "datasource": {
        "type": "prometheus",
        "uid": "${DS_PROMETHEUS}"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "mappings": [],
          "max": 100,
          "min": 0,
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": 0
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          },
          "unit": "percent"
        },
        "overrides": []
      },
      "gridPos": {
        "h": 3,
        "w": 24,
        "x": 0,
        "y": 12
      },
      "id": 6,
      "options": {
        "displayMode": "lcd",
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": false
        },
        "maxVizHeight": 300,
        "minVizHeight": 16,
        "minVizWidth": 8,
        "namePlacement": "auto",
        "orientation": "horizontal",
        "reduceOptions": {
          "calcs": [
            "lastNotNull"
          ],
          "fields": "",
          "values": false
        },
        "showUnfilled": true,
        "sizing": "auto",
        "valueMode": "color"
      },
      "pluginVersion": "12.4.0-pre",
      "targets": [
        {
          "editorMode": "code",
          "expr": "78",
          "legendFormat": "__auto",
          "range": true,
          "refId": "A",
          "datasource": {
            "type": "prometheus",
            "uid": "${DS_PROMETHEUS}"
          }
        }
      ],
      "title": "New panel",
      "transparent": true,
      "type": "bargauge"
    }
  ],
  "preload": false,
  "schemaVersion": 42,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-1h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "Gauges",
  "uid": "adbm9wr",
  "version": 8,
  "weekStart": ""
}
```

</details>

Please also note that this is my first PR and tried to follow the contribution guidelines as best as I could.

Please let me know if this fix seems reasonable, I would be happy to help.

Have a nice day,

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #111467
Fixes #106750


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
