### PR TITLE
Home: preserve query params when redirecting to home page

### DIFF
--- a/packages/grafana-data/src/utils/location.test.ts
+++ b/packages/grafana-data/src/utils/location.test.ts
@@ -245,4 +245,87 @@ describe('locationUtil', () => {
       expect(newURL).toBe('http://www.domain.com:1234/test?a=newValue&b=2&newKey=hello#hashtag');
     });
   });
+
+  describe('processRedirectUri', () => {
+    const mockLocation: Location = {
+      hash: '',
+      pathname: '/',
+      search: '',
+      state: {},
+    };
+
+    beforeEach(() => {
+      locationUtil.initialize({
+        config: {} as GrafanaConfig,
+        getVariablesUrlParams: jest.fn(),
+        getTimeRangeForUrl: jest.fn(),
+      });
+    });
+
+    test('merges current params with redirect URI params', () => {
+      const redirectUri = '/a/custom-home-plugin?tab=recent';
+      const currentLocation = { ...mockLocation, search: '?doc=some-query-value' };
+      const result = locationUtil.processRedirectUri(redirectUri, currentLocation);
+      expect(result).toBe('/a/custom-home-plugin?doc=some-query-value&tab=recent');
+    });
+
+    test('redirect URI params take precedence over current params', () => {
+      const redirectUri = '/d/home-dashboard?from=now-1h';
+      const currentLocation = { ...mockLocation, search: '?from=now-6h&to=now' };
+      const result = locationUtil.processRedirectUri(redirectUri, currentLocation);
+      expect(result).toBe('/d/home-dashboard?from=now-1h&to=now');
+    });
+
+    test('handles redirect URI without query params', () => {
+      const redirectUri = '/d/home-dashboard';
+      const currentLocation = { ...mockLocation, search: '?from=now-6h&to=now' };
+      const result = locationUtil.processRedirectUri(redirectUri, currentLocation);
+      expect(result).toBe('/d/home-dashboard?from=now-6h&to=now');
+    });
+
+    test('handles empty current params', () => {
+      const redirectUri = '/a/custom-home-plugin?tab=overview';
+      const currentLocation = { ...mockLocation, search: '' };
+      const result = locationUtil.processRedirectUri(redirectUri, currentLocation);
+      expect(result).toBe('/a/custom-home-plugin?tab=overview');
+    });
+
+    test('handles both empty params', () => {
+      const redirectUri = '/a/custom-home-plugin';
+      const currentLocation = { ...mockLocation, search: '' };
+      const result = locationUtil.processRedirectUri(redirectUri, currentLocation);
+      expect(result).toBe('/a/custom-home-plugin');
+    });
+
+    test('current params can have multiple values set', () => {
+      const redirectUri = '/a/custom-home-plugin';
+      const currentLocation = { ...mockLocation, search: '?tab=recent&tab=starred' };
+      const result = locationUtil.processRedirectUri(redirectUri, currentLocation);
+      expect(result).toBe('/a/custom-home-plugin?tab=recent&tab=starred');
+    });
+
+    test('redirect URI params can have multiple values set', () => {
+      const redirectUri = '/a/custom-home-plugin?tab=recent&tab=starred';
+      const currentLocation = { ...mockLocation, search: '?tab=overview' };
+      const result = locationUtil.processRedirectUri(redirectUri, currentLocation);
+      expect(result).toBe('/a/custom-home-plugin?tab=recent&tab=starred');
+    });
+
+    describe('with appSubUrl configured', () => {
+      beforeEach(() => {
+        locationUtil.initialize({
+          config: { appSubUrl: '/grafana' } as GrafanaConfig,
+          getVariablesUrlParams: jest.fn(),
+          getTimeRangeForUrl: jest.fn(),
+        });
+      });
+
+      test('strips base from redirect URI', () => {
+        const redirectUri = '/grafana/a/custom-home-plugin?tab=overview';
+        const currentLocation = { ...mockLocation, search: '?theme=dark' };
+        const result = locationUtil.processRedirectUri(redirectUri, currentLocation);
+        expect(result).toBe('/a/custom-home-plugin?theme=dark&tab=overview');
+      });
+    });
+  });
 });

