### PR TITLE
Alerting resolved notifications

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/configure-panel-options/index.md
+++ b/docs/sources/visualizations/panels-visualizations/configure-panel-options/index.md
@@ -71,6 +71,20 @@ Set the following options to provide basic information about a panel and define 
 | Panel links            | Add [links to the panel](ref:links-to-the-panel) to create shortcuts to other dashboards, panels, and external websites. Access panel links by clicking the icon next to the panel title.                                                                                                                                                                 |
 | Repeat options         | Set whether to repeat the panel for each value in the selected variable. For more information, refer to [Configure repeating panels](#configure-repeating-panels).                                                                                                                                                                                        |
 
+### Description formatting
+
+The **Description** field supports [GitHub Flavored Markdown](https://github.github.com/gfm/). You can use it to add formatting to panel descriptions in the tooltip.
+
+Common supported formatting includes:
+
+- **Emphasis:** Use `**bold**`, `_italics_`, and `~~strikethrough~~`.
+- **Links:** Use `[Link text](https://example.com)`.
+- **Lists:** Use ordered and unordered lists.
+- **Code:** Use inline code and fenced code blocks.
+- **Tables and blockquotes:** Use standard GFM table and quote syntax.
+
+Grafana sanitizes the rendered description content before display, and removes unsafe HTML.
+
 You can use generative AI to populate the **Title** and **Description** fields with the [Grafana LLM plugin](ref:grafana-llm-plugin), which is currently in public preview. To enable this, refer to [Set up generative AI features for dashboards](ref:set-up-generative-ai-features-for-dashboards).
 
 ## Configure repeating panels

--- a/docs/sources/visualizations/panels-visualizations/configure-panel-options/index.md
+++ b/docs/sources/visualizations/panels-visualizations/configure-panel-options/index.md
@@ -77,7 +77,7 @@ The **Description** field supports [GitHub Flavored Markdown](https://github.git
 
 Common supported formatting includes:
 
-- **Emphasis:** Use `**bold**`, `_italics_`, and `~~strikethrough~~`.
+- **Emphasis:** Use `**bold**`, `_italics_`, and `~~crossed-out text~~`.
 - **Links:** Use `[Link text](https://example.com)`.
 - **Lists:** Use ordered and unordered lists.
 - **Code:** Use inline code and fenced code blocks.


### PR DESCRIPTION
**Docs: Clarify markdown support in panel option descriptions**

**What is this feature?**

This PR clarifies which markdown formatting is supported in panel option descriptions by adding a new section to the documentation.

**Why do we need this feature?**

The existing documentation was vague regarding markdown support for panel descriptions, leading to user confusion (as reported in issue #75478). This update provides explicit details, improving user experience and documentation clarity.

**Who is this feature for?**

Grafana users who configure panels and wish to use markdown formatting in their panel descriptions.

**Which issue(s) does this PR fix?**:

Fixes #75478

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective. (This is a documentation change, so the "works as expected" refers to the clarity and accuracy of the documentation.)
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A, documentation change)
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. (Docs updated; not a "What's New" level change)

---
<p><a href="https://cursor.com/agents?id=bc-c6b154c7-e404-4db1-8213-ef340a953988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6b154c7-e404-4db1-8213-ef340a953988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

