### PR TITLE
Provisioning: Default to branch-only workflow in onboarding wizard

### DIFF
--- a/public/app/features/provisioning/Config/defaults.ts
+++ b/public/app/features/provisioning/Config/defaults.ts
@@ -31,7 +31,7 @@ export function getDefaultValues({
         target: defaultTarget,
         intervalSeconds: 60,
       },
-      enablePushToConfiguredBranch: true,
+      enablePushToConfiguredBranch: false,
     };
   }
   return specToData(repository);


### PR DESCRIPTION
## Summary
- Disables the `write` workflow (direct push to configured branch) by default in the provisioning onboarding wizard.
- New repositories now start with only the `branch` (PR) workflow enabled, making it an explicit user decision. 
- In follow up, we may use the branch protection settings to even disable the push to main option in the configuration, and fail repository health in the backend. 
- Users can still enable direct push via the "Enable push to configured branch" checkbox in the finish step.


Made with [Cursor](https://cursor.com)