### PR TITLE
Provisioning: Add syncEnabled field to RepositoryView

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/settings.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/settings.go
@@ -42,6 +42,9 @@ type RepositoryView struct {
 	// When syncing, where values are saved
 	Target SyncTargetType `json:"target"`
 
+	// Whether automatic sync is enabled for this repository
+	SyncEnabled bool `json:"syncEnabled"`
+
 	// For git, this is the target branch
 	Branch string `json:"branch,omitempty"`
 

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -2315,45 +2315,53 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositoryView(ref common.ReferenceCa
 							Enum:        []interface{}{"folder", "instance"},
 						},
 					},
-					"branch": {
-						SchemaProps: spec.SchemaProps{
-							Description: "For git, this is the target branch",
-							Type:        []string{"string"},
-							Format:      "",
-						},
+				"syncEnabled": {
+					SchemaProps: spec.SchemaProps{
+						Description: "Whether automatic sync is enabled for this repository",
+						Default:     false,
+						Type:        []string{"boolean"},
+						Format:      "",
 					},
-					"url": {
-						SchemaProps: spec.SchemaProps{
-							Description: "For git, this is the target URL",
-							Type:        []string{"string"},
-							Format:      "",
-						},
+				},
+				"branch": {
+					SchemaProps: spec.SchemaProps{
+						Description: "For git, this is the target branch",
+						Type:        []string{"string"},
+						Format:      "",
 					},
-					"path": {
-						SchemaProps: spec.SchemaProps{
-							Description: "For git, this is the target path",
-							Type:        []string{"string"},
-							Format:      "",
-						},
+				},
+				"url": {
+					SchemaProps: spec.SchemaProps{
+						Description: "For git, this is the target URL",
+						Type:        []string{"string"},
+						Format:      "",
 					},
-					"workflows": {
-						SchemaProps: spec.SchemaProps{
-							Description: "The supported workflows",
-							Type:        []string{"array"},
-							Items: &spec.SchemaOrArray{
-								Schema: &spec.Schema{
-									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
-										Enum:    []interface{}{"branch", "write"},
-									},
+				},
+				"path": {
+					SchemaProps: spec.SchemaProps{
+						Description: "For git, this is the target path",
+						Type:        []string{"string"},
+						Format:      "",
+					},
+				},
+				"workflows": {
+					SchemaProps: spec.SchemaProps{
+						Description: "The supported workflows",
+						Type:        []string{"array"},
+						Items: &spec.SchemaOrArray{
+							Schema: &spec.Schema{
+								SchemaProps: spec.SchemaProps{
+									Default: "",
+									Type:    []string{"string"},
+									Format:  "",
+									Enum:    []interface{}{"branch", "write"},
 								},
 							},
 						},
 					},
 				},
-				Required: []string{"name", "title", "type", "target", "workflows"},
+			},
+			Required: []string{"name", "title", "type", "target", "syncEnabled", "workflows"},
 			},
 		},
 	}

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -2315,53 +2315,53 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositoryView(ref common.ReferenceCa
 							Enum:        []interface{}{"folder", "instance"},
 						},
 					},
-				"syncEnabled": {
-					SchemaProps: spec.SchemaProps{
-						Description: "Whether automatic sync is enabled for this repository",
-						Default:     false,
-						Type:        []string{"boolean"},
-						Format:      "",
+					"syncEnabled": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Whether automatic sync is enabled for this repository",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
 					},
-				},
-				"branch": {
-					SchemaProps: spec.SchemaProps{
-						Description: "For git, this is the target branch",
-						Type:        []string{"string"},
-						Format:      "",
+					"branch": {
+						SchemaProps: spec.SchemaProps{
+							Description: "For git, this is the target branch",
+							Type:        []string{"string"},
+							Format:      "",
+						},
 					},
-				},
-				"url": {
-					SchemaProps: spec.SchemaProps{
-						Description: "For git, this is the target URL",
-						Type:        []string{"string"},
-						Format:      "",
+					"url": {
+						SchemaProps: spec.SchemaProps{
+							Description: "For git, this is the target URL",
+							Type:        []string{"string"},
+							Format:      "",
+						},
 					},
-				},
-				"path": {
-					SchemaProps: spec.SchemaProps{
-						Description: "For git, this is the target path",
-						Type:        []string{"string"},
-						Format:      "",
+					"path": {
+						SchemaProps: spec.SchemaProps{
+							Description: "For git, this is the target path",
+							Type:        []string{"string"},
+							Format:      "",
+						},
 					},
-				},
-				"workflows": {
-					SchemaProps: spec.SchemaProps{
-						Description: "The supported workflows",
-						Type:        []string{"array"},
-						Items: &spec.SchemaOrArray{
-							Schema: &spec.Schema{
-								SchemaProps: spec.SchemaProps{
-									Default: "",
-									Type:    []string{"string"},
-									Format:  "",
-									Enum:    []interface{}{"branch", "write"},
+					"workflows": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The supported workflows",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+										Enum:    []interface{}{"branch", "write"},
+									},
 								},
 							},
 						},
 					},
 				},
-			},
-			Required: []string{"name", "title", "type", "target", "syncEnabled", "workflows"},
+				Required: []string{"name", "title", "type", "target", "syncEnabled", "workflows"},
 			},
 		},
 	}

