### PR TITLE
Alerting: Update notification history views for new API

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/Notifications.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/Notifications.tsx
@@ -4,10 +4,11 @@ import { useDebounce } from 'react-use';
 import { AlertLabels } from '@grafana/alerting/unstable';
 import {
   CreateNotificationqueryNotificationEntry,
-  CreateNotificationqueryNotificationEntryAlert,
   CreateNotificationqueryNotificationOutcome,
   CreateNotificationqueryNotificationStatus,
+  CreateNotificationsqueryalertsNotificationEntryAlert,
   useCreateNotificationqueryMutation,
+  useCreateNotificationsqueryalertsMutation,
 } from '@grafana/api-clients/rtkq/historian.alerting/v0alpha1';
 import { dateTime } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -20,6 +21,7 @@ import {
   Label,
   LoadingPlaceholder,
   RadioButtonGroup,
+  Spinner,
   Stack,
   Text,
   Tooltip,
@@ -354,10 +356,21 @@ interface NotificationExpandedContentProps {
 }
 
 const NotificationExpandedContent = ({ entry }: NotificationExpandedContentProps) => {
-  const firingAlerts =
-    entry.alerts?.filter((alert: CreateNotificationqueryNotificationEntryAlert) => alert.status === 'firing') ?? [];
-  const resolvedAlerts =
-    entry.alerts?.filter((alert: CreateNotificationqueryNotificationEntryAlert) => alert.status === 'resolved') ?? [];
+  const [queryAlerts, { data: alertsData, isLoading: alertsLoading }] = useCreateNotificationsqueryalertsMutation();
+
+  useEffect(() => {
+    const from = entry.timestamp;
+    const to = new Date(new Date(entry.timestamp).getTime() + 1000).toISOString();
+    queryAlerts({ createNotificationsqueryalertsRequestBody: { uuid: entry.uuid, from, to, limit: 10 } });
+  }, [entry.uuid, entry.timestamp, queryAlerts]);
+
+  const alerts = alertsData?.alerts ?? [];
+  const firingAlerts = alerts.filter(
+    (alert: CreateNotificationsqueryalertsNotificationEntryAlert) => alert.status === 'firing'
+  );
+  const resolvedAlerts = alerts.filter(
+    (alert: CreateNotificationsqueryalertsNotificationEntryAlert) => alert.status === 'resolved'
+  );
 
   return (
     <Box padding={2}>
@@ -367,13 +380,21 @@ const NotificationExpandedContent = ({ entry }: NotificationExpandedContentProps
             {entry.error}
           </Alert>
         )}
-        {firingAlerts.length > 0 && (
-          <Stack direction="column" gap={2}>
-            <Text variant="h6">
-              {t('alerting.notification-history.firing-alerts', 'Firing Alerts ({{count}})', {
-                count: firingAlerts.length,
+        {alertsLoading && <Spinner />}
+        {!alertsLoading && alerts.length < entry.alertCount && (
+          <Stack direction="row" gap={0.5} alignItems="center">
+            <Icon name="info-circle" size="xs" />
+            <Text variant="bodySmall" color="secondary">
+              {t('alerting.notification-history.showing-alerts', 'Showing {{showing}} out of {{total}} alerts', {
+                showing: alerts.length,
+                total: entry.alertCount,
               })}
             </Text>
+          </Stack>
+        )}
+        {firingAlerts.length > 0 && (
+          <Stack direction="column" gap={2}>
+            <Text variant="h6">{t('alerting.notification-history.firing-alerts', 'Firing Alerts')}</Text>
             {firingAlerts.map((alert, index) => (
               <AlertDetail key={index} alert={alert} groupLabels={entry.groupLabels} />
             ))}
@@ -381,11 +402,7 @@ const NotificationExpandedContent = ({ entry }: NotificationExpandedContentProps
         )}
         {resolvedAlerts.length > 0 && (
           <Stack direction="column" gap={2}>
-            <Text variant="h6">
-              {t('alerting.notification-history.resolved-alerts', 'Resolved Alerts ({{count}})', {
-                count: resolvedAlerts.length,
-              })}
-            </Text>
+            <Text variant="h6">{t('alerting.notification-history.resolved-alerts', 'Resolved Alerts')}</Text>
             {resolvedAlerts.map((alert, index) => (
               <AlertDetail key={index} alert={alert} groupLabels={entry.groupLabels} />
             ))}
@@ -397,7 +414,7 @@ const NotificationExpandedContent = ({ entry }: NotificationExpandedContentProps
 };
 
 interface AlertDetailProps {
-  alert: CreateNotificationqueryNotificationEntryAlert;
+  alert: CreateNotificationsqueryalertsNotificationEntryAlert;
   groupLabels: Record<string, string>;
 }
 

--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/Notifications.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/Notifications.tsx
@@ -8,7 +8,6 @@ import {
   CreateNotificationqueryNotificationStatus,
   CreateNotificationsqueryalertsNotificationEntryAlert,
   useCreateNotificationqueryMutation,
-  useCreateNotificationsqueryalertsMutation,
 } from '@grafana/api-clients/rtkq/historian.alerting/v0alpha1';
 import { dateTime } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -28,6 +27,7 @@ import {
 } from '@grafana/ui';
 import { RulerGrafanaRuleDTO } from 'app/types/unified-alerting-dto';
 
+import { useNotificationAlerts } from '../../../hooks/useNotificationAlerts';
 import { matcherToOperator } from '../../../utils/alertmanager';
 import { parsePromQLStyleMatcherLooseSafe } from '../../../utils/matchers';
 import { DynamicTable, DynamicTableColumnProps, DynamicTableItemProps } from '../../DynamicTable';
@@ -356,21 +356,12 @@ interface NotificationExpandedContentProps {
 }
 
 const NotificationExpandedContent = ({ entry }: NotificationExpandedContentProps) => {
-  const [queryAlerts, { data: alertsData, isLoading: alertsLoading }] = useCreateNotificationsqueryalertsMutation();
-
-  useEffect(() => {
-    const from = entry.timestamp;
-    const to = new Date(new Date(entry.timestamp).getTime() + 1000).toISOString();
-    queryAlerts({ createNotificationsqueryalertsRequestBody: { uuid: entry.uuid, from, to, limit: 10 } });
-  }, [entry.uuid, entry.timestamp, queryAlerts]);
-
-  const alerts = alertsData?.alerts ?? [];
-  const firingAlerts = alerts.filter(
-    (alert: CreateNotificationsqueryalertsNotificationEntryAlert) => alert.status === 'firing'
-  );
-  const resolvedAlerts = alerts.filter(
-    (alert: CreateNotificationsqueryalertsNotificationEntryAlert) => alert.status === 'resolved'
-  );
+  const {
+    alerts,
+    firingAlerts,
+    resolvedAlerts,
+    isLoading: alertsLoading,
+  } = useNotificationAlerts(entry.uuid, entry.timestamp);
 
   return (
     <Box padding={2}>
@@ -385,7 +376,7 @@ const NotificationExpandedContent = ({ entry }: NotificationExpandedContentProps
           <Stack direction="row" gap={0.5} alignItems="center">
             <Icon name="info-circle" size="xs" />
             <Text variant="bodySmall" color="secondary">
-              {t('alerting.notification-history.showing-alerts', 'Showing {{showing}} out of {{total}} alerts', {
+              {t('alerting.notification-history.showing-alerts', 'Showing {{ showing }} out of {{ total }} alerts', {
                 showing: alerts.length,
                 total: entry.alertCount,
               })}

--- a/public/app/features/alerting/unified/hooks/useNotificationAlerts.ts
+++ b/public/app/features/alerting/unified/hooks/useNotificationAlerts.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+import {
+  CreateNotificationsqueryalertsNotificationEntryAlert,
+  useCreateNotificationsqueryalertsMutation,
+} from '@grafana/api-clients/rtkq/historian.alerting/v0alpha1';
+
+const QUERY_ALERTS_LIMIT = 10;
+const QUERY_ALERTS_TIME_WINDOW_MS = 1000;
+
+export function useNotificationAlerts(uuid: string, timestamp: string) {
+  const [queryAlerts, { data: alertsData, isLoading }] = useCreateNotificationsqueryalertsMutation();
+
+  useEffect(() => {
+    const from = timestamp;
+    const to = new Date(new Date(timestamp).getTime() + QUERY_ALERTS_TIME_WINDOW_MS).toISOString();
+    queryAlerts({ createNotificationsqueryalertsRequestBody: { uuid, from, to, limit: QUERY_ALERTS_LIMIT } });
+  }, [uuid, timestamp, queryAlerts]);
+
+  const alerts = alertsData?.alerts ?? [];
+
+  const firingAlerts = alerts.filter(
+    (alert: CreateNotificationsqueryalertsNotificationEntryAlert) => alert.status === 'firing'
+  );
+  const resolvedAlerts = alerts.filter(
+    (alert: CreateNotificationsqueryalertsNotificationEntryAlert) => alert.status === 'resolved'
+  );
+
+  return { alerts, firingAlerts, resolvedAlerts, isLoading };
+}

--- a/public/app/features/alerting/unified/hooks/useNotificationAlerts.ts
+++ b/public/app/features/alerting/unified/hooks/useNotificationAlerts.ts
@@ -1,9 +1,6 @@
 import { useEffect } from 'react';
 
-import {
-  CreateNotificationsqueryalertsNotificationEntryAlert,
-  useCreateNotificationsqueryalertsMutation,
-} from '@grafana/api-clients/rtkq/historian.alerting/v0alpha1';
+import { useCreateNotificationsqueryalertsMutation } from '@grafana/api-clients/rtkq/historian.alerting/v0alpha1';
 
 const QUERY_ALERTS_LIMIT = 10;
 const QUERY_ALERTS_TIME_WINDOW_MS = 1000;
@@ -19,12 +16,8 @@ export function useNotificationAlerts(uuid: string, timestamp: string) {
 
   const alerts = alertsData?.alerts ?? [];
 
-  const firingAlerts = alerts.filter(
-    (alert: CreateNotificationsqueryalertsNotificationEntryAlert) => alert.status === 'firing'
-  );
-  const resolvedAlerts = alerts.filter(
-    (alert: CreateNotificationsqueryalertsNotificationEntryAlert) => alert.status === 'resolved'
-  );
+  const firingAlerts = alerts.filter((alert) => alert.status === 'firing');
+  const resolvedAlerts = alerts.filter((alert) => alert.status === 'resolved');
 
   return { alerts, firingAlerts, resolvedAlerts, isLoading };
 }

--- a/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
+++ b/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
@@ -107,15 +107,9 @@ export const NotificationsList = React.memo(function NotificationsList({
     } catch {
       // Error is handled by the RTK Query isError state
     }
-  }, [
-    timeRange?.from,
-    timeRange?.to,
-    statusFilter,
-    outcomeFilter,
-    receiverFilter,
-    labelFilter,
-    createNotificationQuery,
-  ]);
+    // Don't include createNotificationQuery in deps to avoid infinite loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [timeRange?.from?.unix(), timeRange?.to?.unix(), statusFilter, outcomeFilter, receiverFilter, labelFilter]);
 
   // Extract entries from API response (data is properly typed from the generated client)
   const entriesArray: NotificationEntry[] = React.useMemo(() => {

--- a/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
+++ b/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
@@ -9,7 +9,6 @@ import {
   CreateNotificationqueryNotificationEntry,
   CreateNotificationsqueryalertsNotificationEntryAlert,
   useCreateNotificationqueryMutation,
-  useCreateNotificationsqueryalertsMutation,
 } from '@grafana/api-clients/rtkq/historian.alerting/v0alpha1';
 import { GrafanaTheme2, TimeRange, dateTime } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -39,6 +38,7 @@ import {
 
 import { CollapseToggle } from '../components/CollapseToggle';
 import { StateTag } from '../components/StateTag';
+import { useNotificationAlerts } from '../hooks/useNotificationAlerts';
 import { usePagination } from '../hooks/usePagination';
 import { prometheusExpressionBuilder } from '../triage/scene/expressionBuilder';
 import { parsePromQLStyleMatcherLooseSafe } from '../utils/matchers';
@@ -261,7 +261,7 @@ function NotificationRow({ record, onLabelClick }: NotificationRowProps) {
       </div>
       {!isCollapsed && (
         <div className={styles.expandedRow}>
-          <NotificationDetails record={record} uuid={record.uuid} />
+          <NotificationDetails record={record} />
         </div>
       )}
     </Stack>
@@ -283,29 +283,17 @@ function NotificationState({ status }: NotificationStateProps) {
 
 interface NotificationDetailsProps {
   record: NotificationEntry;
-  uuid: string;
 }
 
-function NotificationDetails({ record, uuid }: NotificationDetailsProps) {
+function NotificationDetails({ record }: NotificationDetailsProps) {
   const styles = useStyles2(getStyles);
 
-  const [queryAlerts, { data: alertsData, isLoading: alertsLoading }] = useCreateNotificationsqueryalertsMutation();
-
-  React.useEffect(() => {
-    const from = record.timestamp;
-    const to = new Date(new Date(record.timestamp).getTime() + 1000).toISOString();
-    queryAlerts({ createNotificationsqueryalertsRequestBody: { uuid, from, to, limit: 10 } });
-  }, [uuid, record.timestamp, queryAlerts]);
-
-  const alerts = alertsData?.alerts ?? [];
-
-  // Split alerts into firing and resolved
-  const firingAlerts = alerts.filter(
-    (alert: CreateNotificationsqueryalertsNotificationEntryAlert) => alert.status === 'firing'
-  );
-  const resolvedAlerts = alerts.filter(
-    (alert: CreateNotificationsqueryalertsNotificationEntryAlert) => alert.status === 'resolved'
-  );
+  const {
+    alerts,
+    firingAlerts,
+    resolvedAlerts,
+    isLoading: alertsLoading,
+  } = useNotificationAlerts(record.uuid, record.timestamp);
 
   const renderAlert = (alert: CreateNotificationsqueryalertsNotificationEntryAlert, index: number) => {
     const ruleUid = alert.labels?.__alert_rule_uid__;

--- a/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
+++ b/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
@@ -7,8 +7,9 @@ import { AlertLabels } from '@grafana/alerting/unstable';
 import {
   CreateNotificationqueryMatcher,
   CreateNotificationqueryNotificationEntry,
-  CreateNotificationqueryNotificationEntryAlert,
+  CreateNotificationsqueryalertsNotificationEntryAlert,
   useCreateNotificationqueryMutation,
+  useCreateNotificationsqueryalertsMutation,
 } from '@grafana/api-clients/rtkq/historian.alerting/v0alpha1';
 import { GrafanaTheme2, TimeRange, dateTime } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -24,8 +25,10 @@ import {
 import {
   Alert,
   Badge,
+  Icon,
   LoadingBar,
   Pagination,
+  Spinner,
   Stack,
   Text,
   TextLink,
@@ -94,7 +97,7 @@ export const NotificationsList = React.memo(function NotificationsList({
         createNotificationqueryRequestBody: {
           from: fromDate,
           to: toDate,
-          limit: 1000,
+          limit: 100,
           status: isNotificationStatus(statusFilter) ? statusFilter : undefined,
           outcome: isNotificationOutcome(outcomeFilter) ? outcomeFilter : undefined,
           receiver: receiverFilter && receiverFilter !== 'all' ? receiverFilter : undefined,
@@ -258,7 +261,7 @@ function NotificationRow({ record, onLabelClick }: NotificationRowProps) {
       </div>
       {!isCollapsed && (
         <div className={styles.expandedRow}>
-          <NotificationDetails record={record} />
+          <NotificationDetails record={record} uuid={record.uuid} />
         </div>
       )}
     </Stack>
@@ -280,20 +283,31 @@ function NotificationState({ status }: NotificationStateProps) {
 
 interface NotificationDetailsProps {
   record: NotificationEntry;
+  uuid: string;
 }
 
-function NotificationDetails({ record }: NotificationDetailsProps) {
+function NotificationDetails({ record, uuid }: NotificationDetailsProps) {
   const styles = useStyles2(getStyles);
 
+  const [queryAlerts, { data: alertsData, isLoading: alertsLoading }] = useCreateNotificationsqueryalertsMutation();
+
+  React.useEffect(() => {
+    const from = record.timestamp;
+    const to = new Date(new Date(record.timestamp).getTime() + 1000).toISOString();
+    queryAlerts({ createNotificationsqueryalertsRequestBody: { uuid, from, to, limit: 10 } });
+  }, [uuid, record.timestamp, queryAlerts]);
+
+  const alerts = alertsData?.alerts ?? [];
+
   // Split alerts into firing and resolved
-  const firingAlerts = record.alerts.filter(
-    (alert: CreateNotificationqueryNotificationEntryAlert) => alert.status === 'firing'
+  const firingAlerts = alerts.filter(
+    (alert: CreateNotificationsqueryalertsNotificationEntryAlert) => alert.status === 'firing'
   );
-  const resolvedAlerts = record.alerts.filter(
-    (alert: CreateNotificationqueryNotificationEntryAlert) => alert.status === 'resolved'
+  const resolvedAlerts = alerts.filter(
+    (alert: CreateNotificationsqueryalertsNotificationEntryAlert) => alert.status === 'resolved'
   );
 
-  const renderAlert = (alert: CreateNotificationqueryNotificationEntryAlert, index: number) => {
+  const renderAlert = (alert: CreateNotificationsqueryalertsNotificationEntryAlert, index: number) => {
     const ruleUid = alert.labels?.__alert_rule_uid__;
     const alertName = alert.labels?.alertname || 'Alert';
     const folderName = alert.labels?.grafana_folder || '';
@@ -395,13 +409,25 @@ function NotificationDetails({ record }: NotificationDetailsProps) {
           {record.error}
         </Alert>
       )}
+      {alertsLoading && <Spinner />}
+      {!alertsLoading && alerts.length < record.alertCount && (
+        <Stack direction="row" gap={0.5} alignItems="center">
+          <Icon name="info-circle" size="xs" />
+          <Text variant="bodySmall" color="secondary">
+            <Trans
+              i18nKey="alerting.notifications-scene.showing-alerts"
+              values={{ showing: alerts.length, total: record.alertCount }}
+            >
+              {'Showing {{ showing }} out of {{ total }} alerts'}
+            </Trans>
+          </Text>
+        </Stack>
+      )}
       {/* Firing alerts section */}
       {firingAlerts.length > 0 && (
         <Stack direction="column" gap={2}>
           <Text variant="h6">
-            <Trans i18nKey="alerting.notifications-scene.firing-alerts" values={{ count: firingAlerts.length }}>
-              Firing Alerts ({{ count: firingAlerts.length }})
-            </Trans>
+            <Trans i18nKey="alerting.notifications-scene.firing-alerts">Firing Alerts</Trans>
           </Text>
           {firingAlerts.map(renderAlert)}
         </Stack>
@@ -410,9 +436,7 @@ function NotificationDetails({ record }: NotificationDetailsProps) {
       {resolvedAlerts.length > 0 && (
         <Stack direction="column" gap={2}>
           <Text variant="h6">
-            <Trans i18nKey="alerting.notifications-scene.resolved-alerts" values={{ count: resolvedAlerts.length }}>
-              Resolved Alerts ({{ count: resolvedAlerts.length }})
-            </Trans>
+            <Trans i18nKey="alerting.notifications-scene.resolved-alerts">Resolved Alerts</Trans>
           </Text>
           {resolvedAlerts.map(renderAlert)}
         </Stack>

--- a/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
+++ b/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
@@ -107,9 +107,15 @@ export const NotificationsList = React.memo(function NotificationsList({
     } catch {
       // Error is handled by the RTK Query isError state
     }
-    // Don't include createNotificationQuery in deps to avoid infinite loop
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [timeRange?.from?.unix(), timeRange?.to?.unix(), statusFilter, outcomeFilter, receiverFilter, labelFilter]);
+  }, [
+    timeRange?.from,
+    timeRange?.to,
+    statusFilter,
+    outcomeFilter,
+    receiverFilter,
+    labelFilter,
+    createNotificationQuery,
+  ]);
 
   // Extract entries from API response (data is properly typed from the generated client)
   const entriesArray: NotificationEntry[] = React.useMemo(() => {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2173,8 +2173,7 @@
         "status": "Status",
         "tooltip": "Use label matcher expression or click on a group label to filter instances, for example:"
       },
-      "firing-alerts_one": "Firing Alerts ({{count}})",
-      "firing-alerts_other": "Firing Alerts ({{count}})",
+      "firing-alerts": "Firing Alerts",
       "labels": "Labels:",
       "loading": "Loading notifications...",
       "notification-error": "Notification Error",
@@ -2182,8 +2181,8 @@
         "failed": "Failed",
         "success": "Success"
       },
-      "resolved-alerts_one": "Resolved Alerts ({{count}})",
-      "resolved-alerts_other": "Resolved Alerts ({{count}})",
+      "resolved-alerts": "Resolved Alerts",
+      "showing-alerts": "Showing {{showing}} out of {{total}} alerts",
       "started": "Started:",
       "status": {
         "firing": "Firing",
@@ -2279,8 +2278,7 @@
         "clear": "Clear filters"
       },
       "filterBy": "Filter by:",
-      "firing-alerts_one": "Firing Alerts ({{count}})",
-      "firing-alerts_other": "Firing Alerts ({{count}})",
+      "firing-alerts": "Firing Alerts",
       "header": {
         "contact-point": "Contact point",
         "group-labels": "Group Labels",
@@ -2304,8 +2302,8 @@
           "receiver": "Contact point:"
         }
       },
-      "resolved-alerts_one": "Resolved Alerts ({{count}})",
-      "resolved-alerts_other": "Resolved Alerts ({{count}})",
+      "resolved-alerts": "Resolved Alerts",
+      "showing-alerts": "Showing {{ showing }} out of {{ total }} alerts",
       "started": "Started: {{value}}",
       "status-filter-variable": {
         "label": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2182,7 +2182,7 @@
         "success": "Success"
       },
       "resolved-alerts": "Resolved Alerts",
-      "showing-alerts": "Showing {{showing}} out of {{total}} alerts",
+      "showing-alerts": "Showing {{ showing }} out of {{ total }} alerts",
       "started": "Started:",
       "status": {
         "firing": "Firing",


### PR DESCRIPTION
- Switch alert detail fetching to use the new `queryalerts` API endpoint instead of inline alert data from notification entries
- Add loading spinner while fetching alert details on row expansion
- Show an info message when displayed alerts are fewer than the total alert count (truncated results)
- Remove alert counts from "Firing Alerts" and "Resolved Alerts" section headings
- Reduce notification list query limit from 1000 to 100

