### PR TITLE
Alerting: Group notifications returned from historian API.

### DIFF
--- a/apps/alerting/historian/pkg/app/notification/lokireader.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader.go
@@ -193,12 +193,11 @@ func buildQuery(query Query) (string, error) {
 
 // runQuery runs the query and collects results, grouping alerts into notifications.
 func (l *LokiReader) runQuery(ctx context.Context, logql string, from, to time.Time, limit int64) ([]Entry, error) {
-	// Note that we don't limit what Loki returns, which means Loki will return
-	// whatever the server-side configured maximum is (usually 5000).
+	// Note that we ask Loki for the configured maximum lines (usually 5000).
 	// This means that if some notifications have lots of alerts, then we may not
 	// return enough entries.
 	entries := make([]Entry, 0)
-	r, err := l.client.RangeQuery(ctx, logql, from.UnixNano(), to.UnixNano(), 0)
+	r, err := l.client.RangeQuery(ctx, logql, from.UnixNano(), to.UnixNano(), 5000)
 	if err != nil {
 		return nil, fmt.Errorf("loki range query: %w", err)
 	}

--- a/apps/alerting/historian/pkg/app/notification/lokireader.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader.go
@@ -104,6 +104,11 @@ func (h *LokiReader) Query(ctx context.Context, query Query) (QueryResult, error
 		return QueryResult{}, err
 	}
 
+	// Prune entries to the requested limit
+	if int64(len(entries)) > limit {
+		entries = entries[:limit]
+	}
+
 	return QueryResult{
 		Entries: entries,
 	}, nil
@@ -186,10 +191,14 @@ func buildQuery(query Query) (string, error) {
 	return logql, nil
 }
 
-// runQuery runs the query and collects results.
+// runQuery runs the query and collects results, grouping alerts into notifications.
 func (l *LokiReader) runQuery(ctx context.Context, logql string, from, to time.Time, limit int64) ([]Entry, error) {
+	// Note that we don't limit what Loki returns, which means Loki will return
+	// whatever the server-side configured maximum is (usually 5000).
+	// This means that if some notifications have lots of alerts, then we may not
+	// return enough entries.
 	entries := make([]Entry, 0)
-	r, err := l.client.RangeQuery(ctx, logql, from.UnixNano(), to.UnixNano(), limit)
+	r, err := l.client.RangeQuery(ctx, logql, from.UnixNano(), to.UnixNano(), 0)
 	if err != nil {
 		return nil, fmt.Errorf("loki range query: %w", err)
 	}
@@ -205,14 +214,51 @@ func (l *LokiReader) runQuery(ctx context.Context, logql string, from, to time.T
 		}
 	}
 
-	// We need to sort as results might be from a combination of streams.
+	// Group individual alerts into notifications
+	entries = groupEntries(entries)
+
+	// Sort entries by timestamp (descending - newest first)
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].Timestamp.After(entries[j].Timestamp)
 	})
 
-	l.logger.Debug("Notification history query complete", "entries", len(entries))
+	l.logger.Debug("Notification history query complete", "notifications", len(entries))
 
 	return entries, nil
+}
+
+// groupAlerts combines alerts that belong to the same notification.
+// Alerts are grouped together if they have the same groupKey and pipelineTime.
+func groupEntries(entries []Entry) []Entry {
+	type key struct {
+		groupKey     string
+		pipelineTime int64
+	}
+	groups := make(map[key][]Entry)
+	var orderedKeys []key
+
+	for _, entry := range entries {
+		k := key{
+			groupKey:     entry.GroupKey,
+			pipelineTime: entry.PipelineTime.UnixNano(),
+		}
+		if _, exists := groups[k]; !exists {
+			orderedKeys = append(orderedKeys, k)
+		}
+		groups[k] = append(groups[k], entry)
+	}
+
+	result := make([]Entry, 0, len(groups))
+	for _, k := range orderedKeys {
+		groupEntries := groups[k]
+		entry := groupEntries[0]
+		for _, otherEntry := range groupEntries[1:] {
+			entry.Alerts = append(entry.Alerts, otherEntry.Alerts...)
+		}
+		result = append(result, entry)
+	}
+
+	return result
 }
 
 // parseLokiEntry unmarshals the JSON stored in the entry.

