### PR TITLE
QueryEditor: Transformation filters v1 parity

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/TransformationActionButtons.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/TransformationActionButtons.test.tsx
@@ -1,0 +1,216 @@
+import { screen } from '@testing-library/react';
+
+import {
+  DataFrame,
+  DataTransformerInfo,
+  FrameMatcherID,
+  getDefaultTimeRange,
+  LoadingState,
+  TransformerRegistryItem,
+} from '@grafana/data';
+import { DataTopic } from '@grafana/schema';
+
+import { renderWithQueryEditorProvider } from '../testUtils';
+import { Transformation } from '../types';
+
+import { TransformationActionButtons } from './TransformationActionButtons';
+
+const mockTransformerInfo: DataTransformerInfo = {
+  id: 'test-transform',
+  name: 'Test Transform',
+  operator: jest.fn(),
+};
+
+const mockRegistryItem: TransformerRegistryItem = {
+  id: 'test-transform',
+  name: 'Test Transform',
+  transformation: mockTransformerInfo,
+  editor: () => null,
+  imageDark: '',
+  imageLight: '',
+};
+
+function makeTransformation(overrides: Partial<Transformation> = {}): Transformation {
+  return {
+    transformId: 'test-transform',
+    transformConfig: { id: 'test-transform', options: {} },
+    registryItem: mockRegistryItem,
+    ...overrides,
+  };
+}
+
+function makeSeries(): DataFrame[] {
+  return [{ fields: [], length: 0, refId: 'A' }];
+}
+
+function makeData(overrides: Partial<{ series: DataFrame[]; annotations: DataFrame[] }> = {}) {
+  return {
+    state: LoadingState.Done,
+    series: [],
+    timeRange: getDefaultTimeRange(),
+    ...overrides,
+  };
+}
+
+describe('TransformationActionButtons', () => {
+  it('renders nothing when no transformation is selected', () => {
+    const { container } = renderWithQueryEditorProvider(<TransformationActionButtons />, {
+      selectedTransformation: null,
+    });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  describe('filter button visibility', () => {
+    it('hides the filter button when there is no data and no filter configured', () => {
+      renderWithQueryEditorProvider(<TransformationActionButtons />, {
+        selectedTransformation: makeTransformation(),
+        qrState: { data: makeData() },
+      });
+
+      expect(screen.queryByRole('button', { name: /filter/i })).not.toBeInTheDocument();
+    });
+
+    it('shows the filter button when there are data series', () => {
+      renderWithQueryEditorProvider(<TransformationActionButtons />, {
+        selectedTransformation: makeTransformation(),
+        qrState: { data: makeData({ series: makeSeries() }) },
+      });
+
+      expect(screen.getByRole('button', { name: /add filter/i })).toBeInTheDocument();
+    });
+
+    it('shows the filter button when there are annotations', () => {
+      renderWithQueryEditorProvider(<TransformationActionButtons />, {
+        selectedTransformation: makeTransformation(),
+        qrState: { data: makeData({ annotations: [{ fields: [], length: 0 }] }) },
+      });
+
+      expect(screen.getByRole('button', { name: /add filter/i })).toBeInTheDocument();
+    });
+
+    it('shows the filter button when a filter is already configured, even with no data', () => {
+      // The filter button must remain visible when a filter is active so the user
+      // can remove it — regardless of whether data is currently present.
+      renderWithQueryEditorProvider(<TransformationActionButtons />, {
+        selectedTransformation: makeTransformation({
+          transformConfig: {
+            id: 'test-transform',
+            options: {},
+            filter: { id: FrameMatcherID.byRefId, options: 'A' },
+          },
+        }),
+        qrState: { data: makeData() },
+      });
+
+      expect(screen.getByRole('button', { name: /remove filter/i })).toBeInTheDocument();
+    });
+
+    it('shows the filter button when a topic is configured, even with no data', () => {
+      // topic keeps the button visible (and active), but since no explicit filter is set
+      // the label says "Add filter" — clicking will add a filter, not remove the topic.
+      // This mirrors v1 (TransformationOperationRow) where toggleFilter only touches `filter`.
+      renderWithQueryEditorProvider(<TransformationActionButtons />, {
+        selectedTransformation: makeTransformation({
+          transformConfig: {
+            id: 'test-transform',
+            options: {},
+            topic: DataTopic.Annotations,
+          },
+        }),
+        qrState: { data: makeData() },
+      });
+
+      expect(screen.getByRole('button', { name: /add filter/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('filter button toggle behaviour', () => {
+    it('adds a filter when clicking with no filter configured', async () => {
+      const updateTransformation = jest.fn();
+      const transformation = makeTransformation();
+
+      const { user } = renderWithQueryEditorProvider(<TransformationActionButtons />, {
+        selectedTransformation: transformation,
+        qrState: { data: makeData({ series: makeSeries() }) },
+        actionsOverrides: { updateTransformation },
+      });
+
+      await user.click(screen.getByRole('button', { name: /add filter/i }));
+
+      expect(updateTransformation).toHaveBeenCalledWith(transformation.transformConfig, {
+        ...transformation.transformConfig,
+        filter: { id: FrameMatcherID.byRefId, options: '' },
+      });
+    });
+
+    it('removes only the filter when a filter is configured', async () => {
+      const updateTransformation = jest.fn();
+      const config = {
+        id: 'test-transform',
+        options: {},
+        filter: { id: FrameMatcherID.byRefId, options: 'A' },
+      };
+      const transformation = makeTransformation({ transformConfig: config });
+
+      const { user } = renderWithQueryEditorProvider(<TransformationActionButtons />, {
+        selectedTransformation: transformation,
+        qrState: { data: makeData() },
+        actionsOverrides: { updateTransformation },
+      });
+
+      await user.click(screen.getByRole('button', { name: /remove filter/i }));
+
+      expect(updateTransformation).toHaveBeenCalledWith(config, { id: 'test-transform', options: {} });
+    });
+
+    it('adds a filter without removing topic when only topic is configured', async () => {
+      // Mirrors v1: toggleFilter only ever adds/removes `filter`; `topic` is untouched.
+      const updateTransformation = jest.fn();
+      const config = {
+        id: 'test-transform',
+        options: {},
+        topic: DataTopic.Annotations,
+      };
+      const transformation = makeTransformation({ transformConfig: config });
+
+      const { user } = renderWithQueryEditorProvider(<TransformationActionButtons />, {
+        selectedTransformation: transformation,
+        qrState: { data: makeData() },
+        actionsOverrides: { updateTransformation },
+      });
+
+      await user.click(screen.getByRole('button', { name: /add filter/i }));
+
+      expect(updateTransformation).toHaveBeenCalledWith(config, {
+        ...config,
+        filter: { id: FrameMatcherID.byRefId, options: '' },
+      });
+    });
+
+    it('removes filter but leaves topic intact when both are configured', async () => {
+      const updateTransformation = jest.fn();
+      const config = {
+        id: 'test-transform',
+        options: {},
+        filter: { id: FrameMatcherID.byRefId, options: 'A' },
+        topic: DataTopic.Annotations,
+      };
+      const transformation = makeTransformation({ transformConfig: config });
+
+      const { user } = renderWithQueryEditorProvider(<TransformationActionButtons />, {
+        selectedTransformation: transformation,
+        qrState: { data: makeData() },
+        actionsOverrides: { updateTransformation },
+      });
+
+      await user.click(screen.getByRole('button', { name: /remove filter/i }));
+
+      expect(updateTransformation).toHaveBeenCalledWith(config, {
+        id: 'test-transform',
+        options: {},
+        topic: DataTopic.Annotations,
+      });
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationFilterDisplay.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationFilterDisplay.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react';
 import { DataTransformerConfig, GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { DataTopic } from '@grafana/schema';
-import { Combobox, Field, useStyles2 } from '@grafana/ui';
+import { Combobox, Field, Stack, useStyles2 } from '@grafana/ui';
 import { FrameMultiSelectionEditor } from 'app/plugins/panel/geomap/editor/FrameSelectionEditor';
 
 import {
@@ -82,8 +82,12 @@ export function TransformationFilterDisplay() {
 
   return (
     <div className={styles.wrapper}>
-      <Field noMargin label={t('query-editor-next.transformation-filter.label', 'Apply transformation to')}>
-        <>
+      <Field
+        className={styles.field}
+        noMargin
+        label={t('query-editor-next.transformation-filter.label', 'Apply transformation to')}
+      >
+        <Stack direction="column" gap={1}>
           {filterOptions.showTopic && (
             <Combobox
               isClearable={true}
@@ -105,7 +109,7 @@ export function TransformationFilterDisplay() {
               onChange={(filter) => onChange({ ...config, filter })}
             />
           )}
-        </>
+        </Stack>
       </Field>
     </div>
   );
@@ -117,5 +121,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     border: `2px solid ${theme.colors.background.secondary}`,
     borderRadius: theme.shape.radius.default,
     marginBottom: theme.spacing(2),
+  }),
+  field: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
   }),
 });


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->

Resolves https://github.com/grafana/grafana/issues/118144

**Bug**: The transformation filter button was always visible in the QEV2 panel editor, even when there was no data to filter. This was a regression from v1 (`TransformationOperationRow`), where the filter button only appears when meaningful — i.e. data is present, or a filter is already configured.

**Fix**: Gate the filter button behind a `showFilterButton` check so it only renders when there is query data (series or annotations) or an active filter/topic. Also corrected the toggle logic to only add/remove the filter property, leaving topic untouched — matching v1 behaviour.

## Changes
<!--- Describe your changes in detail -->
* See notes above!

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->
N/A

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->
N/A

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* Pull down the branch
* Create a new dashboard with `gdev-testdata` and set it to `error with source`
* Add any transformation
* Note that the "Filter" button shouldn't appear, because there's no data to filter. **UNLESS** that transformation already has filters applied from when the query **WAS** returning data.

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable