### PR TITLE
Alerting: Fix start time on notifications viewer page.

### DIFF
--- a/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
+++ b/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
@@ -375,8 +375,11 @@ function NotificationDetails({ record }: NotificationDetailsProps) {
           )}
           {alert.startsAt && (
             <Text variant="bodySmall" color="secondary">
-              <Trans i18nKey="alerting.notifications-scene.started">
-                Started: {dateTime(alert.startsAt).format('YYYY-MM-DD HH:mm:ss')}
+              <Trans
+                i18nKey="alerting.notifications-scene.started"
+                values={{ value: dateTime(alert.startsAt).format('YYYY-MM-DD HH:mm:ss') }}
+              >
+                Started: {{ value: dateTime(alert.startsAt).format('YYYY-MM-DD HH:mm:ss') }}
               </Trans>
             </Text>
           )}


### PR DESCRIPTION
The translation contains `{{value}}` but it was not being passed in.