### PR TITLE
MixedDatasource: remove re-exports from module.ts

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3820,11 +3820,6 @@
       "count": 2
     }
   },
-  "public/app/plugins/datasource/mixed/module.ts": {
-    "no-barrel-files/no-barrel-files": {
-      "count": 2
-    }
-  },
   "public/app/plugins/datasource/mssql/azureauth/AzureCredentialsForm.tsx": {
     "no-restricted-syntax": {
       "count": 10

--- a/public/app/plugins/datasource/mixed/MixedDataSource.test.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.test.ts
@@ -8,8 +8,7 @@ import { CustomVariable, SceneFlexLayout, SceneVariableSet } from '@grafana/scen
 
 import { TemplateSrv } from '../../../features/templating/template_srv';
 
-import { MIXED_DATASOURCE_NAME } from './MixedDataSource';
-import { MixedDatasource } from './module';
+import { MixedDatasource, MIXED_DATASOURCE_NAME } from './MixedDataSource';
 
 const defaultDS = new MockObservableDataSourceApi('DefaultDS', [{ data: ['DDD'] }]);
 const datasourceSrv = new DatasourceSrvMock(defaultDS, {

--- a/public/app/plugins/datasource/mixed/module.ts
+++ b/public/app/plugins/datasource/mixed/module.ts
@@ -1,2 +1,5 @@
+import { DataSourcePlugin } from '@grafana/data';
+
 import { MixedDatasource } from './MixedDataSource';
-export { MixedDatasource, MixedDatasource as Datasource };
+
+export const plugin = new DataSourcePlugin(MixedDatasource);


### PR DESCRIPTION
**What is this feature?**

Converts `public/app/plugins/datasource/mixed/module.ts` from the legacy `Datasource` class export to the modern `plugin` export pattern, removing the re-export indirection entirely. The test file is updated to import `MixedDatasource` directly from `./MixedDataSource`.

**Why do we need this feature?**

Re-exporting from a plugin `module.ts` creates an indirection that obscures where symbols originate. The modern pattern uses `new DataSourcePlugin(...)` exported as `plugin`, which is checked first by the plugin importer.

**Who is this feature for?**

Grafana frontend contributors.

**Which issue(s) does this PR fix?**:

Relates #107611

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.