### PR TITLE
Allow exporting dashboard in Classic mode 

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.test.tsx
@@ -94,11 +94,17 @@ describe('ResourceExport', () => {
   });
 
   describe('export mode options for v2 dashboard', () => {
-    it('should not show export mode options', async () => {
+    it('should show export mode options for v2 dashboards', async () => {
       render(<ResourceExport {...createDefaultProps({ dashboardJson: createV2DashboardJson() })} />);
       await expandOptions();
 
-      expect(screen.queryByRole('radiogroup', { name: /model/i })).not.toBeInTheDocument();
+      const radioGroup = screen.getByRole('radiogroup', { name: /model/i });
+      const labels = within(radioGroup)
+        .getAllByRole('radio')
+        .map((radio) => radio.parentElement?.textContent?.trim());
+
+      expect(labels).toHaveLength(3);
+      expect(labels).toEqual(['Classic', 'V1 Resource', 'V2 Resource']);
     });
   });
 

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.test.tsx
@@ -58,8 +58,8 @@ const expandOptions = async () => {
 };
 
 describe('ResourceExport', () => {
-  describe('export mode options for v1 dashboard', () => {
-    it('should show three export mode options in correct order: Classic, V1 Resource, V2 Resource', async () => {
+  describe('export mode options', () => {
+    it('should show two export mode options: Classic and V2 Resource', async () => {
       render(<ResourceExport {...createDefaultProps()} />);
       await expandOptions();
 
@@ -68,11 +68,11 @@ describe('ResourceExport', () => {
         .getAllByRole('radio')
         .map((radio) => radio.parentElement?.textContent?.trim());
 
-      expect(labels).toHaveLength(3);
-      expect(labels).toEqual(['Classic', 'V1 Resource', 'V2 Resource']);
+      expect(labels).toHaveLength(2);
+      expect(labels).toEqual(['Classic', 'V2 Resource']);
     });
 
-    it('should have first option selected by default when exportMode is Classic', async () => {
+    it('should have Classic selected by default when exportMode is Classic', async () => {
       render(<ResourceExport {...createDefaultProps({ exportFormat: ExportFormat.Classic })} />);
       await expandOptions();
 
@@ -88,12 +88,10 @@ describe('ResourceExport', () => {
 
       const radioGroup = screen.getByRole('radiogroup', { name: /model/i });
       const radios = within(radioGroup).getAllByRole('radio');
-      await userEvent.click(radios[1]); // V1 Resource
-      expect(onExportFormatChange).toHaveBeenCalledWith(ExportFormat.V1Resource);
+      await userEvent.click(radios[1]); // V2 Resource
+      expect(onExportFormatChange).toHaveBeenCalledWith(ExportFormat.V2Resource);
     });
-  });
 
-  describe('export mode options for v2 dashboard', () => {
     it('should show export mode options for v2 dashboards', async () => {
       render(<ResourceExport {...createDefaultProps({ dashboardJson: createV2DashboardJson() })} />);
       await expandOptions();
@@ -103,8 +101,8 @@ describe('ResourceExport', () => {
         .getAllByRole('radio')
         .map((radio) => radio.parentElement?.textContent?.trim());
 
-      expect(labels).toHaveLength(3);
-      expect(labels).toEqual(['Classic', 'V1 Resource', 'V2 Resource']);
+      expect(labels).toHaveLength(2);
+      expect(labels).toEqual(['Classic', 'V2 Resource']);
     });
   });
 
@@ -117,42 +115,39 @@ describe('ResourceExport', () => {
       expect(screen.queryByRole('radiogroup', { name: /format/i })).not.toBeInTheDocument();
     });
 
-    it.each([ExportFormat.V1Resource, ExportFormat.V2Resource])(
-      'should show format options when export mode is %s',
-      async (exportFormat) => {
-        render(<ResourceExport {...createDefaultProps({ exportFormat })} />);
-        await expandOptions();
-
-        expect(screen.getByRole('radiogroup', { name: /model/i })).toBeInTheDocument();
-        expect(screen.getByRole('radiogroup', { name: /format/i })).toBeInTheDocument();
-      }
-    );
-
-    it('should have first format option selected when isViewingYAML is false', async () => {
-      render(
-        <ResourceExport {...createDefaultProps({ exportFormat: ExportFormat.V1Resource, isViewingYAML: false })} />
-      );
+    it('should show format options when export mode is V2Resource', async () => {
+      render(<ResourceExport {...createDefaultProps({ exportFormat: ExportFormat.V2Resource })} />);
       await expandOptions();
 
-      const formatGroup = screen.getByRole('radiogroup', { name: /format/i });
-      const formatRadios = within(formatGroup).getAllByRole('radio');
-      expect(formatRadios[0]).toBeChecked(); // JSON
+      expect(screen.getByRole('radiogroup', { name: /model/i })).toBeInTheDocument();
+      expect(screen.getByRole('radiogroup', { name: /format/i })).toBeInTheDocument();
     });
 
-    it('should have second format option selected when isViewingYAML is true', async () => {
+    it('should have JSON selected when isViewingYAML is false', async () => {
       render(
-        <ResourceExport {...createDefaultProps({ exportFormat: ExportFormat.V1Resource, isViewingYAML: true })} />
+        <ResourceExport {...createDefaultProps({ exportFormat: ExportFormat.V2Resource, isViewingYAML: false })} />
       );
       await expandOptions();
 
       const formatGroup = screen.getByRole('radiogroup', { name: /format/i });
       const formatRadios = within(formatGroup).getAllByRole('radio');
-      expect(formatRadios[1]).toBeChecked(); // YAML
+      expect(formatRadios[0]).toBeChecked();
+    });
+
+    it('should have YAML selected when isViewingYAML is true', async () => {
+      render(
+        <ResourceExport {...createDefaultProps({ exportFormat: ExportFormat.V2Resource, isViewingYAML: true })} />
+      );
+      await expandOptions();
+
+      const formatGroup = screen.getByRole('radiogroup', { name: /format/i });
+      const formatRadios = within(formatGroup).getAllByRole('radio');
+      expect(formatRadios[1]).toBeChecked();
     });
 
     it('should call onViewYAML when format is changed', async () => {
       const onViewYAML = jest.fn();
-      render(<ResourceExport {...createDefaultProps({ exportFormat: ExportFormat.V1Resource, onViewYAML })} />);
+      render(<ResourceExport {...createDefaultProps({ exportFormat: ExportFormat.V2Resource, onViewYAML })} />);
       await expandOptions();
 
       const formatGroup = screen.getByRole('radiogroup', { name: /format/i });

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
@@ -120,6 +120,15 @@ export function ResourceExport({
         </Stack>
       )}
 
+      {dashboardJson.value?.initialSaveModelVersion === 'v2' && exportFormat === ExportFormat.Classic && (
+        <Alert title="" severity="warning" topSpacing={2}>
+          <Trans i18nKey="dashboard-scene.resource-export.classic-v2-warning">
+            This dashboard uses the V2 schema. Features like tabs and conditional rendering cannot be represented in the
+            classic format and may be lost.
+          </Trans>
+        </Alert>
+      )}
+
       {showV2LibPanelAlert && (
         <Alert
           title={t(

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
@@ -59,10 +59,6 @@ export function ResourceExport({
       value: ExportFormat.Classic,
     },
     {
-      label: t('dashboard-scene.resource-export.label.v1-resource', 'V1 Resource'),
-      value: ExportFormat.V1Resource,
-    },
-    {
       label: t('dashboard-scene.resource-export.label.v2-resource', 'V2 Resource'),
       value: ExportFormat.V2Resource,
     },
@@ -106,9 +102,7 @@ export function ResourceExport({
         </Box>
       </QueryOperationRow>
 
-      {(isV2Dashboard ||
-        exportFormat === ExportFormat.Classic ||
-        (initialSaveModelVersion === 'v2' && exportFormat === ExportFormat.V1Resource)) && (
+      {(isV2Dashboard || exportFormat === ExportFormat.Classic) && (
         <Stack gap={1} alignItems="start">
           <Label>
             <Stack gap={0.5} alignItems="center">

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
@@ -37,7 +37,6 @@ export function ResourceExport({
   onViewYAML,
 }: Props) {
   const hasLibraryPanels = dashboardJson.value?.hasLibraryPanels;
-  const initialSaveModelVersion = dashboardJson.value?.initialSaveModelVersion;
   const isV2Dashboard =
     dashboardJson.value?.json && 'spec' in dashboardJson.value.json && 'elements' in dashboardJson.value.json.spec;
   const showV2LibPanelAlert = isV2Dashboard && isSharingExternally && hasLibraryPanels;
@@ -102,7 +101,7 @@ export function ResourceExport({
         </Box>
       </QueryOperationRow>
 
-      {(isV2Dashboard || exportFormat === ExportFormat.Classic) && (
+      {(isV2Dashboard || exportFormat === ExportFormat.Classic || exportFormat === ExportFormat.V2Resource) && (
         <Stack gap={1} alignItems="start">
           <Label>
             <Stack gap={0.5} alignItems="center">

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
@@ -78,17 +78,15 @@ export function ResourceExport({
       >
         <Box marginTop={2}>
           <Stack gap={1} direction="column">
-            {initialSaveModelVersion === 'v1' && (
-              <Stack gap={1} alignItems="center">
-                <Label>{switchExportModeLabel}</Label>
-                <RadioButtonGroup
-                  options={exportResourceOptions}
-                  value={exportFormat}
-                  onChange={(value) => onExportFormatChange(value)}
-                  aria-label={switchExportModeLabel}
-                />
-              </Stack>
-            )}
+            <Stack gap={1} alignItems="center">
+              <Label>{switchExportModeLabel}</Label>
+              <RadioButtonGroup
+                options={exportResourceOptions}
+                value={exportFormat}
+                onChange={(value) => onExportFormatChange(value)}
+                aria-label={switchExportModeLabel}
+              />
+            </Stack>
 
             {exportFormat !== ExportFormat.Classic && (
               <Stack gap={1} alignItems="center">

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
@@ -162,12 +162,13 @@ describe('ShareExportTab', () => {
   });
 
   describe('V2Resource export mode', () => {
-    it('should default to V2Resource for V2 dashboards', async () => {
+    it('should default to V2Resource export format', async () => {
       const tab = buildV2DashboardScenario();
+
+      expect(tab.state.exportFormat).toBe(ExportFormat.V2Resource);
 
       const result = await tab.getExportableDashboardJson();
 
-      expect(tab.state.exportFormat).toBe(ExportFormat.V2Resource);
       expect(result.json).toMatchObject({
         apiVersion: 'dashboard.grafana.app/v2beta1',
         kind: 'Dashboard',
@@ -176,20 +177,14 @@ describe('ShareExportTab', () => {
       expect(result.json).not.toHaveProperty('access');
     });
 
-    it('should fetch V2 resource from API with correct metadata', async () => {
+    it('should fetch Classic when user switches to Classic mode', async () => {
       const tab = buildV2DashboardScenario();
-      tab.setState({ exportFormat: ExportFormat.V2Resource });
+      tab.setState({ exportFormat: ExportFormat.Classic });
 
       const result = await tab.getExportableDashboardJson();
 
-      expect(result.json).toMatchObject({
-        apiVersion: 'dashboard.grafana.app/v2beta1',
-        kind: 'Dashboard',
-        metadata: expect.objectContaining({ name: 'test-uid-v2' }),
-        spec: expect.objectContaining({ title: 'Test Dashboard V2' }),
-      });
-      expect(result.json).not.toHaveProperty('status');
-      expect(result.json).not.toHaveProperty('access');
+      expect(dashboardApiModule.getDashboardAPI).toHaveBeenCalledWith('v1');
+      expect(result.json).toMatchObject({ title: 'Test Dashboard V1', uid: 'test-uid-v1' });
       expect(result.initialSaveModelVersion).toBe('v2');
     });
 

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
@@ -1,489 +1,368 @@
 import { config } from '@grafana/runtime';
 import { SceneTimeRange } from '@grafana/scenes';
-import { Dashboard } from '@grafana/schema';
 import {
   Spec as DashboardV2Spec,
   defaultQueryGroupKind,
   defaultVizConfigSpec,
 } from '@grafana/schema/apis/dashboard.grafana.app/v2';
-import * as ResponseTransformers from 'app/features/dashboard/api/ResponseTransformers';
-import { ExportFormat } from 'app/features/dashboard/api/types';
-import { DashboardJson } from 'app/features/manage-dashboards/types';
+import * as dashboardApiModule from 'app/features/dashboard/api/dashboard_api';
+import { ExportFormat, DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { DashboardDataDTO } from 'app/types/dashboard';
 
 import { DashboardScene } from '../scene/DashboardScene';
 import * as exporters from '../scene/export/exporters';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
-import * as sceneToV1 from '../serialization/transformSceneToSaveModel';
-import * as sceneToV2 from '../serialization/transformSceneToSaveModelSchemaV2';
 
 import { ShareExportTab } from './ShareExportTab';
 
+jest.mock('app/features/dashboard/api/dashboard_api');
+
+const mockV1Spec: DashboardDataDTO = {
+  title: 'Test Dashboard V1',
+  uid: 'test-uid-v1',
+  version: 1,
+  panels: [],
+  time: { from: 'now-6h', to: 'now' },
+  timepicker: {},
+  timezone: '',
+  weekStart: '',
+  fiscalYearStartMonth: 0,
+  refresh: '',
+  schemaVersion: 30,
+  tags: [],
+  templating: { list: [] },
+};
+
+const mockV2Spec: DashboardV2Spec = {
+  title: 'Test Dashboard V2',
+  description: 'Test V2 dashboard',
+  annotations: [],
+  cursorSync: 'Off',
+  editable: true,
+  elements: {},
+  layout: { kind: 'GridLayout', spec: { items: [] } },
+  links: [],
+  liveNow: false,
+  preload: false,
+  tags: [],
+  timeSettings: {
+    from: 'now-6h',
+    to: 'now',
+    autoRefresh: '',
+    autoRefreshIntervals: [],
+    hideTimepicker: false,
+    timezone: '',
+    weekStart: 'saturday',
+    fiscalYearStartMonth: 0,
+  },
+  variables: [],
+};
+
+const mockV2SpecWithLibraryPanels: DashboardV2Spec = {
+  ...mockV2Spec,
+  title: 'Test Dashboard V2',
+  elements: {
+    'element-1': {
+      kind: 'Panel',
+      spec: {
+        id: 1,
+        title: 'Regular Panel',
+        description: '',
+        links: [],
+        data: defaultQueryGroupKind(),
+        vizConfig: {
+          kind: 'VizConfig',
+          group: '',
+          version: '1.0.0',
+          spec: defaultVizConfigSpec(),
+        },
+      },
+    },
+    'element-2': {
+      kind: 'LibraryPanel',
+      spec: {
+        id: 2,
+        title: 'My Library Panel',
+        libraryPanel: { uid: 'lib-panel-uid', name: 'My Library Panel' },
+      },
+    },
+  },
+};
+
+const mockV1WithLibraryPanels: DashboardDataDTO = {
+  ...mockV1Spec,
+  panels: [
+    {
+      id: 1,
+      type: 'stat',
+      title: 'Regular Panel',
+      gridPos: { x: 0, y: 0, w: 12, h: 8 },
+      targets: [],
+      options: {},
+      fieldConfig: { defaults: {}, overrides: [] },
+    },
+    {
+      id: 2,
+      type: 'library-panel-ref',
+      libraryPanel: { uid: 'lib-panel-uid', name: 'My Library Panel' },
+    },
+  ],
+};
+
+const mockV2ResourceResponse: DashboardWithAccessInfo<DashboardV2Spec> = {
+  apiVersion: 'dashboard.grafana.app/v2beta1',
+  kind: 'DashboardWithAccessInfo',
+  metadata: {
+    name: 'test-uid-v2',
+    resourceVersion: '1',
+    creationTimestamp: '2025-01-01T00:00:00Z',
+    generation: 1,
+  },
+  spec: mockV2Spec,
+  access: {},
+  status: {},
+};
+
+function mockGetDashboardAPI(v1Spec: DashboardDataDTO, v2Response: DashboardWithAccessInfo<DashboardV2Spec>) {
+  const getDashboardAPIMock = dashboardApiModule.getDashboardAPI as jest.Mock;
+  getDashboardAPIMock.mockImplementation((version?: string) => {
+    if (version === 'v1') {
+      return {
+        getDashboardDTO: jest.fn().mockResolvedValue({
+          dashboard: v1Spec,
+          meta: { uid: v1Spec.uid, isNew: false, isFolder: false },
+        }),
+      };
+    }
+    if (version === 'v2') {
+      return {
+        getDashboardDTO: jest.fn().mockResolvedValue(v2Response),
+      };
+    }
+    throw new Error(`Unexpected version: ${version}`);
+  });
+}
+
 describe('ShareExportTab', () => {
-  // Spies to track function calls
-  let transformV2ToV1Spy: jest.SpyInstance;
   let makeExportableV1Spy: jest.SpyInstance;
-  let transformSceneToV1Spy: jest.SpyInstance;
-  let transformSceneToV2Spy: jest.SpyInstance;
+  let makeExportableV2Spy: jest.SpyInstance;
 
   beforeEach(() => {
     config.featureToggles.kubernetesDashboards = true;
     config.featureToggles.dashboardNewLayouts = false;
 
-    // Set up spies on the functions we want to track
-    transformV2ToV1Spy = jest.spyOn(ResponseTransformers, 'transformDashboardV2SpecToV1').mockReturnValue({
-      title: 'Transformed V1',
-      uid: 'transformed-uid',
-      version: 1,
-      panels: [],
-      time: { from: 'now-6h', to: 'now' },
-      timepicker: {},
-      timezone: '',
-      weekStart: '',
-      fiscalYearStartMonth: 0,
-      refresh: '',
-      schemaVersion: 30,
-      tags: [],
-      templating: { list: [] },
-    } as DashboardDataDTO);
-
     makeExportableV1Spy = jest.spyOn(exporters, 'makeExportableV1').mockImplementation(async (dashboard) => dashboard);
+    makeExportableV2Spy = jest.spyOn(exporters, 'makeExportableV2').mockImplementation(async (spec) => spec);
 
-    transformSceneToV1Spy = jest.spyOn(sceneToV1, 'transformSceneToSaveModel').mockReturnValue({
-      title: 'Scene V1',
-      uid: 'scene-v1-uid',
-      version: 1,
-      panels: [],
-      time: { from: 'now-6h', to: 'now' },
-      timepicker: {},
-      timezone: '',
-      weekStart: '',
-      fiscalYearStartMonth: 0,
-      refresh: '',
-      schemaVersion: 30,
-      tags: [],
-      templating: { list: [] },
-    } as Dashboard);
-
-    transformSceneToV2Spy = jest.spyOn(sceneToV2, 'transformSceneToSaveModelSchemaV2').mockReturnValue({
-      title: 'Scene V2',
-      annotations: [],
-      cursorSync: 'Off',
-      description: '',
-      editable: true,
-      elements: {},
-      layout: { kind: 'GridLayout', spec: { items: [] } },
-      links: [],
-      liveNow: false,
-      preload: false,
-      tags: [],
-      timeSettings: {
-        from: 'now-6h',
-        to: 'now',
-        autoRefresh: '',
-        autoRefreshIntervals: [],
-        hideTimepicker: false,
-        timezone: '',
-        weekStart: 'saturday',
-        fiscalYearStartMonth: 0,
-      },
-      variables: [],
-    } as DashboardV2Spec);
+    mockGetDashboardAPI(mockV1Spec, mockV2ResourceResponse);
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  describe('V1Resource export mode', () => {
-    // If V1 dashboard → V1 Resource should export with V1 apiVersion
-    it('should export V1 dashboard as V1 resource with correct apiVersion', async () => {
-      const tab = buildV1DashboardScenario();
-      tab.setState({ exportFormat: ExportFormat.V1Resource });
-
-      const result = await tab.getExportableDashboardJson();
-
-      // Should use V1 API version
-      expect(result.json).toMatchObject({
-        apiVersion: 'dashboard.grafana.app/v1beta1',
-        kind: 'DashboardWithAccessInfo',
-        status: {},
-      });
-
-      // Should call transformSceneToV1 (not transform V2→V1)
-      expect(transformSceneToV1Spy).toHaveBeenCalled();
-      expect(transformV2ToV1Spy).not.toHaveBeenCalled();
-
-      // Should report correct initial version
-      expect(result.initialSaveModelVersion).toBe('v1');
-    });
-
-    // If V2 dashboard → V1 Resource should auto-transform with V1 apiVersion
-    it('should auto-transform V2 dashboard to V1 resource with correct apiVersion', async () => {
-      const tab = buildV2DashboardScenario();
-      // user selects V1Resource even though is V2 dashboard
-      tab.setState({ exportFormat: ExportFormat.V1Resource });
-
-      const result = await tab.getExportableDashboardJson();
-
-      // Should use V1 API version (not V2!)
-      expect(result.json).toMatchObject({
-        apiVersion: 'dashboard.grafana.app/v1beta1',
-        kind: 'DashboardWithAccessInfo',
-        status: {},
-      });
-
-      // Should auto-transform V2→V1
-      expect(transformSceneToV2Spy).toHaveBeenCalled(); // Get V2 spec first
-      expect(transformV2ToV1Spy).toHaveBeenCalled(); // Then transform to V1
-
-      // Should report correct initial version
-      expect(result.initialSaveModelVersion).toBe('v2');
-    });
-
-    // If V2 dashboard → V1 Resource with external sharing should transform and apply external sharing
-    it('should handle external sharing when transforming V2 to V1', async () => {
-      const tab = buildV2DashboardScenario();
-      tab.setState({
-        exportFormat: ExportFormat.V1Resource,
-        isSharingExternally: true,
-      });
-
-      const result = await tab.getExportableDashboardJson();
-
-      // Should use V1 API version
-      expect(result.json).toMatchObject({
-        apiVersion: 'dashboard.grafana.app/v1beta1',
-        kind: 'DashboardWithAccessInfo',
-        status: {},
-      });
-
-      // Should auto-transform V2→V1
-      expect(transformSceneToV2Spy).toHaveBeenCalled();
-      expect(transformV2ToV1Spy).toHaveBeenCalled();
-
-      // Should call makeExportableV1 for external sharing
-      expect(makeExportableV1Spy).toHaveBeenCalled();
-
-      // Should report correct initial version
-      expect(result.initialSaveModelVersion).toBe('v2');
-    });
-  });
-
   describe('V2Resource export mode', () => {
-    // If V2 dashboard → V2 Resource should export with V2 apiVersion
-    it('should export V2 dashboard as V2 resource with correct apiVersion', async () => {
+    it('should default to V2Resource for V2 dashboards', async () => {
       const tab = buildV2DashboardScenario();
-      tab.setState({ exportFormat: ExportFormat.V2Resource });
 
       const result = await tab.getExportableDashboardJson();
 
-      // Should use V2 API version
+      expect(tab.state.exportFormat).toBe(ExportFormat.V2Resource);
       expect(result.json).toMatchObject({
         apiVersion: 'dashboard.grafana.app/v2beta1',
-        kind: 'DashboardWithAccessInfo',
-        status: {},
+        kind: 'Dashboard',
       });
-
-      // Should not call V2→V1 transformation since source is already V2
-      expect(transformV2ToV1Spy).not.toHaveBeenCalled();
-
-      // Should report correct initial version
-      expect(result.initialSaveModelVersion).toBe('v2');
+      expect(result.json).not.toHaveProperty('status');
+      expect(result.json).not.toHaveProperty('access');
     });
 
-    // If V1 dashboard → V2 Resource should detect library panels correctly
-    it('should detect library panels in V1 dashboard when exporting as V2 resource', async () => {
-      const tab = buildV1DashboardWithLibraryPanels();
-      tab.setState({ exportFormat: ExportFormat.V2Resource });
-
-      const result = await tab.getExportableDashboardJson();
-
-      // Should detect library panels from V1 dashboard
-      expect(result.hasLibraryPanels).toBe(true);
-      expect(result.initialSaveModelVersion).toBe('v1');
-    });
-
-    // If V1 dashboard with dashboardNewLayouts disabled → V2 Resource should detect library panels correctly
-    it('should detect library panels in V1 dashboard when user selects V2Resource export mode', async () => {
-      const tab = buildV1DashboardWithLibraryPanels();
-      tab.setState({ exportFormat: ExportFormat.V2Resource });
-
-      const result = await tab.getExportableDashboardJson();
-
-      // Should detect library panels from V1 dashboard (first branch of the logic)
-      expect(result.hasLibraryPanels).toBe(true);
-      expect(result.initialSaveModelVersion).toBe('v1');
-    });
-
-    // If V1 dashboard without library panels → V2 Resource should return false
-    it('should return false for hasLibraryPanels when V1 dashboard has no library panels', async () => {
-      const tab = buildV1DashboardScenario();
-      tab.setState({ exportFormat: ExportFormat.V2Resource });
-
-      const result = await tab.getExportableDashboardJson();
-
-      // Should not detect library panels
-      expect(result.hasLibraryPanels).toBe(false);
-      expect(result.initialSaveModelVersion).toBe('v1');
-    });
-  });
-
-  describe('V2Resource export mode with dashboardNewLayouts disabled', () => {
-    beforeEach(() => {
-      config.featureToggles.dashboardNewLayouts = false;
-    });
-
-    afterEach(() => {
-      config.featureToggles.dashboardNewLayouts = true;
-    });
-
-    // If V2 dashboard → V2 Resource should detect library panels correctly
-    it('should detect library panels in V2 dashboard when exporting as V2 resource', async () => {
-      const tab = buildV2DashboardWithLibraryPanels();
-      tab.setState({ exportFormat: ExportFormat.V2Resource });
-
-      const result = await tab.getExportableDashboardJson();
-
-      // Should detect library panels from V2 dashboard elements (second branch of the logic)
-      expect(result.hasLibraryPanels).toBe(true);
-      expect(result.initialSaveModelVersion).toBe('v2');
-    });
-
-    // Test the second branch: V2 dashboard with V1 initial save model
-    it('should detect library panels in V2 dashboard with V1 initial save model', async () => {
-      const tab = buildV2DashboardWithV1InitialSaveModel();
-      tab.setState({ exportFormat: ExportFormat.V2Resource });
-
-      const result = await tab.getExportableDashboardJson();
-
-      // Should detect library panels from V2 dashboard elements (second branch of the logic)
-      expect(result.hasLibraryPanels).toBe(true);
-      expect(result.initialSaveModelVersion).toBe('v1');
-    });
-
-    // If V2 dashboard without library panels → V2 Resource should return false
-    it('should return false for hasLibraryPanels when V2 dashboard has no library panels', async () => {
+    it('should fetch V2 resource from API with correct metadata', async () => {
       const tab = buildV2DashboardScenario();
       tab.setState({ exportFormat: ExportFormat.V2Resource });
 
       const result = await tab.getExportableDashboardJson();
 
-      // Should not detect library panels
-      expect(result.hasLibraryPanels).toBe(false);
+      expect(result.json).toMatchObject({
+        apiVersion: 'dashboard.grafana.app/v2beta1',
+        kind: 'Dashboard',
+        metadata: expect.objectContaining({ name: 'test-uid-v2' }),
+        spec: expect.objectContaining({ title: 'Test Dashboard V2' }),
+      });
+      expect(result.json).not.toHaveProperty('status');
+      expect(result.json).not.toHaveProperty('access');
       expect(result.initialSaveModelVersion).toBe('v2');
+    });
+
+    it('should strip metadata when sharing externally', async () => {
+      const tab = buildV2DashboardScenario();
+      tab.setState({ exportFormat: ExportFormat.V2Resource, isSharingExternally: true });
+
+      const result = await tab.getExportableDashboardJson();
+
+      expect(makeExportableV2Spy).toHaveBeenCalled();
+      expect(result.json).toMatchObject({
+        apiVersion: 'dashboard.grafana.app/v2beta1',
+        kind: 'Dashboard',
+      });
+      expect(result.json).not.toHaveProperty('status');
+      expect(result.json).not.toHaveProperty('access');
+      if ('metadata' in result.json) {
+        expect(result.json.metadata).not.toHaveProperty('resourceVersion');
+        expect(result.json.metadata).not.toHaveProperty('namespace');
+      }
+    });
+
+    it('should fetch V2 resource for V1 dashboard (server converts)', async () => {
+      const tab = buildV1DashboardScenario();
+      tab.setState({ exportFormat: ExportFormat.V2Resource });
+
+      const result = await tab.getExportableDashboardJson();
+
+      expect(dashboardApiModule.getDashboardAPI).toHaveBeenCalledWith('v2');
+      expect(result.json).toMatchObject({
+        apiVersion: 'dashboard.grafana.app/v2beta1',
+        kind: 'Dashboard',
+      });
+      expect(result.json).not.toHaveProperty('status');
+      expect(result.json).not.toHaveProperty('access');
+    });
+
+    it('should detect library panels in V2 response', async () => {
+      mockGetDashboardAPI(mockV1Spec, {
+        ...mockV2ResourceResponse,
+        spec: mockV2SpecWithLibraryPanels,
+      });
+
+      const tab = buildV2DashboardScenario();
+      tab.setState({ exportFormat: ExportFormat.V2Resource });
+
+      const result = await tab.getExportableDashboardJson();
+      expect(result.hasLibraryPanels).toBe(true);
+    });
+
+    it('should report no library panels when V2 dashboard has none', async () => {
+      const tab = buildV2DashboardScenario();
+      tab.setState({ exportFormat: ExportFormat.V2Resource });
+
+      const result = await tab.getExportableDashboardJson();
+      expect(result.hasLibraryPanels).toBe(false);
+    });
+
+    it('should handle API errors gracefully', async () => {
+      const getDashboardAPIMock = dashboardApiModule.getDashboardAPI as jest.Mock;
+      getDashboardAPIMock.mockImplementation(() => ({
+        getDashboardDTO: jest.fn().mockRejectedValue(new Error('API down')),
+      }));
+
+      const tab = buildV2DashboardScenario();
+      tab.setState({ exportFormat: ExportFormat.V2Resource });
+
+      const result = await tab.getExportableDashboardJson();
+      expect(result.json).toHaveProperty('error');
     });
   });
 
   describe('Classic export mode', () => {
-    // If V1 dashboard → Classic should export plain dashboard JSON
-    it('should export V1 dashboard in classic format', async () => {
+    it('should export V1 dashboard as plain JSON via API', async () => {
       const tab = buildV1DashboardScenario();
       tab.setState({ exportFormat: ExportFormat.Classic });
 
       const result = await tab.getExportableDashboardJson();
 
-      // Should return plain dashboard JSON (not wrapped in resource)
-      expect(result.json).toMatchObject({
-        title: 'Test Dashboard V1',
-        uid: 'test-uid-v1',
-        panels: expect.any(Array),
-      });
-
-      // Should NOT have resource wrapper properties
+      expect(dashboardApiModule.getDashboardAPI).toHaveBeenCalledWith('v1');
+      expect(result.json).toMatchObject({ title: 'Test Dashboard V1', uid: 'test-uid-v1' });
       expect(result.json).not.toHaveProperty('apiVersion');
       expect(result.json).not.toHaveProperty('kind');
-      expect(result.json).not.toHaveProperty('status');
-
-      // Should report correct initial version
       expect(result.initialSaveModelVersion).toBe('v1');
     });
 
-    // If V2 dashboard → Classic should convert to V1 and export plain JSON
-    it('should convert V2 dashboard to classic V1 format', async () => {
+    it('should fetch V1 for V2 dashboard (server converts)', async () => {
       const tab = buildV2DashboardScenario();
+      tab.onExportFormatChange(ExportFormat.Classic);
+
+      const result = await tab.getExportableDashboardJson();
+
+      expect(dashboardApiModule.getDashboardAPI).toHaveBeenCalledWith('v1');
+      expect(result.json).not.toHaveProperty('apiVersion');
+      expect(result.json).not.toHaveProperty('kind');
+      expect(result.json).not.toHaveProperty('elements');
+    });
+
+    it('should apply makeExportableV1 when sharing externally', async () => {
+      const tab = buildV1DashboardScenario();
+      tab.onExportFormatChange(ExportFormat.Classic);
+      tab.setState({ isSharingExternally: true });
+
+      const result = await tab.getExportableDashboardJson();
+
+      expect(makeExportableV1Spy).toHaveBeenCalled();
+      expect(result.json).not.toHaveProperty('apiVersion');
+    });
+
+    it('should detect library panels in classic V1 response', async () => {
+      mockGetDashboardAPI(mockV1WithLibraryPanels, mockV2ResourceResponse);
+
+      const tab = buildV1DashboardScenario();
       tab.setState({ exportFormat: ExportFormat.Classic });
 
       const result = await tab.getExportableDashboardJson();
-
-      // Should return plain V1 dashboard JSON (not wrapped in resource)
-      expect(result.json).toMatchObject({
-        title: 'Transformed V1',
-      });
-
-      // Should NOT have resource wrapper properties
-      expect(result.json).not.toHaveProperty('apiVersion');
-      expect(result.json).not.toHaveProperty('kind');
-      expect(result.json).not.toHaveProperty('status');
-
-      // Should NOT have V2-specific properties
-      expect(result.json).not.toHaveProperty('elements');
-      expect(result.json).not.toHaveProperty('layout');
-
-      // Should call V2→V1 transformation
-      expect(transformSceneToV2Spy).toHaveBeenCalled();
-      expect(transformV2ToV1Spy).toHaveBeenCalled();
-
-      // Should report correct initial version
-      expect(result.initialSaveModelVersion).toBe('v2');
+      expect(result.hasLibraryPanels).toBe(true);
     });
 
-    // If V2 dashboard → Classic with external sharing should transform and apply external sharing
-    it('should handle external sharing when converting V2 dashboard to classic format', async () => {
+    it('should handle API errors gracefully', async () => {
+      const getDashboardAPIMock = dashboardApiModule.getDashboardAPI as jest.Mock;
+      getDashboardAPIMock.mockImplementation(() => ({
+        getDashboardDTO: jest.fn().mockRejectedValue(new Error('Conversion failed')),
+      }));
+
       const tab = buildV2DashboardScenario();
-      tab.setState({
-        exportFormat: ExportFormat.Classic,
-        isSharingExternally: true,
-      });
+      tab.onExportFormatChange(ExportFormat.Classic);
 
       const result = await tab.getExportableDashboardJson();
-
-      // Should NOT have resource wrapper properties
-      expect(result.json).not.toHaveProperty('apiVersion');
-      expect(result.json).not.toHaveProperty('kind');
-      expect(result.json).not.toHaveProperty('status');
-
-      // Should call V2→V1 transformation and makeExportableV1
-      expect(transformSceneToV2Spy).toHaveBeenCalled();
-      expect(transformV2ToV1Spy).toHaveBeenCalled();
-      expect(makeExportableV1Spy).toHaveBeenCalled();
-
-      // Should report correct initial version
-      expect(result.initialSaveModelVersion).toBe('v2');
+      expect(result.json).toHaveProperty('error');
     });
   });
 
   describe('Export mode state management', () => {
-    // If switching to Classic mode should disable YAML viewing
-    it('should disable YAML viewing when switching to Classic mode', async () => {
+    it('should disable YAML viewing when switching to Classic mode', () => {
       const tab = buildV1DashboardScenario();
-
-      // Start with YAML viewing enabled
       tab.setState({ isViewingYAML: true });
       expect(tab.state.isViewingYAML).toBe(true);
 
-      // Switch to Classic mode
       tab.onExportFormatChange(ExportFormat.Classic);
-
-      // Should disable YAML viewing
       expect(tab.state.isViewingYAML).toBe(false);
     });
 
-    // If switching to resource modes should preserve YAML viewing
-    it('should preserve YAML viewing when switching to resource modes', async () => {
+    it('should preserve YAML viewing when switching to V2Resource', () => {
       const tab = buildV2DashboardScenario();
-
-      // Start with YAML viewing enabled
       tab.setState({ isViewingYAML: true });
       expect(tab.state.isViewingYAML).toBe(true);
 
-      // Switch to V1Resource mode
-      tab.onExportFormatChange(ExportFormat.V1Resource);
-      expect(tab.state.isViewingYAML).toBe(true); // Should preserve
-
-      // Switch to V2Resource mode
       tab.onExportFormatChange(ExportFormat.V2Resource);
-      expect(tab.state.isViewingYAML).toBe(true); // Should preserve
+      expect(tab.state.isViewingYAML).toBe(true);
     });
   });
 
-  // Helper factory to create test scenarios
-  function createDashboardScenario(options: {
-    version: 'v1' | 'v2';
-    hasLibraryPanels?: boolean;
-    initialSaveModelVersion?: 'v1' | 'v2';
-  }): ShareExportTab {
-    const { version, hasLibraryPanels = false, initialSaveModelVersion = version } = options;
+  describe('Legacy mode (kubernetesDashboards off)', () => {
+    beforeEach(() => {
+      config.featureToggles.kubernetesDashboards = false;
+      (dashboardApiModule.getDashboardAPI as jest.Mock).mockClear();
+    });
 
-    // Create V1 dashboard
-    const mockV1Dashboard: DashboardDataDTO = {
-      title: `Test Dashboard V1`,
-      uid: 'test-uid-v1',
-      version: 1,
-      panels: hasLibraryPanels
-        ? [
-            {
-              id: 1,
-              type: 'stat',
-              title: 'Regular Panel',
-              gridPos: { x: 0, y: 0, w: 12, h: 8 },
-              targets: [],
-              options: {},
-              fieldConfig: { defaults: {}, overrides: [] },
-            },
-            {
-              id: 2,
-              type: 'library-panel-ref',
-              libraryPanel: { uid: 'lib-panel-uid', name: 'My Library Panel' },
-            },
-          ]
-        : [],
-      time: { from: 'now-6h', to: 'now' },
-      timepicker: {},
-      timezone: '',
-      weekStart: '',
-      fiscalYearStartMonth: 0,
-      refresh: '',
-      schemaVersion: 30,
-      tags: [],
-      templating: { list: [] },
-    };
+    it('should use scene serialization instead of API', async () => {
+      const tab = buildV1DashboardScenario();
 
-    // Create V2 dashboard
-    const mockV2Dashboard: DashboardV2Spec = {
-      title: `Test Dashboard V2`,
-      annotations: [],
-      cursorSync: 'Off',
-      description: 'Test V2 dashboard',
-      editable: true,
-      elements: hasLibraryPanels
-        ? {
-            'element-1': {
-              kind: 'Panel',
-              spec: {
-                id: 1,
-                title: 'Regular Panel',
-                description: '',
-                links: [],
-                data: defaultQueryGroupKind(),
-                vizConfig: {
-                  kind: 'VizConfig',
-                  group: '',
-                  version: '1.0.0',
-                  spec: defaultVizConfigSpec(),
-                },
-              },
-            },
-            'element-2': {
-              kind: 'LibraryPanel',
-              spec: {
-                id: 2,
-                title: 'My Library Panel',
-                libraryPanel: {
-                  uid: 'lib-panel-uid',
-                  name: 'My Library Panel',
-                },
-              },
-            },
-          }
-        : {},
-      layout: { kind: 'GridLayout', spec: { items: [] } },
-      links: [],
-      liveNow: false,
-      preload: false,
-      tags: [],
-      timeSettings: {
-        from: 'now-6h',
-        to: 'now',
-        autoRefresh: '',
-        autoRefreshIntervals: [],
-        hideTimepicker: false,
-        timezone: '',
-        weekStart: 'saturday',
-        fiscalYearStartMonth: 0,
-      },
-      variables: [],
-    };
+      const result = await tab.getExportableDashboardJson();
+
+      expect(dashboardApiModule.getDashboardAPI).not.toHaveBeenCalled();
+      expect(result.json).toMatchObject({ title: 'Test Dashboard V1', uid: 'test-uid-v1' });
+      expect(result.initialSaveModelVersion).toBe('v1');
+    });
+  });
+
+  function createDashboardScenario(version: 'v1' | 'v2'): ShareExportTab {
+    const currentDashboard = version === 'v1' ? mockV1Spec : mockV2Spec;
+    const initialSaveModel = version === 'v1' ? mockV1Spec : mockV2Spec;
 
     const tab = new ShareExportTab({});
     const scene = new DashboardScene({
@@ -495,32 +374,15 @@ describe('ShareExportTab', () => {
       overlay: tab,
     });
 
-    // Set up the scene based on current version
-    const currentDashboard = version === 'v1' ? mockV1Dashboard : mockV2Dashboard;
-    const initialSaveModel = initialSaveModelVersion === 'v1' ? mockV1Dashboard : mockV2Dashboard;
-    const apiVersion = version === 'v1' ? 'dashboard.grafana.app/v1beta1' : 'dashboard.grafana.app/v2beta1';
-
     scene.serializer.getSaveModel = jest.fn(() => currentDashboard);
     scene.serializer.makeExportableExternally = jest.fn(() =>
-      Promise.resolve(
-        version === 'v1' ? ({ ...mockV1Dashboard, panels: mockV1Dashboard.panels } as DashboardJson) : mockV2Dashboard
-      )
-    );
-    scene.serializer.apiVersion = apiVersion;
+      Promise.resolve(currentDashboard)
+    ) as DashboardScene['serializer']['makeExportableExternally'];
     scene.getInitialSaveModel = jest.fn(() => initialSaveModel);
 
     return tab;
   }
 
-  // util functions for common scenarios
-  const buildV1DashboardScenario = () => createDashboardScenario({ version: 'v1' });
-  const buildV2DashboardScenario = () => createDashboardScenario({ version: 'v2' });
-  const buildV1DashboardWithLibraryPanels = () => createDashboardScenario({ version: 'v1', hasLibraryPanels: true });
-  const buildV2DashboardWithLibraryPanels = () => createDashboardScenario({ version: 'v2', hasLibraryPanels: true });
-  const buildV2DashboardWithV1InitialSaveModel = () =>
-    createDashboardScenario({
-      version: 'v2',
-      hasLibraryPanels: true,
-      initialSaveModelVersion: 'v1',
-    });
+  const buildV1DashboardScenario = () => createDashboardScenario('v1');
+  const buildV2DashboardScenario = () => createDashboardScenario('v2');
 });

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
@@ -298,6 +298,59 @@ describe('ShareExportTab', () => {
       // Should report correct initial version
       expect(result.initialSaveModelVersion).toBe('v1');
     });
+
+    // If V2 dashboard → Classic should convert to V1 and export plain JSON
+    it('should convert V2 dashboard to classic V1 format', async () => {
+      const tab = buildV2DashboardScenario();
+      tab.setState({ exportFormat: ExportFormat.Classic });
+
+      const result = await tab.getExportableDashboardJson();
+
+      // Should return plain V1 dashboard JSON (not wrapped in resource)
+      expect(result.json).toMatchObject({
+        title: 'Transformed V1',
+      });
+
+      // Should NOT have resource wrapper properties
+      expect(result.json).not.toHaveProperty('apiVersion');
+      expect(result.json).not.toHaveProperty('kind');
+      expect(result.json).not.toHaveProperty('status');
+
+      // Should NOT have V2-specific properties
+      expect(result.json).not.toHaveProperty('elements');
+      expect(result.json).not.toHaveProperty('layout');
+
+      // Should call V2→V1 transformation
+      expect(transformSceneToV2Spy).toHaveBeenCalled();
+      expect(transformV2ToV1Spy).toHaveBeenCalled();
+
+      // Should report correct initial version
+      expect(result.initialSaveModelVersion).toBe('v2');
+    });
+
+    // If V2 dashboard → Classic with external sharing should transform and apply external sharing
+    it('should handle external sharing when converting V2 dashboard to classic format', async () => {
+      const tab = buildV2DashboardScenario();
+      tab.setState({
+        exportFormat: ExportFormat.Classic,
+        isSharingExternally: true,
+      });
+
+      const result = await tab.getExportableDashboardJson();
+
+      // Should NOT have resource wrapper properties
+      expect(result.json).not.toHaveProperty('apiVersion');
+      expect(result.json).not.toHaveProperty('kind');
+      expect(result.json).not.toHaveProperty('status');
+
+      // Should call V2→V1 transformation and makeExportableV1
+      expect(transformSceneToV2Spy).toHaveBeenCalled();
+      expect(transformV2ToV1Spy).toHaveBeenCalled();
+      expect(makeExportableV1Spy).toHaveBeenCalled();
+
+      // Should report correct initial version
+      expect(result.initialSaveModelVersion).toBe('v2');
+    });
   });
 
   describe('Export mode state management', () => {

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
@@ -162,7 +162,11 @@ describe('ShareExportTab', () => {
   });
 
   describe('V2Resource export mode', () => {
-    it('should default to V2Resource export format', async () => {
+    beforeEach(() => {
+      config.featureToggles.dashboardNewLayouts = true;
+    });
+
+    it('should default to V2Resource when dashboardNewLayouts is enabled', async () => {
       const tab = buildV2DashboardScenario();
 
       expect(tab.state.exportFormat).toBe(ExportFormat.V2Resource);
@@ -258,6 +262,11 @@ describe('ShareExportTab', () => {
   });
 
   describe('Classic export mode', () => {
+    it('should default to Classic when dashboardNewLayouts is disabled', () => {
+      const tab = buildV1DashboardScenario();
+      expect(tab.state.exportFormat).toBe(ExportFormat.Classic);
+    });
+
     it('should export V1 dashboard as plain JSON via API', async () => {
       const tab = buildV1DashboardScenario();
       tab.setState({ exportFormat: ExportFormat.Classic });

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -11,21 +11,14 @@ import { Dashboard } from '@grafana/schema';
 import { Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { Button, ClipboardButton, CodeEditor, Field, Modal, Stack, Switch } from '@grafana/ui';
 import { ObjectMeta } from 'app/features/apiserver/types';
-import { transformDashboardV2SpecToV1 } from 'app/features/dashboard/api/ResponseTransformers';
-import { ExportFormat, DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
-import { isDashboardV2Spec, isV1ClassicDashboard } from 'app/features/dashboard/api/utils';
-import { K8S_V1_DASHBOARD_API_CONFIG } from 'app/features/dashboard/api/v1';
-import { K8S_V2_DASHBOARD_API_CONFIG } from 'app/features/dashboard/api/v2';
+import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
+import { ExportFormat } from 'app/features/dashboard/api/types';
+import { isDashboardV2Spec } from 'app/features/dashboard/api/utils';
 import { shareDashboardType } from 'app/features/dashboard/components/ShareModal/utils';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { DashboardJson } from 'app/features/manage-dashboards/types';
-import { DashboardDataDTO } from 'app/types/dashboard';
 
-import { DashboardScene } from '../scene/DashboardScene';
 import { makeExportableV1, makeExportableV2 } from '../scene/export/exporters';
-import { createV2RowsLayout, transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
-import { transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
-import { transformSceneToSaveModelSchemaV2 } from '../serialization/transformSceneToSaveModelSchemaV2';
 import { getVariablesCompatibility } from '../utils/getVariablesCompatibility';
 import { DashboardInteractions } from '../utils/interactions';
 import { getDashboardSceneFor, hasLibraryPanelsInV1Dashboard } from '../utils/utils';
@@ -35,11 +28,9 @@ import { SceneShareTabState, ShareView } from './types';
 
 export interface ExportableResource {
   apiVersion: string;
-  kind: 'DashboardWithAccessInfo';
-  metadata: DashboardWithAccessInfo<DashboardV2Spec>['metadata'] | Partial<ObjectMeta>;
-  spec: Dashboard | DashboardModel | DashboardV2Spec | DashboardJson | DashboardDataDTO | { error: unknown };
-  // A placeholder for now because as code tooling expects it
-  status: {};
+  kind: 'Dashboard';
+  metadata: Partial<ObjectMeta>;
+  spec: Dashboard | DashboardV2Spec | DashboardJson | { error: unknown };
 }
 
 export interface ShareExportTabState extends SceneShareTabState {
@@ -58,7 +49,6 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
       ...state,
       isSharingExternally: false,
       isViewingJSON: false,
-      exportFormat: config.featureToggles.kubernetesDashboards ? ExportFormat.Classic : undefined,
     });
   }
 
@@ -110,238 +100,140 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
     initialSaveModelVersion: 'v1' | 'v2';
   }> => {
     const { isSharingExternally, exportFormat } = this.state;
-
     const scene = getDashboardSceneFor(this);
-    const exportableDashboard = await scene.serializer.makeExportableExternally(scene);
-    const initialSaveModel = scene.getInitialSaveModel();
-    const initialSaveModelVersion = initialSaveModel && isDashboardV2Spec(initialSaveModel) ? 'v2' : 'v1';
-    const origDashboard = scene.serializer.getSaveModel(scene);
-    const exportable = isSharingExternally ? exportableDashboard : origDashboard;
-    const metadata = getMetadata(scene, Boolean(isSharingExternally));
+    const uid = scene.state.uid;
 
-    if (
-      isDashboardV2Spec(origDashboard) &&
-      'elements' in exportable &&
-      initialSaveModelVersion === 'v2' &&
-      exportFormat !== ExportFormat.V1Resource &&
-      exportFormat !== ExportFormat.Classic
-    ) {
-      this.setState({
-        exportFormat: ExportFormat.V2Resource,
-      });
-
-      // For automatic V2 path, also process library panels when sharing externally
-      let finalSpec = exportable;
-      if (isSharingExternally && isDashboardV2Spec(exportable)) {
-        const specCopy = JSON.parse(JSON.stringify(exportable));
-        const result = await makeExportableV2(specCopy, isSharingExternally);
-        if ('error' in result) {
-          return {
-            json: { error: result.error },
-            initialSaveModelVersion,
-            hasLibraryPanels: Object.values(origDashboard.elements).some((element) => element.kind === 'LibraryPanel'),
-          };
-        }
-        finalSpec = result;
-      }
-
+    if (!uid) {
       return {
-        json: {
-          apiVersion: scene.serializer.apiVersion ?? '',
-          kind: 'DashboardWithAccessInfo',
-          metadata,
-          spec: finalSpec,
-          status: {},
-        },
-        initialSaveModelVersion,
-        hasLibraryPanels: Object.values(origDashboard.elements).some((element) => element.kind === 'LibraryPanel'),
+        json: { error: 'Dashboard has no UID. Save the dashboard first.' },
+        initialSaveModelVersion: 'v1',
+        hasLibraryPanels: undefined,
       };
     }
 
-    if (exportFormat === ExportFormat.V1Resource) {
-      // Check if source is V2 and auto-transform to V1
-      if (isDashboardV2Spec(origDashboard) && initialSaveModelVersion === 'v2') {
-        try {
-          const spec = transformSceneToSaveModelSchemaV2(scene);
-          const metadata = getMetadata(scene, Boolean(isSharingExternally));
-          const spec1 = transformDashboardV2SpecToV1(spec, {
-            name: metadata.name ?? '',
-            generation: metadata.generation ?? 0,
-            resourceVersion: metadata.resourceVersion ?? '0',
-            creationTimestamp: metadata.creationTimestamp ?? '',
-          });
+    const initialSaveModel = scene.getInitialSaveModel();
+    const initialSaveModelVersion = initialSaveModel && isDashboardV2Spec(initialSaveModel) ? 'v2' : 'v1';
 
-          let exportableV1: Dashboard | DashboardDataDTO | DashboardJson | { error: unknown };
-          if (isSharingExternally) {
-            const oldModel = new DashboardModel(spec1, undefined, {
-              getVariablesFromState: () => {
-                return getVariablesCompatibility(window.__grafanaSceneContext);
-              },
-            });
-            exportableV1 = await makeExportableV1(oldModel);
-          } else {
-            exportableV1 = spec1;
-          }
-          return {
-            json: {
-              // Forcing V1 version here to match export mode selection
-              apiVersion: `${K8S_V1_DASHBOARD_API_CONFIG.group}/${K8S_V1_DASHBOARD_API_CONFIG.version}`,
-              kind: 'DashboardWithAccessInfo',
-              metadata,
-              spec: exportableV1,
-              status: {},
-            },
-            initialSaveModelVersion,
-            hasLibraryPanels: hasLibraryPanelsInV1Dashboard(spec1),
-          };
-        } catch (err) {
-          return {
-            json: {
-              error: `Failed to convert dashboard to v1. ${err}`,
-            },
-            initialSaveModelVersion,
-            hasLibraryPanels: undefined,
-          };
-        }
-      } else {
-        // Source is already V1, export as-is
-        const spec = transformSceneToSaveModel(scene);
-        return {
-          json: {
-            // Forcing V1 version here to match export mode selection
-            apiVersion: `${K8S_V1_DASHBOARD_API_CONFIG.group}/${K8S_V1_DASHBOARD_API_CONFIG.version}`,
-            kind: 'DashboardWithAccessInfo',
-            metadata,
-            spec,
-            status: {},
-          },
-          initialSaveModelVersion,
-          hasLibraryPanels: hasLibraryPanelsInV1Dashboard(spec),
-        };
-      }
+    // When kubernetesDashboards is off, use the legacy scene-based export
+    if (!config.featureToggles.kubernetesDashboards) {
+      const origDashboard = scene.serializer.getSaveModel(scene);
+      const exportable = isSharingExternally ? await scene.serializer.makeExportableExternally(scene) : origDashboard;
+      return {
+        json: exportable,
+        hasLibraryPanels:
+          'error' in exportable || !('panels' in origDashboard) ? false : hasLibraryPanelsInV1Dashboard(origDashboard),
+        initialSaveModelVersion,
+      };
     }
 
-    if (exportFormat === ExportFormat.V2Resource) {
-      let sceneForV2Export = scene;
+    const effectiveFormat =
+      exportFormat ?? (initialSaveModelVersion === 'v2' ? ExportFormat.V2Resource : ExportFormat.Classic);
 
-      // When exporting v1 dashboard as v2, we need to recreate the scene with v2 layout creator
-      // to ensure rows are properly serialized. The v1 scene uses DefaultGridLayoutManager which
-      // doesn't know about RowsLayoutManager structure needed for v2 serialization.
-      if (initialSaveModelVersion === 'v1' && initialSaveModel && isV1ClassicDashboard(initialSaveModel)) {
-        // Recreate scene with v2 layout creator to properly handle rows
-        sceneForV2Export = transformSaveModelToScene(
-          {
-            dashboard: { ...initialSaveModel, title: initialSaveModel.title ?? '', uid: initialSaveModel.uid ?? '' },
-            meta: scene.state.meta,
-          },
-          undefined,
-          {
-            createLayout: createV2RowsLayout,
-            targetVersion: 'v2',
-          }
-        );
+    if (exportFormat === undefined) {
+      this.setState({ exportFormat: effectiveFormat });
+    }
+
+    if (effectiveFormat === ExportFormat.V2Resource) {
+      return this.fetchV2Resource(uid, isSharingExternally, initialSaveModelVersion);
+    }
+
+    return this.fetchClassic(uid, isSharingExternally, initialSaveModelVersion);
+  };
+
+  private fetchClassic = async (
+    uid: string,
+    isSharingExternally: boolean | undefined,
+    initialSaveModelVersion: 'v1' | 'v2'
+  ): Promise<{
+    json: Dashboard | DashboardJson | { error: unknown };
+    hasLibraryPanels?: boolean;
+    initialSaveModelVersion: 'v1' | 'v2';
+  }> => {
+    try {
+      const dto = await getDashboardAPI('v1').getDashboardDTO(uid);
+      const spec = dto.dashboard;
+
+      if (isSharingExternally) {
+        const model = new DashboardModel(spec, undefined, {
+          getVariablesFromState: () => getVariablesCompatibility(window.__grafanaSceneContext),
+        });
+        return {
+          json: await makeExportableV1(model),
+          hasLibraryPanels: hasLibraryPanelsInV1Dashboard(spec),
+          initialSaveModelVersion,
+        };
       }
 
-      const spec = transformSceneToSaveModelSchemaV2(sceneForV2Export);
-      const specCopy = JSON.parse(JSON.stringify(spec));
-      const statelessSpec = await makeExportableV2(specCopy, isSharingExternally);
-      const exportableV2 = isSharingExternally ? statelessSpec : spec;
-      // Check if dashboard contains library panels based on dashboard version
-      let hasLibraryPanels = false;
-      // Case: V1 dashboard loaded (with kubernetesDashboards enabled and dashboardNewLayouts disabled), and user explicitly selected V2Resource export mode
-      if (initialSaveModelVersion === 'v1' && !isDashboardV2Spec(origDashboard)) {
-        hasLibraryPanels = hasLibraryPanelsInV1Dashboard(origDashboard);
-      } else if (isDashboardV2Spec(origDashboard)) {
-        // Case: V2 dashboard (either originally V2 or transformed from V1) being exported as V2Resource
-        hasLibraryPanels = Object.values(origDashboard.elements).some((element) => element.kind === 'LibraryPanel');
+      return {
+        json: spec,
+        hasLibraryPanels: hasLibraryPanelsInV1Dashboard(spec),
+        initialSaveModelVersion,
+      };
+    } catch (err) {
+      return {
+        json: { error: `Failed to fetch dashboard in classic format. ${err}` },
+        initialSaveModelVersion,
+        hasLibraryPanels: undefined,
+      };
+    }
+  };
+
+  private fetchV2Resource = async (
+    uid: string,
+    isSharingExternally: boolean | undefined,
+    initialSaveModelVersion: 'v1' | 'v2'
+  ): Promise<{
+    json: ExportableResource | { error: unknown };
+    hasLibraryPanels?: boolean;
+    initialSaveModelVersion: 'v1' | 'v2';
+  }> => {
+    try {
+      const resource = await getDashboardAPI('v2').getDashboardDTO(uid);
+      const spec = resource.spec;
+      const hasLibraryPanels =
+        'elements' in spec
+          ? Object.values(spec.elements).some((el: { kind: string }) => el.kind === 'LibraryPanel')
+          : false;
+
+      if (isSharingExternally) {
+        const specCopy = JSON.parse(JSON.stringify(resource.spec));
+        const exportedSpec = await makeExportableV2(specCopy, true);
+        if ('error' in exportedSpec) {
+          return {
+            json: { error: exportedSpec.error },
+            initialSaveModelVersion,
+            hasLibraryPanels,
+          };
+        }
+        return {
+          json: {
+            apiVersion: resource.apiVersion,
+            kind: 'Dashboard',
+            metadata: stripMetadataForExport(resource.metadata, true),
+            spec: exportedSpec,
+          },
+          initialSaveModelVersion,
+          hasLibraryPanels,
+        };
       }
 
       return {
         json: {
-          // Forcing V2 version here because in this case we have v1 serializer
-          apiVersion: `${K8S_V2_DASHBOARD_API_CONFIG.group}/${K8S_V2_DASHBOARD_API_CONFIG.version}`,
-          kind: 'DashboardWithAccessInfo',
-          metadata,
-          spec: exportableV2,
-          status: {},
+          apiVersion: resource.apiVersion,
+          kind: 'Dashboard',
+          metadata: stripMetadataForExport(resource.metadata, false),
+          spec: resource.spec,
         },
         initialSaveModelVersion,
         hasLibraryPanels,
       };
-    }
-
-    // Classic mode
-    // This handles a case when:
-    // 1. dashboardNewLayouts feature toggle is enabled
-    // 2. v1 dashboard is loaded
-    // 3. dashboard hasn't been edited yet - if it was edited, user would be forced to save it in v2 version
-    if (
-      initialSaveModelVersion === 'v1' &&
-      isDashboardV2Spec(origDashboard) &&
-      initialSaveModel &&
-      'panels' in initialSaveModel
-    ) {
-      const oldModel = new DashboardModel(initialSaveModel, undefined, {
-        getVariablesFromState: () => {
-          return getVariablesCompatibility(window.__grafanaSceneContext);
-        },
-      });
-      const exportableV1 = isSharingExternally ? await makeExportableV1(oldModel) : initialSaveModel;
+    } catch (err) {
       return {
-        json: exportableV1,
-        hasLibraryPanels: hasLibraryPanelsInV1Dashboard(initialSaveModel),
+        json: { error: `Failed to fetch dashboard as V2 resource. ${err}` },
         initialSaveModelVersion,
+        hasLibraryPanels: undefined,
       };
     }
-
-    // Classic mode for natively v2 dashboards: convert v2 -> v1 classic format
-    if (exportFormat === ExportFormat.Classic && initialSaveModelVersion === 'v2' && isDashboardV2Spec(origDashboard)) {
-      try {
-        const spec = transformSceneToSaveModelSchemaV2(scene);
-        const spec1 = transformDashboardV2SpecToV1(spec, {
-          name: metadata.name ?? '',
-          generation: metadata.generation ?? 0,
-          resourceVersion: metadata.resourceVersion ?? '0',
-          creationTimestamp: metadata.creationTimestamp ?? '',
-        });
-
-        if (isSharingExternally) {
-          const oldModel = new DashboardModel(spec1, undefined, {
-            getVariablesFromState: () => {
-              return getVariablesCompatibility(window.__grafanaSceneContext);
-            },
-          });
-          return {
-            json: await makeExportableV1(oldModel),
-            hasLibraryPanels: hasLibraryPanelsInV1Dashboard(spec1),
-            initialSaveModelVersion,
-          };
-        }
-
-        return {
-          json: spec1,
-          hasLibraryPanels: hasLibraryPanelsInV1Dashboard(spec1),
-          initialSaveModelVersion,
-        };
-      } catch (err) {
-        return {
-          json: { error: `Failed to convert dashboard to classic format. ${err}` },
-          initialSaveModelVersion,
-          hasLibraryPanels: undefined,
-        };
-      }
-    }
-
-    // legacy mode or classic mode when dashboardNewLayouts is disabled
-    // At this point we know that dashboard should be V1 or could have produced an error
-    return {
-      json: exportable,
-      hasLibraryPanels:
-        'error' in exportable || !isV1ClassicDashboard(origDashboard)
-          ? false
-          : hasLibraryPanelsInV1Dashboard(origDashboard),
-      initialSaveModelVersion,
-    };
   };
 
   public onSaveAsFile = async () => {
@@ -385,44 +277,25 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
   };
 }
 
-function getMetadata(
-  scene: DashboardScene,
-  isSharingExternally: boolean
-): DashboardWithAccessInfo<DashboardV2Spec>['metadata'] | Partial<ObjectMeta> {
-  let result: Partial<ObjectMeta> = {};
+function stripMetadataForExport(metadata: ObjectMeta, isSharingExternally: boolean): Partial<ObjectMeta> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result: Record<string, any> = cloneDeep(metadata);
 
-  if (scene.serializer.metadata) {
-    if ('k8s' in scene.serializer.metadata) {
-      result = scene.serializer.metadata.k8s ? cloneDeep(scene.serializer.metadata.k8s) : {};
-    } else if ('annotations' in scene.serializer.metadata) {
-      result = cloneDeep(scene.serializer.metadata);
-    }
-  }
-
-  if ('managedFields' in result) {
-    delete result['managedFields'];
-  }
+  delete result['managedFields'];
 
   if (isSharingExternally) {
-    // Remove fields that are not needed for sharing externally
-    if ('uid' in result) {
-      delete result['uid'];
-    }
+    delete result['uid'];
     delete result['resourceVersion'];
     delete result['namespace'];
 
-    // iterate over labels and delete all keys that start with grafana.app/
     for (const key in result['labels']) {
       if (key.startsWith('grafana.app/')) {
-        // @ts-expect-error
         delete result['labels'][key];
       }
     }
 
-    // iterate over annotations and delete all keys that start with grafana.app/
     for (const key in result['annotations']) {
       if (key.startsWith('grafana.app/')) {
-        // @ts-expect-error
         delete result['annotations'][key];
       }
     }

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -49,6 +49,7 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
       ...state,
       isSharingExternally: false,
       isViewingJSON: false,
+      exportFormat: ExportFormat.V2Resource,
     });
   }
 
@@ -126,14 +127,7 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
       };
     }
 
-    const effectiveFormat =
-      exportFormat ?? (initialSaveModelVersion === 'v2' ? ExportFormat.V2Resource : ExportFormat.Classic);
-
-    if (exportFormat === undefined) {
-      this.setState({ exportFormat: effectiveFormat });
-    }
-
-    if (effectiveFormat === ExportFormat.V2Resource) {
+    if (exportFormat === ExportFormat.V2Resource) {
       return this.fetchV2Resource(uid, isSharingExternally, initialSaveModelVersion);
     }
 
@@ -308,8 +302,7 @@ function ShareExportTabRenderer({ model }: SceneComponentProps<ShareExportTab>) 
   const { isSharingExternally, isViewingJSON, modalRef, exportFormat, isViewingYAML } = model.useState();
 
   const dashboardJson = useAsync(async () => {
-    const json = await model.getExportableDashboardJson();
-    return json;
+    return model.getExportableDashboardJson();
   }, [isViewingJSON, isSharingExternally, exportFormat]);
 
   const stringifiedDashboardJson = JSON.stringify(dashboardJson.value?.json, null, 2);

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -49,7 +49,7 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
       ...state,
       isSharingExternally: false,
       isViewingJSON: false,
-      exportFormat: ExportFormat.V2Resource,
+      exportFormat: config.featureToggles.dashboardNewLayouts ? ExportFormat.V2Resource : ExportFormat.Classic,
     });
   }
 
@@ -70,13 +70,8 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
   public onExportFormatChange = (exportFormat: ExportFormat) => {
     this.setState({
       exportFormat,
+      ...(exportFormat === ExportFormat.Classic && { isViewingYAML: false }),
     });
-
-    if (exportFormat === ExportFormat.Classic) {
-      this.setState({
-        isViewingYAML: false,
-      });
-    }
   };
 
   public onViewJSON = () => {
@@ -165,7 +160,9 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
       };
     } catch (err) {
       return {
-        json: { error: `Failed to fetch dashboard in classic format. ${err}` },
+        json: {
+          error: `Failed to fetch dashboard in classic format. ${err instanceof Error ? err.message : String(err)}`,
+        },
         initialSaveModelVersion,
         hasLibraryPanels: undefined,
       };
@@ -223,7 +220,9 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
       };
     } catch (err) {
       return {
-        json: { error: `Failed to fetch dashboard as V2 resource. ${err}` },
+        json: {
+          error: `Failed to fetch dashboard as V2 resource. ${err instanceof Error ? err.message : String(err)}`,
+        },
         initialSaveModelVersion,
         hasLibraryPanels: undefined,
       };
@@ -324,7 +323,10 @@ function ShareExportTabRenderer({ model }: SceneComponentProps<ShareExportTab>) 
             <ResourceExport
               dashboardJson={dashboardJson}
               isSharingExternally={isSharingExternally ?? false}
-              exportFormat={exportFormat ?? ExportFormat.Classic}
+              exportFormat={
+                exportFormat ??
+                (config.featureToggles.dashboardNewLayouts ? ExportFormat.V2Resource : ExportFormat.Classic)
+              }
               isViewingYAML={isViewingYAML ?? false}
               onExportFormatChange={model.onExportFormatChange}
               onShareExternallyChange={model.onShareExternallyChange}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6920,6 +6920,7 @@
       "static-options-legend": "Static options"
     },
     "resource-export": {
+      "classic-v2-warning": "This dashboard uses the V2 schema. Features like tabs and conditional rendering cannot be represented in the classic format and may be lost.",
       "label": {
         "advanced-options": "Advanced options",
         "classic": "Classic",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6924,7 +6924,6 @@
         "advanced-options": "Advanced options",
         "classic": "Classic",
         "json": "JSON",
-        "v1-resource": "V1 Resource",
         "v2-resource": "V2 Resource",
         "yaml": "YAML"
       },


### PR DESCRIPTION
Refactors dashboard export to fetch data through the API (`getDashboardAPI`) instead of serializing on the client side. This ensures exported dashboards are consistent with what the server stores. Simplifies export modes to "Classic" (v1 spec via v1 API) and "V2 Resource" (v2 k8s resource via v2 API), removing the redundant "V1 Resource" option. Exported V2 resources now use `kind: "Dashboard"` and omit `status`/`access` properties.

---
<p><a href="https://cursor.com/agents/bc-25463812-60d5-4814-9ce2-257b59dc52d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25463812-60d5-4814-9ce2-257b59dc52d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

