### PR TITLE
Alerting: Hide action buttons for read only resources

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/form/ChannelOptions.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelOptions.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import type { JSX } from 'react';
 import { DeepMap, FieldError, FieldErrors, useFormContext } from 'react-hook-form';
 
-import { Field, SecretInput } from '@grafana/ui';
+import { Field, Input, SecretInput } from '@grafana/ui';
 import {
   NotificationChannelOption,
   NotificationChannelSecureFields,
@@ -81,11 +81,15 @@ export function ChannelOptions<R extends ChannelValues>({
               htmlFor={`${settingsPath}${option.propertyName}`}
               noMargin
             >
-              <SecretInput
-                id={`${settingsPath}${option.propertyName}`}
-                onReset={() => onResetSecureField(option.secureFieldKey ?? option.propertyName)}
-                isConfigured
-              />
+              {readOnly ? (
+                <Input id={`${settingsPath}${option.propertyName}`} disabled={true} value="configured" />
+              ) : (
+                <SecretInput
+                  id={`${settingsPath}${option.propertyName}`}
+                  onReset={() => onResetSecureField(option.secureFieldKey ?? option.propertyName)}
+                  isConfigured
+                />
+              )}
             </Field>
           );
         }

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelOptions.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelOptions.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import type { JSX } from 'react';
 import { DeepMap, FieldError, FieldErrors, useFormContext } from 'react-hook-form';
 
-import { Field, Input, SecretInput } from '@grafana/ui';
+import { Field } from '@grafana/ui';
 import {
   NotificationChannelOption,
   NotificationChannelSecureFields,
@@ -16,7 +16,7 @@ import {
   ReceiverFormValues,
 } from '../../../types/receiver-form';
 
-import { OptionField } from './fields/OptionField';
+import { ConfiguredSecretInput, OptionField } from './fields/OptionField';
 
 export interface Props<R extends ChannelValues> {
   defaultValues: R;
@@ -81,15 +81,11 @@ export function ChannelOptions<R extends ChannelValues>({
               htmlFor={`${settingsPath}${option.propertyName}`}
               noMargin
             >
-              {readOnly ? (
-                <Input id={`${settingsPath}${option.propertyName}`} disabled={true} value="configured" />
-              ) : (
-                <SecretInput
-                  id={`${settingsPath}${option.propertyName}`}
-                  onReset={() => onResetSecureField(option.secureFieldKey ?? option.propertyName)}
-                  isConfigured
-                />
-              )}
+              <ConfiguredSecretInput
+                id={`${settingsPath}${option.propertyName}`}
+                readOnly={readOnly}
+                onReset={() => onResetSecureField(option.secureFieldKey ?? option.propertyName)}
+              />
             </Field>
           );
         }

--- a/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.test.tsx
@@ -202,6 +202,78 @@ describe('OptionField', () => {
     });
   });
 
+  describe('Read-only encrypted fields', () => {
+    const secureInputOption: NotificationChannelOption = {
+      propertyName: 'apiKey',
+      label: 'API Key',
+      description: 'Secret API key',
+      element: 'input',
+      inputType: 'text',
+      placeholder: '',
+      required: false,
+      secure: true,
+      secureFieldKey: 'apiKey',
+      showWhen: { field: '', is: '' },
+      validationRule: '',
+      protected: false,
+      dependsOn: '',
+    };
+
+    const secureTextareaOption: NotificationChannelOption = {
+      propertyName: 'privateKey',
+      label: 'Private Key',
+      description: 'Secret private key',
+      element: 'textarea',
+      inputType: '',
+      placeholder: '',
+      required: false,
+      secure: true,
+      secureFieldKey: 'privateKey',
+      showWhen: { field: '', is: '' },
+      validationRule: '',
+      protected: false,
+      dependsOn: '',
+    };
+
+    it('should show Reset button for encrypted input field when NOT readOnly', () => {
+      renderOptionField(secureInputOption, {
+        secureFields: { apiKey: true },
+      });
+
+      expect(screen.getByRole('button', { name: 'Reset' })).toBeInTheDocument();
+      expect(screen.getByDisplayValue('configured')).toBeInTheDocument();
+    });
+
+    it('should NOT show Reset button for encrypted input field when readOnly', () => {
+      renderOptionField(secureInputOption, {
+        readOnly: true,
+        secureFields: { apiKey: true },
+      });
+
+      expect(screen.queryByRole('button', { name: 'Reset' })).not.toBeInTheDocument();
+      expect(screen.getByDisplayValue('configured')).toBeInTheDocument();
+    });
+
+    it('should show Reset button for encrypted textarea field when NOT readOnly', () => {
+      renderOptionField(secureTextareaOption, {
+        secureFields: { privateKey: true },
+      });
+
+      expect(screen.getByRole('button', { name: 'Reset' })).toBeInTheDocument();
+      expect(screen.getByDisplayValue('configured')).toBeInTheDocument();
+    });
+
+    it('should NOT show Reset button for encrypted textarea field when readOnly', () => {
+      renderOptionField(secureTextareaOption, {
+        readOnly: true,
+        secureFields: { privateKey: true },
+      });
+
+      expect(screen.queryByRole('button', { name: 'Reset' })).not.toBeInTheDocument();
+      expect(screen.getByDisplayValue('configured')).toBeInTheDocument();
+    });
+  });
+
   describe('Subform fields', () => {
     it('should pass getOptionMeta to SubformField component', () => {
       const getOptionMeta = jest.fn().mockReturnValue({ readOnly: true, required: false });

--- a/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
@@ -130,27 +130,24 @@ export const OptionField: FC<Props> = ({
   );
 };
 
-interface ConfiguredSecureFieldProps {
+export interface ConfiguredSecureFieldProps {
   id: string;
   readOnly: boolean;
   onReset: () => void;
-  variant: 'input' | 'textarea';
 }
 
-function ConfiguredSecureField({ id, readOnly, onReset, variant }: ConfiguredSecureFieldProps) {
+export function ConfiguredSecretInput({ id, readOnly, onReset }: ConfiguredSecureFieldProps) {
   if (readOnly) {
-    return variant === 'input' ? (
-      <Input id={id} disabled={true} value="configured" />
-    ) : (
-      <TextArea id={id} disabled={true} value="configured" />
-    );
+    return <Input id={id} disabled={true} value="configured" />;
   }
+  return <SecretInput id={id} onReset={onReset} isConfigured />;
+}
 
-  return variant === 'input' ? (
-    <SecretInput id={id} onReset={onReset} isConfigured />
-  ) : (
-    <SecretTextArea id={id} onReset={onReset} isConfigured />
-  );
+function ConfiguredSecretTextArea({ id, readOnly, onReset }: ConfiguredSecureFieldProps) {
+  if (readOnly) {
+    return <TextArea id={id} disabled={true} value="configured" />;
+  }
+  return <SecretTextArea id={id} onReset={onReset} isConfigured />;
 }
 
 const OptionInput: FC<Props & { id: string }> = ({
@@ -172,7 +169,7 @@ const OptionInput: FC<Props & { id: string }> = ({
   const name = `${pathPrefix}${option.propertyName}`;
 
   const secureFieldKey = option.secure && option.secureFieldKey ? option.secureFieldKey : '';
-  const isEncryptedInput = secureFieldKey && secureFields?.[secureFieldKey];
+  const isSecureFieldConfigured = secureFieldKey && secureFields?.[secureFieldKey];
 
   const useTemplates = option.placeholder.includes('{{ template');
 
@@ -202,13 +199,8 @@ const OptionInput: FC<Props & { id: string }> = ({
           onSelectTemplate={onSelectTemplate}
           readOnly={readOnly}
         >
-          {isEncryptedInput ? (
-            <ConfiguredSecureField
-              id={id}
-              readOnly={readOnly}
-              onReset={() => onResetSecureField?.(secureFieldKey)}
-              variant="input"
-            />
+          {isSecureFieldConfigured ? (
+            <ConfiguredSecretInput id={id} readOnly={readOnly} onReset={() => onResetSecureField?.(secureFieldKey)} />
           ) : (
             <Input
               id={id}
@@ -283,12 +275,11 @@ const OptionInput: FC<Props & { id: string }> = ({
           onSelectTemplate={onSelectTemplate}
           readOnly={readOnly}
         >
-          {isEncryptedInput ? (
-            <ConfiguredSecureField
+          {isSecureFieldConfigured ? (
+            <ConfiguredSecretTextArea
               id={id}
               readOnly={readOnly}
               onReset={() => onResetSecureField?.(secureFieldKey)}
-              variant="textarea"
             />
           ) : (
             <TextArea

--- a/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
@@ -130,6 +130,29 @@ export const OptionField: FC<Props> = ({
   );
 };
 
+interface ConfiguredSecureFieldProps {
+  id: string;
+  readOnly: boolean;
+  onReset: () => void;
+  variant: 'input' | 'textarea';
+}
+
+function ConfiguredSecureField({ id, readOnly, onReset, variant }: ConfiguredSecureFieldProps) {
+  if (readOnly) {
+    return variant === 'input' ? (
+      <Input id={id} disabled={true} value="configured" />
+    ) : (
+      <TextArea id={id} disabled={true} value="configured" />
+    );
+  }
+
+  return variant === 'input' ? (
+    <SecretInput id={id} onReset={onReset} isConfigured />
+  ) : (
+    <SecretTextArea id={id} onReset={onReset} isConfigured />
+  );
+}
+
 const OptionInput: FC<Props & { id: string }> = ({
   option,
   invalid,
@@ -177,9 +200,15 @@ const OptionInput: FC<Props & { id: string }> = ({
           option={option}
           name={name}
           onSelectTemplate={onSelectTemplate}
+          readOnly={readOnly}
         >
           {isEncryptedInput ? (
-            <SecretInput id={id} onReset={() => onResetSecureField?.(secureFieldKey)} isConfigured />
+            <ConfiguredSecureField
+              id={id}
+              readOnly={readOnly}
+              onReset={() => onResetSecureField?.(secureFieldKey)}
+              variant="input"
+            />
           ) : (
             <Input
               id={id}
@@ -252,9 +281,15 @@ const OptionInput: FC<Props & { id: string }> = ({
           option={option}
           name={name}
           onSelectTemplate={onSelectTemplate}
+          readOnly={readOnly}
         >
           {isEncryptedInput ? (
-            <SecretTextArea id={id} onReset={() => onResetSecureField?.(secureFieldKey)} isConfigured />
+            <ConfiguredSecureField
+              id={id}
+              readOnly={readOnly}
+              onReset={() => onResetSecureField?.(secureFieldKey)}
+              variant="textarea"
+            />
           ) : (
             <TextArea
               id={id}

--- a/public/app/features/alerting/unified/components/receivers/form/fields/TemplateSelector.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/TemplateSelector.tsx
@@ -357,11 +357,11 @@ export function WrapWithTemplateSelection({
   const styles = useStyles2(getStyles);
   const { getValues } = useFormContext();
   const value = getValues(name) ?? '';
+  const showTemplatePicker = useTemplates && !readOnly;
   // if the placeholder does not contain a template, we don't need to show the template picker
   if (!option.placeholder.includes('{{ template ') || typeof value !== 'string') {
     return <>{children}</>;
   }
-  const showTemplatePicker = useTemplates && !readOnly;
 
   // Otherwise, we can use templates on this field
   // if the value is empty, we only show the template picker

--- a/public/app/features/alerting/unified/components/receivers/form/fields/TemplateSelector.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/TemplateSelector.tsx
@@ -344,6 +344,7 @@ interface WrapWithTemplateSelectionProps extends PropsWithChildren {
   onSelectTemplate: (template: string) => void;
   option: NotificationChannelOption;
   name: string;
+  readOnly?: boolean;
 }
 export function WrapWithTemplateSelection({
   useTemplates,
@@ -351,6 +352,7 @@ export function WrapWithTemplateSelection({
   option,
   name,
   children,
+  readOnly = false,
 }: WrapWithTemplateSelectionProps) {
   const styles = useStyles2(getStyles);
   const { getValues } = useFormContext();
@@ -359,13 +361,15 @@ export function WrapWithTemplateSelection({
   if (!option.placeholder.includes('{{ template ') || typeof value !== 'string') {
     return <>{children}</>;
   }
+  const showTemplatePicker = useTemplates && !readOnly;
+
   // Otherwise, we can use templates on this field
   // if the value is empty, we only show the template picker
   if (!value) {
     return (
       <div className={styles.inputContainer}>
         <Stack direction="row" gap={1} alignItems="center">
-          {useTemplates && (
+          {showTemplatePicker && (
             <TemplatesPicker onSelect={onSelectTemplate} option={option} valueInForm={getValues(name) ?? ''} />
           )}
         </Stack>
@@ -378,19 +382,19 @@ export function WrapWithTemplateSelection({
       <div className={styles.inputContainer}>
         <Stack direction="row" gap={1} alignItems="center">
           <Text variant="bodySmall">{`Template: ${getTemplateName(value)}`}</Text>
-          {useTemplates && (
+          {showTemplatePicker && (
             <TemplatesPicker onSelect={onSelectTemplate} option={option} valueInForm={getValues(name) ?? ''} />
           )}
         </Stack>
       </div>
     );
   }
-  // custom template  field
+  // custom template field
   return (
     <div className={styles.inputContainer}>
       <Stack direction="row" gap={1} alignItems="center">
         {children}
-        {useTemplates && (
+        {showTemplatePicker && (
           <TemplatesPicker onSelect={onSelectTemplate} option={option} valueInForm={getValues(name) ?? ''} />
         )}
       </Stack>


### PR DESCRIPTION
**What is this feature?**

This PR hides action buttons such as Reset or Edit in the view page for imported resources


https://github.com/user-attachments/assets/b701b2c0-a0d0-41c5-a06c-91c02a9c6be2

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1446

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
