### PR TITLE
Increase Cloudwatch log group limit to 1000 and allow ability to sort by account ID or log group name

### DIFF
--- a/pkg/tsdb/cloudwatch/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/log_groups_test.go
@@ -122,7 +122,6 @@ func TestLogGroupsRoute(t *testing.T) {
 			LogGroupNamePattern: nil,
 			ListAllLogGroups:     false,
 			OrderBy:             "",
-			MaxResults:          1000,
 		})
 	})
 
@@ -141,7 +140,6 @@ func TestLogGroupsRoute(t *testing.T) {
 			LogGroupNamePrefix: nil,
 			ListAllLogGroups:   false,
 			OrderBy:            "",
-			MaxResults:         1000,
 		})
 	})
 
@@ -156,8 +154,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 
 		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
-			Limit:      2,
-			MaxResults: 1000,
+			Limit: 2,
 		})
 	})
 
@@ -174,7 +171,6 @@ func TestLogGroupsRoute(t *testing.T) {
 		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
 			Limit:              50,
 			LogGroupNamePrefix: utils.Pointer("some-prefix"),
-			MaxResults:         1000,
 		})
 	})
 
@@ -191,7 +187,6 @@ func TestLogGroupsRoute(t *testing.T) {
 		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
 			Limit:               50,
 			LogGroupNamePattern: utils.Pointer("some-pattern"),
-			MaxResults:          1000,
 		})
 	})
 
@@ -210,7 +205,6 @@ func TestLogGroupsRoute(t *testing.T) {
 			ResourceRequest:  resources.ResourceRequest{AccountId: utils.Pointer("some-account-id")},
 			ListAllLogGroups: true,
 			OrderBy:          "nameAsc",
-			MaxResults:       1000,
 		})
 	})
 
@@ -227,7 +221,6 @@ func TestLogGroupsRoute(t *testing.T) {
 		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
 			Limit:           50,
 			ResourceRequest: resources.ResourceRequest{AccountId: utils.Pointer("some-account-id")},
-			MaxResults:      1000,
 		})
 	})
 

--- a/pkg/tsdb/cloudwatch/models/resources/log_groups_resource_request.go
+++ b/pkg/tsdb/cloudwatch/models/resources/log_groups_resource_request.go
@@ -8,8 +8,8 @@ import (
 
 const (
 	defaultLogGroupLimit = int32(50)
-	// defaultMaxLogGroupsResults caps total results when ListAllLogGroups is true to avoid timeouts (0 = no cap)
-	defaultMaxLogGroupsResults = int32(1000)
+	// MaxLogGroupsResults caps total results when ListAllLogGroups is true to avoid timeouts
+	MaxLogGroupsResults = int32(1000)
 )
 
 // LogGroupOrderBy defines sort order for log groups (empty = no sorting, return order from API).
@@ -26,7 +26,6 @@ type LogGroupsRequest struct {
 	LogGroupNamePrefix, LogGroupNamePattern *string
 	ListAllLogGroups                        bool
 	OrderBy                                 string
-	MaxResults                              int32
 }
 
 func (r LogGroupsRequest) IsTargetingAllAccounts() bool {
@@ -50,7 +49,6 @@ func ParseLogGroupsRequest(parameters url.Values) (LogGroupsRequest, error) {
 		LogGroupNamePattern: logGroupPattern,
 		ListAllLogGroups:    parameters.Get("listAllLogGroups") == "true",
 		OrderBy:             parameters.Get("orderBy"),
-		MaxResults:          getMaxResults(parameters.Get("maxResults")),
 	}, nil
 }
 
@@ -68,15 +66,4 @@ func getLimit(limit string) int32 {
 		logGroupLimit = int32(intLimit)
 	}
 	return logGroupLimit
-}
-
-func getMaxResults(maxResults string) int32 {
-	if maxResults == "" {
-		return defaultMaxLogGroupsResults
-	}
-	n, err := strconv.ParseInt(maxResults, 10, 32)
-	if err != nil || n <= 0 {
-		return defaultMaxLogGroupsResults
-	}
-	return int32(n)
 }

--- a/pkg/tsdb/cloudwatch/services/log_groups.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups.go
@@ -57,8 +57,8 @@ func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGr
 		}
 
 		// Cap total results when listing all to avoid unbounded memory and time
-		if req.MaxResults > 0 && int32(len(result)) >= req.MaxResults {
-			result = result[:req.MaxResults]
+		if int32(len(result)) >= resources.MaxLogGroupsResults {
+			result = result[:resources.MaxLogGroupsResults]
 			break
 		}
 
@@ -68,8 +68,8 @@ func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGr
 		input.NextToken = response.NextToken
 	}
 
-	if req.MaxResults > 0 && len(result) > int(req.MaxResults) {
-		result = result[:req.MaxResults]
+	if len(result) > int(resources.MaxLogGroupsResults) {
+		result = result[:resources.MaxLogGroupsResults]
 	}
 
 	sortLogGroupsBy(result, req.OrderBy)

--- a/pkg/tsdb/cloudwatch/services/log_groups.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups.go
@@ -77,6 +77,7 @@ func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGr
 }
 
 // sortLogGroupsBy sorts result in place by name or accountId, asc or desc.
