### PR TITLE
chore: replace `config.panels` in render util

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2874,11 +2874,6 @@
       "count": 3
     }
   },
-  "public/app/features/scopes/tests/utils/render.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "public/app/features/search/page/components/columns.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1

--- a/public/app/features/scopes/tests/utils/render.tsx
+++ b/public/app/features/scopes/tests/utils/render.tsx
@@ -3,7 +3,7 @@ import { KBarProvider } from 'kbar';
 import { render } from 'test/test-utils';
 
 import { getPanelPlugin } from '@grafana/data/test';
-import { config, setPluginImportUtils } from '@grafana/runtime';
+import { setPluginImportUtils } from '@grafana/runtime';
 import { sceneGraph } from '@grafana/scenes';
 import { defaultDashboard } from '@grafana/schema';
 import { AppChrome } from 'app/core/components/AppChrome/AppChrome';
@@ -165,8 +165,6 @@ const panelPlugin = getPanelPlugin({
   id: 'table',
   skipDataQuery: true,
 });
-
-config.panels['table'] = panelPlugin.meta;
 
 setPluginImportUtils({
   importPanelPlugin: () => Promise.resolve(panelPlugin),


### PR DESCRIPTION
**What is this feature?**

This pull request makes minor updates to the test utilities for the scopes feature. The main changes involve updating how panel plugin metadata is set and cleaning up ESLint suppressions.

**Why do we need this feature?**

So we can remove `config.panels`

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates #117467

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
