### PR TITLE
Provisioning: Show warning icon for folders missing metadata

### DIFF
--- a/public/app/features/provisioning/Repository/ResourceTreeView.tsx
+++ b/public/app/features/provisioning/Repository/ResourceTreeView.tsx
@@ -100,31 +100,28 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
         header: t('provisioning.resource-tree.header-status', 'Status'),
         cell: ({ row: { original } }: TreeCell) => {
           const { status, missingFolderMetadata } = original.item;
-          const showWarning = config.featureToggles.provisioningFolderMetadata && missingFolderMetadata;
-          if (!status && !showWarning) {
+          if (config.featureToggles.provisioningFolderMetadata && missingFolderMetadata) {
+            return (
+              <Tooltip
+                content={t('provisioning.resource-tree.missing-folder-metadata', 'Missing folder metadata file')}
+              >
+                <Icon name="exclamation-triangle" className={styles.warningIcon} />
+              </Tooltip>
+            );
+          }
+          if (!status) {
             return null;
           }
           return (
-            <Stack direction="row" gap={1} alignItems="center">
-              {status && (
-                <Icon
-                  name={status === 'synced' ? 'check-circle' : 'sync'}
-                  className={status === 'synced' ? styles.syncedIcon : undefined}
-                  title={
-                    status === 'synced'
-                      ? t('provisioning.resource-tree.status-synced', 'Synced')
-                      : t('provisioning.resource-tree.status-pending', 'Pending')
-                  }
-                />
-              )}
-              {showWarning && (
-                <Tooltip
-                  content={t('provisioning.resource-tree.missing-folder-metadata', 'Missing folder metadata file')}
-                >
-                  <Icon name="exclamation-triangle" className={styles.warningIcon} />
-                </Tooltip>
-              )}
-            </Stack>
+            <Icon
+              name={status === 'synced' ? 'check-circle' : 'sync'}
+              className={status === 'synced' ? styles.syncedIcon : undefined}
+              title={
+                status === 'synced'
+                  ? t('provisioning.resource-tree.status-synced', 'Synced')
+                  : t('provisioning.resource-tree.status-pending', 'Pending')
+              }
+            />
           );
         },
       },

--- a/public/app/features/provisioning/Repository/ResourceTreeView.tsx
+++ b/public/app/features/provisioning/Repository/ResourceTreeView.tsx
@@ -105,7 +105,11 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
               <Tooltip
                 content={t('provisioning.resource-tree.missing-folder-metadata', 'Missing folder metadata file')}
               >
-                <Icon name="exclamation-triangle" className={styles.warningIcon} />
+                <Icon
+                  name="exclamation-triangle"
+                  className={styles.warningIcon}
+                  aria-label={t('provisioning.resource-tree.missing-folder-metadata', 'Missing folder metadata file')}
+                />
               </Tooltip>
             );
           }