+// Uses case-insensitive comparison for true alphabetical order.
 func sortLogGroupsBy(result []resources.ResourceResponse[resources.LogGroup], orderBy string) {
 	if orderBy == "" {
 		return
@@ -87,15 +88,17 @@ func sortLogGroupsBy(result []resources.ResourceResponse[resources.LogGroup], or
 		}
 		return ""
 	}
+	lessName := func(a, b string) bool { return strings.ToLower(a) < strings.ToLower(b) }
+	lessAccountId := func(a, b string) bool { return strings.ToLower(a) < strings.ToLower(b) }
 	switch orderBy {
-	case resources.OrderByNameAsc:
-		sort.Slice(result, func(i, j int) bool { return strings.Compare(result[i].Value.Name, result[j].Value.Name) < 0 })
 	case resources.OrderByNameDesc:
-		sort.Slice(result, func(i, j int) bool { return strings.Compare(result[i].Value.Name, result[j].Value.Name) > 0 })
+		sort.Slice(result, func(i, j int) bool { return lessName(result[j].Value.Name, result[i].Value.Name) })
+	case resources.OrderByNameAsc:
+		sort.Slice(result, func(i, j int) bool { return lessName(result[i].Value.Name, result[j].Value.Name) })
 	case resources.OrderByAccountIDAsc:
-		sort.Slice(result, func(i, j int) bool { return strings.Compare(accountId(result[i]), accountId(result[j])) < 0 })
+		sort.Slice(result, func(i, j int) bool { return lessAccountId(accountId(result[i]), accountId(result[j])) })
 	case resources.OrderByAccountIDDesc:
-		sort.Slice(result, func(i, j int) bool { return strings.Compare(accountId(result[i]), accountId(result[j])) > 0 })
+		sort.Slice(result, func(i, j int) bool { return lessAccountId(accountId(result[j]), accountId(result[i])) })
 	}
 }
 

--- a/pkg/tsdb/cloudwatch/services/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups_test.go
@@ -179,7 +179,29 @@ func TestGetLogGroups(t *testing.T) {
 		}, resp)
 	})
 
