### PR TITLE
Suggested Dashboard: `dashvalidator` Fix Unparseable PromQL Queries via Template Variable Interpolation

### DIFF
--- a/apps/dashvalidator/pkg/validator/prometheus/interpolation.go
+++ b/apps/dashvalidator/pkg/validator/prometheus/interpolation.go
@@ -1,0 +1,45 @@
+package prometheus
+
+import "regexp"
+
+var (
+	// Matches [$__rate_interval], [$__interval], [$__range], [${__rate_interval}]
+	builtinDurationVarRegex = regexp.MustCompile(`\[\$(?:\{__[a-zA-Z_]+\}|__[a-zA-Z_]+)\]`)
+	// Matches [$interval], [${custom_interval}]
+	userDurationVarRegex = regexp.MustCompile(`\[(\$(?:\{[^}]+\}|[a-zA-Z_][a-zA-Z0-9_]*))\]`)
+	// Matches by(...) and without(...) clauses
+	groupingClauseRegex = regexp.MustCompile(`\b(by|without)\s*\(([^)]*)\)`)
+	// Matches any $var or ${var} reference
+	varRefRegex     = regexp.MustCompile(`\$(?:\{[^}]+\}|[a-zA-Z_][a-zA-Z0-9_]*)`)
+	defaultDuration = "[5m]"
+)
+
+// interpolateForParsing replaces Grafana template variables with parseable
+// placeholders so the PromQL parser can extract metric names.
+//
+// Handles:
+//   - Duration vars ([$__rate_interval], [$interval]) → [5m]
+//   - Grouping vars (by($var)) → by(placeholder_label)
+//   - Label vars ({ns=~"$namespace"}) → unchanged (already valid literals)
+func interpolateForParsing(expr string) string {
+	expr = builtinDurationVarRegex.ReplaceAllString(expr, defaultDuration)
+	expr = userDurationVarRegex.ReplaceAllString(expr, defaultDuration)
+	expr = groupingClauseRegex.ReplaceAllStringFunc(expr, replaceGroupingVars)
+	return expr
+}
+
+// replaceGroupingVars substitutes $var references inside by()/without() with
+// a valid label name. Returns unchanged if no variables are present.
+func replaceGroupingVars(match string) string {
+	parts := groupingClauseRegex.FindStringSubmatch(match)
+	if len(parts) != 3 {
+		return match
+	}
+	content := parts[2]
+	if !varRefRegex.MatchString(content) {
+		return match
+	}
+	keyword := parts[1]
+	replaced := varRefRegex.ReplaceAllString(content, "placeholder_label")
+	return keyword + "(" + replaced + ")"
+}

