### PR TITLE
[release-12.3.4] A11y: Fix Navigation and Drawer dialogs missing programatic titles for screen readers

### DIFF
--- a/packages/grafana-ui/src/components/Drawer/Drawer.test.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+
+import { selectors } from '@grafana/e2e-selectors';
+
+import { Drawer } from './Drawer';
+
+describe('Drawer', () => {
+  // Drawer.tsx passes getContainer={'.main-view'} to RcDrawer, which tells it
+  // to portal its content into the element matching that CSS selector.
+  // In the real app, .main-view exists in the page shell. In tests, jsdom
+  // starts with an empty body, so we create it manually — otherwise RcDrawer
+  // has nowhere to render and the Drawer never appears in the DOM.
+  let mainView: HTMLDivElement;
+
+  beforeEach(() => {
+    mainView = document.createElement('div');
+    mainView.classList.add('main-view');
+    document.body.appendChild(mainView);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(mainView);
+  });
+
+  it('renders with string title and children', () => {
+    render(
+      <Drawer title="Test Title" onClose={() => {}}>
+        <div>Drawer content</div>
+      </Drawer>
+    );
+
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+    expect(screen.getByText('Drawer content')).toBeInTheDocument();
+  });
+
+  it('has an accessible name from the visible heading when title is a string', () => {
+    render(
+      <Drawer title="Share" onClose={() => {}}>
+        <div>Content</div>
+      </Drawer>
+    );
+
+    const heading = screen.getByRole('heading', { name: 'Share' });
+    expect(heading).toHaveAttribute('id');
+
+    const drawer = screen.getByRole('dialog');
+    expect(drawer).toHaveAttribute('aria-labelledby', heading.getAttribute('id'));
+    // aria-label kept for e2e selector compatibility
+    expect(drawer).toHaveAttribute('aria-label', selectors.components.Drawer.General.title('Share'));
+  });
+
+  it('has an accessible name from a custom title element', () => {
+    render(
+      <Drawer title={<h3>Custom Title</h3>} onClose={() => {}}>
+        <div>Content</div>
+      </Drawer>
+    );
+
+    const heading = screen.getByText('Custom Title');
+    const titleWrapper = heading.closest('[id]');
+    expect(titleWrapper).toHaveAttribute('id');
+
+    const drawer = screen.getByRole('dialog');
+    expect(drawer).toHaveAttribute('aria-labelledby', titleWrapper?.getAttribute('id'));
+    // no aria-label for non-string titles
+    expect(drawer).not.toHaveAttribute('aria-label');
+  });
+});

--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -3,7 +3,7 @@ import { useDialog } from '@react-aria/dialog';
 import { FocusScope } from '@react-aria/focus';
 import { useOverlay } from '@react-aria/overlays';
 import RcDrawer from 'rc-drawer';
