### PR TITLE
IAM: Add accesscontrol in User search

### DIFF
--- a/apps/iam/kinds/manifest.cue
+++ b/apps/iam/kinds/manifest.cue
@@ -91,4 +91,5 @@ v0alpha1: {
 	lastSeenAtAge: string
 	provisioned: bool
 	score: float64
+	accessControl?: {[string]: bool}
 }

--- a/apps/iam/pkg/apis/iam/v0alpha1/getsearchusers_response_types_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/getsearchusers_response_types_gen.go
@@ -4,15 +4,16 @@ package v0alpha1
 
 // +k8s:openapi-gen=true
 type GetSearchUsersUserHit struct {
-	Name          string  `json:"name"`
-	Title         string  `json:"title"`
-	Login         string  `json:"login"`
-	Email         string  `json:"email"`
-	Role          string  `json:"role"`
-	LastSeenAt    int64   `json:"lastSeenAt"`
-	LastSeenAtAge string  `json:"lastSeenAtAge"`
-	Provisioned   bool    `json:"provisioned"`
-	Score         float64 `json:"score"`
+	Name          string          `json:"name"`
+	Title         string          `json:"title"`
+	Login         string          `json:"login"`
+	Email         string          `json:"email"`
+	Role          string          `json:"role"`
+	LastSeenAt    int64           `json:"lastSeenAt"`
+	LastSeenAtAge string          `json:"lastSeenAtAge"`
+	Provisioned   bool            `json:"provisioned"`
+	Score         float64         `json:"score"`
+	AccessControl map[string]bool `json:"accessControl,omitempty"`
 }
 
 // NewGetSearchUsersUserHit creates a new GetSearchUsersUserHit object.

--- a/packages/grafana-api-clients/src/clients/rtkq/iam/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/iam/v0alpha1/endpoints.gen.ts
@@ -190,6 +190,7 @@ const injectedRtkApi = api
             limit: queryArg.limit,
             page: queryArg.page,
             offset: queryArg.offset,
+            accesscontrol: queryArg.accesscontrol,
             sort: queryArg.sort,
           },
         }),
@@ -960,6 +961,8 @@ export type GetSearchUsersApiArg = {
   page?: number;
   /** number of results to skip */
   offset?: number;
+  /** when true, includes access control metadata in the response */
+  accesscontrol?: boolean;
   /** sortable field */
   sort?: string;
 };

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -137,7 +137,7 @@ func RegisterAPIService(
 		teamSearch: NewTeamSearchHandler(tracing, dual, team.NewLegacyTeamSearchClient(teamService, tracing), unified, features),
 		tracing:    tracing,
 	}
-	builder.userSearchHandler = user.NewSearchHandler(tracing, builder.userSearchClient, features, cfg)
+	builder.userSearchHandler = user.NewSearchHandler(tracing, builder.userSearchClient, features, cfg, accessClient)
 
 	apiregistration.RegisterAPI(builder)
 

