### PR TITLE
AccessControl: Invalidate scope resolver cache on datasource deletion

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -184,6 +184,10 @@ func (hs *HTTPServer) DeleteDataSourceById(c *contextmodel.ReqContext) response.
 
 	hs.Live.HandleDatasourceDelete(c.GetOrgID(), ds.UID)
 
+	// Clear the scope resolution cache for the datasource name to prevent stale name-to-UID mappings
+	nameScope := datasources.ScopeProvider.GetResourceScopeName(ds.Name)
+	hs.AccessControl.InvalidateResolverCache(c.GetOrgID(), nameScope)
+
 	return response.Success("Data source deleted")
 }
 
@@ -270,6 +274,10 @@ func (hs *HTTPServer) DeleteDataSourceByUID(c *contextmodel.ReqContext) response
 
 	hs.Live.HandleDatasourceDelete(c.GetOrgID(), ds.UID)
 
+	// Clear the scope resolution cache for the datasource name to prevent stale name-to-UID mappings
+	nameScope := datasources.ScopeProvider.GetResourceScopeName(ds.Name)
+	hs.AccessControl.InvalidateResolverCache(c.GetOrgID(), nameScope)
+
 	return response.JSON(http.StatusOK, util.DynMap{
 		"message": "Data source deleted",
 		"id":      ds.ID,
@@ -318,6 +326,10 @@ func (hs *HTTPServer) DeleteDataSourceByName(c *contextmodel.ReqContext) respons
 	}
 
 	hs.Live.HandleDatasourceDelete(c.GetOrgID(), dataSource.UID)
+
+	// Clear the scope resolution cache for the datasource name to prevent stale name-to-UID mappings
+	nameScope := datasources.ScopeProvider.GetResourceScopeName(dataSource.Name)
+	hs.AccessControl.InvalidateResolverCache(c.GetOrgID(), nameScope)
 
 	return response.JSON(http.StatusOK, util.DynMap{
 		"message": "Data source deleted",

--- a/pkg/api/datasources_test.go
+++ b/pkg/api/datasources_test.go
@@ -495,6 +495,7 @@ func TestDeleteDataSourceByName_IncludesUIDForPermissions(t *testing.T) {
 			pluginStore:        &pluginstore.FakePluginStore{},
 			DataSourcesService: mockDsService,
 			Live:               newTestLive(t),
+			AccessControl:      acimpl.ProvideAccessControl(featuremgmt.WithFeatures()),
 		}
 
 		// Create scenario context

--- a/pkg/server/search_server_distributor_test.go
+++ b/pkg/server/search_server_distributor_test.go
@@ -47,7 +47,6 @@ var (
 
 //nolint:gocyclo
 func TestIntegrationDistributor(t *testing.T) {
-	t.Skip("Skipping flaky test: 'no healthy replica' errors.")
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	dbType := sqlutil.GetTestDBType()

--- a/pkg/server/search_server_distributor_test.go
+++ b/pkg/server/search_server_distributor_test.go
@@ -47,6 +47,7 @@ var (
 
 //nolint:gocyclo
 func TestIntegrationDistributor(t *testing.T) {
+	t.Skip("Skipping flaky test: 'no healthy replica' errors.")
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	dbType := sqlutil.GetTestDBType()

--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -29,6 +29,8 @@ type AccessControl interface {
 	// This is useful when we don't want to reuse any pre-configured resolvers
 	// for a authorization call.
 	WithoutResolvers() AccessControl
+	// InvalidateResolverCache removes a scope resolution from the cache
+	InvalidateResolverCache(orgID int64, scope string)
 }
 
 type Service interface {

--- a/pkg/services/accesscontrol/acimpl/accesscontrol.go
+++ b/pkg/services/accesscontrol/acimpl/accesscontrol.go
@@ -98,6 +98,10 @@ func (a *AccessControl) WithoutResolvers() accesscontrol.AccessControl {
 	}
 }
 
+func (a *AccessControl) InvalidateResolverCache(orgID int64, scope string) {
+	a.resolvers.InvalidateCache(orgID, scope)
+}
+
 func (a *AccessControl) debug(ctx context.Context, ident identity.Requester, msg string, eval accesscontrol.Evaluator) {
 	ctx, span := tracer.Start(ctx, "accesscontrol.acimpl.debug")
 	defer span.End()

--- a/pkg/services/accesscontrol/actest/fake.go
+++ b/pkg/services/accesscontrol/actest/fake.go
@@ -79,6 +79,10 @@ func (f FakeAccessControl) WithoutResolvers() accesscontrol.AccessControl {
 	return f
 }
 
+func (f FakeAccessControl) InvalidateResolverCache(orgID int64, scope string) {
+	// No-op for fake implementation
+}
+
 type FakeStore struct {
 	ExpectedUserPermissions       []accesscontrol.Permission
 	ExpectedBasicRolesPermissions []accesscontrol.Permission

--- a/pkg/services/accesscontrol/mock/mock.go
+++ b/pkg/services/accesscontrol/mock/mock.go
@@ -277,3 +277,8 @@ func (m *Mock) SyncUserRoles(ctx context.Context, orgID int64, cmd accesscontrol
 func (m *Mock) WithoutResolvers() accesscontrol.AccessControl {
 	return m
 }
+
+// InvalidateResolverCache implements accesscontrol.AccessControl.
+func (m *Mock) InvalidateResolverCache(orgID int64, scope string) {
+	m.scopeResolvers.InvalidateCache(orgID, scope)
+}

--- a/pkg/services/accesscontrol/resolvers.go
+++ b/pkg/services/accesscontrol/resolvers.go
@@ -92,3 +92,10 @@ func (s *Resolvers) GetScopeAttributeMutator(orgID int64) ScopeAttributeMutator 
 func getScopeCacheKey(orgID int64, scope string) string {
 	return fmt.Sprintf("%s-%v", scope, orgID)
 }
+
+// InvalidateCache removes a scope resolution from the cache
+func (s *Resolvers) InvalidateCache(orgID int64, scope string) {
+	key := getScopeCacheKey(orgID, scope)
+	s.cache.Delete(key)
+	s.log.Debug("Invalidated scope cache", "scope", scope, "orgID", orgID)
+}

--- a/pkg/services/libraryelements/api_test.go
+++ b/pkg/services/libraryelements/api_test.go
@@ -159,6 +159,8 @@ type fakeAccessControl struct {
 	evaluateFunc func(ctx context.Context, user identity.Requester, evaluator accesscontrol.Evaluator) (bool, error)
 }
 
+var _ accesscontrol.AccessControl = new(fakeAccessControl)
+
 func (f *fakeAccessControl) Evaluate(ctx context.Context, user identity.Requester, evaluator accesscontrol.Evaluator) (bool, error) {
 	if f.evaluateFunc != nil {
 		return f.evaluateFunc(ctx, user, evaluator)
@@ -172,4 +174,8 @@ func (f *fakeAccessControl) RegisterScopeAttributeResolver(prefix string, resolv
 
 func (f *fakeAccessControl) WithoutResolvers() accesscontrol.AccessControl {
 	return f
+}
+
+func (f *fakeAccessControl) InvalidateResolverCache(orgID int64, scope string) {
+	// no-op for testing
 }


### PR DESCRIPTION
## Summary
- Backport of OSS commit 1bf8245 (AccessControl: Invalidate scope resolver cache on datasource deletion #118334) to release-12.4.1
- Adds `InvalidateResolverCache` to the `AccessControl` interface and implements it in the scope resolver, ensuring stale cached scope resolutions are cleared when a datasource is deleted
- Companion to #117289 (already on release-12.4.1)

## Test plan
- [x] `go vet` passes for `pkg/services/accesscontrol/...` and `pkg/api/`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)