### PR TITLE
 Provisioning: Fix wizard step navigation when server returns errors for fields on other steps

### DIFF
--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
@@ -292,7 +292,11 @@ describe('ProvisioningWizard', () => {
 
       // Fill required fields on authType step
       await typeIntoTokenField(user, 'ghp_xxxxxxxxxxxxxxxxxxxx', 'ghp_testtoken');
-      await pasteIntoInput(user, screen.getByRole('textbox', { name: /Repository URL/i }), 'https://github.com/o/r');
+      await pasteIntoInput(
+        user,
+        screen.getByRole('textbox', { name: /Repository URL/i }),
+        'https://github.com/test/repo'
+      );
 
       // Proceed to next step
       await user.click(screen.getByRole('button', { name: /Configure repository$/i }));
@@ -323,7 +327,7 @@ describe('ProvisioningWizard', () => {
 
       await fillConnectionForm(user, 'github', {
         token: 'test-token',
-        url: 'https://github.com/o/r',
+        url: 'https://github.com/test/repo',
       });
 
       await user.click(screen.getByRole('button', { name: /Choose what to synchronize/i }));
@@ -363,7 +367,7 @@ describe('ProvisioningWizard', () => {
 
       await fillConnectionForm(user, 'github', {
         token: 'test-token',
-        url: 'https://github.com/o/r',
+        url: 'https://github.com/test/repo',
       });
 
       await user.click(screen.getByRole('button', { name: /Choose what to synchronize/i }));
@@ -420,7 +424,7 @@ describe('ProvisioningWizard', () => {
 
       await fillConnectionForm(user, 'github', {
         token: 'test-token',
-        url: 'https://github.com/o/r',
+        url: 'https://github.com/test/repo',
         branch: 'invalid-branch',
       });
 
@@ -476,7 +480,7 @@ describe('ProvisioningWizard', () => {
 
       await fillConnectionForm(user, 'github', {
         token: 'test-token',
-        url: 'https://github.com/o/r',
+        url: 'https://github.com/test/repo',
       });
 
       // First connection attempt — fails with URL error (field not on this step)
@@ -514,7 +518,7 @@ describe('ProvisioningWizard', () => {
       await pasteIntoInput(
         user,
         screen.getByPlaceholderText('https://github.com/owner/repository'),
-        'https://github.com/o/r'
+        'https://github.com/test/repo'
       );
 
       await user.click(screen.getByRole('button', { name: /Configure repository$/i }));
@@ -541,7 +545,7 @@ describe('ProvisioningWizard', () => {
 
       await navigateToConnectionStep(user, 'gitlab', {
         token: 'glpat-test',
-        url: 'https://gitlab.com/o/r',
+        url: 'https://gitlab.com/test/repo',
       });
 
       // Connection step fields
@@ -560,7 +564,7 @@ describe('ProvisioningWizard', () => {
       await navigateToConnectionStep(user, 'bitbucket', {
         token: 'test-token',
         tokenUser: 'test-user',
-        url: 'https://bitbucket.org/o/r',
+        url: 'https://bitbucket.org/test/repo',
       });
 
       // Connection step fields
@@ -579,7 +583,7 @@ describe('ProvisioningWizard', () => {
       await navigateToConnectionStep(user, 'git', {
         token: 'test-token',
         tokenUser: 'test-user',
-        url: 'https://git.example.com/o/r.git',
+        url: 'https://git.example.com/test/repo.git',
       });
 
       // Connection step fields
@@ -608,7 +612,7 @@ describe('ProvisioningWizard', () => {
       await pasteIntoInput(
         user,
         screen.getByPlaceholderText('https://bitbucket.org/owner/repository'),
-        'https://bitbucket.org/o/r'
+        'https://bitbucket.org/test/repo'
       );
 
       expect(screen.getByDisplayValue('test-user')).toBeInTheDocument();
@@ -622,7 +626,7 @@ describe('ProvisioningWizard', () => {
       await pasteIntoInput(
         user,
         screen.getByPlaceholderText('https://git.example.com/owner/repository.git'),
-        'https://git.example.com/o/r.git'
+        'https://git.example.com/test/repo.git'
       );
 
       expect(screen.getByDisplayValue('test-user')).toBeInTheDocument();

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
@@ -64,12 +64,14 @@ function setup(jsx: JSX.Element) {
   return render(<StepStatusProvider>{jsx}</StepStatusProvider>);
 }
 
+async function pasteIntoInput(user: UserEvent, input: HTMLElement, value: string) {
+  await user.click(input);
+  await user.clear(input);
+  await user.paste(value);
+}
+
 async function typeIntoTokenField(user: UserEvent, placeholder: string, value: string) {
-  const resetButton = screen.queryByRole('button', { name: /Reset/i });
-  if (resetButton) {
-    await user.click(resetButton);
-  }
-  await user.type(screen.getByPlaceholderText(placeholder), value);
+  await pasteIntoInput(user, screen.getByPlaceholderText(placeholder), value);
 }
 
 async function navigateToConnectionStep(
@@ -97,7 +99,7 @@ async function navigateToConnectionStep(
   }
 
   if ((type === 'bitbucket' || type === 'git') && data?.tokenUser) {
-    await user.type(screen.getByPlaceholderText('username'), data.tokenUser);
+    await pasteIntoInput(user, screen.getByPlaceholderText('username'), data.tokenUser);
   }
 
   if (type !== 'local' && data?.url) {
@@ -107,7 +109,7 @@ async function navigateToConnectionStep(
       bitbucket: 'https://bitbucket.org/owner/repository',
       git: 'https://git.example.com/owner/repository.git',
     };
-    await user.type(screen.getByPlaceholderText(urlPlaceholders[type]), data.url);
+    await pasteIntoInput(user, screen.getByPlaceholderText(urlPlaceholders[type]), data.url);
   }
 
   if (type !== 'local') {
@@ -141,11 +143,15 @@ async function fillConnectionForm(
   });
 
   if (type !== 'local' && data.branch) {
-    await user.type(screen.getByRole('combobox'), `${data.branch}{Enter}`);
+    const branchCombobox = screen.getByRole('combobox');
+    await user.click(branchCombobox);
+    await user.clear(branchCombobox);
+    await user.paste(data.branch);
+    await user.keyboard('{Enter}');
   }
 
   if (data.path) {
-    await user.type(screen.getByRole('textbox', { name: /Path/i }), data.path);
+    await pasteIntoInput(user, screen.getByRole('textbox', { name: /Path/i }), data.path);
   }
 }
 
@@ -285,8 +291,8 @@ describe('ProvisioningWizard', () => {
       await user.click(screen.getByLabelText(/Connect with Personal Access Token/i));
 
       // Fill required fields on authType step
-      await user.type(screen.getByPlaceholderText('ghp_xxxxxxxxxxxxxxxxxxxx'), 'ghp_testtoken');
-      await user.type(screen.getByRole('textbox', { name: /Repository URL/i }), 'https://github.com/test/repo');
+      await typeIntoTokenField(user, 'ghp_xxxxxxxxxxxxxxxxxxxx', 'ghp_testtoken');
+      await pasteIntoInput(user, screen.getByRole('textbox', { name: /Repository URL/i }), 'https://github.com/o/r');
 
       // Proceed to next step
       await user.click(screen.getByRole('button', { name: /Configure repository$/i }));
@@ -317,9 +323,7 @@ describe('ProvisioningWizard', () => {
 
       await fillConnectionForm(user, 'github', {
         token: 'test-token',
-        url: 'https://github.com/test/repo',
-        branch: 'main',
-        path: '/',
+        url: 'https://github.com/o/r',
       });
 
       await user.click(screen.getByRole('button', { name: /Choose what to synchronize/i }));
@@ -359,9 +363,7 @@ describe('ProvisioningWizard', () => {
 
       await fillConnectionForm(user, 'github', {
         token: 'test-token',
-        url: 'https://github.com/test/repo',
-        branch: 'main',
-        path: '/',
+        url: 'https://github.com/o/r',
       });
 
       await user.click(screen.getByRole('button', { name: /Choose what to synchronize/i }));
@@ -418,9 +420,8 @@ describe('ProvisioningWizard', () => {
 
       await fillConnectionForm(user, 'github', {
         token: 'test-token',
-        url: 'https://github.com/test/repo',
+        url: 'https://github.com/o/r',
         branch: 'invalid-branch',
-        path: '/',
       });
 
       await user.click(screen.getByRole('button', { name: /Choose what to synchronize/i }));
@@ -475,9 +476,7 @@ describe('ProvisioningWizard', () => {
 
       await fillConnectionForm(user, 'github', {
         token: 'test-token',
-        url: 'https://github.com/test/repo',
-        branch: 'main',
-        path: '/',
+        url: 'https://github.com/o/r',
       });
 
       // First connection attempt — fails with URL error (field not on this step)
@@ -490,7 +489,8 @@ describe('ProvisioningWizard', () => {
       // User edits a visible field (branch)
       const branchCombobox = screen.getByRole('combobox');
       await user.clear(branchCombobox);
-      await user.type(branchCombobox, 'develop{Enter}');
+      await user.paste('develop');
+      await user.keyboard('{Enter}');
 
       // Retry — should not be silently blocked
       await user.click(screen.getByRole('button', { name: /Choose what to synchronize/i }));
@@ -501,158 +501,6 @@ describe('ProvisioningWizard', () => {
       // Wizard advances to next step — proves no silent block
       expect(await screen.findByRole('heading', { name: /3\. Choose what to synchronize/i })).toBeInTheDocument();
     });
-
-    it('should show error alert for Status API errors', async () => {
-      const mockSubmitData = jest.fn();
-      const mockMutationState = {
-        status: QueryStatus.uninitialized,
-        isLoading: false,
-        error: null,
-      };
-      (mockUseCreateOrUpdateRepository as jest.Mock).mockReturnValue([
-        mockSubmitData,
-        mockMutationState,
-        mockMutationState,
-      ]);
-
-      const statusError = new Error('decrypt gitlab token: not found');
-      mockSubmitData.mockRejectedValue(statusError);
-
-      const { user } = setup(<ProvisioningWizard type="gitlab" />);
-
-      // Fill required GitLab fields on auth step and submit
-      await typeIntoTokenField(user, 'glpat-xxxxxxxxxxxxxxxxxxxx', 'glpat-test');
-      await user.type(
-        screen.getByPlaceholderText('https://gitlab.com/owner/repository'),
-        'https://gitlab.com/test/repo'
-      );
-
-      await user.click(screen.getByRole('button', { name: /Configure repository$/i }));
-
-      // Now the submit should fail with statusError
-      const alert = await screen.findByRole('alert', { name: /Repository connection failed/i });
-      expect(alert).toBeInTheDocument();
-      expect(screen.getByText('Repository connection failed')).toBeInTheDocument();
-
-      expect(screen.getByRole('heading', { name: /1\. Connect/i })).toBeInTheDocument();
-    });
-
-    it('should show error when repository creation fails', async () => {
-      const mockSubmitData = jest.fn();
-      const mockMutationState = {
-        status: QueryStatus.uninitialized,
-        isLoading: false,
-        error: null,
-      };
-      (mockUseCreateOrUpdateRepository as jest.Mock).mockReturnValue([
-        mockSubmitData,
-        mockMutationState,
-        mockMutationState,
-      ]);
-
-      // First submit (authType) succeeds, second (connection step) fails
-      mockSubmitData.mockResolvedValueOnce({ data: { metadata: { name: 'test-repo-abc123' } } }).mockResolvedValueOnce({
-        error: {
-          kind: 'Status',
-          status: 'Failure',
-          message: 'Repository creation failed',
-          code: 500,
-        },
-      });
-
-      const { user } = setup(<ProvisioningWizard type="github" />);
-
-      await fillConnectionForm(user, 'github', {
-        token: 'test-token',
-        url: 'https://github.com/test/repo',
-        branch: 'main',
-        path: '/',
-      });
-
-      await user.click(screen.getByRole('button', { name: /Choose what to synchronize/i }));
-
-      expect(await screen.findByRole('alert', { name: 'Repository request failed' })).toBeInTheDocument();
-
-      // Still on connection step (now step 2)
-      expect(screen.getByRole('heading', { name: /2\. Configure repository/i })).toBeInTheDocument();
-    });
-  });
-
-  describe('Navigation and State', () => {
-    it('should handle cancel on first step', async () => {
-      const { user } = setup(<ProvisioningWizard type="github" />);
-
-      // First step is now AuthType step for GitHub
-      expect(screen.getByRole('heading', { name: /Connect/i })).toBeInTheDocument();
-
-      await user.click(screen.getByRole('button', { name: /Cancel/i }));
-
-      expect(mockNavigate).toHaveBeenCalledWith('/admin/provisioning');
-    });
-
-    it('should handle going back to previous step', async () => {
-      const { user } = setup(<ProvisioningWizard type="github" />);
-
-      await fillConnectionForm(user, 'github', {
-        token: 'test-token',
-        url: 'https://github.com/test/repo',
-        branch: 'main',
-        path: '/',
-      });
-
-      await user.click(screen.getByRole('button', { name: /Choose what to synchronize/i }));
-
-      expect(await screen.findByRole('heading', { name: /Choose what to synchronize/i })).toBeInTheDocument();
-
-      await user.click(screen.getByRole('button', { name: /Previous/i }));
-
-      expect(await screen.findByRole('heading', { name: /2\. Configure repository/i })).toBeInTheDocument();
-    });
-
-    it('should disable next button when submitting', async () => {
-      const mockSubmitData = jest.fn();
-      const mockMutationState = {
-        status: QueryStatus.uninitialized,
-        isLoading: false,
-        error: null,
-        data: undefined,
-        isUninitialized: true,
-        isSuccess: false,
-        isError: false,
-        reset: jest.fn(),
-      };
-
-      (mockUseCreateOrUpdateRepository as jest.Mock).mockReturnValue([
-        mockSubmitData,
-        mockMutationState,
-        mockMutationState,
-      ]);
-
-      mockSubmitData.mockImplementation(
-        () => new Promise((resolve) => setTimeout(() => resolve({ data: { metadata: { name: 'test-conn' } } }), 100))
-      );
-
-      const { user } = setup(<ProvisioningWizard type="github" />);
-
-      // Select PAT option (GitHub App is the default)
-      await user.click(screen.getByLabelText(/Connect with Personal Access Token/i));
-
-      await user.type(screen.getByPlaceholderText('ghp_xxxxxxxxxxxxxxxxxxxx'), 'test-token');
-
-      const repoUrlInput = screen.getByPlaceholderText('https://github.com/owner/repository');
-      await user.clear(repoUrlInput);
-      await user.type(repoUrlInput, 'https://github.com/test/repo');
-
-      await user.click(screen.getByRole('button', { name: /Configure repository$/i }));
-      expect(await screen.findByRole('heading', { name: /2\. Configure repository/i })).toBeInTheDocument();
-
-      await user.type(screen.getByRole('combobox'), 'main{Enter}');
-      await user.type(screen.getByRole('textbox', { name: /Path/i }), '/');
-
-      await user.click(screen.getByRole('button', { name: /Choose what to synchronize/i }));
-
-      expect(await screen.findByRole('button', { name: /Submitting.../i })).toBeDisabled();
-    });
   });
 
   describe('Form Validation', () => {
@@ -662,10 +510,11 @@ describe('ProvisioningWizard', () => {
       // Select PAT option (GitHub App is the default)
       await user.click(screen.getByLabelText(/Connect with Personal Access Token/i));
 
-      await user.type(screen.getByPlaceholderText('ghp_xxxxxxxxxxxxxxxxxxxx'), 'test-token');
-      await user.type(
+      await typeIntoTokenField(user, 'ghp_xxxxxxxxxxxxxxxxxxxx', 'test-token');
+      await pasteIntoInput(
+        user,
         screen.getByPlaceholderText('https://github.com/owner/repository'),
-        'https://github.com/test/repo'
+        'https://github.com/o/r'
       );
 
       await user.click(screen.getByRole('button', { name: /Configure repository$/i }));
@@ -680,34 +529,6 @@ describe('ProvisioningWizard', () => {
       expect(screen.getByRole('heading', { name: /2\. Configure repository/i })).toBeInTheDocument();
       expect(screen.getByText(/Branch is required/i)).toBeInTheDocument();
     });
-
-    it('should show button text changes based on current step', async () => {
-      mockUseGetRepositoryFilesQuery.mockReturnValue({
-        data: {
-          items: [{ name: 'test.json', path: 'test.json' }],
-        },
-        isLoading: false,
-        error: null,
-        refetch: jest.fn(),
-      });
-
-      const { user } = setup(<ProvisioningWizard type="github" />);
-
-      expect(screen.getByRole('button', { name: /Configure repository$/i })).toBeInTheDocument();
-
-      await fillConnectionForm(user, 'github', {
-        token: 'test-token',
-        url: 'https://github.com/test/repo',
-        branch: 'main',
-        path: '/',
-      });
-
-      expect(screen.getByRole('button', { name: /Choose what to synchronize/i })).toBeInTheDocument();
-
-      await user.click(screen.getByRole('button', { name: /Choose what to synchronize/i }));
-
-      expect(await screen.findByRole('button', { name: /Synchronize with external storage/i })).toBeInTheDocument();
-    });
   });
 
   describe('Different Repository Types', () => {
@@ -720,7 +541,7 @@ describe('ProvisioningWizard', () => {
 
       await navigateToConnectionStep(user, 'gitlab', {
         token: 'glpat-test',
-        url: 'https://gitlab.com/test/repo',
+        url: 'https://gitlab.com/o/r',
       });
 
       // Connection step fields
@@ -739,7 +560,7 @@ describe('ProvisioningWizard', () => {
       await navigateToConnectionStep(user, 'bitbucket', {
         token: 'test-token',
         tokenUser: 'test-user',
-        url: 'https://bitbucket.org/test/repo',
+        url: 'https://bitbucket.org/o/r',
       });
 
       // Connection step fields
@@ -758,7 +579,7 @@ describe('ProvisioningWizard', () => {
       await navigateToConnectionStep(user, 'git', {
         token: 'test-token',
         tokenUser: 'test-user',
-        url: 'https://git.example.com/test/repo.git',
+        url: 'https://git.example.com/o/r.git',
       });
 
       // Connection step fields
@@ -783,10 +604,11 @@ describe('ProvisioningWizard', () => {
       const { user } = setup(<ProvisioningWizard type="bitbucket" />);
 
       await typeIntoTokenField(user, 'ATBBxxxxxxxxxxxxxxxx', 'test-token');
-      await user.type(screen.getByPlaceholderText('username'), 'test-user');
-      await user.type(
+      await pasteIntoInput(user, screen.getByPlaceholderText('username'), 'test-user');
+      await pasteIntoInput(
+        user,
         screen.getByPlaceholderText('https://bitbucket.org/owner/repository'),
-        'https://bitbucket.org/test/repo'
+        'https://bitbucket.org/o/r'
       );
 
       expect(screen.getByDisplayValue('test-user')).toBeInTheDocument();
@@ -796,10 +618,11 @@ describe('ProvisioningWizard', () => {
       const { user } = setup(<ProvisioningWizard type="git" />);
 
       await typeIntoTokenField(user, 'token or password', 'test-token');
-      await user.type(screen.getByPlaceholderText('username'), 'test-user');
-      await user.type(
+      await pasteIntoInput(user, screen.getByPlaceholderText('username'), 'test-user');
+      await pasteIntoInput(
+        user,
         screen.getByPlaceholderText('https://git.example.com/owner/repository.git'),
-        'https://git.example.com/test/repo.git'
+        'https://git.example.com/o/r.git'
       );
 
       expect(screen.getByDisplayValue('test-user')).toBeInTheDocument();

--- a/public/app/features/provisioning/Wizard/Stepper.tsx
+++ b/public/app/features/provisioning/Wizard/Stepper.tsx
@@ -8,6 +8,7 @@ export interface Step<T> {
   name: string;
   title: string;
   submitOnNext?: boolean;
+  formFields?: string[];
 }
 
 export interface Props<T extends string | number> {

--- a/public/app/features/provisioning/Wizard/hooks/useWizardSubmission.test.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useWizardSubmission.test.ts
@@ -216,7 +216,7 @@ describe('useWizardSubmission', () => {
     });
 
     describe('error handling', () => {
-      it('should handle thrown fetch errors with form field errors', async () => {
+      it('should set inline error for fields visible on the current step', async () => {
         mockSubmitData.mockRejectedValue({
           data: {
             message: 'Validation failed',
@@ -230,6 +230,41 @@ describe('useWizardSubmission', () => {
           await result.current.handleSubmit();
         });
 
+        // repository.url belongs to the authType step, not the connection step,
+        // so setError should NOT be called (prevents phantom errors blocking retry)
+        expect(mockSetError).not.toHaveBeenCalled();
+
+        // The error should appear in the step status banner instead
+        expect(mockSetStepStatusInfo).toHaveBeenCalledWith(
+          expect.objectContaining({
+            status: 'error',
+            error: expect.objectContaining({ message: 'Invalid URL' }),
+          })
+        );
+      });
+
+      it('should set inline error for fields visible on the authType step', async () => {
+        mockSubmitData.mockRejectedValue({
+          data: {
+            message: 'Validation failed',
+            errors: { 'repository.url': 'Invalid URL' },
+          },
+        });
+
+        const { result } = renderHook(() =>
+          useWizardSubmission(
+            createParams({
+              activeStep: 'authType',
+              currentStepConfig: authTypeStep,
+            })
+          )
+        );
+
+        await act(async () => {
+          await result.current.handleSubmit();
+        });
+
+        // repository.url IS visible on authType step, so setError should be called
         expect(mockSetError).toHaveBeenCalledWith('repository.url', {
           message: 'Invalid URL',
         });

--- a/public/app/features/provisioning/Wizard/hooks/useWizardSubmission.test.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useWizardSubmission.test.ts
@@ -36,6 +36,7 @@ describe('useWizardSubmission', () => {
     name: 'Connection',
     title: 'Set up connection',
     submitOnNext: true,
+    formFields: ['repository.branch', 'repository.path'],
   };
 
   const bootstrapStep: Step<WizardStep> = {
@@ -50,6 +51,7 @@ describe('useWizardSubmission', () => {
     name: 'Auth Type',
     title: 'Select auth type',
     submitOnNext: true,
+    formFields: ['repository.url', 'repository.token', 'repository.tokenUser'],
   };
 
   function createMockMethods() {

--- a/public/app/features/provisioning/Wizard/hooks/useWizardSubmission.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useWizardSubmission.ts
@@ -27,14 +27,6 @@ export interface UseWizardSubmissionReturn {
   handleSubmit: () => Promise<void>;
 }
 
-// Fields that have visible form inputs on each step.
-// Used to prevent setting phantom errors on fields that aren't rendered on the current step,
-// which would otherwise persist in RHF state and silently block form submission on retry.
-const STEP_FORM_FIELDS: Partial<Record<WizardStep, string[]>> = {
-  authType: ['repository.url', 'repository.token', 'repository.tokenUser'],
-  connection: ['repository.branch', 'repository.path'],
-};
-
 export function useWizardSubmission({
   activeStep,
   currentStepConfig,
@@ -130,7 +122,7 @@ export function useWizardSubmission({
               },
             });
           } else if (errors.length > 0) {
-            const visibleFields = STEP_FORM_FIELDS[activeStep];
+            const visibleFields = currentStepConfig?.formFields;
             for (const [field, errorMessage] of errors) {
               if (!visibleFields || visibleFields.includes(field)) {
                 setError(field, errorMessage);

--- a/public/app/features/provisioning/Wizard/utils/getSteps.ts
+++ b/public/app/features/provisioning/Wizard/utils/getSteps.ts
@@ -14,6 +14,7 @@ export const getSteps = (type: RepoType): Array<Step<WizardStep>> => {
       name: authStepText,
       title: authStepText,
       submitOnNext: true,
+      formFields: ['repository.url', 'repository.token', 'repository.tokenUser'],
     },
     {
       id: 'connection',
@@ -24,6 +25,7 @@ export const getSteps = (type: RepoType): Array<Step<WizardStep>> => {
         ? t('provisioning.wizard.title-connect', 'Connect to external storage')
         : t('provisioning.wizard.title-configure-repo', 'Configure repository'),
       submitOnNext: true,
+      formFields: ['repository.branch', 'repository.path'],
     },
     {
       id: 'bootstrap',


### PR DESCRIPTION
**What is this feature?**

Fixes a bug where the wizard's Next button would silently fail after the user encountered a non-field error on the connection step and then edited a field to retry. Also removes redundant `ProvisioningWizard.test.tsx` tests for the cases covered in the hook tests

**Why do we need this feature?**

When the server returned a field error for a field that wasn't visible on the current step (e.g., repository.url error on the connection step), React Hook Form's state would retain that error even though the field wasn't registered. On retry, this phantom error would silently block form submission without any feedback to the user that the submission had been attempted.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/891
