### PR TITLE
IAM: Add field selectors (spec.email, spec.login) for User resource

### DIFF
--- a/apps/iam/kinds/externalgroupmapping.cue
+++ b/apps/iam/kinds/externalgroupmapping.cue
@@ -17,7 +17,7 @@ externalGroupMappingv0alpha1: externalGroupMappingKind & {
 	schema: {
 		spec: v0alpha1.ExternalGroupMappingSpec
 	}
-	SelectableFields: [
+	selectableFields: [
 		"spec.teamRef.name",
 		"spec.externalGroupId",
 	]

--- a/apps/iam/kinds/teambinding.cue
+++ b/apps/iam/kinds/teambinding.cue
@@ -17,9 +17,9 @@ teambindingv0alpha1: teambindingKind & {
 	schema: {
 		spec: v0alpha1.TeamBindingSpec
 	}
-	SelectableFields: [
+	selectableFields: [
 		"spec.teamRef.name",
 		"spec.subject.name",
 		"spec.external",
-	],
+	]
 }

--- a/apps/iam/kinds/user.cue
+++ b/apps/iam/kinds/user.cue
@@ -14,25 +14,16 @@ userKind: {
 }
 
 userv0alpha1: userKind & {
-	// TODO: Uncomment this when User will be added to ManagedKinds 
-	// validation: {
-	// 	operations: [
-	// 		"CREATE",
-	// 		"UPDATE",
-	// 	]
-	// }
-	// mutation: {
-	// 	operations: [
-	// 		"CREATE",
-	// 		"UPDATE",
-	// 	]
-	// }
 	schema: {
 		spec: v0alpha1.UserSpec
 		status: {
 			lastSeenAt: int64 | 0
 		}
 	}
+	selectableFields: [
+		"spec.email",
+		"spec.login",
+	]
 	routes: {
 		"/teams": {
 			"GET": {

--- a/apps/iam/pkg/apis/iam/v0alpha1/register.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/register.go
@@ -424,6 +424,12 @@ func AddAuthNKnownTypes(scheme *runtime.Scheme) error {
 	if err != nil {
 		return err
 	}
+
+	// Enable field selectors for User
+	err = fieldselectors.AddSelectableFieldLabelConversions(scheme, SchemeGroupVersion, UserKind())
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/apps/iam/pkg/apis/iam/v0alpha1/user_schema_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/user_schema_gen.go
@@ -5,13 +5,37 @@
 package v0alpha1
 
 import (
+	"errors"
+
 	"github.com/grafana/grafana-app-sdk/resource"
 )
 
 // schema is unexported to prevent accidental overwrites
 var (
 	schemaUser = resource.NewSimpleSchema("iam.grafana.app", "v0alpha1", NewUser(), &UserList{}, resource.WithKind("User"),
-		resource.WithPlural("users"), resource.WithScope(resource.NamespacedScope))
+		resource.WithPlural("users"), resource.WithScope(resource.NamespacedScope), resource.WithSelectableFields([]resource.SelectableField{{
+			FieldSelector: "spec.email",
+			FieldValueFunc: func(o resource.Object) (string, error) {
+				cast, ok := o.(*User)
+				if !ok {
+					return "", errors.New("provided object must be of type *User")
+				}
+
+				return cast.Spec.Email, nil
+			},
+		},
+			{
+				FieldSelector: "spec.login",
+				FieldValueFunc: func(o resource.Object) (string, error) {
+					cast, ok := o.(*User)
+					if !ok {
+						return "", errors.New("provided object must be of type *User")
+					}
+
+					return cast.Spec.Login, nil
+				},
+			},
+		}))
 	kindUser = resource.Kind{
 		Schema: schemaUser,
 		Codecs: map[resource.KindEncoding]resource.Codec{

--- a/apps/iam/pkg/apis/iam_manifest.go
+++ b/apps/iam/pkg/apis/iam_manifest.go
@@ -74,6 +74,10 @@ var appManifestData = app.ManifestData{
 					Plural:     "Users",
 					Scope:      "Namespaced",
 					Conversion: false,
+					SelectableFields: []string{
+						"spec.email",
+						"spec.login",
+					},
 					Routes: map[string]spec3.PathProps{
 						"/teams": {
 							Get: &spec3.Operation{

--- a/pkg/registry/apis/iam/legacy/sql_test.go
+++ b/pkg/registry/apis/iam/legacy/sql_test.go
@@ -196,6 +196,20 @@ func TestIdentityQueries(t *testing.T) {
 						},
 					}),
 				},
+				{
+					Name: "users_email",
+					Data: listUsers(&ListUserQuery{
+						Email:      "test@example.com",
+						Pagination: common.Pagination{Limit: 5},
+					}),
+				},
+				{
+					Name: "users_login",
+					Data: listUsers(&ListUserQuery{
+						Login:      "testuser",
+						Pagination: common.Pagination{Limit: 5},
+					}),
+				},
 			},
 			sqlQueryDisplayTemplate: {
 				{

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--users_query-users_email.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--users_query-users_email.sql
@@ -1,0 +1,9 @@
+SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name,
+  u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin,
+  u.email_verified, u.is_provisioned, u.last_seen_at, o.role
+  FROM `grafana`.`user` as u JOIN `grafana`.`org_user` as o ON u.id = o.user_id
+ WHERE o.org_id = 0
+   AND NOT u.is_service_account
+   AND u.email = 'test@example.com'
+ ORDER BY u.id asc
+ LIMIT 5

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--users_query-users_login.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--users_query-users_login.sql
@@ -1,0 +1,9 @@
+SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name,
+  u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin,
+  u.email_verified, u.is_provisioned, u.last_seen_at, o.role
+  FROM `grafana`.`user` as u JOIN `grafana`.`org_user` as o ON u.id = o.user_id
+ WHERE o.org_id = 0
+   AND NOT u.is_service_account
+   AND u.login = 'testuser'
+ ORDER BY u.id asc
+ LIMIT 5

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--users_query-users_email.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--users_query-users_email.sql
@@ -1,0 +1,9 @@
+SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name,
+  u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin,
+  u.email_verified, u.is_provisioned, u.last_seen_at, o.role
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
+ WHERE o.org_id = 0
+   AND NOT u.is_service_account
+   AND u.email = 'test@example.com'
+ ORDER BY u.id asc
+ LIMIT 5

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--users_query-users_login.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--users_query-users_login.sql
@@ -1,0 +1,9 @@
+SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name,
+  u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin,
+  u.email_verified, u.is_provisioned, u.last_seen_at, o.role
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
+ WHERE o.org_id = 0
+   AND NOT u.is_service_account
+   AND u.login = 'testuser'
+ ORDER BY u.id asc
+ LIMIT 5

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--users_query-users_email.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--users_query-users_email.sql
@@ -1,0 +1,9 @@
+SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name,
+  u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin,
+  u.email_verified, u.is_provisioned, u.last_seen_at, o.role
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
+ WHERE o.org_id = 0
+   AND NOT u.is_service_account
+   AND u.email = 'test@example.com'
+ ORDER BY u.id asc
+ LIMIT 5

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--users_query-users_login.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--users_query-users_login.sql
@@ -1,0 +1,9 @@
+SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name,
+  u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin,
+  u.email_verified, u.is_provisioned, u.last_seen_at, o.role
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
+ WHERE o.org_id = 0
+   AND NOT u.is_service_account
+   AND u.login = 'testuser'
+ ORDER BY u.id asc
+ LIMIT 5

--- a/pkg/registry/apis/iam/legacy/user.go
+++ b/pkg/registry/apis/iam/legacy/user.go
@@ -93,6 +93,8 @@ func (s *legacySQLStore) GetUserInternalID(ctx context.Context, ns claims.Namesp
 type ListUserQuery struct {
 	OrgID int64
 	UID   string
+	Email string
+	Login string
 
 	Pagination common.Pagination
 }

--- a/pkg/registry/apis/iam/legacy/users_query.sql
+++ b/pkg/registry/apis/iam/legacy/users_query.sql
@@ -7,6 +7,12 @@ SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name,
 {{ if .Query.UID }}
    AND u.uid = {{ .Arg .Query.UID }}
 {{ end }}
+{{ if .Query.Email }}
+   AND u.email = {{ .Arg .Query.Email }}
+{{ end }}
+{{ if .Query.Login }}
+   AND u.login = {{ .Arg .Query.Login }}
+{{ end }}
 {{ if .Query.Pagination.Continue }}
    AND u.id >= {{ .Arg .Query.Pagination.Continue }}
 {{ end }}

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -472,7 +472,11 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateTeamBindingsAPIGroup(opts bui
 
 func (b *IdentityAccessManagementAPIBuilder) UpdateUsersAPIGroup(opts builder.APIGroupOptions, storage map[string]rest.Storage, enableZanzanaSync bool) error {
 	userResource := iamv0.UserResourceInfo
-	userUniStore, err := grafanaregistry.NewRegistryStore(opts.Scheme, userResource, opts.OptsGetter)
+
+	userSelectableFieldsOpts := grafanaregistry.SelectableFieldsOptions{
+		GetAttrs: fieldselectors.BuildGetAttrsFn(iamv0.UserKind()),
+	}
+	userUniStore, err := grafanaregistry.NewRegistryStoreWithSelectableFields(opts.Scheme, userResource, opts.OptsGetter, userSelectableFieldsOpts)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/unified/search/builders/testdata/doc/user-with-last-seen-at-and-role-out.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/user-with-last-seen-at-and-role-out.json
@@ -12,5 +12,9 @@
     "lastSeenAt": 1698321600,
     "login": "user.three",
     "role": "Editor"
+  },
+  "selectableFields": {
+    "spec.email": "user.three@test.com",
+    "spec.login": "user.three"
   }
 }

--- a/pkg/storage/unified/search/builders/testdata/doc/user-with-login-and-email-out.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/user-with-login-and-email-out.json
@@ -12,5 +12,9 @@
     "lastSeenAt": 0,
     "login": "user.one",
     "role": "Viewer"
+  },
+  "selectableFields": {
+    "spec.email": "user.one@test.com",
+    "spec.login": "user.one"
   }
 }

--- a/pkg/storage/unified/search/builders/testdata/doc/user-with-login-only-out.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/user-with-login-only-out.json
@@ -11,5 +11,8 @@
     "lastSeenAt": 0,
     "login": "user.two",
     "role": "Viewer"
+  },
+  "selectableFields": {
+    "spec.login": "user.two"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `spec.email` and `spec.login` as selectable fields for the IAM `User` resource, following the same pattern as ExternalGroupMapping (#118277)
- Updates the legacy SQL store to pass email/login filters through to the database query
- Adds integration tests covering field selector behavior across all dual-writer modes (0–5)

## Changes
- `apps/iam/kinds/user.cue`: Added `SelectableFields` with `spec.email` and `spec.login`
- `apps/iam/pkg/apis/iam/v0alpha1/user_schema_gen.go`: Added `resource.WithSelectableFields` with field value functions
- `apps/iam/pkg/apis/iam/v0alpha1/register.go`: Registered field label conversions via `fieldselectors.AddSelectableFieldLabelConversions`
- `pkg/registry/apis/iam/register.go`: Updated user store creation to use `NewRegistryStoreWithSelectableFields`
- `pkg/registry/apis/iam/legacy/user.go`: Added `Email` and `Login` fields to `ListUserQuery`
- `pkg/registry/apis/iam/legacy/users_query.sql`: Added conditional WHERE clauses for email and login filters
- `pkg/registry/apis/iam/user/store.go`: Added field selector extraction in `List` method
- `pkg/registry/apis/iam/legacy/sql_test.go`: Added test cases for email and login SQL query snapshots
- `pkg/tests/apis/iam/user_integration_test.go`: Added `doUserFieldSelectorTests` integration test function

## Test plan
- [x] Unit tests pass: `go test ./pkg/registry/apis/iam/...`
- [x] Integration tests pass across all modes (0–5): `go test ./pkg/tests/apis/iam/ -run TestIntegrationUsers`
- [x] Field selector by `spec.email` returns exactly the matching user
- [x] Field selector by `spec.login` returns exactly the matching user
- [x] Field selector with non-existent value returns empty list

🤖 Generated with [Claude Code](https://claude.com/claude-code)