### PR TITLE
Chore: update grafana 12 support levels in docs

### DIFF
--- a/docs/sources/upgrade-guide/when-to-upgrade/index.md
+++ b/docs/sources/upgrade-guide/when-to-upgrade/index.md
@@ -104,11 +104,11 @@ Here is an overview of version support through 2026:
 | 11.4.x                    | December 5, 2024   | September 5, 2025    | Not Supported      |
 | 11.5.x                    | January 28, 2025   | October 28, 2025     | Not Supported      |
 | 11.6.x (Last minor of 11) | March 25, 2025     | June 25, 2026        | Patch Support      |
-| 12.0.x                    | May 5, 2025        | February 5, 2026     | Patch Support      |
+| 12.0.x                    | May 5, 2025        | February 5, 2026     | Not Supported      |
 | 12.1.x                    | July 22, 2025      | April 22, 2026       | Patch Support      |
 | 12.2.x                    | September 23, 2025 | June 23, 2026        | Patch Support      |
 | 12.3.x                    | November 19, 2025  | August 19, 2026      | Patch Support      |
-| 12.4.x (Last minor of 12) | February 24, 2026  | May 24, 2027         | Yet to be released |
+| 12.4.x (Last minor of 12) | February 24, 2026  | May 24, 2027         | Patch Support      |
 | 13.0.0                    | TBD                | TBD                  | Yet to be released |
 
 ## How are these versions supported?


### PR DESCRIPTION
Docs change:

- 12.0.x is out of support
- 12.4.x is released and supported