### PR TITLE
Alerting: Add predefined saved searches for Alert Activity

### DIFF
--- a/public/app/features/alerting/unified/components/saved-searches/SavedSearches.tsx
+++ b/public/app/features/alerting/unified/components/saved-searches/SavedSearches.tsx
@@ -497,9 +497,7 @@ function ListMode({
                 typeof activeAction === 'object' && activeAction.type === 'renaming' && activeAction.id === search.id;
               const isDeleting =
                 typeof activeAction === 'object' && activeAction.type === 'deleting' && activeAction.id === search.id;
-              // Item is disabled if any action is active and this item is not the one being acted upon
               const isItemDisabled = isActionActive && !isRenaming && !isDeleting;
-
               const href = getHref(search);
 
               return (

--- a/public/app/features/alerting/unified/triage/hooks/useTriagePredefinedOverrides.ts
+++ b/public/app/features/alerting/unified/triage/hooks/useTriagePredefinedOverrides.ts
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { UserStorage } from '@grafana/runtime/internal';
+
+const STORAGE_NAMESPACE = 'alerting';
+const KEY_NAME_OVERRIDES = 'triagePredefinedNameOverrides';
+const KEY_DISMISSED = 'triagePredefinedDismissed';
+
+export interface UseTriagePredefinedOverridesResult {
+  /** Custom names for predefined search IDs */
+  nameOverrides: Record<string, string>;
+  /** Predefined search IDs the user has dismissed (hidden from list) */
+  dismissedIds: string[];
+  /** Whether the initial load from storage is complete */
+  isLoading: boolean;
+  /** Set a custom name for a predefined search */
+  setNameOverride: (id: string, name: string) => Promise<void>;
+  /** Dismiss (hide) a predefined search from the list */
+  dismissId: (id: string) => Promise<void>;
+}
+
+function isRecordOfStrings(value: unknown): value is Record<string, string> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  return Object.entries(value).every(([, v]) => typeof v === 'string');
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === 'string');
+}
+
+function parseJsonRecord(raw: string | null): Record<string, string> {
+  if (raw == null || raw === '') {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isRecordOfStrings(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseJsonStringArray(raw: string | null): string[] {
+  if (raw == null || raw === '') {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isStringArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Hook for persisting user customisations to predefined triage saved searches:
+ * custom names (rename) and dismissed IDs (delete = hide from list).
+ */
+export function useTriagePredefinedOverrides(): UseTriagePredefinedOverridesResult {
+  const [nameOverrides, setNameOverridesState] = useState<Record<string, string>>({});
+  const [dismissedIds, setDismissedIdsState] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const userStorage = useMemo(() => new UserStorage(STORAGE_NAMESPACE), []);
+  const hasLoadedRef = useRef(false);
+
+  useEffect(() => {
+    if (hasLoadedRef.current) {
+      return;
+    }
+    hasLoadedRef.current = true;
+
+    const load = async () => {
+      try {
+        const [overridesRaw, dismissedRaw] = await Promise.all([
+          userStorage.getItem(KEY_NAME_OVERRIDES),
+          userStorage.getItem(KEY_DISMISSED),
+        ]);
+        setNameOverridesState(parseJsonRecord(overridesRaw));
+        setDismissedIdsState(parseJsonStringArray(dismissedRaw));
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    load();
+  }, [userStorage]);
+
+  const persistOverrides = useCallback(
+    async (next: Record<string, string>) => {
+      await userStorage.setItem(KEY_NAME_OVERRIDES, JSON.stringify(next));
+    },
+    [userStorage]
+  );
+
+  const persistDismissed = useCallback(
+    async (next: string[]) => {
+      await userStorage.setItem(KEY_DISMISSED, JSON.stringify(next));
+    },
+    [userStorage]
+  );
+
+  const setNameOverride = useCallback(
+    async (id: string, name: string) => {
+      const next = { ...nameOverrides, [id]: name };
+      setNameOverridesState(next);
+      await persistOverrides(next);
+    },
+    [nameOverrides, persistOverrides]
+  );
+
+  const dismissId = useCallback(
+    async (id: string) => {
+      const next = dismissedIds.includes(id) ? dismissedIds : [...dismissedIds, id];
+      setDismissedIdsState(next);
+      await persistDismissed(next);
+    },
+    [dismissedIds, persistDismissed]
+  );
+
+  return {
+    nameOverrides,
+    dismissedIds,
+    isLoading,
+    setNameOverride,
+    dismissId,
+  };
+}

--- a/public/app/features/alerting/unified/triage/hooks/useTriagePredefinedOverrides.ts
+++ b/public/app/features/alerting/unified/triage/hooks/useTriagePredefinedOverrides.ts
@@ -5,6 +5,7 @@ import { UserStorage } from '@grafana/runtime/internal';
 
 import { logError } from '../../Analytics';
 import { isLoading as isLoadingState, isUninitialized, useAsync } from '../../hooks/useAsync';
+import { parseJsonWithSchema } from '../../utils/parseJsonWithSchema';
 
 const STORAGE_NAMESPACE = 'alerting';
 const KEY_NAME_OVERRIDES = 'triagePredefinedNameOverrides';
@@ -32,19 +33,6 @@ export interface UseTriagePredefinedOverridesResult {
 const nameOverridesSchema = z.record(z.string(), z.string());
 const dismissedIdsSchema = z.array(z.string());
 const defaultSearchIdSchema = z.string().min(1).nullable();
-
-function parseJsonWithSchema<T>(raw: string | null, schema: z.ZodType<T>, fallback: T): T {
-  if (raw == null || raw === '') {
-    return fallback;
-  }
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    const result = schema.safeParse(parsed);
-    return result.success ? result.data : fallback;
-  } catch {
-    return fallback;
-  }
-}
 
 /** Data shape returned by the predefined overrides loader. */
 export interface TriagePredefinedOverridesData {

--- a/public/app/features/alerting/unified/triage/hooks/useTriagePredefinedOverrides.ts
+++ b/public/app/features/alerting/unified/triage/hooks/useTriagePredefinedOverrides.ts
@@ -3,6 +3,7 @@ import z from 'zod';
 
 import { UserStorage } from '@grafana/runtime/internal';
 
+import { logError } from '../../Analytics';
 import { isLoading as isLoadingState, isUninitialized, useAsync } from '../../hooks/useAsync';
 
 const STORAGE_NAMESPACE = 'alerting';
@@ -104,8 +105,10 @@ export function useTriagePredefinedOverrides(): UseTriagePredefinedOverridesResu
           setDismissedIdsState(data.dismissedIds);
           setDefaultSearchIdState(data.defaultSearchId);
         }
-      } catch {
-        // Ignore; useAsync tracks error state; we keep initial empty values
+      } catch (error) {
+        logError(error instanceof Error ? error : new Error('Failed to load predefined overrides from storage'), {
+          context: 'useTriagePredefinedOverrides.loadOverrides',
+        });
       }
     };
 

--- a/public/app/features/alerting/unified/triage/hooks/useTriageSavedSearches.ts
+++ b/public/app/features/alerting/unified/triage/hooks/useTriageSavedSearches.ts
@@ -1,5 +1,3 @@
-import { UserStorage } from '@grafana/runtime/internal';
-
 import { SavedSearch } from '../../components/saved-searches/savedSearchesSchema';
 import {
   UseGenericSavedSearchesResult,
@@ -10,7 +8,7 @@ import {
 } from '../../hooks/useGenericSavedSearches';
 import { getTriagePredefinedSearches } from '../triagePredefinedSearches';
 
-import { TRIAGE_DEFAULT_SEARCH_ID_STORAGE_KEY } from './useTriagePredefinedOverrides';
+import { createPredefinedOverridesLoader } from './useTriagePredefinedOverrides';
 
 export const TRIAGE_SAVED_SEARCHES_STORAGE_KEY = 'triageSavedSearches';
 
@@ -36,18 +34,8 @@ export function useTriageSavedSearches(): UseTriageSavedSearchesResult {
  * Used by auto-apply hooks to load default search on first visit.
  */
 export async function loadDefaultTriageSavedSearch(): Promise<SavedSearch | null> {
-  const userStorage = new UserStorage('alerting');
-  const defaultIdRaw = await userStorage.getItem(TRIAGE_DEFAULT_SEARCH_ID_STORAGE_KEY);
-
-  let defaultId: string | null = null;
-  if (defaultIdRaw != null && defaultIdRaw !== '') {
-    try {
-      const parsed: unknown = JSON.parse(defaultIdRaw);
-      defaultId = typeof parsed === 'string' && parsed.length > 0 ? parsed : null;
-    } catch {
-      defaultId = null;
-    }
-  }
+  const loadOverrides = createPredefinedOverridesLoader();
+  const { defaultSearchId: defaultId } = await loadOverrides();
 
   const loadSavedSearches = createStorageLoader(TRIAGE_CONFIG);
 

--- a/public/app/features/alerting/unified/triage/scene/TriageSavedSearchesControl.tsx
+++ b/public/app/features/alerting/unified/triage/scene/TriageSavedSearchesControl.tsx
@@ -17,7 +17,12 @@ import { useTriagePredefinedOverrides } from '../hooks/useTriagePredefinedOverri
 import { trackTriageSavedSearchApplied, useTriageSavedSearches } from '../hooks/useTriageSavedSearches';
 import { getTriagePredefinedSearches, isTriagePredefinedSearchId } from '../triagePredefinedSearches';
 
-import { applyTriageSavedSearchState, generateTriageUrl, serializeTriageState } from './triageSavedSearchUtils';
+import {
+  applyTriageSavedSearchState,
+  generateTriageUrl,
+  mergeTriageSavedSearches,
+  serializeTriageState,
+} from './triageSavedSearchUtils';
 
 /**
  * State interface for TriageSavedSearchesControl.
@@ -126,16 +131,10 @@ function TriageSavedSearchesControlRenderer({ model }: SceneComponentProps<Triag
     [savedSearches, effectiveDefaultId]
   );
 
-  // Default search first, then predefined, then user (so default is always at top)
-  const mergedSavedSearches = useMemo(() => {
-    const merged = [...predefinedList, ...savedSearchesWithDefault];
-    const defaultIndex = merged.findIndex((s) => s.id === effectiveDefaultId);
-    if (defaultIndex <= 0) {
-      return merged;
-    }
-    const defaultItem = merged[defaultIndex];
-    return [defaultItem, ...merged.slice(0, defaultIndex), ...merged.slice(defaultIndex + 1)];
-  }, [predefinedList, savedSearchesWithDefault, effectiveDefaultId]);
+  const mergedSavedSearches = useMemo(
+    () => mergeTriageSavedSearches(predefinedList, savedSearchesWithDefault, effectiveDefaultId),
+    [predefinedList, savedSearchesWithDefault, effectiveDefaultId]
+  );
 
   const handleSave = useCallback(
     async (name: string, query: string) => {

--- a/public/app/features/alerting/unified/triage/scene/triageSavedSearchUtils.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/triageSavedSearchUtils.test.ts
@@ -2,8 +2,10 @@ import { locationService } from '@grafana/runtime';
 
 import {
   applySavedSearch,
+  buildTriageQueryStringFromParts,
   extractFilterObjects,
   generateTriageUrl,
+  mergeTriageSavedSearches,
   serializeCurrentSearchState,
 } from './triageSavedSearchUtils';
 
@@ -36,6 +38,48 @@ describe('triageSavedSearchUtils', () => {
     Object.defineProperty(window, 'location', {
       value: originalLocation,
       writable: true,
+    });
+  });
+
+  describe('buildTriageQueryStringFromParts', () => {
+    it('builds query string with string time range', () => {
+      const result = buildTriageQueryStringFromParts({
+        filters: [{ key: 'alertstate', operator: '=', value: 'firing' }],
+        groupBy: ['grafana_folder'],
+        timeRange: { from: 'now-1h', to: 'now' },
+      });
+      const params = new URLSearchParams(result);
+      expect(params.get('from')).toBe('now-1h');
+      expect(params.get('to')).toBe('now');
+      expect(params.getAll('var-groupBy')).toEqual(['grafana_folder']);
+      expect(params.has('var-filters')).toBe(true);
+    });
+
+    it('builds query string with Date-like time range (DateTime)', () => {
+      const fromDate = new Date('2025-01-15T10:00:00Z');
+      const toDate = new Date('2025-01-15T11:00:00Z');
+      const result = buildTriageQueryStringFromParts({
+        groupBy: [],
+        timeRange: {
+          from: { toISOString: () => fromDate.toISOString() },
+          to: { toISOString: () => toDate.toISOString() },
+        },
+      });
+      const params = new URLSearchParams(result);
+      expect(params.get('from')).toBe('2025-01-15T10:00:00.000Z');
+      expect(params.get('to')).toBe('2025-01-15T11:00:00.000Z');
+    });
+
+    it('handles empty filters and groupBy', () => {
+      const result = buildTriageQueryStringFromParts({
+        groupBy: [],
+        timeRange: { from: 'now-4h', to: 'now' },
+      });
+      const params = new URLSearchParams(result);
+      expect(params.get('from')).toBe('now-4h');
+      expect(params.get('to')).toBe('now');
+      expect(params.has('var-filters')).toBe(false);
+      expect(params.has('var-groupBy')).toBe(false);
     });
   });
 
@@ -125,6 +169,59 @@ describe('triageSavedSearchUtils', () => {
       const result = serializeCurrentSearchState();
       expect(result).toBe('var-groupBy=severity');
       expect(result).not.toContain('unrelated');
+    });
+  });
+
+  describe('mergeTriageSavedSearches', () => {
+    const mkSearch = (id: string, name: string, isDefault = false) => ({
+      id,
+      name,
+      query: `query-${id}`,
+      isDefault,
+    });
+
+    it('returns predefined then user when no default', () => {
+      const predefined = [mkSearch('p1', 'Predefined 1'), mkSearch('p2', 'Predefined 2')];
+      const user = [mkSearch('u1', 'User 1')];
+      const result = mergeTriageSavedSearches(predefined, user, null);
+      expect(result.map((s) => s.id)).toEqual(['p1', 'p2', 'u1']);
+    });
+
+    it('puts default first when it is in predefined', () => {
+      const predefined = [
+        mkSearch('p1', 'Predefined 1'),
+        mkSearch('p2', 'Predefined 2', true),
+        mkSearch('p3', 'Predefined 3'),
+      ];
+      const user = [mkSearch('u1', 'User 1')];
+      const result = mergeTriageSavedSearches(predefined, user, 'p2');
+      expect(result.map((s) => s.id)).toEqual(['p2', 'p1', 'p3', 'u1']);
+    });
+
+    it('puts default first when it is in user saves', () => {
+      const predefined = [mkSearch('p1', 'Predefined 1')];
+      const user = [mkSearch('u1', 'User 1'), mkSearch('u2', 'User 2'), mkSearch('u3', 'User 3')];
+      const result = mergeTriageSavedSearches(predefined, user, 'u2');
+      expect(result.map((s) => s.id)).toEqual(['u2', 'p1', 'u1', 'u3']);
+    });
+
+    it('returns merged order when default is already first (index 0)', () => {
+      const predefined = [mkSearch('p1', 'Predefined 1', true), mkSearch('p2', 'Predefined 2')];
+      const user = [mkSearch('u1', 'User 1')];
+      const result = mergeTriageSavedSearches(predefined, user, 'p1');
+      expect(result.map((s) => s.id)).toEqual(['p1', 'p2', 'u1']);
+    });
+
+    it('handles empty predefined', () => {
+      const user = [mkSearch('u1', 'User 1'), mkSearch('u2', 'User 2')];
+      const result = mergeTriageSavedSearches([], user, 'u2');
+      expect(result.map((s) => s.id)).toEqual(['u2', 'u1']);
+    });
+
+    it('handles empty user', () => {
+      const predefined = [mkSearch('p1', 'Predefined 1'), mkSearch('p2', 'Predefined 2')];
+      const result = mergeTriageSavedSearches(predefined, [], 'p2');
+      expect(result.map((s) => s.id)).toEqual(['p2', 'p1']);
     });
   });
 

--- a/public/app/features/alerting/unified/triage/scene/triageSavedSearchUtils.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/triageSavedSearchUtils.test.ts
@@ -1,3 +1,4 @@
+import { dateTime } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 
 import {
@@ -55,15 +56,12 @@ describe('triageSavedSearchUtils', () => {
       expect(params.has('var-filters')).toBe(true);
     });
 
-    it('builds query string with Date-like time range (DateTime)', () => {
-      const fromDate = new Date('2025-01-15T10:00:00Z');
-      const toDate = new Date('2025-01-15T11:00:00Z');
+    it('builds query string with DateTime time range', () => {
+      const fromDateTime = dateTime('2025-01-15T10:00:00Z');
+      const toDateTime = dateTime('2025-01-15T11:00:00Z');
       const result = buildTriageQueryStringFromParts({
         groupBy: [],
-        timeRange: {
-          from: { toISOString: () => fromDate.toISOString() },
-          to: { toISOString: () => toDate.toISOString() },
-        },
+        timeRange: { from: fromDateTime, to: toDateTime },
       });
       const params = new URLSearchParams(result);
       expect(params.get('from')).toBe('2025-01-15T10:00:00.000Z');

--- a/public/app/features/alerting/unified/triage/scene/triageSavedSearchUtils.ts
+++ b/public/app/features/alerting/unified/triage/scene/triageSavedSearchUtils.ts
@@ -10,7 +10,30 @@ import { locationService } from '@grafana/runtime';
 import { AdHocFiltersVariable, GroupByVariable, SceneObject, sceneGraph } from '@grafana/scenes';
 
 import { toFilters, toUrl } from '../../../../variables/adhoc/urlParser';
+import { SavedSearch } from '../../components/saved-searches/savedSearchesSchema';
 import { TRIAGE_STATE_URL_PARAMS, URL_PARAMS, VARIABLES } from '../constants';
+
+/**
+ * Merges predefined and user saved searches, with the default search first.
+ *
+ * @param predefinedSearches - Predefined searches (with isDefault applied)
+ * @param userSavedSearches - User-created saved searches (with isDefault applied)
+ * @param defaultId - ID of the search set as default, or null
+ * @returns Merged list with default item first, then predefined, then user
+ */
+export function mergeTriageSavedSearches(
+  predefinedSearches: SavedSearch[],
+  userSavedSearches: SavedSearch[],
+  defaultId: string | null
+): SavedSearch[] {
+  const merged = [...predefinedSearches, ...userSavedSearches];
+  const defaultIndex = merged.findIndex((s) => s.id === defaultId);
+  if (defaultIndex <= 0) {
+    return merged;
+  }
+  const defaultItem = merged[defaultIndex];
+  return [defaultItem, ...merged.slice(0, defaultIndex), ...merged.slice(defaultIndex + 1)];
+}
 
 /** Filter shape compatible with AdHocVariableFilter (key, operator, value). Used for building query strings. */
 export interface TriageFilterInput {
@@ -27,8 +50,7 @@ export interface TriageFilterInput {
 export function buildTriageQueryStringFromParts(input: {
   filters?: TriageFilterInput[];
   groupBy: string[];
-  from: string;
-  to: string;
+  timeRange: RawTimeRange;
 }): string {
   const params = new URLSearchParams();
 
@@ -42,8 +64,11 @@ export function buildTriageQueryStringFromParts(input: {
     params.append(URL_PARAMS.groupBy, key);
   });
 
-  params.set(URL_PARAMS.timeFrom, input.from);
-  params.set(URL_PARAMS.timeTo, input.to);
+  const fromValue =
+    typeof input.timeRange.from === 'string' ? input.timeRange.from : input.timeRange.from.toISOString();
+  const toValue = typeof input.timeRange.to === 'string' ? input.timeRange.to : input.timeRange.to.toISOString();
+  params.set(URL_PARAMS.timeFrom, fromValue);
+  params.set(URL_PARAMS.timeTo, toValue);
 
   return params.toString();
 }
@@ -89,14 +114,10 @@ export function serializeTriageState(
   timeRange: RawTimeRange
 ): string {
   const groupByArray = Array.isArray(groupBy) ? groupBy : [groupBy].filter(Boolean);
-  const fromValue = typeof timeRange.from === 'string' ? timeRange.from : timeRange.from.toISOString();
-  const toValue = typeof timeRange.to === 'string' ? timeRange.to : timeRange.to.toISOString();
-
   return buildTriageQueryStringFromParts({
     filters: filters.map((f) => ({ key: f.key, operator: f.operator, value: f.value })),
     groupBy: groupByArray,
-    from: fromValue,
-    to: toValue,
+    timeRange,
   });
 }
 

--- a/public/app/features/alerting/unified/triage/triagePredefinedSearches.test.ts
+++ b/public/app/features/alerting/unified/triage/triagePredefinedSearches.test.ts
@@ -19,10 +19,10 @@ describe('triagePredefinedSearches', () => {
       }
     });
 
-    it('all predefined searches use default time range (now-4h to now)', () => {
+    it('all predefined searches use default time range (15m from scene/utils)', () => {
       for (const search of getTriagePredefinedSearches()) {
         const params = new URLSearchParams(search.query);
-        expect(params.get('from')).toBe('now-4h');
+        expect(params.get('from')).toBe('now-15m');
         expect(params.get('to')).toBe('now');
       }
     });

--- a/public/app/features/alerting/unified/triage/triagePredefinedSearches.test.ts
+++ b/public/app/features/alerting/unified/triage/triagePredefinedSearches.test.ts
@@ -1,0 +1,84 @@
+import { extractFilterObjects } from './scene/triageSavedSearchUtils';
+import {
+  TRIAGE_PREDEFINED_SEARCH_IDS,
+  TRIAGE_PREDEFINED_SEARCH_ID_PREFIX,
+  getTriagePredefinedSearches,
+  isTriagePredefinedSearchId,
+} from './triagePredefinedSearches';
+
+describe('triagePredefinedSearches', () => {
+  describe('getTriagePredefinedSearches()', () => {
+    it('each search has stable id, name, isDefault false, and non-empty query', () => {
+      for (const search of getTriagePredefinedSearches()) {
+        expect(search.id).toMatch(new RegExp(`^${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}`));
+        expect(typeof search.name).toBe('string');
+        expect(search.name.length).toBeGreaterThan(0);
+        expect(search.isDefault).toBe(false);
+        expect(typeof search.query).toBe('string');
+        expect(search.query.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('all predefined searches use default time range (now-4h to now)', () => {
+      for (const search of getTriagePredefinedSearches()) {
+        const params = new URLSearchParams(search.query);
+        expect(params.get('from')).toBe('now-4h');
+        expect(params.get('to')).toBe('now');
+      }
+    });
+
+    it('first search has filter firing and groupBy folder and rule_group', () => {
+      const first = getTriagePredefinedSearches()[0];
+      const params = new URLSearchParams(first.query);
+      expect(params.getAll('var-groupBy')).toEqual(['grafana_folder', 'rule_group']);
+      const filters = extractFilterObjects(first.query);
+      expect(filters).toHaveLength(1);
+      expect(filters[0]).toMatchObject({ key: 'alertstate', value: 'firing' });
+    });
+
+    it('second search has filter firing only (no groupBy)', () => {
+      const second = getTriagePredefinedSearches()[1];
+      const params = new URLSearchParams(second.query);
+      expect(params.getAll('var-groupBy')).toEqual([]);
+      const filters = extractFilterObjects(second.query);
+      expect(filters).toHaveLength(1);
+      expect(filters[0]).toMatchObject({ key: 'alertstate', value: 'firing' });
+    });
+
+    it('third search has groupBy folder and rule_group only', () => {
+      const third = getTriagePredefinedSearches()[2];
+      const params = new URLSearchParams(third.query);
+      expect(params.getAll('var-groupBy')).toEqual(['grafana_folder', 'rule_group']);
+      expect(params.has('var-filters')).toBe(false);
+    });
+
+    it('fourth search has groupBy folder only', () => {
+      const fourth = getTriagePredefinedSearches()[3];
+      const params = new URLSearchParams(fourth.query);
+      expect(params.getAll('var-groupBy')).toEqual(['grafana_folder']);
+      expect(params.has('var-filters')).toBe(false);
+    });
+  });
+
+  describe('TRIAGE_PREDEFINED_SEARCH_IDS', () => {
+    it('contains all predefined search ids', () => {
+      expect(TRIAGE_PREDEFINED_SEARCH_IDS.size).toBe(getTriagePredefinedSearches().length);
+      for (const s of getTriagePredefinedSearches()) {
+        expect(TRIAGE_PREDEFINED_SEARCH_IDS.has(s.id)).toBe(true);
+      }
+    });
+  });
+
+  describe('isTriagePredefinedSearchId', () => {
+    it('returns true for predefined ids', () => {
+      expect(isTriagePredefinedSearchId(`${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}folder-evalgroup`)).toBe(true);
+      expect(isTriagePredefinedSearchId(`${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}folder-firing`)).toBe(true);
+      expect(isTriagePredefinedSearchId(`${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}firing-only`)).toBe(true);
+    });
+
+    it('returns false for user-generated ids', () => {
+      expect(isTriagePredefinedSearchId('abc-123')).toBe(false);
+      expect(isTriagePredefinedSearchId('triage-predefined-x')).toBe(true); // prefix match
+    });
+  });
+});

--- a/public/app/features/alerting/unified/triage/triagePredefinedSearches.test.ts
+++ b/public/app/features/alerting/unified/triage/triagePredefinedSearches.test.ts
@@ -1,6 +1,5 @@
 import { extractFilterObjects } from './scene/triageSavedSearchUtils';
 import {
-  TRIAGE_PREDEFINED_SEARCH_IDS,
   TRIAGE_PREDEFINED_SEARCH_ID_PREFIX,
   getTriagePredefinedSearches,
   isTriagePredefinedSearchId,
@@ -27,10 +26,10 @@ describe('triagePredefinedSearches', () => {
       }
     });
 
-    it('first search has filter firing and groupBy folder and rule_group', () => {
+    it('first search has filter firing and groupBy folder', () => {
       const first = getTriagePredefinedSearches()[0];
       const params = new URLSearchParams(first.query);
-      expect(params.getAll('var-groupBy')).toEqual(['grafana_folder', 'rule_group']);
+      expect(params.getAll('var-groupBy')).toEqual(['grafana_folder']);
       const filters = extractFilterObjects(first.query);
       expect(filters).toHaveLength(1);
       expect(filters[0]).toMatchObject({ key: 'alertstate', value: 'firing' });
@@ -45,35 +44,19 @@ describe('triagePredefinedSearches', () => {
       expect(filters[0]).toMatchObject({ key: 'alertstate', value: 'firing' });
     });
 
-    it('third search has groupBy folder and rule_group only', () => {
+    it('third search has groupBy folder only', () => {
       const third = getTriagePredefinedSearches()[2];
       const params = new URLSearchParams(third.query);
-      expect(params.getAll('var-groupBy')).toEqual(['grafana_folder', 'rule_group']);
-      expect(params.has('var-filters')).toBe(false);
-    });
-
-    it('fourth search has groupBy folder only', () => {
-      const fourth = getTriagePredefinedSearches()[3];
-      const params = new URLSearchParams(fourth.query);
       expect(params.getAll('var-groupBy')).toEqual(['grafana_folder']);
       expect(params.has('var-filters')).toBe(false);
     });
   });
 
-  describe('TRIAGE_PREDEFINED_SEARCH_IDS', () => {
-    it('contains all predefined search ids', () => {
-      expect(TRIAGE_PREDEFINED_SEARCH_IDS.size).toBe(getTriagePredefinedSearches().length);
-      for (const s of getTriagePredefinedSearches()) {
-        expect(TRIAGE_PREDEFINED_SEARCH_IDS.has(s.id)).toBe(true);
-      }
-    });
-  });
-
   describe('isTriagePredefinedSearchId', () => {
     it('returns true for predefined ids', () => {
-      expect(isTriagePredefinedSearchId(`${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}folder-evalgroup`)).toBe(true);
       expect(isTriagePredefinedSearchId(`${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}folder-firing`)).toBe(true);
       expect(isTriagePredefinedSearchId(`${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}firing-only`)).toBe(true);
+      expect(isTriagePredefinedSearchId(`${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}folder-only`)).toBe(true);
     });
 
     it('returns false for user-generated ids', () => {

--- a/public/app/features/alerting/unified/triage/triagePredefinedSearches.ts
+++ b/public/app/features/alerting/unified/triage/triagePredefinedSearches.ts
@@ -13,13 +13,10 @@ import { toUrl } from '../../../variables/adhoc/urlParser';
 import { SavedSearch } from '../components/saved-searches/savedSearchesSchema';
 
 import { URL_PARAMS } from './constants';
+import { defaultTimeRange } from './scene/utils';
 
 /** Prefix for predefined search IDs; used to identify predefined items for overrides and dismissed handling. */
 export const TRIAGE_PREDEFINED_SEARCH_ID_PREFIX = 'triage-predefined-';
-
-/** Default time range for predefined searches (matches applyTriageSavedSearchState fallback). */
-const DEFAULT_TIME_FROM = 'now-4h';
-const DEFAULT_TIME_TO = 'now';
 
 /** Label for evaluation group in state history / GRAFANA_ALERTS metric. */
 const EVAL_GROUP_LABEL = 'rule_group';
@@ -47,8 +44,8 @@ function buildTriageQueryString(options: {
     }
   });
 
-  params.set(URL_PARAMS.timeFrom, options.from ?? DEFAULT_TIME_FROM);
-  params.set(URL_PARAMS.timeTo, options.to ?? DEFAULT_TIME_TO);
+  params.set(URL_PARAMS.timeFrom, options.from ?? defaultTimeRange.from);
+  params.set(URL_PARAMS.timeTo, options.to ?? defaultTimeRange.to);
 
   return params.toString();
 }
@@ -62,7 +59,7 @@ const PREDEFINED_IDS = [
 
 /**
  * Pre-defined triage saved searches for common scenarios.
- * Uses default time range (matches applyTriageSavedSearchState: now-4h to now).
+ * Uses default time range from scene/utils (15m).
  * Order defines display order in the dropdown (before user saves).
  * Must be called from a component or function so t() is not used at top level.
  */

--- a/public/app/features/alerting/unified/triage/triagePredefinedSearches.ts
+++ b/public/app/features/alerting/unified/triage/triagePredefinedSearches.ts
@@ -9,10 +9,9 @@
 
 import { t } from '@grafana/i18n';
 
-import { toUrl } from '../../../variables/adhoc/urlParser';
 import { SavedSearch } from '../components/saved-searches/savedSearchesSchema';
 
-import { URL_PARAMS } from './constants';
+import { buildTriageQueryStringFromParts } from './scene/triageSavedSearchUtils';
 import { defaultTimeRange } from './scene/utils';
 
 /** Prefix for predefined search IDs; used to identify predefined items for overrides and dismissed handling. */
@@ -20,35 +19,6 @@ export const TRIAGE_PREDEFINED_SEARCH_ID_PREFIX = 'triage-predefined-';
 
 /** Label for evaluation group in state history / GRAFANA_ALERTS metric. */
 const EVAL_GROUP_LABEL = 'rule_group';
-
-/**
- * Builds a triage saved search query string from groupBy, filters, and optional time range.
- * Uses the same format as serializeTriageState for consistency.
- */
-function buildTriageQueryString(options: {
-  groupBy: string[];
-  filters?: Array<{ key: string; operator: '=' | '=!'; value: string }>;
-  from?: string;
-  to?: string;
-}): string {
-  const params = new URLSearchParams();
-
-  if (options.filters?.length) {
-    const filterStrings = toUrl(options.filters.map((f) => ({ key: f.key, operator: f.operator, value: f.value })));
-    filterStrings.forEach((s) => params.append(URL_PARAMS.filters, s));
-  }
-
-  options.groupBy.forEach((key) => {
-    if (key) {
-      params.append(URL_PARAMS.groupBy, key);
-    }
-  });
-
-  params.set(URL_PARAMS.timeFrom, options.from ?? defaultTimeRange.from);
-  params.set(URL_PARAMS.timeTo, options.to ?? defaultTimeRange.to);
-
-  return params.toString();
-}
 
 const PREDEFINED_IDS = [
   `${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}folder-evalgroup-firing`,
@@ -72,34 +42,42 @@ export function getTriagePredefinedSearches(): SavedSearch[] {
         'Filter: Firing; Group by: Folder and Evaluation group'
       ),
       isDefault: false,
-      query: buildTriageQueryString({
-        groupBy: ['grafana_folder', EVAL_GROUP_LABEL],
+      query: buildTriageQueryStringFromParts({
         filters: [{ key: 'alertstate', operator: '=', value: 'firing' }],
+        groupBy: ['grafana_folder', EVAL_GROUP_LABEL],
+        from: defaultTimeRange.from,
+        to: defaultTimeRange.to,
       }),
     },
     {
       id: PREDEFINED_IDS[1],
       name: t('alerting.triage.saved-searches.predefined.firing-only', 'Filter: Firing'),
       isDefault: false,
-      query: buildTriageQueryString({
-        groupBy: [],
+      query: buildTriageQueryStringFromParts({
         filters: [{ key: 'alertstate', operator: '=', value: 'firing' }],
+        groupBy: [],
+        from: defaultTimeRange.from,
+        to: defaultTimeRange.to,
       }),
     },
     {
       id: PREDEFINED_IDS[2],
       name: t('alerting.triage.saved-searches.predefined.folder-evalgroup', 'Group by: Folder and Evaluation group'),
       isDefault: false,
-      query: buildTriageQueryString({
+      query: buildTriageQueryStringFromParts({
         groupBy: ['grafana_folder', EVAL_GROUP_LABEL],
+        from: defaultTimeRange.from,
+        to: defaultTimeRange.to,
       }),
     },
     {
       id: PREDEFINED_IDS[3],
       name: t('alerting.triage.saved-searches.predefined.folder-firing', 'Group by: Folder'),
       isDefault: false,
-      query: buildTriageQueryString({
+      query: buildTriageQueryStringFromParts({
         groupBy: ['grafana_folder'],
+        from: defaultTimeRange.from,
+        to: defaultTimeRange.to,
       }),
     },
   ];

--- a/public/app/features/alerting/unified/triage/triagePredefinedSearches.ts
+++ b/public/app/features/alerting/unified/triage/triagePredefinedSearches.ts
@@ -1,0 +1,119 @@
+/**
+ * Pre-defined saved searches for the Alert Activity (Triage) page.
+ *
+ * These appear in the Saved searches dropdown when alertingTriageSavedSearches
+ * is enabled. Users can rename, delete, and set default on them like their own
+ * saves; renames and dismissals are persisted via useTriagePredefinedOverrides.
+ * Stable IDs allow the app to identify predefined items for that behaviour.
+ */
+
+import { t } from '@grafana/i18n';
+
+import { toUrl } from '../../../variables/adhoc/urlParser';
+import { SavedSearch } from '../components/saved-searches/savedSearchesSchema';
+
+import { URL_PARAMS } from './constants';
+
+/** Prefix for predefined search IDs; used to identify predefined items for overrides and dismissed handling. */
+export const TRIAGE_PREDEFINED_SEARCH_ID_PREFIX = 'triage-predefined-';
+
+/** Default time range for predefined searches (matches applyTriageSavedSearchState fallback). */
+const DEFAULT_TIME_FROM = 'now-4h';
+const DEFAULT_TIME_TO = 'now';
+
+/** Label for evaluation group in state history / GRAFANA_ALERTS metric. */
+const EVAL_GROUP_LABEL = 'rule_group';
+
+/**
+ * Builds a triage saved search query string from groupBy, filters, and optional time range.
+ * Uses the same format as serializeTriageState for consistency.
+ */
+function buildTriageQueryString(options: {
+  groupBy: string[];
+  filters?: Array<{ key: string; operator: '=' | '=!'; value: string }>;
+  from?: string;
+  to?: string;
+}): string {
+  const params = new URLSearchParams();
+
+  if (options.filters?.length) {
+    const filterStrings = toUrl(options.filters.map((f) => ({ key: f.key, operator: f.operator, value: f.value })));
+    filterStrings.forEach((s) => params.append(URL_PARAMS.filters, s));
+  }
+
+  options.groupBy.forEach((key) => {
+    if (key) {
+      params.append(URL_PARAMS.groupBy, key);
+    }
+  });
+
+  params.set(URL_PARAMS.timeFrom, options.from ?? DEFAULT_TIME_FROM);
+  params.set(URL_PARAMS.timeTo, options.to ?? DEFAULT_TIME_TO);
+
+  return params.toString();
+}
+
+const PREDEFINED_IDS = [
+  `${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}folder-evalgroup-firing`,
+  `${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}firing-only`,
+  `${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}folder-evalgroup`,
+  `${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}folder-firing`,
+] as const;
+
+/**
+ * Pre-defined triage saved searches for common scenarios.
+ * Uses default time range (matches applyTriageSavedSearchState: now-4h to now).
+ * Order defines display order in the dropdown (before user saves).
+ * Must be called from a component or function so t() is not used at top level.
+ */
+export function getTriagePredefinedSearches(): SavedSearch[] {
+  return [
+    {
+      id: PREDEFINED_IDS[0],
+      name: t(
+        'alerting.triage.saved-searches.predefined.folder-evalgroup-firing',
+        'Filter: Firing; Group by: Folder and Evaluation group'
+      ),
+      isDefault: false,
+      query: buildTriageQueryString({
+        groupBy: ['grafana_folder', EVAL_GROUP_LABEL],
+        filters: [{ key: 'alertstate', operator: '=', value: 'firing' }],
+      }),
+    },
+    {
+      id: PREDEFINED_IDS[1],
+      name: t('alerting.triage.saved-searches.predefined.firing-only', 'Filter: Firing'),
+      isDefault: false,
+      query: buildTriageQueryString({
+        groupBy: [],
+        filters: [{ key: 'alertstate', operator: '=', value: 'firing' }],
+      }),
+    },
+    {
+      id: PREDEFINED_IDS[2],
+      name: t('alerting.triage.saved-searches.predefined.folder-evalgroup', 'Group by: Folder and Evaluation group'),
+      isDefault: false,
+      query: buildTriageQueryString({
+        groupBy: ['grafana_folder', EVAL_GROUP_LABEL],
+      }),
+    },
+    {
+      id: PREDEFINED_IDS[3],
+      name: t('alerting.triage.saved-searches.predefined.folder-firing', 'Group by: Folder'),
+      isDefault: false,
+      query: buildTriageQueryString({
+        groupBy: ['grafana_folder'],
+      }),
+    },
+  ];
+}
+
+/** Set of predefined search IDs (e.g. for identifying predefined items when applying overrides or dismissed state). */
+export const TRIAGE_PREDEFINED_SEARCH_IDS = new Set<string>(PREDEFINED_IDS);
+
+/**
+ * Returns true if the given saved search ID is a predefined search.
+ */
+export function isTriagePredefinedSearchId(id: string): boolean {
+  return id.startsWith(TRIAGE_PREDEFINED_SEARCH_ID_PREFIX);
+}

--- a/public/app/features/alerting/unified/triage/triagePredefinedSearches.ts
+++ b/public/app/features/alerting/unified/triage/triagePredefinedSearches.ts
@@ -17,14 +17,10 @@ import { defaultTimeRange } from './scene/utils';
 /** Prefix for predefined search IDs; used to identify predefined items for overrides and dismissed handling. */
 export const TRIAGE_PREDEFINED_SEARCH_ID_PREFIX = 'triage-predefined-';
 
-/** Label for evaluation group in state history / GRAFANA_ALERTS metric. */
-const EVAL_GROUP_LABEL = 'rule_group';
-
 const PREDEFINED_IDS = [
-  `${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}folder-evalgroup-firing`,
-  `${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}firing-only`,
-  `${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}folder-evalgroup`,
   `${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}folder-firing`,
+  `${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}firing-only`,
+  `${TRIAGE_PREDEFINED_SEARCH_ID_PREFIX}folder-only`,
 ] as const;
 
 /**
@@ -37,16 +33,12 @@ export function getTriagePredefinedSearches(): SavedSearch[] {
   return [
     {
       id: PREDEFINED_IDS[0],
-      name: t(
-        'alerting.triage.saved-searches.predefined.folder-evalgroup-firing',
-        'Filter: Firing; Group by: Folder and Evaluation group'
-      ),
+      name: t('alerting.triage.saved-searches.predefined.folder-firing', 'Filter: Firing; Group by: Folder'),
       isDefault: false,
       query: buildTriageQueryStringFromParts({
         filters: [{ key: 'alertstate', operator: '=', value: 'firing' }],
-        groupBy: ['grafana_folder', EVAL_GROUP_LABEL],
-        from: defaultTimeRange.from,
-        to: defaultTimeRange.to,
+        groupBy: ['grafana_folder'],
+        timeRange: defaultTimeRange,
       }),
     },
     {
@@ -56,35 +48,20 @@ export function getTriagePredefinedSearches(): SavedSearch[] {
       query: buildTriageQueryStringFromParts({
         filters: [{ key: 'alertstate', operator: '=', value: 'firing' }],
         groupBy: [],
-        from: defaultTimeRange.from,
-        to: defaultTimeRange.to,
+        timeRange: defaultTimeRange,
       }),
     },
     {
       id: PREDEFINED_IDS[2],
-      name: t('alerting.triage.saved-searches.predefined.folder-evalgroup', 'Group by: Folder and Evaluation group'),
-      isDefault: false,
-      query: buildTriageQueryStringFromParts({
-        groupBy: ['grafana_folder', EVAL_GROUP_LABEL],
-        from: defaultTimeRange.from,
-        to: defaultTimeRange.to,
-      }),
-    },
-    {
-      id: PREDEFINED_IDS[3],
-      name: t('alerting.triage.saved-searches.predefined.folder-firing', 'Group by: Folder'),
+      name: t('alerting.triage.saved-searches.predefined.folder-only', 'Group by: Folder'),
       isDefault: false,
       query: buildTriageQueryStringFromParts({
         groupBy: ['grafana_folder'],
-        from: defaultTimeRange.from,
-        to: defaultTimeRange.to,
+        timeRange: defaultTimeRange,
       }),
     },
   ];
 }
-
-/** Set of predefined search IDs (e.g. for identifying predefined items when applying overrides or dismissed state). */
-export const TRIAGE_PREDEFINED_SEARCH_IDS = new Set<string>(PREDEFINED_IDS);
 
 /**
  * Returns true if the given saved search ID is a predefined search.

--- a/public/app/features/alerting/unified/triage/triagePredefinedSearches.ts
+++ b/public/app/features/alerting/unified/triage/triagePredefinedSearches.ts
@@ -33,7 +33,7 @@ export function getTriagePredefinedSearches(): SavedSearch[] {
   return [
     {
       id: PREDEFINED_IDS[0],
-      name: t('alerting.triage.saved-searches.predefined.folder-firing', 'Filter: Firing; Group by: Folder'),
+      name: t('alerting.triage.saved-searches.predefined.folder-firing', 'Show only firing, grouped by folder'),
       isDefault: false,
       query: buildTriageQueryStringFromParts({
         filters: [{ key: 'alertstate', operator: '=', value: 'firing' }],
@@ -43,7 +43,7 @@ export function getTriagePredefinedSearches(): SavedSearch[] {
     },
     {
       id: PREDEFINED_IDS[1],
-      name: t('alerting.triage.saved-searches.predefined.firing-only', 'Filter: Firing'),
+      name: t('alerting.triage.saved-searches.predefined.firing-only', 'Show only firing'),
       isDefault: false,
       query: buildTriageQueryStringFromParts({
         filters: [{ key: 'alertstate', operator: '=', value: 'firing' }],
@@ -53,7 +53,7 @@ export function getTriagePredefinedSearches(): SavedSearch[] {
     },
     {
       id: PREDEFINED_IDS[2],
-      name: t('alerting.triage.saved-searches.predefined.folder-only', 'Group by: Folder'),
+      name: t('alerting.triage.saved-searches.predefined.folder-only', 'Grouped by folder'),
       isDefault: false,
       query: buildTriageQueryStringFromParts({
         groupBy: ['grafana_folder'],

--- a/public/app/features/alerting/unified/utils/parseJsonWithSchema.ts
+++ b/public/app/features/alerting/unified/utils/parseJsonWithSchema.ts
@@ -1,0 +1,23 @@
+import type { z } from 'zod';
+
+/**
+ * Parses a JSON string and validates it with a Zod schema.
+ * Returns the parsed data if valid, otherwise returns the fallback value.
+ *
+ * @param raw - The JSON string to parse, or null/empty
+ * @param schema - Zod schema to validate the parsed data
+ * @param fallback - Value to return when parsing fails or input is null/empty
+ * @returns Parsed and validated data, or fallback
+ */
+export function parseJsonWithSchema<T>(raw: string | null, schema: z.ZodType<T>, fallback: T): T {
+  if (raw == null || raw === '') {
+    return fallback;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    const result = schema.safeParse(parsed);
+    return result.success ? result.data : fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3426,7 +3426,15 @@
         "title": "Rule not found"
       },
       "rules-with-firing-instances": "Alert rules with firing instances",
-      "rules-with-pending-instances": "Alert rules with pending instances"
+      "rules-with-pending-instances": "Alert rules with pending instances",
+      "saved-searches": {
+        "predefined": {
+          "firing-only": "Filter: Firing",
+          "folder-evalgroup": "Group by: Folder and Evaluation group",
+          "folder-evalgroup-firing": "Filter: Firing; Group by: Folder and Evaluation group",
+          "folder-firing": "Group by: Folder"
+        }
+      }
     },
     "type-selector-button": {
       "add-expression": "Add expression"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3429,9 +3429,9 @@
       "rules-with-pending-instances": "Alert rules with pending instances",
       "saved-searches": {
         "predefined": {
-          "firing-only": "Filter: Firing",
-          "folder-firing": "Filter: Firing; Group by: Folder",
-          "folder-only": "Group by: Folder"
+          "firing-only": "Show only firing",
+          "folder-firing": "Show only firing, grouped by folder",
+          "folder-only": "Grouped by folder"
         }
       }
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3430,9 +3430,8 @@
       "saved-searches": {
         "predefined": {
           "firing-only": "Filter: Firing",
-          "folder-evalgroup": "Group by: Folder and Evaluation group",
-          "folder-evalgroup-firing": "Filter: Firing; Group by: Folder and Evaluation group",
-          "folder-firing": "Group by: Folder"
+          "folder-firing": "Filter: Firing; Group by: Folder",
+          "folder-only": "Group by: Folder"
         }
       }
     },


### PR DESCRIPTION
This PR add predefined saved searches in alerts activity, these have the same actions as custom saved searches: rename, delete and set as default.
This is behind the alertingTriageSavedSearches feature toggle.

<img width="844" height="428" alt="image" src="https://github.com/user-attachments/assets/18fc0d83-54d2-492f-bc47-8e9a29730762" />

![Kapture 2026-02-27 at 12 20 39](https://github.com/user-attachments/assets/2f1ae058-bf1a-4c08-be8c-d36a8210df6b)

