### PR TITLE
API: Include validation error details in 4xx responses

### DIFF
--- a/pkg/api/response/response.go
+++ b/pkg/api/response/response.go
@@ -252,6 +252,12 @@ func Error(status int, message string, err error) *NormalResponse {
 		data["message"] = message
 	}
 
+	// Include actual error details for 4xx client/validation errors so users can debug issues.
+	// Do not expose error details for 5xx to avoid leaking internal information.
+	if err != nil && status >= 400 && status < 500 {
+		data["error"] = err.Error()
+	}
+
 	resp := JSON(status, data)
 
 	if err != nil {


### PR DESCRIPTION
﻿Fixes grafana/grafana#56387

## Summary

When the Provisioning API receives invalid data (e.g. invalid For duration field), it previously returned only a generic bad request data response. The actual validation error was logged but not included in the API response, making it difficult for users to debug issues.

## Changes

This PR modifies response.Error in pkg/api/response/response.go to include the actual error message in the API response body for 4xx client/validation errors. The response now includes an error field with the validation error details.

## Safety

- Only validation errors (4xx status codes) are exposed in the response
- 5xx internal errors are not exposed to avoid leaking internal information
- The error message is already being logged; this change simply surfaces it in the response for API consumers

## Scope

This fix applies to all APIs using response.Error with 4xx status codes, including the Provisioning API, alert rules, contact points, mute timings, and other endpoints.
