### PR TITLE
Alerting: Fix policies breadcrumb

### DIFF
--- a/public/app/features/alerting/unified/components/notification-policies/PolicyPage.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/PolicyPage.tsx
@@ -42,8 +42,8 @@ function PolicyPage() {
       navId={navId}
       accessType="notification"
       pageNav={{
-        ...pageNav,
         text: routeName,
+        parentItem: pageNav,
       }}
       renderTitle={(title) => <Title name={title} returnToFallback={'/alerting/routes'} />}
       subTitle={t(

--- a/public/app/features/alerting/unified/navigation/useNotificationConfigNav.ts
+++ b/public/app/features/alerting/unified/navigation/useNotificationConfigNav.ts
@@ -87,7 +87,7 @@ export function useNotificationConfigNav() {
         id: 'notification-config-policies',
         text: t('alerting.navigation.notification-policies', 'Notification policies'),
         url: ALERTING_PATHS.ROUTES,
-        active: location.pathname === ALERTING_PATHS.ROUTES,
+        active: location.pathname.startsWith(ALERTING_PATHS.ROUTES),
         parentItem: notificationConfigNav,
       });
     }


### PR DESCRIPTION
**What is this feature?**

This PR fixes the policies breadcrumb when we have the `alertingMultiplePolicies` enabled.

**Who is this feature for?**

Alerting users.

**Special notes for your reviewer:**

https://github.com/user-attachments/assets/7750bd4c-bf6c-4c42-919e-32276f9454e3

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
