### PR TITLE
FiltersOverview: put applied groupBy at the top

### DIFF
--- a/public/app/features/dashboard-scene/scene/dashboard-filters-overview/useFiltersOverviewState.ts
+++ b/public/app/features/dashboard-scene/scene/dashboard-filters-overview/useFiltersOverviewState.ts
@@ -168,13 +168,6 @@ export function useFiltersOverviewState({
       );
 
       const existingKeyValues = new Set(keys.map((k) => k.value ?? k.label).filter(Boolean));
-      for (const key of await adhocFilters._getKeys(null)) {
-        const keyValue = key.value ?? key.label;
-        if (keyValue && !existingKeyValues.has(keyValue)) {
-          keys.push(key);
-          existingKeyValues.add(keyValue);
-        }
-      }
 
       const isGrouped: Record<string, boolean> = {};
       if (groupByVariable) {
@@ -184,6 +177,14 @@ export function useFiltersOverviewState({
             keys.push({ label: v, value: v });
             existingKeyValues.add(v);
           }
+        }
+      }
+
+      for (const key of await adhocFilters._getKeys(null)) {
+        const keyValue = key.value ?? key.label;
+        if (keyValue && !existingKeyValues.has(keyValue)) {
+          keys.push(key);
+          existingKeyValues.add(keyValue);
         }
       }
 


### PR DESCRIPTION
**What is this feature?**

This PR updates filters overview pane to put applied groupBy right after applied adHoc

before: 
<img width="510" height="215" alt="image" src="https://github.com/user-attachments/assets/2b18c180-c094-4b01-b31e-0f154d789b7e" />


after:

<img width="510" height="215" alt="image" src="https://github.com/user-attachments/assets/b250f21c-d7da-422f-9c9b-701b07100020" />