### PR TITLE
Alerting: Fix time range picker bug in alert activity

### DIFF
--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -1,13 +1,24 @@
 import { css } from '@emotion/css';
 import { orderBy } from 'lodash';
-import { Fragment, useMemo } from 'react';
+import { Fragment, useCallback, useMemo, useState } from 'react';
 import { useMeasure } from 'react-use';
 
-import { GrafanaTheme2, Labels } from '@grafana/data';
+import { DataFrame, GrafanaTheme2, Labels, TimeRange } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { isFetchError } from '@grafana/runtime';
-import { TimeRangePicker, useTimeRange } from '@grafana/scenes-react';
-import { Alert, Box, Drawer, Icon, LoadingBar, LoadingPlaceholder, Stack, Text, useStyles2 } from '@grafana/ui';
+import { SceneContextProvider, useTimeRange } from '@grafana/scenes-react';
+import {
+  Alert,
+  Box,
+  Drawer,
+  Icon,
+  LoadingBar,
+  LoadingPlaceholder,
+  Stack,
+  Text,
+  TimeRangePicker,
+  useStyles2,
+} from '@grafana/ui';
 import { AlertQuery, GrafanaRuleDefinition } from 'app/types/unified-alerting-dto';
 
 import { alertRuleApi } from '../../api/alertRuleApi';
@@ -39,12 +50,69 @@ interface InstanceDetailsDrawerProps {
   onClose: () => void;
 }
 
+interface InstanceDrawerChartRowProps {
+  chartKey: string;
+  chartTimeRange: TimeRange;
+  onTimeRangeChange: (range: TimeRange) => void;
+  query: AlertQuery;
+  instanceLabels: Labels;
+  thresholds: ReturnType<typeof getThresholdsForQueries>;
+  annotations: DataFrame[];
+}
+
+function InstanceDrawerChartRow({
+  chartKey,
+  chartTimeRange,
+  onTimeRangeChange,
+  query,
+  instanceLabels,
+  thresholds,
+  annotations,
+}: InstanceDrawerChartRowProps) {
+  return (
+    <Box>
+      <Stack direction="row" justifyContent="flex-end" alignItems="center" gap={1}>
+        <TimeRangePicker
+          value={chartTimeRange}
+          onChange={onTimeRangeChange}
+          onChangeTimeZone={() => {}}
+          onMoveBackward={() => {}}
+          onMoveForward={() => {}}
+          onZoom={() => {}}
+        />
+      </Stack>
+      {/* SceneContextProvider scopes time to this chart only; key forces remount when range changes so queries re-run. */}
+      <SceneContextProvider
+        key={`chart-${chartKey}-${chartTimeRange.from.valueOf()}-${chartTimeRange.to.valueOf()}`}
+        timeRange={{ from: chartTimeRange.from.toString(), to: chartTimeRange.to.toString() }}
+      >
+        <QueryVisualization
+          query={query}
+          instanceLabels={instanceLabels}
+          thresholds={thresholds}
+          annotations={annotations}
+        />
+      </SceneContextProvider>
+    </Box>
+  );
+}
+
 export function InstanceDetailsDrawer({ ruleUID, instanceLabels, onClose }: InstanceDetailsDrawerProps) {
   const [ref, { width: loadingBarWidth }] = useMeasure<HTMLDivElement>();
-  const [timeRange] = useTimeRange();
+  const [sceneTimeRange] = useTimeRange();
   const { rightColumnWidth } = useWorkbenchContext();
+  const [chartTimeRanges, setChartTimeRanges] = useState<Record<string, TimeRange>>({});
 
   const drawerWidth = calculateDrawerWidth(rightColumnWidth);
+
+  const getChartTimeRange = useCallback(
+    (chartKey: string) => chartTimeRanges[chartKey] ?? sceneTimeRange,
+    [chartTimeRanges, sceneTimeRange]
+  );
+
+  const setChartTimeRange = useCallback((chartKey: string, range: TimeRange) => {
+    setChartTimeRanges((prev) => ({ ...prev, [chartKey]: range }));
+  }, []);
 
   const { data: rule, isLoading: loading, error } = useGetAlertRuleQuery({ uid: ruleUID });
 
@@ -63,8 +131,8 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, onClose }: Inst
   } = useGetRuleHistoryQuery({
     ruleUid: ruleUID,
     labels: instanceLabels,
-    from: timeRange.from.unix(),
-    to: timeRange.to.unix(),
+    from: sceneTimeRange.from.unix(),
+    to: sceneTimeRange.to.unix(),
   });
 
   // Convert state history to LogRecords and filter by instance labels
