### PR TITLE
Plugins: Pass AWS credential chain env vars to plugin processes

### DIFF
--- a/pkg/plugins/envvars/envvars.go
+++ b/pkg/plugins/envvars/envvars.go
@@ -18,6 +18,16 @@ var permittedHostEnvVarNames = []string{
 	"https_proxy",
 	"NO_PROXY",
 	"no_proxy",
+
+	// AWS credential chain env vars needed by plugins using SigV4 auth
+	// (e.g. OpenSearch, CloudWatch, Prometheus on ECS/EKS/EC2)
+	"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+	"AWS_CONTAINER_CREDENTIALS_FULL_URI",
+	"AWS_CONTAINER_AUTHORIZATION_TOKEN",
+	"AWS_WEB_IDENTITY_TOKEN_FILE",
+	"AWS_ROLE_ARN",
+	"AWS_DEFAULT_REGION",
+	"AWS_REGION",
 }
 
 type Provider interface {


### PR DESCRIPTION
## What is this PR about?

The `permittedHostEnvVarNames` allowlist in `pkg/plugins/envvars/envvars.go` (introduced in v12.4.0) only includes HTTP proxy variables. This breaks AWS SigV4 authentication for plugins running on ECS Fargate or EKS with IRSA.

## Why?

Without `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` being passed to plugin subprocesses, the AWS SDK's default credential chain cannot locate the ECS container credential endpoint. It falls through to EC2 IMDS, which doesn't exist on Fargate, and fails with:

```
Post "https://.../_plugins/_ppl": failed to refresh cached credentials,
no EC2 IMDS role found, operation error ec2imds: GetMetadata,
exceeded maximum number of attempts, 3, request send failed,
Get "http://169.254.169.254/latest/meta-data/iam/security-credentials/":
dial tcp 169.254.169.254:80: connect: invalid argument
```

This is a regression from v12.3.x where plugins inherited the full process environment.

## Affected plugins

Any plugin using AWS SigV4 authentication on container platforms:
- `grafana-opensearch-datasource`
- Elasticsearch datasource (with SigV4)
- CloudWatch (if running as external plugin)

## What was changed

Added AWS credential chain environment variables to the `permittedHostEnvVarNames` allowlist:

- `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` (ECS Fargate)
- `AWS_CONTAINER_CREDENTIALS_FULL_URI` (ECS Fargate)
- `AWS_CONTAINER_AUTHORIZATION_TOKEN` (ECS Fargate)
- `AWS_WEB_IDENTITY_TOKEN_FILE` (EKS IRSA)
- `AWS_ROLE_ARN` (EKS IRSA)
- `AWS_DEFAULT_REGION`
- `AWS_REGION`

## How was this tested?

1. Built patched Grafana binary from source
2. Deployed to ECS Fargate with OpenSearch datasource using SigV4 auth
3. Confirmed the OpenSearch plugin successfully authenticates via the ECS task role credential provider