### PR TITLE
This PR replaces irate() with rate() in the Prometheus 2.0 Stats dashboard.

### DIFF
--- a/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
+++ b/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
@@ -147,7 +147,7 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "sum(irate(prometheus_tsdb_head_samples_appended_total{job=\"${job}\"}[$__rate_interval]))",
+          "expr": "sum(rate(prometheus_tsdb_head_samples_appended_total{job=\"${job}\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "legendFormat": "samples",
@@ -778,7 +778,7 @@
           "refId": "A"
         },
         {
-          "expr": "irate(prometheus_tsdb_head_gc_duration_seconds_count{job=\"${job}\"}[$__rate_interval])",
+          "expr": "rate(prometheus_tsdb_head_gc_duration_seconds_count{job=\"${job}\"}[$__rate_interval])",
           "format": "time_series",
           "legendFormat": "collections",
           "refId": "B"
@@ -886,19 +886,19 @@
           "refId": "A"
         },
         {
-          "expr": "irate(prometheus_tsdb_compactions_total{job=\"${job}\"}[$__rate_interval])",
+          "expr": "rate(prometheus_tsdb_compactions_total{job=\"${job}\"}[$__rate_interval])",
           "format": "time_series",
           "legendFormat": "compactions",
           "refId": "B"
         },
         {
-          "expr": "irate(prometheus_tsdb_compactions_failed_total{job=\"${job}\"}[$__rate_interval])",
+          "expr": "rate(prometheus_tsdb_compactions_failed_total{job=\"${job}\"}[$__rate_interval])",
           "format": "time_series",
           "legendFormat": "failed",
           "refId": "C"
         },
         {
-          "expr": "irate(prometheus_tsdb_compactions_triggered_total{job=\"${job}\"}[$__rate_interval])",
+          "expr": "rate(prometheus_tsdb_compactions_triggered_total{job=\"${job}\"}[$__rate_interval])",
           "format": "time_series",
           "legendFormat": "triggered",
           "refId": "D"


### PR DESCRIPTION
Fixes #118276

## Summary

This PR replaces `irate()` with `rate()` in the **Prometheus 2.0 Stats** dashboard.

## Problem

When zooming out to longer time ranges (e.g., 7d or more), panels such as:

- Head Block GC Activity
- Compaction Activity
- Samples Appended

may drop to zero or show misleading values.

This happens because `irate()` only considers the last two data points in the selected range, which can lead to unstable or zero results when viewing larger time windows.

## Solution

Replaced all occurrences of:
irate(metric[$__rate_interval]) 
with:
rate(metric[$__rate_interval])

Using `rate()` ensures proper averaging over the selected time range and provides stable, accurate visualizations across both short and long time windows.

## Rationale

According to Prometheus best practices:

- `irate()` is recommended for highly volatile, real-time graphs.
- `rate()` is recommended for long-term trends and dashboards.

Since this dashboard is intended for general monitoring and supports zooming across large time ranges, `rate()` is more appropriate.

## Impact

- Prevents panels from dropping to zero when zooming out
- Improves consistency across time ranges
- Aligns the dashboard with Prometheus query best practices