### PR TITLE
Dashboard: Fix v1beta1 gnetId schema type for API PUT/PATCH endpoints

### DIFF
--- a/apps/dashboard/pkg/apis/dashboard/v0alpha1/dashboard_kind.cue
+++ b/apps/dashboard/pkg/apis/dashboard/v0alpha1/dashboard_kind.cue
@@ -37,7 +37,7 @@ lineage: schemas: [{
 			revision?: int64
 
 			// ID of a dashboard imported from the https://grafana.com/grafana/dashboards/ portal
-			gnetId?: string
+			gnetId?: int64
 
 			// Tags associated with dashboard.
 			tags?: [...string]

--- a/apps/dashboard/pkg/apis/dashboard/v1beta1/dashboard_kind.cue
+++ b/apps/dashboard/pkg/apis/dashboard/v1beta1/dashboard_kind.cue
@@ -37,7 +37,7 @@ lineage: schemas: [{
 			revision?: int64
 
 			// ID of a dashboard imported from the https://grafana.com/grafana/dashboards/ portal
-			gnetId?: string
+			gnetId?: int64
 
 			// Tags associated with dashboard.
 			tags?: [...string]

--- a/apps/dashboard/pkg/apis/dashboard/v1beta1/validation_test.go
+++ b/apps/dashboard/pkg/apis/dashboard/v1beta1/validation_test.go
@@ -1,0 +1,44 @@
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/apps/dashboard/pkg/migration/schemaversion"
+)
+
+func TestValidateDashboardSpec_GnetID(t *testing.T) {
+	t.Run("accepts numeric gnetId", func(t *testing.T) {
+		obj := &Dashboard{
+			Spec: DashboardSpec{
+				Object: map[string]any{
+					"schemaVersion": schemaversion.LATEST_VERSION,
+					"title":         "gnet-id-dashboard",
+					"gnetId":        int64(9628),
+				},
+			},
+		}
+
+		errs, schemaVersionErrs := ValidateDashboardSpec(obj, false)
+		require.Empty(t, schemaVersionErrs)
+		require.Empty(t, errs)
+	})
+
+	t.Run("rejects string gnetId", func(t *testing.T) {
+		obj := &Dashboard{
+			Spec: DashboardSpec{
+				Object: map[string]any{
+					"schemaVersion": schemaversion.LATEST_VERSION,
+					"title":         "gnet-id-dashboard",
+					"gnetId":        "9628",
+				},
+			},
+		}
+
+		errs, schemaVersionErrs := ValidateDashboardSpec(obj, false)
+		require.Empty(t, schemaVersionErrs)
+		require.NotEmpty(t, errs)
+		require.Contains(t, errs.ToAggregate().Error(), "gnetId")
+	})
+}

--- a/kinds/dashboard/dashboard_kind.cue
+++ b/kinds/dashboard/dashboard_kind.cue
@@ -33,7 +33,7 @@ lineage: schemas: [{
 			revision?: int64
 
 			// ID of a dashboard imported from the https://grafana.com/grafana/dashboards/ portal
-			gnetId?: string
+			gnetId?: int64
 
 			// Tags associated with dashboard.
 			tags?: [...string]

--- a/packages/grafana-schema/src/raw/dashboard/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/dashboard/x/types.gen.ts
@@ -1207,7 +1207,7 @@ export interface Dashboard {
   /**
    * ID of a dashboard imported from the https://grafana.com/grafana/dashboards/ portal
    */
-  gnetId?: string;
+  gnetId?: number;
   /**
    * Configuration of dashboard cursor sync behavior.
    * Accepted values are 0 (sync turned off), 1 (shared crosshair), 2 (shared crosshair and tooltip).

--- a/pkg/kinds/dashboard/dashboard_spec_gen.go
+++ b/pkg/kinds/dashboard/dashboard_spec_gen.go
@@ -32,7 +32,7 @@ type Spec struct {
 	// to see if the version has changed since the last time.
 	Revision *int64 `json:"revision,omitempty"`
 	// ID of a dashboard imported from the https://grafana.com/grafana/dashboards/ portal
-	GnetId *string `json:"gnetId,omitempty"`
+	GnetId *int64 `json:"gnetId,omitempty"`
 	// Tags associated with dashboard.
 	Tags []string `json:"tags,omitempty"`
 	// Timezone of dashboard. Accepted values are IANA TZDB zone ID or "browser" or "utc".


### PR DESCRIPTION
## What is this feature?

Fixes a dashboard k8s-style API validation bug where `PUT`/`PATCH` on dashboards imported from Grafana.com fail with `422` when `spec.gnetId` is numeric.

## Why do we need this feature?

Imported dashboards commonly have numeric `gnetId` values. The v1beta1 dashboard CUE schema incorrectly defined `spec.gnetId` as `string`, causing schema validation to reject valid payloads (including GET -> PUT round-trips).

## Who is this feature for?

Users and integrations using the Kubernetes-style dashboard API (`/apis/dashboard.grafana.app/...`) to manage imported dashboards.

## Which issue(s) does this PR fix?:

Fixes #118604 

## Special notes for your reviewer:

- Changes `spec.gnetId` schema type from `string` to `int64` in dashboard CUE schemas.
- Regenerates dependent schema outputs (`pkg/kinds`, `packages/grafana-schema`).
- Adds a regression test in `apps/dashboard/pkg/apis/dashboard/v1beta1/validation_test.go` to verify numeric `gnetId` is accepted.

### Testing
- `make gen-cue`
- `GOCACHE=/tmp/go-build go test ./apps/dashboard/pkg/apis/dashboard/v0alpha1 ./apps/dashboard/pkg/apis/dashboard/v1beta1 ./pkg/kinds/dashboard`