### PR TITLE
Provisioning: Disable migrate in wizard when export flag is disabled

### DIFF
--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -226,12 +226,13 @@ export const SynchronizeStep = memo(function SynchronizeStep({
               description={
                 syncTarget === 'instance' ? (
                   <Trans i18nKey="provisioning.synchronize-step.instance-migrate-resources-description">
-                    Instance sync requires all resources to be managed. Existing resources will be migrated automatically.
+                    Instance sync requires all resources to be managed. Existing resources will be migrated
+                    automatically.
                   </Trans>
                 ) : (
                   <Trans i18nKey="provisioning.synchronize-step.migrate-resources-description">
-                    Import existing dashboards from connected external storage into the provisioning folder created in the
-                    previous step
+                    Import existing dashboards from connected external storage into the provisioning folder created in
+                    the previous step
                   </Trans>
                 )
               }

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -211,6 +211,7 @@ export const SynchronizeStep = memo(function SynchronizeStep({
           </Stack>
         </Alert>
       )}
+      {/* Migration/export functionality is experimental and gated behind the provisioningExport feature flag */}
       {config.featureToggles.provisioningExport && (
         <>
           <Text element="h3">

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { Alert, Box, Button, Checkbox, Field, LoadingPlaceholder, Stack, Text, TextLink } from '@grafana/ui';
 import { Job } from 'app/api/clients/provisioning/v0alpha1';
 
@@ -210,30 +211,34 @@ export const SynchronizeStep = memo(function SynchronizeStep({
           </Stack>
         </Alert>
       )}
-      <Text element="h3">
-        <Trans i18nKey="provisioning.synchronize-step.options">Options</Trans>
-      </Text>
-      <Field noMargin>
-        <Checkbox
-          {...register('migrate.migrateResources')}
-          id="migrate-resources"
-          label={t('provisioning.wizard.sync-option-migrate-resources', 'Migrate existing resources')}
-          checked={syncTarget === 'instance' ? true : undefined}
-          disabled={syncTarget === 'instance'}
-          description={
-            syncTarget === 'instance' ? (
-              <Trans i18nKey="provisioning.synchronize-step.instance-migrate-resources-description">
-                Instance sync requires all resources to be managed. Existing resources will be migrated automatically.
-              </Trans>
-            ) : (
-              <Trans i18nKey="provisioning.synchronize-step.migrate-resources-description">
-                Import existing dashboards from connected external storage into the provisioning folder created in the
-                previous step
-              </Trans>
-            )
-          }
-        />
-      </Field>
+      {config.featureToggles.provisioningExport && (
+        <>
+          <Text element="h3">
+            <Trans i18nKey="provisioning.synchronize-step.options">Options</Trans>
+          </Text>
+          <Field noMargin>
+            <Checkbox
+              {...register('migrate.migrateResources')}
+              id="migrate-resources"
+              label={t('provisioning.wizard.sync-option-migrate-resources', 'Migrate existing resources')}
+              checked={syncTarget === 'instance' ? true : undefined}
+              disabled={syncTarget === 'instance'}
+              description={
+                syncTarget === 'instance' ? (
+                  <Trans i18nKey="provisioning.synchronize-step.instance-migrate-resources-description">
+                    Instance sync requires all resources to be managed. Existing resources will be migrated automatically.
+                  </Trans>
+                ) : (
+                  <Trans i18nKey="provisioning.synchronize-step.migrate-resources-description">
+                    Import existing dashboards from connected external storage into the provisioning folder created in the
+                    previous step
+                  </Trans>
+                )
+              }
+            />
+          </Field>
+        </>
+      )}
       <Field noMargin>
         <Button variant="primary" onClick={startSynchronization} disabled={isButtonDisabled}>
           <Trans i18nKey="provisioning.wizard.button-start">Begin synchronization</Trans>


### PR DESCRIPTION
## Summary

Hide the migration checkbox in the onboarding wizard when `provisioningExport` feature flag is disabled. This prevents users from seeing and attempting migrate operations that are experimental and still being developed.

Part of the fix for: https://github.com/grafana/git-ui-sync-project/issues/931

## Changes

**Frontend:**
- Modified `SynchronizeStep.tsx` to conditionally render the migration checkbox based on `config.featureToggles.provisioningExport`
- When flag is disabled, the entire "Options" section with the migrate checkbox is hidden
- Added comment documenting that migration/export functionality is experimental

## Behavior

When `provisioningExport` is **disabled**:
- Migration checkbox is not shown in the wizard UI
- Users cannot opt in to migrate existing resources
- No migrate jobs will be triggered during onboarding

When `provisioningExport` is **enabled**:
- Migration checkbox is visible as normal
- Instance sync: checkbox is checked and disabled (forced migration)
- Folder sync: checkbox is available for user to opt in

## Implementation

```typescript
{/* Migration/export functionality is experimental and gated behind the provisioningExport feature flag */}
{config.featureToggles.provisioningExport && (
  <>
    <Text element="h3">
      <Trans i18nKey="provisioning.synchronize-step.options">Options</Trans>
    </Text>
    <Field noMargin>
      <Checkbox
        {...register('migrate.migrateResources')}
        id="migrate-resources"
        label={t('provisioning.wizard.sync-option-migrate-resources', 'Migrate existing resources')}
        // ... checkbox implementation
      />
    </Field>
  </>
)}
```

## Test Plan

- [ ] Manual testing: Verify migration checkbox is hidden when flag is off
- [ ] Manual testing: Verify migration checkbox appears when flag is on
- [ ] Verify wizard workflow completes successfully without migration checkbox

## Dependencies

- Depends on: #118674 (provisioningExport feature flag) ✅ Merged
- Pairs with: #118676 (backend job blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)