### PR TITLE
QueryEditor: Fix editor renderer bug

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from '@testing-library/react';
+import { useState } from 'react';
+
+import { DataSourceApi, DataSourceJsonData } from '@grafana/data';
+import { VizPanel } from '@grafana/scenes';
+import { DataQuery } from '@grafana/schema';
+
+import { QueryEditorType } from '../constants';
+
+import { QueryEditorProvider } from './QueryEditorContext';
+import { QueryEditorRenderer } from './QueryEditorRenderer';
+import {
+  ds1SettingsMock,
+  mockActions,
+  mockQueryOptionsState,
+  mockTransformToggles,
+  renderWithQueryEditorProvider,
+} from './testUtils';
+
+jest.mock('app/features/query/components/QueryEditorRow', () => ({
+  filterPanelDataToQuery: jest.fn(() => undefined),
+}));
+
+jest.mock('app/features/query/components/QueryErrorAlert', () => ({
+  QueryErrorAlert: () => null,
+}));
+
+interface TestQuery extends DataQuery {
+  legendFormat?: string;
+}
+
+// Fake query editor that simulates an uncontrolled input — it initialises its
+// display value from props.query on mount and never syncs again.
+function UncontrolledQueryEditor({ query }: { query: TestQuery }) {
+  const [legend] = useState(query.legendFormat ?? '');
+  return <div data-testid="query-editor-legend">{legend}</div>;
+}
+
+const mockDatasource: Partial<DataSourceApi<DataQuery, DataSourceJsonData>> = {
+  components: { QueryEditor: UncontrolledQueryEditor },
+};
+
+const selectedQueryDsData = {
+  datasource: mockDatasource as DataSourceApi,
+  dsSettings: ds1SettingsMock,
+};
+
+const queryA: TestQuery = { refId: 'A', legendFormat: 'series-a' };
+const queryB: TestQuery = { refId: 'B', legendFormat: 'series-b' };
+
+function renderRenderer(
+  selectedQuery: DataQuery | null,
+  uiStateOverrides: NonNullable<Parameters<typeof renderWithQueryEditorProvider>[1]>['uiStateOverrides'] = {}
+) {
+  return renderWithQueryEditorProvider(<QueryEditorRenderer />, {
+    queries: [queryA, queryB],
+    selectedQuery,
+    uiStateOverrides: { selectedQueryDsData, ...uiStateOverrides },
+  });
+}
+
+describe('QueryEditorRenderer', () => {
+  it('renders nothing when no query is selected', () => {
+    renderRenderer(null);
+    expect(screen.queryByTestId('query-editor-legend')).not.toBeInTheDocument();
+  });
+
+  it('shows a loading spinner while the datasource is loading', () => {
+    renderRenderer(queryA, { selectedQueryDsLoading: true, selectedQueryDsData: null });
+    expect(screen.getByText(/loading datasource/i)).toBeInTheDocument();
+  });
+
+  it('shows an error when the datasource fails to load', () => {
+    renderRenderer(queryA, { selectedQueryDsData: null });
+    expect(screen.getByText(/failed to load datasource for this query/i)).toBeInTheDocument();
+  });
+
+  it('renders the query editor for the selected query', () => {
+    renderRenderer(queryA);
+    expect(screen.getByTestId('query-editor-legend')).toHaveTextContent('series-a');
+  });
+
+  it('remounts the query editor when switching queries, resetting uncontrolled input state', () => {
+    // Regression test: datasource plugin editors (e.g. Loki) use uncontrolled
+    // inputs (defaultValue) for options like Legend. Without a `key` prop on
+    // the QueryEditorComponent, React reuses the mounted instance when
+    // switching queries and the DOM values stay stale from the previous query.
+    //
+    // Example: user edits Legend on query A → "foo", switches to query B which
+    // has legendFormat "bar" — without the fix the Legend field still shows "foo".
+
+    // RTL's rerender requires a full ReactElement, so we construct the provider
+    // tree directly here rather than going through renderWithQueryEditorProvider.
+    function buildJsx(selectedQuery: DataQuery) {
+      return (
+        <QueryEditorProvider
+          dsState={{ datasource: undefined, dsSettings: undefined, dsError: undefined }}
+          qrState={{ queries: [queryA, queryB], data: undefined, isLoading: false, queryError: undefined }}
+          panelState={{ panel: new VizPanel({ key: 'panel-1' }), transformations: [] }}
+          alertingState={{ alertRules: [], loading: false, isDashboardSaved: true }}
+          uiState={{
+            selectedQuery,
+            selectedTransformation: null,
+            selectedAlert: null,
+            setSelectedQuery: jest.fn(),
+            setSelectedTransformation: jest.fn(),
+            setSelectedAlert: jest.fn(),
+            queryOptions: mockQueryOptionsState,
+            selectedQueryDsData,
+            selectedQueryDsLoading: false,
+            showingDatasourceHelp: false,
+            toggleDatasourceHelp: jest.fn(),
+            transformToggles: mockTransformToggles,
+            cardType: QueryEditorType.Query,
+            pendingExpression: null,
+            setPendingExpression: jest.fn(),
+            finalizePendingExpression: jest.fn(),
+            pendingTransformation: null,
+            setPendingTransformation: jest.fn(),
+            finalizePendingTransformation: jest.fn(),
+          }}
+          actions={mockActions}
+        >
+          <QueryEditorRenderer />
+        </QueryEditorProvider>
+      );
+    }
+
+    const { rerender } = render(buildJsx(queryA));
+    expect(screen.getByTestId('query-editor-legend')).toHaveTextContent('series-a');
+
+    rerender(buildJsx(queryB));
+
+    // Must show series-b, not the stale series-a value from query A's editor instance
+    expect(screen.getByTestId('query-editor-legend')).toHaveTextContent('series-b');
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
@@ -85,6 +85,7 @@ export function QueryEditorRenderer() {
     <>
       <DataSourcePluginContextProvider instanceSettings={dsSettings}>
         <QueryEditorComponent
+          key={selectedQuery.refId}
           app={CoreApp.Dashboard}
           data={filteredData}
           datasource={datasource}


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->
Resolves https://github.com/grafana/grafana/issues/118423

During user interviews we noticed an editor renderer bug. 

**Bug**

When a panel has multiple queries using the same datasource type (e.g. two Loki datasources), switching between queries in the panel editor caused the second query's editor to display stale values from the first. For example: set Legend to "foo" on query A, switch to query B — query B's Legend field still shows "foo". Change the Legend field to "bar" and query A's Legend becomes "bar".

`QueryEditorRenderer` rendered `QueryEditorComponent` without a key prop. When switching queries, React saw the same component type in the same position and reused the existing mounted instance, only updating its props. Datasource plugin editors (Loki, Prometheus, and others) use uncontrolled inputs (defaultValue) for fields like Legend — these only initialize from props on mount. Since the component never unmounted, the DOM values never reset.

I've been trying to avoid passing just a `key` prop, but honestly I think this is the correct approach, and `refId`s are unique, so this should be safe.

## Changes
<!--- Describe your changes in detail -->
* Passing a `key` prop to instantiate a new editor when the `refId` changes.

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->
N/A I think this mitigates stale data risks more than anything!

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->
N/A please pull down and test with and without the change!

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* Create a new panel, add two Loki queries. Change the first Loki query's Legend field. Change the second Loki query's Legend field, notice it overrides the first query's legend field.

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable