### PR TITLE
feat(query): provide query error context via `useProvidePageContext`

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.test.tsx
+++ b/public/app/features/query/components/QueryEditorRow.test.tsx
@@ -34,6 +34,13 @@ jest.mock('@grafana/i18n', () => ({
   t: (key: string, defaultValue: string) => defaultValue,
 }));
 
+jest.mock('@grafana/assistant', () => ({
+  useAssistant: () => ({ isAvailable: false }),
+  useProvidePageContext: jest.fn(),
+  OpenAssistantButton: () => null,
+  createAssistantContextItem: jest.fn(),
+}));
+
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getDataSourceSrv: () => ({

--- a/public/app/features/query/components/QueryErrorAlert.test.tsx
+++ b/public/app/features/query/components/QueryErrorAlert.test.tsx
@@ -9,6 +9,7 @@ const mockUseAssistant = jest.fn().mockReturnValue({ isAvailable: true });
 
 jest.mock('@grafana/assistant', () => ({
   useAssistant: () => mockUseAssistant(),
+  useProvidePageContext: jest.fn(),
   OpenAssistantButton: ({ title }: { title: string }) => <button>{title}</button>,
   createAssistantContextItem: jest.fn((type: string, params: { title: string; data: unknown }) => ({
     type,

--- a/public/app/features/query/components/QueryErrorAlert.tsx
+++ b/public/app/features/query/components/QueryErrorAlert.tsx
@@ -1,7 +1,12 @@
 import { css } from '@emotion/css';
 import { useMemo } from 'react';
 
-import { OpenAssistantButton, createAssistantContextItem, useAssistant, useProvidePageContext } from '@grafana/assistant';
+import {
+  OpenAssistantButton,
+  createAssistantContextItem,
+  useAssistant,
+  useProvidePageContext,
+} from '@grafana/assistant';
 import { DataQueryError, GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { DataQuery } from '@grafana/schema';

--- a/public/app/features/query/components/QueryErrorAlert.tsx
+++ b/public/app/features/query/components/QueryErrorAlert.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
+import { useMemo } from 'react';
 
-import { OpenAssistantButton, createAssistantContextItem, useAssistant } from '@grafana/assistant';
+import { OpenAssistantButton, createAssistantContextItem, useAssistant, useProvidePageContext } from '@grafana/assistant';
 import { DataQueryError, GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { DataQuery } from '@grafana/schema';
@@ -16,6 +17,9 @@ export function QueryErrorAlert({ error, query }: Props) {
   const { isAvailable } = useAssistant();
 
   const message = error?.message ?? error?.data?.message ?? 'Query error';
+
+  const context = useMemo(() => buildAssistantContext(error, message, query), [error, message, query]);
+  useProvidePageContext(/\/explore.*/, context);
 
   return (
     <div className={styles.wrapper}>
@@ -40,7 +44,6 @@ export function QueryErrorAlert({ error, query }: Props) {
           <OpenAssistantButton
             origin="grafana/query-editor-error"
             prompt={`Help me analyze and fix the following ${error.type ? `\`${error.type}\`` : ''} query error: \`\`\`${message}\`\`\``}
-            context={buildAssistantContext(error, message, query)}
             title={t('query.query-error-alert.fix-with-assistant', 'Fix with Assistant')}
             size="sm"
           />


### PR DESCRIPTION
## Summary

- Adds `useProvidePageContext` from `@grafana/assistant` to `QueryErrorAlert` so error details and query data are registered as page-level assistant context
- The context is memoized and automatically re-synced when the error or query changes
- On unmount (when the error is gone), the registration is cleaned up automatically by the hook
- Removes the explicit `context` prop from `OpenAssistantButton` since it is now covered by the page context — the assistant can access it regardless of how it is opened

## Test plan

- [x] Trigger a query error in Explore and open the Assistant — verify error details and original query appear in context
- [x] Resolve the error (successful query) and confirm the context registration is cleaned up

Made with [Cursor](https://cursor.com)