--- a/apps/alerting/historian/pkg/app/notification/lokireader_test.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader_test.go
@@ -504,11 +504,12 @@ func TestLokiReader_RunQuery(t *testing.T) {
 								SchemaVersion: 1,
 								Receiver:      "receiver-1",
 								Status:        "firing",
+								GroupKey:      "group1",
 								GroupLabels:   map[string]string{},
 								Alert:         historian.NotificationHistoryLokiEntryAlert{},
 								AlertIndex:    0,
 								AlertCount:    1,
-								PipelineTime:  now,
+								PipelineTime:  entry1Time,
 							}),
 						},
 						{
@@ -517,11 +518,12 @@ func TestLokiReader_RunQuery(t *testing.T) {
 								SchemaVersion: 1,
 								Receiver:      "receiver-3",
 								Status:        "firing",
+								GroupKey:      "group3",
 								GroupLabels:   map[string]string{},
 								Alert:         historian.NotificationHistoryLokiEntryAlert{},
 								AlertIndex:    0,
 								AlertCount:    1,
-								PipelineTime:  now,
+								PipelineTime:  entry3Time,
 							}),
 						},
 					},
@@ -534,11 +536,12 @@ func TestLokiReader_RunQuery(t *testing.T) {
 								SchemaVersion: 1,
 								Receiver:      "receiver-2",
 								Status:        "firing",
+								GroupKey:      "group2",
 								GroupLabels:   map[string]string{},
 								Alert:         historian.NotificationHistoryLokiEntryAlert{},
 								AlertIndex:    0,
 								AlertCount:    1,
-								PipelineTime:  now,
+								PipelineTime:  entry2Time,
 							}),
 						},
 					},
