### PR TITLE
chore: add internal functions to expose panels map

### DIFF
--- a/packages/grafana-runtime/src/internal/index.ts
+++ b/packages/grafana-runtime/src/internal/index.ts
@@ -36,12 +36,14 @@ export {
   useAppPluginMetas,
   usePanelPluginMeta,
   usePanelPluginMetas,
+  usePanelPluginMetasMap,
 } from '../services/pluginMeta/hooks';
 export type { AppPluginMetas, PanelPluginMetas } from '../services/pluginMeta/types';
 export { getCachedPromise, invalidateCache, setLogger } from '../utils/getCachedPromise';
 export {
   getPanelPluginMeta,
   getPanelPluginMetas,
+  getPanelPluginMetasMap,
   setPanelPluginMetas,
   refetchPanelPluginMetas,
 } from '../services/pluginMeta/panels';

--- a/packages/grafana-runtime/src/services/pluginMeta/hooks.test.tsx
+++ b/packages/grafana-runtime/src/services/pluginMeta/hooks.test.tsx
@@ -17,11 +17,13 @@ import {
   usePanelPluginMetas,
   usePanelPluginInstalled,
   usePanelPluginVersion,
+  usePanelPluginMetasMap,
 } from './hooks';
 import {
   getListedPanelPluginIds,
   getPanelPluginMeta,
   getPanelPluginMetas,
+  getPanelPluginMetasMap,
   getPanelPluginVersion,
   isPanelPluginInstalled,
   setPanelPluginMetas,
@@ -42,6 +44,7 @@ jest.mock('./panels', () => ({
   ...jest.requireActual('./panels'),
   getPanelPluginMeta: jest.fn(),
   getPanelPluginMetas: jest.fn(),
+  getPanelPluginMetasMap: jest.fn(),
   isPanelPluginInstalled: jest.fn(),
   getPanelPluginVersion: jest.fn(),
   getListedPanelPluginIds: jest.fn(),
@@ -52,6 +55,7 @@ const isAppPluginInstalledMock = jest.mocked(isAppPluginInstalled);
 const getAppPluginVersionMock = jest.mocked(getAppPluginVersion);
 const getPanelPluginMetaMock = jest.mocked(getPanelPluginMeta);
 const getPanelPluginMetasMock = jest.mocked(getPanelPluginMetas);
+const getPanelPluginMetasMapMock = jest.mocked(getPanelPluginMetasMap);
 const isPanelPluginInstalledMock = jest.mocked(isPanelPluginInstalled);
 const getPanelPluginVersionMock = jest.mocked(getPanelPluginVersion);
 const getListedPanelPluginIdsMock = jest.mocked(getListedPanelPluginIds);
@@ -327,6 +331,46 @@ describe('usePanelPluginMetas', () => {
     getPanelPluginMetasMock.mockRejectedValue(new Error('Some error'));
 
     const { result } = renderHook(() => usePanelPluginMetas());
+
+    await waitFor(() => expect(result.current.loading).toEqual(false));
+
+    expect(result.current.loading).toEqual(false);
+    expect(result.current.error).toEqual(new Error('Some error'));
+    expect(result.current.value).toBeUndefined();
+  });
+});
+
+describe('usePanelPluginMetasMap', () => {
+  beforeEach(() => {
+    setPanelPluginMetas(panels);
+    jest.resetAllMocks();
+    getPanelPluginMetasMapMock.mockImplementation(actualPanels.getPanelPluginMetasMap);
+  });
+
+  it('should return correct default values', async () => {
+    const { result } = renderHook(() => usePanelPluginMetasMap());
+
+    expect(result.current.loading).toEqual(true);
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.value).toBeUndefined();
+
+    await waitFor(() => expect(result.current.loading).toEqual(true));
+  });
+
+  it('should return correct values after loading', async () => {
+    const { result } = renderHook(() => usePanelPluginMetasMap());
+
+    await waitFor(() => expect(result.current.loading).toEqual(false));
+
+    expect(result.current.loading).toEqual(false);
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.value).toEqual(panels);
+  });
+
+  it('should return correct values if usePanelPluginMetasMap throws', async () => {
+    getPanelPluginMetasMapMock.mockRejectedValue(new Error('Some error'));
+
+    const { result } = renderHook(() => usePanelPluginMetasMap());
 
     await waitFor(() => expect(result.current.loading).toEqual(false));
 

--- a/packages/grafana-runtime/src/services/pluginMeta/hooks.tsx
+++ b/packages/grafana-runtime/src/services/pluginMeta/hooks.tsx
@@ -5,6 +5,7 @@ import {
   getListedPanelPluginIds,
   getPanelPluginMeta,
   getPanelPluginMetas,
+  getPanelPluginMetasMap,
   getPanelPluginVersion,
   isPanelPluginInstalled,
 } from './panels';
@@ -21,6 +22,11 @@ export function useAppPluginMeta(pluginId: string) {
 
 export function usePanelPluginMetas() {
   const { loading, error, value } = useAsync(async () => getPanelPluginMetas());
+  return { loading, error, value };
+}
+
+export function usePanelPluginMetasMap() {
+  const { loading, error, value } = useAsync(async () => getPanelPluginMetasMap());
   return { loading, error, value };
 }
 

--- a/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
@@ -6,6 +6,7 @@ import {
   getListedPanelPluginIds,
   getPanelPluginMeta,
   getPanelPluginMetas,
+  getPanelPluginMetasMap,
   getPanelPluginVersion,
   isPanelPluginInstalled,
   refetchPanelPluginMetas,
@@ -44,6 +45,13 @@ describe('when useMTPlugins flag is enabled', () => {
       const panels = await getPanelPluginMetas();
 
       expect(panels).toEqual([]);
+      expect(initPluginMetasMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('getPanelPluginMetasMap should call initPluginMetas and return correct result', async () => {
+      const panels = await getPanelPluginMetasMap();
+
+      expect(panels).toEqual({});
       expect(initPluginMetasMock).toHaveBeenCalledTimes(1);
     });
 
@@ -86,6 +94,13 @@ describe('when useMTPlugins flag is enabled', () => {
       const panels = await getPanelPluginMetas();
 
       expect(panels).toEqual([panel]);
+      expect(initPluginMetasMock).not.toHaveBeenCalled();
+    });
+
+    it('getPanelPluginMetasMap should not call initPluginMetas and return correct result', async () => {
+      const panels = await getPanelPluginMetasMap();
+
+      expect(panels).toEqual({ 'grafana-test-panel': panel });
       expect(initPluginMetasMock).not.toHaveBeenCalled();
     });
 
@@ -217,6 +232,13 @@ describe('when useMTPlugins flag is disabled', () => {
       expect(initPluginMetasMock).not.toHaveBeenCalled();
     });
 
+    it('getPanelPluginMetasMap should not call initPluginMetas and return correct result', async () => {
+      const panels = await getPanelPluginMetasMap();
+
+      expect(panels).toEqual({});
+      expect(initPluginMetasMock).not.toHaveBeenCalled();
+    });
+
     it('getPanelPluginMeta should not call initPluginMetas and return correct result', async () => {
       const result = await getPanelPluginMeta('grafana-test-panel');
 
@@ -256,6 +278,13 @@ describe('when useMTPlugins flag is disabled', () => {
       const panels = await getPanelPluginMetas();
 
       expect(panels).toEqual([panel]);
+      expect(initPluginMetasMock).not.toHaveBeenCalled();
+    });
+
+    it('getPanelPluginMetasMap should not call initPluginMetas and return correct result', async () => {
+      const panels = await getPanelPluginMetasMap();
+
+      expect(panels).toEqual({ 'grafana-test-panel': panel });
       expect(initPluginMetasMock).not.toHaveBeenCalled();
     });
 
@@ -395,6 +424,31 @@ describe('immutability', () => {
     // assert that we have not mutated the source
     expect(panels[0].info.author.name).toEqual('Grafana');
     expect(panels[0].info.links).toHaveLength(0);
+  });
+
+  it('getPanelPluginMetasMap should return a deep clone', async () => {
+    const mutatedPanels = await getPanelPluginMetasMap();
+
+    // assert we have correct props
+    expect(mutatedPanels).toEqual({ 'grafana-test-panel': panel });
+    expect(mutatedPanels['grafana-test-panel'].info.author.name).toEqual('Grafana');
+    expect(mutatedPanels['grafana-test-panel'].info.links).toHaveLength(0);
+
+    // mutate deep props
+    mutatedPanels['grafana-test-panel'].info.author.name = '';
+    mutatedPanels['grafana-test-panel'].info.links.push({ name: '', url: '' });
+
+    // assert we have mutated props
+    expect(mutatedPanels['grafana-test-panel'].info.author.name).toEqual('');
+    expect(mutatedPanels['grafana-test-panel'].info.links).toHaveLength(1);
+    expect(mutatedPanels['grafana-test-panel'].info.links[0]).toEqual({ name: '', url: '' });
+
+    const panels = await getPanelPluginMetasMap();
+
+    // assert that we have not mutated the source
+    expect(panels).toEqual({ 'grafana-test-panel': panel });
+    expect(panels['grafana-test-panel'].info.author.name).toEqual('Grafana');
+    expect(panels['grafana-test-panel'].info.links).toHaveLength(0);
   });
 
   it('getPanelPluginMeta should return a deep clone', async () => {

--- a/packages/grafana-runtime/src/services/pluginMeta/panels.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/panels.ts
@@ -34,6 +34,14 @@ export async function getPanelPluginMetas(): Promise<PanelPluginMeta[]> {
   return Object.values(structuredClone(panels));
 }
 
+export async function getPanelPluginMetasMap(): Promise<PanelPluginMetas> {
+  if (!initialized()) {
+    await initPanelPluginMetas();
+  }
+
+  return structuredClone(panels);
+}
+
 export async function getPanelPluginMeta(pluginId: string): Promise<PanelPluginMeta | null> {
   if (!initialized()) {
     await initPanelPluginMetas();


### PR DESCRIPTION
**What is this feature?**

This pull request introduces a new utility for retrieving panel plugin metadata as a map, alongside comprehensive tests to ensure correct behavior and immutability. It also integrates the new functionality into the relevant hooks and updates the test suites accordingly.

**Why do we need this feature?**

So we can remove config.panels

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
