### PR TITLE
Provisioning: Skip webhook creation for read-only repositories

### DIFF
--- a/apps/provisioning/pkg/repository/github/webhook.go
+++ b/apps/provisioning/pkg/repository/github/webhook.go
@@ -306,6 +306,10 @@ func (r *githubWebhookRepository) OnCreate(ctx context.Context) ([]map[string]in
 		return nil, nil
 	}
 
+	if len(r.config.Spec.Workflows) == 0 {
+		return nil, nil
+	}
+
 	ctx, _ = r.logger(ctx, "")
 	hook, err := r.createWebhook(ctx)
 	if err != nil {
@@ -335,6 +339,22 @@ func (r *githubWebhookRepository) OnUpdate(ctx context.Context) ([]map[string]in
 	if len(r.webhookURL) == 0 {
 		return nil, nil
 	}
+
+	if len(r.config.Spec.Workflows) == 0 {
+		if r.config.Status.Webhook != nil {
+			ctx, _ = r.logger(ctx, "")
+			if err := r.deleteWebhook(ctx); err != nil {
+				return nil, err
+			}
+			return []map[string]any{{
+				"op":    "replace",
+				"path":  "/status/webhook",
+				"value": nil,
+			}}, nil
+		}
+		return nil, nil
+	}
+
 	ctx, _ = r.logger(ctx, "")
 	hook, changed, err := r.updateWebhook(ctx)
 	if err != nil || !changed {

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -697,6 +697,33 @@ func TestIntegrationProvisioning_CreatingGitHubRepository(t *testing.T) {
 	})
 }
 
+func TestIntegrationProvisioning_ReadOnlyRepositoryNoWebhook(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafana(t)
+	ctx := context.Background()
+
+	t.Run("repository with no workflows should not create a webhook", func(t *testing.T) {
+		repoName := "readonly-no-webhook"
+		input := helper.RenderObject(t, "testdata/github-readonly.json.tmpl", map[string]any{
+			"Name":        repoName,
+			"SyncEnabled": false,
+		})
+
+		_, err := helper.Repositories.Resource.Create(ctx, input, metav1.CreateOptions{})
+		require.NoError(t, err, "failed to create read-only repository")
+
+		helper.WaitForHealthyRepository(t, repoName)
+
+		repoObj, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		require.NoError(t, err, "failed to get repository")
+
+		repo := unstructuredToRepository(t, repoObj)
+		require.Empty(t, repo.Spec.Workflows, "repository should have no workflows (read-only)")
+		require.Nil(t, repo.Status.Webhook, "read-only repository should not have a webhook")
+	})
+}
+
 func TestIntegrationProvisioning_RepositoryLimits(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 


### PR DESCRIPTION
## Summary

- When a repository has no workflows configured (read-only), skip webhook creation on GitHub during `OnCreate`
- When workflows are removed from an existing repository during `OnUpdate`, delete the existing webhook and clear the status
- Adds unit tests covering all no-workflow webhook scenarios (create skip, update cleanup, update no-op)
- Adds integration test verifying read-only repositories have no webhook in their status

Closes https://github.com/grafana/git-ui-sync-project/issues/459

## Test plan

- [x] Unit tests pass: `go test ./apps/provisioning/pkg/repository/github/ -v`
- [x] Integration test compiles: `go vet ./pkg/tests/apis/provisioning/`
- [x] Run integration test: `go test ./pkg/tests/apis/provisioning/ -run TestIntegrationProvisioning_ReadOnlyRepositoryNoWebhook -v`

Made with [Cursor](https://cursor.com)