### PR TITLE
Don't truncate sha256 hash of legacy datasource secret name

### DIFF
--- a/pkg/registry/apis/datasource/converter.go
+++ b/pkg/registry/apis/datasource/converter.go
@@ -128,8 +128,7 @@ func GetLegacySecureValueName(dsUID string, key string) string {
 	h.Write([]byte(dsUID)) // unique identifier
 	h.Write([]byte("|"))
 	h.Write([]byte(key)) // property name
-	n := hex.EncodeToString(h.Sum(nil))
-	return apistore.LEGACY_DATASOURCE_SECURE_VALUE_NAME_PREFIX + n[0:10] // predictable name for dual writing
+	return apistore.LEGACY_DATASOURCE_SECURE_VALUE_NAME_PREFIX + hex.EncodeToString(h.Sum(nil))
 }
 
 func (r *Converter) ToAddCommand(ds *datasourceV0.DataSource) (*datasources.AddDataSourceCommand, error) {

--- a/pkg/registry/apis/datasource/testdata/convert-dto-testdata-to-resource.json
+++ b/pkg/registry/apis/datasource/testdata/convert-dto-testdata-to-resource.json
@@ -33,7 +33,7 @@
   },
   "secure": {
     "password": {
-      "name": "lds-sv-0d27eff323"
+      "name": "lds-sv-0d27eff3239fcf68b2eabf9e95f7d1e2e58801af3ba6f0af7667cb0195bf4416"
     }
   }
 }

--- a/pkg/registry/apis/datasource/testdata/convert-resource-full-to-cmd-update-roundtrip.json
+++ b/pkg/registry/apis/datasource/testdata/convert-resource-full-to-cmd-update-roundtrip.json
@@ -22,10 +22,10 @@
   },
   "secure": {
     "extra": {
-      "name": "lds-sv-6ed1b76e5d"
+      "name": "lds-sv-6ed1b76e5d2c3a998930582e8d9d2ccff86d4a8577f40400e0a374530d92b072"
     },
     "password": {
-      "name": "lds-sv-edc8fde0ac"
+      "name": "lds-sv-edc8fde0aca4d105120a0a94b726393cd7ae760b83875f706d9a693a1977c4dd"
     }
   }
 }


### PR DESCRIPTION
Truncating a sha256 hash after the first ten bytes makes collisions a lot more likely.

This means that different secret field names are much more likely to collide, and this may open the door to crafting field names for secrets that collide with other field names, allowing touching secrets that shouldn't be touched.