### PR TITLE
CI: Set Storybook preview as a Github Deployment

### DIFF
--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -25,6 +25,10 @@ jobs:
     env:
       BUCKET_NAME: grafana-storybook-previews
 
+    environment:
+      name: "storybook-pr-preview-${{ github.event.pull_request.number }}"
+      url: ${{ steps.storybook-url.outputs.url }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -73,9 +77,16 @@ jobs:
           service_account: github-gf-storybook-preview@grafanalabs-workload-identity.iam.gserviceaccount.com
           parent: false
 
-      - name: Write summary
+      - name: Set storybook URL
+        id: storybook-url
         env:
           DEPLOY_NAME: ${{ steps.create-deploy-name.outputs.deploy-name }}
         run: |
+          echo "url=https://storage.googleapis.com/${BUCKET_NAME}/${DEPLOY_NAME}/index.html" >> "$GITHUB_OUTPUT"
+
+      - name: Write summary
+        env:
+          STORYBOOK_URL: ${{ steps.storybook-url.outputs.url }}
+        run: |
           echo "## Storybook preview deployed! 🚀" >> $GITHUB_STEP_SUMMARY
-          echo "Check it out at https://storage.googleapis.com/${BUCKET_NAME}/${DEPLOY_NAME}/index.html" >> $GITHUB_STEP_SUMMARY
+          echo "Check it out at ${STORYBOOK_URL}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Tweaks the `deploy-storybook-preview.yml` Github Actions workflow to specify an environment/deployment URL. See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idenvironment for some details - the Github docs are pretty light on this topic.

The goal of this is to surface the preview URL in the ‘deployments’ box on the pull request, to make it more visible. 