### PR TITLE
[release-12.3.4] OpenFeature: Remove namespace validation for static provider 

### DIFF
--- a/pkg/registry/apis/ofrep/register.go
+++ b/pkg/registry/apis/ofrep/register.go
@@ -256,16 +256,6 @@ func (b *APIBuilder) oneFlagHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	valid, ns := b.validateNamespace(r)
-	b.logger.Debug("validating namespace in oneFlagHandler handler", "namespace", ns, "valid", valid, "flag", flagKey)
-	if !valid {
-		_ = tracing.Errorf(span, namespaceMismatchMsg)
-		span.SetAttributes(semconv.HTTPStatusCode(http.StatusUnauthorized))
-		b.logger.Error(namespaceMismatchMsg)
-		http.Error(w, namespaceMismatchMsg, http.StatusUnauthorized)
-		return
-	}
-
 	span.SetAttributes(attribute.String("flag_key", flagKey))
 
 	isAuthedReq := b.isAuthenticatedRequest(r)
@@ -280,7 +270,17 @@ func (b *APIBuilder) oneFlagHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if b.providerType == setting.GOFFProviderType {
+	if b.providerType == setting.FeaturesServiceProviderType || b.providerType == setting.OFREPProviderType {
+		valid, ns := b.validateNamespace(r)
+		b.logger.Debug("validating namespace in oneFlagHandler handler", "namespace", ns, "valid", valid, "flag", flagKey)
+		if !valid {
+			_ = tracing.Errorf(span, namespaceMismatchMsg)
+			span.SetAttributes(semconv.HTTPStatusCode(http.StatusUnauthorized))
+			b.logger.Error(namespaceMismatchMsg)
+			http.Error(w, namespaceMismatchMsg, http.StatusUnauthorized)
+			return
+		}
+
 		b.proxyFlagReq(ctx, flagKey, isAuthedReq, w, r)
 		return
 	}
@@ -294,21 +294,21 @@ func (b *APIBuilder) allFlagsHandler(w http.ResponseWriter, r *http.Request) {
 
 	r = r.WithContext(ctx)
 
-	valid, ns := b.validateNamespace(r)
-	b.logger.Debug("validating namespace in allFlagsHandler handler", "namespace", ns, "valid", valid)
-
-	if !valid {
-		_ = tracing.Errorf(span, namespaceMismatchMsg)
-		span.SetAttributes(semconv.HTTPStatusCode(http.StatusUnauthorized))
-		b.logger.Error(namespaceMismatchMsg)
-		http.Error(w, namespaceMismatchMsg, http.StatusUnauthorized)
-		return
-	}
-
 	isAuthedReq := b.isAuthenticatedRequest(r)
 	span.SetAttributes(attribute.Bool("authenticated", isAuthedReq))
 
-	if b.providerType == setting.GOFFProviderType {
+	if b.providerType == setting.FeaturesServiceProviderType || b.providerType == setting.OFREPProviderType {
+		valid, ns := b.validateNamespace(r)
+		b.logger.Debug("validating namespace in allFlagsHandler handler", "namespace", ns, "valid", valid)
+
+		if !valid {
+			_ = tracing.Errorf(span, namespaceMismatchMsg)
+			span.SetAttributes(semconv.HTTPStatusCode(http.StatusUnauthorized))
+			b.logger.Error(namespaceMismatchMsg)
+			http.Error(w, namespaceMismatchMsg, http.StatusUnauthorized)
+			return
+		}
+
 		b.proxyAllFlagReq(ctx, isAuthedReq, w, r)
 		return
 	}
@@ -388,8 +388,8 @@ func (b *APIBuilder) validateNamespace(r *http.Request) (bool, string) {
 	span.SetAttributes(attribute.String("request.body", string(body)))
 
 	evalCtxNamespace := b.namespaceFromEvalCtx(body)
-	// "default" namespace case can only occur in on-prem grafana
-	if (namespace == "default" && evalCtxNamespace == "") || (evalCtxNamespace == namespace) {
+	// Remote providers MUST include namespace in evaluation context
+	if evalCtxNamespace == namespace {
 		span.SetAttributes(attribute.Bool("validation.success", true))
 		return true, evalCtxNamespace
 	}

--- a/pkg/registry/apis/ofrep/register_test.go
+++ b/pkg/registry/apis/ofrep/register_test.go
@@ -1,0 +1,135 @@
+package ofrep
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIBuilder_ValidateNamespace(t *testing.T) {
+	logger := log.NewNopLogger()
+	builder := &APIBuilder{
+		logger: logger,
+	}
+
+	tests := []struct {
+		name              string
+		authNamespace     string // namespace from auth info
+		urlNamespace      string // namespace from URL vars
+		requestBody       string // request body with eval context
+		noAuthInfo        bool   // if true, don't add auth info to context
+		expectedValid     bool
+		expectedNamespace string
+	}{
+		{
+			name:              "matching namespace",
+			authNamespace:     "stacks-1",
+			urlNamespace:      "stacks-1",
+			requestBody:       `{"context":{"namespace":"stacks-1"}}`,
+			expectedValid:     true,
+			expectedNamespace: "stacks-1",
+		},
+		{
+			name:              "matching namespace with other fields",
+			authNamespace:     "stacks-1",
+			urlNamespace:      "stacks-1",
+			requestBody:       `{"context":{"namespace":"stacks-1","cluster":"cluster-1"}}`,
+			expectedValid:     true,
+			expectedNamespace: "stacks-1",
+		},
+		{
+			name:              "mismatched namespace",
+			authNamespace:     "stacks-1",
+			urlNamespace:      "stacks-1",
+			requestBody:       `{"context":{"namespace":"stacks-11111"}}`,
+			expectedValid:     false,
+			expectedNamespace: "stacks-11111",
+		},
+		{
+			name:              "missing namespace in eval context",
+			authNamespace:     "stacks-1",
+			urlNamespace:      "stacks-1",
+			requestBody:       `{"context":{}}`,
+			expectedValid:     false,
+			expectedNamespace: "",
+		},
+		{
+			name:              "empty namespace in eval context",
+			authNamespace:     "stacks-1",
+			urlNamespace:      "stacks-1",
+			requestBody:       `{"context":{"namespace":""}}`,
+			expectedValid:     false,
+			expectedNamespace: "",
+		},
+		{
+			name:              "missing context object",
+			authNamespace:     "stacks-1",
+			urlNamespace:      "stacks-1",
+			requestBody:       `{"field":"value"}`,
+			expectedValid:     false,
+			expectedNamespace: "",
+		},
+		{
+			name:              "auth namespace takes precedence over URL namespace",
+			authNamespace:     "stacks-2",
+			urlNamespace:      "stacks-3",
+			requestBody:       `{"context":{"namespace":"stacks-2"}}`,
+			expectedValid:     true,
+			expectedNamespace: "stacks-2",
+		},
+		{
+			name:              "falls back to URL namespace when auth namespace is empty",
+			urlNamespace:      "stacks-3",
+			requestBody:       `{"context":{"namespace":"stacks-3"}}`,
+			expectedValid:     true,
+			expectedNamespace: "stacks-3",
+		},
+		{
+			name:              "no auth info fails validation",
+			urlNamespace:      "stacks-1",
+			requestBody:       `{"context":{"namespace":"stacks-1"}}`,
+			noAuthInfo:        true,
+			expectedValid:     false,
+			expectedNamespace: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create request with body
+			req := httptest.NewRequest(http.MethodPost, "/ofrep/v1/evaluate/flags/flag1", bytes.NewBufferString(tt.requestBody))
+			req.Header.Set("Content-Type", "application/json")
+			req = mux.SetURLVars(req, map[string]string{"namespace": tt.urlNamespace})
+
+			if !tt.noAuthInfo {
+				requester := &identity.StaticRequester{
+					OrgID:     1,
+					Namespace: tt.authNamespace,
+				}
+				ctx := types.WithAuthInfo(req.Context(), requester)
+				req = req.WithContext(ctx)
+			} else {
+				req = req.WithContext(context.Background())
+			}
+
+			valid, ns := builder.validateNamespace(req)
+			assert.Equal(t, tt.expectedValid, valid, "expected valid namespace")
+			assert.Equal(t, tt.expectedNamespace, ns, "expected namespace to match")
+
+			// Verify body can still be read after validation
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			assert.Equal(t, tt.requestBody, string(body), "request body should be readable after validation")
+		})
+	}
+}

--- a/pkg/setting/setting_openfeature.go
+++ b/pkg/setting/setting_openfeature.go
@@ -6,8 +6,10 @@ import (
 )
 
 const (
-	StaticProviderType = "static"
-	GOFFProviderType   = "goff"
+	StaticProviderType          = "static"
+	GOFFProviderType            = "goff"
+	FeaturesServiceProviderType = "features-service"
+	OFREPProviderType           = "ofrep"
 )
 
 type OpenFeatureSettings struct {


### PR DESCRIPTION
Backport aac8061faaff75f917338a326eaf8c3ce5d38342 from #118184

---

 When switching orgs in on-prem Grafana, feature flag requests were being rejected with 403 errors:
 `feature-flags level=error msg="rejecting request with namespace mismatch"`.

This happened because of namespace validation logic was running for **all provider types**, including the static provider. The static provider is a is just an OFREP compatible wrapper around static configuration (confing.ini flags), so validating namespace is not applicable to it.
