### PR TITLE
Chore: Allow changes to packages/grafana-openapi/ and backend

### DIFF
--- a/.github/workflows/pr-mt-service-compatibility.yml
+++ b/.github/workflows/pr-mt-service-compatibility.yml
@@ -31,6 +31,7 @@ jobs:
               - 'packages/**'
               - '!public/**/*.gen.ts'
               - '!packages/**/*.gen.ts'
+              - '!packages/grafana-openapi/**'
               - 'scripts/webpack/**'
               - '.eslintrc*'
               - '.prettierrc*'


### PR DESCRIPTION
Any change to schemas will always fail now because it updates backend and the openapi package.  This excludes the new openapi package, so we do not see:

> :x: This PR contains both frontend and backend changes.

