### PR TITLE
Alerting: Simplify managed routes UI when there is only one routing tree

### DIFF
--- a/public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx
+++ b/public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx
@@ -602,6 +602,10 @@ describe('alertingMultiplePolicies Feature Flag', () => {
     config.featureToggles.alertingMultiplePolicies = originalFeatureToggle;
   });
 
+  afterEach(() => {
+    resetRoutingTreeMap();
+  });
+
   beforeAll(() => {
     setupDataSources(...Object.values(dataSources));
     grantUserPermissions([AccessControlAction.AlertingNotificationsExternalRead, ...PERMISSIONS_NOTIFICATION_POLICIES]);
@@ -638,6 +642,22 @@ describe('alertingMultiplePolicies Feature Flag', () => {
     await getRootRoute();
 
     expect(uiMultiRoute.policyFilter.query()).not.toBeInTheDocument();
+  });
+
+  it('Should render tree inline with create button when there is only one policy tree', async () => {
+    config.featureToggles.alertingMultiplePolicies = true;
+
+    resetRoutingTreeMap();
+    deleteRoutingTree('Managed Policy - Empty Provisioned');
+    deleteRoutingTree('Managed Policy - Override + Inherit');
+    deleteRoutingTree('Managed Policy - Many Top-Level');
+    deleteRoutingTree('Managed Policy - Deeply Nested');
+
+    renderNotificationPolicies();
+
+    await getRootRoute();
+    expect(uiMultiRoute.policyFilter.query()).not.toBeInTheDocument();
+    expect(screen.getByTestId('create-policy-button')).toBeInTheDocument();
   });
 });
 

--- a/public/app/features/alerting/unified/NotificationPoliciesPage.tsx
+++ b/public/app/features/alerting/unified/NotificationPoliciesPage.tsx
@@ -1,14 +1,19 @@
 import { css } from '@emotion/css';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { GrafanaTheme2, UrlQueryMap } from '@grafana/data';
-import { t } from '@grafana/i18n';
+import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import { Tab, TabContent, TabsBar, useStyles2 } from '@grafana/ui';
+import { Button, LoadingPlaceholder, Stack, Tab, TabContent, TabsBar, useStyles2 } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { useMuteTimings } from 'app/features/alerting/unified/components/mute-timings/useMuteTimings';
 import { PoliciesList } from 'app/features/alerting/unified/components/notification-policies/PoliciesList';
 import { PoliciesTree } from 'app/features/alerting/unified/components/notification-policies/PoliciesTree';
+import { CreateModal } from 'app/features/alerting/unified/components/notification-policies/components/Modals';
+import {
+  useCreateRoutingTree,
+  useListNotificationPolicyRoutes,
+} from 'app/features/alerting/unified/components/notification-policies/useNotificationPolicyRoute';
 import { AlertmanagerAction, useAlertmanagerAbility } from 'app/features/alerting/unified/hooks/useAbilities';
 
 import { AlertmanagerPageWrapper } from './components/AlertingPageWrapper';
@@ -106,13 +111,73 @@ const PolicyTreeTab = () => {
 
   const useMultiplePoliciesView = config.featureToggles.alertingMultiplePolicies;
 
-  // Render just the single main tree if not Grafana Alertmanager or the multiple policies view is disabled.
   if (!isGrafanaAlertmanager || !useMultiplePoliciesView) {
     return <PoliciesTree />;
   }
 
-  return <PoliciesList />;
+  return <MultiplePoliciesView />;
 };