-import { ReactNode, useCallback, useEffect, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useId, useState } from 'react';
 import * as React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -84,8 +84,10 @@ export function Drawer({
   const wrapperStyles = useStyles2(getWrapperStyles, size);
   const dragStyles = useStyles2(getDragStyles);
 
+  const titleId = useId();
   const overlayRef = React.useRef(null);
-  const { dialogProps, titleProps } = useDialog({}, overlayRef);
+  const { dialogProps } = useDialog({}, overlayRef);
+  const { role: _dialogRole, 'aria-labelledby': _ariaLabelledBy, ...restDialogProps } = dialogProps;
   const { overlayProps } = useOverlay(
     {
       isDismissable: false,
@@ -130,19 +132,11 @@ export function Drawer({
         motionAppear: true,
         motionName: styles.maskMotion,
       }}
+      aria-label={typeof title === 'string' ? selectors.components.Drawer.General.title(title) : undefined}
+      aria-labelledby={title ? titleId : undefined}
     >
       <FocusScope restoreFocus contain autoFocus>
-        <div
-          aria-label={
-            typeof title === 'string'
-              ? selectors.components.Drawer.General.title(title)
-              : selectors.components.Drawer.General.title('no title')
-          }
-          className={styles.container}
-          {...overlayProps}
-          {...dialogProps}
-          ref={overlayRef}
-        >
+        <div className={styles.container} {...overlayProps} {...restDialogProps} ref={overlayRef}>
           {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
           <div
             className={cx(dragStyles.dragHandleVertical, styles.resizer)}
@@ -161,7 +155,7 @@ export function Drawer({
             </div>
             {typeof title === 'string' ? (
               <Stack direction="column">
-                <Text element="h3" truncate {...titleProps}>
+                <Text element="h3" id={titleId} truncate>
                   {title}
                 </Text>
                 {subtitle && (
@@ -171,7 +165,7 @@ export function Drawer({
                 )}
               </Stack>
             ) : (
-              title
+              <div id={titleId}>{title}</div>
             )}
             {tabs && <div className={styles.tabsWrapper}>{tabs}</div>}
           </div>

--- a/public/app/core/components/AppChrome/AppChromeMenu.tsx
+++ b/public/app/core/components/AppChrome/AppChromeMenu.tsx
@@ -7,6 +7,7 @@ import CSSTransition from 'react-transition-group/CSSTransition';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
+import { t } from '@grafana/i18n';
 import { useStyles2, useTheme2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 
@@ -43,7 +44,7 @@ export function AppChromeMenu({}: Props) {
     },
     ref
   );
-  const { dialogProps } = useDialog({}, ref);
+  const { dialogProps } = useDialog({ 'aria-label': t('navigation.megamenu.dialog-label', 'Navigation') }, ref);
   const styles = useStyles2(getStyles);
 
   return (

--- a/public/app/features/alerting/unified/Settings.test.tsx
+++ b/public/app/features/alerting/unified/Settings.test.tsx
@@ -26,7 +26,7 @@ const ui = {
   statusReceiving: byText(/receiving grafana-managed alerts/i),
   statusNotReceiving: byText(/not receiving/i),
 
-  configurationDrawer: byRole('dialog', { name: 'Drawer title Grafana built-in Alertmanager' }),
+  configurationDrawer: byRole('dialog', { name: 'Grafana built-in Alertmanager' }),
   editConfigurationButton: byRole('button', { name: /edit configuration/i }),
   viewConfigurationButton: byRole('button', { name: /view configuration/i }),
   saveConfigurationButton: byRole('button', { name: /save/i }),

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
@@ -608,7 +608,7 @@ describe('contact points', () => {
 
       await user.click(await screen.findByRole('menuitem', { name: /manage permissions/i }));
 
-      const permissionsDialog = await screen.findByRole('dialog', { name: /drawer title manage permissions/i });
+      const permissionsDialog = await screen.findByRole('dialog', { name: /manage permissions/i });
 
       expect(permissionsDialog).toBeInTheDocument();
       expect(await screen.findByRole('table')).toBeInTheDocument();

--- a/public/app/features/alerting/unified/components/mute-timings/MuteTimingsTable.test.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/MuteTimingsTable.test.tsx
@@ -49,7 +49,7 @@ describe('MuteTimingsTable', () => {
       renderWithProvider();
       await user.click(await screen.findByRole('button', { name: /export all/i }));
 
-      expect(await screen.findByRole('dialog', { name: /drawer title export/i })).toBeInTheDocument();
+      expect(await screen.findByRole('dialog', { name: /export/i })).toBeInTheDocument();
     });
 
     it("shows individual 'export' drawer when allowed and supported, and can close", async () => {
@@ -58,11 +58,11 @@ describe('MuteTimingsTable', () => {
       const exportMuteTiming = await within(table).findAllByText(/export/i);
       await user.click(exportMuteTiming[0]);
 
-      expect(await screen.findByRole('dialog', { name: /drawer title export/i })).toBeInTheDocument();
+      expect(await screen.findByRole('dialog', { name: /export/i })).toBeInTheDocument();
 
       await user.click(screen.getByText(/cancel/i));
 
-      expect(screen.queryByRole('dialog', { name: /drawer title export/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('dialog', { name: /export/i })).not.toBeInTheDocument();
     });
 
     it('does not show export button when not supported', async () => {

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
@@ -215,7 +215,7 @@ describe('RuleViewer', () => {
       await renderRuleViewer(mockRule, mockRuleIdentifier);
       await openSilenceDrawer();
 
-      const silenceDrawer = await screen.findByRole('dialog', { name: 'Drawer title Silence alert rule' });
+      const silenceDrawer = await screen.findByRole('dialog', { name: 'Silence alert rule' });
       expect(await within(silenceDrawer).findByLabelText(/^alert rule/i)).toHaveValue(
         grafanaRulerRule.grafana_alert.title
       );

--- a/public/app/features/alerting/unified/group-details/GroupDetailsPage.test.tsx
+++ b/public/app/features/alerting/unified/group-details/GroupDetailsPage.test.tsx
@@ -43,7 +43,7 @@ const ui = {
   exportButton: byRole('button', { name: 'Export' }),
   ruleItem: byRole('treeitem'),
   export: {
-    dialog: byRole('dialog', { name: /Drawer title Export .* rules/ }),
+    dialog: byRole('dialog', { name: /Export .* rules/ }),
     jsonTab: byRole('tab', { name: /JSON/ }),
     yamlTab: byRole('tab', { name: /YAML/ }),
     editor: byTestId('code-editor'),

--- a/public/app/features/browse-dashboards/components/CreateNewButton.test.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.test.tsx
@@ -61,7 +61,7 @@ describe('NewActionsButton', () => {
     await userEvent.click(newButton);
     await userEvent.click(screen.getByText('New folder'));
 
-    const drawer = screen.getByRole('dialog', { name: 'Drawer title New folder' });
+    const drawer = screen.getByRole('dialog', { name: 'New folder' });
     expect(drawer).toBeInTheDocument();
     expect(within(drawer).getByRole('heading', { name: 'New folder' })).toBeInTheDocument();
     expect(within(drawer).getByText(`Location: ${mockParentFolder.title}`)).toBeInTheDocument();

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
@@ -120,7 +120,7 @@ describe('browse-dashboards FolderActionsButton', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Folder actions' }));
     await userEvent.click(screen.getByRole('menuitem', { name: 'Manage permissions' }));
-    expect(screen.getByRole('dialog', { name: 'Drawer title Manage permissions' })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Manage permissions' })).toBeInTheDocument();
   });
 
   it('clicking the "Move" option opens the move modal', async () => {

--- a/public/app/features/explore/spec/helper/interactions.ts
+++ b/public/app/features/explore/spec/helper/interactions.ts
@@ -43,10 +43,9 @@ export const openQueryLibrary = async () => {
   const button = screen.getByRole('button', { name: 'Add from saved queries' });
   await userEvent.click(button);
   await waitFor(async () => {
-    const container = screen.getByRole('dialog', {
-      name: /Drawer title/,
+    screen.getByRole('dialog', {
+      name: /Saved queries/,
     });
-    within(container).getByText('Saved queries');
   });
 };
 
@@ -57,7 +56,7 @@ export const addQueryHistoryToQueryLibrary = async () => {
 
 export const submitAddToQueryLibrary = async ({ title }: { title: string }) => {
   const container = screen.getByRole('dialog', {
-    name: /Drawer title/i,
+    name: /Saved queries/i,
   });
 
   const input = within(container).getByRole('textbox', { name: /title/i });

--- a/public/app/features/explore/spec/helper/setup.tsx
+++ b/public/app/features/explore/spec/helper/setup.tsx
@@ -334,8 +334,7 @@ export const withinQueryHistory = () => {
 };
 
 export const withinQueryLibrary = () => {
-  const container = screen.getByRole('dialog', { name: /Drawer title/ });
-  within(container).getByText('Query library');
+  const container = screen.getByRole('dialog', { name: /Query library/ });
   return within(container);
 };
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10628,6 +10628,7 @@
     },
     "megamenu": {
       "close": "Close menu",
+      "dialog-label": "Navigation",
       "dock": "Dock menu",
       "list-label": "Navigation",
       "open": "Open menu",


### PR DESCRIPTION
`Manual` Backport 51cb7a6d2079e88eb0aa2114a64a283bbda8c46d from #118093
---

<!--
Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->
**Note for Backport Reviewer: Drawer was refactored after 12.3.4, so I had to fix conflicts**

The conflict was in release-12.3.4, which uses the older rc-drawer + @react-aria stack instead of the @floating-ui/react stack on main.

The main difference: release-12.3.4 had `titleProps` contained an internal React Aria–generated ID intended to link the dialog to its title. Since we're now using our own titleId (from `useId()`) on `<RcDrawer aria-labelledby={titleId}>` and `<h3 id={titleId}>`, the internal ID from `titleProps` is redundant and would conflict. Our `titleId` is the single source of truth for the `aria-labelledby` → heading relationship.

-----
**What is this feature?**

Fixes issues for Navigation and Share dialogs that were missing programatic titles for screen readers.

**NOTE:**
The fix involves `Drawer` component, I had to update unit tests to stop asserting with the the prefix `Drawer title `
i.e `const drawer = screen.getByRole('dialog', { name: 'Drawer title New folder' });`

**Steps to reproduce**

- Open Grafana in Chrome on Windows
- Enable JAWS screen reader
- Use Tab to trigger and open the navigation dialog (or activate the "Share" button to open the Share dialog)
- Listen to the screen reader announcement for the dialog title

**Actual behavior**
- The screen reader announces an irrelevant title (e.g., the browser window title appended with "dialog") instead of a meaningful and descriptive dialog title.

**Expected behavior**
Each dialog should have a descriptive title that is programmatically associated with the dialog and announced by screen readers (e.g., "Navigation Options" for the nav dialog, "Share Dashboard" for the share dialog).

<img width="2547" height="1190" alt="ProgrammaticName" src="https://github.com/user-attachments/assets/db0ddda2-a753-4b62-9c83-ff16d1100dd2" />



**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/117826

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
