### PR TITLE
fix: data race in unified resource tests

### DIFF
--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -308,9 +308,8 @@ func TestSearchGetOrCreateIndexWithCancellation(t *testing.T) {
 			{NamespacedResource: NamespacedResource{Namespace: "ns", Group: "group", Resource: "resource"}, Count: 50, ResourceVersion: 11111111},
 		},
 	}
-	search := &slowSearchBackendWithCache{
-		mockSearchBackend: mockSearchBackend{},
-	}
+	search := newSlowSearchBackendWithCache()
+
 	supplier := &TestDocumentBuilderSupplier{
 		GroupsResources: map[string]string{
 			"group": "resource",
@@ -336,6 +335,13 @@ func TestSearchGetOrCreateIndexWithCancellation(t *testing.T) {
 	// Make sure we get context deadline error
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 
+	// Ensure BuildIndex actually started (and wg.Add happened) before waiting.
+	select {
+	case <-search.started:
+	case <-time.After(1 * time.Second):
+		t.Fatal("BuildIndex never started")
+	}
+
 	// Wait until indexing is finished.
 	search.wg.Wait()
 
@@ -354,7 +360,16 @@ func TestSearchGetOrCreateIndexWithCancellation(t *testing.T) {
 
 type slowSearchBackendWithCache struct {
 	mockSearchBackend
-	wg sync.WaitGroup
+	wg      sync.WaitGroup
+	started chan struct{}
+	once    sync.Once
+}
+
+func newSlowSearchBackendWithCache() *slowSearchBackendWithCache {
+	return &slowSearchBackendWithCache{
+		mockSearchBackend: mockSearchBackend{},
+		started:           make(chan struct{}),
+	}
 }
 
 func (m *slowSearchBackendWithCache) GetIndex(key NamespacedResource) ResourceIndex {
@@ -364,7 +379,10 @@ func (m *slowSearchBackendWithCache) GetIndex(key NamespacedResource) ResourceIn
 }
 
 func (m *slowSearchBackendWithCache) BuildIndex(ctx context.Context, key NamespacedResource, size int64, fields SearchableDocumentFields, reason string, builder BuildFn, updater UpdateFn, rebuild bool, lastImportTime time.Time) (ResourceIndex, error) {
-	m.wg.Add(1)
+	m.once.Do(func() {
+		m.wg.Add(1)
+		close(m.started)
+	})
 	defer m.wg.Done()
 
 	time.Sleep(1 * time.Second)

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -309,8 +309,9 @@ func TestSearchGetOrCreateIndexWithCancellation(t *testing.T) {
 			{NamespacedResource: NamespacedResource{Namespace: "ns", Group: "group", Resource: "resource"}, Count: 50, ResourceVersion: 11111111},
 		},
 	}
-	search := newSlowSearchBackendWithCache()
-
+	search := &slowSearchBackendWithCache{
+		mockSearchBackend: mockSearchBackend{},
+	}
 	supplier := &TestDocumentBuilderSupplier{
 		GroupsResources: map[string]string{
 			"group": "resource",
@@ -336,13 +337,12 @@ func TestSearchGetOrCreateIndexWithCancellation(t *testing.T) {
 	// Make sure we get context deadline error
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 
-	// Ensure BuildIndex actually started before waiting.
+	// Wait until indexing is finished. We need to wait 2 seconds here,
+	// because BuildIndex simulates a 1 second build time, and we want
+	// to be sure it has started before we check the calls.
 	require.Eventually(t, func() bool {
 		return search.slowBuildCalls.Load() > 0
-	}, 1*time.Second, 100*time.Millisecond, "BuildIndex never started")
-
-	// Wait until indexing is finished.
-	search.wg.Wait()
+	}, 2*time.Second, 100*time.Millisecond, "BuildIndex never started")
 
 	require.NotEmpty(t, search.buildIndexCalls)
 
@@ -359,15 +359,7 @@ func TestSearchGetOrCreateIndexWithCancellation(t *testing.T) {
 
 type slowSearchBackendWithCache struct {
 	mockSearchBackend
-	wg sync.WaitGroup
-
 	slowBuildCalls atomic.Int64
-}
-
-func newSlowSearchBackendWithCache() *slowSearchBackendWithCache {
-	return &slowSearchBackendWithCache{
-		mockSearchBackend: mockSearchBackend{},
-	}
 }
 
 func (m *slowSearchBackendWithCache) GetIndex(key NamespacedResource) ResourceIndex {
@@ -377,9 +369,7 @@ func (m *slowSearchBackendWithCache) GetIndex(key NamespacedResource) ResourceIn
 }
 
 func (m *slowSearchBackendWithCache) BuildIndex(ctx context.Context, key NamespacedResource, size int64, fields SearchableDocumentFields, reason string, builder BuildFn, updater UpdateFn, rebuild bool, lastImportTime time.Time) (ResourceIndex, error) {
-	m.wg.Add(1)
-	m.slowBuildCalls.Add(1)
-	defer m.wg.Done()
+	defer m.slowBuildCalls.Add(1)
 
 	time.Sleep(1 * time.Second)
 

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -379,10 +379,11 @@ func (m *slowSearchBackendWithCache) GetIndex(key NamespacedResource) ResourceIn
 }
 
 func (m *slowSearchBackendWithCache) BuildIndex(ctx context.Context, key NamespacedResource, size int64, fields SearchableDocumentFields, reason string, builder BuildFn, updater UpdateFn, rebuild bool, lastImportTime time.Time) (ResourceIndex, error) {
-	m.once.Do(func() {
-		m.wg.Add(1)
-		close(m.started)
-	})
+	m.wg.Add(1)
+	m.once.Do(
+		func() {
+			close(m.started)
+		})
 	defer m.wg.Done()
 
 	time.Sleep(1 * time.Second)

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -7,6 +7,7 @@ import (
 	"iter"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -335,12 +336,10 @@ func TestSearchGetOrCreateIndexWithCancellation(t *testing.T) {
 	// Make sure we get context deadline error
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 
-	// Ensure BuildIndex actually started (and wg.Add happened) before waiting.
-	select {
-	case <-search.started:
-	case <-time.After(1 * time.Second):
-		t.Fatal("BuildIndex never started")
-	}
+	// Ensure BuildIndex actually started before waiting.
+	require.Eventually(t, func() bool {
+		return search.slowBuildCalls.Load() > 0
+	}, 1*time.Second, 100*time.Millisecond, "BuildIndex never started")
 
 	// Wait until indexing is finished.
 	search.wg.Wait()
@@ -360,15 +359,14 @@ func TestSearchGetOrCreateIndexWithCancellation(t *testing.T) {
 
 type slowSearchBackendWithCache struct {
 	mockSearchBackend
-	wg      sync.WaitGroup
-	started chan struct{}
-	once    sync.Once
+	wg sync.WaitGroup
+
+	slowBuildCalls atomic.Int64
 }
 
 func newSlowSearchBackendWithCache() *slowSearchBackendWithCache {
 	return &slowSearchBackendWithCache{
 		mockSearchBackend: mockSearchBackend{},
-		started:           make(chan struct{}),
 	}
 }
 
@@ -380,10 +378,7 @@ func (m *slowSearchBackendWithCache) GetIndex(key NamespacedResource) ResourceIn
 
 func (m *slowSearchBackendWithCache) BuildIndex(ctx context.Context, key NamespacedResource, size int64, fields SearchableDocumentFields, reason string, builder BuildFn, updater UpdateFn, rebuild bool, lastImportTime time.Time) (ResourceIndex, error) {
 	m.wg.Add(1)
-	m.once.Do(
-		func() {
-			close(m.started)
-		})
+	m.slowBuildCalls.Add(1)
 	defer m.wg.Done()
 
 	time.Sleep(1 * time.Second)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR fixes two data races found when running unified/resource tests:
- Tests were calling search.wg.Wait() before BuildIndex actually have started
- `snowflake.NewNode()` mutates package level variables. When we have multiple processes running, we get multiple concurrent writes and reads to these variables.

This PR fixes both issues by making test synchronization deterministic and turning Snowflake initialization into a thread-safe singleton. 

The data race can be verified by running:

```
go test -failfast -count=5 -race -timeout=10m  ./pkg/storage/unified/resource

==================
WARNING: DATA RACE
Write at 0x00c001aa2c78 by goroutine 7020:
  runtime.racewrite()
      <autogenerated>:1 +0x1e
  github.com/grafana/grafana/pkg/storage/unified/resource.TestSearchGetOrCreateIndexWithCancellation()
      /home/maicon/grafana/grafana/pkg/storage/unified/resource/search_test.go:340 +0x557
  testing.tRunner()
      /home/maicon/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-amd64/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /home/maicon/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-amd64/src/testing/testing.go:1997 +0x44

Previous read at 0x00c001aa2c78 by goroutine 7022:
  runtime.raceread()
      <autogenerated>:1 +0x1e
  github.com/grafana/grafana/pkg/storage/unified/resource.(*slowSearchBackendWithCache).BuildIndex()
      /home/maicon/grafana/grafana/pkg/storage/unified/resource/search_test.go:367 +0xa4
  github.com/grafana/grafana/pkg/storage/unified/resource.(*searchServer).build()
      /home/maicon/grafana/grafana/pkg/storage/unified/resource/search.go:1196 +0x12c1
  github.com/grafana/grafana/pkg/storage/unified/resource.(*searchServer).getOrCreateIndex.func1()
      /home/maicon/grafana/grafana/pkg/storage/unified/resource/search.go:983 +0x80d
  golang.org/x/sync/singleflight.(*Group).doCall.func2()
      /home/maicon/go/pkg/mod/golang.org/x/sync@v0.19.0/singleflight/singleflight.go:198 +0xa9
  golang.org/x/sync/singleflight.(*Group).doCall()
      /home/maicon/go/pkg/mod/golang.org/x/sync@v0.19.0/singleflight/singleflight.go:200 +0x131
  golang.org/x/sync/singleflight.(*Group).DoChan.gowrap1()
      /home/maicon/go/pkg/mod/golang.org/x/sync@v0.19.0/singleflight/singleflight.go:138 +0x6b

Goroutine 7020 (running) created at:
  testing.(*T).Run()
      /home/maicon/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-amd64/src/testing/testing.go:1997 +0x9d2
  testing.runTests.func1()
      /home/maicon/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-amd64/src/testing/testing.go:2477 +0x85
  testing.tRunner()
      /home/maicon/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-amd64/src/testing/testing.go:1934 +0x21c
  testing.runTests()
      /home/maicon/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-amd64/src/testing/testing.go:2475 +0x96c
  testing.(*M).Run()
      /home/maicon/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-amd64/src/testing/testing.go:2337 +0xed4
  github.com/grafana/grafana/pkg/tests/testsuite.Run()
      /home/maicon/grafana/grafana/pkg/tests/testsuite/testsuite.go:12 +0x3e
  github.com/grafana/grafana/pkg/storage/unified/resource.TestMain()
      /home/maicon/grafana/grafana/pkg/storage/unified/resource/eventstore_test.go:22 +0x172
  main.main()
      _testmain.go:325 +0x16d

Goroutine 7022 (running) created at:
  golang.org/x/sync/singleflight.(*Group).DoChan()
      /home/maicon/go/pkg/mod/golang.org/x/sync@v0.19.0/singleflight/singleflight.go:138 +0x55c
  github.com/grafana/grafana/pkg/storage/unified/resource.(*searchServer).getOrCreateIndex()
      /home/maicon/grafana/grafana/pkg/storage/unified/resource/search.go:942 +0xc57
  github.com/grafana/grafana/pkg/storage/unified/resource.TestSearchGetOrCreateIndexWithCancellation()
      /home/maicon/grafana/grafana/pkg/storage/unified/resource/search_test.go:335 +0x4ef
  testing.tRunner()
      /home/maicon/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-amd64/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /home/maicon/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-amd64/src/testing/testing.go:1997 +0x44
==================
--- FAIL: TestSearchGetOrCreateIndexWithCancellation (1.00s)
    testing.go:1617: race detected during execution of test
FAIL
FAIL    github.com/grafana/grafana/pkg/storage/unified/resource 7.867s
FAIL
```

**Why do we need this feature?**

We want to remove data races

**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/675

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
