### PR TITLE
TimeSeries: Update color.seriesBy=last to use lastNotNull

### DIFF
--- a/packages/grafana-data/src/field/fieldColor.ts
+++ b/packages/grafana-data/src/field/fieldColor.ts
@@ -341,9 +341,6 @@ export function getFieldSeriesColor(field: Field, theme: GrafanaTheme2): ColorSc
 
   const scale = getScaleCalculator(field, theme);
   let stat: string = field.config.color?.seriesBy ?? 'last';
-  if (stat === 'last') {
-    stat = 'lastNotNull';
-  }
   const calcs = reduceField({ field, reducers: [stat] });
   const value = calcs[stat] ?? 0;
 

--- a/packages/grafana-data/src/field/fieldColor.ts
+++ b/packages/grafana-data/src/field/fieldColor.ts
@@ -340,7 +340,10 @@ export function getFieldSeriesColor(field: Field, theme: GrafanaTheme2): ColorSc
   }
 
   const scale = getScaleCalculator(field, theme);
-  const stat = field.config.color?.seriesBy ?? 'last';
+  let stat: string = field.config.color?.seriesBy ?? 'last';
+  if (stat === 'last') {
+    stat = 'lastNotNull';
+  }
   const calcs = reduceField({ field, reducers: [stat] });
   const value = calcs[stat] ?? 0;
 

--- a/packages/grafana-data/src/field/fieldColor.ts
+++ b/packages/grafana-data/src/field/fieldColor.ts
@@ -340,7 +340,7 @@ export function getFieldSeriesColor(field: Field, theme: GrafanaTheme2): ColorSc
   }
 
   const scale = getScaleCalculator(field, theme);
-  let stat: string = field.config.color?.seriesBy ?? 'last';
+  const stat = field.config.color?.seriesBy ?? 'last';
   const calcs = reduceField({ field, reducers: [stat] });
   const value = calcs[stat] ?? 0;
 

--- a/public/app/core/components/TimeSeries/utils.ts
+++ b/public/app/core/components/TimeSeries/utils.ts
@@ -251,6 +251,10 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn = ({
 
   for (let i = 1; i < frame.fields.length; i++) {
     const field = frame.fields[i];
+    let originField = field;
+    if (field.state?.origin) {
+      originField = allFrames[field.state.origin.frameIndex]?.fields[field.state.origin.fieldIndex];
+    }
 
     const config: FieldConfig<GraphFieldConfig> = {
       ...field.config,
@@ -280,8 +284,8 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn = ({
       });
     }
     const scaleKey = buildScaleKey(config, field.type);
-    const colorMode = getFieldColorModeForField(field);
-    const scaleColor = getFieldSeriesColor(field, theme);
+    const colorMode = getFieldColorModeForField(originField);
+    const scaleColor = getFieldSeriesColor(originField, theme);
     const seriesColor = scaleColor.color;
 
     // The builder will manage unique scaleKeys and combine where appropriate
@@ -473,10 +477,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn = ({
         indexByName = getNamesToFieldIndex(frame, allFrames);
       }
 
-      const originFrame = allFrames[field.state.origin.frameIndex];
-      const originField = originFrame?.fields[field.state.origin.fieldIndex];
-
-      const dispName = getFieldDisplayName(originField ?? field, originFrame, allFrames);
+      const dispName = getFieldDisplayName(originField, allFrames[field.state.origin.frameIndex], allFrames);
 
       // disable default renderers
       if (customRenderedFields.indexOf(dispName) >= 0) {

--- a/public/app/core/components/TimeSeries/utils.ts
+++ b/public/app/core/components/TimeSeries/utils.ts
@@ -253,7 +253,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn = ({
     const field = frame.fields[i];
     let originField = field;
     if (field.state?.origin) {
-      originField = allFrames[field.state.origin.frameIndex]?.fields[field.state.origin.fieldIndex];
+      originField = allFrames[field.state.origin.frameIndex]?.fields[field.state.origin.fieldIndex] ?? field;
     }
 
     const config: FieldConfig<GraphFieldConfig> = {


### PR DESCRIPTION
Reported by an internal user.

If two series are rendered in the same timeseries, these series are normalized to have values representing a common set of timestamps, and if there's not a value for a given timestamp, the value is instead `undefined`. In the case that was reported, the last value for a series was undefined, and therefore the `last` calc for seriesBy defaulted to `0`.

One possible solution is to use `lastNotNull` instead of last, but we could also use the originField instead of the alignedField for the color calculation.