### PR TITLE
Team Folders: Change permissions check to be "can set permissions" 

### DIFF
--- a/public/app/core/components/OwnerReferences/OwnerReferenceSelector.tsx
+++ b/public/app/core/components/OwnerReferences/OwnerReferenceSelector.tsx
@@ -2,6 +2,7 @@ import { QueryStatus } from '@reduxjs/toolkit/query';
 import { useEffect, useState } from 'react';
 
 import { t, Trans } from '@grafana/i18n';
+import { isFetchError } from '@grafana/runtime';
 import { Alert, Box, Combobox, ComboboxOption, Label } from '@grafana/ui';
 import { OwnerReference } from 'app/api/clients/folder/v1beta1';
 import {
@@ -33,11 +34,17 @@ export const OwnerReferenceSelector = ({
 
   useEffect(() => {
     if (defaultTeamUid) {
-      getTeam({ name: defaultTeamUid }, true).then((query) => {
-        if (query.status === QueryStatus.fulfilled) {
+      getTeam({ name: defaultTeamUid }, true).then(({ data, status }) => {
+        if (status === QueryStatus.fulfilled) {
           setSelectedTeam({
-            label: query.data.spec.title,
-            value: query.data.metadata.name!,
+            label: data.spec.title,
+            value: data.metadata.name!,
+          });
+        }
+        if (status === QueryStatus.rejected) {
+          setSelectedTeam({
+            label: t('manage-owner-references.team-not-found', '[Unknown team]'),
+            value: defaultTeamUid,
           });
         }
         // We ignore errors here as we handle them with the useLazyGetTeamQuery call
@@ -55,14 +62,24 @@ export const OwnerReferenceSelector = ({
 
     return mappedResults;
   };
+
+  const teamIsMissingOrForbidden = isFetchError(selectedTeamError) && [404, 403].includes(selectedTeamError.status);
+  const errorLevel = teamIsMissingOrForbidden ? 'warning' : 'error';
+  const teamErrorMessage = teamIsMissingOrForbidden ? (
+    <Trans i18nKey="manage-owner-references.team-not-found">
+      Selected team not found, or you do not have the necessary permissions to view it.
+    </Trans>
+  ) : (
+    extractErrorMessage(selectedTeamError)
+  );
   return (
     <Box>
       {Boolean(selectedTeamError) && (
         <Alert
-          severity="error"
+          severity={errorLevel}
           title={t('manage-owner-references.error-load-team-details', 'Could not load team details')}
         >
-          {extractErrorMessage(selectedTeamError)}
+          {teamErrorMessage}
         </Alert>
       )}
       <Label htmlFor="owner-reference-selector">

--- a/public/app/core/components/OwnerReferences/OwnerReferenceSelector.tsx
+++ b/public/app/core/components/OwnerReferences/OwnerReferenceSelector.tsx
@@ -66,9 +66,11 @@ export const OwnerReferenceSelector = ({
   const teamIsMissingOrForbidden = isFetchError(selectedTeamError) && [404, 403].includes(selectedTeamError.status);
   const errorLevel = teamIsMissingOrForbidden ? 'warning' : 'error';
   const teamErrorMessage = teamIsMissingOrForbidden ? (
-    <Trans i18nKey="manage-owner-references.team-not-found">
-      Selected team not found, or you do not have the necessary permissions to view it.
-    </Trans>
+    <>
+      <Trans i18nKey="manage-owner-references.selected-team-not-found">
+        Selected team not found, or you do not have the necessary permissions to view it.
+      </Trans>
+    </>
   ) : (
     extractErrorMessage(selectedTeamError)
   );

--- a/public/app/core/components/OwnerReferences/OwnerReferenceSelector.tsx
+++ b/public/app/core/components/OwnerReferences/OwnerReferenceSelector.tsx
@@ -66,11 +66,9 @@ export const OwnerReferenceSelector = ({
   const teamIsMissingOrForbidden = isFetchError(selectedTeamError) && [404, 403].includes(selectedTeamError.status);
   const errorLevel = teamIsMissingOrForbidden ? 'warning' : 'error';
   const teamErrorMessage = teamIsMissingOrForbidden ? (
-    <>
-      <Trans i18nKey="manage-owner-references.selected-team-not-found">
-        Selected team not found, or you do not have the necessary permissions to view it.
-      </Trans>
-    </>
+    <Trans i18nKey="manage-owner-references.selected-team-not-found">
+      Selected team not found, or you do not have the necessary permissions to view it.
+    </Trans>
   ) : (
     extractErrorMessage(selectedTeamError)
   );

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
@@ -7,10 +7,12 @@ import { Button, Drawer, Dropdown, Icon, Menu, MenuItem, Text } from '@grafana/u
 import { appEvents } from 'app/core/app_events';
 import { Permissions } from 'app/core/components/AccessControl/Permissions';
 import { FolderOwnerModal } from 'app/core/components/OwnerReferences/FolderOwnerModal';
+import { contextSrv } from 'app/core/services/context_srv';
 import { RepoType } from 'app/features/provisioning/Wizard/types';
 import { BulkMoveProvisionedResource } from 'app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource';
 import { DeleteProvisionedFolderForm } from 'app/features/provisioning/components/Folders/DeleteProvisionedFolderForm';
 import { useIsProvisionedInstance } from 'app/features/provisioning/hooks/useIsProvisionedInstance';
+import { AccessControlAction } from 'app/types/accessControl';
 import { ShowModalReactEvent } from 'app/types/events';
 import { FolderDTO } from 'app/types/folders';
 
@@ -141,8 +143,12 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
   const moveLabel = t('browse-dashboards.folder-actions-button.move', 'Move this folder');
   const deleteLabel = t('browse-dashboards.folder-actions-button.delete', 'Delete this folder');
 
-  // For now, only admins can manage folder owners
-  const showManageOwners = config.featureToggles.teamFolders && canSetPermissions && !isProvisionedFolder;
+  // If user can set permissions for the folder and read teams, they can manage folder owners
+  const showManageOwners =
+    config.featureToggles.teamFolders &&
+    canSetPermissions &&
+    contextSrv.hasPermission(AccessControlAction.ActionTeamsRead) &&
+    !isProvisionedFolder;
 
   const menu = (
     <Menu>

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
@@ -7,7 +7,6 @@ import { Button, Drawer, Dropdown, Icon, Menu, MenuItem, Text } from '@grafana/u
 import { appEvents } from 'app/core/app_events';
 import { Permissions } from 'app/core/components/AccessControl/Permissions';
 import { FolderOwnerModal } from 'app/core/components/OwnerReferences/FolderOwnerModal';
-import { contextSrv } from 'app/core/services/context_srv';
 import { RepoType } from 'app/features/provisioning/Wizard/types';
 import { BulkMoveProvisionedResource } from 'app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource';
 import { DeleteProvisionedFolderForm } from 'app/features/provisioning/components/Folders/DeleteProvisionedFolderForm';
@@ -38,8 +37,6 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
   const [moveFolder] = useMoveFolderMutationFacade();
   const isProvisionedInstance = useIsProvisionedInstance();
   const deleteFolder = useDeleteFolderMutationFacade();
-
-  const isAdmin = contextSrv.hasRole('Admin') || contextSrv.isGrafanaAdmin;
 
   const {
     canEditFolders,
@@ -145,7 +142,7 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
   const deleteLabel = t('browse-dashboards.folder-actions-button.delete', 'Delete this folder');
 
   // For now, only admins can manage folder owners
-  const showManageOwners = config.featureToggles.teamFolders && isAdmin && !isProvisionedFolder;
+  const showManageOwners = config.featureToggles.teamFolders && canSetPermissions && !isProvisionedFolder;
 
   const menu = (
     <Menu>

--- a/public/app/features/browse-dashboards/components/NewFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewFolderForm.tsx
@@ -10,6 +10,7 @@ import { FolderDTO } from 'app/types/folders';
 
 import { OwnerReferenceSelector } from '../../../core/components/OwnerReferences/OwnerReferenceSelector';
 import { validationSrv } from '../../manage-dashboards/services/ValidationSrv';
+import { getFolderPermissions } from '../permissions';
 
 interface Props {
   onConfirm: (folderName: string, teamOwnerRefs?: OwnerReference[]) => void;
@@ -24,7 +25,8 @@ interface FormModel {
 const initialFormModel: FormModel = { folderName: '' };
 
 export function NewFolderForm({ onCancel, onConfirm, parentFolder }: Props) {
-  const showFolderOwnerSelector = config.featureToggles.teamFolders;
+  const { canSetPermissions } = getFolderPermissions(parentFolder);
+  const showFolderOwnerSelector = canSetPermissions && config.featureToggles.teamFolders;
   const {
     handleSubmit,
     register,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10968,7 +10968,9 @@
     "manage-folder-owner-alert-text": "Folders owned by teams that you belong to will be prioritised for you in the folder picker and other locations.",
     "manage-folder-owner-alert-title": "Select a team to own this folder to help organise your resources.",
     "save-owner": "Save owner",
-    "select-owner": "Select an owner"
+    "select-owner": "Select an owner",
+    "selected-team-not-found": "Selected team not found, or you do not have the necessary permissions to view it.",
+    "team-not-found": "[Unknown team]"
   },
   "metric-select": {
     "noOptionsMessage-no-options-found": "No options found"


### PR DESCRIPTION
**What is this feature?**
Checks whether the user can set permissions on the given folder when deciding whether to show the team folders management functionality

Additionally shows warning when there is a team but details cannot be seen

**Why do we need this feature?**
So we show the relevant functionality dependent on more than just "is admin Yes/No"

**Who is this feature for?**
Team folders users

<img width="848" height="453" alt="image" src="https://github.com/user-attachments/assets/877ff58b-d0a6-44df-b4c4-9a7f4a286357" />
