### PR TITLE
Dashboard: Fix expression query datasource overwritten by panel datasource during schema migration

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/grafana/apps/dashboard/pkg/migration"
 	schemaversion "github.com/grafana/grafana/apps/dashboard/pkg/migration/schemaversion"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	expr "github.com/grafana/grafana/pkg/expr"
 )
 
 // getDefaultDatasourceType gets the default datasource type using the datasource provider
@@ -2262,7 +2263,7 @@ func transformSingleQuery(ctx context.Context, targetMap map[string]interface{},
 	panelHasUID := panelDatasource != nil && panelDatasource.Uid != nil && *panelDatasource.Uid != "" && *panelDatasource.Uid != "-- Mixed --"
 	applyPanelRef := panelHasUID &&
 		(queryDatasourceUID == "" && queryDatasourceType == "" ||
-			(queryDatasourceUID != "__expr__" && queryDatasourceUID != *panelDatasource.Uid))
+			(queryDatasourceUID != expr.DatasourceUID && queryDatasourceType != expr.DatasourceType && queryDatasourceUID != *panelDatasource.Uid))
 
 	if applyPanelRef {
 		if panelDatasource.Type != nil {


### PR DESCRIPTION
**What is this feature?**

Fixes a bug in the v1beta1 ->  v2alpha1 dashboard schema migration where expression queries with a template variable UID (e.g., ${DS_EXPRESSION}) had their datasource incorrectly overwritten by the panel-level datasource.

We now check for both uid and type not to equal `__expr__ ` 