### PR TITLE
Scopes: Remove unused name field from find endpoint types

### DIFF
--- a/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
@@ -66,7 +66,7 @@
     "/externalgroupmappings": {
       "get": {
         "tags": ["ExternalGroupMapping"],
-        "description": "list objects of kind ExternalGroupMapping",
+        "description": "list or watch objects of kind ExternalGroupMapping",
         "operationId": "listExternalGroupMapping",
         "parameters": [
           {
@@ -2267,7 +2267,7 @@
     "/teambindings": {
       "get": {
         "tags": ["TeamBinding"],
-        "description": "list objects of kind TeamBinding",
+        "description": "list or watch objects of kind TeamBinding",
         "operationId": "listTeamBinding",
         "parameters": [
           {
@@ -7750,6 +7750,29 @@
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
         "type": "string",
         "format": "date-time"
+      },
+      "WatchEvent": {
+        "description": "Event represents a single event to a watched resource.",
+        "type": "object",
+        "required": ["type", "object"],
+        "properties": {
+          "object": {
+            "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.runtime.RawExtension"
+              }
+            ]
+          },
+          "type": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.runtime.RawExtension": {
+        "description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package:\n\n\ttype MyAPIObject struct {\n\t\truntime.TypeMeta `json:\",inline\"`\n\t\tMyPlugin runtime.Object `json:\"myPlugin\"`\n\t}\n\n\ttype PluginA struct {\n\t\tAOption string `json:\"aOption\"`\n\t}\n\n// External package:\n\n\ttype MyAPIObject struct {\n\t\truntime.TypeMeta `json:\",inline\"`\n\t\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n\t}\n\n\ttype PluginA struct {\n\t\tAOption string `json:\"aOption\"`\n\t}\n\n// On the wire, the JSON will look something like this:\n\n\t{\n\t\t\"kind\":\"MyAPIObject\",\n\t\t\"apiVersion\":\"v1\",\n\t\t\"myPlugin\": {\n\t\t\t\"kind\":\"PluginA\",\n\t\t\t\"aOption\":\"foo\",\n\t\t},\n\t}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
+        "type": "object"
       }
     }
   }

--- a/packages/grafana-openapi/src/scripts/process-specs.ts
+++ b/packages/grafana-openapi/src/scripts/process-specs.ts
@@ -33,6 +33,15 @@ function processOpenAPISpec(spec: OpenAPIV3.Document) {
       pathItem.parameters = filterNamespaceParameters(pathItem.parameters);
     }
 
+    // Remove the `name` path parameter from /find/* endpoints.
+    // K8s codegen adds it to all connect-type endpoints, but /find/* paths
+    // don't contain {name} so the parameter is unused.
+    if (newPathKey.startsWith('/find/') && Array.isArray(pathItem.parameters)) {
+      pathItem.parameters = pathItem.parameters.filter(
+        (param) => !('in' in param && param.in === 'path' && 'name' in param && param.name === 'name')
+      );
+    }
+
     for (const method of Object.keys(pathItem)) {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const operation = pathItem[method as keyof OpenAPIV3.PathItemObject];


### PR DESCRIPTION
## Summary
- Strip the `name` path parameter from `/find/*` endpoints in OpenAPI post-processing (`process-specs.ts`)
- Remove the spurious required `name` field from `GetFindScopeDashboardBindingsResultsApiArg` and `GetFindScopeNavigationsResultsApiArg` generated types
- Remove `name: ''` workarounds in `ScopesApiClient` that were needed to satisfy the incorrectly required field

## Context
K8s codegen adds a `name` path parameter to all connect-type endpoints by default, even when the URL path doesn't contain `{name}`. This caused tooling complaints and required dummy `name: ''` values in the frontend client.

The fix targets `/find/*` paths specifically. For broader future-proofing, two alternatives were considered:
- **Filter all orphaned path params**: Check every path param against URL `{templates}` — catches any future cases automatically
- **Filter by `x-kubernetes-action: connect`**: Target the root cause (connect endpoints never use `{name}` in their path)

Either could replace the `/find/*` check if this pattern recurs across other specs.

Fixes: grafana/hyperion-planning#526

## Test plan
- [x] `yarn typecheck` passes (all 14 projects)
- [x] All 406 scopes tests pass
- [x] Manual verification: scope selector interaction works normally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)