### PR TITLE
Alerting: Clean up contact point status endpoint(s)

### DIFF
--- a/public/app/features/alerting/unified/api/grafana.ts
+++ b/public/app/features/alerting/unified/api/grafana.ts
@@ -1,9 +1,4 @@
-import { lastValueFrom } from 'rxjs';
-
-import { getBackendSrv } from '@grafana/runtime';
 import { ContactPointsState, ReceiverState, ReceiversStateDTO } from 'app/features/alerting/unified/types/alerting';
-
-import { getDatasourceAPIUid } from '../utils/datasource';
 
 interface IntegrationNameObject {
   type: string;
@@ -57,18 +52,3 @@ export const contactPointsStateDtoToModel = (receiversStateDto: ReceiversStateDT
 
 export const getIntegrationType = (integrationName: string): string | undefined =>
   parseIntegrationName(integrationName)?.type;
-
-export async function fetchContactPointsState(alertManagerSourceName: string): Promise<ContactPointsState> {
-  try {
-    const response = await lastValueFrom(
-      getBackendSrv().fetch<ReceiversStateDTO[]>({
-        url: `/api/alertmanager/${getDatasourceAPIUid(alertManagerSourceName)}/config/api/v1/receivers`,
-        showErrorAlert: false,
-        showSuccessAlert: false,
-      })
-    );
-    return contactPointsStateDtoToModel(response.data);
-  } catch (error) {
-    return contactPointsStateDtoToModel([]);
-  }
-}

--- a/public/app/features/alerting/unified/api/receiversApi.ts
+++ b/public/app/features/alerting/unified/api/receiversApi.ts
@@ -1,26 +1,13 @@
 /** @deprecated To be deleted - use alertingApiServer API instead */
 
-import { ContactPointsState } from 'app/features/alerting/unified/types/alerting';
 import { Receiver, TestReceiversAlert, TestReceiversResult } from 'app/plugins/datasource/alertmanager/types';
 
-import { CONTACT_POINTS_STATE_INTERVAL_MS } from '../utils/constants';
 import { getDatasourceAPIUid } from '../utils/datasource';
 
 import { alertingApi } from './alertingApi';
-import { fetchContactPointsState } from './grafana';
 
 export const receiversApi = alertingApi.injectEndpoints({
   endpoints: (build) => ({
-    contactPointsState: build.query<ContactPointsState, { amSourceName: string }>({
-      queryFn: async ({ amSourceName }) => {
-        try {
-          const contactPointsState = await fetchContactPointsState(amSourceName);
-          return { data: contactPointsState };
-        } catch (error) {
-          return { error: error };
-        }
-      },
-    }),
     testIntegration: build.mutation<TestReceiversResult, TestReceiversOptions>({
       query: ({ alertManagerSourceName, receivers, alert }) => ({
         method: 'POST',
@@ -48,18 +35,6 @@ interface TestReceiversOptions {
   receivers: Receiver[];
   alert?: TestReceiversAlert;
 }
-
-export const useGetContactPointsState = (alertManagerSourceName: string) => {
-  const contactPointsStateEmpty: ContactPointsState = { receivers: {}, errorCount: 0 };
-  const { currentData: contactPointsState } = receiversApi.useContactPointsStateQuery(
-    { amSourceName: alertManagerSourceName ?? '' },
-    {
-      skip: !alertManagerSourceName,
-      pollingInterval: CONTACT_POINTS_STATE_INTERVAL_MS,
-    }
-  );
-  return contactPointsState ?? contactPointsStateEmpty;
-};
 
 export const { useTestIntegrationMutation } = receiversApi;
 


### PR DESCRIPTION
**What is this feature?**

Migrates contact points status fetching in the notification policies tree from the deprecated `receiversApi` / `grafana.ts` implementation to `alertmanagerApi.useGetContactPointsStatusQuery`, as part of the broader move to the alerting API server for contact points.

**Special notes for your reviewer:**

- `fetchContactPointsState` and `useGetContactPointsState` have been removed; `PoliciesTree` now calls `alertmanagerApi.useGetContactPointsStatusQuery` directly.
- The endpoint is Grafana-managed-only by design — `getDatasourceAPIUid(GRAFANA_RULES_SOURCE_NAME)` always resolved to `"grafana"`, so hardcoding it is equivalent to the previous dynamic lookup.
- Polling interval and skip logic are preserved as before.