### PR TITLE
DynamicDashboards: Fix issue where user actions on the interactive elements of a panel are prevented

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
@@ -242,15 +242,38 @@ it('does not select the panel when clicking interactive content', async () => {
       <PanelChrome width={100} height={100} selectionId="panel-1">
         {() => (
           <div>
-            <button type="button">Legend item</button>
+            <button type="button">Button text</button>
+            <a href="#">Anchor text</a>
+            <canvas />
+            <svg />
+            <div className="u-over" />
+            <div role="button" />
             <div>Non-interactive</div>
           </div>
         )}
       </PanelChrome>
+      <div id="grafana-portal-container">
+        <div />
+      </div>
     </ElementSelectionContext.Provider>
   );
 
-  await user.pointer({ keys: '[MouseLeft>]', target: screen.getByRole('button', { name: 'Legend item' }) });
+  await user.pointer({ keys: '[MouseLeft>]', target: screen.getByRole('button', { name: 'Button text' }) });
+  expect(onSelect).not.toHaveBeenCalled();
+
+  await user.pointer({ keys: '[MouseLeft>]', target: screen.getByRole('link', { name: 'Anchor text' }) });
+  expect(onSelect).not.toHaveBeenCalled();
+
+  await user.pointer({ keys: '[MouseLeft>]', target: document.querySelector('canvas')! });
+  expect(onSelect).not.toHaveBeenCalled();
+
+  await user.pointer({ keys: '[MouseLeft>]', target: document.querySelector('svg')! });
+  expect(onSelect).not.toHaveBeenCalled();
+
+  await user.pointer({ keys: '[MouseLeft>]', target: document.querySelector('.u-over')! });
+  expect(onSelect).not.toHaveBeenCalled();
+
+  await user.pointer({ keys: '[MouseLeft>]', target: document.querySelector('div[role="button"]')! });
   expect(onSelect).not.toHaveBeenCalled();
 
   await user.pointer({ keys: '[MouseLeft>]', target: screen.getByText('Non-interactive') });

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -246,7 +246,8 @@ export function PanelChrome({
       // This does prevent a clicks inside a graphs from selecting panel as there is normal div above the canvas element that intercepts the click
       if (
         evt.target instanceof Element &&
-        (evt.target.closest('button,a,canvas,svg') || evt.target.classList.contains('u-over'))
+        (evt.target.closest('button,a,canvas,svg,[role="button"],#grafana-portal-container') ||
+          evt.target.classList.contains('u-over'))
       ) {
         // Stop propagation otherwise row config editor will get selected
         evt.stopPropagation();


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/117703

**Reproduction steps:**

1. Create a dashboard with a new panel
2. Configure the panel to be a canvas with a valid query
4. Go back to the dashboard
5. Double-click on the field to make the dropdown appear
6. Click on the dropdown to open it
7. Select a field in the dropdown
8. The field should be selected and its value should be displayed

Instead, before this PR, the field value wouldn't show up and the dashboard would be selected in the edit pane.

**Cause:**

The dropdown that appears to choose the field :
- has no classic interactive element (button, a, canvas, svg) that could stop the propagation of the click event and stop the selection in the side pane (to be precise it has only an SVG icon so, unless the user clicks on it, the bug occurs)
- is rendered in a portal

**Solution**

1. Preventing clicks on an element with the "button" role to select a panel
2. Preventing clicks within the portal container to select the dashboard
