### PR TITLE
Provisioning: disable push-to-branch option when configured branch is protected

### DIFF
--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -34,7 +34,7 @@ import { useCreateOrUpdateRepository } from '../hooks/useCreateOrUpdateRepositor
 import { RepositoryFormData } from '../types';
 import { dataToSpec } from '../utils/data';
 import { getConfigFormErrors } from '../utils/getFormErrors';
-import { getHasTokenInstructions } from '../utils/git';
+import { getHasTokenInstructions, isBranchProtected } from '../utils/git';
 import { getRepositoryTypeConfig, isGitProvider } from '../utils/repositoryTypes';
 
 import { ConfigFormGithubCollapse } from './ConfigFormGithubCollapse';
@@ -80,6 +80,8 @@ export function ConfigForm({ data }: ConfigFormProps) {
   const [tokenConfigured, setTokenConfigured] = useState(isEdit);
   const [isLoading, setIsLoading] = useState(false);
   const [type, readOnly] = watch(['type', 'readOnly']);
+  const branch = watch('branch');
+  const enablePushToConfiguredBranch = watch('enablePushToConfiguredBranch');
   const targetOptions = useMemo(() => getTargetOptions(settings.data?.allowedTargets || ['folder']), [settings.data]);
   const isGitBased = isGitProvider(type);
 
@@ -107,6 +109,8 @@ export function ConfigForm({ data }: ConfigFormProps) {
       value: ref.name,
     }));
   }, [refsData?.items]);
+
+  const selectedBranchIsProtected = isBranchProtected(refsData?.items, branch);
 
   // Get field configurations based on provider type
   const gitFields = isGitBased ? getGitProviderFields(type) : null;
@@ -355,6 +359,8 @@ export function ConfigForm({ data }: ConfigFormProps) {
             register={register}
             registerName="enablePushToConfiguredBranch"
             readOnly={readOnly}
+            branchIsProtected={selectedBranchIsProtected}
+            currentValue={enablePushToConfiguredBranch}
           />
         )}
         {type === 'github' && <ConfigFormGithubCollapse register={register} />}

--- a/public/app/features/provisioning/Config/EnablePushToConfiguredBranchOption.tsx
+++ b/public/app/features/provisioning/Config/EnablePushToConfiguredBranchOption.tsx
@@ -1,21 +1,31 @@
 import { FieldValues, UseFormRegister, Path } from 'react-hook-form';
 
 import { t } from '@grafana/i18n';
