### PR TITLE
Prometheus: Decouple backend from core

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -111,6 +111,8 @@ linters:
             - '**/pkg/tsdb/opentsdb/**/*'
             - '**/pkg/tsdb/parca/*'
             - '**/pkg/tsdb/parca/**/*'
+            - '**/pkg/tsdb/prometheus/*'
+            - '**/pkg/tsdb/prometheus/**/*'
             - '**/pkg/tsdb/tempo/*'
             - '**/pkg/tsdb/tempo/**/*'
             - '**/pkg/tsdb/cloudwatch/*'

--- a/pkg/promlib/admission_handler_test.go
+++ b/pkg/promlib/admission_handler_test.go
@@ -19,7 +19,7 @@ func Test_ValidateAdmission(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckSuccessRoundTripper]()
 		logger := backend.NewLoggerWith("logger", "test")
 		s := &Service{
-			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
+			im:     datasource.NewInstanceManager(NewInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
 			logger: logger,
 		}
 
@@ -40,7 +40,7 @@ func Test_ValidateAdmission(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckSuccessRoundTripper]()
 		logger := backend.NewLoggerWith("logger", "test")
 		s := &Service{
-			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
+			im:     datasource.NewInstanceManager(NewInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
 			logger: logger,
 		}
 
@@ -74,7 +74,7 @@ func Test_MutateAdmission(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckSuccessRoundTripper]()
 		logger := backend.NewLoggerWith("logger", "test")
 		s := &Service{
-			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
+			im:     datasource.NewInstanceManager(NewInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
 			logger: logger,
 		}
 
@@ -96,7 +96,7 @@ func Test_MutateAdmission(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckSuccessRoundTripper]()
 		logger := backend.NewLoggerWith("logger", "test")
 		s := &Service{
-			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
+			im:     datasource.NewInstanceManager(NewInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
 			logger: logger,
 		}
 
@@ -118,7 +118,7 @@ func Test_MutateAdmission(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckSuccessRoundTripper]()
 		logger := backend.NewLoggerWith("logger", "test")
 		s := &Service{
-			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
+			im:     datasource.NewInstanceManager(NewInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
 			logger: logger,
 		}
 
@@ -139,7 +139,7 @@ func Test_MutateAdmission(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckSuccessRoundTripper]()
 		logger := backend.NewLoggerWith("logger", "test")
 		s := &Service{
-			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
+			im:     datasource.NewInstanceManager(NewInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
 			logger: logger,
 		}
 
@@ -168,7 +168,7 @@ func Test_MutateAdmission(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckSuccessRoundTripper]()
 		logger := backend.NewLoggerWith("logger", "test")
 		s := &Service{
-			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
+			im:     datasource.NewInstanceManager(NewInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
 			logger: logger,
 		}
 
@@ -197,7 +197,7 @@ func Test_MutateAdmission(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckSuccessRoundTripper]()
 		logger := backend.NewLoggerWith("logger", "test")
 		s := &Service{
-			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
+			im:     datasource.NewInstanceManager(NewInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
 			logger: logger,
 		}
 

--- a/pkg/promlib/healthcheck.go
+++ b/pkg/promlib/healthcheck.go
@@ -53,7 +53,7 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 	return hc, nil
 }
 
-func healthcheck(ctx context.Context, req *backend.CheckHealthRequest, i *instance) (*backend.CheckHealthResult, error) {
+func healthcheck(ctx context.Context, req *backend.CheckHealthRequest, i *Instance) (*backend.CheckHealthResult, error) {
 	qm := models.QueryModel{
 		UtcOffsetSec: 0,
 		CommonQueryProperties: sdkapi.CommonQueryProperties{

--- a/pkg/promlib/healthcheck_test.go
+++ b/pkg/promlib/healthcheck_test.go
@@ -84,7 +84,7 @@ func Test_healthcheck(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckSuccessRoundTripper]()
 		logger := backend.NewLoggerWith("logger", "test")
 		s := &Service{
-			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
+			im:     datasource.NewInstanceManager(NewInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
 			logger: logger,
 		}
 
@@ -102,7 +102,7 @@ func Test_healthcheck(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckFailRoundTripper]()
 		logger := backend.NewLoggerWith("logger", "test")
 		s := &Service{
-			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
+			im:     datasource.NewInstanceManager(NewInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
 			logger: logger,
 		}
 

--- a/pkg/promlib/heuristics.go
+++ b/pkg/promlib/heuristics.go
@@ -48,7 +48,7 @@ func (s *Service) GetBuildInfo(ctx context.Context, req BuildInfoRequest) (*Buil
 }
 
 // getBuildInfo queries /api/v1/status/buildinfo
-func getBuildInfo(ctx context.Context, i *instance) (*BuildInfoResponse, error) {
+func getBuildInfo(ctx context.Context, i *Instance) (*BuildInfoResponse, error) {
 	resp, err := i.resource.Execute(ctx, &backend.CallResourceRequest{
 		Path: "api/v1/status/buildinfo",
 	})
@@ -90,7 +90,7 @@ func (s *Service) GetHeuristics(ctx context.Context, req HeuristicsRequest) (*He
 	return getHeuristics(ctx, ds, logger)
 }
 
-func getHeuristics(ctx context.Context, i *instance, logger log.Logger) (*Heuristics, error) {
+func getHeuristics(ctx context.Context, i *Instance, logger log.Logger) (*Heuristics, error) {
 	heuristics := Heuristics{
 		Application: "unknown",
 		Features: Features{

--- a/pkg/promlib/heuristics_test.go
+++ b/pkg/promlib/heuristics_test.go
@@ -55,7 +55,7 @@ func Test_GetHeuristics(t *testing.T) {
 		httpProvider := newHeuristicsSDKProvider(rt)
 		logger := backend.NewLoggerWith("logger", "test")
 		s := &Service{
-			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
+			im:     datasource.NewInstanceManager(NewInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
 			logger: logger,
 		}
 
@@ -77,7 +77,7 @@ func Test_GetHeuristics(t *testing.T) {
 		httpProvider := newHeuristicsSDKProvider(rt)
 		logger := backend.NewLoggerWith("logger", "test")
 		s := &Service{
-			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
+			im:     datasource.NewInstanceManager(NewInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
 			logger: logger,
 		}
 

--- a/pkg/promlib/library.go
+++ b/pkg/promlib/library.go
@@ -22,7 +22,7 @@ type Service struct {
 	logger log.Logger
 }
 
-type instance struct {
+type Instance struct {
 	queryData *querydata.QueryData
 	resource  *resource.Resource
 }
@@ -34,7 +34,7 @@ func NewService(httpClientProvider *sdkhttpclient.Provider, plog log.Logger, ext
 		httpClientProvider = sdkhttpclient.NewProvider()
 	}
 	return &Service{
-		im:     datasource.NewInstanceManager(newInstanceSettings(httpClientProvider, plog, extendOptions)),
+		im:     datasource.NewInstanceManager(NewInstanceSettings(httpClientProvider, plog, extendOptions)),
 		logger: plog,
 	}
 }
@@ -47,7 +47,7 @@ func (s *Service) Dispose() {
 	s.logger.Debug("Disposing the instance...")
 }
 
-func newInstanceSettings(httpClientProvider *sdkhttpclient.Provider, log log.Logger, extendOptions ExtendOptions) datasource.InstanceFactoryFunc {
+func NewInstanceSettings(httpClientProvider *sdkhttpclient.Provider, log log.Logger, extendOptions ExtendOptions) datasource.InstanceFactoryFunc {
 	return func(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 		// Creates a http roundTripper.
 		opts, err := client.CreateTransportOptions(ctx, settings, log)
@@ -81,7 +81,7 @@ func newInstanceSettings(httpClientProvider *sdkhttpclient.Provider, log log.Log
 			return nil, err
 		}
 
-		return instance{
+		return Instance{
 			queryData: qd,
 			resource:  r,
 		}, nil
@@ -130,11 +130,11 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	return sender.Send(resp)
 }
 
-func (s *Service) getInstance(ctx context.Context, pluginCtx backend.PluginContext) (*instance, error) {
+func (s *Service) getInstance(ctx context.Context, pluginCtx backend.PluginContext) (*Instance, error) {
 	i, err := s.im.Get(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}
-	in := i.(instance)
+	in := i.(Instance)
 	return &in, nil
 }

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 
@@ -15,6 +16,14 @@ import (
 
 type Service struct {
 	lib *promlib.Service
+}
+
+func NewInstanceSettings(logger log.Logger) datasource.InstanceFactoryFunc {
+	return promlib.NewInstanceSettings(
+		sdkhttpclient.NewProvider(),
+		logger,
+		extendClientOpts,
+	)
 }
 
 func ProvideService(httpClientProvider *sdkhttpclient.Provider) *Service {

--- a/pkg/tsdb/prometheus/standalone/main.go
+++ b/pkg/tsdb/prometheus/standalone/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"os"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+
+	"github.com/grafana/grafana/pkg/tsdb/prometheus"
+)
+
+func main() {
+	logger := backend.NewLoggerWith("logger", "tsdb.prometheus")
+	if err := datasource.Manage("prometheus", prometheus.NewInstanceSettings(logger), datasource.ManageOpts{}); err != nil {
+		log.DefaultLogger.Error(err.Error())
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary

- Export `Instance` and `NewInstanceSettings` from `pkg/promlib` for standalone plugin use
- Add `NewInstanceSettings` to `pkg/tsdb/prometheus/` wrapping promlib with `extendClientOpts`
- Create `standalone/main.go` entry point using `datasource.Manage`
- Add prometheus to golangci depguard coreplugins rule

Frontend changes are in #119144.