### PR TITLE
Alerting: Use broadcast queue size config for Redis HA backend

### DIFF
--- a/pkg/services/ngalert/notifier/redis_channel.go
+++ b/pkg/services/ngalert/notifier/redis_channel.go
@@ -6,6 +6,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 	alertingCluster "github.com/grafana/alerting/cluster"
 	alertingClusterPB "github.com/grafana/alerting/cluster/clusterpb"
+
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type RedisChannel struct {
@@ -16,14 +18,16 @@ type RedisChannel struct {
 	msgc    chan []byte
 }
 
-func newRedisChannel(p *redisPeer, key, channel, msgType string) alertingCluster.ClusterChannel {
+func newRedisChannel(p *redisPeer, key, channel, msgType string, queueSize int) alertingCluster.ClusterChannel {
+	if queueSize <= 0 {
+		queueSize = setting.AlertBroadcastDefaultQueueSize
+	}
 	redisChannel := &RedisChannel{
 		p:       p,
 		key:     key,
 		channel: channel,
 		msgType: msgType,
-		// The buffer size of 200 was taken from the Memberlist implementation.
-		msgc: make(chan []byte, 200),
+		msgc:    make(chan []byte, queueSize),
 	}
 	go redisChannel.handleMessages()
 	return redisChannel

--- a/pkg/services/ngalert/notifier/redis_channel_test.go
+++ b/pkg/services/ngalert/notifier/redis_channel_test.go
@@ -24,8 +24,17 @@ func TestNewRedisChannel(t *testing.T) {
 		redis: rdb,
 	}
 
-	channel := newRedisChannel(p, "testKey", "testChannel", "testType")
-	require.NotNil(t, channel)
+	t.Run("default queue size when 0 is passed", func(t *testing.T) {
+		channel := newRedisChannel(p, "testKey", "testChannel", "testType", 0)
+		require.NotNil(t, channel)
+		require.Equal(t, 200, cap(channel.(*RedisChannel).msgc))
+	})
+
+	t.Run("custom queue size", func(t *testing.T) {
+		channel := newRedisChannel(p, "testKey", "testChannel", "testType", 500)
+		require.NotNil(t, channel)
+		require.Equal(t, 500, cap(channel.(*RedisChannel).msgc))
+	})
 }
 
 func TestBroadcastAndHandleMessages(t *testing.T) {
@@ -47,7 +56,7 @@ func TestBroadcastAndHandleMessages(t *testing.T) {
 		messagesSentSize: prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{update}),
 	}
 
-	channel := newRedisChannel(p, "testKey", channelName, "testType").(*RedisChannel)
+	channel := newRedisChannel(p, "testKey", channelName, "testType", 0).(*RedisChannel)
 
 	pubSub := rdb.Subscribe(context.Background(), channelName)
 	msgs := pubSub.Channel()

--- a/pkg/services/ngalert/notifier/redis_peer.go
+++ b/pkg/services/ngalert/notifier/redis_peer.go
@@ -459,7 +459,7 @@ func (p *redisPeer) Settle(ctx context.Context, interval time.Duration) {
 	close(p.readyc)
 }
 
-func (p *redisPeer) AddState(key string, state alertingCluster.State, _ prometheus.Registerer, _ ...alertingCluster.ChannelOption) alertingCluster.ClusterChannel {
+func (p *redisPeer) AddState(key string, state alertingCluster.State, _ prometheus.Registerer, opts ...alertingCluster.ChannelOption) alertingCluster.ClusterChannel {
 	p.statesMtx.Lock()
 	defer p.statesMtx.Unlock()
 	p.states[key] = state
@@ -469,7 +469,8 @@ func (p *redisPeer) AddState(key string, state alertingCluster.State, _ promethe
 	p.subsMtx.Lock()
 	p.subs[key] = sub
 	p.subsMtx.Unlock()
-	return newRedisChannel(p, key, p.withPrefix(key), update)
+	resolved := alertingCluster.ResolveOptions(opts...)
+	return newRedisChannel(p, key, p.withPrefix(key), update, resolved.QueueSize)
 }
 
 func (p *redisPeer) receiveLoop(channel *redis.PubSub) {


### PR DESCRIPTION
**What is this feature?**

Wire `ha_single_evaluation_alert_broadcast_queue_size` config to the Redis HA backend. Previously this setting only applied to the Memberlist (gossip) path and the Redis channel hardcoded a buffer of 200. `redisPeer.AddState` now uses `alertingCluster.ResolveOptions` to extract queue size from `ChannelOption` values, matching how the gossip peer works.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/116545

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
