### PR TITLE
[release-12.2.7] Rendering: Add support for custom CA certs in Image Renderer

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1862,6 +1862,8 @@ sas_token_expiration_days =
 # Options to configure a remote HTTP image rendering service, e.g. using https://github.com/grafana/grafana-image-renderer.
 # URL to a remote HTTP image renderer service, e.g. http://localhost:8081/render, will enable Grafana to render panels and dashboards to PNG-images using HTTP requests to an external service.
 server_url =
+# Path to the PEM-encoded CA certificate file from the Image Renderer server.
+ca_cert_file_path =
 # If the remote HTTP image renderer service runs on a different server than the Grafana server you may have to configure this to a URL where Grafana is reachable, e.g. http://grafana.domain/.
 # The `callback_url` can also be configured to support usage of the image renderer running as a plugin with support for SSL / HTTPS. For example https://localhost:3000/.
 callback_url =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1809,6 +1809,8 @@ default_datasource_uid =
 # Options to configure a remote HTTP image rendering service, e.g. using https://github.com/grafana/grafana-image-renderer.
 # URL to a remote HTTP image renderer service, e.g. http://localhost:8081/render, will enable Grafana to render panels and dashboards to PNG-images using HTTP requests to an external service.
 ;server_url =
+# Path to the PEM-encoded CA certificate file from the Image Renderer server.
+;ca_cert_file_path =
 # If the remote HTTP image renderer service runs on a different server than the Grafana server you may have to configure this to a URL where Grafana is reachable, e.g. http://grafana.domain/.
 ;callback_url =
 # An auth token that will be sent to and verified by the renderer. The renderer will deny any request without an auth token matching the one configured on the renderer side.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2525,6 +2525,10 @@ The `callback_url` can also be configured to support usage of the image renderer
 Concurrent render request limit affects when the /render HTTP endpoint is used. Rendering many images at the same time can overload the server,
 which this setting can help protect against by only allowing a certain number of concurrent requests. Default is `30`.
 
+#### `ca_cert_file_path`
+
+Path to the PEM-encoded CA certificate file from the Image Renderer server.
+
 #### `default_image_width`
 
 Configures the width of the rendered image. The default width is `1000`.

--- a/pkg/services/rendering/http_mode.go
+++ b/pkg/services/rendering/http_mode.go
@@ -8,27 +8,12 @@ import (
 	"io"
 	"io/fs"
 	"mime"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"strconv"
 	"time"
-
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
-
-var netTransport = &http.Transport{
-	Proxy: http.ProxyFromEnvironment,
-	Dial: (&net.Dialer{
-		Timeout: 30 * time.Second,
-	}).Dial,
-	TLSHandshakeTimeout: 5 * time.Second,
-}
-
-var netClient = &http.Client{
-	Transport: otelhttp.NewTransport(netTransport),
-}
 
 const authTokenHeader = "X-Auth-Token" //#nosec G101 -- This is a false positive
 const rateLimiterHeader = "X-Tenant-ID"
@@ -170,7 +155,7 @@ func (rs *RenderingService) doRequest(ctx context.Context, u *url.URL, headers m
 	logger.Debug("calling remote rendering service", "url", u)
 
 	// make request to renderer server
-	resp, err := netClient.Do(req)
+	resp, err := rs.netClient.Do(req)
 	if err != nil {
 		logger.Error("Failed to send request to remote rendering service", "error", err)
 		var urlErr *url.Error

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -2,10 +2,14 @@ package rendering
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/gob"
 	"errors"
 	"fmt"
 	"math"
+	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -13,6 +17,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics"
@@ -38,6 +44,7 @@ type RenderingService struct {
 	capabilities        []Capability
 	pluginAvailable     bool
 	rendererCallbackURL string
+	netClient           *http.Client
 
 	perRequestRenderKeyProvider renderKeyProvider
 	Cfg                         *setting.Cfg
@@ -120,6 +127,32 @@ func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, remot
 
 	_, exists := rm.Renderer(context.Background())
 
+	netTransport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 5 * time.Second,
+	}
+
+	if cfg.RendererCACert != "" {
+		caCert, err := os.ReadFile(cfg.RendererCACert)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read renderer CA cert file: %w", err)
+		}
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to parse renderer CA cert")
+		}
+		netTransport.TLSClientConfig = &tls.Config{
+			RootCAs: caCertPool,
+		}
+	}
+
+	netClient := &http.Client{
+		Transport: otelhttp.NewTransport(netTransport),
+	}
+
 	s := &RenderingService{
 		perRequestRenderKeyProvider: renderKeyProvider,
 		capabilities: []Capability{
@@ -144,6 +177,7 @@ func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, remot
 		domain:                domain,
 		pluginAvailable:       exists,
 		rendererCallbackURL:   rendererCallbackURL,
+		netClient:             netClient,
 	}
 
 	gob.Register(&RenderUser{})

--- a/pkg/services/rendering/rendering_test.go
+++ b/pkg/services/rendering/rendering_test.go
@@ -189,8 +189,9 @@ func TestRenderLimitImageError(t *testing.T) {
 func TestRenderingServiceGetRemotePluginVersion(t *testing.T) {
 	cfg := setting.NewCfg()
 	rs := &RenderingService{
-		Cfg: cfg,
-		log: log.New("rendering-test"),
+		Cfg:       cfg,
+		log:       log.New("rendering-test"),
+		netClient: &http.Client{},
 	}
 
 	t.Run("When renderer responds with correct version should return that version", func(t *testing.T) {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -158,6 +158,7 @@ type Cfg struct {
 	RendererDefaultImageWidth      int
 	RendererDefaultImageHeight     int
 	RendererDefaultImageScale      float64
+	RendererCACert                 string
 
 	// Security
 	DisableInitAdminCreation             bool
@@ -1880,6 +1881,7 @@ func (cfg *Cfg) readRenderingSettings(iniFile *ini.File) {
 	cfg.RendererDefaultImageWidth = renderSec.Key("default_image_width").MustInt(1000)
 	cfg.RendererDefaultImageHeight = renderSec.Key("default_image_height").MustInt(500)
 	cfg.RendererDefaultImageScale = renderSec.Key("default_image_scale").MustFloat64(1)
+	cfg.RendererCACert = valueAsString(renderSec, "ca_cert_file_path", "")
 	cfg.ImagesDir = filepath.Join(cfg.DataPath, "png")
 	cfg.CSVsDir = filepath.Join(cfg.DataPath, "csv")
 	cfg.PDFsDir = filepath.Join(cfg.DataPath, "pdf")


### PR DESCRIPTION
Backport of https://github.com/grafana/grafana/pull/118612