### PR TITLE
Alerting: Improve historian performance for receiver matching queries.

### DIFF
--- a/apps/alerting/historian/pkg/app/notification/lokireader.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader.go
@@ -122,9 +122,12 @@ func buildQuery(query Query) (string, error) {
 
 	logql := fmt.Sprintf(`{%s}`, strings.Join(selectors, `,`))
 
-	// Searching for ruleUID before JSON parsing can dramatically improve performance.
+	// Searching for ruleUID and receiver before JSON parsing can dramatically improve performance.
 	if query.RuleUID != nil && *query.RuleUID != "" {
 		logql += fmt.Sprintf(` |= %q`, *query.RuleUID)
+	}
+	if query.Receiver != nil && *query.Receiver != "" {
+		logql += fmt.Sprintf(` |= %q`, *query.Receiver)
 	}
 
 	logql += ` | json`

--- a/apps/alerting/historian/pkg/app/notification/lokireader_test.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader_test.go
@@ -139,12 +139,20 @@ func TestBuildQuery(t *testing.T) {
 				historian.LabelFrom, historian.LabelFromValue),
 		},
 		{
+			name: "query with receiver filter only",
+			query: Query{
+				Receiver: stringPtr("email-receiver"),
+			},
+			expected: fmt.Sprintf(`{%s=%q} |= "email-receiver" | json | receiver = "email-receiver"`,
+				historian.LabelFrom, historian.LabelFromValue),
+		},
+		{
 			name: "query with receiver filter",
 			query: Query{
 				RuleUID:  stringPtr("test-rule-uid"),
 				Receiver: stringPtr("email-receiver"),
 			},
-			expected: fmt.Sprintf(`{%s=%q} |= "test-rule-uid" | json | alert_labels___alert_rule_uid__ = "test-rule-uid" | receiver = "email-receiver"`,
+			expected: fmt.Sprintf(`{%s=%q} |= "test-rule-uid" |= "email-receiver" | json | alert_labels___alert_rule_uid__ = "test-rule-uid" | receiver = "email-receiver"`,
 				historian.LabelFrom, historian.LabelFromValue),
 		},
 		{
@@ -182,7 +190,7 @@ func TestBuildQuery(t *testing.T) {
 				Status:   createStatusPtr(v0alpha1.CreateNotificationqueryRequestNotificationStatusResolved),
 				Outcome:  outcomePtr(v0alpha1.CreateNotificationqueryRequestNotificationOutcomeSuccess),
 			},
-			expected: fmt.Sprintf(`{%s=%q} |= "test-rule-uid" | json | alert_labels___alert_rule_uid__ = "test-rule-uid" | receiver = "email-receiver" | status = "resolved" | error = ""`,
+			expected: fmt.Sprintf(`{%s=%q} |= "test-rule-uid" |= "email-receiver" | json | alert_labels___alert_rule_uid__ = "test-rule-uid" | receiver = "email-receiver" | status = "resolved" | error = ""`,
 				historian.LabelFrom, historian.LabelFromValue),
 		},
 		{


### PR DESCRIPTION
Filtering for the receiver name text reduces the amount of JSON parsing needed.
