### PR TITLE
[release-12.1.9] OpenFeature: Remove namespace validation for static provider 

### DIFF
--- a/pkg/registry/apis/ofrep/register.go
+++ b/pkg/registry/apis/ofrep/register.go
@@ -224,12 +224,6 @@ func (b *APIBuilder) GetAPIRoutes(gv schema.GroupVersion) *builder.APIRoutes {
 }
 
 func (b *APIBuilder) oneFlagHandler(w http.ResponseWriter, r *http.Request) {
-	if !b.validateNamespace(r) {
-		b.logger.Error("stackId in evaluation context does not match requested namespace")
-		http.Error(w, "stackId in evaluation context does not match requested namespace", http.StatusUnauthorized)
-		return
-	}
-
 	flagKey := mux.Vars(r)["flagKey"]
 	if flagKey == "" {
 		http.Error(w, "flagKey parameter is required", http.StatusBadRequest)
@@ -246,6 +240,12 @@ func (b *APIBuilder) oneFlagHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if b.providerType == setting.GOFFProviderType {
+		if !b.validateNamespace(r) {
+			b.logger.Error("stackId in evaluation context does not match requested namespace")
+			http.Error(w, "stackId in evaluation context does not match requested namespace", http.StatusUnauthorized)
+			return
+		}
+
 		b.proxyFlagReq(flagKey, isAuthedReq, w, r)
 		return
 	}
@@ -254,15 +254,15 @@ func (b *APIBuilder) oneFlagHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (b *APIBuilder) allFlagsHandler(w http.ResponseWriter, r *http.Request) {
-	if !b.validateNamespace(r) {
-		b.logger.Error("stackId in evaluation context does not match requested namespace")
-		http.Error(w, "stackId in evaluation context does not match requested namespace", http.StatusUnauthorized)
-		return
-	}
-
 	isAuthedReq := b.isAuthenticatedRequest(r)
 
 	if b.providerType == setting.GOFFProviderType {
+		if !b.validateNamespace(r) {
+			b.logger.Error("stackId in evaluation context does not match requested namespace")
+			http.Error(w, "stackId in evaluation context does not match requested namespace", http.StatusUnauthorized)
+			return
+		}
+
 		b.proxyAllFlagReq(isAuthedReq, w, r)
 		return
 	}


### PR DESCRIPTION
Backport aac8061faaff75f917338a326eaf8c3ce5d38342 from #118184

I minimized the changes to avoid backporting extra code introduced in later versions.

---

 When switching orgs in on-prem Grafana, feature flag requests were being rejected with 403 errors:
 `feature-flags level=error msg="rejecting request with namespace mismatch"`.

This happened because of namespace validation logic was running for **all provider types**, including the static provider. The static provider is a is just an OFREP compatible wrapper around static configuration (confing.ini flags), so validating namespace is not applicable to it.
