### PR TITLE
Alerting: Add historian API for querying notification alerts detail.

### DIFF
--- a/apps/alerting/historian/kinds/v0alpha1/notification.cue
+++ b/apps/alerting/historian/kinds/v0alpha1/notification.cue
@@ -68,6 +68,21 @@ import (
     groupKey: string
 }
 
+#AlertQuery: {
+    // From is the starting timestamp for the query.
+    from?: time.Time
+    // To is the ending timestamp for the query.
+    to?: time.Time
+    // UUID filters the alerts to those belonging to a specific alert rule.
+    uuid?: string
+    // Limit is the maximum number of entries to return.
+    limit?: int64
+}
+
+#AlertQueryResult: {
+    alerts: [...#NotificationEntryAlert]
+}
+
 #NotificationEntryAlert: {
     status: string
     labels: [string]: string

--- a/apps/alerting/historian/kinds/v0alpha1/routes.cue
+++ b/apps/alerting/historian/kinds/v0alpha1/routes.cue
@@ -22,7 +22,18 @@ routes: {
 					body: #NotificationQuery
 				}
 				response: #NotificationQueryResult
-				responseMetadata: typeMeta: false				
+				responseMetadata: typeMeta: false
+			}
+		}
+
+		// Query alerts within notification history.
+		"/notifications/queryalerts": {
+			"POST": {
+				request: {
+					body: #AlertQuery
+				}
+				response: #AlertQueryResult
+				responseMetadata: typeMeta: false
 			}
 		}
 	}

--- a/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationsqueryalerts_request_body_types_gen.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationsqueryalerts_request_body_types_gen.go
@@ -1,0 +1,28 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+import (
+	time "time"
+)
+
+type CreateNotificationsqueryalertsRequestBody struct {
+	// From is the starting timestamp for the query.
+	From *time.Time `json:"from,omitempty"`
+	// To is the ending timestamp for the query.
+	To *time.Time `json:"to,omitempty"`
+	// UUID filters the alerts to those belonging to a specific alert rule.
+	Uuid *string `json:"uuid,omitempty"`
+	// Limit is the maximum number of entries to return.
+	Limit *int64 `json:"limit,omitempty"`
+}
+
+// NewCreateNotificationsqueryalertsRequestBody creates a new CreateNotificationsqueryalertsRequestBody object.
+func NewCreateNotificationsqueryalertsRequestBody() *CreateNotificationsqueryalertsRequestBody {
+	return &CreateNotificationsqueryalertsRequestBody{}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for CreateNotificationsqueryalertsRequestBody.
+func (CreateNotificationsqueryalertsRequestBody) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationsqueryalertsRequestBody"
+}

--- a/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationsqueryalerts_response_types_gen.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationsqueryalerts_response_types_gen.go
@@ -1,0 +1,47 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+import (
+	time "time"
+)
+
+// +k8s:openapi-gen=true
+type CreateNotificationsqueryalertsNotificationEntryAlert struct {
+	Status      string            `json:"status"`
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+	StartsAt    time.Time         `json:"startsAt"`
+	EndsAt      time.Time         `json:"endsAt"`
+	Enrichments interface{}       `json:"enrichments,omitempty"`
+}
+
+// NewCreateNotificationsqueryalertsNotificationEntryAlert creates a new CreateNotificationsqueryalertsNotificationEntryAlert object.
+func NewCreateNotificationsqueryalertsNotificationEntryAlert() *CreateNotificationsqueryalertsNotificationEntryAlert {
+	return &CreateNotificationsqueryalertsNotificationEntryAlert{
+		Labels:      map[string]string{},
+		Annotations: map[string]string{},
+	}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for CreateNotificationsqueryalertsNotificationEntryAlert.
+func (CreateNotificationsqueryalertsNotificationEntryAlert) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationsqueryalertsNotificationEntryAlert"
+}
+
+// +k8s:openapi-gen=true
+type CreateNotificationsqueryalertsResponse struct {
+	Alerts []CreateNotificationsqueryalertsNotificationEntryAlert `json:"alerts"`
+}
+
+// NewCreateNotificationsqueryalertsResponse creates a new CreateNotificationsqueryalertsResponse object.
+func NewCreateNotificationsqueryalertsResponse() *CreateNotificationsqueryalertsResponse {
+	return &CreateNotificationsqueryalertsResponse{
+		Alerts: []CreateNotificationsqueryalertsNotificationEntryAlert{},
+	}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for CreateNotificationsqueryalertsResponse.
+func (CreateNotificationsqueryalertsResponse) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationsqueryalertsResponse"
+}

