### PR TITLE
Elasticsearch: Add variable query editor support

### DIFF
--- a/packages/grafana-schema/src/raw/composable/elasticsearch/dataquery/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/elasticsearch/dataquery/x/types.gen.ts
@@ -396,6 +396,13 @@ export interface ElasticsearchDataQuery extends common.DataQuery {
    */
   editorType?: string;
   /**
+   * Metadata for variable queries
+   */
+  meta?: {
+    textField?: string;
+    valueField?: string;
+  };
+  /**
    * List of metric aggregations
    */
   metrics?: Array<MetricAggregation>;

--- a/pkg/tsdb/elasticsearch/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/elasticsearch/kinds/dataquery/types_dataquery_gen.go
@@ -800,6 +800,8 @@ type ElasticsearchDataQuery struct {
 	BucketAggs []BucketAggregation `json:"bucketAggs,omitempty"`
 	// List of metric aggregations
 	Metrics []MetricAggregation `json:"metrics,omitempty"`
+	// Metadata for variable queries
+	Meta *DataqueryElasticsearchDataQueryMeta `json:"meta,omitempty"`
 	// For mixed data sources the selected datasource is on the query level.
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
@@ -1090,6 +1092,16 @@ type DataqueryMovingAverageHoltWintersModelSettingsSettings struct {
 // NewDataqueryMovingAverageHoltWintersModelSettingsSettings creates a new DataqueryMovingAverageHoltWintersModelSettingsSettings object.
 func NewDataqueryMovingAverageHoltWintersModelSettingsSettings() *DataqueryMovingAverageHoltWintersModelSettingsSettings {
 	return &DataqueryMovingAverageHoltWintersModelSettingsSettings{}
+}
+
+type DataqueryElasticsearchDataQueryMeta struct {
+	TextField  *string `json:"textField,omitempty"`
+	ValueField *string `json:"valueField,omitempty"`
+}
+
+// NewDataqueryElasticsearchDataQueryMeta creates a new DataqueryElasticsearchDataQueryMeta object.
+func NewDataqueryElasticsearchDataQueryMeta() *DataqueryElasticsearchDataQueryMeta {
+	return &DataqueryElasticsearchDataQueryMeta{}
 }
 
 type DateHistogramOrHistogramOrTermsOrFiltersOrGeoHashGridOrNested struct {

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.test.tsx
@@ -67,20 +67,6 @@ describe('ElasticsearchVariableEditor', () => {
     });
   });
 
-  it('should call onChange when text field is selected', async () => {
-    const onChange = jest.fn();
-    const props = { ...defaultProps, onChange };
-
-    render(<ElasticsearchVariableEditor {...props} />);
-
-    await waitFor(() => {
-      expect(defaultProps.datasource.query).toHaveBeenCalled();
-    });
-
-    // Note: Testing Combobox interactions would require more complex setup
-    // This is a basic structure that can be expanded with more detailed interaction tests
-  });
-
   it('should preserve existing meta values', () => {
     const queryWithMeta: ElasticsearchDataQuery = {
       ...defaultProps.query,
@@ -90,19 +76,19 @@ describe('ElasticsearchVariableEditor', () => {
       },
     };
 
-    const props = { ...defaultProps, query: queryWithMeta };
-    render(<ElasticsearchVariableEditor {...props} />);
+    render(<ElasticsearchVariableEditor {...{ ...defaultProps, query: queryWithMeta }} />);
 
-    expect(screen.getByTestId('query-editor')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('name')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('id')).toBeInTheDocument();
   });
 
   it('should migrate string query to object query', () => {
     const stringQuery = 'test string query' as unknown as ElasticsearchDataQuery;
-    const props = { ...defaultProps, query: stringQuery };
 
-    render(<ElasticsearchVariableEditor {...props} />);
+    render(<ElasticsearchVariableEditor {...{ ...defaultProps, query: stringQuery }} />);
 
-    expect(screen.getByTestId('query-editor')).toBeInTheDocument();
+    // migrateVariableQuery should have converted the string into an object query
+    expect(screen.getByText('Query: test string query')).toBeInTheDocument();
   });
 
   it('should handle query errors gracefully', async () => {

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.test.tsx
@@ -1,0 +1,176 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { of } from 'rxjs';
+
+import { dateTime, FieldType } from '@grafana/data';
+
+import { ElasticsearchVariableEditor } from './ElasticsearchVariableEditor';
+import { ElasticQueryEditorProps } from './components/QueryEditor';
+import { ElasticsearchDataQuery } from './dataquery.gen';
+import { ElasticDatasource } from './datasource';
+
+jest.mock('./components/QueryEditor', () => ({
+  QueryEditor: jest.fn(({ query }) => <div data-testid="query-editor">Query: {query.query}</div>),
+  ElasticQueryEditorProps: {},
+}));
+
+describe('ElasticsearchVariableEditor', () => {
+  const defaultProps: ElasticQueryEditorProps = {
+    query: {
+      refId: 'A',
+      query: 'test query',
+      metrics: [{ type: 'raw_document', id: '1' }],
+    },
+    onChange: jest.fn(),
+    onRunQuery: jest.fn(),
+    datasource: {
+      query: jest.fn().mockReturnValue(
+        of({
+          data: [
+            {
+              fields: [
+                { name: 'id', type: FieldType.number, config: {}, values: [1, 2] },
+                { name: 'name', type: FieldType.string, config: {}, values: ['a', 'b'] },
+                { name: 'status', type: FieldType.string, config: {}, values: ['active', 'inactive'] },
+              ],
+            },
+          ],
+        })
+      ),
+    } as unknown as ElasticDatasource,
+    data: undefined,
+    range: {
+      from: dateTime('2021-01-01'),
+      to: dateTime('2021-01-02'),
+      raw: { from: 'now-1h', to: 'now' },
+    },
+  };
+
+  it('should render query editor', () => {
+    render(<ElasticsearchVariableEditor {...defaultProps} />);
+
+    expect(screen.getByTestId('query-editor')).toBeInTheDocument();
+    expect(screen.getByText('Query: test query')).toBeInTheDocument();
+  });
+
+  it('should render field mapping selectors', () => {
+    render(<ElasticsearchVariableEditor {...defaultProps} />);
+
+    expect(screen.getByText('Value Field')).toBeInTheDocument();
+    expect(screen.getByText('Text Field')).toBeInTheDocument();
+  });
+
+  it('should populate field choices from query results', async () => {
+    render(<ElasticsearchVariableEditor {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(defaultProps.datasource.query).toHaveBeenCalled();
+    });
+  });
+
+  it('should call onChange when text field is selected', async () => {
+    const onChange = jest.fn();
+    const props = { ...defaultProps, onChange };
+
+    render(<ElasticsearchVariableEditor {...props} />);
+
+    await waitFor(() => {
+      expect(defaultProps.datasource.query).toHaveBeenCalled();
+    });
+
+    // Note: Testing Combobox interactions would require more complex setup
+    // This is a basic structure that can be expanded with more detailed interaction tests
+  });
+
+  it('should preserve existing meta values', () => {
+    const queryWithMeta: ElasticsearchDataQuery = {
+      ...defaultProps.query,
+      meta: {
+        textField: 'name',
+        valueField: 'id',
+      },
+    };
+
+    const props = { ...defaultProps, query: queryWithMeta };
+    render(<ElasticsearchVariableEditor {...props} />);
+
+    expect(screen.getByTestId('query-editor')).toBeInTheDocument();
+  });
+
+  it('should migrate string query to object query', () => {
+    const stringQuery = 'test string query' as unknown as ElasticsearchDataQuery;
+    const props = { ...defaultProps, query: stringQuery };
+
+    render(<ElasticsearchVariableEditor {...props} />);
+
+    expect(screen.getByTestId('query-editor')).toBeInTheDocument();
+  });
+
+  it('should handle query errors gracefully', async () => {
+    // Mock console.error to suppress error output in tests
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const errorObservable = {
+      subscribe: (observer: { error: (err: Error) => void }) => {
+        setTimeout(() => {
+          if (observer.error) {
+            observer.error(new Error('Query failed'));
+          }
+        }, 0);
+        return { unsubscribe: jest.fn() };
+      },
+    };
+
+    const datasourceWithError = {
+      ...defaultProps.datasource,
+      query: jest.fn().mockReturnValue(errorObservable),
+    } as unknown as ElasticDatasource;
+
+    const props = { ...defaultProps, datasource: datasourceWithError };
+
+    // Should not throw error when rendering
+    expect(() => render(<ElasticsearchVariableEditor {...props} />)).not.toThrow();
+
+    // Wait for the error to be handled
+    await waitFor(() => {
+      expect(datasourceWithError.query).toHaveBeenCalled();
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should update query only when query content changes, not meta', () => {
+    const { rerender } = render(<ElasticsearchVariableEditor {...defaultProps} />);
+
+    const initialCallCount = (defaultProps.datasource.query as jest.Mock).mock.calls.length;
+
+    // Update meta field only
+    const queryWithMeta: ElasticsearchDataQuery = {
+      ...defaultProps.query,
+      meta: {
+        textField: 'name',
+      },
+    };
+
+    rerender(<ElasticsearchVariableEditor {...defaultProps} query={queryWithMeta} />);
+
+    // Should not trigger new query since only meta changed
+    expect((defaultProps.datasource.query as jest.Mock).mock.calls.length).toBe(initialCallCount);
+  });
+
+  it('should trigger new query when query content changes', () => {
+    const { rerender } = render(<ElasticsearchVariableEditor {...defaultProps} />);
+
+    const initialCallCount = (defaultProps.datasource.query as jest.Mock).mock.calls.length;
+
+    // Update query content
+    const updatedQuery: ElasticsearchDataQuery = {
+      ...defaultProps.query,
+      query: 'updated query',
+    };
+
+    rerender(<ElasticsearchVariableEditor {...defaultProps} query={updatedQuery} />);
+
+    // Should trigger new query since query content changed
+    expect((defaultProps.datasource.query as jest.Mock).mock.calls.length).toBeGreaterThan(initialCallCount);
+  });
+});

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.test.tsx
@@ -1,10 +1,10 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { of } from 'rxjs';
 
 import { dateTime, FieldType } from '@grafana/data';
 
 import { ElasticsearchVariableEditor } from './ElasticsearchVariableEditor';
-import { ElasticQueryEditorProps } from './components/QueryEditor';
+import { ElasticQueryEditorProps, QueryEditor } from './components/QueryEditor';
 import { ElasticsearchDataQuery } from './dataquery.gen';
 import { ElasticDatasource } from './datasource';
 
@@ -175,24 +175,53 @@ describe('ElasticsearchVariableEditor', () => {
     expect((defaultProps.datasource.query as jest.Mock).mock.calls.length).toBeGreaterThan(initialCallCount);
   });
 
-  it('should reset meta fields when queryType changes', async () => {
+  it('should reset meta fields when QueryEditor fires onChange with a new queryType', () => {
     const onChange = jest.fn();
     const queryWithMeta: ElasticsearchDataQuery = {
       ...defaultProps.query,
       queryType: 'lucene',
       meta: { textField: 'name', valueField: 'id' },
     };
-    const props = { ...defaultProps, query: queryWithMeta, onChange };
 
-    const { rerender } = render(<ElasticsearchVariableEditor {...props} />);
+    render(<ElasticsearchVariableEditor {...{ ...defaultProps, query: queryWithMeta, onChange }} />);
 
-    const updatedQuery: ElasticsearchDataQuery = { ...queryWithMeta, queryType: 'dsl' };
-    rerender(<ElasticsearchVariableEditor {...props} query={updatedQuery} />);
+    const queryEditorOnChange = (QueryEditor as jest.Mock).mock.calls.at(-1)[0].onChange;
+    act(() => queryEditorOnChange({ ...queryWithMeta, queryType: 'dsl' }));
 
-    await waitFor(() => {
-      const calls = onChange.mock.calls;
-      const resetCall = calls.find((call) => call[0].meta && Object.keys(call[0].meta).length === 0);
-      expect(resetCall).toBeDefined();
-    });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ queryType: 'dsl', meta: {} }));
+  });
+
+  it('should reset meta fields when the metric type tab changes', () => {
+    const onChange = jest.fn();
+    const queryWithMeta: ElasticsearchDataQuery = {
+      ...defaultProps.query,
+      metrics: [{ type: 'raw_document', id: '1' }],
+      meta: { textField: 'name', valueField: 'id' },
+    };
+
+    render(<ElasticsearchVariableEditor {...{ ...defaultProps, query: queryWithMeta, onChange }} />);
+
+    // Simulate the user clicking the Metrics tab inside QueryEditor
+    const queryEditorOnChange = (QueryEditor as jest.Mock).mock.calls.at(-1)[0].onChange;
+    act(() => queryEditorOnChange({ ...queryWithMeta, metrics: [{ type: 'count', id: '1' }] }));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ meta: {} }));
+  });
+
+  it('should not reset meta fields when only the query string changes', () => {
+    const onChange = jest.fn();
+    const queryWithMeta: ElasticsearchDataQuery = {
+      ...defaultProps.query,
+      meta: { textField: 'name', valueField: 'id' },
+    };
+
+    render(<ElasticsearchVariableEditor {...{ ...defaultProps, query: queryWithMeta, onChange }} />);
+
+    const queryEditorOnChange = (QueryEditor as jest.Mock).mock.calls.at(-1)[0].onChange;
+    act(() => queryEditorOnChange({ ...queryWithMeta, query: 'updated lucene query' }));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'updated lucene query', meta: { textField: 'name', valueField: 'id' } })
+    );
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.tsx
@@ -37,9 +37,19 @@ const FieldMapping = (props: FieldMappingProps) => {
 
   // Only re-run the query when the query content changes, not when meta (valueField/textField) changes
   const queryKey = useMemo(
-    () => JSON.stringify({ query: query.query, metrics: query.metrics, bucketAggs: query.bucketAggs }),
-    [query.query, query.metrics, query.bucketAggs]
+    () => JSON.stringify({ query: query.query, metrics: query.metrics, bucketAggs: query.bucketAggs, queryType: query.queryType }),
+    [query.query, query.metrics, query.bucketAggs, query.queryType]
   );
+
+  // Reset field mappings when the query type changes — the available fields may be completely different
+  const prevQueryTypeRef = useRef(query.queryType);
+  useEffect(() => {
+    const prevQueryType = prevQueryTypeRef.current;
+    prevQueryTypeRef.current = query.queryType;
+    if (prevQueryType !== undefined && prevQueryType !== query.queryType) {
+      onChange({ ...queryRef.current, meta: {} });
+    }
+  }, [query.queryType, onChange]);
 
   useEffect(() => {
     let isActive = true;

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { DataQueryRequest, dateTime, Field } from '@grafana/data';
+import { EditorRows, EditorRow, EditorField } from '@grafana/plugin-ui';
+import { Combobox, ComboboxOption } from '@grafana/ui';
+
+import { ElasticsearchVariableQuery, migrateVariableQuery, refId } from './ElasticsearchVariableUtils';
+import { ElasticQueryEditorProps, QueryEditor } from './components/QueryEditor';
+import { ElasticsearchDataQuery } from './dataquery.gen';
+
+type ElasticsearchVariableQueryEditorProps = ElasticQueryEditorProps;
+
+export const ElasticsearchVariableEditor = (props: ElasticsearchVariableQueryEditorProps) => {
+  const query = useMemo(() => migrateVariableQuery(props.query), [props.query]);
+
+  return (
+    <>
+      <QueryEditor {...props} query={query} />
+      <FieldMapping datasource={props.datasource} query={query} onChange={props.onChange} />
+    </>
+  );
+};
+
+interface FieldMappingProps {
+  datasource: ElasticsearchVariableQueryEditorProps['datasource'];
+  query: ElasticsearchVariableQuery;
+  onChange: ElasticsearchVariableQueryEditorProps['onChange'];
+}
+
+const FieldMapping = (props: FieldMappingProps) => {
+  const { query, datasource, onChange } = props;
+  const [choices, setChoices] = useState<ComboboxOption[]>([]);
+
+  // Track the actual query content to avoid re-querying when only meta changes
+  const queryRef = useRef(query);
+  queryRef.current = query;
+
+  // Only re-run the query when the query content changes, not when meta (valueField/textField) changes
+  const queryKey = useMemo(
+    () => JSON.stringify({ query: query.query, metrics: query.metrics, bucketAggs: query.bucketAggs }),
+    [query.query, query.metrics, query.bucketAggs]
+  );
+
+  useEffect(() => {
+    let isActive = true;
+    const request: DataQueryRequest<ElasticsearchDataQuery> = {
+      targets: [queryRef.current],
+      requestId: 'variable-field-fetch',
+      interval: '1s',
+      intervalMs: 1000,
+      range: {
+        from: dateTime(Date.now() - 3600000),
+        to: dateTime(Date.now()),
+        raw: { from: 'now-1h', to: 'now' },
+      },
+      scopedVars: {},
+      timezone: 'browser',
+      app: 'dashboard',
+      startTime: Date.now(),
+    };
+    const subscription = datasource.query(request).subscribe({
+      next: (response) => {
+        if (!isActive) {
+          return;
+        }
+        const fieldNames = (response.data[0] || { fields: [] }).fields
+          .filter((f: Field) => f.name !== refId)
+          .map((f: Field) => f.name);
+        setChoices(fieldNames.map((f: string) => ({ value: f, label: f })));
+      },
+      error: () => {
+        if (isActive) {
+          setChoices([]);
+        }
+      },
+    });
+    return () => {
+      isActive = false;
+      subscription.unsubscribe();
+    };
+  }, [datasource, queryKey]);
+
+  const onMetaPropChange = (key: 'textField' | 'valueField', value: string | undefined) => {
+    const meta = query.meta || {};
+    onChange({ ...query, meta: { ...meta, [key]: value } });
+  };
+
+  return (
+    <EditorRows>
+      <EditorRow>
+        <EditorField label="Value Field">
+          <Combobox
+            isClearable
+            createCustomValue
+            value={query.meta?.valueField}
+            onChange={(e) => onMetaPropChange('valueField', e?.value)}
+            width={40}
+            options={choices}
+          />
+        </EditorField>
+        <EditorField label="Text Field">
+          <Combobox
+            isClearable
+            createCustomValue
+            value={query.meta?.textField}
+            onChange={(e) => onMetaPropChange('textField', e?.value)}
+            width={40}
+            options={choices}
+          />
+        </EditorField>
+      </EditorRow>
+    </EditorRows>
+  );
+};

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.tsx
@@ -13,9 +13,22 @@ type ElasticsearchVariableQueryEditorProps = ElasticQueryEditorProps;
 export const ElasticsearchVariableEditor = (props: ElasticsearchVariableQueryEditorProps) => {
   const query = useMemo(() => migrateVariableQuery(props.query), [props.query]);
 
+  const handleQueryChange = (newQuery: ElasticsearchDataQuery) => {
+    // Clear field mapping when the query structure changes significantly — the available fields
+    // may be completely different (e.g. switching between Raw Document and Metrics tabs, or
+    // switching between Lucene and DSL query types).
+    const metricTypeChanged = newQuery.metrics?.[0]?.type !== query.metrics?.[0]?.type;
+    const queryTypeChanged = newQuery.queryType !== query.queryType;
+    if (metricTypeChanged || queryTypeChanged) {
+      props.onChange({ ...newQuery, meta: {} });
+    } else {
+      props.onChange(newQuery);
+    }
+  };
+
   return (
     <>
-      <QueryEditor {...props} query={query} />
+      <QueryEditor {...props} query={query} onChange={handleQueryChange} />
       <FieldMapping datasource={props.datasource} query={query} onChange={props.onChange} />
     </>
   );
@@ -46,16 +59,6 @@ const FieldMapping = (props: FieldMappingProps) => {
       }),
     [query.query, query.metrics, query.bucketAggs, query.queryType]
   );
-
-  // Reset field mappings when the query type changes — the available fields may be completely different
-  const prevQueryTypeRef = useRef(query.queryType);
-  useEffect(() => {
-    const prevQueryType = prevQueryTypeRef.current;
-    prevQueryTypeRef.current = query.queryType;
-    if (prevQueryType !== undefined && prevQueryType !== query.queryType) {
-      onChange({ ...queryRef.current, meta: {} });
-    }
-  }, [query.queryType, onChange]);
 
   useEffect(() => {
     let isActive = true;

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.test.ts
@@ -1,0 +1,209 @@
+import { of } from 'rxjs';
+
+import { DataQueryRequest, DataQueryResponse, dateTime, FieldType } from '@grafana/data';
+
+import { ElasticsearchVariableSupport } from './ElasticsearchVariableSupport';
+import { ElasticsearchDataQuery } from './dataquery.gen';
+import { ElasticDatasource } from './datasource';
+
+jest.mock('./datasource');
+
+describe('ElasticsearchVariableSupport', () => {
+  let variableSupport: ElasticsearchVariableSupport;
+  let mockDatasource: jest.Mocked<ElasticDatasource>;
+
+  beforeEach(() => {
+    mockDatasource = {
+      query: jest.fn(),
+    } as unknown as jest.Mocked<ElasticDatasource>;
+
+    variableSupport = new ElasticsearchVariableSupport(mockDatasource);
+  });
+
+  describe('getDefaultQuery', () => {
+    it('should return default query with correct structure', () => {
+      const defaultQuery = variableSupport.getDefaultQuery();
+
+      expect(defaultQuery).toEqual({
+        refId: 'ElasticsearchVariableQueryEditor-VariableQuery',
+        query: '',
+        metrics: [{ type: 'raw_document', id: '1' }],
+      });
+    });
+  });
+
+  describe('query', () => {
+    it('should throw error when no targets provided', async () => {
+      const request: DataQueryRequest<ElasticsearchDataQuery> = {
+        targets: [],
+        requestId: 'test',
+        interval: '1s',
+        intervalMs: 1000,
+        range: {
+          from: dateTime(),
+          to: dateTime(),
+          raw: { from: 'now-1h', to: 'now' },
+        },
+        scopedVars: {},
+        timezone: 'browser',
+        app: 'dashboard',
+        startTime: Date.now(),
+      };
+
+      await expect(
+        new Promise((resolve, reject) => {
+          variableSupport.query(request).subscribe({
+            next: resolve,
+            error: reject,
+          });
+        })
+      ).rejects.toThrow('no variable query found');
+    });
+
+    it('should migrate query and return transformed data', (done) => {
+      const mockResponse: DataQueryResponse = {
+        data: [
+          {
+            name: 'test',
+            refId: 'A',
+            length: 2,
+            fields: [
+              { name: 'id', type: FieldType.number, config: {}, values: [1, 2] },
+              { name: 'name', type: FieldType.string, config: {}, values: ['a', 'b'] },
+            ],
+          },
+        ],
+      };
+
+      mockDatasource.query.mockReturnValue(of(mockResponse));
+
+      const request: DataQueryRequest<ElasticsearchDataQuery> = {
+        targets: [
+          {
+            refId: 'A',
+            query: 'test',
+            meta: {
+              textField: 'name',
+              valueField: 'id',
+            },
+          },
+        ],
+        requestId: 'test',
+        interval: '1s',
+        intervalMs: 1000,
+        range: {
+          from: dateTime(),
+          to: dateTime(),
+          raw: { from: 'now-1h', to: 'now' },
+        },
+        scopedVars: {},
+        timezone: 'browser',
+        app: 'dashboard',
+        startTime: Date.now(),
+      };
+
+      variableSupport.query(request).subscribe({
+        next: (response) => {
+          expect(response.data).toHaveLength(1);
+          expect(response.data[0].fields.length).toBeGreaterThanOrEqual(2);
+          expect(response.data[0].fields[0].name).toBe('text');
+          expect(response.data[0].fields[0].values).toEqual(['a', 'b']);
+          expect(response.data[0].fields[1].name).toBe('value');
+          expect(response.data[0].fields[1].values).toEqual([1, 2]);
+          done();
+        },
+        error: done,
+      });
+    });
+
+    it('should handle string query migration', (done) => {
+      const mockResponse: DataQueryResponse = {
+        data: [
+          {
+            name: 'test',
+            refId: 'A',
+            length: 1,
+            fields: [{ name: 'field', type: FieldType.string, config: {}, values: ['value'] }],
+          },
+        ],
+      };
+
+      mockDatasource.query.mockReturnValue(of(mockResponse));
+
+      const request: DataQueryRequest<ElasticsearchDataQuery> = {
+        targets: ['test query' as unknown as ElasticsearchDataQuery],
+        requestId: 'test',
+        interval: '1s',
+        intervalMs: 1000,
+        range: {
+          from: dateTime(),
+          to: dateTime(),
+          raw: { from: 'now-1h', to: 'now' },
+        },
+        scopedVars: {},
+        timezone: 'browser',
+        app: 'dashboard',
+        startTime: Date.now(),
+      };
+
+      variableSupport.query(request).subscribe({
+        next: (response) => {
+          expect(mockDatasource.query).toHaveBeenCalled();
+          const calledRequest = mockDatasource.query.mock.calls[0][0];
+          expect(calledRequest.targets[0].query).toBe('test query');
+          expect(calledRequest.targets[0].metrics).toEqual([{ type: 'raw_document', id: '1' }]);
+          done();
+        },
+        error: done,
+      });
+    });
+
+    it('should handle meta field transformation', (done) => {
+      const mockResponse: DataQueryResponse = {
+        data: [
+          {
+            name: 'test',
+            refId: 'A',
+            length: 2,
+            fields: [
+              { name: '__text', type: FieldType.string, config: {}, values: ['text1', 'text2'] },
+              { name: '__value', type: FieldType.string, config: {}, values: ['val1', 'val2'] },
+            ],
+          },
+        ],
+      };
+
+      mockDatasource.query.mockReturnValue(of(mockResponse));
+
+      const request: DataQueryRequest<ElasticsearchDataQuery> = {
+        targets: [
+          {
+            refId: 'A',
+            query: 'test',
+          },
+        ],
+        requestId: 'test',
+        interval: '1s',
+        intervalMs: 1000,
+        range: {
+          from: dateTime(),
+          to: dateTime(),
+          raw: { from: 'now-1h', to: 'now' },
+        },
+        scopedVars: {},
+        timezone: 'browser',
+        app: 'dashboard',
+        startTime: Date.now(),
+      };
+
+      variableSupport.query(request).subscribe({
+        next: (response) => {
+          expect(response.data[0].fields[0].name).toBe('text');
+          expect(response.data[0].fields[1].name).toBe('value');
+          done();
+        },
+        error: done,
+      });
+    });
+  });
+});

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.test.ts
@@ -9,7 +9,7 @@ import { ElasticDatasource } from './datasource';
 jest.mock('./datasource');
 
 describe('ElasticsearchVariableSupport', () => {
-  let variableSupport: ElasticsearchVariableSupport;
+  let variableSupport: ElasticsearchVariableSupport<jest.Mocked<ElasticDatasource>>;
   let mockDatasource: jest.Mocked<ElasticDatasource>;
 
   beforeEach(() => {
@@ -17,7 +17,7 @@ describe('ElasticsearchVariableSupport', () => {
       query: jest.fn(),
     } as unknown as jest.Mocked<ElasticDatasource>;
 
-    variableSupport = new ElasticsearchVariableSupport(mockDatasource);
+    variableSupport = new ElasticsearchVariableSupport(mockDatasource, jest.fn());
   });
 
   describe('getDefaultQuery', () => {

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.ts
@@ -1,0 +1,40 @@
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { CustomVariableSupport, DataQueryRequest, DataQueryResponse, DataFrame } from '@grafana/data';
+
+import { ElasticsearchVariableEditor } from './ElasticsearchVariableEditor';
+import { migrateVariableQuery, updateFrame, refId } from './ElasticsearchVariableUtils';
+import { ElasticsearchDataQuery } from './dataquery.gen';
+import { ElasticDatasource } from './datasource';
+
+export class ElasticsearchVariableSupport extends CustomVariableSupport<ElasticDatasource, ElasticsearchDataQuery> {
+  constructor(readonly datasource: ElasticDatasource) {
+    super();
+  }
+
+  editor = ElasticsearchVariableEditor;
+
+  query(request: DataQueryRequest<ElasticsearchDataQuery>): Observable<DataQueryResponse> {
+    if (request.targets.length < 1) {
+      throw new Error('no variable query found');
+    }
+    const updatedQuery = migrateVariableQuery(request.targets[0]);
+    return this.datasource.query({ ...request, targets: [updatedQuery] }).pipe(
+      map((d: DataQueryResponse) => {
+        return {
+          ...d,
+          data: (d.data || []).map((frame: DataFrame) => updateFrame(frame, updatedQuery.meta)),
+        };
+      })
+    );
+  }
+
+  getDefaultQuery(): Partial<ElasticsearchDataQuery> {
+    return {
+      refId,
+      query: '',
+      metrics: [{ type: 'raw_document', id: '1' }],
+    };
+  }
+}

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.ts
@@ -1,26 +1,36 @@
-import { Observable } from 'rxjs';
+import { ComponentType } from 'react';
+import { from, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { CustomVariableSupport, DataQueryRequest, DataQueryResponse, DataFrame } from '@grafana/data';
+import {
+  CustomVariableSupport,
+  DataQueryRequest,
+  DataQueryResponse,
+  DataFrame,
+  DataSourceApi,
+  QueryEditorProps,
+} from '@grafana/data';
 
-import { ElasticsearchVariableEditor } from './ElasticsearchVariableEditor';
 import { migrateVariableQuery, updateFrame, refId } from './ElasticsearchVariableUtils';
 import { ElasticsearchDataQuery } from './dataquery.gen';
-import { ElasticDatasource } from './datasource';
+import { ElasticsearchOptions } from './types';
 
-export class ElasticsearchVariableSupport extends CustomVariableSupport<ElasticDatasource, ElasticsearchDataQuery> {
-  constructor(readonly datasource: ElasticDatasource) {
+export class ElasticsearchVariableSupport<
+  DS extends DataSourceApi<ElasticsearchDataQuery, ElasticsearchOptions>,
+> extends CustomVariableSupport<DS, ElasticsearchDataQuery, ElasticsearchDataQuery, ElasticsearchOptions> {
+  constructor(
+    readonly datasource: DS,
+    public editor: ComponentType<QueryEditorProps<DS, ElasticsearchDataQuery, ElasticsearchOptions>>
+  ) {
     super();
   }
-
-  editor = ElasticsearchVariableEditor;
 
   query(request: DataQueryRequest<ElasticsearchDataQuery>): Observable<DataQueryResponse> {
     if (request.targets.length < 1) {
       throw new Error('no variable query found');
     }
     const updatedQuery = migrateVariableQuery(request.targets[0]);
-    return this.datasource.query({ ...request, targets: [updatedQuery] }).pipe(
+    return from(this.datasource.query({ ...request, targets: [updatedQuery] })).pipe(
       map((d: DataQueryResponse) => {
         return {
           ...d,

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableUtils.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableUtils.test.ts
@@ -171,7 +171,7 @@ describe('ElasticsearchVariableUtils', () => {
       expect(result[0].values).toEqual(['a', 'b', 'c']);
     });
 
-    it('should deduplicate values in fallback', () => {
+    it('should preserve duplicate values in fallback (deduplication is left to Grafana core)', () => {
       const fields = [
         { name: 'field1', type: FieldType.string, config: {}, values: ['a', 'b', 'a'] },
         { name: 'field2', type: FieldType.string, config: {}, values: ['b', 'c'] },
@@ -179,7 +179,7 @@ describe('ElasticsearchVariableUtils', () => {
 
       const result = convertFieldsToVariableFields(fields);
 
-      expect(result[0].values).toEqual(['a', 'b', 'c']);
+      expect(result[0].values).toEqual(['a', 'b', 'a', 'b', 'c']);
     });
   });
 

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableUtils.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableUtils.test.ts
@@ -1,0 +1,220 @@
+import { FieldType } from '@grafana/data';
+
+import { convertFieldsToVariableFields, migrateVariableQuery, refId, updateFrame } from './ElasticsearchVariableUtils';
+import { ElasticsearchDataQuery } from './dataquery.gen';
+
+describe('ElasticsearchVariableUtils', () => {
+  describe('migrateVariableQuery', () => {
+    it('should migrate string query to variable query', () => {
+      const result = migrateVariableQuery('test query');
+
+      expect(result).toEqual({
+        refId,
+        query: 'test query',
+        metrics: [{ type: 'raw_document', id: '1' }],
+      });
+    });
+
+    it('should migrate ElasticsearchDataQuery with refId', () => {
+      const query: ElasticsearchDataQuery = {
+        refId: 'A',
+        query: 'test',
+        metrics: [{ type: 'count', id: '1' }],
+      };
+
+      const result = migrateVariableQuery(query);
+
+      expect(result).toEqual({
+        ...query,
+        refId: 'A',
+        query: 'test',
+        meta: undefined,
+      });
+    });
+
+    it('should use default refId when not provided', () => {
+      const query: ElasticsearchDataQuery = {
+        refId: '',
+        query: 'test',
+      };
+
+      const result = migrateVariableQuery(query);
+
+      expect(result.refId).toBe(refId);
+    });
+
+    it('should preserve meta field', () => {
+      const query: ElasticsearchDataQuery = {
+        refId: 'A',
+        query: 'test',
+        meta: {
+          textField: 'name',
+          valueField: 'id',
+        },
+      };
+
+      const result = migrateVariableQuery(query);
+
+      expect(result.meta).toEqual({
+        textField: 'name',
+        valueField: 'id',
+      });
+    });
+
+    it('should use empty string for query if not provided', () => {
+      const query: ElasticsearchDataQuery = {
+        refId: 'A',
+      };
+
+      const result = migrateVariableQuery(query);
+
+      expect(result.query).toBe('');
+    });
+  });
+
+  describe('convertFieldsToVariableFields', () => {
+    it('should throw error when no fields provided', () => {
+      expect(() => convertFieldsToVariableFields([])).toThrow('at least one field expected for variable');
+    });
+
+    it('should use meta fields when provided', () => {
+      const fields = [
+        { name: 'id', type: FieldType.number, config: {}, values: [1, 2, 3] },
+        { name: 'name', type: FieldType.string, config: {}, values: ['a', 'b', 'c'] },
+        { name: 'other', type: FieldType.string, config: {}, values: ['x', 'y', 'z'] },
+      ];
+
+      const result = convertFieldsToVariableFields(fields, {
+        textField: 'name',
+        valueField: 'id',
+      });
+
+      expect(result.length).toBeGreaterThanOrEqual(3);
+      expect(result[0].name).toBe('text');
+      expect(result[0].values).toEqual(['a', 'b', 'c']);
+      expect(result[1].name).toBe('value');
+      expect(result[1].values).toEqual([1, 2, 3]);
+      // Other fields are preserved
+      expect(result.some((f) => f.name === 'other')).toBe(true);
+    });
+
+    it('should use textField for both when valueField not specified', () => {
+      const fields = [
+        { name: 'name', type: FieldType.string, config: {}, values: ['a', 'b'] },
+        { name: 'other', type: FieldType.string, config: {}, values: ['x', 'y'] },
+      ];
+
+      const result = convertFieldsToVariableFields(fields, {
+        textField: 'name',
+      });
+
+      expect(result[0].name).toBe('text');
+      expect(result[0].values).toEqual(['a', 'b']);
+      expect(result[1].name).toBe('value');
+      expect(result[1].values).toEqual(['a', 'b']);
+    });
+
+    it('should use first field when meta fields not found', () => {
+      const fields = [
+        { name: 'id', type: FieldType.number, config: {}, values: [1, 2] },
+        { name: 'name', type: FieldType.string, config: {}, values: ['a', 'b'] },
+      ];
+
+      const result = convertFieldsToVariableFields(fields, {
+        textField: 'notfound',
+        valueField: 'alsonotfound',
+      });
+
+      expect(result[0].name).toBe('text');
+      expect(result[0].values).toEqual([1, 2]);
+      expect(result[1].name).toBe('value');
+      expect(result[1].values).toEqual([1, 2]);
+    });
+
+    it('should handle __text and __value fields', () => {
+      const fields = [
+        { name: '__text', type: FieldType.string, config: {}, values: ['a', 'b'] },
+        { name: '__value', type: FieldType.string, config: {}, values: [1, 2] },
+        { name: 'other', type: FieldType.string, config: {}, values: ['x', 'y'] },
+      ];
+
+      const result = convertFieldsToVariableFields(fields);
+
+      expect(result).toHaveLength(3);
+      expect(result[0].name).toBe('text');
+      expect(result[0].values).toEqual(['a', 'b']);
+      expect(result[1].name).toBe('value');
+      expect(result[1].values).toEqual(['1', '2']);
+      expect(result[2].name).toBe('other');
+    });
+
+    it('should fallback to combining all fields into single value', () => {
+      const fields = [
+        { name: 'field1', type: FieldType.string, config: {}, values: ['a', 'b'] },
+        { name: 'field2', type: FieldType.string, config: {}, values: ['c', 'd'] },
+      ];
+
+      const result = convertFieldsToVariableFields(fields);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('text');
+      expect(result[1].name).toBe('value');
+      expect(result[0].values).toEqual(['a', 'b', 'c', 'd']);
+      expect(result[1].values).toEqual(['a', 'b', 'c', 'd']);
+    });
+
+    it('should skip null and undefined values in fallback', () => {
+      const fields = [{ name: 'field1', type: FieldType.string, config: {}, values: ['a', null, 'b', undefined, 'c'] }];
+
+      const result = convertFieldsToVariableFields(fields);
+
+      expect(result[0].values).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should deduplicate values in fallback', () => {
+      const fields = [
+        { name: 'field1', type: FieldType.string, config: {}, values: ['a', 'b', 'a'] },
+        { name: 'field2', type: FieldType.string, config: {}, values: ['b', 'c'] },
+      ];
+
+      const result = convertFieldsToVariableFields(fields);
+
+      expect(result[0].values).toEqual(['a', 'b', 'c']);
+    });
+  });
+
+  describe('updateFrame', () => {
+    it('should update frame with converted fields', () => {
+      const frame = {
+        name: 'test',
+        refId: 'A',
+        length: 2,
+        fields: [
+          { name: 'id', type: FieldType.number, config: {}, values: [1, 2] },
+          { name: 'name', type: FieldType.string, config: {}, values: ['a', 'b'] },
+        ],
+      };
+
+      const result = updateFrame(frame, {
+        textField: 'name',
+        valueField: 'id',
+      });
+
+      expect(result.fields.length).toBeGreaterThanOrEqual(2);
+      expect(result.fields[0].name).toBe('text');
+      expect(result.fields[1].name).toBe('value');
+      expect(result.length).toBe(2);
+    });
+
+    it('should handle empty frame', () => {
+      const frame = {
+        name: 'test',
+        refId: 'A',
+        length: 0,
+        fields: [],
+      };
+
+      expect(() => updateFrame(frame)).toThrow('at least one field expected for variable');
+    });
+  });
+});

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableUtils.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableUtils.ts
@@ -1,0 +1,79 @@
+import { uniq } from 'lodash';
+
+import { DataFrame, Field, FieldType } from '@grafana/data';
+
+import { ElasticsearchDataQuery } from './dataquery.gen';
+
+export const refId = 'ElasticsearchVariableQueryEditor-VariableQuery';
+
+export type ElasticsearchVariableQuery = ElasticsearchDataQuery;
+
+export const migrateVariableQuery = (rawQuery: string | ElasticsearchDataQuery): ElasticsearchVariableQuery => {
+  if (typeof rawQuery !== 'string') {
+    return {
+      ...rawQuery,
+      refId: rawQuery.refId || refId,
+      query: rawQuery.query || '',
+      meta: rawQuery.meta,
+    };
+  }
+  // Legacy string-based query
+  return {
+    refId,
+    query: rawQuery,
+    metrics: [{ type: 'raw_document', id: '1' }],
+  };
+};
+
+export const updateFrame = (frame: DataFrame, meta?: { textField?: string; valueField?: string }): DataFrame => {
+  const fields = convertFieldsToVariableFields(frame.fields, meta);
+  let length = fields.length > 0 ? fields[0].values.length : frame.length;
+  return { ...frame, length, fields };
+};
+
+export const convertFieldsToVariableFields = (
+  original_fields: Field[],
+  meta?: { textField?: string; valueField?: string }
+): Field[] => {
+  // scenario 1: If no fields found, throw error
+  if (original_fields.length < 1) {
+    throw new Error('at least one field expected for variable');
+  }
+
+  // scenario 2: If meta field found, use and return (at least one text field / value field exist / or first field)
+  if (meta) {
+    let tf = meta.textField ? original_fields.find((f) => f.name === meta.textField) : undefined;
+    let vf = meta.valueField ? original_fields.find((f) => f.name === meta.valueField) : undefined;
+    const textField = tf || vf || original_fields[0];
+    const valueField = vf || tf || original_fields[0];
+    const otherFields = original_fields.filter((f: Field) => f.name !== 'value' && f.name !== 'text');
+    return [{ ...textField, name: 'text' }, { ...valueField, name: 'value' }, ...otherFields];
+  }
+
+  // scenario 3: If both __text field & __value field found
+  let tf = original_fields.find((f) => f.name === '__text');
+  let vf = original_fields.find((f) => f.name === '__value');
+  if (tf && vf) {
+    const otherFields = original_fields.filter((f: Field) => f.name !== '__text' && f.name !== '__value');
+    return [
+      { ...tf, name: 'text', values: tf.values.map((v) => '' + v) },
+      { ...vf, name: 'value', values: vf.values.map((v) => '' + v) },
+      ...otherFields,
+    ];
+  }
+
+  // scenario 4: fallback scenario / legacy scenario where return all fields into a single field.
+  let values: string[] = [];
+  for (const field of original_fields) {
+    for (const value of field.values) {
+      if (value !== null && value !== undefined) {
+        values.push('' + value);
+      }
+    }
+  }
+  values = uniq(values);
+  return [
+    { name: 'text', type: FieldType.string, config: {}, values },
+    { name: 'value', type: FieldType.string, config: {}, values },
+  ];
+};

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableUtils.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableUtils.ts
@@ -1,5 +1,3 @@
-import { uniq } from 'lodash';
-
 import { DataFrame, Field, FieldType } from '@grafana/data';
 
 import { ElasticsearchDataQuery } from './dataquery.gen';
@@ -71,7 +69,6 @@ export const convertFieldsToVariableFields = (
       }
     }
   }
-  values = uniq(values);
   return [
     { name: 'text', type: FieldType.string, config: {}, values },
     { name: 'value', type: FieldType.string, config: {}, values },

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
@@ -3,14 +3,14 @@ import { Context, createContext, PropsWithChildren, useCallback, useContext, use
 import { TimeRange } from '@grafana/data';
 
 import { ElasticsearchDataQuery } from '../../dataquery.gen';
-import { ElasticDatasource } from '../../datasource';
 import { combineReducers, useStatelessReducer, DispatchContext } from '../../hooks/useStatelessReducer';
+import { ElasticDatasourceLike } from '../../types';
 
 import { createReducer as createBucketAggsReducer } from './BucketAggregationsEditor/state/reducer';
 import { reducer as metricsReducer } from './MetricAggregationsEditor/state/reducer';
 import { aliasPatternReducer, queryReducer, queryTypeReducer, editorTypeReducer, initQuery } from './state';
 
-const DatasourceContext = createContext<ElasticDatasource | undefined>(undefined);
+const DatasourceContext = createContext<ElasticDatasourceLike | undefined>(undefined);
 const QueryContext = createContext<ElasticsearchDataQuery | undefined>(undefined);
 const RangeContext = createContext<TimeRange | undefined>(undefined);
 
@@ -18,7 +18,7 @@ interface Props {
   query: ElasticsearchDataQuery;
   onChange: (query: ElasticsearchDataQuery) => void;
   onRunQuery: () => void;
-  datasource: ElasticDatasource;
+  datasource: ElasticDatasourceLike;
   range: TimeRange;
 }
 

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -7,10 +7,9 @@ import { config } from '@grafana/runtime';
 import { Alert, ConfirmModal, InlineField, InlineLabel, Input, QueryField, useStyles2 } from '@grafana/ui';
 
 import { ElasticsearchDataQuery } from '../../dataquery.gen';
-import { ElasticDatasource } from '../../datasource';
 import { useNextId } from '../../hooks/useNextId';
 import { useDispatch } from '../../hooks/useStatelessReducer';
-import { EditorType, ElasticsearchOptions } from '../../types';
+import { ElasticDatasourceLike, EditorType, ElasticsearchOptions } from '../../types';
 import { isSupportedVersion, isTimeSeriesQuery, unsupportedVersionMessage } from '../../utils';
 
 import { BucketAggregationsEditor } from './BucketAggregationsEditor';
@@ -22,11 +21,15 @@ import { QueryTypeSelector } from './QueryTypeSelector';
 import { RawQueryEditor } from './RawQueryEditor';
 import { changeAliasPattern, changeEditorTypeAndResetQuery, changeQuery } from './state';
 
-export type ElasticQueryEditorProps = QueryEditorProps<ElasticDatasource, ElasticsearchDataQuery, ElasticsearchOptions>;
+export type ElasticQueryEditorProps = QueryEditorProps<
+  ElasticDatasourceLike,
+  ElasticsearchDataQuery,
+  ElasticsearchOptions
+>;
 
 // a react hook that returns the elasticsearch database version,
 // or `null`, while loading, or if it is not possible to determine the value.
-function useElasticVersion(datasource: ElasticDatasource): SemVer | null {
+function useElasticVersion(datasource: ElasticDatasourceLike): SemVer | null {
   const [version, setVersion] = useState<SemVer | null>(null);
   useEffect(() => {
     let canceled = false;

--- a/public/app/plugins/datasource/elasticsearch/dataquery.cue
+++ b/public/app/plugins/datasource/elasticsearch/dataquery.cue
@@ -41,6 +41,11 @@ composableKinds: DataQuery: {
 				bucketAggs?: [...#BucketAggregation]
 				// List of metric aggregations
 				metrics?: [...#MetricAggregation]
+				// Metadata for variable queries
+				meta?: {
+					textField?:  string
+					valueField?: string
+				}
 
 				#QueryType: "lucene" | "dsl" @cuetsy(kind="type")
 

--- a/public/app/plugins/datasource/elasticsearch/dataquery.gen.ts
+++ b/public/app/plugins/datasource/elasticsearch/dataquery.gen.ts
@@ -394,6 +394,13 @@ export interface ElasticsearchDataQuery extends common.DataQuery {
    */
   editorType?: string;
   /**
+   * Metadata for variable queries
+   */
+  meta?: {
+    textField?: string;
+    valueField?: string;
+  };
+  /**
    * List of metric aggregations
    */
   metrics?: Array<MetricAggregation>;

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -49,6 +49,7 @@ import {
   config,
 } from '@grafana/runtime';
 
+import { ElasticsearchVariableSupport } from './ElasticsearchVariableSupport';
 import { IndexPattern, intervalMap } from './IndexPattern';
 import LanguageProvider from './LanguageProvider';
 import { ElasticQueryBuilder } from './QueryBuilder';
@@ -165,6 +166,7 @@ export class ElasticDatasource
       this.logLevelField = undefined;
     }
     this.languageProvider = new LanguageProvider(this);
+    this.variables = new ElasticsearchVariableSupport(this);
   }
 
   getResourceRequest(path: string, params?: BackendSrvRequest['params'], options?: Partial<BackendSrvRequest>) {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -49,6 +49,7 @@ import {
   config,
 } from '@grafana/runtime';
 
+import { ElasticsearchVariableEditor } from './ElasticsearchVariableEditor';
 import { ElasticsearchVariableSupport } from './ElasticsearchVariableSupport';
 import { IndexPattern, intervalMap } from './IndexPattern';
 import LanguageProvider from './LanguageProvider';
@@ -166,7 +167,7 @@ export class ElasticDatasource
       this.logLevelField = undefined;
     }
     this.languageProvider = new LanguageProvider(this);
-    this.variables = new ElasticsearchVariableSupport(this);
+    this.variables = new ElasticsearchVariableSupport(this, ElasticsearchVariableEditor);
   }
 
   getResourceRequest(path: string, params?: BackendSrvRequest['params'], options?: Partial<BackendSrvRequest>) {

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -1,4 +1,14 @@
-import { DataSourceJsonData } from '@grafana/data';
+import { Observable } from 'rxjs';
+import { SemVer } from 'semver';
+
+import {
+  DataQueryRequest,
+  DataQueryResponse,
+  DataSourceApi,
+  DataSourceJsonData,
+  MetricFindValue,
+  TimeRange,
+} from '@grafana/data';
 import { DataSourceRef } from '@grafana/schema';
 
 import {
@@ -189,6 +199,19 @@ export const isElasticsearchResponseWithHits = (res: unknown): res is Elasticsea
     })
   );
 };
+
+/**
+ * Minimal interface for what the QueryEditor components need from ElasticDatasource.
+ * Using this instead of importing ElasticDatasource directly breaks the circular import
+ * chain from components/QueryEditor back to datasource.ts.
+ */
+export interface ElasticDatasourceLike extends DataSourceApi<ElasticsearchDataQuery, ElasticsearchOptions> {
+  timeField: string;
+  defaultQueryMode?: QueryType;
+  query(request: DataQueryRequest<ElasticsearchDataQuery>): Observable<DataQueryResponse>;
+  getDatabaseVersion(useCachedData?: boolean): Promise<SemVer | null>;
+  getFields(type?: string[], range?: TimeRange): Observable<MetricFindValue[]>;
+}
 
 export const isElasticsearchResponseWithAggregations = (res: unknown): res is ElasticsearchResponseWithAggregations => {
   return (


### PR DESCRIPTION
Closes https://github.com/grafana/data-sources/issues/1014. 

This PR implements variable query editor support in the Elasticsearch data source.

## Test Instructions 

These were generated by our New AI Overlords™️ , so YMMV! However, these instructions did work for me locally.

### Basic editor rendering

1. Open a dashboard → **Settings** → **Variables** → **Add variable**
2. Set **Variable type** to **Query**
3. Set **Data source** to your Elasticsearch datasource

**Expected:**  
The full Elasticsearch query editor renders (Query type tabs: *Metrics / Logs / Raw Data / Raw Document*, Builder/Code toggle, Lucene Query input) — not just a plain text box. A **Value Field** and **Text Field** row appears below the query builder.

---

### Terms aggregation — field dropdown population

1. In the variable editor, set **Query type** to **Metrics**
2. Add a **Group By → Terms** on a keyword field that has data (e.g. `log.level`, `status`, `host.name`)
3. Click elsewhere or wait a moment

**Expected:**  
The **Value Field** and **Text Field** dropdowns populate with the field names returned by the query (e.g. `key`, `Count`). The internal `refId` string (`ElasticsearchVariableQueryEditor-VariableQuery`) must **not** appear as an option.

---

### Manual field entry (no data / empty index)

1. Configure any query type (e.g. **Metrics + Terms** on a field in an empty index or a time range with no data)
2. Click the **Value Field** dropdown — it will show *"No options found"*
3. Type a field name (e.g. `log.level`) directly into the input

**Expected:**  
A **"Use custom value"** option appears. Select it — the field name is accepted and displayed with a clear (×) button.

---

### Save and reload persistence

1. Set **Value Field** and **Text Field** to known values (either from the dropdown or typed manually)
2. Save the dashboard
3. Reload the page (hard reload: `Cmd/Ctrl+Shift+R`)
4. Re-open the variable editor

**Expected:**  
Both **Value Field** and **Text Field** show the previously saved values — even when the options list is empty (i.e. the combobox correctly displays values not in the options list).

---

### Legacy string query migration

1. Open an existing dashboard that has an Elasticsearch variable defined as a plain string query (e.g. `{"find": "terms", "field": "host.name"}` or a bare Lucene string)
2. Open the variable editor

**Expected:**  
The legacy string is correctly migrated to the new object format and displayed in the query editor without errors. The editor should be functional and editable.

### Variable interpolation in a panel

1. After configuring the variable (use a **Terms** query on a field with real data, or use **Allow custom values** to manually set a value in the dashboard toolbar)
2. Add a **Text** panel to the dashboard
3. Set the content to:

```
value: ${query0}
text: ${query0:text}
value explicit: ${query0:value}
raw: ${query0:raw}
```

4. Change the variable value using the dashboard toolbar dropdown

**Expected:**  
All four interpolation syntaxes update reactively when the variable value changes.

- `${query0}` and `${query0:value}` should show the **value field**
- `${query0:text}` should show the **text field** (differs from value when **Value Field** and **Text Field** are set to different columns)

### Value Field / Text Field differentiation

1. Use a **Terms** aggregation query on a field that returns data — the response will have at least `key` and `Count` fields
2. Set **Value Field** to `key` and **Text Field** to `Count` (or vice versa)
3. Save, then check the variable preview at the bottom of the variable editor

**Expected:**  
`${query0:value}` and `${query0:text}` resolve to different values, matching the fields you selected.

## Known limitations

- The local index must have data in the selected time range for field dropdowns to auto-populate. Use the time range picker to expand the window if needed.
- **Raw Document** query type returns no meaningful column fields to populate the dropdowns — this is expected behaviour; use **Value Field / Text Field** for other query types.
