### PR TITLE
Provisioning: Skip path conflict checks when sync is disabled

### DIFF
--- a/apps/provisioning/pkg/repository/verify.go
+++ b/apps/provisioning/pkg/repository/verify.go
@@ -70,8 +70,10 @@ func (v *VerifyAgainstExistingRepositoriesValidator) Validate(ctx context.Contex
 		}
 	}
 
-	// If repo is git, ensure no other repository is defined with a child path
-	if cfg.Spec.Type.IsGit() {
+	// If repo is git and sync is enabled, ensure no other repository is defined with a conflicting path.
+	// Path checks are skipped when sync is disabled to allow the onboarding wizard to create repositories
+	// in multiple steps (first with empty path, then configure path, then enable sync).
+	if cfg.Spec.Type.IsGit() && cfg.Spec.Sync.Enabled {
 		for _, v := range all {
 			// skip itself
 			if cfg.Name == v.Name {

--- a/apps/provisioning/pkg/repository/verify_test.go
+++ b/apps/provisioning/pkg/repository/verify_test.go
@@ -99,11 +99,12 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 			maxRepositories: 10,
 		},
 		{
-			name: "forbids duplicate git path",
+			name: "forbids duplicate git path when sync is enabled",
 			cfg: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
 				Spec: provisioning.RepositorySpec{
 					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: true},
 					GitHub: &provisioning.GitHubRepositoryConfig{
 						URL:  "https://github.com/org/repo",
 						Path: "grafana/",
@@ -127,11 +128,40 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 			maxRepositories: 10,
 		},
 		{
+			name: "allows duplicate git path when sync is disabled",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: false},
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:  "https://github.com/org/repo",
+						Path: "grafana/",
+					},
+				},
+			},
+			existingRepos: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-repo"},
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							URL:  "https://github.com/org/repo",
+							Path: "grafana/",
+						},
+					},
+				},
+			},
+			wantErr:         false,
+			maxRepositories: 10,
+		},
+		{
 			name: "allows duplicate empty paths in same repo",
 			cfg: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
 				Spec: provisioning.RepositorySpec{
 					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: true},
 					GitHub: &provisioning.GitHubRepositoryConfig{
 						URL:  "https://github.com/org/repo",
 						Path: "",
@@ -153,11 +183,12 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "forbids parent folder conflict",
+			name: "forbids parent folder conflict when sync is enabled",
 			cfg: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
 				Spec: provisioning.RepositorySpec{
 					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: true},
 					GitHub: &provisioning.GitHubRepositoryConfig{
 						URL:  "https://github.com/org/repo",
 						Path: "grafana/dashboards/",
@@ -181,11 +212,68 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 			maxRepositories: 10,
 		},
 		{
+			name: "allows parent folder path when sync is disabled",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: false},
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:  "https://github.com/org/repo",
+						Path: "grafana/dashboards/",
+					},
+				},
+			},
+			existingRepos: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-repo"},
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							URL:  "https://github.com/org/repo",
+							Path: "grafana/",
+						},
+					},
+				},
+			},
+			wantErr:         false,
+			maxRepositories: 10,
+		},
+		{
+			name: "allows empty path when sync is disabled (wizard onboarding flow)",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: false},
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:  "https://github.com/org/repo",
+						Path: "",
+					},
+				},
+			},
+			existingRepos: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-repo"},
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							URL:  "https://github.com/org/repo",
+							Path: "grafana/",
+						},
+					},
+				},
+			},
+			wantErr:         false,
+			maxRepositories: 10,
+		},
+		{
 			name: "allows different paths in same repo",
 			cfg: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
 				Spec: provisioning.RepositorySpec{
 					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: true},
 					GitHub: &provisioning.GitHubRepositoryConfig{
 						URL:  "https://github.com/org/repo",
 						Path: "other/",
@@ -213,6 +301,7 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
 				Spec: provisioning.RepositorySpec{
 					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: true},
 					GitHub: &provisioning.GitHubRepositoryConfig{
 						URL:  "https://github.com/org/repo2",
 						Path: "grafana/",

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -401,8 +401,8 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 		})
 	}
 
