### PR TITLE
Elasticsearch: Refactor to use a unified query field with a queryType property (frontend)

### DIFF
--- a/packages/grafana-schema/src/raw/composable/elasticsearch/dataquery/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/elasticsearch/dataquery/x/types.gen.ts
@@ -14,6 +14,8 @@ import * as common from '@grafana/schema';
 
 export const pluginVersion = "%VERSION%";
 
+export type QueryType = ('lucene' | 'dsl');
+
 export type BucketAggregation = (DateHistogram | Histogram | Terms | Filters | GeoHashGrid | Nested);
 
 export type MetricAggregation = (Count | PipelineMetricAggregation | MetricAggregationWithSettings);
@@ -398,13 +400,17 @@ export interface ElasticsearchDataQuery extends common.DataQuery {
    */
   metrics?: Array<MetricAggregation>;
   /**
-   * Lucene query
+   * Query string (Lucene or DSL depending on queryType)
    */
   query?: string;
   /**
-   * Raw DSL query
+   * Specify the query flavor
+   * TODO make this required and give it a default
    */
-  rawDSLQuery?: string;
+  /**
+   * Query type - determines how the query field is interpreted
+   */
+  queryType?: string;
   /**
    * Name of time field
    */

--- a/pkg/tsdb/elasticsearch/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/elasticsearch/kinds/dataquery/types_dataquery_gen.go
@@ -494,6 +494,13 @@ func NewTopMetrics() *TopMetrics {
 	}
 }
 
