### PR TITLE
Scopes: Add useScopeDepthPrefetch feature flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -529,6 +529,11 @@ export interface FeatureToggles {
   */
   useMultipleScopeNodesEndpoint?: boolean;
   /**
+  * Use depth and rootScope parameters for scope node prefetching to reduce API calls during tree navigation
+  * @default false
+  */
+  useScopeDepthPrefetch?: boolean;
+  /**
   * In-development feature that will allow injection of labels into loki queries.
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -822,6 +822,15 @@ var (
 			HideFromDocs: true,
 		},
 		{
+			Name:         "useScopeDepthPrefetch",
+			Description:  "Use depth and rootScope parameters for scope node prefetching to reduce API calls during tree navigation",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaOperatorExperienceSquad,
+			Expression:   "false",
+			FrontendOnly: true,
+			HideFromDocs: true,
+		},
+		{
 			Name:         "logQLScope",
 			Description:  "In-development feature that will allow injection of labels into loki queries.",
 			Stage:        FeatureStagePrivatePreview,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -22,7 +22,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2023-04-12,disableSSEDataplane,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2023-04-03,renderAuthJWT,preview,@grafana/grafana-operator-experience-squad,false,false,false
 2023-06-06,refactorVariablesTimeRange,preview,@grafana/dashboards-squad,false,false,false
-2023-05-04,faroDatasourceSelector,preview,@grafana/app-o11y,false,false,true
+2023-05-05,faroDatasourceSelector,preview,@grafana/app-o11y,false,false,true
 2023-04-24,enableDatagridEditing,preview,@grafana/dataviz-squad,false,false,false
 2026-02-18,faroSessionReplay,experimental,@grafana/session-replay,false,false,true
 2023-07-12,logsExploreTableVisualisation,GA,@grafana/observability-logs,false,false,true
@@ -101,6 +101,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-11-27,scopeApi,experimental,@grafana/grafana-app-platform-squad,false,false,false
 2025-07-31,useScopeSingleNodeEndpoint,experimental,@grafana/grafana-operator-experience-squad,false,false,true
 2025-08-29,useMultipleScopeNodesEndpoint,experimental,@grafana/grafana-operator-experience-squad,false,false,true
+2026-02-26,useScopeDepthPrefetch,experimental,@grafana/grafana-operator-experience-squad,false,false,true
 2024-11-11,logQLScope,privatePreview,@grafana/oss-big-tent,false,false,false
 2024-02-27,sqlExpressions,preview,@grafana/grafana-datasources-core-services,false,false,false
 2025-07-23,sqlExpressionsColumnAutoComplete,experimental,@grafana/datapro,false,false,true
@@ -155,10 +156,10 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-10-04,pluginsSriChecks,GA,@grafana/plugins-platform-backend,false,false,false
 2024-10-17,unifiedStorageBigObjectsSupport,experimental,@grafana/search-and-storage,false,false,false
 2024-10-22,timeRangeProvider,experimental,@grafana/grafana-frontend-platform,false,false,false
-2025-11-04,timeRangePan,GA,@grafana/dataviz-squad,false,false,true
+2025-11-05,timeRangePan,GA,@grafana/dataviz-squad,false,false,true
 2025-11-20,newTimeRangeZoomShortcuts,GA,@grafana/dataviz-squad,false,false,true
 2024-10-24,azureMonitorDisableLogLimit,GA,@grafana/partner-datasources,false,false,false
-2024-12-19,playlistsReconciler,experimental,@grafana/grafana-app-platform-squad,false,true,false
+2024-12-20,playlistsReconciler,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2024-11-14,passwordlessMagicLinkAuthentication,experimental,@grafana/identity-access-team,false,false,false
 2024-12-18,prometheusSpecialCharsInLabelValues,experimental,@grafana/oss-big-tent,false,false,true
 2024-11-05,enableExtensionsAdminPage,experimental,@grafana/plugins-platform-backend,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4341,6 +4341,21 @@
     },
     {
       "metadata": {
+        "name": "useScopeDepthPrefetch",
+        "resourceVersion": "1772084331657",
+        "creationTimestamp": "2026-02-26T05:38:51Z"
+      },
+      "spec": {
+        "description": "Use depth and rootScope parameters for scope node prefetching to reduce API calls during tree navigation",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontend": true,
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "useScopeSingleNodeEndpoint",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2025-07-31T14:32:41Z"


### PR DESCRIPTION
## Summary
- Register experimental `useScopeDepthPrefetch` feature flag (frontend-only, hidden from docs)
- When enabled, frontend will pass `depth` and `rootScope` params to scope navigation requests to reduce API round-trips during tree traversal
- Backend support for these params is being implemented separately

## Context
Ref: grafana/hyperion-planning#523

Scope tree navigation currently requires sequential API calls per tree level. The `depth` param enables multi-level prefetching, and `rootScope` enables single-call breadcrumb reconstruction.

This flag gates the frontend behavioral change. Backend always accepts the params regardless of flag state.

## Test plan
- [x] Feature toggle codegen passes
- [x] No behavioral change (flag defaults to `false`)
- [x] `useScopeDepthPrefetch` appears in `featureToggles.gen.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)