@@ -106,21 +174,24 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, onClose }: Inst
       width={drawerWidth}
     >
       <Stack direction="column" gap={3}>
-        <Stack justifyContent="flex-end">
-          <TimeRangePicker />
-        </Stack>
         {dataQueries.length > 0 && (
           <Box>
             <Stack direction="column" gap={2}>
-              {dataQueries.map((query, index) => (
-                <QueryVisualization
-                  key={query.refId || `query-${index}`}
-                  query={query}
-                  instanceLabels={instanceLabels}
-                  thresholds={thresholds}
-                  annotations={annotations}
-                />
-              ))}
+              {dataQueries.map((query, index) => {
+                const chartKey = query.refId ?? `query-${index}`;
+                return (
+                  <InstanceDrawerChartRow
+                    key={chartKey}
+                    chartKey={chartKey}
+                    chartTimeRange={getChartTimeRange(chartKey)}
+                    onTimeRangeChange={(range) => setChartTimeRange(chartKey, range)}
+                    query={query}
+                    instanceLabels={instanceLabels}
+                    thresholds={thresholds}
+                    annotations={annotations}
+                  />
+                );
+              })}
             </Stack>
           </Box>
         )}

--- a/public/app/features/alerting/unified/triage/rows/InstanceRow.tsx
+++ b/public/app/features/alerting/unified/triage/rows/InstanceRow.tsx
@@ -6,7 +6,7 @@ import { AlertLabels } from '@grafana/alerting/unstable';
 import { DataFrame, GrafanaTheme2, Labels, LoadingState, TimeRange } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { SceneDataNode, VizConfigBuilders } from '@grafana/scenes';
-import { VizPanel } from '@grafana/scenes-react';
+import { SceneContextProvider, VizPanel } from '@grafana/scenes-react';
 import { GraphDrawStyle, VisibilityMode } from '@grafana/schema';
 import {
   AxisPlacement,
@@ -135,7 +135,14 @@ export function InstanceRow({
       />
 
       {isDrawerOpen && (
-        <InstanceDetailsDrawer ruleUID={ruleUID} instanceLabels={instance.labels} onClose={handleDrawerClose} />
+        <SceneContextProvider
+          timeRange={{
+            from: typeof timeRange.raw.from === 'string' ? timeRange.raw.from : timeRange.raw.from.toISOString(),
+            to: typeof timeRange.raw.to === 'string' ? timeRange.raw.to : timeRange.raw.to.toISOString(),
+          }}
+        >
+          <InstanceDetailsDrawer ruleUID={ruleUID} instanceLabels={instance.labels} onClose={handleDrawerClose} />
+        </SceneContextProvider>
       )}
     </>
   );


### PR DESCRIPTION
This PR address bugs in the Alert Activity instance drawer time range picker:
- The time picker applied to every chart instead of only the one being viewed
- The instance drawer closed after a time range was selected

This PR:
- Wraps InstanceDetailsDrawer in SceneContextProvider where it is rendered (InstanceRow), giving the drawer its own scene time context

**Before:**
![time-range-picker-bug](https://github.com/user-attachments/assets/3e85ff71-f5c2-4b78-983d-2b43832003c5)

**After:**
![time-picker-bug-fix](https://github.com/user-attachments/assets/46c74def-5e2c-4fd2-8256-3bcaf9705660)