--- a/apps/alerting/historian/pkg/apis/alertinghistorian_manifest.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian_manifest.go
@@ -201,6 +201,90 @@ var appManifestData = app.ManifestData{
 							},
 						},
 					},
+					"/notifications/queryalerts": {
+						Post: &spec3.Operation{
+							OperationProps: spec3.OperationProps{
+
+								OperationId: "createNotificationsqueryalerts",
+
+								RequestBody: &spec3.RequestBody{
+									RequestBodyProps: spec3.RequestBodyProps{
+
+										Content: map[string]*spec3.MediaType{
+											"application/json": {
+												MediaTypeProps: spec3.MediaTypeProps{
+													Schema: &spec.Schema{
+														SchemaProps: spec.SchemaProps{
+															Type: []string{"object"},
+															Properties: map[string]spec.Schema{
+																"from": {
+																	SchemaProps: spec.SchemaProps{
+																		Type:        []string{"string"},
+																		Format:      "date-time",
+																		Description: "From is the starting timestamp for the query.",
+																	},
+																},
+																"limit": {
+																	SchemaProps: spec.SchemaProps{
+																		Type:        []string{"integer"},
+																		Description: "Limit is the maximum number of entries to return.",
+																	},
+																},
+																"to": {
+																	SchemaProps: spec.SchemaProps{
+																		Type:        []string{"string"},
+																		Format:      "date-time",
+																		Description: "To is the ending timestamp for the query.",
+																	},
+																},
+																"uuid": {
+																	SchemaProps: spec.SchemaProps{
+																		Type:        []string{"string"},
+																		Description: "UUID filters the alerts to those belonging to a specific alert rule.",
+																	},
+																},
+															},
+														}},
+												}},
+										},
+									}},
+								Responses: &spec3.Responses{
+									ResponsesProps: spec3.ResponsesProps{
+										Default: &spec3.Response{
+											ResponseProps: spec3.ResponseProps{
+												Description: "Default OK response",
+												Content: map[string]*spec3.MediaType{
+													"application/json": {
+														MediaTypeProps: spec3.MediaTypeProps{
+															Schema: &spec.Schema{
+																SchemaProps: spec.SchemaProps{
+																	Type: []string{"object"},
+																	Properties: map[string]spec.Schema{
+																		"alerts": {
+																			SchemaProps: spec.SchemaProps{
+																				Type: []string{"array"},
+																				Items: &spec.SchemaOrArray{
+																					Schema: &spec.Schema{
+																						SchemaProps: spec.SchemaProps{
+
+																							Ref: spec.MustCreateRef("#/components/schemas/createNotificationsqueryalertsNotificationEntryAlert"),
+																						}},
+																				},
+																			},
+																		},
+																	},
+																	Required: []string{
+																		"alerts",
+																	},
+																}},
+														}},
+												},
+											},
+										},
+									}},
+							},
+						},
+					},
 				},
 				Cluster: map[string]spec3.PathProps{},
 				Schemas: map[string]spec.Schema{
@@ -476,6 +560,71 @@ var appManifestData = app.ManifestData{
 							},
 						},
 					},
+					"createNotificationsqueryalertsNotificationEntryAlert": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"annotations": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"object"},
+										AdditionalProperties: &spec.SchemaOrBool{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+								},
+								"endsAt": {
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "date-time",
+									},
+								},
+								"enrichments": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"object"},
+										AdditionalProperties: &spec.SchemaOrBool{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{},
+											},
+										},
+									},
+								},
+								"labels": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"object"},
+										AdditionalProperties: &spec.SchemaOrBool{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+								},
+								"startsAt": {
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "date-time",
+									},
+								},
+								"status": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+							},
+							Required: []string{
+								"status",
+								"labels",
+								"annotations",
+								"startsAt",
+								"endsAt",
+							},
+						},
+					},
 				},
 			},
 		},
@@ -502,8 +651,9 @@ func ManifestGoTypeAssociator(kind, version string) (goType resource.Kind, exist
 }
 
 var customRouteToGoResponseType = map[string]any{
-	"v0alpha1||<namespace>/alertstate/history|GET":  v0alpha1.GetAlertstatehistoryResponse{},
-	"v0alpha1||<namespace>/notification/query|POST": v0alpha1.CreateNotificationqueryResponse{},
+	"v0alpha1||<namespace>/alertstate/history|GET":         v0alpha1.GetAlertstatehistoryResponse{},
+	"v0alpha1||<namespace>/notification/query|POST":        v0alpha1.CreateNotificationqueryResponse{},
+	"v0alpha1||<namespace>/notifications/queryalerts|POST": v0alpha1.CreateNotificationsqueryalertsResponse{},
 }
 
 // ManifestCustomRouteResponsesAssociator returns the associated response go type for a given kind, version, custom route path, and method, if one exists.
