### PR TITLE
chore: replace `config.panels` in DashboardQueryEditor

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3450,7 +3450,7 @@
   },
   "public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx": {
     "no-restricted-syntax": {
-      "count": 6
+      "count": 4
     }
   },
   "public/app/plugins/datasource/dashboard/runSharedRequest.ts": {


### PR DESCRIPTION
**What is this feature?**

This pull request refactors how panel plugin metadata is accessed in the `DashboardQueryEditor` component and its tests, moving from a static config-based approach to using the `usePanelPluginMetasMap` hook. It also improves error handling and test coverage for plugin metadata loading failures.

**Why do we need this feature?**

So we can remove `config.panels`

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates #117467

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
