### PR TITLE
Query: Revert query.grafana.app to datasource.grafana.app change

### DIFF
--- a/pkg/registry/apis/query/register.go
+++ b/pkg/registry/apis/query/register.go
@@ -186,9 +186,10 @@ func addKnownTypes(scheme *apiruntime.Scheme, gv schema.GroupVersion) {
 }
 
 func (b *QueryAPIBuilder) InstallSchema(scheme *apiruntime.Scheme) error {
-	addKnownTypes(scheme, datasourceV0.SchemeGroupVersion)
-	metav1.AddToGroupVersion(scheme, datasourceV0.SchemeGroupVersion)
-	return scheme.SetVersionPriority(datasourceV0.SchemeGroupVersion)
+	gv := b.GetGroupVersion()
+	addKnownTypes(scheme, gv)
+	metav1.AddToGroupVersion(scheme, gv)
+	return scheme.SetVersionPriority(gv)
 }
 
 func (b *QueryAPIBuilder) AllowedV0Alpha1Resources() []string {

--- a/pkg/registry/apis/query/register.go
+++ b/pkg/registry/apis/query/register.go
@@ -168,7 +168,8 @@ func RegisterAPIService(
 }
 
 func (b *QueryAPIBuilder) GetGroupVersion() schema.GroupVersion {
-	return datasourceV0.SchemeGroupVersion
+	// TODO, finish rename return datasourceV0.SchemeGroupVersion
+	return schema.GroupVersion{Group: "query.grafana.app", Version: datasourceV0.VERSION}
 }
 
 func addKnownTypes(scheme *apiruntime.Scheme, gv schema.GroupVersion) {

--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -50,10 +50,10 @@ var PathRewriters = []filters.PathRewriter{
 			return matches[1] + matches[2] + "/name" // connector requires a name
 		},
 	},
-	{ // Migrate query.grafana.app to datasource.grafana.app
-		Pattern: regexp.MustCompile(`/apis/query.grafana.app/v0alpha1(.*$)`),
+	{ // Migrate datasource.grafana.app to query.grafana.app
+		Pattern: regexp.MustCompile(`/apis/datasource.grafana.app/v0alpha1(.*$)`),
 		ReplaceFunc: func(matches []string) string {
-			result := "/apis/datasource.grafana.app/v0alpha1" + matches[1]
+			result := "/apis/query.grafana.app/v0alpha1" + matches[1]
 			if strings.HasSuffix(matches[1], "/query") {
 				result += "/name" // same as the rewrite pattern below
 			}
@@ -64,9 +64,18 @@ var PathRewriters = []filters.PathRewriter{
 		},
 	},
 	{
-		Pattern: regexp.MustCompile(`(/apis/datasource.grafana.app/v0alpha1/namespaces/.*/query$)`),
+		Pattern: regexp.MustCompile(`(/apis/query.grafana.app/v0alpha1/namespaces/.*/query$)`),
 		ReplaceFunc: func(matches []string) string {
 			return matches[1] + "/name" // connector requires a name
+		},
+	},
+	{
+		Pattern: regexp.MustCompile(`(/apis/query.grafana.app/v0alpha1/namespaces/.*/)sqlschemas$`),
+		ReplaceFunc: func(matches []string) string {
+			if strings.HasSuffix(matches[0], "query/sqlschemas") {
+				return matches[0] // already rewritten
+			}
+			return matches[1] + "query/sqlschemas"
 		},
 	},
 	{

--- a/pkg/services/apiserver/builder/helper_test.go
+++ b/pkg/services/apiserver/builder/helper_test.go
@@ -96,21 +96,33 @@ func TestRedirection(t *testing.T) {
 		expect string
 	}{
 		{
-			name:   "query to datasource",
+			name:   "query connections",
 			url:    "/apis/query.grafana.app/v0alpha1/namespaces/default/connections",
-			expect: "/apis/datasource.grafana.app/v0alpha1/namespaces/default/connections",
+			expect: "/apis/query.grafana.app/v0alpha1/namespaces/default/connections",
 		}, {
-			name:   "query to datasource (with name hack)",
+			name:   "query (with name hack)",
 			url:    "/apis/query.grafana.app/v0alpha1/namespaces/default/query",
-			expect: "/apis/datasource.grafana.app/v0alpha1/namespaces/default/query/name",
+			expect: "/apis/query.grafana.app/v0alpha1/namespaces/default/query/name",
 		}, {
-			name:   "query sqlschemas",
+			name:   "query sqlschemas at root",
 			url:    "/apis/query.grafana.app/v0alpha1/namespaces/default/sqlschemas",
-			expect: "/apis/datasource.grafana.app/v0alpha1/namespaces/default/query/sqlschemas",
+			expect: "/apis/query.grafana.app/v0alpha1/namespaces/default/query/sqlschemas",
+		}, {
+			name:   "query sqlschemas as subresource",
+			url:    "/apis/query.grafana.app/v0alpha1/namespaces/default/query/sqlschemas",
+			expect: "/apis/query.grafana.app/v0alpha1/namespaces/default/query/sqlschemas",
 		}, {
 			name:   "name hack in datasource service",
+			url:    "/apis/query.grafana.app/v0alpha1/namespaces/default/query",
+			expect: "/apis/query.grafana.app/v0alpha1/namespaces/default/query/name", // hack :(
+		}, {
+			name:   "datasource connections",
+			url:    "/apis/datasource.grafana.app/v0alpha1/namespaces/default/connections",
+			expect: "/apis/query.grafana.app/v0alpha1/namespaces/default/connections",
+		}, {
+			name:   "datasource query",
 			url:    "/apis/datasource.grafana.app/v0alpha1/namespaces/default/query",
-			expect: "/apis/datasource.grafana.app/v0alpha1/namespaces/default/query/name", // hack :(
+			expect: "/apis/query.grafana.app/v0alpha1/namespaces/default/query/name",
 		},
 	}
 

--- a/pkg/tests/apis/openapi_snapshots/query.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/query.grafana.app-v0alpha1.json
@@ -2,10 +2,10 @@
   "openapi": "3.0.0",
   "info": {
     "description": "Query service",
-    "title": "datasource.grafana.app/v0alpha1"
+    "title": "query.grafana.app/v0alpha1"
   },
   "paths": {
-    "/apis/datasource.grafana.app/v0alpha1/": {
+    "/apis/query.grafana.app/v0alpha1/": {
       "get": {
         "tags": [
           "API Discovery"
@@ -31,7 +31,7 @@
         }
       }
     },
-    "/apis/datasource.grafana.app/v0alpha1/namespaces/{namespace}/connections": {
+    "/apis/query.grafana.app/v0alpha1/namespaces/{namespace}/connections": {
       "get": {
         "tags": [
           "Connections"
@@ -102,7 +102,7 @@
         }
       }
     },
-    "/apis/datasource.grafana.app/v0alpha1/namespaces/{namespace}/query": {
+    "/apis/query.grafana.app/v0alpha1/namespaces/{namespace}/query": {
       "post": {
         "tags": [
           "Query"
@@ -144,7 +144,7 @@
         },
         "x-kubernetes-action": "connect",
         "x-kubernetes-group-version-kind": {
-          "group": "datasource.grafana.app",
+          "group": "query.grafana.app",
           "version": "v0alpha1",
           "kind": "QueryDataResponse"
         }
@@ -162,7 +162,7 @@
         }
       ]
     },
-    "/apis/datasource.grafana.app/v0alpha1/namespaces/{namespace}/query/sqlschemas": {
+    "/apis/query.grafana.app/v0alpha1/namespaces/{namespace}/query/sqlschemas": {
       "post": {
         "tags": [
           "Query"
@@ -284,7 +284,7 @@
         },
         "x-kubernetes-group-version-kind": [
           {
-            "group": "datasource.grafana.app",
+            "group": "query.grafana.app",
             "kind": "QueryDataResponse",
             "version": "v0alpha1"
           }

--- a/pkg/tests/apis/openapi_test.go
+++ b/pkg/tests/apis/openapi_test.go
@@ -99,7 +99,7 @@ func TestIntegrationOpenAPIs(t *testing.T) {
 		Group:   "iam.grafana.app",
 		Version: "v0alpha1",
 	}, {
-		Group:   "datasource.grafana.app",
+		Group:   "query.grafana.app",
 		Version: "v0alpha1",
 	}, {
 		Group:   "advisor.grafana.app",


### PR DESCRIPTION
Reverts the group name change in https://github.com/grafana/grafana/pull/118267