-	// Test Git repository path validation - ensure child paths are rejected
-	t.Run("Git repository path validation", func(t *testing.T) {
+	// Test Git repository path validation - ensure child paths are rejected when sync is enabled
+	t.Run("Git repository path validation with sync enabled", func(t *testing.T) {
 		baseURL := "https://github.com/grafana/test-repo-path-validation"
 
 		pathTests := []struct {
@@ -444,7 +444,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 					"Name":        repoName,
 					"URL":         baseURL,
 					"Path":        test.path,
-					"SyncEnabled": false, // Disable sync to avoid external dependencies
+					"SyncEnabled": true, // Sync enabled triggers path conflict checks
 					"SyncTarget":  "folder",
 				})
 
@@ -463,6 +463,91 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	// Test that path conflicts are skipped when sync is disabled (wizard onboarding flow).
+	// The wizard creates repositories without sync first, then the user configures the path
+	// and enables sync in a later step. Conflict checks should only fire when sync is enabled.
+	t.Run("Git repository path validation allows conflicting paths when sync is disabled", func(t *testing.T) {
+		baseURL := "https://github.com/grafana/test-repo-path-sync-disabled"
+
+		// Create an initial repo with sync disabled and a specific path
+		firstRepo := helper.RenderObject(t, "testdata/github-readonly.json.tmpl", map[string]any{
+			"Name":        "git-sync-disabled-1",
+			"URL":         baseURL,
+			"Path":        "demo/nested",
+			"SyncEnabled": false,
+			"SyncTarget":  "folder",
+		})
+		_, err := helper.Repositories.Resource.Create(ctx, firstRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "First repository should be created successfully")
+
+		// Create a second repo pointing to same URL with a child path and sync disabled.
+		// This simulates the wizard onboarding flow where sync is not yet enabled.
+		secondRepo := helper.RenderObject(t, "testdata/github-readonly.json.tmpl", map[string]any{
+			"Name":        "git-sync-disabled-2",
+			"URL":         baseURL,
+			"Path":        "demo/nested/child",
+			"SyncEnabled": false,
+			"SyncTarget":  "folder",
+		})
+		_, err = helper.Repositories.Resource.Create(ctx, secondRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "Second repository with child path should succeed when sync is disabled")
+
+		// Create a third repo with the same path (duplicate) and sync disabled
+		thirdRepo := helper.RenderObject(t, "testdata/github-readonly.json.tmpl", map[string]any{
+			"Name":        "git-sync-disabled-3",
+			"URL":         baseURL,
+			"Path":        "demo/nested",
+			"SyncEnabled": false,
+			"SyncTarget":  "folder",
+		})
+		_, err = helper.Repositories.Resource.Create(ctx, thirdRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "Third repository with duplicate path should succeed when sync is disabled")
+
+		// Create a fourth repo with empty path (root) and sync disabled - wizard step 1 scenario
+		fourthRepo := helper.RenderObject(t, "testdata/github-readonly.json.tmpl", map[string]any{
+			"Name":        "git-sync-disabled-4",
+			"URL":         baseURL,
+			"Path":        "",
+			"SyncEnabled": false,
+			"SyncTarget":  "folder",
+		})
+		_, err = helper.Repositories.Resource.Create(ctx, fourthRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "Fourth repository with empty path should succeed when sync is disabled")
+	})
+
+	// Test that enabling sync on a repo with a conflicting path is rejected
+	t.Run("Git repository path conflict detected when enabling sync", func(t *testing.T) {
+		baseURL := "https://github.com/grafana/test-repo-enable-sync-conflict"
+
+		// Create an initial repo with sync enabled and a specific path
+		firstRepo := helper.RenderObject(t, "testdata/github-readonly.json.tmpl", map[string]any{
+			"Name":        "git-enable-sync-1",
+			"URL":         baseURL,
+			"Path":        "demo/nested",
+			"SyncEnabled": true,
+			"SyncTarget":  "folder",
+		})
+		_, err := helper.Repositories.Resource.Create(ctx, firstRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "First repository should be created successfully")
+
+		// Create second repo with conflicting child path but sync disabled (should succeed)
+		secondRepo := helper.RenderObject(t, "testdata/github-readonly.json.tmpl", map[string]any{
+			"Name":        "git-enable-sync-2",
+			"URL":         baseURL,
+			"Path":        "demo/nested/child",
+			"SyncEnabled": false,
+			"SyncTarget":  "folder",
+		})
+		created, err := helper.Repositories.Resource.Create(ctx, secondRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "Second repository with child path should succeed when sync is disabled")
+
+		// Now try to enable sync on the second repo - this should fail due to parent/child conflict
+		created.Object["spec"].(map[string]interface{})["sync"].(map[string]interface{})["enabled"] = true
+		_, err = helper.Repositories.Resource.Update(ctx, created, metav1.UpdateOptions{FieldValidation: "Strict"})
+		require.Error(t, err, "Enabling sync should fail due to parent/child path conflict")
+		require.ErrorContains(t, err, provisioningAPIServer.ErrRepositoryParentFolderConflict.Error())
 	})
 
 	t.Run("should update sync interval", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Gate the duplicate-path and parent/child path conflict checks in `VerifyAgainstExistingRepositoriesValidator` behind `cfg.Spec.Sync.Enabled`
- When sync is disabled (wizard onboarding steps 1-4), repositories can be created/updated with any path without conflict errors
- When sync is enabled (wizard step 5 / later updates), the existing conflict checks fire and block overlapping or duplicate paths

## Problem

The onboarding wizard creates repositories in multiple steps:
1. **AuthType step**: creates repo with URL + token, `sync.enabled = false`, `path = ""`
2. **Connection step**: updates repo with branch + path, `sync.enabled` still `false`
3. **Finish step**: sets `sync.enabled = true` and submits

The path conflict validation was running unconditionally at step 1, blocking repository creation when another repo with the same URL already existed (since root path `""` is a parent of any existing path).

## Test plan

- [x] Unit tests: updated existing conflict tests to set `Sync.Enabled: true`; added 3 new tests for sync-disabled bypass
- [x] Integration tests: added test for sync-disabled creation with conflicting paths; added test that enabling sync catches the conflict
- [x] All `go test ./apps/provisioning/pkg/repository/...` pass
- [x] `go build ./pkg/registry/apis/provisioning/...` compiles cleanly


Made with [Cursor](https://cursor.com)