### PR TITLE
Dashboard Datasource: Subscribe to source panel queries that don't have transformations

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
@@ -201,7 +201,7 @@ describe('DashboardDatasourceBehaviour', () => {
       expect(behaviour['prevRequestIds'].size).toBe(0);
     });
 
-    it('Should not re-run queries in behaviour on scene load', async () => {
+    it('Should re-run queries when source panel data arrives on scene load', async () => {
       const sourcePanel = new VizPanel({
         title: 'Panel A',
         pluginId: 'table',
@@ -240,8 +240,12 @@ describe('DashboardDatasourceBehaviour', () => {
 
       await new Promise((r) => setTimeout(r, 1));
 
-      expect(spy).toHaveBeenCalledTimes(1);
-      // since there is no previous request ID on dashboard load, the behaviour should not re-run queries
+      // Called twice: once for the initial activation query, and once when the
+      // source panel's data arrives via the onSourceDataChange subscription.
+      // The second call ensures the dashboard DS panel picks up the source
+      // panel's completed data (prevents stale data when it activates first).
+      expect(spy).toHaveBeenCalledTimes(2);
+      // prevRequestIds should still be empty — no deactivate/reactivate cycle occurred
       expect(behaviour['prevRequestIds'].size).toBe(0);
     });
 

--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.tsx
@@ -143,7 +143,10 @@ export class DashboardDatasourceBehaviour extends SceneObjectBase<DashboardDatas
         // so we re-run when the source panel's data updates (e.g. after variable resolution or
         // time range change). Without this, the dashboard-datasource panel can read stale data
         // when it runs before the source panels complete and never updates.
-        const onSourceDataChange = (newState: typeof sourcePanelQueryRunner.state, oldState: typeof sourcePanelQueryRunner.state) => {
+        const onSourceDataChange = (
+          newState: typeof sourcePanelQueryRunner.state,
+          oldState: typeof sourcePanelQueryRunner.state
+        ) => {
           const newRequestId = newState.data?.request?.requestId;
           const oldRequestId = oldState.data?.request?.requestId;
           const hasNewRequest = newRequestId !== oldRequestId;

--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.tsx
@@ -138,6 +138,22 @@ export class DashboardDatasourceBehaviour extends SceneObjectBase<DashboardDatas
           }
         });
         transformerSubs.push(transformerSub);
+      } else {
+        // Source panel has no transformer (or empty transformations). Subscribe to the query runner
+        // so we re-run when the source panel's data updates (e.g. after variable resolution or
+        // time range change). Without this, the dashboard-datasource panel can read stale data
+        // when it runs before the source panels complete and never updates.
+        const onSourceDataChange = (newState: typeof sourcePanelQueryRunner.state, oldState: typeof sourcePanelQueryRunner.state) => {
+          const newRequestId = newState.data?.request?.requestId;
+          const oldRequestId = oldState.data?.request?.requestId;
+          const hasNewRequest = newRequestId !== oldRequestId;
+          const isStreaming = newState.data?.state === LoadingState.Streaming;
+          if (newState.data !== oldState.data && (hasNewRequest || isStreaming)) {
+            queryRunner.runQueries();
+          }
+        };
+        const queryRunnerSub = sourcePanelQueryRunner.subscribeToState(onSourceDataChange);
+        transformerSubs.push(queryRunnerSub);
       }
     }
 

--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.tsx
@@ -114,6 +114,25 @@ export class DashboardDatasourceBehaviour extends SceneObjectBase<DashboardDatas
         shouldRunQueries = true;
       }
 
+      // Only re-run if there's actually new data to process.
+      // This prevents re-running when the source panel is cancelled, which only changes
+      // the loading state but keeps the same requestId.
+      // We trigger when:
+      // 1. requestId changed (new query completed)
+      // 2. isStreaming (continuous data updates)
+      const onSourceDataChange = (
+        newState: { data?: typeof sourcePanelQueryRunner.state.data },
+        oldState: { data?: typeof sourcePanelQueryRunner.state.data }
+      ) => {
+        const newRequestId = newState.data?.request?.requestId;
+        const oldRequestId = oldState.data?.request?.requestId;
+        const hasNewRequest = newRequestId !== oldRequestId;
+        const isStreaming = newState.data?.state === LoadingState.Streaming;
+        if (newState.data !== oldState.data && (hasNewRequest || isStreaming)) {
+          queryRunner.runQueries();
+        }
+      };
+
       const dataTransformer = sourcePanelQueryRunner.parent;
 
       if (dataTransformer instanceof SceneDataTransformer && dataTransformer.state.transformations.length) {
@@ -121,40 +140,13 @@ export class DashboardDatasourceBehaviour extends SceneObjectBase<DashboardDatas
         // the data transformer will emit but there will be no subscription and thus no visual update
         // on the panel. Similar thing happens when going to edit mode and back, where we unsubscribe and
         // since we never re-run the query, only reprocess the transformations, the panel will not update.
-        const transformerSub = dataTransformer.subscribeToState((newState, oldState) => {
-          // Only re-run if there's actually new data to process.
-          // This prevents re-running when the source panel is cancelled, which only changes
-          // the loading state but keeps the same requestId.
-          // We trigger when:
-          // 1. requestId changed (new query completed)
-          // 2. isStreaming (continuous data updates)
-          const newRequestId = newState.data?.request?.requestId;
-          const oldRequestId = oldState.data?.request?.requestId;
-          const hasNewRequest = newRequestId !== oldRequestId;
-          const isStreaming = newState.data?.state === LoadingState.Streaming;
-
-          if (newState.data !== oldState.data && (hasNewRequest || isStreaming)) {
-            queryRunner.runQueries();
-          }
-        });
+        const transformerSub = dataTransformer.subscribeToState(onSourceDataChange);
         transformerSubs.push(transformerSub);
       } else {
         // Source panel has no transformer (or empty transformations). Subscribe to the query runner
         // so we re-run when the source panel's data updates (e.g. after variable resolution or
         // time range change). Without this, the dashboard-datasource panel can read stale data
         // when it runs before the source panels complete and never updates.
-        const onSourceDataChange = (
-          newState: typeof sourcePanelQueryRunner.state,
-          oldState: typeof sourcePanelQueryRunner.state
-        ) => {
-          const newRequestId = newState.data?.request?.requestId;
-          const oldRequestId = oldState.data?.request?.requestId;
-          const hasNewRequest = newRequestId !== oldRequestId;
-          const isStreaming = newState.data?.state === LoadingState.Streaming;
-          if (newState.data !== oldState.data && (hasNewRequest || isStreaming)) {
-            queryRunner.runQueries();
-          }
-        };
         const queryRunnerSub = sourcePanelQueryRunner.subscribeToState(onSourceDataChange);
         transformerSubs.push(queryRunnerSub);
       }


### PR DESCRIPTION
When a panel uses the **"-- Dashboard --"** (dashboard) datasource to pull data from other panels by `panelId`, changing the time range can leave the panel showing **stale data** (e.g. still the previous 1h) until the user clicks **Refresh** or reloads the page. The backend receives the correct time range and the source panels do re-query with the new range; the bug is in the frontend: the dashboard-datasource panel is not re-running when the source panels complete.

**Root cause**

In `DashboardDatasourceBehaviour`, we only subscribe to source panel updates when the source panel has a **SceneDataTransformer with at least one transformation**. When the source has no transformations, no subscription is added. So:

1. User changes time range (e.g. 1h → 3h).
2. The dashboard-datasource panel runs immediately (it subscribes to time range). The source panels often wait on variables (`onTimeRangeChanged`) or are still in flight.
3. The dashboard panel reads from the source panels at that moment and gets **stale** (e.g. 1h) data.
4. When the source panels later complete with new (3h) data, the dashboard panel is not subscribed to them, so it never re-runs and keeps showing the old data.

So this is a **race**: the dashboard panel can run before the source panels finish; without a subscription it never updates when they do.

**Why it's more visible on some dashboards**

Dashboards with many variables that use `refresh: "onTimeRangeChanged"` (and/or `$__from`/`$__to`) delay the source panels while they wait for variable resolution. The dashboard-datasource panel does not depend on those variables, so it runs as soon as the time range changes and often reads stale data. With breakpoints, the delay can let the source panels finish first, so the bug can disappear when debugging.

Unfortunatelly I wasn't able to reproduce this locally, but it's reproducible in customer's instance where large clickhouse queries are run. 

Fixes https://github.com/grafana/support-escalations/issues/20795

