### PR TITLE
IAM: Use responder pattern in UserTeamREST handler

### DIFF
--- a/apps/iam/pkg/apis/iam/v0alpha1/register.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/register.go
@@ -401,6 +401,7 @@ func AddAuthNKnownTypes(scheme *runtime.Scheme) error {
 		&ExternalGroupMappingList{},
 		&GetGroupsResponse{},
 		&GetMembersResponse{},
+		&GetTeamsResponse{},
 		// For now these are registered in pkg/apis/iam/v0alpha1/register.go
 		// &UserTeamList{},
 		// &ServiceAccountTokenList{},

--- a/pkg/registry/apis/iam/user/rest_user_team.go
+++ b/pkg/registry/apis/iam/user/rest_user_team.go
@@ -2,7 +2,7 @@ package user
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -10,6 +10,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -69,7 +70,8 @@ func (s *UserTeamREST) Connect(ctx context.Context, name string, options runtime
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		//nolint:staticcheck // not migrated to OpenFeature
 		if !s.features.IsEnabledGlobally(featuremgmt.FlagKubernetesTeamBindings) {
-			http.Error(w, "functionality not available", http.StatusForbidden)
+			responder.Error(apierrors.NewForbidden(iamv0alpha1.UserResourceInfo.GroupResource(),
+				name, errors.New("functionality not available")))
 			return
 		}
 
@@ -84,7 +86,7 @@ func (s *UserTeamREST) Connect(ctx context.Context, name string, options runtime
 
 		requester, err := identity.GetRequester(ctx)
 		if err != nil {
-			responder.Error(fmt.Errorf("no identity found for request: %w", err))
+			responder.Error(apierrors.NewUnauthorized("no identity found"))
 			return
 		}
 
@@ -138,20 +140,19 @@ func (s *UserTeamREST) Connect(ctx context.Context, name string, options runtime
 
 		result, err := s.client.Search(ctx, searchRequest)
 		if err != nil {
-			responder.Error(err)
+			responder.Error(apierrors.NewInternalError(err))
 			return
 		}
 
 		searchResults, err := parseResults(result, searchRequest.Offset)
 		if err != nil {
-			responder.Error(err)
+			responder.Error(apierrors.NewInternalError(err))
 			return
 		}
 
-		if err := json.NewEncoder(w).Encode(searchResults); err != nil {
-			responder.Error(err)
-			return
-		}
+		responder.Object(http.StatusOK, &iamv0alpha1.GetTeamsResponse{
+			GetTeamsBody: searchResults,
+		})
 	}), nil
 }
 

--- a/pkg/registry/apis/iam/user/rest_user_team_test.go
+++ b/pkg/registry/apis/iam/user/rest_user_team_test.go
@@ -2,7 +2,6 @@ package user
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -217,7 +216,7 @@ func TestUserTeamREST_Connect(t *testing.T) {
 
 		require.True(t, responder.called)
 		require.NotNil(t, responder.err)
-		require.Equal(t, "search failed", responder.err.Error())
+		require.Contains(t, responder.err.Error(), "search failed")
 	})
 
 	t.Run("should return JSON response with teams", func(t *testing.T) {
@@ -269,12 +268,11 @@ func TestUserTeamREST_Connect(t *testing.T) {
 
 		httpHandler.ServeHTTP(w, req)
 
-		require.False(t, responder.called)
-		require.Equal(t, http.StatusOK, w.Code)
+		require.True(t, responder.called)
+		require.Equal(t, http.StatusOK, responder.code)
 
-		var result iamv0alpha1.GetTeamsBody
-		err = json.Unmarshal(w.Body.Bytes(), &result)
-		require.NoError(t, err)
+		result, ok := responder.obj.(*iamv0alpha1.GetTeamsResponse)
+		require.True(t, ok)
 		require.Len(t, result.Items, 2)
 		require.Equal(t, "user1", result.Items[0].User)
 		require.Equal(t, "team1", result.Items[0].Team)


### PR DESCRIPTION
## Summary
- Replace `json.NewEncoder(w).Encode()` with `responder.Object()` in `UserTeamREST`, aligning it with the existing `TeamMembersREST` pattern
- Use `apierrors` for consistent error responses (Forbidden, Unauthorized, InternalError)
- Wrap response in `GetTeamsResponse` (a proper `runtime.Object`) instead of encoding `GetTeamsBody` directly


🤖 Generated with [Claude Code](https://claude.com/claude-code)