### PR TITLE
InfluxDB: Use text input for regex tag values in query builder

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.test.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.test.tsx
@@ -204,4 +204,42 @@ describe('InfluxDB InfluxQL Editor tags section', () => {
 
     await assertSegmentSelect('t1_v1', 't1_v5', onChange, newTags);
   });
+  it('should handle changing the regex tag-value', async () => {
+    const onChange = jest.fn();
+    const regexTags: InfluxQueryTag[] = [
+      {
+        key: 'host',
+        value: '/prod.*/',
+        operator: '=~',
+      },
+    ];
+
+    render(
+      <TagsSection
+        tags={regexTags}
+        getTagKeyOptions={getTagKeys}
+        getTagValueOptions={getTagValuesForKey}
+        onChange={onChange}
+      />
+    );
+
+    const seg = screen.getByRole('button', { name: '/prod.*/' });
+    act(() => {
+      fireEvent.click(seg);
+    });
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveValue('/prod.*/');
+    fireEvent.change(input, { target: { value: '/staging.*/' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        key: 'host',
+        value: '/staging.*/',
+        operator: '=~',
+      },
+    ]);
+  });
 });

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
@@ -64,6 +64,8 @@ const Tag = ({ tag, isFirst, onRemove, onChange, getTagKeyOptions, getTagValueOp
     return getTagValueOptions(tag.key).then((tags) => tags.map(toSelectableValue));
   };
 
+  const isRegexOperator = operator === '=~' || operator === '!~';
+
   return (
     <div className="gf-form">
       {condition != null && (
@@ -98,7 +100,7 @@ const Tag = ({ tag, isFirst, onRemove, onChange, getTagKeyOptions, getTagValueOp
       <Seg
         allowCustomValue
         value={tag.value}
-        loadOptions={getTagValueSegmentOptions}
+        loadOptions={isRegexOperator ? undefined : getTagValueSegmentOptions}
         onChange={(v) => {
           const value = v.value ?? '';
           onChange({ ...tag, value, operator: adjustOperatorIfNeeded(operator, value) });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When using regex operators (=~ or !~) in the InfluxQL query builder's WHERE clause, the tag value field now displays a text input instead of a dropdown selector.

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

Previously, clicking on a regex value in the WHERE clause would delete the regex and show a dropdown list of tag values. This made it impossible to edit existing regex patterns - users had to re-enter them from scratch.

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

Anyone who uses the InfluxQL query editor with regex filters.

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #109994

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

No feature toggle or docs update needed - this is a bug fix for existing functionality.

Note: Re-opening this PR(#118162) because I accidentally deleted my old fork, which auto-closed the previous PR. This contains the same changes.