### PR TITLE
unified-storage: add list bench tests to sqlbackend and sqlkv

### DIFF
--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -19,11 +19,13 @@ import (
 
 // BenchmarkOptions configures the benchmark parameters
 type BenchmarkOptions struct {
-	NumResources     int // total number of resources to write
-	Concurrency      int // number of concurrent writers
-	NumNamespaces    int // number of different namespaces
-	NumGroups        int // number of different groups
-	NumResourceTypes int // number of different resource types
+	NumResources       int // total number of resources to write
+	Concurrency        int // number of concurrent writers
+	NumNamespaces      int // number of different namespaces
+	NumGroups          int // number of different groups
+	NumResourceTypes   int // number of different resource types
+	NumHistoryVersions int // history depth per resource for list seed (default 10)
+	NumListIterations  int // number of List calls to measure (default 100)
 }
 
 // DefaultBenchmarkOptions returns the default benchmark options
@@ -41,25 +43,27 @@ func DefaultBenchmarkOptions(t *testing.T) *BenchmarkOptions {
 	}
 
 	return &BenchmarkOptions{
-		NumResources:     envOrDefault("RESOURCES", 1000),
-		Concurrency:      envOrDefault("CONCURRENCY", 50),
-		NumNamespaces:    envOrDefault("NAMESPACES", 1),
-		NumGroups:        envOrDefault("GROUPS", 1),
-		NumResourceTypes: envOrDefault("RESOURCE_TYPES", 1),
+		NumResources:       envOrDefault("RESOURCES", 1000),
+		Concurrency:        envOrDefault("CONCURRENCY", 50),
+		NumNamespaces:      envOrDefault("NAMESPACES", 1),
+		NumGroups:          envOrDefault("GROUPS", 1),
+		NumResourceTypes:   envOrDefault("RESOURCE_TYPES", 1),
+		NumHistoryVersions: envOrDefault("HISTORY_VERSIONS", 10),
+		NumListIterations:  envOrDefault("LIST_ITERATIONS", 100),
 	}
 }
 
 func (opts *BenchmarkOptions) String() string {
 	return fmt.Sprintf(
-		"Workers=%d, Resources=%d, Namespaces=%d, Groups=%d, Resource Types=%d",
-		opts.Concurrency, opts.NumResources, opts.NumNamespaces, opts.NumGroups, opts.NumResourceTypes,
+		"Workers=%d, Resources=%d, Namespaces=%d, Groups=%d, Resource Types=%d, History Versions=%d, List Iterations=%d",
+		opts.Concurrency, opts.NumResources, opts.NumNamespaces, opts.NumGroups, opts.NumResourceTypes, opts.NumHistoryVersions, opts.NumListIterations,
 	)
 }
 
 // BenchmarkResult contains the benchmark metrics for a particular operation.
 type BenchmarkResult struct {
 	TotalDuration time.Duration
-	WriteCount    int
+	ReqCount      int
 	Throughput    float64 // writes per second
 	P50Latency    time.Duration
 	P90Latency    time.Duration
@@ -70,7 +74,7 @@ func (r BenchmarkResult) String() string {
 	var out strings.Builder
 
 	fmt.Fprintf(&out, "Total Duration: %v\n", r.TotalDuration)
-	fmt.Fprintf(&out, "Write Count: %d\n", r.WriteCount)
+	fmt.Fprintf(&out, "Write Count: %d\n", r.ReqCount)
 	fmt.Fprintf(&out, "Throughput: %.2f writes/sec\n", r.Throughput)
 	fmt.Fprintf(&out, "P50 Latency: %v\n", r.P50Latency)
 	fmt.Fprintf(&out, "P90 Latency: %v\n", r.P90Latency)
@@ -80,17 +84,18 @@ func (r BenchmarkResult) String() string {
 }
 
 // BenchmarkResults aggregates results of a benchmark run for
-// create/update/delete operations.
+// create/update/delete/list operations.
 type BenchmarkResults struct {
 	CreateResults BenchmarkResult
 	UpdateResults BenchmarkResult
 	DeleteResults BenchmarkResult
+	ListResults   BenchmarkResult
 }
 
 func (r BenchmarkResults) String() string {
 	return fmt.Sprintf(
-		"CREATE:\n%s\n\nUPDATE:\n%s\n\nDELETE:\n%s\n",
-		r.CreateResults, r.UpdateResults, r.DeleteResults,
+		"CREATE:\n%s\n\nUPDATE:\n%s\n\nDELETE:\n%s\n\nLIST:\n%s\n",
+		r.CreateResults, r.UpdateResults, r.DeleteResults, r.ListResults,
 	)
 }
 
@@ -165,7 +170,7 @@ func runStorageBackendBenchmark(t *testing.T, backend resource.StorageBackend, o
 		totalDuration := time.Since(startTime)
 		return BenchmarkResult{
 			TotalDuration: time.Since(startTime),
-			WriteCount:    opts.NumResources,
+			ReqCount:      opts.NumResources,
 			Throughput:    float64(opts.NumResources) / totalDuration.Seconds(),
 			P50Latency:    latencies[len(latencies)*50/100],
 			P90Latency:    latencies[len(latencies)*90/100],
@@ -207,7 +212,112 @@ func runStorageBackendBenchmark(t *testing.T, backend resource.StorageBackend, o
 		return err
 	})
 
-	return &BenchmarkResults{createResult, updateResult, deleteResult}
+	return &BenchmarkResults{
+		CreateResults: createResult,
+		UpdateResults: updateResult,
+		DeleteResults: deleteResult,
+	}
+}
+
+// runListBenchmark seeds resources with history and measures concurrent List latency.
+func runListBenchmark(t *testing.T, backend resource.StorageBackend, opts *BenchmarkOptions) BenchmarkResult {
+	ctx := t.Context()
+
+	// All resources go into a single namespace/group/resource to maximize scan scope.
+	const (
+		listNS       = "bench-list-ns"
+		listGroup    = "bench-list-group"
+		listResource = "bench-list-resource"
+	)
+
+	// --- Seed phase (sequential to avoid OCC conflicts) ---
+	t.Log("List benchmark: seeding resources with history...")
+	seedStart := time.Now()
+
+	rvs := make([]int64, opts.NumResources)
+	for i := 0; i < opts.NumResources; i++ {
+		name := fmt.Sprintf("list-item-%d", i)
+
+		// Create
+		rv, err := WriteEvent(ctx, backend, name, resourcepb.WatchEvent_ADDED,
+			WithNamespace(listNS),
+			WithGroup(listGroup),
+			WithResource(listResource),
+			WithValue(strings.Repeat("abcdefghijklmnopqrstuvwxyz", 10)))
+		require.NoError(t, err)
+		rvs[i] = rv
+
+		// Add history versions (MODIFIED events)
+		for v := 0; v < opts.NumHistoryVersions; v++ {
+			rv, err = WriteEvent(ctx, backend, name, resourcepb.WatchEvent_MODIFIED,
+				WithNamespaceAndRV(listNS, rvs[i]),
+				WithGroup(listGroup),
+				WithResource(listResource),
+				WithValue(strings.Repeat("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 10)))
+			require.NoError(t, err)
+			rvs[i] = rv
+		}
+	}
+	t.Logf("List benchmark: seeded %d resources x %d versions in %v",
+		opts.NumResources, opts.NumHistoryVersions+1, time.Since(seedStart))
+
+	// --- Measure phase (concurrent List calls) ---
+	listReq := &resourcepb.ListRequest{
+		Options: &resourcepb.ListOptions{
+			Key: &resourcepb.ResourceKey{
+				Namespace: listNS,
+				Group:     listGroup,
+				Resource:  listResource,
+			},
+		},
+	}
+
+	jobs := make(chan int, opts.NumListIterations)
+	latencies := make([]time.Duration, opts.NumListIterations)
+
+	for i := 0; i < opts.NumListIterations; i++ {
+		jobs <- i
+	}
+	close(jobs)
+
+	g, groupCtx := errgroup.WithContext(ctx)
+	startTime := time.Now()
+
+	for w := 0; w < opts.Concurrency; w++ {
+		g.Go(func() error {
+			for jobID := range jobs {
+				opStart := time.Now()
+				_, err := backend.ListIterator(groupCtx, listReq, func(iter resource.ListIterator) error {
+					for iter.Next() {
+						if err := iter.Error(); err != nil {
+							return err
+						}
+						_ = iter.Value() // drain the iterator
+					}
+					return iter.Error()
+				})
+				if err != nil {
+					return err
+				}
+				latencies[jobID] = time.Since(opStart)
+			}
+			return nil
+		})
+	}
+
+	require.NoError(t, g.Wait())
+
+	slices.Sort(latencies)
+	totalDuration := time.Since(startTime)
+
+	return BenchmarkResult{
+		TotalDuration: totalDuration,
+		ReqCount:      opts.NumListIterations,
+		Throughput:    float64(opts.NumListIterations) / totalDuration.Seconds(),
+		P50Latency:    latencies[len(latencies)*50/100],
+		P90Latency:    latencies[len(latencies)*90/100],
+		P99Latency:    latencies[len(latencies)*99/100],
+	}
 }
 
 // RunStorageBackendBenchmark runs a benchmark test for a storage backend implementation
@@ -215,8 +325,9 @@ func RunStorageBackendBenchmark(t *testing.T, backend resource.StorageBackend, o
 	// Initialize the backend
 	require.NoError(t, initializeBackend(t.Context(), backend, opts))
 
-	// Run the benchmark
 	results := runStorageBackendBenchmark(t, backend, opts)
+
+	results.ListResults = runListBenchmark(t, backend, opts)
 
 	// Log the results for better visibility.
 	t.Logf("Benchmark Configuration: %s", opts)
@@ -324,7 +435,7 @@ func runSearchBackendBenchmarkWriteThroughput(ctx context.Context, backend resou
 
 	return &BenchmarkResult{
 		TotalDuration: totalDuration,
-		WriteCount:    opts.NumResources,
+		ReqCount:      opts.NumResources,
 		Throughput:    throughput,
 		P50Latency:    latencies[len(latencies)*50/100],
 		P90Latency:    latencies[len(latencies)*90/100],
@@ -342,8 +453,8 @@ func RunSearchBackendBenchmark(t *testing.T, backend resource.SearchBackend, opt
 	t.Logf("")
 	t.Logf("Benchmark Results:")
 	t.Logf("Total Duration: %v", result.TotalDuration)
-	t.Logf("Write Count: %d", result.WriteCount)
-	t.Logf("Throughput: %.2f writes/sec", result.Throughput)
+	t.Logf("Req Count: %d", result.ReqCount)
+	t.Logf("Throughput: %.2f req/sec", result.Throughput)
 	t.Logf("P50 Latency: %v", result.P50Latency)
 	t.Logf("P90 Latency: %v", result.P90Latency)
 	t.Logf("P99 Latency: %v", result.P99Latency)

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -74,7 +74,7 @@ func (r BenchmarkResult) String() string {
 	var out strings.Builder
 
 	fmt.Fprintf(&out, "Total Duration: %v\n", r.TotalDuration)
-	fmt.Fprintf(&out, "Write Count: %d\n", r.ReqCount)
+	fmt.Fprintf(&out, "Req Count: %d\n", r.ReqCount)
 	fmt.Fprintf(&out, "Throughput: %.2f writes/sec\n", r.Throughput)
 	fmt.Fprintf(&out, "P50 Latency: %v\n", r.P50Latency)
 	fmt.Fprintf(&out, "P90 Latency: %v\n", r.P90Latency)
@@ -230,7 +230,7 @@ func runListBenchmark(t *testing.T, backend resource.StorageBackend, opts *Bench
 		listResource = "bench-list-resource"
 	)
 
-	// --- Seed phase (sequential to avoid OCC conflicts) ---
+	// --- Seed phase (sequential to avoid Optimistic locking conflicts) ---
 	t.Log("List benchmark: seeding resources with history...")
 	seedStart := time.Now()
 


### PR DESCRIPTION
As I was working on https://github.com/grafana/search-and-storage-team/issues/636 I noticed a [much higher latency in list operations](https://ops.grafana-ops.net/d/3aa0ed13b96eb0d4d0c6a3e2b478f3aa/grafana-unified-storage-storage?orgId=1&from=now-2d&to=now&timezone=utc&var-datasource=2z9d6ElGk&var-cluster=$__all&var-namespace=unified-storage-dev-002&var-latency_metrics=-1&refresh=10s) in sqlkv compared to the sqlbackend. So I went to do some digging.

Ultimately, the ListIterator implementation is a lot less efficient between them:

### sqlbackend

Does a single SQL query that fetches all the keys + values. Worst case it has to do an extra check against `resource_version` if the client did not provide a `ResourceVersion`.

### sqlkv

* Fixed call to get the latest RV from the events table
* Single call to list all keys from `resource_history` followed by a filter in memory
* N batch calls to retrieve the latest keys values in batches of 50

So here we have a varying number of round trips to the database. I played around with the code to see if I could improve it a bit, there's two biggest offenders for the worse performance:

1. The BatchGet calls have a strict ordering for the return statement. This is done at the database. Changing this to return keys in any order increases the list performance a little bit, locally it went from ~70 req/s to ~90 req/s
2. The biggest culprit is the fact that we simply need to list the entire history. 

The performance difference we're seeing in dev is not as drastic (see results below). We're seeing 3x worse performance, here it shows 5x. But the volume of List calls to the sqlkv backend is a lot smaller since it's just the Grafana instances talking to it.

Bench results. SQL Backend:

```
=== RUN   TestIntegrationBenchmarkSQLStorageBackend
    benchmark.go:238: List benchmark: seeding resources with history...
    benchmark.go:265: List benchmark: seeded 1000 resources x 11 versions in 47.591593291s
    benchmark.go:339: Benchmark Configuration: Workers=50, Resources=1000, Namespaces=1, Groups=1, Resource Types=1, History Versions=10, List Iterations=100
    benchmark.go:340:
    benchmark.go:341: Benchmark Results:
    benchmark.go:342:
        CREATE:
        Total Duration: 4.035818959s
        Write Count: 1000
        Throughput: 247.78 writes/sec
        P50 Latency: 202.433042ms
        P90 Latency: 207.901417ms
        P99 Latency: 213.472292ms


        UPDATE:
        Total Duration: 1.510367417s
        Write Count: 1000
        Throughput: 662.09 writes/sec
        P50 Latency: 75.380833ms
        P90 Latency: 76.875209ms
        P99 Latency: 84.721583ms


        DELETE:
        Total Duration: 1.132131042s
        Write Count: 1000
        Throughput: 883.29 writes/sec
        P50 Latency: 55.68125ms
        P90 Latency: 60.644334ms
        P99 Latency: 62.508416ms


        LIST:
        Total Duration: 292.371125ms
        Write Count: 100
        Throughput: 342.03 writes/sec
        P50 Latency: 118.94875ms
        P90 Latency: 276.560833ms
        P99 Latency: 292.189625ms
```

SQL KV
```
=== RUN   TestIntegrationBenchmarkSQLKVStorageBackend/rvmanager=true
    benchmark.go:238: List benchmark: seeding resources with history...
    benchmark.go:265: List benchmark: seeded 1000 resources x 11 versions in 1m8.126354084s
    benchmark.go:339: Benchmark Configuration: Workers=50, Resources=1000, Namespaces=1, Groups=1, Resource Types=1, History Versions=10, List Iterations=100
    benchmark.go:340:
    benchmark.go:341: Benchmark Results:
    benchmark.go:342:
        CREATE:
        Total Duration: 2.236380375s
        Write Count: 1000
        Throughput: 447.15 writes/sec
        P50 Latency: 110.336ms
        P90 Latency: 118.916709ms
        P99 Latency: 137.458625ms


        UPDATE:
        Total Duration: 2.356367s
        Write Count: 1000
        Throughput: 424.38 writes/sec
        P50 Latency: 117.0985ms
        P90 Latency: 123.558042ms
        P99 Latency: 131.76475ms


        DELETE:
        Total Duration: 2.154519541s
        Write Count: 1000
        Throughput: 464.14 writes/sec
        P50 Latency: 105.979917ms
        P90 Latency: 118.18725ms
        P99 Latency: 126.833583ms


        LIST:
        Total Duration: 909.419ms
        Write Count: 100
        Throughput: 109.96 writes/sec
        P50 Latency: 384.768125ms
        P90 Latency: 731.457792ms
        P99 Latency: 823.488042ms

=== RUN   TestIntegrationBenchmarkSQLKVStorageBackend/rvmanager=false
    benchmark.go:238: List benchmark: seeding resources with history...
    benchmark.go:265: List benchmark: seeded 1000 resources x 11 versions in 29.653817208s
    benchmark.go:339: Benchmark Configuration: Workers=50, Resources=1000, Namespaces=1, Groups=1, Resource Types=1, History Versions=10, List Iterations=100
    benchmark.go:340:
    benchmark.go:341: Benchmark Results:
    benchmark.go:342:
        CREATE:
        Total Duration: 646.319917ms
        Write Count: 1000
        Throughput: 1547.22 writes/sec
        P50 Latency: 31.322916ms
        P90 Latency: 40.68475ms
        P99 Latency: 60.467459ms


        UPDATE:
        Total Duration: 607.840333ms
        Write Count: 1000
        Throughput: 1645.17 writes/sec
        P50 Latency: 29.633625ms
        P90 Latency: 40.118791ms
        P99 Latency: 49.42675ms


        DELETE:
        Total Duration: 627.483125ms
        Write Count: 1000
        Throughput: 1593.67 writes/sec
        P50 Latency: 30.811625ms
        P90 Latency: 38.944708ms
        P99 Latency: 49.203792ms


        LIST:
        Total Duration: 1.202399s
        Write Count: 100
        Throughput: 83.17 writes/sec
        P50 Latency: 542.13875ms
        P90 Latency: 700.936542ms
        P99 Latency: 795.989875ms
```
