### PR TITLE
Enable text selection for uPlot y-axis labels in state-timeline

### DIFF
--- a/public/app/plugins/panel/state-timeline/styles.ts
+++ b/public/app/plugins/panel/state-timeline/styles.ts
@@ -3,4 +3,9 @@ import { css } from '@emotion/css';
 export const containerStyles = css({
   display: 'flex',
   flexDirection: 'column',
+
+  // Allow selecting/copying row label text rendered on the uPlot y-axis.
+  '.u-axis': {
+    userSelect: 'text',
+  },
 });


### PR DESCRIPTION
### Motivation
- Allow selecting and copying row label text rendered on the uPlot y-axis in the state-timeline panel for easier copying of labels.

### Description
- Add a CSS rule to `public/app/plugins/panel/state-timeline/styles.ts` so `.u-axis` uses `userSelect: 'text'` within `containerStyles` to enable text selection.

### Testing
- Ran `yarn lint`, `yarn test`, and type checks against the repository and the existing test suite passed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699f638fa0ec8326b988552253288eb3)