### PR TITLE
Provisioning: set default repo types differently

### DIFF
--- a/pkg/registry/apis/provisioning/extras/register.go
+++ b/pkg/registry/apis/provisioning/extras/register.go
@@ -62,6 +62,7 @@ func ProvideExtraWorkers(pullRequestWorker *pullrequest.PullRequestWorker) []job
 func ProvideFactoryFromConfig(cfg *setting.Cfg, extras []repository.Extra) (repository.Factory, error) {
 	types := cfg.ProvisioningRepositoryTypes
 	if len(types) == 0 {
+		// Enforcing default repository values if settings are not set
 		types = []string{"git", "github", "local"}
 	}
 	enabledTypes := make(map[apisprovisioning.RepositoryType]struct{}, len(types))
@@ -73,8 +74,13 @@ func ProvideFactoryFromConfig(cfg *setting.Cfg, extras []repository.Extra) (repo
 }
 
 func ProvideConnectionFactoryFromConfig(cfg *setting.Cfg, extras []connection.Extra) (connection.Factory, error) {
-	enabledTypes := make(map[apisprovisioning.ConnectionType]struct{}, len(cfg.ProvisioningRepositoryTypes))
-	for _, e := range cfg.ProvisioningRepositoryTypes {
+	types := cfg.ProvisioningRepositoryTypes
+	if len(types) == 0 {
+		// Enforcing default connection values if settings are not set
+		types = []string{"github"}
+	}
+	enabledTypes := make(map[apisprovisioning.ConnectionType]struct{}, len(types))
+	for _, e := range types {
 		enabledTypes[apisprovisioning.ConnectionType(e)] = struct{}{}
 	}
 

--- a/pkg/registry/apis/provisioning/extras/register.go
+++ b/pkg/registry/apis/provisioning/extras/register.go
@@ -60,8 +60,12 @@ func ProvideExtraWorkers(pullRequestWorker *pullrequest.PullRequestWorker) []job
 }
 
 func ProvideFactoryFromConfig(cfg *setting.Cfg, extras []repository.Extra) (repository.Factory, error) {
-	enabledTypes := make(map[apisprovisioning.RepositoryType]struct{}, len(cfg.ProvisioningRepositoryTypes))
-	for _, e := range cfg.ProvisioningRepositoryTypes {
+	types := cfg.ProvisioningRepositoryTypes
+	if len(types) == 0 {
+		types = []string{"git", "github", "local"}
+	}
+	enabledTypes := make(map[apisprovisioning.RepositoryType]struct{}, len(types))
+	for _, e := range types {
 		enabledTypes[apisprovisioning.RepositoryType(e)] = struct{}{}
 	}
 

--- a/pkg/registry/apis/wireset.go
+++ b/pkg/registry/apis/wireset.go
@@ -48,7 +48,6 @@ var WireSetExts = wire.NewSet(
 var provisioningExtras = wire.NewSet(
 	pullrequest.ProvidePullRequestWorker,
 	webhooks.ProvideWebhooksWithImages,
-	extras.ProvideFactoryFromConfig,
 	extras.ProvideConnectionFactoryFromConfig,
 	extras.ProvideProvisioningExtraAPIs,
 	extras.ProvideExtraWorkers,

--- a/pkg/server/wireexts_oss.go
+++ b/pkg/server/wireexts_oss.go
@@ -74,6 +74,7 @@ import (
 var provisioningExtras = wire.NewSet(
 	extras.ProvideProvisioningOSSRepositoryExtras,
 	extras.ProvideProvisioningOSSConnectionExtras,
+	extras.ProvideFactoryFromConfig,
 )
 
 var configProviderExtras = wire.NewSet(

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -2198,7 +2198,7 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 		}
 	}
 
-	repositoryTypes := strings.TrimSpace(valueAsString(iniFile.Section("provisioning"), "repository_types", "git|github|local"))
+	repositoryTypes := strings.TrimSpace(valueAsString(iniFile.Section("provisioning"), "repository_types", ""))
 	if repositoryTypes != "|" && repositoryTypes != "" {
 		cfg.ProvisioningRepositoryTypes = strings.Split(repositoryTypes, "|")
 		for i, s := range cfg.ProvisioningRepositoryTypes {

--- a/pkg/tests/apis/provisioning/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection_test.go
@@ -930,7 +930,8 @@ func TestIntegrationProvisioning_ConnectionEnterpriseValidation(t *testing.T) {
 		t.Skip("Skipping integration test when not enterprise")
 	}
 
-	helper := runGrafana(t)
+	// Enforcing enterprise connection types for the test (defaults to github only)
+	helper := runGrafana(t, withRepositoryTypes([]string{"github", "gitlab", "bitbucket"}))
 	createOptions := metav1.CreateOptions{FieldValidation: "Strict"}
 	ctx := context.Background()
 
@@ -2289,7 +2290,8 @@ func TestIntegrationConnectionController_EnterpriseWiring(t *testing.T) {
 		t.Skip("Skipping integration test when not enterprise")
 	}
 
-	helper := runGrafana(t)
+	// Enforcing enterprise connection types for the test (defaults to github only)
+	helper := runGrafana(t, withRepositoryTypes([]string{"github", "gitlab", "bitbucket"}))
 	ctx := context.Background()
 
 	t.Run("GitLab connection can be created and reconciled", func(t *testing.T) {

--- a/pkg/tests/apis/provisioning/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection_test.go
@@ -341,7 +341,8 @@ func TestIntegrationProvisioning_ConnectionEnterpriseMutation(t *testing.T) {
 		t.Skip("Skipping integration test when not enterprise")
 	}
 
-	helper := runGrafana(t)
+	// Enforcing enterprise connection types for the test (defaults to github only)
+	helper := runGrafana(t, withRepositoryTypes([]string{"github", "gitlab", "bitbucket"}))
 	ctx := context.Background()
 
 	gitlabNamePrefix := fmt.Sprintf("%s-", provisioning.GitlabConnectionType)

--- a/pkg/tests/apis/provisioning/helper_test.go
+++ b/pkg/tests/apis/provisioning/helper_test.go
@@ -34,7 +34,6 @@ import (
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	githubConnection "github.com/grafana/grafana/apps/provisioning/pkg/connection/github"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
-	"github.com/grafana/grafana/pkg/extensions"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
@@ -734,6 +733,12 @@ func withLogs(opts *testinfra.GrafanaOpts) {
 	opts.EnableLog = true
 }
 
+func withRepositoryTypes(types []string) grafanaOption {
+	return func(opts *testinfra.GrafanaOpts) {
+		opts.ProvisioningRepositoryTypes = types
+	}
+}
+
 func runGrafana(t *testing.T, options ...grafanaOption) *provisioningTestHelper {
 	provisioningPath := t.TempDir()
 	opts := testinfra.GrafanaOpts{
@@ -758,10 +763,6 @@ func runGrafana(t *testing.T, options ...grafanaOption) *provisioningTestHelper 
 		// Allow both folder and instance sync targets for tests
 		// (instance is needed for export jobs, folder for most operations)
 		ProvisioningAllowedTargets: []string{"folder", "instance"},
-	}
-
-	if extensions.IsEnterprise {
-		opts.ProvisioningRepositoryTypes = []string{"local", "git", "github", "gitlab", "bitbucket"}
 	}
 
 	for _, o := range options {


### PR DESCRIPTION
**What is this feature?**

This PR changes a bit the way we set the default repository types, so that we can setup correctly in enterprise.
It also adds some integration tests to check if we can set types correctly.

Counterpart: https://github.com/grafana/grafana-enterprise/pull/11070

**Why do we need this feature?**

We're adding new repository types as default in OSS / Enterprise. 

**Who is this feature for?**

Users of GitSync

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/856

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
