### PR TITLE
Tempo: Fix search frame transformation when attributes are missing.

### DIFF
--- a/pkg/tsdb/tempo/search.go
+++ b/pkg/tsdb/tempo/search.go
@@ -366,7 +366,7 @@ func transformTraceSearchResponseSubFrame(trace *tempopb.TraceSearchMetadata, sp
 			if attribute, ok := traceData.attributes[attributeName]; ok {
 				frame.Fields[attributeIndex].Append(attribute)
 			} else {
-				frame.Fields[attributeIndex].Append("")
+				frame.Fields[attributeIndex].Append(nil)
 			}
 			attributeIndex++
 		}

--- a/pkg/tsdb/tempo/search_test.go
+++ b/pkg/tsdb/tempo/search_test.go
@@ -2,6 +2,7 @@ package tempo
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -45,7 +46,23 @@ func TestTransformTraceSearchResponse(t *testing.T) {
 		RootTraceName:     "test-root-trace-name",
 		StartTimeUnixNano: 1000000,
 		DurationMs:        10,
-		SpanSet:           &tempopb.SpanSet{Spans: []*tempopb.Span{{SpanID: "span1", Name: "op", StartTimeUnixNano: 1000000, DurationNanos: 1000}}},
+		SpanSet: &tempopb.SpanSet{
+			Spans: []*tempopb.Span{
+				{
+					SpanID:            "span1",
+					Name:              "op",
+					StartTimeUnixNano: 1000000,
+					DurationNanos:     1000,
+					Attributes:        []*v1.KeyValue{{Key: "http.method", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "GET"}}}},
+				},
+				{
+					SpanID:            "span2",
+					Name:              "op",
+					StartTimeUnixNano: 1000000,
+					DurationNanos:     1000,
+				},
+			},
+		},
 	}}}
 
 	frames, err := transformTraceSearchResponse(pCtx, resp)
@@ -71,13 +88,15 @@ func TestTransformSpanSearchResponse(t *testing.T) {
 		StartTimeUnixNano: 1000,
 		SpanSets: []*tempopb.SpanSet{{
 			Attributes: []*v1.KeyValue{{Key: "service.name", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "test-service-name"}}}},
-			Spans: []*tempopb.Span{{
-				SpanID:            "test-span-id",
-				Name:              "test-span-name",
-				StartTimeUnixNano: 2000,
-				DurationNanos:     3000,
-				Attributes:        []*v1.KeyValue{{Key: "http.method", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "GET"}}}},
-			}},
+			Spans: []*tempopb.Span{
+				{
+					SpanID:            "test-span-id",
+					Name:              "test-span-name",
+					StartTimeUnixNano: 2000,
+					DurationNanos:     3000,
+					Attributes:        []*v1.KeyValue{{Key: "http.method", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "GET"}}}},
+				},
+			},
 		}},
 	}}}
 
