### PR TITLE
Plugins: Add useConfigSaveReporter hook

### DIFF
--- a/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.test.tsx
+++ b/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.test.tsx
@@ -14,7 +14,7 @@ import {
 } from '@grafana/data';
 import iconGaugeSvg from 'app/plugins/panel/gauge/img/icon_gauge.svg';
 
-import { useConfigSaveReporter } from './useConfigSaveReporter';
+import { ConfigSaveReporterProperties, useConfigSaveReporter } from './useConfigSaveReporter';
 
 const testEventBus = new EventBusSrv();
 
@@ -160,6 +160,56 @@ describe('useConfigSaveReporter', () => {
 
     expect(subscribeSpy).not.toHaveBeenCalled();
     subscribeSpy.mockRestore();
+  });
+});
+
+describe('ConfigSaveReporterProperties', () => {
+  it('accepts string values', () => {
+    const properties: ConfigSaveReporterProperties = {
+      auth_type: 'keys',
+      region: 'us-east-1',
+    };
+    expect(properties).toBeDefined();
+  });
+
+  it('rejects number values', () => {
+    const properties: ConfigSaveReporterProperties = {
+      // @ts-expect-error number values are not allowed
+      retry_count: 3,
+    };
+    expect(properties).toBeDefined();
+  });
+
+  it('rejects boolean values', () => {
+    const properties: ConfigSaveReporterProperties = {
+      // @ts-expect-error boolean values are not allowed
+      tls_enabled: true,
+    };
+    expect(properties).toBeDefined();
+  });
+
+  it('rejects object values', () => {
+    const properties: ConfigSaveReporterProperties = {
+      // @ts-expect-error object values are not allowed — they may contain nested sensitive data
+      credentials: { key: 'secret' },
+    };
+    expect(properties).toBeDefined();
+  });
+
+  it('rejects array values', () => {
+    const properties: ConfigSaveReporterProperties = {
+      // @ts-expect-error array values are not allowed
+      regions: ['us-east-1', 'eu-west-1'],
+    };
+    expect(properties).toBeDefined();
+  });
+
+  it('rejects null values', () => {
+    const properties: ConfigSaveReporterProperties = {
+      // @ts-expect-error null is not allowed
+      auth_type: null,
+    };
+    expect(properties).toBeDefined();
   });
 });
 

