### PR TITLE
feat: allow cluster scoped resources in qos

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1710,6 +1710,11 @@ func (s *server) runInQueue(ctx context.Context, tenantID string, runnable func(
 		MaxRetries: s.queueConfig.MaxRetries,
 	})
 
+	// Allow cluster-scoped resources to be enqueued with an empty tenantID.
+	if tenantID == "" {
+		tenantID = clusterScopeNamespace
+	}
+
 	for {
 		err := s.queue.Enqueue(queueCtx, tenantID, wrappedRunnable)
 		if err == nil {

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -517,6 +517,19 @@ func TestRunInQueue(t *testing.T) {
 		<-executed
 	})
 
+	t.Run("should use cluster-scoped tenant for empty tenantID", func(t *testing.T) {
+		s, _ := newTestServerWithQueue(t, 1, 1)
+		executed := make(chan bool, 1)
+
+		runnable := func(ctx context.Context) {
+			executed <- true
+		}
+
+		err := s.runInQueue(context.Background(), "", runnable)
+		require.NoError(t, err)
+		assert.True(t, <-executed, "runnable should have been executed with cluster-scoped tenantID")
+	})
+
 	t.Run("should return an error if queue is consistently full after retrying", func(t *testing.T) {
 		s, q := newTestServerWithQueue(t, 1, 1)
 		// Task 1: This will be picked up by the worker and block it.


### PR DESCRIPTION
Allow cluster scoped resources in `QoS`. 

Currently checks that `tenantID` is empty, and adds `clusterScopeNamespace` key.

Technically it could be done in a higher level (apistore), but this would require a big more complex refactoring across multiple touch-points, as [an example](https://github.com/grafana/grafana/blob/main/pkg/storage/unified/resource/storage_backend_test.go#L1983).