### PR TITLE
Transformations: Add copy-to-clipboard for debug input/output data

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationDebugDisplay.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationDebugDisplay.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { Drawer, Icon, JSONFormatter, Stack, useStyles2 } from '@grafana/ui';
+import { ClipboardButton, Drawer, Icon, JSONFormatter, Stack, useStyles2 } from '@grafana/ui';
 
 import { usePanelContext, useQueryEditorUIContext, useQueryRunnerContext } from './QueryEditorContext';
 import { useTransformationDebugData } from './hooks/useTransformationDebugData';
@@ -36,8 +36,11 @@ export function TransformationDebugDisplay() {
     >
       <Stack direction="row" gap={1}>
         <div className={styles.debug}>
-          <div className={styles.debugTitle}>
-            <Trans i18nKey="query-editor-next.transformation-debug.input-data">Input data</Trans>
+          <div className={styles.debugTitleRow}>
+            <div className={styles.debugTitle}>
+              <Trans i18nKey="query-editor-next.transformation-debug.input-data">Input data</Trans>
+            </div>
+            <ClipboardButton icon="copy" size="sm" getText={() => JSON.stringify(input, null, 2)} title="Copy to clipboard" />
           </div>
           <div className={styles.debugJson}>
             <JSONFormatter json={input} />
@@ -47,8 +50,11 @@ export function TransformationDebugDisplay() {
           <Icon name="arrow-right" />
         </div>
         <div className={styles.debug}>
-          <div className={styles.debugTitle}>
-            <Trans i18nKey="query-editor-next.transformation-debug.output-data">Output data</Trans>
+          <div className={styles.debugTitleRow}>
+            <div className={styles.debugTitle}>
+              <Trans i18nKey="query-editor-next.transformation-debug.output-data">Output data</Trans>
+            </div>
+            <ClipboardButton icon="copy" size="sm" getText={() => JSON.stringify(output, null, 2)} title="Copy to clipboard" />
           </div>
           <div className={styles.debugJson}>
             <JSONFormatter json={output} />
@@ -71,12 +77,17 @@ const getStyles = (theme: GrafanaTheme2) => {
       margin: `0 ${theme.spacing(0.5)}`,
       color: theme.colors.primary.text,
     }),
+    debugTitleRow: css({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      padding: theme.spacing(1, 0.25),
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
+    }),
     debugTitle: css({
-      padding: `${theme.spacing(1)} ${theme.spacing(0.25)}`,
       fontFamily: theme.typography.fontFamilyMonospace,
       fontSize: theme.typography.bodySmall.fontSize,
       color: theme.colors.text.primary,
-      borderBottom: `1px solid ${theme.colors.border.weak}`,
       flexGrow: 0,
       flexShrink: 1,
     }),

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationEditor.tsx
@@ -4,7 +4,7 @@ import { createElement, useMemo } from 'react';
 import { DataFrame, DataTransformerConfig, GrafanaTheme2, TransformerRegistryItem } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { Icon, JSONFormatter, useStyles2, Drawer } from '@grafana/ui';
+import { ClipboardButton, Icon, JSONFormatter, useStyles2, Drawer } from '@grafana/ui';
 
 import { TransformationsEditorTransformation } from './types';
 
@@ -61,8 +61,11 @@ export const TransformationEditor = ({
             data-testid={selectors.components.TransformTab.transformationEditorDebugger(uiConfig.name)}
           >
             <div className={styles.debug}>
-              <div className={styles.debugTitle}>
-                <Trans i18nKey="dashboard.transformation-editor.input-data">Input data</Trans>
+              <div className={styles.debugTitleRow}>
+                <div className={styles.debugTitle}>
+                  <Trans i18nKey="dashboard.transformation-editor.input-data">Input data</Trans>
+                </div>
+                <ClipboardButton icon="copy" size="sm" getText={() => JSON.stringify(input, null, 2)} title="Copy to clipboard" />
               </div>
               <div className={styles.debugJson}>
                 <JSONFormatter json={input} />
@@ -72,8 +75,11 @@ export const TransformationEditor = ({
               <Icon name="arrow-right" />
             </div>
             <div className={styles.debug}>
-              <div className={styles.debugTitle}>
-                <Trans i18nKey="dashboard.transformation-editor.output-data">Output data</Trans>
+              <div className={styles.debugTitleRow}>
+                <div className={styles.debugTitle}>
+                  <Trans i18nKey="dashboard.transformation-editor.output-data">Output data</Trans>
+                </div>
+                <ClipboardButton icon="copy" size="sm" getText={() => JSON.stringify(output, null, 2)} title="Copy to clipboard" />
               </div>
               <div className={styles.debugJson}>{output && <JSONFormatter json={output} />}</div>
             </div>
@@ -100,12 +106,17 @@ const getStyles = (theme: GrafanaTheme2) => {
       margin: `0 ${theme.spacing(0.5)}`,
       color: theme.colors.primary.text,
     }),
+    debugTitleRow: css({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      padding: theme.spacing(1, 0.25),
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
+    }),
     debugTitle: css({
-      padding: `${theme.spacing(1)} ${theme.spacing(0.25)}`,
       fontFamily: theme.typography.fontFamilyMonospace,
       fontSize: theme.typography.bodySmall.fontSize,
       color: theme.colors.text.primary,
-      borderBottom: `1px solid ${theme.colors.border.weak}`,
       flexGrow: 0,
       flexShrink: 1,
     }),


### PR DESCRIPTION
**What is this feature?**

Adds a copy-to-clipboard button next to the "Input data" and "Output data" section headers in the transformation debug drawer.

**Why do we need this feature?**

When a transformation's input or output data is large or complex, it's difficult to inspect just by scrolling through the JSON viewer. Being able to copy the raw JSON to the clipboard lets users paste it into external tools (jq, custom scripts, etc.) for easier debugging.

**Who is this feature for?**

Dashboard editors and developers who use transformations and need to debug data pipelines.

**Which issue(s) does this PR fix?**

Fixes #115711

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

Changes affect two files with the same debug drawer pattern:
- `TransformationsEditor/TransformationEditor.tsx` (legacy dashboard)
- `PanelEditNext/QueryEditor/TransformationDebugDisplay.tsx` (dashboard scene / new editor)

Both get a `ClipboardButton` from `@grafana/ui` placed in a flex row alongside the section title.