### PR TITLE
Website: Fix incorrect Getting Started documentation link

### DIFF
--- a/emails/templates/welcome_on_signup.mjml
+++ b/emails/templates/welcome_on_signup.mjml
@@ -23,10 +23,10 @@
           Welcome! Ready to start building some beautiful metric and analytic dashboards?
         </mj-text>
         <mj-text>
-          If you are new to Grafana, refer to the <a href="https://grafana.com/docs/grafana/latest/getting-started/getting-started/">Getting started with Grafana</a>
+          If you are new to Grafana, refer to the <a href="https://grafana.com/docs/grafana/latest/getting-started/">Getting started with Grafana</a>
           guide.
         </mj-text>
-        <mj-button href="https://grafana.com/docs/grafana/latest/getting-started/getting-started/">
+        <mj-button href="https://grafana.com/docs/grafana/latest/getting-started/">
           Check out our getting started guide
         </mj-button>
         <mj-text>

--- a/emails/templates/welcome_on_signup.txt
+++ b/emails/templates/welcome_on_signup.txt
@@ -4,7 +4,7 @@ Hi [[.Name]],
 
 Welcome! Ready to start building some beautiful metric and analytic dashboards?
 
-If you are new to Grafana, refer to the Getting started with Grafana guide on https://grafana.com/docs/grafana/latest/getting-started/getting-started/.
+If you are new to Grafana, refer to the Getting started with Grafana guide on https://grafana.com/docs/grafana/latest/getting-started/.
 
 Thank you for joining our community.
 

--- a/public/emails/welcome_on_signup.html
+++ b/public/emails/welcome_on_signup.html
@@ -152,7 +152,7 @@
                     </tr>
                     <tr>
                       <td align="left" class="txt" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family: Inter, Helvetica, Arial; font-size: 13px; line-height: 150%; text-align: left; color: #000000;">If you are new to Grafana, refer to the <a href="https://grafana.com/docs/grafana/latest/getting-started/getting-started/" style="color: #6E9FFF;">Getting started with Grafana</a> guide.</div>
+                        <div style="font-family: Inter, Helvetica, Arial; font-size: 13px; line-height: 150%; text-align: left; color: #000000;">If you are new to Grafana, refer to the <a href="https://grafana.com/docs/grafana/latest/getting-started/" style="color: #6E9FFF;">Getting started with Grafana</a> guide.</div>
                       </td>
                     </tr>
                     <tr>
@@ -161,7 +161,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#3D71D9" role="presentation" style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;background:#3D71D9;" valign="middle">
-                                <a href="https://grafana.com/docs/grafana/latest/getting-started/getting-started/" rel="noopener" style="display: inline-block; background: #3D71D9; color: #ffffff; font-family: Inter, Helvetica, Arial; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 3px;" target="_blank"> Check out our getting started guide </a>
+                                <a href="https://grafana.com/docs/grafana/latest/getting-started/" rel="noopener" style="display: inline-block; background: #3D71D9; color: #ffffff; font-family: Inter, Helvetica, Arial; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 3px;" target="_blank"> Check out our getting started guide </a>
                               </td>
                             </tr>
                           </tbody>

--- a/public/emails/welcome_on_signup.txt
+++ b/public/emails/welcome_on_signup.txt
@@ -4,7 +4,7 @@ Hi {{.Name}},
 
 Welcome! Ready to start building some beautiful metric and analytic dashboards?
 
-If you are new to Grafana, refer to the Getting started with Grafana guide on https://grafana.com/docs/grafana/latest/getting-started/getting-started/.
+If you are new to Grafana, refer to the Getting started with Grafana guide on https://grafana.com/docs/grafana/latest/getting-started/.
 
 Thank you for joining our community.
 


### PR DESCRIPTION
**What is this feature?**

This PR fixes an incorrect "Getting Started" documentation link on the main website.

**Why do we need this feature?**

The current link points to:

`https://grafana.com/docs/grafana/latest/getting-started/getting-started/`

This URL is incorrect and may cause confusion or unnecessary redirects.

It has been updated to the correct URL:

`https://grafana.com/docs/grafana/latest/getting-started/`

**Who is this feature for?**

All users navigating to the Getting Started documentation from the main website.

**Special notes for your reviewer:**

Small website link correction. No functional or behavioral changes.