### PR TITLE
Alerting: Single-node evaluation mode

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1441,6 +1441,15 @@ ha_reconnect_timeout = 6h
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 ha_push_pull_interval = 60s
 
+# Enable single-node evaluation mode. When enabled, only one instance in the HA cluster evaluates
+# alert rules, reducing query load on data sources. Requires HA clustering to be configured.
+ha_single_node_evaluation = false
+
+# The size of the message queue used to broadcast alerts from the primary instance to other instances
+# in single-node evaluation mode. Increase this value if you have many alert rules and see broadcast
+# messages being dropped. Only used when ha_single_node_evaluation is true.
+ha_single_evaluation_alert_broadcast_queue_size = 200
+
 # Enable or disable alerting rule execution. The alerting UI remains visible.
 execute_alerts = true
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1405,6 +1405,15 @@
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 ;ha_push_pull_interval = "60s"
 
+# Enable single-node evaluation mode. When enabled, only one instance in the HA cluster evaluates
+# alert rules, reducing query load on data sources. Requires HA clustering to be configured.
+;ha_single_node_evaluation = false
+
+# The size of the message queue used to broadcast alerts from the primary instance to other instances
+# in single-node evaluation mode. Increase this value if you have many alert rules and see broadcast
+# messages being dropped. Only used when ha_single_node_evaluation is true.
+;ha_single_evaluation_alert_broadcast_queue_size = 200
+
 # Enable or disable alerting rule execution. The alerting UI remains visible.
 ;execute_alerts = true
 

--- a/docs/sources/alerting/set-up/configure-high-availability/_index.md
+++ b/docs/sources/alerting/set-up/configure-high-availability/_index.md
@@ -37,7 +37,9 @@ Grafana Alerting uses the Prometheus model of separating the evaluation of alert
 
 {{< figure src="/static/img/docs/alerting/unified/high-availability-ua.png" class="docs-image--no-shadow" max-width= "750px" caption="High availability" >}}
 
