### PR TITLE
Logs Explore: fix add level when in the dataframe and not labels

### DIFF
--- a/public/app/features/logs/components/fieldSelector/getFieldsWithStats.test.ts
+++ b/public/app/features/logs/components/fieldSelector/getFieldsWithStats.test.ts
@@ -1,0 +1,54 @@
+import { createDataFrame, FieldType } from '@grafana/data';
+
+import { getFieldsWithStats } from './getFieldsWithStats';
+
+describe('getFieldsWithStats', () => {
+  it('should include severity field (level) in available fields', () => {
+    const frame = createDataFrame({
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [1000, 2000, 3000] },
+        { name: 'message', type: FieldType.string, values: ['Info line', 'Warn line', 'Error line'] },
+        { name: 'level', type: FieldType.string, values: ['info', 'warn', 'error'] },
+        { name: '_id', type: FieldType.string, values: ['1', '2', '3'] },
+      ],
+    });
+
+    const result = getFieldsWithStats([frame]);
+
+    const fieldNames = result.map((f) => f.name);
+    expect(fieldNames).toContain('level');
+    expect(result.find((f) => f.name === 'level')?.stats.percentOfLinesWithLabel).toBe(100);
+  });
+
+  it('should include detected_level when used as severity field', () => {
+    const frame = createDataFrame({
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [1000, 2000] },
+        { name: 'message', type: FieldType.string, values: ['line1', 'line2'] },
+        { name: 'detected_level', type: FieldType.string, values: ['info', 'error'] },
+      ],
+    });
+
+    const result = getFieldsWithStats([frame]);
+
+    const fieldNames = result.map((f) => f.name);
+    expect(fieldNames).toContain('detected_level');
+  });
+
+  it('should include extraFields and severity field', () => {
+    const frame = createDataFrame({
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [1000, 2000, 3000] },
+        { name: 'message', type: FieldType.string, values: ['a', 'b', 'c'] },
+        { name: 'level', type: FieldType.string, values: ['info', 'warn', 'error'] },
+        { name: 'hostname', type: FieldType.string, values: ['h1', 'h2', 'h3'] },
+      ],
+    });
+
+    const result = getFieldsWithStats([frame]);
+
+    const fieldNames = result.map((f) => f.name);
+    expect(fieldNames).toContain('level');
+    expect(fieldNames).toContain('hostname');
+  });
+});

--- a/public/app/features/logs/components/fieldSelector/getFieldsWithStats.ts
+++ b/public/app/features/logs/components/fieldSelector/getFieldsWithStats.ts
@@ -22,7 +22,8 @@ export function getFieldsWithStats(dataFrames: DataFrame[]): FieldWithStats[] {
     const fields = (logsFrame?.extraFields ?? [])
       .filter((field) => !field?.config?.custom?.hidden)
       .map((field) => {
-        cardinality.set(field.name, field.values.filter((value) => value !== null && value !== undefined).length);
+        const count = field.values.filter((value) => value !== null && value !== undefined).length;
+        cardinality.set(field.name, (cardinality.get(field.name) ?? 0) + count);
         return field.name;
       });
 

--- a/public/app/features/logs/components/fieldSelector/getFieldsWithStats.ts
+++ b/public/app/features/logs/components/fieldSelector/getFieldsWithStats.ts
@@ -26,7 +26,15 @@ export function getFieldsWithStats(dataFrames: DataFrame[]): FieldWithStats[] {
         return field.name;
       });
 
-    return [...labels, ...fields];
+    // Include severity field (level/detected_level) - it's excluded from extraFields but should be selectable
+    const severityFieldNames: string[] = [];
+    if (logsFrame?.severityField && !logsFrame.severityField.config?.custom?.hidden) {
+      const count = logsFrame.severityField.values.filter((value) => value !== null && value !== undefined).length;
+      cardinality.set(logsFrame.severityField.name, count);
+      severityFieldNames.push(logsFrame.severityField.name);
+    }
+
+    return [...labels, ...fields, ...severityFieldNames];
   });
 
   const labels = [...new Set(allFields)];

--- a/public/app/features/logs/components/fieldSelector/getFieldsWithStats.ts
+++ b/public/app/features/logs/components/fieldSelector/getFieldsWithStats.ts
@@ -30,7 +30,7 @@ export function getFieldsWithStats(dataFrames: DataFrame[]): FieldWithStats[] {
     const severityFieldNames: string[] = [];
     if (logsFrame?.severityField && !logsFrame.severityField.config?.custom?.hidden) {
       const count = logsFrame.severityField.values.filter((value) => value !== null && value !== undefined).length;
-      cardinality.set(logsFrame.severityField.name, count);
+      cardinality.set(logsFrame.severityField.name, (cardinality.get(logsFrame.severityField.name) ?? 0) + count);
       severityFieldNames.push(logsFrame.severityField.name);
     }
 


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes # https://github.com/grafana/grafana/issues/117767
I believe this is happening because getFieldsWithStats() was not checking dataframes for levels and assuming it would come from labels. I must admit I haven't been able to create a data set that returns level as a dataframe field instead of labels, so I'm relying on the tests.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