--- a/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.test.tsx
+++ b/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.test.tsx
@@ -6,6 +6,7 @@ import {
   DataSourcePluginContextProvider,
   DataSourceTestFailed,
   DataSourceTestSucceeded,
+  EventBusSrv,
   PluginMeta,
   PluginMetaInfo,
   PluginSignatureStatus,
@@ -13,12 +14,13 @@ import {
 } from '@grafana/data';
 import iconGaugeSvg from 'app/plugins/panel/gauge/img/icon_gauge.svg';
 
-import { appEvents } from 'app/core/app_events';
-
 import { useConfigSaveReporter } from './useConfigSaveReporter';
+
+const testEventBus = new EventBusSrv();
 
 const mockReport = jest.fn();
 jest.mock('./usePluginInteractionReporter', () => ({ usePluginInteractionReporter: () => mockReport }));
+jest.mock('../../services', () => ({ ...jest.requireActual('../../services'), getAppEvents: () => testEventBus }));
 
 describe('useConfigSaveReporter', () => {
   beforeEach(() => {
@@ -31,7 +33,7 @@ describe('useConfigSaveReporter', () => {
     });
 
     act(() => {
-      appEvents.publish(new DataSourceTestSucceeded());
+      testEventBus.publish(new DataSourceTestSucceeded());
     });
 
     expect(mockReport).toHaveBeenCalledTimes(1);
@@ -47,7 +49,7 @@ describe('useConfigSaveReporter', () => {
     });
 
     act(() => {
-      appEvents.publish(new DataSourceTestFailed());
+      testEventBus.publish(new DataSourceTestFailed());
     });
 
     expect(mockReport).toHaveBeenCalledTimes(1);
@@ -70,7 +72,7 @@ describe('useConfigSaveReporter', () => {
     });
 
     act(() => {
-      appEvents.publish(new DataSourceTestSucceeded());
+      testEventBus.publish(new DataSourceTestSucceeded());
     });
 
     expect(mockReport).toHaveBeenCalledWith(
@@ -85,7 +87,7 @@ describe('useConfigSaveReporter', () => {
     });
 
     act(() => {
-      appEvents.publish(new DataSourceTestSucceeded());
+      testEventBus.publish(new DataSourceTestSucceeded());
     });
 
     expect(mockReport).toHaveBeenCalledWith(
@@ -102,7 +104,7 @@ describe('useConfigSaveReporter', () => {
     );
 
     act(() => {
-      appEvents.publish(new DataSourceTestSucceeded());
+      testEventBus.publish(new DataSourceTestSucceeded());
     });
 
     expect(mockReport).toHaveBeenCalledWith(
@@ -120,8 +122,8 @@ describe('useConfigSaveReporter', () => {
     unmount();
 
     act(() => {
-      appEvents.publish(new DataSourceTestSucceeded());
-      appEvents.publish(new DataSourceTestFailed());
+      testEventBus.publish(new DataSourceTestSucceeded());
+      testEventBus.publish(new DataSourceTestFailed());
     });
 
     expect(mockReport).not.toHaveBeenCalled();
@@ -137,7 +139,7 @@ describe('useConfigSaveReporter', () => {
     authType = 'keys';
 
     act(() => {
-      appEvents.publish(new DataSourceTestSucceeded());
+      testEventBus.publish(new DataSourceTestSucceeded());
     });
 
     expect(mockReport).toHaveBeenCalledWith(
@@ -153,7 +155,7 @@ describe('useConfigSaveReporter', () => {
       { wrapper: createWrapper(), initialProps: { authType: 'default' } }
     );
 
-    const subscribeSpy = jest.spyOn(appEvents, 'subscribe');
+    const subscribeSpy = jest.spyOn(testEventBus, 'subscribe');
     rerender({ authType: 'default' });
 
     expect(subscribeSpy).not.toHaveBeenCalled();

--- a/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.test.tsx
+++ b/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.test.tsx
@@ -20,6 +20,7 @@ import { reportInteraction } from '../utils';
 import { useConfigSaveReporter } from './useConfigSaveReporter';
 
 jest.mock('../utils', () => ({ reportInteraction: jest.fn() }));
+jest.mock('../../services', () => ({ ...jest.requireActual('../../services'), getAppEvents: jest.fn() }));
 const reportInteractionMock = jest.mocked(reportInteraction);
 
 describe('useConfigSaveReporter', () => {
@@ -28,7 +29,7 @@ describe('useConfigSaveReporter', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     appEventBus = new EventBusSrv();
-    jest.spyOn(services, 'getAppEvents').mockReturnValue(appEventBus);
+    jest.mocked(services.getAppEvents).mockReturnValue(appEventBus);
   });
 
   it('reports grafana_plugin_save_result with result success when DataSourceTestSucceeded is published', () => {
@@ -160,10 +161,10 @@ describe('useConfigSaveReporter', () => {
       { wrapper: createWrapper(), initialProps: { authType: 'default' } }
     );
 
-    const getAppEventsSpy = jest.spyOn(services, 'getAppEvents');
+    jest.mocked(services.getAppEvents).mockClear();
     rerender({ authType: 'default' });
 
-    expect(getAppEventsSpy).not.toHaveBeenCalled();
+    expect(services.getAppEvents).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.test.tsx
+++ b/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.test.tsx
@@ -1,0 +1,203 @@
+import { act, renderHook } from '@testing-library/react';
+import * as React from 'react';
+
+import {
+  DataSourceInstanceSettings,
+  DataSourcePluginContextProvider,
+  DataSourceTestFailed,
+  DataSourceTestSucceeded,
+  EventBusSrv,
+  PluginMeta,
+  PluginMetaInfo,
+  PluginSignatureStatus,
+  PluginType,
+} from '@grafana/data';
+import iconGaugeSvg from 'app/plugins/panel/gauge/img/icon_gauge.svg';
+
+import * as services from '../../services';
+import { reportInteraction } from '../utils';
+
+import { useConfigSaveReporter } from './useConfigSaveReporter';
+
+jest.mock('../utils', () => ({ reportInteraction: jest.fn() }));
+const reportInteractionMock = jest.mocked(reportInteraction);
+
+describe('useConfigSaveReporter', () => {
+  let appEventBus: EventBusSrv;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    appEventBus = new EventBusSrv();
+    jest.spyOn(services, 'getAppEvents').mockReturnValue(appEventBus);
+  });
+
+  it('reports grafana_plugin_save_result with result success when DataSourceTestSucceeded is published', () => {
+    renderHook(() => useConfigSaveReporter('grafana-cloudwatch-datasource', { auth_type: 'default' }), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      appEventBus.publish(new DataSourceTestSucceeded());
+    });
+
+    expect(reportInteractionMock).toHaveBeenCalledTimes(1);
+    expect(reportInteractionMock).toHaveBeenCalledWith(
+      'grafana_plugin_save_result',
+      expect.objectContaining({ plugin_id: 'grafana-cloudwatch-datasource', result: 'success', auth_type: 'default' })
+    );
+  });
+
+  it('reports grafana_plugin_save_result with result error when DataSourceTestFailed is published', () => {
+    renderHook(() => useConfigSaveReporter('grafana-cloudwatch-datasource', { auth_type: 'default' }), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      appEventBus.publish(new DataSourceTestFailed());
+    });
+
+    expect(reportInteractionMock).toHaveBeenCalledTimes(1);
+    expect(reportInteractionMock).toHaveBeenCalledWith(
+      'grafana_plugin_save_result',
+      expect.objectContaining({ plugin_id: 'grafana-cloudwatch-datasource', result: 'error', auth_type: 'default' })
+    );
+  });
+
+  it('includes datasource plugin context info in the reported properties', () => {
+    renderHook(() => useConfigSaveReporter('grafana-cloudwatch-datasource', { auth_type: 'default' }), {
+      wrapper: createWrapper({
+        uid: 'abc123',
+        meta: createPluginMeta({ id: 'grafana-cloudwatch-datasource', name: 'CloudWatch', info: createPluginMetaInfo({ version: '1.0.0' }) }),
+      }),
+    });
+
+    act(() => {
+      appEventBus.publish(new DataSourceTestSucceeded());
+    });
+
+    expect(reportInteractionMock).toHaveBeenCalledWith('grafana_plugin_save_result', {
+      plugin_id: 'grafana-cloudwatch-datasource',
+      result: 'success',
+      auth_type: 'default',
+      grafana_version: '1.0',
+      plugin_type: 'datasource',
+      plugin_version: '1.0.0',
+      plugin_name: 'CloudWatch',
+      datasource_uid: 'abc123',
+    });
+  });
+
+  it('works with no properties argument', () => {
+    renderHook(() => useConfigSaveReporter('grafana-cloudwatch-datasource'), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      appEventBus.publish(new DataSourceTestSucceeded());
+    });
+
+    expect(reportInteractionMock).toHaveBeenCalledWith(
+      'grafana_plugin_save_result',
+      expect.objectContaining({ plugin_id: 'grafana-cloudwatch-datasource', result: 'success' })
+    );
+  });
+
+  it('forwards arbitrary extra properties to the interaction event', () => {
+    renderHook(
+      () => useConfigSaveReporter('grafana-cloudwatch-datasource', { auth_type: 'default', custom_prop: 'value' }),
+      { wrapper: createWrapper() }
+    );
+
+    act(() => {
+      appEventBus.publish(new DataSourceTestSucceeded());
+    });
+
+    expect(reportInteractionMock).toHaveBeenCalledWith(
+      'grafana_plugin_save_result',
+      expect.objectContaining({ auth_type: 'default', custom_prop: 'value' })
+    );
+  });
+
+  it('stops reporting after unmount', () => {
+    const { unmount } = renderHook(
+      () => useConfigSaveReporter('grafana-cloudwatch-datasource', { auth_type: 'default' }),
+      { wrapper: createWrapper() }
+    );
+
+    unmount();
+
+    act(() => {
+      appEventBus.publish(new DataSourceTestSucceeded());
+      appEventBus.publish(new DataSourceTestFailed());
+    });
+
+    expect(reportInteractionMock).not.toHaveBeenCalled();
+  });
+
+  it('uses the updated properties after re-render', () => {
+    const { rerender } = renderHook(
+      ({ authType }: { authType: string }) =>
+        useConfigSaveReporter('grafana-cloudwatch-datasource', { auth_type: authType }),
+      { wrapper: createWrapper(), initialProps: { authType: 'default' } }
+    );
+
+    rerender({ authType: 'keys' });
+
+    act(() => {
+      appEventBus.publish(new DataSourceTestSucceeded());
+    });
+
+    expect(reportInteractionMock).toHaveBeenCalledWith(
+      'grafana_plugin_save_result',
+      expect.objectContaining({ auth_type: 'keys' })
+    );
+  });
+});
+
+function createWrapper(settings?: Partial<DataSourceInstanceSettings>) {
+  return ({ children }: React.PropsWithChildren<{}>) => (
+    <DataSourcePluginContextProvider instanceSettings={createDataSourceInstanceSettings(settings)}>
+      {children}
+    </DataSourcePluginContextProvider>
+  );
+}
+
+function createDataSourceInstanceSettings(settings: Partial<DataSourceInstanceSettings> = {}): DataSourceInstanceSettings {
+  const { meta, ...rest } = settings;
+  return {
+    uid: '',
+    name: '',
+    meta: createPluginMeta(meta),
+    type: PluginType.datasource,
+    readOnly: false,
+    jsonData: {},
+    access: 'proxy',
+    ...rest,
+  };
+}
+
+function createPluginMeta(meta: Partial<PluginMeta> = {}): PluginMeta {
+  return {
+    id: 'grafana-cloudwatch-datasource',
+    name: 'CloudWatch',
+    type: PluginType.datasource,
+    info: createPluginMetaInfo(),
+    module: 'app/plugins/datasource/cloudwatch/module',
+    baseUrl: '',
+    signature: PluginSignatureStatus.internal,
+    ...meta,
+  };
+}
+
+function createPluginMetaInfo(info: Partial<PluginMetaInfo> = {}): PluginMetaInfo {
+  return {
+    author: { name: 'Grafana Labs' },
+    description: '',
+    links: [],
+    logos: { large: iconGaugeSvg, small: iconGaugeSvg },
+    screenshots: [],
+    updated: '',
+    version: '',
+    ...info,
+  };
+}

--- a/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.test.tsx
+++ b/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.test.tsx
@@ -61,7 +61,11 @@ describe('useConfigSaveReporter', () => {
     renderHook(() => useConfigSaveReporter('grafana-cloudwatch-datasource', () => ({ auth_type: 'default' })), {
       wrapper: createWrapper({
         uid: 'abc123',
-        meta: createPluginMeta({ id: 'grafana-cloudwatch-datasource', name: 'CloudWatch', info: createPluginMetaInfo({ version: '1.0.0' }) }),
+        meta: createPluginMeta({
+          id: 'grafana-cloudwatch-datasource',
+          name: 'CloudWatch',
+          info: createPluginMetaInfo({ version: '1.0.0' }),
+        }),
       }),
     });
 
@@ -92,7 +96,8 @@ describe('useConfigSaveReporter', () => {
 
   it('forwards arbitrary extra properties to the interaction event', () => {
     renderHook(
-      () => useConfigSaveReporter('grafana-cloudwatch-datasource', () => ({ auth_type: 'default', custom_prop: 'value' })),
+      () =>
+        useConfigSaveReporter('grafana-cloudwatch-datasource', () => ({ auth_type: 'default', custom_prop: 'value' })),
       { wrapper: createWrapper() }
     );
 
@@ -159,13 +164,13 @@ describe('useConfigSaveReporter', () => {
 function createWrapper(settings?: Partial<DataSourceInstanceSettings>) {
   const instanceSettings = createDataSourceInstanceSettings(settings);
   return ({ children }: React.PropsWithChildren<{}>) => (
-    <DataSourcePluginContextProvider instanceSettings={instanceSettings}>
-      {children}
-    </DataSourcePluginContextProvider>
+    <DataSourcePluginContextProvider instanceSettings={instanceSettings}>{children}</DataSourcePluginContextProvider>
   );
 }
 
-function createDataSourceInstanceSettings(settings: Partial<DataSourceInstanceSettings> = {}): DataSourceInstanceSettings {
+function createDataSourceInstanceSettings(
+  settings: Partial<DataSourceInstanceSettings> = {}
+): DataSourceInstanceSettings {
   const { meta, ...rest } = settings;
   return {
     uid: '',

--- a/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.ts
+++ b/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.ts
@@ -12,7 +12,6 @@ import { usePluginInteractionReporter } from './usePluginInteractionReporter';
  *
  * @param pluginId - The plugin ID (e.g. `'grafana-cloudwatch-datasource'`)
  * @param getProperties - A function returning additional properties to include in the interaction event.
- *   Called at event time so it always reflects the latest state.
  *
  * @alpha
  */

--- a/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.ts
+++ b/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.ts
@@ -7,15 +7,35 @@ import { getAppEvents } from '../../services';
 import { usePluginInteractionReporter } from './usePluginInteractionReporter';
 
 /**
+ * Non-sensitive configuration metadata to include in a `grafana_plugin_save_result` event.
+ * Values are intentionally restricted to strings to prevent accidentally logging
+ * complex objects that may contain credentials or other sensitive data.
+ *
+ * @example
+ * ```ts
+ * // Good: configuration choices that are safe to log
+ * { auth_type: 'keys', region: 'us-east-1' }
+ *
+ * // Bad: never include secrets, passwords, tokens, or user-entered data
+ * { password: '...', api_key: '...' }
+ * ```
+ *
+ * @alpha
+ */
+export type ConfigSaveReporterProperties = Record<string, string>;
+
+/**
  * Reports a `grafana_plugin_save_result` interaction event when a datasource
  * configuration save succeeds or fails.
  *
  * @param pluginId - The plugin ID (e.g. `'grafana-cloudwatch-datasource'`)
- * @param getProperties - A function returning additional properties to include in the interaction event.
+ * @param getProperties - Returns non-sensitive configuration metadata (e.g. auth type, region)
+ *   to include in the event. Called at save time so it always reflects the latest state.
+ *   Restrict values to configuration choices — never include secrets, passwords, or user data.
  *
  * @alpha
  */
-export function useConfigSaveReporter(pluginId: string, getProperties?: () => Record<string, unknown>) {
+export function useConfigSaveReporter(pluginId: string, getProperties?: () => ConfigSaveReporterProperties) {
   const report = usePluginInteractionReporter();
   const getPropertiesRef = useRef(getProperties);
   getPropertiesRef.current = getProperties;

--- a/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.ts
+++ b/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+
+import { DataSourceTestFailed, DataSourceTestSucceeded } from '@grafana/data';
+
+import { getAppEvents } from '../../services';
+
+import { usePluginInteractionReporter } from './usePluginInteractionReporter';
+
+/**
+ * Reports a `grafana_plugin_save_result` interaction event when a datasource
+ * configuration save succeeds or fails.
+ *
+ * @param pluginId - The plugin ID (e.g. `'grafana-cloudwatch-datasource'`)
+ * @param properties - Additional properties to include in the interaction event
+ *
+ * @alpha
+ */
+export function useConfigSaveReporter(pluginId: string, properties?: Record<string, unknown>) {
+  const report = usePluginInteractionReporter();
+
+  useEffect(() => {
+    const successSubscription = getAppEvents().subscribe<DataSourceTestSucceeded>(DataSourceTestSucceeded, () => {
+      report('grafana_plugin_save_result', { ...properties, plugin_id: pluginId, result: 'success' });
+    });
+    const failSubscription = getAppEvents().subscribe<DataSourceTestFailed>(DataSourceTestFailed, () => {
+      report('grafana_plugin_save_result', { ...properties, plugin_id: pluginId, result: 'error' });
+    });
+    return () => {
+      successSubscription.unsubscribe();
+      failSubscription.unsubscribe();
+    };
+  }, [pluginId, properties, report]);
+}

--- a/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.ts
+++ b/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 
 import { DataSourceTestFailed, DataSourceTestSucceeded } from '@grafana/data';
 
-import { appEvents } from 'app/core/app_events';
+import { getAppEvents } from '../../services';
 
 import { usePluginInteractionReporter } from './usePluginInteractionReporter';
 
@@ -22,10 +22,10 @@ export function useConfigSaveReporter(pluginId: string, getProperties?: () => Re
   getPropertiesRef.current = getProperties;
 
   useEffect(() => {
-    const successSubscription = appEvents.subscribe<DataSourceTestSucceeded>(DataSourceTestSucceeded, () => {
+    const successSubscription = getAppEvents().subscribe<DataSourceTestSucceeded>(DataSourceTestSucceeded, () => {
       report('grafana_plugin_save_result', { ...getPropertiesRef.current?.(), plugin_id: pluginId, result: 'success' });
     });
-    const failSubscription = appEvents.subscribe<DataSourceTestFailed>(DataSourceTestFailed, () => {
+    const failSubscription = getAppEvents().subscribe<DataSourceTestFailed>(DataSourceTestFailed, () => {
       report('grafana_plugin_save_result', { ...getPropertiesRef.current?.(), plugin_id: pluginId, result: 'error' });
     });
     return () => {

--- a/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.ts
+++ b/packages/grafana-runtime/src/analytics/plugins/useConfigSaveReporter.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 
 import { DataSourceTestFailed, DataSourceTestSucceeded } from '@grafana/data';
 
-import { getAppEvents } from '../../services';
+import { appEvents } from 'app/core/app_events';
 
 import { usePluginInteractionReporter } from './usePluginInteractionReporter';
 
@@ -22,10 +22,10 @@ export function useConfigSaveReporter(pluginId: string, getProperties?: () => Re
   getPropertiesRef.current = getProperties;
 
   useEffect(() => {
-    const successSubscription = getAppEvents().subscribe<DataSourceTestSucceeded>(DataSourceTestSucceeded, () => {
+    const successSubscription = appEvents.subscribe<DataSourceTestSucceeded>(DataSourceTestSucceeded, () => {
       report('grafana_plugin_save_result', { ...getPropertiesRef.current?.(), plugin_id: pluginId, result: 'success' });
     });
-    const failSubscription = getAppEvents().subscribe<DataSourceTestFailed>(DataSourceTestFailed, () => {
+    const failSubscription = appEvents.subscribe<DataSourceTestFailed>(DataSourceTestFailed, () => {
       report('grafana_plugin_save_result', { ...getPropertiesRef.current?.(), plugin_id: pluginId, result: 'error' });
     });
     return () => {

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -58,6 +58,7 @@ export {
   createDataSourcePluginEventProperties,
 } from './analytics/plugins/eventProperties';
 export { usePluginInteractionReporter } from './analytics/plugins/usePluginInteractionReporter';
+export { useConfigSaveReporter } from './analytics/plugins/useConfigSaveReporter';
 export { setReturnToPreviousHook, useReturnToPrevious } from './utils/returnToPrevious';
 export { setMegaMenuOpenHook, useMegaMenuOpen } from './utils/megaMenuOpen';
 export { setChromeHeaderHeightHook, useChromeHeaderHeight } from './utils/chromeHeaderHeight';

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.test.tsx
@@ -27,9 +27,6 @@ jest.mock('./XrayLinkConfig', () => ({
 
 const putMock = jest.fn();
 const getMock = jest.fn();
-const mockAppEvents = {
-  subscribe: () => ({ unsubscribe: jest.fn() }),
-};
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: () => ({
@@ -39,7 +36,7 @@ jest.mock('@grafana/runtime', () => ({
   getDataSourceSrv: () => ({
     get: loadDataSourceMock,
   }),
-  getAppEvents: () => mockAppEvents,
+  useConfigSaveReporter: jest.fn(),
   config: {
     ...jest.requireActual('@grafana/runtime').config,
     awsAssumeRoleEnabled: true,

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx
@@ -44,7 +44,7 @@ export const ConfigEditor = (props: Props) => {
   });
 
   useEffect(() => setLogGroupFieldState({ invalid: false }), [props.options]);
-  useConfigSaveReporter('cloudwatch', { auth_type: options.jsonData.authType });
+  useConfigSaveReporter('cloudwatch', () => ({ auth_type: options.jsonData.authType }));
   const [externalId, setExternalId] = useState('');
   useEffect(() => {
     if (!externalId && datasource) {

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx
@@ -44,7 +44,7 @@ export const ConfigEditor = (props: Props) => {
   });
 
   useEffect(() => setLogGroupFieldState({ invalid: false }), [props.options]);
-  useConfigSaveReporter('cloudwatch', () => ({ auth_type: options.jsonData.authType }));
+  useConfigSaveReporter('cloudwatch', () => ({ auth_type: options.jsonData.authType ?? '' }));
   const [externalId, setExternalId] = useState('');
   useEffect(() => {
     if (!externalId && datasource) {

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx
@@ -8,12 +8,10 @@ import {
   DataSourcePluginOptionsEditorProps,
   onUpdateDatasourceJsonDataOption,
   updateDatasourcePluginJsonDataOption,
-  DataSourceTestSucceeded,
-  DataSourceTestFailed,
   GrafanaTheme2,
 } from '@grafana/data';
 import { ConfigSection, DataSourceDescription } from '@grafana/plugin-ui';
-import { getAppEvents, usePluginInteractionReporter, getDataSourceSrv, config } from '@grafana/runtime';
+import { getDataSourceSrv, config, useConfigSaveReporter } from '@grafana/runtime';
 import { Alert, Input, FieldProps, Field, Divider, useStyles2 } from '@grafana/ui';
 
 import { CloudWatchDatasource } from '../../datasource';
@@ -46,23 +44,7 @@ export const ConfigEditor = (props: Props) => {
   });
 
   useEffect(() => setLogGroupFieldState({ invalid: false }), [props.options]);
-  const report = usePluginInteractionReporter();
-  useEffect(() => {
-    const successSubscription = getAppEvents().subscribe<DataSourceTestSucceeded>(DataSourceTestSucceeded, () => {
-      report('grafana_plugin_cloudwatch_save_succeeded', {
-        auth_type: options.jsonData.authType,
-      });
-    });
-    const failSubscription = getAppEvents().subscribe<DataSourceTestFailed>(DataSourceTestFailed, () => {
-      report('grafana_plugin_cloudwatch_save_failed', {
-        auth_type: options.jsonData.authType,
-      });
-    });
-    return () => {
-      successSubscription.unsubscribe();
-      failSubscription.unsubscribe();
-    };
-  }, [options.jsonData.authType, report]);
+  useConfigSaveReporter('cloudwatch', { auth_type: options.jsonData.authType });
   const [externalId, setExternalId] = useState('');
   useEffect(() => {
     if (!externalId && datasource) {


### PR DESCRIPTION
**What is this feature?**
This adds a generic way to report datasource config save results, replacing the one-off mechanism used in CloudWatch.

**Why do we need this feature?**
The AWS datasources team wants to add these events for all plugins. Moving the ad-hoc code from CW into a central place rather than duplicating it made sense, and putting the code into `@grafana/runtime` (rather than `grafana/grafana-aws-sdk-react` as I first intended) makes it available to all plugins, not just AWS ones.

**Who is this feature for?**
Operators of plugins in Grafana Cloud, mostly.

**Which issue(s) does this PR fix?**:
This is the first step in closing https://github.com/grafana/oss-plugin-partnerships/issues/1427. Once a version of the `@grafana/runtime` package with these changes has been published we'll update all the AWS plugins to use it.
