### PR TITLE
Provisioning: check GH app installation permissions in Connection tester

### DIFF
--- a/apps/provisioning/pkg/connection/github/client.go
+++ b/apps/provisioning/pkg/connection/github/client.go
@@ -50,22 +50,22 @@ type App struct {
 	// Owner represents the GH account/org owning the app
 	Owner string
 	// Permissions granted to the GitHub App
-	Permissions AppPermissions
+	Permissions Permissions
 }
-type AppPermission int
+type Permission int
 
 const (
-	AppPermissionNone AppPermission = iota
-	AppPermissionRead
-	AppPermissionWrite
+	PermissionNone Permission = iota
+	PermissionRead
+	PermissionWrite
 )
 
-// AppPermissions represents the permissions granted to a GitHub App installation
-type AppPermissions struct {
-	Contents     AppPermission
-	Metadata     AppPermission
-	PullRequests AppPermission
-	Webhooks     AppPermission
+// Permissions represents the permissions granted to a GitHub Apps and their installations.
+type Permissions struct {
+	Contents     Permission
+	Metadata     Permission
+	PullRequests Permission
+	Webhooks     Permission
 }
 
 // AppInstallation represents a Github App Installation.
@@ -77,7 +77,7 @@ type AppInstallation struct {
 	// Permissions granted to this installation.
 	// These may differ from App permissions if the installation owner has not yet accepted
 	// the App's updated permissions on GitHub.
-	Permissions AppPermissions
+	Permissions Permissions
 }
 
 // InstallationToken represents a Github App Installation Access Token.
@@ -118,11 +118,11 @@ func (r *githubClient) GetApp(ctx context.Context) (App, error) {
 		ID:    app.GetID(),
 		Slug:  app.GetSlug(),
 		Owner: app.GetOwner().GetLogin(),
-		Permissions: AppPermissions{
-			Contents:     toAppPermission(app.GetPermissions().GetContents()),
-			Metadata:     toAppPermission(app.GetPermissions().GetMetadata()),
-			PullRequests: toAppPermission(app.GetPermissions().GetPullRequests()),
-			Webhooks:     toAppPermission(app.GetPermissions().GetRepositoryHooks()),
+		Permissions: Permissions{
+			Contents:     toPermission(app.GetPermissions().GetContents()),
+			Metadata:     toPermission(app.GetPermissions().GetMetadata()),
+			PullRequests: toPermission(app.GetPermissions().GetPullRequests()),
+			Webhooks:     toPermission(app.GetPermissions().GetRepositoryHooks()),
 		},
 	}, nil
 }
@@ -153,23 +153,23 @@ func (r *githubClient) GetAppInstallation(ctx context.Context, installationID st
 	return AppInstallation{
 		ID:      installation.GetID(),
 		Enabled: installation.GetSuspendedAt().IsZero(),
-		Permissions: AppPermissions{
-			Contents:     toAppPermission(installation.GetPermissions().GetContents()),
-			Metadata:     toAppPermission(installation.GetPermissions().GetMetadata()),
-			PullRequests: toAppPermission(installation.GetPermissions().GetPullRequests()),
-			Webhooks:     toAppPermission(installation.GetPermissions().GetRepositoryHooks()),
+		Permissions: Permissions{
+			Contents:     toPermission(installation.GetPermissions().GetContents()),
+			Metadata:     toPermission(installation.GetPermissions().GetMetadata()),
+			PullRequests: toPermission(installation.GetPermissions().GetPullRequests()),
+			Webhooks:     toPermission(installation.GetPermissions().GetRepositoryHooks()),
 		},
 	}, nil
 }
 
-func toAppPermission(permissions string) AppPermission {
+func toPermission(permissions string) Permission {
 	switch permissions {
 	case "read":
-		return AppPermissionRead
+		return PermissionRead
 	case "write":
-		return AppPermissionWrite
+		return PermissionWrite
 	default:
-		return AppPermissionNone
+		return PermissionNone
 	}
 }
 

--- a/apps/provisioning/pkg/connection/github/client.go
+++ b/apps/provisioning/pkg/connection/github/client.go
@@ -74,6 +74,10 @@ type AppInstallation struct {
 	ID int64
 	// Whether the installation is enabled or not.
 	Enabled bool
+	// Permissions granted to this installation.
+	// These may differ from App permissions if the installation owner has not yet accepted
+	// the App's updated permissions on GitHub.
+	Permissions AppPermissions
 }
 
 // InstallationToken represents a Github App Installation Access Token.
@@ -149,6 +153,12 @@ func (r *githubClient) GetAppInstallation(ctx context.Context, installationID st
 	return AppInstallation{
 		ID:      installation.GetID(),
 		Enabled: installation.GetSuspendedAt().IsZero(),
+		Permissions: AppPermissions{
+			Contents:     toAppPermission(installation.GetPermissions().GetContents()),
+			Metadata:     toAppPermission(installation.GetPermissions().GetMetadata()),
+			PullRequests: toAppPermission(installation.GetPermissions().GetPullRequests()),
+			Webhooks:     toAppPermission(installation.GetPermissions().GetRepositoryHooks()),
+		},
 	}, nil
 }
 

--- a/apps/provisioning/pkg/connection/github/client_test.go
+++ b/apps/provisioning/pkg/connection/github/client_test.go
@@ -53,11 +53,11 @@ func TestGithubClient_GetApp(t *testing.T) {
 				ID:    12345,
 				Slug:  "my-test-app",
 				Owner: "grafana",
-				Permissions: conngh.AppPermissions{
-					Contents:     conngh.AppPermissionWrite,
-					Metadata:     conngh.AppPermissionRead,
-					PullRequests: conngh.AppPermissionWrite,
-					Webhooks:     conngh.AppPermissionWrite,
+				Permissions: conngh.Permissions{
+					Contents:     conngh.PermissionWrite,
+					Metadata:     conngh.PermissionRead,
+					PullRequests: conngh.PermissionWrite,
+					Webhooks:     conngh.PermissionWrite,
 				},
 			},
 			wantErr: nil,
@@ -252,11 +252,11 @@ func TestGithubClient_GetAppInstallation(t *testing.T) {
 			wantInstallation: conngh.AppInstallation{
 				ID:      67890,
 				Enabled: true,
-				Permissions: conngh.AppPermissions{
-					Contents:     conngh.AppPermissionWrite,
-					Metadata:     conngh.AppPermissionRead,
-					PullRequests: conngh.AppPermissionWrite,
-					Webhooks:     conngh.AppPermissionWrite,
+				Permissions: conngh.Permissions{
+					Contents:     conngh.PermissionWrite,
+					Metadata:     conngh.PermissionRead,
+					PullRequests: conngh.PermissionWrite,
+					Webhooks:     conngh.PermissionWrite,
 				},
 			},
 			wantErr: false,
@@ -309,8 +309,8 @@ func TestGithubClient_GetAppInstallation(t *testing.T) {
 			wantInstallation: conngh.AppInstallation{
 				ID:      67890,
 				Enabled: true,
-				Permissions: conngh.AppPermissions{
-					Contents: conngh.AppPermissionRead,
+				Permissions: conngh.Permissions{
+					Contents: conngh.PermissionRead,
 				},
 			},
 			wantErr: false,

--- a/apps/provisioning/pkg/connection/github/client_test.go
+++ b/apps/provisioning/pkg/connection/github/client_test.go
@@ -252,6 +252,12 @@ func TestGithubClient_GetAppInstallation(t *testing.T) {
 			wantInstallation: conngh.AppInstallation{
 				ID:      67890,
 				Enabled: true,
+				Permissions: conngh.AppPermissions{
+					Contents:     conngh.AppPermissionWrite,
+					Metadata:     conngh.AppPermissionRead,
+					PullRequests: conngh.AppPermissionWrite,
+					Webhooks:     conngh.AppPermissionWrite,
+				},
 			},
 			wantErr: false,
 		},
@@ -303,6 +309,9 @@ func TestGithubClient_GetAppInstallation(t *testing.T) {
 			wantInstallation: conngh.AppInstallation{
 				ID:      67890,
 				Enabled: true,
+				Permissions: conngh.AppPermissions{
+					Contents: conngh.AppPermissionRead,
+				},
 			},
 			wantErr: false,
 		},

--- a/apps/provisioning/pkg/connection/github/connection_test.go
+++ b/apps/provisioning/pkg/connection/github/connection_test.go
@@ -985,9 +985,9 @@ func TestConnection_Test(t *testing.T) {
 			expectSuccess: false,
 			expectedErrors: []provisioning.ErrorDetails{
 				{
-					Type:   metav1.CauseTypeForbidden,
-					Field:  "spec.github.installationID",
-					Detail: "GitHub App installation lacks required 'contents' permission: requires 'write', has ''. Accept the updated permissions at https://github.com/settings/installations/456",
+					Type:     metav1.CauseTypeForbidden,
+					Field:    "spec.github.installationID",
+					Detail:   "GitHub App installation lacks required 'contents' permission: requires 'write', has ''. Accept the updated permissions at https://github.com/settings/installations/456",
 					BadValue: "456",
 				},
 			},
@@ -1035,9 +1035,9 @@ func TestConnection_Test(t *testing.T) {
 			expectSuccess: false,
 			expectedErrors: []provisioning.ErrorDetails{
 				{
-					Type:   metav1.CauseTypeForbidden,
-					Field:  "spec.github.installationID",
-					Detail: "GitHub App installation lacks required 'contents' permission: requires 'write', has 'read'. Accept the updated permissions at https://github.com/settings/installations/456",
+					Type:     metav1.CauseTypeForbidden,
+					Field:    "spec.github.installationID",
+					Detail:   "GitHub App installation lacks required 'contents' permission: requires 'write', has 'read'. Accept the updated permissions at https://github.com/settings/installations/456",
 					BadValue: "456",
 				},
 			},
@@ -1085,9 +1085,9 @@ func TestConnection_Test(t *testing.T) {
 			expectSuccess: false,
 			expectedErrors: []provisioning.ErrorDetails{
 				{
-					Type:   metav1.CauseTypeForbidden,
-					Field:  "spec.github.installationID",
-					Detail: "GitHub App installation lacks required 'metadata' permission: requires 'read', has ''. Accept the updated permissions at https://github.com/settings/installations/456",
+					Type:     metav1.CauseTypeForbidden,
+					Field:    "spec.github.installationID",
+					Detail:   "GitHub App installation lacks required 'metadata' permission: requires 'read', has ''. Accept the updated permissions at https://github.com/settings/installations/456",
 					BadValue: "456",
 				},
 			},
@@ -1135,9 +1135,9 @@ func TestConnection_Test(t *testing.T) {
 			expectSuccess: false,
 			expectedErrors: []provisioning.ErrorDetails{
 				{
-					Type:   metav1.CauseTypeForbidden,
-					Field:  "spec.github.installationID",
-					Detail: "GitHub App installation lacks required 'pull_requests' permission: requires 'write', has ''. Accept the updated permissions at https://github.com/settings/installations/456",
+					Type:     metav1.CauseTypeForbidden,
+					Field:    "spec.github.installationID",
+					Detail:   "GitHub App installation lacks required 'pull_requests' permission: requires 'write', has ''. Accept the updated permissions at https://github.com/settings/installations/456",
 					BadValue: "456",
 				},
 			},
@@ -1185,9 +1185,9 @@ func TestConnection_Test(t *testing.T) {
 			expectSuccess: false,
 			expectedErrors: []provisioning.ErrorDetails{
 				{
-					Type:   metav1.CauseTypeForbidden,
-					Field:  "spec.github.installationID",
-					Detail: "GitHub App installation lacks required 'webhooks' permission: requires 'write', has ''. Accept the updated permissions at https://github.com/settings/installations/456",
+					Type:     metav1.CauseTypeForbidden,
+					Field:    "spec.github.installationID",
+					Detail:   "GitHub App installation lacks required 'webhooks' permission: requires 'write', has ''. Accept the updated permissions at https://github.com/settings/installations/456",
 					BadValue: "456",
 				},
 			},

--- a/apps/provisioning/pkg/connection/github/connection_test.go
+++ b/apps/provisioning/pkg/connection/github/connection_test.go
@@ -182,21 +182,21 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 				mockClient.EXPECT().GetAppInstallation(mock.Anything, "456").Return(github.AppInstallation{
 					ID:      456,
 					Enabled: true,
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 			},
@@ -362,21 +362,21 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 				mockClient.EXPECT().GetAppInstallation(mock.Anything, "456").Return(github.AppInstallation{
 					ID:      456,
 					Enabled: true,
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 			},
@@ -567,11 +567,11 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionNone,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionNone,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 			},
@@ -607,11 +607,11 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionRead,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionRead,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 			},
@@ -647,11 +647,11 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionNone,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionNone,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 			},
@@ -687,11 +687,11 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionNone,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionNone,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 			},
@@ -727,11 +727,11 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionNone,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionNone,
 					},
 				}, nil)
 			},
@@ -767,11 +767,11 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionRead,
-						Metadata:     github.AppPermissionNone,
-						PullRequests: github.AppPermissionNone,
-						Webhooks:     github.AppPermissionNone,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionRead,
+						Metadata:     github.PermissionNone,
+						PullRequests: github.PermissionNone,
+						Webhooks:     github.PermissionNone,
 					},
 				}, nil)
 			},
@@ -799,11 +799,11 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 				mockClient.EXPECT().GetAppInstallation(mock.Anything, "456").Return(github.AppInstallation{}, github.ErrNotFound)
@@ -840,11 +840,11 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 				mockClient.EXPECT().GetAppInstallation(mock.Anything, "456").Return(github.AppInstallation{}, github.ErrAuthentication)
@@ -881,11 +881,11 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 				mockClient.EXPECT().GetAppInstallation(mock.Anything, "456").Return(github.AppInstallation{}, github.ErrServiceUnavailable)
@@ -922,11 +922,11 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 				mockClient.EXPECT().GetAppInstallation(mock.Anything, "456").Return(github.AppInstallation{}, errors.New("unexpected error"))
@@ -963,21 +963,21 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 				mockClient.EXPECT().GetAppInstallation(mock.Anything, "456").Return(github.AppInstallation{
 					ID:      456,
 					Enabled: true,
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionNone,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionNone,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 			},
@@ -988,6 +988,7 @@ func TestConnection_Test(t *testing.T) {
 					Type:   metav1.CauseTypeForbidden,
 					Field:  "spec.github.installationID",
 					Detail: "GitHub App installation lacks required 'contents' permission: requires 'write', has ''. Accept the updated permissions at https://github.com/settings/installations/456",
+					BadValue: "456",
 				},
 			},
 		},
@@ -1012,21 +1013,21 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 				mockClient.EXPECT().GetAppInstallation(mock.Anything, "456").Return(github.AppInstallation{
 					ID:      456,
 					Enabled: true,
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionRead,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionRead,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 			},
@@ -1037,6 +1038,7 @@ func TestConnection_Test(t *testing.T) {
 					Type:   metav1.CauseTypeForbidden,
 					Field:  "spec.github.installationID",
 					Detail: "GitHub App installation lacks required 'contents' permission: requires 'write', has 'read'. Accept the updated permissions at https://github.com/settings/installations/456",
+					BadValue: "456",
 				},
 			},
 		},
@@ -1061,21 +1063,21 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 				mockClient.EXPECT().GetAppInstallation(mock.Anything, "456").Return(github.AppInstallation{
 					ID:      456,
 					Enabled: true,
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionNone,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionNone,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 			},
@@ -1086,6 +1088,7 @@ func TestConnection_Test(t *testing.T) {
 					Type:   metav1.CauseTypeForbidden,
 					Field:  "spec.github.installationID",
 					Detail: "GitHub App installation lacks required 'metadata' permission: requires 'read', has ''. Accept the updated permissions at https://github.com/settings/installations/456",
+					BadValue: "456",
 				},
 			},
 		},
