### PR TITLE
Data: Add LoadingState.PartialResult for partially loading queries

### DIFF
--- a/.changelog/118659.md
+++ b/.changelog/118659.md
@@ -1,0 +1,20 @@
+---
+kind: feature
+body: 'LoadingState: Add PartialResult state for partially loading queries'
+---
+
+Add `LoadingState.PartialResult` to support data sources that load partial results.
+
+This new state behaves functionally the same as `LoadingState.Streaming`, with the key difference that it is expected to receive a `LoadingState.Done` before being considered complete. This prevents issues where streaming data sources are incorrectly marked as "done" too early, particularly in reporting contexts.
+
+**For data source developers:**
+
+- Use `LoadingState.PartialResult` when returning partial query results that will be followed by more data
+- Always send `LoadingState.Done` when all results have been loaded
+- This is especially useful for query splitting strategies (e.g., `lokiQuerySplitting`)
+
+**Breaking changes:**
+
+- None. This is an additive change marked as `@alpha`
+
+**Note:** The corresponding Go SDK will need to be updated in `grafana-plugin-sdk-go/data/frame_meta.go` to maintain compatibility.

--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -15,6 +15,8 @@ export enum LoadingState {
   NotStarted = 'NotStarted',
   Loading = 'Loading',
   Streaming = 'Streaming',
+  /** @alpha - Indicates partial results are being loaded, expects LoadingState.Done when complete */
+  PartialResult = 'PartialResult',
   Done = 'Done',
   Error = 'Error',
 }

--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -15,10 +15,34 @@ export enum LoadingState {
   NotStarted = 'NotStarted',
   Loading = 'Loading',
   Streaming = 'Streaming',
-  /** @alpha - Indicates partial results are being loaded, expects LoadingState.Done when complete */
+  /**
+   * @alpha
+   * Indicates partial results are being loaded.
+   * Unlike Streaming, PartialResult expects LoadingState.Done when all data is loaded.
+   * Use this for query splitting or partial data loading scenarios where you need
+   * to signal completion explicitly (e.g., lokiQuerySplitting).
+   */
   PartialResult = 'PartialResult',
   Done = 'Done',
   Error = 'Error',
+}
+
+/**
+ * Helper to check if a loading state represents an in-progress query.
+ * Returns true for Loading, Streaming, or PartialResult states.
+ * @alpha
+ */
+export function isLoadingStateInProgress(state: LoadingState): boolean {
+  return state === LoadingState.Loading || state === LoadingState.Streaming || state === LoadingState.PartialResult;
+}
+
+/**
+ * Helper to check if a loading state represents a completed query.
+ * Returns true for Done or Error states.
+ * @alpha
+ */
+export function isLoadingStateComplete(state: LoadingState): boolean {
+  return state === LoadingState.Done || state === LoadingState.Error;
 }
 
 // Should be kept in sync with grafana-plugin-sdk-go/data/frame_meta.go

--- a/packages/grafana-data/src/types/loadingState.test.ts
+++ b/packages/grafana-data/src/types/loadingState.test.ts
@@ -1,0 +1,130 @@
+import { LoadingState, isLoadingStateInProgress, isLoadingStateComplete } from './data';
+
+describe('LoadingState', () => {
+  it('has all defined values', () => {
+    expect(LoadingState.NotStarted).toBe('NotStarted');
+    expect(LoadingState.Loading).toBe('Loading');
+    expect(LoadingState.Streaming).toBe('Streaming');
+    expect(LoadingState.PartialResult).toBe('PartialResult');
+    expect(LoadingState.Done).toBe('Done');
+    expect(LoadingState.Error).toBe('Error');
+  });
+
+  it('should have PartialResult as a valid state', () => {
+    const states = Object.values(LoadingState);
+    expect(states).toContain('PartialResult');
+    expect(states).toHaveLength(6);
+  });
+
+  describe('state semantics', () => {
+    it('should treat PartialResult as in-progress (not done)', () => {
+      const inProgressStates = [LoadingState.Loading, LoadingState.Streaming, LoadingState.PartialResult];
+      const doneStates = [LoadingState.Done, LoadingState.Error];
+
+      // PartialResult should be treated like Loading/Streaming
+      expect(inProgressStates).toContain(LoadingState.PartialResult);
+      expect(doneStates).not.toContain(LoadingState.PartialResult);
+    });
+
+    it('should distinguish PartialResult from Streaming', () => {
+      // Both are in-progress states but serve different purposes
+      expect(LoadingState.PartialResult).not.toBe(LoadingState.Streaming);
+
+      // PartialResult: expects LoadingState.Done when complete
+      // Streaming: may never send Done (continuous stream)
+    });
+  });
+
+  describe('usage patterns', () => {
+    it('should handle partial result workflow', () => {
+      // Simulates query splitting or partial loading
+      const states: LoadingState[] = [];
+
+      // Start loading
+      states.push(LoadingState.Loading);
+
+      // Receive first partial result
+      states.push(LoadingState.PartialResult);
+
+      // Receive more partial results
+      states.push(LoadingState.PartialResult);
+
+      // All results received
+      states.push(LoadingState.Done);
+
+      expect(states).toHaveLength(4);
+      expect(states[states.length - 1]).toBe(LoadingState.Done);
+    });
+
+    it('should distinguish from streaming workflow', () => {
+      // Streaming may never send Done
+      const streamingStates: LoadingState[] = [];
+
+      streamingStates.push(LoadingState.Loading);
+      streamingStates.push(LoadingState.Streaming);
+      // ... continuous stream, no Done
+
+      // PartialResult must end with Done
+      const partialStates: LoadingState[] = [];
+
+      partialStates.push(LoadingState.Loading);
+      partialStates.push(LoadingState.PartialResult);
+      partialStates.push(LoadingState.Done);
+
+      expect(streamingStates).not.toContain(LoadingState.Done);
+      expect(partialStates).toContain(LoadingState.Done);
+    });
+  });
+});
+
+describe('isLoadingStateInProgress', () => {
+  it('should return true for Loading state', () => {
+    expect(isLoadingStateInProgress(LoadingState.Loading)).toBe(true);
+  });
+
+  it('should return true for Streaming state', () => {
+    expect(isLoadingStateInProgress(LoadingState.Streaming)).toBe(true);
+  });
+
+  it('should return true for PartialResult state', () => {
+    expect(isLoadingStateInProgress(LoadingState.PartialResult)).toBe(true);
+  });
+
+  it('should return false for NotStarted state', () => {
+    expect(isLoadingStateInProgress(LoadingState.NotStarted)).toBe(false);
+  });
+
+  it('should return false for Done state', () => {
+    expect(isLoadingStateInProgress(LoadingState.Done)).toBe(false);
+  });
+
+  it('should return false for Error state', () => {
+    expect(isLoadingStateInProgress(LoadingState.Error)).toBe(false);
+  });
+});
+
+describe('isLoadingStateComplete', () => {
+  it('should return true for Done state', () => {
+    expect(isLoadingStateComplete(LoadingState.Done)).toBe(true);
+  });
+
+  it('should return true for Error state', () => {
+    expect(isLoadingStateComplete(LoadingState.Error)).toBe(true);
+  });
+
+  it('should return false for NotStarted state', () => {
+    expect(isLoadingStateComplete(LoadingState.NotStarted)).toBe(false);
+  });
+
+  it('should return false for Loading state', () => {
+    expect(isLoadingStateComplete(LoadingState.Loading)).toBe(false);
+  });
+
+  it('should return false for Streaming state', () => {
+    expect(isLoadingStateComplete(LoadingState.Streaming)).toBe(false);
+  });
+
+  it('should return false for PartialResult state', () => {
+    expect(isLoadingStateComplete(LoadingState.PartialResult)).toBe(false);
+  });
+});

