### PR TITLE
CI: Update checkum error message to encourage use of the make command

### DIFF
--- a/apps/dashboard/pkg/migration/testutil/golden.go
+++ b/apps/dashboard/pkg/migration/testutil/golden.go
@@ -97,12 +97,12 @@ func (s *ChecksumStore) ValidateOrUpdate(t *testing.T, key string, data []byte) 
 
 	expected, ok := s.data[key]
 	if !ok {
-		t.Errorf("no checksum found for %s (got %s); run with REGENERATE_CHECKSUMS=true to generate", key, hash)
+		t.Errorf("no checksum found for %s (got %s); run 'make regenerate-golden-checksums' to update", key, hash)
 		return
 	}
 
 	if expected != hash {
-		t.Errorf("checksum mismatch for %s:\n  expected: %s\n       got: %s\nRun with REGENERATE_CHECKSUMS=true to update", key, expected, hash)
+		t.Errorf("checksum mismatch for %s:\n  expected: %s\n       got: %s\nrun 'make regenerate-golden-checksums' to update", key, expected, hash)
 	}
 }
 


### PR DESCRIPTION
Hey there! I'm happy that the checksum thing has replaced the previous impelementation with the JSON files! However, I got confused when I did the following:

- ran an individual Go test in my IDE that was failing in CI
- got the message to run that test with the env variable
- re-ran that individual Go test with the env variable

it wrote over the whole JSON object, deleting many of the keys, since both of these tests need to be run with the env variable to result in the correct snapshot JSON. I think it's cleaner to just recommend the make command, which is pretty easy to search for and run.