### PR TITLE
Explore: Provide datasource and query context to the assistant

### DIFF
--- a/public/app/features/explore/ExplorePage.tsx
+++ b/public/app/features/explore/ExplorePage.tsx
@@ -17,6 +17,7 @@ import { ExploreDrawer } from './ExploreDrawer';
 import { ExplorePaneContainer } from './ExplorePaneContainer';
 import { useQueriesDrawerContext } from './QueriesDrawer/QueriesDrawerContext';
 import RichHistoryContainer from './RichHistory/RichHistoryContainer';
+import { useExplorePageContext } from './hooks/useExplorePageContext';
 import { useExplorePageTitle } from './hooks/useExplorePageTitle';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useSplitSizeUpdater } from './hooks/useSplitSizeUpdater';
@@ -60,6 +61,7 @@ function ExplorePageContent(props: GrafanaRouteComponentProps<{}, ExploreQueryPa
   }, [chrome, navModel]);
 
   useKeyboardShortcuts();
+  useExplorePageContext(panes);
 
   return (
     <div

--- a/public/app/features/explore/hooks/useExplorePageContext.ts
+++ b/public/app/features/explore/hooks/useExplorePageContext.ts
@@ -63,9 +63,7 @@ function buildDatasourceContext(
   queries: DataQuery[],
   ds?: DataSourceApi
 ): ChatContextItem[] {
-  const items: ChatContextItem[] = [
-    createAssistantContextItem('datasource', { datasourceUid: uid, img }),
-  ];
+  const items: ChatContextItem[] = [createAssistantContextItem('datasource', { datasourceUid: uid, img })];
 
   const nonEmptyQueries = queries.filter((q) => !isQueryEmpty(q, ds));
   if (nonEmptyQueries.length > 0) {

--- a/public/app/features/explore/hooks/useExplorePageContext.ts
+++ b/public/app/features/explore/hooks/useExplorePageContext.ts
@@ -1,0 +1,124 @@
+import { useEffect } from 'react';
+
+import { createAssistantContextItem, ChatContextItem, useProvidePageContext } from '@grafana/assistant';
+import { DataSourceApi } from '@grafana/data';
+import { getDataSourceSrv } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
+import { ExploreItemState } from 'app/types/explore';
+
+export function useExplorePageContext(panes: Array<[string, ExploreItemState]>): void {
+  const setContext = useProvidePageContext(/^\/explore/);
+
+  useEffect(() => {
+    setContext(buildContext(panes));
+  }, [panes, setContext]);
+}
+
+function buildContext(panes: Array<[string, ExploreItemState]>): ChatContextItem[] {
+  return panes.flatMap(([, pane]) => {
+    const ds = pane.datasourceInstance;
+    if (!ds) {
+      return [];
+    }
+
+    // if `-- Mixed --` datasource, we add each data source individual
+    if (ds.meta.mixed) {
+      return buildMixedContext(pane.queries);
+    }
+
+    return buildDatasourceContext(ds.uid, ds.name, ds.meta?.info?.logos?.small, pane.queries, ds);
+  });
+}
+
+function buildMixedContext(queries: DataQuery[]): ChatContextItem[] {
+  const grouped = new Map<string, DataQuery[]>();
+  for (const query of queries) {
+    const uid = query.datasource?.uid;
+    if (!uid) {
+      continue;
+    }
+    const existing = grouped.get(uid);
+    if (existing) {
+      existing.push(query);
+    } else {
+      grouped.set(uid, [query]);
+    }
+  }
+
+  const items: ChatContextItem[] = [];
+  for (const [uid, dsQueries] of grouped) {
+    const settings = getDataSourceSrv().getInstanceSettings(uid);
+    if (!settings) {
+      continue;
+    }
+    items.push(...buildDatasourceContext(uid, settings.name, settings.meta?.info?.logos?.small, dsQueries));
+  }
+  return items;
+}
+
+function buildDatasourceContext(
+  uid: string,
+  name: string,
+  img: string | undefined,
+  queries: DataQuery[],
+  ds?: DataSourceApi
+): ChatContextItem[] {
+  const items: ChatContextItem[] = [
+    createAssistantContextItem('datasource', { datasourceUid: uid, img }),
+  ];
+
+  const nonEmptyQueries = queries.filter((q) => !isQueryEmpty(q, ds));
+  if (nonEmptyQueries.length > 0) {
+    items.push(
+      createAssistantContextItem('structured', {
+        title: `Explore queries (${name})`,
+        data: {
+          queries: nonEmptyQueries.map((q) => summarizeQuery(q, ds)),
+        },
+      })
+    );
+  }
+
+  return items;
+}
+
+// maintain these field lists to avoid passing full query objects to the assistant.
+const EXPRESSION_FIELDS = new Set(['expr', 'expression', 'query', 'rawSql', 'rawQuery']);
+const METADATA_FIELDS = new Set([
+  'queryType',
+  'format',
+  'instant',
+  'range',
+  'legendFormat',
+  'editorMode',
+  'maxLines',
+  'direction',
+]);
+
+function summarizeQuery(query: DataQuery, ds?: DataSourceApi): Record<string, unknown> {
+  const summary: Record<string, unknown> = { refId: query.refId };
+
+  const displayText = ds?.getQueryDisplayText?.(query);
+  if (displayText) {
+    summary.expression = displayText;
+  }
+
+  for (const [key, value] of Object.entries(query)) {
+    if (!summary.expression && EXPRESSION_FIELDS.has(key) && value) {
+      summary.expression = value;
+    }
+    if (METADATA_FIELDS.has(key) && value != null) {
+      summary[key] = value;
+    }
+  }
+
+  return summary;
+}
+
+function isQueryEmpty(query: DataQuery, ds?: DataSourceApi): boolean {
+  if (ds?.getQueryDisplayText) {
+    return !ds.getQueryDisplayText(query)?.trim();
+  }
+  const { refId, datasource, ...rest } = query;
+  return Object.keys(rest).length === 0;
+}

--- a/public/test/mocks/assistant.ts
+++ b/public/test/mocks/assistant.ts
@@ -10,6 +10,7 @@ export const useAssistant = jest.fn().mockReturnValue({
 });
 
 export const createAssistantContextItem = jest.fn();
+export const useProvidePageContext = jest.fn().mockReturnValue(jest.fn());
 
 // Additional exports that may be used
 export const toggleAssistant = jest.fn();


### PR DESCRIPTION
## Summary

- Adds a new `useExplorePageContext` hook that uses `useProvidePageContext` from `@grafana/assistant` to register page context on `/explore` pages
- Provides the assistant with awareness of active datasources (uid, name, logo) and queries (expression, queryType, format, range/instant, legendFormat, etc.)
- Handles Mixed datasource mode by grouping queries per actual datasource rather than reporting the Mixed datasource itself
- Summarizes queries with a curated set of fields to avoid sending excessive internal state to the assistant

## Test plan

- [ ] Open Explore with a single datasource (e.g. Prometheus or Loki), write a query, and verify the assistant receives datasource + query context
- [ ] Open Explore with Mixed datasource and multiple query rows targeting different datasources — verify each datasource appears as a separate context item with its own queries
- [ ] Verify empty queries are excluded from the context
- [ ] Verify split view provides context for both panes
- [ ] Verify context updates when switching datasources or modifying queries


Made with [Cursor](https://cursor.com)