### PR TITLE
chore: fix broken main

### DIFF
--- a/public/app/plugins/panel/geomap/GeomapPanel.test.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.test.tsx
@@ -7,7 +7,7 @@ import { dateTime, EventBusSrv, LoadingState } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 
 import { GeomapPanel } from './GeomapPanel';
-import { TooltipMode } from './types';
+import { TooltipMode } from './panelcfg.gen';
 
 // Mock React components
 jest.mock('./GeomapTooltip', () => ({


### PR DESCRIPTION
**What is this feature?**

This pull request makes a minor update to the import path for the `TooltipMode` type in the `GeomapPanel.test.tsx` test file, ensuring it is imported from the generated configuration file instead of the local `types` file.

**Why do we need this feature?**

So builds on `main` becomes green

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