@@ -1110,21 +1113,21 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 				mockClient.EXPECT().GetAppInstallation(mock.Anything, "456").Return(github.AppInstallation{
 					ID:      456,
 					Enabled: true,
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionNone,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionNone,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 			},
@@ -1135,6 +1138,7 @@ func TestConnection_Test(t *testing.T) {
 					Type:   metav1.CauseTypeForbidden,
 					Field:  "spec.github.installationID",
 					Detail: "GitHub App installation lacks required 'pull_requests' permission: requires 'write', has ''. Accept the updated permissions at https://github.com/settings/installations/456",
+					BadValue: "456",
 				},
 			},
 		},
@@ -1159,21 +1163,21 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 				mockClient.EXPECT().GetAppInstallation(mock.Anything, "456").Return(github.AppInstallation{
 					ID:      456,
 					Enabled: true,
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionNone,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionNone,
 					},
 				}, nil)
 			},
@@ -1184,6 +1188,7 @@ func TestConnection_Test(t *testing.T) {
 					Type:   metav1.CauseTypeForbidden,
 					Field:  "spec.github.installationID",
 					Detail: "GitHub App installation lacks required 'webhooks' permission: requires 'write', has ''. Accept the updated permissions at https://github.com/settings/installations/456",
+					BadValue: "456",
 				},
 			},
 		},
