### PR TITLE
Alerting: Fix no data display Alerts Activity

### DIFF
--- a/public/app/features/alerting/unified/triage/instance-details/DrawerTimeRangeInfoBanner.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/DrawerTimeRangeInfoBanner.tsx
@@ -1,0 +1,18 @@
+import { Trans, t } from '@grafana/i18n';
+import { Alert } from '@grafana/ui';
+
+/**
+ * Info banner shown when the drawer time range is shorter than the rule's query evaluation window,
+ */
+export function DrawerTimeRangeInfoBanner() {
+  return (
+    <Alert
+      severity="info"
+      title={t('alerting.instance-details.drawer-time-range-short.title', 'Time range shorter than evaluation window')}
+    >
+      <Trans i18nKey="alerting.instance-details.drawer-time-range-short.description">
+        The selected time range is shorter than the rule&apos;s query evaluation window so a graph may not be available.
+      </Trans>
+    </Alert>
+  );
+}

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -20,7 +20,9 @@ import { stringifyErrorLike } from '../../utils/misc';
 import { useWorkbenchContext } from '../WorkbenchContext';
 
 import { InstanceDetailsDrawerTitle } from './InstanceDetailsDrawerTitle';
+import { InstanceStateInfoBanner } from './InstanceStateInfoBanner';
 import { QueryVisualization } from './QueryVisualization';
+import { useInstanceAlertState } from './instanceStateUtils';
 import { convertStateHistoryToAnnotations } from './stateHistoryUtils';
 
 const { useGetAlertRuleQuery } = alertRuleApi;
@@ -75,6 +77,8 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, onClose }: Inst
     return { historyRecords, annotations };
   }, [stateHistoryData]);
 
