### PR TITLE
IAM: Handle existing non-external team memberships gracefully

### DIFF
--- a/pkg/registry/apis/iam/legacy/team_binding.go
+++ b/pkg/registry/apis/iam/legacy/team_binding.go
@@ -200,6 +200,9 @@ func (s *legacySQLStore) CreateTeamMember(ctx context.Context, ns claims.Namespa
 
 		teamMemberID, err := st.ExecWithReturningId(ctx, teamMemberQuery, req.GetArgs()...)
 		if err != nil {
+			if sql.DB.GetDialect().IsUniqueConstraintViolation(err) {
+				return team.ErrTeamMemberAlreadyAdded
+			}
 			return fmt.Errorf("failed to create team member: %w", err)
 		}
 

--- a/pkg/registry/apis/iam/teambinding/store.go
+++ b/pkg/registry/apis/iam/teambinding/store.go
@@ -243,6 +243,9 @@ func (l *LegacyBindingStore) Create(ctx context.Context, obj runtime.Object, cre
 
 	result, err := l.store.CreateTeamMember(ctx, ns, createCmd)
 	if err != nil {
+		if errors.Is(err, team.ErrTeamMemberAlreadyAdded) {
+			return nil, apierrors.NewConflict(bindingResource.GroupResource(), teamMemberObj.Name, err)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

When a user already has a non-external (manually assigned) team membership and the sync attempts to create an external binding for the same team, the underlying database raises a `UNIQUE constraint failed: team_member.org_id, team_member.team_id, team_member.user_id` error that was previously bubbled up as an unhandled error.

- Detect the UNIQUE constraint violation in `CreateTeamMember` (`legacy/team_binding.go`) using the DB dialect and return the semantic `team.ErrTeamMemberAlreadyAdded` instead of the raw database error
- Convert `ErrTeamMemberAlreadyAdded` to a proper HTTP 409 Conflict in the TeamBinding K8s store (`teambinding/store.go`) so callers receive a well-formed K8s status error

The matching fix in `grafana-enterprise` (`syncTeamsK8s`) handles `k8serrors.IsConflict` gracefully and also fixes stale legacy binding cleanup — see the linked enterprise PR.

## Test plan

- [ ] Integration tests added in `grafana-enterprise` covering the fixed scenario (`should not overwrite non-external, existing team binding when syncing`)
- [ ] All existing `TestIntegrationSyncTeamsK8s` subtests continue to pass across all dual-writer modes (0–5)
- [ ] Build passes: `go build --tags "pro" ./pkg/registry/apis/iam/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)