--- a/apps/dashvalidator/pkg/validator/prometheus/interpolation_test.go
+++ b/apps/dashvalidator/pkg/validator/prometheus/interpolation_test.go
@@ -1,0 +1,94 @@
+package prometheus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterpolateForParsing(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     string
+		expected string
+	}{
+		// No variables — passthrough
+		{
+			name:     "no variables passthrough",
+			expr:     `rate(http_requests_total{job="api"}[5m])`,
+			expected: `rate(http_requests_total{job="api"}[5m])`,
+		},
+
+		// Built-in duration variables
+		{
+			name:     "builtin $__rate_interval",
+			expr:     `rate(metric[$__rate_interval])`,
+			expected: `rate(metric[5m])`,
+		},
+		{
+			name:     "builtin $__interval",
+			expr:     `rate(metric[$__interval])`,
+			expected: `rate(metric[5m])`,
+		},
+		{
+			name:     "builtin $__range",
+			expr:     `avg_over_time(metric[$__range])`,
+			expected: `avg_over_time(metric[5m])`,
+		},
+		{
+			name:     "builtin ${__rate_interval} alt syntax",
+			expr:     `rate(metric[${__rate_interval}])`,
+			expected: `rate(metric[5m])`,
+		},
+
+		// User-defined duration variables
+		{
+			name:     "user duration var [$interval]",
+			expr:     `increase(metric[$interval])`,
+			expected: `increase(metric[5m])`,
+		},
+		{
+			name:     "user duration var [${custom}]",
+			expr:     `rate(metric[${custom_interval}])`,
+			expected: `rate(metric[5m])`,
+		},
+
+		// User-defined grouping variables
+		{
+			name:     "grouping var by($grouping)",
+			expr:     `sum(metric) by($grouping)`,
+			expected: `sum(metric) by(placeholder_label)`,
+		},
+		{
+			name:     "grouping var mixed with literal labels",
+			expr:     `sum(metric) by($grouping, job)`,
+			expected: `sum(metric) by(placeholder_label, job)`,
+		},
+		{
+			name:     "without clause with var",
+			expr:     `sum(metric) without($excluded)`,
+			expected: `sum(metric) without(placeholder_label)`,
+		},
+
+		// Label context — should NOT be modified
+		{
+			name:     "label context vars unchanged",
+			expr:     `up{namespace=~"$namespace", job="api"}`,
+			expected: `up{namespace=~"$namespace", job="api"}`,
+		},
+
+		// Real-world integration
+		{
+			name:     "real world Istio query",
+			expr:     `sum by (pod) (irate(container_cpu_usage_seconds_total{container="discovery",pod=~"istiod-.*"}[$__rate_interval]))`,
+			expected: `sum by (pod) (irate(container_cpu_usage_seconds_total{container="discovery",pod=~"istiod-.*"}[5m]))`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := interpolateForParsing(tt.expr)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/apps/dashvalidator/pkg/validator/prometheus/validator.go
+++ b/apps/dashvalidator/pkg/validator/prometheus/validator.go
@@ -75,13 +75,16 @@ func fetchAvailableMetrics(ctx context.Context, metricsCache *cache.MetricsCache
 // parseQueries parses all queries to extract metrics.
 // Returns per-query parse results, a deduplicated list of all metrics, and
 // the count of successfully parsed queries.
+// Template variables are interpolated before parsing so queries like
+// rate(m[$__rate_interval]) can be parsed successfully.
 func parseQueries(queries []validator.Query, parser validator.MetricExtractor) ([]parseQueryResult, []string, int) {
 	parseResults := make([]parseQueryResult, len(queries))
 	allMetrics := make(map[string]bool)
 	checkedCount := 0
 
 	for i, query := range queries {
-		metrics, err := parser.ExtractMetrics(query.QueryText)
+		interpolated := interpolateForParsing(query.QueryText)
+		metrics, err := parser.ExtractMetrics(interpolated)
 
 		parseResults[i] = parseQueryResult{
 			metrics:    metrics,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Queries with grafana template variables ($__rate_interval, $interval, by($grouping)) were failing to parse, so we couldn't extract metric names from them

**The Fix**

  added a regex-based interpolation step before the PromQL parser runs:
  - duration vars ([$__rate_interval], [$interval]) → [5m]
  - grouping vars (by($var)) → by(placeholder_label)
  - label vars ({ns=~"$namespace"}) → left as-is, they parse fine

  we don't need accurate values here — just need the parser to not choke so we can extract metric names

Feature toggles:

```
dashboardLibrary = true
dashboardValidatorApp = true
suggestedDashboards = true
```
**How to test**

* Open the suggested dashboard modal: prometheus config page -> build dashboard -> View All -> Community Tab in modal
* Search for `Istio Performance Dashboard`
* Open Dev Tools Network tab (clear network request)
* Click "Check Compatibility"
* Open details of `/check` endpoint
* Check there is no parsing error in the results

<img width="2517" height="1356" alt="compatibilityCheckErrorParsin" src="https://github.com/user-attachments/assets/3d07321e-5a30-4a1d-86bd-7f5bf63b4177" />


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/118344

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
