### PR TITLE
Alerting: Enable reliable delivery for single-eval alert broadcasting

### DIFF
--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -265,8 +265,15 @@ func (moa *MultiOrgAlertmanager) initAlertBroadcast() {
 	if _, ok := moa.peer.(*NilPeer); ok {
 		return
 	}
+	queueSize := moa.settings.UnifiedAlerting.HASingleEvaluationAlertBroadcastQueueSize
+	if queueSize <= 0 {
+		queueSize = setting.AlertBroadcastDefaultQueueSize
+	}
 	state := newAlertBroadcastState(moa.logger.New("component", "alert-broadcast"), moa)
-	moa.alertsBroadcastChannel = moa.peer.AddState(alertBroadcastKey, state, moa.metrics.Registerer)
+	moa.alertsBroadcastChannel = moa.peer.AddState(alertBroadcastKey, state, moa.metrics.Registerer,
+		alertingCluster.WithReliableDelivery(true),
+		alertingCluster.WithQueueSize(queueSize),
+	)
 }
 
 // BroadcastAlerts sends alerts to all peers via the cluster channel.

--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -482,7 +482,8 @@ func (m *MockBroadcastChannel) Broadcasts() [][]byte {
 
 // MockClusterPeer implements alertingNotify.ClusterPeer for testing.
 type MockClusterPeer struct {
-	Channel *MockBroadcastChannel
+	Channel     *MockBroadcastChannel
+	LastOptions []alertingCluster.ChannelOption
 }
 
 // Position implements alertingNotify.ClusterPeer.
@@ -496,7 +497,8 @@ func (m *MockClusterPeer) WaitReady(context.Context) error {
 }
 
 // AddState implements alertingNotify.ClusterPeer.
-func (m *MockClusterPeer) AddState(_ string, _ alertingCluster.State, _ prometheus.Registerer, _ ...alertingCluster.ChannelOption) alertingCluster.ClusterChannel {
+func (m *MockClusterPeer) AddState(_ string, _ alertingCluster.State, _ prometheus.Registerer, opts ...alertingCluster.ChannelOption) alertingCluster.ClusterChannel {
+	m.LastOptions = opts
 	return m.Channel
 }
 


### PR DESCRIPTION
**What is this feature?**

When HA single-node evaluation is enabled, alerts broadcast from the primary evaluator to peers can be sent via UDP gossip for small payloads (< 700 bytes), which risks silent delivery failures. Enable TCP-based reliable delivery for all alert broadcasts regardless of size.
                            
The broadcast queue size is configurable via `ha_single_evaluation_alert_broadcast_queue_size` (default: 200).

`ha_single_evaluation_alert_broadcast_queue_size` is not documented yet (and not in sample.ini / defaults.ini), I will document it together with `ha_single_node_evaluation` in a separate PR.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/116545

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
