### PR TITLE
fix(expressions): quote table names with spaces in SQL expressions

### DIFF
--- a/public/app/features/expressions/components/SqlExpressions/CompletionProvider/sqlCompletionProvider.test.ts
+++ b/public/app/features/expressions/components/SqlExpressions/CompletionProvider/sqlCompletionProvider.test.ts
@@ -1,0 +1,34 @@
+import { getSqlCompletionProvider } from './sqlCompletionProvider';
+
+describe('getSqlCompletionProvider', () => {
+  const mockMonaco = {} as any;
+  const mockLanguage = {} as any;
+
+  it('quotes table names with spaces in completion text', async () => {
+    const provider = getSqlCompletionProvider({
+      getFields: jest.fn(),
+      refIds: [{ value: 'gdp per capita', label: 'gdp per capita' }],
+    });
+
+    const result = provider(mockMonaco, mockLanguage);
+    const tables = await result.tables!.resolve!();
+
+    expect(tables).toHaveLength(1);
+    expect(tables![0].name).toBe('gdp per capita');
+    expect(tables![0].completion).toBe('`gdp per capita`');
+  });
+
+  it('does not quote simple table names', async () => {
+    const provider = getSqlCompletionProvider({
+      getFields: jest.fn(),
+      refIds: [{ value: 'A', label: 'A' }],
+    });
+
+    const result = provider(mockMonaco, mockLanguage);
+    const tables = await result.tables!.resolve!();
+
+    expect(tables).toHaveLength(1);
+    expect(tables![0].name).toBe('A');
+    expect(tables![0].completion).toBe('A');
+  });
+});

--- a/public/app/features/expressions/components/SqlExpressions/CompletionProvider/sqlCompletionProvider.ts
+++ b/public/app/features/expressions/components/SqlExpressions/CompletionProvider/sqlCompletionProvider.ts
@@ -1,6 +1,7 @@
 import { SelectableValue } from '@grafana/data';
 import { ColumnDefinition, LanguageCompletionProvider, TableDefinition, TableIdentifier } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
+import { quoteIdentifierIfNecessary } from 'app/plugins/datasource/mysql/sqlUtil';
 
 import { ALLOWED_FUNCTIONS } from '../../../utils/metaSqlExpr';
 
@@ -18,7 +19,7 @@ export const getSqlCompletionProvider: (args: CompletionProviderGetterArgs) => L
         const refIdsToTableDefs = args.refIds.map((refId) => {
           const tableDef: TableDefinition = {
             name: refId.label || refId.value || '',
-            completion: refId.label || refId.value || '',
+            completion: quoteIdentifierIfNecessary(refId.label || refId.value || ''),
           };
           return tableDef;
         });

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
@@ -84,6 +84,38 @@ describe('SqlExpr', () => {
     expect(updatedQuery.expression.toUpperCase()).toContain('SELECT');
   });
 
+  it('quotes table names with spaces in initial query', async () => {
+    const onChange = jest.fn();
+    const refIds = [{ value: 'gdp per capita' }];
+    const query = { refId: 'expr1', type: 'sql', expression: '' } as ExpressionQuery;
+
+    render(<SqlExpr onChange={onChange} refIds={refIds} query={query} queries={[]} />);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    const updatedQuery = onChange.mock.calls[0][0];
+    expect(updatedQuery.expression).toContain('`gdp per capita`');
+    expect(updatedQuery.expression).not.toMatch(/FROM\s+gdp per capita/);
+  });
+
+  it('does not quote simple table names', async () => {
+    const onChange = jest.fn();
+    const refIds = [{ value: 'A' }];
+    const query = { refId: 'expr1', type: 'sql', expression: '' } as ExpressionQuery;
+
+    render(<SqlExpr onChange={onChange} refIds={refIds} query={query} queries={[]} />);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    const updatedQuery = onChange.mock.calls[0][0];
+    expect(updatedQuery.expression).toContain('A');
+    expect(updatedQuery.expression).not.toContain('`A`');
+  });
+
   it('preserves existing expressions when mounted', async () => {
     const onChange = jest.fn();
     const refIds = [{ value: 'A' }];

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
@@ -10,6 +10,7 @@ import { reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { formatSQL } from '@grafana/sql';
 import { Button, Stack, useStyles2 } from '@grafana/ui';
+import { quoteIdentifierIfNecessary } from 'app/plugins/datasource/mysql/sqlUtil';
 
 import { ExpressionQueryEditorProps } from '../../ExpressionQueryEditor';
 import { SqlExpressionQuery } from '../../types';
@@ -71,7 +72,7 @@ export const SqlExpr = ({ onChange, refIds, query, alerting = false, queries, me
   const initialQuery = `SELECT
   *
 FROM
-  ${vars[0]}
+  ${quoteIdentifierIfNecessary(vars[0])}
 LIMIT
   10`;
 

--- a/public/app/features/expressions/utils/metaSqlExpr.ts
+++ b/public/app/features/expressions/utils/metaSqlExpr.ts
@@ -14,7 +14,7 @@ export async function fetchSQLFields(query: Partial<SQLQuery>, queries: DataQuer
     return [];
   }
 
-  const queryString = `SELECT * FROM ${query.table} LIMIT 1`;
+  const queryString = `SELECT * FROM ${quoteIdentifierIfNecessary(query.table)} LIMIT 1`;
 
   const queryResponse = await datasource.runMetaSQLExprQuery(
     { rawSql: queryString, format: QueryFormat.Table, refId: `fields-${uuidv4()}` },


### PR DESCRIPTION
## What

Fixes #117497 — SQL Expressions fail to parse when the source query has a refId containing spaces (e.g. `gdp per capita`).

The generated SQL produces `FROM gdp per capita` instead of `FROM \`gdp per capita\``, causing a syntax error.

## Changes

Applies `quoteIdentifierIfNecessary` (existing MySQL utility) to table names in three locations:

1. **`SqlExpr.tsx`** — initial query template now quotes the refId
2. **`sqlCompletionProvider.ts`** — autocomplete insertions now quote names with spaces
3. **`metaSqlExpr.ts`** — schema fetch query now quotes the table name

## Tests

- Added tests in `SqlExpr.test.tsx` verifying quoted/unquoted behavior
- Added new test file `sqlCompletionProvider.test.ts` for completion quoting