### PR TITLE
Alerting: Fix Time intervals tab highlighting Notification policies tab

### DIFF
--- a/public/app/features/alerting/unified/navigation/useNotificationConfigNav.ts
+++ b/public/app/features/alerting/unified/navigation/useNotificationConfigNav.ts
@@ -87,7 +87,9 @@ export function useNotificationConfigNav() {
         id: 'notification-config-policies',
         text: t('alerting.navigation.notification-policies', 'Notification policies'),
         url: ALERTING_PATHS.ROUTES,
-        active: location.pathname.startsWith(ALERTING_PATHS.ROUTES),
+        active:
+          location.pathname.startsWith(ALERTING_PATHS.ROUTES) &&
+          !location.pathname.startsWith(ALERTING_PATHS.TIME_INTERVALS),
         parentItem: notificationConfigNav,
       });
     }


### PR DESCRIPTION
The Time intervals path (`/alerting/routes/mute-timing`) is a sub-path of Notification policies (`/alerting/routes`), causing both tabs to appear active when navigating to Time intervals. Exclude the time intervals path from the notification policies active check.


**What is this feature?**
This PR fixes Time intervals tab incorrectly highlighting Notification policies tab when time intervals tab is selected.

### Problem

When navigating to the **Time intervals** tab on the Notification configuration page, both the **Notification policies** and **Time intervals** tabs appear highlighted/active simultaneously.

This happens because the Time intervals route (`/alerting/routes/mute-timing`) is a sub-path of the Notification policies route (`/alerting/routes`). Both tabs use `startsWith` to determine their active state, so any path under `/alerting/routes` matches both checks.

**Why do we need this feature?**

Its fixing a bug.

**Who is this feature for?**

Alerting users

**Special notes for your reviewer:**

**Before the change:**

<img width="638" height="154" alt="Screenshot 2026-02-24 at 13 10 54" src="https://github.com/user-attachments/assets/46ab2bd2-eb45-41f1-bfef-e895ea8d0453" />


**After the change:**
<img width="649" height="142" alt="Screenshot 2026-02-24 at 13 11 16" src="https://github.com/user-attachments/assets/6a8f17be-6c17-4315-ad40-f5054a6e0957" />


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
