### PR TITLE
Server: Support simultaneous TCP and Unix domain socket serving

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -91,6 +91,9 @@ socket_mode = 0660
 # Unix socket path
 socket = /tmp/grafana.sock
 
+# Serve on socket in addition to the protocol above
+serve_on_socket = false
+
 # CDN Url
 cdn_url =
 

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -91,7 +91,7 @@ socket_mode = 0660
 # Unix socket path
 socket = /tmp/grafana.sock
 
-# Serve on socket in addition to the protocol above
+# If set to `true` and the primary `protocol` is `http`, `https`, or `h2`, Grafana will additionally serve on the Unix domain socket configured via `socket`. Defaults to `false`.
 serve_on_socket = false
 
 # CDN Url

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -92,6 +92,9 @@
 # Unix socket path
 ;socket =
 
+# If set to `true` and the primary `protocol` is `http`, `https`, or `h2`, Grafana will additionally serve on the Unix domain socket configured via `socket`. Defaults to `false`.
+;serve_on_socket = false
+
 # CDN Url
 ;cdn_url =
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -335,6 +335,10 @@ Mode where the socket should be set when `protocol=socket`. Make sure that Grafa
 
 Path where the socket should be created when `protocol=socket`. Make sure Grafana has appropriate permissions for that path before you change this setting.
 
+#### `serve_on_socket`
+
+If set to `true` and the primary `protocol` is `http`, `https`, or `h2`, Grafana will additionally serve on the Unix domain socket configured via `socket`. Defaults to `false`.
+
 #### `cdn_url`
 
 Specify a full HTTP URL address to the root of your Grafana CDN assets. Grafana adds edition and version paths.

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/youmark/pkcs8"
@@ -469,13 +471,15 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 	default:
 	}
 
-	listener, err := hs.getListener()
+	listeners, err := hs.getListeners()
 	if err != nil {
 		return err
 	}
 
-	hs.log.Info("HTTP Server Listen", "address", listener.Addr().String(), "protocol",
-		hs.Cfg.Protocol, "subUrl", hs.Cfg.AppSubURL, "socket", hs.Cfg.SocketPath)
+	for _, listener := range listeners {
+		hs.log.Info("HTTP Server Listen", "address", listener.Addr().String(), "protocol",
+			hs.Cfg.Protocol, "subUrl", hs.Cfg.AppSubURL, "socket", hs.Cfg.SocketPath)
+	}
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -490,25 +494,40 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 		}
 	}()
 
