### PR TITLE
Alerting docs: Add managed routes option to alert rule docs

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -317,9 +317,9 @@ The **Default** option allows to select a [contact point](ref:contact-points) to
 
 {{< collapse title="Advanced options" >}}
 
-With this option, all notifications for this alert rule are managed by the [notification policy tree](ref:notification-policies), which routes alerts based on their labels. 
+With this option, all notifications for this alert rule are managed by the [notification policy tree](ref:notification-policies), which routes alerts based on their labels.
 
-Click **Change** to change the routing from the default policy to another policy. If you change to a custom policy, Grafana adds the __grafana_managed_route__ label.
+Click **Change** to change the routing from the default policy to another policy. If you change to a custom policy, Grafana adds the `__grafana_managed_route__` label.
 
 You can preview which notification policy would handle notifications from this alert rule.
 

--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -317,7 +317,9 @@ The **Default** option allows to select a [contact point](ref:contact-points) to
 
 {{< collapse title="Advanced options" >}}
 
-With this option, all notifications for this alert rule are managed by the [notification policy tree](ref:notification-policies), which routes alerts based on their labels.
+With this option, all notifications for this alert rule are managed by the [notification policy tree](ref:notification-policies), which routes alerts based on their labels. 
+
+Click **Change** to change the routing from the default policy to another policy. If you change to a custom policy, Grafana adds the __grafana_managed_route__ label.
 
 You can preview which notification policy would handle notifications from this alert rule.
 


### PR DESCRIPTION
This PR documents the managed routes option in the alert rule creation wizard.
