### PR TITLE
Dashboard Controls: Prefix default variables to prevent URL collisions

### DIFF
--- a/public/app/features/dashboard-scene/utils/dashboardControls.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardControls.ts
@@ -41,11 +41,16 @@ async function loadDefaultControlsByRefs(refs: DataSourceRef[], traceId: string)
         });
 
         if (dsVariables && dsVariables.length) {
+          // Replace non-word characters so the name satisfies WORD_CHARACTERS_REGEX
+          // from ../settings/variables/utils (template variable names must match \w+).
+          const sanitizedType = ds.type.replace(/\W/g, '_');
           defaultVariables.push(
             ...dsVariables.map((v) => {
               const variable = { ...v };
               variable.spec = {
                 ...variable.spec,
+                name: `${sanitizedType}_${variable.spec.name}`,
+                label: variable.spec.label || variable.spec.name,
                 origin: {
                   type: 'datasource' as const,
                   group: ds.type,


### PR DESCRIPTION
**Why is this needed**:
This is a follow up after: https://github.com/grafana/grafana/pull/109108

Default variables from datasources and user-defined template variables share the same URL namespace (`var-`). 

When a datasource exposes a variable like `region`, it uses the same URL key (`var-region`) as a user-defined template variable named `region`, which can cause collisions and overwrite or conflict in dashboard URLs and state.

**What would you like to be added**:
Prefix all default variable names (those provided by datasources) with the datasource type so they use a separate URL namespace.

For example: 

A datasource providing `region` should use a prefixed name such as `prometheus_region` and thus URL key `var-prometheus_region`, while the original name `region` is kept in the variable’s `label` for display. This removes collision risk between datasource default variables and user-defined template variables.

**Who is this feature for?**
Dashboard authors and viewers who use datasources that expose default variables alongside custom template variables, and anyone who shares or bookmarks dashboard URLs and needs stable, non-conflicting variable keys.

