### PR TITLE
Use the openfeature to check for useNewAPIsForDatasourceCRUD in the UI

### DIFF
--- a/public/app/features/datasources/api.ts
+++ b/public/app/features/datasources/api.ts
@@ -2,6 +2,7 @@ import { lastValueFrom } from 'rxjs';
 
 import { DataSourceSettings, DataSourceJsonData } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { getFeatureFlagClient } from '@grafana/runtime/internal';
 import { getBackendSrv } from 'app/core/services/backend_srv';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
 
@@ -208,7 +209,7 @@ export const getDataSourceFromK8sAPI = async (k8sName: string, namespace: string
 };
 
 export const getDataSourceByUid = async (uid: string) => {
-  if (config.featureToggles.useNewAPIsForDatasourceCRUD) {
+  if (getFeatureFlagClient().getBooleanValue('datasources.config.ui.useNewDatasourceCRUDAPIs', false)) {
     return getDataSourceFromK8sAPI(uid, config.namespace);
   }
 
@@ -257,7 +258,7 @@ export const createDataSource = (dataSource: Partial<DataSourceSettings>) =>
 export const getDataSourcePlugins = () => getBackendSrv().get('/api/plugins', { enabled: 1, type: 'datasource' });
 
 export const updateDataSource = async (dataSource: DataSourceSettings) => {
-  if (config.featureToggles.useNewAPIsForDatasourceCRUD) {
+  if (getFeatureFlagClient().getBooleanValue('datasources.config.ui.useNewDatasourceCRUDAPIs', false)) {
     let k8sVersion = 'v0alpha1';
     let dsK8sSettings = convertLegacyDatasourceSettingsToK8sDatasourceSettings(
       dataSource,
@@ -312,7 +313,7 @@ export const updateDataSource = async (dataSource: DataSourceSettings) => {
 
 export const deleteDataSource = (uid: string) => {
   let deleteUrl = `/api/datasources/uid/${uid}`;
-  if (config.featureToggles.useNewAPIsForDatasourceCRUD) {
+  if (getFeatureFlagClient().getBooleanValue('datasources.config.ui.useNewDatasourceCRUDAPIs', false)) {
     let namespace = config.namespace;
     let apiVersion = `${getDataSourceK8sGroup(uid)}/v0alpha1`;
     deleteUrl = `/apis/${apiVersion}/namespaces/${namespace}/datasources/${uid}`;


### PR DESCRIPTION
This PR ports the datasource UI to use the new OpenFeature feature toggles for the CRUD UI k8s rollout.

Only the frontend is changed, with a default of false, so this is safe to ship.

`deployment_tools` PR to add the flag is [here](https://github.com/grafana/deployment_tools/pull/498674).