### PR TITLE
Unified: fix parquet and use it as fallback in migrations

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -607,7 +607,11 @@ type Cfg struct {
 	// MigrationCacheSizeKB sets SQLite PRAGMA cache_size during data migrations (in KB).
 	// Larger values reduce lock contention. Default: 50000 (50MB).
 	MigrationCacheSizeKB int
-	MaxPageSizeBytes     int
+	// MigrationParquetBuffer enables bulk migration data through a temporary Parquet file.
+	// This separates the read phase (legacy DB) from the write phase (unified storage)
+	// Default: false.
+	MigrationParquetBuffer bool
+	MaxPageSizeBytes       int
 	// IndexPath the directory where index files are stored.
 	// Note: Bleve locks index files, so mounts cannot be shared between multiple instances.
 	IndexPath                                  string

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -79,6 +79,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	section := cfg.Raw.Section("unified_storage")
 	cfg.DisableDataMigrations = section.Key("disable_data_migrations").MustBool(false)
 	cfg.MigrationCacheSizeKB = section.Key("migration_cache_size_kb").MustInt(50000)
+	cfg.MigrationParquetBuffer = section.Key("migration_parquet_buffer").MustBool(false)
 	if !cfg.DisableDataMigrations && cfg.UnifiedStorageType() == "unified" {
 		// Helper log to find instances running migrations in the future
 		cfg.Logger.Info("Unified migration configs enforced")

--- a/pkg/storage/unified/migrations/migrator_test.go
+++ b/pkg/storage/unified/migrations/migrator_test.go
@@ -263,13 +263,14 @@ func runMigrationTestSuite(t *testing.T, testCases []testcases.ResourceMigratorT
 		}
 		helper := apis.NewK8sTestHelperWithOpts(t, apis.K8sTestHelperOpts{
 			GrafanaOpts: testinfra.GrafanaOpts{
-				// EnableLog:             true,
-				AppModeProduction:     true,
-				DisableAnonymous:      true,
-				DisableDataMigrations: false,
-				APIServerStorageType:  "unified",
-				UnifiedStorageConfig:  unifiedConfig,
-				EnableFeatureToggles:  featureToggles,
+				//EnableLog:              true,
+				AppModeProduction:      true,
+				DisableAnonymous:       true,
+				DisableDataMigrations:  false,
+				APIServerStorageType:   "unified",
+				UnifiedStorageConfig:   unifiedConfig,
+				MigrationParquetBuffer: true,
+				EnableFeatureToggles:   featureToggles,
 			},
 			Org1Users: org1,
 			OrgBUsers: orgB,

--- a/pkg/storage/unified/parquet/reader.go
+++ b/pkg/storage/unified/parquet/reader.go
@@ -49,12 +49,10 @@ func (r *parquetReader) Next() bool {
 	r.req = nil
 	for r.err == nil && r.reader != nil {
 		if r.bufferIndex >= r.bufferSize && r.value.reader.HasNext() {
-			r.bufferIndex = 0
 			r.err = r.readBulk()
 			if r.err != nil {
 				return false
 			}
-			r.bufferIndex = r.value.count
 		}
 
 		if r.bufferSize > r.bufferIndex {
@@ -146,6 +144,7 @@ func newResourceReader(inputPath string, batchSize int64) (*parquetReader, error
 		reader.group,
 		reader.resource,
 		reader.name,
+		reader.folder,
 		reader.action,
 		reader.value,
 	}

--- a/pkg/storage/unified/parquet/reader_test.go
+++ b/pkg/storage/unified/parquet/reader_test.go
@@ -81,9 +81,9 @@ func TestParquetWriteThenRead(t *testing.T) {
 
 		// Verify that we read all values
 		require.Equal(t, []string{
-			"rrr/ns/ggg/aaa",
-			"rrr/ns/ggg/bbb",
-			"rrr/ns/ggg/ccc",
+			"ns/ggg/rrr/aaa",
+			"ns/ggg/rrr/bbb",
+			"ns/ggg/rrr/ccc",
 		}, keys)
 	})
 

--- a/pkg/storage/unified/parquet/writer.go
+++ b/pkg/storage/unified/parquet/writer.go
@@ -104,11 +104,16 @@ func (w *parquetWriter) CloseWithResults() (*resourcepb.BulkResponse, error) {
 }
 
 func (w *parquetWriter) Close() error {
+	if w.writer == nil {
+		return nil
+	}
 	if w.rv.Len() > 0 {
 		_ = w.flush()
 	}
 	w.logger.Info("close")
-	return w.writer.Close()
+	err := w.writer.Close()
+	w.writer = nil
+	return err
 }
 
 // writes the current buffer to parquet and re-inits the arrow buffer
@@ -116,9 +121,9 @@ func (w *parquetWriter) flush() error {
 	w.logger.Info("flush", "count", w.rv.Len())
 	rec := array.NewRecordBatch(w.schema, []arrow.Array{
 		w.rv.NewArray(),
-		w.namespace.NewArray(),
 		w.group.NewArray(),
 		w.resource.NewArray(),
+		w.namespace.NewArray(),
 		w.name.NewArray(),
 		w.folder.NewArray(),
 		w.action.NewArray(),

--- a/pkg/storage/unified/resource/transaction.go
+++ b/pkg/storage/unified/resource/transaction.go
@@ -6,6 +6,7 @@ import (
 )
 
 type transactionContextKey struct{}
+type parquetBufferContextKey struct{}
 
 // ContextWithTransaction returns a new context with the transaction stored directly.
 // This is used for SQLite migrations where the transaction needs to be shared
@@ -22,4 +23,16 @@ func TransactionFromContext(ctx context.Context) *sql.Tx {
 		}
 	}
 	return nil
+}
+
+// ContextWithParquetBuffer returns a context that signals ProcessBulk to stage
+// data through a temporary Parquet file before writing to the database.
+func ContextWithParquetBuffer(ctx context.Context) context.Context {
+	return context.WithValue(ctx, parquetBufferContextKey{}, true)
+}
+
+// ParquetBufferFromContext returns true if the context requests parquet buffering.
+func ParquetBufferFromContext(ctx context.Context) bool {
+	v, _ := ctx.Value(parquetBufferContextKey{}).(bool)
+	return v
 }

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -115,6 +115,7 @@ func NewStorageBackend(
 				DashboardsMaxAge: cfg.DashboardsGarbageCollectionMaxAge,
 			},
 			SimulatedNetworkLatency: cfg.SimulatedNetworkLatency,
+			MigrationParquetBuffer:  cfg.MigrationParquetBuffer,
 			DisableStorageServices:  disableStorageServices,
 		})
 	}
@@ -188,6 +189,9 @@ type BackendOptions struct {
 
 	DisableStorageServices bool
 
+	// When true, bulk migrations buffer data through a temporary Parquet file
+	MigrationParquetBuffer bool
+
 	// testing
 	SimulatedNetworkLatency time.Duration // slows down the create transactions by a fixed amount
 
@@ -220,6 +224,7 @@ func NewBackend(opts BackendOptions) (Backend, error) {
 		storageMetrics:          opts.storageMetrics,
 		bulkLock:                &bulkLock{running: make(map[string]bool)},
 		simulatedNetworkLatency: opts.SimulatedNetworkLatency,
+		migrationParquetBuffer:  opts.MigrationParquetBuffer,
 		lastImportTimeMaxAge:    opts.LastImportTimeMaxAge,
 		garbageCollection:       opts.GarbageCollection,
 	}
@@ -274,6 +279,9 @@ type backend struct {
 	historyPruner resource.Pruner
 
 	garbageCollection GarbageCollectionConfig
+
+	// When true, bulk migrations buffer data through a temporary Parquet file
+	migrationParquetBuffer bool
 
 	// Fields to control the cleanup of "lastImportTime" rows (used to find indexes to rebuild)
 	lastImportTimeMaxAge       time.Duration

--- a/pkg/storage/unified/sql/backend_bulk.go
+++ b/pkg/storage/unified/sql/backend_bulk.go
@@ -139,8 +139,14 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 	}
 	defer b.bulkLock.Finish(setting.Collection)
 
-	// We may want to first write parquet, then read parquet
-	if b.dialect.DialectName() == "sqlite" {
+	// Use a temporary Parquet file to separate read and write for SQLite.
+	// Enabled via config (migration_parquet_buffer) or context (automatic retry on failure).
+	useParquet := b.migrationParquetBuffer
+	clientCtx := inprocgrpc.ClientContext(ctx) // inprocgrpc contains the migrator context
+	if !useParquet && clientCtx != nil {
+		useParquet = resource.ParquetBufferFromContext(clientCtx)
+	}
+	if useParquet && b.dialect.DialectName() == "sqlite" {
 		file, err := os.CreateTemp("", "grafana-bulk-export-*.parquet")
 		if err != nil {
 			return &resourcepb.BulkResponse{
@@ -172,8 +178,7 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 		}
 	}
 
-	// If provided, reuse the inproc transaction for SQLite
-	if clientCtx := inprocgrpc.ClientContext(ctx); clientCtx != nil && b.dialect.DialectName() == "sqlite" {
+	if clientCtx != nil && b.dialect.DialectName() == "sqlite" {
 		if externalTx := resource.TransactionFromContext(clientCtx); externalTx != nil {
 			b.log.Info("Using SQLite transaction from client context")
 			rsp := &resourcepb.BulkResponse{}

--- a/pkg/storage/unified/sql/backend_bulk.go
+++ b/pkg/storage/unified/sql/backend_bulk.go
@@ -32,6 +32,15 @@ var (
 	_ resource.BulkProcessingBackend = (*backend)(nil)
 )
 
+// noRollbackTx wraps a db.Tx but makes Rollback() a no-op.
+// Used for external (migration) transactions where we want to keep the
+// transaction alive on failure so the caller can retry with parquet buffering.
+type noRollbackTx struct {
+	db.Tx
+}
+
+func (t *noRollbackTx) Rollback() error { return nil }
+
 type bulkRV struct {
 	max     int64
 	counter int64
@@ -139,8 +148,10 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 	}
 	defer b.bulkLock.Finish(setting.Collection)
 
-	// Use a temporary Parquet file to separate read and write for SQLite.
-	// Enabled via config (migration_parquet_buffer) or context (automatic retry on failure).
+	// Use a temporary Parquet file to separate read and write phases for SQLite.
+	// This avoids lock contention between the SHARED lock held by legacy row cursors
+	// and the EXCLUSIVE lock needed for cache spills during bulk inserts.
+	// Enabled via config (migration_parquet_buffer) or context (retry after failure).
 	useParquet := b.migrationParquetBuffer
 	clientCtx := inprocgrpc.ClientContext(ctx) // inprocgrpc contains the migrator context
 	if !useParquet && clientCtx != nil {
@@ -167,7 +178,7 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 			return rsp
 		}
 
-		b.log.Info("using parquet buffer", "parquet", file)
+		b.log.Info("using parquet buffer", "path", file.Name(), "processed", rsp.Processed)
 
 		// Replace the iterator with one from parquet
 		iter, err = parquet.NewParquetReader(file.Name(), 50)
@@ -182,7 +193,9 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 		if externalTx := resource.TransactionFromContext(clientCtx); externalTx != nil {
 			b.log.Info("Using SQLite transaction from client context")
 			rsp := &resourcepb.BulkResponse{}
-			err := b.processBulkWithTx(ctx, dbimpl.NewTx(externalTx), setting, iter, rsp)
+			// Let migrator rollback its transaction on error
+			tx := &noRollbackTx{dbimpl.NewTx(externalTx)}
+			err := b.processBulkWithTx(ctx, tx, setting, iter, rsp)
 			if err != nil {
 				rsp.Error = resource.AsErrorResult(err)
 			}

--- a/pkg/storage/unified/sql/backend_bulk.go
+++ b/pkg/storage/unified/sql/backend_bulk.go
@@ -139,19 +139,6 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 	}
 	defer b.bulkLock.Finish(setting.Collection)
 
-	// If provided, reuse the inproc transaction for SQLite
-	if clientCtx := inprocgrpc.ClientContext(ctx); clientCtx != nil && b.dialect.DialectName() == "sqlite" {
-		if externalTx := resource.TransactionFromContext(clientCtx); externalTx != nil {
-			b.log.Info("Using SQLite transaction from client context")
-			rsp := &resourcepb.BulkResponse{}
-			err := b.processBulkWithTx(ctx, dbimpl.NewTx(externalTx), setting, iter, rsp)
-			if err != nil {
-				rsp.Error = resource.AsErrorResult(err)
-			}
-			return rsp
-		}
-	}
-
 	// We may want to first write parquet, then read parquet
 	if b.dialect.DialectName() == "sqlite" {
 		file, err := os.CreateTemp("", "grafana-bulk-export-*.parquet")
@@ -182,6 +169,19 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 			return &resourcepb.BulkResponse{
 				Error: resource.AsErrorResult(err),
 			}
+		}
+	}
+
+	// If provided, reuse the inproc transaction for SQLite
+	if clientCtx := inprocgrpc.ClientContext(ctx); clientCtx != nil && b.dialect.DialectName() == "sqlite" {
+		if externalTx := resource.TransactionFromContext(clientCtx); externalTx != nil {
+			b.log.Info("Using SQLite transaction from client context")
+			rsp := &resourcepb.BulkResponse{}
+			err := b.processBulkWithTx(ctx, dbimpl.NewTx(externalTx), setting, iter, rsp)
+			if err != nil {
+				rsp.Error = resource.AsErrorResult(err)
+			}
+			return rsp
 		}
 	}
 

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -661,6 +661,12 @@ func CreateGrafDir(t *testing.T, opts GrafanaOpts) (string, string) {
 		_, err = section.NewKey("disable_data_migrations", "true")
 		require.NoError(t, err)
 	}
+	if opts.MigrationParquetBuffer {
+		section, err := getOrCreateSection("unified_storage")
+		require.NoError(t, err)
+		_, err = section.NewKey("migration_parquet_buffer", "true")
+		require.NoError(t, err)
+	}
 	if opts.PermittedProvisioningPaths != "" {
 		_, err = pathsSect.NewKey("permitted_provisioning_paths", opts.PermittedProvisioningPaths)
 		require.NoError(t, err)
@@ -817,6 +823,7 @@ type GrafanaOpts struct {
 	DisableControllers                    bool
 	DisableDBCleanup                      bool
 	DisableDataMigrations                 bool
+	MigrationParquetBuffer                bool
 	SecretsManagerEnableDBMigrations      bool
 	OpenFeatureAPIEnabled                 bool
 	DisableAuthZClientCache               bool


### PR DESCRIPTION
**What is this feature?**

Fixes a couple of issues in the parquet buffer that were blocking its usage and failing the migration.

If SQLite migration fails, it will retry with the parquet buffer. It's also possible to configure it to always run migrations directly with parquet.

**Why do we need this feature?**

Using the SQLite cache_size might not be possible in all environments since it uses memory over disk. We could have migrations that get OOM killed always.

Leaving it as a fallback since migrations with parquet is considerable slower when SQLite is not blocking,  ~43s (SQLite only) vs ~2min13 (Parquet buffer) with complex SQLite file from @ryantxu.

**Who is this feature for?**

SQLite OSS migration 

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
