### PR TITLE
Revert "Unified: Enable folder/dashboard migrations by default for OS…

### DIFF
--- a/pkg/setting/setting_unified_storage_test.go
+++ b/pkg/setting/setting_unified_storage_test.go
@@ -42,9 +42,15 @@ func TestCfg_setUnifiedStorageConfig(t *testing.T) {
 				}
 				assert.Equal(t, exists, true, migratedResource)
 
+				expectedThreshold := 0
+				if AutoMigratedUnifiedResources[migratedResource] {
+					expectedThreshold = DefaultAutoMigrationThreshold
+				}
+
 				assert.Equal(t, UnifiedStorageConfig{
-					DualWriterMode:  5,
-					EnableMigration: isEnabled,
+					DualWriterMode:         5,
+					EnableMigration:        isEnabled,
+					AutoMigrationThreshold: expectedThreshold,
 				}, resourceCfg, migratedResource)
 			}
 		}

--- a/pkg/storage/unified/migrations/migrator_test.go
+++ b/pkg/storage/unified/migrations/migrator_test.go
@@ -232,10 +232,12 @@ func runMigrationTestSuite(t *testing.T, testCases []testcases.ResourceMigratorT
 			t.Run(state.tc.Name(), func(t *testing.T) {
 				for _, gvr := range state.tc.Resources() {
 					resourceKey := fmt.Sprintf("%s.%s", gvr.Resource, gvr.Group)
-					// Only verify resources that are expected to be migrated by default.
-					// Resources outside this map won't have mode 5 enforced, so the K8s API
+					// Only verify resources that are expected to be migrated, either:
+					// 1. In MigratedUnifiedResources (enabled by default), OR
+					// 2. In AutoMigratedUnifiedResources (auto-migrated because count is below threshold)
+					// Resources not in either map won't have mode 5 enforced, so the K8s API
 					// may still serve them from legacy storage, making verification unreliable.
-					if !setting.MigratedUnifiedResources[resourceKey] {
+					if !setting.MigratedUnifiedResources[resourceKey] && !setting.AutoMigratedUnifiedResources[resourceKey] {
 						t.Skipf("Resource %s is not migrated by default, skipping verification", resourceKey)
 						return
 					}

--- a/pkg/storage/unified/migrations/resources_test.go
+++ b/pkg/storage/unified/migrations/resources_test.go
@@ -1,6 +1,8 @@
 package migrations
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	sqlstoremigrator "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
@@ -11,6 +13,7 @@ import (
 
 // TestIsMigrationEnabled tests the isMigrationEnabled function directly
 func TestIsMigrationEnabled(t *testing.T) {
+	// Use fake resource names that are NOT in setting.AutoMigratedUnifiedResources
 	const (
 		fakePlaylistResource  = "fake.playlists.resource"
 		fakeFolderResource    = "fake.folders.resource"
@@ -84,6 +87,8 @@ func TestIsMigrationEnabled(t *testing.T) {
 
 // TestRegisterMigrations exercises registerMigrations with various EnableMigration configs using a table-driven test.
 func TestRegisterMigrations(t *testing.T) {
+	// Use fake resource names that are NOT in setting.AutoMigratedUnifiedResources
+	// to avoid triggering the auto-migrate code path which requires a non-nil sqlStore.
 	const (
 		fakePlaylistResource  = "fake.playlists.resource"
 		fakeFolderResource    = "fake.folders.resource"
@@ -130,7 +135,7 @@ func TestRegisterMigrations(t *testing.T) {
 		_ = sqlstoremigrator.CheckExpectedMigrations(sqlstoremigrator.SQLite,
 			[]sqlstoremigrator.ExpectedMigration{},
 			func(mg *sqlstoremigrator.Migrator) {
-				capturedErr = registerMigrations(cfg, mg, nil, nil, registry)
+				capturedErr = registerMigrations(context.Background(), cfg, mg, nil, nil, nil, registry)
 				ids = mg.GetMigrationIDs(false)
 			})
 		return ids, capturedErr
@@ -190,8 +195,175 @@ func TestRegisterMigrations(t *testing.T) {
 	})
 }
 
-// TestResourceMigration_SkipMigrationLog verifies migration log writing is always enabled.
+// TestResourceMigration_AutoMigrateEnablesMode5 verifies the autoMigrate behavior:
+// - When autoMigrate=true AND cfg is set AND storage type is "unified", mode 5 should be enabled
+// - In all other cases, mode 5 should NOT be enabled
+func TestResourceMigration_AutoMigrateEnablesMode5(t *testing.T) {
+	// Helper to create a cfg with unified storage type
+	makeUnifiedCfg := func() *setting.Cfg {
+		cfg := setting.NewCfg()
+		cfg.Raw.Section("grafana-apiserver").Key("storage_type").SetValue("unified")
+		cfg.UnifiedStorage = make(map[string]setting.UnifiedStorageConfig)
+		return cfg
+	}
+
+	// Helper to create a cfg with legacy storage type
+	makeLegacyCfg := func() *setting.Cfg {
+		cfg := setting.NewCfg()
+		cfg.Raw.Section("grafana-apiserver").Key("storage_type").SetValue("legacy")
+		cfg.UnifiedStorage = make(map[string]setting.UnifiedStorageConfig)
+		return cfg
+	}
+
+	tests := []struct {
+		name             string
+		autoMigrate      bool
+		cfg              *setting.Cfg
+		resources        []string
+		wantMode5Enabled bool
+		description      string
+	}{
+		{
+			name:             "autoMigrate enabled with unified storage",
+			autoMigrate:      true,
+			cfg:              makeUnifiedCfg(),
+			resources:        []string{setting.DashboardResource},
+			wantMode5Enabled: true,
+			description:      "Should enable mode 5 when autoMigrate=true and storage type is unified",
+		},
+		{
+			name:             "autoMigrate disabled with unified storage",
+			autoMigrate:      false,
+			cfg:              makeUnifiedCfg(),
+			resources:        []string{setting.DashboardResource},
+			wantMode5Enabled: false,
+			description:      "Should NOT enable mode 5 when autoMigrate=false",
+		},
+		{
+			name:             "autoMigrate enabled with legacy storage",
+			autoMigrate:      true,
+			cfg:              makeLegacyCfg(),
+			resources:        []string{setting.DashboardResource},
+			wantMode5Enabled: false,
+			description:      "Should NOT enable mode 5 when storage type is legacy",
+		},
+		{
+			name:             "autoMigrate enabled with nil cfg",
+			autoMigrate:      true,
+			cfg:              nil,
+			resources:        []string{setting.DashboardResource},
+			wantMode5Enabled: false,
+			description:      "Should NOT enable mode 5 when cfg is nil",
+		},
+		{
+			name:             "autoMigrate enabled with multiple resources",
+			autoMigrate:      true,
+			cfg:              makeUnifiedCfg(),
+			resources:        []string{setting.FolderResource, setting.DashboardResource},
+			wantMode5Enabled: true,
+			description:      "Should enable mode 5 for all resources when autoMigrate=true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Build schema.GroupResource from resource strings
+			resources := make([]schema.GroupResource, 0, len(tt.resources))
+			for _, r := range tt.resources {
+				parts := strings.SplitN(r, ".", 2)
+				resources = append(resources, schema.GroupResource{
+					Resource: parts[0],
+					Group:    parts[1],
+				})
+			}
+
+			// Create the migration with options
+			var opts []ResourceMigrationOption
+			if tt.autoMigrate {
+				opts = append(opts, WithAutoMigrate(tt.cfg))
+			}
+
+			m := NewResourceMigration(nil, resources, "test-auto-migrate", nil, opts...)
+
+			// Simulate what happens at the end of a successful migration
+			// This is the logic from MigrationRunner.Run() that we're testing
+			// Note: EnableMode5 should only be called for unified storage type
+			if m.runner.autoEnableMode5 && m.runner.cfg != nil && m.runner.cfg.UnifiedStorageType() == "unified" {
+				for _, gr := range m.resources {
+					m.runner.cfg.EnableMode5(gr.Resource + "." + gr.Group)
+				}
+			}
+
+			// Verify mode 5 was enabled (or not) for each resource
+			for _, resourceName := range tt.resources {
+				if tt.cfg == nil {
+					// If cfg is nil, we can't check - just verify we didn't panic
+					continue
+				}
+				config := tt.cfg.UnifiedStorageConfig(resourceName)
+				if tt.wantMode5Enabled {
+					require.Equal(t, 5, int(config.DualWriterMode), "%s: %s", tt.description, resourceName)
+					require.True(t, config.EnableMigration, "%s: EnableMigration should be true for %s", tt.description, resourceName)
+				} else {
+					require.Equal(t, 0, int(config.DualWriterMode), "%s: mode should be 0 for %s", tt.description, resourceName)
+				}
+			}
+		})
+	}
+}
+
+// TestResourceMigration_SkipMigrationLog verifies the SkipMigrationLog behavior:
+//   - When ignoreErrors=true AND errors occurred (hadErrors=true), skip writing to migration log
+//     This allows the migration to be re-run on the next startup
+//   - In all other cases, write to migration log normally
+//
+// This is important for the folders/dashboards migration which uses WithIgnoreErrors() to handle
+// partial failures gracefully while still allowing retry on next startup.
 func TestResourceMigration_SkipMigrationLog(t *testing.T) {
-	m := &ResourceMigration{}
-	require.False(t, m.SkipMigrationLog())
+	tests := []struct {
+		name        string
+		autoMigrate bool
+		hadErrors   bool
+		want        bool
+		description string
+	}{
+		{
+			name:        "normal migration success",
+			autoMigrate: false,
+			hadErrors:   false,
+			want:        false,
+			description: "Normal successful migration should write to log",
+		},
+		{
+			name:        "ignoreErrors migration success",
+			autoMigrate: true,
+			hadErrors:   false,
+			want:        false,
+			description: "Migration with ignoreErrors that succeeds should still write to log",
+		},
+		{
+			name:        "normal migration with errors",
+			autoMigrate: false,
+			hadErrors:   true,
+			want:        false,
+			description: "Migration that fails without ignoreErrors should write error to log",
+		},
+		{
+			name:        "ignoreErrors migration with errors - skip log",
+			autoMigrate: true,
+			hadErrors:   true,
+			want:        true,
+			description: "Migration with ignoreErrors that has errors should SKIP log to allow retry",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &ResourceMigration{
+				autoMigrate: tt.autoMigrate,
+				hadErrors:   tt.hadErrors,
+			}
+			require.Equal(t, tt.want, m.SkipMigrationLog(), tt.description)
+		})
+	}
 }

--- a/pkg/storage/unified/migrations/service.go
+++ b/pkg/storage/unified/migrations/service.go
@@ -93,7 +93,7 @@ func RegisterMigrations(
 		return err
 	}
 
-	if err := registerMigrations(cfg, mg, migrator, client, registry); err != nil {
+	if err := registerMigrations(ctx, cfg, mg, migrator, client, sqlStore, registry); err != nil {
 		return err
 	}
 

--- a/pkg/storage/unified/migrations/threshold/migrator_threshold_test.go
+++ b/pkg/storage/unified/migrations/threshold/migrator_threshold_test.go
@@ -1,0 +1,211 @@
+package threshold
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	authlib "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/tests/apis"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/tests/testsuite"
+	"github.com/grafana/grafana/pkg/util/testutil"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TODO: remove this test before Grafana 13 GA
+func TestMain(m *testing.M) {
+	testsuite.Run(m)
+}
+
+// TestIntegrationAutoMigrateThresholdExceeded verifies that auto-migration is skipped when
+// resource count exceeds the configured threshold.
+// TODO: remove this test before Grafana 13 GA
+func TestIntegrationAutoMigrateThresholdExceeded(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	if db.IsTestDbSQLite() {
+		// Share the same SQLite DB file between steps
+		tmpDir := t.TempDir()
+		dbPath := tmpDir + "/shared-threshold-test.db"
+
+		oldVal := os.Getenv("SQLITE_TEST_DB")
+		require.NoError(t, os.Setenv("SQLITE_TEST_DB", dbPath))
+		t.Cleanup(func() {
+			if oldVal == "" {
+				_ = os.Unsetenv("SQLITE_TEST_DB")
+			} else {
+				_ = os.Setenv("SQLITE_TEST_DB", oldVal)
+			}
+		})
+		t.Logf("Using shared database path: %s", dbPath)
+	}
+
+	var org1 *apis.OrgUsers
+	var orgB *apis.OrgUsers
+
+	dashboardGVR := schema.GroupVersionResource{
+		Group:    "dashboard.grafana.app",
+		Version:  "v1beta1",
+		Resource: "dashboards",
+	}
+	folderGVR := schema.GroupVersionResource{
+		Group:    "folder.grafana.app",
+		Version:  "v1beta1",
+		Resource: "folders",
+	}
+
+	dashboardKey := fmt.Sprintf("%s.%s", dashboardGVR.Resource, dashboardGVR.Group)
+	folderKey := fmt.Sprintf("%s.%s", folderGVR.Resource, folderGVR.Group)
+	playlistKey := "playlists.playlist.grafana.app"
+
+	// Step 1: Create resources exceeding the threshold (3 resources, threshold=1)
+	t.Run("Step 1: Create resources exceeding threshold", func(t *testing.T) {
+		unifiedConfig := map[string]setting.UnifiedStorageConfig{}
+		helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+			AppModeProduction:     true,
+			DisableAnonymous:      true,
+			DisableDataMigrations: true,
+			DisableDBCleanup:      true,
+			APIServerStorageType:  "unified",
+			UnifiedStorageConfig:  unifiedConfig,
+		})
+		org1 = &helper.Org1
+		orgB = &helper.OrgB
+
+		// Create 3 dashboards
+		for i := 1; i <= 3; i++ {
+			createTestDashboard(t, helper, fmt.Sprintf("Threshold Dashboard %d", i))
+		}
+
+		// Create 3 folders
+		for i := 1; i <= 3; i++ {
+			createTestFolder(t, helper, fmt.Sprintf("folder-%d", i), fmt.Sprintf("Threshold Folder %d", i), "")
+		}
+
+		// Explicitly shutdown helper before Step 1 ends to ensure database is properly closed
+		helper.Shutdown()
+	})
+
+	// Set SKIP_DB_TRUNCATE to prevent truncation in subsequent steps
+	oldSkipTruncate := os.Getenv("SKIP_DB_TRUNCATE")
+	require.NoError(t, os.Setenv("SKIP_DB_TRUNCATE", "true"))
+	t.Cleanup(func() {
+		if oldSkipTruncate == "" {
+			_ = os.Unsetenv("SKIP_DB_TRUNCATE")
+		} else {
+			_ = os.Setenv("SKIP_DB_TRUNCATE", oldSkipTruncate)
+		}
+	})
+
+	// Step 2: Verify auto-migration is skipped due to threshold
+	t.Run("Step 2: Verify auto-migration skipped (threshold exceeded)", func(t *testing.T) {
+		// Set threshold=1, but we have 3 resources of each type, so migration should be skipped
+		// Disable playlists migration since we're only testing dashboard/folder threshold behavior
+		unifiedConfig := map[string]setting.UnifiedStorageConfig{
+			dashboardKey: {AutoMigrationThreshold: 1, EnableMigration: false},
+			folderKey:    {AutoMigrationThreshold: 1, EnableMigration: false},
+			playlistKey:  {EnableMigration: false},
+		}
+		helper := apis.NewK8sTestHelperWithOpts(t, apis.K8sTestHelperOpts{
+			GrafanaOpts: testinfra.GrafanaOpts{
+				AppModeProduction:     true,
+				DisableAnonymous:      true,
+				DisableDataMigrations: false, // Allow migration system to run
+				APIServerStorageType:  "unified",
+				UnifiedStorageConfig:  unifiedConfig,
+			},
+			Org1Users: org1,
+			OrgBUsers: orgB,
+		})
+		t.Cleanup(helper.Shutdown)
+
+		namespace := authlib.OrgNamespaceFormatter(helper.Org1.OrgID)
+
+		dashCli := helper.GetResourceClient(apis.ResourceClientArgs{
+			User:      helper.Org1.Admin,
+			Namespace: namespace,
+			GVR:       dashboardGVR,
+		})
+		verifyResourceCount(t, dashCli, 3)
+
+		folderCli := helper.GetResourceClient(apis.ResourceClientArgs{
+			User:      helper.Org1.Admin,
+			Namespace: namespace,
+			GVR:       folderGVR,
+		})
+		verifyResourceCount(t, folderCli, 3)
+
+		// Verify migration did NOT run by checking the migration log
+		count, err := helper.GetEnv().SQLStore.GetEngine().Table("unifiedstorage_migration_log").
+			Where("migration_id = ?", "folders and dashboards migration").
+			Count()
+		require.NoError(t, err)
+		require.Equal(t, int64(0), count, "Migration should not have run")
+	})
+}
+
+func createTestDashboard(t *testing.T, helper *apis.K8sTestHelper, title string) string {
+	t.Helper()
+
+	payload := fmt.Sprintf(`{"dashboard": {"title": "%s", "panels": []}, "overwrite": false}`, title)
+
+	result := apis.DoRequest(helper, apis.RequestParams{
+		User:   helper.Org1.Admin,
+		Method: "POST",
+		Path:   "/api/dashboards/db",
+		Body:   []byte(payload),
+	}, &map[string]interface{}{})
+
+	require.NotNil(t, result.Response)
+	require.Equal(t, 200, result.Response.StatusCode)
+
+	uid := (*result.Result)["uid"].(string)
+	require.NotEmpty(t, uid)
+	return uid
+}
+
+func createTestFolder(t *testing.T, helper *apis.K8sTestHelper, uid, title, parentUID string) *folder.Folder {
+	t.Helper()
+
+	payload := fmt.Sprintf(`{
+		"title": "%s",
+		"uid": "%s"`, title, uid)
+
+	if parentUID != "" {
+		payload += fmt.Sprintf(`,
+		"parentUid": "%s"`, parentUID)
+	}
+
+	payload += "}"
+
+	folderCreate := apis.DoRequest(helper, apis.RequestParams{
+		User:   helper.Org1.Admin,
+		Method: http.MethodPost,
+		Path:   "/api/folders",
+		Body:   []byte(payload),
+	}, &folder.Folder{})
+
+	require.NotNil(t, folderCreate.Result)
+	return folderCreate.Result
+}
+
+// verifyResourceCount verifies that the expected number of resources exist in K8s storage
+func verifyResourceCount(t *testing.T, client *apis.K8sResourceClient, expectedCount int) {
+	t.Helper()
+
+	l, err := client.Resource.List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+
+	resources, err := meta.ExtractList(l)
+	require.NoError(t, err)
+	require.Equal(t, expectedCount, len(resources))
+}

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -257,9 +257,6 @@ func TestIntegrationFolderDeletionBlockedByAlertRules(t *testing.T) {
 			APIServerStorageType: "unified",
 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
 				folders.RESOURCEGROUP: {DualWriterMode: grafanarest.Mode5},
-				setting.DashboardResource: {
-					DualWriterMode: grafanarest.Mode5,
-				},
 			},
 			UnifiedStorageEnableSearch: true,
 		})
@@ -1839,9 +1836,6 @@ func TestIntegrationMoveNestedFolderToRootK8S(t *testing.T) {
 		APIServerStorageType: "unified",
 		UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
 			folders.RESOURCEGROUP: {
-				DualWriterMode: grafanarest.Mode5,
-			},
-			setting.DashboardResource: {
 				DualWriterMode: grafanarest.Mode5,
 			},
 		},


### PR DESCRIPTION
Reverts https://github.com/grafana/grafana/pull/118715

Migrations for some SQLite users are getting stuck (we are investigating why).

```
Error: ✗ unable to start dualwrite service due to migration error: unified storage data migration failed: migration failed (id = folders and dashboards migration): rebuilding indexes failed for org 1 (default): rebuild index error: resource_last_import_time_query.sql: Query with 0 input arguments and 0 output destination arguments: database is locked (5) (SQLITE_BUSY); query: SELECT "namespace", "group", "resource", "last_import_time"
    FROM "resource_last_import_time";
[14:30:40] Process Exit with Code: 1
```