### PR TITLE
Provisioning: Wrap duplicate resource name as validation error (warning)

### DIFF
--- a/pkg/registry/apis/provisioning/resources/resources.go
+++ b/pkg/registry/apis/provisioning/resources/resources.go
@@ -282,7 +282,9 @@ func (r *ResourcesManager) WriteResourceFromFile(ctx context.Context, path strin
 	}
 
 	if existing, found := r.findResource(id); found {
-		return "", parsed.GVK, fmt.Errorf("duplicate resource name: %s, %s and %s: %w", parsed.Obj.GetName(), path, existing, ErrDuplicateName)
+		return "", parsed.GVK, NewResourceValidationError(
+			fmt.Errorf("duplicate resource name: %s, %s and %s: %w", parsed.Obj.GetName(), path, existing, ErrDuplicateName),
+		)
 	}
 	r.addResource(id, path)
 

--- a/pkg/tests/apis/provisioning/testdata/dashboard-duplicate-name-copy.json
+++ b/pkg/tests/apis/provisioning/testdata/dashboard-duplicate-name-copy.json
@@ -1,0 +1,10 @@
+{
+  "apiVersion": "dashboard.grafana.app/v0alpha1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "test-dashboard-duplicate"
+  },
+  "spec": {
+    "title": "Dashboard For Duplicate Name Test (Copy)"
+  }
+}

--- a/pkg/tests/apis/provisioning/testdata/dashboard-duplicate-name.json
+++ b/pkg/tests/apis/provisioning/testdata/dashboard-duplicate-name.json
@@ -1,0 +1,10 @@
+{
+  "apiVersion": "dashboard.grafana.app/v0alpha1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "test-dashboard-duplicate"
+  },
+  "spec": {
+    "title": "Dashboard For Duplicate Name Test"
+  }
+}


### PR DESCRIPTION
## Summary

- Wraps the "duplicate resource name" error in `WriteResourceFromFile` with `NewResourceValidationError` so it is treated as a **warning** (not a hard error) during pull jobs. Previously the error was returned as a plain `fmt.Errorf` and never passed through the validation-error wrapping path.
- Adds an integration test (`TestIntegrationProvisioning_JobWarningResult_DuplicateName`) that verifies a pull job with two dashboard files sharing the same `metadata.name` completes with **warning** state, not error state.

## Test plan

- [x] Existing unit tests pass (`TestResourceValidationError`, jobs package tests)
- [x] New integration test covers the duplicate name warning scenario
- [ ] Run integration test suite: `go test ./pkg/tests/apis/provisioning/... -run TestIntegrationProvisioning_JobWarningResult_DuplicateName`


Made with [Cursor](https://cursor.com)