### PR TITLE
Provisioning: Add protected field to repository refs API

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
@@ -837,6 +837,8 @@ type RefItem struct {
 	Hash string `json:"hash,omitempty"`
 	// The URL to the reference (branch or tag)
 	RefURL string `json:"refURL,omitempty"`
+	// Whether this ref is protected (e.g. branch protection rules)
+	Protected bool `json:"protected,omitempty"`
 }
 
 func (RefItem) OpenAPIModelName() string {

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -1837,6 +1837,13 @@ func schema_pkg_apis_provisioning_v0alpha1_RefItem(ref common.ReferenceCallback)
 							Format:      "",
 						},
 					},
+					"protected": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Whether this ref is protected (e.g. branch protection rules)",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"name"},
 			},

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -5293,6 +5293,10 @@
             "type": "string",
             "default": ""
           },
+          "protected": {
+            "description": "Whether this ref is protected (e.g. branch protection rules)",
+            "type": "boolean"
+          },
           "refURL": {
             "description": "The URL to the reference (branch or tag)",
             "type": "string"


### PR DESCRIPTION
## Summary

- Adds a boolean `protected` field to `RefItem` in the repository refs endpoint, indicating whether a branch or tag has protection rules applied (e.g. GitHub branch protection).
- API-only change: type definition, generated OpenAPI schema, and snapshot updated. No implementation wiring yet.

## Why

When users configure the `write` workflow on a protected branch, direct pushes are silently rejected by GitHub with a `403 Forbidden`. This surfaces as a confusing error at sync time. By exposing branch protection status in the refs API, the frontend can warn users before they select a protected branch — preventing misconfiguration early.

Ticket: https://github.com/grafana/git-ui-sync-project/issues/931

Related PR (branch protection validation in the Test endpoint): https://github.com/grafana/grafana/pull/118717

## Test plan

- [ ] Verify codegen output matches (`./hack/update-codegen.sh provisioning`)
- [ ] Regenerate frontend client (`yarn generate-apis`) and fix any resulting TS issues
- [ ] Wire up `protected` field population in repository implementations (GitHub, Git, etc.)