### PR TITLE
QueryVariable: fix queries resetting when switching data sources

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/components/QueryEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/QueryEditor.tsx
@@ -43,7 +43,7 @@ export function QueryEditor({
         </Text>
         <Box marginTop={0.25}>
           <VariableQueryEditor
-            key={datasource.uid}
+            key={datasource.type}
             datasource={datasource}
             query={queryWithDefaults}
             templateSrv={getTemplateSrv()}
@@ -59,7 +59,7 @@ export function QueryEditor({
       <Box marginBottom={2}>
         <Box marginTop={0.25}>
           <VariableQueryEditor
-            key={datasource.uid}
+            key={datasource.type}
             datasource={datasource}
             query={queryWithDefaults}
             onChange={onQueryChange}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Currently, QueryEditor resets states when switching AMP data source to another AMP datasource.

**Why do we need this feature?**

This is a regression from prometheus core where it doesn't reset states when switching between prometheus core data sources.

**Which issue(s) does this PR fix?**:

Fixes `AMP -> AMP` issue mentioned in https://github.com/grafana/grafana-amazonprometheus-datasource/issues/478#issuecomment-3960965663

**Special notes for your reviewer:**

The solution here is to remount based on the data source type instead of datasource uid. This prevents remounting when switching data sources that have the same type

Alternatively we can remove `key` entirely to fix switching prometheus core -> AMP as mentioned in https://github.com/grafana/grafana-amazonprometheus-datasource/issues/478, but it might persist states in unwanted situations

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
