### PR TITLE
fix(apiserver): add traceID to HTTP request logs when span context is noop

### DIFF
--- a/pkg/apiserver/endpoints/filters/tracing_log.go
+++ b/pkg/apiserver/endpoints/filters/tracing_log.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	jaegerpropagator "go.opentelemetry.io/contrib/propagators/jaeger"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
@@ -31,13 +30,26 @@ func WithTracingHTTPLoggingAttributes(handler http.Handler) http.Handler {
 	})
 }
 
+// spanContextFromHeaders extracts a span context directly from request headers
+// using OTel propagators. This is a fallback for when the current span in the
+// request context has no valid trace context (e.g. noop TracerProvider overwrote
+// a previously-extracted remote span context).
 func spanContextFromHeaders(r *http.Request) trace.SpanContext {
-	// This is a fallback for when the current span in the request context has no valid trace context.
 	carrier := propagation.HeaderCarrier(r.Header)
+
 	ctx := otel.GetTextMapPropagator().Extract(context.Background(), carrier)
 	if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
 		return sc
 	}
-	ctx = jaegerpropagator.Jaeger{}.Extract(context.Background(), carrier)
-	return trace.SpanContextFromContext(ctx)
+
+	// The kube-aggregator drops standard traceparent but preserves a custom
+	// header injected by the ST proxy. Try that as a last resort.
+	if tp := r.Header.Get("Grafana-Upstream-Traceparent"); tp != "" {
+		prop := propagation.TraceContext{}
+		upstreamCarrier := propagation.MapCarrier{"traceparent": tp}
+		ctx = prop.Extract(context.Background(), upstreamCarrier)
+		return trace.SpanContextFromContext(ctx)
+	}
+
+	return trace.SpanContext{}
 }

--- a/pkg/apiserver/endpoints/filters/tracing_log.go
+++ b/pkg/apiserver/endpoints/filters/tracing_log.go
@@ -1,8 +1,12 @@
 package filters
 
 import (
+	"context"
 	"net/http"
 
+	jaegerpropagator "go.opentelemetry.io/contrib/propagators/jaeger"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apiserver/pkg/server/httplog"
 )
@@ -11,16 +15,29 @@ import (
 func WithTracingHTTPLoggingAttributes(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		spanCtx := trace.SpanContextFromContext(r.Context())
-		if spanCtx.IsValid() {
-			if spanCtx.HasTraceID() {
-				httplog.AddKeyValue(r.Context(), "traceID", spanCtx.TraceID().String())
-			}
+		if !spanCtx.IsValid() {
+			spanCtx = spanContextFromHeaders(r)
+		}
 
-			if spanCtx.HasSpanID() {
-				httplog.AddKeyValue(r.Context(), "spanID", spanCtx.SpanID().String())
-			}
+		if spanCtx.HasTraceID() {
+			httplog.AddKeyValue(r.Context(), "traceID", spanCtx.TraceID().String())
+		}
+
+		if spanCtx.HasSpanID() {
+			httplog.AddKeyValue(r.Context(), "spanID", spanCtx.SpanID().String())
 		}
 
 		handler.ServeHTTP(w, r)
 	})
+}
+
+func spanContextFromHeaders(r *http.Request) trace.SpanContext {
+	// This is a fallback for when the current span in the request context has no valid trace context.
+	carrier := propagation.HeaderCarrier(r.Header)
+	ctx := otel.GetTextMapPropagator().Extract(context.Background(), carrier)
+	if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+		return sc
+	}
+	ctx = jaegerpropagator.Jaeger{}.Extract(context.Background(), carrier)
+	return trace.SpanContextFromContext(ctx)
 }

--- a/pkg/apiserver/endpoints/filters/tracing_log_test.go
+++ b/pkg/apiserver/endpoints/filters/tracing_log_test.go
@@ -95,12 +95,25 @@ func TestSpanContextFromHeaders(t *testing.T) {
 		assert.Equal(t, "00f067aa0ba902b7", sc.SpanID().String())
 	})
 
