### PR TITLE
QueryEditor: Fix transformation pipeline bug

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditorRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditorRenderer.test.tsx
@@ -1,0 +1,87 @@
+import { screen } from '@testing-library/react';
+
+import { DataTransformerInfo, TransformerRegistryItem } from '@grafana/data';
+
+import { TransformationEditorRenderer } from './TransformationEditorRenderer';
+import { renderWithQueryEditorProvider } from './testUtils';
+import { Transformation } from './types';
+
+// Prevent the real hook from running subscriptions against transformDataFrame.
+jest.mock('./hooks/useTransformationInputData', () => ({
+  useTransformationInputData: jest.fn(() => []),
+}));
+
+jest.mock('./TransformationFilterDisplay', () => ({
+  TransformationFilterDisplay: () => <div data-testid="transformation-filter-display" />,
+}));
+
+jest.mock('./TransformationEditor', () => ({
+  TransformationEditor: () => <div data-testid="transformation-editor" />,
+}));
+
+jest.mock('./TransformationHelpDisplay', () => ({
+  TransformationHelpDisplay: () => <div data-testid="transformation-help-display" />,
+}));
+
+jest.mock('./TransformationDebugDisplay', () => ({
+  TransformationDebugDisplay: () => <div data-testid="transformation-debug-display" />,
+}));
+
+const mockTransformation: DataTransformerInfo = {
+  id: 'test-transform',
+  name: 'Test Transform',
+  operator: jest.fn(),
+};
+
+const mockRegistryItem: TransformerRegistryItem = {
+  id: 'test-transform',
+  name: 'Test Transform',
+  transformation: mockTransformation,
+  editor: () => null,
+  imageDark: '',
+  imageLight: '',
+};
+
+function makeTransformation(registryItem: TransformerRegistryItem | undefined): Transformation {
+  return {
+    transformId: 'test-transform',
+    transformConfig: { id: 'test-transform', options: {} },
+    registryItem,
+  };
+}
+
+describe('TransformationEditorRenderer', () => {
+  it('renders nothing when no transformation is selected', () => {
+    // The renderer is mounted regardless of selection state, so it must guard against
+    // rendering the editor when nothing is selected (e.g. on initial load or after deselection).
+    const { container } = renderWithQueryEditorProvider(<TransformationEditorRenderer />, {
+      selectedTransformation: null,
+    });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders an error alert when the selected transformation has no registry item', () => {
+    // A transformation can exist in the config without a matching registry entry if a plugin
+    // is missing or unloaded. The renderer must degrade gracefully rather than crash.
+    renderWithQueryEditorProvider(<TransformationEditorRenderer />, {
+      selectedTransformation: makeTransformation(undefined),
+    });
+
+    expect(screen.getByText(/transformation does not have an editor component/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('transformation-editor')).not.toBeInTheDocument();
+  });
+
+  it('renders the full editor suite when a transformation with a valid editor is selected', () => {
+    renderWithQueryEditorProvider(<TransformationEditorRenderer />, {
+      selectedTransformation: makeTransformation(mockRegistryItem),
+    });
+
+    // All four sections — filter, editor, help, debug — should be present. If any is missing
+    // the user loses capability (can't configure, inspect, or debug the transformation).
+    expect(screen.getByTestId('transformation-filter-display')).toBeInTheDocument();
+    expect(screen.getByTestId('transformation-editor')).toBeInTheDocument();
+    expect(screen.getByTestId('transformation-help-display')).toBeInTheDocument();
+    expect(screen.getByTestId('transformation-debug-display')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditorRenderer.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { t } from '@grafana/i18n';
 import { Alert } from '@grafana/ui';
 
@@ -19,10 +21,12 @@ export function TransformationEditorRenderer() {
   const { transformations } = usePanelContext();
   const { updateTransformation } = useActionsContext();
 
+  const rawData = useMemo(() => data?.series ?? [], [data]);
+
   const inputData = useTransformationInputData({
     selectedTransformation,
     allTransformations: transformations,
-    rawData: data?.series ?? [],
+    rawData,
   });
 
   if (!selectedTransformation) {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditorRenderer.tsx
@@ -1,22 +1,29 @@
-import { useMemo } from 'react';
-
 import { t } from '@grafana/i18n';
 import { Alert } from '@grafana/ui';
 
-import { useActionsContext, useQueryEditorUIContext, useQueryRunnerContext } from './QueryEditorContext';
+import {
+  useActionsContext,
+  usePanelContext,
+  useQueryEditorUIContext,
+  useQueryRunnerContext,
+} from './QueryEditorContext';
 import { TransformationDebugDisplay } from './TransformationDebugDisplay';
 import { TransformationEditor } from './TransformationEditor';
 import { TransformationFilterDisplay } from './TransformationFilterDisplay';
 import { TransformationHelpDisplay } from './TransformationHelpDisplay';
+import { useTransformationInputData } from './hooks/useTransformationInputData';
 
 export function TransformationEditorRenderer() {
   const { data } = useQueryRunnerContext();
   const { selectedTransformation } = useQueryEditorUIContext();
+  const { transformations } = usePanelContext();
   const { updateTransformation } = useActionsContext();
 
-  // Memoize to avoid recreating potentially large data.series array reference on every render.
-  // This prevents unnecessary re-renders and processing in TransformationEditor.
-  const inputData = useMemo(() => data?.series ?? [], [data?.series]);
+  const inputData = useTransformationInputData({
+    selectedTransformation,
+    allTransformations: transformations,
+    rawData: data?.series ?? [],
+  });
 
   if (!selectedTransformation) {
     return null;

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformationInputData.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformationInputData.test.ts
@@ -1,0 +1,218 @@
+import { act, renderHook } from '@testing-library/react';
+import { Observable } from 'rxjs';
+
+import { DataFrame, transformDataFrame } from '@grafana/data';
+
+import { Transformation } from '../types';
+
+import { useTransformationInputData } from './useTransformationInputData';
+
+jest.mock('@grafana/data', () => ({
+  ...jest.requireActual('@grafana/data'),
+  transformDataFrame: jest.fn(),
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getTemplateSrv: () => ({ replace: (v: string) => v }),
+}));
+
+const mockTransformDataFrame = jest.mocked(transformDataFrame);
+
+function makeTransformation(id: string): Transformation {
+  return {
+    transformId: id,
+    transformConfig: { id, options: {} },
+    registryItem: undefined,
+  };
+}
+
+function makeFrames(count: number): DataFrame[] {
+  return Array.from({ length: count }, (_, i) => ({
+    name: `frame-${i}`,
+    fields: [],
+    length: 0,
+  }));
+}
+
+describe('useTransformationInputData', () => {
+  const rawData = makeFrames(2);
+  const mockPipelineOutput = makeFrames(1);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Default mock: emit mockPipelineOutput synchronously
+    mockTransformDataFrame.mockReturnValue(
+      new Observable((subscriber) => {
+        subscriber.next(mockPipelineOutput);
+      })
+    );
+  });
+
+  it('passes rawData directly when the first transformation is selected — nothing precedes it in the pipeline', () => {
+    // Pipeline: [joinByField, organize] — joinByField is selected (index 0)
+    // There's nothing before it, so the editor should receive the raw query data unchanged.
+    const transformations = [makeTransformation('joinByField'), makeTransformation('organize')];
+
+    const { result } = renderHook(() =>
+      useTransformationInputData({
+        selectedTransformation: transformations[0],
+        allTransformations: transformations,
+        rawData,
+      })
+    );
+
+    // Raw data should pass through untouched — no pipeline computation needed.
+    expect(result.current).toBe(rawData);
+    // Sanity check: we shouldn't be calling transformDataFrame at all when there's nothing to run.
+    expect(mockTransformDataFrame).not.toHaveBeenCalled();
+  });
+
+  it('runs preceding transformations when selected transformation is not the first', () => {
+    // Pipeline: [joinByField, organize] — organize is selected (index 1).
+    const transformations = [makeTransformation('joinByField'), makeTransformation('organize')];
+
+    const { result } = renderHook(() =>
+      useTransformationInputData({
+        selectedTransformation: transformations[1],
+        allTransformations: transformations,
+        rawData,
+      })
+    );
+
+    // The key assertion: only joinByField's config should be passed to transformDataFrame,
+    // applied to the raw query data. This proves we correctly sliced "everything before organize".
+    expect(mockTransformDataFrame).toHaveBeenCalledWith(
+      [transformations[0].transformConfig],
+      rawData,
+      expect.any(Object)
+    );
+    // Pipeline should only run once — guards against effect firing multiple times due to bad deps.
+    expect(mockTransformDataFrame).toHaveBeenCalledTimes(1);
+    // The hook should return whatever transformDataFrame emitted — the transformed frames.
+    expect(result.current).toBe(mockPipelineOutput);
+  });
+
+  it('runs all preceding transformations for a transformation deep in the pipeline', () => {
+    // Pipeline: [joinByField, organize, filterByValue] — filterByValue is selected (index 2).
+    // Both joinByField AND organize must run first to produce the correct input.
+    // This test proves the slice grows correctly with pipeline depth.
+    const transformations = [
+      makeTransformation('joinByField'),
+      makeTransformation('organize'),
+      makeTransformation('filterByValue'),
+    ];
+
+    const { result } = renderHook(() =>
+      useTransformationInputData({
+        selectedTransformation: transformations[2],
+        allTransformations: transformations,
+        rawData,
+      })
+    );
+
+    // Both configs before filterByValue must be passed — order matters.
+    expect(mockTransformDataFrame).toHaveBeenCalledWith(
+      [transformations[0].transformConfig, transformations[1].transformConfig],
+      rawData,
+      expect.any(Object)
+    );
+    // Pipeline should only run once — guards against effect firing multiple times due to bad deps.
+    expect(mockTransformDataFrame).toHaveBeenCalledTimes(1);
+    // Output should be whatever the pipeline emitted.
+    expect(result.current).toBe(mockPipelineOutput);
+  });
+
+  it('recomputes with the correct preceding configs when the selected transformation changes', () => {
+    // Simulates the user switching from the first transformation to the second.
+    // When joinByField is selected, nothing precedes it — no pipeline runs.
+    // When organize is selected, joinByField must run first to compute its input.
+    const transformations = [makeTransformation('joinByField'), makeTransformation('organize')];
+
+    const { result, rerender } = renderHook(
+      ({ selected }: { selected: Transformation }) =>
+        useTransformationInputData({
+          selectedTransformation: selected,
+          allTransformations: transformations,
+          rawData,
+        }),
+      { initialProps: { selected: transformations[0] } }
+    );
+
+    // First transformation selected — nothing to run.
+    expect(result.current).toBe(rawData);
+    expect(mockTransformDataFrame).not.toHaveBeenCalled();
+
+    act(() => rerender({ selected: transformations[1] }));
+
+    // Now organize is selected — joinByField must have run first with the raw data.
+    expect(mockTransformDataFrame).toHaveBeenCalledWith(
+      [transformations[0].transformConfig],
+      rawData,
+      expect.any(Object)
+    );
+    expect(result.current).toBe(mockPipelineOutput);
+  });
+
+  it('reruns the pipeline against the new data when rawData changes', () => {
+    // Simulates a query refreshing — new frames arrive and the preceding transformations
+    // must re-run against the fresh data to keep the editor input up to date.
+    const transformations = [makeTransformation('joinByField'), makeTransformation('organize')];
+    const newRawData = makeFrames(3); // fresh query results
+
+    const { rerender } = renderHook(
+      ({ data }: { data: DataFrame[] }) =>
+        useTransformationInputData({
+          selectedTransformation: transformations[1],
+          allTransformations: transformations,
+          rawData: data,
+        }),
+      { initialProps: { data: rawData } }
+    );
+
+    // Initial run — pipeline ran against original rawData.
+    expect(mockTransformDataFrame).toHaveBeenLastCalledWith(
+      [transformations[0].transformConfig],
+      rawData,
+      expect.any(Object)
+    );
+
+    act(() => rerender({ data: newRawData }));
+
+    // After data changes — pipeline must rerun against the new frames, not the old ones.
+    expect(mockTransformDataFrame).toHaveBeenLastCalledWith(
+      [transformations[0].transformConfig],
+      newRawData,
+      expect.any(Object)
+    );
+  });
+
+  it('cleans up the subscription when the component unmounts', () => {
+    // Without cleanup, a stale subscription could call setState on an unmounted component,
+    // causing React warnings and potential bugs if new query data arrives after navigation.
+    const unsubscribe = jest.fn();
+    mockTransformDataFrame.mockReturnValue(
+      new Observable((subscriber) => {
+        subscriber.next(mockPipelineOutput);
+        // Returning a function from the Observable subscriber is the RxJS teardown mechanism —
+        // it gets called when the subscription is unsubscribed.
+        return unsubscribe;
+      })
+    );
+
+    const transformations = [makeTransformation('joinByField'), makeTransformation('organize')];
+
+    const { unmount } = renderHook(() =>
+      useTransformationInputData({
+        selectedTransformation: transformations[1],
+        allTransformations: transformations,
+        rawData,
+      })
+    );
+
+    unmount();
+
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformationInputData.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformationInputData.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+
+import { DataFrame, DataTransformContext, transformDataFrame } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
+
+import { Transformation } from '../types';
+
+interface UseTransformationInputDataOptions {
+  selectedTransformation: Transformation | null;
+  allTransformations: Transformation[];
+  rawData: DataFrame[];
+}
+
+/**
+ * Returns the input data for the selected transformation — the output of everything before it
+ * in the pipeline. The first transformation gets raw query data.
+ *
+ * Without this, editors always see raw query data regardless of where they sit in the pipeline.
+ * That causes false errors like "Organize fields only works with a single frame" even when
+ * a Join earlier in the pipeline has already merged the frames.
+ *
+ * @param selectedTransformation - The transformation currently open in the editor.
+ * @param allTransformations - The full ordered list of transformations in the pipeline.
+ * @param rawData - Raw data frames from the query runner, before any transformations.
+ * @returns Data frames that feed into the selected transformation.
+ */
+export function useTransformationInputData({
+  selectedTransformation,
+  allTransformations,
+  rawData,
+}: UseTransformationInputDataOptions): DataFrame[] {
+  const [inputData, setInputData] = useState<DataFrame[]>(rawData);
+
+  useEffect(() => {
+    // TransformationEditorRenderer won't render without a selected transformation, but
+    // the hook accepts null so we guard here too and fall back to rawData.
+    if (!selectedTransformation) {
+      setInputData(rawData);
+      return;
+    }
+
+    // Where in the pipeline is this transformation? Everything before it needs to run first.
+    const selectedIndex = allTransformations.findIndex(
+      ({ transformId }) => transformId === selectedTransformation.transformId
+    );
+
+    // First in the pipeline (or not found) — raw query data is the input.
+    if (selectedIndex <= 0) {
+      setInputData(rawData);
+      return;
+    }
+
+    // Collect the DataTransformerConfig for every transformation that runs before the selected one.
+    const precedingConfigs = allTransformations.slice(0, selectedIndex).map(({ transformConfig }) => transformConfig);
+    // Provide template variable interpolation so transformers can resolve $variables in their options.
+    const ctx: DataTransformContext = { interpolate: (v: string) => getTemplateSrv().replace(v) };
+
+    // Run the pipeline up to (but not including) the selected transformation and update state when it emits.
+    const subscription = transformDataFrame(precedingConfigs, rawData, ctx).subscribe(setInputData);
+
+    return () => subscription.unsubscribe();
+  }, [selectedTransformation, allTransformations, rawData]);
+
+  return inputData;
+}


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->
Resolves https://github.com/grafana/grafana/issues/118517

Before, the transformation editor was always receiving the unprocessed frames directly from the query runner — regardless of where the transformation sat in the pipeline. Basically the pipeline wasn't pipelining. 

The bug: If you had a merge followed by an organize fields, the organize fields editor would see two raw frames (one per query) instead of the one merged frame that merge would produce at runtime. Organize fields validates its input and immediately errors: "only works with a single frame" — even though the actual transformation pipeline was executing correctly.

## Changes
<!--- Describe your changes in detail -->
This PR adds logic wires up the transformation editor so that each transformation's editor receives the correct input data. Which is the output of **all preceding transformations** in the pipeline, not raw query data. This matches legacy v1 beahviour. 

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->
* Added tests to mitigate this risk in the future.

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->
* Difficult to demo, pull down and test locally. See steps below

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
Test dashboard: [debug--2026-02-19 18_37_53.json.txt](https://github.com/user-attachments/files/25424472/debug--2026-02-19.18_37_53.json.txt)

Do the following steps on this branch and main to see it broken and resolved. 

* Create a dashboard with more than one query (so you can merge the dataframes)
* Add a merge transformation
* Add an organize fields by name transformation after it
* Click on organize fields to open its editor
* BUG - "Organize fields only works with a single frame. Consider applying a join transformation or filtering the input first."
* FIX - shows organize fields transform correctly

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable