### PR TITLE
Provisioning: Add ParseFileResource to unify decode+fallback logic

### DIFF
--- a/pkg/registry/apis/provisioning/resources/fileformat.go
+++ b/pkg/registry/apis/provisioning/resources/fileformat.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -88,6 +89,28 @@ func ReadClassicResource(ctx context.Context, info *repository.FileInfo) (*unstr
 	}
 
 	return nil, nil, "", ErrUnableToReadResourceBytes
+}
+
+// DecodeFileResource attempts to decode file data as a Kubernetes resource, falling back to
+// classic Grafana resource formats (e.g. dashboards with panels/schemaVersion/tags).
+// This is the single entry point for all code paths that need to extract an object and GVK
+// from repository file data.
+func DecodeFileResource(ctx context.Context, info *repository.FileInfo) (*unstructured.Unstructured, *schema.GroupVersionKind, provisioning.ClassicFileType, error) {
+	obj, gvk, err := DecodeYAMLObject(bytes.NewReader(info.Data))
+	if err == nil && obj != nil && gvk != nil {
+		return obj, gvk, "", nil
+	}
+
+	logging.FromContext(ctx).Debug("failed to decode as k8s resource, trying classic format", "error", err)
+	obj, gvk, classic, classicErr := ReadClassicResource(ctx, info)
+	if obj != nil && gvk != nil {
+		return obj, gvk, classic, nil
+	}
+
+	if classicErr != nil {
+		return nil, nil, "", classicErr
+	}
+	return nil, nil, "", err
 }
 
 // DecodeYAMLObject reads the input as YAML and outputs its Kubernetes resource, if it is one.

--- a/pkg/registry/apis/provisioning/resources/fileformat.go
+++ b/pkg/registry/apis/provisioning/resources/fileformat.go
@@ -91,11 +91,13 @@ func ReadClassicResource(ctx context.Context, info *repository.FileInfo) (*unstr
 	return nil, nil, "", ErrUnableToReadResourceBytes
 }
 
-// DecodeFileResource attempts to decode file data as a Kubernetes resource, falling back to
-// classic Grafana resource formats (e.g. dashboards with panels/schemaVersion/tags).
-// This is the single entry point for all code paths that need to extract an object and GVK
-// from repository file data.
-func DecodeFileResource(ctx context.Context, info *repository.FileInfo) (*unstructured.Unstructured, *schema.GroupVersionKind, provisioning.ClassicFileType, error) {
+// ParseFileResource parses repository file data into a Kubernetes resource. It first tries the
+// standard K8s YAML/JSON decoder, then falls back to classic Grafana formats (e.g. dashboards
+// with panels/schemaVersion/tags but no apiVersion/kind).
+//
+// On success the returned object and GVK are guaranteed to be non-nil.
+// Returns a ResourceValidationError when the file does not contain a recognised resource format.
+func ParseFileResource(ctx context.Context, info *repository.FileInfo) (*unstructured.Unstructured, *schema.GroupVersionKind, provisioning.ClassicFileType, error) {
 	obj, gvk, err := DecodeYAMLObject(bytes.NewReader(info.Data))
 	if err == nil && obj != nil && gvk != nil {
 		return obj, gvk, "", nil
@@ -103,14 +105,16 @@ func DecodeFileResource(ctx context.Context, info *repository.FileInfo) (*unstru
 
 	logging.FromContext(ctx).Debug("failed to decode as k8s resource, trying classic format", "error", err)
 	obj, gvk, classic, classicErr := ReadClassicResource(ctx, info)
-	if obj != nil && gvk != nil {
+	if classicErr == nil && obj != nil && gvk != nil {
 		return obj, gvk, classic, nil
 	}
 
+	// Neither decoder recognised the file — return a validation error so callers
+	// can treat this as a "not a resource" rather than a transient failure.
 	if classicErr != nil {
-		return nil, nil, "", classicErr
+		return nil, nil, "", NewResourceValidationError(fmt.Errorf("file does not contain a valid resource: %w", classicErr))
 	}
-	return nil, nil, "", err
+	return nil, nil, "", NewResourceValidationError(fmt.Errorf("file does not contain a valid resource: %w", err))
 }
 
 // DecodeYAMLObject reads the input as YAML and outputs its Kubernetes resource, if it is one.

--- a/pkg/registry/apis/provisioning/resources/fileformat_test.go
+++ b/pkg/registry/apis/provisioning/resources/fileformat_test.go
@@ -262,8 +262,8 @@ spec:
 	})
 }
 
-func TestDecodeFileResource(t *testing.T) {
-	t.Run("k8s resource decoded directly", func(t *testing.T) {
+func TestParseFileResource(t *testing.T) {
+	t.Run("k8s resource parsed directly", func(t *testing.T) {
 		info := &repository.FileInfo{
 			Data: []byte(`{
 				"apiVersion": "playlist.grafana.app/v0alpha1",
@@ -272,14 +272,15 @@ func TestDecodeFileResource(t *testing.T) {
 				"spec": { "title": "A playlist" }
 			}`),
 		}
-		obj, gvk, classic, err := DecodeFileResource(context.Background(), info)
+		obj, gvk, classic, err := ParseFileResource(context.Background(), info)
 		require.NoError(t, err)
 		require.NotNil(t, obj)
+		require.NotNil(t, gvk)
 		require.Equal(t, "Playlist", gvk.Kind)
 		require.Empty(t, classic, "k8s resources should not have a classic type")
 	})
 
-	t.Run("classic dashboard decoded via fallback", func(t *testing.T) {
+	t.Run("classic dashboard parsed via fallback", func(t *testing.T) {
 		info := &repository.FileInfo{
 			Data: []byte(`{
 				"uid": "my-dash",
@@ -288,21 +289,26 @@ func TestDecodeFileResource(t *testing.T) {
 				"tags": []
 			}`),
 		}
-		obj, gvk, classic, err := DecodeFileResource(context.Background(), info)
+		obj, gvk, classic, err := ParseFileResource(context.Background(), info)
 		require.NoError(t, err)
 		require.NotNil(t, obj)
+		require.NotNil(t, gvk)
 		require.Equal(t, "Dashboard", gvk.Kind)
 		require.Equal(t, provisioning.ClassicDashboard, classic)
 		require.Equal(t, "my-dash", obj.GetName())
 	})
 
-	t.Run("non-resource JSON returns error", func(t *testing.T) {
+	t.Run("non-resource JSON returns validation error", func(t *testing.T) {
 		info := &repository.FileInfo{
 			Data: []byte(`{"random": "data"}`),
 		}
-		obj, gvk, _, err := DecodeFileResource(context.Background(), info)
+		obj, gvk, _, err := ParseFileResource(context.Background(), info)
 		require.Error(t, err)
 		require.Nil(t, obj)
 		require.Nil(t, gvk)
+
+		var validationErr *ResourceValidationError
+		require.ErrorAs(t, err, &validationErr, "should be a ResourceValidationError")
+		require.Contains(t, err.Error(), "file does not contain a valid resource")
 	})
 }

--- a/pkg/registry/apis/provisioning/resources/fileformat_test.go
+++ b/pkg/registry/apis/provisioning/resources/fileformat_test.go
@@ -261,3 +261,48 @@ spec:
 		require.NotNil(t, spec["title"])
 	})
 }
+
+func TestDecodeFileResource(t *testing.T) {
+	t.Run("k8s resource decoded directly", func(t *testing.T) {
+		info := &repository.FileInfo{
+			Data: []byte(`{
+				"apiVersion": "playlist.grafana.app/v0alpha1",
+				"kind": "Playlist",
+				"metadata": { "name": "hello" },
+				"spec": { "title": "A playlist" }
+			}`),
+		}
+		obj, gvk, classic, err := DecodeFileResource(context.Background(), info)
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+		require.Equal(t, "Playlist", gvk.Kind)
+		require.Empty(t, classic, "k8s resources should not have a classic type")
+	})
+
+	t.Run("classic dashboard decoded via fallback", func(t *testing.T) {
+		info := &repository.FileInfo{
+			Data: []byte(`{
+				"uid": "my-dash",
+				"schemaVersion": 7,
+				"panels": [],
+				"tags": []
+			}`),
+		}
+		obj, gvk, classic, err := DecodeFileResource(context.Background(), info)
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+		require.Equal(t, "Dashboard", gvk.Kind)
+		require.Equal(t, provisioning.ClassicDashboard, classic)
+		require.Equal(t, "my-dash", obj.GetName())
+	})
+
+	t.Run("non-resource JSON returns error", func(t *testing.T) {
+		info := &repository.FileInfo{
+			Data: []byte(`{"random": "data"}`),
+		}
+		obj, gvk, _, err := DecodeFileResource(context.Background(), info)
+		require.Error(t, err)
+		require.Nil(t, obj)
+		require.Nil(t, gvk)
+	})
+}

--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -15,8 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-
-	"github.com/grafana/grafana-app-sdk/logging"
 
 	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
 	folder "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
@@ -130,7 +127,6 @@ type ParsedResource struct {
 }
 
 func (r *parser) Parse(ctx context.Context, info *repository.FileInfo) (parsed *ParsedResource, err error) {
-	logger := logging.FromContext(ctx).With("path", info.Path)
 	parsed = &ParsedResource{
 		Info: info,
 		Repo: r.repo,
@@ -141,13 +137,9 @@ func (r *parser) Parse(ctx context.Context, info *repository.FileInfo) (parsed *
 	}
 
 	var gvk *schema.GroupVersionKind
-	parsed.Obj, gvk, err = DecodeYAMLObject(bytes.NewBuffer(info.Data))
+	parsed.Obj, gvk, parsed.Classic, err = DecodeFileResource(ctx, info)
 	if err != nil || gvk == nil {
-		logger.Debug("failed to find GVK of the input data, trying fallback loader", "error", err)
-		parsed.Obj, gvk, parsed.Classic, err = ReadClassicResource(ctx, info)
-		if err != nil || gvk == nil {
-			return nil, NewResourceValidationError(err)
-		}
+		return nil, NewResourceValidationError(err)
 	}
 
 	parsed.GVK = *gvk

--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -137,9 +137,9 @@ func (r *parser) Parse(ctx context.Context, info *repository.FileInfo) (parsed *
 	}
 
 	var gvk *schema.GroupVersionKind
-	parsed.Obj, gvk, parsed.Classic, err = DecodeFileResource(ctx, info)
-	if err != nil || gvk == nil {
-		return nil, NewResourceValidationError(err)
+	parsed.Obj, gvk, parsed.Classic, err = ParseFileResource(ctx, info)
+	if err != nil {
+		return nil, err
 	}
 
 	parsed.GVK = *gvk

--- a/pkg/registry/apis/provisioning/resources/resources.go
+++ b/pkg/registry/apis/provisioning/resources/resources.go
@@ -337,12 +337,9 @@ func (r *ResourcesManager) RemoveResourceFromFile(ctx context.Context, path stri
 		return "", "", schema.GroupVersionKind{}, fmt.Errorf("failed to read file: %w", err)
 	}
 
-	obj, gvk, _, decodeErr := DecodeFileResource(ctx, info)
-	if obj == nil || gvk == nil {
-		if decodeErr != nil {
-			return "", "", schema.GroupVersionKind{}, fmt.Errorf("no object found: %w", decodeErr)
-		}
-		return "", "", schema.GroupVersionKind{}, fmt.Errorf("no object found")
+	obj, gvk, _, err := ParseFileResource(ctx, info)
+	if err != nil {
+		return "", "", schema.GroupVersionKind{}, err
 	}
 
 	objName := obj.GetName()

--- a/pkg/registry/apis/provisioning/resources/resources.go
+++ b/pkg/registry/apis/provisioning/resources/resources.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -338,8 +337,11 @@ func (r *ResourcesManager) RemoveResourceFromFile(ctx context.Context, path stri
 		return "", "", schema.GroupVersionKind{}, fmt.Errorf("failed to read file: %w", err)
 	}
 
-	obj, gvk, _ := DecodeYAMLObject(bytes.NewBuffer(info.Data))
-	if obj == nil {
+	obj, gvk, _, decodeErr := DecodeFileResource(ctx, info)
+	if obj == nil || gvk == nil {
+		if decodeErr != nil {
+			return "", "", schema.GroupVersionKind{}, fmt.Errorf("no object found: %w", decodeErr)
+		}
 		return "", "", schema.GroupVersionKind{}, fmt.Errorf("no object found")
 	}
 

--- a/pkg/registry/apis/provisioning/resources/resources_remove_test.go
+++ b/pkg/registry/apis/provisioning/resources/resources_remove_test.go
@@ -1,0 +1,185 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+)
+
+func TestRemoveResourceFromFile(t *testing.T) {
+	dashboardGVK := schema.GroupVersionKind{
+		Group:   "dashboard.grafana.app",
+		Version: "v0alpha1",
+		Kind:    "Dashboard",
+	}
+
+	t.Run("k8s formatted resource is deleted successfully", func(t *testing.T) {
+		repo := repository.NewMockReaderWriter(t)
+		clients := NewMockResourceClients(t)
+		mockClient := &MockDynamicResourceInterface{}
+
+		k8sResource := map[string]any{
+			"apiVersion": "dashboard.grafana.app/v0alpha1",
+			"kind":       "Dashboard",
+			"metadata": map[string]any{
+				"name": "my-dashboard",
+			},
+			"spec": map[string]any{
+				"title": "My Dashboard",
+			},
+		}
+		data, _ := json.Marshal(k8sResource)
+
+		repo.On("Read", mock.Anything, "dashboards/my-dashboard.json", "abc123").
+			Return(&repository.FileInfo{Data: data, Path: "dashboards/my-dashboard.json"}, nil)
+
+		clients.On("ForKind", mock.Anything, dashboardGVK).
+			Return(mockClient, schema.GroupVersionResource{}, nil)
+
+		grafanaObj := &unstructured.Unstructured{
+			Object: map[string]any{
+				"metadata": map[string]any{
+					"name":      "my-dashboard",
+					"namespace": "default",
+					"annotations": map[string]any{
+						utils.AnnoKeyFolder: "my-folder",
+					},
+				},
+			},
+		}
+		mockClient.On("Get", mock.Anything, "my-dashboard", metav1.GetOptions{}, mock.Anything).
+			Return(grafanaObj, nil)
+		mockClient.On("Delete", mock.Anything, "my-dashboard", metav1.DeleteOptions{}, mock.Anything).
+			Return(nil)
+
+		mgr := NewResourcesManager(repo, nil, nil, clients)
+		name, folderName, gvk, err := mgr.RemoveResourceFromFile(context.Background(), "dashboards/my-dashboard.json", "abc123")
+
+		require.NoError(t, err)
+		require.Equal(t, "my-dashboard", name)
+		require.Equal(t, "my-folder", folderName)
+		// NOTE: RemoveResourceFromFile currently returns empty GVK on success (line 395 of resources.go).
+		// This is a pre-existing issue separate from the classic dashboard fallback bug.
+		require.Equal(t, schema.GroupVersionKind{}, gvk)
+	})
+
+	t.Run("classic dashboard format is deleted successfully", func(t *testing.T) {
+		repo := repository.NewMockReaderWriter(t)
+		clients := NewMockResourceClients(t)
+		mockClient := &MockDynamicResourceInterface{}
+
+		classicDashboard := map[string]any{
+			"uid":           "classic-dash-uid",
+			"title":         "Classic Dashboard",
+			"schemaVersion": 7,
+			"panels":        []any{},
+			"tags":          []any{},
+		}
+		data, _ := json.Marshal(classicDashboard)
+
+		repo.On("Read", mock.Anything, "dashboards/classic.json", "abc123").
+			Return(&repository.FileInfo{Data: data, Path: "dashboards/classic.json"}, nil)
+
+		clients.On("ForKind", mock.Anything, dashboardGVK).
+			Return(mockClient, schema.GroupVersionResource{}, nil)
+
+		grafanaObj := &unstructured.Unstructured{
+			Object: map[string]any{
+				"metadata": map[string]any{
+					"name":      "classic-dash-uid",
+					"namespace": "default",
+					"annotations": map[string]any{
+						utils.AnnoKeyFolder: "my-folder",
+					},
+				},
+			},
+		}
+		mockClient.On("Get", mock.Anything, "classic-dash-uid", metav1.GetOptions{}, mock.Anything).
+			Return(grafanaObj, nil)
+		mockClient.On("Delete", mock.Anything, "classic-dash-uid", metav1.DeleteOptions{}, mock.Anything).
+			Return(nil)
+
+		mgr := NewResourcesManager(repo, nil, nil, clients)
+		name, folderName, gvk, err := mgr.RemoveResourceFromFile(context.Background(), "dashboards/classic.json", "abc123")
+
+		require.NoError(t, err, "classic dashboard format should be handled by RemoveResourceFromFile via ReadClassicResource fallback")
+		require.Equal(t, "classic-dash-uid", name)
+		require.Equal(t, "my-folder", folderName)
+		// Same pre-existing GVK issue: RemoveResourceFromFile always returns empty GVK
+		require.Equal(t, schema.GroupVersionKind{}, gvk)
+	})
+
+	t.Run("non-resource JSON file returns no object found error", func(t *testing.T) {
+		repo := repository.NewMockReaderWriter(t)
+		clients := NewMockResourceClients(t)
+
+		nonResource := map[string]any{
+			"some_key":    "some_value",
+			"another_key": 42,
+		}
+		data, _ := json.Marshal(nonResource)
+
+		repo.On("Read", mock.Anything, "config/settings.json", "abc123").
+			Return(&repository.FileInfo{Data: data, Path: "config/settings.json"}, nil)
+
+		mgr := NewResourcesManager(repo, nil, nil, clients)
+		_, _, _, err := mgr.RemoveResourceFromFile(context.Background(), "config/settings.json", "abc123")
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no object found")
+	})
+
+	t.Run("file read error is propagated", func(t *testing.T) {
+		repo := repository.NewMockReaderWriter(t)
+		clients := NewMockResourceClients(t)
+
+		repo.On("Read", mock.Anything, "dashboards/missing.json", "abc123").
+			Return((*repository.FileInfo)(nil), repository.ErrFileNotFound)
+
+		mgr := NewResourcesManager(repo, nil, nil, clients)
+		_, _, _, err := mgr.RemoveResourceFromFile(context.Background(), "dashboards/missing.json", "abc123")
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to read file")
+	})
+
+	t.Run("already deleted resource is a no-op", func(t *testing.T) {
+		repo := repository.NewMockReaderWriter(t)
+		clients := NewMockResourceClients(t)
+		mockClient := &MockDynamicResourceInterface{}
+
+		k8sResource := map[string]any{
+			"apiVersion": "dashboard.grafana.app/v0alpha1",
+			"kind":       "Dashboard",
+			"metadata": map[string]any{
+				"name": "deleted-dashboard",
+			},
+		}
+		data, _ := json.Marshal(k8sResource)
+
+		repo.On("Read", mock.Anything, "dashboards/deleted.json", "abc123").
+			Return(&repository.FileInfo{Data: data, Path: "dashboards/deleted.json"}, nil)
+
+		clients.On("ForKind", mock.Anything, dashboardGVK).
+			Return(mockClient, schema.GroupVersionResource{}, nil)
+
+		mockClient.On("Get", mock.Anything, "deleted-dashboard", metav1.GetOptions{}, mock.Anything).
+			Return(nil, apierrors.NewNotFound(schema.GroupResource{}, "deleted-dashboard"))
+
+		mgr := NewResourcesManager(repo, nil, nil, clients)
+		name, _, _, err := mgr.RemoveResourceFromFile(context.Background(), "dashboards/deleted.json", "abc123")
+
+		require.NoError(t, err)
+		require.Equal(t, "deleted-dashboard", name)
+	})
+}

--- a/pkg/registry/apis/provisioning/resources/resources_remove_test.go
+++ b/pkg/registry/apis/provisioning/resources/resources_remove_test.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -119,7 +120,7 @@ func TestRemoveResourceFromFile(t *testing.T) {
 		require.Equal(t, schema.GroupVersionKind{}, gvk)
 	})
 
-	t.Run("non-resource JSON file returns no object found error", func(t *testing.T) {
+	t.Run("non-resource JSON file returns validation error", func(t *testing.T) {
 		repo := repository.NewMockReaderWriter(t)
 		clients := NewMockResourceClients(t)
 
@@ -136,7 +137,10 @@ func TestRemoveResourceFromFile(t *testing.T) {
 		_, _, _, err := mgr.RemoveResourceFromFile(context.Background(), "config/settings.json", "abc123")
 
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "no object found")
+		require.Contains(t, err.Error(), "file does not contain a valid resource")
+
+		var validationErr *ResourceValidationError
+		require.ErrorAs(t, err, &validationErr, "should be a ResourceValidationError")
 	})
 
 	t.Run("file read error is propagated", func(t *testing.T) {
@@ -181,5 +185,126 @@ func TestRemoveResourceFromFile(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, "deleted-dashboard", name)
+	})
+}
+
+func TestRenameResourceFile(t *testing.T) {
+	dashboardGVK := schema.GroupVersionKind{
+		Group:   "dashboard.grafana.app",
+		Version: "v0alpha1",
+		Kind:    "Dashboard",
+	}
+
+	// RenameResourceFile calls RemoveResourceFromFile (old path) then WriteResourceFromFile (new path).
+	// The classic dashboard bug was in the remove step: it failed with "no object found" for classic-format files.
+	// These tests verify the remove step succeeds for classic dashboards during a rename.
+	//
+	// NOTE: integration-level rename tests are not feasible because file renames are only detected
+	// by Git-backed repositories (via CompareFiles), not by local filesystem repositories.
+
+	t.Run("classic dashboard rename succeeds at remove step", func(t *testing.T) {
+		repo := repository.NewMockReaderWriter(t)
+		clients := NewMockResourceClients(t)
+		mockParser := NewMockParser(t)
+		mockClient := &MockDynamicResourceInterface{}
+
+		classicDashboard := map[string]any{
+			"uid":           "rename-classic-uid",
+			"title":         "Classic Dashboard Being Renamed",
+			"schemaVersion": 39,
+			"panels":        []any{},
+			"tags":          []any{},
+		}
+		data, _ := json.Marshal(classicDashboard)
+
+		repo.On("Read", mock.Anything, "old-path/classic.json", "old-ref").
+			Return(&repository.FileInfo{Data: data, Path: "old-path/classic.json"}, nil)
+
+		clients.On("ForKind", mock.Anything, dashboardGVK).
+			Return(mockClient, schema.GroupVersionResource{}, nil)
+
+		grafanaObj := &unstructured.Unstructured{
+			Object: map[string]any{
+				"metadata": map[string]any{
+					"name":      "rename-classic-uid",
+					"namespace": "default",
+					"annotations": map[string]any{
+						utils.AnnoKeyFolder: "src-folder",
+					},
+				},
+			},
+		}
+		mockClient.On("Get", mock.Anything, "rename-classic-uid", metav1.GetOptions{}, mock.Anything).
+			Return(grafanaObj, nil)
+		mockClient.On("Delete", mock.Anything, "rename-classic-uid", metav1.DeleteOptions{}, mock.Anything).
+			Return(nil)
+
+		// The write step reads and parses the new file; stub the parser to return an error
+		// so we can isolate the test to the remove step.
+		repo.On("Read", mock.Anything, "new-path/classic.json", "new-ref").
+			Return(&repository.FileInfo{Data: data, Path: "new-path/classic.json"}, nil)
+		mockParser.On("Parse", mock.Anything, mock.Anything).
+			Return(nil, fmt.Errorf("parse not implemented in test"))
+
+		mgr := NewResourcesManager(repo, nil, mockParser, clients)
+		_, _, _, err := mgr.RenameResourceFile(context.Background(), "old-path/classic.json", "old-ref", "new-path/classic.json", "new-ref")
+
+		// The error comes from the write step (stubbed parser), not from the remove step.
+		// Before the fix, this would have failed with "file does not contain a valid resource"
+		// from the remove step because classic dashboards were not recognized.
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to write resource")
+		require.NotContains(t, err.Error(), "file does not contain a valid resource",
+			"remove step should have succeeded for the classic dashboard; error should be from the write step only")
+	})
+
+	t.Run("k8s resource rename succeeds at remove step", func(t *testing.T) {
+		repo := repository.NewMockReaderWriter(t)
+		clients := NewMockResourceClients(t)
+		mockParser := NewMockParser(t)
+		mockClient := &MockDynamicResourceInterface{}
+
+		k8sResource := map[string]any{
+			"apiVersion": "dashboard.grafana.app/v0alpha1",
+			"kind":       "Dashboard",
+			"metadata":   map[string]any{"name": "rename-k8s-uid"},
+			"spec":       map[string]any{"title": "K8s Dashboard Being Renamed"},
+		}
+		data, _ := json.Marshal(k8sResource)
+
+		repo.On("Read", mock.Anything, "old-path/k8s.json", "old-ref").
+			Return(&repository.FileInfo{Data: data, Path: "old-path/k8s.json"}, nil)
+
+		clients.On("ForKind", mock.Anything, dashboardGVK).
+			Return(mockClient, schema.GroupVersionResource{}, nil)
+
+		grafanaObj := &unstructured.Unstructured{
+			Object: map[string]any{
+				"metadata": map[string]any{
+					"name":      "rename-k8s-uid",
+					"namespace": "default",
+					"annotations": map[string]any{
+						utils.AnnoKeyFolder: "src-folder",
+					},
+				},
+			},
+		}
+		mockClient.On("Get", mock.Anything, "rename-k8s-uid", metav1.GetOptions{}, mock.Anything).
+			Return(grafanaObj, nil)
+		mockClient.On("Delete", mock.Anything, "rename-k8s-uid", metav1.DeleteOptions{}, mock.Anything).
+			Return(nil)
+
+		repo.On("Read", mock.Anything, "new-path/k8s.json", "new-ref").
+			Return(&repository.FileInfo{Data: data, Path: "new-path/k8s.json"}, nil)
+		mockParser.On("Parse", mock.Anything, mock.Anything).
+			Return(nil, fmt.Errorf("parse not implemented in test"))
+
+		mgr := NewResourcesManager(repo, nil, mockParser, clients)
+		_, _, _, err := mgr.RenameResourceFile(context.Background(), "old-path/k8s.json", "old-ref", "new-path/k8s.json", "new-ref")
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to write resource")
+		require.NotContains(t, err.Error(), "file does not contain a valid resource",
+			"remove step should have succeeded for the k8s resource")
 	})
 }

--- a/pkg/tests/apis/provisioning/classic_delete_test.go
+++ b/pkg/tests/apis/provisioning/classic_delete_test.go
@@ -1,0 +1,215 @@
+package provisioning
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+// TestIntegrationProvisioning_ClassicDashboardDeletion verifies that classic-format dashboards
+// (JSON without apiVersion/kind) can be properly deleted during incremental sync.
+// This is a regression test for a bug where RemoveResourceFromFile only tried DecodeYAMLObject
+// and lacked the ReadClassicResource fallback, causing "no object found" errors when deleting
+// classic dashboards.
+func TestIntegrationProvisioning_ClassicDashboardDeletion(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafana(t)
+
+	t.Run("classic dashboard deleted via filesystem removal and sync", func(t *testing.T) {
+		const repo = "classic-delete-repo"
+		repoPath := filepath.Join(helper.ProvisioningPath, repo)
+
+		helper.CreateRepo(t, TestRepo{
+			Name:   repo,
+			Path:   repoPath,
+			Target: "folder",
+			Copies: map[string]string{
+				"testdata/all-panels.json": "dashboard1.json",
+			},
+			SkipResourceAssertions: true,
+		})
+
+		// Verify the classic dashboard was created (all-panels.json has uid "n1jR8vnnz")
+		helper.RequireRepoDashboardCount(t, repo, 1)
+		_, err := helper.DashboardsV1.Resource.Get(t.Context(), "n1jR8vnnz", metav1.GetOptions{})
+		require.NoError(t, err, "classic dashboard should exist after initial sync")
+
+		// Delete the classic dashboard file from the filesystem
+		err = os.Remove(filepath.Join(repoPath, "dashboard1.json"))
+		require.NoError(t, err, "should be able to delete file")
+
+		// Trigger sync - incremental sync should detect the deletion and remove the resource
+		helper.SyncAndWait(t, repo, nil)
+
+		// Verify the dashboard was deleted from Grafana
+		helper.RequireRepoDashboardCount(t, repo, 0)
+	})
+
+	t.Run("inline classic dashboard deleted via filesystem removal and sync", func(t *testing.T) {
+		const repo = "classic-inline-delete-repo"
+		repoPath := filepath.Join(helper.ProvisioningPath, repo)
+
+		// Write a minimal classic dashboard directly (no testdata file)
+		classicDashboard := []byte(`{
+			"uid": "inline-classic-uid",
+			"title": "Inline Classic Dashboard",
+			"schemaVersion": 39,
+			"panels": [],
+			"tags": []
+		}`)
+
+		err := os.MkdirAll(repoPath, 0o750)
+		require.NoError(t, err)
+		err = os.WriteFile(filepath.Join(repoPath, "inline-classic.json"), classicDashboard, 0o600)
+		require.NoError(t, err)
+
+		helper.CreateRepo(t, TestRepo{
+			Name:                   repo,
+			Path:                   repoPath,
+			Target:                 "folder",
+			SkipResourceAssertions: true,
+		})
+
+		// Verify the dashboard was created
+		helper.RequireRepoDashboardCount(t, repo, 1)
+		_, err = helper.DashboardsV1.Resource.Get(t.Context(), "inline-classic-uid", metav1.GetOptions{})
+		require.NoError(t, err, "inline classic dashboard should exist after initial sync")
+
+		// Delete the file
+		err = os.Remove(filepath.Join(repoPath, "inline-classic.json"))
+		require.NoError(t, err, "should be able to delete file")
+
+		// Trigger sync - this should succeed without "no object found" errors
+		helper.SyncAndWait(t, repo, nil)
+
+		// Verify the dashboard was removed
+		helper.RequireRepoDashboardCount(t, repo, 0)
+	})
+
+	t.Run("sync job succeeds without errors when classic dashboard is deleted", func(t *testing.T) {
+		const repo = "classic-delete-status-repo"
+		repoPath := filepath.Join(helper.ProvisioningPath, repo)
+
+		classicDashboard := []byte(`{
+			"uid": "status-check-uid",
+			"title": "Status Check Dashboard",
+			"schemaVersion": 39,
+			"panels": [],
+			"tags": []
+		}`)
+
+		err := os.MkdirAll(repoPath, 0o750)
+		require.NoError(t, err)
+		err = os.WriteFile(filepath.Join(repoPath, "status-check.json"), classicDashboard, 0o600)
+		require.NoError(t, err)
+
+		helper.CreateRepo(t, TestRepo{
+			Name:                   repo,
+			Path:                   repoPath,
+			Target:                 "folder",
+			SkipResourceAssertions: true,
+		})
+
+		helper.RequireRepoDashboardCount(t, repo, 1)
+
+		// Delete the file
+		err = os.Remove(filepath.Join(repoPath, "status-check.json"))
+		require.NoError(t, err)
+
+		// Trigger sync and verify the job succeeds (not warning/error state)
+		job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{},
+		})
+
+		jobObj := &provisioning.Job{}
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj)
+		require.NoError(t, err)
+
+		require.Equal(t, provisioning.JobStateSuccess, jobObj.Status.State,
+			"sync job should succeed when deleting a classic dashboard, got state=%s errors=%v",
+			jobObj.Status.State, jobObj.Status.Errors)
+		require.Empty(t, jobObj.Status.Errors, "should have no errors when deleting classic dashboard")
+
+		helper.RequireRepoDashboardCount(t, repo, 0)
+	})
+
+	t.Run("mixed k8s and classic dashboards deleted together", func(t *testing.T) {
+		const repo = "mixed-delete-repo"
+		repoPath := filepath.Join(helper.ProvisioningPath, repo)
+
+		// Classic dashboard (no apiVersion/kind)
+		classicDashboard := []byte(`{
+			"uid": "mixed-classic-uid",
+			"title": "Mixed Classic Dashboard",
+			"schemaVersion": 39,
+			"panels": [],
+			"tags": []
+		}`)
+
+		// K8s-formatted dashboard (has apiVersion/kind)
+		k8sDashboard := []byte(`{
+			"apiVersion": "dashboard.grafana.app/v0alpha1",
+			"kind": "Dashboard",
+			"metadata": {
+				"name": "mixed-k8s-uid"
+			},
+			"spec": {
+				"title": "Mixed K8s Dashboard",
+				"schemaVersion": 39,
+				"panels": [],
+				"tags": []
+			}
+		}`)
+
+		err := os.MkdirAll(repoPath, 0o750)
+		require.NoError(t, err)
+		err = os.WriteFile(filepath.Join(repoPath, "classic.json"), classicDashboard, 0o600)
+		require.NoError(t, err)
+		err = os.WriteFile(filepath.Join(repoPath, "k8s.json"), k8sDashboard, 0o600)
+		require.NoError(t, err)
+
+		helper.CreateRepo(t, TestRepo{
+			Name:                   repo,
+			Path:                   repoPath,
+			Target:                 "folder",
+			SkipResourceAssertions: true,
+		})
+
+		// Verify both dashboards were created
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			count := 0
+			dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
+			if !assert.NoError(collect, err) {
+				return
+			}
+			for _, d := range dashboards.Items {
+				name := d.GetName()
+				if name == "mixed-classic-uid" || name == "mixed-k8s-uid" {
+					count++
+				}
+			}
+			assert.Equal(collect, 2, count, "both dashboards should exist")
+		}, waitTimeoutDefault, waitIntervalDefault, "both dashboards should be created")
+
+		// Delete both files
+		err = os.Remove(filepath.Join(repoPath, "classic.json"))
+		require.NoError(t, err)
+		err = os.Remove(filepath.Join(repoPath, "k8s.json"))
+		require.NoError(t, err)
+
+		// Sync should handle both deletions
+		helper.SyncAndWait(t, repo, nil)
+
+		helper.RequireRepoDashboardCount(t, repo, 0)
+	})
+}

--- a/pkg/tests/apis/provisioning/job_warning_result_test.go
+++ b/pkg/tests/apis/provisioning/job_warning_result_test.go
@@ -57,7 +57,7 @@ func TestIntegrationProvisioning_JobWarningResult(t *testing.T) {
 
 	// Verify that the warning message mentions the malformed resource
 	found := false
-	expectedWarningMsg := "writing resource from file dashboard1.json: failed to parse file: resource validation failed: unable to read file (file: dashboard1.json, name: , action: created)"
+	expectedWarningMsg := "writing resource from file dashboard1.json: failed to parse file: resource validation failed: file does not contain a valid resource: unable to read file (file: dashboard1.json, name: , action: created)"
 	for _, warningMsg := range jobObj.Status.Warnings {
 		fmt.Println(warningMsg)
 		if warningMsg == expectedWarningMsg {

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1152,6 +1153,107 @@ func TestIntegrationProvisioning_DeleteRepositoryAndReleaseResources(t *testing.
 			assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeySourceChecksum)
 		}
 	}, time.Second*20, time.Millisecond*10, "Expected folders to be released")
+}
+
+func TestIntegrationProvisioning_DeleteRepositoryAndCleanupClassicDashboards(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafana(t)
+	ctx := context.Background()
+
+	t.Run("remove-orphan-resources finalizer deletes classic dashboards", func(t *testing.T) {
+		const repo = "finalizer-remove-classic"
+		repoPath := filepath.Join(helper.ProvisioningPath, repo)
+
+		classicDashboard := []byte(`{
+			"uid": "finalizer-remove-classic-uid",
+			"title": "Classic Dashboard for Remove Finalizer",
+			"schemaVersion": 39,
+			"panels": [],
+			"tags": []
+		}`)
+
+		require.NoError(t, os.MkdirAll(repoPath, 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(repoPath, "classic.json"), classicDashboard, 0o600))
+
+		helper.CreateRepo(t, TestRepo{
+			Name:                   repo,
+			Path:                   repoPath,
+			Target:                 "folder",
+			SkipResourceAssertions: true,
+		})
+
+		helper.RequireRepoDashboardCount(t, repo, 1)
+
+		dashboard, err := helper.DashboardsV1.Resource.Get(ctx, "finalizer-remove-classic-uid", metav1.GetOptions{})
+		require.NoError(t, err, "classic dashboard should exist after initial sync")
+		require.Contains(t, dashboard.GetAnnotations(), utils.AnnoKeyManagerKind)
+		require.Contains(t, dashboard.GetAnnotations(), utils.AnnoKeyManagerIdentity)
+
+		err = helper.Repositories.Resource.Delete(ctx, repo, metav1.DeleteOptions{})
+		require.NoError(t, err, "should delete repository")
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+			assert.True(collect, apierrors.IsNotFound(err), "repository should be deleted")
+		}, time.Second*20, time.Millisecond*50, "repository should be deleted")
+
+		_, err = helper.DashboardsV1.Resource.Get(ctx, "finalizer-remove-classic-uid", metav1.GetOptions{})
+		require.Error(t, err, "classic dashboard should be deleted by remove-orphan-resources finalizer")
+		require.True(t, apierrors.IsNotFound(err))
+	})
+
+	t.Run("release-orphan-resources finalizer releases classic dashboards", func(t *testing.T) {
+		const repo = "finalizer-release-classic"
+		repoPath := filepath.Join(helper.ProvisioningPath, repo)
+
+		classicDashboard := []byte(`{
+			"uid": "finalizer-release-classic-uid",
+			"title": "Classic Dashboard for Release Finalizer",
+			"schemaVersion": 39,
+			"panels": [],
+			"tags": []
+		}`)
+
+		require.NoError(t, os.MkdirAll(repoPath, 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(repoPath, "classic.json"), classicDashboard, 0o600))
+
+		helper.CreateRepo(t, TestRepo{
+			Name:                   repo,
+			Path:                   repoPath,
+			Target:                 "folder",
+			SkipResourceAssertions: true,
+		})
+
+		helper.RequireRepoDashboardCount(t, repo, 1)
+
+		dashboard, err := helper.DashboardsV1.Resource.Get(ctx, "finalizer-release-classic-uid", metav1.GetOptions{})
+		require.NoError(t, err, "classic dashboard should exist after initial sync")
+		require.Contains(t, dashboard.GetAnnotations(), utils.AnnoKeyManagerKind)
+		require.Contains(t, dashboard.GetAnnotations(), utils.AnnoKeyManagerIdentity)
+
+		_, err = helper.Repositories.Resource.Patch(ctx, repo, types.JSONPatchType, []byte(`[
+			{"op": "replace", "path": "/metadata/finalizers", "value": ["cleanup", "release-orphan-resources"]}
+		]`), metav1.PatchOptions{})
+		require.NoError(t, err, "should successfully patch finalizers")
+
+		err = helper.Repositories.Resource.Delete(ctx, repo, metav1.DeleteOptions{})
+		require.NoError(t, err, "should delete repository")
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+			assert.True(collect, apierrors.IsNotFound(err), "repository should be deleted")
+		}, time.Second*20, time.Millisecond*50, "repository should be deleted")
+
+		dashboard, err = helper.DashboardsV1.Resource.Get(ctx, "finalizer-release-classic-uid", metav1.GetOptions{})
+		require.NoError(t, err, "classic dashboard should still exist after release")
+
+		annotations := dashboard.GetAnnotations()
+		require.NotContains(t, annotations, utils.AnnoKeyManagerKind, "managedBy annotation should be removed")
+		require.NotContains(t, annotations, utils.AnnoKeyManagerIdentity, "managerId annotation should be removed")
+		require.NotContains(t, annotations, utils.AnnoKeySourcePath, "sourcePath annotation should be removed")
+		require.NotContains(t, annotations, utils.AnnoKeySourceChecksum, "sourceChecksum annotation should be removed")
+	})
 }
 
 func TestIntegrationProvisioning_JobPermissions(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/grafana/git-ui-sync-project/issues/925

## What

During incremental sync, deleting a classic-format dashboard (JSON with `panels`/`schemaVersion`/`tags` but no `apiVersion`/`kind`) from a repository caused:

```
err="removing resource from file upwind-customerassetcollectorresources.json: no object found"
```

## Why

`RemoveResourceFromFile` used `DecodeYAMLObject` as its only decode path. This function requires K8s-style `apiVersion`/`kind` fields, so it fails on classic Grafana dashboards.

The write path (`parser.Parse`) already handled this via a `ReadClassicResource` fallback, but the delete path did not — creating an asymmetry where classic dashboards could be synced **in** but never properly cleaned up on **deletion**.

## How

Introduces `ParseFileResource` in `fileformat.go` as the single entry point for decoding repository file data. It:
- Tries `DecodeYAMLObject` first, then falls back to `ReadClassicResource` for classic formats
- Guarantees non-nil `obj` and `gvk` on success
- Returns `ResourceValidationError` with a descriptive message ("file does not contain a valid resource") for unrecognized file formats

Both `parser.Parse` and `RemoveResourceFromFile` now call this unified function, eliminating the duplication and the asymmetry.

### Call site analysis

All production call sites of `RemoveResourceFromFile` were audited:

| Call Site | Code Path | Affected by bug? | Coverage |
|---|---|---|---|
| `incremental.go` | File deleted during sync | Yes — **fixed** | Integration tests (`classic_delete_test.go`) |
| `resources.go` `RenameResourceFile` | File renamed during sync | Yes — **fixed** (delegates to `RemoveResourceFromFile`) | Unit tests (`resources_remove_test.go`) |
| `delete/worker.go` | Delete job | No — deletes files then triggers full sync | Existing tests (`deletejob_test.go`) |
| `controller/finalizers.go` | Repo deletion cleanup | No — lists resources by annotation, doesn't read files | Integration tests (`repository_test.go`) |

**Rename test limitation:** Integration tests for `RenameResourceFile` with classic dashboards are not feasible because file renames are only detected by Git-backed repositories (via `CompareFiles`), not by local filesystem repositories used in integration tests. The unit tests verify the remove step (which had the bug) succeeds for classic dashboards during a rename by stubbing the parser for the write step.

### Changes

| File | Change |
|---|---|
| `resources/fileformat.go` | New `ParseFileResource` function (decode + classic fallback + validation error) |
| `resources/parser.go` | Replaced inline decode+fallback with `ParseFileResource` call |
| `resources/resources.go` | Replaced inline decode (no fallback) with `ParseFileResource` call |
| `resources/fileformat_test.go` | Unit tests for `ParseFileResource` (K8s, classic, non-resource) |
| `resources/resources_remove_test.go` | Unit tests for `RemoveResourceFromFile` (5 cases) + `RenameResourceFile` (2 cases) |
| `tests/apis/provisioning/classic_delete_test.go` | Integration tests for classic dashboard deletion via sync (4 cases) |
| `tests/apis/provisioning/repository_test.go` | Integration tests for classic dashboard cleanup via finalizers (2 cases) |

## Test plan

- [x] Unit tests for `ParseFileResource`: K8s resource, classic dashboard fallback, non-resource JSON
- [x] Unit tests for `RemoveResourceFromFile`: K8s deletion, classic deletion, non-resource error, file read error, already-deleted no-op
- [x] Unit tests for `RenameResourceFile`: classic dashboard rename, K8s resource rename (both verify remove step succeeds)
- [x] Classic dashboard deletion test confirmed to **fail before** the fix and **pass after**
- [x] All existing tests pass: `go test ./pkg/registry/apis/provisioning/resources/...` and `go test ./pkg/registry/apis/provisioning/jobs/sync/...`
- [ ] Integration tests: classic dashboard filesystem deletion + sync, inline classic, job status verification, mixed K8s + classic deletion
- [ ] Integration tests: classic dashboard cleanup via finalizers (remove-orphan-resources and release-orphan-resources)