--- a/public/app/features/provisioning/Repository/ResourceTreeView.tsx
+++ b/public/app/features/provisioning/Repository/ResourceTreeView.tsx
@@ -14,6 +14,7 @@ import {
   LinkButton,
   Spinner,
   Stack,
+  Tooltip,
   useStyles2,
 } from '@grafana/ui';
 import {
@@ -101,11 +102,11 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
           const { status, missingFolderMetadata } = original.item;
           if (config.featureToggles.provisioningFolderMetadata && missingFolderMetadata) {
             return (
-              <Icon
-                name="exclamation-triangle"
-                className={styles.warningIcon}
-                title={t('provisioning.resource-tree.missing-folder-metadata', 'Missing folder metadata file')}
-              />
+              <Tooltip
+                content={t('provisioning.resource-tree.missing-folder-metadata', 'Missing folder metadata file')}
+              >
+                <Icon name="exclamation-triangle" className={styles.warningIcon} />
+              </Tooltip>
             );
           }
           if (!status) {

--- a/public/app/features/provisioning/Repository/ResourceTreeView.tsx
+++ b/public/app/features/provisioning/Repository/ResourceTreeView.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import {
   CellProps,
   Column,
@@ -97,7 +98,16 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
         id: 'status',
         header: t('provisioning.resource-tree.header-status', 'Status'),
         cell: ({ row: { original } }: TreeCell) => {
-          const { status } = original.item;
+          const { status, missingFolderMetadata } = original.item;
+          if (config.featureToggles.provisioningFolderMetadata && missingFolderMetadata) {
+            return (
+              <Icon
+                name="exclamation-triangle"
+                className={styles.warningIcon}
+                title={t('provisioning.resource-tree.missing-folder-metadata', 'Missing folder metadata file')}
+              />
+            );
+          }
           if (!status) {
             return null;
           }
@@ -222,5 +232,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   syncedIcon: css({
     color: theme.colors.success.text,
+  }),
+  warningIcon: css({
+    color: theme.colors.warning.text,
   }),
 });

--- a/public/app/features/provisioning/Repository/ResourceTreeView.tsx
+++ b/public/app/features/provisioning/Repository/ResourceTreeView.tsx
@@ -100,28 +100,31 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
         header: t('provisioning.resource-tree.header-status', 'Status'),
         cell: ({ row: { original } }: TreeCell) => {
           const { status, missingFolderMetadata } = original.item;
-          if (config.featureToggles.provisioningFolderMetadata && missingFolderMetadata) {
-            return (
-              <Tooltip
-                content={t('provisioning.resource-tree.missing-folder-metadata', 'Missing folder metadata file')}
-              >
-                <Icon name="exclamation-triangle" className={styles.warningIcon} />
-              </Tooltip>
-            );
-          }
-          if (!status) {
+          const showWarning = config.featureToggles.provisioningFolderMetadata && missingFolderMetadata;
+          if (!status && !showWarning) {
             return null;
           }
           return (
-            <Icon
-              name={status === 'synced' ? 'check-circle' : 'sync'}
-              className={status === 'synced' ? styles.syncedIcon : undefined}
-              title={
-                status === 'synced'
-                  ? t('provisioning.resource-tree.status-synced', 'Synced')
-                  : t('provisioning.resource-tree.status-pending', 'Pending')
-              }
-            />
+            <Stack direction="row" gap={1} alignItems="center">
+              {status && (
+                <Icon
+                  name={status === 'synced' ? 'check-circle' : 'sync'}
+                  className={status === 'synced' ? styles.syncedIcon : undefined}
+                  title={
+                    status === 'synced'
+                      ? t('provisioning.resource-tree.status-synced', 'Synced')
+                      : t('provisioning.resource-tree.status-pending', 'Pending')
+                  }
+                />
+              )}
+              {showWarning && (
+                <Tooltip
+                  content={t('provisioning.resource-tree.missing-folder-metadata', 'Missing folder metadata file')}
+                >
+                  <Icon name="exclamation-triangle" className={styles.warningIcon} />
+                </Tooltip>
+              )}
+            </Stack>
           );
         },
       },

--- a/public/app/features/provisioning/constants.ts
+++ b/public/app/features/provisioning/constants.ts
@@ -11,3 +11,5 @@ export const DEFAULT_REPOSITORY_TYPES: Array<'github' | 'local'> = ['github', 'l
 export const FREE_TIER_CONNECTION_LIMIT = 1;
 
 export const DEFAULT_BRANCH_NAMES = ['main', 'master'] as const;
+
+export const FOLDER_METADATA_FILE = '_folder.json';

--- a/public/app/features/provisioning/types.ts
+++ b/public/app/features/provisioning/types.ts
@@ -97,6 +97,7 @@ export interface TreeItem {
   hash?: string;
   status?: SyncStatus;
   hasFile?: boolean;
+  missingFolderMetadata?: boolean;
 }
 
 export interface FlatTreeItem {

--- a/public/app/features/provisioning/utils/treeUtils.ts
+++ b/public/app/features/provisioning/utils/treeUtils.ts
@@ -1,6 +1,7 @@
 import { IconName } from '@grafana/ui';
 import { ResourceListItem } from 'app/api/clients/provisioning/v0alpha1';
 
+import { FOLDER_METADATA_FILE } from '../constants';
 import { FileDetails, FlatTreeItem, ItemType, SyncStatus, TreeItem } from '../types';
 
 const collator = new Intl.Collator();
@@ -132,6 +133,14 @@ export function buildTree(mergedItems: MergedItem[]): TreeItem[] {
       status: showStatus ? getStatus(item.file?.hash, item.resource?.hash) : undefined,
       hasFile: !!item.file,
     });
+  }
+
+  // Detect provisioned folders missing _folder.json metadata
+  for (const [path, node] of nodeMap) {
+    if (node.type === 'Folder' && node.resourceName) {
+      const metadataPath = path ? `${path}/${FOLDER_METADATA_FILE}` : FOLDER_METADATA_FILE;
+      node.missingFolderMetadata = !nodeMap.has(metadataPath);
+    }
   }
 
   // Build parent-child relationships

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12902,6 +12902,7 @@
       "header-status": "Status",
       "header-title": "Title",
       "header-type": "Type",
+      "missing-folder-metadata": "Missing folder metadata file",
       "search-placeholder": "Search by path or title",
       "source": "Source",
       "status-pending": "Pending",


### PR DESCRIPTION
**What is this feature?**

Displays a warning icon in the Resources tab for provisioned folders that are missing `_folder.json` metadata files, providing at-a-glance visibility of which folders need attention.

**Why do we need this feature?**

Users need a clear indication when provisioned folders lack metadata files, so they can quickly identify which folders require remediation.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/894

<img width="1085" height="377" alt="Screenshot 2026-02-24 at 14 59 24" src="https://github.com/user-attachments/assets/59118c43-63f9-475e-b954-136c535f0a07" />
