### PR TITLE
Provisioning: Fix missing slash in resource source link

### DIFF
--- a/public/app/features/provisioning/utils/git.test.ts
+++ b/public/app/features/provisioning/utils/git.test.ts
@@ -1,6 +1,6 @@
 import { RepositorySpec } from 'app/api/clients/provisioning/v0alpha1';
 
-import { getRepoHrefForProvider } from './git';
+import { getRepoFileUrl, getRepoHrefForProvider } from './git';
 
 // Partial specs for testing; getRepoHrefForProvider only reads type and provider url/branch/path.
 function spec(s: Partial<RepositorySpec>): RepositorySpec {
@@ -157,5 +157,62 @@ describe('buildRepoUrl', () => {
     it('returns undefined for unknown provider type', () => {
       expect(getRepoHrefForProvider({ type: 'unknown' } as unknown as RepositorySpec)).toBeUndefined();
     });
+  });
+});
+
+describe('getRepoFileUrl', () => {
+  it('joins pathPrefix and filePath with a slash', () => {
+    expect(
+      getRepoFileUrl({
+        repoType: 'github',
+        url: 'https://github.com/owner/repo',
+        branch: 'main',
+        filePath: 'dashboards/my-dashboard.json',
+        pathPrefix: 'grafana',
+      })
+    ).toBe('https://github.com/owner/repo/blob/main/grafana/dashboards/my-dashboard.json');
+  });
+
+  it('handles pathPrefix with trailing slash', () => {
+    expect(
+      getRepoFileUrl({
+        repoType: 'github',
+        url: 'https://github.com/owner/repo',
+        branch: 'main',
+        filePath: 'dashboards/my-dashboard.json',
+        pathPrefix: 'grafana/',
+      })
+    ).toBe('https://github.com/owner/repo/blob/main/grafana/dashboards/my-dashboard.json');
+  });
+
+  it('uses filePath as-is when pathPrefix is not set', () => {
+    expect(
+      getRepoFileUrl({
+        repoType: 'github',
+        url: 'https://github.com/owner/repo',
+        branch: 'main',
+        filePath: 'dashboards/my-dashboard.json',
+      })
+    ).toBe('https://github.com/owner/repo/blob/main/dashboards/my-dashboard.json');
+  });
+
+  it('returns undefined when url is missing', () => {
+    expect(
+      getRepoFileUrl({
+        repoType: 'github',
+        url: undefined,
+        filePath: 'dashboards/my-dashboard.json',
+      })
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when filePath is missing', () => {
+    expect(
+      getRepoFileUrl({
+        repoType: 'github',
+        url: 'https://github.com/owner/repo',
+        filePath: undefined,
+      })
+    ).toBeUndefined();
   });
 });

--- a/public/app/features/provisioning/utils/git.ts
+++ b/public/app/features/provisioning/utils/git.ts
@@ -138,7 +138,7 @@ export function getRepoFileUrl({
   }
 
   const effectiveBranch = branch || 'main';
-  const fullPath = pathPrefix ? `${pathPrefix}${filePath}` : filePath;
+  const fullPath = pathPrefix ? `${pathPrefix.replace(/\/+$/, '')}/${filePath}` : filePath;
 
   switch (repoType) {
     case 'github':


### PR DESCRIPTION
**What is this feature?**

Fixes the source link generation for resources in Git-sync repositories. The link was missing a forward slash between the repo path and resource path.

**Why do we need this feature?**

When viewing the Resources tab of a Git-sync repository overview, the "Source" link was broken due to incorrect URL concatenation (e.g., `/repodashboards` instead of `/repo/dashboards`).

**Which issue(s) does this PR fix?**

Fixes https://github.com/grafana/git-ui-sync-project/issues/914
