### PR TITLE
Suggestions: Fix no data scenario error

### DIFF
--- a/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
@@ -299,7 +299,7 @@ export function VisualizationSuggestions({ onChange, data, panel, searchQuery, i
                   suggestion={suggestion}
                   width={width}
                   tabIndex={index}
-                  onClick={() => applySuggestion(suggestion, index)}
+                  onClick={() => applySuggestion(suggestion, index, false, true)}
                 />
               </div>
             ))}


### PR DESCRIPTION
When `newVizSuggestions` is set to `false`, for no data scenario, selecting a suggestion was not opening the options. This was leading to a crash upon switching panel types.

Before:
![Feb-26-2026 00-04-28](https://github.com/user-attachments/assets/202b2b3b-5ee1-4cb3-a556-39aae9c7cd51)

After:
![Feb-26-2026 00-02-45](https://github.com/user-attachments/assets/d9ad38f6-0547-4a2b-a18a-aabd291c9664)


Fixes https://github.com/grafana/grafana/issues/118728