### PR TITLE
Alerting: Increase limit_alerts for grouped alert list panel mode

### DIFF
--- a/public/app/plugins/panel/alertlist/module.tsx
+++ b/public/app/plugins/panel/alertlist/module.tsx
@@ -74,6 +74,7 @@ const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertLi
       path: 'maxItems',
       description: t('alertlist.description-max-items', 'Maximum alerts to display'),
       defaultValue: 20,
+      showIf: (options) => options.groupMode !== GroupMode.Custom,
       category: optionsCategory,
     })
     .addSelect({


### PR DESCRIPTION
For grouped mode, limit to 100 instances per alert rule and hide `maxItems` (since it does nothing).