### PR TITLE
Provisioning: Show custom branch as new option

### DIFF
--- a/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.test.tsx
+++ b/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.test.tsx
@@ -199,6 +199,51 @@ describe('ResourceEditFormSharedFields', () => {
       expect(configuredOption.infoOption).toBe(true);
       expect(configuredOption.label).toBe('main (read-only)');
     });
+
+    it('should add selected custom branch as a new option', () => {
+      const customBranch = 'feature/new-branch';
+
+      const { result } = renderHook(() =>
+        useBranchDropdownOptions({
+          repository: { ...mockRepo.github, branch: 'main' },
+          selectedBranch: customBranch,
+          branchData: { items: [{ name: 'develop' }] },
+          canPushToConfiguredBranch: true,
+          canPushToNonConfiguredBranch: true,
+        })
+      );
+
+      const customOption = result.current.find((option) => option.value === customBranch);
+      expect(customOption).toEqual(
+        expect.objectContaining({
+          label: 'feature/new-branch',
+          description: 'New branch',
+          value: 'feature/new-branch',
+        })
+      );
+    });
+
+    it('should not mark selected branch as new when it already exists in repository refs', () => {
+      const existingBranch = 'feature/existing-branch';
+
+      const { result } = renderHook(() =>
+        useBranchDropdownOptions({
+          repository: { ...mockRepo.github, branch: 'main' },
+          selectedBranch: existingBranch,
+          branchData: { items: [{ name: existingBranch }] },
+          canPushToConfiguredBranch: true,
+          canPushToNonConfiguredBranch: true,
+        })
+      );
+
+      const existingOption = result.current.find((option) => option.value === existingBranch);
+      expect(existingOption).toEqual(
+        expect.objectContaining({
+          label: existingBranch,
+          value: existingBranch,
+        })
+      );
+    });
   });
 
   describe('User Interactions', () => {

--- a/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
+++ b/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
@@ -29,6 +29,7 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
       register,
       formState: { errors },
       setValue,
+      watch,
     } = useFormContext();
 
     const canPushToNonConfiguredBranch = repository?.workflows?.includes('branch');
@@ -45,11 +46,13 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
     const { getLastBranch } = useLastBranch();
     const prBranch = usePRBranch();
     const lastBranch = getLastBranch(repository?.name);
+    const selectedBranch = watch('ref');
 
     const branchOptions = useBranchDropdownOptions({
       repository,
       prBranch,
       lastBranch,
+      selectedBranch,
       branchData,
       canPushToConfiguredBranch,
       canPushToNonConfiguredBranch,

--- a/public/app/features/provisioning/hooks/useBranchDropdownOptions.ts
+++ b/public/app/features/provisioning/hooks/useBranchDropdownOptions.ts
@@ -7,6 +7,7 @@ interface UseBranchDropdownOptionsParams {
   repository?: RepositoryView;
   prBranch?: string;
   lastBranch?: string;
+  selectedBranch?: string;
   branchData?: GetRepositoryRefsApiResponse;
   canPushToConfiguredBranch?: boolean;
   canPushToNonConfiguredBranch?: boolean;
@@ -27,6 +28,7 @@ function getBranchDescriptions() {
     ),
     pr: t('provisioned-resource-form.save-or-delete-resource-shared-fields.suffix-pr-branch', 'Pull request branch'),
     lastUsed: t('provisioned-resource-form.save-or-delete-resource-shared-fields.suffix-last-used', 'Last branch'),
+    newBranch: t('provisioned-resource-form.save-or-delete-resource-shared-fields.suffix-new-branch', 'New branch'),
     disabledConfigured: t(
       'provisioned-resource-form.save-or-delete-resource-shared-fields.info-branch-disabled',
       'Push to configured branch is disabled'
@@ -40,12 +42,13 @@ function getBranchDescriptions() {
 
 /**
  * Hook to generate branch dropdown options with proper ordering and deduplication.
- * Order: Configured branch → PR branch → Last used branch → Other branches
+ * Order: Configured branch → PR branch → Last used branch → Selected custom branch → Other branches
  */
 export const useBranchDropdownOptions = ({
   repository,
   prBranch,
   lastBranch,
+  selectedBranch,
   branchData,
   canPushToConfiguredBranch,
   canPushToNonConfiguredBranch,
@@ -88,6 +91,16 @@ export const useBranchDropdownOptions = ({
       description: descriptions.lastUsed,
     });
     addedBranches.add(lastBranch);
+  }
+
+  const selectedExistsInRepository = branchData?.items?.some((ref) => ref.name === selectedBranch);
+  if (selectedBranch && !selectedExistsInRepository && !addedBranches.has(selectedBranch)) {
+    options.push({
+      label: selectedBranch,
+      value: selectedBranch,
+      description: descriptions.newBranch,
+    });
+    addedBranches.add(selectedBranch);
   }
 
   if (branchData?.items) {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12375,6 +12375,7 @@
       "placeholder-branch": "Select or enter branch name",
       "suffix-configured-branch": "Synchronized branch",
       "suffix-last-used": "Last branch",
+      "suffix-new-branch": "New branch",
       "suffix-pr-branch": "Pull request branch",
       "suffix-read-only-branch": " (read-only)"
     }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12372,6 +12372,7 @@
       "placeholder-branch": "Select or enter branch name",
       "suffix-configured-branch": "Synchronized branch",
       "suffix-last-used": "Last branch",
+      "suffix-new-branch": "New branch",
       "suffix-pr-branch": "Pull request branch",
       "suffix-read-only-branch": " (read-only)"
     }


### PR DESCRIPTION
**What is this feature?**

Updates the provisioning branch picker so a user-selected custom branch is added to the options list and shown with a `New branch` description. It also wires the current `ref` form value into branch option generation so the selected custom branch remains visible in the dropdown.


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/846

**Special notes for your reviewer:**

<img width="421" height="266" alt="Screenshot 2026-02-23 at 17 16 57" src="https://github.com/user-attachments/assets/7397b584-62a6-4c64-a286-c311b737d983" />

