### PR TITLE
Alerting: Fix missing series evaluations to resolve not preserved when duplicating a rule

### DIFF
--- a/public/app/features/alerting/unified/rule-editor/formDefaults.test.ts
+++ b/public/app/features/alerting/unified/rule-editor/formDefaults.test.ts
@@ -571,4 +571,15 @@ describe('formValuesFromPrefill', () => {
     expect(query.model).not.toHaveProperty('expression');
     expect(query.model).not.toHaveProperty('queryType');
   });
+
+  it('should preserve missingSeriesEvalsToResolve when duplicating a rule', () => {
+    const prefillData = {
+      type: RuleFormType.grafana,
+      missingSeriesEvalsToResolve: 5,
+    };
+
+    const result = formValuesFromPrefill(prefillData);
+
+    expect(result.missingSeriesEvalsToResolve).toBe(5);
+  });
 });

--- a/public/app/features/plugins/components/restrictedGrafanaApis/alerting/alertRuleFormSchema.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/alerting/alertRuleFormSchema.ts
@@ -81,6 +81,12 @@ export const alertingAlertRuleFormSchema = z.object({
   evaluateFor: z.string().optional().describe('Evaluation duration'),
   keepFiringFor: z.string().optional().describe('Keep firing duration'),
   isPaused: z.boolean().optional().default(false).describe('Whether the rule is paused'),
+  missingSeriesEvalsToResolve: z
+    .number()
+    .optional()
+    .describe(
+      'Number of consecutive evaluation intervals a dimension must be missing before the alert instance is resolved'
+    ),
 
   // Manual routing and contact points
   manualRouting: z


### PR DESCRIPTION
**What is this feature?**

Fixes the "Missing series evaluations to resolve" setting being lost when duplicating an alert rule via the UI.

**Why do we need this feature?**

When a user clicks "Duplicate" on an alert rule that has a custom `missingSeriesEvalsToResolve` value, the cloned rule silently drops this setting. This PR fixes that.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
