### PR TITLE
Alerting: Fix CollateAlertRuleGroup migration for MariaDB compatibility

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_group_collation.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_group_collation.go
@@ -2,8 +2,12 @@ package ualert
 
 import "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 
-// CollateAlertRuleGroup ensures that rule_group column collates.
+// CollateAlertRuleGroup ensures that rule_group column uses a case-sensitive collation.
+// Originally used utf8mb4_0900_as_cs, but that collation is not supported by MariaDB (see #118836).
+// Changed to utf8mb4_bin for compatibility. This is superseded by CollateBinAlertRuleGroup which
+// also sets utf8mb4_bin, but we keep this migration (rather than removing it) to avoid leaving
+// orphan entries in the migration_log table for users who already ran it successfully.
 func CollateAlertRuleGroup(mg *migrator.Migrator) {
 	mg.AddMigration("ensure rule_group column is case sensitive in returned results", migrator.NewRawSQLMigration("").
-		Mysql("ALTER TABLE alert_rule MODIFY rule_group VARCHAR(190) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL;"))
+		Mysql("ALTER TABLE alert_rule MODIFY rule_group VARCHAR(190) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;"))
 }


### PR DESCRIPTION
The `utf8mb4_0900_as_cs` collation used in the migration (added in https://github.com/grafana/grafana/pull/111336) is MySQL 8.0+ only and not supported by MariaDB, which causes startup failure for instances using MariaDB < 11.4.5 (see #118836, https://jira.mariadb.org/browse/MDEV-20912). This migration is already superseded by a later migration ([CollateBinAlertRuleGroup](https://github.com/grafana/grafana/blob/29e6c7a419ab6fadc0edeb0a993646a1da039d52/pkg/services/sqlstore/migrations/ualert/alert_rule_group_collation_bin.go#L6)) that sets `utf8mb4_bin` on the same column. Rather than deleting this migration to avoid keeping orphan entries in the migration_log table for users who already ran it successfully, just changing it to be the same `utf8mb4_bin`.

**Which issue(s) does this PR fix?**:

Fixes #118836

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
