### PR TITLE
Provisioning: Show repository URL for Bitbucket and GitLab cards

### DIFF
--- a/public/app/features/provisioning/Repository/RepositoryListItem.test.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryListItem.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from 'test/test-utils';
+
+import { Repository } from 'app/api/clients/provisioning/v0alpha1';
+
+import { RepositoryListItem } from './RepositoryListItem';
+
+jest.mock('app/api/clients/provisioning/v0alpha1', () => ({
+  ...jest.requireActual('app/api/clients/provisioning/v0alpha1'),
+  useCreateRepositoryJobsMutation: jest.fn().mockReturnValue([jest.fn(), { isLoading: false }]),
+  useListJobQuery: jest.fn().mockReturnValue({ data: undefined }),
+}));
+
+const createMockRepository = (overrides: Partial<Repository> = {}): Repository => ({
+  metadata: { name: 'test-repo' },
+  spec: {
+    title: 'Test Repository',
+    type: 'github',
+    sync: { target: 'folder', enabled: true },
+    workflows: [],
+    github: {
+      url: 'https://github.com/owner/repo',
+      branch: 'main',
+    },
+  },
+  status: {
+    health: { healthy: true, checked: Date.now() },
+    sync: { state: 'success', message: [] },
+    observedGeneration: 1,
+    webhook: {},
+  },
+  ...overrides,
+});
+
+describe('RepositoryListItem', () => {
+  describe('repository URL display', () => {
+    it('should display repository URL for GitHub repos', () => {
+      render(<RepositoryListItem repository={createMockRepository()} />);
+
+      const link = screen.getByRole('link', { name: /owner\/repo/ });
+      expect(link).toHaveAttribute('href', expect.stringContaining('github.com/owner/repo'));
+    });
+
+    it('should display repository URL for GitLab repos', () => {
+      const repo = createMockRepository({
+        spec: {
+          title: 'GitLab Repo',
+          type: 'gitlab',
+          gitlab: { url: 'https://gitlab.com/group/project', branch: 'main' },
+          sync: { target: 'folder', enabled: true },
+          workflows: [],
+        },
+      });
+      render(<RepositoryListItem repository={repo} />);
+
+      const link = screen.getByRole('link', { name: /group\/project/ });
+      expect(link).toHaveAttribute('href', expect.stringContaining('gitlab.com/group/project'));
+    });
+
+    it('should display repository URL for Bitbucket repos', () => {
+      const repo = createMockRepository({
+        spec: {
+          title: 'Bitbucket Repo',
+          type: 'bitbucket',
+          bitbucket: { url: 'https://bitbucket.org/workspace/repo', branch: 'main' },
+          sync: { target: 'folder', enabled: true },
+          workflows: [],
+        },
+      });
+      render(<RepositoryListItem repository={repo} />);
+
+      const link = screen.getByRole('link', { name: /workspace\/repo/ });
+      expect(link).toHaveAttribute('href', expect.stringContaining('bitbucket.org/workspace/repo'));
+    });
+
+    it('should display repository URL for generic git repos', () => {
+      const repo = createMockRepository({
+        spec: {
+          title: 'Git Repo',
+          type: 'git',
+          git: { url: 'https://git.example.com/owner/repo', branch: 'main' },
+          sync: { target: 'folder', enabled: true },
+          workflows: [],
+        },
+      });
+      render(<RepositoryListItem repository={repo} />);
+
+      const link = screen.getByRole('link', { name: /owner\/repo/ });
+      expect(link).toHaveAttribute('href', expect.stringContaining('git.example.com/owner/repo'));
+    });
+
+    it('should display path for local repos instead of a link', () => {
+      const repo = createMockRepository({
+        spec: {
+          title: 'Local Repo',
+          type: 'local',
+          local: { path: '/var/lib/grafana/repos/test' },
+          sync: { target: 'folder', enabled: true },
+          workflows: [],
+        },
+      });
+      render(<RepositoryListItem repository={repo} />);
+
+      expect(screen.getByText('/var/lib/grafana/repos/test')).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/provisioning/Repository/RepositoryListItem.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryListItem.tsx
@@ -26,22 +26,21 @@ export function RepositoryListItem({ repository }: Props) {
   const getRepositoryMeta = (): ReactNode[] => {
     const meta: ReactNode[] = [];
 
-    if (spec?.type === 'github') {
-      const { url = '', branch } = spec.github ?? {};
-      const branchUrl = branch ? `${url}/tree/${branch}` : url;
-      const href = getRepoHrefForProvider(spec) || branchUrl;
-
-      meta.push(
-        <TextLink key="link" external href={href}>
-          {formatRepoUrl(href)}
-        </TextLink>
-      );
-    } else if (spec?.type === 'local') {
+    if (spec?.type === 'local') {
       meta.push(
         <Text variant="bodySmall" key="path">
           {spec.local?.path ?? ''}
         </Text>
       );
+    } else {
+      const href = getRepoHrefForProvider(spec);
+      if (href) {
+        meta.push(
+          <TextLink key="link" external href={href}>
+            {formatRepoUrl(href)}
+          </TextLink>
+        );
+      }
     }
 
     if (status?.sync?.finished) {


### PR DESCRIPTION
**What is this feature?**

Show repository URL as a clickable link in the repository list for GitLab, Bitbucket, and generic git repositories. Previously, only GitHub repositories displayed a URL.


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/932

**Special notes for your reviewer:**

<img width="716" height="746" alt="Screenshot 2026-02-24 at 16 03 31" src="https://github.com/user-attachments/assets/f6db5ad1-5e88-4ee3-a89d-3d8f9dbed3b9" />

