### PR TITLE
chore: replaces `config.panels` usages in columns

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2882,9 +2882,6 @@
   "public/app/features/search/page/components/columns.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
-    },
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "public/app/features/search/state/SearchStateManager.ts": {

--- a/public/app/features/search/page/components/SearchResultsTable.tsx
+++ b/public/app/features/search/page/components/SearchResultsTable.tsx
@@ -9,6 +9,7 @@ import { Observable } from 'rxjs';
 import { Field, GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
+import { usePanelPluginMetasMap } from '@grafana/runtime/internal';
 import { TableCellHeight } from '@grafana/schema';
 import { useStyles2, useTheme2 } from '@grafana/ui';
 import { useTableStyles, TableCell } from '@grafana/ui/internal';
@@ -39,6 +40,7 @@ export type TableColumn = Column & {
 };
 
 const ROW_HEIGHT = 36; // pixels
+const EMPTY_PANEL_PLUGIN_METAS = {};
 
 export const SearchResultsTable = React.memo(
   ({
@@ -60,6 +62,7 @@ export const SearchResultsTable = React.memo(
     const infiniteLoaderRef = useRef<InfiniteLoader>(null);
     const [listEl, setListEl] = useState<FixedSizeList | null>(null);
     const highlightIndex = useSearchKeyboardNavigation(keyboardEvents, 0, response);
+    const { value: panelPluginMetas = EMPTY_PANEL_PLUGIN_METAS } = usePanelPluginMetasMap();
 
     const memoizedData = useMemo(() => {
       if (!response?.view?.dataFrame.fields.length) {
@@ -93,9 +96,20 @@ export const SearchResultsTable = React.memo(
         columnStyles,
         onTagSelected,
         onDatasourceChange,
-        response.view?.length >= response.totalRows
+        response.view?.length >= response.totalRows,
+        panelPluginMetas
       );
-    }, [response, width, columnStyles, selection, selectionToggle, clearSelection, onTagSelected, onDatasourceChange]);
+    }, [
+      response,
+      width,
+      columnStyles,
+      selection,
+      selectionToggle,
+      clearSelection,
+      onTagSelected,
+      onDatasourceChange,
+      panelPluginMetas,
+    ]);
 
     const options: TableOptions<{}> = useMemo(
       () => ({

--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -12,6 +12,7 @@ import {
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, getDataSourceSrv } from '@grafana/runtime';
+import { type PanelPluginMetas } from '@grafana/runtime/internal';
 import { Checkbox, Icon, IconName, TagList, Text, Tooltip } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
 import { formatDate, formatDuration } from 'app/core/internationalization/dates';
@@ -38,7 +39,8 @@ export const generateColumns = (
   styles: { [key: string]: string },
   onTagSelected: (tag: string) => void,
   onDatasourceChange?: (datasource?: string) => void,
-  showingEverything?: boolean
+  showingEverything?: boolean,
+  panelPluginMetas: PanelPluginMetas = {}
 ): TableColumn[] => {
   const columns: TableColumn[] = [];
   const access = response.view.fields;
@@ -154,7 +156,7 @@ export const generateColumns = (
     availableWidth -= width;
   } else {
     width = TYPE_COLUMN_WIDTH;
-    columns.push(makeTypeColumn(response, access.kind, access.panel_type, width, styles));
+    columns.push(makeTypeColumn(response, access.kind, access.panel_type, width, styles, panelPluginMetas));
     availableWidth -= width;
   }
 
@@ -418,7 +420,8 @@ function makeTypeColumn(
   kindField: Field<string>,
   typeField: Field<string>,
   width: number,
-  styles: Record<string, string>
+  styles: Record<string, string>,
+  panelPluginMetas: PanelPluginMetas
 ): TableColumn {
   return {
     id: `column-type`,
@@ -446,7 +449,7 @@ function makeTypeColumn(
             const type = typeField.values[i];
             if (type) {
               txt = type;
-              const info = config.panels[txt];
+              const info = panelPluginMetas[txt];
               if (info?.name) {
                 txt = info.name;
               } else {


### PR DESCRIPTION
**What is this feature?**

This pull request enhances the search results table in the Grafana app by improving the way panel plugin names are displayed in the "Type" column. Instead of relying on a static config, the table now uses dynamically loaded panel plugin metadata, ensuring that plugin names are accurate and up-to-date. Additionally, comprehensive tests have been added to verify this new behavior.

**Why do we need this feature?**

So we can remove `config.panels`

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates #117467

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