--- a/packages/grafana-schema/src/veneer/common.types.ts
+++ b/packages/grafana-schema/src/veneer/common.types.ts
@@ -57,6 +57,8 @@ export enum LoadingState {
   NotStarted = 'NotStarted',
   Loading = 'Loading',
   Streaming = 'Streaming',
+  /** @alpha - Indicates partial results are being loaded, expects LoadingState.Done when complete */
+  PartialResult = 'PartialResult',
   Done = 'Done',
   Error = 'Error',
 }

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -17,6 +17,7 @@ import {
   DataTransformContext,
   DataTransformerConfig,
   getDefaultTimeRange,
+  isLoadingStateInProgress,
   LoadingState,
   PanelData,
   rangeUtil,
@@ -434,13 +435,8 @@ export class PanelQueryRunner {
 
     this.subscription.unsubscribe();
 
-    // If we have an old result with loading or streaming state, send it with done state
-    if (
-      this.lastResult &&
-      (this.lastResult.state === LoadingState.Loading ||
-        this.lastResult.state === LoadingState.Streaming ||
-        this.lastResult.state === LoadingState.PartialResult)
-    ) {
+    // If we have an old result with in-progress state, send it with done state
+    if (this.lastResult && isLoadingStateInProgress(this.lastResult.state)) {
       this.subject.next({
         ...this.lastResult,
         state: LoadingState.Done,

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -437,7 +437,9 @@ export class PanelQueryRunner {
     // If we have an old result with loading or streaming state, send it with done state
     if (
       this.lastResult &&
-      (this.lastResult.state === LoadingState.Loading || this.lastResult.state === LoadingState.Streaming)
+      (this.lastResult.state === LoadingState.Loading ||
+        this.lastResult.state === LoadingState.Streaming ||
+        this.lastResult.state === LoadingState.PartialResult)
     ) {
       this.subject.next({
         ...this.lastResult,


### PR DESCRIPTION
## Summary

Adds `LoadingState.PartialResult` enum value to support data sources that load partial results over time.

## Problem

Currently, `lokiQuerySplitting` and similar strategies use `LoadingState.Streaming`, which causes issues with reporting and other systems. Streaming data sources are marked as "done" as soon as the stream is set up, causing dashboards and queries to be considered complete prematurely.

## Solution

- Add new `LoadingState.PartialResult` state (marked `@alpha`)
- Behaves functionally like `Streaming`, but explicitly expects `LoadingState.Done` before being considered complete
- Update `PanelQueryRunner` to treat `PartialResult` as an in-progress state (like `Loading` and `Streaming`)

## Changes

- `packages/grafana-data/src/types/data.ts`: Add PartialResult to enum
- `packages/grafana-schema/src/veneer/common.types.ts`: Add PartialResult to deprecated enum (for consistency)
- `public/app/features/query/state/PanelQueryRunner.ts`: Include PartialResult in in-progress state checks
- `.changelog/118659.md`: Changelog entry with guidance for data source developers

## Testing

- [ ] Manual testing with Loki query splitting
- [ ] Verify reporting waits for PartialResult → Done transition
- [ ] Confirm no regression with existing Streaming behavior

## Notes

- This is an additive change with no breaking changes
- The Go SDK will need a corresponding update in `grafana-plugin-sdk-go/data/frame_meta.go`
- Data source developers should use `PartialResult` for query splitting and similar partial loading strategies

Fixes #118659

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)