### PR TITLE
Suggested Dashboards: Add `featureVariant` to loaded and item click events

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/BasicProvisionedDashboardsEmptyPage.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/BasicProvisionedDashboardsEmptyPage.tsx
@@ -12,9 +12,9 @@ import { DASHBOARD_LIBRARY_ROUTES } from '../types';
 
 import { fetchProvisionedDashboards } from './api/dashboardLibraryApi';
 import {
+  BasicProvisionedDashboardInteractions,
   CONTENT_KINDS,
   CREATION_ORIGINS,
-  DashboardLibraryInteractions,
   DISCOVERY_METHODS,
   EVENT_LOCATIONS,
   SOURCE_ENTRY_POINTS,
@@ -41,7 +41,7 @@ export const BasicProvisionedDashboardsEmptyPage = ({ datasourceUid }: Props) =>
     const dashboards = await fetchProvisionedDashboards(ds.type);
 
     if (dashboards.length > 0) {
-      DashboardLibraryInteractions.loaded({
+      BasicProvisionedDashboardInteractions.loaded({
         numberOfItems: dashboards.length,
         contentKinds: [CONTENT_KINDS.DATASOURCE_DASHBOARD],
         datasourceTypes: [ds.type],
@@ -59,7 +59,7 @@ export const BasicProvisionedDashboardsEmptyPage = ({ datasourceUid }: Props) =>
   const styles = useStyles2(getStyles);
 
   const onImportDashboardClick = async (dashboard: PluginDashboard) => {
-    DashboardLibraryInteractions.itemClicked({
+    BasicProvisionedDashboardInteractions.itemClicked({
       contentKind: CONTENT_KINDS.DATASOURCE_DASHBOARD,
       datasourceTypes: [dashboard.pluginId],
       libraryItemId: dashboard.uid,

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboards.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboards.tsx
@@ -15,10 +15,10 @@ import { fetchCommunityDashboards, fetchProvisionedDashboards } from './api/dash
 import {
   CONTENT_KINDS,
   CREATION_ORIGINS,
-  DashboardLibraryInteractions,
   DISCOVERY_METHODS,
   EVENT_LOCATIONS,
   SOURCE_ENTRY_POINTS,
+  SuggestedDashboardInteractions,
 } from './interactions';
 import { GnetDashboard } from './types';
 import {
@@ -164,7 +164,7 @@ export const SuggestedDashboards = ({ datasourceUid }: Props) => {
         ),
       ];
 
-      DashboardLibraryInteractions.loaded({
+      SuggestedDashboardInteractions.loaded({
         numberOfItems: result.dashboards.length,
         contentKinds,
         datasourceTypes: [datasourceType],
@@ -209,7 +209,7 @@ export const SuggestedDashboards = ({ datasourceUid }: Props) => {
       return;
     }
 
-    DashboardLibraryInteractions.itemClicked({
+    SuggestedDashboardInteractions.itemClicked({
       contentKind: CONTENT_KINDS.DATASOURCE_DASHBOARD,
       datasourceTypes: [ds.type],
       libraryItemId: dashboard.uid,
@@ -247,7 +247,7 @@ export const SuggestedDashboards = ({ datasourceUid }: Props) => {
       }
 
       // Track item click
-      DashboardLibraryInteractions.itemClicked({
+      SuggestedDashboardInteractions.itemClicked({
         contentKind: CONTENT_KINDS.COMMUNITY_DASHBOARD,
         datasourceTypes: [ds.type],
         libraryItemId: String(dashboard.id),

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/interactions.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/interactions.ts
@@ -43,12 +43,21 @@ export const CREATION_ORIGINS = {
   DASHBOARD_LIBRARY_TEMPLATE_DASHBOARD: 'dashboard_library_template_dashboard',
 } as const;
 
+// Which experiment variant the user saw on the empty dashboard page:
+// - SUGGESTED_DASHBOARDS: inline cards with provisioned + community dashboards (suggestedDashboards + dashboardLibrary flags)
+// - BASIC_PROVISIONED_DASHBOARDS: provisioned dashboards only (dashboardLibrary flag, no suggestedDashboards)
+export const FEATURE_VARIANTS = {
+  SUGGESTED_DASHBOARDS: 'suggested_dashboards',
+  BASIC_PROVISIONED_DASHBOARDS: 'basic_provisioned_dashboards',
+} as const;
+
 // Derive types from constant maps for single source of truth
 export type EventLocation = (typeof EVENT_LOCATIONS)[keyof typeof EVENT_LOCATIONS];
 export type ContentKind = (typeof CONTENT_KINDS)[keyof typeof CONTENT_KINDS];
 export type SourceEntryPoint = (typeof SOURCE_ENTRY_POINTS)[keyof typeof SOURCE_ENTRY_POINTS];
 export type DiscoveryMethod = (typeof DISCOVERY_METHODS)[keyof typeof DISCOVERY_METHODS];
 export type CreationOrigin = (typeof CREATION_ORIGINS)[keyof typeof CREATION_ORIGINS];
+export type FeatureVariant = (typeof FEATURE_VARIANTS)[keyof typeof FEATURE_VARIANTS];
 
 type LoadedInteractionProperties = {
   numberOfItems: number;
@@ -173,6 +182,38 @@ export const TemplateDashboardInteractions = {
       ...properties,
       isDashboardTemplatesAssistantEnabled:
         isDashboardTemplatesAssistantButtonEnabled && isDashboardTemplatesAssistantToolEnabled,
+    });
+  },
+};
+
+export const SuggestedDashboardInteractions = {
+  ...DashboardLibraryInteractions,
+  loaded: (properties: LoadedInteractionProperties) => {
+    reportDashboardLibraryInteraction('loaded', {
+      ...properties,
+      featureVariant: FEATURE_VARIANTS.SUGGESTED_DASHBOARDS,
+    });
+  },
+  itemClicked: (properties: ItemClickedInteractionProperties) => {
+    reportDashboardLibraryInteraction('item_clicked', {
+      ...properties,
+      featureVariant: FEATURE_VARIANTS.SUGGESTED_DASHBOARDS,
+    });
+  },
+};
+
+export const BasicProvisionedDashboardInteractions = {
+  ...DashboardLibraryInteractions,
+  loaded: (properties: LoadedInteractionProperties) => {
+    reportDashboardLibraryInteraction('loaded', {
+      ...properties,
+      featureVariant: FEATURE_VARIANTS.BASIC_PROVISIONED_DASHBOARDS,
+    });
+  },
+  itemClicked: (properties: ItemClickedInteractionProperties) => {
+    reportDashboardLibraryInteraction('item_clicked', {
+      ...properties,
+      featureVariant: FEATURE_VARIANTS.BASIC_PROVISIONED_DASHBOARDS,
     });
   },
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When working on our feature analytics dashboards, I noticed we don't know which experiment variant the user sees on the empty dashboard page (currently it's using heuristics based on content kind, but they are not exact)

> SUGGESTED_DASHBOARDS: inline cards with provisioned + community dashboards (`suggestedDashboards + dashboardLibrary` flags)
> 
> BASIC_PROVISIONED_DASHBOARDS: provisioned dashboards only (`dashboardLibrary` flag, no `suggestedDashboards`)

I added new property called `featureVariant` to this events `grafana_dashboard_library_loaded` and `grafana_dashboard_library_item_clicked`

Values: `basic_provisioned_dashboards` and `suggested_dashboards`. 

**Why do we need this feature?**

Better analytics to make informed decisions


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
I created new `BasicProvisionedDashboardInteractions` and `SuggestedDashboardInteractions` interaction objects to automatically enrich events with the correct featureVariant (followed the same pattern as `TemplateDashboardInteractions`)

