### PR TITLE
Provisioning: Return empty list instead of nil for file and resource list items

### DIFF
--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -324,19 +324,19 @@ func (c *filesConnector) listFolderFiles(ctx context.Context, filePath string, r
 		return nil, err
 	}
 
-	files := &provisioning.FileList{}
+	items := make([]provisioning.FileItem, 0, len(rsp))
 	for _, v := range rsp {
 		if !v.Blob {
-			continue // folder item
+			continue
 		}
-		files.Items = append(files.Items, provisioning.FileItem{
+		items = append(items, provisioning.FileItem{
 			Path: v.Path,
 			Size: v.Size,
 			Hash: v.Hash,
 		})
 	}
 
-	return files, nil
+	return &provisioning.FileList{Items: items}, nil
 }
 
 // checkQuota verifies that the repository resource quota allows the operation.

--- a/pkg/registry/apis/provisioning/resources/object.go
+++ b/pkg/registry/apis/provisioning/resources/object.go
@@ -52,9 +52,9 @@ func (o *ResourceListerFromSearch) List(ctx context.Context, namespace, reposito
 		return nil, resource.GetError(objects.Error)
 	}
 
-	list := &provisioning.ResourceList{}
+	items := make([]provisioning.ResourceListItem, 0, len(objects.Items))
 	for _, v := range objects.Items {
-		list.Items = append(list.Items, provisioning.ResourceListItem{
+		items = append(items, provisioning.ResourceListItem{
 			Path:     v.Path,
 			Group:    v.Object.Group,
 			Resource: v.Object.Resource,
@@ -65,7 +65,7 @@ func (o *ResourceListerFromSearch) List(ctx context.Context, namespace, reposito
 			Folder:   v.Folder,
 		})
 	}
-	return list, nil
+	return &provisioning.ResourceList{Items: items}, nil
 }
 
 // Stats implements ResourceLister.


### PR DESCRIPTION
## Summary
- Initialize `Items` to an empty slice (`[]`) instead of `nil` in `FileList` and `ResourceList` responses, so the JSON serialization returns `"items": []` instead of `"items": null` when there are no entries.
- Affected endpoints: repository files listing and resource listing.

## Test plan
- [x] Unit tests pass (`go test ./pkg/registry/apis/provisioning/... -short`)
- [x] Verify `GET /repositories/{name}/files/` returns `"items": []` for an empty repository
- [ ] Verify resource list endpoint returns `"items": []` when no resources exist


Made with [Cursor](https://cursor.com)