### PR TITLE
Alerting: Cleanup historian API

### DIFF
--- a/apps/alerting/historian/kinds/v0alpha1/notification.cue
+++ b/apps/alerting/historian/kinds/v0alpha1/notification.cue
@@ -36,15 +36,25 @@ import (
 #NotificationEntry: {
     // Timestamp is the time at which the notification attempt completed.
     timestamp: time.Time
+    // Uuid is a unique identifier for the notification attempt.
+    uuid: string
     // Receiver is the receiver (contact point) title.
     receiver: string
+    // Integration is the integration (contact point type) name.
+    integration: string
+    // IntegrationIndex is the index of the integration within the receiver.
+    integrationIndex: int
     // Status indicates if the notification contains one or more firing alerts.
     status: #NotificationStatus
     // Outcome indicaes if the notificaion attempt was successful or if it failed.
     outcome: #NotificationOutcome
     // GroupLabels are the labels uniquely identifying the alert group within a route.
     groupLabels: [string]: string
-    // Alerts are the alerts grouped into the notification.
+    // RuleUIDs are the unique identifiers of the alert rules included in the notification.
+    ruleUIDs: [...string]
+    // AlertCount is the total number of alerts included in the notification.
+    alertCount: int
+    // Alerts are the alerts grouped into the notification. Deprecated: not populated, will be removed.
     alerts: [...#NotificationEntryAlert]
     // Retry indicates if the attempt was a retried attempt.
     retry: bool

--- a/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationquery_response_types_gen.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationquery_response_types_gen.go
@@ -10,15 +10,25 @@ import (
 type CreateNotificationqueryNotificationEntry struct {
 	// Timestamp is the time at which the notification attempt completed.
 	Timestamp time.Time `json:"timestamp"`
+	// Uuid is a unique identifier for the notification attempt.
+	Uuid string `json:"uuid"`
 	// Receiver is the receiver (contact point) title.
 	Receiver string `json:"receiver"`
+	// Integration is the integration (contact point type) name.
+	Integration string `json:"integration"`
+	// IntegrationIndex is the index of the integration within the receiver.
+	IntegrationIndex int64 `json:"integrationIndex"`
 	// Status indicates if the notification contains one or more firing alerts.
 	Status CreateNotificationqueryNotificationStatus `json:"status"`
 	// Outcome indicaes if the notificaion attempt was successful or if it failed.
 	Outcome CreateNotificationqueryNotificationOutcome `json:"outcome"`
 	// GroupLabels are the labels uniquely identifying the alert group within a route.
 	GroupLabels map[string]string `json:"groupLabels"`
-	// Alerts are the alerts grouped into the notification.
+	// RuleUIDs are the unique identifiers of the alert rules included in the notification.
+	RuleUIDs []string `json:"ruleUIDs"`
+	// AlertCount is the total number of alerts included in the notification.
+	AlertCount int64 `json:"alertCount"`
+	// Alerts are the alerts grouped into the notification. Deprecated: not populated, will be removed.
 	Alerts []CreateNotificationqueryNotificationEntryAlert `json:"alerts"`
 	// Retry indicates if the attempt was a retried attempt.
 	Retry bool `json:"retry"`
@@ -36,6 +46,7 @@ type CreateNotificationqueryNotificationEntry struct {
 func NewCreateNotificationqueryNotificationEntry() *CreateNotificationqueryNotificationEntry {
 	return &CreateNotificationqueryNotificationEntry{
 		GroupLabels: map[string]string{},
+		RuleUIDs:    []string{},
 		Alerts:      []CreateNotificationqueryNotificationEntryAlert{},
 	}
 }

--- a/apps/alerting/historian/pkg/apis/alertinghistorian_manifest.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian_manifest.go
@@ -253,10 +253,16 @@ var appManifestData = app.ManifestData{
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"object"},
 							Properties: map[string]spec.Schema{
+								"alertCount": {
+									SchemaProps: spec.SchemaProps{
+										Type:        []string{"integer"},
+										Description: "AlertCount is the total number of alerts included in the notification.",
+									},
+								},
 								"alerts": {
 									SchemaProps: spec.SchemaProps{
 										Type:        []string{"array"},
-										Description: "Alerts are the alerts grouped into the notification.",
+										Description: "Alerts are the alerts grouped into the notification. Deprecated: not populated, will be removed.",
 										Items: &spec.SchemaOrArray{
 											Schema: &spec.Schema{
 												SchemaProps: spec.SchemaProps{
@@ -297,6 +303,18 @@ var appManifestData = app.ManifestData{
 										},
 									},
 								},
+								"integration": {
+									SchemaProps: spec.SchemaProps{
+										Type:        []string{"string"},
+										Description: "Integration is the integration (contact point type) name.",
+									},
+								},
+								"integrationIndex": {
+									SchemaProps: spec.SchemaProps{
+										Type:        []string{"integer"},
+										Description: "IntegrationIndex is the index of the integration within the receiver.",
+									},
+								},
 								"outcome": {
 									SchemaProps: spec.SchemaProps{
 
@@ -323,6 +341,18 @@ var appManifestData = app.ManifestData{
 										Description: "Retry indicates if the attempt was a retried attempt.",
 									},
 								},
+								"ruleUIDs": {
+									SchemaProps: spec.SchemaProps{
+										Type:        []string{"array"},
+										Description: "RuleUIDs are the unique identifiers of the alert rules included in the notification.",
+										Items: &spec.SchemaOrArray{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												}},
+										},
+									},
+								},
 								"status": {
 									SchemaProps: spec.SchemaProps{
 
@@ -337,13 +367,24 @@ var appManifestData = app.ManifestData{
 										Description: "Timestamp is the time at which the notification attempt completed.",
 									},
 								},
+								"uuid": {
+									SchemaProps: spec.SchemaProps{
+										Type:        []string{"string"},
+										Description: "Uuid is a unique identifier for the notification attempt.",
+									},
+								},
 							},
 							Required: []string{
 								"timestamp",
+								"uuid",
 								"receiver",
+								"integration",
+								"integrationIndex",
 								"status",
 								"outcome",
 								"groupLabels",
+								"ruleUIDs",
+								"alertCount",
 								"alerts",
 								"retry",
 								"duration",

--- a/apps/alerting/historian/pkg/app/notification/lokireader.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader.go
@@ -225,17 +225,27 @@ func parseLokiEntry(s lokiclient.Sample) (Entry, error) {
 		groupLabels = make(map[string]string)
 	}
 
+	ruleUIDs := lokiEntry.RuleUIDs
+	if ruleUIDs == nil {
+		ruleUIDs = []string{}
+	}
+
 	return Entry{
-		Timestamp:    s.T,
-		Receiver:     lokiEntry.Receiver,
-		Status:       Status(lokiEntry.Status),
-		Outcome:      outcome,
-		GroupKey:     lokiEntry.GroupKey,
-		GroupLabels:  groupLabels,
-		Alerts:       []EntryAlert{},
-		Retry:        lokiEntry.Retry,
-		Error:        entryError,
-		Duration:     lokiEntry.Duration,
-		PipelineTime: lokiEntry.PipelineTime,
+		Timestamp:        s.T,
+		Uuid:             lokiEntry.UUID,
+		Receiver:         lokiEntry.Receiver,
+		Integration:      lokiEntry.Integration,
+		IntegrationIndex: int64(lokiEntry.IntegrationIdx),
+		Status:           Status(lokiEntry.Status),
+		Outcome:          outcome,
+		GroupKey:         lokiEntry.GroupKey,
+		GroupLabels:      groupLabels,
+		RuleUIDs:         ruleUIDs,
+		AlertCount:       int64(lokiEntry.AlertCount),
+		Alerts:           []EntryAlert{},
+		Retry:            lokiEntry.Retry,
+		Error:            entryError,
+		Duration:         lokiEntry.Duration,
+		PipelineTime:     lokiEntry.PipelineTime,
 	}, nil
 }

--- a/packages/grafana-api-clients/src/clients/rtkq/historian.alerting/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/historian.alerting/v0alpha1/endpoints.gen.ts
@@ -616,7 +616,9 @@ export type CreateNotificationqueryNotificationEntryAlert = {
 export type CreateNotificationqueryNotificationOutcome = 'success' | 'error';
 export type CreateNotificationqueryNotificationStatus = 'firing' | 'resolved';
 export type CreateNotificationqueryNotificationEntry = {
-  /** Alerts are the alerts grouped into the notification. */
+  /** AlertCount is the total number of alerts included in the notification. */
+  alertCount: number;
+  /** Alerts are the alerts grouped into the notification. Deprecated: not populated, will be removed. */
   alerts: CreateNotificationqueryNotificationEntryAlert[];
   /** Duration is the length of time the notification attempt took in nanoseconds. */
   duration: number;
@@ -628,6 +630,10 @@ export type CreateNotificationqueryNotificationEntry = {
   groupLabels: {
     [key: string]: string;
   };
+  /** Integration is the integration (contact point type) name. */
+  integration: string;
+  /** IntegrationIndex is the index of the integration within the receiver. */
+  integrationIndex: number;
   /** Outcome indicaes if the notificaion attempt was successful or if it failed. */
   outcome: CreateNotificationqueryNotificationOutcome;
   /** PipelineTime is the time at which the flush began. */
@@ -636,10 +642,14 @@ export type CreateNotificationqueryNotificationEntry = {
   receiver: string;
   /** Retry indicates if the attempt was a retried attempt. */
   retry: boolean;
+  /** RuleUIDs are the unique identifiers of the alert rules included in the notification. */
+  ruleUIDs: string[];
   /** Status indicates if the notification contains one or more firing alerts. */
   status: CreateNotificationqueryNotificationStatus;
   /** Timestamp is the time at which the notification attempt completed. */
   timestamp: string;
+  /** Uuid is a unique identifier for the notification attempt. */
+  uuid: string;
 };
 export type CreateNotificationqueryResponse = {
   entries: CreateNotificationqueryNotificationEntry[];

--- a/packages/grafana-openapi/src/apis/historian.alerting.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/historian.alerting.grafana.app-v0alpha1.json
@@ -1093,10 +1093,15 @@
         "type": "object",
         "required": [
           "timestamp",
+          "uuid",
           "receiver",
+          "integration",
+          "integrationIndex",
           "status",
           "outcome",
           "groupLabels",
+          "ruleUIDs",
+          "alertCount",
           "alerts",
           "retry",
           "duration",
@@ -1104,8 +1109,12 @@
           "groupKey"
         ],
         "properties": {
+          "alertCount": {
+            "description": "AlertCount is the total number of alerts included in the notification.",
+            "type": "integer"
+          },
           "alerts": {
-            "description": "Alerts are the alerts grouped into the notification.",
+            "description": "Alerts are the alerts grouped into the notification. Deprecated: not populated, will be removed.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/CreateNotificationqueryNotificationEntryAlert"
@@ -1130,6 +1139,14 @@
               "type": "string"
             }
           },
+          "integration": {
+            "description": "Integration is the integration (contact point type) name.",
+            "type": "string"
+          },
+          "integrationIndex": {
+            "description": "IntegrationIndex is the index of the integration within the receiver.",
+            "type": "integer"
+          },
           "outcome": {
             "description": "Outcome indicaes if the notificaion attempt was successful or if it failed.",
             "allOf": [
@@ -1151,6 +1168,13 @@
             "description": "Retry indicates if the attempt was a retried attempt.",
             "type": "boolean"
           },
+          "ruleUIDs": {
+            "description": "RuleUIDs are the unique identifiers of the alert rules included in the notification.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "status": {
             "description": "Status indicates if the notification contains one or more firing alerts.",
             "allOf": [
@@ -1163,6 +1187,10 @@
             "description": "Timestamp is the time at which the notification attempt completed.",
             "type": "string",
             "format": "date-time"
+          },
+          "uuid": {
+            "description": "Uuid is a unique identifier for the notification attempt.",
+            "type": "string"
           }
         }
       },

--- a/pkg/tests/apis/openapi_snapshots/historian.alerting.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/historian.alerting.grafana.app-v0alpha1.json
@@ -1176,10 +1176,15 @@
         "type": "object",
         "required": [
           "timestamp",
+          "uuid",
           "receiver",
+          "integration",
+          "integrationIndex",
           "status",
           "outcome",
           "groupLabels",
+          "ruleUIDs",
+          "alertCount",
           "alerts",
           "retry",
           "duration",
@@ -1187,8 +1192,12 @@
           "groupKey"
         ],
         "properties": {
+          "alertCount": {
+            "description": "AlertCount is the total number of alerts included in the notification.",
+            "type": "integer"
+          },
           "alerts": {
-            "description": "Alerts are the alerts grouped into the notification.",
+            "description": "Alerts are the alerts grouped into the notification. Deprecated: not populated, will be removed.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationqueryNotificationEntryAlert"
@@ -1213,6 +1222,14 @@
               "type": "string"
             }
           },
+          "integration": {
+            "description": "Integration is the integration (contact point type) name.",
+            "type": "string"
+          },
+          "integrationIndex": {
+            "description": "IntegrationIndex is the index of the integration within the receiver.",
+            "type": "integer"
+          },
           "outcome": {
             "description": "Outcome indicaes if the notificaion attempt was successful or if it failed.",
             "allOf": [
@@ -1234,6 +1251,13 @@
             "description": "Retry indicates if the attempt was a retried attempt.",
             "type": "boolean"
           },
+          "ruleUIDs": {
+            "description": "RuleUIDs are the unique identifiers of the alert rules included in the notification.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "status": {
             "description": "Status indicates if the notification contains one or more firing alerts.",
             "allOf": [
@@ -1246,6 +1270,10 @@
             "description": "Timestamp is the time at which the notification attempt completed.",
             "type": "string",
             "format": "date-time"
+          },
+          "uuid": {
+            "description": "Uuid is a unique identifier for the notification attempt.",
+            "type": "string"
           }
         }
       },

--- a/public/app/features/alerting/unified/notifications/NotificationsRuntimeDataSource.test.ts
+++ b/public/app/features/alerting/unified/notifications/NotificationsRuntimeDataSource.test.ts
@@ -139,10 +139,15 @@ describe('notificationsToDataFrame', () => {
 function makeEntry(timestamp: string) {
   return {
     timestamp,
+    uuid: 'test-uuid',
     receiver: 'slack',
+    integration: 'slack',
+    integrationIndex: 0,
     status: 'firing' as const,
     outcome: 'success' as const,
     groupLabels: { alertname: 'test' },
+    ruleUIDs: [],
+    alertCount: 1,
     alerts: [],
     retry: false,
     duration: 100,


### PR DESCRIPTION
Replace the alerts array in the notification history API response with fields that match the schema v2 Loki data model:

- Add uuid (unique notification identifier)
- Add integration and integrationIndex (contact point type/index)
- Add ruleUIDs (alert rule UIDs included in the notification)
- Add alertCount (total number of alerts in the group)

Note that the `alerts` field in the response is kept for now to avoid breaking the frontend build. It will be removed in a follow up.
