### PR TITLE
TopBar: Add a separator between top nav sidebar extension items

### DIFF
--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.tsx
@@ -97,13 +97,17 @@ export function ExtensionToolbarItem({ compact }: Props) {
   return (
     <>
       {/* renders a single `ExtensionToolbarItemButton` for each plugin; if a plugin has multiple components, it renders them inside a `Dropdown` */}
-      {Array.from(availableComponents.entries()).map(
-        ([pluginId, { addedComponents }]: [string, { addedComponents: ExtensionInfo[] }]) =>
+      {Array.from(availableComponents.entries())
+        .map(([pluginId, { addedComponents }]: [string, { addedComponents: ExtensionInfo[] }]) =>
           renderPluginButton(
             pluginId,
             addedComponents.map((c: ExtensionInfo) => ({ ...c, pluginId }))
           )
-      )}
+        )
+        .filter(Boolean)
+        .flatMap((button, index, arr) =>
+          index < arr.length - 1 ? [button, <NavToolbarSeparator key={`sep-${index}`} />] : [button]
+        )}
       <NavToolbarSeparator />
     </>
   );


### PR DESCRIPTION
If there are multiple sidebar extension items in top bar, they are rendered without separator. It looks odd, as other items are separated out.

Before:
<img width="287" height="130" alt="image" src="https://github.com/user-attachments/assets/541620c2-fb97-4eec-99ec-9993f6d8ce5e" />

After:

<img width="388" height="125" alt="image" src="https://github.com/user-attachments/assets/3823e2f7-5400-4f5f-9c20-b591291d5dcb" />


**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
