### PR TITLE
Provisioning: Add provisioningFolderMetadata feature flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -179,6 +179,11 @@ export interface FeatureToggles {
   */
   provisioning?: boolean;
   /**
+  * Allow setting folder metadata for provisioned folders
+  * @default false
+  */
+  provisioningFolderMetadata?: boolean;
+  /**
   * Start an additional https handler and write kubectl options
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -265,6 +265,14 @@ var (
 			Expression:      "false",
 		},
 		{
+			Name:            "provisioningFolderMetadata",
+			Description:     "Allow setting folder metadata for provisioned folders",
+			Stage:           FeatureStageExperimental,
+			RequiresRestart: true,
+			Owner:           grafanaAppPlatformSquad,
+			Expression:      "false",
+		},
+		{
 			Name:            "grafanaAPIServerEnsureKubectlAccess",
 			Description:     "Start an additional https handler and write kubectl options",
 			Stage:           FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -31,6 +31,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-09-19,datasourceAPIServers,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2023-10-06,grafanaAPIServerWithExperimentalAPIs,experimental,@grafana/grafana-app-platform-squad,true,true,false
 2024-11-22,provisioning,experimental,@grafana/grafana-app-platform-squad,false,true,false
+2026-02-23,provisioningFolderMetadata,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2023-12-06,grafanaAPIServerEnsureKubectlAccess,experimental,@grafana/grafana-app-platform-squad,true,true,false
 2023-07-21,awsAsyncQueryCaching,GA,@grafana/aws-datasources,false,false,false
 2025-08-29,queryCacheRequestDeduplication,experimental,@grafana/grafana-operator-experience-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -95,6 +95,10 @@ const (
 	// Next generation provisioning... and git
 	FlagProvisioning = "provisioning"
 
+	// FlagProvisioningFolderMetadata
+	// Allow setting folder metadata for provisioned folders
+	FlagProvisioningFolderMetadata = "provisioningFolderMetadata"
+
 	// FlagGrafanaAPIServerEnsureKubectlAccess
 	// Start an additional https handler and write kubectl options
 	FlagGrafanaAPIServerEnsureKubectlAccess = "grafanaAPIServerEnsureKubectlAccess"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3403,6 +3403,23 @@
     },
     {
       "metadata": {
+        "name": "provisioningFolderMetadata",
+        "resourceVersion": "1771843876800",
+        "creationTimestamp": "2026-02-23T10:49:14Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-02-23 10:51:16.80095 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Allow setting folder metadata for provisioned folders",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "publicDashboardsEmailSharing",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2023-01-03T19:45:15Z"


### PR DESCRIPTION
## Summary

Add experimental feature flag `provisioningFolderMetadata` to control folder metadata (permissions, annotations) for provisioned folders. This is the foundation flag that enables gradual rollout and easy rollback of folder metadata functionality in the git-ui-sync project.

## Changes

- Added `provisioningFolderMetadata` feature flag in `pkg/services/featuremgmt/registry.go`
- Generated Go constant `FlagProvisioningFolderMetadata` 
- Generated TypeScript type definition
- Flag is disabled by default (`Expression: "false"`)
- Stage: Experimental
- Requires restart to take effect

## Usage

```go
import "github.com/grafana/grafana/pkg/services/featuremgmt"

if features.IsEnabledGlobally(featuremgmt.FlagProvisioningFolderMetadata) {
    // Allow folder metadata modifications
}
```

### Enabling in Dev Instances

Add to `custom.ini`:
```ini
[feature_toggles]
provisioningFolderMetadata = true
```

Or via environment variable:
```bash
export GF_FEATURE_TOGGLES_ENABLE=provisioningFolderMetadata
```

## Related Issues

- Implements: grafana/git-ui-sync-project#892
- Blocks: grafana/git-ui-sync-project#893, grafana/git-ui-sync-project#894, grafana/git-ui-sync-project#895, grafana/git-ui-sync-project#896, grafana/git-ui-sync-project#897, grafana/git-ui-sync-project#898, grafana/git-ui-sync-project#899, grafana/git-ui-sync-project#900, grafana/git-ui-sync-project#902, grafana/git-ui-sync-project#908

## Test Plan

- [x] Feature flag definition added to registry
- [x] Generated files (Go, TypeScript, CSV, JSON) updated via `make gen-feature-toggles`
- [x] All feature toggle tests pass
- [ ] Manual testing: Enable flag in dev instance and verify it can be toggled
- [ ] Integration with folder provisioning code (future PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)