### PR TITLE
Postgres: Introduce auto migration for quotes variables in repeated panels

### DIFF
--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -99,10 +99,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
    * Called at the end of interpolateVariable with the already-interpolated result.
    * Override in subclasses to handle cases like repeated panel quote stripping.
    */
-  protected migrateInterpolatedVariable(
-    result: string | number,
-    _variable: VariableWithMultiSupport
-  ): string | number {
+  protected migrateInterpolatedVariable(result: string | number, _variable: VariableWithMultiSupport): string | number {
     return result;
   }
 

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -75,25 +75,36 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
   }
 
   interpolateVariable = (value: string | string[] | number, variable: VariableWithMultiSupport) => {
+    let result: string | number;
+
     if (typeof value === 'string') {
       if (variable.multi || variable.includeAll) {
-        return this.getQueryModel().quoteLiteral(value);
+        result = this.getQueryModel().quoteLiteral(value);
       } else {
-        return String(value).replace(/'/g, "''");
+        result = String(value).replace(/'/g, "''");
       }
+    } else if (typeof value === 'number') {
+      result = value;
+    } else if (Array.isArray(value)) {
+      result = value.map((v) => this.getQueryModel().quoteLiteral(v)).join(',');
+    } else {
+      result = value;
     }
 
-    if (typeof value === 'number') {
-      return value;
-    }
-
-    if (Array.isArray(value)) {
-      const quotedValues = value.map((v) => this.getQueryModel().quoteLiteral(v));
-      return quotedValues.join(',');
-    }
-
-    return value;
+    return this.migrateInterpolatedVariable(result, variable);
   };
+
+  /**
+   * Hook for child classes to apply post-interpolation migration logic.
+   * Called at the end of interpolateVariable with the already-interpolated result.
+   * Override in subclasses to handle cases like repeated panel quote stripping.
+   */
+  protected migrateInterpolatedVariable(
+    result: string | number,
+    _variable: VariableWithMultiSupport
+  ): string | number {
+    return result;
+  }
 
   interpolateVariablesInQueries(queries: SQLQuery[], scopedVars: ScopedVars): SQLQuery[] {
     let expandedQueries = queries;

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/datasource.test.ts
@@ -714,7 +714,7 @@ describe('PostgreSQLDatasource', () => {
       it('should return a quoted value', () => {
         const { ds, variable } = setupTestContext({});
         variable.multi = true;
-        expect(ds.interpolateVariable('abc', variable)).toEqual('abc');
+        expect(ds.interpolateVariable('abc', variable)).toEqual("'abc'");
       });
     });
 
@@ -722,8 +722,8 @@ describe('PostgreSQLDatasource', () => {
       it('should return a quoted value', () => {
         const { ds, variable } = setupTestContext({});
         variable.multi = true;
-        expect(ds.interpolateVariable("a'bc", variable)).toEqual("a''bc");
-        expect(ds.interpolateVariable("a'b'c", variable)).toEqual("a''b''c");
+        expect(ds.interpolateVariable("a'bc", variable)).toEqual("'a''bc'");
+        expect(ds.interpolateVariable("a'b'c", variable)).toEqual("'a''b''c'");
       });
     });
 
@@ -731,7 +731,7 @@ describe('PostgreSQLDatasource', () => {
       it('should return a quoted value', () => {
         const { ds, variable } = setupTestContext({});
         variable.includeAll = true;
-        expect(ds.interpolateVariable('abc', variable)).toEqual('abc');
+        expect(ds.interpolateVariable('abc', variable)).toEqual("'abc'");
       });
     });
   });

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/datasource.ts
@@ -3,19 +3,21 @@ import { v4 as uuidv4 } from 'uuid';
 import { DataSourceInstanceSettings, ScopedVars, VariableWithMultiSupport } from '@grafana/data';
 import { LanguageDefinition } from '@grafana/plugin-ui';
 import { TemplateSrv } from '@grafana/runtime';
+import { isSceneObject } from '@grafana/scenes';
 import {
   COMMON_FNS,
   DB,
+  formatSQL,
   FuncParameter,
   MACRO_FUNCTIONS,
+  SqlDatasource,
   SQLQuery,
   SQLSelectableValue,
-  SqlDatasource,
   SQLVariableSupport,
-  formatSQL,
 } from '@grafana/sql';
 
 import { PostgresQueryModel } from './PostgresQueryModel';
+import { migrateInterpolation } from './migration';
 import { getSchema, getTimescaleDBVersion, getVersion, showTables } from './postgresMetaQuery';
 import { fetchColumns, fetchTables, getSqlCompletionProvider } from './sqlCompletionProvider';
 import { getFieldConfig, toRawSql } from './sqlUtil';
@@ -23,6 +25,8 @@ import { PostgresOptions } from './types';
 
 export class PostgresDatasource extends SqlDatasource {
   sqlLanguageDefinition: LanguageDefinition | undefined = undefined;
+  private _currentRawSql?: string;
+  private _currentSceneObj?: import('@grafana/scenes').SceneObject;
 
   constructor(instanceSettings: DataSourceInstanceSettings<PostgresOptions>) {
     super(instanceSettings);
@@ -34,27 +38,34 @@ export class PostgresDatasource extends SqlDatasource {
     return new PostgresQueryModel(target, templateSrv, scopedVars);
   }
 
-  interpolateVariable = (value: string | string[] | number, variable: VariableWithMultiSupport) => {
-    if (typeof value === 'string') {
-      // For single string values, just escape quotes (don't add outer quotes)
-      // The quotes are provided by the query template: WHERE x = '$var'
-      // We only escape internal single quotes: O'Brien -> O''Brien
-      return String(value).replace(/'/g, "''");
-    }
+  // Strips redundant quotes from interpolated values on repeated panels
+  // where the raw SQL already wraps the variable reference in quotes.
+  protected migrateInterpolatedVariable(
+    result: string | number,
+    variable: VariableWithMultiSupport
+  ): string | number {
+    return migrateInterpolation(result, variable.name, this._currentRawSql, this._currentSceneObj);
+  }
 
-    if (typeof value === 'number') {
-      return value;
-    }
+  applyTemplateVariables(target: SQLQuery, scopedVars: ScopedVars) {
+    const sceneScopedVar = scopedVars?.__sceneObject;
+    const sceneValue = sceneScopedVar?.value.valueOf();
 
-    if (Array.isArray(value)) {
-      // For arrays, quote each value individually and join with comma
-      // Used in: WHERE x IN ($var) -> WHERE x IN ('val1','val2','val3')
-      const quotedValues = value.map((v) => this.getQueryModel().quoteLiteral(v));
-      return quotedValues.join(',');
-    }
+    this._currentRawSql = target.rawSql;
+    this._currentSceneObj = sceneValue && isSceneObject(sceneValue) ? sceneValue : undefined;
 
-    return value;
-  };
+    const rawSql = this.templateSrv.replace(target.rawSql, scopedVars, this.interpolateVariable);
+
+    this._currentRawSql = undefined;
+    this._currentSceneObj = undefined;
+
+    return {
+      refId: target.refId,
+      datasource: this.getRef(),
+      rawSql,
+      format: target.format,
+    };
+  }
 
   async getVersion(): Promise<string> {
     const value = await this.runSql<{ version: number }>(getVersion());

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/datasource.ts
@@ -40,10 +40,7 @@ export class PostgresDatasource extends SqlDatasource {
 
   // Strips redundant quotes from interpolated values on repeated panels
   // where the raw SQL already wraps the variable reference in quotes.
-  protected migrateInterpolatedVariable(
-    result: string | number,
-    variable: VariableWithMultiSupport
-  ): string | number {
+  protected migrateInterpolatedVariable(result: string | number, variable: VariableWithMultiSupport): string | number {
     return migrateInterpolation(result, variable.name, this._currentRawSql, this._currentSceneObj);
   }
 

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/migration.test.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/migration.test.ts
@@ -10,10 +10,6 @@ import {
 
 const quoteLiteral = (value: string) => `'${value.replace(/'/g, "''")}'`;
 
-// ---------------------------------------------------------------------------
-// Helpers for building mock scene objects
-// ---------------------------------------------------------------------------
-
 function createMockSceneObject(name: string, state: Record<string, unknown> = {}, parent?: SceneObject): SceneObject {
   const obj = {
     state: { ...state },
@@ -32,8 +28,7 @@ function createMockVizPanel(
   parentState: Partial<{ variableName?: string; repeatDirection?: 'v' | 'h'; repeatedPanels?: unknown[] }> = {}
 ): SceneObject {
   const gridItem = createMockSceneObject('DashboardGridItem', parentState);
-  const panel = createMockSceneObject('VizPanel', state, gridItem);
-  return panel;
+  return createMockSceneObject('VizPanel', state, gridItem);
 }
 
 function createNestedSceneObject(
@@ -41,13 +36,8 @@ function createNestedSceneObject(
   parentState: Partial<{ variableName?: string; repeatDirection?: 'v' | 'h'; repeatedPanels?: unknown[] }> = {}
 ): SceneObject {
   const vizPanel = createMockVizPanel(vizPanelState, parentState);
-  const child = createMockSceneObject('SceneQueryRunner', {}, vizPanel);
-  return child;
+  return createMockSceneObject('SceneQueryRunner', {}, vizPanel);
 }
-
-// ---------------------------------------------------------------------------
-// isVariableQuotedInQuery
-// ---------------------------------------------------------------------------
 
 describe('isVariableQuotedInQuery', () => {
   it('should detect $var wrapped in single quotes', () => {
@@ -87,10 +77,6 @@ describe('isVariableQuotedInQuery', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// stripOuterQuotes
-// ---------------------------------------------------------------------------
-
 describe('stripOuterQuotes', () => {
   it('should strip outer single quotes', () => {
     expect(stripOuterQuotes("'value'")).toBe('value');
@@ -120,10 +106,6 @@ describe('stripOuterQuotes', () => {
     expect(stripOuterQuotes("value'")).toBe("value'");
   });
 });
-
-// ---------------------------------------------------------------------------
-// getRepeatInfo
-// ---------------------------------------------------------------------------
 
 describe('getRepeatInfo', () => {
   it('should return undefined when no scene object is provided', () => {
@@ -165,10 +147,6 @@ describe('getRepeatInfo', () => {
     expect(info.variableName).toBeUndefined();
   });
 });
-
-// ---------------------------------------------------------------------------
-// migrateInterpolation
-// ---------------------------------------------------------------------------
 
 describe('migrateInterpolation', () => {
   describe('without scene context (no migration applied)', () => {

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/migration.test.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/migration.test.ts
@@ -1,0 +1,300 @@
+import { SceneObject } from '@grafana/scenes';
+
+import {
+  getRepeatInfo,
+  isVariableQuotedInQuery,
+  migrateInterpolation,
+  PanelRepeatInfo,
+  stripOuterQuotes,
+} from './migration';
+
+const quoteLiteral = (value: string) => `'${value.replace(/'/g, "''")}'`;
+
+// ---------------------------------------------------------------------------
+// Helpers for building mock scene objects
+// ---------------------------------------------------------------------------
+
+function createMockSceneObject(name: string, state: Record<string, unknown> = {}, parent?: SceneObject): SceneObject {
+  const obj = {
+    state: { ...state },
+    parent,
+  } as unknown as SceneObject;
+
+  Object.defineProperty(obj, 'constructor', {
+    value: { name },
+  });
+
+  return obj;
+}
+
+function createMockVizPanel(
+  state: Partial<{ title: string; key: string; pluginId: string; repeatSourceKey?: string }> = {},
+  parentState: Partial<{ variableName?: string; repeatDirection?: 'v' | 'h'; repeatedPanels?: unknown[] }> = {}
+): SceneObject {
+  const gridItem = createMockSceneObject('DashboardGridItem', parentState);
+  const panel = createMockSceneObject('VizPanel', state, gridItem);
+  return panel;
+}
+
+function createNestedSceneObject(
+  vizPanelState: Partial<{ title: string; key: string; pluginId: string; repeatSourceKey?: string }> = {},
+  parentState: Partial<{ variableName?: string; repeatDirection?: 'v' | 'h'; repeatedPanels?: unknown[] }> = {}
+): SceneObject {
+  const vizPanel = createMockVizPanel(vizPanelState, parentState);
+  const child = createMockSceneObject('SceneQueryRunner', {}, vizPanel);
+  return child;
+}
+
+// ---------------------------------------------------------------------------
+// isVariableQuotedInQuery
+// ---------------------------------------------------------------------------
+
+describe('isVariableQuotedInQuery', () => {
+  it('should detect $var wrapped in single quotes', () => {
+    expect(isVariableQuotedInQuery('host', "WHERE host = '$host'")).toBe(true);
+  });
+
+  it('should detect ${var} wrapped in single quotes', () => {
+    expect(isVariableQuotedInQuery('host', "WHERE host = '${host}'")).toBe(true);
+  });
+
+  it('should return false when $var is not quoted', () => {
+    expect(isVariableQuotedInQuery('host', 'WHERE host = $host')).toBe(false);
+  });
+
+  it('should return false when ${var} is not quoted', () => {
+    expect(isVariableQuotedInQuery('host', 'WHERE host = ${host}')).toBe(false);
+  });
+
+  it('should return false for IN clause without quotes around variable', () => {
+    expect(isVariableQuotedInQuery('host', 'WHERE host IN ($host)')).toBe(false);
+  });
+
+  it('should detect variable in complex query', () => {
+    expect(isVariableQuotedInQuery('host', "SELECT * FROM metrics WHERE host = '$host' ORDER BY time")).toBe(true);
+  });
+
+  it('should not match a different variable name', () => {
+    expect(isVariableQuotedInQuery('server', "WHERE host = '$host'")).toBe(false);
+  });
+
+  it('should handle variable names with special regex characters', () => {
+    expect(isVariableQuotedInQuery('host.name', "WHERE x = '$host.name'")).toBe(true);
+  });
+
+  it('should handle multiple occurrences where at least one is quoted', () => {
+    expect(isVariableQuotedInQuery('host', "WHERE a = '$host' AND b = $host")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripOuterQuotes
+// ---------------------------------------------------------------------------
+
+describe('stripOuterQuotes', () => {
+  it('should strip outer single quotes', () => {
+    expect(stripOuterQuotes("'value'")).toBe('value');
+  });
+
+  it('should preserve inner escaped quotes', () => {
+    expect(stripOuterQuotes("'O''Brien'")).toBe("O''Brien");
+  });
+
+  it('should return value unchanged if not quoted', () => {
+    expect(stripOuterQuotes('value')).toBe('value');
+  });
+
+  it('should return value unchanged for single character quote', () => {
+    expect(stripOuterQuotes("'")).toBe("'");
+  });
+
+  it('should handle empty quoted string', () => {
+    expect(stripOuterQuotes("''")).toBe('');
+  });
+
+  it('should not strip if only leading quote', () => {
+    expect(stripOuterQuotes("'value")).toBe("'value");
+  });
+
+  it('should not strip if only trailing quote', () => {
+    expect(stripOuterQuotes("value'")).toBe("value'");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getRepeatInfo
+// ---------------------------------------------------------------------------
+
+describe('getRepeatInfo', () => {
+  it('should return undefined when no scene object is provided', () => {
+    expect(getRepeatInfo(undefined)).toBeUndefined();
+  });
+
+  it('should return undefined when no VizPanel is in the parent chain', () => {
+    const scene = createMockSceneObject('SomeOtherObject');
+    expect(getRepeatInfo(scene)).toBeUndefined();
+  });
+
+  it('should detect a repeated panel (clone)', () => {
+    const scene = createNestedSceneObject(
+      { repeatSourceKey: 'panel-1', title: 'Clone', key: 'panel-1-clone-0' },
+      { variableName: 'host', repeatDirection: 'h' }
+    );
+
+    const info = getRepeatInfo(scene) as PanelRepeatInfo;
+    expect(info).toBeDefined();
+    expect(info.isRepeated).toBe(true);
+    expect(info.variableName).toBe('host');
+  });
+
+  it('should detect a source panel (not a clone)', () => {
+    const scene = createNestedSceneObject({ title: 'Source', key: 'panel-1' }, { variableName: 'host' });
+
+    const info = getRepeatInfo(scene) as PanelRepeatInfo;
+    expect(info).toBeDefined();
+    expect(info.isRepeated).toBe(false);
+    expect(info.variableName).toBe('host');
+  });
+
+  it('should report no repeat when parent has no variableName', () => {
+    const scene = createNestedSceneObject({ title: 'Regular', key: 'panel-2' }, {});
+
+    const info = getRepeatInfo(scene) as PanelRepeatInfo;
+    expect(info).toBeDefined();
+    expect(info.isRepeated).toBe(false);
+    expect(info.variableName).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// migrateInterpolation
+// ---------------------------------------------------------------------------
+
+describe('migrateInterpolation', () => {
+  describe('without scene context (no migration applied)', () => {
+    it('should pass through a quoted string unchanged', () => {
+      expect(migrateInterpolation("'value1'", 'host')).toBe("'value1'");
+    });
+
+    it('should pass through a comma-separated array string unchanged', () => {
+      expect(migrateInterpolation("'a','b'", 'host')).toBe("'a','b'");
+    });
+
+    it('should pass through a number unchanged', () => {
+      expect(migrateInterpolation(42, 'host')).toBe(42);
+    });
+
+    it('should pass through an unquoted string unchanged', () => {
+      expect(migrateInterpolation('server1', 'host')).toBe('server1');
+    });
+  });
+
+  describe('with repeated panel and quoted variable in SQL', () => {
+    it('should strip outer quotes for multi variable (single value on repeated clone)', () => {
+      const scene = createNestedSceneObject({ repeatSourceKey: 'panel-1' }, { variableName: 'host' });
+      const rawSql = "SELECT * FROM metrics WHERE host = '$host'";
+      const interpolated = quoteLiteral('server1');
+
+      expect(migrateInterpolation(interpolated, 'host', rawSql, scene)).toBe('server1');
+    });
+
+    it('should strip outer quotes and preserve escaped inner quotes', () => {
+      const scene = createNestedSceneObject({ repeatSourceKey: 'panel-1' }, { variableName: 'host' });
+      const rawSql = "SELECT * FROM metrics WHERE host = '$host'";
+      const interpolated = quoteLiteral("O'Brien");
+
+      expect(migrateInterpolation(interpolated, 'host', rawSql, scene)).toBe("O''Brien");
+    });
+
+    it('should strip outer quotes for source panel too', () => {
+      const scene = createNestedSceneObject({ title: 'Source' }, { variableName: 'host' });
+      const rawSql = "SELECT * FROM metrics WHERE host = '$host'";
+      const interpolated = quoteLiteral('server1');
+
+      expect(migrateInterpolation(interpolated, 'host', rawSql, scene)).toBe('server1');
+    });
+
+    it('should strip outer quotes with ${var} syntax', () => {
+      const scene = createNestedSceneObject({ repeatSourceKey: 'panel-1' }, { variableName: 'host' });
+      const rawSql = "SELECT * FROM metrics WHERE host = '${host}'";
+      const interpolated = quoteLiteral('server1');
+
+      expect(migrateInterpolation(interpolated, 'host', rawSql, scene)).toBe('server1');
+    });
+  });
+
+  describe('with repeated panel but unquoted variable in SQL', () => {
+    it('should NOT strip quotes when variable is not quoted in SQL', () => {
+      const scene = createNestedSceneObject({ repeatSourceKey: 'panel-1' }, { variableName: 'host' });
+      const rawSql = 'SELECT * FROM metrics WHERE host = $host';
+      const interpolated = quoteLiteral('server1');
+
+      expect(migrateInterpolation(interpolated, 'host', rawSql, scene)).toBe("'server1'");
+    });
+
+    it('should NOT strip quotes for IN clause without quoted variable', () => {
+      const scene = createNestedSceneObject({ repeatSourceKey: 'panel-1' }, { variableName: 'host' });
+      const rawSql = 'SELECT * FROM metrics WHERE host IN ($host)';
+      const interpolated = quoteLiteral('server1');
+
+      expect(migrateInterpolation(interpolated, 'host', rawSql, scene)).toBe("'server1'");
+    });
+  });
+
+  describe('with non-repeated panel (no migration)', () => {
+    it('should not strip quotes even if variable is quoted in SQL', () => {
+      const scene = createNestedSceneObject({ title: 'Regular' }, {});
+      const rawSql = "SELECT * FROM metrics WHERE host = '$host'";
+      const interpolated = quoteLiteral('server1');
+
+      expect(migrateInterpolation(interpolated, 'host', rawSql, scene)).toBe("'server1'");
+    });
+  });
+
+  describe('non-multi string values on repeated panels', () => {
+    it('should not alter unquoted values (escape-only result from parent)', () => {
+      const scene = createNestedSceneObject({ repeatSourceKey: 'panel-1' }, { variableName: 'host' });
+      const rawSql = "SELECT * FROM metrics WHERE host = '$host'";
+      const interpolated = 'server1';
+
+      expect(migrateInterpolation(interpolated, 'host', rawSql, scene)).toBe('server1');
+    });
+  });
+
+  describe('array results on repeated panels', () => {
+    it('should not affect comma-separated array results (not wrapped in a single outer quote pair)', () => {
+      const scene = createNestedSceneObject({ repeatSourceKey: 'panel-1' }, { variableName: 'host' });
+      const rawSql = 'SELECT * FROM metrics WHERE host IN ($host)';
+      const interpolated = "'a','b','c'";
+
+      expect(migrateInterpolation(interpolated, 'host', rawSql, scene)).toBe("'a','b','c'");
+    });
+  });
+
+  describe('number values on repeated panels', () => {
+    it('should pass through numbers without migration', () => {
+      const scene = createNestedSceneObject({ repeatSourceKey: 'panel-1' }, { variableName: 'host' });
+      const rawSql = 'SELECT * FROM metrics WHERE id = $host';
+
+      expect(migrateInterpolation(42, 'host', rawSql, scene)).toBe(42);
+    });
+  });
+
+  describe('different variable than repeat variable', () => {
+    it('should still strip quotes if the interpolated variable is quoted in SQL', () => {
+      const scene = createNestedSceneObject({ repeatSourceKey: 'panel-1' }, { variableName: 'host' });
+      const rawSql = "SELECT * FROM metrics WHERE host = '$host' AND env = '$env'";
+      const interpolated = quoteLiteral('production');
+
+      expect(migrateInterpolation(interpolated, 'env', rawSql, scene)).toBe('production');
+    });
+
+    it('should not strip quotes if the other variable is not quoted', () => {
+      const scene = createNestedSceneObject({ repeatSourceKey: 'panel-1' }, { variableName: 'host' });
+      const rawSql = "SELECT * FROM metrics WHERE host = '$host' AND env = $env";
+      const interpolated = quoteLiteral('production');
+
+      expect(migrateInterpolation(interpolated, 'env', rawSql, scene)).toBe("'production'");
+    });
+  });
+});

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/migration.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/migration.ts
@@ -1,0 +1,127 @@
+import { SceneObject, VizPanel } from '@grafana/scenes';
+
+interface RepeatableParentState {
+  variableName?: string;
+  repeatDirection?: 'v' | 'h';
+  repeatedPanels?: VizPanel[];
+}
+
+export interface PanelRepeatInfo {
+  isRepeated: boolean;
+  variableName?: string;
+}
+
+/**
+ * Applies migration to an already-interpolated variable result for repeated panels.
+ *
+ * Repeated panels receive a single string value from a multi-select variable.
+ * SqlDatasource.interpolateVariable wraps such values with quoteLiteral
+ * (e.g. 'value'). If the raw SQL already has quotes around the variable reference
+ * (e.g. WHERE x = '$var'), this produces double-quoting: WHERE x = ''value''.
+ *
+ * This function detects that scenario and strips the redundant outer quotes.
+ */
+export function migrateInterpolation(
+  interpolatedResult: string | number,
+  variableName: string,
+  rawSql?: string,
+  sceneObj?: SceneObject
+): string | number {
+  if (typeof interpolatedResult === 'string' && rawSql && sceneObj) {
+    const repeatInfo = getRepeatInfo(sceneObj);
+    if (repeatInfo?.variableName && isVariableQuotedInQuery(variableName, rawSql)) {
+      return stripOuterQuotes(interpolatedResult);
+    }
+  }
+
+  return interpolatedResult;
+}
+
+/**
+ * Checks whether a variable reference is wrapped in single quotes in the raw SQL.
+ * Matches patterns like '$varName' and '${varName}'.
+ */
+export function isVariableQuotedInQuery(variableName: string, rawSql: string): boolean {
+  const escaped = variableName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`'\\$\\{?${escaped}\\}?'`);
+  return pattern.test(rawSql);
+}
+
+/**
+ * Strips the outermost pair of single quotes from a string value.
+ * E.g. "'value'" → "value", "'O''Brien'" → "O''Brien".
+ */
+export function stripOuterQuotes(value: string): string {
+  if (value.length >= 2 && value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+/**
+ * Extracts repeat information from the scene object hierarchy.
+ * Returns undefined if no VizPanel is found in the parent chain.
+ */
+export function getRepeatInfo(sceneObj?: SceneObject): PanelRepeatInfo | undefined {
+  if (!sceneObj) {
+    return undefined;
+  }
+
+  const vizPanel = getVizPanelFromScene(sceneObj);
+  if (!vizPanel) {
+    return undefined;
+  }
+
+  return getPanelRepeatInfo(vizPanel);
+}
+
+function getVizPanelFromScene(scene: SceneObject): VizPanel | undefined {
+  let current: SceneObject | undefined = scene;
+  let depth = 0;
+
+  while (current && depth < 20) {
+    if (isVizPanel(current)) {
+      return current;
+    }
+    current = current.parent;
+    depth++;
+  }
+
+  return undefined;
+}
+
+function isVizPanel(obj: SceneObject): obj is VizPanel {
+  return obj.constructor.name === 'VizPanel';
+}
+
+function getPanelRepeatInfo(vizPanel: VizPanel): PanelRepeatInfo {
+  const panelState = vizPanel.state;
+  const parent = vizPanel.parent;
+  const parentState = getRepeatableParentState(parent);
+
+  return {
+    isRepeated: Boolean(panelState.repeatSourceKey),
+    variableName: parentState?.variableName,
+  };
+}
+
+function getRepeatableParentState(parent: SceneObject | undefined): RepeatableParentState | undefined {
+  if (!parent || !('state' in parent)) {
+    return undefined;
+  }
+
+  const state = parent.state;
+  if (isRepeatableParentState(state)) {
+    return state;
+  }
+
+  return undefined;
+}
+
+function isRepeatableParentState(state: unknown): state is RepeatableParentState {
+  return (
+    typeof state === 'object' &&
+    state !== null &&
+    ('variableName' in state || 'repeatDirection' in state || 'repeatedPanels' in state)
+  );
+}


### PR DESCRIPTION
**What is this feature?**

This PR is reverting what we've introduced in https://github.com/grafana/grafana/pull/114058
The initial goal was to serve a smooth experience to the users but after an extensive investigation we found out that the problem wasn't related to postgres. More information https://github.com/grafana/grafana/issues/114045

Shortly; the "fix"I introduced was trying to solve something which shouldn't even exist. It's because a bug in somewhere else caused a bad result become the default result.

We convinced that the old logic was the right logic. The old logic unfortunately introduced a false behaviour which became a default behaviour in queries. This is expecially a problem with repeated panels. 

In this PR I revert the change it was done in https://github.com/grafana/grafana/pull/114058 and introduce a migration for queries which are in repeated panels with template variables (`isMulti=true` or `includeAll=true`)

**What's this doing?** 
- It revert the code https://github.com/grafana/grafana/pull/114058
- It creates a migration for `queries` that are in repeated panels and has variables wrapped in quotes.

<details><summary>dashboard.json for testing</summary>

```json
{
    "annotations": {
      "list": [
        {
          "builtIn": 1,
          "datasource": {
            "type": "grafana",
            "uid": "-- Grafana --"
          },
          "enable": true,
          "hide": true,
          "iconColor": "rgba(0, 211, 255, 1)",
          "name": "Annotations & Alerts",
          "type": "dashboard"
        }
      ]
    },
    "editable": true,
    "fiscalYearStartMonth": 0,
    "graphTooltip": 0,
    "links": [],
    "panels": [
      {
        "datasource": {
          "type": "grafana-postgresql-datasource",
          "uid": "ff3qnec29569sf"
        },
        "fieldConfig": {
          "defaults": {
            "color": {
              "mode": "thresholds"
            },
            "custom": {
              "align": "auto",
              "cellOptions": {
                "type": "auto"
              },
              "footer": {
                "reducers": []
              },
              "inspect": false
            },
            "mappings": [],
            "thresholds": {
              "mode": "absolute",
              "steps": [
                {
                  "color": "green",
                  "value": 0
                },
                {
                  "color": "red",
                  "value": 80
                }
              ]
            }
          },
          "overrides": []
        },
        "gridPos": {
          "h": 10,
          "w": 24,
          "x": 0,
          "y": 0
        },
        "id": 13,
        "options": {
          "cellHeight": "sm",
          "showHeader": true
        },
        "pluginVersion": "12.4.0-pre",
        "repeat": "table_columns",
        "repeatDirection": "h",
        "targets": [
          {
            "dataset": "grafana",
            "datasource": {
              "type": "grafana-postgresql-datasource",
              "uid": "ff3qnec29569sf"
            },
            "editorMode": "code",
            "format": "table",
            "rawQuery": true,
            "rawSql": "SELECT COUNT(\"$table_columns\") FROM grafana_metric LIMIT 50 ",
            "refId": "A",
            "sql": {
              "columns": [
                {
                  "name": "COUNT",
                  "parameters": [
                    {
                      "name": "\"$table_columns\"",
                      "type": "functionParameter"
                    }
                  ],
                  "type": "function"
                }
              ],
              "groupBy": [
                {
                  "property": {
                    "type": "string"
                  },
                  "type": "groupBy"
                }
              ],
              "limit": 50
            },
            "table": "grafana_metric"
          }
        ],
        "title": "New panel",
        "type": "table"
      },
      {
        "collapsed": false,
        "gridPos": {
          "h": 1,
          "w": 24,
          "x": 0,
          "y": 20
        },
        "id": 11,
        "panels": [],
        "title": "Repeated Panels",
        "type": "row"
      },
      {
        "datasource": {
          "type": "grafana-postgresql-datasource",
          "uid": "ff3qnec29569sf"
        },
        "fieldConfig": {
          "defaults": {
            "color": {
              "mode": "thresholds"
            },
            "custom": {
              "align": "auto",
              "cellOptions": {
                "type": "auto"
              },
              "footer": {
                "reducers": []
              },
              "hideFrom": {
                "viz": false
              },
              "inspect": false
            },
            "mappings": [],
            "thresholds": {
              "mode": "absolute",
              "steps": [
                {
                  "color": "green",
                  "value": 0
                },
                {
                  "color": "red",
                  "value": 80
                }
              ]
            }
          },
          "overrides": []
        },
        "gridPos": {
          "h": 8,
          "w": 24,
          "x": 0,
          "y": 21
        },
        "id": 12,
        "options": {
          "cellHeight": "sm",
          "showHeader": true
        },
        "pluginVersion": "12.4.0-pre",
        "repeat": "hostnames_just_include_all",
        "repeatDirection": "h",
        "targets": [
          {
            "dataset": "grafana",
            "datasource": {
              "type": "grafana-postgresql-datasource",
              "uid": "ff3qnec29569sf"
            },
            "editorMode": "code",
            "format": "table",
            "rawQuery": true,
            "rawSql": "SELECT\n  *\nFROM\n  grafana_metric\nWHERE\n  hostname = '$hostnames_just_include_all'\nLIMIT\n  5",
            "refId": "A",
            "sql": {
              "columns": [
                {
                  "parameters": [
                    {
                      "name": "*",
                      "type": "functionParameter"
                    }
                  ],
                  "type": "function"
                }
              ],
              "groupBy": [
                {
                  "property": {
                    "type": "string"
                  },
                  "type": "groupBy"
                }
              ],
              "limit": 5,
              "whereJsonTree": {
                "children1": [
                  {
                    "id": "aaa9bb9b-cdef-4012-b456-719bc880cd14",
                    "properties": {
                      "field": "hostname",
                      "fieldSrc": "field",
                      "operator": "equal",
                      "value": [
                        "$hostnames_multi"
                      ],
                      "valueError": [
                        null
                      ],
                      "valueSrc": [
                        "value"
                      ],
                      "valueType": [
                        "text"
                      ]
                    },
                    "type": "rule"
                  }
                ],
                "id": "a98babba-0123-4456-b89a-b19bc77f0e88",
                "type": "group"
              },
              "whereString": "hostname = '$hostnames_multi'"
            },
            "table": "grafana_metric"
          }
        ],
        "title": "REPEATED [$hostnames_just_include_all] multi variable, where equals with single quotes",
        "type": "table"
      },
      {
        "collapsed": true,
        "gridPos": {
          "h": 1,
          "w": 24,
          "x": 0,
          "y": 29
        },
        "id": 5,
        "panels": [
          {
            "datasource": {
              "type": "grafana-postgresql-datasource",
              "uid": "ff3qnec29569sf"
            },
            "fieldConfig": {
              "defaults": {
                "color": {
                  "mode": "thresholds"
                },
                "custom": {
                  "align": "auto",
                  "cellOptions": {
                    "type": "auto"
                  },
                  "footer": {
                    "reducers": []
                  },
                  "hideFrom": {
                    "viz": false
                  },
                  "inspect": false
                },
                "mappings": [],
                "thresholds": {
                  "mode": "absolute",
                  "steps": [
                    {
                      "color": "green",
                      "value": 0
                    },
                    {
                      "color": "red",
                      "value": 80
                    }
                  ]
                }
              },
              "overrides": []
            },
            "gridPos": {
              "h": 8,
              "w": 12,
              "x": 0,
              "y": 62
            },
            "id": 2,
            "options": {
              "cellHeight": "sm",
              "showHeader": true
            },
            "pluginVersion": "12.4.0-pre",
            "targets": [
              {
                "dataset": "grafana",
                "datasource": {
                  "type": "grafana-postgresql-datasource",
                  "uid": "ff3qnec29569sf"
                },
                "editorMode": "code",
                "format": "table",
                "rawQuery": true,
                "rawSql": "SELECT\n  *\nFROM\n  grafana_metric\nWHERE\n  hostname = $hostnames_multi\nLIMIT\n  5",
                "refId": "A",
                "sql": {
                  "columns": [
                    {
                      "parameters": [
                        {
                          "name": "*",
                          "type": "functionParameter"
                        }
                      ],
                      "type": "function"
                    }
                  ],
                  "groupBy": [
                    {
                      "property": {
                        "type": "string"
                      },
                      "type": "groupBy"
                    }
                  ],
                  "limit": 5,
                  "whereJsonTree": {
                    "children1": [
                      {
                        "id": "aaa9bb9b-cdef-4012-b456-719bc880cd14",
                        "properties": {
                          "field": "hostname",
                          "fieldSrc": "field",
                          "operator": "equal",
                          "value": [
                            "$hostnames_multi"
                          ],
                          "valueError": [
                            null
                          ],
                          "valueSrc": [
                            "value"
                          ],
                          "valueType": [
                            "text"
                          ]
                        },
                        "type": "rule"
                      }
                    ],
                    "id": "a98babba-0123-4456-b89a-b19bc77f0e88",
                    "type": "group"
                  },
                  "whereString": "hostname = '$hostnames_multi'"
                },
                "table": "grafana_metric"
              }
            ],
            "title": "multi variable, where equals",
            "type": "table"
          },
          {
            "datasource": {
              "type": "grafana-postgresql-datasource",
              "uid": "ff3qnec29569sf"
            },
            "fieldConfig": {
              "defaults": {
                "color": {
                  "mode": "thresholds"
                },
                "custom": {
                  "align": "auto",
                  "cellOptions": {
                    "type": "auto"
                  },
                  "footer": {
                    "reducers": []
                  },
                  "hideFrom": {
                    "viz": false
                  },
                  "inspect": false
                },
                "mappings": [],
                "thresholds": {
                  "mode": "absolute",
                  "steps": [
                    {
                      "color": "green",
                      "value": 0
                    },
                    {
                      "color": "red",
                      "value": 80
                    }
                  ]
                }
              },
              "overrides": []
            },
            "gridPos": {
              "h": 8,
              "w": 12,
              "x": 12,
              "y": 62
            },
            "id": 1,
            "options": {
              "cellHeight": "sm",
              "showHeader": true
            },
            "pluginVersion": "12.4.0-pre",
            "targets": [
              {
                "dataset": "grafana",
                "datasource": {
                  "type": "grafana-postgresql-datasource",
                  "uid": "ff3qnec29569sf"
                },
                "editorMode": "code",
                "format": "table",
                "rawQuery": true,
                "rawSql": "SELECT\n  *\nFROM\n  grafana_metric\nWHERE\n  hostname = '$hostnames_single'\nLIMIT\n  5",
                "refId": "A",
                "sql": {
                  "columns": [
                    {
                      "parameters": [
                        {
                          "name": "*",
                          "type": "functionParameter"
                        }
                      ],
                      "type": "function"
                    }
                  ],
                  "groupBy": [
                    {
                      "property": {
                        "type": "string"
                      },
                      "type": "groupBy"
                    }
                  ],
                  "limit": 5,
                  "whereJsonTree": {
                    "children1": [
                      {
                        "id": "aaa9bb9b-cdef-4012-b456-719bc880cd14",
                        "properties": {
                          "field": "hostname",
                          "fieldSrc": "field",
                          "operator": "equal",
                          "value": [
                            "$hostnames_single"
                          ],
                          "valueError": [
                            null
                          ],
                          "valueSrc": [
                            "value"
                          ],
                          "valueType": [
                            "text"
                          ]
                        },
                        "type": "rule"
                      }
                    ],
                    "id": "a98babba-0123-4456-b89a-b19bc77f0e88",
                    "type": "group"
                  },
                  "whereString": "hostname = '$hostnames_single'"
                },
                "table": "grafana_metric"
              }
            ],
            "title": "single variable, where equals",
            "type": "table"
          },
          {
            "datasource": {
              "type": "grafana-postgresql-datasource",
              "uid": "ff3qnec29569sf"
            },
            "fieldConfig": {
              "defaults": {
                "color": {
                  "mode": "thresholds"
                },
                "custom": {
                  "align": "auto",
                  "cellOptions": {
                    "type": "auto"
                  },
                  "footer": {
                    "reducers": []
                  },
                  "hideFrom": {
                    "viz": false
                  },
                  "inspect": false
                },
                "mappings": [],
                "thresholds": {
                  "mode": "absolute",
                  "steps": [
                    {
                      "color": "green",
                      "value": 0
                    },
                    {
                      "color": "red",
                      "value": 80
                    }
                  ]
                }
              },
              "overrides": []
            },
            "gridPos": {
              "h": 8,
              "w": 12,
              "x": 0,
              "y": 70
            },
            "id": 3,
            "options": {
              "cellHeight": "sm",
              "showHeader": true
            },
            "pluginVersion": "12.4.0-pre",
            "targets": [
              {
                "dataset": "grafana",
                "datasource": {
                  "type": "grafana-postgresql-datasource",
                  "uid": "ff3qnec29569sf"
                },
                "editorMode": "code",
                "format": "table",
                "rawQuery": true,
                "rawSql": "SELECT * FROM grafana_metric WHERE hostname IN ($hostnames_multi) LIMIT 5 ",
                "refId": "A",
                "sql": {
                  "columns": [
                    {
                      "parameters": [
                        {
                          "name": "*",
                          "type": "functionParameter"
                        }
                      ],
                      "type": "function"
                    }
                  ],
                  "groupBy": [
                    {
                      "property": {
                        "type": "string"
                      },
                      "type": "groupBy"
                    }
                  ],
                  "limit": 5,
                  "whereJsonTree": {
                    "children1": [
                      {
                        "id": "aaa9bb9b-cdef-4012-b456-719bc880cd14",
                        "properties": {
                          "field": "hostname",
                          "fieldSrc": "field",
                          "operator": "select_any_in",
                          "value": [
                            "$hostnames_multi"
                          ],
                          "valueError": [
                            null
                          ],
                          "valueSrc": [
                            "value"
                          ],
                          "valueType": [
                            "text"
                          ]
                        },
                        "type": "rule"
                      }
                    ],
                    "id": "a98babba-0123-4456-b89a-b19bc77f0e88",
                    "type": "group"
                  },
                  "whereString": "hostname IN ($hostnames_multi)"
                },
                "table": "grafana_metric"
              }
            ],
            "title": "multi variable, where IN",
            "type": "table"
          },
          {
            "datasource": {
              "type": "grafana-postgresql-datasource",
              "uid": "ff3qnec29569sf"
            },
            "fieldConfig": {
              "defaults": {
                "color": {
                  "mode": "thresholds"
                },
                "custom": {
                  "align": "auto",
                  "cellOptions": {
                    "type": "auto"
                  },
                  "footer": {
                    "reducers": []
                  },
                  "hideFrom": {
                    "viz": false
                  },
                  "inspect": false
                },
                "mappings": [],
                "thresholds": {
                  "mode": "absolute",
                  "steps": [
                    {
                      "color": "green",
                      "value": 0
                    },
                    {
                      "color": "red",
                      "value": 80
                    }
                  ]
                }
              },
              "overrides": []
            },
            "gridPos": {
              "h": 8,
              "w": 12,
              "x": 12,
              "y": 70
            },
            "id": 4,
            "options": {
              "cellHeight": "sm",
              "showHeader": true
            },
            "pluginVersion": "12.4.0-pre",
            "targets": [
              {
                "dataset": "grafana",
                "datasource": {
                  "type": "grafana-postgresql-datasource",
                  "uid": "ff3qnec29569sf"
                },
                "editorMode": "code",
                "format": "table",
                "rawQuery": true,
                "rawSql": "SELECT * FROM grafana_metric WHERE hostname IN ('$hostnames_single') LIMIT 5 ",
                "refId": "A",
                "sql": {
                  "columns": [
                    {
                      "parameters": [
                        {
                          "name": "*",
                          "type": "functionParameter"
                        }
                      ],
                      "type": "function"
                    }
                  ],
                  "groupBy": [
                    {
                      "property": {
                        "type": "string"
                      },
                      "type": "groupBy"
                    }
                  ],
                  "limit": 5,
                  "whereJsonTree": {
                    "children1": [
                      {
                        "id": "aaa9bb9b-cdef-4012-b456-719bc880cd14",
                        "properties": {
                          "field": "hostname",
                          "fieldSrc": "field",
                          "operator": "select_any_in",
                          "value": [
                            "$hostnames_single"
                          ],
                          "valueError": [
                            null
                          ],
                          "valueSrc": [
                            "value"
                          ],
                          "valueType": [
                            "text"
                          ]
                        },
                        "type": "rule"
                      }
                    ],
                    "id": "a98babba-0123-4456-b89a-b19bc77f0e88",
                    "type": "group"
                  },
                  "whereString": "hostname IN ('$hostnames_single')"
                },
                "table": "grafana_metric"
              }
            ],
            "title": "single variable, where IN",
            "type": "table"
          }
        ],
        "title": "Panels created with Code Editor",
        "type": "row"
      },
      {
        "collapsed": true,
        "gridPos": {
          "h": 1,
          "w": 24,
          "x": 0,
          "y": 30
        },
        "id": 6,
        "panels": [
          {
            "datasource": {
              "type": "grafana-postgresql-datasource",
              "uid": "ff3qnec29569sf"
            },
            "fieldConfig": {
              "defaults": {
                "color": {
                  "mode": "thresholds"
                },
                "custom": {
                  "align": "auto",
                  "cellOptions": {
                    "type": "auto"
                  },
                  "footer": {
                    "reducers": []
                  },
                  "hideFrom": {
                    "viz": false
                  },
                  "inspect": false
                },
                "mappings": [],
                "thresholds": {
                  "mode": "absolute",
                  "steps": [
                    {
                      "color": "green",
                      "value": 0
                    },
                    {
                      "color": "red",
                      "value": 80
                    }
                  ]
                }
              },
              "overrides": []
            },
            "gridPos": {
              "h": 8,
              "w": 12,
              "x": 0,
              "y": 95
            },
            "id": 7,
            "options": {
              "cellHeight": "sm",
              "showHeader": true
            },
            "pluginVersion": "12.4.0-pre",
            "targets": [
              {
                "dataset": "grafana",
                "datasource": {
                  "type": "grafana-postgresql-datasource",
                  "uid": "ff3qnec29569sf"
                },
                "editorMode": "builder",
                "format": "table",
                "rawQuery": true,
                "rawSql": "SELECT * FROM grafana_metric WHERE hostname = '$hostnames_multi' LIMIT 5 ",
                "refId": "A",
                "sql": {
                  "columns": [
                    {
                      "parameters": [
                        {
                          "name": "*",
                          "type": "functionParameter"
                        }
                      ],
                      "type": "function"
                    }
                  ],
                  "groupBy": [
                    {
                      "property": {
                        "type": "string"
                      },
                      "type": "groupBy"
                    }
                  ],
                  "limit": 5,
                  "whereJsonTree": {
                    "children1": [
                      {
                        "id": "aaa9bb9b-cdef-4012-b456-719bc880cd14",
                        "properties": {
                          "field": "hostname",
                          "fieldSrc": "field",
                          "operator": "equal",
                          "value": [
                            "$hostnames_multi"
                          ],
                          "valueError": [
                            null
                          ],
                          "valueSrc": [
                            "value"
                          ],
                          "valueType": [
                            "text"
                          ]
                        },
                        "type": "rule"
                      }
                    ],
                    "id": "a98babba-0123-4456-b89a-b19bc77f0e88",
                    "type": "group"
                  },
                  "whereString": "hostname = '$hostnames_multi'"
                },
                "table": "grafana_metric"
              }
            ],
            "title": "multi variable, where equals",
            "type": "table"
          },
          {
            "datasource": {
              "type": "grafana-postgresql-datasource",
              "uid": "ff3qnec29569sf"
            },
            "fieldConfig": {
              "defaults": {
                "color": {
                  "mode": "thresholds"
                },
                "custom": {
                  "align": "auto",
                  "cellOptions": {
                    "type": "auto"
                  },
                  "footer": {
                    "reducers": []
                  },
                  "hideFrom": {
                    "viz": false
                  },
                  "inspect": false
                },
                "mappings": [],
                "thresholds": {
                  "mode": "absolute",
                  "steps": [
                    {
                      "color": "green",
                      "value": 0
                    },
                    {
                      "color": "red",
                      "value": 80
                    }
                  ]
                }
              },
              "overrides": []
            },
            "gridPos": {
              "h": 8,
              "w": 12,
              "x": 12,
              "y": 95
            },
            "id": 8,
            "options": {
              "cellHeight": "sm",
              "showHeader": true
            },
            "pluginVersion": "12.4.0-pre",
            "targets": [
              {
                "dataset": "grafana",
                "datasource": {
                  "type": "grafana-postgresql-datasource",
                  "uid": "ff3qnec29569sf"
                },
                "editorMode": "builder",
                "format": "table",
                "rawQuery": true,
                "rawSql": "SELECT * FROM grafana_metric WHERE hostname = '$hostnames_single' LIMIT 5 ",
                "refId": "A",
                "sql": {
                  "columns": [
                    {
                      "parameters": [
                        {
                          "name": "*",
                          "type": "functionParameter"
                        }
                      ],
                      "type": "function"
                    }
                  ],
                  "groupBy": [
                    {
                      "property": {
                        "type": "string"
                      },
                      "type": "groupBy"
                    }
                  ],
                  "limit": 5,
                  "whereJsonTree": {
                    "children1": [
                      {
                        "id": "aaa9bb9b-cdef-4012-b456-719bc880cd14",
                        "properties": {
                          "field": "hostname",
                          "fieldSrc": "field",
                          "operator": "equal",
                          "value": [
                            "$hostnames_single"
                          ],
                          "valueError": [
                            null
                          ],
                          "valueSrc": [
                            "value"
                          ],
                          "valueType": [
                            "text"
                          ]
                        },
                        "type": "rule"
                      }
                    ],
                    "id": "a98babba-0123-4456-b89a-b19bc77f0e88",
                    "type": "group"
                  },
                  "whereString": "hostname = '$hostnames_single'"
                },
                "table": "grafana_metric"
              }
            ],
            "title": "single variable, where equals",
            "type": "table"
          },
          {
            "datasource": {
              "type": "grafana-postgresql-datasource",
              "uid": "ff3qnec29569sf"
            },
            "fieldConfig": {
              "defaults": {
                "color": {
                  "mode": "thresholds"
                },
                "custom": {
                  "align": "auto",
                  "cellOptions": {
                    "type": "auto"
                  },
                  "footer": {
                    "reducers": []
                  },
                  "hideFrom": {
                    "viz": false
                  },
                  "inspect": false
                },
                "mappings": [],
                "thresholds": {
                  "mode": "absolute",
                  "steps": [
                    {
                      "color": "green",
                      "value": 0
                    },
                    {
                      "color": "red",
                      "value": 80
                    }
                  ]
                }
              },
              "overrides": []
            },
            "gridPos": {
              "h": 8,
              "w": 12,
              "x": 0,
              "y": 103
            },
            "id": 9,
            "options": {
              "cellHeight": "sm",
              "showHeader": true
            },
            "pluginVersion": "12.4.0-pre",
            "targets": [
              {
                "dataset": "grafana",
                "datasource": {
                  "type": "grafana-postgresql-datasource",
                  "uid": "ff3qnec29569sf"
                },
                "editorMode": "builder",
                "format": "table",
                "rawQuery": true,
                "rawSql": "SELECT * FROM grafana_metric WHERE hostname IN ($hostnames_multi) LIMIT 5 ",
                "refId": "A",
                "sql": {
                  "columns": [
                    {
                      "parameters": [
                        {
                          "name": "*",
                          "type": "functionParameter"
                        }
                      ],
                      "type": "function"
                    }
                  ],
                  "groupBy": [
                    {
                      "property": {
                        "type": "string"
                      },
                      "type": "groupBy"
                    }
                  ],
                  "limit": 5,
                  "whereJsonTree": {
                    "children1": [
                      {
                        "id": "aaa9bb9b-cdef-4012-b456-719bc880cd14",
                        "properties": {
                          "field": "hostname",
                          "fieldSrc": "field",
                          "operator": "select_any_in",
                          "value": [
                            "$hostnames_multi"
                          ],
                          "valueError": [
                            null
                          ],
                          "valueSrc": [
                            "value"
                          ],
                          "valueType": [
                            "text"
                          ]
                        },
                        "type": "rule"
                      }
                    ],
                    "id": "a98babba-0123-4456-b89a-b19bc77f0e88",
                    "type": "group"
                  },
                  "whereString": "hostname IN ($hostnames_multi)"
                },
                "table": "grafana_metric"
              }
            ],
            "title": "multi variable, where IN",
            "type": "table"
          },
          {
            "datasource": {
              "type": "grafana-postgresql-datasource",
              "uid": "ff3qnec29569sf"
            },
            "fieldConfig": {
              "defaults": {
                "color": {
                  "mode": "thresholds"
                },
                "custom": {
                  "align": "auto",
                  "cellOptions": {
                    "type": "auto"
                  },
                  "footer": {
                    "reducers": []
                  },
                  "hideFrom": {
                    "viz": false
                  },
                  "inspect": false
                },
                "mappings": [],
                "thresholds": {
                  "mode": "absolute",
                  "steps": [
                    {
                      "color": "green",
                      "value": 0
                    },
                    {
                      "color": "red",
                      "value": 80
                    }
                  ]
                }
              },
              "overrides": []
            },
            "gridPos": {
              "h": 8,
              "w": 12,
              "x": 12,
              "y": 103
            },
            "id": 10,
            "options": {
              "cellHeight": "sm",
              "showHeader": true
            },
            "pluginVersion": "12.4.0-pre",
            "targets": [
              {
                "dataset": "grafana",
                "datasource": {
                  "type": "grafana-postgresql-datasource",
                  "uid": "ff3qnec29569sf"
                },
                "editorMode": "builder",
                "format": "table",
                "rawQuery": true,
                "rawSql": "SELECT * FROM grafana_metric WHERE hostname IN ('$hostnames_single') LIMIT 5 ",
                "refId": "A",
                "sql": {
                  "columns": [
                    {
                      "parameters": [
                        {
                          "name": "*",
                          "type": "functionParameter"
                        }
                      ],
                      "type": "function"
                    }
                  ],
                  "groupBy": [
                    {
                      "property": {
                        "type": "string"
                      },
                      "type": "groupBy"
                    }
                  ],
                  "limit": 5,
                  "whereJsonTree": {
                    "children1": [
                      {
                        "id": "aaa9bb9b-cdef-4012-b456-719bc880cd14",
                        "properties": {
                          "field": "hostname",
                          "fieldSrc": "field",
                          "operator": "select_any_in",
                          "value": [
                            "$hostnames_single"
                          ],
                          "valueError": [
                            null
                          ],
                          "valueSrc": [
                            "value"
                          ],
                          "valueType": [
                            "text"
                          ]
                        },
                        "type": "rule"
                      }
                    ],
                    "id": "a98babba-0123-4456-b89a-b19bc77f0e88",
                    "type": "group"
                  },
                  "whereString": "hostname IN ('$hostnames_single')"
                },
                "table": "grafana_metric"
              }
            ],
            "title": "single variable, where IN",
            "type": "table"
          }
        ],
        "title": "Panels created with Visual Query Builder",
        "type": "row"
      }
    ],
    "preload": false,
    "schemaVersion": 42,
    "tags": [],
    "templating": {
      "list": [
        {
          "allowCustomValue": false,
          "current": {
            "text": [
              "server1"
            ],
            "value": [
              "server1"
            ]
          },
          "datasource": {
            "type": "grafana-postgresql-datasource",
            "uid": "ff3qnec29569sf"
          },
          "definition": "SELECT\n  hostname\nFROM\n  grafana_metric\nGROUP BY\n  id,\n  hostname\nLIMIT\n  50",
          "includeAll": false,
          "multi": true,
          "name": "hostnames_multi",
          "options": [],
          "query": "SELECT\n  hostname\nFROM\n  grafana_metric\nGROUP BY\n  id,\n  hostname\nLIMIT\n  50",
          "refresh": 1,
          "regex": "",
          "regexApplyTo": "value",
          "type": "query"
        },
        {
          "allowCustomValue": false,
          "current": {
            "text": "All",
            "value": "$__all"
          },
          "datasource": {
            "type": "grafana-postgresql-datasource",
            "uid": "ff3qnec29569sf"
          },
          "definition": "SELECT\n  hostname\nFROM\n  grafana_metric\nGROUP BY\n  id,\n  hostname\nLIMIT\n  2",
          "includeAll": true,
          "name": "hostnames_just_include_all",
          "options": [],
          "query": "SELECT\n  hostname\nFROM\n  grafana_metric\nGROUP BY\n  id,\n  hostname\nLIMIT\n  2",
          "refresh": 1,
          "regex": "",
          "regexApplyTo": "value",
          "type": "query"
        },
        {
          "allowCustomValue": false,
          "current": {
            "text": "10.1.100.1",
            "value": "10.1.100.1"
          },
          "datasource": {
            "type": "grafana-postgresql-datasource",
            "uid": "ff3qnec29569sf"
          },
          "definition": "SELECT\n  hostname\nFROM\n  grafana_metric\nGROUP BY\n  id,\n  hostname\nLIMIT\n  50",
          "includeAll": false,
          "name": "hostnames_single",
          "options": [],
          "query": "SELECT\n  hostname\nFROM\n  grafana_metric\nGROUP BY\n  id,\n  hostname\nLIMIT\n  50",
          "refresh": 1,
          "regex": "",
          "regexApplyTo": "value",
          "type": "query"
        },
        {
          "allowCustomValue": false,
          "current": {
            "text": "All",
            "value": "$__all"
          },
          "datasource": {
            "type": "grafana-postgresql-datasource",
            "uid": "ff3qnec29569sf"
          },
          "definition": "SELECT column_name FROM information_schema.columns WHERE table_name = 'grafana_metric' AND column_name != 'createdAt' ORDER BY ordinal_position; ",
          "includeAll": true,
          "name": "table_columns",
          "options": [],
          "query": {
            "dataset": "grafana",
            "editorMode": "code",
            "format": "table",
            "query": "SELECT column_name FROM information_schema.columns WHERE table_name = 'grafana_metric' AND column_name != 'createdAt' ORDER BY ordinal_position; ",
            "rawQuery": true,
            "rawSql": "SELECT column_name FROM information_schema.columns WHERE table_name = 'grafana_metric' AND column_name != 'createdAt' ORDER BY ordinal_position; ",
            "refId": "SQLVariableQueryEditor-VariableQuery",
            "sql": {
              "columns": [
                {
                  "parameters": [],
                  "type": "function"
                }
              ],
              "groupBy": [
                {
                  "property": {
                    "type": "string"
                  },
                  "type": "groupBy"
                }
              ],
              "limit": 50
            }
          },
          "refresh": 1,
          "regex": "",
          "regexApplyTo": "value",
          "type": "query"
        }
      ]
    },
    "time": {
      "from": "now-30m",
      "to": "now"
    },
    "timepicker": {},
    "timezone": "browser",
    "title": "postgres testing",
    "weekStart": ""
  }
```

</details> 

**Why do we need this feature?**

To have less diviated code in the codebase, to prevent future maintenance costs (Sadly, introducing this migration is also a maintenance cost too). And we came into conclusion that the old logic was clean and more stable.

**Who is this feature for?**

Users who have dashboards that use postgres datasource panels (repeated panels) with template variables.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/116844

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
