### PR TITLE
Provisioning: Fix watch stream permission error for anonymous users

### DIFF
--- a/pkg/services/live/features/watch.go
+++ b/pkg/services/live/features/watch.go
@@ -50,9 +50,11 @@ func (b *WatchRunner) GetHandlerForPath(_ string) (model.ChannelHandler, error) 
 // * v0alpha1/dashboards/u12345
 // * v0alpha1/dashboards=ABCD/u12345
 func (b *WatchRunner) OnSubscribe(_ context.Context, u identity.Requester, e model.SubscribeEvent) (model.SubscribeReply, backend.SubscribeStreamStatus, error) {
-	// To make sure we do not share resources across users, in clude the UID in the path
+	// To make sure we do not share resources across users, include the UID in the path
 	userID := u.GetIdentifier()
-	if userID == "" {
+	if u.GetIdentityType() == types.TypeAnonymous {
+		userID = "anonymous"
+	} else if userID == "" {
 		return model.SubscribeReply{}, backend.SubscribeStreamStatusPermissionDenied, fmt.Errorf("missing user identity")
 	}
 	if !strings.HasSuffix(e.Path, userID) {

--- a/public/app/api/clients/provisioning/v0alpha1/index.ts
+++ b/public/app/api/clients/provisioning/v0alpha1/index.ts
@@ -5,8 +5,6 @@ import {
   type ErrorDetails,
   type JobSpec,
   type JobStatus,
-  type ListConnectionApiArg,
-  type ListRepositoryApiArg,
   type RepositorySpec,
   type RepositoryStatus,
   type Status,
@@ -82,34 +80,18 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
         params: queryArg,
       }),
       onCacheEntryAdded: createOnCacheEntryAdded<RepositorySpec, RepositoryStatus>('repositories', {
-        onError: (_error, _updateCachedData, dispatch, arg) => {
-          if (!arg) {
-            return;
-          }
-
-          const pollTimer = setInterval(async () => {
-            try {
-              await dispatch(
-                generatedAPI.endpoints.listRepository.initiate(arg satisfies ListRepositoryApiArg, {
-                  forceRefetch: true,
-                })
-              ).unwrap();
-            } catch {
-              dispatch(
-                notifyApp(
-                  createWarningNotification(
-                    t('provisioning.watch-stream.error-title', 'Live updates unavailable'),
-                    t(
-                      'provisioning.watch-stream.error-description',
-                      'Real-time updates could not be started. Refresh the page to see the latest data.'
-                    )
-                  )
+        onError: (_error, _updateCachedData, dispatch) => {
+          dispatch(
+            notifyApp(
+              createWarningNotification(
+                t('provisioning.watch-stream.error-title', 'Live updates unavailable'),
+                t(
+                  'provisioning.watch-stream.error-description',
+                  'Real-time updates could not be started. Refresh the page to see the latest data.'
                 )
-              );
-            }
-          }, 5000);
-
-          return () => clearInterval(pollTimer);
+              )
+            )
+          );
         },
       }),
     },
@@ -119,34 +101,18 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
         params: queryArg,
       }),
       onCacheEntryAdded: createOnCacheEntryAdded<ConnectionSpec, ConnectionStatus>('connections', {
-        onError: (_error, _updateCachedData, dispatch, arg) => {
-          if (!arg) {
-            return;
-          }
-
-          const pollTimer = setInterval(async () => {
-            try {
-              await dispatch(
-                generatedAPI.endpoints.listConnection.initiate(arg satisfies ListConnectionApiArg, {
-                  forceRefetch: true,
-                })
-              ).unwrap();
-            } catch {
-              dispatch(
-                notifyApp(
-                  createWarningNotification(
-                    t('provisioning.watch-stream.error-title', 'Live updates unavailable'),
-                    t(
-                      'provisioning.watch-stream.error-description',
-                      'Real-time updates could not be started. Refresh the page to see the latest data.'
-                    )
-                  )
+        onError: (_error, _updateCachedData, dispatch) => {
+          dispatch(
+            notifyApp(
+              createWarningNotification(
+                t('provisioning.watch-stream.error-title', 'Live updates unavailable'),
+                t(
+                  'provisioning.watch-stream.error-description',
+                  'Real-time updates could not be started. Refresh the page to see the latest data.'
                 )
-              );
-            }
-          }, 5000);
-
-          return () => clearInterval(pollTimer);
+              )
+            )
+          );
         },
       }),
       providesTags: (result) =>

--- a/public/app/features/apiserver/client.ts
+++ b/public/app/features/apiserver/client.ts
@@ -58,7 +58,7 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
         .getStream<ResourceEvent<T, S, K>>({
           scope: LiveChannelScope.Watch,
           stream: this.gvr.group,
-          path: `${this.gvr.version}/${this.gvr.resource}${query}/${contextSrv.user.uid}`,
+          path: `${this.gvr.version}/${this.gvr.resource}${query}/${contextSrv.user.uid || 'anonymous'}`,
           data: params?.resourceVersion ? { resourceVersion: params.resourceVersion } : undefined,
         })
         .pipe(

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13060,6 +13060,10 @@
       "make-sure": "Create a token with these permissions"
     },
     "warning-title-default": "Warning",
+    "watch-stream": {
+      "error-description": "Real-time updates could not be started. Refresh the page to see the latest data.",
+      "error-title": "Live updates unavailable"
+    },
     "wizard": {
       "alert-intro": "Please be aware of the following limitations. For more details, see the <2>Git Sync documentation</2>.",
       "alert-point-1": "Resources can still be created, edited, or deleted during this process, but changes may not be exported.",


### PR DESCRIPTION
**What is this feature?**

Fixes watch streams failing with "permission denied" when anonymous auth is enabled. Previously, anonymous users had no user UID, causing both the backend subscription and frontend stream path to reject them. The provisioning UI (e.g., branch dropdown in the Wizard) would hang indefinitely waiting for data that never arrived.

**Why do we need this feature?**

With anonymous auth, the watch stream backend rejects subscriptions because the user identifier is empty. On the frontend, the stream path also sends an empty UID segment. This PR fixes both sides so anonymous users get working watch streams. Additionally, the `onError` handler now shows a clear warning notification instead of silently failing or attempting a polling fallback that added complexity without clear benefit.

Fixes https://github.com/grafana/git-ui-sync-project/issues/933

**Special notes for your reviewer:**

Even though this pull request contains both backend and frontend changes, nothing will break if they are not released at the same time. However, the issue will be fixed only when both changes are deployed.