### PR TITLE
chore: transfer ownership of MatchersUI to dataviz

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -726,6 +726,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 
 # @grafana/ui
 /packages/grafana-ui/ @grafana/grafana-frontend-platform
+/packages/grafana-ui/src/components/MatchersUI/ @grafana/dataviz-squad
 /packages/grafana-ui/src/components/BarGauge/ @grafana/dataviz-squad
 /packages/grafana-ui/src/components/DataLinks/ @grafana/dataviz-squad
 /packages/grafana-ui/src/components/Gauge/ @grafana/dataviz-squad


### PR DESCRIPTION
**What is this feature?**

MatchersUI hasn't really been touched by folks outside of dataviz in years, and dataviz has some upcoming projects that will require heavier touches on these files.

**Why do we need this feature?**
MatchersUI is technically owned by `frontend-platform` but IRL doesn't really have any ownership, dataviz/datapro should take ownership since they are most impacted by changes to field overrides and config from query results.