### PR TITLE
Provisioning: Map nanogit HTTP errors in files endpoint

### DIFF
--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -766,7 +766,7 @@ func (r *gitRepository) resolveRefToHash(ctx context.Context, ref string) (hash.
 		if errors.Is(err, nanogit.ErrObjectNotFound) {
 			return hash.Zero, fmt.Errorf("ref not found: %s: %w", ref, repository.ErrRefNotFound)
 		}
-		return hash.Zero, fmt.Errorf("get ref %s: %w", ref, err)
+		return hash.Zero, fmt.Errorf("get ref %s: %w", ref, mapNanogitError(err))
 	}
 
 	return branchRef.Hash, nil

--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -294,7 +294,7 @@ func (r *gitRepository) Read(ctx context.Context, filePath, ref string) (*reposi
 	// TODO: Fix GetTree in nanogit as it does not work commit hash
 	commit, err := r.client.GetCommit(ctx, refHash)
 	if err != nil {
-		return nil, fmt.Errorf("get commit: %w", err)
+		return nil, fmt.Errorf("get commit: %w", mapNanogitError(err))
 	}
 
 	// Check if the path represents a directory
@@ -307,7 +307,7 @@ func (r *gitRepository) Read(ctx context.Context, filePath, ref string) (*reposi
 				return nil, repository.ErrFileNotFound
 			}
 
-			return nil, fmt.Errorf("get tree by path: %w", err)
+			return nil, fmt.Errorf("get tree by path: %w", mapNanogitError(err))
 		}
 
 		return &repository.FileInfo{
@@ -323,7 +323,7 @@ func (r *gitRepository) Read(ctx context.Context, filePath, ref string) (*reposi
 			return nil, repository.ErrFileNotFound
 		}
 
-		return nil, fmt.Errorf("read blob: %w", err)
+		return nil, fmt.Errorf("read blob: %w", mapNanogitError(err))
 	}
 
 	return &repository.FileInfo{
@@ -349,7 +349,7 @@ func (r *gitRepository) ReadTree(ctx context.Context, ref string) ([]repository.
 		if errors.Is(err, nanogit.ErrObjectNotFound) {
 			return nil, repository.ErrRefNotFound
 		}
-		return nil, fmt.Errorf("get flat tree: %w", err)
+		return nil, fmt.Errorf("get flat tree: %w", mapNanogitError(err))
 	}
 
 	entries := make([]repository.FileTreeEntry, 0, len(tree.Entries))
@@ -391,7 +391,7 @@ func (r *gitRepository) Create(ctx context.Context, path, ref string, data []byt
 
 	writer, err := r.client.NewStagedWriter(ctx, branchRef)
 	if err != nil {
-		return fmt.Errorf("create staged writer: %w", err)
+		return fmt.Errorf("create staged writer: %w", mapNanogitError(err))
 	}
 
 	if err := r.create(ctx, path, data, writer); err != nil {
@@ -418,7 +418,7 @@ func (r *gitRepository) create(ctx context.Context, path string, data []byte, wr
 			return repository.ErrFileAlreadyExists
 		}
 
-		return fmt.Errorf("create blob: %w", err)
+		return fmt.Errorf("create blob: %w", mapNanogitError(err))
 	}
 
 	return nil
@@ -442,7 +442,7 @@ func (r *gitRepository) Update(ctx context.Context, path, ref string, data []byt
 	// Create a staged writer
 	writer, err := r.client.NewStagedWriter(ctx, branchRef)
 	if err != nil {
-		return fmt.Errorf("create staged writer: %w", err)
+		return fmt.Errorf("create staged writer: %w", mapNanogitError(err))
 	}
 
 	if err := r.update(ctx, path, data, writer); err != nil {
@@ -464,7 +464,7 @@ func (r *gitRepository) update(ctx context.Context, path string, data []byte, wr
 			return repository.ErrFileNotFound
 		}
 
-		return fmt.Errorf("update blob: %w", err)
+		return fmt.Errorf("update blob: %w", mapNanogitError(err))
 	}
 
 	return nil
@@ -504,7 +504,7 @@ func (r *gitRepository) Delete(ctx context.Context, path, ref, comment string) e
 	// Create a staged writer
 	writer, err := r.client.NewStagedWriter(ctx, branchRef)
 	if err != nil {
-		return fmt.Errorf("create staged writer: %w", err)
+		return fmt.Errorf("create staged writer: %w", mapNanogitError(err))
 	}
 
 	if err := r.delete(ctx, path, writer); err != nil {
@@ -528,7 +528,7 @@ func (r *gitRepository) Move(ctx context.Context, oldPath, newPath, ref, comment
 	// Create a staged writer
 	writer, err := r.client.NewStagedWriter(ctx, branchRef)
 	if err != nil {
-		return fmt.Errorf("create staged writer: %w", err)
+		return fmt.Errorf("create staged writer: %w", mapNanogitError(err))
 	}
 
 	if err := r.move(ctx, oldPath, newPath, writer); err != nil {
@@ -547,14 +547,14 @@ func (r *gitRepository) delete(ctx context.Context, path string, writer nanogit.
 			if errors.Is(err, nanogit.ErrObjectNotFound) {
 				return repository.ErrFileNotFound
 			}
-			return fmt.Errorf("delete tree: %w", err)
+			return fmt.Errorf("delete tree: %w", mapNanogitError(err))
 		}
 	} else {
 		if _, err := writer.DeleteBlob(ctx, finalPath); err != nil {
 			if errors.Is(err, nanogit.ErrObjectNotFound) {
 				return repository.ErrFileNotFound
 			}
-			return fmt.Errorf("delete blob: %w", err)
+			return fmt.Errorf("delete blob: %w", mapNanogitError(err))
 		}
 	}
 
@@ -578,7 +578,7 @@ func (r *gitRepository) move(ctx context.Context, oldPath, newPath string, write
 			if errors.Is(err, nanogit.ErrObjectAlreadyExists) {
 				return repository.ErrFileAlreadyExists
 			}
-			return fmt.Errorf("move tree: %w", err)
+			return fmt.Errorf("move tree: %w", mapNanogitError(err))
 		}
 	} else if !safepath.IsDir(oldPath) && !safepath.IsDir(newPath) {
 		// For files, use MoveBlob operation
@@ -589,7 +589,7 @@ func (r *gitRepository) move(ctx context.Context, oldPath, newPath string, write
 			if errors.Is(err, nanogit.ErrObjectAlreadyExists) {
 				return repository.ErrFileAlreadyExists
 			}
-			return fmt.Errorf("move blob: %w", err)
+			return fmt.Errorf("move blob: %w", mapNanogitError(err))
 		}
 	} else {
 		// Mismatched types (file to directory or vice versa)
@@ -867,7 +867,7 @@ func (r *gitRepository) commitAndPush(ctx context.Context, writer nanogit.Staged
 	}
 
 	if err := writer.Push(ctx); err != nil {
-		return fmt.Errorf("push changes: %w", err)
+		return fmt.Errorf("push changes: %w", mapNanogitError(err))
 	}
 
 	return nil

--- a/apps/provisioning/pkg/repository/git/repository_file_operations_error_test.go
+++ b/apps/provisioning/pkg/repository/git/repository_file_operations_error_test.go
@@ -1,0 +1,533 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/nanogit"
+	"github.com/grafana/nanogit/mocks"
+	"github.com/grafana/nanogit/protocol/client"
+	"github.com/grafana/nanogit/protocol/hash"
+)
+
+// TestFileOperations_HTTPErrorMapping verifies that HTTP auth/permission errors
+// from nanogit are properly mapped to repository errors with correct status codes
+func TestFileOperations_HTTPErrorMapping(t *testing.T) {
+	testCases := []struct {
+		name           string
+		nanogitError   error
+		wantStatusCode int32
+		wantRepoError  error
+	}{
+		{
+			name:           "unauthorized (401) error",
+			nanogitError:   client.NewUnauthorizedError("GET", "/info/refs", nil),
+			wantStatusCode: http.StatusUnauthorized,
+			wantRepoError:  repository.ErrUnauthorized,
+		},
+		{
+			name:           "permission denied (403) error",
+			nanogitError:   client.NewPermissionDeniedError("POST", "/git-receive-pack", nil),
+			wantStatusCode: http.StatusForbidden,
+			wantRepoError:  repository.ErrPermissionDenied,
+		},
+		{
+			name:           "server unavailable (503) error",
+			nanogitError:   client.NewServerUnavailableError("GET", 503, nil),
+			wantStatusCode: http.StatusServiceUnavailable,
+			wantRepoError:  repository.ErrServerUnavailable,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test Read operation
+			t.Run("Read", func(t *testing.T) {
+				mockClient := &mocks.FakeClient{}
+				mockClient.GetRefReturns(nanogit.Ref{
+					Name: "refs/heads/main",
+					Hash: hash.Hash{},
+				}, nil)
+				mockClient.GetCommitReturns(nil, tc.nanogitError)
+
+				gitRepo := &gitRepository{
+					client: mockClient,
+					gitConfig: RepositoryConfig{
+						Branch: "main",
+						Path:   "configs",
+					},
+					config: &provisioning.Repository{
+						Spec: provisioning.RepositorySpec{
+							Type: provisioning.GitHubRepositoryType,
+						},
+					},
+				}
+
+				_, err := gitRepo.Read(context.Background(), "test.yaml", "main")
+				verifyHTTPError(t, err, tc.wantRepoError, tc.wantStatusCode)
+			})
+
+			// Test ReadTree operation
+			t.Run("ReadTree", func(t *testing.T) {
+				mockClient := &mocks.FakeClient{}
+				mockClient.GetRefReturns(nanogit.Ref{
+					Name: "refs/heads/main",
+					Hash: hash.Hash{},
+				}, tc.nanogitError)
+
+				gitRepo := &gitRepository{
+					client: mockClient,
+					gitConfig: RepositoryConfig{
+						Branch: "main",
+						Path:   "configs",
+					},
+					config: &provisioning.Repository{
+						Spec: provisioning.RepositorySpec{
+							Type: provisioning.GitHubRepositoryType,
+						},
+					},
+				}
+
+				_, err := gitRepo.ReadTree(context.Background(), "main")
+				verifyHTTPError(t, err, tc.wantRepoError, tc.wantStatusCode)
+			})
+
+			// Test Create operation - NewStagedWriter error
+			t.Run("Create_StagedWriter", func(t *testing.T) {
+				mockClient := &mocks.FakeClient{}
+				mockClient.GetRefReturns(nanogit.Ref{
+					Name: "refs/heads/main",
+					Hash: hash.Hash{},
+				}, nil)
+				mockClient.NewStagedWriterReturns(nil, tc.nanogitError)
+
+				gitRepo := &gitRepository{
+					client: mockClient,
+					gitConfig: RepositoryConfig{
+						Branch: "main",
+						Path:   "configs",
+					},
+					config: &provisioning.Repository{
+						Spec: provisioning.RepositorySpec{
+							Type: provisioning.GitHubRepositoryType,
+						},
+					},
+				}
+
+				err := gitRepo.Create(context.Background(), "test.yaml", "main", []byte("data"), "commit")
+				verifyHTTPError(t, err, tc.wantRepoError, tc.wantStatusCode)
+			})
+
+			// Test Create operation - Push error
+			t.Run("Create_Push", func(t *testing.T) {
+				mockClient := &mocks.FakeClient{}
+				mockClient.GetRefReturns(nanogit.Ref{
+					Name: "refs/heads/main",
+					Hash: hash.Hash{},
+				}, nil)
+				mockWriter := &mocks.FakeStagedWriter{}
+				mockWriter.CreateBlobReturns(hash.Hash{}, nil)
+				mockWriter.CommitReturns(&nanogit.Commit{}, nil)
+				mockWriter.PushReturns(tc.nanogitError)
+				mockClient.NewStagedWriterReturns(mockWriter, nil)
+
+				gitRepo := &gitRepository{
+					client: mockClient,
+					gitConfig: RepositoryConfig{
+						Branch: "main",
+						Path:   "configs",
+					},
+					config: &provisioning.Repository{
+						Spec: provisioning.RepositorySpec{
+							Type: provisioning.GitHubRepositoryType,
+						},
+					},
+				}
+
+				err := gitRepo.Create(context.Background(), "test.yaml", "main", []byte("data"), "commit")
+				verifyHTTPError(t, err, tc.wantRepoError, tc.wantStatusCode)
+			})
+
+			// Test Update operation - NewStagedWriter error
+			t.Run("Update_StagedWriter", func(t *testing.T) {
+				mockClient := &mocks.FakeClient{}
+				mockClient.GetRefReturns(nanogit.Ref{
+					Name: "refs/heads/main",
+					Hash: hash.Hash{},
+				}, nil)
+				mockClient.NewStagedWriterReturns(nil, tc.nanogitError)
+
+				gitRepo := &gitRepository{
+					client: mockClient,
+					gitConfig: RepositoryConfig{
+						Branch: "main",
+						Path:   "configs",
+					},
+					config: &provisioning.Repository{
+						Spec: provisioning.RepositorySpec{
+							Type: provisioning.GitHubRepositoryType,
+						},
+					},
+				}
+
+				err := gitRepo.Update(context.Background(), "test.yaml", "main", []byte("data"), "commit")
+				verifyHTTPError(t, err, tc.wantRepoError, tc.wantStatusCode)
+			})
+
+			// Test Update operation - Push error
+			t.Run("Update_Push", func(t *testing.T) {
+				mockClient := &mocks.FakeClient{}
+				mockClient.GetRefReturns(nanogit.Ref{
+					Name: "refs/heads/main",
+					Hash: hash.Hash{},
+				}, nil)
+				mockWriter := &mocks.FakeStagedWriter{}
+				mockWriter.UpdateBlobReturns(hash.Hash{}, nil)
+				mockWriter.CommitReturns(&nanogit.Commit{}, nil)
+				mockWriter.PushReturns(tc.nanogitError)
+				mockClient.NewStagedWriterReturns(mockWriter, nil)
+
+				gitRepo := &gitRepository{
+					client: mockClient,
+					gitConfig: RepositoryConfig{
+						Branch: "main",
+						Path:   "configs",
+					},
+					config: &provisioning.Repository{
+						Spec: provisioning.RepositorySpec{
+							Type: provisioning.GitHubRepositoryType,
+						},
+					},
+				}
+
+				err := gitRepo.Update(context.Background(), "test.yaml", "main", []byte("data"), "commit")
+				verifyHTTPError(t, err, tc.wantRepoError, tc.wantStatusCode)
+			})
+
+			// Test Delete operation - NewStagedWriter error
+			t.Run("Delete_StagedWriter", func(t *testing.T) {
+				mockClient := &mocks.FakeClient{}
+				mockClient.GetRefReturns(nanogit.Ref{
+					Name: "refs/heads/main",
+					Hash: hash.Hash{},
+				}, nil)
+				mockClient.NewStagedWriterReturns(nil, tc.nanogitError)
+
+				gitRepo := &gitRepository{
+					client: mockClient,
+					gitConfig: RepositoryConfig{
+						Branch: "main",
+						Path:   "configs",
+					},
+					config: &provisioning.Repository{
+						Spec: provisioning.RepositorySpec{
+							Type: provisioning.GitHubRepositoryType,
+						},
+					},
+				}
+
+				err := gitRepo.Delete(context.Background(), "test.yaml", "main", "commit")
+				verifyHTTPError(t, err, tc.wantRepoError, tc.wantStatusCode)
+			})
+
+			// Test Delete operation - Push error
+			t.Run("Delete_Push", func(t *testing.T) {
+				mockClient := &mocks.FakeClient{}
+				mockClient.GetRefReturns(nanogit.Ref{
+					Name: "refs/heads/main",
+					Hash: hash.Hash{},
+				}, nil)
+				mockWriter := &mocks.FakeStagedWriter{}
+				mockWriter.DeleteBlobReturns(hash.Hash{}, nil)
+				mockWriter.CommitReturns(&nanogit.Commit{}, nil)
+				mockWriter.PushReturns(tc.nanogitError)
+				mockClient.NewStagedWriterReturns(mockWriter, nil)
+
+				gitRepo := &gitRepository{
+					client: mockClient,
+					gitConfig: RepositoryConfig{
+						Branch: "main",
+						Path:   "configs",
+					},
+					config: &provisioning.Repository{
+						Spec: provisioning.RepositorySpec{
+							Type: provisioning.GitHubRepositoryType,
+						},
+					},
+				}
+
+				err := gitRepo.Delete(context.Background(), "test.yaml", "main", "commit")
+				verifyHTTPError(t, err, tc.wantRepoError, tc.wantStatusCode)
+			})
+
+			// Test Move operation - NewStagedWriter error
+			t.Run("Move_StagedWriter", func(t *testing.T) {
+				mockClient := &mocks.FakeClient{}
+				mockClient.GetRefReturns(nanogit.Ref{
+					Name: "refs/heads/main",
+					Hash: hash.Hash{},
+				}, nil)
+				mockClient.NewStagedWriterReturns(nil, tc.nanogitError)
+
+				gitRepo := &gitRepository{
+					client: mockClient,
+					gitConfig: RepositoryConfig{
+						Branch: "main",
+						Path:   "configs",
+					},
+					config: &provisioning.Repository{
+						Spec: provisioning.RepositorySpec{
+							Type: provisioning.GitHubRepositoryType,
+						},
+					},
+				}
+
+				err := gitRepo.Move(context.Background(), "old.yaml", "new.yaml", "main", "commit")
+				verifyHTTPError(t, err, tc.wantRepoError, tc.wantStatusCode)
+			})
+
+			// Test Move operation - Push error
+			t.Run("Move_Push", func(t *testing.T) {
+				mockClient := &mocks.FakeClient{}
+				mockClient.GetRefReturns(nanogit.Ref{
+					Name: "refs/heads/main",
+					Hash: hash.Hash{},
+				}, nil)
+				mockWriter := &mocks.FakeStagedWriter{}
+				mockWriter.MoveBlobReturns(hash.Hash{}, nil)
+				mockWriter.CommitReturns(&nanogit.Commit{}, nil)
+				mockWriter.PushReturns(tc.nanogitError)
+				mockClient.NewStagedWriterReturns(mockWriter, nil)
+
+				gitRepo := &gitRepository{
+					client: mockClient,
+					gitConfig: RepositoryConfig{
+						Branch: "main",
+						Path:   "configs",
+					},
+					config: &provisioning.Repository{
+						Spec: provisioning.RepositorySpec{
+							Type: provisioning.GitHubRepositoryType,
+						},
+					},
+				}
+
+				err := gitRepo.Move(context.Background(), "old.yaml", "new.yaml", "main", "commit")
+				verifyHTTPError(t, err, tc.wantRepoError, tc.wantStatusCode)
+			})
+		})
+	}
+}
+
+// verifyHTTPError checks that an error wraps the expected repository error
+// and has the correct HTTP status code
+func verifyHTTPError(t *testing.T, err error, wantRepoError error, wantStatusCode int32) {
+	t.Helper()
+
+	require.Error(t, err, "expected an error")
+	require.ErrorIs(t, err, wantRepoError, "error should wrap the expected repository error")
+
+	// Verify HTTP status code using k8s StatusError interface
+	var statusErr apierrors.APIStatus
+	if errors.As(err, &statusErr) {
+		require.Equal(t, wantStatusCode, statusErr.Status().Code,
+			"mapped error should have correct HTTP status code")
+	} else {
+		t.Fatalf("error should implement APIStatus interface, got: %T", err)
+	}
+}
+
+// TestFileOperations_PreservesSpecificErrorHandling verifies that specific
+// error handling (like ErrObjectNotFound -> ErrFileNotFound) is preserved
+func TestFileOperations_PreservesSpecificErrorHandling(t *testing.T) {
+	t.Run("Read preserves ErrFileNotFound", func(t *testing.T) {
+		mockClient := &mocks.FakeClient{}
+		mockClient.GetRefReturns(nanogit.Ref{
+			Name: "refs/heads/main",
+			Hash: hash.Hash{},
+		}, nil)
+		mockClient.GetCommitReturns(&nanogit.Commit{
+			Tree: hash.Hash{},
+		}, nil)
+		mockClient.GetBlobByPathReturns(nil, nanogit.ErrObjectNotFound)
+
+		gitRepo := &gitRepository{
+			client: mockClient,
+			gitConfig: RepositoryConfig{
+				Branch: "main",
+				Path:   "configs",
+			},
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+				},
+			},
+		}
+
+		_, err := gitRepo.Read(context.Background(), "missing.yaml", "main")
+		require.ErrorIs(t, err, repository.ErrFileNotFound)
+	})
+
+	t.Run("ReadTree preserves ErrRefNotFound", func(t *testing.T) {
+		mockClient := &mocks.FakeClient{}
+		mockClient.GetRefReturns(nanogit.Ref{}, nanogit.ErrObjectNotFound)
+
+		gitRepo := &gitRepository{
+			client: mockClient,
+			gitConfig: RepositoryConfig{
+				Branch: "main",
+				Path:   "configs",
+			},
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+				},
+			},
+		}
+
+		_, err := gitRepo.ReadTree(context.Background(), "main")
+		require.ErrorIs(t, err, repository.ErrRefNotFound)
+	})
+
+	t.Run("Create preserves ErrFileAlreadyExists", func(t *testing.T) {
+		mockClient := &mocks.FakeClient{}
+		mockClient.GetRefReturns(nanogit.Ref{
+			Name: "refs/heads/main",
+			Hash: hash.Hash{},
+		}, nil)
+		mockWriter := &mocks.FakeStagedWriter{}
+		mockWriter.CreateBlobReturns(hash.Hash{}, nanogit.ErrObjectAlreadyExists)
+		mockClient.NewStagedWriterReturns(mockWriter, nil)
+
+		gitRepo := &gitRepository{
+			client: mockClient,
+			gitConfig: RepositoryConfig{
+				Branch: "main",
+				Path:   "configs",
+			},
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+				},
+			},
+		}
+
+		err := gitRepo.Create(context.Background(), "existing.yaml", "main", []byte("data"), "commit")
+		require.ErrorIs(t, err, repository.ErrFileAlreadyExists)
+	})
+
+	t.Run("Update preserves ErrFileNotFound", func(t *testing.T) {
+		mockClient := &mocks.FakeClient{}
+		mockClient.GetRefReturns(nanogit.Ref{
+			Name: "refs/heads/main",
+			Hash: hash.Hash{},
+		}, nil)
+		mockWriter := &mocks.FakeStagedWriter{}
+		mockWriter.UpdateBlobReturns(hash.Hash{}, nanogit.ErrObjectNotFound)
+		mockClient.NewStagedWriterReturns(mockWriter, nil)
+
+		gitRepo := &gitRepository{
+			client: mockClient,
+			gitConfig: RepositoryConfig{
+				Branch: "main",
+				Path:   "configs",
+			},
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+				},
+			},
+		}
+
+		err := gitRepo.Update(context.Background(), "missing.yaml", "main", []byte("data"), "commit")
+		require.ErrorIs(t, err, repository.ErrFileNotFound)
+	})
+
+	t.Run("Delete preserves ErrFileNotFound", func(t *testing.T) {
+		mockClient := &mocks.FakeClient{}
+		mockClient.GetRefReturns(nanogit.Ref{
+			Name: "refs/heads/main",
+			Hash: hash.Hash{},
+		}, nil)
+		mockWriter := &mocks.FakeStagedWriter{}
+		mockWriter.DeleteBlobReturns(hash.Hash{}, nanogit.ErrObjectNotFound)
+		mockClient.NewStagedWriterReturns(mockWriter, nil)
+
+		gitRepo := &gitRepository{
+			client: mockClient,
+			gitConfig: RepositoryConfig{
+				Branch: "main",
+				Path:   "configs",
+			},
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+				},
+			},
+		}
+
+		err := gitRepo.Delete(context.Background(), "missing.yaml", "main", "commit")
+		require.ErrorIs(t, err, repository.ErrFileNotFound)
+	})
+
+	t.Run("Move preserves ErrFileNotFound", func(t *testing.T) {
+		mockClient := &mocks.FakeClient{}
+		mockClient.GetRefReturns(nanogit.Ref{
+			Name: "refs/heads/main",
+			Hash: hash.Hash{},
+		}, nil)
+		mockWriter := &mocks.FakeStagedWriter{}
+		mockWriter.MoveBlobReturns(hash.Hash{}, nanogit.ErrObjectNotFound)
+		mockClient.NewStagedWriterReturns(mockWriter, nil)
+
+		gitRepo := &gitRepository{
+			client: mockClient,
+			gitConfig: RepositoryConfig{
+				Branch: "main",
+				Path:   "configs",
+			},
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+				},
+			},
+		}
+
+		err := gitRepo.Move(context.Background(), "missing.yaml", "new.yaml", "main", "commit")
+		require.ErrorIs(t, err, repository.ErrFileNotFound)
+	})
+
+	t.Run("Move preserves ErrFileAlreadyExists", func(t *testing.T) {
+		mockClient := &mocks.FakeClient{}
+		mockClient.GetRefReturns(nanogit.Ref{
+			Name: "refs/heads/main",
+			Hash: hash.Hash{},
+		}, nil)
+		mockWriter := &mocks.FakeStagedWriter{}
+		mockWriter.MoveBlobReturns(hash.Hash{}, nanogit.ErrObjectAlreadyExists)
+		mockClient.NewStagedWriterReturns(mockWriter, nil)
+
+		gitRepo := &gitRepository{
+			client: mockClient,
+			gitConfig: RepositoryConfig{
+				Branch: "main",
+				Path:   "configs",
+			},
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+				},
+			},
+		}
+
+		err := gitRepo.Move(context.Background(), "old.yaml", "existing.yaml", "main", "commit")
+		require.ErrorIs(t, err, repository.ErrFileAlreadyExists)
+	})
+}


