### PR TITLE
chore: replaces `config.panels` usages in DashboardExporter

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1928,9 +1928,6 @@
   "public/app/features/dashboard/components/DashExportModal/DashboardExporter.test.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 6
-    },
-    "no-restricted-syntax": {
-      "count": 3
     }
   },
   "public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts": {
@@ -1939,9 +1936,6 @@
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 7
-    },
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "public/app/features/dashboard/components/DashNav/DashNavTimeControls.tsx": {

--- a/public/app/features/dashboard/components/DashExportModal/DashboardExporter.test.ts
+++ b/public/app/features/dashboard/components/DashExportModal/DashboardExporter.test.ts
@@ -1,6 +1,7 @@
 import { find } from 'lodash';
 
 import { DataSourceInstanceSettings, DataSourceRef, PanelPluginMeta, TypedVariableModel } from '@grafana/data';
+import { setPanelPluginMetas } from '@grafana/runtime/internal';
 import { Dashboard, DashboardCursorSync, ThresholdsMode } from '@grafana/schema';
 import config from 'app/core/config';
 
@@ -340,23 +341,11 @@ describe('given dashboard with repeated panels', () => {
 
     config.buildInfo.version = '3.0.2';
 
-    config.panels['graph'] = {
-      id: 'graph',
-      name: 'Graph',
-      info: { version: '1.1.0' },
-    } as PanelPluginMeta;
-
-    config.panels['table'] = {
-      id: 'table',
-      name: 'Table',
-      info: { version: '1.1.1' },
-    } as PanelPluginMeta;
-
-    config.panels['heatmap'] = {
-      id: 'heatmap',
-      name: 'Heatmap',
-      info: { version: '1.1.2' },
-    } as PanelPluginMeta;
+    setPanelPluginMetas({
+      graph: { id: 'graph', name: 'Graph', info: { version: '1.1.0' } } as PanelPluginMeta,
+      table: { id: 'table', name: 'Table', info: { version: '1.1.1' } } as PanelPluginMeta,
+      heatmap: { id: 'heatmap', name: 'Heatmap', info: { version: '1.1.2' } } as PanelPluginMeta,
+    });
 
     dash = new DashboardModel(
       dash,
@@ -382,6 +371,10 @@ describe('given dashboard with repeated panels', () => {
       exported = clean;
       done();
     });
+  });
+
+  afterEach(() => {
+    setPanelPluginMetas({});
   });
 
   it('should replace datasource refs', () => {

--- a/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
+++ b/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
@@ -1,7 +1,8 @@
 import { defaults, each, sortBy } from 'lodash';
 
-import { DataSourceRef, PanelPluginMeta, VariableOption, VariableRefresh } from '@grafana/data';
+import { DataSourceRef, VariableOption, VariableRefresh } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
+import { getPanelPluginMeta } from '@grafana/runtime/internal';
 import config from 'app/core/config';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
@@ -179,7 +180,7 @@ export class DashboardExporter {
           }
         }
 
-        const panelDef: PanelPluginMeta = config.panels[panel.type];
+        const panelDef = await getPanelPluginMeta(panel.type);
         if (panelDef) {
           requires['panel' + panelDef.id] = {
             type: 'panel',


### PR DESCRIPTION
**What is this feature?**

Replaces `config.panels` usages in `DashboardExporter` with `getPanelPluginMeta` from `@grafana/runtime/internal` and removes the corresponding `eslint-suppressions.json` entries.

**Why do we need this feature?**

So we can remove `config.panels`

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates #117467

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

