### PR TITLE
fix(LogsTable): correlation links using variables

### DIFF
--- a/public/app/features/explore/Logs/LogsTable.tsx
+++ b/public/app/features/explore/Logs/LogsTable.tsx
@@ -13,6 +13,7 @@ import {
   FieldType,
   guessFieldTypeForField,
   LogsSortOrder,
+  ScopedVars,
   sortDataFrame,
   SplitOpen,
   TimeRange,
@@ -33,7 +34,7 @@ import {
   useStyles2,
 } from '@grafana/ui';
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR } from '@grafana/ui/internal';
-import { DATAPLANE_ID_NAME, LogsFrame } from 'app/features/logs/logsFrame';
+import { DATAPLANE_ID_NAME, LogFrameLabels, LogsFrame, parseLogsFrame } from 'app/features/logs/logsFrame';
 
 import { getFieldLinksForExplore } from '../utils/links';
 
@@ -134,7 +135,7 @@ export function LogsTable(props: Props) {
   }, []);
 
   const prepareTableFrame = useCallback(
-    (frame: DataFrame): DataFrame => {
+    (frame: DataFrame, labelValues?: LogFrameLabels[] | null): DataFrame => {
       if (!frame.length) {
         return frame;
       }
@@ -170,12 +171,23 @@ export function LogsTable(props: Props) {
         }
 
         field.getLinks = (config: ValueLinkConfig) => {
+          // Build label scoped vars from the original (untransformed) dataFrame.
+          // The transformation pipeline removes the 'labels' field, so
+          // getFieldLinksForExplore cannot resolve label variables from sortedFrame.
+          const labelVars: ScopedVars = {};
+          if (labelValues && labelValues[config.valueRowIndex!]) {
+            for (const [key, value] of Object.entries(labelValues[config.valueRowIndex!])) {
+              labelVars[key] = { value };
+            }
+          }
+
           return getFieldLinksForExplore({
             field,
             rowIndex: config.valueRowIndex!,
             splitOpenFn: splitOpen,
             range: range,
             dataFrame: sortedFrame!,
+            vars: labelVars,
           });
         };
 
@@ -251,6 +263,11 @@ export function LogsTable(props: Props) {
         return;
       }
 
+      // Pre-extract label values from the original frame before transformation,
+      // since the extractFields + organize transformations remove the 'labels' field.
+      const origLogsFrame = parseLogsFrame(dataFrame);
+      const labelValues = origLogsFrame?.getLogFrameLabels() ?? null;
+
       // create extract JSON transformation for every field that is `json.RawMessage`
       const transformations: Array<DataTransformerConfig | CustomTransformOperator> = getLogsExtractFields(dataFrame);
 
@@ -291,10 +308,10 @@ export function LogsTable(props: Props) {
 
       if (transformations.length > 0) {
         const transformedDataFrame = await lastValueFrom(transformDataFrame(transformations, [dataFrame]));
-        const tableFrame = prepareTableFrame(transformedDataFrame[0]);
+        const tableFrame = prepareTableFrame(transformedDataFrame[0], labelValues);
         setTableFrame(tableFrame);
       } else {
-        setTableFrame(prepareTableFrame(dataFrame));
+        setTableFrame(prepareTableFrame(dataFrame, labelValues));
       }
     };
     prepare();

--- a/public/app/features/explore/utils/links.test.ts
+++ b/public/app/features/explore/utils/links.test.ts
@@ -625,6 +625,43 @@ describe('explore links utils', () => {
       expect(links[0]).toHaveLength(0);
     });
 
+    it('returns internal links when label variables are provided via vars parameter', () => {
+      const { field, range, dataFrame } = setup({
+        title: '',
+        url: '',
+        internal: {
+          query: { query: 'query_1-${app}' },
+          datasourceUid: 'uid_1',
+          datasourceName: 'test_ds',
+        },
+      });
+      // Without vars, ${app} is undefined and the link would be filtered out
+      const linksWithoutVars = getFieldLinksForExplore({
+        field,
+        rowIndex: ROW_WITH_TEXT_VALUE.index,
+        range,
+        dataFrame,
+      });
+      expect(linksWithoutVars).toHaveLength(0);
+
+      // With vars providing the label value, the link should be returned
+      const linksWithVars = getFieldLinksForExplore({
+        field,
+        rowIndex: ROW_WITH_TEXT_VALUE.index,
+        range,
+        dataFrame,
+        vars: {
+          app: { value: 'grafana' },
+        },
+      });
+      expect(linksWithVars).toHaveLength(1);
+      expect(linksWithVars[0].href).toBe(
+        `/explore?left=${encodeURIComponent(
+          '{"range":{"from":"now-1h","to":"now"},"datasource":"uid_1","queries":[{"query":"query_1-grafana","datasource":{"uid":"uid_1"}}]}'
+        )}`
+      );
+    });
+
     it('does return internal link when there are no variables (static link)', () => {
       const transformationLink: DataLink = {
         title: '',


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
Fixes correlation links for table view when the link references a label.

This works correctly with the logs view, but links for the table view only worked when not referencing labels.

