### PR TITLE
fix(expressions): quote SQL table names that contain spaces

### DIFF
--- a/public/app/features/expressions/components/SqlExpressions/CompletionProvider/sqlCompletionProvider.ts
+++ b/public/app/features/expressions/components/SqlExpressions/CompletionProvider/sqlCompletionProvider.ts
@@ -2,6 +2,7 @@ import { SelectableValue } from '@grafana/data';
 import { ColumnDefinition, LanguageCompletionProvider, TableDefinition, TableIdentifier } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
 
+import { quoteIdentifierIfNecessary } from '../../../../../plugins/datasource/mysql/sqlUtil';
 import { ALLOWED_FUNCTIONS } from '../../../utils/metaSqlExpr';
 
 interface CompletionProviderGetterArgs {
@@ -16,9 +17,12 @@ export const getSqlCompletionProvider: (args: CompletionProviderGetterArgs) => L
     tables: {
       resolve: async () => {
         const refIdsToTableDefs = args.refIds.map((refId) => {
+          const name = refId.label || refId.value || '';
           const tableDef: TableDefinition = {
-            name: refId.label || refId.value || '',
-            completion: refId.label || refId.value || '',
+            name,
+            // Quote table names that contain spaces or special characters so
+            // that selecting them from autocomplete produces valid SQL.
+            completion: quoteIdentifierIfNecessary(name),
           };
           return tableDef;
         });

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
@@ -13,6 +13,7 @@ import { Button, Stack, useStyles2 } from '@grafana/ui';
 
 import { ExpressionQueryEditorProps } from '../../ExpressionQueryEditor';
 import { SqlExpressionQuery } from '../../types';
+import { quoteIdentifierIfNecessary } from '../../../../plugins/datasource/mysql/sqlUtil';
 import { fetchSQLFields } from '../../utils/metaSqlExpr';
 import { QueryToolbox } from '../QueryToolbox';
 
@@ -68,10 +69,12 @@ export const SqlExpr = ({ onChange, refIds, query, alerting = false, queries, me
     formatter: formatSQL,
   };
 
+  // Quote the first refId in case it contains spaces or special characters
+  // (e.g. "gdp per capita") that would otherwise produce invalid SQL.
   const initialQuery = `SELECT
   *
 FROM
-  ${vars[0]}
+  ${quoteIdentifierIfNecessary(vars[0])}
 LIMIT
   10`;
 

--- a/public/app/features/expressions/utils/metaSqlExpr.ts
+++ b/public/app/features/expressions/utils/metaSqlExpr.ts
@@ -14,7 +14,10 @@ export async function fetchSQLFields(query: Partial<SQLQuery>, queries: DataQuer
     return [];
   }
 
-  const queryString = `SELECT * FROM ${query.table} LIMIT 1`;
+  // Quote the table name so that refIds containing spaces or other special
+  // characters (e.g. "gdp per capita") produce valid SQL.
+  const quotedTable = quoteIdentifierIfNecessary(query.table);
+  const queryString = `SELECT * FROM ${quotedTable} LIMIT 1`;
 
   const queryResponse = await datasource.runMetaSQLExprQuery(
     { rawSql: queryString, format: QueryFormat.Table, refId: `fields-${uuidv4()}` },


### PR DESCRIPTION
Fixes #117497

## Problem

When a data query's **refId contains spaces** (e.g. `gdp per capita`), the SQL Expression editor generates invalid SQL because the table name is interpolated verbatim:

```sql
SELECT * FROM gdp per capita LIMIT 10
-- Error: syntax error at position 33 near 'capita'
```

## Root Cause

Three call sites interpolated a refId into a SQL string without quoting it:

| File | Line | Unquoted usage |
|------|------|----------------|
| `SqlExpr.tsx` | 74 | `${vars[0]}` in `initialQuery` template |
| `metaSqlExpr.ts` | 17 | `SELECT * FROM ${query.table} LIMIT 1` |
| `sqlCompletionProvider.ts` | 21 | `completion: refId.label \|\| refId.value` |

## Fix

All three sites now call `quoteIdentifierIfNecessary()` — a helper that already exists and is already imported in `metaSqlExpr.ts` (used for field names on line 31).

The helper wraps the name in backticks only when it contains characters that are invalid in unquoted MySQL identifiers (spaces, hyphens, etc.), so single-word refIds like `A` or `B` are **completely unaffected**.

### After fix

```sql
-- refId: 'gdp per capita'
SELECT * FROM `gdp per capita` LIMIT 10  ✅

-- refId: 'A'
SELECT * FROM A LIMIT 10                   ✅ (unchanged)
```

## Changed files

- `SqlExpr.tsx` — quote `vars[0]` in `initialQuery`
- `metaSqlExpr.ts` — quote `query.table` in the metadata SELECT
- `sqlCompletionProvider.ts` — quote the autocomplete `completion` text

Made with [Cursor](https://cursor.com)