+type QueryType string
+
+const (
+	QueryTypeLucene QueryType = "lucene"
+	QueryTypeDsl    QueryType = "dsl"
+)
+
 type BaseBucketAggregation struct {
 	Id       string                `json:"id"`
 	Type     BucketAggregationType `json:"type"`
@@ -773,18 +780,8 @@ func NewMovingAverageHoltWintersModelSettings() *MovingAverageHoltWintersModelSe
 type ElasticsearchDataQuery struct {
 	// Alias pattern
 	Alias *string `json:"alias,omitempty"`
-	// Lucene query
+	// Query string (Lucene or DSL depending on queryType)
 	Query *string `json:"query,omitempty"`
-	// Raw DSL query
-	RawDSLQuery *string `json:"rawDSLQuery,omitempty"`
-	// Name of time field
-	TimeField *string `json:"timeField,omitempty"`
-	// Editor type
-	EditorType *string `json:"editorType,omitempty"`
-	// List of bucket aggregations
-	BucketAggs []BucketAggregation `json:"bucketAggs,omitempty"`
-	// List of metric aggregations
-	Metrics []MetricAggregation `json:"metrics,omitempty"`
 	// A unique identifier for the query within the list of targets.
 	// In server side expressions, the refId is used as a variable name to identify results.
 	// By default, the UI will assign A->Z; however setting meaningful names may be useful.
@@ -793,7 +790,16 @@ type ElasticsearchDataQuery struct {
 	Hide *bool `json:"hide,omitempty"`
 	// Specify the query flavor
 	// TODO make this required and give it a default
+	// Query type - determines how the query field is interpreted
 	QueryType *string `json:"queryType,omitempty"`
+	// Name of time field
+	TimeField *string `json:"timeField,omitempty"`
+	// Editor type
+	EditorType *string `json:"editorType,omitempty"`
+	// List of bucket aggregations
+	BucketAggs []BucketAggregation `json:"bucketAggs,omitempty"`
+	// List of metric aggregations
+	Metrics []MetricAggregation `json:"metrics,omitempty"`
 	// For mixed data sources the selected datasource is on the query level.
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
@@ -8,7 +8,7 @@ import { combineReducers, useStatelessReducer, DispatchContext } from '../../hoo
 
 import { createReducer as createBucketAggsReducer } from './BucketAggregationsEditor/state/reducer';
 import { reducer as metricsReducer } from './MetricAggregationsEditor/state/reducer';
-import { aliasPatternReducer, queryReducer, rawDSLQueryReducer, editorTypeReducer, initQuery } from './state';
+import { aliasPatternReducer, queryReducer, queryTypeReducer, editorTypeReducer, initQuery } from './state';
 
 const DatasourceContext = createContext<ElasticDatasource | undefined>(undefined);
 const QueryContext = createContext<ElasticsearchDataQuery | undefined>(undefined);
@@ -41,10 +41,10 @@ export const ElasticsearchProvider = ({
   );
 
   const reducer = combineReducers<
-    Pick<ElasticsearchDataQuery, 'query' | 'rawDSLQuery' | 'alias' | 'editorType' | 'metrics' | 'bucketAggs'>
+    Pick<ElasticsearchDataQuery, 'query' | 'queryType' | 'alias' | 'editorType' | 'metrics' | 'bucketAggs'>
   >({
     query: queryReducer,
-    rawDSLQuery: rawDSLQueryReducer,
+    queryType: queryTypeReducer,
     alias: aliasPatternReducer,
     editorType: editorTypeReducer,
     metrics: metricsReducer,

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -20,7 +20,7 @@ import { MetricAggregationsEditor } from './MetricAggregationsEditor';
 import { metricAggregationConfig } from './MetricAggregationsEditor/utils';
 import { QueryTypeSelector } from './QueryTypeSelector';
 import { RawQueryEditor } from './RawQueryEditor';
-import { changeAliasPattern, changeEditorTypeAndResetQuery, changeQuery, changeRawDSLQuery } from './state';
+import { changeAliasPattern, changeEditorTypeAndResetQuery, changeQuery } from './state';
 
 export type ElasticQueryEditorProps = QueryEditorProps<ElasticDatasource, ElasticsearchDataQuery, ElasticsearchOptions>;
 
@@ -155,8 +155,8 @@ const QueryEditorForm = ({ value, onRunQuery }: Props & { onRunQuery: () => void
 
       {isCodeEditor && rawDSLFeatureEnabled && (
         <RawQueryEditor
-          value={value.rawDSLQuery}
-          onChange={(rawDSLQuery) => dispatch(changeRawDSLQuery(rawDSLQuery))}
+          value={value.query}
+          onChange={(query) => dispatch(changeQuery(query))}
           onRunQuery={onRunQuery}
         />
       )}

--- a/public/app/plugins/datasource/elasticsearch/dataquery.cue
+++ b/public/app/plugins/datasource/elasticsearch/dataquery.cue
@@ -29,10 +29,10 @@ composableKinds: DataQuery: {
 
 				// Alias pattern
 				alias?: string
-				// Lucene query
+				// Query string (Lucene or DSL depending on queryType)
 				query?: string
-				// Raw DSL query
-				rawDSLQuery?: string
+				// Query type - determines how the query field is interpreted
+				queryType?: #QueryType
 				// Name of time field
 				timeField?: string
 				// Editor type
@@ -41,6 +41,8 @@ composableKinds: DataQuery: {
 				bucketAggs?: [...#BucketAggregation]
 				// List of metric aggregations
 				metrics?: [...#MetricAggregation]
+
+				#QueryType: "lucene" | "dsl" @cuetsy(kind="type")
 
 				#BucketAggregation: #DateHistogram | #Histogram | #Terms | #Filters | #GeoHashGrid | #Nested @cuetsy(kind="type")
 				#MetricAggregation: #Count | #PipelineMetricAggregation | #MetricAggregationWithSettings     @cuetsy(kind="type")

--- a/public/app/plugins/datasource/elasticsearch/dataquery.gen.ts
+++ b/public/app/plugins/datasource/elasticsearch/dataquery.gen.ts
@@ -12,6 +12,8 @@
 
 import * as common from '@grafana/schema';
 
+export type QueryType = ('lucene' | 'dsl');
+
 export type BucketAggregation = (DateHistogram | Histogram | Terms | Filters | GeoHashGrid | Nested);
 
 export type MetricAggregation = (Count | PipelineMetricAggregation | MetricAggregationWithSettings);
@@ -396,13 +398,17 @@ export interface ElasticsearchDataQuery extends common.DataQuery {
    */
   metrics?: Array<MetricAggregation>;
   /**
-   * Lucene query
+   * Query string (Lucene or DSL depending on queryType)
    */
   query?: string;
   /**
-   * Raw DSL query
+   * Specify the query flavor
+   * TODO make this required and give it a default
    */
-  rawDSLQuery?: string;
+  /**
+   * Query type - determines how the query field is interpreted
+   */
+  queryType?: string;
   /**
    * Name of time field
    */

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -244,16 +244,22 @@ describe('ElasticDatasource', () => {
 
     describe('reportInteraction', () => {
       it('should report metric query', async () => {
-        const query = { ...createElasticQuery(), app: CoreApp.Explore };
+        const query = {
+          ...createElasticQuery(),
+          targets: [{ ...createElasticQuery().targets[0], queryType: 'lucene' }],
+          app: CoreApp.Explore,
+        };
         await expect(ds.query(query)).toEmitValuesWith((received) => {
           expect(received[0].state).toBe(LoadingState.Done);
           expect(reportInteraction).toHaveBeenCalledWith(
             'grafana_elasticsearch_query_executed',
             expect.objectContaining({
               app: CoreApp.Explore,
+              editor_type: 'builder',
               has_data: false,
               has_error: false,
               line_limit: undefined,
+              query_language: 'lucene',
               query_type: 'metric',
               simultaneously_sent_query_count: 1,
               with_lucene_query: true,
@@ -270,6 +276,7 @@ describe('ElasticDatasource', () => {
               refId: 'A',
               metrics: [{ type: 'logs', id: '1' }],
               query: 'foo="bar"',
+              queryType: 'lucene',
             } as ElasticsearchDataQuery,
           ],
           app: CoreApp.Explore,
@@ -280,9 +287,11 @@ describe('ElasticDatasource', () => {
             'grafana_elasticsearch_query_executed',
             expect.objectContaining({
               app: CoreApp.Explore,
+              editor_type: 'builder',
               has_data: false,
               has_error: false,
               line_limit: undefined,
+              query_language: 'lucene',
               query_type: 'logs',
               simultaneously_sent_query_count: 1,
               with_lucene_query: true,
@@ -299,6 +308,7 @@ describe('ElasticDatasource', () => {
               refId: 'A',
               metrics: [{ type: 'raw_data', id: '1' }],
               query: 'foo="bar"',
+              queryType: 'lucene',
             } as ElasticsearchDataQuery,
           ],
           app: CoreApp.Explore,
@@ -309,9 +319,11 @@ describe('ElasticDatasource', () => {
             'grafana_elasticsearch_query_executed',
             expect.objectContaining({
               app: CoreApp.Explore,
+              editor_type: 'builder',
               has_data: false,
               has_error: false,
               line_limit: undefined,
+              query_language: 'lucene',
               query_type: 'raw_data',
               simultaneously_sent_query_count: 1,
               with_lucene_query: true,

--- a/public/app/plugins/datasource/elasticsearch/tracking.ts
+++ b/public/app/plugins/datasource/elasticsearch/tracking.ts
@@ -126,19 +126,20 @@ export function trackQuery(
       return;
     }
     reportInteraction('grafana_elasticsearch_query_executed', {
-      app,
-      grafana_version: config.buildInfo.version,
-      with_lucene_query: query.query ? true : false,
-      query_type: getQueryType(query),
-      line_limit: getLineLimit(query),
       alias: query.alias,
-      has_error: response.error !== undefined,
+      app,
+      editor_type: query.editorType || 'builder',
+      grafana_version: config.buildInfo.version,
       has_data: response.data.some((frame) => frame.length > 0),
+      has_error: response.error !== undefined,
+      line_limit: getLineLimit(query),
+      query_language: query.queryType,
+      query_type: getQueryType(query),
       simultaneously_sent_query_count: queries.length,
       time_range_from: request?.range?.from?.toISOString(),
       time_range_to: request?.range?.to?.toISOString(),
       time_taken: Date.now() - startTime.getTime(),
-      editor_type: query.editorType || 'builder',
+      with_lucene_query: query.queryType === 'lucene' && query.query !== undefined,
     });
   }
 }


### PR DESCRIPTION
- Refactors the Elasticsearch datasource to use a unified `query` field with a `queryType` property in the frontend
- Updates TypeScript types and generated schema files (`types.gen.ts`, `dataquery.gen.ts`, `dataquery.cue`)
- Updates query editor components (`ElasticsearchQueryContext.tsx`, `index.tsx`, `state.ts`) to use the new unified query structure
- Updates tests (`state.test.ts`, `datasource.test.ts`) and tracking (`tracking.ts`) to match the new model

**Note:** This is the frontend half of a split refactor. The backend changes are in a separate PR.