--- a/packages/grafana-data/src/utils/location.test.ts
+++ b/packages/grafana-data/src/utils/location.test.ts
@@ -266,7 +266,7 @@ describe('locationUtil', () => {
       const redirectUri = '/a/custom-home-plugin?tab=recent';
       const currentLocation = { ...mockLocation, search: '?doc=some-query-value' };
       const result = locationUtil.processRedirectUri(redirectUri, currentLocation);
-      expect(result).toBe('/a/custom-home-plugin?doc=some-query-value&tab=recent');
+      expect(result).toBe('/a/custom-home-plugin?tab=recent&doc=some-query-value');
     });
 
     test('redirect URI params take precedence over current params', () => {
@@ -311,6 +311,13 @@ describe('locationUtil', () => {
       expect(result).toBe('/a/custom-home-plugin?tab=recent&tab=starred');
     });
 
+    test('redirect URI can be an absolute URL', () => {
+      const redirectUri = 'http://www.domain.com:1234/a/custom-home-plugin?tab=recent';
+      const currentLocation = { ...mockLocation, search: '?doc=some-query-value' };
+      const result = locationUtil.processRedirectUri(redirectUri, currentLocation);
+      expect(result).toBe('http://www.domain.com:1234/a/custom-home-plugin?tab=recent&doc=some-query-value');
+    });
+
     describe('with appSubUrl configured', () => {
       beforeEach(() => {
         locationUtil.initialize({
@@ -324,7 +331,14 @@ describe('locationUtil', () => {
         const redirectUri = '/grafana/a/custom-home-plugin?tab=overview';
         const currentLocation = { ...mockLocation, search: '?theme=dark' };
         const result = locationUtil.processRedirectUri(redirectUri, currentLocation);
-        expect(result).toBe('/a/custom-home-plugin?theme=dark&tab=overview');
+        expect(result).toBe('/a/custom-home-plugin?tab=overview&theme=dark');
+      });
+
+      test('does not strip base from redirect URI when an absolute URL is provided', () => {
+        const redirectUri = 'http://www.domain.com:1234/grafana/a/custom-home-plugin?tab=overview';
+        const currentLocation = { ...mockLocation, search: '?theme=dark' };
+        const result = locationUtil.processRedirectUri(redirectUri, currentLocation);
+        expect(result).toBe('http://www.domain.com:1234/grafana/a/custom-home-plugin?tab=overview&theme=dark');
       });
     });
   });

--- a/packages/grafana-data/src/utils/location.ts
+++ b/packages/grafana-data/src/utils/location.ts
@@ -157,18 +157,20 @@ export const locationUtil = {
    * @internal
    */
   processRedirectUri: (redirectUri: string, currentLocation: Location): string => {
-    const [path, queryString] = redirectUri.split('?');
-    const newUrl = stripBaseFromUrl(path);
+    try {
+      const redirectUrl = new URL(redirectUri, window.location.origin);
+      const redirectParams = new Set(redirectUrl.searchParams.keys());
 
-    // Parse current location's query params
-    const currentParams = urlUtil.parseKeyValue(
-      currentLocation.search.startsWith('?') ? currentLocation.search.substring(1) : currentLocation.search
-    );
+      const currentParams = new URLSearchParams(currentLocation.search);
+      currentParams.forEach((value, key) => {
+        if (!redirectParams.has(key)) {
+          redirectUrl.searchParams.append(key, value);
+        }
+      });
 
-    // Parse redirect URI query params
-    const redirectParams = urlUtil.parseKeyValue(queryString || '');
-
-    // Build final URL with merged params (original redirect params take precedence)
-    return urlUtil.renderUrl(newUrl, { ...currentParams, ...redirectParams });
+      return stripBaseFromUrl(redirectUrl.href);
+    } catch {
+      return stripBaseFromUrl(redirectUri);
+    }
   },
 };

--- a/packages/grafana-data/src/utils/location.ts
+++ b/packages/grafana-data/src/utils/location.ts
@@ -147,4 +147,28 @@ export const locationUtil = {
   processUrl: (url: string) => {
     return grafanaConfig.disableSanitizeHtml ? url : textUtil.sanitizeUrl(url);
   },
+  /**
+   * Process a redirect URI by merging its query parameters with current location's query parameters.
+   * Current query params are preserved, but redirect URI params take precedence.
+   *
+   * @param redirectUri - The redirect URI from the backend (may contain query params)
+   * @param currentLocation - Current location object to preserve query params
+   * @returns Final URL with merged query parameters
+   * @internal
+   */
+  processRedirectUri: (redirectUri: string, currentLocation: Location): string => {
+    const [path, queryString] = redirectUri.split('?');
+    const newUrl = stripBaseFromUrl(path);
+
+    // Parse current location's query params
+    const currentParams = urlUtil.parseKeyValue(
+      currentLocation.search.startsWith('?') ? currentLocation.search.substring(1) : currentLocation.search
+    );
+
+    // Parse redirect URI query params
+    const redirectParams = urlUtil.parseKeyValue(queryString || '');
+
+    // Build final URL with merged params (original redirect params take precedence)
+    return urlUtil.renderUrl(newUrl, { ...currentParams, ...redirectParams });
+  },
 };

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
@@ -883,6 +883,35 @@ describe('DashboardScenePageStateManager v2', () => {
         expect(loader.state.loadError).toBeUndefined();
       });
 
+      it('should preserve query params when redirecting to custom home dashboard', async () => {
+        const mockLocationService = locationService as jest.Mocked<typeof locationService>;
+        const originalReplace = locationService.replace;
+        const originalGetLocation = locationService.getLocation;
+
+        try {
+          mockLocationService.replace = jest.fn();
+          mockLocationService.getLocation = jest.fn().mockReturnValue({
+            pathname: '/',
+            search: '?doc=some-query-value',
+            hash: '',
+            state: {},
+          });
+
+          setBackendSrv({
+            get: () => Promise.resolve({ redirectUri: '/d/custom-home?tab=recent' }),
+          } as unknown as BackendSrv);
+
+          const loader = new DashboardScenePageStateManagerV2({});
+          await loader.loadDashboard({ uid: '', route: DashboardRoutes.Home });
+
+          expect(mockLocationService.replace).toHaveBeenCalledWith('/d/custom-home?doc=some-query-value&tab=recent');
+          expect(loader.state.dashboard).toBeUndefined();
+        } finally {
+          locationService.replace = originalReplace;
+          locationService.getLocation = originalGetLocation;
+        }
+      });
+
       it('should handle invalid home dashboard request', async () => {
         setBackendSrv({
           get: () =>
@@ -1614,6 +1643,37 @@ describe('UnifiedDashboardScenePageStateManager', () => {
       expect(loader.state.dashboard).toBeUndefined();
       expect(loader.state.loadError).toBeUndefined();
       expect(locationService.getLocation().pathname).toBe('/d/asd');
+    });
+
+    it('should preserve query params when redirecting to custom home dashboard', async () => {
+      const mockLocationService = locationService as jest.Mocked<typeof locationService>;
+      const originalReplace = locationService.replace;
+      const originalGetLocation = locationService.getLocation;
+
+      try {
+        mockLocationService.replace = jest.fn();
+        mockLocationService.getLocation = jest.fn().mockReturnValue({
+          pathname: '/',
+          search: '?doc=some-query-value',
+          hash: '',
+          state: {},
+        });
+
+        setBackendSrv({
+          get: () => Promise.resolve({ redirectUri: '/a/custom-home-plugin?tab=recent' }),
+        } as unknown as BackendSrv);
+
+        const loader = new UnifiedDashboardScenePageStateManager({});
+        await loader.loadDashboard({ uid: '', route: DashboardRoutes.Home });
+
+        expect(mockLocationService.replace).toHaveBeenCalledWith(
+          '/a/custom-home-plugin?doc=some-query-value&tab=recent'
+        );
+        expect(loader.state.dashboard).toBeUndefined();
+      } finally {
+        locationService.replace = originalReplace;
+        locationService.getLocation = originalGetLocation;
+      }
     });
 
     it('should handle invalid home dashboard request', async () => {

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
@@ -904,7 +904,7 @@ describe('DashboardScenePageStateManager v2', () => {
           const loader = new DashboardScenePageStateManagerV2({});
           await loader.loadDashboard({ uid: '', route: DashboardRoutes.Home });
 
-          expect(mockLocationService.replace).toHaveBeenCalledWith('/d/custom-home?doc=some-query-value&tab=recent');
+          expect(mockLocationService.replace).toHaveBeenCalledWith('/d/custom-home?tab=recent&doc=some-query-value');
           expect(loader.state.dashboard).toBeUndefined();
         } finally {
           locationService.replace = originalReplace;
@@ -1667,7 +1667,7 @@ describe('UnifiedDashboardScenePageStateManager', () => {
         await loader.loadDashboard({ uid: '', route: DashboardRoutes.Home });
 
         expect(mockLocationService.replace).toHaveBeenCalledWith(
-          '/a/custom-home-plugin?doc=some-query-value&tab=recent'
+          '/a/custom-home-plugin?tab=recent&doc=some-query-value'
         );
         expect(loader.state.dashboard).toBeUndefined();
       } finally {

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -161,7 +161,7 @@ abstract class DashboardScenePageStateManagerBase<T>
     const rsp = await getBackendSrv().get<HomeDashboardDTO | HomeDashboardRedirectDTO>('/api/dashboards/home');
 
     if (isRedirectResponse(rsp)) {
-      const newUrl = locationUtil.stripBaseFromUrl(rsp.redirectUri);
+      const newUrl = locationUtil.processRedirectUri(rsp.redirectUri, locationService.getLocation());
       locationService.replace(newUrl);
       return null;
     }

--- a/public/app/features/dashboard/state/initDashboard.test.ts
+++ b/public/app/features/dashboard/state/initDashboard.test.ts
@@ -299,6 +299,27 @@ describeInitScenario('Initializing home dashboard', (ctx) => {
   });
 });
 
+describeInitScenario('Initializing home dashboard with query params', (ctx) => {
+  ctx.setup(() => {
+    // Set initial location with query params
+    locationService.push('/?doc=some-query-value');
+
+    ctx.args.routeName = DashboardRoutes.Home;
+    ctx.backendSrv.get.mockResolvedValue({
+      redirectUri: '/a/custom-home-plugin?tab=recent',
+    });
+  });
+
+  it('Should preserve query params when redirecting to custom home dashboard', () => {
+    const location = locationService.getLocation();
+    expect(location.pathname).toBe('/a/custom-home-plugin');
+
+    const search = locationService.getSearch();
+    expect(search.get('doc')).toBe('some-query-value');
+    expect(search.get('tab')).toBe('recent');
+  });
+});
+
 describeInitScenario('Initializing home dashboard cancelled', (ctx) => {
   ctx.setup(() => {
     ctx.args.routeName = DashboardRoutes.Home;

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -74,7 +74,7 @@ async function fetchDashboard(
 
         // if user specified a custom home dashboard redirect to that
         if (isRedirectResponse(dashDTO)) {
-          const newUrl = locationUtil.stripBaseFromUrl(dashDTO.redirectUri);
+          const newUrl = locationUtil.processRedirectUri(dashDTO.redirectUri, locationService.getLocation());
           locationService.replace(newUrl);
           return null;
         }


### PR DESCRIPTION
**What is this feature?**

When we redirect the user from `/` to whatever homepage the instance has configured, this will now preserve any query params that the user had set when they landed on `/` initially.

**Why do we need this feature?**

For Pathfinder, we're linking to `grafana.com/launch?doc=...` to allow the user to select their instance and be redirected, while not hard-coding a specific page to land on, but we need the `doc` query param to persist to actually trigger Pathfinder to open.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

cc https://github.com/grafana/website/pull/29257 (🔐)

**Special notes for your reviewer:**

Access https://grafana-dev.com/launch?doc=/docs/learning-paths/grafana-cloud-onboarding/ (🔐), select the ephemeral org, search for the `ephemeral15111821118829mattip.grafana-dev.net` instance, select it, and observe that you're taken to the instance with Pathfinder open!