### PR TITLE
add feature flag to build URL to go towards api server endpoints

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -607,16 +607,16 @@ describe('DataSourceWithBackend', () => {
     });
   });
 
-  describe('buildDatasourceUrl', () => {
-    test('check that buildDatasourceUrl uses the new URL based on the feature toggle', () => {
+  describe('buildResourcesDatasourceUrl', () => {
+    test('check that buildResourcesDatasourceUrl uses the new URL based on the feature toggle', () => {
       config.featureToggles.datasourcesApiServerEnableResourceEndpointFrontend = true;
-      const url = createMockDatasource().ds.buildDatasourceUrl('api/v1/labels');
+      const url = createMockDatasource().ds.buildResourcesDatasourceUrl('api/v1/labels');
       expect(url).toBe('/apis/dummy.grafana.app/v0alpha1/namespaces/default/datasources/abc/resources/api/v1/labels');
     });
 
-    test('check that buildDatasourceUrl uses the legacy URL based on the feature toggle', () => {
+    test('check that buildResourcesDatasourceUrl uses the legacy URL based on the feature toggle', () => {
       config.featureToggles.datasourcesApiServerEnableResourceEndpointFrontend = false;
-      const url = createMockDatasource().ds.buildDatasourceUrl('api/v1/labels');
+      const url = createMockDatasource().ds.buildResourcesDatasourceUrl('api/v1/labels');
       expect(url).toBe('/api/datasources/uid/abc/resources/api/v1/labels');
     });
   });

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -609,13 +609,13 @@ describe('DataSourceWithBackend', () => {
 
   describe('buildDatasourceUrl', () => {
     test('check that buildDatasourceUrl uses the new URL based on the feature toggle', () => {
-      config.featureToggles.datasourcesResourceResourceApi = true;
+      config.featureToggles.datasourcesApiServerEnableResourceEndpointFrontend = true;
       const url = createMockDatasource().ds.buildDatasourceUrl('api/v1/labels');
       expect(url).toBe('/apis/dummy.grafana.app/v0alpha1/namespaces/default/datasources/abc/resources/api/v1/labels');
     });
 
     test('check that buildDatasourceUrl uses the legacy URL based on the feature toggle', () => {
-      config.featureToggles.datasourcesResourceResourceApi = false;
+      config.featureToggles.datasourcesApiServerEnableResourceEndpointFrontend = false;
       const url = createMockDatasource().ds.buildDatasourceUrl('api/v1/labels');
       expect(url).toBe('/api/datasources/uid/abc/resources/api/v1/labels');
     });

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -606,6 +606,20 @@ describe('DataSourceWithBackend', () => {
       expect(await ds.getValue('multiplier')).toBe('1');
     });
   });
+
+  describe('buildDatasourceUrl', () => {
+    test('check that buildDatasourceUrl uses the new URL based on the feature toggle', () => {
+      config.featureToggles.datasourcesResourceResourceApi = true;
+      const url = createMockDatasource().ds.buildDatasourceUrl('api/v1/labels');
+      expect(url).toBe('/apis/dummy.grafana.app/v0alpha1/namespaces/default/datasources/abc/resources/api/v1/labels');
+    });
+
+    test('check that buildDatasourceUrl uses the legacy URL based on the feature toggle', () => {
+      config.featureToggles.datasourcesResourceResourceApi = false;
+      const url = createMockDatasource().ds.buildDatasourceUrl('api/v1/labels');
+      expect(url).toBe('/api/datasources/uid/abc/resources/api/v1/labels');
+    });
+  });
 });
 
 function createMockDatasource() {

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -69,6 +69,14 @@ jest.mock('../services', () => ({
 }));
 jest.mock('./publicDashboardQueryHandler');
 
+const mockGetObjectValue = jest.fn().mockReturnValue([]);
+jest.mock('../internal/openFeature', () => ({
+  ...jest.requireActual('../internal/openFeature'),
+  getFeatureFlagClient: () => ({
+    getObjectValue: mockGetObjectValue,
+  }),
+}));
+
 describe('DataSourceWithBackend', () => {
   beforeEach(async () => {
     jest.useFakeTimers();
@@ -608,14 +616,27 @@ describe('DataSourceWithBackend', () => {
   });
 
   describe('buildResourcesDatasourceUrl', () => {
-    test('check that buildResourcesDatasourceUrl uses the new URL based on the feature toggle', () => {
-      config.featureToggles.datasourcesApiServerEnableResourceEndpointFrontend = true;
+    afterEach(() => {
+      mockGetObjectValue.mockReset().mockReturnValue([]);
+    });
+
+    test('check that buildResourcesDatasourceUrl uses the new URL when datasource type is in allowed list', () => {
+      mockGetObjectValue.mockReturnValue(['dummy']);
       const url = createMockDatasource().ds.buildResourcesDatasourceUrl('api/v1/labels');
+      expect(mockGetObjectValue).toHaveBeenCalledWith('datasources.apiserver.useNewAPIsForDatasourceResources', {
+        types: [],
+      });
       expect(url).toBe('/apis/dummy.grafana.app/v0alpha1/namespaces/default/datasources/abc/resources/api/v1/labels');
     });
 
-    test('check that buildResourcesDatasourceUrl uses the legacy URL based on the feature toggle', () => {
-      config.featureToggles.datasourcesApiServerEnableResourceEndpointFrontend = false;
+    test('check that buildResourcesDatasourceUrl uses the legacy URL when datasource type is not in allowed list', () => {
+      mockGetObjectValue.mockReturnValue([]);
+      const url = createMockDatasource().ds.buildResourcesDatasourceUrl('api/v1/labels');
+      expect(url).toBe('/api/datasources/uid/abc/resources/api/v1/labels');
+    });
+
+    test('check that buildResourcesDatasourceUrl uses the legacy URL when allowed list contains other types', () => {
+      mockGetObjectValue.mockReturnValue(['prometheus', 'loki']);
       const url = createMockDatasource().ds.buildResourcesDatasourceUrl('api/v1/labels');
       expect(url).toBe('/api/datasources/uid/abc/resources/api/v1/labels');
     });

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -623,10 +623,7 @@ describe('DataSourceWithBackend', () => {
     test('check that buildResourcesDatasourceUrl uses the new URL when feature flag is enabled', () => {
       mockGetBooleanValue.mockReturnValue(true);
       const url = createMockDatasource().ds.buildResourcesDatasourceUrl('api/v1/labels');
-      expect(mockGetBooleanValue).toHaveBeenCalledWith(
-        'datasources.apiserver.useNewAPIsForDatasourceResources',
-        false
-      );
+      expect(mockGetBooleanValue).toHaveBeenCalledWith('datasources.apiserver.useNewAPIsForDatasourceResources', false);
       expect(url).toBe('/apis/dummy.grafana.app/v0alpha1/namespaces/default/datasources/abc/resources/api/v1/labels');
     });
 

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -69,11 +69,11 @@ jest.mock('../services', () => ({
 }));
 jest.mock('./publicDashboardQueryHandler');
 
-const mockGetObjectValue = jest.fn().mockReturnValue([]);
+const mockGetBooleanValue = jest.fn().mockReturnValue(false);
 jest.mock('../internal/openFeature', () => ({
   ...jest.requireActual('../internal/openFeature'),
   getFeatureFlagClient: () => ({
-    getObjectValue: mockGetObjectValue,
+    getBooleanValue: mockGetBooleanValue,
   }),
 }));
 
@@ -617,26 +617,21 @@ describe('DataSourceWithBackend', () => {
 
   describe('buildResourcesDatasourceUrl', () => {
     afterEach(() => {
-      mockGetObjectValue.mockReset().mockReturnValue([]);
+      mockGetBooleanValue.mockReset().mockReturnValue(false);
     });
 
-    test('check that buildResourcesDatasourceUrl uses the new URL when datasource type is in allowed list', () => {
-      mockGetObjectValue.mockReturnValue(['dummy']);
+    test('check that buildResourcesDatasourceUrl uses the new URL when feature flag is enabled', () => {
+      mockGetBooleanValue.mockReturnValue(true);
       const url = createMockDatasource().ds.buildResourcesDatasourceUrl('api/v1/labels');
-      expect(mockGetObjectValue).toHaveBeenCalledWith('datasources.apiserver.useNewAPIsForDatasourceResources', {
-        types: [],
-      });
+      expect(mockGetBooleanValue).toHaveBeenCalledWith(
+        'datasources.apiserver.useNewAPIsForDatasourceResources',
+        false
+      );
       expect(url).toBe('/apis/dummy.grafana.app/v0alpha1/namespaces/default/datasources/abc/resources/api/v1/labels');
     });
 
-    test('check that buildResourcesDatasourceUrl uses the legacy URL when datasource type is not in allowed list', () => {
-      mockGetObjectValue.mockReturnValue([]);
-      const url = createMockDatasource().ds.buildResourcesDatasourceUrl('api/v1/labels');
-      expect(url).toBe('/api/datasources/uid/abc/resources/api/v1/labels');
-    });
-
-    test('check that buildResourcesDatasourceUrl uses the legacy URL when allowed list contains other types', () => {
-      mockGetObjectValue.mockReturnValue(['prometheus', 'loki']);
+    test('check that buildResourcesDatasourceUrl uses the legacy URL when feature flag is disabled', () => {
+      mockGetBooleanValue.mockReturnValue(false);
       const url = createMockDatasource().ds.buildResourcesDatasourceUrl('api/v1/labels');
       expect(url).toBe('/api/datasources/uid/abc/resources/api/v1/labels');
     });

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -327,7 +327,7 @@ class DataSourceWithBackend<
         method: 'GET',
         headers: options?.headers ? { ...options.headers, ...headers } : headers,
         params: params ?? options?.params,
-        url: this.buildDatasourceUrl(path),
+        url: this.buildResourcesDatasourceUrl(path),
       })
     );
     return result.data;
@@ -348,7 +348,7 @@ class DataSourceWithBackend<
         method: 'POST',
         headers: options?.headers ? { ...options.headers, ...headers } : headers,
         data: data ?? { ...data },
-        url: this.buildDatasourceUrl(path),
+        url: this.buildResourcesDatasourceUrl(path),
       })
     );
     return result.data;
@@ -356,11 +356,11 @@ class DataSourceWithBackend<
 
   /**
    * Internal function to build the datasource URL based on the feature toggle
-   * example:
-   * /apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/stacks-1/datasources/local-prometheus/resource/api/v1/labels
    */
-  buildDatasourceUrl(path: string): string {
+  buildResourcesDatasourceUrl(path: string): string {
     if (config.featureToggles.datasourcesApiServerEnableResourceEndpointFrontend) {
+      // example:
+      // /apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/stacks-1/datasources/local-prometheus/resources/api/v1/labels
       const apiVersion = 'v0alpha1';
       return `/apis/${this.type}.grafana.app/${apiVersion}/namespaces/${config.namespace}/datasources/${this.uid}/resources/${path}`;
     }

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -37,6 +37,7 @@ import { isQueryServiceCompatible } from './qscheck';
 import { BackendDataSourceResponse, toDataQueryResponse } from './queryResponse';
 import { UserStorage } from './userStorage';
 
+
 /**
  * @internal
  */
@@ -326,7 +327,7 @@ class DataSourceWithBackend<
         method: 'GET',
         headers: options?.headers ? { ...options.headers, ...headers } : headers,
         params: params ?? options?.params,
-        url: `/api/datasources/uid/${this.uid}/resources/${path}`,
+        url: this.buildDatasourceUrl(path),
       })
     );
     return result.data;
@@ -347,10 +348,23 @@ class DataSourceWithBackend<
         method: 'POST',
         headers: options?.headers ? { ...options.headers, ...headers } : headers,
         data: data ?? { ...data },
-        url: `/api/datasources/uid/${this.uid}/resources/${path}`,
+        url: this.buildDatasourceUrl(path),
       })
     );
     return result.data;
+  }
+
+  /**
+   * Internal function to build the datasource URL based on the feature toggle
+   * example:
+   * /apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/stacks-1/datasources/local-prometheus/resource/api/v1/labels
+   */
+  buildDatasourceUrl(path: string): string {
+    if (config.featureToggles.datasourcesResourceResourceApi) {
+      const apiVersion = 'v0alpha1';
+      return `/apis/${this.type}.grafana.app/${apiVersion}/namespaces/${config.namespace}/datasources/${this.uid}/resources/${path}`;
+    }
+    return `/api/datasources/uid/${this.uid}/resources/${path}`;
   }
 
   /**

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -360,7 +360,7 @@ class DataSourceWithBackend<
    * /apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/stacks-1/datasources/local-prometheus/resource/api/v1/labels
    */
   buildDatasourceUrl(path: string): string {
-    if (config.featureToggles.datasourcesResourceResourceApi) {
+    if (config.featureToggles.datasourcesApiServerEnableResourceEndpointFrontend) {
       const apiVersion = 'v0alpha1';
       return `/apis/${this.type}.grafana.app/${apiVersion}/namespaces/${config.namespace}/datasources/${this.uid}/resources/${path}`;
     }

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -37,7 +37,6 @@ import { isQueryServiceCompatible } from './qscheck';
 import { BackendDataSourceResponse, toDataQueryResponse } from './queryResponse';
 import { UserStorage } from './userStorage';
 
-
 /**
  * @internal
  */

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -357,7 +357,10 @@ class DataSourceWithBackend<
    * Internal function to build the datasource URL based on the feature toggle
    */
   buildResourcesDatasourceUrl(path: string): string {
-    if (config.featureToggles.datasourcesApiServerEnableResourceEndpointFrontend) {
+    const allowedTypes = getFeatureFlagClient().getObjectValue('datasources.apiserver.useNewAPIsForDatasourceResources', {
+      types: [],
+    }) as string[];
+    if (allowedTypes.includes(this.type)) {
       // example:
       // /apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/stacks-1/datasources/local-prometheus/resources/api/v1/labels
       const apiVersion = 'v0alpha1';

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -357,7 +357,10 @@ class DataSourceWithBackend<
    * Internal function to build the datasource URL based on the feature toggle
    */
   buildResourcesDatasourceUrl(path: string): string {
-    const enabledRedirect = getFeatureFlagClient().getBooleanValue('datasources.apiserver.useNewAPIsForDatasourceResources', false);
+    const enabledRedirect = getFeatureFlagClient().getBooleanValue(
+      'datasources.apiserver.useNewAPIsForDatasourceResources',
+      false
+    );
     if (enabledRedirect) {
       // example:
       // /apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/stacks-1/datasources/local-prometheus/resources/api/v1/labels

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -357,10 +357,8 @@ class DataSourceWithBackend<
    * Internal function to build the datasource URL based on the feature toggle
    */
   buildResourcesDatasourceUrl(path: string): string {
-    const allowedTypes = getFeatureFlagClient().getObjectValue('datasources.apiserver.useNewAPIsForDatasourceResources', {
-      types: [],
-    }) as string[];
-    if (allowedTypes.includes(this.type)) {
+    const enabledRedirect = getFeatureFlagClient().getBooleanValue('datasources.apiserver.useNewAPIsForDatasourceResources', false);
+    if (enabledRedirect) {
       // example:
       // /apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/stacks-1/datasources/local-prometheus/resources/api/v1/labels
       const apiVersion = 'v0alpha1';


### PR DESCRIPTION
Updates the frontend to send resource requests to new endpoints based on a [feature flag](https://github.com/grafana/grafana/pull/118450) that will be merged before this one.

[Part of resources mt endpoint migration](https://github.com/grafana/grafana-enterprise/issues/8975)