### PR TITLE
Query Editor: Expand collapsed query list when adding a query or expression

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -28,9 +28,10 @@ interface AddCardButtonProps {
   variant: 'query' | 'transformation';
   afterId?: string;
   alwaysVisible?: boolean;
+  onAdd?: () => void;
 }
 
-export const AddCardButton = ({ variant, afterId, alwaysVisible = false }: AddCardButtonProps) => {
+export const AddCardButton = ({ variant, afterId, alwaysVisible = false, onAdd }: AddCardButtonProps) => {
   const styles = useStyles2(getStyles, alwaysVisible);
   const theme = useTheme2();
   const { addQuery } = useActionsContext();
@@ -52,9 +53,10 @@ export const AddCardButton = ({ variant, afterId, alwaysVisible = false }: AddCa
       if (newRefId) {
         const selectTarget: DataQuery = { refId: newRefId, hide: false };
         setSelectedQuery(selectTarget);
+        onAdd?.();
       }
     },
-    [addQuery, afterId, setSelectedQuery]
+    [addQuery, afterId, setSelectedQuery, onAdd]
   );
 
   const handleMenuVisibleChange = useCallback((visible: boolean) => {
@@ -86,16 +88,18 @@ export const AddCardButton = ({ variant, afterId, alwaysVisible = false }: AddCa
           icon="calculator-alt"
           onClick={() => {
             setPendingExpression({ insertAfter: afterId ?? '' });
+            onAdd?.();
           }}
         />
       </Menu>
     ),
-    [addAndSelectQuery, canReadQueries, openDrawer, queryLibraryEnabled, setPendingExpression, afterId]
+    [addAndSelectQuery, canReadQueries, openDrawer, queryLibraryEnabled, setPendingExpression, afterId, onAdd]
   );
 
   const handleTransformationClick = useCallback(() => {
     setPendingTransformation({ insertAfter: afterId });
-  }, [afterId, setPendingTransformation]);
+    onAdd?.();
+  }, [afterId, setPendingTransformation, onAdd]);
 
   const ariaLabel = getButtonAriaLabel(variant, afterId);
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -31,7 +31,7 @@ interface AddCardButtonProps {
   onAdd?: () => void;
 }
 
