### PR TITLE
datasources: improve isDataQuery to handle query-service urls

### DIFF
--- a/public/app/core/utils/query.test.ts
+++ b/public/app/core/utils/query.test.ts
@@ -1,6 +1,6 @@
 import { DataQuery } from '@grafana/data';
 
-import { queryIsEmpty } from './query';
+import { queryIsEmpty, isDataQuery } from './query';
 
 interface TestQuery extends DataQuery {
   name?: string;
@@ -20,5 +20,27 @@ describe('queryIsEmpty', () => {
   it('should return false if query only includes props that are not defined in the DataQuery interface', () => {
     const testQuery: TestQuery = { refId: 'A', name: 'test' };
     expect(queryIsEmpty(testQuery)).toEqual(false);
+  });
+});
+
+describe('isDataQuery', () => {
+  it('should return false for empty-string', () => {
+    const url = '';
+    expect(isDataQuery(url)).toEqual(false);
+  });
+
+  it('should return true if URL starts with /api/ds/query', () => {
+    const url = '/api/ds/query?a=b';
+    expect(isDataQuery(url)).toEqual(true);
+  });
+
+  it('should return true if URL starts with /api/ds/query', () => {
+    const url = '/api/datasources/proxy/a/b/c';
+    expect(isDataQuery(url)).toEqual(true);
+  });
+
+  it('should return false for other URLs', () => {
+    const url = '/api/something/else';
+    expect(isDataQuery(url)).toEqual(false);
   });
 });

--- a/public/app/core/utils/query.test.ts
+++ b/public/app/core/utils/query.test.ts
@@ -34,8 +34,13 @@ describe('isDataQuery', () => {
     expect(isDataQuery(url)).toEqual(true);
   });
 
-  it('should return true if URL starts with /api/ds/query', () => {
+  it('should return true if URL starts with /api/datasources/proxy', () => {
     const url = '/api/datasources/proxy/a/b/c';
+    expect(isDataQuery(url)).toEqual(true);
+  });
+
+  it('should return true for query-service-style URLs', () => {
+    const url = '/apis/query.grafana.app/v0alpha1/namespaces/something/query?ds_type=prometheus';
     expect(isDataQuery(url)).toEqual(true);
   });
 

--- a/public/app/core/utils/query.ts
+++ b/public/app/core/utils/query.ts
@@ -31,8 +31,14 @@ export function addQuery(queries: DataQuery[], query?: Partial<DataQuery>, datas
   return [...queries, q];
 }
 
+const QUERY_SERVICE_URL_RE = /^\/apis\/query\.grafana\.app\/[^/]+\/namespaces\/[^/]+\/query/;
+
 export function isDataQuery(url: string): boolean {
   if (url.indexOf('api/datasources/proxy') !== -1 || url.indexOf('api/ds/query') !== -1) {
+    return true;
+  }
+
+  if (QUERY_SERVICE_URL_RE.test(url)) {
     return true;
   }
 


### PR DESCRIPTION
the `isDataQuery` function currently does not handle the query-service's urls. this PR adds support for those.