### PR TITLE
FieldOverrides: Avoid some perf issues

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -109,16 +109,18 @@ export function applyFieldOverrides(
 
     // start by making a copy. looping twice is currently unavoidable, as methods downstream (like the displayName
     // uniqueness check) depend on clone already being present in the fields array.
-    newFrame.fields = Array.from({ length: newFrame.fields.length }, (_, i) => {
+    const newFields = Array(newFrame.fields.length);
+    for (let i = 0; i < newFrame.fields.length; i++) {
       const originalField = newFrame.fields[i];
-      return {
+      newFields[i] = {
         ...originalField,
         config: cloneDeep(originalField.config),
         state: {
           ...originalField.state,
         },
       };
-    });
+    }
+    newFrame.fields = newFields;
 
     // now that the frame has the new fields, we can mutate the fields in place.
     for (const field of newFrame.fields) {
@@ -130,7 +132,7 @@ export function applyFieldOverrides(
             data,
             frame: newFrame,
             frameIndex: index,
-            field: field,
+            field,
           },
         },
       };

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -422,7 +422,7 @@ export function setFieldConfigDefaults(config: FieldConfig, defaults: FieldConfi
         return;
       }
 
-      if (item?.shouldApply(context.field!)) {
+      if (item.shouldApply(context.field!)) {
         const val = item.process(get(source, item.path), context, item.settings);
         if (val != null) {
           set(destination, item.path, val);


### PR DESCRIPTION
This is a noticeable improvement in the nested table case, about 15%-20%. I suspect it's actually more for non-nested tables, need to investigate.

This PR mostly just avoids a lot of unnecessary allocations, swaps some `Array.propotype.map` to for loops with length-preallocated arrays, and retools a couple conditionals to make them more efficient. I also inlined a method into a loop because it could avoid double-checking something and did some `!= null`s.

## Test results

### Nested LogsTable test data, 5x toggle of a transform, build:nominify

#### Old branch nested table:
- no slowdown: 672.9ms
- 4x slowdown: 2444.2ms

#### New branch nested table:
- no slowdown: 443ms
- 4x slowdown: 1946.5ms

#### Conclusion:
new branch is 20-35% faster than old branch for complex nested table.