-export const AddCardButton = ({ variant, afterId, alwaysVisible = false, onAdd }: AddCardButtonProps) => {
+export const AddCardButton = ({ variant, afterId, onAdd, alwaysVisible = false }: AddCardButtonProps) => {
   const styles = useStyles2(getStyles, alwaysVisible);
   const theme = useTheme2();
   const { addQuery } = useActionsContext();

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
@@ -98,6 +98,33 @@ describe('QueryEditorSidebar', () => {
     expect(screen.getByRole('button', { name: /select card organize/i })).toBeInTheDocument();
   });
 
+  it('should expand collapsed queries section when adding an expression', async () => {
+    const queries: DataQuery[] = [{ refId: 'A', datasource: { type: 'test', uid: 'test' } }];
+
+    const { user } = renderWithQueryEditorProvider(<QueriesAndTransformationsView />, {
+      queries,
+      selectedQuery: queries[0],
+    });
+
+    // Verify query card is visible
+    expect(screen.getByRole('button', { name: /select card A/i })).toBeInTheDocument();
+
+    // Collapse the "Queries & Expressions" section
+    await user.click(screen.getByRole('button', { name: /queries & expressions/i }));
+
+    // Query card should be unmounted
+    expect(screen.queryByRole('button', { name: /select card A/i })).not.toBeInTheDocument();
+
+    // Click the header "+" button to open the add menu
+    await user.click(screen.getByRole('button', { name: /add query or expression/i }));
+
+    // Click "Add expression" from the dropdown
+    await user.click(screen.getByRole('menuitem', { name: /add expression/i }));
+
+    // Section should now be expanded — query card is visible again
+    expect(screen.getByRole('button', { name: /select card A/i })).toBeInTheDocument();
+  });
+
   it('should render "Add below" buttons for both query/expression and transformation cards', () => {
     const queries: DataQuery[] = [
       { refId: 'A', datasource: { type: 'test', uid: 'test' } },

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
@@ -1,3 +1,5 @@
+import { useCallback, useState } from 'react';
+
 import { t } from '@grafana/i18n';
 import { LoadingBar } from '@grafana/ui';
 
@@ -15,6 +17,12 @@ export function QueriesAndTransformationsView() {
   const { transformations } = usePanelContext();
   const { onQueryDragEnd, onTransformationDragEnd } = useSidebarDragAndDrop();
 
+  const [queriesOpen, setQueriesOpen] = useState(true);
+  const [transformationsOpen, setTransformationsOpen] = useState(true);
+
+  const expandQueries = useCallback(() => setQueriesOpen(true), []);
+  const expandTransformations = useCallback(() => setTransformationsOpen(true), []);
+
   if (isLoading) {
     return (
       <LoadingBar
@@ -31,7 +39,9 @@ export function QueriesAndTransformationsView() {
     <>
       <QuerySidebarCollapsableHeader
         label={t('query-editor-next.sidebar.queries-expressions', 'Queries & Expressions')}
-        headerAction={<AddCardButton variant="query" alwaysVisible />}
+        isOpen={queriesOpen}
+        onToggle={setQueriesOpen}
+        headerAction={<AddCardButton variant="query" alwaysVisible onAdd={expandQueries} />}
       >
         <DraggableList
           droppableId="query-sidebar-queries"
@@ -43,7 +53,9 @@ export function QueriesAndTransformationsView() {
       </QuerySidebarCollapsableHeader>
       <QuerySidebarCollapsableHeader
         label={t('query-editor-next.sidebar.transformations', 'Transformations')}
-        headerAction={<AddCardButton variant="transformation" alwaysVisible />}
+        isOpen={transformationsOpen}
+        onToggle={setTransformationsOpen}
+        headerAction={<AddCardButton variant="transformation" alwaysVisible onAdd={expandTransformations} />}
       >
         {transformations.length > 0 && (
           <DraggableList

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QuerySidebarCollapsableHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QuerySidebarCollapsableHeader.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/css';
-import { useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { CollapsableSection, Stack, Text, useStyles2 } from '@grafana/ui';
@@ -8,14 +7,17 @@ interface QuerySidebarCollapsableHeaderProps {
   label: string;
   children: React.ReactNode;
   headerAction?: React.ReactNode;
+  isOpen: boolean;
+  onToggle: (isOpen: boolean) => void;
 }
 
 export const QuerySidebarCollapsableHeader = ({
   label,
   children,
   headerAction,
+  isOpen,
+  onToggle,
 }: QuerySidebarCollapsableHeaderProps) => {
-  const [isOpen, setIsOpen] = useState(true);
   const styles = useStyles2(getStyles);
 
   return (
@@ -34,7 +36,7 @@ export const QuerySidebarCollapsableHeader = ({
         </Stack>
       }
       isOpen={isOpen}
-      onToggle={setIsOpen}
+      onToggle={onToggle}
       className={styles.collapsableSection}
       contentClassName={styles.contentArea}
     >


### PR DESCRIPTION
## Description
When the query/expression or transformation section is collapsed in the panel edit sidebar, clicking "Add query", "Add expression", or "Add transformation" now automatically expands the section so the newly added item is visible.

## Changes
* Converted `QuerySidebarCollapsableHeader` from an uncontrolled component to a controlled component (`isOpen`/`onToggle` props)
* Added `onAdd` callback prop to `AddCardButton`, invoked after adding a query, expression, or transformation
* Lifted collapse state up to `QueriesAndTransformationsView` and wired expand callbacks to `AddCardButton.onAdd`

## Risks
* Low risk - `QuerySidebarCollapsableHeader` is only consumed by `QueriesAndTransformationsView`, so the API change has no other impact
* Collapse/expand behavior is unchanged for direct user toggling; only the "add" action now also triggers expand

## Demo

https://github.com/user-attachments/assets/67be5b6b-a5f3-4ace-9834-9e1308afd66d


## Testing Instructions
* Open a panel in edit mode (new query editor)
* Collapse the "Queries & Expressions" section by clicking its header
* Click the "+" button next to the header to add a query or expression
* Verify the section expands automatically, revealing the new item
* Repeat for the "Transformations" section
* Verify that manual collapse/expand toggling still works as before

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable