### PR TITLE
Dashboard: Show controls when time controls are hidden in dynamic dashboards

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -163,6 +163,24 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
   const useUnifiedDrilldownUI = config.featureToggles.dashboardAdHocAndGroupByWrapper && adHocVar && groupByVar;
 
   if (!model.hasControls()) {
+    // If dynamic dashboards is enabled, we need to show the edit/share/playlist buttons
+    // However we shouldn't do it if we're in edit panel view
+    // `DashboardControlActions` already check for edit panel view but we need to prevent showing the container as well
+    if (config.featureToggles.dashboardNewLayouts && !editPanel) {
+      return (
+        <div
+          data-testid={selectors.pages.Dashboard.Controls}
+          className={cx(styles.controls, editPanel && styles.controlsPanelEdit)}
+        >
+          <div className={cx(styles.rightControls, editPanel && styles.rightControlsWrap)}>
+            <div className={styles.fixedControls}>
+              <DashboardControlActions dashboard={dashboard} />
+            </div>
+          </div>
+        </div>
+      );
+    }
+
     // To still have spacing when no controls are rendered
     return <Box padding={1}>{renderHiddenVariables(dashboard)}</Box>;
   }

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -168,16 +168,16 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
     // `DashboardControlActions` already check for edit panel view but we need to prevent showing the container as well
     if (config.featureToggles.dashboardNewLayouts && !editPanel) {
       return (
-        <div
-          data-testid={selectors.pages.Dashboard.Controls}
-          className={cx(styles.controls, editPanel && styles.controlsPanelEdit)}
-        >
-          <div className={cx(styles.rightControls, editPanel && styles.rightControlsWrap)}>
-            <div className={styles.fixedControls}>
-              <DashboardControlActions dashboard={dashboard} />
+        <>
+          <div data-testid={selectors.pages.Dashboard.Controls} className={styles.controls}>
+            <div className={styles.rightControls}>
+              <div className={styles.fixedControls}>
+                <DashboardControlActions dashboard={dashboard} />
+              </div>
             </div>
           </div>
-        </div>
+          {renderHiddenVariables(dashboard)}
+        </>
       );
     }
 


### PR DESCRIPTION
When there are no dashboard controls, there's no way to go to edit mode unless one clicks on "edit panel".

This PR fixes this.