### PR TITLE
Alerting: Fix new rules api validation

### DIFF
--- a/apps/alerting/rules/go.mod
+++ b/apps/alerting/rules/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/grafana/grafana-app-sdk v0.51.4
 	github.com/grafana/grafana-app-sdk/logging v0.51.4
 	github.com/prometheus/common v0.67.5
+	github.com/stretchr/testify v1.11.1
 	k8s.io/apimachinery v0.35.1
 	k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4
 )

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/alertrule_ext.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/alertrule_ext.go
@@ -124,3 +124,23 @@ func (spec *AlertRuleSpec) ClampDurations() error {
 	}
 	return nil
 }
+
+func (e *AlertRuleExpression) IsSource() bool {
+	return e.Source != nil && *e.Source
+}
+
+func (e *AlertRuleExpression) IsNonExpressionQuery() bool {
+	return e.DatasourceUID != nil && *e.DatasourceUID != "__expr__"
+}
+
+func (e *AlertRuleExpression) HasValidRelativeTimeRange() bool {
+	if e.RelativeTimeRange == nil {
+		return false
+	}
+	from, errFrom := ToDuration(string(e.RelativeTimeRange.From))
+	to, errTo := ToDuration(string(e.RelativeTimeRange.To))
+	if errFrom != nil || errTo != nil {
+		return false
+	}
+	return from > to
+}

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/alertrule_ext.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/alertrule_ext.go
@@ -129,8 +129,8 @@ func (e *AlertRuleExpression) IsSource() bool {
 	return e.Source != nil && *e.Source
 }
 
-func (e *AlertRuleExpression) IsNonExpressionQuery() bool {
-	return e.DatasourceUID != nil && *e.DatasourceUID != "__expr__"
+func (e *AlertRuleExpression) GetDatasource() *string {
+	return (*string)(e.DatasourceUID)
 }
 
 func (e *AlertRuleExpression) HasValidRelativeTimeRange() bool {

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/recordingrule_ext.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/recordingrule_ext.go
@@ -72,3 +72,23 @@ func (spec *RecordingRuleSpec) ClampDurations() error {
 	}
 	return nil
 }
+
+func (e *RecordingRuleExpression) IsSource() bool {
+	return e.Source != nil && *e.Source
+}
+
+func (e *RecordingRuleExpression) IsNonExpressionQuery() bool {
+	return e.DatasourceUID != nil && *e.DatasourceUID != "__expr__"
+}
+
+func (e *RecordingRuleExpression) HasValidRelativeTimeRange() bool {
+	if e.RelativeTimeRange == nil {
+		return false
+	}
+	from, errFrom := ToDuration(string(e.RelativeTimeRange.From))
+	to, errTo := ToDuration(string(e.RelativeTimeRange.To))
+	if errFrom != nil || errTo != nil {
+		return false
+	}
+	return from > to
+}

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/recordingrule_ext.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/recordingrule_ext.go
@@ -77,8 +77,8 @@ func (e *RecordingRuleExpression) IsSource() bool {
 	return e.Source != nil && *e.Source
 }
 
-func (e *RecordingRuleExpression) IsNonExpressionQuery() bool {
-	return e.DatasourceUID != nil && *e.DatasourceUID != "__expr__"
+func (e *RecordingRuleExpression) GetDatasource() *string {
+	return (*string)(e.DatasourceUID)
 }
 
 func (e *RecordingRuleExpression) HasValidRelativeTimeRange() bool {

--- a/apps/alerting/rules/pkg/app/alertrule/validator.go
+++ b/apps/alerting/rules/pkg/app/alertrule/validator.go
@@ -115,7 +115,14 @@ func NewValidator(cfg config.RuntimeConfig) *simple.Validator {
 					return fmt.Errorf("'keepFiringFor' cannot be less than 0")
 				}
 			}
-
+			// 9) Validate that the expressions
+			expressions := make([]util.Expression, 0, len(r.Spec.Expressions))
+			for _, expression := range r.Spec.Expressions {
+				expressions = append(expressions, &expression)
+			}
+			if err := util.ValidateExpressions(expressions); err != nil {
+				return err
+			}
 			return nil
 		},
 	}

--- a/apps/alerting/rules/pkg/app/alertrule/validator.go
+++ b/apps/alerting/rules/pkg/app/alertrule/validator.go
@@ -115,7 +115,7 @@ func NewValidator(cfg config.RuntimeConfig) *simple.Validator {
 					return fmt.Errorf("'keepFiringFor' cannot be less than 0")
 				}
 			}
