### PR TITLE
Provisioning: Remove backend restrictions on permission API calls for provisioned folders

### DIFF
--- a/pkg/api/folder_permission.go
+++ b/pkg/api/folder_permission.go
@@ -96,6 +96,7 @@ func (hs *HTTPServer) UpdateFolderPermissions(c *contextmodel.ReqContext) respon
 
 	// Block permission changes for folders managed by provisioning,
 	// unless the provisioningFolderMetadata feature flag is enabled.
+	//nolint:staticcheck
 	if folder.ManagedBy == utils.ManagerKindRepo && !hs.Features.IsEnabled(c.Req.Context(), featuremgmt.FlagProvisioningFolderMetadata) {
 		return response.Error(http.StatusForbidden, "Cannot update permissions for folders managed by provisioning.", nil)
 	}

--- a/pkg/api/folder_permission.go
+++ b/pkg/api/folder_permission.go
@@ -14,6 +14,7 @@ import (
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/web"
@@ -93,8 +94,9 @@ func (hs *HTTPServer) UpdateFolderPermissions(c *contextmodel.ReqContext) respon
 		return apierrors.ToFolderErrorResponse(err)
 	}
 
-	// Block permission changes for folders managed by provisioning
-	if folder.ManagedBy == utils.ManagerKindRepo {
+	// Block permission changes for folders managed by provisioning,
+	// unless the provisioningFolderMetadata feature flag is enabled.
+	if folder.ManagedBy == utils.ManagerKindRepo && !hs.Features.IsEnabled(c.Req.Context(), featuremgmt.FlagProvisioningFolderMetadata) {
 		return response.Error(http.StatusForbidden, "Cannot update permissions for folders managed by provisioning.", nil)
 	}
 


### PR DESCRIPTION
**What is this feature?**

Remove the Be restrictions on folder's permission API calls for Provisioned folders, **in case the FlagProvisioningFolderMetadata is enabled**

**Why do we need this feature?**

We are building support for folder permissions changes in provisioned folder, this change makes users able to change their folder permissions, when the feature flag is enabled.

**Who is this feature for?**

Users of GitSync

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/899

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