+  const instanceState = useInstanceAlertState(ruleUID, instanceLabels);
+
   if (error) {
     return (
       <Drawer
@@ -109,6 +113,7 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, onClose }: Inst
         <Stack justifyContent="flex-end">
           <TimeRangePicker />
         </Stack>
+        {instanceState && <InstanceStateInfoBanner state={instanceState} />}
         {dataQueries.length > 0 && (
           <Box>
             <Stack direction="column" gap={2}>

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -7,7 +7,18 @@ import { GrafanaTheme2, Labels } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { isFetchError } from '@grafana/runtime';
 import { TimeRangePicker, useTimeRange } from '@grafana/scenes-react';
-import { Alert, Box, Drawer, Icon, LoadingBar, LoadingPlaceholder, Stack, Text, useStyles2 } from '@grafana/ui';
+import {
+  Alert,
+  Box,
+  Drawer,
+  Icon,
+  LoadingBar,
+  LoadingPlaceholder,
+  Stack,
+  Text,
+  TextLink,
+  useStyles2,
+} from '@grafana/ui';
 import { AlertQuery, GrafanaRuleDefinition } from 'app/types/unified-alerting-dto';
 
 import { alertRuleApi } from '../../api/alertRuleApi';
@@ -16,7 +27,10 @@ import { getThresholdsForQueries } from '../../components/rule-editor/util';
 import { EventState } from '../../components/rules/central-state-history/EventListSceneObject';
 import { LogRecord, historyDataFrameToLogRecords } from '../../components/rules/state-history/common';
 import { isAlertQueryOfAlertData } from '../../rule-editor/formProcessing';
+import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { stringifyErrorLike } from '../../utils/misc';
+import { groups as alertingGroups } from '../../utils/navigation';
+import { createRelativeUrl } from '../../utils/url';
 import { useWorkbenchContext } from '../WorkbenchContext';
 
 import { InstanceDetailsDrawerTitle } from './InstanceDetailsDrawerTitle';
@@ -163,18 +177,38 @@ export interface InstanceLocationProps {
   folderTitle: string;
   groupName: string;
   ruleName: string;
+  namespaceUid?: string;
+  ruleUid?: string;
 }
 
-export function InstanceLocation({ folderTitle, groupName, ruleName }: InstanceLocationProps) {
+export function InstanceLocation({ folderTitle, groupName, ruleName, namespaceUid, ruleUid }: InstanceLocationProps) {
+  const groupUrl =
+    namespaceUid != null
+      ? alertingGroups.detailsPageLink(GRAFANA_RULES_SOURCE_NAME, namespaceUid, groupName)
+      : undefined;
+  const ruleViewUrl = ruleUid ? createRelativeUrl(`/alerting/${GRAFANA_RULES_SOURCE_NAME}/${ruleUid}/view`) : undefined;
+
   return (
     <Stack direction="row" alignItems="center" gap={1}>
       <Icon size="xs" name="folder" />
       <Stack direction="row" alignItems="center" gap={0.5}>
         <Text variant="bodySmall">{folderTitle}</Text>
         <Icon size="sm" name="angle-right" />
-        <Text variant="bodySmall">{groupName}</Text>
+        {groupUrl ? (
+          <TextLink href={groupUrl} variant="bodySmall" color="primary" inline={false}>
+            {groupName}
+          </TextLink>
+        ) : (
+          <Text variant="bodySmall">{groupName}</Text>
+        )}
         <Icon size="sm" name="angle-right" />
-        <Text variant="bodySmall">{ruleName}</Text>
+        {ruleViewUrl ? (
+          <TextLink href={ruleViewUrl} variant="bodySmall" color="primary" inline={false}>
+            {ruleName}
+          </TextLink>
+        ) : (
+          <Text variant="bodySmall">{ruleName}</Text>
+        )}
       </Stack>
     </Stack>
   );

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -33,9 +33,11 @@ import { groups as alertingGroups } from '../../utils/navigation';
 import { createRelativeUrl } from '../../utils/url';
 import { useWorkbenchContext } from '../WorkbenchContext';
 
+import { DrawerTimeRangeInfoBanner } from './DrawerTimeRangeInfoBanner';
 import { InstanceDetailsDrawerTitle } from './InstanceDetailsDrawerTitle';
 import { InstanceStateInfoBanner } from './InstanceStateInfoBanner';
 import { QueryVisualization } from './QueryVisualization';
+import { isDrawerRangeShorterThanQuery } from './drawerTimeRangeUtils';
 import { useInstanceAlertState } from './instanceStateUtils';
 import { convertStateHistoryToAnnotations } from './stateHistoryUtils';
 
@@ -93,6 +95,13 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, onClose }: Inst
 
   const instanceState = useInstanceAlertState(ruleUID, instanceLabels);
 
+  const showDrawerTimeRangeBanner = useMemo(() => {
+    if (!rule?.grafana_alert) {
+      return false;
+    }
+    return isDrawerRangeShorterThanQuery(rule.grafana_alert, timeRange);
+  }, [rule, timeRange]);
+
   if (error) {
     return (
       <Drawer
@@ -127,6 +136,7 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, onClose }: Inst
         <Stack justifyContent="flex-end">
           <TimeRangePicker />
         </Stack>
+        {showDrawerTimeRangeBanner && !instanceState && <DrawerTimeRangeInfoBanner />}
         {instanceState && <InstanceStateInfoBanner state={instanceState} />}
         {dataQueries.length > 0 && (
           <Box>

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -29,6 +29,7 @@ import { LogRecord, historyDataFrameToLogRecords } from '../../components/rules/
 import { isAlertQueryOfAlertData } from '../../rule-editor/formProcessing';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { stringifyErrorLike } from '../../utils/misc';
+import { groups, rulesNav } from '../../utils/navigation';
 import { useWorkbenchContext } from '../WorkbenchContext';
 
 import { DrawerTimeRangeInfoBanner } from './DrawerTimeRangeInfoBanner';
@@ -191,10 +192,11 @@ export interface InstanceLocationProps {
 
 export function InstanceLocation({ folderTitle, groupName, ruleName, namespaceUid, ruleUid }: InstanceLocationProps) {
   const groupUrl =
-    namespaceUid != null
-      ? `/alerting/${GRAFANA_RULES_SOURCE_NAME}/namespaces/${encodeURIComponent(namespaceUid)}/groups/${encodeURIComponent(groupName)}/view`
+    namespaceUid != null ? groups.detailsPageLink(GRAFANA_RULES_SOURCE_NAME, namespaceUid, groupName) : undefined;
+  const ruleViewUrl =
+    ruleUid != null
+      ? rulesNav.detailsPageLink(GRAFANA_RULES_SOURCE_NAME, { uid: ruleUid, ruleSourceName: 'grafana' })
       : undefined;
-  const ruleViewUrl = ruleUid ? `/alerting/${GRAFANA_RULES_SOURCE_NAME}/${ruleUid}/view` : undefined;
 
   return (
     <Stack direction="row" alignItems="center" gap={1}>

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -29,8 +29,6 @@ import { LogRecord, historyDataFrameToLogRecords } from '../../components/rules/
 import { isAlertQueryOfAlertData } from '../../rule-editor/formProcessing';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { stringifyErrorLike } from '../../utils/misc';
-import { groups as alertingGroups } from '../../utils/navigation';
-import { createRelativeUrl } from '../../utils/url';
 import { useWorkbenchContext } from '../WorkbenchContext';
 
 import { DrawerTimeRangeInfoBanner } from './DrawerTimeRangeInfoBanner';
@@ -194,9 +192,9 @@ export interface InstanceLocationProps {
 export function InstanceLocation({ folderTitle, groupName, ruleName, namespaceUid, ruleUid }: InstanceLocationProps) {
   const groupUrl =
     namespaceUid != null
-      ? alertingGroups.detailsPageLink(GRAFANA_RULES_SOURCE_NAME, namespaceUid, groupName)
+      ? `/alerting/${GRAFANA_RULES_SOURCE_NAME}/namespaces/${encodeURIComponent(namespaceUid)}/groups/${encodeURIComponent(groupName)}/view`
       : undefined;
-  const ruleViewUrl = ruleUid ? createRelativeUrl(`/alerting/${GRAFANA_RULES_SOURCE_NAME}/${ruleUid}/view`) : undefined;
+  const ruleViewUrl = ruleUid ? `/alerting/${GRAFANA_RULES_SOURCE_NAME}/${ruleUid}/view` : undefined;
 
   return (
     <Stack direction="row" alignItems="center" gap={1}>

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
@@ -32,7 +32,13 @@ export function InstanceDetailsDrawerTitle({ instanceLabels, rule }: InstanceDet
         <Box flex={1} />
       </Stack>
       {folder && rule && (
-        <InstanceLocation folderTitle={stringifyFolder(folder)} groupName={rule.rule_group} ruleName={rule.title} />
+        <InstanceLocation
+          folderTitle={stringifyFolder(folder)}
+          groupName={rule.rule_group}
+          ruleName={rule.title}
+          namespaceUid={rule.namespace_uid}
+          ruleUid={rule.uid}
+        />
       )}
     </Stack>
   );

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceStateInfoBanner.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceStateInfoBanner.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react';
+
+import { Trans, t } from '@grafana/i18n';
+import { Alert } from '@grafana/ui';
+
+export type InstanceStateType = 'nodata' | 'error';
+
+const BANNER_CONFIG: Record<InstanceStateType, { titleKey: string; titleDefault: string; description: ReactNode }> = {
+  nodata: {
+    titleKey: 'alerting.instance-details.state-nodata.title',
+    titleDefault: 'No data state',
+    description: (
+      <Trans i18nKey="alerting.instance-details.state-nodata.description">
+        This instance is in <strong>No data</strong> state. The alert fired because the query returned no data in the
+        evaluation window, so a graph may not be available.
+      </Trans>
+    ),
+  },
+  error: {
+    titleKey: 'alerting.instance-details.state-error.title',
+    titleDefault: 'Error state',
+    description: (
+      <Trans i18nKey="alerting.instance-details.state-error-description">
+        This instance is in <strong>Error</strong> state. An evaluation error occurred, so a graph may not be available.
+      </Trans>
+    ),
+  },
+};
+
+interface InstanceStateInfoBannerProps {
+  state: InstanceStateType;
+}
+
+/**
+ * Info banner shown above the query graph when the instance is in NoData or Error state.
+ */
+export function InstanceStateInfoBanner({ state }: InstanceStateInfoBannerProps) {
+  const { titleKey, titleDefault, description } = BANNER_CONFIG[state];
+  return (
+    <Alert severity="info" title={t(titleKey, titleDefault)}>
+      {description}
+    </Alert>
+  );
+}

--- a/public/app/features/alerting/unified/triage/instance-details/drawerTimeRangeUtils.test.ts
+++ b/public/app/features/alerting/unified/triage/instance-details/drawerTimeRangeUtils.test.ts
@@ -1,0 +1,89 @@
+import { type TimeRange, dateTime } from '@grafana/data';
+import type { GrafanaRuleDefinition } from 'app/types/unified-alerting-dto';
+
+import { getMaxQueryEvaluationWindowSeconds, isDrawerRangeShorterThanQuery } from './drawerTimeRangeUtils';
+
+function dataQuery(relativeTimeRange: { from: number; to: number }) {
+  return {
+    refId: 'A',
+    queryType: 'prometheus',
+    datasourceUid: 'ds1',
+    model: { expr: 'up' },
+    relativeTimeRange,
+  };
+}
+
+function makeTimeRange(fromMs: number, toMs: number): TimeRange {
+  const from = dateTime(fromMs);
+  const to = dateTime(toMs);
+  return { from, to, raw: { from, to } };
+}
+
+describe('drawerTimeRangeUtils', () => {
+  describe('getMaxQueryEvaluationWindowSeconds', () => {
+    it('returns 0 when rule has no data', () => {
+      const rule = { data: [] } as unknown as GrafanaRuleDefinition;
+      expect(getMaxQueryEvaluationWindowSeconds(rule)).toBe(0);
+    });
+
+    it('returns 0 when rule has no data queries with relativeTimeRange', () => {
+      const rule = {
+        data: [
+          {
+            refId: 'B',
+            queryType: 'expression',
+            datasourceUid: '__expr',
+            model: { type: 'math', expression: '1' },
+            // no relativeTimeRange
+          },
+        ],
+      } as unknown as GrafanaRuleDefinition;
+      expect(getMaxQueryEvaluationWindowSeconds(rule)).toBe(0);
+    });
+
+    it('returns max from when data queries have relativeTimeRange', () => {
+      const rule = {
+        data: [dataQuery({ from: 300, to: 0 }), dataQuery({ from: 600, to: 0 }), dataQuery({ from: 400, to: 0 })],
+      } as unknown as GrafanaRuleDefinition;
+      expect(getMaxQueryEvaluationWindowSeconds(rule)).toBe(600);
+    });
+
+    it('mixed: only counts data queries with relativeTimeRange', () => {
+      const rule = {
+        data: [
+          dataQuery({ from: 900, to: 0 }),
+          { refId: 'B', queryType: 'prometheus', datasourceUid: 'ds', model: { expr: 'up' } }, // no relativeTimeRange
+          dataQuery({ from: 300, to: 0 }),
+        ],
+      } as unknown as GrafanaRuleDefinition;
+      expect(getMaxQueryEvaluationWindowSeconds(rule)).toBe(900);
+    });
+  });
+
+  describe('isDrawerRangeShorterThanQuery', () => {
+    const ruleWith600sWindow = {
+      data: [dataQuery({ from: 600, to: 0 })],
+    } as unknown as GrafanaRuleDefinition;
+
+    it('returns false when rule has no evaluation window (0)', () => {
+      const rule = { data: [dataQuery({ from: 0, to: 0 })] } as unknown as GrafanaRuleDefinition;
+      const range = makeTimeRange(0, 100 * 1000);
+      expect(isDrawerRangeShorterThanQuery(rule, range)).toBe(false);
+    });
+
+    it('returns true when drawer range is shorter than window', () => {
+      const range = makeTimeRange(0, 300 * 1000); // 300s
+      expect(isDrawerRangeShorterThanQuery(ruleWith600sWindow, range)).toBe(true);
+    });
+
+    it('returns false when drawer range equals window', () => {
+      const range = makeTimeRange(0, 600 * 1000); // 600s
+      expect(isDrawerRangeShorterThanQuery(ruleWith600sWindow, range)).toBe(false);
+    });
+
+    it('returns false when drawer range is longer than window', () => {
+      const range = makeTimeRange(0, 900 * 1000); // 900s
+      expect(isDrawerRangeShorterThanQuery(ruleWith600sWindow, range)).toBe(false);
+    });
+  });
+});

--- a/public/app/features/alerting/unified/triage/instance-details/drawerTimeRangeUtils.ts
+++ b/public/app/features/alerting/unified/triage/instance-details/drawerTimeRangeUtils.ts
@@ -1,0 +1,36 @@
+import type { TimeRange } from '@grafana/data';
+import type { AlertQuery, GrafanaRuleDefinition } from 'app/types/unified-alerting-dto';
+
+import { isAlertQueryOfAlertData } from '../../rule-editor/formProcessing';
+
+/**
+ * Returns the maximum evaluation window (seconds) required by the rule's data queries.
+ * Only considers queries that have relativeTimeRange; returns 0 if none.
+ */
+export function getMaxQueryEvaluationWindowSeconds(rule: GrafanaRuleDefinition): number {
+  if (!rule?.data?.length) {
+    return 0;
+  }
+  const dataQueries = rule.data.filter((q: AlertQuery) => isAlertQueryOfAlertData(q));
+  let maxFrom = 0;
+  for (const q of dataQueries) {
+    const rtr = q.relativeTimeRange;
+    if (rtr && typeof rtr.from === 'number' && rtr.from > maxFrom) {
+      maxFrom = rtr.from;
+    }
+  }
+  return maxFrom;
+}
+
+/**
+ * True when the drawer's selected time range is shorter than the rule's query evaluation window,
+ * in which case the graph may not show data.
+ */
+export function isDrawerRangeShorterThanQuery(rule: GrafanaRuleDefinition, timeRange: TimeRange): boolean {
+  const requiredSeconds = getMaxQueryEvaluationWindowSeconds(rule);
+  if (requiredSeconds <= 0) {
+    return false;
+  }
+  const drawerDurationSeconds = (timeRange.to.valueOf() - timeRange.from.valueOf()) / 1000;
+  return drawerDurationSeconds < requiredSeconds;
+}

--- a/public/app/features/alerting/unified/triage/instance-details/drawerTimeRangeUtils.ts
+++ b/public/app/features/alerting/unified/triage/instance-details/drawerTimeRangeUtils.ts
@@ -1,3 +1,5 @@
+import { maxBy } from 'lodash';
+
 import type { TimeRange } from '@grafana/data';
 import type { AlertQuery, GrafanaRuleDefinition } from 'app/types/unified-alerting-dto';
 
@@ -12,14 +14,12 @@ export function getMaxQueryEvaluationWindowSeconds(rule: GrafanaRuleDefinition):
     return 0;
   }
   const dataQueries = rule.data.filter((q: AlertQuery) => isAlertQueryOfAlertData(q));
-  let maxFrom = 0;
-  for (const q of dataQueries) {
-    const rtr = q.relativeTimeRange;
-    if (rtr && typeof rtr.from === 'number' && rtr.from > maxFrom) {
-      maxFrom = rtr.from;
-    }
-  }
-  return maxFrom;
+  const queryWithMaxFrom = maxBy(dataQueries, (q) =>
+    typeof q.relativeTimeRange?.from === 'number' ? q.relativeTimeRange.from : -Infinity
+  );
+  return queryWithMaxFrom && typeof queryWithMaxFrom.relativeTimeRange?.from === 'number'
+    ? queryWithMaxFrom.relativeTimeRange.from
+    : 0;
 }
 
 /**

--- a/public/app/features/alerting/unified/triage/instance-details/instanceStateUtils.test.ts
+++ b/public/app/features/alerting/unified/triage/instance-details/instanceStateUtils.test.ts
@@ -1,0 +1,184 @@
+import { renderHook } from '@testing-library/react';
+
+import { FieldType } from '@grafana/data';
+
+import {
+  buildInstanceStateQueryExpr,
+  getInstanceStateFromMetricSeries,
+  useInstanceAlertState,
+} from './instanceStateUtils';
+
+jest.mock('../constants', () => ({
+  DATASOURCE_UID: 'test-ds-uid',
+  METRIC_NAME: 'GRAFANA_ALERTS',
+}));
+
+const mockUseQueryRunner = jest.fn();
+jest.mock('@grafana/scenes-react', () => ({
+  useQueryRunner: (opts: unknown) => mockUseQueryRunner(opts),
+}));
+
+describe('instanceStateUtils', () => {
+  beforeEach(() => {
+    mockUseQueryRunner.mockReset();
+    mockUseQueryRunner.mockReturnValue({ useState: () => ({ data: { series: [] } }) });
+  });
+  describe('buildInstanceStateQueryExpr', () => {
+    it('includes grafana_rule_uid and metric name', () => {
+      const expr = buildInstanceStateQueryExpr('rule-1', {});
+      expect(expr).toBe('GRAFANA_ALERTS{grafana_rule_uid="rule-1"}');
+    });
+
+    it('includes non-empty instance labels and excludes __-prefixed keys', () => {
+      const expr = buildInstanceStateQueryExpr('r2', {
+        team: 'platform',
+        __internal: 'skip',
+        env: 'prod',
+      });
+      expect(expr).toContain('grafana_rule_uid="r2"');
+      expect(expr).toContain('team="platform"');
+      expect(expr).toContain('env="prod"');
+      expect(expr).not.toContain('__internal');
+    });
+
+    it('excludes empty string and null/undefined values', () => {
+      const expr = buildInstanceStateQueryExpr('r3', {
+        a: 'x',
+        b: '',
+        c: null as unknown as string,
+        d: undefined as unknown as string,
+      });
+      expect(expr).toBe('GRAFANA_ALERTS{grafana_rule_uid="r3",a="x"}');
+    });
+
+    it('escapes backslash and double-quote in rule UID and label values', () => {
+      const expr = buildInstanceStateQueryExpr('rule\\with"quotes', { label: 'val\\ue"here' });
+      expect(expr).toContain('grafana_rule_uid="rule\\\\with\\"quotes"');
+      expect(expr).toContain('label="val\\\\ue\\"here"');
+    });
+  });
+
+  describe('getInstanceStateFromMetricSeries', () => {
+    function makeSeries(grafana_alertstate: string) {
+      const valueField = {
+        name: 'Value',
+        type: FieldType.number,
+        values: [1],
+        config: {},
+        labels: { grafana_alertstate },
+      };
+      return [
+        {
+          fields: [{ name: 'Time', type: FieldType.time, values: [1000], config: {} }, valueField],
+          length: 1,
+        },
+      ];
+    }
+
+    it('returns null when series is undefined or empty', () => {
+      expect(getInstanceStateFromMetricSeries(undefined)).toBe(null);
+      expect(getInstanceStateFromMetricSeries([])).toBe(null);
+    });
+
+    it('returns "nodata" when grafana_alertstate is nodata', () => {
+      expect(getInstanceStateFromMetricSeries(makeSeries('nodata'))).toBe('nodata');
+      expect(getInstanceStateFromMetricSeries(makeSeries('NoData'))).toBe('nodata');
+    });
+
+    it('returns "error" when grafana_alertstate is error', () => {
+      expect(getInstanceStateFromMetricSeries(makeSeries('error'))).toBe('error');
+      expect(getInstanceStateFromMetricSeries(makeSeries('Error'))).toBe('error');
+    });
+
+    it('returns null for other states (alerting, pending, recovering)', () => {
+      expect(getInstanceStateFromMetricSeries(makeSeries('alerting'))).toBe(null);
+      expect(getInstanceStateFromMetricSeries(makeSeries('pending'))).toBe(null);
+      expect(getInstanceStateFromMetricSeries(makeSeries('recovering'))).toBe(null);
+    });
+
+    it('returns null when value field has no grafana_alertstate label', () => {
+      const series = [
+        {
+          fields: [
+            { name: 'Time', type: FieldType.time, values: [1000], config: {} },
+            { name: 'Value', type: FieldType.number, values: [1], config: {}, labels: {} },
+          ],
+          length: 1,
+        },
+      ];
+      expect(getInstanceStateFromMetricSeries(series)).toBe(null);
+    });
+
+    it('returns null when there is no non-time field', () => {
+      const series = [
+        {
+          fields: [{ name: 'Time', type: FieldType.time, values: [1000], config: {} }],
+          length: 1,
+        },
+      ];
+      expect(getInstanceStateFromMetricSeries(series)).toBe(null);
+    });
+  });
+
+  describe('useInstanceAlertState', () => {
+    it('returns null when query runner has no series', () => {
+      mockUseQueryRunner.mockReturnValue({
+        useState: () => ({ data: { series: [] } }),
+      });
+      const { result } = renderHook(() => useInstanceAlertState('rule-1', {}));
+      expect(result.current).toBe(null);
+    });
+
+    it('returns nodata when series has grafana_alertstate nodata', () => {
+      mockUseQueryRunner.mockReturnValue({
+        useState: () => ({
+          data: {
+            series: [
+              {
+                fields: [
+                  { name: 'Time', type: FieldType.time, values: [1000], config: {} },
+                  {
+                    name: 'Value',
+                    type: FieldType.number,
+                    values: [1],
+                    config: {},
+                    labels: { grafana_alertstate: 'nodata' },
+                  },
+                ],
+                length: 1,
+              },
+            ],
+          },
+        }),
+      });
+      const { result } = renderHook(() => useInstanceAlertState('rule-1', {}));
+      expect(result.current).toBe('nodata');
+    });
+
+    it('returns error when series has grafana_alertstate error', () => {
+      mockUseQueryRunner.mockReturnValue({
+        useState: () => ({
+          data: {
+            series: [
+              {
+                fields: [
+                  { name: 'Time', type: FieldType.time, values: [1000], config: {} },
+                  {
+                    name: 'Value',
+                    type: FieldType.number,
+                    values: [1],
+                    config: {},
+                    labels: { grafana_alertstate: 'error' },
+                  },
+                ],
+                length: 1,
+              },
+            ],
+          },
+        }),
+      });
+      const { result } = renderHook(() => useInstanceAlertState('rule-1', {}));
+      expect(result.current).toBe('error');
+    });
+  });
+});

--- a/public/app/features/alerting/unified/triage/instance-details/instanceStateUtils.ts
+++ b/public/app/features/alerting/unified/triage/instance-details/instanceStateUtils.ts
@@ -1,0 +1,74 @@
+import { useMemo } from 'react';
+
+import { DataFrame, Labels } from '@grafana/data';
+import { useQueryRunner } from '@grafana/scenes-react';
+
+import { DATASOURCE_UID, METRIC_NAME } from '../constants';
+
+/** Escape a label value for use in a Prometheus selector (double-quoted). */
+function escapePrometheusLabelValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/**
+ * Builds a PromQL selector for GRAFANA_ALERTS that matches this instance
+ * (grafana_rule_uid + instance labels). Used to query the current alert state.
+ */
+export function buildInstanceStateQueryExpr(ruleUID: string, instanceLabels: Labels): string {
+  const parts: string[] = [`grafana_rule_uid="${escapePrometheusLabelValue(ruleUID)}"`];
+  for (const [k, v] of Object.entries(instanceLabels)) {
+    if (k && v != null && v !== '' && !k.startsWith('__')) {
+      parts.push(`${k}="${escapePrometheusLabelValue(String(v))}"`);
+    }
+  }
+  return `${METRIC_NAME}{${parts.join(',')}}`;
+}
+
+const GRAFANA_ALERTSTATE_LABEL = 'grafana_alertstate';
+
+/**
+ * Reads grafana_alertstate from the first series in the query result.
+ * The backend writes it lowercase (nodata, error, alerting, pending, recovering).
+ */
+export function getInstanceStateFromMetricSeries(series: DataFrame[] | undefined): 'nodata' | 'error' | null {
+  if (!series?.length) {
+    return null;
+  }
+  const frame = series[0];
+  const valueField = frame.fields.find((f) => f.type !== 'time');
+  const stateLabel = valueField?.labels?.[GRAFANA_ALERTSTATE_LABEL];
+  if (typeof stateLabel !== 'string') {
+    return null;
+  }
+  const normalized = stateLabel.toLowerCase();
+  return normalized === 'nodata' || normalized === 'error' ? normalized : null;
+}
+
+export type InstanceAlertState = 'nodata' | 'error' | null;
+
+/**
+ * Queries GRAFANA_ALERTS for the current instance state when state history Prometheus is configured.
+ * Returns nodata/error when the instance is in that state, otherwise null.
+ */
+export function useInstanceAlertState(ruleUID: string, instanceLabels: Labels): InstanceAlertState {
+  const query = useMemo(() => {
+    if (!DATASOURCE_UID) {
+      return null;
+    }
+    const expr = buildInstanceStateQueryExpr(ruleUID, instanceLabels);
+    return { refId: 'state', expr, instant: true, datasource: { type: 'prometheus' as const, uid: DATASOURCE_UID } };
+  }, [ruleUID, instanceLabels]);
+
+  const runner = useQueryRunner({
+    datasource: { uid: DATASOURCE_UID ?? '' },
+    queries: query ? [query] : [],
+  });
+  const { data } = runner.useState();
+
+  return useMemo(() => {
+    if (!DATASOURCE_UID || !query || !data?.series) {
+      return null;
+    }
+    return getInstanceStateFromMetricSeries(data.series);
+  }, [query, data?.series]);
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1835,7 +1835,15 @@
       "history-error": "Failed to load state history",
       "history-error-desc": "Unable to fetch state transition history for this instance.",
       "no-history": "No recent state changes",
-      "state-history": "Recent State Changes"
+      "state-error": {
+        "title": "Error state"
+      },
+      "state-error-description": "This instance is in <strong>Error</strong> state. An evaluation error occurred, so a graph may not be available.",
+      "state-history": "Recent State Changes",
+      "state-nodata": {
+        "description": "This instance is in <strong>No data</strong> state. The alert fired because the query returned no data in the evaluation window, so a graph may not be available.",
+        "title": "No data state"
+      }
     },
     "instance-match": {
       "non-matching-labels": "Non-matching labels",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1832,17 +1832,17 @@
       "apply": "Apply"
     },
     "instance-details": {
+      "drawer-time-range-short": {
+        "description": "The selected time range is shorter than the rule's query evaluation window so a graph may not be available.",
+        "title": "Time range shorter than evaluation window"
+      },
       "history-error": "Failed to load state history",
       "history-error-desc": "Unable to fetch state transition history for this instance.",
       "no-history": "No recent state changes",
-      "state-error": {
-        "title": "Error state"
-      },
       "state-error-description": "This instance is in <strong>Error</strong> state. An evaluation error occurred, so a graph may not be available.",
       "state-history": "Recent State Changes",
       "state-nodata": {
-        "description": "This instance is in <strong>No data</strong> state. The alert fired because the query returned no data in the evaluation window, so a graph may not be available.",
-        "title": "No data state"
+        "description": "This instance is in <strong>No data</strong> state. The alert fired because the query returned no data in the evaluation window, so a graph may not be available."
       }
     },
     "instance-match": {


### PR DESCRIPTION
This PR adds helpful info messages if the firing alert instance is in a nodata or error state, or if the rule evaluation period is greater than the selected time range.
Previously the user would only see a graph showing 'No data'.

This PR also allows the user to click into the navigation breadcrumbs on the instance drawer to navigate to the instance group or rule page. 

If alertState is `nodata`
<img width="850" height="711" alt="image" src="https://github.com/user-attachments/assets/216534dc-9d5d-4146-a1d7-2ea65e4f6882" />

If alertstate is `error`
<img width="850" height="681" alt="image" src="https://github.com/user-attachments/assets/ac99f3c0-a56d-4806-bd14-df668851bd18" />

<img width="1154" height="569" alt="image" src="https://github.com/user-attachments/assets/f799ecc3-6cbd-455a-913d-7101e6a5f01d" />

If evaluation time period > selected time range:
<img width="791" height="688" alt="image" src="https://github.com/user-attachments/assets/6dcd0707-63eb-46e6-837f-dd1e42735a75" />
