### PR TITLE
Chore: Remove 'devenv' from 'backend_strict' of mt-service CI checks

### DIFF
--- a/.github/workflows/pr-mt-service-compatibility.yml
+++ b/.github/workflows/pr-mt-service-compatibility.yml
@@ -51,7 +51,6 @@ jobs:
               - 'build.go'
               - 'apiserver/**'
               - 'pkg-gen/**'
-              - 'devenv/**'
               - 'scripts/drone/**'
               - 'scripts/go/**'
               - '.air.toml'


### PR DESCRIPTION
makes PRs pass checks when they update gdev dashboards