### PR TITLE
Alerting: Use consistent "New" verb for notification config creation buttons

### DIFF
--- a/docs/sources/alerting/configure-notifications/manage-contact-points/_index.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/_index.md
@@ -195,7 +195,7 @@ Complete the following steps to add a contact point.
 1. In the left-side menu, click **Alerts & IRM** and then **Alerting**.
 1. Click **Contact points**.
 1. From the **Choose Alertmanager** dropdown, select an Alertmanager. By default, **Grafana Alertmanager** is selected.
-1. On the **Contact Points** tab, click **+ Add contact point**.
+1. On the **Contact Points** tab, click **+ New contact point**.
 1. Enter a descriptive name for the contact point.
 1. From **Integration**, select a type and fill out mandatory fields. For example, if you choose email, enter the email addresses. Or if you choose Slack, enter the Slack channel and users who should be contacted.
 1. Some [contact point integrations](#supported-contact-point-integrations), like email or Webhook, have optional settings. In **Optional settings**, specify additional settings for the selected contact point integration.

--- a/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-email.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-email.md
@@ -54,7 +54,7 @@ In Grafana Cloud, SMTP configuration is not required.
 To create a contact point with a email integration, complete the following steps.
 
 1. Navigate to **Alerts & IRM** -> **Alerting** -> **Contact points**.
-1. Click **+ Create contact point**.
+1. Click **+ New contact point**.
 1. Enter a name for the contact point.
 1. From the **Integration** list, select **Email**.
 1. Set up the required [settings](#email-settings) for your Email configuration.

--- a/docs/sources/alerting/configure-notifications/mute-timings.md
+++ b/docs/sources/alerting/configure-notifications/mute-timings.md
@@ -70,7 +70,7 @@ The following table highlights the key differences between mute timings and sile
 1. In the left-side menu, click **Alerts & IRM**, and then **Alerting**.
 1. Click **Notification policies** and then the **Time intervals** tab.
 1. From the **Alertmanager** dropdown, select an external Alertmanager. By default, the **Grafana Alertmanager** is selected.
-1. Click **+ Add time interval**.
+1. Click **+ New time interval**.
 1. Fill out the form to create a [time interval](#time-intervals) to match against for your mute timing or active time interval.
 1. Save your changes.
 

--- a/docs/sources/alerting/configure-notifications/template-notifications/_index.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/_index.md
@@ -109,7 +109,7 @@ To use AI to create your template, follow these steps:
 
 1. Go to **Alerting -> Contact points**.
 
-1. Click the Notification Templates tab then, click the **+ Add notification template group** button.
+1. Click the Notification Templates tab then, click the **+ New notification template** button.
 
 1. Name your template.
 

--- a/docs/sources/alerting/configure-notifications/template-notifications/manage-notification-templates.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/manage-notification-templates.md
@@ -75,7 +75,7 @@ Your notification template name (`{{define "<NAME>"}}`) must be unique. You cann
 To create a notification template in Grafana, complete the following steps.
 
 1. Click **Alerts & IRM** -> **Contact points**.
-1. Click the **Notification Templates** tab and then **+ Add notification template group**.
+1. Click the **Notification Templates** tab and then **+ New notification template**.
 
 1. Enter a name for the notification template group.
 
@@ -87,7 +87,7 @@ To create a notification template in Grafana, complete the following steps.
 
 To create a notification template group that contains more than one notification template, complete the following steps.
 
-1. Click **+ Add notification template group**.
+1. Click **+ New notification template**.
 
 1. Enter a name for the notification template group.
 
@@ -108,7 +108,7 @@ Notification template preview is only for Grafana Alertmanager.
 To preview your notification templates:
 
 1. Navigate to **Alerts&IRM** -> **Alerting** -> **Contact points** -> **Notification Templates**.
-1. Click **+ Add notification template group** or edit an existing template group.
+1. Click **+ New notification template** or edit an existing template group.
 1. Add or update your template content.
 
    Default data is provided and you can add or edit alert data to it as well as alert instances. You can add alert data directly in the Payload data window itself or click **Select alert instances** or **Add custom alerts**.

--- a/docs/sources/tutorials/alerting-get-started-pt4/index.md
+++ b/docs/sources/tutorials/alerting-get-started-pt4/index.md
@@ -305,7 +305,7 @@ Without a notification template, the alert messages would include the default Gr
 
 1. Navigate to **Alerts & IRM** > **Alerting** > **Contact point**s.
 1. Select the **Notification Templates** tab.
-1. Click **+ Add notification template group**.
+1. Click **+ New notification template**.
 1. Enter a name. E.g `instance-cpu-summary`.
 1. From the **Add example** dropdown menu, choose `Print firing and resolved alerts`.
 

--- a/docs/sources/tutorials/alerting-get-started/index.md
+++ b/docs/sources/tutorials/alerting-get-started/index.md
@@ -157,7 +157,7 @@ Your webhook endpoint is now waiting for the first request.
 Next, let's configure a contact point in Grafana's Alerting UI to send notifications to our webhook endpoint.
 
 1. Return to Grafana. In Grafana's sidebar, hover over the **Alerting** (bell) icon and then click **Contact points**.
-1. Click **+ Create contact point**.
+1. Click **+ New contact point**.
 1. In **Name**, write **Webhook**.
 1. In **Integration**, choose **Webhook**.
 1. In **URL**, paste the endpoint to your webhook endpoint.

--- a/docs/sources/tutorials/create-alerts-with-logs/index.md
+++ b/docs/sources/tutorials/create-alerts-with-logs/index.md
@@ -168,7 +168,7 @@ Your webhook endpoint is now waiting for the first request.
 Next, let's configure a contact point in Grafana's Alerting UI to send notifications to our webhook endpoint.
 
 1. Return to Grafana. In Grafana's sidebar, hover over the **Alerting** (bell) icon and then click **Contact points**.
-1. Click **+ Create contact point**.
+1. Click **+ New contact point**.
 1. In **Name**, write **Webhook**.
 1. In **Integration**, choose **Webhook**.
 1. In **URL**, paste the endpoint to your webhook endpoint.

--- a/public/app/features/alerting/unified/MuteTimings.test.tsx
+++ b/public/app/features/alerting/unified/MuteTimings.test.tsx
@@ -177,7 +177,7 @@ describe('Mute timings', () => {
     const capture = captureRequests();
     renderMuteTimings({ pathname: '/alerting/routes/new', search: `?alertmanager=${dataSources.am.name}` });
 
-    await screen.findByText(/add time interval/i);
+    await screen.findByText(/new time interval/i);
 
     await fillOutForm({
       name: 'maintenance period',

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
@@ -135,39 +135,39 @@ describe('contact points', () => {
       test('loads contact points tab', async () => {
         renderWithProvider(<ContactPointsPageContents />, { initialEntries: ['/?tab=contact_points'] });
 
-        expect(await screen.findByText(/create contact point/i)).toBeInTheDocument();
+        expect(await screen.findByText(/new contact point/i)).toBeInTheDocument();
       });
 
       test('loads templates tab', async () => {
         renderWithProvider(<ContactPointsPageContents />, { initialEntries: ['/?tab=templates'] });
 
-        expect(await screen.findByText(/add notification template/i)).toBeInTheDocument();
+        expect(await screen.findByText(/new notification template/i)).toBeInTheDocument();
       });
 
       test('defaults to contact points tab with invalid query param', async () => {
         renderWithProvider(<ContactPointsPageContents />, { initialEntries: ['/?tab=foo_bar'] });
 
-        expect(await screen.findByText(/create contact point/i)).toBeInTheDocument();
+        expect(await screen.findByText(/new contact point/i)).toBeInTheDocument();
       });
 
       test('defaults to contact points tab with no query param', async () => {
         renderWithProvider(<ContactPointsPageContents />);
 
-        expect(await screen.findByText(/create contact point/i)).toBeInTheDocument();
+        expect(await screen.findByText(/new contact point/i)).toBeInTheDocument();
       });
 
       test('defaults to contact points tab if user has only read permission', async () => {
         grantUserPermissions([AccessControlAction.AlertingReceiversRead]);
         renderWithProvider(<ContactPointsPageContents />);
 
-        expect(await screen.findByText(/create contact point/i)).toBeInTheDocument();
+        expect(await screen.findByText(/new contact point/i)).toBeInTheDocument();
       });
 
       test('defaults to contact points tab if user has only create permission', async () => {
         grantUserPermissions([AccessControlAction.AlertingReceiversCreate]);
         renderWithProvider(<ContactPointsPageContents />);
 
-        expect(await screen.findByText(/create contact point/i)).toBeInTheDocument();
+        expect(await screen.findByText(/new contact point/i)).toBeInTheDocument();
       });
     });
 

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
@@ -263,10 +263,7 @@ describe('contact points', () => {
       // check buttons in Notification Templates
       const notificationTemplatesTab = screen.getByRole('tab', { name: 'Notification Templates' });
       await user.click(notificationTemplatesTab);
-      expect(screen.getByRole('link', { name: 'Add notification template group' })).toHaveAttribute(
-        'aria-disabled',
-        'true'
-      );
+      expect(screen.getByRole('link', { name: 'New notification template' })).toHaveAttribute('aria-disabled', 'true');
     });
 
     it('allows deleting when not disabled', async () => {
@@ -477,7 +474,7 @@ describe('contact points', () => {
       // check buttons in Notification Templates
       const notificationTemplatesTab = screen.getByRole('tab', { name: 'Notification Templates' });
       await user.click(notificationTemplatesTab);
-      expect(screen.queryByRole('link', { name: 'Add notification template group' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'New notification template' })).not.toBeInTheDocument();
     });
   });
 

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
@@ -90,7 +90,7 @@ const ContactPointsTab = () => {
               icon="plus"
               size="lg"
             >
-              <Trans i18nKey="alerting.contact-points.create">Create contact point</Trans>
+              <Trans i18nKey="alerting.contact-points.create">New contact point</Trans>
             </LinkButton>
           )
         }
@@ -114,7 +114,7 @@ const ContactPointsTab = () => {
               href="/alerting/notifications/receivers/new"
               disabled={!addContactPointAllowed}
             >
-              <Trans i18nKey="alerting.contact-points.create">Create contact point</Trans>
+              <Trans i18nKey="alerting.contact-points.create">New contact point</Trans>
             </LinkButton>
           )}
           {exportContactPointsSupported && (
@@ -171,7 +171,7 @@ const NotificationTemplatesTab = () => {
             disabled={!createTemplateAllowed}
           >
             <Trans i18nKey="alerting.notification-templates-tab.add-notification-template-group">
-              Add notification template group
+              New notification template
             </Trans>
           </LinkButton>
         )}

--- a/public/app/features/alerting/unified/components/contact-points/TemplatesPage.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/TemplatesPage.tsx
@@ -29,7 +29,7 @@ function TemplatesPageContent() {
             href="/alerting/notifications/templates/new"
             disabled={!createTemplateAllowed}
           >
-            <Trans i18nKey="alerting.templates-page.add-template">Add notification template group</Trans>
+            <Trans i18nKey="alerting.templates-page.add-template">New notification template</Trans>
           </LinkButton>
         )}
       </Stack>

--- a/public/app/features/alerting/unified/components/mute-timings/MuteTimingsTable.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/MuteTimingsTable.tsx
@@ -86,7 +86,7 @@ export const TimeIntervalsTable = () => {
               variant="primary"
               href={makeAMLink('alerting/routes/mute-timing/new', alertManagerSourceName)}
             >
-              <Trans i18nKey="alerting.time-interval.add-time-interval">Add time interval</Trans>
+              <Trans i18nKey="alerting.time-interval.add-time-interval">New time interval</Trans>
             </LinkButton>
           </Authorize>
         )}
@@ -113,7 +113,7 @@ export const TimeIntervalsTable = () => {
                 'alerting.time-intervals-table.text-havent-created-time-intervals',
                 "You haven't created any time intervals yet"
               )}
-              buttonLabel="Add time interval"
+              buttonLabel="New time interval"
               buttonIcon="plus"
               buttonSize="lg"
               href={makeAMLink('alerting/routes/mute-timing/new', alertManagerSourceName)}

--- a/public/app/features/alerting/unified/components/mute-timings/NewMuteTiming.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/NewMuteTiming.tsx
@@ -18,7 +18,7 @@ function NewMuteTimingPage() {
       navId={navId}
       pageNav={{
         id: 'alert-policy-new',
-        text: t('alerting.new-mute-timing-page.text.add-time-interval', 'Add time interval'),
+        text: t('alerting.new-mute-timing-page.text.add-time-interval', 'New time interval'),
         parentItem: {
           text: t('alerting.time-intervals.title', 'Time intervals'),
           url: parentUrl,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -906,7 +906,7 @@
       "title-failed-to-fetch-contact-points": "Failed to fetch contact points"
     },
     "contact-points": {
-      "create": "Create contact point",
+      "create": "New contact point",
       "custom-template-value": "Custom template value",
       "delete-reasons": {
         "heading": "Contact point cannot be deleted for the following reasons:",
@@ -2129,7 +2129,7 @@
     },
     "new-mute-timing-page": {
       "text": {
-        "add-time-interval": "Add time interval"
+        "add-time-interval": "New time interval"
       }
     },
     "new-rule-from-panel-button": {
@@ -2252,7 +2252,7 @@
       "title-failed-to-fetch-notification-templates": "Failed to fetch notification templates"
     },
     "notification-templates-tab": {
-      "add-notification-template-group": "Add notification template group",
+      "add-notification-template-group": "New notification template",
       "create-notification-templates-customize-notifications": "Create notification templates to customize your notifications."
     },
     "notifications-list": {
@@ -3317,7 +3317,7 @@
       "misconfigured-warning-details": "Templates must be defined in both the <2></2> and <5></5> sections of your alertmanager configuration."
     },
     "templates-page": {
-      "add-template": "Add notification template group",
+      "add-template": "New notification template",
       "description": "Create notification templates to customize your notifications."
     },
     "templates-picker": {
@@ -3350,7 +3350,7 @@
       "stop-alerting-when": "Stop alerting (or pending state) when"
     },
     "time-interval": {
-      "add-time-interval": "Add time interval",
+      "add-time-interval": "New time interval",
       "save": "Save time interval",
       "saving": "Saving time interval"
     },


### PR DESCRIPTION
## What is this PR about?

Renames the main creation buttons across alerting notification configuration pages to follow a consistent naming pattern:

- **"New xyz"** — for buttons that trigger creation of a new major object
- **"Create xyz"** — for the submit button inside the creation form
- **"Add"** — reserved for adding existing objects to something

### Changes

| Before | After |
|--------|-------|
| Create contact point | New contact point |
| Add notification template group | New notification template |
| Add time interval | New time interval |

### Files changed

**UI components (5 files):**
- `ContactPoints.tsx` — empty state + primary button
- `TemplatesPage.tsx` — templates tab button
- `MuteTimingsTable.tsx` — primary button + empty state
- `NewMuteTiming.tsx` — page navigation title
- `ContactPoints.test.tsx` — updated test assertions

**Translations (1 file):**
- `public/locales/en-US/grafana.json`

**Documentation (8 files):**
- Tutorials: `alerting-get-started`, `create-alerts-with-logs`, `alerting-get-started-pt4`
- Config docs: `manage-contact-points`, `configure-email`, `template-notifications`, `manage-notification-templates`, `mute-timings`

### Out of scope

Buttons that correctly use "Add" (adding existing objects to something) are intentionally unchanged:
- "Add contact point integration"
- "Add another time range"
- "Add another time interval item"
- "Add mute timing to policy"

Form headings like "Create contact point" in `ReceiverForm.tsx` are submit-context labels and are correct per the convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)