### PR TITLE
SearchStateManager: Add createdBy tracking

### DIFF
--- a/public/app/features/search/page/reporting.ts
+++ b/public/app/features/search/page/reporting.ts
@@ -11,6 +11,7 @@ interface QueryProps {
   tagCount: number;
   includePanels?: boolean;
   deleted: boolean;
+  createdBy?: boolean;
 }
 
 export const reportDashboardListViewed = (eventTrackingNamespace: EventTrackingNamespace, query: QueryProps) => {
@@ -49,5 +50,6 @@ const getQuerySearchContext = (query: QueryProps) => {
     queryLength: query.query?.length ?? 0,
     includePanels: query.includePanels ?? false,
     deleted: query.deleted ?? false,
+    createdBy: query.createdBy ?? false,
   };
 };

--- a/public/app/features/search/state/SearchStateManager.ts
+++ b/public/app/features/search/state/SearchStateManager.ts
@@ -267,6 +267,7 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
       tagCount: this.state.tag?.length,
       includePanels: this.state.includePanels,
       deleted: this.state.deleted,
+      createdBy: !!this.state.createdBy,
     };
 
     reportSearchQueryInteraction(this.state.eventTrackingNamespace, trackingInfo);
@@ -319,6 +320,7 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
       tagCount: this.state.tag?.length,
       includePanels: this.state.includePanels,
       deleted: this.state.deleted,
+      createdBy: !!this.state.createdBy,
     });
   };
 
@@ -334,6 +336,7 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
       tagCount: this.state.tag?.length,
       includePanels: this.state.includePanels,
       deleted: this.state.deleted,
+      createdBy: !!this.state.createdBy,
     });
   };
 }


### PR DESCRIPTION
**What is this feature?**
Adds `createdBy` boolean to search Rudderstack events to track usage of the "Created by me" filter:
- `dashboard_search_query_submitted`
- `dashboard_search_result_clicked, dashboard_search_viewed`

**Why do we need this feature?**

To track new filter `Created by me` usage

**Who is this feature for?**

internal

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/114802

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