-	t.Run("Should sort by name descending when OrderBy is nameDesc", func(t *testing.T) {
+	t.Run("Should sort by name ascending (A–Z) when OrderBy is nameAsc", func(t *testing.T) {
+		mockLogsAPI := &mocks.LogsAPI{}
+		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(
+			&cloudwatchlogs.DescribeLogGroupsOutput{
+				LogGroups: []cloudwatchlogstypes.LogGroup{
+					{Arn: utils.Pointer("arn:aws:logs:us-east-1:111:log-group:group_a"), LogGroupName: utils.Pointer("group_a")},
+					{Arn: utils.Pointer("arn:aws:logs:us-east-1:222:log-group:group_b"), LogGroupName: utils.Pointer("group_b")},
+					{Arn: utils.Pointer("arn:aws:logs:us-east-1:333:log-group:group_c"), LogGroupName: utils.Pointer("group_c")},
+				},
+			}, nil)
+		service := NewLogGroupsService(mockLogsAPI, false)
+
+		resp, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
+			OrderBy: resources.OrderByNameAsc,
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, "group_a", resp[0].Value.Name)
+		assert.Equal(t, "group_b", resp[1].Value.Name)
+		assert.Equal(t, "group_c", resp[2].Value.Name)
+	})
+
+	t.Run("Should sort by name descending (Z–A) when OrderBy is nameDesc", func(t *testing.T) {
 		mockLogsAPI := &mocks.LogsAPI{}
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(
 			&cloudwatchlogs.DescribeLogGroupsOutput{

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
@@ -115,7 +115,7 @@ describe('LogGroupsSelector', () => {
       accountId: 'all',
       logGroupPattern: 'something',
       listAllLogGroups: true,
-      orderBy: 'nameAsc',
+      orderBy: 'nameDesc',
     });
   });
 
@@ -149,7 +149,7 @@ describe('LogGroupsSelector', () => {
       accountId: 'account-id123',
       logGroupPattern: '',
       listAllLogGroups: true,
-      orderBy: 'nameAsc',
+      orderBy: 'nameDesc',
     });
   });
 

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
@@ -30,8 +30,8 @@ import Search from './Search';
 const ORDER_BY_OPTIONS: Array<{ value: LogGroupOrderBy; label: string }> = [
   { value: 'nameAsc', label: 'Name (A–Z)' },
   { value: 'nameDesc', label: 'Name (Z–A)' },
-  { value: 'accountIdAsc', label: 'Account ID (A–Z)' },
-  { value: 'accountIdDesc', label: 'Account ID (Z–A)' },
+  { value: 'accountIdAsc', label: 'Account ID (0-9)' },
+  { value: 'accountIdDesc', label: 'Account ID (9-0)' },
 ];
 
 type CrossAccountLogsQueryProps = {
@@ -96,14 +96,18 @@ export const LogGroupsSelector = ({
     return idsToNames;
   }, [accountOptions]);
 
-  const searchFn = async (searchTerm?: string, accountId?: string) => {
+  const searchFn = async (
+    searchTerm?: string,
+    accountId?: string,
+    orderByOverride?: LogGroupOrderBy
+  ) => {
     setIsLoading(true);
     try {
       const possibleLogGroups = await fetchLogGroups({
         logGroupPattern: searchTerm,
         accountId: accountId,
         listAllLogGroups: true,
-        orderBy,
+        orderBy: orderByOverride ?? orderBy,
       });
       setSelectableLogGroups(
         possibleLogGroups.map((lg) => ({
@@ -170,7 +174,7 @@ export const LogGroupsSelector = ({
                 const v = opt?.value;
                 if (v) {
                   setOrderBy(v);
-                  searchFn(searchPhrase, searchAccountId);
+                  searchFn(searchPhrase, searchAccountId, v);
                 }
               }}
               aria-label="Sort log groups by"

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
@@ -70,12 +70,27 @@ export class ResourcesAPI extends CloudWatchRequest {
   }
 
   getLogGroups(params: DescribeLogGroupsRequest): Promise<Array<ResourceResponse<LogGroupResponse>>> {
-    return this.memoizedGetRequest<Array<ResourceResponse<LogGroupResponse>>>('log-groups', {
-      ...params,
+    const query: Record<string, string> = {
       region: this.templateSrv.replace(this.getActualRegion(params.region)),
-      accountId: this.templateSrv.replace(params.accountId),
+      accountId: this.templateSrv.replace(params.accountId ?? ''),
       listAllLogGroups: params.listAllLogGroups ? 'true' : 'false',
-    });
+    };
+    if (params.logGroupNamePrefix != null && params.logGroupNamePrefix !== '') {
+      query.logGroupNamePrefix = params.logGroupNamePrefix;
+    }
+    if (params.logGroupPattern != null && params.logGroupPattern !== '') {
+      query.logGroupPattern = params.logGroupPattern;
+    }
+    if (params.orderBy != null && params.orderBy !== '') {
+      query.orderBy = params.orderBy;
+    }
+    if (params.maxResults != null && params.maxResults > 0) {
+      query.maxResults = String(params.maxResults);
+    }
+    if (params.limit != null && params.limit > 0) {
+      query.limit = String(params.limit);
+    }
+    return this.memoizedGetRequest<Array<ResourceResponse<LogGroupResponse>>>('log-groups', query);
   }
 
   getLogGroupFields(region: string, logGroupName: string): Promise<Array<ResourceResponse<LogGroupField>>> {

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
@@ -84,9 +84,6 @@ export class ResourcesAPI extends CloudWatchRequest {
     if (params.orderBy != null && params.orderBy !== '') {
       query.orderBy = params.orderBy;
     }
-    if (params.maxResults != null && params.maxResults > 0) {
-      query.maxResults = String(params.maxResults);
-    }
     if (params.limit != null && params.limit > 0) {
       query.limit = String(params.limit);
     }

--- a/public/app/plugins/datasource/cloudwatch/resources/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/types.ts
@@ -29,11 +29,16 @@ export interface GetMetricsRequest extends ResourceRequest {
   namespace?: string;
 }
 
+/** Sort order for log groups (backend: nameAsc | nameDesc | accountIdAsc | accountIdDesc) */
+export type LogGroupOrderBy = 'nameAsc' | 'nameDesc' | 'accountIdAsc' | 'accountIdDesc';
+
 export interface DescribeLogGroupsRequest extends ResourceRequest {
   logGroupNamePrefix?: string;
   logGroupPattern?: string;
   limit?: number;
   listAllLogGroups?: boolean;
+  orderBy?: LogGroupOrderBy;
+  maxResults?: number;
   accountId?: string;
 }
 

--- a/public/app/plugins/datasource/cloudwatch/resources/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/types.ts
@@ -38,7 +38,6 @@ export interface DescribeLogGroupsRequest extends ResourceRequest {
   limit?: number;
   listAllLogGroups?: boolean;
   orderBy?: LogGroupOrderBy;
-  maxResults?: number;
   accountId?: string;
 }
 


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/118097

This PR changes the defaultLogGroupLimit to 1000 so that the user can see more log groups.  It also allows the user to sort by log group name or Account ID.

This PR is a mixture of hand written code and AI code.  The backend is entirely AI with the exception of a few variable name changes I made.  My go skills are entry level so I want to improve them in order to feel more confident opening PRs that make changes on Frontend and backend.

Before:

https://github.com/user-attachments/assets/ef298a8a-329b-4b8d-875a-5809fe35869f


After: 
https://github.com/user-attachments/assets/b46537bb-5584-428c-afd7-ef419d24445c