@@ -110,4 +129,129 @@ func TestTransformRawSearchResponse(t *testing.T) {
 	raw := frames[0].Fields[0].At(0).(string)
 	expected := "{\n  \"traces\": [\n    {\n      \"traceID\": \"test-trace-id-raw\"\n    }\n  ]\n}"
 	assert.Equal(t, expected, raw)
+}
+
+func TestTransformTraceSearchResponse_DurationBelowOneMsIsNil(t *testing.T) {
+	pCtx := backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{UID: "u", Name: "n"}}
+	resp := &tempopb.SearchResponse{Traces: []*tempopb.TraceSearchMetadata{{
+		TraceID:           "test-trace-id",
+		RootServiceName:   "test-service-name",
+		RootTraceName:     "test-root-trace-name",
+		StartTimeUnixNano: 2000000,
+		DurationMs:        0,
+		SpanSet:           &tempopb.SpanSet{Spans: []*tempopb.Span{{SpanID: "span1", Name: "op", StartTimeUnixNano: 1000000, DurationNanos: 1000}}},
+	}}}
+
+	frames, err := transformTraceSearchResponse(pCtx, resp)
+	require.NoError(t, err)
+	require.Len(t, frames, 1)
+	require.Equal(t, 1, frames[0].Rows())
+	assert.Nil(t, frames[0].Fields[4].At(0))
+}
+
+func TestTransformTraceSearchResponse_UsesSpanSetsWhenSpanSetMissing(t *testing.T) {
+	pCtx := backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{UID: "u", Name: "n"}}
+	resp := &tempopb.SearchResponse{Traces: []*tempopb.TraceSearchMetadata{{
+		TraceID:           "test-trace-id",
+		RootServiceName:   "test-service-name",
+		RootTraceName:     "test-root-trace-name",
+		StartTimeUnixNano: 1000000,
+		DurationMs:        10,
+		SpanSets: []*tempopb.SpanSet{
+			{Spans: []*tempopb.Span{{SpanID: "span1", Name: "op1", StartTimeUnixNano: 1000000, DurationNanos: 1000}}},
+			{Spans: []*tempopb.Span{{SpanID: "span2", Name: "op2", StartTimeUnixNano: 1001000, DurationNanos: 1000}}},
+		},
+	}}}
+
+	frames, err := transformTraceSearchResponse(pCtx, resp)
+	require.NoError(t, err)
+	require.Len(t, frames, 1)
+
+	require.Equal(t, 1, frames[0].Rows())
+	require.NotNil(t, frames[0].Fields[5].At(0))
+
+	var nestedFrames []json.RawMessage
+	require.NoError(t, json.Unmarshal(frames[0].Fields[5].At(0).(json.RawMessage), &nestedFrames))
+	assert.Len(t, nestedFrames, 2)
+}
+
+func TestTransformTraceSearchResponseSubFrame_MissingDynamicAttributeUsesNil(t *testing.T) {
+	pCtx := backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{UID: "u", Name: "n"}}
+	trace := &tempopb.TraceSearchMetadata{
+		TraceID:           "test-trace-id",
+		RootServiceName:   "test-service-name",
+		RootTraceName:     "test-root-trace-name",
+		StartTimeUnixNano: 1000000,
+		DurationMs:        10,
+	}
+	spanSet := &tempopb.SpanSet{
+		Spans: []*tempopb.Span{
+			{
+				SpanID:            "span1",
+				Name:              "op1",
+				StartTimeUnixNano: 1000000,
+				DurationNanos:     1000,
+				Attributes: []*v1.KeyValue{
+					{
+						Key:   "http.method",
+						Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "GET"}},
+					},
+				},
+			},
+			{
+				SpanID:            "span2",
+				Name:              "op2",
+				StartTimeUnixNano: 1001000,
+				DurationNanos:     1000,
+			},
+		},
+	}
+
+	frame := transformTraceSearchResponseSubFrame(trace, spanSet, pCtx)
+	require.NotNil(t, frame)
+	require.Equal(t, 2, frame.Rows())
+	require.GreaterOrEqual(t, len(frame.Fields), 6)
+	assert.Equal(t, "http.method", frame.Fields[4].Name)
+	assert.Equal(t, "GET", *(frame.Fields[4].At(0).(*string)))
+	assert.True(t, frame.Fields[4].NilAt(1))
+}
+
+func TestTransformSpanSearchResponse_MissingDynamicAttributeUsesNil(t *testing.T) {
+	pCtx := backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{UID: "u", Name: "n"}}
+	resp := &tempopb.SearchResponse{Traces: []*tempopb.TraceSearchMetadata{{
+		TraceID:           "test-trace-id",
+		RootServiceName:   "test-service-name",
+		RootTraceName:     "test-root-trace-name",
+		StartTimeUnixNano: 1000,
+		SpanSets: []*tempopb.SpanSet{{
+			Spans: []*tempopb.Span{
+				{
+					SpanID:            "test-span-id-1",
+					Name:              "test-span-name-1",
+					StartTimeUnixNano: 2000,
+					DurationNanos:     3000,
+					Attributes: []*v1.KeyValue{
+						{
+							Key:   "http.method",
+							Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "GET"}},
+						},
+					},
+				},
+				{
+					SpanID:            "test-span-id-2",
+					Name:              "test-span-name-2",
+					StartTimeUnixNano: 3000,
+					DurationNanos:     4000,
+				},
+			},
+		}},
+	}}}
+
+	frames, err := transformSpanSearchResponse(pCtx, resp)
+	require.NoError(t, err)
+	require.Len(t, frames, 1)
+	require.Equal(t, 2, frames[0].Rows())
+
+	assert.Equal(t, "GET", *(frames[0].Fields[6].At(0).(*string)))
+	assert.True(t, frames[0].Fields[6].NilAt(1))
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a small fix for when customers spans contain attributes only in some of their spans but not all of them

**Why do we need this feature?**

A panic is thrown when trying to convert from `interface{}` because we are currently appending an `""` instead of a `nil` pointer when there are no attributes present. This errors out with:

`panic: interface conversion: interface {} is string, not *string`

This is only caused when some of the spans don't have attributes but others do.

**Who is this feature for?**

Anyone using tempo

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/orgs/grafana/projects/457/views/33?sliceBy%5Bvalue%5D=2026+Q1&pane=issue&itemId=158199838&issue=grafana%7Coss-big-tent-squad%7C199
