### PR TITLE
Provisioning: set pure git as default in OSS

### DIFF
--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -529,7 +529,7 @@ func (c *ControllerConfig) RepositoryExtras() ([]repository.Extra, error) {
 	provisioningSec := c.Settings.SectionWithEnvOverrides("provisioning")
 	repoTypes := provisioningSec.Key("repository_types").Strings("|")
 	if len(repoTypes) == 0 {
-		repoTypes = []string{"github"}
+		repoTypes = []string{"git", "github"}
 	}
 
 	extras := make([]repository.Extra, 0)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -2184,7 +2184,7 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 		}
 	}
 
-	repositoryTypes := strings.TrimSpace(valueAsString(iniFile.Section("provisioning"), "repository_types", "github|local"))
+	repositoryTypes := strings.TrimSpace(valueAsString(iniFile.Section("provisioning"), "repository_types", "git|github|local"))
 	if repositoryTypes != "|" && repositoryTypes != "" {
 		cfg.ProvisioningRepositoryTypes = strings.Split(repositoryTypes, "|")
 		for i, s := range cfg.ProvisioningRepositoryTypes {

--- a/pkg/tests/apis/provisioning/helper_test.go
+++ b/pkg/tests/apis/provisioning/helper_test.go
@@ -742,7 +742,7 @@ func runGrafana(t *testing.T, options ...grafanaOption) *provisioningTestHelper 
 	}
 
 	if extensions.IsEnterprise {
-		opts.ProvisioningRepositoryTypes = []string{"local", "github", "gitlab", "bitbucket"}
+		opts.ProvisioningRepositoryTypes = []string{"local", "git", "github", "gitlab", "bitbucket"}
 	}
 
 	for _, o := range options {

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -169,6 +169,7 @@ func TestIntegrationProvisioning_CreatingAndGetting(t *testing.T) {
 			if extensions.IsEnterprise {
 				assert.ElementsMatch(collect, []provisioning.RepositoryType{
 					provisioning.LocalRepositoryType,
+					provisioning.GitRepositoryType,
 					provisioning.GitHubRepositoryType,
 					provisioning.BitbucketRepositoryType,
 					provisioning.GitLabRepositoryType,
@@ -176,6 +177,7 @@ func TestIntegrationProvisioning_CreatingAndGetting(t *testing.T) {
 			} else {
 				assert.ElementsMatch(collect, []provisioning.RepositoryType{
 					provisioning.LocalRepositoryType,
+					provisioning.GitRepositoryType,
 					provisioning.GitHubRepositoryType,
 				}, settings.AvailableRepositoryTypes)
 			}


### PR DESCRIPTION
**What is this feature?**

Enabled `git` (aka pure git) Repository type in Provisioning API.
This is achieved by just adding that as a default repository type in settings, as such a type is already supported by default in both OSS APIs and controllers. 

**Why do we need this feature?**

We are enabling this type of Repositories by default in Provisioning API.

**Who is this feature for?**

Users of Git Sync

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/855

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
