### PR TITLE
Alerting: Track rule list V1/V2 page view on mount

### DIFF
--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -432,3 +432,11 @@ export function trackViewExperienceToggleConfirmed(
 ) {
   reportInteraction('grafana_alerting_view_experience_confirmed', { ...payload });
 }
+
+/**
+ * Track which rule list version (V1 or V2) is displayed on page load.
+ * Fired once per mount in the RuleList router component.
+ */
+export function trackRuleListPageView(payload: { view: 'v1' | 'v2' }) {
+  reportInteraction('grafana_alerting_rule_list_page_view', payload);
+}

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -1,5 +1,6 @@
-import { Suspense, lazy } from 'react';
+import { Suspense, lazy, useEffect, useRef } from 'react';
 
+import { trackRuleListPageView } from './Analytics';
 import { shouldUseAlertingListViewV2 } from './featureToggles';
 import RuleListV1 from './rule-list/RuleList.v1';
 import { withPageErrorBoundary } from './withPageErrorBoundary';
@@ -8,6 +9,14 @@ const RuleListV2 = lazy(() => import('./rule-list/RuleList.v2'));
 
 const RuleList = () => {
   const newView = shouldUseAlertingListViewV2();
+  const tracked = useRef(false);
+
+  useEffect(() => {
+    if (!tracked.current) {
+      trackRuleListPageView({ view: newView ? 'v2' : 'v1' });
+      tracked.current = true;
+    }
+  }, [newView]);
 
   return <Suspense>{newView ? <RuleListV2 /> : <RuleListV1 />}</Suspense>;
 };


### PR DESCRIPTION
## Summary

- Adds a `grafana_alerting_rule_list_page_view` interaction event that fires once when the rule list page mounts, recording whether V1 or V2 is displayed
- Enables building adoption metrics (users and sessions per version) to compare V1 vs V2 usage
- Uses `useRef` guard to prevent duplicate fires, consistent with existing `AlertsActivityBanner` pattern