### PR TITLE
datasources: create a legacy implementation of connectionsClient 

### DIFF
--- a/pkg/api/datasource/connections_test.go
+++ b/pkg/api/datasource/connections_test.go
@@ -2,7 +2,9 @@ package datasource
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,8 +15,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientrest "k8s.io/client-go/rest"
 
+	dsV0 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
 	queryV0 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/web"
 )
@@ -132,4 +136,85 @@ func mustMarshal(t *testing.T, v any) []byte {
 	data, err := json.Marshal(v)
 	require.NoError(t, err)
 	return data
+}
+
+func TestGetConnectionByUIDLegacy(t *testing.T) {
+	tests := []struct {
+		name           string
+		dsResponse     *datasources.DataSource
+		dsError        error
+		expectedResult *dsV0.DataSourceConnectionList
+		expectedError  error
+	}{
+		{
+			name:          "service error returns error",
+			dsResponse:    nil,
+			dsError:       errors.New("some error"),
+			expectedError: errors.New("some error"),
+		},
+		{
+			name:       "datasource not found returns empty list",
+			dsResponse: nil,
+			expectedResult: &dsV0.DataSourceConnectionList{
+				Items: []dsV0.DataSourceConnection{},
+			},
+		},
+		{
+			name: "datasource found returns connection",
+			dsResponse: &datasources.DataSource{
+				UID:  "uid",
+				Type: "type",
+			},
+			expectedResult: &dsV0.DataSourceConnectionList{
+				Items: []dsV0.DataSourceConnection{
+					{
+						Name:       "uid",
+						APIGroup:   "type.datasource.grafana.app",
+						APIVersion: "v0alpha1",
+						Plugin:     "type",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &legacyConnectionClientImpl{
+				datasourceService: &mockDataSourceService{
+					response: tt.dsResponse,
+					error:    tt.dsError,
+				},
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			reqCtx := &contextmodel.ReqContext{
+				Context:      &web.Context{Req: req},
+				SignedInUser: &user.SignedInUser{OrgID: 1},
+			}
+
+			conn, err := client.GetConnectionByUID(reqCtx, "uid")
+
+			if tt.expectedError != nil {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError.Error())
+				assert.Nil(t, conn)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, conn)
+				assert.Equal(t, tt.expectedResult, conn)
+			}
+		})
+	}
+}
+
+// mock the datasource service
+type mockDataSourceService struct {
+	datasources.DataSourceService
+	response *datasources.DataSource
+	error    error
+}
+
+func (m *mockDataSourceService) GetDataSource(ctx context.Context, query *datasources.GetDataSourceQuery) (*datasources.DataSource, error) {
+	return m.response, m.error
 }

--- a/pkg/api/datasource/connections_test.go
+++ b/pkg/api/datasource/connections_test.go
@@ -16,7 +16,6 @@ import (
 	clientrest "k8s.io/client-go/rest"
 
 	dsV0 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
-	queryV0 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -61,7 +60,7 @@ func TestGetConnectionByUID(t *testing.T) {
 		statusCode    int
 		responseBody  []byte
 		expectedError string
-		expectedItems []queryV0.DataSourceConnection
+		expectedItems []dsV0.DataSourceConnection
 	}{
 		{
 			name:          "connection not found returns error",
@@ -81,19 +80,19 @@ func TestGetConnectionByUID(t *testing.T) {
 			name:       "multiple connections returned",
 			uid:        "test-uid",
 			statusCode: http.StatusOK,
-			responseBody: mustMarshal(t, queryV0.DataSourceConnectionList{
-				Items: []queryV0.DataSourceConnection{{Name: "conn1"}, {Name: "conn2"}},
+			responseBody: mustMarshal(t, dsV0.DataSourceConnectionList{
+				Items: []dsV0.DataSourceConnection{{Name: "conn1"}, {Name: "conn2"}},
 			}),
-			expectedItems: []queryV0.DataSourceConnection{{Name: "conn1"}, {Name: "conn2"}},
+			expectedItems: []dsV0.DataSourceConnection{{Name: "conn1"}, {Name: "conn2"}},
 		},
 		{
 			name:       "single connection returned",
 			uid:        "test-uid",
 			statusCode: http.StatusOK,
-			responseBody: mustMarshal(t, queryV0.DataSourceConnectionList{
-				Items: []queryV0.DataSourceConnection{{Name: "test-uid"}},
+			responseBody: mustMarshal(t, dsV0.DataSourceConnectionList{
+				Items: []dsV0.DataSourceConnection{{Name: "test-uid"}},
 			}),
-			expectedItems: []queryV0.DataSourceConnection{{Name: "test-uid"}},
+			expectedItems: []dsV0.DataSourceConnection{{Name: "test-uid"}},
 		},
 	}
 

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -389,7 +389,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 			Name:      "ds_config_handler_requests_duration_seconds",
 			Help:      "Duration of requests handled by datasource configuration handlers",
 		}, []string{"handler"}),
-		dsConnectionClient: datasource.NewConnectionClient(cfg, clientConfigProvider),
+		dsConnectionClient: datasource.NewLegacyConnectionClient(dataSourcesService),
 	}
 
 	promRegister.MustRegister(hs.htmlHandlerRequestsDuration)


### PR DESCRIPTION
Part of https://github.com/grafana/grafana-enterprise/issues/10467

We're currently using a ConnectionsClient implementation that calls `query.grafana.app/.../connections` to get the connections info. This is fine locally, but there are some implementations of the `query.grafana.app` APIgroup where we aren't serving the `connections` endpoint yet.

This PR adds a new ConnectionsClient implementation that just calls the legacy datasource service to get the connection info. This temporarily untangles the `/api` => `/apis` rerouting progress from the support for `/connections` in any remote `query.grafana.app` instances running.