### PR TITLE
QueryEditor: Query options feature parity with datasource-specific fields

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorDetailsSidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorDetailsSidebar.tsx
@@ -12,6 +12,7 @@ import {
   useQueryEditorUIContext,
   useQueryRunnerContext,
 } from '../QueryEditorContext';
+import { useCacheOptionsInfo } from '../hooks/useCacheOptionsInfo';
 import { QueryOptionField } from '../types';
 
 import { OptionField } from './OptionField';
@@ -28,7 +29,7 @@ export function QueryEditorDetailsSidebar() {
   const styles = useStyles2(getStyles);
 
   const { datasource, dsSettings } = useDatasourceContext();
-  const { data } = useQueryRunnerContext();
+  const { data, queries } = useQueryRunnerContext();
   const { queryOptions } = useQueryEditorUIContext();
   const { onQueryOptionsChange } = useActionsContext();
   const { options, closeSidebar, focusedField } = queryOptions;
@@ -38,8 +39,7 @@ export function QueryEditorDetailsSidebar() {
   const realMaxDataPoints = data?.request?.maxDataPoints;
   const realInterval = data?.request?.interval;
   const minIntervalOnDs = datasource?.interval ?? t('query-editor-next.details-sidebar.no-limit', 'No limit');
-  const showCacheTimeout = dsSettings?.meta.queryOptions?.cacheTimeout;
-  const showCacheTTL = dsSettings?.cachingConfig?.enabled;
+  const { showCacheTimeout, showCacheTTL, cacheTTLPlaceholder } = useCacheOptionsInfo(dsSettings, queries);
 
   const handleCloseSidebar = useCallback(() => {
     // Blur any focused input to trigger its blur handler before closing
@@ -182,7 +182,7 @@ export function QueryEditorDetailsSidebar() {
                 field={QueryOptionField.queryCachingTTL}
                 {...inputProps}
                 defaultValue={options.queryCachingTTL ?? ''}
-                placeholder={dsSettings?.cachingConfig?.TTLMs ? String(dsSettings.cachingConfig.TTLMs) : undefined}
+                placeholder={cacheTTLPlaceholder}
               />
             )}
           </Stack>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorDetailsSidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorDetailsSidebar.tsx
@@ -3,7 +3,7 @@ import { FocusEvent, useCallback, useRef } from 'react';
 
 import { GrafanaTheme2, rangeUtil } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { Button, ClickOutsideWrapper, Stack, useStyles2 } from '@grafana/ui';
+import { Button, ClickOutsideWrapper, InlineSwitch, Stack, useStyles2 } from '@grafana/ui';
 
 import { CONTENT_SIDE_BAR } from '../../constants';
 import {
@@ -97,7 +97,18 @@ export function QueryEditorDetailsSidebar() {
     [options, onQueryOptionsChange]
   );
 
-  // Shared props for all input-based OptionFields
+  const handleToggleHideTimeInfo = useCallback(() => {
+    onQueryOptionsChange({
+      ...options,
+      timeRange: {
+        ...(options.timeRange ?? {}),
+        hide: !options.timeRange?.hide,
+      },
+    });
+  }, [options, onQueryOptionsChange]);
+
+  const showHideTimeInfo = Boolean(options.timeRange?.from || options.timeRange?.shift);
+
   const inputProps = { onBlur: handleBlur, focusedField };
 
   return (
@@ -147,6 +158,16 @@ export function QueryEditorDetailsSidebar() {
               {...inputProps}
               defaultValue={options.timeRange?.shift ?? ''}
             />
+
+            {showHideTimeInfo && (
+              <OptionField field={QueryOptionField.hideTimeInfo}>
+                <InlineSwitch
+                  value={options.timeRange?.hide ?? false}
+                  onChange={handleToggleHideTimeInfo}
+                  aria-label={t('query-editor-next.details-sidebar.hide-time-info', 'Hide time info')}
+                />
+              </OptionField>
+            )}
 
             {showCacheTimeout && (
               <OptionField

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Footer/QueryEditorFooter.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Footer/QueryEditorFooter.tsx
@@ -7,6 +7,7 @@ import { Button, useStyles2 } from '@grafana/ui';
 
 import { QUERY_EDITOR_COLORS, TIME_OPTION_PLACEHOLDER } from '../../constants';
 import { useDatasourceContext, useQueryEditorUIContext, useQueryRunnerContext } from '../QueryEditorContext';
+import { useCacheOptionsInfo } from '../hooks/useCacheOptionsInfo';
 import { QueryOptionField } from '../types';
 
 interface FooterLabelValue {
@@ -21,11 +22,10 @@ export function QueryEditorFooter() {
 
   const { queryOptions } = useQueryEditorUIContext();
   const { options, openSidebar } = queryOptions;
-  const { data } = useQueryRunnerContext();
+  const { data, queries } = useQueryRunnerContext();
   const { datasource, dsSettings } = useDatasourceContext();
 
-  const showCacheTimeout = dsSettings?.meta.queryOptions?.cacheTimeout;
-  const showCacheTTL = dsSettings?.cachingConfig?.enabled;
+  const { showCacheTimeout, showCacheTTL, cacheTTLPlaceholder } = useCacheOptionsInfo(dsSettings, queries);
 
   const items: FooterLabelValue[] = useMemo(() => {
     const realMaxDataPoints = data?.request?.maxDataPoints;
@@ -78,18 +78,13 @@ export function QueryEditorFooter() {
       result.push({
         id: QueryOptionField.queryCachingTTL,
         label: t('query-editor-next.footer.label.cache-ttl', 'Cache TTL'),
-        value:
-          options.queryCachingTTL != null
-            ? String(options.queryCachingTTL)
-            : dsSettings?.cachingConfig?.TTLMs != null
-              ? String(dsSettings.cachingConfig.TTLMs)
-              : '-',
+        value: options.queryCachingTTL != null ? String(options.queryCachingTTL) : (cacheTTLPlaceholder ?? '-'),
         isActive: options.queryCachingTTL != null,
       });
     }
 
     return result;
-  }, [options, data, datasource, showCacheTimeout, showCacheTTL, dsSettings?.cachingConfig?.TTLMs]);
+  }, [options, data, datasource, showCacheTimeout, showCacheTTL, cacheTTLPlaceholder]);
 
   const handleItemClick = (event: React.MouseEvent, fieldId?: QueryOptionField) => {
     // Stop propagation to prevent ClickOutsideWrapper from immediately closing

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useCacheOptionsInfo.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useCacheOptionsInfo.test.ts
@@ -1,0 +1,210 @@
+import { renderHook } from '@testing-library/react';
+
+import { DataSourceInstanceSettings } from '@grafana/data';
+import { getDataSourceSrv } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
+import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
+
+import { ds1SettingsMock } from '../testUtils';
+
+import { useCacheOptionsInfo } from './useCacheOptionsInfo';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getDataSourceSrv: jest.fn(),
+  isExpressionReference: jest.fn((ref) => ref?.uid === '__expr__' || ref?.type === '__expr__'),
+}));
+
+const mixedDsSettings: DataSourceInstanceSettings = {
+  ...ds1SettingsMock,
+  uid: MIXED_DATASOURCE_NAME,
+  name: 'Mixed',
+  type: 'mixed',
+};
+
+function createQuery(refId: string, dsUid: string, dsType = 'test'): DataQuery {
+  return { refId, datasource: { uid: dsUid, type: dsType } };
+}
+
+function mockGetInstanceSettings(settingsMap: Record<string, Partial<DataSourceInstanceSettings>>) {
+  (getDataSourceSrv as jest.Mock).mockReturnValue({
+    getInstanceSettings: (uid: string) => settingsMap[uid] ?? null,
+  });
+}
+
+describe('useCacheOptionsInfo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('non-Mixed mode', () => {
+    it('should show cache timeout when DS supports it', () => {
+      const dsWithCacheTimeout: DataSourceInstanceSettings = {
+        ...ds1SettingsMock,
+        meta: { ...ds1SettingsMock.meta, queryOptions: { cacheTimeout: true } },
+      };
+
+      const { result } = renderHook(() => useCacheOptionsInfo(dsWithCacheTimeout, []));
+
+      expect(result.current.showCacheTimeout).toBe(true);
+      expect(result.current.showCacheTTL).toBe(false);
+    });
+
+    it('should show cache TTL when DS caching is enabled', () => {
+      const dsWithCacheTTL: DataSourceInstanceSettings = {
+        ...ds1SettingsMock,
+        cachingConfig: { enabled: true, TTLMs: 60000 },
+      };
+
+      const { result } = renderHook(() => useCacheOptionsInfo(dsWithCacheTTL, []));
+
+      expect(result.current.showCacheTTL).toBe(true);
+      expect(result.current.cacheTTLPlaceholder).toBe('60000');
+    });
+
+    it('should hide both cache options when DS does not support them', () => {
+      const { result } = renderHook(() => useCacheOptionsInfo(ds1SettingsMock, []));
+
+      expect(result.current.showCacheTimeout).toBe(false);
+      expect(result.current.showCacheTTL).toBe(false);
+      expect(result.current.cacheTTLPlaceholder).toBeUndefined();
+    });
+
+    it('should return undefined for dsSettings=undefined', () => {
+      const { result } = renderHook(() => useCacheOptionsInfo(undefined, []));
+
+      expect(result.current.showCacheTimeout).toBe(false);
+      expect(result.current.showCacheTTL).toBe(false);
+    });
+  });
+
+  describe('Mixed mode', () => {
+    it('should show cache timeout when any query DS supports it', () => {
+      mockGetInstanceSettings({
+        'ds-prom': {
+          ...ds1SettingsMock,
+          uid: 'ds-prom',
+          meta: { ...ds1SettingsMock.meta, queryOptions: { cacheTimeout: true } },
+        },
+        'ds-loki': {
+          ...ds1SettingsMock,
+          uid: 'ds-loki',
+        },
+      });
+
+      const queries = [createQuery('A', 'ds-prom'), createQuery('B', 'ds-loki')];
+      const { result } = renderHook(() => useCacheOptionsInfo(mixedDsSettings, queries));
+
+      expect(result.current.showCacheTimeout).toBe(true);
+    });
+
+    it('should show cache TTL when any query DS has caching enabled', () => {
+      mockGetInstanceSettings({
+        'ds-prom': {
+          ...ds1SettingsMock,
+          uid: 'ds-prom',
+          cachingConfig: { enabled: true, TTLMs: 60000 },
+        },
+        'ds-loki': {
+          ...ds1SettingsMock,
+          uid: 'ds-loki',
+        },
+      });
+
+      const queries = [createQuery('A', 'ds-prom'), createQuery('B', 'ds-loki')];
+      const { result } = renderHook(() => useCacheOptionsInfo(mixedDsSettings, queries));
+
+      expect(result.current.showCacheTTL).toBe(true);
+      expect(result.current.cacheTTLPlaceholder).toBe('60000');
+    });
+
+    it('should use the lowest TTL as placeholder when multiple DSs have caching enabled', () => {
+      mockGetInstanceSettings({
+        'ds-prom': {
+          ...ds1SettingsMock,
+          uid: 'ds-prom',
+          cachingConfig: { enabled: true, TTLMs: 300000 },
+        },
+        'ds-loki': {
+          ...ds1SettingsMock,
+          uid: 'ds-loki',
+          cachingConfig: { enabled: true, TTLMs: 60000 },
+        },
+      });
+
+      const queries = [createQuery('A', 'ds-prom'), createQuery('B', 'ds-loki')];
+      const { result } = renderHook(() => useCacheOptionsInfo(mixedDsSettings, queries));
+
+      expect(result.current.showCacheTTL).toBe(true);
+      expect(result.current.cacheTTLPlaceholder).toBe('60000');
+    });
+
+    it('should hide cache options when no query DS supports them', () => {
+      mockGetInstanceSettings({
+        'ds-prom': { ...ds1SettingsMock, uid: 'ds-prom' },
+        'ds-loki': { ...ds1SettingsMock, uid: 'ds-loki' },
+      });
+
+      const queries = [createQuery('A', 'ds-prom'), createQuery('B', 'ds-loki')];
+      const { result } = renderHook(() => useCacheOptionsInfo(mixedDsSettings, queries));
+
+      expect(result.current.showCacheTimeout).toBe(false);
+      expect(result.current.showCacheTTL).toBe(false);
+    });
+
+    it('should ignore expression queries', () => {
+      mockGetInstanceSettings({
+        'ds-prom': {
+          ...ds1SettingsMock,
+          uid: 'ds-prom',
+          cachingConfig: { enabled: true, TTLMs: 60000 },
+        },
+      });
+
+      const queries = [createQuery('A', 'ds-prom'), createQuery('B', '__expr__', '__expr__')];
+      const { result } = renderHook(() => useCacheOptionsInfo(mixedDsSettings, queries));
+
+      expect(result.current.showCacheTTL).toBe(true);
+      expect(result.current.cacheTTLPlaceholder).toBe('60000');
+    });
+
+    it('should handle empty queries array', () => {
+      const { result } = renderHook(() => useCacheOptionsInfo(mixedDsSettings, []));
+
+      expect(result.current.showCacheTimeout).toBe(false);
+      expect(result.current.showCacheTTL).toBe(false);
+    });
+
+    it('should handle queries with missing datasource uid', () => {
+      mockGetInstanceSettings({});
+
+      const queries: DataQuery[] = [{ refId: 'A' }];
+      const { result } = renderHook(() => useCacheOptionsInfo(mixedDsSettings, queries));
+
+      expect(result.current.showCacheTimeout).toBe(false);
+      expect(result.current.showCacheTTL).toBe(false);
+    });
+
+    it('should not look up the same datasource twice', () => {
+      const getInstanceSettingsMock = jest.fn((uid: string) => {
+        if (uid === 'ds-prom') {
+          return {
+            ...ds1SettingsMock,
+            uid: 'ds-prom',
+            cachingConfig: { enabled: true, TTLMs: 60000 },
+          };
+        }
+        return null;
+      });
+
+      (getDataSourceSrv as jest.Mock).mockReturnValue({
+        getInstanceSettings: getInstanceSettingsMock,
+      });
+
+      const queries = [createQuery('A', 'ds-prom'), createQuery('B', 'ds-prom')];
+      renderHook(() => useCacheOptionsInfo(mixedDsSettings, queries));
+
+      expect(getInstanceSettingsMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useCacheOptionsInfo.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useCacheOptionsInfo.ts
@@ -1,0 +1,72 @@
+import { useMemo } from 'react';
+
+import { DataSourceInstanceSettings } from '@grafana/data';
+import { getDataSourceSrv, isExpressionReference } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
+import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
+
+export interface CacheOptionsInfo {
+  showCacheTimeout: boolean;
+  showCacheTTL: boolean;
+  cacheTTLPlaceholder: string | undefined;
+}
+
+/**
+ * Determines cache option visibility and placeholder values.
+ *
+ * In non-Mixed mode, derives values from the panel-level datasource settings.
+ * In Mixed mode, aggregates across all queries' datasources so that cache options
+ * remain visible when at least one datasource supports them.
+ * The TTL placeholder uses the lowest value among all datasources (most conservative default).
+ */
+export function useCacheOptionsInfo(
+  dsSettings: DataSourceInstanceSettings | undefined,
+  queries: DataQuery[]
+): CacheOptionsInfo {
+  return useMemo(() => {
+    if (!dsSettings || dsSettings.uid !== MIXED_DATASOURCE_NAME) {
+      return {
+        showCacheTimeout: Boolean(dsSettings?.meta.queryOptions?.cacheTimeout),
+        showCacheTTL: Boolean(dsSettings?.cachingConfig?.enabled),
+        cacheTTLPlaceholder:
+          dsSettings?.cachingConfig?.TTLMs != null ? String(dsSettings.cachingConfig.TTLMs) : undefined,
+      };
+    }
+
+    let showCacheTimeout = false;
+    let showCacheTTL = false;
+    let lowestTTL: number | undefined;
+
+    const seen = new Set<string>();
+    for (const query of queries) {
+      const uid = query.datasource?.uid;
+      if (!uid || seen.has(uid) || isExpressionReference(query.datasource)) {
+        continue;
+      }
+      seen.add(uid);
+
+      const settings = getDataSourceSrv().getInstanceSettings(uid);
+      if (!settings) {
+        continue;
+      }
+
+      if (settings.meta.queryOptions?.cacheTimeout) {
+        showCacheTimeout = true;
+      }
+
+      if (settings.cachingConfig?.enabled) {
+        showCacheTTL = true;
+        const ttl = settings.cachingConfig.TTLMs;
+        if (ttl != null && (lowestTTL == null || ttl < lowestTTL)) {
+          lowestTTL = ttl;
+        }
+      }
+    }
+
+    return {
+      showCacheTimeout,
+      showCacheTTL,
+      cacheTTLPlaceholder: lowestTTL != null ? String(lowestTTL) : undefined,
+    };
+  }, [dsSettings, queries]);
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useQueryOptions.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useQueryOptions.ts
@@ -2,9 +2,12 @@ import { useMemo } from 'react';
 
 import { DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
 import { SceneQueryRunner, VizPanel } from '@grafana/scenes';
+import { DataQuery } from '@grafana/schema';
 import { QueryGroupOptions } from 'app/types/query';
 
 import { PanelTimeRange } from '../../../../scene/panel-timerange/PanelTimeRange';
+
+import { useCacheOptionsInfo } from './useCacheOptionsInfo';
 
 interface UseQueryOptionsParams {
   panel: VizPanel;
@@ -35,11 +38,11 @@ function extractTimeRange(timeRangeObj: unknown): QueryGroupOptions['timeRange']
 export function useQueryOptions({ panel, queryRunner, dsSettings }: UseQueryOptionsParams): QueryGroupOptions {
   const panelState = panel.useState();
   const queryRunnerState = queryRunner?.useState();
+  const queries: DataQuery[] = queryRunnerState?.queries ?? [];
+
+  const { showCacheTimeout, showCacheTTL } = useCacheOptionsInfo(dsSettings, queries);
 
   const queryOptions: QueryGroupOptions = useMemo(() => {
-    const showCacheTimeout = dsSettings?.meta.queryOptions?.cacheTimeout;
-    const showCacheTTL = dsSettings?.cachingConfig?.enabled;
-
     const dataSource = dsSettings
       ? { default: dsSettings.isDefault, ...getDataSourceRef(dsSettings) }
       : { default: undefined, type: undefined, uid: undefined };
@@ -62,6 +65,8 @@ export function useQueryOptions({ panel, queryRunner, dsSettings }: UseQueryOpti
     queryRunnerState?.cacheTimeout,
     queryRunnerState?.queryCachingTTL,
     dsSettings,
+    showCacheTimeout,
+    showCacheTTL,
   ]);
 
   return queryOptions;

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/types.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/types.ts
@@ -48,4 +48,5 @@ export enum QueryOptionField {
   timeShift = 'timeShift',
   cacheTimeout = 'cacheTimeout',
   queryCachingTTL = 'queryCachingTTL',
+  hideTimeInfo = 'hideTimeInfo',
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
@@ -187,6 +187,14 @@ export const QUERY_OPTION_FIELD_CONFIG: Record<QueryOptionField, QueryOptionFiel
     getLabel: () => t('query-editor-next.details-sidebar.cache-ttl', 'Cache TTL'),
     inputType: 'number',
   },
+  [QueryOptionField.hideTimeInfo]: {
+    getTooltip: () =>
+      t(
+        'query-editor-next.details-sidebar.hide-time-info-tooltip',
+        'Hide the time override information displayed on the panel.'
+      ),
+    getLabel: () => t('query-editor-next.details-sidebar.hide-time-info', 'Hide time info'),
+  },
 };
 
 export const EXPRESSION_IMAGE_MAP: Record<ExpressionQueryType, { dark: string; light: string }> = {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13301,6 +13301,8 @@
       "cache-ttl": "Cache TTL",
       "cache-ttl-tooltip": "Cache time-to-live: How long results from the queries in this panel will be cached, in milliseconds.",
       "collapse": "Collapse query options sidebar",
+      "hide-time-info": "Hide time info",
+      "hide-time-info-tooltip": "Hide the time override information displayed on the panel.",
       "interval": "Interval",
       "interval-tooltip": "The evaluated interval that is sent to data source and is used in $__interval and $__interval_ms.",
       "max-data-points": "Max data points",
@@ -13318,6 +13320,8 @@
     "footer": {
       "edit-option": "Edit {{label}}",
       "label": {
+        "cache-timeout": "Cache timeout",
+        "cache-ttl": "Cache TTL",
         "interval": "Interval",
         "max-data-points": "Max data points",
         "min-interval": "Min interval",


### PR DESCRIPTION
## Description
Achieves feature parity between the new panel editor (PanelEditNext) and the old query options UI by surfacing datasource-specific query options and adding the missing "Hide time info" toggle.