### PR TITLE
Browse Dashboards: Show permissions for provisioned folders with feature flag

### DIFF
--- a/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, userEvent } from 'test/test-utils';
+import { render, screen, testWithFeatureToggles, userEvent } from 'test/test-utils';
 
 import { appEvents } from 'app/core/app_events';
 import { ManagerKind } from 'app/features/apiserver/types';
@@ -198,5 +198,24 @@ describe('browse-dashboards FolderActionsButton', () => {
       <FolderActionsButton folder={{ ...mockFolder, managedBy: ManagerKind.Repo, parentUid: '123' }} isReadOnlyRepo />
     );
     expect(screen.queryByRole('button', { name: 'Folder actions' })).not.toBeInTheDocument();
+  });
+
+  describe('with provisioningFolderMetadata feature flag', () => {
+    testWithFeatureToggles({ enable: ['provisioningFolderMetadata'] });
+
+    it('renders the "Manage permissions" option for provisioned folders', async () => {
+      render(<FolderActionsButton folder={{ ...mockFolder, managedBy: ManagerKind.Repo, parentUid: '123' }} />);
+
+      await userEvent.click(screen.getByRole('button', { name: 'Folder actions' }));
+      expect(screen.getByRole('menuitem', { name: managePermissionsLabel })).toBeInTheDocument();
+    });
+
+    it('renders the "Folder actions" button for provisioned root repo folder when user can view permissions', async () => {
+      render(<FolderActionsButton folder={{ ...mockFolder, managedBy: ManagerKind.Repo, parentUid: undefined }} />);
+
+      expect(screen.getByRole('button', { name: 'Folder actions' })).toBeInTheDocument();
+      await userEvent.click(screen.getByRole('button', { name: 'Folder actions' }));
+      expect(screen.getByRole('menuitem', { name: managePermissionsLabel })).toBeInTheDocument();
+    });
   });
 });

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
@@ -54,8 +54,9 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
   const canMoveFolder = canEditFolders && !isProvisionedRootFolder && !isReadOnlyRepo;
   // Can only delete folders when the folder has the right permission and is not provisioned root folder
   const canDeleteFolders = canDeleteFoldersPermissions && !isProvisionedRootFolder && !isReadOnlyRepo;
-  // Show permissions only if the folder is not provisioned
-  const canShowPermissions = canViewPermissions && !isProvisionedFolder;
+  // Show permissions only if the folder is not provisioned, or if the provisioningFolderMetadata flag is enabled
+  const canShowPermissions =
+    canViewPermissions && (!isProvisionedFolder || !!config.featureToggles.provisioningFolderMetadata);
 
   const onMove = async (destinationUID: string) => {
     await moveFolder({ folderUID: folder.uid, destinationUID: destinationUID });
@@ -148,9 +149,7 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
 
   const menu = (
     <Menu>
-      {canViewPermissions && !isProvisionedFolder && (
-        <MenuItem onClick={() => setShowPermissionsDrawer(true)} label={managePermissionsLabel} />
-      )}
+      {canShowPermissions && <MenuItem onClick={() => setShowPermissionsDrawer(true)} label={managePermissionsLabel} />}
       {showManageOwners && (
         <MenuItem
           onClick={() => {


### PR DESCRIPTION
**What is this feature?**

Remove frontend restrictions on folder permissions for provisioned folders when the `provisioningFolderMetadata` feature flag is enabled. Provisioned folders now show the "Manage permissions" menu item and have the same permissions UI as non-provisioned folders when the flag is on.


**Which issue(s) does this PR fix?**

Fixes https://github.com/grafana/git-ui-sync-project/issues/895