--- a/pkg/registry/apis/iam/user/search.go
+++ b/pkg/registry/apis/iam/user/search.go
@@ -47,6 +47,7 @@ type accessControlCheck struct {
 	group    string
 	resource string
 	verb     string
+	name     string // user UID of the resource being checked
 }
 
 var userAccessControlChecks = []accessControlCheck{
@@ -366,9 +367,12 @@ func (s *SearchHandler) stampAccessControl(ctx context.Context, requester identi
 	namespace := requester.GetNamespace()
 
 	items := func(yield func(accessControlCheck) bool) {
-		for _, c := range userAccessControlChecks {
-			if !yield(c) {
-				return
+		for _, hit := range hits {
+			for _, c := range userAccessControlChecks {
+				c.name = hit.Name
+				if !yield(c) {
+					return
+				}
 			}
 		}
 	}
@@ -379,19 +383,25 @@ func (s *SearchHandler) stampAccessControl(ctx context.Context, requester identi
 			Group:     c.group,
 			Resource:  c.resource,
 			Namespace: namespace,
+			Name:      c.name,
+			// Folder is omitted: users are not folder-scoped resources.
+			// TODO: set FreshnessTimestamp once we decide whether cached AC is acceptable here.
 		}
 	}
 
-	acMap := make(map[string]bool, len(userAccessControlChecks))
+	acMap := make(map[string]map[string]bool, len(hits))
 	for c, err := range authz.FilterAuthorized(ctx, s.accessClient, items, extractFn, authz.WithTracer(s.tracer)) {
 		if err != nil {
 			return fmt.Errorf("access control check failed: %w", err)
 		}
-		acMap[c.action] = true
+		if acMap[c.name] == nil {
+			acMap[c.name] = make(map[string]bool, len(userAccessControlChecks))
+		}
+		acMap[c.name][c.action] = true
 	}
 
 	for i := range hits {
-		hits[i].AccessControl = acMap
+		hits[i].AccessControl = acMap[hits[i].Name]
 	}
 
 	return nil

--- a/pkg/registry/apis/iam/user/search.go
+++ b/pkg/registry/apis/iam/user/search.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -12,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/authlib/authz"
+	authlib "github.com/grafana/authlib/types"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -22,6 +25,7 @@ import (
 
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -35,21 +39,42 @@ import (
 
 const maxLimit = 100
 
-type SearchHandler struct {
-	log      log.Logger
-	client   resourcepb.ResourceIndexClient
-	tracer   trace.Tracer
-	features featuremgmt.FeatureToggles
-	cfg      *setting.Cfg
+// accessControlCheck maps a legacy RBAC action name to a K8s-style check.
+// The RBAC authz server translates Group/Resource/Verb through the mapper
+// to resolve the underlying RBAC action.
+type accessControlCheck struct {
+	action   string // legacy RBAC action name returned to callers
+	group    string
+	resource string
+	verb     string
 }
 
-func NewSearchHandler(tracer trace.Tracer, searchClient resourcepb.ResourceIndexClient, features featuremgmt.FeatureToggles, cfg *setting.Cfg) *SearchHandler {
+var userAccessControlChecks = []accessControlCheck{
+	{action: "org.users:read", group: iamv0.GROUP, resource: "users", verb: utils.VerbList},
+	{action: "org.users:add", group: iamv0.GROUP, resource: "users", verb: utils.VerbCreate},
+	{action: "org.users:remove", group: iamv0.GROUP, resource: "users", verb: utils.VerbDelete},
+	{action: "org.users:write", group: iamv0.GROUP, resource: "users", verb: utils.VerbUpdate},
+	{action: "users.permissions:read", group: iamv0.GROUP, resource: "users", verb: utils.VerbGetPermissions},
+	{action: "users.roles:read", group: iamv0.GROUP, resource: "rolebindings", verb: utils.VerbList},
+}
+
+type SearchHandler struct {
+	log          log.Logger
+	client       resourcepb.ResourceIndexClient
+	tracer       trace.Tracer
+	features     featuremgmt.FeatureToggles
+	cfg          *setting.Cfg
+	accessClient authlib.AccessClient
+}
+
+func NewSearchHandler(tracer trace.Tracer, searchClient resourcepb.ResourceIndexClient, features featuremgmt.FeatureToggles, cfg *setting.Cfg, accessClient authlib.AccessClient) *SearchHandler {
 	return &SearchHandler{
-		client:   searchClient,
-		log:      log.New("grafana-apiserver.users.search"),
-		tracer:   tracer,
-		features: features,
-		cfg:      cfg,
+		client:       searchClient,
+		log:          log.New("grafana-apiserver.users.search"),
+		tracer:       tracer,
+		features:     features,
+		cfg:          cfg,
+		accessClient: accessClient,
 	}
 }
 
@@ -112,6 +137,15 @@ func (s *SearchHandler) GetAPIRoutes(defs map[string]common.OpenAPIDefinition) *
 										Example:     0,
 										Required:    false,
 										Schema:      spec.Int64Property(),
+									},
+								},
+								{
+									ParameterProps: spec3.ParameterProps{
+										Name:        "accesscontrol",
+										In:          "query",
+										Description: "when true, includes access control metadata in the response",
+										Required:    false,
+										Schema:      spec.BoolProperty(),
 									},
 								},
 								{
@@ -317,7 +351,50 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 		errhttp.Write(ctx, err, w)
 		return
 	}
+
+	if queryParams.Get("accesscontrol") == "true" && s.accessClient != nil {
+		if err := s.stampAccessControl(ctx, requester, result.Hits); err != nil {
+			span.RecordError(err)
+			s.log.Warn("failed to get access control metadata", "error", err)
+		}
+	}
+
 	s.write(w, result)
+}
+
+func (s *SearchHandler) stampAccessControl(ctx context.Context, requester identity.Requester, hits []iamv0.GetSearchUsersUserHit) error {
+	namespace := requester.GetNamespace()
+
+	items := func(yield func(accessControlCheck) bool) {
+		for _, c := range userAccessControlChecks {
+			if !yield(c) {
+				return
+			}
+		}
+	}
+
+	extractFn := func(c accessControlCheck) authz.BatchCheckItem {
+		return authz.BatchCheckItem{
+			Verb:      c.verb,
+			Group:     c.group,
+			Resource:  c.resource,
+			Namespace: namespace,
+		}
+	}
+
+	acMap := make(map[string]bool, len(userAccessControlChecks))
+	for c, err := range authz.FilterAuthorized(ctx, s.accessClient, items, extractFn, authz.WithTracer(s.tracer)) {
+		if err != nil {
+			return fmt.Errorf("access control check failed: %w", err)
+		}
+		acMap[c.action] = true
+	}
+
+	for i := range hits {
+		hits[i].AccessControl = acMap
+	}
+
+	return nil
 }
 
 func (s *SearchHandler) write(w http.ResponseWriter, obj any) {

--- a/pkg/registry/apis/iam/user/search_test.go
+++ b/pkg/registry/apis/iam/user/search_test.go
@@ -2,9 +2,14 @@ package user
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http/httptest"
 	"testing"
 
+	authlib "github.com/grafana/authlib/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
@@ -46,7 +51,7 @@ func TestSearchFallback(t *testing.T) {
 			dual := dualwrite.ProvideStaticServiceForTests(cfg)
 
 			searchClient := resource.NewSearchClient(dualwrite.NewSearchAdapter(dual), iamv0.UserResourceInfo.GroupResource(), mockClient, mockLegacyClient, featuremgmt.WithFeatures())
-			searchHandler := NewSearchHandler(tracing.NewNoopTracerService(), searchClient, featuremgmt.WithFeatures(), cfg)
+			searchHandler := NewSearchHandler(tracing.NewNoopTracerService(), searchClient, featuremgmt.WithFeatures(), cfg, nil)
 
 			rr := httptest.NewRecorder()
 			req := httptest.NewRequest("GET", "/searchUsers", nil)
@@ -147,6 +152,181 @@ func (m *MockClient) UpdateIndex(ctx context.Context, reason string) error {
 
 func (m *MockClient) GetQuotaUsage(ctx context.Context, req *resourcepb.QuotaUsageRequest, opts ...grpc.CallOption) (*resourcepb.QuotaUsageResponse, error) {
 	return nil, nil
+}
+
+func mockClientWithHits() *MockClient {
+	return &MockClient{
+		MockResponses: []*resourcepb.ResourceSearchResponse{
+			{
+				Results: &resourcepb.ResourceTable{
+					Columns: []*resourcepb.ResourceTableColumnDefinition{
+						{Name: "title"},
+					},
+					Rows: []*resourcepb.ResourceTableRow{
+						{Key: &resourcepb.ResourceKey{Name: "user-1"}, Cells: [][]byte{[]byte("User One")}},
+						{Key: &resourcepb.ResourceKey{Name: "user-2"}, Cells: [][]byte{[]byte("User Two")}},
+					},
+				},
+				TotalHits: 2,
+			},
+		},
+	}
+}
+
+func TestAccessControl(t *testing.T) {
+	partialClient := &mockAccessClient{
+		batchCheckFunc: func(_ context.Context, _ authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+			allowed := map[string]bool{
+				"org.users:read":         true,
+				"users.permissions:read": true,
+				"users.roles:read":       true,
+			}
+			results := make(map[string]authlib.BatchCheckResult, len(req.Checks))
+			for _, check := range req.Checks {
+				for _, c := range userAccessControlChecks {
+					if c.group == check.Group && c.resource == check.Resource && c.verb == check.Verb {
+						results[check.CorrelationID] = authlib.BatchCheckResult{Allowed: allowed[c.action]}
+						break
+					}
+				}
+			}
+			return authlib.BatchCheckResponse{Results: results}, nil
+		},
+	}
+
+	errorClient := &mockAccessClient{
+		batchCheckFunc: func(_ context.Context, _ authlib.AuthInfo, _ authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+			return authlib.BatchCheckResponse{}, fmt.Errorf("access service unavailable")
+		},
+	}
+
+	tests := []struct {
+		name      string
+		url       string
+		client    authlib.AccessClient
+		checkHits func(t *testing.T, hits []iamv0.GetSearchUsersUserHit)
+	}{
+		{
+			name:   "param absent - no access control on hits",
+			url:    "/searchUsers",
+			client: authlib.FixedAccessClient(true),
+			checkHits: func(t *testing.T, hits []iamv0.GetSearchUsersUserHit) {
+				t.Helper()
+				for _, hit := range hits {
+					assert.Nil(t, hit.AccessControl)
+				}
+			},
+		},
+		{
+			name:   "param false - no access control on hits",
+			url:    "/searchUsers?accesscontrol=false",
+			client: authlib.FixedAccessClient(true),
+			checkHits: func(t *testing.T, hits []iamv0.GetSearchUsersUserHit) {
+				t.Helper()
+				for _, hit := range hits {
+					assert.Nil(t, hit.AccessControl)
+				}
+			},
+		},
+		{
+			name:   "all allowed",
+			url:    "/searchUsers?accesscontrol=true",
+			client: authlib.FixedAccessClient(true),
+			checkHits: func(t *testing.T, hits []iamv0.GetSearchUsersUserHit) {
+				t.Helper()
+				for _, hit := range hits {
+					require.NotNil(t, hit.AccessControl)
+					for _, c := range userAccessControlChecks {
+						assert.True(t, hit.AccessControl[c.action], "expected %s to be allowed", c.action)
+					}
+				}
+			},
+		},
+		{
+			name:   "all denied - empty map on hits",
+			url:    "/searchUsers?accesscontrol=true",
+			client: authlib.FixedAccessClient(false),
+			checkHits: func(t *testing.T, hits []iamv0.GetSearchUsersUserHit) {
+				t.Helper()
+				for _, hit := range hits {
+					assert.Empty(t, hit.AccessControl)
+				}
+			},
+		},
+		{
+			name:   "partial permissions",
+			url:    "/searchUsers?accesscontrol=true",
+			client: partialClient,
+			checkHits: func(t *testing.T, hits []iamv0.GetSearchUsersUserHit) {
+				t.Helper()
+				for _, hit := range hits {
+					require.NotNil(t, hit.AccessControl)
+					assert.True(t, hit.AccessControl["org.users:read"])
+					assert.True(t, hit.AccessControl["users.permissions:read"])
+					assert.True(t, hit.AccessControl["users.roles:read"])
+					assert.False(t, hit.AccessControl["org.users:add"])
+					assert.False(t, hit.AccessControl["org.users:remove"])
+					assert.False(t, hit.AccessControl["org.users:write"])
+				}
+			},
+		},
+		{
+			name:   "access service error - graceful degradation, empty map on hits",
+			url:    "/searchUsers?accesscontrol=true",
+			client: errorClient,
+			checkHits: func(t *testing.T, hits []iamv0.GetSearchUsersUserHit) {
+				t.Helper()
+				for _, hit := range hits {
+					assert.Empty(t, hit.AccessControl)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			searchHandler := NewSearchHandler(
+				tracing.NewNoopTracerService(),
+				mockClientWithHits(),
+				featuremgmt.WithFeatures(),
+				&setting.Cfg{},
+				tc.client,
+			)
+
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", tc.url, nil)
+			req.Header.Add("content-type", "application/json")
+			req = req.WithContext(identity.WithRequester(req.Context(), &legacyuser.SignedInUser{Namespace: "default"}))
+
+			searchHandler.DoSearch(rr, req)
+
+			require.Equal(t, 200, rr.Code)
+
+			var resp iamv0.GetSearchUsersResponse
+			require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+			require.Len(t, resp.Hits, 2)
+			tc.checkHits(t, resp.Hits)
+		})
+	}
+}
+
+type mockAccessClient struct {
+	batchCheckFunc func(ctx context.Context, info authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error)
+}
+
+func (m *mockAccessClient) Check(_ context.Context, _ authlib.AuthInfo, req authlib.CheckRequest, _ string) (authlib.CheckResponse, error) {
+	return authlib.CheckResponse{}, nil
+}
+
+func (m *mockAccessClient) Compile(_ context.Context, _ authlib.AuthInfo, _ authlib.ListRequest) (authlib.ItemChecker, authlib.Zookie, error) {
+	return nil, nil, nil
+}
+
+func (m *mockAccessClient) BatchCheck(ctx context.Context, info authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+	if m.batchCheckFunc != nil {
+		return m.batchCheckFunc(ctx, info, req)
+	}
+	return authlib.BatchCheckResponse{}, nil
 }
 
 func TestEscapeBleveQuery(t *testing.T) {

--- a/pkg/registry/apis/iam/user/search_test.go
+++ b/pkg/registry/apis/iam/user/search_test.go
@@ -194,6 +194,25 @@ func TestAccessControl(t *testing.T) {
 		},
 	}
 
+	perUserClient := &mockAccessClient{
+		batchCheckFunc: func(_ context.Context, _ authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+			results := make(map[string]authlib.BatchCheckResult, len(req.Checks))
+			for _, check := range req.Checks {
+				allowed := false
+				for _, c := range userAccessControlChecks {
+					if c.group == check.Group && c.resource == check.Resource && c.verb == check.Verb {
+						if check.Name == "user-1" {
+							allowed = c.action == "org.users:read" || c.action == "org.users:write"
+						}
+						break
+					}
+				}
+				results[check.CorrelationID] = authlib.BatchCheckResult{Allowed: allowed}
+			}
+			return authlib.BatchCheckResponse{Results: results}, nil
+		},
+	}
+
 	errorClient := &mockAccessClient{
 		batchCheckFunc: func(_ context.Context, _ authlib.AuthInfo, _ authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
 			return authlib.BatchCheckResponse{}, fmt.Errorf("access service unavailable")
@@ -267,6 +286,25 @@ func TestAccessControl(t *testing.T) {
 					assert.False(t, hit.AccessControl["org.users:add"])
 					assert.False(t, hit.AccessControl["org.users:remove"])
 					assert.False(t, hit.AccessControl["org.users:write"])
+				}
+			},
+		},
+		{
+			name:   "per-user scoped permissions",
+			url:    "/searchUsers?accesscontrol=true",
+			client: perUserClient,
+			checkHits: func(t *testing.T, hits []iamv0.GetSearchUsersUserHit) {
+				t.Helper()
+				for _, hit := range hits {
+					if hit.Name == "user-1" {
+						require.NotNil(t, hit.AccessControl)
+						assert.True(t, hit.AccessControl["org.users:read"])
+						assert.True(t, hit.AccessControl["org.users:write"])
+						assert.False(t, hit.AccessControl["org.users:add"])
+						assert.False(t, hit.AccessControl["org.users:remove"])
+					} else {
+						assert.Empty(t, hit.AccessControl, "user-2 should have no permissions")
+					}
 				}
 			},
 		},

--- a/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
@@ -1055,6 +1055,14 @@
             "example": 0
           },
           {
+            "name": "accesscontrol",
+            "in": "query",
+            "description": "when true, includes access control metadata in the response",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "sort",
             "in": "query",
             "description": "sortable field",


### PR DESCRIPTION
Add support for accesscontrol in new api

<img width="859" height="773" alt="image" src="https://github.com/user-attachments/assets/9721eede-fe0c-42c7-a8e8-c58477a5ba7b" />

Relates to https://github.com/grafana/identity-access-team/issues/1876
