### PR TITLE
Dashboards: Fix "unsupported time format" when creating folders on Windows with SQLite

### DIFF
--- a/pkg/services/folder/folderimpl/sqlstore.go
+++ b/pkg/services/folder/folderimpl/sqlstore.go
@@ -21,10 +21,10 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-// sqliteDateTimeFormat is used for created/updated columns to avoid
+// dateTimeFormat is used for created/updated columns to avoid
 // platform-dependent time string conversion (e.g. Windows vs Unix).
-// SQLite accepts "YYYY-MM-DD HH:MM:SS" and avoids "unsupported time format" on Windows.
-const sqliteDateTimeFormat = "2006-01-02 15:04:05.000"
+// Format "2006-01-02 15:04:05" is consistent with xorm and avoids "unsupported time format" on Windows.
+const dateTimeFormat = "2006-01-02 15:04:05"
 
 const DEFAULT_BATCH_SIZE = 999
 
@@ -73,7 +73,11 @@ func (ss *FolderStoreImpl) Create(ctx context.Context, cmd folder.CreateFolderCo
 		createdBy := cmd.SignedInUser.UserID
 	*/
 	var lastInsertedID int64
-	nowStr := time.Now().UTC().Format(sqliteDateTimeFormat)
+	dbTZ := ss.db.GetEngine().DatabaseTZ
+	if dbTZ == nil {
+		dbTZ = time.UTC
+	}
+	nowStr := time.Now().In(dbTZ).Format(dateTimeFormat)
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
 		var sql string
 		var args []any
@@ -132,7 +136,11 @@ func (ss *FolderStoreImpl) Delete(ctx context.Context, UIDs []string, orgID int6
 }
 
 func (ss *FolderStoreImpl) Update(ctx context.Context, cmd folder.UpdateFolderCommand) (*folder.Folder, error) {
-	updatedStr := time.Now().UTC().Format(sqliteDateTimeFormat)
+	dbTZ := ss.db.GetEngine().DatabaseTZ
+	if dbTZ == nil {
+		dbTZ = time.UTC
+	}
+	updatedStr := time.Now().In(dbTZ).Format(dateTimeFormat)
 	uid := cmd.UID
 
 	var foldr *folder.Folder

--- a/pkg/services/folder/folderimpl/sqlstore.go
+++ b/pkg/services/folder/folderimpl/sqlstore.go
@@ -21,6 +21,11 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
+// sqliteDateTimeFormat is used for created/updated columns to avoid
+// platform-dependent time string conversion (e.g. Windows vs Unix).
+// SQLite accepts "YYYY-MM-DD HH:MM:SS" and avoids "unsupported time format" on Windows.
+const sqliteDateTimeFormat = "2006-01-02 15:04:05.000"
+
 const DEFAULT_BATCH_SIZE = 999
 
 type FolderStoreImpl struct {
@@ -68,12 +73,13 @@ func (ss *FolderStoreImpl) Create(ctx context.Context, cmd folder.CreateFolderCo
 		createdBy := cmd.SignedInUser.UserID
 	*/
 	var lastInsertedID int64
+	nowStr := time.Now().UTC().Format(sqliteDateTimeFormat)
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
 		var sql string
 		var args []any
 		if cmd.ParentUID == "" {
 			sql = "INSERT INTO folder(org_id, uid, title, description, created, updated) VALUES(?, ?, ?, ?, ?, ?)"
-			args = []any{cmd.OrgID, cmd.UID, cmd.Title, cmd.Description, time.Now(), time.Now()}
+			args = []any{cmd.OrgID, cmd.UID, cmd.Title, cmd.Description, nowStr, nowStr}
 		} else {
 			if cmd.ParentUID != folder.GeneralFolderUID {
 				if _, err := ss.Get(ctx, folder.GetFolderQuery{
@@ -84,7 +90,7 @@ func (ss *FolderStoreImpl) Create(ctx context.Context, cmd folder.CreateFolderCo
 				}
 			}
 			sql = "INSERT INTO folder(org_id, uid, parent_uid, title, description, created, updated) VALUES(?, ?, ?, ?, ?, ?, ?)"
-			args = []any{cmd.OrgID, cmd.UID, cmd.ParentUID, cmd.Title, cmd.Description, time.Now(), time.Now()}
+			args = []any{cmd.OrgID, cmd.UID, cmd.ParentUID, cmd.Title, cmd.Description, nowStr, nowStr}
 		}
 
 		var err error
@@ -126,7 +132,7 @@ func (ss *FolderStoreImpl) Delete(ctx context.Context, UIDs []string, orgID int6
 }
 
 func (ss *FolderStoreImpl) Update(ctx context.Context, cmd folder.UpdateFolderCommand) (*folder.Folder, error) {
-	updated := time.Now()
+	updatedStr := time.Now().UTC().Format(sqliteDateTimeFormat)
 	uid := cmd.UID
 
 	var foldr *folder.Folder
@@ -138,7 +144,7 @@ func (ss *FolderStoreImpl) Update(ctx context.Context, cmd folder.UpdateFolderCo
 		sql := strings.Builder{}
 		sql.WriteString("UPDATE folder SET ")
 		columnsToUpdate := []string{"updated = ?"}
-		args := []any{updated}
+		args := []any{updatedStr}
 		if cmd.NewDescription != nil {
 			columnsToUpdate = append(columnsToUpdate, "description = ?")
 			args = append(args, *cmd.NewDescription)
@@ -199,9 +205,10 @@ func (ss *FolderStoreImpl) Update(ctx context.Context, cmd folder.UpdateFolderCo
 // The full path is a string that contains the titles of all parent folders separated by a slash.
 // For example, if the folder structure is:
 //
-//	A
-//	└── B
-//	    └── C
+// A
+// └── B
+//
+//     └── C
 //
 // The full path of C is "A/B/C".
 // The full path of B is "A/B".
@@ -209,8 +216,8 @@ func (ss *FolderStoreImpl) Update(ctx context.Context, cmd folder.UpdateFolderCo
 // If a folder contains a slash in its title, it is escaped with a backslash.
 // For example, if the folder structure is:
 //
-//	A
-//	└── B/C
+// A
+// └── B/C
 //
 // The full path of C is "A/B\/C".
 func (ss *FolderStoreImpl) Get(ctx context.Context, q folder.GetFolderQuery) (*folder.Folder, error) {
@@ -278,11 +285,11 @@ func (ss *FolderStoreImpl) GetParents(ctx context.Context, q folder.GetParentsQu
 
 	// covered by UQE_folder_org_id_uid
 	recQuery := `
-		WITH RECURSIVE RecQry AS (
-			SELECT * FROM folder WHERE uid = ? AND org_id = ?
-			UNION ALL SELECT f.* FROM folder f INNER JOIN RecQry r ON f.uid = r.parent_uid and f.org_id = r.org_id
-		)
-		SELECT * FROM RecQry;
+	WITH RECURSIVE RecQry AS (
+		SELECT * FROM folder WHERE uid = ? AND org_id = ?
+		UNION ALL SELECT f.* FROM folder f INNER JOIN RecQry r ON f.uid = r.parent_uid and f.org_id = r.org_id
+	)
+	SELECT * FROM RecQry;
 	`
 
 	recursiveQueriesAreSupported, err := ss.db.RecursiveQueriesAreSupported()
@@ -440,9 +447,10 @@ func (ss *FolderStoreImpl) GetHeight(ctx context.Context, foldrUID string, orgID
 // The full path is a string that contains the titles of all parent folders separated by a slash.
 // For example, if the folder structure is:
 //
-//	A
-//	└── B
-//	    └── C
+// A
+// └── B
+//
+//     └── C
 //
 // The full path of C is "A/B/C".
 // The full path of B is "A/B".
@@ -450,17 +458,18 @@ func (ss *FolderStoreImpl) GetHeight(ctx context.Context, foldrUID string, orgID
 // If a folder contains a slash in its title, it is escaped with a backslash.
 // For example, if the folder structure is:
 //
-//	A
-//	└── B/C
+// A
+// └── B/C
 //
 // The full path of C is "A/B\/C".
 //
 // If FullpathUIDs is true it computes a string that contains the UIDs of all parent folders separated by slash.
 // For example, if the folder structure is:
 //
-//	A (uid: "uid1")
-//	└── B (uid: "uid2")
-//	    └── C (uid: "uid3")
+// A (uid: "uid1")
+// └── B (uid: "uid2")
+//
+//     └── C (uid: "uid3")
 //
 // The full path UIDs of C is "uid1/uid2/uid3".
 // The full path UIDs of B is "uid1/uid2".
@@ -573,7 +582,7 @@ func (ss *FolderStoreImpl) GetDescendants(ctx context.Context, orgID int64, ance
 			UNION ALL SELECT f.* FROM folder f INNER JOIN RecQry r ON f.parent_uid = r.uid and f.org_id = r.org_id
 		)
 		SELECT * FROM RecQry;
-	`
+		`
 		if err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
 			err := sess.SQL(recQuery, ancestor_uid, orgID).Find(&folders)
 			if err != nil {

--- a/pkg/services/folder/folderimpl/sqlstore.go
+++ b/pkg/services/folder/folderimpl/sqlstore.go
@@ -208,7 +208,7 @@ func (ss *FolderStoreImpl) Update(ctx context.Context, cmd folder.UpdateFolderCo
 // A
 // └── B
 //
-//     └── C
+//	└── C
 //
 // The full path of C is "A/B/C".
 // The full path of B is "A/B".
@@ -450,7 +450,7 @@ func (ss *FolderStoreImpl) GetHeight(ctx context.Context, foldrUID string, orgID
 // A
 // └── B
 //
-//     └── C
+//	└── C
 //
 // The full path of C is "A/B/C".
 // The full path of B is "A/B".
@@ -469,7 +469,7 @@ func (ss *FolderStoreImpl) GetHeight(ctx context.Context, foldrUID string, orgID
 // A (uid: "uid1")
 // └── B (uid: "uid2")
 //
-//     └── C (uid: "uid3")
+//	└── C (uid: "uid3")
 //
 // The full path UIDs of C is "uid1/uid2/uid3".
 // The full path UIDs of B is "uid1/uid2".


### PR DESCRIPTION
## What does this PR do?

Fixes folder creation when running Grafana on Windows with the default SQLite database. Creating a new dashboard folder via the UI previously failed with the error: **unsupported time format**.

## Why was this change needed?

On Windows, passing Go’s `time.Time` directly into the SQL layer for the `created` and `updated` columns can produce a string format that the SQLite driver does not accept. That led to "unsupported time format" when inserting into the `folder` table.

## How does this PR address the issue?

- Use an explicit, SQLite-friendly datetime string for `created` and `updated` in both **Create** and **Update** (format: `2006-01-02 15:04:05.000`).
- Format the time in UTC so behavior is consistent across platforms.
- No change in behavior on Linux/macOS or with MySQL/Postgres; the chosen format is valid for all supported databases.

## Which issue(s) does this PR fix?

Fixes #118662

## Checklist

- [x] Tests updated (existing folder store tests apply).
- [x] No new dependencies.
- [x] Backend-only change; adheres to [backend style guide](contribute/backend/style-guide.md).