### PR TITLE
fix: log storage mode comparison in static dual writer

### DIFF
--- a/pkg/services/apiserver/appinstaller/storage.go
+++ b/pkg/services/apiserver/appinstaller/storage.go
@@ -36,6 +36,10 @@ func NewDualWriter(
 
 	builderMetrics.RecordDualWriterModes(gr.Resource, gr.Group, mode)
 
+	if dualWriteService != nil {
+		dualWriteService.LogStorageModeComparison(gr, mode)
+	}
+
 	switch mode {
 	case grafanarest.Mode0:
 		return legacy, nil

--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -305,6 +305,10 @@ func InstallAPIs(
 
 			builderMetrics.RecordDualWriterModes(gr.Resource, gr.Group, mode)
 
+			if dualWriteService != nil {
+				dualWriteService.LogStorageModeComparison(gr, mode)
+			}
+
 			switch mode {
 			case grafanarest.Mode0:
 				return legacy, nil

--- a/pkg/storage/legacysql/dualwrite/mock.go
+++ b/pkg/storage/legacysql/dualwrite/mock.go
@@ -57,3 +57,6 @@ func (m *mockService) Status(ctx context.Context, gr schema.GroupResource) (Stor
 func (m *mockService) Update(ctx context.Context, status StorageStatus) (StorageStatus, error) {
 	return m.status, fmt.Errorf("not implemented")
 }
+
+// LogStorageModeComparison implements Service.
+func (m *mockService) LogStorageModeComparison(_ schema.GroupResource, _ rest.DualWriterMode) {}

--- a/pkg/storage/legacysql/dualwrite/service.go
+++ b/pkg/storage/legacysql/dualwrite/service.go
@@ -297,6 +297,30 @@ func (m *service) logStorageModeComparison(gr schema.GroupResource, status Stora
 	)
 }
 
+// LogStorageModeComparison implements Service.
+func (m *service) LogStorageModeComparison(gr schema.GroupResource, configMode rest.DualWriterMode) {
+	if m.statusReader == nil {
+		return
+	}
+	newMode, err := m.statusReader.GetStorageMode(context.Background(), gr)
+	if err != nil {
+		logger.Warn("Failed to get storage mode from MigrationStatusReader",
+			"resource", gr.String(), "error", err)
+		return
+	}
+
+	currentMode := storageModeFromConfigMode(configMode)
+	if currentMode != newMode && m.metrics != nil {
+		m.metrics.ModeMismatchCounter.WithLabelValues(gr.String(), currentMode.String(), newMode.String()).Inc()
+	}
+
+	logger.Info("Storage mode comparison",
+		"resource", gr.String(),
+		"newMode", newMode.String(),
+		"currentMode", currentMode.String(),
+	)
+}
+
 // storageModeFromStatus derives a StorageMode from the current StorageStatus.
 func storageModeFromStatus(status StorageStatus) unifiedmigrations.StorageMode {
 	if status.ReadUnified && status.WriteUnified && !status.WriteLegacy {

--- a/pkg/storage/legacysql/dualwrite/service.go
+++ b/pkg/storage/legacysql/dualwrite/service.go
@@ -134,7 +134,7 @@ func (m *service) NewStorage(gr schema.GroupResource, legacy rest.Storage, unifi
 		return nil, err
 	}
 
-	m.logStorageModeComparison(gr, status)
+	logModeComparison(m.statusReader, m.metrics, gr, storageModeFromStatus(status))
 
 	if m.enabled && status.Runtime {
 		// Dynamic storage behavior
@@ -271,47 +271,26 @@ func (m *service) Update(ctx context.Context, status StorageStatus) (StorageStat
 	return status, m.db.set(ctx, status)
 }
 
-// logStorageModeComparison logs the storage mode from MigrationStatusReader alongside the
-// current status for observability. This allows validating that the new mode determination
-// agrees with the existing behavior before switching over in a future PR.
-func (m *service) logStorageModeComparison(gr schema.GroupResource, status StorageStatus) {
-	if m.statusReader == nil {
-		return
-	}
-	newMode, err := m.statusReader.GetStorageMode(context.Background(), gr)
-	if err != nil {
-		logger.Warn("Failed to get storage mode from MigrationStatusReader",
-			"resource", gr.String(), "error", err)
-		return
-	}
-
-	currentMode := storageModeFromStatus(status)
-	if currentMode != newMode && m.metrics != nil {
-		m.metrics.ModeMismatchCounter.WithLabelValues(gr.String(), currentMode.String(), newMode.String()).Inc()
-	}
-
-	logger.Info("Storage mode comparison",
-		"resource", gr.String(),
-		"newMode", newMode.String(),
-		"currentMode", currentMode.String(),
-	)
-}
-
 // LogStorageModeComparison implements Service.
 func (m *service) LogStorageModeComparison(gr schema.GroupResource, configMode rest.DualWriterMode) {
-	if m.statusReader == nil {
+	logModeComparison(m.statusReader, m.metrics, gr, storageModeFromConfigMode(configMode))
+}
+
+// logModeComparison compares currentMode with the mode from MigrationStatusReader
+// and emits metrics/logs for observability.
+func logModeComparison(statusReader unifiedmigrations.MigrationStatusReader, metrics *Metrics, gr schema.GroupResource, currentMode unifiedmigrations.StorageMode) {
+	if statusReader == nil {
 		return
 	}
-	newMode, err := m.statusReader.GetStorageMode(context.Background(), gr)
+	newMode, err := statusReader.GetStorageMode(context.Background(), gr)
 	if err != nil {
 		logger.Warn("Failed to get storage mode from MigrationStatusReader",
 			"resource", gr.String(), "error", err)
 		return
 	}
 
-	currentMode := storageModeFromConfigMode(configMode)
-	if currentMode != newMode && m.metrics != nil {
-		m.metrics.ModeMismatchCounter.WithLabelValues(gr.String(), currentMode.String(), newMode.String()).Inc()
+	if currentMode != newMode && metrics != nil {
+		metrics.ModeMismatchCounter.WithLabelValues(gr.String(), currentMode.String(), newMode.String()).Inc()
 	}
 
 	logger.Info("Storage mode comparison",

--- a/pkg/storage/legacysql/dualwrite/service_mock.go
+++ b/pkg/storage/legacysql/dualwrite/service_mock.go
@@ -24,6 +24,40 @@ func (_m *MockService) EXPECT() *MockService_Expecter {
 	return &MockService_Expecter{mock: &_m.Mock}
 }
 
+// LogStorageModeComparison provides a mock function with given fields: gr, configMode
+func (_m *MockService) LogStorageModeComparison(gr schema.GroupResource, configMode rest.DualWriterMode) {
+	_m.Called(gr, configMode)
+}
+
+// MockService_LogStorageModeComparison_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LogStorageModeComparison'
+type MockService_LogStorageModeComparison_Call struct {
+	*mock.Call
+}
+
+// LogStorageModeComparison is a helper method to define mock.On call
+//   - gr schema.GroupResource
+//   - configMode rest.DualWriterMode
+func (_e *MockService_Expecter) LogStorageModeComparison(gr interface{}, configMode interface{}) *MockService_LogStorageModeComparison_Call {
+	return &MockService_LogStorageModeComparison_Call{Call: _e.mock.On("LogStorageModeComparison", gr, configMode)}
+}
+
+func (_c *MockService_LogStorageModeComparison_Call) Run(run func(gr schema.GroupResource, configMode rest.DualWriterMode)) *MockService_LogStorageModeComparison_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(schema.GroupResource), args[1].(rest.DualWriterMode))
+	})
+	return _c
+}
+
+func (_c *MockService_LogStorageModeComparison_Call) Return() *MockService_LogStorageModeComparison_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockService_LogStorageModeComparison_Call) RunAndReturn(run func(schema.GroupResource, rest.DualWriterMode)) *MockService_LogStorageModeComparison_Call {
+	_c.Run(run)
+	return _c
+}
+
 // NewStorage provides a mock function with given fields: gr, legacy, storage
 func (_m *MockService) NewStorage(gr schema.GroupResource, legacy rest.Storage, storage rest.Storage) (rest.Storage, error) {
 	ret := _m.Called(gr, legacy, storage)

--- a/pkg/storage/legacysql/dualwrite/static.go
+++ b/pkg/storage/legacysql/dualwrite/static.go
@@ -65,26 +65,7 @@ func (m *staticService) NewStorage(gr schema.GroupResource, legacy rest.Storage,
 
 // LogStorageModeComparison implements Service.
 func (m *staticService) LogStorageModeComparison(gr schema.GroupResource, configMode rest.DualWriterMode) {
-	if m.statusReader == nil {
-		return
-	}
-	newMode, err := m.statusReader.GetStorageMode(context.Background(), gr)
-	if err != nil {
-		logger.Warn("Failed to get storage mode from MigrationStatusReader",
-			"resource", gr.String(), "error", err)
-		return
-	}
-
-	currentMode := storageModeFromConfigMode(configMode)
-	if currentMode != newMode && m.metrics != nil {
-		m.metrics.ModeMismatchCounter.WithLabelValues(gr.String(), currentMode.String(), newMode.String()).Inc()
-	}
-
-	logger.Info("Storage mode comparison",
-		"resource", gr.String(),
-		"newMode", newMode.String(),
-		"currentMode", currentMode.String(),
-	)
+	logModeComparison(m.statusReader, m.metrics, gr, storageModeFromConfigMode(configMode))
 }
 
 // storageModeFromConfigMode maps a DualWriterMode config value to a StorageMode.

--- a/pkg/storage/legacysql/dualwrite/static.go
+++ b/pkg/storage/legacysql/dualwrite/static.go
@@ -45,7 +45,7 @@ func (m *staticService) SetMode(gr schema.GroupResource, mode rest.DualWriterMod
 func (m *staticService) NewStorage(gr schema.GroupResource, legacy rest.Storage, unified rest.Storage) (rest.Storage, error) {
 	config := m.cfg.UnifiedStorage[gr.String()]
 
-	m.logStorageModeComparison(gr, config.DualWriterMode)
+	m.LogStorageModeComparison(gr, config.DualWriterMode)
 
 	switch config.DualWriterMode {
 	case rest.Mode1:
@@ -63,9 +63,8 @@ func (m *staticService) NewStorage(gr schema.GroupResource, legacy rest.Storage,
 	}
 }
 
-// logStorageModeComparison logs the storage mode from MigrationStatusReader alongside the
-// current config mode for observability.
-func (m *staticService) logStorageModeComparison(gr schema.GroupResource, configMode rest.DualWriterMode) {
+// LogStorageModeComparison implements Service.
+func (m *staticService) LogStorageModeComparison(gr schema.GroupResource, configMode rest.DualWriterMode) {
 	if m.statusReader == nil {
 		return
 	}

--- a/pkg/storage/legacysql/dualwrite/types.go
+++ b/pkg/storage/legacysql/dualwrite/types.go
@@ -69,6 +69,12 @@ type Service interface {
 
 	// change the status (finish migration etc)
 	Update(ctx context.Context, status StorageStatus) (StorageStatus, error)
+
+	// LogStorageModeComparison compares the config-based storage mode with the mode
+	// reported by MigrationStatusReader and emits metrics/logs for observability.
+	// This is used for non-managed resources that bypass NewStorage and go through
+	// NewStaticStorage directly.
+	LogStorageModeComparison(gr schema.GroupResource, configMode grafanarest.DualWriterMode)
 }
 
 type SearchAdapter struct {


### PR DESCRIPTION
Include the static dual writer mode comparisons. It was unfortunately missed in the previous PRs.

Ticket: https://github.com/grafana/search-and-storage-team/issues/661