### PR TITLE
Alerting: Add tracking to import to gma wizard

### DIFF
--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -231,7 +231,8 @@ export const trackDeletedRuleRestoreFail = async () => {
 };
 
 export const trackImportToGMASuccess = async (payload: {
-  importSource: 'yaml' | 'datasource';
+  notificationsSource?: 'yaml' | 'datasource';
+  rulesSource?: 'yaml' | 'datasource';
   isRootFolder: boolean;
   namespace?: string;
   ruleGroup?: string;
@@ -241,7 +242,10 @@ export const trackImportToGMASuccess = async (payload: {
   reportInteraction('grafana_alerting_import_to_gma_success', { ...payload });
 };
 
-export const trackImportToGMAError = async (payload: { importSource: 'yaml' | 'datasource' }) => {
+export const trackImportToGMAError = async (payload: {
+  notificationsSource?: 'yaml' | 'datasource';
+  rulesSource?: 'yaml' | 'datasource';
+}) => {
   reportInteraction('grafana_alerting_import_to_gma_error', { ...payload });
 };
 

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -245,6 +245,33 @@ export const trackImportToGMAError = async (payload: { importSource: 'yaml' | 'd
   reportInteraction('grafana_alerting_import_to_gma_error', { ...payload });
 };
 
+export function trackImportToGMAWizardStarted() {
+  reportInteraction('grafana_alerting_import_to_gma_wizard_started');
+}
+
+export function trackImportToGMAWizardCancelled(payload: { cancelledAtStep: string; formDirty: boolean }) {
+  reportInteraction('grafana_alerting_import_to_gma_wizard_cancelled', payload);
+}
+
+export function trackImportToGMAWizardStepSkipped(payload: { step: 'notifications' | 'rules' }) {
+  reportInteraction('grafana_alerting_import_to_gma_wizard_step_skipped', payload);
+}
+
+export function trackImportToGMADryrunSuccess() {
+  reportInteraction('grafana_alerting_import_to_gma_dryrun_success');
+}
+
+export function trackImportToGMADryrunWarning(payload: {
+  renamedReceiversCount: number;
+  renamedTimeIntervalsCount: number;
+}) {
+  reportInteraction('grafana_alerting_import_to_gma_dryrun_warning', payload);
+}
+
+export function trackImportToGMADryrunError() {
+  reportInteraction('grafana_alerting_import_to_gma_dryrun_error');
+}
+
 export function trackRulesListViewChange(payload: { view: string }) {
   reportInteraction('grafana_alerting_rules_list_mode', { ...payload });
 }

--- a/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.tsx
@@ -169,7 +169,7 @@ export const ConfirmConversionModal = ({ importPayload, isOpen, onDismiss }: Mod
       const isRootFolder = isEmpty(targetFolder?.uid);
 
       trackImportToGMASuccess({
-        importSource,
+        rulesSource: importSource,
         isRootFolder,
         namespace,
         ruleGroup,
@@ -184,7 +184,7 @@ export const ConfirmConversionModal = ({ importPayload, isOpen, onDismiss }: Mod
       );
       locationService.push(ruleListUrl);
     } catch (error) {
-      trackImportToGMAError({ importSource });
+      trackImportToGMAError({ rulesSource: importSource });
       notifyApp.error(
         t('alerting.import-to-gma.error', 'Failed to import alert rules: {{error}}', {
           error: stringifyErrorLike(error),

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { isEmpty } from 'lodash';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -98,12 +98,8 @@ const ImportToGMA = () => {
 function ImportWizardContent() {
   const { activeStep, setStepErrors } = useStepperState();
 
-  const wizardStartedTracked = useRef(false);
   useEffect(() => {
-    if (!wizardStartedTracked.current) {
-      trackImportToGMAWizardStarted();
-      wizardStartedTracked.current = true;
-    }
+    trackImportToGMAWizardStarted();
   }, []);
 
   const [showConfirmModal, setShowConfirmModal] = useState(false);
@@ -272,7 +268,6 @@ function ImportWizardContent() {
     const values = getValues();
     const willImportNotifications = values.step1Completed && !values.step1Skipped;
     const willImportRules = values.step2Completed && !values.step2Skipped;
-    const importSource = willImportNotifications ? values.notificationsSource : values.rulesSource;
 
     try {
       // Import notifications first (if step 1 was completed)
@@ -317,7 +312,8 @@ function ImportWizardContent() {
       const isRootFolder = isEmpty(targetFolder?.uid);
 
       trackImportToGMASuccess({
-        importSource,
+        notificationsSource: willImportNotifications ? values.notificationsSource : undefined,
+        rulesSource: willImportRules ? values.rulesSource : undefined,
         isRootFolder,
         namespace: values.namespace,
         ruleGroup: values.ruleGroup,
@@ -337,7 +333,10 @@ function ImportWizardContent() {
       }, 1500);
     } catch (err) {
       setImportStatus('error');
-      trackImportToGMAError({ importSource });
+      trackImportToGMAError({
+        notificationsSource: willImportNotifications ? values.notificationsSource : undefined,
+        rulesSource: willImportRules ? values.rulesSource : undefined,
+      });
       notifyApp.error(t('alerting.import-to-gma.error', 'Failed to import resources'), stringifyErrorLike(err));
     }
   }, [getValues, importNotifications, importRules, rulesFromDatasource, notifyApp]);

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { isEmpty } from 'lodash';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -12,6 +12,16 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 import { RulerRulesConfigDTO } from 'app/types/unified-alerting-dto';
 
+import {
+  trackImportToGMADryrunError,
+  trackImportToGMADryrunSuccess,
+  trackImportToGMADryrunWarning,
+  trackImportToGMAError,
+  trackImportToGMASuccess,
+  trackImportToGMAWizardCancelled,
+  trackImportToGMAWizardStarted,
+  trackImportToGMAWizardStepSkipped,
+} from '../../Analytics';
 import { fetchAlertManagerConfig } from '../../api/alertmanager';
 import { Folder } from '../../types/rule-form';
 import { DOCS_URL_ALERTING_MIGRATION } from '../../utils/docs';
@@ -87,6 +97,14 @@ const ImportToGMA = () => {
  */
 function ImportWizardContent() {
   const { activeStep, setStepErrors } = useStepperState();
+
+  const wizardStartedTracked = useRef(false);
+  useEffect(() => {
+    if (!wizardStartedTracked.current) {
+      trackImportToGMAWizardStarted();
+      wizardStartedTracked.current = true;
+    }
+  }, []);
 
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [importStatus, setImportStatus] = useState<'idle' | 'importing' | 'success' | 'error'>('idle');
@@ -186,14 +204,22 @@ function ImportWizardContent() {
     });
   }, [getValues, runDryRun]);
 
-  // Sync step errors with dry-run state
+  // Sync step errors with dry-run state and track dry-run outcomes
   useEffect(() => {
     if (dryRunState === 'error') {
       setStepErrors(StepKey.Notifications, true);
-    } else if (dryRunState === 'success' || dryRunState === 'warning') {
+      trackImportToGMADryrunError();
+    } else if (dryRunState === 'success') {
       setStepErrors(StepKey.Notifications, false);
+      trackImportToGMADryrunSuccess();
+    } else if (dryRunState === 'warning') {
+      setStepErrors(StepKey.Notifications, false);
+      trackImportToGMADryrunWarning({
+        renamedReceiversCount: dryRunResult?.renamedReceivers.length ?? 0,
+        renamedTimeIntervalsCount: dryRunResult?.renamedTimeIntervals.length ?? 0,
+      });
     }
-  }, [dryRunState, setStepErrors]);
+  }, [dryRunState, dryRunResult, setStepErrors]);
 
   // Step 1 handlers
   // Note: WizardStep and NextButton handle stepper state (completed, skipped, visited, navigation)
@@ -212,6 +238,7 @@ function ImportWizardContent() {
     setValue('step1Completed', false);
     setValue('step1Skipped', true);
     setValue('selectedRoutingTree', '');
+    trackImportToGMAWizardStepSkipped({ step: 'notifications' });
   }, [setValue]);
 
   // Step 2 handlers
@@ -224,6 +251,7 @@ function ImportWizardContent() {
   const handleStep2Skip = useCallback(() => {
     setValue('step2Completed', false);
     setValue('step2Skipped', true);
+    trackImportToGMAWizardStepSkipped({ step: 'rules' });
   }, [setValue]);
 
   // Get ruler rules for rules import (needed when importing from datasource)
@@ -244,6 +272,7 @@ function ImportWizardContent() {
     const values = getValues();
     const willImportNotifications = values.step1Completed && !values.step1Skipped;
     const willImportRules = values.step2Completed && !values.step2Skipped;
+    const importSource = willImportNotifications ? values.notificationsSource : values.rulesSource;
 
     try {
       // Import notifications first (if step 1 was completed)
@@ -284,9 +313,19 @@ function ImportWizardContent() {
 
       setImportStatus('success');
 
-      // Redirect to alert list with folder filter after a short delay
       const targetFolder = values.targetFolder;
       const isRootFolder = isEmpty(targetFolder?.uid);
+
+      trackImportToGMASuccess({
+        importSource,
+        isRootFolder,
+        namespace: values.namespace,
+        ruleGroup: values.ruleGroup,
+        pauseRecordingRules: values.pauseRecordingRules,
+        pauseAlertingRules: values.pauseAlertingRules,
+      });
+
+      // Redirect to alert list with folder filter after a short delay
       const ruleListUrl = createListFilterLink(isRootFolder ? [] : [['namespace', targetFolder?.title ?? '']], {
         skipSubPath: true,
       });
@@ -298,6 +337,7 @@ function ImportWizardContent() {
       }, 1500);
     } catch (err) {
       setImportStatus('error');
+      trackImportToGMAError({ importSource });
       notifyApp.error(t('alerting.import-to-gma.error', 'Failed to import resources'), stringifyErrorLike(err));
     }
   }, [getValues, importNotifications, importRules, rulesFromDatasource, notifyApp]);
@@ -309,6 +349,14 @@ function ImportWizardContent() {
       setImportStatus('idle');
     }
   }, [importStatus]);
+
+  const handleWizardCancel = useCallback(() => {
+    const { formState } = formAPI;
+    trackImportToGMAWizardCancelled({
+      cancelledAtStep: activeStep,
+      formDirty: formState.isDirty,
+    });
+  }, [activeStep, formAPI]);
 
   return (
     <>
@@ -333,6 +381,7 @@ function ImportWizardContent() {
               canImport={canImportNotifications}
               onNext={handleStep1Next}
               onSkip={handleStep1Skip}
+              onCancel={handleWizardCancel}
               dryRunState={dryRunState}
               dryRunResult={dryRunResult}
               onTriggerDryRun={handleTriggerDryRun}
@@ -348,6 +397,7 @@ function ImportWizardContent() {
               canImport={canImportRules}
               onNext={handleStep2Next}
               onSkip={handleStep2Skip}
+              onCancel={handleWizardCancel}
             />
           )}
 
@@ -356,6 +406,7 @@ function ImportWizardContent() {
             <ReviewStep
               formData={getValues()}
               onStartImport={handleStartImport}
+              onCancel={handleWizardCancel}
               dryRunResult={dryRunResult}
               rulesFromDatasource={rulesFromDatasource}
             />
@@ -381,6 +432,7 @@ interface Step1WrapperProps {
   canImport: boolean;
   onNext: () => boolean;
   onSkip: () => void;
+  onCancel: () => void;
   dryRunState: 'idle' | 'loading' | 'success' | 'warning' | 'error';
   dryRunResult?: DryRunValidationResult;
   onTriggerDryRun: () => void;
@@ -392,6 +444,7 @@ function Step1Wrapper({
   canImport,
   onNext,
   onSkip,
+  onCancel,
   dryRunState,
   dryRunResult,
   onTriggerDryRun,
@@ -412,6 +465,7 @@ function Step1Wrapper({
       }
       onNext={onNext}
       onSkip={onSkip}
+      onCancel={onCancel}
       canSkip
       skipLabel={t('alerting.import-to-gma.step1.skip', 'Skip this step')}
       disableNext={!canProceed}
@@ -436,9 +490,10 @@ interface Step2WrapperProps {
   canImport: boolean;
   onNext: () => boolean;
   onSkip: () => void;
+  onCancel: () => void;
 }
 
-function Step2Wrapper({ step1Completed, step1Skipped, canImport, onNext, onSkip }: Step2WrapperProps) {
+function Step2Wrapper({ step1Completed, step1Skipped, canImport, onNext, onSkip, onCancel }: Step2WrapperProps) {
   const isStep2Valid = useStep2Validation(canImport);
 
   return (
@@ -452,6 +507,7 @@ function Step2Wrapper({ step1Completed, step1Skipped, canImport, onNext, onSkip 
       }
       onNext={onNext}
       onSkip={onSkip}
+      onCancel={onCancel}
       canSkip
       skipLabel={t('alerting.import-to-gma.step2.skip', 'Skip this step')}
       disableNext={!isStep2Valid}
@@ -525,11 +581,12 @@ const getValidationIndicatorStyles = (theme: GrafanaTheme2) => ({
 interface ReviewStepProps {
   formData: ImportFormValues;
   onStartImport: () => void;
+  onCancel: () => void;
   dryRunResult?: DryRunValidationResult;
   rulesFromDatasource?: RulerRulesConfigDTO;
 }
 
-function ReviewStep({ formData, onStartImport, dryRunResult, rulesFromDatasource }: ReviewStepProps) {
+function ReviewStep({ formData, onStartImport, onCancel, dryRunResult, rulesFromDatasource }: ReviewStepProps) {
   const styles = useStyles2(getStyles);
   const { setActiveStep } = useStepperState();
 
@@ -770,7 +827,7 @@ function ReviewStep({ formData, onStartImport, dryRunResult, rulesFromDatasource
             {t('alerting.import-to-gma.review.start', 'Start import')}
           </Button>
         </Stack>
-        <CancelButton />
+        <CancelButton onCancel={onCancel} />
       </Stack>
 
       {/* Notifications Preview Modal */}

--- a/public/app/features/alerting/unified/components/import-to-gma/Wizard/CancelButton.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/Wizard/CancelButton.test.tsx
@@ -123,4 +123,33 @@ describe('CancelButton', () => {
 
     expect(locationService.push).toHaveBeenCalledWith('/custom/path');
   });
+
+  it('should call onCancel when user cancels (non-dirty)', async () => {
+    const onCancel = jest.fn();
+    render(
+      <FormWrapper isDirty={false}>
+        <CancelButton onCancel={onCancel} />
+      </FormWrapper>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(locationService.push).toHaveBeenCalledWith('/alerting/list');
+  });
+
+  it('should call onCancel when user confirms cancellation (dirty)', async () => {
+    const onCancel = jest.fn();
+    render(
+      <FormWrapper isDirty={true}>
+        <CancelButton onCancel={onCancel} />
+      </FormWrapper>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await user.click(await screen.findByRole('button', { name: 'Discard changes' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(locationService.push).toHaveBeenCalledWith('/alerting/list');
+  });
 });

--- a/public/app/features/alerting/unified/components/import-to-gma/Wizard/CancelButton.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/Wizard/CancelButton.tsx
@@ -10,16 +10,19 @@ import { useCancelWizardModal } from './useCancelWizardModal';
 interface CancelButtonProps {
   /** Custom redirect URL when canceling */
   redirectUrl?: RelativeUrl;
+  /** Callback fired when the user confirms cancellation */
+  onCancel?: () => void;
 }
 
 /**
  * CancelButton - button to exit the wizard without completing
  */
-export function CancelButton({ redirectUrl = '/alerting/list' }: CancelButtonProps) {
+export function CancelButton({ redirectUrl = '/alerting/list', onCancel }: CancelButtonProps) {
   const { formState } = useFormContext();
   const [CancelModal, handleCancel] = useCancelWizardModal({
     redirectUrl,
     isDirty: formState.isDirty,
+    onCancel,
   });
 
   return (

--- a/public/app/features/alerting/unified/components/import-to-gma/Wizard/WizardStep.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/Wizard/WizardStep.tsx
@@ -31,6 +31,8 @@ interface WizardStepProps {
   onBack?: () => void;
   /** Disable the next button */
   disableNext?: boolean;
+  /** Handler called when the wizard is cancelled */
+  onCancel?: () => void;
 }
 
 /**
@@ -53,6 +55,7 @@ export const WizardStep = ({
   onSkip,
   onBack,
   disableNext = false,
+  onCancel,
 }: WizardStepProps) => {
   const styles = useStyles2(getStyles);
   const { setVisitedStep, setStepCompleted, setStepSkipped } = useStepperState();
@@ -102,7 +105,7 @@ export const WizardStep = ({
             disabled={disableNext}
           />
         </Stack>
-        <CancelButton />
+        <CancelButton onCancel={onCancel} />
       </div>
     </FieldSet>
   );

--- a/public/app/features/alerting/unified/components/import-to-gma/Wizard/useCancelWizardModal.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/Wizard/useCancelWizardModal.tsx
@@ -12,11 +12,13 @@ type CancelModalHook = [
 interface UseCancelWizardModalOptions {
   redirectUrl?: string;
   isDirty?: boolean;
+  onCancel?: () => void;
 }
 
 export function useCancelWizardModal({
   redirectUrl = '/alerting/list',
   isDirty = false,
+  onCancel,
 }: UseCancelWizardModalOptions = {}): CancelModalHook {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -25,8 +27,9 @@ export function useCancelWizardModal({
   }, []);
 
   const navigateAway = useCallback(() => {
+    onCancel?.();
     locationService.push(redirectUrl);
-  }, [redirectUrl]);
+  }, [redirectUrl, onCancel]);
 
   const handleCancel = useCallback(() => {
     if (isDirty) {

--- a/public/app/features/alerting/unified/components/import-to-gma/useImport.ts
+++ b/public/app/features/alerting/unified/components/import-to-gma/useImport.ts
@@ -1,5 +1,5 @@
 import { load } from 'js-yaml';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { RulerRulesConfigDTO } from 'app/types/unified-alerting-dto';
 
@@ -270,7 +270,7 @@ export function useDryRunNotifications() {
     [dryRunAlertmanagerConfig]
   );
 
-  const result = data ? parseDryRunResponse(data) : undefined;
+  const result = useMemo(() => (data ? parseDryRunResponse(data) : undefined), [data]);
   const error = mutationError ? stringifyErrorLike(mutationError) : preRunError;
 
   return { runDryRun, isLoading, result, error };


### PR DESCRIPTION
**What is this feature?**

This PR adds tracking to the following events in the import wizard:
- Wizard started
- Wizard step skipped
- Wizard cancelled
- Wizard dry run success
- Wizard dry run warning
- Wizard dry run error

https://github.com/user-attachments/assets/45e94cdb-ea0d-4e57-bc81-b8cce540cfe7

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1437

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
