### PR TITLE
Provisioning SynchronizeStep: Use response fieldErrors 

### DIFF
--- a/public/app/features/provisioning/Wizard/BootstrapStep.test.tsx
+++ b/public/app/features/provisioning/Wizard/BootstrapStep.test.tsx
@@ -148,6 +148,7 @@ describe('BootstrapStep', () => {
       isReconciled: true,
       healthMessage: undefined,
       healthStatusNotReady: false,
+      fieldErrors: undefined,
       refetch: jest.fn(),
     });
 
@@ -530,6 +531,7 @@ describe('BootstrapStep', () => {
         isReconciled: false, // Not yet reconciled
         healthMessage: ['Some temporary error'],
         healthStatusNotReady: true,
+        fieldErrors: undefined,
         refetch: jest.fn(),
       });
 
@@ -564,6 +566,7 @@ describe('BootstrapStep', () => {
         isReconciled: true, // Fully reconciled
         healthMessage: ['Connection failed'],
         healthStatusNotReady: false,
+        fieldErrors: undefined,
         refetch: jest.fn(),
       });
 
@@ -597,6 +600,7 @@ describe('BootstrapStep', () => {
         isReconciled: true,
         healthMessage: undefined,
         healthStatusNotReady: false,
+        fieldErrors: undefined,
         refetch: jest.fn(),
       });
 

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
@@ -97,6 +97,7 @@ export const ProvisioningWizard = memo(function ProvisioningWizard({
     visibleStepIndex,
     goToNextStep,
     goToPreviousStep,
+    goToStep,
   } = useWizardNavigation({
     steps,
     canSkipSync,
@@ -227,6 +228,7 @@ export const ProvisioningWizard = memo(function ProvisioningWizard({
                 onGitHubAppSubmit={handleGitHubAppCreation}
                 onRepositoryDeletion={handleRepositoryDeletion}
                 isCancelling={isCancelling}
+                goToStep={goToStep}
               />
             </div>
 

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -43,8 +43,6 @@ export const SynchronizeStep = memo(function SynchronizeStep({
     isLoading,
   } = useRepositoryStatus(repoName);
 
-  const hasFieldErrors = Boolean(fieldErrors?.length);
-
   const { requiresMigration } = useResourceStats(repoName, syncTarget, migrateResources, {
     isHealthy,
     healthStatusNotReady,
@@ -57,9 +55,10 @@ export const SynchronizeStep = memo(function SynchronizeStep({
   const [job, setJob] = useState<Job>();
 
   useEffect(() => {
+    // This useEffect is used to update the step status info based on the repository status and the form errors
     setStepStatusInfo(
       getSyncStepStatus({
-        hasFieldErrors,
+        fieldErrors,
         hasError,
         isUnhealthy,
         isLoading,
@@ -69,7 +68,7 @@ export const SynchronizeStep = memo(function SynchronizeStep({
       })
     );
   }, [
-    hasFieldErrors,
+    fieldErrors,
     hasError,
     isUnhealthy,
     isLoading,

--- a/public/app/features/provisioning/Wizard/components/WizardStepContent.tsx
+++ b/public/app/features/provisioning/Wizard/components/WizardStepContent.tsx
@@ -14,6 +14,7 @@ export interface WizardStepContentProps {
   onGitHubAppSubmit: (result: ConnectionCreationResult) => void;
   onRepositoryDeletion: (name: string) => Promise<void>;
   isCancelling: boolean;
+  goToStep: (stepId: WizardStep) => void;
 }
 
 export function WizardStepContent({
@@ -23,6 +24,7 @@ export function WizardStepContent({
   onGitHubAppSubmit,
   onRepositoryDeletion,
   isCancelling,
+  goToStep,
 }: WizardStepContentProps) {
   switch (activeStep) {
     case 'authType':
@@ -32,7 +34,7 @@ export function WizardStepContent({
     case 'bootstrap':
       return <BootstrapStep settingsData={settingsData} repoName={repoName} />;
     case 'synchronize':
-      return <SynchronizeStep onCancel={onRepositoryDeletion} isCancelling={isCancelling} />;
+      return <SynchronizeStep onCancel={onRepositoryDeletion} isCancelling={isCancelling} goToStep={goToStep} />;
     case 'finish':
       return <FinishStep />;
     default:

--- a/public/app/features/provisioning/Wizard/hooks/useRepositoryStatus.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useRepositoryStatus.ts
@@ -16,6 +16,7 @@ export function useRepositoryStatus(repoName?: string) {
 
   const repository = query.data?.items?.[0];
   const { healthy: rawIsHealthy, message: healthMessage } = repository?.status?.health || {};
+  const fieldErrors = repository?.status?.fieldErrors;
 
   const isReconciled = isResourceReconciled(repository);
   const isReady = Boolean(repoName) && query.isSuccess;
@@ -33,6 +34,7 @@ export function useRepositoryStatus(repoName?: string) {
     isReconciled,
     healthMessage,
     healthStatusNotReady, // true when waiting for reconciliation
+    fieldErrors,
     isLoading: query.isLoading,
     isFetching: query.isFetching,
     hasError: query.isError,

--- a/public/app/features/provisioning/Wizard/hooks/useWizardNavigation.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useWizardNavigation.ts
@@ -28,6 +28,7 @@ export interface UseWizardNavigationReturn {
   visibleStepIndex: number;
   goToNextStep: () => Promise<void>;
   goToPreviousStep: () => void;
+  goToStep: (stepId: WizardStep) => void;
 }
 
 export function useWizardNavigation({
@@ -131,6 +132,24 @@ export function useWizardNavigation({
     setStepStatusInfo,
   ]);
 
+  const goToStep = useCallback(
+    (stepId: WizardStep) => {
+      const targetIndex = steps.findIndex((s) => s.id === stepId);
+      if (targetIndex >= 0) {
+        setActiveStep(stepId);
+        // Only keep steps completed before the target
+        setCompletedSteps((prev) =>
+          prev.filter((s) => {
+            const sIndex = steps.findIndex((st) => st.id === s);
+            return sIndex < targetIndex;
+          })
+        );
+        setStepStatusInfo({ status: 'idle' });
+      }
+    },
+    [steps, setStepStatusInfo]
+  );
+
   return {
     activeStep,
     completedSteps,
@@ -140,5 +159,6 @@ export function useWizardNavigation({
     visibleStepIndex,
     goToNextStep,
     goToPreviousStep,
+    goToStep,
   };
 }

--- a/public/app/features/provisioning/Wizard/utils/getSteps.test.ts
+++ b/public/app/features/provisioning/Wizard/utils/getSteps.test.ts
@@ -1,4 +1,4 @@
-import { getSteps } from './getSteps';
+import { getSteps, getSyncStepStatus } from './getSteps';
 
 describe('getSteps', () => {
   const expectedStepOrder = ['authType', 'connection', 'bootstrap', 'synchronize', 'finish'];
@@ -31,5 +31,93 @@ describe('getSteps', () => {
     expect(authTypeStep?.title).toBe('Connect');
     expect(connectionStep?.name).toBe('Configure repository');
     expect(connectionStep?.title).toBe('Configure repository');
+  });
+});
+
+describe('getSyncStepStatus', () => {
+  const defaultState = {
+    hasFieldErrors: false,
+    hasError: false,
+    isUnhealthy: false,
+    isLoading: false,
+    healthStatusNotReady: false,
+    repositoryHealthMessages: undefined,
+    goToStep: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns running when loading', () => {
+    const result = getSyncStepStatus({ ...defaultState, isLoading: true });
+    expect(result.status).toBe('running');
+  });
+
+  it('returns running when health status not ready', () => {
+    const result = getSyncStepStatus({ ...defaultState, healthStatusNotReady: true });
+    expect(result.status).toBe('running');
+  });
+
+  it('returns error when query has error', () => {
+    const result = getSyncStepStatus({ ...defaultState, hasError: true });
+    expect(result.status).toBe('error');
+    expect(result).toHaveProperty('error');
+  });
+
+  it('returns error with action when unhealthy with field errors', () => {
+    const goToStep = jest.fn();
+    const result = getSyncStepStatus({
+      ...defaultState,
+      isUnhealthy: true,
+      hasFieldErrors: true,
+      goToStep,
+    });
+    expect(result.status).toBe('error');
+    expect(result).toHaveProperty('action');
+    // Verify the action calls goToStep with 'connection'
+    if ('action' in result && result.action?.onClick) {
+      result.action.onClick();
+      expect(goToStep).toHaveBeenCalledWith('connection');
+    }
+  });
+
+  it('returns error without action when unhealthy without field errors', () => {
+    const result = getSyncStepStatus({
+      ...defaultState,
+      isUnhealthy: true,
+      repositoryHealthMessages: ['Token expired'],
+    });
+    expect(result.status).toBe('error');
+    expect(result).not.toHaveProperty('action');
+    if ('error' in result && typeof result.error === 'object') {
+      expect(result.error.message).toEqual(['Token expired']);
+    }
+  });
+
+  it('returns idle when everything is healthy', () => {
+    const result = getSyncStepStatus(defaultState);
+    expect(result.status).toBe('idle');
+  });
+
+  it('prioritizes loading over error states', () => {
+    const result = getSyncStepStatus({
+      ...defaultState,
+      isLoading: true,
+      hasError: true,
+      isUnhealthy: true,
+    });
+    expect(result.status).toBe('running');
+  });
+
+  it('prioritizes hasError over isUnhealthy', () => {
+    const result = getSyncStepStatus({
+      ...defaultState,
+      hasError: true,
+      isUnhealthy: true,
+      hasFieldErrors: true,
+    });
+    expect(result.status).toBe('error');
+    expect(result).not.toHaveProperty('action');
   });
 });

--- a/public/app/features/provisioning/Wizard/utils/getSteps.test.ts
+++ b/public/app/features/provisioning/Wizard/utils/getSteps.test.ts
@@ -36,7 +36,6 @@ describe('getSteps', () => {
 
 describe('getSyncStepStatus', () => {
   const defaultState = {
-    hasFieldErrors: false,
     hasError: false,
     isUnhealthy: false,
     isLoading: false,

--- a/public/app/features/provisioning/Wizard/utils/getSteps.test.ts
+++ b/public/app/features/provisioning/Wizard/utils/getSteps.test.ts
@@ -50,17 +50,17 @@ describe('getSyncStepStatus', () => {
   });
 
   it('returns running when loading', () => {
-    const result = getSyncStepStatus({ ...defaultState, isLoading: true });
+    const result = getSyncStepStatus({ ...defaultState, isLoading: true, fieldErrors: undefined });
     expect(result.status).toBe('running');
   });
 
   it('returns running when health status not ready', () => {
-    const result = getSyncStepStatus({ ...defaultState, healthStatusNotReady: true });
+    const result = getSyncStepStatus({ ...defaultState, healthStatusNotReady: true, fieldErrors: undefined });
     expect(result.status).toBe('running');
   });
 
   it('returns error when query has error', () => {
-    const result = getSyncStepStatus({ ...defaultState, hasError: true });
+    const result = getSyncStepStatus({ ...defaultState, hasError: true, fieldErrors: undefined });
     expect(result.status).toBe('error');
     expect(result).toHaveProperty('error');
   });
@@ -70,7 +70,7 @@ describe('getSyncStepStatus', () => {
     const result = getSyncStepStatus({
       ...defaultState,
       isUnhealthy: true,
-      hasFieldErrors: true,
+      fieldErrors: [{ field: 'repository.token', detail: 'Token is invalid', type: 'FieldValueInvalid' }],
       goToStep,
     });
     expect(result.status).toBe('error');
@@ -87,6 +87,7 @@ describe('getSyncStepStatus', () => {
       ...defaultState,
       isUnhealthy: true,
       repositoryHealthMessages: ['Token expired'],
+      fieldErrors: undefined,
     });
     expect(result.status).toBe('error');
     expect(result).not.toHaveProperty('action');
@@ -96,7 +97,7 @@ describe('getSyncStepStatus', () => {
   });
 
   it('returns idle when everything is healthy', () => {
-    const result = getSyncStepStatus(defaultState);
+    const result = getSyncStepStatus({ ...defaultState, fieldErrors: undefined });
     expect(result.status).toBe('idle');
   });
 
@@ -105,6 +106,7 @@ describe('getSyncStepStatus', () => {
       ...defaultState,
       isLoading: true,
       hasError: true,
+      fieldErrors: undefined,
       isUnhealthy: true,
     });
     expect(result.status).toBe('running');
@@ -115,7 +117,7 @@ describe('getSyncStepStatus', () => {
       ...defaultState,
       hasError: true,
       isUnhealthy: true,
-      hasFieldErrors: true,
+      fieldErrors: [{ field: 'repository.token', detail: 'Token is invalid', type: 'FieldValueInvalid' }],
     });
     expect(result.status).toBe('error');
     expect(result).not.toHaveProperty('action');

--- a/public/app/features/provisioning/Wizard/utils/getSteps.test.ts
+++ b/public/app/features/provisioning/Wizard/utils/getSteps.test.ts
@@ -69,15 +69,14 @@ describe('getSyncStepStatus', () => {
     const result = getSyncStepStatus({
       ...defaultState,
       isUnhealthy: true,
-      fieldErrors: [{ field: 'repository.token', detail: 'Token is invalid', type: 'FieldValueInvalid' }],
+      fieldErrors: [{ field: 'secure.token', detail: 'Token is invalid', type: 'FieldValueInvalid' }],
       goToStep,
     });
     expect(result.status).toBe('error');
     expect(result).toHaveProperty('action');
-    // Verify the action calls goToStep with 'connection'
     if ('action' in result && result.action?.onClick) {
       result.action.onClick();
-      expect(goToStep).toHaveBeenCalledWith('connection');
+      expect(goToStep).toHaveBeenCalledWith('authType');
     }
   });
 
@@ -116,9 +115,23 @@ describe('getSyncStepStatus', () => {
       ...defaultState,
       hasError: true,
       isUnhealthy: true,
-      fieldErrors: [{ field: 'repository.token', detail: 'Token is invalid', type: 'FieldValueInvalid' }],
+      fieldErrors: [{ field: 'secure.token', detail: 'Token is invalid', type: 'FieldValueInvalid' }],
     });
     expect(result.status).toBe('error');
     expect(result).not.toHaveProperty('action');
+  });
+
+  it('navigates to connection step for branch field errors', () => {
+    const goToStep = jest.fn();
+    const result = getSyncStepStatus({
+      ...defaultState,
+      isUnhealthy: true,
+      fieldErrors: [{ field: 'github.branch', detail: 'Branch not found', type: 'FieldValueInvalid' }],
+      goToStep,
+    });
+    if ('action' in result && result.action?.onClick) {
+      result.action.onClick();
+      expect(goToStep).toHaveBeenCalledWith('connection');
+    }
   });
 });

--- a/public/app/features/provisioning/Wizard/utils/getSteps.ts
+++ b/public/app/features/provisioning/Wizard/utils/getSteps.ts
@@ -123,34 +123,10 @@ export function getSyncStepStatus(state: SyncStepState): StepStatusInfo {
   return { status: 'idle' };
 }
 
-// Map field to step for form errors
-const FIELD_TO_STEP: Record<string, WizardStep> = {
-  'repository.token': 'authType',
-  'repository.tokenUser': 'authType',
-  'repository.url': 'authType',
-  'repository.branch': 'connection',
-  'repository.path': 'connection',
-  'repository.title': 'bootstrap',
-  'repository.sync.target': 'bootstrap',
-  'repository.sync.intervalSeconds': 'bootstrap',
-};
-
-const STEP_ORDER: WizardStep[] = ['authType', 'connection', 'bootstrap', 'synchronize', 'finish'];
+const AUTH_TYPE_FIELDS = new Set(['repository.token', 'repository.tokenUser', 'repository.url']);
 
 export function getEarliestErrorStep(fieldErrors: ErrorDetails[]): WizardStep {
   const formErrors = getFormErrors(fieldErrors);
-
-  let earliestIndex = STEP_ORDER.length;
-  for (const [formPath] of formErrors) {
-    const step = FIELD_TO_STEP[formPath];
-    if (step) {
-      const idx = STEP_ORDER.indexOf(step);
-      if (idx < earliestIndex) {
-        earliestIndex = idx;
-      }
-    }
-  }
-
-  // Default to 'authType' (first step) if no mapping found
-  return earliestIndex < STEP_ORDER.length ? STEP_ORDER[earliestIndex] : 'authType';
+  // If any of the form errors are in the auth type fields, return the auth type step, otherwise return the connection step
+  return formErrors.some(([path]) => AUTH_TYPE_FIELDS.has(path)) ? 'authType' : 'connection';
 }

--- a/public/app/features/provisioning/utils/getFormErrors.ts
+++ b/public/app/features/provisioning/utils/getFormErrors.ts
@@ -3,7 +3,7 @@ import { Path } from 'react-hook-form';
 import { ErrorDetails, StatusCause, Status } from 'app/api/clients/provisioning/v0alpha1';
 import { extractStatusCauses } from 'app/api/utils';
 
-import { WizardFormData, WizardStep } from '../Wizard/types';
+import { WizardFormData } from '../Wizard/types';
 import { ConnectionFormData, RepositoryFormData } from '../types';
 
 export type RepositoryField = keyof WizardFormData['repository'];

--- a/public/app/features/provisioning/utils/getFormErrors.ts
+++ b/public/app/features/provisioning/utils/getFormErrors.ts
@@ -3,7 +3,7 @@ import { Path } from 'react-hook-form';
 import { ErrorDetails, StatusCause, Status } from 'app/api/clients/provisioning/v0alpha1';
 import { extractStatusCauses } from 'app/api/utils';
 
-import { WizardFormData } from '../Wizard/types';
+import { WizardFormData, WizardStep } from '../Wizard/types';
 import { ConnectionFormData, RepositoryFormData } from '../types';
 
 export type RepositoryField = keyof WizardFormData['repository'];

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12908,12 +12908,15 @@
       "tooltip-unhealthy-repository": "Unable to pull an unhealthy repository"
     },
     "synchronize-step": {
+      "field-errors": "Configuration errors detected",
+      "field-errors-message": "There are issues with the repository configuration. Please review your settings.",
       "instance-migrate-resources-description": "Instance sync requires all resources to be managed. Existing resources will be migrated automatically.",
       "migrate-resources-description": "Import existing dashboards from connected external storage into the provisioning folder created in the previous step",
       "options": "Options",
       "repository-error": "Repository error",
       "repository-error-message": "Unable to check repository status. Please verify the repository configuration and try again.",
-      "repository-unhealthy": "The repository cannot be synchronized. Cancel provisioning and try again once the issue has been resolved. See details below.",
+      "repository-unhealthy": "The repository cannot be synchronized",
+      "review-configuration": "Review configuration",
       "text-checking-repository": "Checking repository status..."
     },
     "token-permissions-info": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12915,7 +12915,7 @@
       "options": "Options",
       "repository-error": "Repository error",
       "repository-error-message": "Unable to check repository status. Please verify the repository configuration and try again.",
-      "repository-unhealthy": "The repository cannot be synchronized",
+      "repository-unhealthy": "The repository cannot be synchronized. Cancel provisioning and try again once the issue has been resolved. See details below.",
       "review-configuration": "Review configuration",
       "text-checking-repository": "Checking repository status..."
     },


### PR DESCRIPTION
**What is this feature?**

In Synchronize step: Leverage backend `fieldErrors` from the repository health check:

**When a repository is unhealthy or error out:**
- Ready = False and fieldErrors -> Show configuration error message
<img width="757" height="272" alt="image" src="https://github.com/user-attachments/assets/0db4f14c-2082-4247-8a18-86f000f533e9" />

- Ready = False, but no fieldErrors -> Show error details (condition msg) and Abort button. Disable previous.

**Why do we need this feature?**



**Who is this feature for?**

Git sync users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/793

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
