### PR TITLE
FilterPill: Selected border style update

### DIFF
--- a/packages/grafana-ui/src/components/FilterPill/FilterPill.tsx
+++ b/packages/grafana-ui/src/components/FilterPill/FilterPill.tsx
@@ -56,6 +56,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     selected: css({
       color: theme.colors.text.primary,
       background: theme.colors.action.selected,
+      border: `1px solid ${theme.colors.action.selectedBorder}`,
 
       '&:hover': {
         background: theme.colors.action.focus,


### PR DESCRIPTION
**What is this feature?**

`FilterPill` component: Added selected border style `1px solid ${theme.colors.action.selectedBorder}`   

**After:**  
<img width="565" height="89" alt="image" src="https://github.com/user-attachments/assets/874fb41e-07c3-489b-9e20-0eceef623061" />

**Before:**  
<img width="550" height="75" alt="image" src="https://github.com/user-attachments/assets/71c50840-0844-40de-a7c6-e99e841c6fa3" />



**Why do we need this feature?**

Improve `FilterPill` active state to differentiate from default state

**Who is this feature for?**

Dev


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/118990

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
