### PR TITLE
Prometheus: Decouple frontend from core

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -465,6 +465,7 @@ module.exports = [
       'public/app/plugins/datasource/mysql/**/*.{ts,tsx}',
       'public/app/plugins/datasource/opentsdb/**/*.{ts,tsx}',
       'public/app/plugins/datasource/parca/**/*.{ts,tsx}',
+      'public/app/plugins/datasource/prometheus/**/*.{ts,tsx}',
       'public/app/plugins/datasource/tempo/**/*.{ts,tsx}',
       'public/app/plugins/datasource/zipkin/**/*.{ts,tsx}',
     ],

--- a/jest.config.js
+++ b/jest.config.js
@@ -91,6 +91,7 @@ module.exports = {
     '<rootDir>/public/app/plugins/datasource/loki',
     '<rootDir>/public/app/plugins/datasource/mysql',
     '<rootDir>/public/app/plugins/datasource/parca',
+    '<rootDir>/public/app/plugins/datasource/prometheus',
     '<rootDir>/public/app/plugins/datasource/tempo',
     '<rootDir>/public/app/plugins/datasource/zipkin',
   ],

--- a/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
+++ b/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
@@ -1,7 +1,8 @@
 import { render } from 'test/test-utils';
 import { byTestId, byText } from 'testing-library-selector';
 
-import { PromOptions } from '@grafana/prometheus';
+import { DataSourcePlugin } from '@grafana/data';
+import { PrometheusDatasource, PromOptions } from '@grafana/prometheus';
 import { setPluginLinksHook } from '@grafana/runtime';
 import config from 'app/core/config';
 import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
@@ -28,6 +29,11 @@ import { Annotation } from './utils/constants';
 import { DataSourceType, GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
 
 jest.mock('./api/ruler');
+jest.mock('app/features/plugins/importer/pluginImporter', () => ({
+  pluginImporter: {
+    importDataSource: () => Promise.resolve(new DataSourcePlugin(PrometheusDatasource as any)),
+  },
+}));
 jest.mock('@grafana/assistant', () => ({
   useAssistant: () => ({ isAvailable: false, openAssistant: jest.fn() }),
 }));

--- a/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
+++ b/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
@@ -2,7 +2,7 @@ import { render } from 'test/test-utils';
 import { byTestId, byText } from 'testing-library-selector';
 
 import { DataSourcePlugin } from '@grafana/data';
-import { PrometheusDatasource, PromOptions } from '@grafana/prometheus';
+import { PromOptions, PrometheusDatasource } from '@grafana/prometheus';
 import { setPluginLinksHook } from '@grafana/runtime';
 import config from 'app/core/config';
 import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
@@ -31,7 +31,7 @@ import { DataSourceType, GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
 jest.mock('./api/ruler');
 jest.mock('app/features/plugins/importer/pluginImporter', () => ({
   pluginImporter: {
-    importDataSource: () => Promise.resolve(new DataSourcePlugin(PrometheusDatasource as any)),
+    importDataSource: () => Promise.resolve(new DataSourcePlugin(PrometheusDatasource as never)),
   },
 }));
 jest.mock('@grafana/assistant', () => ({

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataAlertingTab.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataAlertingTab.test.tsx
@@ -2,7 +2,8 @@ import userEvent from '@testing-library/user-event';
 import { render } from 'test/test-utils';
 import { byTestId } from 'testing-library-selector';
 
-import { PromOptions } from '@grafana/prometheus';
+import { DataSourcePlugin } from '@grafana/data';
+import { PrometheusDatasource, PromOptions } from '@grafana/prometheus';
 import { config, locationService, setPluginLinksHook } from '@grafana/runtime';
 import * as ruler from 'app/features/alerting/unified/api/ruler';
 import * as ruleActionButtons from 'app/features/alerting/unified/components/rules/RuleActionsButtons';
@@ -39,6 +40,12 @@ import { PanelDataAlertingTab, PanelDataAlertingTabRendered } from './PanelDataA
 
 jest.mock('app/features/alerting/unified/api/prometheus');
 jest.mock('app/features/alerting/unified/api/ruler');
+
+jest.mock('app/features/plugins/importer/pluginImporter', () => ({
+  pluginImporter: {
+    importDataSource: () => Promise.resolve(new DataSourcePlugin(PrometheusDatasource as any)),
+  },
+}));
 
 jest.mock('@grafana/assistant', () => ({
   useAssistant: () => ({ isAvailable: false, openAssistant: jest.fn() }),

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataAlertingTab.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataAlertingTab.test.tsx
@@ -43,7 +43,7 @@ jest.mock('app/features/alerting/unified/api/ruler');
 
 jest.mock('app/features/plugins/importer/pluginImporter', () => ({
   pluginImporter: {
-    importDataSource: () => Promise.resolve(new DataSourcePlugin(PrometheusDatasource as any)),
+    importDataSource: () => Promise.resolve(new DataSourcePlugin(PrometheusDatasource as never)),
   },
 }));
 

--- a/public/app/features/plugins/built_in_plugins.ts
+++ b/public/app/features/plugins/built_in_plugins.ts
@@ -8,8 +8,6 @@ const influxdbPlugin = async () =>
   await import(/* webpackChunkName: "influxdbPlugin" */ 'app/plugins/datasource/influxdb/module');
 const mixedPlugin = async () =>
   await import(/* webpackChunkName: "mixedPlugin" */ 'app/plugins/datasource/mixed/module');
-const prometheusPlugin = async () =>
-  await import(/* webpackChunkName: "prometheusPlugin" */ 'app/plugins/datasource/prometheus/module');
 const alertmanagerPlugin = async () =>
   await import(/* webpackChunkName: "alertmanagerPlugin" */ 'app/plugins/datasource/alertmanager/module');
 
@@ -73,7 +71,6 @@ const builtInPlugins: Record<string, System.Module | (() => Promise<System.Modul
   'core:plugin/grafana': grafanaPlugin,
   'core:plugin/influxdb': influxdbPlugin,
   'core:plugin/mixed': mixedPlugin,
-  'core:plugin/prometheus': prometheusPlugin,
   'core:plugin/alertmanager': alertmanagerPlugin,
   // panels
   'core:plugin/text': textPanel,

--- a/public/app/plugins/datasource/prometheus/jest-setup.js
+++ b/public/app/plugins/datasource/prometheus/jest-setup.js
@@ -1,0 +1,1 @@
+import '@grafana/plugin-configs/jest/jest-setup';

--- a/public/app/plugins/datasource/prometheus/jest.config.js
+++ b/public/app/plugins/datasource/prometheus/jest.config.js
@@ -1,0 +1,3 @@
+import defaultConfig from '@grafana/plugin-configs/jest/jest.config.js';
+
+export default defaultConfig;

--- a/public/app/plugins/datasource/prometheus/package.json
+++ b/public/app/plugins/datasource/prometheus/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@grafana-plugins/prometheus",
+  "description": "Prometheus data source plugin",
+  "private": true,
+  "version": "13.0.0-pre",
+  "dependencies": {
+    "@emotion/css": "11.13.5",
+    "@grafana/aws-sdk": "^0.10.1",
+    "@grafana/azure-sdk": "0.0.8",
+    "@grafana/data": "13.0.0-pre",
+    "@grafana/plugin-ui": "^0.13.1",
+    "@grafana/prometheus": "13.0.0-pre",
+    "@grafana/runtime": "13.0.0-pre",
+    "@grafana/ui": "13.0.0-pre",
+    "react": "18.3.1",
+    "tslib": "2.8.1"
+  },
+  "devDependencies": {
+    "@grafana/plugin-configs": "13.0.0-pre",
+    "@testing-library/dom": "10.4.1",
+    "@testing-library/react": "16.3.0",
+    "@types/jest": "29.5.14",
+    "@types/node": "24.10.1",
+    "@types/react": "18.3.18",
+    "jest": "29.7.0",
+    "ts-node": "10.9.2",
+    "typescript": "5.9.2",
+    "webpack": "^5.105.0"
+  },
+  "peerDependencies": {
+    "@grafana/runtime": "*"
+  },
+  "scripts": {
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
+    "test": "jest --watch --onlyChanged",
+    "test:ci": "jest --maxWorkers 4"
+  },
+  "packageManager": "yarn@4.11.0"
+}

--- a/public/app/plugins/datasource/prometheus/plugin.json
+++ b/public/app/plugins/datasource/prometheus/plugin.json
@@ -2,6 +2,7 @@
   "type": "datasource",
   "name": "Prometheus",
   "id": "prometheus",
+  "executable": "gpx_prometheus",
   "category": "tsdb",
   "routes": [
     {
@@ -100,6 +101,7 @@
       "small": "img/prometheus_logo.svg",
       "large": "img/prometheus_logo.svg"
     },
+    "version": "%VERSION%",
     "links": [
       {
         "name": "Learn more",
@@ -114,5 +116,9 @@
         "url": "https://grafana.com/docs/grafana/latest/datasources/prometheus/"
       }
     ]
+  },
+  "dependencies": {
+    "grafanaDependency": ">=12.3.0",
+    "plugins": []
   }
 }

--- a/public/app/plugins/datasource/prometheus/project.json
+++ b/public/app/plugins/datasource/prometheus/project.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "tags": ["scope:plugin", "type:datasource"],
+  "targets": {
+    "build": {},
+    "dev": {}
+  }
+}

--- a/public/app/plugins/datasource/prometheus/tsconfig.json
+++ b/public/app/plugins/datasource/prometheus/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "extends": "@grafana/plugin-configs/tsconfig.json",
+  "include": ["."]
+}

--- a/public/app/plugins/datasource/prometheus/webpack.config.ts
+++ b/public/app/plugins/datasource/prometheus/webpack.config.ts
@@ -1,0 +1,3 @@
+import config from '@grafana/plugin-configs/webpack.config.ts';
+
+export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3109,6 +3109,35 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@grafana-plugins/prometheus@workspace:public/app/plugins/datasource/prometheus":
+  version: 0.0.0-use.local
+  resolution: "@grafana-plugins/prometheus@workspace:public/app/plugins/datasource/prometheus"
+  dependencies:
+    "@emotion/css": "npm:11.13.5"
+    "@grafana/aws-sdk": "npm:^0.10.1"
+    "@grafana/azure-sdk": "npm:0.0.8"
+    "@grafana/data": "npm:13.0.0-pre"
+    "@grafana/plugin-configs": "npm:13.0.0-pre"
+    "@grafana/plugin-ui": "npm:^0.13.1"
+    "@grafana/prometheus": "npm:13.0.0-pre"
+    "@grafana/runtime": "npm:13.0.0-pre"
+    "@grafana/ui": "npm:13.0.0-pre"
+    "@testing-library/dom": "npm:10.4.1"
+    "@testing-library/react": "npm:16.3.0"
+    "@types/jest": "npm:29.5.14"
+    "@types/node": "npm:24.10.1"
+    "@types/react": "npm:18.3.18"
+    jest: "npm:29.7.0"
+    react: "npm:18.3.1"
+    ts-node: "npm:10.9.2"
+    tslib: "npm:2.8.1"
+    typescript: "npm:5.9.2"
+    webpack: "npm:^5.105.0"
+  peerDependencies:
+    "@grafana/runtime": "*"
+  languageName: unknown
+  linkType: soft
+
 "@grafana-plugins/stackdriver@workspace:public/app/plugins/datasource/cloud-monitoring":
   version: 0.0.0-use.local
   resolution: "@grafana-plugins/stackdriver@workspace:public/app/plugins/datasource/cloud-monitoring"
@@ -3769,7 +3798,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/prometheus@workspace:*, @grafana/prometheus@workspace:packages/grafana-prometheus":
+"@grafana/prometheus@npm:13.0.0-pre, @grafana/prometheus@workspace:*, @grafana/prometheus@workspace:packages/grafana-prometheus":
   version: 0.0.0-use.local
   resolution: "@grafana/prometheus@workspace:packages/grafana-prometheus"
   dependencies:


### PR DESCRIPTION
## Summary

- Add prometheus to ESLint decoupled-plugins rule and root jest testPathIgnorePatterns
- Remove prometheus from `built_in_plugins.ts`
- Add plugin.json fields (`executable`, `version`, `grafanaDependency`)
- Add yarn workspace files (package.json, project.json, tsconfig.json, webpack.config.ts, jest.config.js, jest-setup.js)
- Fix FE unit tests broken by the decoupling: mock `pluginImporter` in alerting test files that load prometheus via `getDataSourceSrv().get()`

Backend changes are in #119143.