@@ -665,4 +668,468 @@ func TestRuleUIDLabelConstant(t *testing.T) {
 	// If this changes in the alerting module, our LogQL field path constant will be incorrect
 	// and filtering for a single alert rule by its UID will break.
 	assert.Equal(t, "__alert_rule_uid__", models.RuleUIDLabel)
+}
+
+func TestGroupAlerts(t *testing.T) {
+	now := time.Now().UTC()
+	pipelineTime := now.Add(-5 * time.Minute)
+
+	tests := []struct {
+		name     string
+		entries  []Entry
+		expected []Entry
+	}{
+		{
+			name:     "empty entries",
+			entries:  []Entry{},
+			expected: []Entry{},
+		},
+		{
+			name: "single entry with single alert",
+			entries: []Entry{
+				{
+					Timestamp:    now,
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "1"}},
+					},
+				},
+			},
+			expected: []Entry{
+				{
+					Timestamp:    now,
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "1"}},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple alerts for same notification",
+			entries: []Entry{
+				{
+					Timestamp:    now,
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "1"}},
+					},
+				},
+				{
+					Timestamp:    now,
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "2"}},
+					},
+				},
+				{
+					Timestamp:    now,
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "3"}},
+					},
+				},
+			},
+			expected: []Entry{
+				{
+					Timestamp:    now,
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "1"}},
+						{Status: "firing", Labels: map[string]string{"alert": "2"}},
+						{Status: "firing", Labels: map[string]string{"alert": "3"}},
+					},
+				},
+			},
+		},
+		{
+			name: "different group keys - separate notifications",
+			entries: []Entry{
+				{
+					Timestamp:    now,
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "1"}},
+					},
+				},
+				{
+					Timestamp:    now,
+					GroupKey:     "group2",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "2"}},
+					},
+				},
+			},
+			expected: []Entry{
+				{
+					Timestamp:    now,
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "1"}},
+					},
+				},
+				{
+					Timestamp:    now,
+					GroupKey:     "group2",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "2"}},
+					},
+				},
+			},
+		},
+		{
+			name: "different timestamps - same notification (grouped)",
+			entries: []Entry{
+				{
+					Timestamp:    now,
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "1"}},
+					},
+				},
+				{
+					Timestamp:    now.Add(-1 * time.Second),
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "2"}},
+					},
+				},
+			},
+			expected: []Entry{
+				{
+					Timestamp:    now,
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "1"}},
+						{Status: "firing", Labels: map[string]string{"alert": "2"}},
+					},
+				},
+			},
+		},
+		{
+			name: "different pipeline times - separate notifications",
+			entries: []Entry{
+				{
+					Timestamp:    now,
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "1"}},
+					},
+				},
+				{
+					Timestamp:    now,
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime.Add(-1 * time.Second),
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "2"}},
+					},
+				},
+			},
+			expected: []Entry{
+				{
+					Timestamp:    now,
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "1"}},
+					},
+				},
+				{
+					Timestamp:    now,
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime.Add(-1 * time.Second),
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "2"}},
+					},
+				},
+			},
+		},
+		{
+			name: "complex scenario with mixed grouping",
+			entries: []Entry{
+				// Notification 1: group1, pipeline1 (3 alerts across different timestamps)
+				{
+					Timestamp:    now,
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "1"}},
+					},
+				},
+				{
+					Timestamp:    now,
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "2"}},
+					},
+				},
+				// Notification 2: group2, pipeline1 (1 alert)
+				{
+					Timestamp:    now,
+					GroupKey:     "group2",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver2",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "3"}},
+					},
+				},
+				// This entry will be grouped with the first two (same groupKey and pipelineTime)
+				{
+					Timestamp:    now.Add(-1 * time.Minute),
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "resolved",
+					Alerts: []EntryAlert{
+						{Status: "resolved", Labels: map[string]string{"alert": "4"}},
+					},
+				},
+			},
+			expected: []Entry{
+				{
+					Timestamp:    now,
+					GroupKey:     "group1",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver1",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "1"}},
+						{Status: "firing", Labels: map[string]string{"alert": "2"}},
+						{Status: "resolved", Labels: map[string]string{"alert": "4"}},
+					},
+				},
+				{
+					Timestamp:    now,
+					GroupKey:     "group2",
+					PipelineTime: pipelineTime,
+					Receiver:     "receiver2",
+					Status:       "firing",
+					Alerts: []EntryAlert{
+						{Status: "firing", Labels: map[string]string{"alert": "3"}},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := groupEntries(tt.entries)
+			require.Equal(t, len(tt.expected), len(result), "number of grouped notifications should match")
+
+			for i := range tt.expected {
+				assert.Equal(t, tt.expected[i].Timestamp, result[i].Timestamp, "timestamp should match")
+				assert.Equal(t, tt.expected[i].GroupKey, result[i].GroupKey, "groupKey should match")
+				assert.Equal(t, tt.expected[i].PipelineTime, result[i].PipelineTime, "pipelineTime should match")
+				assert.Equal(t, tt.expected[i].Receiver, result[i].Receiver, "receiver should match")
+				assert.Equal(t, tt.expected[i].Status, result[i].Status, "status should match")
+				assert.Equal(t, len(tt.expected[i].Alerts), len(result[i].Alerts), "number of alerts should match")
+
+				for j := range tt.expected[i].Alerts {
+					assert.Equal(t, tt.expected[i].Alerts[j].Status, result[i].Alerts[j].Status, "alert status should match")
+					assert.Equal(t, tt.expected[i].Alerts[j].Labels, result[i].Alerts[j].Labels, "alert labels should match")
+				}
+			}
+		})
+	}
+}
+
+func TestLokiReader_RunQueryWithGrouping(t *testing.T) {
+	now := time.Now().UTC()
+	pipelineTime := now.Add(-5 * time.Minute)
+
+	entry2Time := now.Add(-2 * time.Hour)
+	entry3Time := now.Add(-1 * time.Hour)
+
+	// Create a mock response with 5 log lines representing 2 notifications:
+	// - Notification 1: 3 alerts with the same groupKey, timestamp, and pipelineTime
+	// - Notification 2: 2 alerts with the same groupKey, timestamp, and pipelineTime
+	mockResponse := lokiclient.QueryRes{
+		Data: lokiclient.QueryData{
+			Result: []lokiclient.Stream{
+				{
+					Values: []lokiclient.Sample{
+						// Notification 1 - Alert 1
+						{
+							T: entry3Time,
+							V: createLokiEntryJSON(t, historian.NotificationHistoryLokiEntry{
+								SchemaVersion: 1,
+								Receiver:      "receiver-1",
+								GroupKey:      "groupkey-1",
+								Status:        "firing",
+								GroupLabels:   map[string]string{"alertname": "alert1"},
+								Alert: historian.NotificationHistoryLokiEntryAlert{
+									Status: "firing",
+									Labels: map[string]string{"instance": "host1"},
+								},
+								AlertIndex:   0,
+								AlertCount:   3,
+								PipelineTime: pipelineTime,
+							}),
+						},
+						// Notification 1 - Alert 2
+						{
+							T: entry3Time,
+							V: createLokiEntryJSON(t, historian.NotificationHistoryLokiEntry{
+								SchemaVersion: 1,
+								Receiver:      "receiver-1",
+								GroupKey:      "groupkey-1",
+								Status:        "firing",
+								GroupLabels:   map[string]string{"alertname": "alert1"},
+								Alert: historian.NotificationHistoryLokiEntryAlert{
+									Status: "firing",
+									Labels: map[string]string{"instance": "host2"},
+								},
+								AlertIndex:   1,
+								AlertCount:   3,
+								PipelineTime: pipelineTime,
+							}),
+						},
+						// Notification 1 - Alert 3
+						{
+							T: entry3Time,
+							V: createLokiEntryJSON(t, historian.NotificationHistoryLokiEntry{
+								SchemaVersion: 1,
+								Receiver:      "receiver-1",
+								GroupKey:      "groupkey-1",
+								Status:        "firing",
+								GroupLabels:   map[string]string{"alertname": "alert1"},
+								Alert: historian.NotificationHistoryLokiEntryAlert{
+									Status: "firing",
+									Labels: map[string]string{"instance": "host3"},
+								},
+								AlertIndex:   2,
+								AlertCount:   3,
+								PipelineTime: pipelineTime,
+							}),
+						},
+						// Notification 2 - Alert 1
+						{
+							T: entry2Time,
+							V: createLokiEntryJSON(t, historian.NotificationHistoryLokiEntry{
+								SchemaVersion: 1,
+								Receiver:      "receiver-2",
+								GroupKey:      "groupkey-2",
+								Status:        "resolved",
+								GroupLabels:   map[string]string{"alertname": "alert2"},
+								Alert: historian.NotificationHistoryLokiEntryAlert{
+									Status: "resolved",
+									Labels: map[string]string{"instance": "host1"},
+								},
+								AlertIndex:   0,
+								AlertCount:   2,
+								PipelineTime: pipelineTime,
+							}),
+						},
+						// Notification 2 - Alert 2
+						{
+							T: entry2Time,
+							V: createLokiEntryJSON(t, historian.NotificationHistoryLokiEntry{
+								SchemaVersion: 1,
+								Receiver:      "receiver-2",
+								GroupKey:      "groupkey-2",
+								Status:        "resolved",
+								GroupLabels:   map[string]string{"alertname": "alert2"},
+								Alert: historian.NotificationHistoryLokiEntryAlert{
+									Status: "resolved",
+									Labels: map[string]string{"instance": "host2"},
+								},
+								AlertIndex:   1,
+								AlertCount:   2,
+								PipelineTime: pipelineTime,
+							}),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mockClient := &mockLokiClient{}
+	mockClient.On("RangeQuery", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(mockResponse, nil)
+
+	reader := &LokiReader{
+		client: mockClient,
+		logger: &logging.NoOpLogger{},
+	}
+
+	entries, err := reader.runQuery(context.Background(), "test query", now.Add(-6*time.Hour), now, 1000)
+	require.NoError(t, err)
+
+	// Should get 2 notifications (grouped from 5 log lines)
+	require.Len(t, entries, 2, "should have 2 notifications after grouping")
+
+	mockClient.AssertExpectations(t)
+
+	// Verify first notification (newest first, so entry3Time)
+	assert.Equal(t, "receiver-1", entries[0].Receiver)
+	assert.Equal(t, "groupkey-1", entries[0].GroupKey)
+	assert.Equal(t, entry3Time, entries[0].Timestamp)
+	assert.Len(t, entries[0].Alerts, 3, "first notification should have 3 alerts")
+	assert.Equal(t, "host1", entries[0].Alerts[0].Labels["instance"])
+	assert.Equal(t, "host2", entries[0].Alerts[1].Labels["instance"])
+	assert.Equal(t, "host3", entries[0].Alerts[2].Labels["instance"])
+
+	// Verify second notification
+	assert.Equal(t, "receiver-2", entries[1].Receiver)
+	assert.Equal(t, "groupkey-2", entries[1].GroupKey)
+	assert.Equal(t, entry2Time, entries[1].Timestamp)
+	assert.Len(t, entries[1].Alerts, 2, "second notification should have 2 alerts")
+	assert.Equal(t, "host1", entries[1].Alerts[0].Labels["instance"])
+	assert.Equal(t, "host2", entries[1].Alerts[1].Labels["instance"])
 }


### PR DESCRIPTION
We store notifications in Loki; one line per alert in each notification.
This means each alert looks like a separate notification, but we actually
need to group them together based on groupKey and pipelineTime.

Note: This implementation is not final, but a first step in getting the
API to function: the problem remains that if some notifications have lots
of alerts in, then we will blow through the server side limit that Loki
enforces on lines to return. We can paginate, but then if a notification
has more than 5000 alerts in it, because every alert (log line) for the
notification has the same timestamp, we are unable to query all alerts.
We will likely need to tweak how we write the data to Loki to fix this
entirely, so this is a partial solution.
