### PR TITLE
Dashboards: groupBy default filters

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -607,6 +607,9 @@ export const versionedPages = {
             modeToggle: {
               '10.4.0': 'data-testid group by variable mode toggle',
             },
+            defaultValueSection: {
+              '12.5.0': 'data-testid group by variable default value',
+            },
           },
           AdHocFiltersVariable: {
             datasourceSelect: {

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -608,7 +608,7 @@ export const versionedPages = {
               '10.4.0': 'data-testid group by variable mode toggle',
             },
             defaultValueSection: {
-              '12.5.0': 'data-testid group by variable default value',
+              '13.0.0': 'data-testid group by variable default value',
             },
           },
           AdHocFiltersVariable: {

--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
@@ -76,7 +76,7 @@ const runRequestMock = jest.fn().mockImplementation((ds: DataSourceApi, request:
   return of([]).pipe(
     map(() => {
       result.state = LoadingState.Done;
-      result.series = [];
+      result.series = [{ fields: [], length: 0 }];
 
       return result;
     })

--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
@@ -76,7 +76,7 @@ const runRequestMock = jest.fn().mockImplementation((ds: DataSourceApi, request:
   return of([]).pipe(
     map(() => {
       result.state = LoadingState.Done;
-      result.series = [{ fields: [], length: 0 }];
+      result.series = [];
 
       return result;
     })

--- a/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { DefaultValueEditor, DefaultValueEditorProps } from './DefaultValueEditor';
+
+describe('DefaultValueEditor', () => {
+  const defaultProps: DefaultValueEditorProps = {
+    values: [],
+    options: [],
+    onChange: jest.fn(),
+  };
+
+  beforeAll(() => {
+    Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
+      value: jest.fn(() => ({
+        width: 200,
+        height: 200,
+        x: 0,
+        y: 0,
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+      })),
+    });
+  });
+
+  function setup(overrides?: Partial<DefaultValueEditorProps>) {
+    const props = { ...defaultProps, ...overrides, onChange: overrides?.onChange ?? jest.fn() };
+    return {
+      renderer: render(<DefaultValueEditor {...props} />),
+      user: userEvent.setup(),
+      onChange: props.onChange,
+    };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render a row for each value', () => {
+    setup({ values: ['foo', 'bar', 'baz'] });
+    expect(screen.getAllByRole('button', { name: 'Remove default value' })).toHaveLength(3);
+    expect(screen.getAllByRole('combobox')).toHaveLength(3);
+  });
+
+  it('should call onChange with the value removed when remove is clicked', async () => {
+    const onChange = jest.fn();
+    const { user } = setup({ values: ['a', 'b', 'c'], onChange });
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove default value' });
+    await user.click(removeButtons[1]);
+    expect(onChange).toHaveBeenCalledWith(['a', 'c']);
+  });
+
+  it('should call onChange with updated value when a combobox option is selected', async () => {
+    const onChange = jest.fn();
+    const { user } = setup({
+      values: [''],
+      options: [
+        { label: 'job', value: 'job' },
+        { label: 'instance', value: 'instance' },
+      ],
+      onChange,
+    });
+    const combobox = screen.getByRole('combobox');
+    await user.click(combobox);
+    await user.click(screen.getByRole('option', { name: 'job' }));
+    expect(onChange).toHaveBeenCalledWith(['job']);
+  });
+
+  it('should call onChange with updated value when a custom value is typed', async () => {
+    const onChange = jest.fn();
+    const { user } = setup({
+      values: [''],
+      options: [],
+      onChange,
+    });
+    const combobox = screen.getByRole('combobox');
+    await user.type(combobox, 'custom-val');
+    await user.keyboard('{Enter}');
+    expect(onChange).toHaveBeenCalledWith(['custom-val']);
+  });
+});

--- a/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.test.tsx
@@ -47,7 +47,7 @@ describe('DefaultValueEditor', () => {
       ],
     });
     expect(screen.getByText('job')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Remove job' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Remove' })).toHaveLength(1);
   });
 
   it('should show options in dropdown', async () => {
@@ -77,7 +77,7 @@ describe('DefaultValueEditor', () => {
     await user.click(combobox);
     await user.click(await screen.findByRole('option', { name: 'job' }));
 
-    expect(onChange).toHaveBeenCalledWith([{ label: 'job', value: 'job' }]);
+    expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ label: 'job', value: 'job' })]);
   });
 
   it('should call onChange when removing a value via pill', async () => {
@@ -94,9 +94,9 @@ describe('DefaultValueEditor', () => {
       onChange,
     });
 
-    const removeButton = screen.getByRole('button', { name: 'Remove job' });
-    await user.click(removeButton);
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove' });
+    await user.click(removeButtons[0]);
 
-    expect(onChange).toHaveBeenCalledWith([{ label: 'instance', value: 'instance' }]);
+    expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ label: 'instance', value: 'instance' })]);
   });
 });

--- a/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.test.tsx
@@ -38,24 +38,35 @@ describe('DefaultValueEditor', () => {
     jest.clearAllMocks();
   });
 