### PR DESCRIPTION
This commit improves error handling for provisioning repository file operations by properly mapping nanogit v0.4.0's structured HTTP authentication and permission errors to appropriate HTTP status codes.

## Changes

1. **Added new repository error types:**
   - `ErrUnauthorized` (HTTP 401) - authentication failed
   - `ErrPermissionDenied` (HTTP 403) - insufficient permissions
   - `ErrServerUnavailable` (HTTP 503) - server unavailable

2. **Added `mapNanogitError()` helper function:**
   - Converts nanogit client errors to repository errors
   - Maintains abstraction boundary
   - Uses errors.Is() with nanogit sentinel errors

3. **Wrapped all nanogit client calls with error mapping:**
   - Read(), ReadTree() - read operations
   - Create(), Update(), Delete(), Move() - write operations
   - commitAndPush(), GetDefaultBranch() - supporting operations
   - Existing specific error handling preserved (e.g., ErrObjectNotFound)

## Error Flow

```
nanogit client error
    ↓
mapNanogitError() → repository.ErrUnauthorized (HTTP 401)
    ↓
files endpoint propagates error
    ↓
respondWithError() unwraps StatusError
    ↓
HTTP 401/403/503 response to client
```

## Benefits

- Files endpoint returns proper HTTP status codes for auth/permission errors
- Clients can distinguish between auth failure (401), permission denied (403), and server unavailable (503)
- Existing error handling maintained (e.g., file not found → 404)
- Foundation for consistent error handling across all endpoints

## Part of nanogit v0.4.0 structured error handling implementation

This is **PR 2 of 3** - applies proper error handling to the files endpoint.

**Depends on:** PR 1 (health checks) - merge that first

## Test Plan

- [x] Unit tests pass
- [x] Package builds without errors
- [ ] Integration testing with invalid credentials returns HTTP 401 on file read
- [ ] Integration testing with read-only token returns HTTP 403 on file write
- [ ] Integration testing with server errors returns HTTP 503
- [ ] File not found still returns HTTP 404 (regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)