### PR TITLE
Provisioning: Display repo URL, branch and path in pull status card

### DIFF
--- a/public/app/features/provisioning/Repository/RepositoryPullStatusCard.test.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryPullStatusCard.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from 'test/test-utils';
+
+import { Repository } from 'app/api/clients/provisioning/v0alpha1';
+
+import { RepositoryPullStatusCard } from './RepositoryPullStatusCard';
+
+const createMockRepository = (overrides: Partial<Repository> = {}): Repository => ({
+  metadata: { name: 'test-repo' },
+  spec: {
+    title: 'Test Repository',
+    type: 'github',
+    sync: { target: 'folder', enabled: true },
+    workflows: [],
+    github: {
+      url: 'https://github.com/owner/repo',
+      branch: 'main',
+      path: 'grafana/',
+    },
+  },
+  status: {
+    health: { healthy: true, checked: Date.now() },
+    sync: { state: 'success', message: [] },
+    observedGeneration: 1,
+    webhook: {},
+  },
+  ...overrides,
+});
+
+describe('RepositoryPullStatusCard', () => {
+  describe('source information display', () => {
+    it('should display repository URL as a link for GitHub repos', () => {
+      render(<RepositoryPullStatusCard repo={createMockRepository()} />);
+
+      expect(screen.getByText('Repository URL:')).toBeInTheDocument();
+      const link = screen.getByRole('link', { name: /owner\/repo/ });
+      expect(link).toHaveAttribute('href', expect.stringContaining('github.com/owner/repo'));
+    });
+
+    it('should display branch name', () => {
+      render(<RepositoryPullStatusCard repo={createMockRepository()} />);
+
+      expect(screen.getByText('Branch:')).toBeInTheDocument();
+      expect(screen.getByText('main')).toBeInTheDocument();
+    });
+
+    it('should display path when configured', () => {
+      render(<RepositoryPullStatusCard repo={createMockRepository()} />);
+
+      expect(screen.getByText('Path:')).toBeInTheDocument();
+      expect(screen.getByText('grafana/')).toBeInTheDocument();
+    });
+
+    it('should not display path row when path is not set', () => {
+      const repo = createMockRepository({
+        spec: {
+          title: 'Test',
+          type: 'github',
+          github: { url: 'https://github.com/owner/repo', branch: 'main' },
+          sync: { target: 'folder', enabled: true },
+          workflows: [],
+        },
+      });
+      render(<RepositoryPullStatusCard repo={repo} />);
+
+      expect(screen.queryByText('Path:')).not.toBeInTheDocument();
+    });
+
+    it('should not display URL or branch rows for local repos', () => {
+      const repo = createMockRepository({
+        spec: {
+          title: 'Test',
+          type: 'local',
+          local: { path: '/var/lib/grafana/repos/test' },
+          sync: { target: 'folder', enabled: true },
+          workflows: [],
+        },
+      });
+      render(<RepositoryPullStatusCard repo={repo} />);
+
+      expect(screen.queryByText('Repository URL:')).not.toBeInTheDocument();
+      expect(screen.queryByText('Branch:')).not.toBeInTheDocument();
+      expect(screen.getByText('Path:')).toBeInTheDocument();
+      expect(screen.getByText('/var/lib/grafana/repos/test')).toBeInTheDocument();
+    });
+
+    it('should display source info for GitLab repos', () => {
+      const repo = createMockRepository({
+        spec: {
+          title: 'Test',
+          type: 'gitlab',
+          gitlab: { url: 'https://gitlab.com/group/project', branch: 'main', path: 'grafana' },
+          sync: { target: 'folder', enabled: true },
+          workflows: [],
+        },
+      });
+      render(<RepositoryPullStatusCard repo={repo} />);
+
+      expect(screen.getByText('Repository URL:')).toBeInTheDocument();
+      expect(screen.getByText('Branch:')).toBeInTheDocument();
+      expect(screen.getByText('Path:')).toBeInTheDocument();
+    });
+  });
+});

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12827,6 +12827,7 @@
       "no-repositories": "No repositories configured"
     },
     "repository-overview": {
+      "branch": "Branch:",
       "checked": "Checked:",
       "connection-status": "Connection status:",
       "finished": "Last successful pull:",
@@ -12836,7 +12837,9 @@
       "last-ref": "Last Ref:",
       "messages": "Messages:",
       "not-available": "N/A",
+      "path": "Path:",
       "pull-status": "Pull status",
+      "repo-url": "Repository URL:",
       "resources": "Resources",
       "status": "Status:",
       "unhealthy": "Unhealthy",


### PR DESCRIPTION
**What is this feature?**

Adds repository source information (URL, branch, path) to the Pull Status card on the Repository Status page. The URL is rendered as a clickable external link to the repository. Branch and path are shown as plain text. All three rows are conditionally rendered — hidden when the value is not set (e.g., local repos hide URL and branch).



**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/869

**Special notes for your reviewer:**

<img width="630" height="331" alt="Screenshot 2026-02-23 at 16 39 32" src="https://github.com/user-attachments/assets/cc4153f6-bcb9-42a0-807e-fb44501967d7" />
