### PR TITLE
[AuthZ] roles resource: general improvements

### DIFF
--- a/apps/iam/kinds/v0alpha1/rolespec.cue
+++ b/apps/iam/kinds/v0alpha1/rolespec.cue
@@ -21,10 +21,10 @@ RoleSpec: {
 	group: string
 
 	// Added permissions (permissions in actual role but NOT in seed) - for basic roles only. For custom roles, this contains all permissions.
-	permissions: [...#Permission]
+	permissions?: [...#Permission]
 
 	// Permissions that exist in seed but NOT in actual role (missing/omitted permissions) - used for basic roles only
-	permissionsOmitted: [...#Permission] | *[]
+	permissionsOmitted?: [...#Permission]
 
 	// Roles to take permissions from (for now the list should be of size 1)
 	roleRefs?: [...#RoleRef]

--- a/apps/iam/pkg/apis/iam/v0alpha1/corerole_spec_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/corerole_spec_gen.go
@@ -45,9 +45,9 @@ type CoreRoleSpec struct {
 	Description string `json:"description"`
 	Group       string `json:"group"`
 	// Added permissions (permissions in actual role but NOT in seed) - for basic roles only. For custom roles, this contains all permissions.
-	Permissions []CoreRolespecPermission `json:"permissions"`
+	Permissions []CoreRolespecPermission `json:"permissions,omitempty"`
 	// Permissions that exist in seed but NOT in actual role (missing/omitted permissions) - used for basic roles only
-	PermissionsOmitted []CoreRolespecPermission `json:"permissionsOmitted"`
+	PermissionsOmitted []CoreRolespecPermission `json:"permissionsOmitted,omitempty"`
 	// Roles to take permissions from (for now the list should be of size 1)
 	// TODO:
 	// delegatable?: bool
@@ -58,10 +58,7 @@ type CoreRoleSpec struct {
 
 // NewCoreRoleSpec creates a new CoreRoleSpec object.
 func NewCoreRoleSpec() *CoreRoleSpec {
-	return &CoreRoleSpec{
-		Permissions:        []CoreRolespecPermission{},
-		PermissionsOmitted: []CoreRolespecPermission{},
-	}
+	return &CoreRoleSpec{}
 }
 
 // OpenAPIModelName returns the OpenAPI model name for CoreRoleSpec.

--- a/apps/iam/pkg/apis/iam/v0alpha1/globalrole_spec_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/globalrole_spec_gen.go
@@ -45,9 +45,9 @@ type GlobalRoleSpec struct {
 	Description string `json:"description"`
 	Group       string `json:"group"`
 	// Added permissions (permissions in actual role but NOT in seed) - for basic roles only. For custom roles, this contains all permissions.
-	Permissions []GlobalRolespecPermission `json:"permissions"`
+	Permissions []GlobalRolespecPermission `json:"permissions,omitempty"`
 	// Permissions that exist in seed but NOT in actual role (missing/omitted permissions) - used for basic roles only
-	PermissionsOmitted []GlobalRolespecPermission `json:"permissionsOmitted"`
+	PermissionsOmitted []GlobalRolespecPermission `json:"permissionsOmitted,omitempty"`
 	// Roles to take permissions from (for now the list should be of size 1)
 	// TODO:
 	// delegatable?: bool
@@ -58,10 +58,7 @@ type GlobalRoleSpec struct {
 
 // NewGlobalRoleSpec creates a new GlobalRoleSpec object.
 func NewGlobalRoleSpec() *GlobalRoleSpec {
-	return &GlobalRoleSpec{
-		Permissions:        []GlobalRolespecPermission{},
-		PermissionsOmitted: []GlobalRolespecPermission{},
-	}
+	return &GlobalRoleSpec{}
 }
 
 // OpenAPIModelName returns the OpenAPI model name for GlobalRoleSpec.

--- a/apps/iam/pkg/apis/iam/v0alpha1/role_spec_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/role_spec_gen.go
@@ -45,9 +45,9 @@ type RoleSpec struct {
 	Description string `json:"description"`
 	Group       string `json:"group"`
 	// Added permissions (permissions in actual role but NOT in seed) - for basic roles only. For custom roles, this contains all permissions.
-	Permissions []RolespecPermission `json:"permissions"`
+	Permissions []RolespecPermission `json:"permissions,omitempty"`
 	// Permissions that exist in seed but NOT in actual role (missing/omitted permissions) - used for basic roles only
-	PermissionsOmitted []RolespecPermission `json:"permissionsOmitted"`
+	PermissionsOmitted []RolespecPermission `json:"permissionsOmitted,omitempty"`
 	// Roles to take permissions from (for now the list should be of size 1)
 	// TODO:
 	// delegatable?: bool
@@ -58,10 +58,7 @@ type RoleSpec struct {
 
 // NewRoleSpec creates a new RoleSpec object.
 func NewRoleSpec() *RoleSpec {
-	return &RoleSpec{
-		Permissions:        []RolespecPermission{},
-		PermissionsOmitted: []RolespecPermission{},
-	}
+	return &RoleSpec{}
 }
 
 // OpenAPIModelName returns the OpenAPI model name for RoleSpec.

--- a/apps/iam/pkg/apis/iam/v0alpha1/zz_openapi_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/zz_openapi_gen.go
@@ -256,7 +256,7 @@ func schema_pkg_apis_iam_v0alpha1_CoreRoleSpec(ref common.ReferenceCallback) com
 						},
 					},
 				},
-				Required: []string{"title", "description", "group", "permissions", "permissionsOmitted"},
+				Required: []string{"title", "description", "group"},
 			},
 		},
 		Dependencies: []string{
@@ -1619,7 +1619,7 @@ func schema_pkg_apis_iam_v0alpha1_GlobalRoleSpec(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"title", "description", "group", "permissions", "permissionsOmitted"},
+				Required: []string{"title", "description", "group"},
 			},
 		},
 		Dependencies: []string{
@@ -2511,7 +2511,7 @@ func schema_pkg_apis_iam_v0alpha1_RoleSpec(ref common.ReferenceCallback) common.
 						},
 					},
 				},
-				Required: []string{"title", "description", "group", "permissions", "permissionsOmitted"},
+				Required: []string{"title", "description", "group"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
@@ -4982,9 +4982,7 @@
         "required": [
           "title",
           "description",
-          "group",
-          "permissions",
-          "permissionsOmitted"
+          "group"
         ],
         "properties": {
           "description": {
@@ -5739,9 +5737,7 @@
         "required": [
           "title",
           "description",
-          "group",
-          "permissions",
-          "permissionsOmitted"
+          "group"
         ],
         "properties": {
           "description": {
@@ -6097,9 +6093,7 @@
         "required": [
           "title",
           "description",
-          "group",
-          "permissions",
-          "permissionsOmitted"
+          "group"
         ],
         "properties": {
           "description": {


### PR DESCRIPTION
**What is this feature?**

This PR makes the following roles spec properties optional; hiding them when rendering responses.

**Why do we need this feature?**

Addressing [comments](https://github.com/grafana/grafana-enterprise/pull/10817#pullrequestreview-3818609658) from the work done on IAM: Add added and omit permissions list to role definition#[10817](https://github.com/grafana/grafana-enterprise/pull/10817)

Additionally, what this PR doesn't do
- Add a validation hook for create / update
- Add basic roles to the roleRef

**Who is this feature for?**

IAM

**Which issue(s) does this PR fix?**:

1/2 for https://github.com/grafana/identity-access-team/issues/1944