### PR TITLE
Fix readOnly field missing on version from k8s to legacy and back

### DIFF
--- a/public/app/features/datasources/api.test.ts
+++ b/public/app/features/datasources/api.test.ts
@@ -63,7 +63,7 @@ describe('Datasources / API', () => {
         secureJsonFields: {
           basicAuthPassword: true,
         },
-        readOnly: false,
+        readOnly: true,
         withCredentials: false,
       };
 
@@ -71,7 +71,7 @@ describe('Datasources / API', () => {
         name: 'fortytwo',
         namespace: 'default',
         uid: 'fortytwo',
-        resourceVersion: 'fortytwo',
+        resourceVersion: '',
         generation: 42,
         creationTimestamp: '1234',
         labels: { 'grafana.app/deprecatedInternalID': '42' },
@@ -85,6 +85,7 @@ describe('Datasources / API', () => {
         basicAuth: true,
         basicAuthUser: 'zaphod',
         isDefault: true,
+        readOnly: true,
       };
       let dsK8sSettings: DataSourceSettingsK8s = {
         kind: 'DataSource',
@@ -116,13 +117,13 @@ describe('Datasources / API', () => {
         isDefault: true,
         jsonData: { authType: 'bar' },
         secureJsonFields: {},
-        readOnly: false,
+        readOnly: true,
         withCredentials: false,
       };
       let k8sMetadata: K8sMetadata = {
         name: 'fortytwo',
         namespace: 'default',
-        resourceVersion: 'fortytwo',
+        resourceVersion: '',
         labels: { 'grafana.app/deprecatedInternalID': '42' },
         annotations: {},
       };
@@ -134,6 +135,7 @@ describe('Datasources / API', () => {
         basicAuth: true,
         basicAuthUser: 'zaphod',
         isDefault: true,
+        readOnly: true,
       };
       let dsK8sSettings: DataSourceSettingsK8s = {
         kind: 'DataSource',

--- a/public/app/features/datasources/api.ts
+++ b/public/app/features/datasources/api.ts
@@ -31,6 +31,7 @@ export interface DatasourceInstanceK8sSpec {
   basicAuth: boolean;
   basicAuthUser: string;
   isDefault?: boolean;
+  readOnly?: boolean;
 }
 
 export interface DatasourceAccessK8s {
@@ -87,7 +88,7 @@ export const convertLegacyDatasourceSettingsToK8sDatasourceSettings = (
   let k8sMetadata: K8sMetadata = {
     name: dsSettings.uid,
     namespace: namespace,
-    resourceVersion: 'fortytwo',
+    resourceVersion: '',
     labels: { 'grafana.app/deprecatedInternalID': dsSettings.id.toString() },
     annotations: {},
   };
@@ -99,6 +100,7 @@ export const convertLegacyDatasourceSettingsToK8sDatasourceSettings = (
     basicAuth: dsSettings.basicAuth,
     basicAuthUser: dsSettings.basicAuthUser,
     isDefault: dsSettings.isDefault,
+    readOnly: dsSettings.readOnly,
   };
   let dsK8sSettings: DataSourceSettingsK8s = {
     kind: 'DataSource',
@@ -142,7 +144,7 @@ export const convertK8sDatasourceSettingsToLegacyDatasourceSettings = (
     isDefault: dsK8sSettings.spec.isDefault ? true : false,
     jsonData: dsK8sSettings.spec.jsonData,
     secureJsonFields: {},
-    readOnly: false,
+    readOnly: dsK8sSettings.spec.readOnly ? dsK8sSettings.spec.readOnly : false,
     withCredentials: false,
   };
   if (dsK8sSettings.secure) {


### PR DESCRIPTION
The `readOnly` field was not being carried over when converting to and from k8s datasource config shape and legacy shape.