@@ -1208,21 +1213,21 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionRead,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionRead,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 				mockClient.EXPECT().GetAppInstallation(mock.Anything, "456").Return(github.AppInstallation{
 					ID:      456,
 					Enabled: true,
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionRead,
-						Metadata:     github.AppPermissionNone,
-						PullRequests: github.AppPermissionNone,
-						Webhooks:     github.AppPermissionNone,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionRead,
+						Metadata:     github.PermissionNone,
+						PullRequests: github.PermissionNone,
+						Webhooks:     github.PermissionNone,
 					},
 				}, nil)
 			},
@@ -1250,21 +1255,21 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetApp(mock.Anything).Return(github.App{
 					ID:   123,
 					Slug: "test-app",
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionWrite,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionWrite,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 				mockClient.EXPECT().GetAppInstallation(mock.Anything, "456").Return(github.AppInstallation{
 					ID:      456,
 					Enabled: true,
-					Permissions: github.AppPermissions{
-						Contents:     github.AppPermissionWrite,
-						Metadata:     github.AppPermissionWrite,
-						PullRequests: github.AppPermissionWrite,
-						Webhooks:     github.AppPermissionWrite,
+					Permissions: github.Permissions{
+						Contents:     github.PermissionWrite,
+						Metadata:     github.PermissionWrite,
+						PullRequests: github.PermissionWrite,
+						Webhooks:     github.PermissionWrite,
 					},
 				}, nil)
 			},

--- a/apps/provisioning/pkg/connection/github/connection_test.go
+++ b/apps/provisioning/pkg/connection/github/connection_test.go
@@ -192,6 +192,12 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetAppInstallation(mock.Anything, "456").Return(github.AppInstallation{
 					ID:      456,
 					Enabled: true,
+					Permissions: github.AppPermissions{
+						Contents:     github.AppPermissionWrite,
+						Metadata:     github.AppPermissionRead,
+						PullRequests: github.AppPermissionWrite,
+						Webhooks:     github.AppPermissionWrite,
+					},
 				}, nil)
 			},
 			expectedCode:  http.StatusOK,
@@ -961,6 +967,12 @@ func TestConnection_Test(t *testing.T) {
 				mockClient.EXPECT().GetAppInstallation(mock.Anything, "456").Return(github.AppInstallation{
 					ID:      456,
 					Enabled: true,
+					Permissions: github.AppPermissions{
+						Contents:     github.AppPermissionWrite,
+						Metadata:     github.AppPermissionWrite,
+						PullRequests: github.AppPermissionWrite,
+						Webhooks:     github.AppPermissionWrite,
+					},
 				}, nil)
 			},
 			expectedCode:  http.StatusOK,

--- a/pkg/tests/apis/provisioning/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection_test.go
@@ -2553,7 +2553,7 @@ func createAppWithPermissions(id int64, permissions map[string]string) *github.A
 // createInstallationWithPermissions creates a GitHub installation with specific permissions
 func createAppInstallationWithPermissions(id int64, permissions map[string]string) *github.Installation {
 	installation := &github.Installation{
-		ID:   github.Ptr(id),
+		ID: github.Ptr(id),
 		Permissions: &github.InstallationPermissions{
 			Contents:        github.Ptr("write"),
 			Metadata:        github.Ptr("read"),

--- a/pkg/tests/apis/provisioning/health_test.go
+++ b/pkg/tests/apis/provisioning/health_test.go
@@ -300,7 +300,7 @@ func TestIntegrationProvisioning_ConnectionTestEndpointWithPermissions(t *testin
 
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(testPrivateKeyPEM))
 
-	t.Run("test endpoint returns 403 for insufficient permissions", func(t *testing.T) {
+	t.Run("dryRun call with App's insufficient permissions returns 403", func(t *testing.T) {
 		// Setup mock with insufficient permissions
 		connectionFactory := helper.GetEnv().GithubConnectionFactory.(*githubConnection.Factory)
 
@@ -386,7 +386,97 @@ func TestIntegrationProvisioning_ConnectionTestEndpointWithPermissions(t *testin
 		}
 	})
 
-	t.Run("test endpoint succeeds with all permissions", func(t *testing.T) {
+	t.Run("dryRun call with App Installation's insufficient permissions returns 403", func(t *testing.T) {
+		// Setup mock with insufficient permissions
+		connectionFactory := helper.GetEnv().GithubConnectionFactory.(*githubConnection.Factory)
+
+		app := createAppWithPermissions(123456, map[string]string{
+			// App has all permissions
+			"contents":      "write",
+			"metadata":      "read",
+			"pull_requests": "write",
+			"webhooks":      "write",
+		})
+		installation := createAppInstallationWithPermissions(454545, map[string]string{
+			"contents":      "read", // needs write
+			"metadata":      "read",
+			"pull_requests": "read", // needs write
+			"webhooks":      "read", // needs write
+		})
+
+		connectionFactory.Client = ghmock.NewMockedHTTPClient(
+			ghmock.WithRequestMatchHandler(
+				ghmock.GetApp,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(ghmock.MustMarshal(app))
+				}),
+			),
+			ghmock.WithRequestMatchHandler(
+				ghmock.GetAppInstallationsByInstallationId,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(ghmock.MustMarshal(installation))
+				}),
+			),
+		)
+		helper.SetGithubConnectionFactory(connectionFactory)
+
+		// Create connection config for test
+		config := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "provisioning.grafana.app/v0alpha1",
+				"kind":       "Connection",
+				"metadata": map[string]any{
+					"name": "test",
+				},
+				"spec": map[string]any{
+					"title": "Test Connection",
+					"type":  "github",
+					"github": map[string]any{
+						"appID":          "123456",
+						"installationID": "454545",
+					},
+				},
+				"secure": map[string]any{
+					"privateKey": map[string]any{
+						"create": privateKeyBase64,
+					},
+				},
+			},
+		}
+
+		// Create with dryRun - that would test the connection
+		c, err := helper.Connections.Resource.Create(ctx, config, metav1.CreateOptions{
+			DryRun: []string{"All"},
+		})
+		require.Error(t, err)
+		require.Nil(t, c)
+
+		var k8sErr *k8serrors.StatusError
+		require.True(t, errors.As(err, &k8sErr))
+
+		require.Equal(t, metav1.StatusReasonInvalid, k8sErr.Status().Reason)
+		require.NotNil(t, k8sErr.Status().Details)
+
+		for _, reason := range k8sErr.Status().Details.Causes {
+			require.Equal(t, metav1.CauseTypeFieldValueInvalid, reason.Type)
+			require.Equal(t, "spec.github.installationID", reason.Field)
+
+			switch {
+			case strings.Contains(reason.Message, "pull_requests"):
+				require.Contains(t, reason.Message, "requires 'write', has 'read'")
+			case strings.Contains(reason.Message, "webhooks"):
+				require.Contains(t, reason.Message, "requires 'write', has 'read'")
+			case strings.Contains(reason.Message, "contents"):
+				require.Contains(t, reason.Message, "requires 'write', has 'read'")
+			case strings.Contains(reason.Message, "metadata"):
+				t.Fatalf("should not error on metadata")
+			}
+		}
+	})
+
+	t.Run("dryRun call with App's and Installation's all permissions succeeds", func(t *testing.T) {
 		// Setup mock with all required permissions
 		connectionFactory := helper.GetEnv().GithubConnectionFactory.(*githubConnection.Factory)
 

--- a/pkg/tests/apis/provisioning/health_test.go
+++ b/pkg/tests/apis/provisioning/health_test.go
@@ -398,6 +398,12 @@ func TestIntegrationProvisioning_ConnectionTestEndpointWithPermissions(t *testin
 		})
 		installation := &github.Installation{
 			ID: github.Ptr(int64(454545)),
+			Permissions: &github.InstallationPermissions{
+				Contents:        github.Ptr("write"),
+				Metadata:        github.Ptr("read"),
+				PullRequests:    github.Ptr("write"),
+				RepositoryHooks: github.Ptr("write"),
+			},
 		}
 
 		connectionFactory.Client = ghmock.NewMockedHTTPClient(


### PR DESCRIPTION
**What is this feature?**

In `Connection` tester, adding a new check on GH app installation permissions, returning an error in case they don't match what we expect.

**Note**: This needs to be merged after https://github.com/grafana/grafana/pull/118500, which will make us able to also add the installationID in the invalid value.  

**Why do we need this feature?**

When a Github App permissions are changed, the owners of the installation need to confirm they want to propagate such changes in the installation itself.

This affect us when we fail creating/reconciling the `Connection` as not enough permissions are in the App, i.e.
- We let the user know they need to update the App permission;
- The user does that, but w/o updating the installation ones;
- The `Connection` is marked as healthy;
- `Repository` resources created via that `Connection` fail to reconcile, as the installation doesn't have the correct permissions.

To avoid that, the connection tester should also check the installation permissions, and let the user know they need to accept those in Github.

**Who is this feature for?**

Users of GitSync

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/916

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
