### PR TITLE
A11y: fix both pages which fail heading checks which are pa11y certified

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/VariablesUnknownTable.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariablesUnknownTable.test.tsx
@@ -26,9 +26,7 @@ async function getTestContext(
   };
   const props = { ...defaults, ...overrides };
   const { rerender } = render(<VariablesUnknownTable {...props} />);
-  await waitFor(() =>
-    expect(screen.getByRole('heading', { name: /renamed or missing variables/i })).toBeInTheDocument()
-  );
+  await waitFor(() => expect(screen.getByLabelText('Renamed or missing variables')).toBeInTheDocument());
 
   return { reportInteractionSpy, getUnknownsNetworkSpy, rerender };
 }
@@ -44,14 +42,14 @@ describe('VariablesUnknownTable', () => {
     it('then it should call getUnknownsNetwork', async () => {
       const { getUnknownsNetworkSpy } = await getTestContext();
 
-      await userEvent.click(screen.getByRole('heading', { name: /renamed or missing variables/i }));
+      await userEvent.click(screen.getByLabelText('Renamed or missing variables'));
       await waitFor(() => expect(getUnknownsNetworkSpy).toHaveBeenCalledTimes(1));
     });
 
     it('then it should report the interaction', async () => {
       const { reportInteractionSpy } = await getTestContext();
 
-      await userEvent.click(screen.getByRole('heading', { name: /renamed or missing variables/i }));
+      await userEvent.click(screen.getByLabelText('Renamed or missing variables'));
 
       expect(reportInteractionSpy).toHaveBeenCalledTimes(1);
       expect(reportInteractionSpy).toHaveBeenCalledWith('Unknown variables section expanded');
@@ -61,14 +59,14 @@ describe('VariablesUnknownTable', () => {
       it('then it should not call getUnknownsNetwork', async () => {
         const { getUnknownsNetworkSpy } = await getTestContext();
 
-        await userEvent.click(screen.getByRole('heading', { name: /renamed or missing variables/i }));
+        await userEvent.click(screen.getByLabelText('Renamed or missing variables'));
         await waitFor(() => expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true'));
         expect(getUnknownsNetworkSpy).toHaveBeenCalledTimes(1);
 
-        await userEvent.click(screen.getByRole('heading', { name: /renamed or missing variables/i }));
+        await userEvent.click(screen.getByLabelText('Renamed or missing variables'));
         await waitFor(() => expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'false'));
 
-        await userEvent.click(screen.getByRole('heading', { name: /renamed or missing variables/i }));
+        await userEvent.click(screen.getByLabelText('Renamed or missing variables'));
         await waitFor(() => expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true'));
 
         expect(getUnknownsNetworkSpy).toHaveBeenCalledTimes(1);
@@ -79,7 +77,7 @@ describe('VariablesUnknownTable', () => {
       it('then it should render the correct message', async () => {
         await getTestContext();
 
-        await userEvent.click(screen.getByRole('heading', { name: /renamed or missing variables/i }));
+        await userEvent.click(screen.getByLabelText('Renamed or missing variables'));
 
         expect(screen.getByText('No renamed or missing variables found.')).toBeInTheDocument();
       });
@@ -91,7 +89,7 @@ describe('VariablesUnknownTable', () => {
         const usages = [{ variable, nodes: [], edges: [], showGraph: false }];
         const { reportInteractionSpy } = await getTestContext({}, usages);
 
-        await userEvent.click(screen.getByRole('heading', { name: /renamed or missing variables/i }));
+        await userEvent.click(screen.getByLabelText('Renamed or missing variables'));
 
         expect(screen.queryByText('No renamed or missing variables found.')).not.toBeInTheDocument();
         expect(screen.getByText('Renamed Variable')).toBeInTheDocument();
@@ -134,7 +132,7 @@ describe('VariablesUnknownTable', () => {
             });
           });
 
-          await user.click(screen.getByRole('heading', { name: /renamed or missing variables/i }));
+          await user.click(screen.getByLabelText('Renamed or missing variables'));
 
           jest.advanceTimersByTime(SLOW_VARIABLES_EXPANSION_THRESHOLD);
 

--- a/public/app/features/dashboard-scene/settings/variables/VariablesUnknownTable.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariablesUnknownTable.tsx
@@ -7,7 +7,7 @@ import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { SceneVariable, SceneVariableState } from '@grafana/scenes';
 import { Dashboard } from '@grafana/schema';
-import { CollapsableSection, Icon, Spinner, Stack, Tooltip, useStyles2 } from '@grafana/ui';
+import { CollapsableSection, Icon, Spinner, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { VariableUsagesButton } from '../../variables/VariableUsagesButton';
 import { getUnknownsNetwork, UsagesToNetwork } from '../../variables/utils';
@@ -78,7 +78,7 @@ function CollapseLabel(): ReactElement {
   const style = useStyles2(getStyles);
 
   return (
-    <h5>
+    <Text variant="h5">
       <Trans i18nKey="variables.unknown-table.renamed-or-missing-variables">Renamed or missing variables</Trans>
       <Tooltip
         content={t(
@@ -88,7 +88,7 @@ function CollapseLabel(): ReactElement {
       >
         <Icon name="info-circle" className={style.infoIcon} />
       </Tooltip>
-    </h5>
+    </Text>
   );
 }
 

--- a/public/app/features/variables/inspect/VariablesUnknownTable.test.tsx
+++ b/public/app/features/variables/inspect/VariablesUnknownTable.test.tsx
@@ -26,9 +26,7 @@ async function getTestContext(
   };
   const props = { ...defaults, ...overrides };
   const { rerender } = render(<VariablesUnknownTable {...props} />);
-  await waitFor(() =>
-    expect(screen.getByRole('heading', { name: /renamed or missing variables/i })).toBeInTheDocument()
-  );
+  await waitFor(() => expect(screen.getByLabelText('Renamed or missing variables')).toBeInTheDocument());
 
   return { reportInteractionSpy, getUnknownsNetworkSpy, rerender };
 }
@@ -44,14 +42,14 @@ describe('VariablesUnknownTable', () => {
     it('then it should call getUnknownsNetwork', async () => {
       const { getUnknownsNetworkSpy } = await getTestContext();
 
-      await userEvent.click(screen.getByRole('heading', { name: /renamed or missing variables/i }));
+      await userEvent.click(screen.getByLabelText('Renamed or missing variables'));
       await waitFor(() => expect(getUnknownsNetworkSpy).toHaveBeenCalledTimes(1));
     });
 
     it('then it should report the interaction', async () => {
       const { reportInteractionSpy } = await getTestContext();
 
-      await userEvent.click(screen.getByRole('heading', { name: /renamed or missing variables/i }));
+      await userEvent.click(screen.getByLabelText('Renamed or missing variables'));
 
       expect(reportInteractionSpy).toHaveBeenCalledTimes(1);
       expect(reportInteractionSpy).toHaveBeenCalledWith('Unknown variables section expanded');
@@ -61,14 +59,14 @@ describe('VariablesUnknownTable', () => {
       it('then it should not call getUnknownsNetwork', async () => {
         const { getUnknownsNetworkSpy } = await getTestContext();
 
-        await userEvent.click(screen.getByRole('heading', { name: /renamed or missing variables/i }));
+        await userEvent.click(screen.getByLabelText('Renamed or missing variables'));
         await waitFor(() => expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true'));
         expect(getUnknownsNetworkSpy).toHaveBeenCalledTimes(1);
 
-        await userEvent.click(screen.getByRole('heading', { name: /renamed or missing variables/i }));
+        await userEvent.click(screen.getByLabelText('Renamed or missing variables'));
         await waitFor(() => expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'false'));
 
-        await userEvent.click(screen.getByRole('heading', { name: /renamed or missing variables/i }));
+        await userEvent.click(screen.getByLabelText('Renamed or missing variables'));
         await waitFor(() => expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true'));
 
         expect(getUnknownsNetworkSpy).toHaveBeenCalledTimes(1);
@@ -79,7 +77,7 @@ describe('VariablesUnknownTable', () => {
       it('then it should render the correct message', async () => {
         await getTestContext();
 
-        await userEvent.click(screen.getByRole('heading', { name: /renamed or missing variables/i }));
+        await userEvent.click(screen.getByLabelText('Renamed or missing variables'));
 
         await waitFor(() => expect(screen.queryByTestId('Spinner')).not.toBeInTheDocument());
         expect(screen.getByText('No renamed or missing variables found.')).toBeInTheDocument();
@@ -92,7 +90,7 @@ describe('VariablesUnknownTable', () => {
         const usages = [{ variable, nodes: [], edges: [], showGraph: false }];
         const { reportInteractionSpy } = await getTestContext({}, usages);
 
-        await userEvent.click(screen.getByRole('heading', { name: /renamed or missing variables/i }));
+        await userEvent.click(screen.getByLabelText('Renamed or missing variables'));
 
         expect(screen.queryByText('No renamed or missing variables found.')).not.toBeInTheDocument();
         expect(screen.getByText('Renamed Variable')).toBeInTheDocument();
@@ -129,7 +127,7 @@ describe('VariablesUnknownTable', () => {
             });
           });
 
-          await user.click(screen.getByRole('heading', { name: /renamed or missing variables/i }));
+          await user.click(screen.getByLabelText('Renamed or missing variables'));
 
           jest.advanceTimersByTime(SLOW_VARIABLES_EXPANSION_THRESHOLD);
 

--- a/public/app/features/variables/inspect/VariablesUnknownTable.tsx
+++ b/public/app/features/variables/inspect/VariablesUnknownTable.tsx
@@ -5,7 +5,7 @@ import { useAsync } from 'react-use';
 import { BaseVariableModel, GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { CollapsableSection, Icon, Spinner, Stack, Tooltip, useStyles2 } from '@grafana/ui';
+import { CollapsableSection, Icon, Spinner, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { DashboardModel } from '../../dashboard/state/DashboardModel';
 
@@ -80,7 +80,7 @@ function CollapseLabel(): ReactElement {
   const style = useStyles2(getStyles);
 
   return (
-    <h5>
+    <Text variant="h5">
       <Trans i18nKey="variables.variables-unknown-table.collapse-label">Renamed or missing variables</Trans>
       <Tooltip
         content={t(
@@ -90,7 +90,7 @@ function CollapseLabel(): ReactElement {
       >
         <Icon name="info-circle" className={style.infoIcon} />
       </Tooltip>
-    </h5>
+    </Text>
   );
 }
 

--- a/public/app/plugins/panel/dashlist/DashList.test.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.test.tsx
@@ -56,7 +56,7 @@ describe.each(fixtures)('%s', (_title, featureTogglesSetup) => {
     });
     render(<DashList {...props} />);
 
-    const headings = (await screen.findAllByRole('heading')).map((heading) => heading.textContent);
+    const headings = (await screen.findAllByTestId('dashlist-header')).map((heading) => heading.textContent);
     expect(headings).toEqual(['Starred dashboards', 'Recently viewed dashboards', 'Search']);
   });
 

--- a/public/app/plugins/panel/dashlist/DashList.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.tsx
@@ -217,7 +217,12 @@ export function DashList(props: PanelProps<Options>) {
             <Box marginBottom={2} paddingTop={0.5} key={`dash-group-${i}`}>
               {showHeadings && (
                 <Box marginRight={1} paddingX={1} paddingY={0.25}>
-                  <Text variant="h6">{header}</Text>
+                  {/* this testid is only necessary because we cannot determine what heading level to use here without some kind of
+                   top-level way to manage that across the application. these _should_ be headings, we just won't know what level they should be
+                   without something global, so for now we're using a testid to target these in tests. */}
+                  <Text data-testid="dashlist-header" variant="h6">
+                    {header}
+                  </Text>
                 </Box>
               )}
               {renderList(dashboards)}

--- a/public/app/plugins/panel/dashlist/DashList.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.tsx
@@ -217,9 +217,7 @@ export function DashList(props: PanelProps<Options>) {
             <Box marginBottom={2} paddingTop={0.5} key={`dash-group-${i}`}>
               {showHeadings && (
                 <Box marginRight={1} paddingX={1} paddingY={0.25}>
-                  <Text variant="h6" element="h6">
-                    {header}
-                  </Text>
+                  <Text variant="h6">{header}</Text>
                 </Box>
               )}
               {renderList(dashboards)}

--- a/public/app/plugins/panel/welcome/Welcome.tsx
+++ b/public/app/plugins/panel/welcome/Welcome.tsx
@@ -20,9 +20,9 @@ export const WelcomeBanner = () => {
         <Trans i18nKey="welcome.welcome-banner.welcome-to-grafana">Welcome to Grafana</Trans>
       </h1>
       <div className={styles.help}>
-        <h3 className={styles.helpText}>
+        <h2 className={styles.helpText}>
           <Trans i18nKey="welcome.welcome-banner.need-help">Need help?</Trans>
-        </h3>
+        </h2>
         <div className={styles.helpLinks}>
           {helpOptions.map((option, index) => (
             <TextLink
@@ -80,6 +80,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       alignItems: 'baseline',
     }),
     helpText: css({
+      ...theme.typography.h3,
       marginRight: theme.spacing(2),
       marginBottom: 0,
 


### PR DESCRIPTION
Relates to #117836

Of the pa11y-audited views, there were a couple that fail this check, but pa11y doesn't actually _perform_ this check in the first place for some reason. I confirmed the fix on both of these using Lighthouse and manually loaded the page to confirm the styles still looked good.

<img width="1728" height="965" alt="Screenshot 2026-02-20 at 4 07 29 PM" src="https://github.com/user-attachments/assets/fa3b556b-a3d3-479c-b11e-0cf85be03bbd" />
<img width="1728" height="961" alt="Screenshot 2026-02-20 at 4 07 02 PM" src="https://github.com/user-attachments/assets/880a361c-72e4-478f-8c45-3dc5793a156d" />