-  it('should render a row for each value', () => {
-    setup({ values: [{ value: 'foo' }, { value: 'bar' }, { value: 'baz' }] });
-    expect(screen.getAllByRole('button', { name: 'Remove default value' })).toHaveLength(3);
-    expect(screen.getAllByRole('combobox')).toHaveLength(3);
+  it('should render selected values as pills', () => {
+    setup({
+      values: [{ value: 'job', label: 'job' }],
+      options: [
+        { value: 'job', label: 'job' },
+        { value: 'instance', label: 'instance' },
+      ],
+    });
+    expect(screen.getByText('job')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove job' })).toBeInTheDocument();
   });
 
-  it('should call onChange with the value removed when remove is clicked', async () => {
-    const onChange = jest.fn();
-    const { user } = setup({ values: [{ value: 'a' }, { value: 'b' }, { value: 'c' }], onChange });
-    const removeButtons = screen.getAllByRole('button', { name: 'Remove default value' });
-    await user.click(removeButtons[1]);
-    expect(onChange).toHaveBeenCalledWith([{ value: 'a' }, { value: 'c' }]);
+  it('should show options in dropdown', async () => {
+    const { user } = setup({
+      options: [
+        { label: 'job', value: 'job' },
+        { label: 'instance', value: 'instance' },
+      ],
+    });
+    const combobox = screen.getByRole('combobox');
+    await user.click(combobox);
+
+    expect(await screen.findByRole('option', { name: 'job' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'instance' })).toBeInTheDocument();
   });
 
-  it('should call onChange with updated option when a combobox option is selected', async () => {
+  it('should call onChange when selecting an option', async () => {
     const onChange = jest.fn();
     const { user } = setup({
-      values: [{ value: '' }],
       options: [
         { label: 'job', value: 'job' },
         { label: 'instance', value: 'instance' },
@@ -64,20 +75,28 @@ describe('DefaultValueEditor', () => {
     });
     const combobox = screen.getByRole('combobox');
     await user.click(combobox);
-    await user.click(screen.getByRole('option', { name: 'job' }));
-    expect(onChange).toHaveBeenCalledWith([{ value: 'job', label: 'job' }]);
+    await user.click(await screen.findByRole('option', { name: 'job' }));
+
+    expect(onChange).toHaveBeenCalledWith([{ label: 'job', value: 'job' }]);
   });
 
-  it('should call onChange with updated option when a custom value is typed', async () => {
+  it('should call onChange when removing a value via pill', async () => {
     const onChange = jest.fn();
     const { user } = setup({
-      values: [{ value: '' }],
-      options: [],
+      values: [
+        { value: 'job', label: 'job' },
+        { value: 'instance', label: 'instance' },
+      ],
+      options: [
+        { value: 'job', label: 'job' },
+        { value: 'instance', label: 'instance' },
+      ],
       onChange,
     });
-    const combobox = screen.getByRole('combobox');
-    await user.type(combobox, 'custom-val');
-    await user.keyboard('{Enter}');
-    expect(onChange).toHaveBeenCalledWith([{ value: 'custom-val', label: 'custom-val' }]);
+
+    const removeButton = screen.getByRole('button', { name: 'Remove job' });
+    await user.click(removeButton);
+
+    expect(onChange).toHaveBeenCalledWith([{ label: 'instance', value: 'instance' }]);
   });
 });

--- a/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.test.tsx
@@ -39,23 +39,23 @@ describe('DefaultValueEditor', () => {
   });
 
   it('should render a row for each value', () => {
-    setup({ values: ['foo', 'bar', 'baz'] });
+    setup({ values: [{ value: 'foo' }, { value: 'bar' }, { value: 'baz' }] });
     expect(screen.getAllByRole('button', { name: 'Remove default value' })).toHaveLength(3);
     expect(screen.getAllByRole('combobox')).toHaveLength(3);
   });
 
   it('should call onChange with the value removed when remove is clicked', async () => {
     const onChange = jest.fn();
-    const { user } = setup({ values: ['a', 'b', 'c'], onChange });
+    const { user } = setup({ values: [{ value: 'a' }, { value: 'b' }, { value: 'c' }], onChange });
     const removeButtons = screen.getAllByRole('button', { name: 'Remove default value' });
     await user.click(removeButtons[1]);
-    expect(onChange).toHaveBeenCalledWith(['a', 'c']);
+    expect(onChange).toHaveBeenCalledWith([{ value: 'a' }, { value: 'c' }]);
   });
 
-  it('should call onChange with updated value when a combobox option is selected', async () => {
+  it('should call onChange with updated option when a combobox option is selected', async () => {
     const onChange = jest.fn();
     const { user } = setup({
-      values: [''],
+      values: [{ value: '' }],
       options: [
         { label: 'job', value: 'job' },
         { label: 'instance', value: 'instance' },
@@ -65,19 +65,19 @@ describe('DefaultValueEditor', () => {
     const combobox = screen.getByRole('combobox');
     await user.click(combobox);
     await user.click(screen.getByRole('option', { name: 'job' }));
-    expect(onChange).toHaveBeenCalledWith(['job']);
+    expect(onChange).toHaveBeenCalledWith([{ value: 'job', label: 'job' }]);
   });
 
-  it('should call onChange with updated value when a custom value is typed', async () => {
+  it('should call onChange with updated option when a custom value is typed', async () => {
     const onChange = jest.fn();
     const { user } = setup({
-      values: [''],
+      values: [{ value: '' }],
       options: [],
       onChange,
     });
     const combobox = screen.getByRole('combobox');
     await user.type(combobox, 'custom-val');
     await user.keyboard('{Enter}');
-    expect(onChange).toHaveBeenCalledWith(['custom-val']);
+    expect(onChange).toHaveBeenCalledWith([{ value: 'custom-val', label: 'custom-val' }]);
   });
 });

--- a/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.tsx
@@ -1,0 +1,93 @@
+import { ReactElement } from 'react';
+
+import { t } from '@grafana/i18n';
+import { Button, Combobox, ComboboxOption, Field, Stack } from '@grafana/ui';
+
+export interface DefaultValueEditorProps {
+  values: string[];
+  options?: Array<ComboboxOption<string>>;
+  onChange: (values: string[]) => void;
+  'data-testid'?: string;
+}
+
+interface DefaultValueRowProps {
+  value: string;
+  options: Array<ComboboxOption<string>>;
+  onChange: (value: string) => void;
+  onRemove: () => void;
+}
+
+function DefaultValueRow({ value, options, onChange, onRemove }: DefaultValueRowProps): ReactElement {
+  return (
+    <Stack gap={0.5} alignItems="center">
+      <Combobox
+        aria-label={t('dashboard-scene.default-value-row.value-aria-label', 'Default value')}
+        placeholder={t('dashboard-scene.default-value-row.value-placeholder', 'Value')}
+        value={value || null}
+        options={options}
+        onChange={(option) => onChange(option.value)}
+        createCustomValue
+      />
+      <Button
+        aria-label={t('dashboard-scene.default-value-row.remove-aria-label', 'Remove default value')}
+        icon="times"
+        variant="secondary"
+        fill="text"
+        onClick={onRemove}
+        tooltip={t('dashboard-scene.default-value-row.remove-tooltip', 'Remove value')}
+      />
+    </Stack>
+  );
+}
+
+export function DefaultValueEditor({ values, options = [], onChange, ...rest }: DefaultValueEditorProps): ReactElement {
+  const onAddValue = () => {
+    onChange([...values, '']);
+  };
+
+  const onRemoveValue = (index: number) => {
+    const newValues = [...values];
+    newValues.splice(index, 1);
+    onChange(newValues);
+  };
+
+  const onChangeValue = (index: number, value: string) => {
+    const newValues = [...values];
+    newValues[index] = value;
+    onChange(newValues);
+  };
+
+  return (
+    <Stack direction="column" gap={1} data-testid={rest['data-testid']}>
+      <Field
+        label={t('dashboard-scene.default-value-editor.label', 'Default value')}
+        description={t('dashboard-scene.default-value-editor.description', 'Values that are pre-selected by default.')}
+        noMargin
+      >
+        <Stack direction="column" gap={0.5}>
+          {values.map((value, index) => (
+            <DefaultValueRow
+              key={index}
+              value={value}
+              options={options}
+              onChange={(updatedValue) => onChangeValue(index, updatedValue)}
+              onRemove={() => onRemoveValue(index)}
+            />
+          ))}
+        </Stack>
+      </Field>
+      <div>
+        <Button
+          icon="plus"
+          variant="secondary"
+          size="sm"
+          onClick={onAddValue}
+          aria-label={t('dashboard-scene.default-value-editor.add-aria-label', 'Add default value')}
+          type="button"
+        >
+          {t('dashboard-scene.default-value-editor.add-button', 'Add value')}
+        </Button>
+      </div>
+    </Stack>
+  );
+}

--- a/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.tsx
@@ -1,13 +1,14 @@
 import { ReactElement } from 'react';
 
+import { SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { ComboboxOption, Field, MultiCombobox, Stack } from '@grafana/ui';
+import { Field, MultiSelect, Stack } from '@grafana/ui';
 
 export interface DefaultValueEditorProps {
-  values: Array<ComboboxOption<string>>;
-  options?: Array<ComboboxOption<string>>;
-  onChange: (values: Array<ComboboxOption<string>>) => void;
+  values: Array<SelectableValue<string>>;
+  options?: Array<SelectableValue<string>>;
+  onChange: (values: Array<SelectableValue<string>>) => void;
 }
 
 export function DefaultValueEditor({ values, options = [], onChange }: DefaultValueEditorProps): ReactElement {
@@ -22,13 +23,13 @@ export function DefaultValueEditor({ values, options = [], onChange }: DefaultVa
         description={t('dashboard-scene.default-value-editor.description', 'Values that are pre-selected by default.')}
         noMargin
       >
-        <MultiCombobox
+        <MultiSelect<string>
           aria-label={t('dashboard-scene.default-value-editor.aria-label', 'Default value')}
           placeholder={t('dashboard-scene.default-value-editor.placeholder', 'Choose default values')}
           options={options}
           value={values}
-          onChange={onChange}
-          createCustomValue
+          onChange={(items) => onChange(items)}
+          allowCustomValue
           isClearable
         />
       </Field>

--- a/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.tsx
@@ -1,4 +1,5 @@
-import { ReactElement } from 'react';
+import { uniqueId } from 'lodash';
+import { ReactElement, useRef } from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
@@ -40,7 +41,13 @@ function DefaultValueRow({ value, options, onChange, onRemove }: DefaultValueRow
   );
 }
 
-export function DefaultValueEditor({ values, options = [], onChange, ...rest }: DefaultValueEditorProps): ReactElement {
+export function DefaultValueEditor({ values, options = [], onChange }: DefaultValueEditorProps): ReactElement {
+  const rowIds = useRef<string[]>([]);
+
+  while (rowIds.current.length < values.length) {
+    rowIds.current.push(uniqueId('default-value-'));
+  }
+
   const onAddValue = () => {
     onChange([...values, { value: '' }]);
   };
@@ -48,6 +55,7 @@ export function DefaultValueEditor({ values, options = [], onChange, ...rest }: 
   const onRemoveValue = (index: number) => {
     const newValues = [...values];
     newValues.splice(index, 1);
+    rowIds.current.splice(index, 1);
     onChange(newValues);
   };
 
@@ -71,7 +79,7 @@ export function DefaultValueEditor({ values, options = [], onChange, ...rest }: 
         <Stack direction="column" gap={0.5}>
           {values.map((value, index) => (
             <DefaultValueRow
-              key={index}
+              key={rowIds.current[index]}
               value={value}
               options={options}
               onChange={(updatedOption) => onChangeValue(index, updatedOption)}

--- a/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.tsx
@@ -1,105 +1,33 @@
-import { uniqueId } from 'lodash';
-import { ReactElement, useRef } from 'react';
+import { ReactElement } from 'react';
 
-import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { Button, Combobox, ComboboxOption, Field, Stack } from '@grafana/ui';
+import { ComboboxOption, Field, MultiCombobox, Stack } from '@grafana/ui';
 
 export interface DefaultValueEditorProps {
   values: Array<ComboboxOption<string>>;
   options?: Array<ComboboxOption<string>>;
   onChange: (values: Array<ComboboxOption<string>>) => void;
+  'data-testid'?: string;
 }
 
-interface DefaultValueRowProps {
-  value: ComboboxOption<string>;
-  options: Array<ComboboxOption<string>>;
-  onChange: (option: ComboboxOption<string>) => void;
-  onRemove: () => void;
-}
-
-function DefaultValueRow({ value, options, onChange, onRemove }: DefaultValueRowProps): ReactElement {
+export function DefaultValueEditor({ values, options = [], onChange, ...rest }: DefaultValueEditorProps): ReactElement {
   return (
-    <Stack gap={0.5} alignItems="center">
-      <Combobox
-        aria-label={t('dashboard-scene.default-value-row.value-aria-label', 'Default value')}
-        placeholder={t('dashboard-scene.default-value-row.value-placeholder', 'Value')}
-        value={value.value || null}
-        options={options}
-        onChange={(option) => onChange({ value: option.value, label: option.label ?? option.value })}
-        createCustomValue
-      />
-      <Button
-        aria-label={t('dashboard-scene.default-value-row.remove-aria-label', 'Remove default value')}
-        icon="times"
-        variant="secondary"
-        fill="text"
-        onClick={onRemove}
-        tooltip={t('dashboard-scene.default-value-row.remove-tooltip', 'Remove value')}
-      />
-    </Stack>
-  );
-}
-
-export function DefaultValueEditor({ values, options = [], onChange }: DefaultValueEditorProps): ReactElement {
-  const rowIds = useRef<string[]>([]);
-
-  while (rowIds.current.length < values.length) {
-    rowIds.current.push(uniqueId('default-value-'));
-  }
-
-  const onAddValue = () => {
-    onChange([...values, { value: '' }]);
-  };
-
-  const onRemoveValue = (index: number) => {
-    const newValues = [...values];
-    newValues.splice(index, 1);
-    rowIds.current.splice(index, 1);
-    onChange(newValues);
-  };
-
-  const onChangeValue = (index: number, option: ComboboxOption<string>) => {
-    const newValues = [...values];
-    newValues[index] = option;
-    onChange(newValues);
-  };
-
-  return (
-    <Stack
-      direction="column"
-      gap={1}
-      data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.GroupByVariable.infoText}
-    >
+    <Stack direction="column" gap={1} data-testid={rest['data-testid']}>
       <Field
         label={t('dashboard-scene.default-value-editor.label', 'Default value')}
         description={t('dashboard-scene.default-value-editor.description', 'Values that are pre-selected by default.')}
         noMargin
       >
-        <Stack direction="column" gap={0.5}>
-          {values.map((value, index) => (
-            <DefaultValueRow
-              key={rowIds.current[index]}
-              value={value}
-              options={options}
-              onChange={(updatedOption) => onChangeValue(index, updatedOption)}
-              onRemove={() => onRemoveValue(index)}
-            />
-          ))}
-        </Stack>
+        <MultiCombobox
+          aria-label={t('dashboard-scene.default-value-editor.aria-label', 'Default value')}
+          placeholder={t('dashboard-scene.default-value-editor.placeholder', 'Choose default values')}
+          options={options}
+          value={values}
+          onChange={onChange}
+          createCustomValue
+          isClearable
+        />
       </Field>
-      <div>
-        <Button
-          icon="plus"
-          variant="secondary"
-          size="sm"
-          onClick={onAddValue}
-          aria-label={t('dashboard-scene.default-value-editor.add-aria-label', 'Add default value')}
-          type="button"
-        >
-          {t('dashboard-scene.default-value-editor.add-button', 'Add value')}
-        </Button>
-      </div>
     </Stack>
   );
 }

--- a/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.tsx
@@ -1,5 +1,6 @@
 import { ReactElement } from 'react';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { ComboboxOption, Field, MultiCombobox, Stack } from '@grafana/ui';
 
@@ -7,12 +8,15 @@ export interface DefaultValueEditorProps {
   values: Array<ComboboxOption<string>>;
   options?: Array<ComboboxOption<string>>;
   onChange: (values: Array<ComboboxOption<string>>) => void;
-  'data-testid'?: string;
 }
 
-export function DefaultValueEditor({ values, options = [], onChange, ...rest }: DefaultValueEditorProps): ReactElement {
+export function DefaultValueEditor({ values, options = [], onChange }: DefaultValueEditorProps): ReactElement {
   return (
-    <Stack direction="column" gap={1} data-testid={rest['data-testid']}>
+    <Stack
+      direction="column"
+      gap={1}
+      data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.GroupByVariable.defaultValueSection}
+    >
       <Field
         label={t('dashboard-scene.default-value-editor.label', 'Default value')}
         description={t('dashboard-scene.default-value-editor.description', 'Values that are pre-selected by default.')}

--- a/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/DefaultValueEditor.tsx
@@ -1,19 +1,19 @@
 import { ReactElement } from 'react';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { Button, Combobox, ComboboxOption, Field, Stack } from '@grafana/ui';
 
 export interface DefaultValueEditorProps {
-  values: string[];
+  values: Array<ComboboxOption<string>>;
   options?: Array<ComboboxOption<string>>;
-  onChange: (values: string[]) => void;
-  'data-testid'?: string;
+  onChange: (values: Array<ComboboxOption<string>>) => void;
 }
 
 interface DefaultValueRowProps {
-  value: string;
+  value: ComboboxOption<string>;
   options: Array<ComboboxOption<string>>;
-  onChange: (value: string) => void;
+  onChange: (option: ComboboxOption<string>) => void;
   onRemove: () => void;
 }
 
@@ -23,9 +23,9 @@ function DefaultValueRow({ value, options, onChange, onRemove }: DefaultValueRow
       <Combobox
         aria-label={t('dashboard-scene.default-value-row.value-aria-label', 'Default value')}
         placeholder={t('dashboard-scene.default-value-row.value-placeholder', 'Value')}
-        value={value || null}
+        value={value.value || null}
         options={options}
-        onChange={(option) => onChange(option.value)}
+        onChange={(option) => onChange({ value: option.value, label: option.label ?? option.value })}
         createCustomValue
       />
       <Button
@@ -42,7 +42,7 @@ function DefaultValueRow({ value, options, onChange, onRemove }: DefaultValueRow
 
 export function DefaultValueEditor({ values, options = [], onChange, ...rest }: DefaultValueEditorProps): ReactElement {
   const onAddValue = () => {
-    onChange([...values, '']);
+    onChange([...values, { value: '' }]);
   };
 
   const onRemoveValue = (index: number) => {
@@ -51,14 +51,18 @@ export function DefaultValueEditor({ values, options = [], onChange, ...rest }: 
     onChange(newValues);
   };
 
-  const onChangeValue = (index: number, value: string) => {
+  const onChangeValue = (index: number, option: ComboboxOption<string>) => {
     const newValues = [...values];
-    newValues[index] = value;
+    newValues[index] = option;
     onChange(newValues);
   };
 
   return (
-    <Stack direction="column" gap={1} data-testid={rest['data-testid']}>
+    <Stack
+      direction="column"
+      gap={1}
+      data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.GroupByVariable.infoText}
+    >
       <Field
         label={t('dashboard-scene.default-value-editor.label', 'Default value')}
         description={t('dashboard-scene.default-value-editor.description', 'Values that are pre-selected by default.')}
@@ -70,7 +74,7 @@ export function DefaultValueEditor({ values, options = [], onChange, ...rest }: 
               key={index}
               value={value}
               options={options}
-              onChange={(updatedValue) => onChangeValue(index, updatedValue)}
+              onChange={(updatedOption) => onChangeValue(index, updatedOption)}
               onRemove={() => onRemoveValue(index)}
             />
           ))}

--- a/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
@@ -36,6 +36,21 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 describe('GroupByVariableForm', () => {
+  beforeAll(() => {
+    Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
+      value: jest.fn(() => ({
+        width: 200,
+        height: 200,
+        x: 0,
+        y: 0,
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+      })),
+    });
+  });
+
   const onDataSourceChangeMock = jest.fn();
   const onDefaultOptionsChangeMock = jest.fn();
   const onAllowCustomValueChangeMock = jest.fn();
@@ -130,6 +145,46 @@ describe('GroupByVariableForm', () => {
     await userEvent.click(toggle);
     expect(onDefaultOptionsChangeMock).toHaveBeenCalledTimes(1);
     expect(onDefaultOptionsChangeMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should call onDefaultValueChange when adding a new default value', async () => {
+    const mockOnDefaultValueChange = jest.fn();
+    const { user } = setup({
+      defaultValue: [],
+      onDefaultValueChange: mockOnDefaultValueChange,
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Add default value' }));
+    expect(mockOnDefaultValueChange).toHaveBeenCalledWith(['']);
+  });
+
+  it('should call onDefaultValueChange when removing a default value', async () => {
+    const mockOnDefaultValueChange = jest.fn();
+    const { user } = setup({
+      defaultValue: ['job'],
+      onDefaultValueChange: mockOnDefaultValueChange,
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Remove default value' }));
+    expect(mockOnDefaultValueChange).toHaveBeenCalledWith([]);
+  });
+
+  it('should show defaultValueOptions in combobox dropdown', async () => {
+    const mockOnDefaultValueChange = jest.fn();
+    const { user } = setup({
+      defaultValue: [''],
+      defaultValueOptions: [
+        { label: 'job', value: 'job' },
+        { label: 'instance', value: 'instance' },
+      ],
+      onDefaultValueChange: mockOnDefaultValueChange,
+    });
+
+    const combobox = screen.getByRole('combobox');
+    await user.click(combobox);
+
+    expect(screen.getByRole('option', { name: 'job' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'instance' })).toBeInTheDocument();
   });
 
   it('should render only datasource picker and alert when not supported', async () => {

--- a/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
@@ -147,32 +147,42 @@ describe('GroupByVariableForm', () => {
     expect(onDefaultOptionsChangeMock).toHaveBeenCalledWith(undefined);
   });
 
-  it('should call onDefaultValueChange when adding a new default value', async () => {
+  it('should call onDefaultValueChange when selecting a default value', async () => {
     const mockOnDefaultValueChange = jest.fn();
     const { user } = setup({
       defaultValue: [],
+      defaultValueOptions: [
+        { label: 'job', value: 'job' },
+        { label: 'instance', value: 'instance' },
+      ],
       onDefaultValueChange: mockOnDefaultValueChange,
     });
 
-    await user.click(screen.getByRole('button', { name: 'Add default value' }));
-    expect(mockOnDefaultValueChange).toHaveBeenCalledWith([{ value: '' }]);
+    const combobox = screen.getByRole('combobox');
+    await user.click(combobox);
+    await user.click(await screen.findByRole('option', { name: 'job' }));
+    expect(mockOnDefaultValueChange).toHaveBeenCalledWith([{ label: 'job', value: 'job' }]);
   });
 
-  it('should call onDefaultValueChange when removing a default value', async () => {
+  it('should call onDefaultValueChange when removing a default value via pill', async () => {
     const mockOnDefaultValueChange = jest.fn();
     const { user } = setup({
       defaultValue: [{ value: 'job', label: 'job' }],
+      defaultValueOptions: [
+        { label: 'job', value: 'job' },
+        { label: 'instance', value: 'instance' },
+      ],
       onDefaultValueChange: mockOnDefaultValueChange,
     });
 
-    await user.click(screen.getByRole('button', { name: 'Remove default value' }));
+    await user.click(screen.getByRole('button', { name: 'Remove job' }));
     expect(mockOnDefaultValueChange).toHaveBeenCalledWith([]);
   });
 
   it('should show defaultValueOptions in combobox dropdown', async () => {
     const mockOnDefaultValueChange = jest.fn();
     const { user } = setup({
-      defaultValue: [{ value: '' }],
+      defaultValue: [],
       defaultValueOptions: [
         { label: 'job', value: 'job' },
         { label: 'instance', value: 'instance' },
@@ -183,7 +193,7 @@ describe('GroupByVariableForm', () => {
     const combobox = screen.getByRole('combobox');
     await user.click(combobox);
 
-    expect(screen.getByRole('option', { name: 'job' })).toBeInTheDocument();
+    expect(await screen.findByRole('option', { name: 'job' })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'instance' })).toBeInTheDocument();
   });
 

--- a/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
@@ -155,13 +155,13 @@ describe('GroupByVariableForm', () => {
     });
 
     await user.click(screen.getByRole('button', { name: 'Add default value' }));
-    expect(mockOnDefaultValueChange).toHaveBeenCalledWith(['']);
+    expect(mockOnDefaultValueChange).toHaveBeenCalledWith([{ value: '' }]);
   });
 
   it('should call onDefaultValueChange when removing a default value', async () => {
     const mockOnDefaultValueChange = jest.fn();
     const { user } = setup({
-      defaultValue: ['job'],
+      defaultValue: [{ value: 'job', label: 'job' }],
       onDefaultValueChange: mockOnDefaultValueChange,
     });
 
@@ -172,7 +172,7 @@ describe('GroupByVariableForm', () => {
   it('should show defaultValueOptions in combobox dropdown', async () => {
     const mockOnDefaultValueChange = jest.fn();
     const { user } = setup({
-      defaultValue: [''],
+      defaultValue: [{ value: '' }],
       defaultValueOptions: [
         { label: 'job', value: 'job' },
         { label: 'instance', value: 'instance' },

--- a/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
@@ -161,7 +161,7 @@ describe('GroupByVariableForm', () => {
     const combobox = screen.getByRole('combobox');
     await user.click(combobox);
     await user.click(await screen.findByRole('option', { name: 'job' }));
-    expect(mockOnDefaultValueChange).toHaveBeenCalledWith([{ label: 'job', value: 'job' }]);
+    expect(mockOnDefaultValueChange).toHaveBeenCalledWith([expect.objectContaining({ label: 'job', value: 'job' })]);
   });
 
   it('should call onDefaultValueChange when removing a default value via pill', async () => {
@@ -175,7 +175,7 @@ describe('GroupByVariableForm', () => {
       onDefaultValueChange: mockOnDefaultValueChange,
     });
 
-    await user.click(screen.getByRole('button', { name: 'Remove job' }));
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
     expect(mockOnDefaultValueChange).toHaveBeenCalledWith([]);
   });
 

--- a/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.tsx
@@ -20,9 +20,9 @@ export interface GroupByVariableFormProps {
   defaultOptions?: MetricFindValue[];
   allowCustomValue: boolean;
   onAllowCustomValueChange: (event: FormEvent<HTMLInputElement>) => void;
-  defaultValue?: string[];
+  defaultValue?: Array<ComboboxOption<string>>;
   defaultValueOptions?: Array<ComboboxOption<string>>;
-  onDefaultValueChange?: (values: string[]) => void;
+  onDefaultValueChange?: (options: Array<ComboboxOption<string>>) => void;
   inline?: boolean;
   datasourceSupported: boolean;
 }

--- a/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.tsx
@@ -89,12 +89,7 @@ export function GroupByVariableForm({
       ) : null}
 
       {datasourceSupported && onDefaultValueChange && (
-        <DefaultValueEditor
-          values={defaultValue ?? []}
-          options={defaultValueOptions}
-          onChange={onDefaultValueChange}
-          data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.GroupByVariable.defaultValueSection}
-        />
+        <DefaultValueEditor values={defaultValue ?? []} options={defaultValueOptions} onChange={onDefaultValueChange} />
       )}
 
       {datasourceSupported && (

--- a/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.tsx
@@ -1,11 +1,11 @@
 import { FormEvent, useCallback } from 'react';
 
-import { DataSourceInstanceSettings, MetricFindValue, readCSV } from '@grafana/data';
+import { DataSourceInstanceSettings, MetricFindValue, SelectableValue, readCSV } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { EditorField } from '@grafana/plugin-ui';
 import { DataSourceRef } from '@grafana/schema';
-import { Alert, ComboboxOption, Stack, CodeEditor, Field, Switch } from '@grafana/ui';
+import { Alert, Stack, CodeEditor, Field, Switch } from '@grafana/ui';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
 
 import { DefaultValueEditor } from './DefaultValueEditor';
@@ -20,9 +20,9 @@ export interface GroupByVariableFormProps {
   defaultOptions?: MetricFindValue[];
   allowCustomValue: boolean;
   onAllowCustomValueChange: (event: FormEvent<HTMLInputElement>) => void;
-  defaultValue?: Array<ComboboxOption<string>>;
-  defaultValueOptions?: Array<ComboboxOption<string>>;
-  onDefaultValueChange?: (options: Array<ComboboxOption<string>>) => void;
+  defaultValue?: Array<SelectableValue<string>>;
+  defaultValueOptions?: Array<SelectableValue<string>>;
+  onDefaultValueChange?: (options: Array<SelectableValue<string>>) => void;
   inline?: boolean;
   datasourceSupported: boolean;
 }

--- a/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.tsx
@@ -5,9 +5,10 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { EditorField } from '@grafana/plugin-ui';
 import { DataSourceRef } from '@grafana/schema';
-import { Alert, Stack, CodeEditor, Field, Switch } from '@grafana/ui';
+import { Alert, ComboboxOption, Stack, CodeEditor, Field, Switch } from '@grafana/ui';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
 
+import { DefaultValueEditor } from './DefaultValueEditor';
 import { VariableCheckboxField } from './VariableCheckboxField';
 import { VariableLegend } from './VariableLegend';
 
@@ -19,6 +20,9 @@ export interface GroupByVariableFormProps {
   defaultOptions?: MetricFindValue[];
   allowCustomValue: boolean;
   onAllowCustomValueChange: (event: FormEvent<HTMLInputElement>) => void;
+  defaultValue?: string[];
+  defaultValueOptions?: Array<ComboboxOption<string>>;
+  onDefaultValueChange?: (values: string[]) => void;
   inline?: boolean;
   datasourceSupported: boolean;
 }
@@ -31,6 +35,9 @@ export function GroupByVariableForm({
   onDefaultOptionsChange,
   allowCustomValue,
   onAllowCustomValueChange,
+  defaultValue,
+  defaultValueOptions,
+  onDefaultValueChange,
   inline,
   datasourceSupported,
 }: GroupByVariableFormProps) {
@@ -80,6 +87,15 @@ export function GroupByVariableForm({
           data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.GroupByVariable.infoText}
         />
       ) : null}
+
+      {datasourceSupported && onDefaultValueChange && (
+        <DefaultValueEditor
+          values={defaultValue ?? []}
+          options={defaultValueOptions}
+          onChange={onDefaultValueChange}
+          data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.GroupByVariable.defaultValueSection}
+        />
+      )}
 
       {datasourceSupported && (
         <>

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
@@ -168,7 +168,6 @@ async function setup(defaultOptions?: MetricFindValue[], defaultValue?: { value:
 
   await act(async () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
-    await new Promise((resolve) => setTimeout(resolve, 0));
   });
 
   return {

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, waitFor, screen } from '@testing-library/react';
+import { act, render, waitFor, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { MetricFindValue, VariableSupportType } from '@grafana/data';
@@ -22,6 +22,11 @@ const promDatasource = mockDataSource({
   type: 'prometheus',
 });
 
+const mockGetTagKeys = jest.fn().mockReturnValue([
+  { text: 'job', value: 'job' },
+  { text: 'instance', value: 'instance' },
+]);
+
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getDataSourceSrv: () => ({
@@ -32,7 +37,7 @@ jest.mock('@grafana/runtime', () => ({
         query: jest.fn(),
         editor: jest.fn().mockImplementation(LegacyVariableQueryEditor),
       },
-      getGroupByKeys: () => [],
+      getTagKeys: mockGetTagKeys,
     }),
     getList: () => [defaultDatasource, promDatasource],
     getInstanceSettings: () => ({ ...defaultDatasource }),
@@ -88,6 +93,40 @@ describe('GroupByVariableEditor', () => {
     expect(variable.state.defaultOptions).toEqual(undefined);
   });
 
+  it('should fetch tag keys from datasource', async () => {
+    await setup();
+
+    await waitFor(() => {
+      expect(mockGetTagKeys).toHaveBeenCalledWith({ filters: [] });
+    });
+  });
+
+  it('should render provided default values as inputs', async () => {
+    const { renderer } = await setup(undefined, { value: ['job', 'instance'], text: ['job', 'instance'] });
+
+    const section = renderer.getByTestId(
+      selectors.pages.Dashboard.Settings.Variables.Edit.GroupByVariable.defaultValueSection
+    );
+    const inputs = within(section).getAllByRole('combobox');
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0]).toHaveValue('job');
+    expect(inputs[1]).toHaveValue('instance');
+  });
+
+  it('should update variable defaultValue when adding a default value', async () => {
+    const { renderer, variable, user } = await setup();
+
+    await waitFor(() => {
+      expect(
+        renderer.getByTestId(selectors.pages.Dashboard.Settings.Variables.Edit.GroupByVariable.defaultValueSection)
+      ).toBeInTheDocument();
+    });
+
+    await user.click(renderer.getByRole('button', { name: 'Add default value' }));
+
+    expect(variable.state.defaultValue).toEqual({ value: [''], text: [''] });
+  });
+
   it('should return an OptionsPaneItemDescriptor that renders Editor', async () => {
     const variable = new GroupByVariable({
       name: 'test',
@@ -114,7 +153,7 @@ describe('GroupByVariableEditor', () => {
   });
 });
 
-async function setup(defaultOptions?: MetricFindValue[]) {
+async function setup(defaultOptions?: MetricFindValue[], defaultValue?: { value: string[]; text: string[] }) {
   const onRunQuery = jest.fn();
   const variable = new GroupByVariable({
     name: 'groupByVariable',
@@ -122,9 +161,17 @@ async function setup(defaultOptions?: MetricFindValue[]) {
     label: 'Group By',
     datasource: { uid: defaultDatasource.uid, type: defaultDatasource.type },
     defaultOptions,
+    defaultValue,
   });
+  const renderer = render(<GroupByVariableEditor variable={variable} onRunQuery={onRunQuery} />);
+
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
   return {
-    renderer: await act(() => render(<GroupByVariableEditor variable={variable} onRunQuery={onRunQuery} />)),
+    renderer,
     variable,
     user: userEvent.setup(),
     mocks: { onRunQuery },

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
@@ -123,7 +123,7 @@ describe('GroupByVariableEditor', () => {
       selectors.pages.Dashboard.Settings.Variables.Edit.GroupByVariable.defaultValueSection
     );
     expect(within(section).getByText('job')).toBeInTheDocument();
-    expect(within(section).getByRole('button', { name: 'Remove job' })).toBeInTheDocument();
+    expect(within(section).getByRole('button', { name: 'Remove' })).toBeInTheDocument();
   });
 
   it('should update variable defaultValue when selecting a value from dropdown', async () => {

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
@@ -45,6 +45,21 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 describe('GroupByVariableEditor', () => {
+  beforeAll(() => {
+    Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
+      value: jest.fn(() => ({
+        width: 1000,
+        height: 1000,
+        x: 0,
+        y: 0,
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+      })),
+    });
+  });
+
   it('renders GroupByVariableForm with correct props', async () => {
     const { renderer } = await setup();
     const dataSourcePicker = renderer.getByTestId(
@@ -101,19 +116,17 @@ describe('GroupByVariableEditor', () => {
     });
   });
 
-  it('should render provided default values as inputs', async () => {
-    const { renderer } = await setup(undefined, { value: ['job', 'instance'], text: ['job', 'instance'] });
+  it('should render provided default values as pills', async () => {
+    const { renderer } = await setup(undefined, { value: ['job'], text: ['job'] });
 
     const section = renderer.getByTestId(
       selectors.pages.Dashboard.Settings.Variables.Edit.GroupByVariable.defaultValueSection
     );
-    const inputs = within(section).getAllByRole('combobox');
-    expect(inputs).toHaveLength(2);
-    expect(inputs[0]).toHaveValue('job');
-    expect(inputs[1]).toHaveValue('instance');
+    expect(within(section).getByText('job')).toBeInTheDocument();
+    expect(within(section).getByRole('button', { name: 'Remove job' })).toBeInTheDocument();
   });
 
-  it('should update variable defaultValue when adding a default value', async () => {
+  it('should update variable defaultValue when selecting a value from dropdown', async () => {
     const { renderer, variable, user } = await setup();
 
     await waitFor(() => {
@@ -122,9 +135,13 @@ describe('GroupByVariableEditor', () => {
       ).toBeInTheDocument();
     });
 
-    await user.click(renderer.getByRole('button', { name: 'Add default value' }));
+    const combobox = within(
+      renderer.getByTestId(selectors.pages.Dashboard.Settings.Variables.Edit.GroupByVariable.defaultValueSection)
+    ).getByRole('combobox');
+    await user.click(combobox);
+    await user.click(await screen.findByRole('option', { name: 'job' }));
 
-    expect(variable.state.defaultValue).toEqual({ value: [''], text: [''] });
+    expect(variable.state.defaultValue).toEqual({ value: ['job'], text: ['job'] });
   });
 
   it('should return an OptionsPaneItemDescriptor that renders Editor', async () => {
@@ -166,6 +183,12 @@ async function setup(defaultOptions?: MetricFindValue[], defaultValue?: { value:
   });
   const renderer = render(<GroupByVariableEditor variable={variable} onRunQuery={onRunQuery} />);
 
+  // Flush first useAsync (datasource)
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  // Flush second useAsync (groupByKeys, depends on datasource)
   await act(async () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
   });

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
@@ -22,7 +22,7 @@ const promDatasource = mockDataSource({
   type: 'prometheus',
 });
 
-const mockGetTagKeys = jest.fn().mockReturnValue([
+const mockGetGroupByKeys = jest.fn().mockReturnValue([
   { text: 'job', value: 'job' },
   { text: 'instance', value: 'instance' },
 ]);
@@ -37,7 +37,7 @@ jest.mock('@grafana/runtime', () => ({
         query: jest.fn(),
         editor: jest.fn().mockImplementation(LegacyVariableQueryEditor),
       },
-      getTagKeys: mockGetTagKeys,
+      getGroupByKeys: mockGetGroupByKeys,
     }),
     getList: () => [defaultDatasource, promDatasource],
     getInstanceSettings: () => ({ ...defaultDatasource }),
@@ -93,11 +93,11 @@ describe('GroupByVariableEditor', () => {
     expect(variable.state.defaultOptions).toEqual(undefined);
   });
 
-  it('should fetch tag keys from datasource', async () => {
+  it('should fetch group by keys from datasource', async () => {
     await setup();
 
     await waitFor(() => {
-      expect(mockGetTagKeys).toHaveBeenCalledWith({ filters: [] });
+      expect(mockGetGroupByKeys).toHaveBeenCalledWith({ filters: [] });
     });
   });
 
@@ -147,8 +147,9 @@ describe('GroupByVariableEditor', () => {
     render(descriptor.renderElement());
 
     await waitFor(() => {
-      // Check that some part of the component renders
-      expect(screen.getByText(/data source does not support/i)).toBeInTheDocument();
+      expect(
+        screen.getByTestId(selectors.pages.Dashboard.Settings.Variables.Edit.GroupByVariable.dataSourceSelect)
+      ).toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
@@ -5,6 +5,7 @@ import { useAsync } from 'react-use';
 import { DataSourceInstanceSettings, MetricFindValue, getDataSourceRef } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { GroupByVariable, SceneVariable } from '@grafana/scenes';
+import { ComboboxOption } from '@grafana/ui';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
 import { GroupByVariableForm } from '../components/GroupByVariableForm';
@@ -48,23 +49,28 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
     onRunQuery();
   };
 
-  const onDefaultValueChange = (values: string[]) => {
-    if (values.length === 0) {
+  const onDefaultValueChange = (options: Array<ComboboxOption<string>>) => {
+    if (options.length === 0) {
       variable.setState({ defaultValue: undefined });
     } else {
       variable.setState({
         defaultValue: {
-          value: values,
-          text: values,
+          value: options.map((opt) => opt.value),
+          text: options.map((opt) => opt.label ?? opt.value),
         },
       });
     }
+    onRunQuery();
   };
 
-  const defaultValueStrings: string[] = defaultValue
+  const defaultValueSelection: Array<ComboboxOption<string>> = defaultValue
     ? Array.isArray(defaultValue.value)
-      ? defaultValue.value.map(String)
-      : [String(defaultValue.value)]
+      ? defaultValue.value.map((v, i) => {
+          const texts = defaultValue.text;
+          const label = Array.isArray(texts) ? String(texts[i]) : String(texts);
+          return { value: String(v), label };
+        })
+      : [{ value: String(defaultValue.value), label: String(defaultValue.text ?? defaultValue.value) }]
     : [];
 
   const onAllowCustomValueChange = (event: FormEvent<HTMLInputElement>) => {
@@ -78,7 +84,7 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
       infoText={datasourceRef ? message : undefined}
       onDataSourceChange={onDataSourceChange}
       onDefaultOptionsChange={onDefaultOptionsChange}
-      defaultValue={defaultValueStrings}
+      defaultValue={defaultValueSelection}
       defaultValueOptions={groupByKeys}
       onDefaultValueChange={onDefaultValueChange}
       allowCustomValue={allowCustomValue}

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
@@ -17,11 +17,20 @@ interface GroupByVariableEditorProps {
 
 export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
   const { variable, onRunQuery, inline } = props;
-  const { datasource: datasourceRef, defaultOptions, allowCustomValue = true } = variable.useState();
+  const { datasource: datasourceRef, defaultOptions, allowCustomValue = true, defaultValue } = variable.useState();
 
   const { value: datasource } = useAsync(async () => {
     return await getDataSourceSrv().get(datasourceRef);
   }, [variable.state]);
+
+  const { value: tagKeyOptions = [] } = useAsync(async () => {
+    if (!datasource?.getTagKeys) {
+      return [];
+    }
+    const result = await datasource.getTagKeys({ filters: [] });
+    const keys = Array.isArray(result) ? result : (result.data ?? []);
+    return keys.map((k) => ({ label: k.text || String(k.value), value: String(k.value) }));
+  }, [datasource]);
 
   const message = datasource?.getGroupByKeys
     ? 'Group by dimensions are applied automatically to all queries that target this data source'
@@ -39,6 +48,25 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
     onRunQuery();
   };
 
+  const onDefaultValueChange = (values: string[]) => {
+    if (values.length === 0) {
+      variable.setState({ defaultValue: undefined });
+    } else {
+      variable.setState({
+        defaultValue: {
+          value: values,
+          text: values,
+        },
+      });
+    }
+  };
+
+  const defaultValueStrings: string[] = defaultValue
+    ? Array.isArray(defaultValue.value)
+      ? defaultValue.value.map(String)
+      : [String(defaultValue.value)]
+    : [];
+
   const onAllowCustomValueChange = (event: FormEvent<HTMLInputElement>) => {
     variable.setState({ allowCustomValue: event.currentTarget.checked });
   };
@@ -50,6 +78,9 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
       infoText={datasourceRef ? message : undefined}
       onDataSourceChange={onDataSourceChange}
       onDefaultOptionsChange={onDefaultOptionsChange}
+      defaultValue={defaultValueStrings}
+      defaultValueOptions={tagKeyOptions}
+      onDefaultValueChange={onDefaultValueChange}
       allowCustomValue={allowCustomValue}
       onAllowCustomValueChange={onAllowCustomValueChange}
       inline={inline}

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
@@ -50,13 +50,17 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
 
   const onDefaultValueChange = (options: Array<SelectableValue<string>>) => {
     if (options.length === 0) {
-      variable.setState({ defaultValue: undefined });
+      variable.setState({
+        defaultValue: undefined,
+        restorable: false,
+      });
     } else {
       variable.setState({
         defaultValue: {
           value: options.map((opt) => opt.value!),
           text: options.map((opt) => opt.label ?? opt.value!),
         },
+        restorable: false,
       });
     }
     onRunQuery();

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
@@ -23,11 +23,11 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
     return await getDataSourceSrv().get(datasourceRef);
   }, [variable.state]);
 
-  const { value: tagKeyOptions = [] } = useAsync(async () => {
-    if (!datasource?.getTagKeys) {
+  const { value: groupByKeys = [] } = useAsync(async () => {
+    if (!datasource?.getGroupByKeys) {
       return [];
     }
-    const result = await datasource.getTagKeys({ filters: [] });
+    const result = await datasource.getGroupByKeys({ filters: [] });
     const keys = Array.isArray(result) ? result : (result.data ?? []);
     return keys.map((k) => ({ label: k.text || String(k.value), value: String(k.value) }));
   }, [datasource]);
@@ -79,7 +79,7 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
       onDataSourceChange={onDataSourceChange}
       onDefaultOptionsChange={onDefaultOptionsChange}
       defaultValue={defaultValueStrings}
-      defaultValueOptions={tagKeyOptions}
+      defaultValueOptions={groupByKeys}
       onDefaultValueChange={onDefaultValueChange}
       allowCustomValue={allowCustomValue}
       onAllowCustomValueChange={onAllowCustomValueChange}

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
@@ -55,7 +55,7 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
       variable.setState({
         defaultValue: {
           value: options.map((opt) => opt.value!),
-          text: options.map((opt) => opt.label ?? opt.value ?? ''),
+          text: options.map((opt) => opt.label ?? opt.value!),
         },
       });
     }

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
@@ -2,10 +2,9 @@ import { noop } from 'lodash';
 import { FormEvent } from 'react';
 import { useAsync } from 'react-use';
 
-import { DataSourceInstanceSettings, MetricFindValue, getDataSourceRef } from '@grafana/data';
+import { DataSourceInstanceSettings, MetricFindValue, SelectableValue, getDataSourceRef } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { GroupByVariable, SceneVariable } from '@grafana/scenes';
-import { ComboboxOption } from '@grafana/ui';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
 import { GroupByVariableForm } from '../components/GroupByVariableForm';
@@ -49,21 +48,21 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
     onRunQuery();
   };
 
-  const onDefaultValueChange = (options: Array<ComboboxOption<string>>) => {
+  const onDefaultValueChange = (options: Array<SelectableValue<string>>) => {
     if (options.length === 0) {
       variable.setState({ defaultValue: undefined });
     } else {
       variable.setState({
         defaultValue: {
-          value: options.map((opt) => opt.value),
-          text: options.map((opt) => opt.label ?? opt.value),
+          value: options.map((opt) => opt.value!),
+          text: options.map((opt) => opt.label ?? opt.value ?? ''),
         },
       });
     }
     onRunQuery();
   };
 
-  const defaultValueSelection: Array<ComboboxOption<string>> = defaultValue
+  const defaultValueSelection: Array<SelectableValue<string>> = defaultValue
     ? Array.isArray(defaultValue.value)
       ? defaultValue.value.map((v, i) => {
           const texts = defaultValue.text;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6606,16 +6606,10 @@
       }
     },
     "default-value-editor": {
-      "add-aria-label": "Add default value",
-      "add-button": "Add value",
+      "aria-label": "Default value",
       "description": "Values that are pre-selected by default.",
-      "label": "Default value"
-    },
-    "default-value-row": {
-      "remove-aria-label": "Remove default value",
-      "remove-tooltip": "Remove value",
-      "value-aria-label": "Default value",
-      "value-placeholder": "Value"
+      "label": "Default value",
+      "placeholder": "Choose default values"
     },
     "delete-provisioned-dashboard-form": {
       "api-error": "Failed to delete dashboard",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6605,6 +6605,18 @@
         }
       }
     },
+    "default-value-editor": {
+      "add-aria-label": "Add default value",
+      "add-button": "Add value",
+      "description": "Values that are pre-selected by default.",
+      "label": "Default value"
+    },
+    "default-value-row": {
+      "remove-aria-label": "Remove default value",
+      "remove-tooltip": "Remove value",
+      "value-aria-label": "Default value",
+      "value-placeholder": "Value"
+    },
     "delete-provisioned-dashboard-form": {
       "api-error": "Failed to delete dashboard",
       "cancel-action": "Cancel",


### PR DESCRIPTION
**What is this feature?**

Introduces UI for default groubBy filters

<img width="386" height="316" alt="image" src="https://github.com/user-attachments/assets/2ec45c00-48c1-4d38-b443-5ec03b864442" />


**Which issue(s) does this PR fix?:**

Fixes https://github.com/grafana/grafana/issues/117538