-	switch hs.Cfg.Protocol {
-	case setting.HTTPScheme, setting.SocketScheme:
-		if err := hs.httpSrv.Serve(listener); err != nil {
-			if errors.Is(err, http.ErrServerClosed) {
-				hs.log.Debug("server was shutdown gracefully")
-				return nil
+	errg, _ := errgroup.WithContext(ctx)
+
+	for _, listener := range listeners {
+		l := listener
+		errg.Go(func() error {
+			switch hs.Cfg.Protocol {
+			case setting.HTTPScheme, setting.SocketScheme:
+				// If serving on socket concurrently with HTTPScheme, the unix listener needs Serve too.
+				// Serve handles both tcp and unix listeners exactly the same.
+				if err := hs.httpSrv.Serve(l); err != nil {
+					if errors.Is(err, http.ErrServerClosed) {
+						hs.log.Debug("server was shutdown gracefully")
+						return nil
+					}
+					return err
+				}
+			case setting.HTTP2Scheme, setting.HTTPSScheme, setting.SocketHTTP2Scheme:
+				// Similarly for ServeTLS
+				if err := hs.httpSrv.ServeTLS(l, "", ""); err != nil {
+					if errors.Is(err, http.ErrServerClosed) {
+						hs.log.Debug("server was shutdown gracefully")
+						return nil
+					}
+					return err
+				}
+			default:
+				panic(fmt.Sprintf("Unhandled protocol %q", hs.Cfg.Protocol))
 			}
-			return err
-		}
-	case setting.HTTP2Scheme, setting.HTTPSScheme, setting.SocketHTTP2Scheme:
-		if err := hs.httpSrv.ServeTLS(listener, "", ""); err != nil {
-			if errors.Is(err, http.ErrServerClosed) {
-				hs.log.Debug("server was shutdown gracefully")
-				return nil
-			}
-			return err
-		}
-	default:
-		panic(fmt.Sprintf("Unhandled protocol %q", hs.Cfg.Protocol))
+			return nil
+		})
+	}
+
+	if err := errg.Wait(); err != nil {
+		return err
 	}
 
 	wg.Wait()
@@ -516,10 +535,12 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 	return nil
 }
 
-func (hs *HTTPServer) getListener() (net.Listener, error) {
+func (hs *HTTPServer) getListeners() ([]net.Listener, error) {
 	if hs.Listener != nil {
-		return hs.Listener, nil
+		return []net.Listener{hs.Listener}, nil
 	}
+
+	var listeners []net.Listener
 
 	switch hs.Cfg.Protocol {
 	case setting.HTTPScheme, setting.HTTPSScheme, setting.HTTP2Scheme:
@@ -527,7 +548,7 @@ func (hs *HTTPServer) getListener() (net.Listener, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to open listener on address %s: %w", hs.httpSrv.Addr, err)
 		}
-		return listener, nil
+		listeners = append(listeners, listener)
 	case setting.SocketScheme, setting.SocketHTTP2Scheme:
 		listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: hs.Cfg.SocketPath, Net: "unix"})
 		if err != nil {
@@ -546,11 +567,34 @@ func (hs *HTTPServer) getListener() (net.Listener, error) {
 			return nil, fmt.Errorf("failed to change socket group id %d: %w", hs.Cfg.SocketGid, err)
 		}
 
-		return listener, nil
+		listeners = append(listeners, listener)
 	default:
 		hs.log.Error("Invalid protocol", "protocol", hs.Cfg.Protocol)
 		return nil, fmt.Errorf("invalid protocol %q", hs.Cfg.Protocol)
 	}
+
+	if hs.Cfg.ServeOnSocket && (hs.Cfg.Protocol == setting.HTTPScheme || hs.Cfg.Protocol == setting.HTTPSScheme || hs.Cfg.Protocol == setting.HTTP2Scheme) {
+		listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: hs.Cfg.SocketPath, Net: "unix"})
+		if err != nil {
+			return nil, fmt.Errorf("failed to open listener for socket %s: %w", hs.Cfg.SocketPath, err)
+		}
+
+		// Make socket writable by group
+		// nolint:gosec
+		if err := os.Chmod(hs.Cfg.SocketPath, os.FileMode(hs.Cfg.SocketMode)); err != nil {
+			return nil, fmt.Errorf("failed to change socket mode %d: %w", hs.Cfg.SocketMode, err)
+		}
+
+		// golang.org/pkg/os does not have chgrp
+		// Changing the gid of a file without privileges requires that the target group is in the group of the process and that the process is the file owner
+		if err := os.Chown(hs.Cfg.SocketPath, -1, hs.Cfg.SocketGid); err != nil {
+			return nil, fmt.Errorf("failed to change socket group id %d: %w", hs.Cfg.SocketGid, err)
+		}
+
+		listeners = append(listeners, listener)
+	}
+
+	return listeners, nil
 }
 
 func (hs *HTTPServer) selfSignedCert() ([]tls.Certificate, error) {

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -563,8 +563,10 @@ func (hs *HTTPServer) getListeners() ([]net.Listener, error) {
 
 		// golang.org/pkg/os does not have chgrp
 		// Changing the gid of a file without privileges requires that the target group is in the group of the process and that the process is the file owner
-		if err := os.Chown(hs.Cfg.SocketPath, -1, hs.Cfg.SocketGid); err != nil {
-			return nil, fmt.Errorf("failed to change socket group id %d: %w", hs.Cfg.SocketGid, err)
+		if hs.Cfg.SocketGid != -1 {
+			if err := os.Chown(hs.Cfg.SocketPath, -1, hs.Cfg.SocketGid); err != nil {
+				return nil, fmt.Errorf("failed to change socket group id %d: %w", hs.Cfg.SocketGid, err)
+			}
 		}
 
 		listeners = append(listeners, listener)
@@ -587,8 +589,10 @@ func (hs *HTTPServer) getListeners() ([]net.Listener, error) {
 
 		// golang.org/pkg/os does not have chgrp
 		// Changing the gid of a file without privileges requires that the target group is in the group of the process and that the process is the file owner
-		if err := os.Chown(hs.Cfg.SocketPath, -1, hs.Cfg.SocketGid); err != nil {
-			return nil, fmt.Errorf("failed to change socket group id %d: %w", hs.Cfg.SocketGid, err)
+		if hs.Cfg.SocketGid != -1 {
+			if err := os.Chown(hs.Cfg.SocketPath, -1, hs.Cfg.SocketGid); err != nil {
+				return nil, fmt.Errorf("failed to change socket group id %d: %w", hs.Cfg.SocketGid, err)
+			}
 		}
 
 		listeners = append(listeners, listener)

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -23,10 +23,10 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/sync/errgroup"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/youmark/pkcs8"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/grafana/pkg/api/avatar"
 	"github.com/grafana/grafana/pkg/api/datasource"

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/youmark/pkcs8"
@@ -497,13 +496,12 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 	errg, _ := errgroup.WithContext(ctx)
 
 	for _, listener := range listeners {
-		l := listener
 		errg.Go(func() error {
 			switch hs.Cfg.Protocol {
 			case setting.HTTPScheme, setting.SocketScheme:
 				// If serving on socket concurrently with HTTPScheme, the unix listener needs Serve too.
 				// Serve handles both tcp and unix listeners exactly the same.
-				if err := hs.httpSrv.Serve(l); err != nil {
+				if err := hs.httpSrv.Serve(listener); err != nil {
 					if errors.Is(err, http.ErrServerClosed) {
 						hs.log.Debug("server was shutdown gracefully")
 						return nil
@@ -512,7 +510,7 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 				}
 			case setting.HTTP2Scheme, setting.HTTPSScheme, setting.SocketHTTP2Scheme:
 				// Similarly for ServeTLS
-				if err := hs.httpSrv.ServeTLS(l, "", ""); err != nil {
+				if err := hs.httpSrv.ServeTLS(listener, "", ""); err != nil {
 					if errors.Is(err, http.ErrServerClosed) {
 						hs.log.Debug("server was shutdown gracefully")
 						return nil
@@ -520,7 +518,7 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 					return err
 				}
 			default:
-				panic(fmt.Sprintf("Unhandled protocol %q", hs.Cfg.Protocol))
+				return fmt.Errorf("unhandled protocol %q", hs.Cfg.Protocol)
 			}
 			return nil
 		})
@@ -549,6 +547,12 @@ func (hs *HTTPServer) getListeners() ([]net.Listener, error) {
 			return nil, fmt.Errorf("failed to open listener on address %s: %w", hs.httpSrv.Addr, err)
 		}
 		listeners = append(listeners, listener)
+
+		// if `serve_on_socket` is configured, fall through and listen on a unix socket as well
+		if !hs.Cfg.ServeOnSocket {
+			break
+		}
+		fallthrough
 	case setting.SocketScheme, setting.SocketHTTP2Scheme:
 		listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: hs.Cfg.SocketPath, Net: "unix"})
 		if err != nil {
@@ -573,29 +577,6 @@ func (hs *HTTPServer) getListeners() ([]net.Listener, error) {
 	default:
 		hs.log.Error("Invalid protocol", "protocol", hs.Cfg.Protocol)
 		return nil, fmt.Errorf("invalid protocol %q", hs.Cfg.Protocol)
-	}
-
-	if hs.Cfg.ServeOnSocket && (hs.Cfg.Protocol == setting.HTTPScheme || hs.Cfg.Protocol == setting.HTTPSScheme || hs.Cfg.Protocol == setting.HTTP2Scheme) {
-		listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: hs.Cfg.SocketPath, Net: "unix"})
-		if err != nil {
-			return nil, fmt.Errorf("failed to open listener for socket %s: %w", hs.Cfg.SocketPath, err)
-		}
-
-		// Make socket writable by group
-		// nolint:gosec
-		if err := os.Chmod(hs.Cfg.SocketPath, os.FileMode(hs.Cfg.SocketMode)); err != nil {
-			return nil, fmt.Errorf("failed to change socket mode %d: %w", hs.Cfg.SocketMode, err)
-		}
-
-		// golang.org/pkg/os does not have chgrp
-		// Changing the gid of a file without privileges requires that the target group is in the group of the process and that the process is the file owner
-		if hs.Cfg.SocketGid != -1 {
-			if err := os.Chown(hs.Cfg.SocketPath, -1, hs.Cfg.SocketGid); err != nil {
-				return nil, fmt.Errorf("failed to change socket group id %d: %w", hs.Cfg.SocketGid, err)
-			}
-		}
-
-		listeners = append(listeners, listener)
 	}
 
 	return listeners, nil

--- a/pkg/api/http_server_test.go
+++ b/pkg/api/http_server_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"net"
+	"net/http"
 	"os"
 	"testing"
 
@@ -327,3 +329,65 @@ ZXEiT0mcWOdtRV5WfkkSrjE0BtWUW6r+eW/0ZSLPESnGqBIpTgzDEk29bWbbMdwh
 dsdSPwCrdg9wYOPr1CNjfoA6GjX5SipJ6rU1hOzcOF8SQh0Oh9a5kpfkVD+ktHxr
 +eLHA9/oarks8uDsI8ZzsPI=
 -----END CERTIFICATE-----`)
+
+func TestHTTPServer_getListeners(t *testing.T) {
+	t.Run("protocol=http, serve_on_socket=false", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		cfg.Protocol = setting.HTTPScheme
+		cfg.HTTPPort = "0"
+
+		hs := &HTTPServer{
+			Cfg:     cfg,
+			httpSrv: &http.Server{},
+		}
+		hs.httpSrv.Addr = net.JoinHostPort(cfg.HTTPAddr, cfg.HTTPPort)
+
+		listeners, err := hs.getListeners()
+		require.NoError(t, err)
+		assert.Len(t, listeners, 1)
+		_ = listeners[0].Close()
+	})
+
+	t.Run("protocol=http, serve_on_socket=true", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		cfg.Protocol = setting.HTTPScheme
+		cfg.HTTPPort = "0"
+		cfg.ServeOnSocket = true
+		cfg.SocketGid = -1
+		cfg.SocketPath = os.TempDir() + "/grafana_test.sock"
+		_ = os.Remove(cfg.SocketPath)
+		defer func() { _ = os.Remove(cfg.SocketPath) }()
+
+		hs := &HTTPServer{
+			Cfg:     cfg,
+			httpSrv: &http.Server{},
+		}
+		hs.httpSrv.Addr = net.JoinHostPort(cfg.HTTPAddr, cfg.HTTPPort)
+
+		listeners, err := hs.getListeners()
+		require.NoError(t, err)
+		assert.Len(t, listeners, 2)
+		for _, l := range listeners {
+			_ = l.Close()
+		}
+	})
+
+	t.Run("protocol=socket, serve_on_socket=false", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		cfg.Protocol = setting.SocketScheme
+		cfg.SocketGid = -1
+		cfg.SocketPath = os.TempDir() + "/grafana_test_only.sock"
+		_ = os.Remove(cfg.SocketPath)
+		defer func() { _ = os.Remove(cfg.SocketPath) }()
+
+		hs := &HTTPServer{
+			Cfg:     cfg,
+			httpSrv: &http.Server{},
+		}
+
+		listeners, err := hs.getListeners()
+		require.NoError(t, err)
+		assert.Len(t, listeners, 1)
+		_ = listeners[0].Close()
+	})
+}

--- a/pkg/api/http_server_test.go
+++ b/pkg/api/http_server_test.go
@@ -355,8 +355,7 @@ func TestHTTPServer_getListeners(t *testing.T) {
 		cfg.ServeOnSocket = true
 		cfg.SocketGid = -1
 		cfg.SocketPath = os.TempDir() + "/grafana_test.sock"
-		_ = os.Remove(cfg.SocketPath)
-		defer func() { _ = os.Remove(cfg.SocketPath) }()
+		t.Cleanup(func() { _ = os.Remove(cfg.SocketPath) })
 
 		hs := &HTTPServer{
 			Cfg:     cfg,
@@ -377,8 +376,7 @@ func TestHTTPServer_getListeners(t *testing.T) {
 		cfg.Protocol = setting.SocketScheme
 		cfg.SocketGid = -1
 		cfg.SocketPath = os.TempDir() + "/grafana_test_only.sock"
-		_ = os.Remove(cfg.SocketPath)
-		defer func() { _ = os.Remove(cfg.SocketPath) }()
+		t.Cleanup(func() { _ = os.Remove(cfg.SocketPath) })
 
 		hs := &HTTPServer{
 			Cfg:     cfg,

--- a/pkg/api/http_server_test.go
+++ b/pkg/api/http_server_test.go
@@ -338,7 +338,7 @@ func TestHTTPServer_getListeners(t *testing.T) {
 
 		hs := &HTTPServer{
 			Cfg:     cfg,
-			httpSrv: &http.Server{},
+			httpSrv: &http.Server{}, //nolint:gosec
 		}
 		hs.httpSrv.Addr = net.JoinHostPort(cfg.HTTPAddr, cfg.HTTPPort)
 
@@ -359,7 +359,7 @@ func TestHTTPServer_getListeners(t *testing.T) {
 
 		hs := &HTTPServer{
 			Cfg:     cfg,
-			httpSrv: &http.Server{},
+			httpSrv: &http.Server{}, //nolint:gosec
 		}
 		hs.httpSrv.Addr = net.JoinHostPort(cfg.HTTPAddr, cfg.HTTPPort)
 
@@ -380,7 +380,7 @@ func TestHTTPServer_getListeners(t *testing.T) {
 
 		hs := &HTTPServer{
 			Cfg:     cfg,
-			httpSrv: &http.Server{},
+			httpSrv: &http.Server{}, //nolint:gosec
 		}
 
 		listeners, err := hs.getListeners()

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -106,6 +106,7 @@ type Cfg struct {
 	ServeFromSubPath  bool
 	StaticRootPath    string
 	Protocol          Scheme
+	ServeOnSocket     bool
 	SocketGid         int
 	SocketMode        int
 	SocketPath        string
@@ -1984,6 +1985,11 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 
 	protocolStr := valueAsString(server, "protocol", "http")
 
+	cfg.ServeOnSocket = server.Key("serve_on_socket").MustBool(false)
+	cfg.SocketGid = server.Key("socket_gid").MustInt(-1)
+	cfg.SocketMode = server.Key("socket_mode").MustInt(0660)
+	cfg.SocketPath = server.Key("socket").String()
+
 	switch protocolStr {
 	case "https":
 		cfg.Protocol = HTTPSScheme
@@ -1997,14 +2003,8 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 		cfg.CertPassword = server.Key("cert_pass").String()
 	case "socket":
 		cfg.Protocol = SocketScheme
-		cfg.SocketGid = server.Key("socket_gid").MustInt(-1)
-		cfg.SocketMode = server.Key("socket_mode").MustInt(0660)
-		cfg.SocketPath = server.Key("socket").String()
 	case "socket_h2":
 		cfg.Protocol = SocketHTTP2Scheme
-		cfg.SocketGid = server.Key("socket_gid").MustInt(-1)
-		cfg.SocketMode = server.Key("socket_mode").MustInt(0660)
-		cfg.SocketPath = server.Key("socket").String()
 		cfg.CertFile = server.Key("cert_file").String()
 		cfg.KeyFile = server.Key("cert_key").String()
 		cfg.CertPassword = server.Key("cert_pass").String()

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1986,9 +1986,11 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 	protocolStr := valueAsString(server, "protocol", "http")
 
 	cfg.ServeOnSocket = server.Key("serve_on_socket").MustBool(false)
-	cfg.SocketGid = server.Key("socket_gid").MustInt(-1)
-	cfg.SocketMode = server.Key("socket_mode").MustInt(0660)
-	cfg.SocketPath = server.Key("socket").String()
+	if cfg.ServeOnSocket && (protocolStr == "http" || protocolStr == "https" || protocolStr == "h2") {
+		cfg.SocketGid = server.Key("socket_gid").MustInt(-1)
+		cfg.SocketMode = server.Key("socket_mode").MustInt(0660)
+		cfg.SocketPath = server.Key("socket").String()
+	}
 
 	switch protocolStr {
 	case "https":
@@ -2003,8 +2005,14 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 		cfg.CertPassword = server.Key("cert_pass").String()
 	case "socket":
 		cfg.Protocol = SocketScheme
+		cfg.SocketGid = server.Key("socket_gid").MustInt(-1)
+		cfg.SocketMode = server.Key("socket_mode").MustInt(0660)
+		cfg.SocketPath = server.Key("socket").String()
 	case "socket_h2":
 		cfg.Protocol = SocketHTTP2Scheme
+		cfg.SocketGid = server.Key("socket_gid").MustInt(-1)
+		cfg.SocketMode = server.Key("socket_mode").MustInt(0660)
+		cfg.SocketPath = server.Key("socket").String()
 		cfg.CertFile = server.Key("cert_file").String()
 		cfg.KeyFile = server.Key("cert_key").String()
 		cfg.CertPassword = server.Key("cert_pass").String()


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This commit introduces the 'serve_on_socket' configuration option, allowing Grafana to listen on both a TCP port and a Unix domain socket simultaneously.

**Why do we need this feature?**

- Performance: Provides a high-performance, low-latency connection path for local reverse proxies or load balancers using Unix domain sockets.
- Observability: Maintains direct TCP access, enabling sidecars or external services (like Prometheus) to scrape metrics or perform health checks without requiring UDS support.

**Who is this feature for?**

It's also for people who'd like to use a Unix socket for exposing a self-hosted instance via a Cloudflare tunnel (or similar solutions) but also want to access the instance directly via TCP in the local network.

**Which issue(s) does this PR fix?**:

Fixes #105209

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
