### PR TITLE
Template Dashboards: Add new Assistant tracking properties 

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.test.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.test.tsx
@@ -8,9 +8,9 @@ import { backendSrv } from 'app/core/services/backend_srv';
 import { DASHBOARD_LIBRARY_ROUTES } from '../types';
 
 import { TemplateDashboardModal } from './TemplateDashboardModal';
-import { DashboardLibraryInteractions } from './interactions';
+import { TemplateDashboardInteractions } from './interactions';
 
-const mockItemClicked = jest.spyOn(DashboardLibraryInteractions, 'itemClicked').mockImplementation();
+const mockItemClicked = jest.spyOn(TemplateDashboardInteractions, 'itemClicked').mockImplementation();
 
 setBackendSrv(backendSrv);
 setupMockServer();

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.tsx
@@ -12,10 +12,10 @@ import { Box, Grid, Modal, Text, useStyles2 } from '@grafana/ui';
 import { DashboardCard } from './DashboardCard';
 import {
   CONTENT_KINDS,
-  DashboardLibraryInteractions,
   DISCOVERY_METHODS,
   EVENT_LOCATIONS,
   SourceEntryPoint,
+  TemplateDashboardInteractions,
   TemplateDashboardSourceEntryPoint,
 } from './interactions';
 import { GnetDashboard, GnetDashboardsResponse, Link } from './types';
@@ -49,7 +49,7 @@ export const TemplateDashboardModal = () => {
   const onPreviewDashboardClick = async (dashboard: GnetDashboard, customizeWithAssistant = false) => {
     const sourceEntryPoint = SourceEntryPointMap[entryPoint] || 'unknown';
 
-    DashboardLibraryInteractions.itemClicked({
+    TemplateDashboardInteractions.itemClicked({
       contentKind: CONTENT_KINDS.TEMPLATE_DASHBOARD,
       datasourceTypes: [String(testDataSource?.type)],
       libraryItemId: String(dashboard.id),
@@ -92,7 +92,7 @@ export const TemplateDashboardModal = () => {
 
   useEffect(() => {
     if (isOpen && !loading && dashboards.length > 0) {
-      DashboardLibraryInteractions.loaded({
+      TemplateDashboardInteractions.loaded({
         numberOfItems: dashboards.length,
         contentKinds: [CONTENT_KINDS.TEMPLATE_DASHBOARD],
         datasourceTypes: [String(testDataSource?.type)],


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It adds `isDashboardTemplatesAssistantEnabled` property not only in the dashboard save event (already done), but also in the loaded and item click events.
Thanks to this, I can make better analytics like:
- Conversion between `assistant help click / total templates loads`, **with** the FF enabled
- Conversion between `assistant help click / total clicks` **with** the FF enabled 

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

I created a new `TemplateDashboardInteractions` to override 2 functions for template dashboard specific use case, so the declaration of those functions aren't affected

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
