### PR TITLE
Suggestions: Fix no data auto selection bug

### DIFF
--- a/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
@@ -166,6 +166,12 @@ export function VisualizationSuggestions({ onChange, data, panel, searchQuery, i
       return;
     }
 
+    // Skip auto-selection until real data arrives; `data` is omitted from deps
+    // because suggestions already re-compute when data changes.
+    if (!data || !hasData(data)) {
+      return;
+    }
+
     // if the first suggestion has changed, we're going to change the currently selected suggestion and
     // set the firstCardHash to the new first suggestion's hash. We also choose the first suggestion if
     // the previously selected suggestion is no longer present in the list.
@@ -175,6 +181,7 @@ export function VisualizationSuggestions({ onChange, data, panel, searchQuery, i
       setFirstCardHash(newFirstCardHash);
       return;
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     suggestions,
     suggestionHash,


### PR DESCRIPTION
Only apply a suggestion if data is available. This prevents the stale pre-selection that was occurring when starting with no data, then switching to data.

Before:
![Feb-24-2026 09-34-44](https://github.com/user-attachments/assets/8333bc71-27d5-4940-bc07-10ce95474002)

After:
![Feb-24-2026 09-29-45](https://github.com/user-attachments/assets/12dee8d4-d909-4a08-bb99-74cf178ca0e6)


Fixes https://github.com/grafana/grafana/issues/118521