### PR TITLE
Expressions: Fix SQL schema fetch failing when using default datasource

### DIFF
--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
@@ -59,9 +59,17 @@ const mockBackendSrv = {
   }),
 };
 
+const mockDataSourceSrv = {
+  get: jest.fn().mockResolvedValue({
+    getRef: () => ({ uid: 'mock-ds-uid', type: 'mock-ds-type' }),
+  }),
+  getInstanceSettings: jest.fn().mockReturnValue({ uid: 'mock-ds-uid', type: 'mock-ds-type' }),
+};
+
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: () => mockBackendSrv,
+  getDataSourceSrv: () => mockDataSourceSrv,
 }));
 
 // Note: Add more mocks if needed for other lazy components


### PR DESCRIPTION
## Summary

- Fixes a 500 error when adding a SQL expression to a panel that uses the default datasource. The `/sqlschemas` request was sent without a `datasource` field because default-datasource queries don't populate `query.datasource` until the user explicitly switches datasources.
- Resolves the default datasource via `getDataSourceSrv().getInstanceSettings()` before posting to the backend, matching the existing pattern in `QueryRunner.ts`.