### PR TITLE
Alerting: Add sort by full path to prometheus rules API

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -69,6 +69,11 @@ export interface FeatureToggles {
   */
   alertingBacktesting?: boolean;
   /**
+  * Sort alert rule groups by folder full path in the Prometheus rules API
+  * @default false
+  */
+  alertingRuleGroupSortByFolderFullpath?: boolean;
+  /**
   * Allow datasource to provide custom UI for context view
   * @default true
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -91,6 +91,13 @@ var (
 			Expression:  "false",
 		},
 		{
+			Name:        "alertingRuleGroupSortByFolderFullpath",
+			Description: "Sort alert rule groups by folder full path in the Prometheus rules API",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaAlertingSquad,
+			Expression:  "false",
+		},
+		{
 			Name:         "logsContextDatasourceUi",
 			Description:  "Allow datasource to provide custom UI for context view",
 			Stage:        FeatureStageGeneralAvailability,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -9,6 +9,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2022-09-26,grpcServer,preview,@grafana/search-and-storage,false,false,false
 2022-11-28,cloudWatchCrossAccountQuerying,GA,@grafana/aws-datasources,false,false,false
 2022-12-14,alertingBacktesting,experimental,@grafana/alerting-squad,false,false,false
+2026-02-10,alertingRuleGroupSortByFolderFullpath,experimental,@grafana/alerting-squad,false,false,false
 2023-01-27,logsContextDatasourceUi,GA,@grafana/observability-logs,false,false,true
 2024-10-23,lokiShardSplitting,experimental,@grafana/observability-logs,false,false,true
 2023-02-09,lokiQuerySplitting,GA,@grafana/observability-logs,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -39,6 +39,10 @@ const (
 	// Rule backtesting API for alerting
 	FlagAlertingBacktesting = "alertingBacktesting"
 
+	// FlagAlertingRuleGroupSortByFolderFullpath
+	// Sort alert rule groups by folder full path in the Prometheus rules API
+	FlagAlertingRuleGroupSortByFolderFullpath = "alertingRuleGroupSortByFolderFullpath"
+
 	// FlagLiveAPIServer
 	// Registers a live apiserver
 	FlagLiveAPIServer = "liveAPIServer"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -553,6 +553,19 @@
     },
     {
       "metadata": {
+        "name": "alertingRuleGroupSortByFolderFullpath",
+        "resourceVersion": "1770763646748",
+        "creationTimestamp": "2026-02-10T22:47:26Z"
+      },
+      "spec": {
+        "description": "Sort alert rule groups by folder full path in the Prometheus rules API",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingRulePermanentlyDelete",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2025-04-03T11:18:25Z"

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -1008,8 +1008,9 @@ const (
 )
 
 type GroupCursor struct {
-	NamespaceUID string `json:"n"`
-	RuleGroup    string `json:"g"`
+	FolderFullpath string `json:"f,omitempty"`
+	NamespaceUID   string `json:"n"`
+	RuleGroup      string `json:"g"`
 }
 
 func EncodeGroupCursor(c GroupCursor) string {
@@ -1070,10 +1071,11 @@ type ListAlertRulesExtendedQuery struct {
 	RuleType           RuleTypeFilter
 	PluginOriginFilter PluginOriginFilter
 
-	Limit         int64
-	RuleLimit     int64
-	ContinueToken string
-	Compact       bool
+	Limit          int64
+	RuleLimit      int64
+	ContinueToken  string
+	Compact        bool
+	SortByFullpath bool
 }
 
 // CountAlertRulesQuery is the query for counting alert rules


### PR DESCRIPTION
**What is this feature?**

This PR adds an optional full-path sort mode for the Prometheus rules API pagination flow in Unified Alerting.

- adds `SortByFullpath` plumbing from API -> query model -> store
- uses a feature toggle (`alertingRuleGroupSortByFolderFullpath`) to enable the new behavior
- extends group cursor payload to include folder full path (`f`) when fullpath sorting is used
- keeps cursor backward compatibility for older tokens without `f`

**Why do we need this feature?**

Pagination by `namespace_uid/rule_group` can produce less intuitive ordering than folder full path ordering for users browsing rule groups by folder hierarchy. This change enables stable, path-aware ordering and continuation tokens aligned with folder paths.

**Who is this feature for?**

Grafana Alerting users and operators consuming the Prometheus-compatible rules endpoint, especially in environments with nested folders and many rule groups.

**Special notes for your reviewer:**

Implementation highlights:
- `RouteGetRuleStatuses` now reads the feature flag and sets `RuleGroupStatusesOptions.SortByFullpath`
- store query ordering uses `folder_fullpath, namespace_uid, rule_group, ...` when enabled
- pagination cursor condition supports both fullpath-aware cursor and legacy cursor fallback
- token encode/decode supports `{f,n,g}` and legacy `{n,g}`

Test coverage added:
- API test: feature flag controls `SortByFullpath` in store query
- Store integration tests:
  - verifies ordering changes under fullpath sort
  - verifies fullpath cursor pagination behavior across pages and token contents
- Model test: cursor encode/decode for new format + legacy compatibility

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc. (Not applicable: internal API pagination behavior behind feature flag; no user-facing docs update in this PR.)