### PR TITLE
chore: add migration status reader in dry-run mode for steady

### DIFF
--- a/pkg/services/apiserver/appinstaller/storage.go
+++ b/pkg/services/apiserver/appinstaller/storage.go
@@ -36,6 +36,10 @@ func NewDualWriter(
 
 	builderMetrics.RecordDualWriterModes(gr.Resource, gr.Group, mode)
 
+	if dualWriteService != nil {
+		dualWriteService.LogStorageModeComparison(gr, mode)
+	}
+
 	switch mode {
 	case grafanarest.Mode0:
 		return legacy, nil

--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -305,6 +305,10 @@ func InstallAPIs(
 
 			builderMetrics.RecordDualWriterModes(gr.Resource, gr.Group, mode)
 
+			if dualWriteService != nil {
+				dualWriteService.LogStorageModeComparison(gr, mode)
+			}
+
 			switch mode {
 			case grafanarest.Mode0:
 				return legacy, nil

--- a/pkg/storage/legacysql/dualwrite/mock.go
+++ b/pkg/storage/legacysql/dualwrite/mock.go
@@ -57,3 +57,6 @@ func (m *mockService) Status(ctx context.Context, gr schema.GroupResource) (Stor
 func (m *mockService) Update(ctx context.Context, status StorageStatus) (StorageStatus, error) {
 	return m.status, fmt.Errorf("not implemented")
 }
+
+// LogStorageModeComparison implements Service.
+func (m *mockService) LogStorageModeComparison(_ schema.GroupResource, _ rest.DualWriterMode) {}

--- a/pkg/storage/legacysql/dualwrite/service_mock.go
+++ b/pkg/storage/legacysql/dualwrite/service_mock.go
@@ -24,6 +24,40 @@ func (_m *MockService) EXPECT() *MockService_Expecter {
 	return &MockService_Expecter{mock: &_m.Mock}
 }
 
+// LogStorageModeComparison provides a mock function with given fields: gr, configMode
+func (_m *MockService) LogStorageModeComparison(gr schema.GroupResource, configMode rest.DualWriterMode) {
+	_m.Called(gr, configMode)
+}
+
+// MockService_LogStorageModeComparison_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LogStorageModeComparison'
+type MockService_LogStorageModeComparison_Call struct {
+	*mock.Call
+}
+
+// LogStorageModeComparison is a helper method to define mock.On call
+//   - gr schema.GroupResource
+//   - configMode rest.DualWriterMode
+func (_e *MockService_Expecter) LogStorageModeComparison(gr interface{}, configMode interface{}) *MockService_LogStorageModeComparison_Call {
+	return &MockService_LogStorageModeComparison_Call{Call: _e.mock.On("LogStorageModeComparison", gr, configMode)}
+}
+
+func (_c *MockService_LogStorageModeComparison_Call) Run(run func(gr schema.GroupResource, configMode rest.DualWriterMode)) *MockService_LogStorageModeComparison_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(schema.GroupResource), args[1].(rest.DualWriterMode))
+	})
+	return _c
+}
+
+func (_c *MockService_LogStorageModeComparison_Call) Return() *MockService_LogStorageModeComparison_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockService_LogStorageModeComparison_Call) RunAndReturn(run func(schema.GroupResource, rest.DualWriterMode)) *MockService_LogStorageModeComparison_Call {
+	_c.Run(run)
+	return _c
+}
+
 // NewStorage provides a mock function with given fields: gr, legacy, storage
 func (_m *MockService) NewStorage(gr schema.GroupResource, legacy rest.Storage, storage rest.Storage) (rest.Storage, error) {
 	ret := _m.Called(gr, legacy, storage)

--- a/pkg/storage/legacysql/dualwrite/types.go
+++ b/pkg/storage/legacysql/dualwrite/types.go
@@ -69,6 +69,12 @@ type Service interface {
 
 	// change the status (finish migration etc)
 	Update(ctx context.Context, status StorageStatus) (StorageStatus, error)
+
+	// LogStorageModeComparison compares the config-based storage mode with the mode
+	// reported by MigrationStatusReader and emits metrics/logs for observability.
+	// This is used for non-managed resources that bypass NewStorage and go through
+	// NewStaticStorage directly.
+	LogStorageModeComparison(gr schema.GroupResource, configMode grafanarest.DualWriterMode)
 }
 
 type SearchAdapter struct {


### PR DESCRIPTION
- **fix: log storage mode comparison in static dual writer (https://github.com/grafana/grafana/pull/118942)**