### PR TITLE
Alerting: Add tracking events for multi notification policies feature

### DIFF
--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -440,3 +440,39 @@ export function trackViewExperienceToggleConfirmed(
 export function trackRuleListPageView(payload: { view: 'v1' | 'v2' }) {
   reportInteraction('grafana_alerting_rule_list_page_view', payload);
 }
+
+// ============================================================================
+// Multiple Notification Policies Telemetry
+// ============================================================================
+
+export function trackNotificationPolicyCreated(payload: { hasCustomTimings: boolean; hasCustomGrouping: boolean }) {
+  reportInteraction('grafana_alerting_notification_policy_created', payload);
+}
+
+export function trackNotificationPolicyCreateError(payload: { error: string }) {
+  reportInteraction('grafana_alerting_notification_policy_create_error', payload);
+}
+
+export function trackNotificationPolicyDeleted() {
+  reportInteraction('grafana_alerting_notification_policy_deleted');
+}
+
+export function trackNotificationPolicyDeleteError(payload: { error: string }) {
+  reportInteraction('grafana_alerting_notification_policy_delete_error', payload);
+}
+
+export function trackNotificationPolicyReset() {
+  reportInteraction('grafana_alerting_notification_policy_reset');
+}
+
+export function trackNotificationPolicyResetError(payload: { error: string }) {
+  reportInteraction('grafana_alerting_notification_policy_reset_error', payload);
+}
+
+export function trackNotificationPolicyExported(payload: { isDefaultPolicy: boolean }) {
+  reportInteraction('grafana_alerting_notification_policy_exported', payload);
+}
+
+export function trackNotificationPolicySelectorChanged(payload: { fromDefault: boolean; toDefault: boolean }) {
+  reportInteraction('grafana_alerting_notification_policy_selector_changed', payload);
+}

--- a/public/app/features/alerting/unified/components/notification-policies/components/ActionButtons.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/components/ActionButtons.tsx
@@ -4,6 +4,7 @@ import { Trans, t } from '@grafana/i18n';
 import { LinkButton, Stack, Tooltip } from '@grafana/ui';
 
 import { ROUTES_META_SYMBOL, Route } from '../../../../../../plugins/datasource/alertmanager/types';
+import { trackNotificationPolicyExported } from '../../../Analytics';
 import { AlertmanagerAction, useAlertmanagerAbilities } from '../../../hooks/useAbilities';
 import { ROOT_ROUTE_NAME } from '../../../utils/k8s/constants';
 import { createRelativeUrl } from '../../../utils/url';
@@ -64,7 +65,10 @@ export const ActionButtons = ({ route }: ActionButtonsProps) => {
         size="sm"
         data-testid="export-action"
         disabled={!exportPoliciesAllowed}
-        onClick={() => showExportDrawer(route.name ?? '')}
+        onClick={() => {
+          trackNotificationPolicyExported({ isDefaultPolicy: route.name === ROOT_ROUTE_NAME });
+          showExportDrawer(route.name ?? '');
+        }}
       >
         <Trans i18nKey="alerting.common.export">Export</Trans>
       </LinkButton>

--- a/public/app/features/alerting/unified/components/notification-policies/components/Modals.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/components/Modals.tsx
@@ -5,6 +5,14 @@ import { isFetchError } from '@grafana/runtime';
 import { Button, ConfirmModal, Modal, ModalProps, Space, Spinner, Stack, Text } from '@grafana/ui';
 
 import { RouteWithID } from '../../../../../../plugins/datasource/alertmanager/types';
+import {
+  trackNotificationPolicyCreateError,
+  trackNotificationPolicyCreated,
+  trackNotificationPolicyDeleteError,
+  trackNotificationPolicyDeleted,
+  trackNotificationPolicyReset,
+  trackNotificationPolicyResetError,
+} from '../../../Analytics';
 import { FormAmRoute } from '../../../types/amroutes';
 import { defaultGroupBy } from '../../../utils/amroutes';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../../utils/datasource';
@@ -33,9 +41,13 @@ export const DeleteModal = React.memo(({ onConfirm, onDismiss, isOpen, routeName
     setIsDeleting(true);
     onConfirm()
       .then(() => {
+        trackNotificationPolicyDeleted();
         onDeleteDismiss();
       })
-      .catch(setError)
+      .catch((err) => {
+        trackNotificationPolicyDeleteError({ error: stringifyErrorLike(err) });
+        setError(err);
+      })
       .finally(() => {
         setIsDeleting(false);
       });
@@ -90,9 +102,13 @@ export const ResetModal = React.memo(({ onConfirm, onDismiss, isOpen, routeName 
     setIsResetting(true);
     onConfirm()
       .then(() => {
+        trackNotificationPolicyReset();
         onResetDismiss();
       })
-      .catch(setError)
+      .catch((err) => {
+        trackNotificationPolicyResetError({ error: stringifyErrorLike(err) });
+        setError(err);
+      })
       .finally(() => {
         setIsResetting(false);
       });
@@ -165,9 +181,14 @@ export const CreateModal = React.memo(({ existingPolicyNames, onConfirm, onDismi
       setError(undefined);
       onConfirm(newRoute)
         .then(() => {
+          trackNotificationPolicyCreated({
+            hasCustomTimings: newRoute.overrideTimings ?? false,
+            hasCustomGrouping: newRoute.overrideGrouping ?? false,
+          });
           onCreateDismiss();
         })
         .catch((err) => {
+          trackNotificationPolicyCreateError({ error: stringifyErrorLike(err) });
           setError(err);
         })
         .finally(() => {

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.tsx
@@ -6,6 +6,7 @@ import { Trans, t } from '@grafana/i18n';
 import { Badge, Box, Button, Field, Select, Stack, Text, TextLink } from '@grafana/ui';
 import { Route } from 'app/plugins/datasource/alertmanager/types';
 
+import { trackNotificationPolicySelectorChanged } from '../../../Analytics';
 import { RuleFormValues } from '../../../types/rule-form';
 import { ALERTING_PATHS } from '../../../utils/navigation';
 import {
@@ -150,15 +151,24 @@ export function PolicyTreeSelector() {
 
   const handlePolicyChange = (option: SelectableValue<string>) => {
     const newValue = option.value ?? '';
+
+    trackNotificationPolicySelectorChanged({
+      fromDefault: isUsingDefaultPolicy,
+      toDefault: newValue === '',
+    });
+
     updatePolicyLabel(newValue);
 
-    // If user selects default, collapse back
     if (newValue === '') {
       setIsExpanded(false);
     }
   };
 
   const handleResetToDefault = () => {
+    trackNotificationPolicySelectorChanged({
+      fromDefault: false,
+      toDefault: true,
+    });
     updatePolicyLabel('');
     setIsExpanded(false);
   };


### PR DESCRIPTION
**What is this feature?**

This PR adds tracking for the following events:
- Notification policy creation
- Notification policy creation error
- Notification policy export
- Notification policy deletion
- Default notification policy reset
- Notification policy tree selection in alert rule creation

https://github.com/user-attachments/assets/1833fff4-51d5-4f89-88f3-d52a4f9b0bce



**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1438

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
