### PR TITLE
Tests: Set _txlock=immediate for SQLite integration tests

### DIFF
--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
-          go test -tags=sqlite -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
+          go test -tags=sqlite -timeout=20m -run '^TestIntegration' "${PACKAGES[@]}"
 
   sqlite_nocgo:
     # Run this workflow only for PRs from forks
@@ -113,7 +113,7 @@ jobs:
           # Build regex pattern like: pkg1$|pkg2$|pkg3$
           SKIP_PATTERN=$(echo "$SKIP_PACKAGES" | sed '/^$/d' | sed 's|.*|&$|' | paste -sd '|' -)
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N "$SHARD" -d - | grep -Ev "($SKIP_PATTERN)")"
-          go test -tags=sqlite -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
+          go test -tags=sqlite -timeout=20m -run '^TestIntegration' "${PACKAGES[@]}"
       - name: Run profiled tests
         id: run-profiled-tests
         if: matrix.shard == 'profiled'
@@ -139,7 +139,7 @@ jobs:
             pkg_name=$(basename "$full_pkg" | tr '/' '_' | tr '.' '_')
             echo "📦 Running $full_pkg"
             set +e
-            go test -tags=sqlite -timeout=8m -run '^TestIntegration' \
+            go test -tags=sqlite -timeout=20m -run '^TestIntegration' \
               -outputdir=profiles \
               -cpuprofile="cpu_${pkg_name}.prof" \
               -memprofile="mem_${pkg_name}.prof" \
@@ -309,7 +309,7 @@ jobs:
         run: |
           set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
-          go test -tags=enterprise,sqlite -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
+          go test -tags=enterprise,sqlite -timeout=20m -run '^TestIntegration' "${PACKAGES[@]}"
 
   sqlite_nocgo-enterprise:
     # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
@@ -356,7 +356,7 @@ jobs:
           # Build regex pattern like: pkg1$|pkg2$|pkg3$
           SKIP_PATTERN=$(echo "$SKIP_PACKAGES" | sed '/^$/d' | sed 's|.*|&$|' | paste -sd '|' -)
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N "$SHARD" -d - | grep -Ev "($SKIP_PATTERN)")"
-          go test -tags=enterprise,sqlite -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
+          go test -tags=enterprise,sqlite -timeout=20m -run '^TestIntegration' "${PACKAGES[@]}"
       - name: Run profiled tests
         id: run-profiled-tests
         if: matrix.shard == 'profiled'
@@ -382,7 +382,7 @@ jobs:
             pkg_name=$(basename "$full_pkg" | tr '/' '_' | tr '.' '_')
             echo "📦 Running $full_pkg"
             set +e
-            go test -tags=enterprise,sqlite -timeout=8m -run '^TestIntegration' \
+            go test -tags=enterprise,sqlite -timeout=20m -run '^TestIntegration' \
               -outputdir=profiles \
               -cpuprofile="cpu_${pkg_name}.prof" \
               -memprofile="mem_${pkg_name}.prof" \

--- a/pkg/services/sqlstore/sqlstore_testinfra.go
+++ b/pkg/services/sqlstore/sqlstore_testinfra.go
@@ -373,7 +373,7 @@ func newSQLite3DB(tb TestingTB) (*testDB, error) {
 	return &testDB{
 		Driver: "sqlite3",
 		Path:   tmp.Name(),
-		Conn:   fmt.Sprintf("file:%s?cache=private&mode=rwc&_journal_mode=WAL&_synchronous=OFF&_txlock=immediate", tmp.Name()),
+		Conn:   fmt.Sprintf("file:%s?cache=private&mode=rwc&_journal_mode=WAL&_synchronous=OFF&_txlock=immediate&_busy_timeout=15000&_temp_store=memory&_cache_size=1000000000", tmp.Name()),
 	}, nil
 }
 

--- a/pkg/services/sqlstore/sqlstore_testinfra.go
+++ b/pkg/services/sqlstore/sqlstore_testinfra.go
@@ -369,10 +369,11 @@ func newSQLite3DB(tb TestingTB) (*testDB, error) {
 
 	// For tests, set sync=OFF for faster commits. Reference: https://www.sqlite.org/pragma.html#pragma_synchronous
 	// Sync is used in more production-y environments to avoid the database becoming corrupted. Test databases are fine to break.
+	// Use _txlock immediate to assume most transactions will write: https://kerkour.com/sqlite-for-servers
 	return &testDB{
 		Driver: "sqlite3",
 		Path:   tmp.Name(),
-		Conn:   fmt.Sprintf("file:%s?cache=private&mode=rwc&_journal_mode=WAL&_synchronous=OFF", tmp.Name()),
+		Conn:   fmt.Sprintf("file:%s?cache=private&mode=rwc&_journal_mode=WAL&_synchronous=OFF&_txlock=immediate", tmp.Name()),
 	}, nil
 }
 

--- a/pkg/services/sqlstore/sqlutil/sqlutil.go
+++ b/pkg/services/sqlstore/sqlutil/sqlutil.go
@@ -119,7 +119,7 @@ func sqLite3TestDB() (*TestDB, error) {
 		// For tests, set sync=OFF for faster commits. Reference: https://www.sqlite.org/pragma.html#pragma_synchronous
 		// Sync is used in more production-y environments to avoid the database becoming corrupted. Test databases are fine to break.
 		// Use _txlock immediate to assume most transactions will write: https://kerkour.com/sqlite-for-servers
-		ret.ConnStr += "&_journal_mode=WAL&_synchronous=OFF&_txlock=immediate"
+		ret.ConnStr += "&_journal_mode=WAL&_synchronous=OFF&_txlock=immediate&_busy_timeout=15000&_temp_store=memory&_cache_size=1000000000"
 	}
 	ret.Path = sqliteDb
 

--- a/pkg/services/sqlstore/sqlutil/sqlutil.go
+++ b/pkg/services/sqlstore/sqlutil/sqlutil.go
@@ -116,8 +116,10 @@ func sqLite3TestDB() (*TestDB, error) {
 
 	ret.ConnStr = "file:" + sqliteDb + "?cache=private&mode=rwc"
 	if os.Getenv("SQLITE_JOURNAL_MODE") != "false" {
-		// For tests, set sync=OFF for faster commits. Reference: https://www.sqlite.org/pragma.html#pragma_synchronous.
-		ret.ConnStr += "&_journal_mode=WAL&_synchronous=OFF"
+		// For tests, set sync=OFF for faster commits. Reference: https://www.sqlite.org/pragma.html#pragma_synchronous
+		// Sync is used in more production-y environments to avoid the database becoming corrupted. Test databases are fine to break.
+		// Use _txlock immediate to assume most transactions will write: https://kerkour.com/sqlite-for-servers
+		ret.ConnStr += "&_journal_mode=WAL&_synchronous=OFF&_txlock=immediate"
 	}
 	ret.Path = sqliteDb
 


### PR DESCRIPTION
Applying a suggestion from this article: https://kerkour.com/sqlite-for-servers

We can assume that most transactions we open are going to write, to avoid busy_timeout errors.

Only applies to tests but in theory we could make this apply everywhere if it performs well.