--- a/pkg/registry/apis/provisioning/routes.go
+++ b/pkg/registry/apis/provisioning/routes.go
@@ -184,15 +184,15 @@ func (b *APIBuilder) handleSettings(w http.ResponseWriter, r *http.Request) {
 		path := val.Path()
 
 		settings.Items[i] = provisioning.RepositoryView{
-			Name:      val.Name,
-			Title:     val.Spec.Title,
-			Type:      val.Spec.Type,
-			Target:    val.Spec.Sync.Target,
+			Name:        val.Name,
+			Title:       val.Spec.Title,
+			Type:        val.Spec.Type,
+			Target:      val.Spec.Sync.Target,
 			SyncEnabled: val.Spec.Sync.Enabled,
-			Branch:    branch,
-			URL:       url,
-			Path:      path,
-			Workflows: val.Spec.Workflows,
+			Branch:      branch,
+			URL:         url,
+			Path:        path,
+			Workflows:   val.Spec.Workflows,
 		}
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/registry/apis/provisioning/routes.go
+++ b/pkg/registry/apis/provisioning/routes.go
@@ -188,6 +188,7 @@ func (b *APIBuilder) handleSettings(w http.ResponseWriter, r *http.Request) {
 			Title:     val.Spec.Title,
 			Type:      val.Spec.Type,
 			Target:    val.Spec.Sync.Target,
+			SyncEnabled: val.Spec.Sync.Enabled,
 			Branch:    branch,
 			URL:       url,
 			Path:      path,

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -5681,6 +5681,7 @@
           "title",
           "type",
           "target",
+          "syncEnabled",
           "workflows"
         ],
         "properties": {
@@ -5696,6 +5697,11 @@
           "path": {
             "description": "For git, this is the target path",
             "type": "string"
+          },
+          "syncEnabled": {
+            "description": "Whether automatic sync is enabled for this repository",
+            "type": "boolean",
+            "default": false
           },
           "target": {
             "description": "When syncing, where values are saved\n\nPossible enum values:\n - `\"folder\"` Resources will be saved into a folder managed by this repository It will contain a copy of everything from the remote The folder k8s name will be the same as the repository k8s name\n - `\"instance\"` Resources are saved in the global context Only one repository may specify the `instance` target When this exists, the UI will promote writing to the instance repo rather than the grafana database (where possible)",


### PR DESCRIPTION
**What is this feature?**

- Adds `syncEnabled` boolean to the `RepositoryView` struct so the frontend settings endpoint exposes whether automatic sync is enabled for each repository.

**Why do we need this feature?**

This allows the frontend to check sync status via the lightweight `RepositoryView` without needing to fetch the full `Repository` object

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

N/A, to unblock https://github.com/grafana/git-ui-sync-project/issues/887

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