-			// 9) Validate that the expressions
+			// 9) Validate the expressions
 			expressions := make([]util.Expression, 0, len(r.Spec.Expressions))
 			for _, expression := range r.Spec.Expressions {
 				expressions = append(expressions, &expression)

--- a/apps/alerting/rules/pkg/app/app_test.go
+++ b/apps/alerting/rules/pkg/app/app_test.go
@@ -7,6 +7,8 @@ import (
 
 	appsdk "github.com/grafana/grafana-app-sdk/app"
 	"github.com/grafana/grafana-app-sdk/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	v1 "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
 	"github.com/grafana/grafana/apps/alerting/rules/pkg/app/alertrule"
@@ -41,9 +43,7 @@ func TestAlertRuleValidation_Success(t *testing.T) {
 
 	req := &appsdk.AdmissionRequest{Action: resource.AdmissionActionCreate, Object: r}
 	validator := alertrule.NewValidator(makeDefaultRuntimeConfig())
-	if err := validator.Validate(context.Background(), req); err != nil {
-		t.Fatalf("expected success, got error: %v", err)
-	}
+	require.NoError(t, validator.Validate(context.Background(), req))
 }
 
 func TestAlertRuleValidation_SuccessWithDatasourceQuery(t *testing.T) {
@@ -74,9 +74,34 @@ func TestAlertRuleValidation_SuccessWithDatasourceQuery(t *testing.T) {
 
 	req := &appsdk.AdmissionRequest{Action: resource.AdmissionActionCreate, Object: r}
 	validator := alertrule.NewValidator(makeDefaultRuntimeConfig())
-	if err := validator.Validate(context.Background(), req); err != nil {
-		t.Fatalf("expected success, got error: %v", err)
+	require.NoError(t, validator.Validate(context.Background(), req))
+}
+
+func TestAlertRuleValidation_SuccessWithExpressionDatasourceWithoutRelativeTimeRange(t *testing.T) {
+	dsUID := v1.AlertRuleDatasourceUID("__expr__")
+	r := &v1.AlertRule{}
+	r.SetGroupVersionKind(v1.AlertRuleKind().GroupVersionKind())
+	r.Name = "uid-1"
+	r.Namespace = "ns1"
+	r.Annotations = map[string]string{v1.FolderAnnotationKey: "f1"}
+	r.Labels = map[string]string{}
+	r.Spec = v1.AlertRuleSpec{
+		Title:   "ok",
+		Trigger: v1.AlertRuleIntervalTrigger{Interval: v1.AlertRulePromDuration("60s")},
+		Expressions: v1.AlertRuleExpressionMap{
+			"A": v1.AlertRuleExpression{
+				Model:         map[string]any{"expr": "1"},
+				Source:        boolPtr(true),
+				DatasourceUID: &dsUID,
+			},
+		},
+		NoDataState:  v1.DefaultNoDataState,
+		ExecErrState: v1.DefaultExecErrState,
 	}
+
+	req := &appsdk.AdmissionRequest{Action: resource.AdmissionActionCreate, Object: r}
+	validator := alertrule.NewValidator(makeDefaultRuntimeConfig())
+	require.NoError(t, validator.Validate(context.Background(), req))
 }
 
 func TestAlertRuleValidation_Errors(t *testing.T) {
@@ -86,60 +111,40 @@ func TestAlertRuleValidation_Errors(t *testing.T) {
 		return alertrule.NewValidator(makeDefaultRuntimeConfig()).Validate(context.Background(), &appsdk.AdmissionRequest{Action: resource.AdmissionActionCreate, Object: r})
 	}
 
-	if err := mk(func(r *v1.AlertRule) { r.Annotations = nil }); err == nil {
-		t.Errorf("want folder required error")
-	}
-	if err := mk(func(r *v1.AlertRule) { r.Annotations[v1.FolderAnnotationKey] = "bad" }); err == nil {
-		t.Errorf("want folder not exist error")
-	}
-	if err := mk(func(r *v1.AlertRule) { r.Spec.Trigger.Interval = v1.AlertRulePromDuration("30s") }); err == nil {
-		t.Errorf("want base interval multiple error")
-	}
-	if err := mk(func(r *v1.AlertRule) {
+	assert.Error(t, mk(func(r *v1.AlertRule) { r.Annotations = nil }), "want folder required error")
+	assert.Error(t, mk(func(r *v1.AlertRule) { r.Annotations[v1.FolderAnnotationKey] = "bad" }), "want folder not exist error")
+	assert.Error(t, mk(func(r *v1.AlertRule) { r.Spec.Trigger.Interval = v1.AlertRulePromDuration("30s") }), "want base interval multiple error")
+	assert.Error(t, mk(func(r *v1.AlertRule) {
 		r.Spec.NotificationSettings = &v1.AlertRuleV0alpha1SpecNotificationSettings{Receiver: "bad"}
-	}); err == nil {
-		t.Errorf("want invalid receiver error")
-	}
-	if err := mk(func(r *v1.AlertRule) { r.Labels[v1.GroupLabelKey] = "grp" }); err == nil {
-		t.Errorf("want group set on create error")
-	}
-	if err := mk(func(r *v1.AlertRule) { r.Spec.For = strPtr("-10s") }); err == nil {
-		t.Errorf("want for>=0 error")
-	}
-	if err := mk(func(r *v1.AlertRule) {
+	}), "want invalid receiver error")
+	assert.Error(t, mk(func(r *v1.AlertRule) { r.Labels[v1.GroupLabelKey] = "grp" }), "want group set on create error")
+	assert.Error(t, mk(func(r *v1.AlertRule) { r.Spec.For = strPtr("-10s") }), "want for>=0 error")
+	assert.Error(t, mk(func(r *v1.AlertRule) {
 		if r.Spec.Labels == nil {
 			r.Spec.Labels = map[string]v1.AlertRuleTemplateString{}
 		}
 		r.Spec.Labels["__reserved__"] = v1.AlertRuleTemplateString("x")
-	}); err == nil {
-		t.Errorf("want reserved label key error")
-	}
+	}), "want reserved label key error")
 	// Expression validation: no source expression
-	if err := mk(func(r *v1.AlertRule) {
+	assert.Error(t, mk(func(r *v1.AlertRule) {
 		r.Spec.Expressions = v1.AlertRuleExpressionMap{
 			"A": v1.AlertRuleExpression{Model: map[string]any{"expr": "1"}},
 		}
-	}); err == nil {
-		t.Errorf("want no source expression error")
-	}
+	}), "want no source expression error")
 	// Expression validation: multiple source expressions
-	if err := mk(func(r *v1.AlertRule) {
+	assert.Error(t, mk(func(r *v1.AlertRule) {
 		r.Spec.Expressions = v1.AlertRuleExpressionMap{
 			"A": v1.AlertRuleExpression{Model: map[string]any{"expr": "1"}, Source: boolPtr(true)},
 			"B": v1.AlertRuleExpression{Model: map[string]any{"expr": "2"}, Source: boolPtr(true)},
 		}
-	}); err == nil {
-		t.Errorf("want multiple source expressions error")
-	}
+	}), "want multiple source expressions error")
 	// Expression validation: non-expression query without relative time range
-	if err := mk(func(r *v1.AlertRule) {
+	assert.Error(t, mk(func(r *v1.AlertRule) {
 		dsUID := v1.AlertRuleDatasourceUID("prometheus")
 		r.Spec.Expressions = v1.AlertRuleExpressionMap{
 			"A": v1.AlertRuleExpression{Model: map[string]any{"expr": "1"}, Source: boolPtr(true), DatasourceUID: &dsUID},
 		}
-	}); err == nil {
-		t.Errorf("want query expression requires relative time range error")
-	}
+	}), "want query expression requires relative time range error")
 }
 
 func baseAlertRule() *v1.AlertRule {
@@ -176,9 +181,7 @@ func TestRecordingRuleValidation_Success(t *testing.T) {
 
 	req := &appsdk.AdmissionRequest{Action: resource.AdmissionActionCreate, Object: r}
 	validator := recordingrule.NewValidator(makeDefaultRuntimeConfig())
-	if err := validator.Validate(context.Background(), req); err != nil {
-		t.Fatalf("expected success, got error: %v", err)
-	}
+	require.NoError(t, validator.Validate(context.Background(), req))
 }
 
 func TestRecordingRuleValidation_SuccessWithDatasourceQuery(t *testing.T) {
@@ -209,9 +212,34 @@ func TestRecordingRuleValidation_SuccessWithDatasourceQuery(t *testing.T) {
 
 	req := &appsdk.AdmissionRequest{Action: resource.AdmissionActionCreate, Object: r}
 	validator := recordingrule.NewValidator(makeDefaultRuntimeConfig())
-	if err := validator.Validate(context.Background(), req); err != nil {
-		t.Fatalf("expected success, got error: %v", err)
+	require.NoError(t, validator.Validate(context.Background(), req))
+}
+
+func TestRecordingRuleValidation_SuccessWithExpressionDatasourceWithoutRelativeTimeRange(t *testing.T) {
+	dsUID := v1.RecordingRuleDatasourceUID("__expr__")
+	r := &v1.RecordingRule{}
+	r.SetGroupVersionKind(v1.RecordingRuleKind().GroupVersionKind())
+	r.Name = "uid-2"
+	r.Namespace = "ns1"
+	r.Annotations = map[string]string{v1.FolderAnnotationKey: "f1"}
+	r.Labels = map[string]string{}
+	r.Spec = v1.RecordingRuleSpec{
+		Title:   "ok",
+		Trigger: v1.RecordingRuleIntervalTrigger{Interval: v1.RecordingRulePromDuration("60s")},
+		Expressions: v1.RecordingRuleExpressionMap{
+			"A": v1.RecordingRuleExpression{
+				Model:         map[string]any{"expr": "1"},
+				Source:        boolPtr(true),
+				DatasourceUID: &dsUID,
+			},
+		},
+		Metric:              "test_metric",
+		TargetDatasourceUID: "ds1",
 	}
+
+	req := &appsdk.AdmissionRequest{Action: resource.AdmissionActionCreate, Object: r}
+	validator := recordingrule.NewValidator(makeDefaultRuntimeConfig())
+	require.NoError(t, validator.Validate(context.Background(), req))
 }
 
 func TestRecordingRuleValidation_Errors(t *testing.T) {
@@ -221,55 +249,37 @@ func TestRecordingRuleValidation_Errors(t *testing.T) {
 		return recordingrule.NewValidator(makeDefaultRuntimeConfig()).Validate(context.Background(), &appsdk.AdmissionRequest{Action: resource.AdmissionActionCreate, Object: r})
 	}
 
-	if err := mk(func(r *v1.RecordingRule) { r.Annotations = nil }); err == nil {
-		t.Errorf("want folder required error")
-	}
-	if err := mk(func(r *v1.RecordingRule) { r.Annotations[v1.FolderAnnotationKey] = "bad" }); err == nil {
-		t.Errorf("want folder not exist error")
-	}
-	if err := mk(func(r *v1.RecordingRule) { r.Spec.Trigger.Interval = v1.RecordingRulePromDuration("30s") }); err == nil {
-		t.Errorf("want base interval multiple error")
-	}
-	if err := mk(func(r *v1.RecordingRule) { r.Labels[v1.GroupLabelKey] = "grp" }); err == nil {
-		t.Errorf("want group set on create error")
-	}
-	if err := mk(func(r *v1.RecordingRule) { r.Spec.Metric = "" }); err == nil {
-		t.Errorf("want metric required error")
-	}
-	if err := mk(func(r *v1.RecordingRule) {
+	assert.Error(t, mk(func(r *v1.RecordingRule) { r.Annotations = nil }), "want folder required error")
+	assert.Error(t, mk(func(r *v1.RecordingRule) { r.Annotations[v1.FolderAnnotationKey] = "bad" }), "want folder not exist error")
+	assert.Error(t, mk(func(r *v1.RecordingRule) { r.Spec.Trigger.Interval = v1.RecordingRulePromDuration("30s") }), "want base interval multiple error")
+	assert.Error(t, mk(func(r *v1.RecordingRule) { r.Labels[v1.GroupLabelKey] = "grp" }), "want group set on create error")
+	assert.Error(t, mk(func(r *v1.RecordingRule) { r.Spec.Metric = "" }), "want metric required error")
+	assert.Error(t, mk(func(r *v1.RecordingRule) {
 		if r.Spec.Labels == nil {
 			r.Spec.Labels = map[string]v1.RecordingRuleTemplateString{}
 		}
 		r.Spec.Labels["__reserved__"] = v1.RecordingRuleTemplateString("x")
-	}); err == nil {
-		t.Errorf("want reserved label key error")
-	}
+	}), "want reserved label key error")
 	// Expression validation: no source expression
-	if err := mk(func(r *v1.RecordingRule) {
+	assert.Error(t, mk(func(r *v1.RecordingRule) {
 		r.Spec.Expressions = v1.RecordingRuleExpressionMap{
 			"A": v1.RecordingRuleExpression{Model: map[string]any{"expr": "1"}},
 		}
-	}); err == nil {
-		t.Errorf("want no source expression error")
-	}
+	}), "want no source expression error")
 	// Expression validation: multiple source expressions
-	if err := mk(func(r *v1.RecordingRule) {
+	assert.Error(t, mk(func(r *v1.RecordingRule) {
 		r.Spec.Expressions = v1.RecordingRuleExpressionMap{
 			"A": v1.RecordingRuleExpression{Model: map[string]any{"expr": "1"}, Source: boolPtr(true)},
 			"B": v1.RecordingRuleExpression{Model: map[string]any{"expr": "2"}, Source: boolPtr(true)},
 		}
-	}); err == nil {
-		t.Errorf("want multiple source expressions error")
-	}
+	}), "want multiple source expressions error")
 	// Expression validation: non-expression query without relative time range
-	if err := mk(func(r *v1.RecordingRule) {
+	assert.Error(t, mk(func(r *v1.RecordingRule) {
 		dsUID := v1.RecordingRuleDatasourceUID("prometheus")
 		r.Spec.Expressions = v1.RecordingRuleExpressionMap{
 			"A": v1.RecordingRuleExpression{Model: map[string]any{"expr": "1"}, Source: boolPtr(true), DatasourceUID: &dsUID},
 		}
-	}); err == nil {
-		t.Errorf("want query expression requires relative time range error")
-	}
+	}), "want query expression requires relative time range error")
 }
 
 func baseRecordingRule() *v1.RecordingRule {

--- a/apps/alerting/rules/pkg/app/app_test.go
+++ b/apps/alerting/rules/pkg/app/app_test.go
@@ -104,6 +104,31 @@ func TestAlertRuleValidation_SuccessWithExpressionDatasourceWithoutRelativeTimeR
 	require.NoError(t, validator.Validate(context.Background(), req))
 }
 
+func TestAlertRuleValidation_SuccessWithoutDatasourceUIDWithoutRelativeTimeRange(t *testing.T) {
+	r := &v1.AlertRule{}
+	r.SetGroupVersionKind(v1.AlertRuleKind().GroupVersionKind())
+	r.Name = "uid-1"
+	r.Namespace = "ns1"
+	r.Annotations = map[string]string{v1.FolderAnnotationKey: "f1"}
+	r.Labels = map[string]string{}
+	r.Spec = v1.AlertRuleSpec{
+		Title:   "ok",
+		Trigger: v1.AlertRuleIntervalTrigger{Interval: v1.AlertRulePromDuration("60s")},
+		Expressions: v1.AlertRuleExpressionMap{
+			"A": v1.AlertRuleExpression{
+				Model:  map[string]any{"expr": "1"},
+				Source: boolPtr(true),
+			},
+		},
+		NoDataState:  v1.DefaultNoDataState,
+		ExecErrState: v1.DefaultExecErrState,
+	}
+
+	req := &appsdk.AdmissionRequest{Action: resource.AdmissionActionCreate, Object: r}
+	validator := alertrule.NewValidator(makeDefaultRuntimeConfig())
+	require.NoError(t, validator.Validate(context.Background(), req))
+}
+
 func TestAlertRuleValidation_Errors(t *testing.T) {
 	mk := func(mut func(r *v1.AlertRule)) error {
 		r := baseAlertRule()
@@ -231,6 +256,31 @@ func TestRecordingRuleValidation_SuccessWithExpressionDatasourceWithoutRelativeT
 				Model:         map[string]any{"expr": "1"},
 				Source:        boolPtr(true),
 				DatasourceUID: &dsUID,
+			},
+		},
+		Metric:              "test_metric",
+		TargetDatasourceUID: "ds1",
+	}
+
+	req := &appsdk.AdmissionRequest{Action: resource.AdmissionActionCreate, Object: r}
+	validator := recordingrule.NewValidator(makeDefaultRuntimeConfig())
+	require.NoError(t, validator.Validate(context.Background(), req))
+}
+
+func TestRecordingRuleValidation_SuccessWithoutDatasourceUIDWithoutRelativeTimeRange(t *testing.T) {
+	r := &v1.RecordingRule{}
+	r.SetGroupVersionKind(v1.RecordingRuleKind().GroupVersionKind())
+	r.Name = "uid-2"
+	r.Namespace = "ns1"
+	r.Annotations = map[string]string{v1.FolderAnnotationKey: "f1"}
+	r.Labels = map[string]string{}
+	r.Spec = v1.RecordingRuleSpec{
+		Title:   "ok",
+		Trigger: v1.RecordingRuleIntervalTrigger{Interval: v1.RecordingRulePromDuration("60s")},
+		Expressions: v1.RecordingRuleExpressionMap{
+			"A": v1.RecordingRuleExpression{
+				Model:  map[string]any{"expr": "1"},
+				Source: boolPtr(true),
 			},
 		},
 		Metric:              "test_metric",

--- a/apps/alerting/rules/pkg/app/recordingrule/validator.go
+++ b/apps/alerting/rules/pkg/app/recordingrule/validator.go
@@ -78,6 +78,14 @@ func NewValidator(cfg config.RuntimeConfig) *simple.Validator {
 				}
 			}
 
+			expressions := make([]util.Expression, 0, len(r.Spec.Expressions))
+			for _, expression := range r.Spec.Expressions {
+				expressions = append(expressions, &expression)
+			}
+			if err := util.ValidateExpressions(expressions); err != nil {
+				return err
+			}
+
 			if r.Spec.Metric == "" {
 				return fmt.Errorf("metric must be specified")
 			}

--- a/apps/alerting/rules/pkg/app/util/validator.go
+++ b/apps/alerting/rules/pkg/app/util/validator.go
@@ -25,3 +25,30 @@ func ValidateInterval(baseInterval time.Duration, d DurationLike) error {
 	}
 	return nil
 }
+
+type Expression interface {
+	IsSource() bool
+	// IsNonExpressionQuery returns true if the datasource for this expression is not the expression evaluator datasource
+	IsNonExpressionQuery() bool
+	HasValidRelativeTimeRange() bool
+}
+
+func ValidateExpressions(expressions []Expression) error {
+	hasSource := false
+	for _, expression := range expressions {
+		if expression.IsNonExpressionQuery() && !expression.HasValidRelativeTimeRange() {
+			return fmt.Errorf("query expressions must have a relative time range")
+		}
+		if expression.IsSource() {
+			if hasSource {
+				return fmt.Errorf("only one expression can be marked as source")
+			}
+			hasSource = true
+			continue
+		}
+	}
+	if !hasSource {
+		return fmt.Errorf("one expression must be marked as source")
+	}
+	return nil
+}

--- a/apps/alerting/rules/pkg/app/util/validator.go
+++ b/apps/alerting/rules/pkg/app/util/validator.go
@@ -28,15 +28,15 @@ func ValidateInterval(baseInterval time.Duration, d DurationLike) error {
 
 type Expression interface {
 	IsSource() bool
-	// IsNonExpressionQuery returns true if the datasource for this expression is not the expression evaluator datasource
-	IsNonExpressionQuery() bool
+	GetDatasource() *string
 	HasValidRelativeTimeRange() bool
 }
 
 func ValidateExpressions(expressions []Expression) error {
 	hasSource := false
 	for _, expression := range expressions {
-		if expression.IsNonExpressionQuery() && !expression.HasValidRelativeTimeRange() {
+		datasource := expression.GetDatasource()
+		if (datasource != nil && *datasource != "__expr__") && !expression.HasValidRelativeTimeRange() {
 			return fmt.Errorf("query expressions must have a relative time range")
 		}
 		if expression.IsSource() {

--- a/pkg/tests/apis/alerting/rules/alertrule/alertrule_test.go
+++ b/pkg/tests/apis/alerting/rules/alertrule/alertrule_test.go
@@ -423,7 +423,7 @@ func TestIntegrationCRUD(t *testing.T) {
 		}
 
 		created, err := adminClient.Create(ctx, alertRule, v1.CreateOptions{})
-		require.ErrorContains(t, err, "no query marked as source")
+		require.ErrorContains(t, err, "one expression must be marked as source")
 		require.Nil(t, created)
 	})
 	t.Run("should not be able to create rule with interval less than base", func(t *testing.T) {

--- a/pkg/tests/apis/alerting/rules/recordingrule/recordingrule_test.go
+++ b/pkg/tests/apis/alerting/rules/recordingrule/recordingrule_test.go
@@ -417,7 +417,7 @@ func TestIntegrationCRUD(t *testing.T) {
 		}
 
 		created, err := adminClient.Create(ctx, recordingRule, v1.CreateOptions{})
-		require.ErrorContains(t, err, "no query marked as source")
+		require.ErrorContains(t, err, "one expression must be marked as source")
 		require.Nil(t, created)
 	})
 	t.Run("should not be able to create rule with interval less than base", func(t *testing.T) {


### PR DESCRIPTION
We were missing some validations on expressions in the new rules apis, this PR adds those validations and also adds some tests to cover them.
