### PR TITLE
Heatmap: remove re-exports from types.ts

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -4142,9 +4142,6 @@
   "public/app/plugins/panel/heatmap/types.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
-    },
-    "no-barrel-files/no-barrel-files": {
-      "count": 1
     }
   },
   "public/app/plugins/panel/heatmap/utils.ts": {

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -27,7 +27,7 @@ import { getXAnnotationFrames } from '../timeseries/plugins/utils';
 import { HeatmapTooltip } from './HeatmapTooltip';
 import { HeatmapData, prepareHeatmapData } from './fields';
 import { quantizeScheme } from './palettes';
-import { Options } from './types';
+import { Options } from './panelcfg.gen';
 import { calculateYSizeDivisor, prepConfig } from './utils';
 
 interface HeatmapPanelProps extends PanelProps<Options> {}

--- a/public/app/plugins/panel/heatmap/fields.test.ts
+++ b/public/app/plugins/panel/heatmap/fields.test.ts
@@ -1,6 +1,6 @@
 import { createTheme } from '@grafana/data';
 
-import { Options } from './types';
+import { Options } from './panelcfg.gen';
 
 const theme = createTheme();
 

--- a/public/app/plugins/panel/heatmap/fields.ts
+++ b/public/app/plugins/panel/heatmap/fields.ts
@@ -27,7 +27,7 @@ import {
   rowsToCellsHeatmap,
 } from 'app/features/transformers/calculateHeatmap/heatmap';
 
-import { CellValues, Options } from './types';
+import { CellValues, Options } from './panelcfg.gen';
 import { boundedMinMax, valuesToFills } from './utils';
 
 export interface HeatmapData {

--- a/public/app/plugins/panel/heatmap/migrations.ts
+++ b/public/app/plugins/panel/heatmap/migrations.ts
@@ -10,7 +10,8 @@ import {
 import { TooltipDisplayMode } from '@grafana/ui';
 
 import { colorSchemes } from './palettes';
-import { Options, defaultOptions, HeatmapColorMode } from './types';
+import { Options, HeatmapColorMode } from './panelcfg.gen';
+import { defaultOptions } from './types';
 
 /** Called when the version number changes */
 export const heatmapMigrationHandler = (panel: PanelModel): Partial<Options> => {

--- a/public/app/plugins/panel/heatmap/module.tsx
+++ b/public/app/plugins/panel/heatmap/module.tsx
@@ -26,8 +26,9 @@ import { YBucketScaleEditor } from './YBucketScaleEditor';
 import { prepareHeatmapData } from './fields';
 import { heatmapChangedHandler, heatmapMigrationHandler } from './migrations';
 import { colorSchemes, quantizeScheme } from './palettes';
+import { Options, HeatmapColorMode, HeatmapColorScale } from './panelcfg.gen';
 import { heatmapSuggestionsSupplier } from './suggestions';
-import { Options, defaultOptions, HeatmapColorMode, HeatmapColorScale } from './types';
+import { defaultOptions } from './types';
 
 export const plugin = new PanelPlugin<Options, GraphFieldConfig>(HeatmapPanel)
   .useFieldConfig({

--- a/public/app/plugins/panel/heatmap/palettes.ts
+++ b/public/app/plugins/panel/heatmap/palettes.ts
@@ -4,7 +4,8 @@ import tinycolor from 'tinycolor2';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
-import { HeatmapColorOptions, defaultOptions, HeatmapColorMode, HeatmapColorScale } from './types';
+import { HeatmapColorOptions, HeatmapColorMode, HeatmapColorScale } from './panelcfg.gen';
+import { defaultOptions } from './types';
 
 // https://observablehq.com/@d3/color-schemes?collection=@d3/d3-scale-chromatic
 

--- a/public/app/plugins/panel/heatmap/suggestions.ts
+++ b/public/app/plugins/panel/heatmap/suggestions.ts
@@ -10,7 +10,8 @@ import { GraphFieldConfig } from '@grafana/schema';
 
 import { prepareHeatmapData } from './fields';
 import { quantizeScheme } from './palettes';
-import { Options, defaultOptions } from './types';
+import { Options } from './panelcfg.gen';
+import { defaultOptions } from './types';
 
 function determineScore(dataSummary: PanelDataSummary): VisualizationSuggestionScore {
   // look to see if the data has an explicity marker for heatmap data on it.

--- a/public/app/plugins/panel/heatmap/types.ts
+++ b/public/app/plugins/panel/heatmap/types.ts
@@ -1,5 +1,3 @@
-export * from './panelcfg.gen';
-
 import { AxisPlacement, HeatmapCellLayout } from '@grafana/schema';
 
 import { defaultOptions as defaultOptionsGen, HeatmapColorMode, HeatmapColorScale, Options } from './panelcfg.gen';

--- a/public/app/plugins/panel/heatmap/utils.ts
+++ b/public/app/plugins/panel/heatmap/utils.ts
@@ -23,7 +23,7 @@ import {
 import { pointWithin, Quadtree, Rect } from '../barchart/quadtree';
 
 import { HeatmapData } from './fields';
-import { FieldConfig, HeatmapSelectionMode, YAxisConfig } from './types';
+import { FieldConfig, HeatmapSelectionMode, YAxisConfig } from './panelcfg.gen';
 
 /** Validates and returns a safe log base (2 or 10), defaults to 2 if invalid */
 export function toLogBase(value: number | undefined): 2 | 10 {


### PR DESCRIPTION
**What is this feature?**

Removes the `export * from './panelcfg.gen'` re-export from `public/app/plugins/panel/heatmap/types.ts`. Consumers now import those types directly from `panelcfg.gen`, while `defaultOptions` (defined in `types.ts`) continues to be imported from `types`.

**Why do we need this feature?**

Re-exporting generated types through a hand-written `types.ts` creates an indirection that obscures where types originate and makes the barrel harder to maintain.

**Who is this feature for?**

Grafana frontend contributors.

**Which issue(s) does this PR fix?**:

Relates #107611

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.