-When running multiple instances of Grafana, all alert rules are evaluated on all instances. You can think of the evaluation of alert rules as being duplicated by the number of running Grafana instances. This is how Grafana Alerting makes sure that as long as at least one Grafana instance is working, alert rules are still be evaluated and notifications for alerts are still sent.
+When running multiple instances of Grafana, all alert rules are evaluated on all instances by default. You can think of the evaluation of alert rules as being duplicated by the number of running Grafana instances. This is how Grafana Alerting makes sure that as long as at least one Grafana instance is working, alert rules are still be evaluated and notifications for alerts are still sent.
+
+If you want to reduce this duplication, you can enable [single-node evaluation mode](#single-node-evaluation-mode) so that only one instance evaluates alert rules.
 
 You can find this duplication in state history and it is a good way to [verify your high availability setup](#verify-your-high-availability-setup).
 
@@ -159,9 +161,81 @@ For a demo, see this [example using Docker Compose](https://github.com/grafana/a
    ha_reconnect_timeout = 2m
    ```
 
+## Single-node evaluation mode
+
+{{< docs/public-preview product="Single-node evaluation mode" >}}
+
+By default, all Grafana instances in a high-availability cluster evaluate all alert rules. This means query load on data sources is multiplied by the number of Grafana instances. Single-node evaluation mode changes this so that only one instance evaluates alert rules, reducing query load from N times to 1.
+
+**To enable single-node evaluation mode**, add the following to your `[unified_alerting]` section:
+
+```ini
+[unified_alerting]
+ha_single_node_evaluation = true
+```
+
+This setting requires high availability clustering to be configured (either Memberlist or Redis).
+
+### How it works
+
+The Grafana cluster automatically chooses a primary instance that is responsible for evaluating all alert rules. Other instances skip evaluation entirely.
+
+- **Alert broadcasting:** The primary instance broadcasts fired alerts to all other instances through the cluster communication channel. This ensures that every instance's embedded Alertmanager has the current alerts, which is needed for failure recovery and for the Alertmanager API to return correct data on all instances.
+- **Automatic failure recovery:** When the primary instance becomes unavailable, the cluster reassigns positions and a new instance becomes responsible for evaluation. During failure recovery, there is a brief gap in evaluations. Existing alert states remain in the database.
+
+### Tradeoffs
+
+| Default HA (all instances evaluate)         | Single-node evaluation mode                  |
+| ------------------------------------------- | -------------------------------------------- |
+| Redundant evaluation on all nodes           | Only one node evaluates                      |
+| Higher query load on data sources (N times) | Reduced query load (1 time)                  |
+| No evaluation gap on instance failure       | Brief evaluation gap during failure recovery |
+
+### Monitor single-node evaluation mode
+
+You can verify that single-node evaluation mode is working correctly by monitoring the following metrics.
+
+| Metric                                                 | Description                                                                                                                          |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `grafana_alertmanager_peer_position`                   | The position of each instance in the cluster. The instance at position 0 is the primary and evaluates all alert rules.               |
+| `grafana_alerting_alerts_received_total`               | Total number of alerts received by each instance. Non-primary instances should receive alerts through the cluster broadcast channel. |
+| `grafana_alerting_alertmanager_alerts{state="active"}` | Number of active alerts on each instance. This value should be the same across all instances.                                        |
+
+The following metrics are specific to the HA backend you are using:
+
+**Memberlist (gossip)**
+
+| Metric                                                                                  | Description                                                                                                |
+| --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `grafana_alertmanager_oversized_gossip_message_dropped_total{key="alerts:broadcast"}`   | Number of broadcast messages dropped due to a full message queue. A non-zero value indicates message loss. |
+| `grafana_alertmanager_oversized_gossip_message_failure_total{key="alerts:broadcast"}`   | Number of broadcast messages that failed to send to a peer.                                                |
+| `grafana_alertmanager_oversized_gossip_message_sent_total{key="alerts:broadcast"}`      | Number of broadcast messages sent to peers.                                                                |
+| `grafana_alertmanager_oversize_gossip_message_duration_seconds{key="alerts:broadcast"}` | Duration of broadcast message sends. Useful for detecting network latency between peers.                   |
+
+**Redis**
+
+| Metric                                                                                                     | Description                                                                                                                                                                                                                        |
+| ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `grafana_alertmanager_cluster_messages_publish_failures_total{msg_type="update",reason="buffer_overflow"}` | Number of state sync messages dropped due to a full message queue. A non-zero value indicates message loss. These metrics are shared across all HA state channels (alerts, silences, notification log), not only alert broadcasts. |
+| `grafana_alertmanager_cluster_messages_publish_failures_total{msg_type="update",reason="redis_issue"}`     | Number of state sync messages that failed due to a Redis error.                                                                                                                                                                    |
+| `grafana_alertmanager_cluster_messages_sent_total{msg_type="update"}`                                      | Total number of state sync messages sent to Redis. Includes all HA state channels, not only alert broadcasts.                                                                                                                      |
+
+### Tune alert broadcast queue size
+
+The primary instance uses a message queue to broadcast alerts to other instances. By default, the queue holds up to 200 messages. If you have a large number of alert rules, the queue may fill up, causing messages to be dropped. You can detect this by monitoring the drop metric for your HA backend (see metrics tables above).
+
+To increase the queue size, add the following to your `[unified_alerting]` section:
+
+```ini
+[unified_alerting]
+ha_single_evaluation_alert_broadcast_queue_size = 500
+```
+
+The default value is `200`. This setting applies to both Memberlist and Redis HA backends.
+
 ## Verify your high availability setup
 
-When running multiple Grafana instances, all alert rules are evaluated on every instance. This multiple evaluation of alert rules is visible in the [state history](ref:state-history) and provides a straightforward way to verify that your high availability configuration is working correctly.
+When running multiple Grafana instances, all alert rules are evaluated on every instance by default. This multiple evaluation of alert rules is visible in the [state history](ref:state-history) and provides a straightforward way to verify that your high availability configuration is working correctly.
 
 {{< admonition type="note" >}}
 
@@ -208,7 +282,7 @@ For more information on monitoring alerting metrics, refer to [Alerting meta-mon
 
 In high-availability mode, each Grafana instance runs its own pre-configured alertmanager to handle alert notifications.
 
-When multiple Grafana instances are running, all alert rules are evaluated on each instance. By default, each instance sends firing alerts to its respective alertmanager. This results in notification handling being duplicated across all running Grafana instances.
+When multiple Grafana instances are running, all alert rules are evaluated on each instance by default. Each instance sends firing alerts to its respective Alertmanager. This results in notification handling being duplicated across all running Grafana instances.
 
 Alertmanagers in HA mode communicate with each other to coordinate notification delivery. However, this setup can sometimes lead to duplicated or out-of-order notifications. By design, HA prioritizes sending duplicate notifications over the risk of missing notifications.
 

--- a/docs/sources/alerting/set-up/configure-high-availability/_index.md
+++ b/docs/sources/alerting/set-up/configure-high-availability/_index.md
@@ -37,7 +37,7 @@ Grafana Alerting uses the Prometheus model of separating the evaluation of alert
 
 {{< figure src="/static/img/docs/alerting/unified/high-availability-ua.png" class="docs-image--no-shadow" max-width= "750px" caption="High availability" >}}
 
-When running multiple instances of Grafana, all alert rules are evaluated on all instances by default. You can think of the evaluation of alert rules as being duplicated by the number of running Grafana instances. This is how Grafana Alerting makes sure that as long as at least one Grafana instance is working, alert rules are still be evaluated and notifications for alerts are still sent.
+When running multiple instances of Grafana, all alert rules are evaluated on all instances by default. You can think of the evaluation of alert rules as being duplicated by the number of running Grafana instances. This is how Grafana Alerting ensures that as long as at least one Grafana instance is working, alert rules are still evaluated and notifications for alerts are still sent.
 
 If you want to reduce this duplication, you can enable [single-node evaluation mode](#single-node-evaluation-mode) so that only one instance evaluates alert rules.
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1915,6 +1915,18 @@ The default value is `60s`.
 
 The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), for example, 30s or 1m.
 
+#### `ha_single_node_evaluation`
+
+Enable single-node evaluation mode for alerting in high availability. When enabled, only one Grafana instance in the cluster evaluates alert rules, instead of all instances evaluating all rules. This reduces query load on data sources from N times to 1. The default value is `false`.
+
+Requires high availability clustering to be configured (either Memberlist or Redis).
+
+For more information, refer to [Single-node evaluation mode](/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-high-availability/#single-node-evaluation-mode).
+
+#### `ha_single_evaluation_alert_broadcast_queue_size`
+
+The size of the message queue used to broadcast alerts from the primary instance to other instances in single-node evaluation mode. Increase this value if you have many alert rules and see broadcast messages being dropped. The default value is `200`. Only used when `ha_single_node_evaluation` is `true`.
+
 #### `execute_alerts`
 
 Enable or disable alerting rule execution. The default value is `true`. The alerting UI remains visible.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1917,7 +1917,7 @@ The interval string is a possibly signed sequence of decimal numbers, followed b
 
 #### `ha_single_node_evaluation`
 
-Enable single-node evaluation mode for alerting in high availability. When enabled, only one Grafana instance in the cluster evaluates alert rules, instead of all instances evaluating all rules. This reduces query load on data sources from N times to 1. The default value is `false`.
+Enable single-node evaluation mode for alerting in high availability. When enabled, only one Grafana instance in the cluster evaluates alert rules instead of all instances evaluating all rules. This reduces query load on data sources from N times to 1. The default value is `false`.
 
 Requires high availability clustering to be configured (either Memberlist or Redis).
 


### PR DESCRIPTION
**What is this feature?**

Documents single-node evaluation mode for Grafana Alerting high availability.

Example: https://deploy-preview-grafana-118527-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/set-up/configure-high-availability/

Adds:
- New section in the HA docs explaining how single-node evaluation works, tradeoffs vs default HA, monitoring metrics (Memberlist and Redis), and broadcast queue tuning
- Configuration reference entries in `defaults.ini`, `sample.ini`, and `configure-grafana/_index.md`
- Minor update to the existing HA intro to mention single-node evaluation as an option

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/116545

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