@@ -529,7 +679,8 @@ func ManifestCustomRouteQueryAssociator(kind, version, path, verb string) (goTyp
 }
 
 var customRouteToGoRequestBodyType = map[string]any{
-	"v0alpha1||<namespace>/notification/query|POST": v0alpha1.CreateNotificationqueryRequestBody{},
+	"v0alpha1||<namespace>/notification/query|POST":        v0alpha1.CreateNotificationqueryRequestBody{},
+	"v0alpha1||<namespace>/notifications/queryalerts|POST": v0alpha1.CreateNotificationsqueryalertsRequestBody{},
 }
 
 func ManifestCustomRouteRequestBodyAssociator(kind, version, path, verb string) (goType any, exists bool) {

--- a/apps/alerting/historian/pkg/app/app.go
+++ b/apps/alerting/historian/pkg/app/app.go
@@ -45,6 +45,11 @@ func New(cfg app.Config) (app.App, error) {
 					Path:       "/notification/query",
 					Method:     "POST",
 				}: notificationHandler.QueryHandler,
+				{
+					Namespaced: true,
+					Path:       "/notifications/queryalerts",
+					Method:     "POST",
+				}: notificationHandler.QueryAlertsHandler,
 			},
 		},
 		// TODO: Remove when SDK is fixed.

--- a/apps/alerting/historian/pkg/app/notification/types.go
+++ b/apps/alerting/historian/pkg/app/notification/types.go
@@ -26,3 +26,9 @@ const (
 type Entry = v0alpha1.CreateNotificationqueryNotificationEntry
 
 type EntryAlert = v0alpha1.CreateNotificationqueryNotificationEntryAlert
+
+type AlertQuery = v0alpha1.CreateNotificationsqueryalertsRequestBody
+
+type AlertQueryResult = v0alpha1.CreateNotificationsqueryalertsResponse
+
+type AlertEntry = v0alpha1.CreateNotificationsqueryalertsNotificationEntryAlert

--- a/packages/grafana-api-clients/src/clients/rtkq/historian.alerting/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/historian.alerting/v0alpha1/endpoints.gen.ts
@@ -167,6 +167,16 @@ const injectedRtkApi = api
           body: queryArg.createNotificationqueryRequestBody,
         }),
       }),
