### PR TITLE
Alert: Add independent action prop for custom buttons

### DIFF
--- a/packages/grafana-ui/src/components/Alert/Alert.story.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.story.tsx
@@ -2,6 +2,7 @@ import { action } from '@storybook/addon-actions';
 import { StoryFn, Meta } from '@storybook/react';
 
 import { StoryExample } from '../../utils/storybook/StoryExample';
+import { Button } from '../Button/Button';
 import { Stack } from '../Layout/Stack/Stack';
 
 import { Alert, AlertVariant } from './Alert';
@@ -16,7 +17,7 @@ const meta: Meta = {
     docs: {
       page: mdx,
     },
-    controls: { exclude: ['onRemove'] },
+    controls: { exclude: ['onRemove', 'action'] },
   },
   argTypes: {
     severity: {
@@ -36,17 +37,6 @@ export const Basic: StoryFn<typeof Alert> = (args) => {
 Basic.args = {
   severity: 'error',
   title: 'Basic',
-};
-
-export const WithActions: StoryFn<typeof Alert> = (args) => {
-  return <Alert {...args}>Child content that includes some alert details, like maybe what actually happened.</Alert>;
-};
-
-WithActions.args = {
-  title: 'With action',
-  severity: 'error',
-  onRemove: action('Remove button clicked'),
-  buttonContent: 'Close',
 };
 
 export const Examples: StoryFn<typeof Alert> = () => {
@@ -76,6 +66,51 @@ export const Examples: StoryFn<typeof Alert> = () => {
       </StoryExample>
     </Stack>
   );
+};
+
+export const WithActionAndDismiss: StoryFn<typeof Alert> = (args) => {
+  return <Alert {...args}>You have reached your quota limit. Request an increase or dismiss this alert.</Alert>;
+};
+
+WithActionAndDismiss.args = {
+  title: 'Quota limit reached',
+  severity: 'warning',
+  action: (
+    <Button variant="secondary" onClick={action('Action button clicked')}>
+      Request increase
+    </Button>
+  ),
+  onRemove: action('Dismiss button clicked'),
+};
+
+export const WithActionOnly: StoryFn<typeof Alert> = (args) => {
+  return <Alert {...args}>The rule you are trying to copy does not exist.</Alert>;
+};
+
+WithActionOnly.args = {
+  title: 'Cannot copy the rule',
+  severity: 'error',
+  action: (
+    <Button variant="secondary" onClick={action('Action button clicked')}>
+      Go back to alert list
+    </Button>
+  ),
+};
+
+export const WithActionAndRemoveButton: StoryFn<typeof Alert> = (args) => {
+  return <Alert {...args}>This alert has both a custom action and a remove button with custom content.</Alert>;
+};
+
+WithActionAndRemoveButton.args = {
+  title: 'Multiple actions',
+  severity: 'info',
+  action: (
+    <Button variant="primary" onClick={action('Action button clicked')}>
+      View docs
+    </Button>
+  ),
+  onRemove: action('Remove button clicked'),
+  buttonContent: 'Dismiss',
 };
 
 export const Toast: StoryFn<typeof Alert> = (args) => {

--- a/packages/grafana-ui/src/components/Alert/Alert.test.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.test.tsx
@@ -1,4 +1,7 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Button } from '../Button/Button';
 
 import { Alert } from './Alert';
 
@@ -32,5 +35,52 @@ describe('Alert', () => {
     render(<Alert title="Error message" severity="error" role="status" />);
     expect(screen.queryByRole('alert', { name: 'Error message' })).not.toBeInTheDocument();
     expect(screen.getByRole('status', { name: 'Error message' })).toBeInTheDocument();
+  });
+
+  describe('action prop', () => {
+    it('renders the provided action element', () => {
+      render(
+        <Alert
+          title="Quota exceeded"
+          severity="warning"
+          action={<Button onClick={jest.fn()}>Request increase</Button>}
+        />
+      );
+      expect(screen.getByRole('button', { name: 'Request increase' })).toBeInTheDocument();
+    });
+
+    it('renders both action element and dismiss button when onRemove is also set', () => {
+      render(
+        <Alert
+          title="Quota exceeded"
+          severity="warning"
+          action={<Button onClick={jest.fn()}>Request increase</Button>}
+          onRemove={jest.fn()}
+        />
+      );
+      expect(screen.getByRole('button', { name: 'Request increase' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /close alert/i })).toBeInTheDocument();
+    });
+
+    it('calls the action handler when clicked', async () => {
+      const user = userEvent.setup();
+      const onAction = jest.fn();
+      render(<Alert title="Test" severity="info" action={<Button onClick={onAction}>Do action</Button>} />);
+      await user.click(screen.getByRole('button', { name: 'Do action' }));
+      expect(onAction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('backward compatibility', () => {
+    it('renders buttonContent with onRemove as before', () => {
+      render(<Alert title="Test" buttonContent="Go back" onRemove={jest.fn()} />);
+      expect(screen.getByRole('button', { name: /close alert/i })).toBeInTheDocument();
+      expect(screen.getByText('Go back')).toBeInTheDocument();
+    });
+
+    it('renders dismiss X icon when only onRemove is set', () => {
+      render(<Alert title="Test" onRemove={jest.fn()} />);
+      expect(screen.getByRole('button', { name: /close alert/i })).toBeInTheDocument();
+    });
   });
 });

--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -24,6 +24,8 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
   buttonContent?: React.ReactNode | string;
   bottomSpacing?: number;
   topSpacing?: number;
+  /** Custom action element rendered in the alert's button area, independently from the dismiss button. */
+  action?: ReactNode;
 }
 
 /**
@@ -43,6 +45,7 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
       topSpacing,
       className,
       severity = 'error',
+      action,
       ...restProps
     },
     ref
@@ -87,6 +90,11 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
             </Text>
             {children && <div className={styles.content}>{children}</div>}
           </Box>
+          {action && (
+            <Box marginLeft={1} display="flex" alignItems="center">
+              {action}
+            </Box>
+          )}
           {/* If onRemove is specified, giving preference to onRemove */}
           {onRemove && !buttonContent && (
             <div className={styles.close}>


### PR DESCRIPTION
**What is this feature?**

The Alert component now supports a new `action` prop that accepts a custom ReactNode element (e.g., a styled `<Button>`). This element renders independently in the alert's button area, separate from the dismiss (X) icon. This allows both a custom action button and a dismiss button to appear simultaneously.

**Why do we need this feature?**

The existing API had two design issues:
1. When using `buttonContent` with `onRemove`, the button always received `aria-label="Close alert"` even when performing non-dismiss actions (navigate, open link, request quota increase, etc.).
2. It was impossible to show both a custom action button and a dismiss X icon together—`buttonContent` would replace the X entirely.


**Special notes for your reviewer:**

<img width="938" height="153" alt="Screenshot 2026-02-23 at 13 04 54" src="https://github.com/user-attachments/assets/0fdb6ef2-f149-4254-9a83-ec4c1e556b18" />
<img width="931" height="133" alt="Screenshot 2026-02-23 at 13 05 11" src="https://github.com/user-attachments/assets/4ce5935d-5b32-4082-8573-3dc15c687110" />
