### PR TITLE
[release-12.4.1] Unified: fix parquet and use it as fallback in migrations

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -599,7 +599,11 @@ type Cfg struct {
 	// MigrationCacheSizeKB sets SQLite PRAGMA cache_size during data migrations (in KB).
 	// Larger values reduce lock contention. Default: 1000000 (~1GB).
 	MigrationCacheSizeKB int
-	MaxPageSizeBytes     int
+	// MigrationParquetBuffer enables bulk migration data through a temporary Parquet file.
+	// This separates the read phase (legacy DB) from the write phase (unified storage)
+	// Default: false.
+	MigrationParquetBuffer bool
+	MaxPageSizeBytes       int
 	// IndexPath the directory where index files are stored.
 	// Note: Bleve locks index files, so mounts cannot be shared between multiple instances.
 	IndexPath                                  string

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -79,6 +79,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	section := cfg.Raw.Section("unified_storage")
 	cfg.DisableDataMigrations = section.Key("disable_data_migrations").MustBool(false)
 	cfg.MigrationCacheSizeKB = section.Key("migration_cache_size_kb").MustInt(1000000)
+	cfg.MigrationParquetBuffer = section.Key("migration_parquet_buffer").MustBool(false)
 	if !cfg.DisableDataMigrations && cfg.UnifiedStorageType() == "unified" {
 		// Helper log to find instances running migrations in the future
 		cfg.Logger.Info("Unified migration configs enforced")

--- a/pkg/storage/unified/migrations/migrator_test.go
+++ b/pkg/storage/unified/migrations/migrator_test.go
@@ -245,12 +245,13 @@ func runMigrationTestSuite(t *testing.T, testCases []testcases.ResourceMigratorT
 		}
 		helper := apis.NewK8sTestHelperWithOpts(t, apis.K8sTestHelperOpts{
 			GrafanaOpts: testinfra.GrafanaOpts{
-				// EnableLog:             true,
-				AppModeProduction:     true,
-				DisableAnonymous:      true,
-				DisableDataMigrations: false,
-				APIServerStorageType:  "unified",
-				UnifiedStorageConfig:  unifiedConfig,
+				//EnableLog:              true,
+				AppModeProduction:      true,
+				DisableAnonymous:       true,
+				DisableDataMigrations:  false,
+				APIServerStorageType:   "unified",
+				UnifiedStorageConfig:   unifiedConfig,
+				MigrationParquetBuffer: true,
 			},
 			Org1Users: org1,
 			OrgBUsers: orgB,

--- a/pkg/storage/unified/migrations/resource_migration.go
+++ b/pkg/storage/unified/migrations/resource_migration.go
@@ -94,13 +94,13 @@ func (r *MigrationRunner) Run(ctx context.Context, sess *xorm.Session, opts RunO
 		r.log.Info("Stored migrator transaction in context for bulk operations (SQLite compatibility)")
 	}
 
-	for _, org := range orgs {
-		info, err := types.ParseNamespace(types.OrgNamespaceFormatter(org.ID))
-		if err != nil {
-			r.log.Error("Failed to parse organization namespace", "org_id", org.ID, "error", err)
-			return fmt.Errorf("failed to parse namespace for org %d: %w", org.ID, err)
+	if err := r.migrateAllOrgs(ctx, sess, orgs, opts); err != nil {
+		if opts.DriverName != migrator.SQLite {
+			return err
 		}
-		if err = r.MigrateOrg(ctx, sess, info, opts); err != nil {
+		r.log.Warn("SQLite migration failed, retrying with parquet buffer", "error", err)
+		ctx = resource.ContextWithParquetBuffer(ctx)
+		if err := r.migrateAllOrgs(ctx, sess, orgs, opts); err != nil {
 			return err
 		}
 	}
@@ -115,6 +115,20 @@ func (r *MigrationRunner) Run(ctx context.Context, sess *xorm.Session, opts RunO
 
 	r.log.Info("Migration completed successfully for all organizations", "org_count", len(orgs))
 
+	return nil
+}
+
+func (r *MigrationRunner) migrateAllOrgs(ctx context.Context, sess *xorm.Session, orgs []orgInfo, opts RunOptions) error {
+	for _, org := range orgs {
+		info, err := types.ParseNamespace(types.OrgNamespaceFormatter(org.ID))
+		if err != nil {
+			r.log.Error("Failed to parse organization namespace", "org_id", org.ID, "error", err)
+			return fmt.Errorf("failed to parse namespace for org %d: %w", org.ID, err)
+		}
+		if err = r.MigrateOrg(ctx, sess, info, opts); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/storage/unified/parquet/reader.go
+++ b/pkg/storage/unified/parquet/reader.go
@@ -49,12 +49,10 @@ func (r *parquetReader) Next() bool {
 	r.req = nil
 	for r.err == nil && r.reader != nil {
 		if r.bufferIndex >= r.bufferSize && r.value.reader.HasNext() {
-			r.bufferIndex = 0
 			r.err = r.readBulk()
 			if r.err != nil {
 				return false
 			}
-			r.bufferIndex = r.value.count
 		}
 
 		if r.bufferSize > r.bufferIndex {
@@ -146,6 +144,7 @@ func newResourceReader(inputPath string, batchSize int64) (*parquetReader, error
 		reader.group,
 		reader.resource,
 		reader.name,
+		reader.folder,
 		reader.action,
 		reader.value,
 	}

--- a/pkg/storage/unified/parquet/reader_test.go
+++ b/pkg/storage/unified/parquet/reader_test.go
@@ -81,9 +81,9 @@ func TestParquetWriteThenRead(t *testing.T) {
 
 		// Verify that we read all values
 		require.Equal(t, []string{
-			"rrr/ns/ggg/aaa",
-			"rrr/ns/ggg/bbb",
-			"rrr/ns/ggg/ccc",
+			"ns/ggg/rrr/aaa",
+			"ns/ggg/rrr/bbb",
+			"ns/ggg/rrr/ccc",
 		}, keys)
 	})
 

--- a/pkg/storage/unified/parquet/writer.go
+++ b/pkg/storage/unified/parquet/writer.go
@@ -104,11 +104,16 @@ func (w *parquetWriter) CloseWithResults() (*resourcepb.BulkResponse, error) {
 }
 
 func (w *parquetWriter) Close() error {
+	if w.writer == nil {
+		return nil
+	}
 	if w.rv.Len() > 0 {
 		_ = w.flush()
 	}
 	w.logger.Info("close")
-	return w.writer.Close()
+	err := w.writer.Close()
+	w.writer = nil
+	return err
 }
 
 // writes the current buffer to parquet and re-inits the arrow buffer
@@ -116,9 +121,9 @@ func (w *parquetWriter) flush() error {
 	w.logger.Info("flush", "count", w.rv.Len())
 	rec := array.NewRecordBatch(w.schema, []arrow.Array{
 		w.rv.NewArray(),
-		w.namespace.NewArray(),
 		w.group.NewArray(),
 		w.resource.NewArray(),
+		w.namespace.NewArray(),
 		w.name.NewArray(),
 		w.folder.NewArray(),
 		w.action.NewArray(),

--- a/pkg/storage/unified/resource/transaction.go
+++ b/pkg/storage/unified/resource/transaction.go
@@ -6,6 +6,7 @@ import (
 )
 
 type transactionContextKey struct{}
+type parquetBufferContextKey struct{}
 
 // ContextWithTransaction returns a new context with the transaction stored directly.
 // This is used for SQLite migrations where the transaction needs to be shared
@@ -22,4 +23,16 @@ func TransactionFromContext(ctx context.Context) *sql.Tx {
 		}
 	}
 	return nil
+}
+
+// ContextWithParquetBuffer returns a context that signals ProcessBulk to stage
+// data through a temporary Parquet file before writing to the database.
+func ContextWithParquetBuffer(ctx context.Context) context.Context {
+	return context.WithValue(ctx, parquetBufferContextKey{}, true)
+}
+
+// ParquetBufferFromContext returns true if the context requests parquet buffering.
+func ParquetBufferFromContext(ctx context.Context) bool {
+	v, _ := ctx.Value(parquetBufferContextKey{}).(bool)
+	return v
 }

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -74,6 +74,9 @@ type BackendOptions struct {
 
 	DisableStorageServices bool
 
+	// When true, bulk migrations buffer data through a temporary Parquet file
+	MigrationParquetBuffer bool
+
 	// testing
 	SimulatedNetworkLatency time.Duration // slows down the create transactions by a fixed amount
 
@@ -106,6 +109,7 @@ func NewBackend(opts BackendOptions) (Backend, error) {
 		storageMetrics:          opts.storageMetrics,
 		bulkLock:                &bulkLock{running: make(map[string]bool)},
 		simulatedNetworkLatency: opts.SimulatedNetworkLatency,
+		migrationParquetBuffer:  opts.MigrationParquetBuffer,
 		lastImportTimeMaxAge:    opts.LastImportTimeMaxAge,
 		garbageCollection:       opts.GarbageCollection,
 	}, nil
@@ -150,6 +154,9 @@ type backend struct {
 	historyPruner resource.Pruner
 
 	garbageCollection GarbageCollectionConfig
+
+	// When true, bulk migrations buffer data through a temporary Parquet file
+	migrationParquetBuffer bool
 
 	// Fields to control the cleanup of "lastImportTime" rows (used to find indexes to rebuild)
 	lastImportTimeMaxAge       time.Duration

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -191,6 +191,7 @@ func withBackend(opts *ServerOptions, resourceOpts *resource.ResourceServerOptio
 				DashboardsMaxAge: opts.Cfg.DashboardsGarbageCollectionMaxAge,
 			},
 			DisableStorageServices: opts.DisableStorageServices,
+			MigrationParquetBuffer: opts.Cfg.MigrationParquetBuffer,
 		})
 		if err != nil {
 			return err

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -631,6 +631,12 @@ func CreateGrafDir(t *testing.T, opts GrafanaOpts) (string, string) {
 		_, err = section.NewKey("disable_data_migrations", "true")
 		require.NoError(t, err)
 	}
+	if opts.MigrationParquetBuffer {
+		section, err := getOrCreateSection("unified_storage")
+		require.NoError(t, err)
+		_, err = section.NewKey("migration_parquet_buffer", "true")
+		require.NoError(t, err)
+	}
 	if opts.PermittedProvisioningPaths != "" {
 		_, err = pathsSect.NewKey("permitted_provisioning_paths", opts.PermittedProvisioningPaths)
 		require.NoError(t, err)
@@ -783,6 +789,7 @@ type GrafanaOpts struct {
 	DisableControllers                    bool
 	DisableDBCleanup                      bool
 	DisableDataMigrations                 bool
+	MigrationParquetBuffer                bool
 	SecretsManagerEnableDBMigrations      bool
 	OpenFeatureAPIEnabled                 bool
 	DisableAuthZClientCache               bool


### PR DESCRIPTION
Backport 82877e90d1dab08b45ea556c682b0f19127e02a4 from #119069

---

**What is this feature?**

Fixes a couple of issues in the parquet buffer that were blocking its usage and failing the migration.

If SQLite migration fails, it will retry with the parquet buffer. It's also possible to configure it to always run migrations directly with parquet.

**Why do we need this feature?**

Using the SQLite cache_size might not be possible in all environments since it uses memory over disk. We could have migrations that get OOM killed always.

Leaving it as a fallback since migrations with parquet is considerable slower when SQLite is not blocking,  ~43s (SQLite only) vs ~2min13 (Parquet buffer) with complex SQLite file from @ryantxu.

**Who is this feature for?**

SQLite OSS migration 

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