+      createNotificationsqueryalerts: build.mutation<
+        CreateNotificationsqueryalertsApiResponse,
+        CreateNotificationsqueryalertsApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/notifications/queryalerts`,
+          method: 'POST',
+          body: queryArg.createNotificationsqueryalertsRequestBody,
+        }),
+      }),
     }),
     overrideExisting: false,
   });
@@ -380,6 +390,10 @@ export type UpdateDummyStatusApiArg = {
 export type CreateNotificationqueryApiResponse = /** status 200 OK */ CreateNotificationqueryResponse;
 export type CreateNotificationqueryApiArg = {
   createNotificationqueryRequestBody: CreateNotificationqueryRequestBody;
+};
+export type CreateNotificationsqueryalertsApiResponse = /** status 200 OK */ CreateNotificationsqueryalertsResponse;
+export type CreateNotificationsqueryalertsApiArg = {
+  createNotificationsqueryalertsRequestBody: CreateNotificationsqueryalertsRequestBody;
 };
 export type ApiResource = {
   /** categories is a list of the grouped resources this resource belongs to (e.g. 'all') */
@@ -680,6 +694,33 @@ export type CreateNotificationqueryRequestBody = {
   /** To is the starting timestamp for the query. */
   to?: string;
 };
+export type CreateNotificationsqueryalertsNotificationEntryAlert = {
+  annotations: {
+    [key: string]: string;
+  };
+  endsAt: string;
+  enrichments?: {
+    [key: string]: any;
+  };
+  labels: {
+    [key: string]: string;
+  };
+  startsAt: string;
+  status: string;
+};
+export type CreateNotificationsqueryalertsResponse = {
+  alerts: CreateNotificationsqueryalertsNotificationEntryAlert[];
+};
+export type CreateNotificationsqueryalertsRequestBody = {
+  /** From is the starting timestamp for the query. */
+  from?: string;
+  /** Limit is the maximum number of entries to return. */
+  limit?: number;
+  /** To is the ending timestamp for the query. */
+  to?: string;
+  /** UUID filters the alerts to those belonging to a specific alert rule. */
+  uuid?: string;
+};
 export const {
   useGetApiResourcesQuery,
   useLazyGetApiResourcesQuery,
@@ -699,4 +740,5 @@ export const {
   useReplaceDummyStatusMutation,
   useUpdateDummyStatusMutation,
   useCreateNotificationqueryMutation,
+  useCreateNotificationsqueryalertsMutation,
 } = injectedRtkApi;

--- a/packages/grafana-openapi/src/apis/historian.alerting.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/historian.alerting.grafana.app-v0alpha1.json
@@ -1063,6 +1063,49 @@
         }
       },
       "parameters": []
+    },
+    "/notifications/queryalerts": {
+      "post": {
+        "operationId": "createNotificationsqueryalerts",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateNotificationsqueryalertsRequestBody"
+              }
+            },
+            "application/yaml": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateNotificationsqueryalertsRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateNotificationsqueryalertsResponse"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateNotificationsqueryalertsResponse"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateNotificationsqueryalertsResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": []
     }
   },
   "components": {
@@ -1302,6 +1345,74 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/CreateNotificationqueryNotificationEntry"
+            }
+          }
+        }
+      },
+      "CreateNotificationsqueryalertsNotificationEntryAlert": {
+        "type": "object",
+        "required": ["status", "labels", "annotations", "startsAt", "endsAt"],
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "endsAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "enrichments": {
+            "type": "object",
+            "additionalProperties": {}
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "startsAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "CreateNotificationsqueryalertsRequestBody": {
+        "type": "object",
+        "properties": {
+          "from": {
+            "description": "From is the starting timestamp for the query.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "limit": {
+            "description": "Limit is the maximum number of entries to return.",
+            "type": "integer"
+          },
+          "to": {
+            "description": "To is the ending timestamp for the query.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "uuid": {
+            "description": "UUID filters the alerts to those belonging to a specific alert rule.",
+            "type": "string"
+          }
+        }
+      },
+      "CreateNotificationsqueryalertsResponse": {
+        "type": "object",
+        "required": ["alerts"],
+        "properties": {
+          "alerts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateNotificationsqueryalertsNotificationEntryAlert"
             }
           }
         }

--- a/pkg/tests/apis/openapi_snapshots/historian.alerting.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/historian.alerting.grafana.app-v0alpha1.json
@@ -1137,6 +1137,60 @@
           }
         }
       ]
+    },
+    "/apis/historian.alerting.grafana.app/v0alpha1/namespaces/{namespace}/notifications/queryalerts": {
+      "post": {
+        "operationId": "createNotificationsqueryalerts",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationsqueryalertsRequestBody"
+              }
+            },
+            "application/yaml": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationsqueryalertsRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationsqueryalertsResponse"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationsqueryalertsResponse"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationsqueryalertsResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "namespace",
+          "in": "path",
+          "description": "object name and auth scope, such as for teams and projects",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ]
     }
   },
   "components": {
@@ -1399,6 +1453,82 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationqueryNotificationEntry"
+            }
+          }
+        }
+      },
+      "com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationsqueryalertsNotificationEntryAlert": {
+        "type": "object",
+        "required": [
+          "status",
+          "labels",
+          "annotations",
+          "startsAt",
+          "endsAt"
+        ],
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "endsAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "enrichments": {
+            "type": "object",
+            "additionalProperties": {}
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "startsAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationsqueryalertsRequestBody": {
+        "type": "object",
+        "properties": {
+          "from": {
+            "description": "From is the starting timestamp for the query.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "limit": {
+            "description": "Limit is the maximum number of entries to return.",
+            "type": "integer"
+          },
+          "to": {
+            "description": "To is the ending timestamp for the query.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "uuid": {
+            "description": "UUID filters the alerts to those belonging to a specific alert rule.",
+            "type": "string"
+          }
+        }
+      },
+      "com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationsqueryalertsResponse": {
+        "type": "object",
+        "required": [
+          "alerts"
+        ],
+        "properties": {
+          "alerts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationsqueryalertsNotificationEntryAlert"
             }
           }
         }


### PR DESCRIPTION
The write format is split into notifications and alerts, so the alerts need to
be queried separately. This API will be typically used to lookup the alerts
for a specific notification, but could also be extended to support more
advanced searching of alert payloads.
