### PR TITLE
QueryEditor: Enforce minimum sidebar width in pixels

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.test.ts
@@ -51,14 +51,16 @@ describe('buildVizAndDataPaneGrid', () => {
     expect(buildVizAndDataPaneGrid({ ...base, vizRatio: 0.75 }).gridTemplateRows).toBe('3fr 1fr');
   });
 
-  it('converts sidebarRatio 0.5 to equal columns (1fr 1fr)', () => {
-    expect(buildVizAndDataPaneGrid({ ...base, sidebarRatio: 0.5 }).gridTemplateColumns).toBe('1fr 1fr');
+  it('converts sidebarRatio 0.5 to equal columns (minmax(200px, 1fr) 1fr)', () => {
+    expect(buildVizAndDataPaneGrid({ ...base, sidebarRatio: 0.5 }).gridTemplateColumns).toBe('minmax(200px, 1fr) 1fr');
   });
 
   it('converts sidebarRatio 0.25 to approximately one-third of the available width', () => {
-    // 0.25 / (1 - 0.25) = 0.333...fr
-    const [sidebarFr] = buildVizAndDataPaneGrid({ ...base, sidebarRatio: 0.25 }).gridTemplateColumns.split(' ');
-    expect(parseFloat(sidebarFr)).toBeCloseTo(1 / 3, 5);
+    // 0.25 / (1 - 0.25) = 0.333...fr — wrapped in minmax(200px, Xfr)
+    const columns = buildVizAndDataPaneGrid({ ...base, sidebarRatio: 0.25 }).gridTemplateColumns;
+    const match = columns.match(/minmax\(\d+px,\s*([\d.]+)fr\)/);
+    expect(match).not.toBeNull();
+    expect(parseFloat(match![1])).toBeCloseTo(1 / 3, 5);
   });
 });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.test.ts
@@ -51,8 +51,8 @@ describe('buildVizAndDataPaneGrid', () => {
     expect(buildVizAndDataPaneGrid({ ...base, vizRatio: 0.75 }).gridTemplateRows).toBe('3fr 1fr');
   });
 
-  it('converts sidebarRatio 0.5 to equal columns (minmax(200px, 1fr) 1fr)', () => {
-    expect(buildVizAndDataPaneGrid({ ...base, sidebarRatio: 0.5 }).gridTemplateColumns).toBe('minmax(200px, 1fr) 1fr');
+  it('converts sidebarRatio 0.5 to equal columns (minmax(220px, 1fr) 1fr)', () => {
+    expect(buildVizAndDataPaneGrid({ ...base, sidebarRatio: 0.5 }).gridTemplateColumns).toBe('minmax(220px, 1fr) 1fr');
   });
 
   it('converts sidebarRatio 0.25 to approximately one-third of the available width', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.ts
@@ -16,7 +16,7 @@ import { QUERY_EDITOR_SIDEBAR_SIZE_KEY, SidebarSize } from './constants';
 const CONTROLS_ROW_HEIGHT = 'auto';
 const MIN_SIDEBAR_RATIO = 0.1;
 const MAX_SIDEBAR_RATIO = 0.5;
-const MIN_SIDEBAR_PIXELS = 200;
+const MIN_SIDEBAR_PIXELS = 220;
 const vizResizerClassName = css({ height: 2, width: '100%' });
 // Pre-mount placeholder — useLayoutEffect replaces this with the responsive default before the first paint.
 const FALLBACK_SIDEBAR_RATIO = 0.25;

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.ts
@@ -16,6 +16,7 @@ import { QUERY_EDITOR_SIDEBAR_SIZE_KEY, SidebarSize } from './constants';
 const CONTROLS_ROW_HEIGHT = 'auto';
 const MIN_SIDEBAR_RATIO = 0.1;
 const MAX_SIDEBAR_RATIO = 0.5;
+const MIN_SIDEBAR_PIXELS = 200;
 const vizResizerClassName = css({ height: 2, width: '100%' });
 // Pre-mount placeholder — useLayoutEffect replaces this with the responsive default before the first paint.
 const FALLBACK_SIDEBAR_RATIO = 0.25;
@@ -282,9 +283,11 @@ export function buildVizAndDataPaneGrid({
     }
   }
 
-  // Convert sidebar ratio to fractional units (ratio is clamped to [0.1, 0.5] so 0 and 1 are unreachable)
+  // Convert sidebar ratio to fractional units (ratio is clamped to [0.1, 0.5] so 0 and 1 are unreachable).
+  // minmax() enforces the pixel floor at the CSS level so window resizes can't push the sidebar
+  // below MIN_SIDEBAR_PIXELS — consistent with the same floor applied in the drag handler.
   const sidebarFr = sidebarRatio / (1 - sidebarRatio);
-  const columns = `${sidebarFr}fr 1fr`;
+  const columns = `minmax(${MIN_SIDEBAR_PIXELS}px, ${sidebarFr}fr) 1fr`;
 
   return {
     height: '100%',


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->
Resolves https://github.com/grafana/grafana/issues/118471

Basically the minimum width of the sidebar is the smallest of either 10% of the width, or 200px. This just uses grid minmax to do it! This prevents the cropping of the "Transformations" label and the button.

## Changes
<!--- Describe your changes in detail -->
* See above

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->
N/A

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* Pull it down and try it out!

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable