### PR TITLE
Alerting: Add labels breakdown summary and AllLabelsDrawer to triage view

### DIFF
--- a/public/app/features/alerting/unified/triage/scene/AllLabelsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/scene/AllLabelsDrawer.tsx
@@ -1,0 +1,164 @@
+import { css } from '@emotion/css';
+import { Fragment, useState } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { useSceneContext } from '@grafana/scenes-react';
+import { Button, Drawer, useStyles2 } from '@grafana/ui';
+
+import { FiringCount, PendingCount } from './BadgeCounts';
+import { type LabelStats, type LabelValueCount } from './useLabelsBreakdown';
+import { addOrReplaceFilter } from './utils';
+
+// --- Public API ---
+
+interface AllLabelsDrawerProps {
+  allLabels: LabelStats[];
+  onClose: () => void;
+}
+
+const DEFAULT_VISIBLE_LABELS = 24;
+const DEFAULT_VISIBLE_VALUES = 12;
+
+export function AllLabelsDrawer({ allLabels, onClose }: AllLabelsDrawerProps) {
+  const styles = useStyles2(getDrawerStyles);
+  const sceneContext = useSceneContext();
+  const [showAll, setShowAll] = useState(false);
+
+  const visibleLabels = showAll ? allLabels : allLabels.slice(0, DEFAULT_VISIBLE_LABELS);
+  const hasMore = allLabels.length > DEFAULT_VISIBLE_LABELS;
+
+  const handleValueClick = (key: string, value: string) => {
+    addOrReplaceFilter(sceneContext, key, '=', value);
+    onClose();
+  };
+
+  const handleKeyClick = (key: string) => {
+    addOrReplaceFilter(sceneContext, key, '=~', '.+');
+    onClose();
+  };
+
+  return (
+    <Drawer title={t('alerting.triage.all-labels-drawer-title', 'All labels')} size="sm" onClose={onClose}>
+      <div className={styles.drawerContent}>
+        {visibleLabels.map((label, index) => (
+          <Fragment key={label.key}>
+            {index > 0 && <div className={styles.sectionSeparator} />}
+            <span className={styles.labelHeaderKey}>
+              <Button
+                variant="secondary"
+                fill="text"
+                className={styles.labelKeyButton}
+                onClick={() => handleKeyClick(label.key)}
+              >
+                {label.key}
+              </Button>
+            </span>
+            <PendingCount count={label.pending} />
+            <FiringCount count={label.firing} />
+            <LabelValuesList values={label.values} onValueClick={(value) => handleValueClick(label.key, value)} />
+          </Fragment>
+        ))}
+        {hasMore && !showAll && (
+          <Button variant="secondary" fill="text" className={styles.spanAllColumns} onClick={() => setShowAll(true)}>
+            <Trans
+              i18nKey="alerting.triage.show-all-labels"
+              values={{ count: allLabels.length }}
+              defaults={'Show all ({{ count }})'}
+            />
+          </Button>
+        )}
+      </div>
+    </Drawer>
+  );
+}
+
+// --- Internal components ---
+
+interface LabelValuesListProps {
+  values: LabelValueCount[];
+  onValueClick: (value: string) => void;
+}
+
+function LabelValuesList({ values, onValueClick }: LabelValuesListProps) {
+  const styles = useStyles2(getDrawerStyles);
+  const [expanded, setExpanded] = useState(false);
+
+  const visibleValues = expanded ? values : values.slice(0, DEFAULT_VISIBLE_VALUES);
+  const hasMore = values.length > DEFAULT_VISIBLE_VALUES;
+
+  return (
+    <>
+      {visibleValues.map(({ value, firing, pending }) => (
+        <Fragment key={value}>
+          <Button
+            variant="secondary"
+            fill="text"
+            size="sm"
+            className={styles.valueButton}
+            onClick={() => onValueClick(value)}
+          >
+            {value}
+          </Button>
+          <PendingCount count={pending} />
+          <FiringCount count={firing} />
+        </Fragment>
+      ))}
+      {hasMore && !expanded && (
+        <Button variant="secondary" fill="text" className={styles.spanAllColumns} onClick={() => setExpanded(true)}>
+          <Trans
+            i18nKey="alerting.triage.show-all-values"
+            values={{ count: values.length }}
+            defaults={'Show all ({{ count }})'}
+          />
+        </Button>
+      )}
+    </>
+  );
+}
+
+// --- Styles ---
+
+const getDrawerStyles = (theme: GrafanaTheme2) => ({
+  drawerContent: css({
+    display: 'grid',
+    gridTemplateColumns: `${theme.spacing(2)} minmax(0, 1fr) max-content max-content`,
+    alignItems: 'center',
+    justifyItems: 'end',
+    rowGap: theme.spacing(0.25),
+    columnGap: theme.spacing(1),
+  }),
+  sectionSeparator: css({
+    gridColumn: '1 / -1',
+    justifySelf: 'stretch',
+    borderTop: `1px solid ${theme.colors.border.weak}`,
+    marginTop: theme.spacing(0.75),
+    marginBottom: theme.spacing(0.75),
+  }),
+  labelHeaderKey: css({
+    gridColumn: '1 / 3',
+    justifySelf: 'start',
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+  }),
+  labelKeyButton: css({
+    fontWeight: theme.typography.fontWeightBold,
+  }),
+  spanAllColumns: css({
+    gridColumn: '1 / -1',
+    justifySelf: 'start',
+  }),
+  valueButton: css({
+    gridColumn: '2',
+    justifySelf: 'stretch',
+    minWidth: 0,
+    '& > span': {
+      overflow: 'hidden',
+      whiteSpace: 'nowrap',
+      textOverflow: 'ellipsis',
+      display: 'block',
+      minWidth: 0,
+    },
+  }),
+});

--- a/public/app/features/alerting/unified/triage/scene/BadgeCounts.tsx
+++ b/public/app/features/alerting/unified/triage/scene/BadgeCounts.tsx
@@ -1,0 +1,38 @@
+import { Icon, Stack, Text } from '@grafana/ui';
+
+export function FiringCount({ count }: { count: number }) {
+  if (count === 0) {
+    return <span />;
+  }
+  return (
+    <Text color="error" tabular>
+      <Stack direction="row" gap={0.25} alignItems="center">
+        <Icon name="exclamation-circle" size="xs" />
+        {count}
+      </Stack>
+    </Text>
+  );
+}
+
+export function PendingCount({ count }: { count: number }) {
+  if (count === 0) {
+    return <span />;
+  }
+  return (
+    <Text color="warning" tabular>
+      <Stack direction="row" gap={0.25} alignItems="center">
+        <Icon name="circle" size="xs" />
+        {count}
+      </Stack>
+    </Text>
+  );
+}
+
+export function LabelBadgeCounts({ firing, pending }: { firing: number; pending: number }) {
+  return (
+    <Stack direction="row" gap={0.5} alignItems="center">
+      <FiringCount count={firing} />
+      <PendingCount count={pending} />
+    </Stack>
+  );
+}

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
@@ -1,4 +1,6 @@
-import { DataSourceApi, MetricFindValue } from '@grafana/data';
+import { of } from 'rxjs';
+
+import { DataSourceApi, FieldType, MetricFindValue, toDataFrame } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
@@ -10,19 +12,47 @@ import {
 
 import { getAdHocTagKeysProvider, getAdHocTagValuesProvider, getGroupByTagKeysProvider } from './tagKeysProviders';
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: jest.fn(),
-  // AdHocFiltersVariable constructor calls getTemplateSrv().getAdhocFilters to patch it.
-  // Without this stub it logs "Failed to patch getAdhocFilters".
-  getTemplateSrv: () => ({ getAdhocFilters: jest.fn().mockReturnValue([]) }),
-}));
+jest.mock('@grafana/runtime', () => {
+  // Stub class for instanceof DataSourceWithBackend checks.
+  // Must be defined inside the factory because jest.mock is hoisted above all declarations.
+  class MockDataSourceWithBackend {}
+  return {
+    ...jest.requireActual('@grafana/runtime'),
+    getDataSourceSrv: jest.fn(),
+    DataSourceWithBackend: MockDataSourceWithBackend,
+    // AdHocFiltersVariable constructor calls getTemplateSrv().getAdhocFilters to patch it.
+    // Without this stub it logs "Failed to patch getAdhocFilters".
+    getTemplateSrv: () => ({ getAdhocFilters: jest.fn().mockReturnValue([]) }),
+  };
+});
 
 const getDataSourceSrvMock = jest.mocked(getDataSourceSrv);
 
-function mockGetDataSourceSrv(dsOverrides: Partial<DataSourceApi> = {}) {
+/**
+ * Build a DataFrame mimicking an instant-query table result:
+ * one string field per label key, one row per metric series.
+ */
+function buildInstantFrame(metrics: Array<Record<string, string>>) {
+  if (metrics.length === 0) {
+    return toDataFrame({ fields: [] });
+  }
+  const keys = [...new Set(metrics.flatMap((m) => Object.keys(m)))];
+  return toDataFrame({
+    fields: keys.map((key) => ({
+      name: key,
+      type: FieldType.string,
+      values: metrics.map((m) => m[key] ?? ''),
+    })),
+  });
+}
+
+function mockGetDataSourceSrv(dsOverrides: Partial<DataSourceApi> & { query?: jest.Mock } = {}) {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { DataSourceWithBackend } = require('@grafana/runtime');
+  // Make the mock pass instanceof DataSourceWithBackend checks
+  const ds = Object.assign(Object.create(DataSourceWithBackend.prototype), dsOverrides);
   getDataSourceSrvMock.mockReturnValue({
-    get: async () => dsOverrides as DataSourceApi,
+    get: async () => ds as DataSourceApi,
   } as ReturnType<typeof getDataSourceSrv>);
 }
 
@@ -37,14 +67,26 @@ function activateWithScene(variable: GroupByVariable | AdHocFiltersVariable) {
 
 describe('tagKeysProviders', () => {
   describe('getGroupByTagKeysProvider', () => {
-    it('should show promoted labels first and remaining sorted under All', async () => {
+    it('should show promoted labels first, frequent labels, then remaining sorted under All', async () => {
       mockGetDataSourceSrv({
         getTagKeys: jest.fn().mockResolvedValue([
           { text: 'severity', value: 'severity' },
           { text: 'grafana_folder', value: 'grafana_folder' },
           { text: '__name__', value: '__name__' },
           { text: 'team', value: 'team' },
+          { text: 'region', value: 'region' },
         ] satisfies MetricFindValue[]),
+        query: jest.fn().mockReturnValue(
+          of({
+            data: [
+              buildInstantFrame([
+                { __name__: 'GRAFANA_ALERTS', alertname: 'r1', team: 'platform', severity: 'critical' },
+                { __name__: 'GRAFANA_ALERTS', alertname: 'r2', team: 'infra', region: 'eu' },
+                { __name__: 'GRAFANA_ALERTS', alertname: 'r3', team: 'platform' },
+              ]),
+            ],
+          })
+        ),
       });
 
       const variable = new GroupByVariable({ name: 'groupBy', datasource: { uid: 'test' } });
@@ -55,14 +97,17 @@ describe('tagKeysProviders', () => {
       expect(result.replace).toBe(true);
       expect(result.values).toEqual([
         { value: 'grafana_folder', text: 'Folder', group: 'Common' },
-        { text: 'severity', value: 'severity', group: 'All' },
-        { text: 'team', value: 'team', group: 'All' },
+        // team appears in 3 series, severity in 1, region in 1
+        { value: 'team', text: 'team', group: 'Frequent' },
+        { value: 'severity', text: 'severity', group: 'Frequent' },
+        { value: 'region', text: 'region', group: 'Frequent' },
       ]);
     });
 
     it('should return only promoted labels when DS returns no extra keys', async () => {
       mockGetDataSourceSrv({
         getTagKeys: jest.fn().mockResolvedValue([] satisfies MetricFindValue[]),
+        query: jest.fn().mockReturnValue(of({ data: [buildInstantFrame([])] })),
       });
 
       const variable = new GroupByVariable({ name: 'groupBy', datasource: { uid: 'test' } });
@@ -75,7 +120,7 @@ describe('tagKeysProviders', () => {
   });
 
   describe('getAdHocTagKeysProvider', () => {
-    it('should show promoted labels first and remaining sorted under All', async () => {
+    it('should show promoted labels first, frequent labels, then remaining sorted under All', async () => {
       mockGetDataSourceSrv({
         getTagKeys: jest.fn().mockResolvedValue([
           { text: 'alertstate', value: 'alertstate' },
@@ -84,7 +129,36 @@ describe('tagKeysProviders', () => {
           { text: 'severity', value: 'severity' },
           { text: '__name__', value: '__name__' },
           { text: 'team', value: 'team' },
+          { text: 'env', value: 'env' },
         ] satisfies MetricFindValue[]),
+        query: jest.fn().mockReturnValue(
+          of({
+            data: [
+              buildInstantFrame([
+                {
+                  __name__: 'GRAFANA_ALERTS',
+                  alertname: 'r1',
+                  alertstate: 'firing',
+                  team: 'platform',
+                  severity: 'critical',
+                },
+                {
+                  __name__: 'GRAFANA_ALERTS',
+                  alertname: 'r2',
+                  alertstate: 'firing',
+                  team: 'infra',
+                  env: 'prod',
+                },
+                {
+                  __name__: 'GRAFANA_ALERTS',
+                  alertname: 'r3',
+                  alertstate: 'pending',
+                  team: 'platform',
+                },
+              ]),
+            ],
+          })
+        ),
       });
 
       const variable = new AdHocFiltersVariable({ name: 'filters', datasource: { uid: 'test' } });
@@ -97,9 +171,34 @@ describe('tagKeysProviders', () => {
         { value: 'alertstate', text: 'State', group: 'Common' },
         { value: 'alertname', text: 'Rule name', group: 'Common' },
         { value: 'grafana_folder', text: 'Folder', group: 'Common' },
-        { text: 'severity', value: 'severity', group: 'All' },
-        { text: 'team', value: 'team', group: 'All' },
+        // team (3), severity (1), env (1) — alertstate/alertname excluded as internal
+        { value: 'team', text: 'team', group: 'Frequent' },
+        { value: 'severity', text: 'severity', group: 'Frequent' },
+        { value: 'env', text: 'env', group: 'Frequent' },
       ]);
+    });
+
+    it('should not duplicate promoted labels in Frequent group', async () => {
+      mockGetDataSourceSrv({
+        getTagKeys: jest.fn().mockResolvedValue([
+          { text: 'alertstate', value: 'alertstate' },
+          { text: 'team', value: 'team' },
+        ] satisfies MetricFindValue[]),
+        // alertstate is promoted AND would be frequent, but INTERNAL_LABELS excludes it from counting
+        query: jest.fn().mockReturnValue(
+          of({
+            data: [buildInstantFrame([{ __name__: 'GRAFANA_ALERTS', alertstate: 'firing', team: 'platform' }])],
+          })
+        ),
+      });
+
+      const variable = new AdHocFiltersVariable({ name: 'filters', datasource: { uid: 'test' } });
+      activateWithScene(variable);
+
+      const result = await getAdHocTagKeysProvider(variable, null);
+
+      const frequentValues = result.values.filter((v) => v.group === 'Frequent');
+      expect(frequentValues).toEqual([{ value: 'team', text: 'team', group: 'Frequent' }]);
     });
   });
 
@@ -130,6 +229,25 @@ describe('tagKeysProviders', () => {
       const result = await getGroupByTagKeysProvider(variable, null);
 
       expect(result.values).toEqual([{ value: 'grafana_folder', text: 'Folder', group: 'Common' }]);
+    });
+
+    it('should skip Frequent group when fetching alert instances fails', async () => {
+      mockGetDataSourceSrv({
+        getTagKeys: jest.fn().mockResolvedValue([{ text: 'team', value: 'team' }] satisfies MetricFindValue[]),
+        query: jest.fn().mockImplementation(() => {
+          throw new Error('query failed');
+        }),
+      });
+
+      const variable = new GroupByVariable({ name: 'groupBy', datasource: { uid: 'test' } });
+      activateWithScene(variable);
+
+      const result = await getGroupByTagKeysProvider(variable, null);
+
+      expect(result.values).toEqual([
+        { value: 'grafana_folder', text: 'Folder', group: 'Common' },
+        { text: 'team', value: 'team', group: 'All' },
+      ]);
     });
   });
 });

--- a/public/app/features/alerting/unified/triage/scene/useLabelsBreakdown.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/useLabelsBreakdown.test.ts
@@ -1,0 +1,241 @@
+import { computeLabelStats } from './useLabelsBreakdown';
+
+describe('computeLabelStats', () => {
+  it('should return empty array for empty series', () => {
+    expect(computeLabelStats([])).toEqual([]);
+  });
+
+  it('should exclude internal labels', () => {
+    const series = [
+      { __name__: 'GRAFANA_ALERTS', alertname: 'rule1', alertstate: 'firing', team: 'infra' },
+      { __name__: 'GRAFANA_ALERTS', alertname: 'rule2', alertstate: 'pending', team: 'platform' },
+    ];
+
+    const result = computeLabelStats(series);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe('team');
+  });
+
+  it('should sort labels by frequency', () => {
+    const series: Array<Record<string, string>> = [
+      { team: 'a', env: 'prod', region: 'us', service: 'api', severity: 'critical', rare: 'x' },
+      { team: 'b', env: 'prod', region: 'eu', service: 'web', severity: 'warn' },
+      { team: 'c', env: 'staging', region: 'us', service: 'api' },
+      { team: 'd', env: 'prod' },
+      { team: 'e' },
+    ];
+
+    const result = computeLabelStats(series);
+
+    expect(result).toHaveLength(6);
+    // team appears in all 5
+    expect(result[0].key).toBe('team');
+    expect(result[0].count).toBe(5);
+    // env appears in 4
+    expect(result[1].key).toBe('env');
+    expect(result[1].count).toBe(4);
+    // region appears in 3
+    expect(result[2].key).toBe('region');
+    expect(result[2].count).toBe(3);
+    // service appears in 3
+    expect(result[3].key).toBe('service');
+    expect(result[3].count).toBe(3);
+    // severity appears in 2
+    expect(result[4].key).toBe('severity');
+    expect(result[4].count).toBe(2);
+  });
+
+  it('should include value distributions sorted by count', () => {
+    const series = [
+      { team: 'infra' },
+      { team: 'infra' },
+      { team: 'infra' },
+      { team: 'platform' },
+      { team: 'platform' },
+      { team: 'backend' },
+    ];
+
+    const result = computeLabelStats(series);
+
+    expect(result[0].key).toBe('team');
+    expect(result[0].count).toBe(6);
+    expect(result[0].values).toEqual([
+      { value: 'infra', count: 3, firing: 0, pending: 0 },
+      { value: 'platform', count: 2, firing: 0, pending: 0 },
+      { value: 'backend', count: 1, firing: 0, pending: 0 },
+    ]);
+  });
+
+  it('should handle series with only internal labels', () => {
+    const series = [
+      { __name__: 'GRAFANA_ALERTS', alertname: 'rule1', alertstate: 'firing' },
+      { __name__: 'GRAFANA_ALERTS', alertname: 'rule2', alertstate: 'pending' },
+    ];
+
+    expect(computeLabelStats(series)).toEqual([]);
+  });
+
+  it('should sort values by frequency', () => {
+    const series = Array.from({ length: 15 }, (_, i) => ({ host: `host-${i}` }));
+
+    const result = computeLabelStats(series);
+
+    expect(result[0].key).toBe('host');
+    expect(result[0].count).toBe(15);
+    expect(result[0].values).toHaveLength(15);
+  });
+
+  it('should return all labels sorted by frequency', () => {
+    const series: Array<Record<string, string>> = [
+      { team: 'a', env: 'prod', region: 'us', service: 'api', severity: 'critical', rare: 'x' },
+      { team: 'b', env: 'prod', region: 'eu', service: 'web', severity: 'warn' },
+      { team: 'c', env: 'staging', region: 'us', service: 'api' },
+      { team: 'd', env: 'prod' },
+      { team: 'e' },
+    ];
+
+    const result = computeLabelStats(series);
+
+    expect(result).toHaveLength(6);
+    expect(result.map((r) => r.key)).toEqual(['team', 'env', 'region', 'service', 'severity', 'rare']);
+  });
+
+  it('should return all values sorted by frequency', () => {
+    const series = Array.from({ length: 15 }, (_, i) => ({ host: `host-${i}` }));
+
+    const result = computeLabelStats(series);
+
+    expect(result[0].key).toBe('host');
+    expect(result[0].count).toBe(15);
+    expect(result[0].values).toHaveLength(15);
+  });
+
+  it('should count firing and pending instances per label key', () => {
+    const series = [
+      { alertstate: 'firing', team: 'infra', env: 'prod' },
+      { alertstate: 'firing', team: 'infra', env: 'staging' },
+      { alertstate: 'pending', team: 'platform', env: 'prod' },
+      { alertstate: 'pending', team: 'infra', env: 'prod' },
+    ];
+
+    const result = computeLabelStats(series);
+
+    const team = result.find((r) => r.key === 'team')!;
+    expect(team.firing).toBe(2);
+    expect(team.pending).toBe(2);
+    expect(team.count).toBe(4);
+
+    const env = result.find((r) => r.key === 'env')!;
+    expect(env.firing).toBe(2);
+    expect(env.pending).toBe(2);
+    expect(env.count).toBe(4);
+  });
+
+  it('should count firing and pending per label value', () => {
+    const series = [
+      { alertstate: 'firing', team: 'infra' },
+      { alertstate: 'firing', team: 'infra' },
+      { alertstate: 'pending', team: 'infra' },
+      { alertstate: 'firing', team: 'platform' },
+      { alertstate: 'pending', team: 'platform' },
+      { alertstate: 'pending', team: 'platform' },
+    ];
+
+    const result = computeLabelStats(series);
+    const team = result.find((r) => r.key === 'team')!;
+
+    const infra = team.values.find((v) => v.value === 'infra')!;
+    expect(infra.firing).toBe(2);
+    expect(infra.pending).toBe(1);
+    expect(infra.count).toBe(3);
+
+    const platform = team.values.find((v) => v.value === 'platform')!;
+    expect(platform.firing).toBe(1);
+    expect(platform.pending).toBe(2);
+    expect(platform.count).toBe(3);
+  });
+
+  it('should report zero firing or pending when state is absent', () => {
+    const series = [
+      { alertstate: 'firing', team: 'infra' },
+      { alertstate: 'firing', team: 'infra' },
+    ];
+
+    const result = computeLabelStats(series);
+
+    const team = result.find((r) => r.key === 'team')!;
+    expect(team.firing).toBe(2);
+    expect(team.pending).toBe(0);
+  });
+
+  it('should exclude all internal labels', () => {
+    const series = [
+      {
+        __name__: 'GRAFANA_ALERTS',
+        alertname: 'HighCPU',
+        alertstate: 'firing',
+        folderUID: 'abc123',
+        from: 'grafana',
+        grafana_alertstate: 'Alerting',
+        grafana_folder: 'MyFolder',
+        grafana_rule_uid: 'rule1',
+        orgID: '1',
+        team: 'infra',
+      },
+    ];
+
+    const result = computeLabelStats(series);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe('team');
+  });
+
+  it('should handle non-standard alertstate values', () => {
+    const series: Array<Record<string, string>> = [
+      { alertstate: 'inactive', team: 'infra' },
+      { alertstate: 'resolved', team: 'infra' },
+      { team: 'infra' },
+    ];
+
+    const result = computeLabelStats(series);
+    const team = result.find((r) => r.key === 'team')!;
+
+    expect(team.count).toBe(3);
+    expect(team.firing).toBe(0);
+    expect(team.pending).toBe(0);
+  });
+
+  it('should correctly count mixed alertstate values', () => {
+    const series: Array<Record<string, string>> = [
+      { alertstate: 'firing', team: 'infra' },
+      { alertstate: 'pending', team: 'infra' },
+      { team: 'infra' },
+      { alertstate: 'inactive', team: 'infra' },
+    ];
+
+    const result = computeLabelStats(series);
+    const team = result.find((r) => r.key === 'team')!;
+
+    expect(team.count).toBe(4);
+    expect(team.firing).toBe(1);
+    expect(team.pending).toBe(1);
+
+    const infraValue = team.values.find((v) => v.value === 'infra')!;
+    expect(infraValue.count).toBe(4);
+    expect(infraValue.firing).toBe(1);
+    expect(infraValue.pending).toBe(1);
+  });
+
+  it('should count empty string as a valid label value', () => {
+    const series = [{ team: '' }, { team: '' }, { team: 'infra' }];
+
+    const result = computeLabelStats(series);
+    const team = result.find((r) => r.key === 'team')!;
+
+    expect(team.count).toBe(3);
+    expect(team.values).toHaveLength(2);
+    expect(team.values[0]).toEqual({ value: '', count: 2, firing: 0, pending: 0 });
+    expect(team.values[1]).toEqual({ value: 'infra', count: 1, firing: 0, pending: 0 });
+  });
+});

--- a/public/app/features/alerting/unified/triage/scene/useLabelsBreakdown.ts
+++ b/public/app/features/alerting/unified/triage/scene/useLabelsBreakdown.ts
@@ -1,0 +1,126 @@
+import { useMemo } from 'react';
+
+import { useQueryRunner } from '@grafana/scenes-react';
+
+import { INTERNAL_LABELS } from '../constants';
+
+import { dataFrameToLabelMaps } from './dataFrameUtils';
+import { uniqueAlertInstancesQuery } from './queries';
+import { useQueryFilter } from './utils';
+
+export interface LabelValueCount {
+  value: string;
+  count: number;
+  firing: number;
+  pending: number;
+}
+
+export interface LabelStats {
+  key: string;
+  count: number;
+  firing: number;
+  pending: number;
+  values: LabelValueCount[];
+}
+
+export function useLabelsBreakdown(): {
+  labels: LabelStats[];
+  isLoading: boolean;
+} {
+  const { filter, alertStateFilter } = useQueryFilter();
+  const dataProvider = useQueryRunner({ queries: [uniqueAlertInstancesQuery(filter, alertStateFilter)] });
+  const { data } = dataProvider.useState();
+  const frame = data?.series?.at(0);
+
+  const labels = useMemo(() => {
+    if (!frame) {
+      return [];
+    }
+    return computeLabelStats(dataFrameToLabelMaps(frame));
+  }, [frame]);
+
+  return { labels, isLoading: !dataProvider.isDataReadyToDisplay() };
+}
+
+/**
+ * Given an array of series (label maps), compute label keys sorted by frequency,
+ * along with value distributions for each key.
+ */
+export function computeLabelStats(series: Array<Record<string, string>>): LabelStats[] {
+  const keyStats = new Map<string, LabelKeyStats>();
+
+  for (const s of series) {
+    const isFiring = s.alertstate === 'firing';
+    const isPending = s.alertstate === 'pending';
+
+    for (const [key, value] of Object.entries(s)) {
+      if (INTERNAL_LABELS.has(key)) {
+        continue;
+      }
+
+      const stats = getOrCreate(keyStats, key, () => ({
+        count: 0,
+        firing: 0,
+        pending: 0,
+        values: new Map<string, LabelValueStats>(),
+      }));
+      stats.count++;
+
+      const valueStats = getOrCreate(stats.values, value, () => ({
+        count: 0,
+        firing: 0,
+        pending: 0,
+      }));
+      valueStats.count++;
+
+      if (isFiring) {
+        stats.firing++;
+        valueStats.firing++;
+      } else if (isPending) {
+        stats.pending++;
+        valueStats.pending++;
+      }
+    }
+  }
+
+  return [...keyStats.entries()]
+    .sort((a, b) => b[1].count - a[1].count)
+    .map(([key, stats]) => ({
+      key,
+      count: stats.count,
+      firing: stats.firing,
+      pending: stats.pending,
+      values: [...stats.values.entries()]
+        .sort((a, b) => b[1].count - a[1].count)
+        .map(([value, vs]) => ({
+          value,
+          count: vs.count,
+          firing: vs.firing,
+          pending: vs.pending,
+        })),
+    }));
+}
+
+// --- Implementation details ---
+
+interface LabelValueStats {
+  count: number;
+  firing: number;
+  pending: number;
+}
+
+interface LabelKeyStats {
+  count: number;
+  firing: number;
+  pending: number;
+  values: Map<string, LabelValueStats>;
+}
+
+function getOrCreate<K, V>(map: Map<K, V>, key: K, factory: () => V): V {
+  let val = map.get(key);
+  if (val === undefined) {
+    val = factory();
+    map.set(key, val);
+  }
+  return val;
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3401,8 +3401,16 @@
     },
     "triage": {
       "alert-instances": "Alert instances",
+      "all-labels": "All labels",
+      "all-labels-drawer-title": "All labels",
+      "compact-firing": "firing",
+      "compact-instances": "instances",
+      "compact-pending": "pending",
+      "compact-rules": "rules",
       "error-loading-rule": "Error loading rule",
-      "firing-instances-count": "Firing alert instances",
+      "hidden-label-count_one": "and {{ count }} more",
+      "hidden-label-count_other": "and {{ count }} more",
+      "high-activity-labels": "High Activity Labels",
       "instance-details-drawer": {
         "instance-details": "Instance details"
       },
@@ -3412,7 +3420,6 @@
       "no-matching-instances-with-filters": "No alert instances match your current set of filters for the selected time range.",
       "open-in-sidebar": "Open in sidebar",
       "open-rule-details": "Open rule details",
-      "pending-instances-count": "Pending alert instances",
       "rule-details": {
         "subtitle": "Rule details and conditions",
         "title": "Rule Details"
@@ -3421,8 +3428,12 @@
         "description": "The requested rule could not be found.",
         "title": "Rule not found"
       },
-      "rules-with-firing-instances": "Alert rules with firing instances",
-      "rules-with-pending-instances": "Alert rules with pending instances"
+      "show-all-labels_one": "Show all ({{ count }})",
+      "show-all-labels_other": "Show all ({{ count }})",
+      "show-all-values_one": "Show all ({{ count }})",
+      "show-all-values_other": "Show all ({{ count }})",
+      "tooltip-more-values_one": "and {{ count }} more",
+      "tooltip-more-values_other": "and {{ count }} more"
     },
     "type-selector-button": {
       "add-expression": "Add expression"
@@ -5054,7 +5065,7 @@
     "canvas-actions": {
       "add-panel": "Add panel",
       "disabled-child-contains-tabs": "Cannot change to tabs because a row already contains tabs",
-      "disabled-nested-grouping": "Grouping is limited to 3 levels",
+      "disabled-nested-grouping": "Grouping is limited to 2 levels",
       "disabled-nested-tabs": "Tabs cannot be nested inside other tabs",
       "group-into-row": "Group into row",
       "group-into-tab": "Group into tab",
@@ -5682,7 +5693,10 @@
       "empty-state-message": "Run a query to visualize it here or go to all visualizations to add other panel types",
       "menu-open-panel-editor": "Configure",
       "menu-use-library-panel": "Use library panel",
-      "missing-config": "Missing panel configuration"
+      "missing-config": "Missing panel configuration",
+      "suggestions": {
+        "empty-state-message": "Run a query to start seeing suggested visualizations"
+      }
     },
     "new-panel-title": "New panel",
     "on-create-new-row": {
@@ -6917,11 +6931,11 @@
       "static-options-legend": "Static options"
     },
     "resource-export": {
-      "classic-v2-warning": "This dashboard uses the V2 schema. Features like tabs and conditional rendering cannot be represented in the classic format and may be lost.",
       "label": {
         "advanced-options": "Advanced options",
         "classic": "Classic",
         "json": "JSON",
+        "v1-resource": "V1 Resource",
         "v2-resource": "V2 Resource",
         "yaml": "YAML"
       },
@@ -11921,10 +11935,6 @@
         "title": "Error",
         "try-again-button": "Try again"
       },
-      "or-divider": "OR",
-      "run-query-hint": "Run a query to start seeing suggested visualizations",
-      "start-without-data-description": "Add panels that don't require a query",
-      "start-without-data-title": "Start without data",
       "unknown-viz-type": "Unknown visualization type"
     },
     "viz-type-picker": {
@@ -12635,9 +12645,6 @@
       "label-read-only": "Read only",
       "label-sync-interval": "Sync Interval (seconds)"
     },
-    "folder-permissions": {
-      "loading": "Loading..."
-    },
     "folder-repository-list": {
       "all-resources-managed_one": "All {{count}} resources are managed",
       "all-resources-managed_other": "All {{count}} resources are managed",
@@ -12771,12 +12778,6 @@
       "show-less": "show less",
       "show-more": "show more",
       "truncated": "Message truncated"
-    },
-    "missing-folder-metadata-banner": {
-      "error-message": "Could not verify whether this folder has a metadata file. Please try again later.",
-      "error-title": "Unable to check folder metadata status.",
-      "message": "Since this folder doesn't contain a metadata file, the folder ID is based on the folder path. If you move or rename the folder, the folder ID will change, and permissions may no longer apply to the folder.",
-      "title": "This folder is missing metadata."
     },
     "mode-options": {
       "disabled": {
@@ -13310,8 +13311,7 @@
       "cache-timeout-tooltip": "If your time series store has a query cache this option can override the default cache timeout. Specify a numeric value in seconds.",
       "cache-ttl": "Cache TTL",
       "cache-ttl-tooltip": "Cache time-to-live: How long results from the queries in this panel will be cached, in milliseconds.",
-      "hide-time-override": "Hide time info",
-      "hide-time-override-tooltip": "Hides the time override displayed in the panel header when relative time or time shift is set.",
+      "collapse": "Collapse query options sidebar",
       "interval": "Interval",
       "interval-tooltip": "The evaluated interval that is sent to data source and is used in $__interval and $__interval_ms.",
       "max-data-points": "Max data points",
@@ -13321,10 +13321,9 @@
       "no-limit": "No limit",
       "relative-time": "Relative time",
       "relative-time-tooltip": "Overrides the relative time range for individual panels. For example, to configure the Last 5 minutes use now-5m.",
-      "time-range-max-data-points": "Time range / max data points",
       "time-shift": "Time shift",
       "time-shift-tooltip": "Overrides the time range for individual panels by shifting its start and end relative to the time picker.",
-      "width-of-panel": "Width of panel"
+      "title": "Query Options"
     },
     "edit-query-name": "Edit query name",
     "footer": {
@@ -13368,9 +13367,13 @@
       "add-saved-query": "Add saved query",
       "add-transformation": "Add transformation",
       "add-transformation-below": "Add transformation below {{id}}",
+      "alert-indicator": {
+        "button-label": "View alert rules",
+        "button-label-hide": "Hide alert rules",
+        "close": "Close"
+      },
       "alerts_one": "Alerts ({{count}})",
       "alerts_other": "Alerts ({{count}})",
-      "alerts-loading": "Alerts",
       "card-click": "Select card {{id}}",
       "data": "Data",
       "footer-items_one": "{{count}} item",
@@ -13378,8 +13381,7 @@
       "loading-queries-transformations": "Loading queries and transformations",
       "queries-expressions": "Queries & Expressions",
       "toggle-size": "Toggle sidebar size",
-      "transformations": "Transformations",
-      "view-toggle": "View"
+      "transformations": "Transformations"
     },
     "transformation-debug": {
       "input-data": "Input data",
@@ -13576,7 +13578,6 @@
       "panel-type": "Panel: {{panel}}"
     },
     "actions": {
-      "created-by-me": "Created by me",
       "include-panels": "Include panels",
       "remove-datasource-filter": "Datasource: {{datasource}}",
       "sort-placeholder": "Sort",


### PR DESCRIPTION
## Summary

- Adds a labels breakdown section to the triage summary stats showing the most frequent user-defined labels across active alert instances
- Introduces `useLabelsBreakdown` hook with `computeLabelStats` for label frequency analysis
- Adds `AllLabelsDrawer` component for viewing all labels with per-value firing/pending counts
- Adds `BadgeCounts` components (`FiringCount`, `PendingCount`, `LabelBadgeCounts`)
- Renders `LabelStatsSection` in SummaryStats showing top 5 labels with interactive tooltips
- Enhances `tagKeysProviders` with a "Frequent" label group in filter/group-by dropdowns

## Test plan

- [x] Unit tests for `computeLabelStats` (useLabelsBreakdown.test.ts)
- [x] Unit tests for enhanced tagKeysProviders with frequent labels (tagKeysProviders.test.ts)
- [ ] Verify labels breakdown section appears below summary stats
- [ ] Verify "All labels" drawer opens and displays full label list with counts
- [ ] Verify clicking a label badge adds a filter
- [ ] Verify "Frequent" group appears in filter and group-by dropdowns

Part 2 of 2 — depends on #119066.