### PR TITLE
NewProvisionedFolderForm: Show banner when folder is pushed but not yet synced to Grafana

### DIFF
--- a/public/app/features/provisioning/components/Dashboards/DashboardPreviewBanner.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/DashboardPreviewBanner.test.tsx
@@ -106,6 +106,7 @@ function setup(props: Partial<DashboardPreviewBannerProps> = {}, overrides: Setu
     repoURL: undefined,
     repoType: 'github',
     ...overrides.pullRequestParam,
+    resourcePushedTo: 'abc',
   });
 
   mockUseGetResourceRepositoryView.mockReturnValue({

--- a/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.tsx
+++ b/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.tsx
@@ -63,7 +63,8 @@ function FormContent({ initialValues, repository, canPushToConfiguredBranch, fol
       return;
     }
 
-    // When new folder is created but we don't have metadata, show user resource created banner
+    // When sync is disabled, the BE returns resource.upsert as null (no Grafana resource created).
+    // Redirect to dashboards with a banner linking to the repo status page.
     const url = buildResourceBranchRedirectUrl({
       paramName: 'resource_pushed_to',
       paramValue: repository?.name,

--- a/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.tsx
+++ b/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.tsx
@@ -8,7 +8,6 @@ import { Alert, Button, Field, Input, Stack } from '@grafana/ui';
 import { Folder } from 'app/api/clients/folder/v1beta1';
 import { RepositoryView, useCreateRepositoryFilesWithPathMutation } from 'app/api/clients/provisioning/v0alpha1';
 import { AnnoKeySourcePath, Resource } from 'app/features/apiserver/types';
-import { PROVISIONING_URL } from 'app/features/provisioning/constants';
 import { usePullRequestParam } from 'app/features/provisioning/hooks/usePullRequestParam';
 import { FolderDTO } from 'app/types/folders';
 
@@ -64,14 +63,14 @@ function FormContent({ initialValues, repository, canPushToConfiguredBranch, fol
       return;
     }
 
-    // Fallback to provisioning URL
-    if (repository?.name && request.data?.path) {
-      let url = `${PROVISIONING_URL}/${repository.name}/file/${request.data.path}`;
-      if (request.data.ref?.length) {
-        url += '?ref=' + request.data.ref;
-      }
-      navigate(url);
-    }
+    // When new folder is created but we don't have metadata, show user resource created banner
+    const url = buildResourceBranchRedirectUrl({
+      paramName: 'resource_pushed_to',
+      paramValue: repository?.name,
+      repoType: repository?.type,
+    });
+
+    navigate(url);
   };
 
   const onError = (error: unknown) => {

--- a/public/app/features/provisioning/components/Folders/ProvisionedFolderPreviewBanner.tsx
+++ b/public/app/features/provisioning/components/Folders/ProvisionedFolderPreviewBanner.tsx
@@ -1,11 +1,15 @@
-import { config } from '@grafana/runtime';
+import { t, Trans } from '@grafana/i18n';
+import { config, locationService } from '@grafana/runtime';
+import { Alert } from '@grafana/ui';
 import { CommonBannerProps } from 'app/features/provisioning/components/Dashboards/DashboardPreviewBanner';
 import { PreviewBannerViewPR } from 'app/features/provisioning/components/Shared/PreviewBannerViewPR';
 import { usePullRequestParam } from 'app/features/provisioning/hooks/usePullRequestParam';
 
+import { PROVISIONING_URL } from '../../constants';
+
 export function ProvisionedFolderPreviewBanner({ queryParams }: CommonBannerProps) {
   const provisioningEnabled = config.featureToggles.provisioning;
-  const { prURL, newPrURL, repoURL } = usePullRequestParam();
+  const { prURL, newPrURL, repoURL, resourcePushedTo } = usePullRequestParam();
 
   if (!provisioningEnabled || 'kiosk' in queryParams) {
     return null;
@@ -21,6 +25,22 @@ export function ProvisionedFolderPreviewBanner({ queryParams }: CommonBannerProp
 
   if (repoURL) {
     return <PreviewBannerViewPR repoUrl={repoURL} behindBranch />;
+  }
+
+  if (resourcePushedTo) {
+    return (
+      <Alert
+        title={t('provisioned-folder-preview-banner.folder-pushed-to-repository', 'Folder pushed to repository')}
+        severity="info"
+        buttonContent={t('provisioned-folder-preview-banner.view-folder', 'View repository status')}
+        onRemove={() => locationService.push(`${PROVISIONING_URL}/${resourcePushedTo}/?tab=overview`)}
+      >
+        <Trans i18nKey="provisioned-folder-preview-banner.sync-needed">
+          The folder has been successfully pushed to the repository but is not yet available in Grafana. It will appear
+          once changes are synced from the repository
+        </Trans>
+      </Alert>
+    );
   }
 
   return null;

--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
@@ -38,6 +38,7 @@ function setup(
     newPrURL: undefined,
     repoURL: undefined,
     repoType: options.repoType || 'github',
+    resourcePushedTo: 'abc'
   });
 
   const renderResult = render(<PreviewBannerViewPR {...componentProps} />);

--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
@@ -38,7 +38,7 @@ function setup(
     newPrURL: undefined,
     repoURL: undefined,
     repoType: options.repoType || 'github',
-    resourcePushedTo: 'abc'
+    resourcePushedTo: 'abc',
   });
 
   const renderResult = render(<PreviewBannerViewPR {...componentProps} />);

--- a/public/app/features/provisioning/hooks/usePullRequestParam.ts
+++ b/public/app/features/provisioning/hooks/usePullRequestParam.ts
@@ -7,11 +7,14 @@ export const usePullRequestParam = () => {
   const newPrParam = params.get('new_pull_request_url');
   const repoUrl = params.get('repo_url');
   const repoType = params.get('repo_type');
+  const resourcePushedTo = params.get('resource_pushed_to');
 
   return {
     prURL: prParam ? textUtil.sanitizeUrl(decodeURIComponent(prParam)) : undefined,
     newPrURL: newPrParam ? textUtil.sanitizeUrl(decodeURIComponent(newPrParam)) : undefined,
     repoURL: repoUrl ? textUtil.sanitizeUrl(decodeURIComponent(repoUrl)) : undefined,
     repoType: repoType ? textUtil.sanitizeUrl(decodeURIComponent(repoType)) : undefined,
+    // Repository name the resource was pushed to, used to link to its status overview page
+    resourcePushedTo: resourcePushedTo ? textUtil.sanitizeUrl(decodeURIComponent(resourcePushedTo)) : undefined,
   };
 };

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12368,6 +12368,11 @@
       "text-loading-teams": "Loading teams..."
     }
   },
+  "provisioned-folder-preview-banner": {
+    "folder-pushed-to-repository": "Folder pushed to repository",
+    "sync-needed": "The folder has been successfully pushed to the repository but is not yet available in Grafana. It will appear once changes are synced from the repository",
+    "view-folder": "View repository status"
+  },
   "provisioned-resource-form": {
     "save-or-delete-resource-shared-fields": {
       "comment-placeholder-describe-changes-optional": "Add a note to describe your changes (optional)",


### PR DESCRIPTION
**What is this feature?**

- When a new provisioned folder is created via the `write` workflow but the response doesn't include metadata (e.g. sync is disabled or hasn't run yet), show user a banner instead (Currently we are showing user a error page unexpectedly because resource is not ready).
- The banner shows the user the folder was pushed to the repository and links to the repository status page so they can check sync status or trigger a manual pull.

<img width="893" height="131" alt="image" src="https://github.com/user-attachments/assets/ef407c49-6b84-42b4-be6f-9cdfab7ef657" />


**Why do we need this feature?**

To prevent user confusion

**Who is this feature for?**

Git sync users who creates folder

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/887

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
