### PR TITLE
LogsTable: Panel text wrap option - PoC

### DIFF
--- a/packages/grafana-data/src/types/explore.ts
+++ b/packages/grafana-data/src/types/explore.ts
@@ -1,6 +1,9 @@
 import { DataQuery, LogsSortOrder } from '@grafana/schema';
 
+import { Options } from '../../../../public/app/plugins/panel/logstable/options/types';
+
 import { PreferredVisualisationType } from './data';
+import { FieldConfig } from './dataFrame';
 import { SelectableValue } from './select';
 import { TimeRange } from './time';
 
@@ -89,6 +92,8 @@ export interface ExploreLogsPanelState {
   // Column sort state for table view. Persists between query changes.
   tableSortBy?: string;
   tableSortDir?: 'asc' | 'desc';
+  // fieldConfig.defaults
+  tableFieldConfig: FieldConfig<Options>;
 }
 
 export interface SplitOpenOptions<T extends AnyQuery = AnyQuery> {

--- a/public/app/features/explore/Logs/ExploreLogsTable.tsx
+++ b/public/app/features/explore/Logs/ExploreLogsTable.tsx
@@ -5,7 +5,8 @@ import {
   DataFrame,
   EventBus,
   EventBusSrv,
-  FieldConfigSource,
+  ExploreLogsPanelState,
+  FieldConfig,
   PanelData,
   urlUtil,
 } from '@grafana/data';
@@ -17,12 +18,16 @@ import { Options } from 'app/plugins/panel/logstable/options/types';
 import { defaultOptions as logsTablePanelDefaultOptions } from 'app/plugins/panel/logstable/panelcfg.gen';
 import { BuildLinkToLogLine } from 'app/plugins/panel/logstable/types';
 
+import { exploreLogsTableFieldConfigDefaults } from './constants';
+
 /**
  * New Logs Table panel
  * @param props
  * @constructor
  */
 export function ExploreLogsTable(props: {
+  tableFieldConfig: FieldConfig<Options> | undefined;
+  updatePanelState: (panelState: ExploreLogsPanelState) => void;
   eventBus: EventBus;
   data: PanelData;
   timeZone: 'utc' | 'browser' | string;
@@ -30,7 +35,6 @@ export function ExploreLogsTable(props: {
   width: number;
   height: number;
   onOptionsChange: (options: Options) => void;
-  onFieldConfigChange: (config: FieldConfigSource) => void;
   onChangeTimeRange: (range: AbsoluteTimeRange) => void;
   onClickFilterLabel: ((key: string, value: string, frame?: DataFrame) => void) | undefined;
   onClickFilterOutLabel: ((key: string, value: string, frame?: DataFrame) => void) | undefined;
@@ -39,7 +43,7 @@ export function ExploreLogsTable(props: {
     'sortBy' | 'sortOrder' | 'displayedFields' | 'permalinkedLogId' | 'frameIndex' | 'fieldSelectorWidth'
   >;
 }) {
-  const { onClickFilterLabel, onClickFilterOutLabel } = props;
+  const { onClickFilterLabel, onClickFilterOutLabel, tableFieldConfig, updatePanelState } = props;
   const frames = useMemo(() => props?.data.series ?? [], [props.data.series]);
   const frame = useMemo(() => frames[props.externalOptions.frameIndex], [frames, props.externalOptions.frameIndex]);
 
@@ -76,6 +80,8 @@ export function ExploreLogsTable(props: {
     }
   }, []);
 
+  console.log('fieldCOnfig', tableFieldConfig);
+
   return (
     <PanelContextProvider
       value={{
@@ -101,18 +107,17 @@ export function ExploreLogsTable(props: {
         width={props.width}
         height={props.height}
         fieldConfig={{
-          defaults: {
-            custom: {
-              filterable: true,
-            },
-          },
+          defaults: tableFieldConfig ?? exploreLogsTableFieldConfigDefaults,
           overrides: [],
         }}
         renderCounter={0}
         title={''}
         eventBus={props.eventBus}
         onOptionsChange={props.onOptionsChange}
-        onFieldConfigChange={props.onFieldConfigChange}
+        onFieldConfigChange={(config) => {
+          console.log('onFieldConfigChange', config);
+          updatePanelState({ tableFieldConfig: config.defaults });
+        }}
         replaceVariables={getTemplateSrv().replace}
         onChangeTimeRange={props.onChangeTimeRange}
       />

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -15,7 +15,6 @@ import {
   EventBus,
   ExploreLogsPanelState,
   ExplorePanelsState,
-  FieldConfigSource,
   GrafanaTheme2,
   LoadingState,
   LogLevel,
@@ -90,7 +89,7 @@ import { LogsMetaRow } from './LogsMetaRow';
 import LogsNavigation from './LogsNavigation';
 import { getLogsTableHeight, LogsTableWrap } from './LogsTableWrap';
 import { LogsVolumePanelList } from './LogsVolumePanelList';
-import { LogsVisualisationType } from './constants';
+import { exploreLogsTableFieldConfigDefaults, LogsVisualisationType } from './constants';
 import { LOGS_TABLE_SETTING_KEYS, SETTING_KEY_ROOT, SETTINGS_KEYS, visualisationTypeKey } from './utils/logs';
 import { getDefaultDisplayedFieldsFromExploreState } from './utils/table/columnsMigration';
 import { getDefaultTableSortBy } from './utils/table/logsTable';
@@ -252,7 +251,19 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
   const updatePanelState = useCallback(
     (logsPanelState: Partial<ExploreLogsPanelState>) => {
       const state: ExploreItemState | undefined = getState().explore.panes[exploreId];
+
       if (state?.panelsState) {
+        console.log('panelState', {
+          ...state.panelsState.logs,
+          columns: logsPanelState.columns ?? panelState?.logs?.columns,
+          visualisationType: logsPanelState.visualisationType ?? visualisationType,
+          labelFieldName: logsPanelState.labelFieldName,
+          refId: logsPanelState.refId ?? panelState?.logs?.refId,
+          displayedFields: logsPanelState.displayedFields ?? panelState?.logs?.displayedFields,
+          tableSortBy: logsPanelState.tableSortBy ?? panelState?.logs?.tableSortBy,
+          tableSortDir: logsPanelState.tableSortDir ?? panelState?.logs?.tableSortDir,
+          tableFieldConfig: logsPanelState.tableFieldConfig ?? panelState?.logs?.tableFieldConfig,
+        });
         dispatch(
           changePanelState(exploreId, 'logs', {
             ...state.panelsState.logs,
@@ -263,6 +274,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
             displayedFields: logsPanelState.displayedFields ?? panelState?.logs?.displayedFields,
             tableSortBy: logsPanelState.tableSortBy ?? panelState?.logs?.tableSortBy,
             tableSortDir: logsPanelState.tableSortDir ?? panelState?.logs?.tableSortDir,
+            tableFieldConfig: logsPanelState.tableFieldConfig ?? panelState?.logs?.tableFieldConfig,
           })
         );
       }
@@ -275,6 +287,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
       panelState?.logs?.refId,
       panelState?.logs?.tableSortBy,
       panelState?.logs?.tableSortDir,
+      panelState?.logs?.tableFieldConfig,
       visualisationType,
     ]
   );
@@ -646,6 +659,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
           visualisationType: visualisationType ?? getDefaultVisualisationType(),
           displayedFields,
           sortOrder: logsSortOrder,
+          tableFieldConfig: panelState?.logs?.tableFieldConfig ?? exploreLogsTableFieldConfigDefaults,
         },
       };
       urlState.range = getLogsPermalinkRange(row, logRows, absoluteRange);
@@ -684,6 +698,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
           visualisationType: visualisationType ?? getDefaultVisualisationType(),
           displayedFields,
           sortOrder: logsSortOrder,
+          tableFieldConfig: panelState?.logs?.tableFieldConfig ?? exploreLogsTableFieldConfigDefaults,
         },
       };
 
@@ -1097,6 +1112,8 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
 
           {enableNewLogsTable && visualisationType === 'table' && (
             <ExploreLogsTable
+              tableFieldConfig={panelState?.logs?.tableFieldConfig}
+              updatePanelState={updatePanelState}
               eventBus={eventBus}
               data={panelData}
               timeZone={timeZone}
@@ -1142,9 +1159,6 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
                     updatePanelState({ refId });
                   }
                 }
-              }}
-              onFieldConfigChange={function (config: FieldConfigSource): void {
-                // @todo save field overrides somewhere (e.g. column widths)
               }}
               onChangeTimeRange={onChangeTime}
             />

--- a/public/app/features/explore/Logs/constants.ts
+++ b/public/app/features/explore/Logs/constants.ts
@@ -1,1 +1,10 @@
+import { FieldConfig } from '@grafana/data';
+
 export type LogsVisualisationType = 'table' | 'logs';
+// @todo field config types
+export const exploreLogsTableFieldConfigDefaults: FieldConfig = {
+  filterable: true,
+  custom: {
+    filterable: true,
+  },
+};

--- a/public/app/features/explore/hooks/useStateSync/external.utils.ts
+++ b/public/app/features/explore/hooks/useStateSync/external.utils.ts
@@ -18,6 +18,7 @@ export function getUrlStateFromPaneState(pane: ExploreItemState): ExploreUrlStat
 }
 
 /**
+ * @todo this has zero test coverage and it doesn't work as expected, objects with values are pruned
  * recursively walks an object, removing keys where the value is undefined
  * if the resulting object is empty, returns undefined
  **/
@@ -35,7 +36,12 @@ function pruneObject(obj: object): object | undefined {
     }
     return value;
   });
-  pruned = omitBy<typeof pruned>(pruned, isEmpty);
+
+  // @todo this will fail to prune sub-objects that have a mix of null and non null values
+  if (Object.values(pruned).filter((a) => a !== undefined && a !== null).length === 0) {
+    pruned = omitBy<typeof pruned>(pruned, isEmpty);
+  }
+
   if (isEmpty(pruned)) {
     return undefined;
   }

--- a/public/app/features/logs/components/panel/LogListCommon.ts
+++ b/public/app/features/logs/components/panel/LogListCommon.ts
@@ -1,0 +1,19 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
+
+export const getWrapButtonStyles = (theme: GrafanaTheme2, expanded: boolean) => {
+  return {
+    menuItemActive: css({
+      '&:before': {
+        content: '""',
+        position: 'absolute',
+        left: 0,
+        top: theme.spacing(0.5),
+        height: `calc(100% - ${theme.spacing(1)})`,
+        width: '2px',
+        backgroundColor: theme.colors.warning.main,
+      },
+    }),
+  };
+};

--- a/public/app/features/logs/components/panel/LogListControls.tsx
+++ b/public/app/features/logs/components/panel/LogListControls.tsx
@@ -19,6 +19,7 @@ import { Dropdown, Menu, useStyles2 } from '@grafana/ui';
 import { LogsVisualisationType } from '../../../explore/Logs/constants';
 import { DownloadFormat } from '../../utils';
 
+import { getWrapButtonStyles } from './LogListCommon';
 import { useLogListContext } from './LogListContext';
 import { LogListControlsOption, LogListControlsSelectOption } from './LogListControlsOption';
 import { useLogListSearchContext } from './LogListSearchContext';
@@ -780,22 +781,6 @@ const WrapLogMessageButton = ({ expanded }: LogSelectOptionProps) => {
       customTagText={prettifyJSON ? '+' : ''}
     />
   );
-};
-
-const getWrapButtonStyles = (theme: GrafanaTheme2, expanded: boolean) => {
-  return {
-    menuItemActive: css({
-      '&:before': {
-        content: '""',
-        position: 'absolute',
-        left: 0,
-        top: theme.spacing(0.5),
-        height: `calc(100% - ${theme.spacing(1)})`,
-        width: '2px',
-        backgroundColor: theme.colors.warning.main,
-      },
-    }),
-  };
 };
 
 export const CONTROLS_WIDTH_EXPANDED = 176;

--- a/public/app/plugins/panel/logstable/TableNGWrap.tsx
+++ b/public/app/plugins/panel/logstable/TableNGWrap.tsx
@@ -21,6 +21,7 @@ import { LOG_LIST_CONTROLS_WIDTH } from 'app/features/logs/components/panel/virt
 import { dataFrameToLogsModel } from 'app/features/logs/logsModel';
 import { DownloadFormat, downloadLogs as download } from 'app/features/logs/utils';
 
+import { exploreLogsTableFieldConfigDefaults } from '../../../features/explore/Logs/constants';
 import { TablePanel } from '../table/TablePanel';
 
 import { Options } from './options/types';
@@ -110,6 +111,22 @@ export function TableNGWrap({
             sortOrder={options.sortOrder ?? LogsSortOrder.Descending}
             setSortOrder={handleSortOrderChange}
             downloadLogs={downloadLogs}
+            // @todo clean up
+            setWrapLogMessage={(wrapText: boolean) =>
+              handleTableOnFieldConfigChange({
+                ...fieldConfig,
+                defaults: {
+                  ...exploreLogsTableFieldConfigDefaults,
+                  ...fieldConfig.defaults,
+                  custom: {
+                    ...exploreLogsTableFieldConfigDefaults.custom,
+                    ...fieldConfig.defaults.custom,
+                    wrapText,
+                  },
+                },
+              })
+            }
+            wrapLogMessage={fieldConfig.defaults.custom.wrapText}
           />
         </div>
       )}


### PR DESCRIPTION
**What is this feature?**
PoC adding text wrap control to Logs table panel. 

**Special notes for your reviewer:**
The current `pruneObject` that removes null/undefined values doesn't work for objects with additional nesting, and it currently has zero test coverage.

Also we want to remove the menu in the text wrap button which was copied from Logs panel and just use a toggle.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