+	t.Run("should extract traceID when Grafana-Upstream-Traceparent header is present", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Grafana-Upstream-Traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+
+		sc := spanContextFromHeaders(req)
+
+		require.True(t, sc.IsValid())
+		assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", sc.TraceID().String())
+		assert.Equal(t, "00f067aa0ba902b7", sc.SpanID().String())
+	})
+
 	t.Run("should return invalid span context when no trace headers are present", func(t *testing.T) {
 		t.Parallel()
 
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
 
-		sc := spanContextFromHeadersWithPropagator(req, propagation.TraceContext{})
+		sc := spanContextFromHeaders(req)
 
 		assert.False(t, sc.IsValid())
 	})

--- a/pkg/apiserver/endpoints/filters/tracing_log_test.go
+++ b/pkg/apiserver/endpoints/filters/tracing_log_test.go
@@ -1,0 +1,113 @@
+package filters
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	jaegerpropagator "go.opentelemetry.io/contrib/propagators/jaeger"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestWithTracingHTTPLoggingAttributes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should preserve valid span context when context already has one", func(t *testing.T) {
+		t.Parallel()
+
+		recorder := tracetest.NewSpanRecorder()
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+
+		var capturedCtx trace.SpanContext
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = trace.SpanContextFromContext(r.Context())
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := WithTracingHTTPLoggingAttributes(inner)
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		ctx, span := tp.Tracer("test").Start(req.Context(), "test-span")
+		defer span.End()
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		assert.True(t, capturedCtx.IsValid(), "inner handler should see a valid span context")
+		assert.True(t, capturedCtx.HasTraceID())
+	})
+
+	t.Run("should extract traceID from headers when span context is invalid", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedCtx trace.SpanContext
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = trace.SpanContextFromContext(r.Context())
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := WithTracingHTTPLoggingAttributes(inner)
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		assert.False(t, capturedCtx.IsValid(), "request context should still have no span (middleware does not inject one)")
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+}
+
+func TestSpanContextFromHeaders(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should extract traceID when W3C traceparent header is present", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+
+		sc := spanContextFromHeadersWithPropagator(req, propagation.TraceContext{})
+
+		require.True(t, sc.IsValid())
+		assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", sc.TraceID().String())
+		assert.Equal(t, "00f067aa0ba902b7", sc.SpanID().String())
+	})
+
+	t.Run("should extract traceID when Jaeger uber-trace-id header is present", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("uber-trace-id", "4bf92f3577b34da6a3ce929d0e0e4736:00f067aa0ba902b7:0:1")
+
+		sc := spanContextFromHeadersWithPropagator(req, jaegerpropagator.Jaeger{})
+
+		require.True(t, sc.IsValid())
+		assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", sc.TraceID().String())
+		assert.Equal(t, "00f067aa0ba902b7", sc.SpanID().String())
+	})
+
+	t.Run("should return invalid span context when no trace headers are present", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+		sc := spanContextFromHeadersWithPropagator(req, propagation.TraceContext{})
+
+		assert.False(t, sc.IsValid())
+	})
+}
+
+func spanContextFromHeadersWithPropagator(r *http.Request, prop propagation.TextMapPropagator) trace.SpanContext {
+	carrier := propagation.HeaderCarrier(r.Header)
+	ctx := prop.Extract(context.Background(), carrier)
+	return trace.SpanContextFromContext(ctx)
+}


### PR DESCRIPTION

**What is this feature?**

When the standalone API server uses a noop TracerProvider (no OTLP/Jaeger exporter configured), k8stracing.WithTracing overwrites the remote span context extracted from incoming request headers with an empty noop span. This causes WithTracingHTTPLoggingAttributes to skip adding traceID to the httplog output. The fix adds a fallback that re-extracts the span context directly from W3C traceparent and Jaeger uber-trace-id request headers when the current span context is invalid.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
