### PR TITLE
QueryEditor: Add error state display for Sidebar Cards

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/Actions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/Actions.tsx
@@ -10,6 +10,7 @@ export interface ActionItem {
   name: string;
   type: QueryEditorType;
   isHidden: boolean;
+  isError?: boolean;
   /** Alert state for dynamic styling (only used when type is Alert) */
   alertState?: AlertState | null;
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
@@ -5,7 +5,7 @@ import { RefObject, useRef } from 'react';
 import { DataSourceInstanceSettings, GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { DataQuery } from '@grafana/schema';
-import { Button, useStyles2, Icon, Text } from '@grafana/ui';
+import { Button, Icon, Text, useStyles2 } from '@grafana/ui';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
 import { ExpressionQuery } from 'app/features/expressions/types';
 
@@ -261,7 +261,7 @@ const getStyles = (
   theme: GrafanaTheme2,
   { cardType, selectedAlert }: { cardType: QueryEditorType; selectedAlert: AlertRule | null }
 ) => {
-  const borderColor = getEditorBorderColor(theme, cardType, selectedAlert?.state);
+  const borderColor = getEditorBorderColor({ theme, editorType: cardType, alertState: selectedAlert?.state });
 
   return {
     container: css({

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
@@ -68,7 +68,7 @@ export function QueryEditorContextWrapper({
     () => ({
       queries: queryRunnerState?.queries ?? [],
       data: queryRunnerState?.data,
-      isLoading: queryRunnerState?.data?.state === LoadingState.Loading,
+      isLoading: queryRunnerState?.data?.state === LoadingState.Loading || queryRunnerState?.data?.state === undefined,
       queryError,
     }),
     [queryRunnerState?.queries, queryRunnerState?.data, queryError]

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
@@ -60,6 +60,7 @@ export function QueryEditorContextWrapper({
     [datasource, dsSettings, dsError]
   );
 
+  // TODO: this doesn't seem to be working, when i click one erroring card then all the cards show the error based on how i render it in QueryCard.tsx
   const queryError = useMemo(() => {
     return queryRunnerState?.data?.errors?.find(({ refId }) => refId === selectedQueryRefId);
   }, [queryRunnerState?.data?.errors, selectedQueryRefId]);

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
@@ -60,7 +60,6 @@ export function QueryEditorContextWrapper({
     [datasource, dsSettings, dsError]
   );
 
-  // TODO: this doesn't seem to be working, when i click one erroring card then all the cards show the error based on how i render it in QueryCard.tsx
   const queryError = useMemo(() => {
     return queryRunnerState?.data?.errors?.find(({ refId }) => refId === selectedQueryRefId);
   }, [queryRunnerState?.data?.errors, selectedQueryRefId]);

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Alerts/AlertCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Alerts/AlertCard.tsx
@@ -1,11 +1,10 @@
 import { Icon, useTheme2 } from '@grafana/ui';
 
-import { getAlertStateColor, QUERY_EDITOR_TYPE_CONFIG, QueryEditorType } from '../../constants';
-import { useQueryEditorUIContext } from '../QueryEditorContext';
-import { AlertRule } from '../types';
-
-import { CardTitle } from './CardTitle';
-import { SidebarCard } from './SidebarCard';
+import { getAlertStateColor, QUERY_EDITOR_TYPE_CONFIG, QueryEditorType } from '../../../constants';
+import { useQueryEditorUIContext } from '../../QueryEditorContext';
+import { AlertRule } from '../../types';
+import { CardTitle } from '../CardTitle';
+import { SidebarCard } from '../SidebarCard';
 
 export const AlertCard = ({ alert }: { alert: AlertRule }) => {
   const { selectedAlert, setSelectedAlert } = useQueryEditorUIContext();

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Alerts/AlertIndicator.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Alerts/AlertIndicator.tsx
@@ -1,9 +1,9 @@
 import { t } from '@grafana/i18n';
 import { Button } from '@grafana/ui';
 
-import { QueryEditorType } from '../../constants';
-import { useAlertingContext, useQueryEditorUIContext } from '../QueryEditorContext';
-import { EMPTY_ALERT } from '../types';
+import { QueryEditorType } from '../../../constants';
+import { useAlertingContext, useQueryEditorUIContext } from '../../QueryEditorContext';
+import { EMPTY_ALERT } from '../../types';
 
 export function AlertIndicator() {
   const { alertRules, loading } = useAlertingContext();

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Alerts/AlertsView.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Alerts/AlertsView.tsx
@@ -3,14 +3,14 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Icon, useStyles2, useTheme2 } from '@grafana/ui';
 
-import { ScenesNewRuleFromPanelButton } from '../../../PanelDataPane/NewAlertRuleButton';
-import { ActionItem } from '../../Actions';
-import { getAlertStateColor, QUERY_EDITOR_TYPE_CONFIG, QueryEditorType } from '../../constants';
-import { usePanelContext } from '../QueryEditorContext';
-import { AlertRule } from '../types';
+import { ScenesNewRuleFromPanelButton } from '../../../../PanelDataPane/NewAlertRuleButton';
+import { ActionItem } from '../../../Actions';
+import { getAlertStateColor, QUERY_EDITOR_TYPE_CONFIG, QueryEditorType } from '../../../constants';
+import { usePanelContext } from '../../QueryEditorContext';
+import { AlertRule } from '../../types';
 
+import { SidebarCard } from '../SidebarCard';
 import { AlertCard } from './AlertCard';
-import { SidebarCard } from './SidebarCard';
 
 interface AlertsViewProps {
   alertRules: AlertRule[];

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Alerts/AlertsView.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Alerts/AlertsView.tsx
@@ -8,8 +8,8 @@ import { ActionItem } from '../../../Actions';
 import { getAlertStateColor, QUERY_EDITOR_TYPE_CONFIG, QueryEditorType } from '../../../constants';
 import { usePanelContext } from '../../QueryEditorContext';
 import { AlertRule } from '../../types';
-
 import { SidebarCard } from '../SidebarCard';
+
 import { AlertCard } from './AlertCard';
 
 interface AlertsViewProps {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/CardTitle.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/CardTitle.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react';
 
+import { QUERY_EDITOR_COLORS } from '../../constants';
+
 import { CardTitle } from './CardTitle';
 
 describe('CardTitle', () => {
@@ -32,5 +34,12 @@ describe('CardTitle', () => {
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
     });
+  });
+
+  it('applies error style when isError is true', () => {
+    const { container } = render(<CardTitle title="Error Query" isHidden={false} isError={true} />);
+
+    const titleSpan = container.querySelector('span');
+    expect(titleSpan).toHaveStyle({ color: QUERY_EDITOR_COLORS.error });
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/CardTitle.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/CardTitle.tsx
@@ -8,14 +8,7 @@ import { QUERY_EDITOR_COLORS } from '../../constants';
 // Text component doesn't let us use strikethrough so we use a span with the correct style instead
 export const CardTitle = ({ title, isHidden, isError }: { title: string; isHidden: boolean; isError?: boolean }) => {
   const styles = useStyles2(getStyles);
-  return (
-    <span className={cx(styles.title, { [styles.error]: isError, [styles.hidden]: isHidden })}>
-      {title}
-      {/* <Text weight="light" variant="code" color={isError ? 'error' : 'primary'} truncate>
-        {title}
-      </Text> */}
-    </span>
-  );
+  return <span className={cx(styles.title, { [styles.error]: isError, [styles.hidden]: isHidden })}>{title}</span>;
 };
 
 function getStyles(theme: GrafanaTheme2) {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/CardTitle.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/CardTitle.tsx
@@ -1,27 +1,40 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Text, useStyles2 } from '@grafana/ui';
+import { useStyles2 } from '@grafana/ui';
+
+import { QUERY_EDITOR_COLORS } from '../../constants';
 
 // Text component doesn't let us use strikethrough so we use a span with the correct style instead
 export const CardTitle = ({ title, isHidden, isError }: { title: string; isHidden: boolean; isError?: boolean }) => {
-  const styles = useStyles2(getStyles, { isHidden });
+  const styles = useStyles2(getStyles);
   return (
-    <span className={styles.title}>
-      <Text weight="light" variant="code" color={isError ? 'error' : 'primary'} truncate>
+    <span className={cx(styles.title, { [styles.error]: isError, [styles.hidden]: isHidden })}>
+      {title}
+      {/* <Text weight="light" variant="code" color={isError ? 'error' : 'primary'} truncate>
         {title}
-      </Text>
+      </Text> */}
     </span>
   );
 };
 
-function getStyles(theme: GrafanaTheme2, { isHidden }: { isHidden: boolean }) {
+function getStyles(theme: GrafanaTheme2) {
   return {
     title: css({
-      textDecoration: isHidden ? 'line-through' : 'none',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
+      color: theme.colors.text.primary,
+      ...theme.typography.code,
+      fontWeight: theme.typography.fontWeightLight,
+    }),
+
+    error: css({
+      color: QUERY_EDITOR_COLORS.error,
+    }),
+
+    hidden: css({
+      textDecoration: 'line-through',
     }),
   };
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/CardTitle.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/CardTitle.tsx
@@ -17,6 +17,7 @@ function getStyles(theme: GrafanaTheme2) {
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
+      textDecoration: 'none',
       color: theme.colors.text.primary,
       ...theme.typography.code,
       fontWeight: theme.typography.fontWeightLight,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/CardTitle.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/CardTitle.tsx
@@ -4,11 +4,11 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Text, useStyles2 } from '@grafana/ui';
 
 // Text component doesn't let us use strikethrough so we use a span with the correct style instead
-export const CardTitle = ({ title, isHidden }: { title: string; isHidden: boolean }) => {
+export const CardTitle = ({ title, isHidden, isError }: { title: string; isHidden: boolean; isError?: boolean }) => {
   const styles = useStyles2(getStyles, { isHidden });
   return (
     <span className={styles.title}>
-      <Text weight="light" variant="code" color="primary" truncate>
+      <Text weight="light" variant="code" color={isError ? 'error' : 'primary'} truncate>
         {title}
       </Text>
     </span>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
@@ -1,0 +1,129 @@
+import { screen } from '@testing-library/react';
+
+import { getDefaultTimeRange, LoadingState } from '@grafana/data';
+import { DataQuery } from '@grafana/schema';
+
+import { ds1SettingsMock, renderWithQueryEditorProvider } from '../testUtils';
+import { Transformation } from '../types';
+
+import { QueriesAndTransformationsView } from './QueriesAndTransformationsView';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getDataSourceSrv: () => ({
+    getInstanceSettings: () => ds1SettingsMock,
+  }),
+}));
+
+describe('QueryEditorSidebar', () => {
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render loading bar when data is loading', () => {
+    renderWithQueryEditorProvider(<QueriesAndTransformationsView />, {
+      qrState: {
+        data: {
+          state: LoadingState.Loading,
+          series: [],
+          timeRange: getDefaultTimeRange(),
+        },
+      },
+    });
+
+    expect(screen.getByLabelText(/loading queries and transformations/i)).toBeInTheDocument();
+  });
+
+  it('should always render transformations section even when no transformations exist', () => {
+    const queries: DataQuery[] = [{ refId: 'A', datasource: { type: 'test', uid: 'test' } }];
+
+    renderWithQueryEditorProvider(<QueriesAndTransformationsView />, {
+      queries,
+      selectedQuery: queries[0],
+    });
+
+    expect(screen.getByText(/transformations/i)).toBeInTheDocument();
+  });
+
+  it('should render queries section even when no queries exist', () => {
+    renderWithQueryEditorProvider(<QueriesAndTransformationsView />);
+
+    // Should still render the queries section header
+    expect(screen.getByText(/queries & expressions/i)).toBeInTheDocument();
+  });
+
+  it('should only render DataTransformerConfig cards and not CustomTransformerDefinition', () => {
+    const queries: DataQuery[] = [{ refId: 'A', datasource: { type: 'test', uid: 'test' } }];
+
+    const transformations: Transformation[] = [
+      { transformId: 'organize', registryItem: undefined, transformConfig: { id: 'organize', options: {} } },
+      { transformId: 'reduce', registryItem: undefined, transformConfig: { id: 'reduce', options: {} } },
+    ];
+
+    renderWithQueryEditorProvider(<QueriesAndTransformationsView />, {
+      queries,
+      transformations,
+      selectedQuery: queries[0],
+    });
+
+    // Should render both transformation cards
+    expect(screen.getByRole('button', { name: /select card organize/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /select card reduce/i })).toBeInTheDocument();
+
+    // Count total transformation cards (should be 2).
+    // Filter to "Select card" buttons only, excluding the "Add below" ("+" icon) buttons.
+    const transformCards = screen.getAllByRole('button').filter((button) => {
+      const label = button.getAttribute('aria-label') || '';
+      return label.startsWith('Select card') && (label.includes('organize') || label.includes('reduce'));
+    });
+    expect(transformCards).toHaveLength(2);
+  });
+
+  it('should handle mix of query cards and transformation cards', () => {
+    const queries: DataQuery[] = [
+      { refId: 'A', datasource: { type: 'test', uid: 'test' } },
+      { refId: 'B', datasource: { type: 'test', uid: 'test' } },
+    ];
+
+    const transformations: Transformation[] = [
+      { transformId: 'organize', registryItem: undefined, transformConfig: { id: 'organize', options: {} } },
+    ];
+
+    renderWithQueryEditorProvider(<QueriesAndTransformationsView />, {
+      queries,
+      transformations,
+      selectedQuery: queries[0],
+    });
+
+    // Should render both query cards
+    expect(screen.getByRole('button', { name: /select card A/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /select card B/i })).toBeInTheDocument();
+
+    // Should render transformation card
+    expect(screen.getByRole('button', { name: /select card organize/i })).toBeInTheDocument();
+  });
+
+  it('should render "Add below" buttons for both query/expression and transformation cards', () => {
+    const queries: DataQuery[] = [
+      { refId: 'A', datasource: { type: 'test', uid: 'test' } },
+      { refId: 'B', datasource: { type: 'test', uid: 'test' } },
+    ];
+
+    const transformations: Transformation[] = [
+      { transformId: 'organize', registryItem: undefined, transformConfig: { id: 'organize', options: {} } },
+    ];
+
+    renderWithQueryEditorProvider(<QueriesAndTransformationsView />, {
+      queries,
+      transformations,
+      selectedQuery: queries[0],
+    });
+
+    // Query cards should have an "Add below" button
+    expect(screen.getByRole('button', { name: /add below A/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add below B/i })).toBeInTheDocument();
+
+    // Transformation cards should also have an add button
+    expect(screen.getByRole('button', { name: /add transformation below organize/i })).toBeInTheDocument();
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
@@ -1,6 +1,5 @@
 import { screen } from '@testing-library/react';
 
-import { getDefaultTimeRange, LoadingState } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
 
 import { ds1SettingsMock, renderWithQueryEditorProvider } from '../testUtils';
@@ -23,11 +22,7 @@ describe('QueryEditorSidebar', () => {
   it('should render loading bar when data is loading', () => {
     renderWithQueryEditorProvider(<QueriesAndTransformationsView />, {
       qrState: {
-        data: {
-          state: LoadingState.Loading,
-          series: [],
-          timeRange: getDefaultTimeRange(),
-        },
+        isLoading: true,
       },
     });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
@@ -1,5 +1,6 @@
 import { LoadingState } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { LoadingBar } from '@grafana/ui';
 
 import { usePanelContext, useQueryRunnerContext } from '../QueryEditorContext';
 
@@ -17,9 +18,16 @@ export function QueriesAndTransformationsView() {
 
   const isLoading = data?.state === LoadingState.Loading || data?.state === undefined;
 
-  // TODO: fix
   if (isLoading) {
-    return <div>Loading...</div>;
+    return (
+      <LoadingBar
+        width={400}
+        ariaLabel={t(
+          'query-editor-next.sidebar.loading-queries-transformations',
+          'Loading queries and transformations'
+        )}
+      />
+    );
   }
 
   return (

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
@@ -1,4 +1,3 @@
-import { LoadingState } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { LoadingBar } from '@grafana/ui';
 
@@ -12,11 +11,9 @@ import { TransformationCard } from './TransformationCard';
 import { useSidebarDragAndDrop } from './useSidebarDragAndDrop';
 
 export function QueriesAndTransformationsView() {
-  const { queries, data } = useQueryRunnerContext();
+  const { queries, isLoading } = useQueryRunnerContext();
   const { transformations } = usePanelContext();
   const { onQueryDragEnd, onTransformationDragEnd } = useSidebarDragAndDrop();
-
-  const isLoading = data?.state === LoadingState.Loading || data?.state === undefined;
 
   if (isLoading) {
     return (

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
@@ -1,29 +1,27 @@
-import { DropResult } from '@hello-pangea/dnd';
-
+import { LoadingState } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { DataQuery } from '@grafana/schema';
 
-import { Transformation } from '../types';
+import { usePanelContext, useQueryRunnerContext } from '../QueryEditorContext';
 
 import { AddCardButton } from './AddCardButton';
 import { DraggableList } from './DraggableList';
 import { QueryCard } from './QueryCard';
 import { QuerySidebarCollapsableHeader } from './QuerySidebarCollapsableHeader';
 import { TransformationCard } from './TransformationCard';
+import { useSidebarDragAndDrop } from './useSidebarDragAndDrop';
 
-interface QueriesAndTransformationsViewProps {
-  queries: DataQuery[];
-  transformations: Transformation[];
-  onQueryDragEnd: (result: DropResult) => void;
-  onTransformationDragEnd: (result: DropResult) => void;
-}
+export function QueriesAndTransformationsView() {
+  const { queries, data } = useQueryRunnerContext();
+  const { transformations } = usePanelContext();
+  const { onQueryDragEnd, onTransformationDragEnd } = useSidebarDragAndDrop();
 
-export function QueriesAndTransformationsView({
-  queries,
-  transformations,
-  onQueryDragEnd,
-  onTransformationDragEnd,
-}: QueriesAndTransformationsViewProps) {
+  const isLoading = data?.state === LoadingState.Loading;
+
+  // TODO: fix
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <>
       <QuerySidebarCollapsableHeader

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
@@ -15,7 +15,7 @@ export function QueriesAndTransformationsView() {
   const { transformations } = usePanelContext();
   const { onQueryDragEnd, onTransformationDragEnd } = useSidebarDragAndDrop();
 
-  const isLoading = data?.state === LoadingState.Loading;
+  const isLoading = data?.state === LoadingState.Loading || data?.state === undefined;
 
   // TODO: fix
   if (isLoading) {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryCard.tsx
@@ -4,7 +4,7 @@ import { DataSourceLogo } from 'app/features/datasources/components/picker/DataS
 import { useDatasource } from 'app/features/datasources/hooks';
 
 import { QUERY_EDITOR_TYPE_CONFIG, QueryEditorType } from '../../constants';
-import { useActionsContext, useQueryEditorUIContext } from '../QueryEditorContext';
+import { useActionsContext, useQueryEditorUIContext, useQueryRunnerContext } from '../QueryEditorContext';
 import { getEditorType } from '../utils';
 
 import { CardTitle } from './CardTitle';
@@ -15,6 +15,8 @@ export const QueryCard = ({ query }: { query: DataQuery }) => {
   const queryDsSettings = useDatasource(query.datasource);
   const { selectedQuery, setSelectedQuery } = useQueryEditorUIContext();
   const { duplicateQuery, deleteQuery, toggleQueryHide } = useActionsContext();
+  const { data } = useQueryRunnerContext();
+  const isError = data?.errors?.some((e) => e.refId === query.refId) ?? false;
   const isSelected = selectedQuery?.refId === query.refId;
 
   const isHidden = !!query.hide;
@@ -23,6 +25,7 @@ export const QueryCard = ({ query }: { query: DataQuery }) => {
     name: query.refId,
     type: editorType,
     isHidden,
+    isError,
   };
 
   return (
@@ -43,7 +46,7 @@ export const QueryCard = ({ query }: { query: DataQuery }) => {
           size="sm"
         />
       )}
-      <CardTitle title={query.refId} isHidden={isHidden} />
+      <CardTitle title={query.refId} isHidden={isHidden} isError={isError} />
     </SidebarCard>
   );
 };

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryCard.tsx
@@ -16,9 +16,9 @@ export const QueryCard = ({ query }: { query: DataQuery }) => {
   const { selectedQuery, setSelectedQuery } = useQueryEditorUIContext();
   const { duplicateQuery, deleteQuery, toggleQueryHide } = useActionsContext();
   const { data } = useQueryRunnerContext();
+
   const isError = data?.errors?.some((e) => e.refId === query.refId) ?? false;
   const isSelected = selectedQuery?.refId === query.refId;
-
   const isHidden = !!query.hide;
 
   const item = {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.test.tsx
@@ -1,10 +1,7 @@
 import { screen } from '@testing-library/react';
 
-import { DataQuery } from '@grafana/schema';
-
 import { SidebarSize } from '../../constants';
-import { renderWithQueryEditorProvider, ds1SettingsMock } from '../testUtils';
-import { Transformation } from '../types';
+import { ds1SettingsMock, renderWithQueryEditorProvider } from '../testUtils';
 
 import { QueryEditorSidebar } from './QueryEditorSidebar';
 
@@ -18,99 +15,6 @@ jest.mock('@grafana/runtime', () => ({
 describe('QueryEditorSidebar', () => {
   afterAll(() => {
     jest.clearAllMocks();
-  });
-
-  it('should always render transformations section even when no transformations exist', () => {
-    const queries: DataQuery[] = [{ refId: 'A', datasource: { type: 'test', uid: 'test' } }];
-
-    renderWithQueryEditorProvider(<QueryEditorSidebar sidebarSize={SidebarSize.Full} setSidebarSize={jest.fn()} />, {
-      queries,
-      selectedQuery: queries[0],
-    });
-
-    expect(screen.getByText(/transformations/i)).toBeInTheDocument();
-  });
-
-  it('should render queries section even when no queries exist', () => {
-    renderWithQueryEditorProvider(<QueryEditorSidebar sidebarSize={SidebarSize.Full} setSidebarSize={jest.fn()} />);
-
-    // Should still render the queries section header
-    expect(screen.getByText(/queries & expressions/i)).toBeInTheDocument();
-  });
-
-  it('should only render DataTransformerConfig cards and not CustomTransformerDefinition', () => {
-    const queries: DataQuery[] = [{ refId: 'A', datasource: { type: 'test', uid: 'test' } }];
-
-    const transformations: Transformation[] = [
-      { transformId: 'organize', registryItem: undefined, transformConfig: { id: 'organize', options: {} } },
-      { transformId: 'reduce', registryItem: undefined, transformConfig: { id: 'reduce', options: {} } },
-    ];
-
-    renderWithQueryEditorProvider(<QueryEditorSidebar sidebarSize={SidebarSize.Full} setSidebarSize={jest.fn()} />, {
-      queries,
-      transformations,
-      selectedQuery: queries[0],
-    });
-
-    // Should render both transformation cards
-    expect(screen.getByRole('button', { name: /select card organize/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /select card reduce/i })).toBeInTheDocument();
-
-    // Count total transformation cards (should be 2).
-    // Filter to "Select card" buttons only, excluding the "Add below" ("+" icon) buttons.
-    const transformCards = screen.getAllByRole('button').filter((button) => {
-      const label = button.getAttribute('aria-label') || '';
-      return label.startsWith('Select card') && (label.includes('organize') || label.includes('reduce'));
-    });
-    expect(transformCards).toHaveLength(2);
-  });
-
-  it('should handle mix of query cards and transformation cards', () => {
-    const queries: DataQuery[] = [
-      { refId: 'A', datasource: { type: 'test', uid: 'test' } },
-      { refId: 'B', datasource: { type: 'test', uid: 'test' } },
-    ];
-
-    const transformations: Transformation[] = [
-      { transformId: 'organize', registryItem: undefined, transformConfig: { id: 'organize', options: {} } },
-    ];
-
-    renderWithQueryEditorProvider(<QueryEditorSidebar sidebarSize={SidebarSize.Full} setSidebarSize={jest.fn()} />, {
-      queries,
-      transformations,
-      selectedQuery: queries[0],
-    });
-
-    // Should render both query cards
-    expect(screen.getByRole('button', { name: /select card A/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /select card B/i })).toBeInTheDocument();
-
-    // Should render transformation card
-    expect(screen.getByRole('button', { name: /select card organize/i })).toBeInTheDocument();
-  });
-
-  it('should render "Add below" buttons for both query/expression and transformation cards', () => {
-    const queries: DataQuery[] = [
-      { refId: 'A', datasource: { type: 'test', uid: 'test' } },
-      { refId: 'B', datasource: { type: 'test', uid: 'test' } },
-    ];
-
-    const transformations: Transformation[] = [
-      { transformId: 'organize', registryItem: undefined, transformConfig: { id: 'organize', options: {} } },
-    ];
-
-    renderWithQueryEditorProvider(<QueryEditorSidebar sidebarSize={SidebarSize.Full} setSidebarSize={jest.fn()} />, {
-      queries,
-      transformations,
-      selectedQuery: queries[0],
-    });
-
-    // Query cards should have an "Add below" button
-    expect(screen.getByRole('button', { name: /add below A/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /add below B/i })).toBeInTheDocument();
-
-    // Transformation cards should also have an add button
-    expect(screen.getByRole('button', { name: /add transformation below organize/i })).toBeInTheDocument();
   });
 
   it('should call setSidebarSize with Full when toggling from Mini', async () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.tsx
@@ -14,7 +14,7 @@ import {
 } from '../QueryEditorContext';
 
 import { AlertIndicator } from './AlertIndicator';
-import { AlertsView } from './AlertsView';
+import { AlertsView } from './Alerts/AlertsView';
 import { QueriesAndTransformationsView } from './QueriesAndTransformationsView';
 import { SidebarFooter } from './SidebarFooter';
 import { useSidebarDragAndDrop } from './useSidebarDragAndDrop';

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.tsx
@@ -6,18 +6,12 @@ import { t } from '@grafana/i18n';
 import { IconButton, ScrollContainer, Stack, Text, useStyles2 } from '@grafana/ui';
 
 import { QUERY_EDITOR_COLORS, QueryEditorType, SidebarSize } from '../../constants';
-import {
-  useAlertingContext,
-  usePanelContext,
-  useQueryEditorUIContext,
-  useQueryRunnerContext,
-} from '../QueryEditorContext';
+import { useAlertingContext, useQueryEditorUIContext } from '../QueryEditorContext';
 
 import { AlertIndicator } from './Alerts/AlertIndicator';
 import { AlertsView } from './Alerts/AlertsView';
 import { QueriesAndTransformationsView } from './QueriesAndTransformationsView';
 import { SidebarFooter } from './SidebarFooter';
-import { useSidebarDragAndDrop } from './useSidebarDragAndDrop';
 
 interface QueryEditorSidebarProps {
   sidebarSize: SidebarSize;
@@ -30,11 +24,9 @@ export const QueryEditorSidebar = memo(function QueryEditorSidebar({
 }: QueryEditorSidebarProps) {
   const styles = useStyles2(getStyles);
   const isMini = sidebarSize === SidebarSize.Mini;
-  const { queries } = useQueryRunnerContext();
-  const { transformations } = usePanelContext();
+
   const { alertRules } = useAlertingContext();
   const { cardType } = useQueryEditorUIContext();
-  const { onQueryDragEnd, onTransformationDragEnd } = useSidebarDragAndDrop();
 
   const toggleSize = () => {
     setSidebarSize(isMini ? SidebarSize.Full : SidebarSize.Mini);
@@ -67,16 +59,7 @@ export const QueryEditorSidebar = memo(function QueryEditorSidebar({
       {/** The translateX property of the hoverActions in SidebarCard causes the scroll container to overflow by 8px. */}
       <ScrollContainer overflowX="hidden">
         <div className={styles.content}>
-          {isAlertView ? (
-            <AlertsView alertRules={alertRules} />
-          ) : (
-            <QueriesAndTransformationsView
-              queries={queries}
-              transformations={transformations}
-              onQueryDragEnd={onQueryDragEnd}
-              onTransformationDragEnd={onTransformationDragEnd}
-            />
-          )}
+          {isAlertView ? <AlertsView alertRules={alertRules} /> : <QueriesAndTransformationsView />}
         </div>
       </ScrollContainer>
       <SidebarFooter />

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.tsx
@@ -13,7 +13,7 @@ import {
   useQueryRunnerContext,
 } from '../QueryEditorContext';
 
-import { AlertIndicator } from './AlertIndicator';
+import { AlertIndicator } from './Alerts/AlertIndicator';
 import { AlertsView } from './Alerts/AlertsView';
 import { QueriesAndTransformationsView } from './QueriesAndTransformationsView';
 import { SidebarFooter } from './SidebarFooter';

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { useStyles2 } from '@grafana/ui';
+import { Icon, useStyles2 } from '@grafana/ui';
 
 import { ActionItem, Actions } from '../../Actions';
 import { QUERY_EDITOR_COLORS, QueryEditorType } from '../../constants';
@@ -95,17 +95,24 @@ export const SidebarCard = ({
         aria-pressed={isSelected}
       >
         <div className={cx(styles.cardContent, { [styles.hidden]: item.isHidden })}>{children}</div>
-        {hasActions && (
-          <div className={cx(styles.hoverActions, { [styles.hoverActionsVisible]: hasFocusWithin })}>
-            <Actions
-              handleResetFocus={handleResetFocus}
-              item={item}
-              onDelete={onDelete}
-              onDuplicate={onDuplicate}
-              onToggleHide={onToggleHide}
-            />
-          </div>
-        )}
+        <div>
+          {item.isError && (
+            <div className={styles.errorIcon}>
+              <Icon name="exclamation-triangle" size="sm" color={QUERY_EDITOR_COLORS.error} />
+            </div>
+          )}
+          {hasActions && (
+            <div className={cx(styles.hoverActions, { [styles.hoverActionsVisible]: hasFocusWithin })}>
+              <Actions
+                handleResetFocus={handleResetFocus}
+                item={item}
+                onDelete={onDelete}
+                onDuplicate={onDuplicate}
+                onToggleHide={onToggleHide}
+              />
+            </div>
+          )}
+        </div>
       </div>
       <AddCardButton variant={addVariant} afterId={id} />
     </div>
@@ -127,7 +134,12 @@ function getStyles(
     item: ActionItem;
   }
 ) {
-  const borderColor = getEditorBorderColor(theme, item.type, item.alertState);
+  const borderColor = getEditorBorderColor({
+    theme,
+    editorType: item.type,
+    alertState: item.alertState,
+    isError: item.isError,
+  });
 
   const backgroundColor = isSelected ? QUERY_EDITOR_COLORS.card.activeBg : QUERY_EDITOR_COLORS.card.hoverBg;
   const hoverActions = css({
@@ -282,6 +294,10 @@ function getStyles(
       [theme.transitions.handleMotion('no-preference')]: {
         animation: `${ghostCardPulse} 3s ease-in-out infinite`,
       },
+    }),
+
+    errorIcon: css({
+      paddingRight: theme.spacing(1),
     }),
   };
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/testUtils.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/testUtils.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ReactElement } from 'react';
 
-import { DataSourceInstanceSettings, PluginType } from '@grafana/data';
+import { DataSourceInstanceSettings, getDefaultTimeRange, LoadingState, PluginType } from '@grafana/data';
 import { VizPanel } from '@grafana/scenes';
 import { DataQuery } from '@grafana/schema';
 import { QueryGroupOptions } from 'app/types/query';
@@ -10,14 +10,14 @@ import { QueryGroupOptions } from 'app/types/query';
 import { QueryEditorType } from '../constants';
 
 import {
+  AlertingState,
   DatasourceState,
   PanelState,
   QueryEditorActions,
+  QueryEditorProvider,
   QueryEditorUIState,
   QueryOptionsState,
   QueryRunnerState,
-  QueryEditorProvider,
-  AlertingState,
 } from './QueryEditorContext';
 import { Transformation } from './types';
 
@@ -159,7 +159,11 @@ export function renderWithQueryEditorProvider(children: ReactElement, options: C
 
   const defaultQrState: QueryRunnerState = {
     queries,
-    data: undefined,
+    data: {
+      state: LoadingState.Done,
+      series: [],
+      timeRange: getDefaultTimeRange(),
+    },
     isLoading: false,
     queryError: undefined,
     ...qrState,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
@@ -3,7 +3,7 @@ import { CustomTransformerDefinition } from '@grafana/scenes';
 import { DataQuery } from '@grafana/schema';
 import { isExpressionQuery } from 'app/features/expressions/guards';
 
-import { getAlertStateColor, QUERY_EDITOR_TYPE_CONFIG, QueryEditorType } from '../constants';
+import { getAlertStateColor, QUERY_EDITOR_COLORS, QUERY_EDITOR_TYPE_CONFIG, QueryEditorType } from '../constants';
 
 import { PendingExpression, PendingTransformation } from './QueryEditorContext';
 import { AlertRule, Transformation } from './types';
@@ -72,11 +72,21 @@ export function getTransformId(transformConfigId: string, index: number): string
  * @param alertState - Optional alert state (only used when editorType is Alert)
  * @returns The border color string
  */
-export function getEditorBorderColor(
-  theme: GrafanaTheme2,
-  editorType: QueryEditorType,
-  alertState?: AlertState | null
-): string {
+export function getEditorBorderColor({
+  theme,
+  editorType,
+  alertState,
+  isError,
+}: {
+  theme: GrafanaTheme2;
+  editorType: QueryEditorType;
+  alertState?: AlertState | null;
+  isError?: boolean;
+}): string {
+  if (isError) {
+    return QUERY_EDITOR_COLORS.error;
+  }
+
   if (editorType === QueryEditorType.Alert && alertState) {
     return getAlertStateColor(theme, alertState);
   }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
@@ -40,6 +40,7 @@ export const QUERY_EDITOR_COLORS = {
     hoverBg: '#1D293D',
     headerBg: '#20262F',
   },
+  error: '#D10E5C',
 };
 
 export interface QueryEditorTypeConfig {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13366,6 +13366,7 @@
       "data": "Data",
       "footer-items_one": "{{count}} item",
       "footer-items_other": "{{count}} items",
+      "loading-queries-transformations": "Loading queries and transformations",
       "queries-expressions": "Queries & Expressions",
       "toggle-size": "Toggle sidebar size",
       "transformations": "Transformations"


### PR DESCRIPTION
## Description
Adds Error State display for Queries and Expressions to the Sidebar Cards

## Changes
* Displays error state on the SidebarCard if `item.isError` is true
* Moves some state specific to non-alerts out of `QueryEditorSidebar.tsx` and into `QueriesAndTransformationsView.tsx`
  * Moves appropriate tests around rendering queries and transformations as well
* Adds a loading indicator to `QueriesAndTransformationsView` to avoid render flicker when errors are being surfaced
* Adds error styling to CardTitle and removes the Text component usage since that does not support custom colors for text
* Also moved the Alerts components under Sidebar to an Alerts subfolder 

## Demo
https://github.com/user-attachments/assets/1a57c391-74ad-4f20-bfe2-4c82f9008c3f

## Testing Instructions
* Create a dashboard with errors and see if it works properly
* Note: the way that errors are surfaced means when adding a new SQL Expression, the errors are updated properly until refreshed.

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable