### PR TITLE
GroupBy: responsive datasource picker

### DIFF
--- a/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
@@ -66,7 +66,7 @@
     "/externalgroupmappings": {
       "get": {
         "tags": ["ExternalGroupMapping"],
-        "description": "list objects of kind ExternalGroupMapping",
+        "description": "list or watch objects of kind ExternalGroupMapping",
         "operationId": "listExternalGroupMapping",
         "parameters": [
           {
@@ -2267,7 +2267,7 @@
     "/teambindings": {
       "get": {
         "tags": ["TeamBinding"],
-        "description": "list objects of kind TeamBinding",
+        "description": "list or watch objects of kind TeamBinding",
         "operationId": "listTeamBinding",
         "parameters": [
           {
@@ -7750,6 +7750,29 @@
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
         "type": "string",
         "format": "date-time"
+      },
+      "WatchEvent": {
+        "description": "Event represents a single event to a watched resource.",
+        "type": "object",
+        "required": ["type", "object"],
+        "properties": {
+          "object": {
+            "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.runtime.RawExtension"
+              }
+            ]
+          },
+          "type": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.runtime.RawExtension": {
+        "description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package:\n\n\ttype MyAPIObject struct {\n\t\truntime.TypeMeta `json:\",inline\"`\n\t\tMyPlugin runtime.Object `json:\"myPlugin\"`\n\t}\n\n\ttype PluginA struct {\n\t\tAOption string `json:\"aOption\"`\n\t}\n\n// External package:\n\n\ttype MyAPIObject struct {\n\t\truntime.TypeMeta `json:\",inline\"`\n\t\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n\t}\n\n\ttype PluginA struct {\n\t\tAOption string `json:\"aOption\"`\n\t}\n\n// On the wire, the JSON will look something like this:\n\n\t{\n\t\t\"kind\":\"MyAPIObject\",\n\t\t\"apiVersion\":\"v1\",\n\t\t\"myPlugin\": {\n\t\t\t\"kind\":\"PluginA\",\n\t\t\t\"aOption\":\"foo\",\n\t\t},\n\t}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
+        "type": "object"
       }
     }
   }

--- a/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.tsx
@@ -60,7 +60,13 @@ export function GroupByVariableForm({
         htmlFor="data-source-picker"
         tooltip={infoText}
       >
-        <DataSourcePicker current={datasource} onChange={onDataSourceChange} width={30} variables={true} noDefault />
+        <DataSourcePicker
+          current={datasource}
+          onChange={onDataSourceChange}
+          width={inline ? undefined : 30}
+          variables={true}
+          noDefault
+        />
       </EditorField>
 
       {!datasourceSupported ? (


### PR DESCRIPTION
**What is this feature?**

Make datasource picker responsive

before:
<img width="449" height="680" alt="image" src="https://github.com/user-attachments/assets/0fc1c22d-8a72-49be-8157-622c273f0367" />

<img width="618" height="805" alt="image" src="https://github.com/user-attachments/assets/f49e0c91-cae6-42e6-8c6c-d0b23e747c63" />


after:
<img width="538" height="805" alt="image" src="https://github.com/user-attachments/assets/bc1a1f35-6ef2-4d52-bcfe-2d4e8ddf1c27" />

<img width="618" height="805" alt="image" src="https://github.com/user-attachments/assets/6834c3bb-d9c5-427c-93f7-96c0384e4a6f" />