+
+/**
+ * When multiple policies are enabled, decide whether to show the full list
+ * or the single-tree view with a "New notification policy" button.
+ */
+function MultiplePoliciesView() {
+  const { currentData: allPolicies, isLoading } = useListNotificationPolicyRoutes();
+
+  if (isLoading) {
+    return <LoadingPlaceholder text={t('alerting.policies-list.text-loading', 'Loading....')} />;
+  }
+
+  if (!allPolicies || allPolicies.length > 1) {
+    return <PoliciesList />;
+  }
+
+  return <SinglePolicyView allPolicies={allPolicies} />;
+}
+
+/**
+ * Shows the default policy tree inline with a button to create additional policy trees.
+ * Used when there's only one routing tree so users don't have to click through a list.
+ */
+function SinglePolicyView({ allPolicies }: { allPolicies: Array<{ name?: string }> }) {
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [createPoliciesSupported, createPoliciesAllowed] = useAlertmanagerAbility(
+    AlertmanagerAction.CreateNotificationPolicy
+  );
+  const [createTrigger] = useCreateRoutingTree();
+
+  const existingPolicyNames = useMemo(
+    () => allPolicies.map((p) => p.name).filter((name): name is string => name !== undefined),
+    [allPolicies]
+  );
+
+  return (
+    <Stack direction="column" gap={2}>
+      {createPoliciesSupported && (
+        <Stack direction="row" justifyContent="flex-end">
+          <Button
+            data-testid="create-policy-button"
+            icon="plus"
+            aria-label={t('alerting.policies-list.create.aria-label', 'add policy')}
+            variant="primary"
+            disabled={!createPoliciesAllowed}
+            onClick={() => setIsCreateModalOpen(true)}
+          >
+            <Trans i18nKey="alerting.policies-list.create.text">New notification policy</Trans>
+          </Button>
+        </Stack>
+      )}
+      <PoliciesTree />
+      <CreateModal
+        existingPolicyNames={existingPolicyNames}
+        isOpen={isCreateModalOpen}
+        onConfirm={(route) => createTrigger.execute(route)}
+        onDismiss={() => setIsCreateModalOpen(false)}
+      />
+    </Stack>
+  );
+}
 
 const getStyles = (theme: GrafanaTheme2) => ({
   tabContent: css({

--- a/public/app/features/alerting/unified/NotificationPoliciesPage.tsx
+++ b/public/app/features/alerting/unified/NotificationPoliciesPage.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { GrafanaTheme2, UrlQueryMap } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -11,10 +11,11 @@ import { PoliciesList } from 'app/features/alerting/unified/components/notificat
 import { PoliciesTree } from 'app/features/alerting/unified/components/notification-policies/PoliciesTree';
 import { CreateModal } from 'app/features/alerting/unified/components/notification-policies/components/Modals';
 import {
-  useCreateRoutingTree,
+  useCreatePolicyAction,
   useListNotificationPolicyRoutes,
 } from 'app/features/alerting/unified/components/notification-policies/useNotificationPolicyRoute';
 import { AlertmanagerAction, useAlertmanagerAbility } from 'app/features/alerting/unified/hooks/useAbilities';
+import { Route } from 'app/plugins/datasource/alertmanager/types';
 
 import { AlertmanagerPageWrapper } from './components/AlertingPageWrapper';
 import { GrafanaAlertmanagerWarning } from './components/GrafanaAlertmanagerWarning';
@@ -129,6 +130,7 @@ function MultiplePoliciesView() {
     return <LoadingPlaceholder text={t('alerting.policies-list.text-loading', 'Loading....')} />;
   }
 
+  // allPolicies is undefined on error — PoliciesList handles error UI
   if (!allPolicies || allPolicies.length > 1) {
     return <PoliciesList />;
   }
@@ -140,17 +142,16 @@ function MultiplePoliciesView() {
  * Shows the default policy tree inline with a button to create additional policy trees.
  * Used when there's only one routing tree so users don't have to click through a list.
  */
-function SinglePolicyView({ allPolicies }: { allPolicies: Array<{ name?: string }> }) {
-  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
-  const [createPoliciesSupported, createPoliciesAllowed] = useAlertmanagerAbility(
-    AlertmanagerAction.CreateNotificationPolicy
-  );
-  const [createTrigger] = useCreateRoutingTree();
-
-  const existingPolicyNames = useMemo(
-    () => allPolicies.map((p) => p.name).filter((name): name is string => name !== undefined),
-    [allPolicies]
-  );
+function SinglePolicyView({ allPolicies }: { allPolicies: Route[] }) {
+  const {
+    isCreateModalOpen,
+    openCreateModal,
+    closeCreateModal,
+    createPoliciesSupported,
+    createPoliciesAllowed,
+    createTrigger,
+    existingPolicyNames,
+  } = useCreatePolicyAction(allPolicies);
 
   return (
     <Stack direction="column" gap={2}>
@@ -162,7 +163,7 @@ function SinglePolicyView({ allPolicies }: { allPolicies: Array<{ name?: string 
             aria-label={t('alerting.policies-list.create.aria-label', 'add policy')}
             variant="primary"
             disabled={!createPoliciesAllowed}
-            onClick={() => setIsCreateModalOpen(true)}
+            onClick={openCreateModal}
           >
             <Trans i18nKey="alerting.policies-list.create.text">New notification policy</Trans>
           </Button>
@@ -173,7 +174,7 @@ function SinglePolicyView({ allPolicies }: { allPolicies: Array<{ name?: string 
         existingPolicyNames={existingPolicyNames}
         isOpen={isCreateModalOpen}
         onConfirm={(route) => createTrigger.execute(route)}
-        onDismiss={() => setIsCreateModalOpen(false)}
+        onDismiss={closeCreateModal}
       />
     </Stack>
   );

--- a/public/app/features/alerting/unified/components/notification-policies/PoliciesList.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/PoliciesList.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/css';
-import { useMemo, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -26,7 +25,7 @@ import { RoutingTreeFilter } from './components/RoutingTreeFilter';
 import { TIMING_OPTIONS_DEFAULTS } from './timingOptions';
 import {
   isRouteProvisioned,
-  useCreateRoutingTree,
+  useCreatePolicyAction,
   useListNotificationPolicyRoutes,
   useRootRouteSearch,
 } from './useNotificationPolicyRoute';
@@ -34,21 +33,18 @@ import {
 const DEFAULT_PAGE_SIZE = 10;
 
 export const PoliciesList = () => {
-  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [queryParams] = useURLSearchParams();
-
-  const [createPoliciesSupported, createPoliciesAllowed] = useAlertmanagerAbility(
-    AlertmanagerAction.CreateNotificationPolicy
-  );
-
   const { currentData: allPolicies, isLoading, error: fetchPoliciesError } = useListNotificationPolicyRoutes();
 
-  const existingPolicyNames = useMemo(
-    () => (allPolicies ?? []).map((p) => p.name).filter((name): name is string => name !== undefined),
-    [allPolicies]
-  );
-
-  const [createTrigger] = useCreateRoutingTree();
+  const {
+    isCreateModalOpen,
+    openCreateModal,
+    closeCreateModal,
+    createPoliciesSupported,
+    createPoliciesAllowed,
+    createTrigger,
+    existingPolicyNames,
+  } = useCreatePolicyAction(allPolicies);
 
   const search = queryParams.get('search');
 
@@ -78,7 +74,7 @@ export const PoliciesList = () => {
               aria-label={t('alerting.policies-list.create.aria-label', 'add policy')}
               variant="primary"
               disabled={!createPoliciesAllowed}
-              onClick={() => setIsCreateModalOpen(true)}
+              onClick={openCreateModal}
             >
               <Trans i18nKey="alerting.policies-list.create.text">New notification policy</Trans>
             </Button>
@@ -101,7 +97,7 @@ export const PoliciesList = () => {
         existingPolicyNames={existingPolicyNames}
         isOpen={isCreateModalOpen}
         onConfirm={(route) => createTrigger.execute(route)}
-        onDismiss={() => setIsCreateModalOpen(false)}
+        onDismiss={closeCreateModal}
       />
     </Stack>
   );


### PR DESCRIPTION
**What is this feature?**
## Summary

When the `alertingMultiplePolicies` feature flag is enabled but the user only has a single routing tree, the full `PoliciesList` table view is unnecessary. This change renders the policy tree inline with a "New notification policy" button instead, reducing friction for the most common case.

Once a second routing tree is created, the UI automatically switches to the full list view.

## Changes

- Introduced `MultiplePoliciesView` component that checks the number of routing trees and renders either the inline tree (`SinglePolicyView`) or the full list (`PoliciesList`)
- `SinglePolicyView` displays the default policy tree directly alongside a create button and modal for adding new notification policies
- Falls back to `PoliciesList` when data is unavailable (e.g. API error), since `PoliciesList` has its own error handling UI
- Extracted `useCreatePolicyAction` hook to share create-policy logic (modal state, RBAC checks, create mutation, policy-name dedup) between `PoliciesList` and `SinglePolicyView`
- Added test coverage for the single-policy-tree scenario
- Improved test cleanup by moving `resetRoutingTreeMap()` to `afterEach` to prevent stale state if a test fails mid-execution

## Test plan
- [ ] Enable `alertingMultiplePolicies` feature flag
- [ ] With a single routing tree: verify the tree renders inline with a "New notification policy" button (no list/table UI)
- [ ] Click "New notification policy" and create a second tree — verify the UI switches to the full list view
- [ ] With multiple routing trees: verify the `PoliciesList` table renders as before
- [ ] Disable the feature flag: verify the single `PoliciesTree` renders without any list or create button
- [ ] Run `yarn test public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx

**Why do we need this feature?**

Simplify experience for users not having more than one policy tree

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:


Fixes https://github.com/grafana/alerting-squad/issues/1434

**Special notes for your reviewer:**


https://github.com/user-attachments/assets/6e124aac-e784-40cb-a356-70c2df20ab3b



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
