### PR TITLE
Provisioning: Add folder pickers for path fields

### DIFF
--- a/public/app/features/provisioning/Wizard/ConnectStep.tsx
+++ b/public/app/features/provisioning/Wizard/ConnectStep.tsx
@@ -80,7 +80,6 @@ export const ConnectStep = memo(function ConnectStep() {
                   placeholder={gitFields.branchConfig.placeholder}
                   options={repositoryRefsOptions || []}
                   loading={isRefsLoading}
-                  disabled={isRefsLoading}
                   createCustomValue
                   isClearable
                   {...field}

--- a/public/app/features/provisioning/Wizard/ConnectStep.tsx
+++ b/public/app/features/provisioning/Wizard/ConnectStep.tsx
@@ -40,6 +40,7 @@ export const ConnectStep = memo(function ConnectStep() {
     options: folderOptions,
     loading: isFoldersLoading,
     error: foldersError,
+    hint: foldersHint,
   } = useGetRepositoryFolders({
     repositoryName: repositoryName || undefined,
     ref: branch || undefined,
@@ -91,9 +92,9 @@ export const ConnectStep = memo(function ConnectStep() {
           <Field
             noMargin
             label={gitFields.pathConfig.label}
-            description={gitFields.pathConfig.description}
+            description={foldersHint || gitFields.pathConfig.description}
             error={errors?.repository?.path?.message || foldersError}
-            invalid={!!errors?.repository?.path?.message}
+            invalid={Boolean(errors?.repository?.path?.message || foldersError)}
             required={gitFields.pathConfig.required}
           >
             <Controller

--- a/public/app/features/provisioning/Wizard/ConnectStep.tsx
+++ b/public/app/features/provisioning/Wizard/ConnectStep.tsx
@@ -104,7 +104,7 @@ export const ConnectStep = memo(function ConnectStep() {
               render={({ field: { ref, onChange, ...field } }) => (
                 <Combobox
                   invalid={!!errors?.repository?.path?.message}
-                  onChange={(option) => onChange(option?.value ?? '')}
+                  onChange={(option) => onChange(option?.value || '')}
                   placeholder={gitFields.pathConfig.placeholder}
                   options={folderOptions}
                   loading={isFoldersLoading}

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
@@ -114,7 +114,8 @@ async function fillConnectionForm(
   });
 
   if (type !== 'local' && data.branch) {
-    const branchCombobox = screen.getByRole('combobox');
+    const comboboxes = screen.getAllByRole('combobox');
+    const branchCombobox = comboboxes[0];
     await user.click(branchCombobox);
     await user.clear(branchCombobox);
     await user.paste(data.branch);
@@ -122,7 +123,16 @@ async function fillConnectionForm(
   }
 
   if (data.path) {
-    await pasteIntoInput(user, screen.getByRole('textbox', { name: /Path/i }), data.path);
+    if (type === 'local') {
+      await pasteIntoInput(user, screen.getByRole('textbox', { name: /Path/i }), data.path);
+    } else {
+      const comboboxes = screen.getAllByRole('combobox');
+      const pathCombobox = comboboxes[1];
+      await user.click(pathCombobox);
+      await user.clear(pathCombobox);
+      await user.paste(data.path);
+      await user.keyboard('{Enter}');
+    }
   }
 }
 
@@ -340,7 +350,7 @@ describe('ProvisioningWizard', () => {
       expect(screen.getByRole('heading', { name: /2\. Configure repository/i })).toBeInTheDocument();
 
       // User edits a visible field (branch)
-      const branchCombobox = screen.getByRole('combobox');
+      const branchCombobox = screen.getAllByRole('combobox')[0];
       await user.clear(branchCombobox);
       await user.paste('develop');
       await user.keyboard('{Enter}');
@@ -373,8 +383,8 @@ describe('ProvisioningWizard', () => {
       await user.click(screen.getByRole('button', { name: /Configure repository$/i }));
       expect(await screen.findByRole('heading', { name: /2\. Configure repository/i })).toBeInTheDocument();
 
-      const clearButton = screen.getByTitle(/Clear value/i);
-      await user.click(clearButton);
+      const clearButtons = screen.getAllByTitle(/Clear value/i);
+      await user.click(clearButtons[0]); // Clear the branch combobox
 
       await user.click(screen.getByRole('button', { name: /Choose what to synchronize/i }));
 
@@ -397,9 +407,8 @@ describe('ProvisioningWizard', () => {
         url: 'https://gitlab.com/test/repo',
       });
 
-      // Connection step fields
-      expect(screen.getByRole('combobox')).toBeInTheDocument();
-      expect(screen.getByRole('textbox', { name: /Path/i })).toBeInTheDocument();
+      // Connection step fields (branch combobox + path combobox)
+      expect(screen.getAllByRole('combobox')).toHaveLength(2);
     });
 
     it('should render Bitbucket-specific fields', async () => {
@@ -416,9 +425,8 @@ describe('ProvisioningWizard', () => {
         url: 'https://bitbucket.org/test/repo',
       });
 
-      // Connection step fields
-      expect(screen.getByRole('combobox')).toBeInTheDocument();
-      expect(screen.getByRole('textbox', { name: /Path/i })).toBeInTheDocument();
+      // Connection step fields (branch combobox + path combobox)
+      expect(screen.getAllByRole('combobox')).toHaveLength(2);
     });
 
     it('should render Git-specific fields', async () => {
@@ -435,9 +443,8 @@ describe('ProvisioningWizard', () => {
         url: 'https://git.example.com/test/repo.git',
       });
 
-      // Connection step fields
-      expect(screen.getByRole('combobox')).toBeInTheDocument();
-      expect(screen.getByRole('textbox', { name: /Path/i })).toBeInTheDocument();
+      // Connection step fields (branch combobox + path combobox)
+      expect(screen.getAllByRole('combobox')).toHaveLength(2);
     });
 
     it('should render local repository fields', async () => {

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
@@ -114,8 +114,9 @@ async function fillConnectionForm(
   });
 
   if (type !== 'local' && data.branch) {
-    const comboboxes = screen.getAllByRole('combobox');
-    const branchCombobox = comboboxes[0];
+    // Index-based: Combobox uses downshift-generated IDs so Field's htmlFor
+    // doesn't associate and getByRole({ name }) can't match the label.
+    const branchCombobox = screen.getAllByRole('combobox')[0];
     await user.click(branchCombobox);
     await user.clear(branchCombobox);
     await user.paste(data.branch);
@@ -126,8 +127,7 @@ async function fillConnectionForm(
     if (type === 'local') {
       await pasteIntoInput(user, screen.getByRole('textbox', { name: /Path/i }), data.path);
     } else {
-      const comboboxes = screen.getAllByRole('combobox');
-      const pathCombobox = comboboxes[1];
+      const pathCombobox = screen.getAllByRole('combobox')[1];
       await user.click(pathCombobox);
       await user.clear(pathCombobox);
       await user.paste(data.path);

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
@@ -74,6 +74,10 @@ jest.mock('../../hooks/useLastBranch', () => ({
   }),
 }));
 
+jest.mock('../../hooks/useGetRepositoryFolders', () => ({
+  useGetRepositoryFolders: jest.fn().mockReturnValue({ options: [], loading: false, error: null }),
+}));
+
 jest.mock('app/features/dashboard-scene/saving/SaveDashboardForm', () => {
   const actual = jest.requireActual('app/features/dashboard-scene/saving/SaveDashboardForm');
   return {
@@ -168,7 +172,8 @@ describe('SaveProvisionedDashboardForm', () => {
     expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: /description/i })).toBeInTheDocument();
     expect(screen.getByTestId('folder-picker')).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: /path/i })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /folder/i })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /filename/i })).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: /comment/i })).toBeInTheDocument();
     expect(screen.getByRole('combobox', { name: /branch/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
@@ -218,17 +223,17 @@ describe('SaveProvisionedDashboardForm', () => {
 
     const titleInput = screen.getByRole('textbox', { name: /title/i });
     const descriptionInput = screen.getByRole('textbox', { name: /description/i });
-    const pathInput = screen.getByRole('textbox', { name: /path/i });
+    const filenameInput = screen.getByRole('textbox', { name: /filename/i });
     const commentInput = screen.getByRole('textbox', { name: /comment/i });
 
     await user.clear(titleInput);
     await user.clear(descriptionInput);
-    await user.clear(pathInput);
+    await user.clear(filenameInput);
     await user.clear(commentInput);
 
     await user.type(titleInput, 'New Dashboard');
     await user.type(descriptionInput, 'New Description');
-    await user.type(pathInput, 'test-dashboard.json');
+    await user.type(filenameInput, 'test-dashboard.json');
     await user.type(commentInput, 'Initial commit');
 
     const submitButton = screen.getByRole('button', { name: /save/i });
@@ -338,17 +343,17 @@ describe('SaveProvisionedDashboardForm', () => {
 
     const titleInput = screen.getByRole('textbox', { name: /title/i });
     const descriptionInput = screen.getByRole('textbox', { name: /description/i });
-    const pathInput = screen.getByRole('textbox', { name: /path/i });
+    const filenameInput = screen.getByRole('textbox', { name: /filename/i });
     const commentInput = screen.getByRole('textbox', { name: /comment/i });
 
     await user.clear(titleInput);
     await user.clear(descriptionInput);
-    await user.clear(pathInput);
+    await user.clear(filenameInput);
     await user.clear(commentInput);
 
     await user.type(titleInput, 'New Dashboard');
     await user.type(descriptionInput, 'New Description');
-    await user.type(pathInput, 'error-dashboard.json');
+    await user.type(filenameInput, 'error-dashboard.json');
     await user.type(commentInput, 'Error commit');
 
     const submitButton = screen.getByRole('button', { name: /save/i });

--- a/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.test.tsx
+++ b/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.test.tsx
@@ -289,6 +289,8 @@ describe('NewProvisionedFolderForm', () => {
     expect(request.body).toEqual({ title: 'Branch Folder', type: 'folder' });
   });
 
+  // Error response handling (alertError publish, onDismiss) is tested in useProvisionedRequestHandler.test.ts.
+  // This test verifies the correct request is sent; the handler mock prevents response side-effects.
   it('should send correct request body when folder creation fails', async () => {
     server.use(
       http.post(`${BASE}/repositories/:name/files/*`, async ({ request }) => {

--- a/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
+++ b/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
@@ -10,8 +10,10 @@ import { validateBranchName } from 'app/features/provisioning/utils/git';
 import { isGitProvider } from 'app/features/provisioning/utils/repositoryTypes';
 
 import { useBranchDropdownOptions } from '../../hooks/useBranchDropdownOptions';
+import { useGetRepositoryFolders } from '../../hooks/useGetRepositoryFolders';
 import { useLastBranch } from '../../hooks/useLastBranch';
 import { usePRBranch } from '../../hooks/usePRBranch';
+import { joinPath, splitPath } from '../utils/path';
 
 type SharedFieldName = 'path' | 'comment';
 
@@ -58,6 +60,15 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
       branchData,
       canPushToConfiguredBranch,
       canPushToNonConfiguredBranch,
+    });
+
+    const showFolderFilename = isNew && resourceType === 'dashboard';
+    const currentPath = watch('path') || '';
+    const { directory, filename } = splitPath(currentPath);
+
+    const { options: folderOptions, loading: isFoldersLoading } = useGetRepositoryFolders({
+      repositoryName: showFolderFilename ? repository?.name : undefined,
+      ref: selectedBranch || undefined,
     });
 
     const pathText =
@@ -142,8 +153,58 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
           </>
         )}
 
-        {/* Path */}
-        {!hiddenFields?.includes('path') && (
+        {/* Path — split into folder + filename for new dashboards */}
+        {!hiddenFields?.includes('path') && showFolderFilename && (
+          <>
+            <input type="hidden" {...register('path')} />
+            <Field
+              noMargin
+              htmlFor="folder-path"
+              label={t('provisioned-resource-form.save-or-delete-resource-shared-fields.label-folder', 'Folder')}
+              description={t(
+                'provisioned-resource-form.save-or-delete-resource-shared-fields.description-folder',
+                'Folder inside the repository'
+              )}
+            >
+              <Combobox
+                id="folder-path"
+                value={directory}
+                onChange={(option) => {
+                  setValue('path', joinPath(option?.value ?? '', filename));
+                }}
+                options={folderOptions}
+                loading={isFoldersLoading}
+                createCustomValue
+                isClearable
+                placeholder={t(
+                  'provisioned-resource-form.save-or-delete-resource-shared-fields.placeholder-folder',
+                  'Select or enter folder path'
+                )}
+              />
+            </Field>
+            <Field
+              noMargin
+              htmlFor="dashboard-filename"
+              label={t('provisioned-resource-form.save-or-delete-resource-shared-fields.label-filename', 'Filename')}
+              description={t(
+                'provisioned-resource-form.save-or-delete-resource-shared-fields.description-filename',
+                'File name for the dashboard (.json or .yaml)'
+              )}
+            >
+              <Input
+                id="dashboard-filename"
+                type="text"
+                value={filename}
+                onChange={(e) => {
+                  setValue('path', joinPath(directory, e.currentTarget.value));
+                }}
+              />
+            </Field>
+          </>
+        )}
+
+        {/* Path — single read-only field for existing resources */}
+        {!hiddenFields?.includes('path') && !showFolderFilename && (
           <Field
             noMargin
             label={t('provisioned-resource-form.save-or-delete-resource-shared-fields.label-path', 'Path')}

--- a/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
+++ b/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
@@ -166,7 +166,7 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
                     label={t('provisioned-resource-form.save-or-delete-resource-shared-fields.label-folder', 'Folder')}
                     description={t(
                       'provisioned-resource-form.save-or-delete-resource-shared-fields.description-folder',
-                      'Folder inside the repository'
+                      'Folder inside the repository. Leave empty for the repository root.'
                     )}
                   >
                     <Combobox

--- a/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
+++ b/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
@@ -63,8 +63,6 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
     });
 
     const showFolderFilename = isNew && resourceType === 'dashboard';
-    const currentPath = watch('path') || '';
-    const { directory, filename } = splitPath(currentPath);
 
     const { options: folderOptions, loading: isFoldersLoading } = useGetRepositoryFolders({
       repositoryName: showFolderFilename ? repository?.name : undefined,
@@ -155,52 +153,63 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
 
         {/* Path — split into folder + filename for new dashboards */}
         {!hiddenFields?.includes('path') && showFolderFilename && (
-          <>
-            <input type="hidden" {...register('path')} />
-            <Field
-              noMargin
-              htmlFor="folder-path"
-              label={t('provisioned-resource-form.save-or-delete-resource-shared-fields.label-folder', 'Folder')}
-              description={t(
-                'provisioned-resource-form.save-or-delete-resource-shared-fields.description-folder',
-                'Folder inside the repository'
-              )}
-            >
-              <Combobox
-                id="folder-path"
-                value={directory}
-                onChange={(option) => {
-                  setValue('path', joinPath(option?.value ?? '', filename));
-                }}
-                options={folderOptions}
-                loading={isFoldersLoading}
-                createCustomValue
-                isClearable
-                placeholder={t(
-                  'provisioned-resource-form.save-or-delete-resource-shared-fields.placeholder-folder',
-                  'Select or enter folder path'
-                )}
-              />
-            </Field>
-            <Field
-              noMargin
-              htmlFor="dashboard-filename"
-              label={t('provisioned-resource-form.save-or-delete-resource-shared-fields.label-filename', 'Filename')}
-              description={t(
-                'provisioned-resource-form.save-or-delete-resource-shared-fields.description-filename',
-                'File name for the dashboard (.json or .yaml)'
-              )}
-            >
-              <Input
-                id="dashboard-filename"
-                type="text"
-                value={filename}
-                onChange={(e) => {
-                  setValue('path', joinPath(directory, e.currentTarget.value));
-                }}
-              />
-            </Field>
-          </>
+          <Controller
+            name="path"
+            control={control}
+            render={({ field: { ref, onChange, value } }) => {
+              const { directory: dir, filename: file } = splitPath(value || '');
+              return (
+                <>
+                  <Field
+                    noMargin
+                    htmlFor="folder-path"
+                    label={t('provisioned-resource-form.save-or-delete-resource-shared-fields.label-folder', 'Folder')}
+                    description={t(
+                      'provisioned-resource-form.save-or-delete-resource-shared-fields.description-folder',
+                      'Folder inside the repository'
+                    )}
+                  >
+                    <Combobox
+                      id="folder-path"
+                      value={dir}
+                      onChange={(option) => {
+                        onChange(joinPath(option?.value ?? '', file));
+                      }}
+                      options={folderOptions}
+                      loading={isFoldersLoading}
+                      createCustomValue
+                      isClearable
+                      placeholder={t(
+                        'provisioned-resource-form.save-or-delete-resource-shared-fields.placeholder-folder',
+                        'Select or enter folder path'
+                      )}
+                    />
+                  </Field>
+                  <Field
+                    noMargin
+                    htmlFor="dashboard-filename"
+                    label={t(
+                      'provisioned-resource-form.save-or-delete-resource-shared-fields.label-filename',
+                      'Filename'
+                    )}
+                    description={t(
+                      'provisioned-resource-form.save-or-delete-resource-shared-fields.description-filename',
+                      'File name for the dashboard (.json or .yaml)'
+                    )}
+                  >
+                    <Input
+                      id="dashboard-filename"
+                      type="text"
+                      value={file}
+                      onChange={(e) => {
+                        onChange(joinPath(dir, e.currentTarget.value));
+                      }}
+                    />
+                  </Field>
+                </>
+              );
+            }}
+          />
         )}
 
         {/* Path — single read-only field for existing resources */}

--- a/public/app/features/provisioning/components/utils/path.test.ts
+++ b/public/app/features/provisioning/components/utils/path.test.ts
@@ -1,4 +1,4 @@
-import { generatePath } from './path';
+import { generatePath, joinPath, splitPath } from './path';
 
 describe('generatePath', () => {
   const timestamp = '2023-05-15-abcde';
@@ -67,5 +67,57 @@ describe('generatePath', () => {
     });
 
     expect(result).toBe('my-dashboard.json');
+  });
+});
+
+describe('splitPath', () => {
+  it('should split a path with directory and filename', () => {
+    expect(splitPath('dashboards/my-dash.json')).toEqual({ directory: 'dashboards', filename: 'my-dash.json' });
+  });
+
+  it('should handle nested directories', () => {
+    expect(splitPath('a/b/c/file.json')).toEqual({ directory: 'a/b/c', filename: 'file.json' });
+  });
+
+  it('should handle filename only', () => {
+    expect(splitPath('my-dash.json')).toEqual({ directory: '', filename: 'my-dash.json' });
+  });
+
+  it('should handle empty string', () => {
+    expect(splitPath('')).toEqual({ directory: '', filename: '' });
+  });
+
+  it('should handle trailing slash', () => {
+    expect(splitPath('dashboards/')).toEqual({ directory: 'dashboards', filename: '' });
+  });
+});
+
+describe('joinPath', () => {
+  it('should join directory and filename', () => {
+    expect(joinPath('dashboards', 'my-dash.json')).toBe('dashboards/my-dash.json');
+  });
+
+  it('should handle empty directory', () => {
+    expect(joinPath('', 'my-dash.json')).toBe('my-dash.json');
+  });
+
+  it('should strip trailing slashes from directory', () => {
+    expect(joinPath('dashboards/', 'my-dash.json')).toBe('dashboards/my-dash.json');
+  });
+
+  it('should strip leading slashes from filename', () => {
+    expect(joinPath('dashboards', '/my-dash.json')).toBe('dashboards/my-dash.json');
+  });
+
+  it('should handle both trailing and leading slashes', () => {
+    expect(joinPath('dashboards/', '/my-dash.json')).toBe('dashboards/my-dash.json');
+  });
+
+  it('should handle empty filename', () => {
+    expect(joinPath('dashboards', '')).toBe('dashboards/');
+  });
+
+  it('should handle both empty', () => {
+    expect(joinPath('', '')).toBe('');
   });
 });

--- a/public/app/features/provisioning/components/utils/path.ts
+++ b/public/app/features/provisioning/components/utils/path.ts
@@ -53,5 +53,6 @@ export function splitPath(path: string): { directory: string; filename: string }
  */
 export function joinPath(directory: string, filename: string): string {
   const cleanDir = directory.replace(/\/+$/, '');
-  return cleanDir ? `${cleanDir}/${filename}` : filename;
+  const cleanFile = filename.replace(/^\/+/, '');
+  return cleanDir ? `${cleanDir}/${cleanFile}` : cleanFile;
 }

--- a/public/app/features/provisioning/components/utils/path.ts
+++ b/public/app/features/provisioning/components/utils/path.ts
@@ -32,3 +32,26 @@ export function generatePath({ timestamp, pathFromAnnotation, slug, folderPath =
 
   return path;
 }
+
+/**
+ * Splits a file path into its directory and filename components.
+ * e.g. "dashboards/my-dash.json" → { directory: "dashboards", filename: "my-dash.json" }
+ * e.g. "my-dash.json" → { directory: "", filename: "my-dash.json" }
+ */
+export function splitPath(path: string): { directory: string; filename: string } {
+  const lastSlash = path.lastIndexOf('/');
+  if (lastSlash === -1) {
+    return { directory: '', filename: path };
+  }
+  return { directory: path.substring(0, lastSlash), filename: path.substring(lastSlash + 1) };
+}
+
+/**
+ * Joins a directory and filename into a full path.
+ * e.g. ("dashboards", "my-dash.json") → "dashboards/my-dash.json"
+ * e.g. ("", "my-dash.json") → "my-dash.json"
+ */
+export function joinPath(directory: string, filename: string): string {
+  const cleanDir = directory.replace(/\/+$/, '');
+  return cleanDir ? `${cleanDir}/${filename}` : filename;
+}

--- a/public/app/features/provisioning/hooks/useGetRepositoryFolders.test.ts
+++ b/public/app/features/provisioning/hooks/useGetRepositoryFolders.test.ts
@@ -1,0 +1,91 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { getWrapper } from 'test/test-utils';
+
+import { PROVISIONING_API_BASE as BASE } from '@grafana/test-utils/handlers';
+import server from '@grafana/test-utils/server';
+
+import { setupProvisioningMswServer } from '../mocks/server';
+
+import { useGetRepositoryFolders } from './useGetRepositoryFolders';
+
+setupProvisioningMswServer();
+
+describe('useGetRepositoryFolders', () => {
+  it('should extract unique folder paths from file items', async () => {
+    server.use(
+      http.get(`${BASE}/repositories/:name/files/`, () =>
+        HttpResponse.json({
+          items: [{ path: 'dashboards/prod/dashboard.json' }, { path: 'dashboards/staging/dashboard.json' }],
+        })
+      )
+    );
+
+    const { result } = renderHook(() => useGetRepositoryFolders({ repositoryName: 'test-repo' }), {
+      wrapper: getWrapper({}),
+    });
+
+    await waitFor(() =>
+      expect(result.current.options).toEqual([
+        { label: 'dashboards', value: 'dashboards' },
+        { label: 'dashboards/prod', value: 'dashboards/prod' },
+        { label: 'dashboards/staging', value: 'dashboards/staging' },
+      ])
+    );
+  });
+
+  it('should exclude dot-prefixed paths', async () => {
+    server.use(
+      http.get(`${BASE}/repositories/:name/files/`, () =>
+        HttpResponse.json({
+          items: [
+            { path: '.grafana/folder-metadata-fixed-1772438142' },
+            { path: '.github/workflows/ci.yml' },
+            { path: 'dashboards/dashboard.json' },
+          ],
+        })
+      )
+    );
+
+    const { result } = renderHook(() => useGetRepositoryFolders({ repositoryName: 'test-repo' }), {
+      wrapper: getWrapper({}),
+    });
+
+    await waitFor(() => expect(result.current.options).toEqual([{ label: 'dashboards', value: 'dashboards' }]));
+  });
+
+  it('should return empty options for root-level files', async () => {
+    server.use(
+      http.get(`${BASE}/repositories/:name/files/`, () => HttpResponse.json({ items: [{ path: 'dashboard.json' }] }))
+    );
+
+    const { result } = renderHook(() => useGetRepositoryFolders({ repositoryName: 'test-repo' }), {
+      wrapper: getWrapper({}),
+    });
+
+    await waitFor(() => expect(result.current.options).toEqual([]));
+  });
+
+  it('should return hint when no repository name is provided', () => {
+    const { result } = renderHook(() => useGetRepositoryFolders({}), {
+      wrapper: getWrapper({}),
+    });
+
+    expect(result.current.hint).toBe('Folder suggestions will be available after the repository is connected.');
+    expect(result.current.options).toEqual([]);
+  });
+
+  it('should surface repo-status error when repository query fails', async () => {
+    server.use(http.get(`${BASE}/repositories`, () => HttpResponse.json({ message: 'boom' }, { status: 500 })));
+
+    const { result } = renderHook(() => useGetRepositoryFolders({ repositoryName: 'test-repo' }), {
+      wrapper: getWrapper({}),
+    });
+
+    await waitFor(() =>
+      expect(result.current.error).toBe(
+        'There was an issue connecting to the repository. You can still manually enter the folder path.'
+      )
+    );
+  });
+});

--- a/public/app/features/provisioning/hooks/useGetRepositoryFolders.ts
+++ b/public/app/features/provisioning/hooks/useGetRepositoryFolders.ts
@@ -57,13 +57,12 @@ export function useGetRepositoryFolders({ repositoryName, ref }: UseGetRepositor
   return {
     options,
     loading: isFilesLoading || isRepoLoading || healthStatusNotReady,
-    error: filesError
-      ? getErrorMessage(filesError)
-      : repositoryName
-        ? null
-        : t(
-            'provisioning.connect-step.text-folders-not-available',
-            'Folder suggestions will be available after the repository is connected.'
-          ),
+    error: filesError ? getErrorMessage(filesError) : null,
+    hint: repositoryName
+      ? null
+      : t(
+          'provisioning.connect-step.text-folders-not-available',
+          'Folder suggestions will be available after the repository is connected.'
+        ),
   };
 }

--- a/public/app/features/provisioning/hooks/useGetRepositoryFolders.ts
+++ b/public/app/features/provisioning/hooks/useGetRepositoryFolders.ts
@@ -1,0 +1,69 @@
+/**
+ * A hook to fetch folder paths from a repository's file listing.
+ * Used to populate the path dropdown in the onboarding wizard.
+ */
+import { skipToken } from '@reduxjs/toolkit/query';
+import { useMemo } from 'react';
+
+import { t } from '@grafana/i18n';
+import { getErrorMessage } from 'app/api/clients/provisioning/utils/httpUtils';
+import { useGetRepositoryFilesQuery } from 'app/api/clients/provisioning/v0alpha1';
+
+import { useRepositoryStatus } from '../Wizard/hooks/useRepositoryStatus';
+
+export interface UseGetRepositoryFoldersProps {
+  repositoryName?: string;
+  ref?: string;
+}
+
+function isFileItem(obj: unknown): obj is { path: string } {
+  if (typeof obj !== 'object' || obj === null || !('path' in obj)) {
+    return false;
+  }
+  const candidate: { path: unknown } = obj;
+  return typeof candidate.path === 'string';
+}
+
+export function useGetRepositoryFolders({ repositoryName, ref }: UseGetRepositoryFoldersProps) {
+  const { isReconciled, isLoading: isRepoLoading, healthStatusNotReady } = useRepositoryStatus(repositoryName);
+
+  const shouldSkipQuery = !repositoryName || !isReconciled;
+  const {
+    data: filesData,
+    isLoading: isFilesLoading,
+    error: filesError,
+  } = useGetRepositoryFilesQuery(shouldSkipQuery ? skipToken : { name: repositoryName, ref });
+
+  const options = useMemo(() => {
+    const folders = new Set<string>();
+
+    for (const file of filesData?.items ?? []) {
+      if (!isFileItem(file)) {
+        continue;
+      }
+
+      const parts = file.path.split('/');
+      for (let i = 1; i < parts.length; i++) {
+        const folderPath = parts.slice(0, i).join('/');
+        folders.add(folderPath);
+      }
+    }
+
+    return Array.from(folders)
+      .sort()
+      .map((path) => ({ label: path, value: path }));
+  }, [filesData]);
+
+  return {
+    options,
+    loading: isFilesLoading || isRepoLoading || healthStatusNotReady,
+    error: filesError
+      ? getErrorMessage(filesError)
+      : repositoryName
+        ? null
+        : t(
+            'provisioning.connect-step.text-folders-not-available',
+            'Folder suggestions will be available after the repository is connected.'
+          ),
+  };
+}

--- a/public/app/features/provisioning/hooks/useGetRepositoryFolders.ts
+++ b/public/app/features/provisioning/hooks/useGetRepositoryFolders.ts
@@ -5,6 +5,7 @@
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useMemo } from 'react';
 
+import { isObject } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getErrorMessage } from 'app/api/clients/provisioning/utils/httpUtils';
 import { useGetRepositoryFilesQuery } from 'app/api/clients/provisioning/v0alpha1';
@@ -16,16 +17,19 @@ export interface UseGetRepositoryFoldersProps {
   ref?: string;
 }
 
+// The generated API client types `items` loosely (path is optional/unknown),
+// so a runtime guard is needed to safely access `file.path`.
 function isFileItem(obj: unknown): obj is { path: string } {
-  if (typeof obj !== 'object' || obj === null || !('path' in obj)) {
-    return false;
-  }
-  const candidate: { path: unknown } = obj;
-  return typeof candidate.path === 'string';
+  return isObject(obj) && 'path' in obj && typeof obj.path === 'string';
 }
 
 export function useGetRepositoryFolders({ repositoryName, ref }: UseGetRepositoryFoldersProps) {
-  const { isReconciled, isLoading: isRepoLoading, healthStatusNotReady } = useRepositoryStatus(repositoryName);
+  const {
+    isReconciled,
+    isLoading: isRepoLoading,
+    hasError: isRepoError,
+    healthStatusNotReady,
+  } = useRepositoryStatus(repositoryName);
 
   const shouldSkipQuery = !repositoryName || !isReconciled;
   const {
@@ -38,7 +42,7 @@ export function useGetRepositoryFolders({ repositoryName, ref }: UseGetRepositor
     const folders = new Set<string>();
 
     for (const file of filesData?.items ?? []) {
-      if (!isFileItem(file)) {
+      if (!isFileItem(file) || file.path.startsWith('.')) {
         continue;
       }
 
@@ -57,7 +61,14 @@ export function useGetRepositoryFolders({ repositoryName, ref }: UseGetRepositor
   return {
     options,
     loading: isFilesLoading || isRepoLoading || healthStatusNotReady,
-    error: filesError ? getErrorMessage(filesError) : null,
+    error: isRepoError
+      ? t(
+          'provisioning.connect-step.text-repository-folders-not-ready',
+          'There was an issue connecting to the repository. You can still manually enter the folder path.'
+        )
+      : filesError
+        ? getErrorMessage(filesError)
+        : null,
     hint: repositoryName
       ? null
       : t(

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12420,13 +12420,18 @@
       "description-branch": "Select an existing branch or enter a new branch name to create a branch",
       "description-branch-restricted": "This repository is restricted to the configured branch only",
       "description-file-path": "File path inside the repository (.json or .yaml)",
+      "description-filename": "File name for the dashboard (.json or .yaml)",
+      "description-folder": "Folder inside the repository",
       "description-folder-path": "Folder path inside the repository",
       "description-inside-repository": "",
       "info-branch-disabled": "Push to configured branch is disabled",
       "label-branch": "Branch",
       "label-comment": "Comment",
+      "label-filename": "Filename",
+      "label-folder": "Folder",
       "label-path": "Path",
       "placeholder-branch": "Select or enter branch name",
+      "placeholder-folder": "Select or enter folder path",
       "suffix-configured-branch": "Synchronized branch",
       "suffix-last-used": "Last branch",
       "suffix-new-branch": "New branch",
@@ -12540,6 +12545,7 @@
       "instance-fully-managed-tooltip": "Configuration is disabled because this instance is fully managed"
     },
     "connect-step": {
+      "text-folders-not-available": "Folder suggestions will be available after the repository is connected.",
       "text-repository-not-ready": "There was an issue connecting to the repository. You can still manually enter the branch name."
     },
     "connection": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12546,6 +12546,7 @@
     },
     "connect-step": {
       "text-folders-not-available": "Folder suggestions will be available after the repository is connected.",
+      "text-repository-folders-not-ready": "There was an issue connecting to the repository. You can still manually enter the folder path.",
       "text-repository-not-ready": "There was an issue connecting to the repository. You can still manually enter the branch name."
     },
     "connection": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12421,7 +12421,7 @@
       "description-branch-restricted": "This repository is restricted to the configured branch only",
       "description-file-path": "File path inside the repository (.json or .yaml)",
       "description-filename": "File name for the dashboard (.json or .yaml)",
-      "description-folder": "Folder inside the repository",
+      "description-folder": "Folder inside the repository. Leave empty for the repository root.",
       "description-folder-path": "Folder path inside the repository",
       "description-inside-repository": "",
       "info-branch-disabled": "Push to configured branch is disabled",


### PR DESCRIPTION
**What is this feature?**

Add folder picker dropdowns to allow users to browse and select existing git repository directories when specifying paths in provisioning workflows. Implemented in two places:
1. **ConnectStep (onboarding wizard)**: Replace plain Input for repository.path with Combobox listing existing directories
2. **SaveProvisionedDashboardForm (save drawer)**: For new dashboards, split path field into Folder Combobox + Filename Input

**Which issue(s) does this PR fix?**

Fixes https://github.com/grafana/git-ui-sync-project/issues/796
Fixes https://github.com/grafana/git-ui-sync-project/issues/795
