### PR TITLE
PromDS: Fixes AdHoc filters one-of operator

### DIFF
--- a/packages/grafana-prometheus/src/datasource.test.ts
+++ b/packages/grafana-prometheus/src/datasource.test.ts
@@ -325,7 +325,7 @@ describe('PrometheusDatasource', () => {
           {
             key: 'cluster',
             operator: '=|',
-            value: 'prod-us-east-1|staging-eu-west-1|dev-eu-west-2',
+            value: 'prod-us-east-1',
             values: ['prod-us-east-1', 'staging-eu-west-1', 'dev-eu-west-2'],
           },
         ];
@@ -346,7 +346,7 @@ describe('PrometheusDatasource', () => {
           {
             key: 'namespace',
             operator: '!=|',
-            value: 'kube-system|kube-public',
+            value: 'kube-system',
             values: ['kube-system', 'kube-public'],
           },
         ];

--- a/packages/grafana-prometheus/src/datasource.test.ts
+++ b/packages/grafana-prometheus/src/datasource.test.ts
@@ -318,6 +318,71 @@ describe('PrometheusDatasource', () => {
         });
       });
     });
+
+    describe('with multi-value operators', () => {
+      it('should remap =| to =~ and apply filter to expression', () => {
+        const filters = [
+          {
+            key: 'cluster',
+            operator: '=|',
+            value: 'prod-us-east-1|staging-eu-west-1|dev-eu-west-2',
+            values: ['prod-us-east-1', 'staging-eu-west-1', 'dev-eu-west-2'],
+          },
+        ];
+        ds.query({
+          interval: '15s',
+          range: getMockTimeRange(),
+          filters,
+          targets: [target],
+        } as DataQueryRequest<PromQuery>);
+        const [result] = fetchMockCalledWith(fetchMock);
+        expect(result).toMatchObject({
+          expr: `metric{job="foo", cluster=~"prod-us-east-1|staging-eu-west-1|dev-eu-west-2"} - metric{cluster=~"prod-us-east-1|staging-eu-west-1|dev-eu-west-2"}`,
+        });
+      });
+
+      it('should remap !=| to !~ and apply filter to expression', () => {
+        const filters = [
+          {
+            key: 'namespace',
+            operator: '!=|',
+            value: 'kube-system|kube-public',
+            values: ['kube-system', 'kube-public'],
+          },
+        ];
+        ds.query({
+          interval: '15s',
+          range: getMockTimeRange(),
+          filters,
+          targets: [target],
+        } as DataQueryRequest<PromQuery>);
+        const [result] = fetchMockCalledWith(fetchMock);
+        expect(result).toMatchObject({
+          expr: `metric{job="foo", namespace!~"kube-system|kube-public"} - metric{namespace!~"kube-system|kube-public"}`,
+        });
+      });
+
+      it('should handle =| with a single value', () => {
+        const filters = [
+          {
+            key: 'cluster',
+            operator: '=|',
+            value: 'prod',
+            values: ['prod'],
+          },
+        ];
+        ds.query({
+          interval: '15s',
+          range: getMockTimeRange(),
+          filters,
+          targets: [target],
+        } as DataQueryRequest<PromQuery>);
+        const [result] = fetchMockCalledWith(fetchMock);
+        expect(result).toMatchObject({
+          expr: `metric{job="foo", cluster=~"prod"} - metric{cluster=~"prod"}`,
+        });
+      });
+    });
   });
 
   describe('Test query range snapping', () => {

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -752,8 +752,17 @@ export class PrometheusDatasource
     }
 
     const finalQuery = filters.reduce((acc, filter) => {
-      const { key, operator } = filter;
-      let { value } = filter;
+      const { key } = filter;
+      let { value, operator } = filter;
+
+      if (operator === '=|') {
+        operator = '=~';
+      }
+
+      if (operator === '!=|') {
+        operator = '!~';
+      }
+
       if (operator === '=~' || operator === '!~') {
         value = prometheusRegularEscape(value);
       }

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -754,7 +754,6 @@ export class PrometheusDatasource
     const finalQuery = filters.map(remapOneOf).reduce((acc, filter) => {
       const { key, operator } = filter;
       let { value } = filter;
-
       if (operator === '=~' || operator === '!~') {
         value = prometheusRegularEscape(value);
       }

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -752,8 +752,8 @@ export class PrometheusDatasource
     }
 
     const finalQuery = filters.map(remapOneOf).reduce((acc, filter) => {
-      const { key } = filter;
-      let { value, operator } = filter;
+      const { key, operator } = filter;
+      let { value } = filter;
 
       if (operator === '=~' || operator === '!~') {
         value = prometheusRegularEscape(value);
@@ -925,13 +925,11 @@ export const extractResourceMatcher = (
 
 export function remapOneOf(filter: AdHocVariableFilter) {
   let { operator, value, values } = filter;
-  if (operator === '=|') {
-    operator = '=~';
-    value = values?.map(prometheusRegularEscape).join('|') ?? '';
-  } else if (operator === '!=|') {
-    operator = '!~';
+  if (operator === '=|' || operator === '!=|') {
+    operator = operator === '=|' ? '=~' : '!~';
     value = values?.map(prometheusRegularEscape).join('|') ?? '';
   }
+
   return {
     ...filter,
     operator,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

With the introduction of the multi value operators here [1](https://github.com/grafana/grafana/pull/91837) and [2](https://github.com/grafana/grafana/pull/92995) and the introduction of the `promQLScope` feature toggle related to scopes, PromDS would properly manipulate expressions containing this new operator, but it was not backwards compatible for pre-scopes dashboards that would try to use this new `one-of` operator.

Basically, this would work fine if you would've had scopes ff turned on and would've used `one-of`, because it went down a codepath that dealt with it [here](https://github.com/grafana/grafana/blob/main/packages/grafana-prometheus/src/datasource.ts#L798). but if you would turn off the ff and try to use `one-of` it would crash due to going down the older existing prometheus logic which did not account for this new operator.

This became evident with the merge of [this](https://github.com/grafana/grafana/pull/112035) PR that took out the said scopes ff.

Since the `one-of` operator is basically a nice UI packaging of the regex operator this should be a simple remap between `=| one-of op` and `=~ regex op`.

I have brought back the `remapOneOf` method added and removed a while ago for this backward comp support, while everything else remains as it was on the BE side

**Why do we need this feature?**

Fixes `one-of` operator which is now currently broken for everyone except scopes users

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