-import { Checkbox, Field } from '@grafana/ui';
+import { Checkbox, Field, Tooltip } from '@grafana/ui';
+
+interface EnablePushToConfiguredBranchOptionProps<T extends FieldValues> {
+  register: UseFormRegister<T>;
+  registerName: Path<T>;
+  readOnly: boolean;
+  branchIsProtected?: boolean;
+  currentValue?: boolean;
+}
 
 export function EnablePushToConfiguredBranchOption<T extends FieldValues>({
   register,
   registerName,
   readOnly,
-}: {
-  register: UseFormRegister<T>;
-  registerName: Path<T>;
-  readOnly: boolean;
-}) {
-  return (
+  branchIsProtected = false,
+  currentValue = false,
+}: EnablePushToConfiguredBranchOptionProps<T>) {
+  // Allow unchecking even when the branch is protected so users can fix misconfiguration
+  const isDisabledByProtection = branchIsProtected && !currentValue;
+  const isDisabled = readOnly || isDisabledByProtection;
+
+  const checkbox = (
     <Field noMargin>
       <Checkbox
-        disabled={readOnly}
+        disabled={isDisabled}
         {...register(registerName)}
         label={t('provisioning.enable-push-to-configured-branch-label', 'Enable push to synchronized branch')}
         description={t(
@@ -25,4 +35,19 @@ export function EnablePushToConfiguredBranchOption<T extends FieldValues>({
       />
     </Field>
   );
+
+  if (isDisabledByProtection) {
+    return (
+      <Tooltip
+        content={t(
+          'provisioning.enable-push-to-configured-branch-protected-tooltip',
+          'Push to synchronized branch is not available because the configured branch is protected.'
+        )}
+      >
+        <div>{checkbox}</div>
+      </Tooltip>
+    );
+  }
+
+  return checkbox;
 }

--- a/public/app/features/provisioning/Wizard/FinishStep.tsx
+++ b/public/app/features/provisioning/Wizard/FinishStep.tsx
@@ -7,6 +7,8 @@ import { useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alph
 
 import { EnablePushToConfiguredBranchOption } from '../Config/EnablePushToConfiguredBranchOption';
 import { checkImageRenderer, checkImageRenderingAllowed, checkPublicAccess } from '../GettingStarted/features';
+import { useGetRepositoryRefs } from '../hooks/useGetRepositoryRefs';
+import { isBranchProtected } from '../utils/git';
 import { isGitProvider } from '../utils/repositoryTypes';
 
 import { getGitProviderFields } from './fields';
@@ -21,7 +23,16 @@ export const FinishStep = memo(function FinishStep() {
   } = useFormContext<WizardFormData>();
   const settings = useGetFrontendSettingsQuery();
 
-  const [type, readOnly] = watch(['repository.type', 'repository.readOnly']);
+  const [type, readOnly, repositoryName, branch, enablePushToConfiguredBranch] = watch([
+    'repository.type',
+    'repository.readOnly',
+    'repositoryName',
+    'repository.branch',
+    'repository.enablePushToConfiguredBranch',
+  ]);
+
+  const { branchData } = useGetRepositoryRefs({ repositoryType: type, repositoryName });
+  const branchIsProtected = isBranchProtected(branchData?.items, branch);
 
   const isGithub = type === 'github';
   const isGitBased = isGitProvider(type);
@@ -97,6 +108,8 @@ export const FinishStep = memo(function FinishStep() {
           register={register}
           readOnly={readOnly}
           registerName="repository.enablePushToConfiguredBranch"
+          branchIsProtected={branchIsProtected}
+          currentValue={enablePushToConfiguredBranch}
         />
       )}
 

--- a/public/app/features/provisioning/utils/git.test.ts
+++ b/public/app/features/provisioning/utils/git.test.ts
@@ -1,6 +1,6 @@
 import { RepositorySpec } from 'app/api/clients/provisioning/v0alpha1';
 
-import { getRepoFileUrl, getRepoHrefForProvider } from './git';
+import { getRepoFileUrl, getRepoHrefForProvider, isBranchProtected } from './git';
 
 // Partial specs for testing; getRepoHrefForProvider only reads type and provider url/branch/path.
 function spec(s: Partial<RepositorySpec>): RepositorySpec {
@@ -214,5 +214,37 @@ describe('getRepoFileUrl', () => {
         filePath: undefined,
       })
     ).toBeUndefined();
+  });
+});
+
+describe('isBranchProtected', () => {
+  const refs = [{ name: 'main', protected: true }, { name: 'develop', protected: false }, { name: 'feature/test' }];
+
+  it('returns true when the branch is marked as protected', () => {
+    expect(isBranchProtected(refs, 'main')).toBe(true);
+  });
+
+  it('returns false when the branch is explicitly not protected', () => {
+    expect(isBranchProtected(refs, 'develop')).toBe(false);
+  });
+
+  it('returns false when the branch has no protected field', () => {
+    expect(isBranchProtected(refs, 'feature/test')).toBe(false);
+  });
+
+  it('returns false when the branch is not found in refs', () => {
+    expect(isBranchProtected(refs, 'nonexistent')).toBe(false);
+  });
+
+  it('returns false when refs is undefined', () => {
+    expect(isBranchProtected(undefined, 'main')).toBe(false);
+  });
+
+  it('returns false when branchName is undefined', () => {
+    expect(isBranchProtected(refs, undefined)).toBe(false);
+  });
+
+  it('returns false when both arguments are undefined', () => {
+    expect(isBranchProtected(undefined, undefined)).toBe(false);
   });
 });

--- a/public/app/features/provisioning/utils/git.ts
+++ b/public/app/features/provisioning/utils/git.ts
@@ -3,6 +3,19 @@ import { RepositorySpec } from 'app/api/clients/provisioning/v0alpha1';
 import { InstructionAvailability, RepoType } from '../Wizard/types';
 
 /**
+ * Check whether a branch is marked as protected in the refs endpoint response.
+ */
+export function isBranchProtected(
+  refsItems: Array<{ name?: string; protected?: boolean }> | undefined,
+  branchName: string | undefined
+): boolean {
+  if (!refsItems || !branchName) {
+    return false;
+  }
+  return refsItems.find((ref) => ref.name === branchName)?.protected ?? false;
+}
+
+/**
  * Validates a Git branch name according to the following rules:
  * 1. The branch name cannot start with `/`, end with `/`, `.`, or whitespace.
  * 2. The branch name cannot contain consecutive slashes (`//`).

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12586,6 +12586,7 @@
     },
     "enable-push-to-configured-branch-description": "Allow direct commits to the synchronized branch.",
     "enable-push-to-configured-branch-label": "Enable push to synchronized branch",
+    "enable-push-to-configured-branch-protected-tooltip": "Push to synchronized branch is not available because the configured branch is protected.",
     "enhanced-features": {
       "description": "Get the most out of your GitHub integration with these optional add-ons",
       "description-instant-updates": "Get instant updates in Grafana as soon as changes are committed. Review and approve changes using pull requests before they go live.",


### PR DESCRIPTION
## Summary

- When the `refs` endpoint reports a branch as protected, the **"Enable push to synchronized branch"** checkbox is disabled with an explanatory tooltip in both the onboarding wizard (FinishStep) and the repository configuration form (ConfigForm).
- Users can still **uncheck** the option if it was already enabled, allowing them to fix a misconfigured repository.
- Adds the `isBranchProtected` utility function to `utils/git.ts` with comprehensive tests.

## Changes

| File | What changed |
|------|-------------|
| `EnablePushToConfiguredBranchOption.tsx` | Accepts `branchIsProtected` and `currentValue` props; disables checkbox and wraps in tooltip when branch is protected and option is not currently enabled |
| `FinishStep.tsx` | Fetches refs data via `useGetRepositoryRefs`, determines branch protection, passes to checkbox component |
| `ConfigForm.tsx` | Uses existing `refsData` query result, determines branch protection, passes to checkbox component |
| `utils/git.ts` | New `isBranchProtected()` helper |
| `utils/git.test.ts` | Tests for `isBranchProtected()` |
| `en-US/grafana.json` | New i18n key for the tooltip message |

## Test plan

- [ ] Connect a repository with a protected branch and verify the checkbox is disabled with a tooltip
- [ ] Connect a repository with a non-protected branch and verify the checkbox works normally
- [ ] If the checkbox was already enabled on a protected branch, verify it can still be unchecked
- [ ] Verify the same behavior in the repository config/edit page
- [ ] Run `isBranchProtected` unit tests


Made with [Cursor](https://cursor.com)