### PR TITLE
`AuthZ-Service`: Prefetch folder tree for `BatchCheck`

### DIFF
--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -148,7 +148,7 @@ func (s *Service) Check(ctx context.Context, req *authzv1.CheckRequest) (*authzv
 
 	cachedPerms, err := s.getCachedIdentityPermissions(ctx, checkReq.Namespace, checkReq.IdentityType, checkReq.UserUID, checkReq.Action)
 	if err == nil {
-		allowed, err := s.checkPermission(ctx, cachedPerms, checkReq)
+		allowed, err := s.checkPermission(ctx, cachedPerms, checkReq, nil)
 		if err != nil {
 			ctxLogger.Error("could not check permission", "error", err)
 			s.metrics.requestCount.WithLabelValues("true", "true", req.GetVerb(), req.GetGroup(), req.GetResource()).Inc()
@@ -170,7 +170,7 @@ func (s *Service) Check(ctx context.Context, req *authzv1.CheckRequest) (*authzv
 		return deny, err
 	}
 
-	allowed, err := s.checkPermission(ctx, permissions, checkReq)
+	allowed, err := s.checkPermission(ctx, permissions, checkReq, nil)
 	if err != nil {
 		ctxLogger.Error("could not check permission", "error", err)
 		s.metrics.requestCount.WithLabelValues("true", "true", req.GetVerb(), req.GetGroup(), req.GetResource()).Inc()
@@ -363,15 +363,50 @@ func (s *Service) processBatchCheckGroup(
 		return
 	}
 
+	tree, err := s.resolveGroupFolderTree(ctx, ns, group)
+	if err != nil {
+		ctxLogger.Error("could not resolve folder tree", "namespace", ns.Value, "action", group.action, "error", err)
+		for _, item := range group.items {
+			results[item.GetCorrelationId()] = &authzv1.BatchCheckResult{Allowed: false, Error: err.Error()}
+		}
+		return
+	}
+
 	for i, item := range group.items {
 		checkReq := group.checkReqs[i]
-		allowed, err := s.checkPermission(ctx, permissions, checkReq)
+		allowed, err := s.checkPermission(ctx, permissions, checkReq, tree)
 		if err != nil {
 			results[item.GetCorrelationId()] = &authzv1.BatchCheckResult{Allowed: false, Error: err.Error()}
 			continue
 		}
 		results[item.GetCorrelationId()] = &authzv1.BatchCheckResult{Allowed: allowed}
 	}
+}
+
+// resolveGroupFolderTree fetches or builds the folder tree once for all items in a batch check group.
+// It returns nil if the resource type does not have folder support.
+// When a non-nil tree is returned, it is passed directly into checkPermission/checkInheritedPermissions,
+// eliminating per-item cache lookups inside the item loop.
+func (s *Service) resolveGroupFolderTree(ctx context.Context, ns types.NamespaceInfo, group *batchCheckGroup) (*folderTree, error) {
+	// All items in a group share the same action → same resource type → same HasFolderSupport value.
+	// Check folder support once using the first request, then scan items for actual folder usage.
+	first := group.checkReqs[0]
+	t, ok := s.mapper.Get(first.Group, first.Resource)
+	if !ok || !t.HasFolderSupport() {
+		return nil, nil
+	}
+
+	if !group.requiresFreshData {
+		if tree, ok := s.getCachedFolderTree(ctx, ns); ok {
+			return &tree, nil
+		}
+	}
+
+	tree, err := s.buildFolderTree(ctx, ns)
+	if err != nil {
+		return nil, err
+	}
+	return &tree, nil
 }
 
 // getPermissionsForGroup fetches permissions for a batch check group,
@@ -809,7 +844,7 @@ func (s *Service) getUserBasicRole(ctx context.Context, ns types.NamespaceInfo, 
 	return *basicRole, nil
 }
 
-func (s *Service) checkPermission(ctx context.Context, scopeMap map[string]bool, req *checkRequest) (bool, error) {
+func (s *Service) checkPermission(ctx context.Context, scopeMap map[string]bool, req *checkRequest, tree *folderTree) (bool, error) {
 	ctx, span := s.tracer.Start(ctx, "authz_direct_db.service.checkPermission", trace.WithAttributes(
 		attribute.Int("scope_count", len(scopeMap))))
 	defer span.End()
@@ -854,7 +889,7 @@ func (s *Service) checkPermission(ctx context.Context, scopeMap map[string]bool,
 		return false, nil
 	}
 
-	return s.checkInheritedPermissions(ctx, scopeMap, req)
+	return s.checkInheritedPermissions(ctx, scopeMap, req, tree)
 }
 
 func (s *Service) getScopeMap(permissions []accesscontrol.Permission) map[string]bool {
@@ -875,7 +910,7 @@ func (s *Service) getScopeMap(permissions []accesscontrol.Permission) map[string
 	return permMap
 }
 
-func (s *Service) checkInheritedPermissions(ctx context.Context, scopeMap map[string]bool, req *checkRequest) (bool, error) {
+func (s *Service) checkInheritedPermissions(ctx context.Context, scopeMap map[string]bool, req *checkRequest, preResolvedTree *folderTree) (bool, error) {
 	if req.ParentFolder == "" {
 		return false, nil
 	}
@@ -884,20 +919,26 @@ func (s *Service) checkInheritedPermissions(ctx context.Context, scopeMap map[st
 	defer span.End()
 	ctxLogger := s.logger.FromContext(ctx)
 
-	tree, ok := s.getCachedFolderTree(ctx, req.Namespace)
+	var tree folderTree
+	if preResolvedTree != nil {
+		tree = *preResolvedTree
+	} else {
+		var ok bool
+		tree, ok = s.getCachedFolderTree(ctx, req.Namespace)
 
-	// Check cached tree is up to date
-	if !ok || !s.isFolderInTree(tree, req.ParentFolder) {
-		var err error
-		tree, err = s.buildFolderTree(ctx, req.Namespace)
-		if err != nil {
-			ctxLogger.Error("could not build folder and dashboard tree", "error", err)
-			return false, err
-		}
-		if !s.isFolderInTree(tree, req.ParentFolder) {
-			// Not erroring here as the permission might exist but the folder wasn't synchronized yet
-			// Once in mode 5 we can deny access here
-			ctxLogger.Error("parent folder not found in folder tree", "folder", req.ParentFolder)
+		// Check cached tree is up to date
+		if !ok || !s.isFolderInTree(tree, req.ParentFolder) {
+			var err error
+			tree, err = s.buildFolderTree(ctx, req.Namespace)
+			if err != nil {
+				ctxLogger.Error("could not build folder and dashboard tree", "error", err)
+				return false, err
+			}
+			if !s.isFolderInTree(tree, req.ParentFolder) {
+				// Not erroring here as the permission might exist but the folder wasn't synchronized yet
+				// Once in mode 5 we can deny access here
+				ctxLogger.Error("parent folder not found in folder tree", "folder", req.ParentFolder)
+			}
 		}
 	}
 

--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -146,9 +146,11 @@ func (s *Service) Check(ctx context.Context, req *authzv1.CheckRequest) (*authzv
 		return deny, nil
 	}
 
+	getTree := s.newFolderTreeGetter(ctx, checkReq.Namespace, false)
+
 	cachedPerms, err := s.getCachedIdentityPermissions(ctx, checkReq.Namespace, checkReq.IdentityType, checkReq.UserUID, checkReq.Action)
 	if err == nil {
-		allowed, err := s.checkPermission(ctx, cachedPerms, checkReq, nil)
+		allowed, err := s.checkPermission(ctx, cachedPerms, checkReq, getTree)
 		if err != nil {
 			ctxLogger.Error("could not check permission", "error", err)
 			s.metrics.requestCount.WithLabelValues("true", "true", req.GetVerb(), req.GetGroup(), req.GetResource()).Inc()
@@ -170,7 +172,7 @@ func (s *Service) Check(ctx context.Context, req *authzv1.CheckRequest) (*authzv
 		return deny, err
 	}
 
-	allowed, err := s.checkPermission(ctx, permissions, checkReq, nil)
+	allowed, err := s.checkPermission(ctx, permissions, checkReq, getTree)
 	if err != nil {
 		ctxLogger.Error("could not check permission", "error", err)
 		s.metrics.requestCount.WithLabelValues("true", "true", req.GetVerb(), req.GetGroup(), req.GetResource()).Inc()
@@ -345,6 +347,7 @@ func (s *Service) requiresFreshData(freshnessTimestamp int64) bool {
 
 // processBatchCheckGroup processes a single group of checks that share the same action.
 // It fetches permissions once and evaluates all checks in the group against them.
+// A single folderTreeGetter is shared across all items so the tree is fetched at most once.
 func (s *Service) processBatchCheckGroup(
 	ctx context.Context,
 	ctxLogger log.Logger,
@@ -363,50 +366,17 @@ func (s *Service) processBatchCheckGroup(
 		return
 	}
 
-	tree, err := s.resolveGroupFolderTree(ctx, ns, group)
-	if err != nil {
-		ctxLogger.Error("could not resolve folder tree", "namespace", ns.Value, "action", group.action, "error", err)
-		for _, item := range group.items {
-			results[item.GetCorrelationId()] = &authzv1.BatchCheckResult{Allowed: false, Error: err.Error()}
-		}
-		return
-	}
+	getTree := s.newFolderTreeGetter(ctx, ns, group.requiresFreshData)
 
 	for i, item := range group.items {
 		checkReq := group.checkReqs[i]
-		allowed, err := s.checkPermission(ctx, permissions, checkReq, tree)
+		allowed, err := s.checkPermission(ctx, permissions, checkReq, getTree)
 		if err != nil {
 			results[item.GetCorrelationId()] = &authzv1.BatchCheckResult{Allowed: false, Error: err.Error()}
 			continue
 		}
 		results[item.GetCorrelationId()] = &authzv1.BatchCheckResult{Allowed: allowed}
 	}
-}
-
-// resolveGroupFolderTree fetches or builds the folder tree once for all items in a batch check group.
-// It returns nil if the resource type does not have folder support.
-// When a non-nil tree is returned, it is passed directly into checkPermission/checkInheritedPermissions,
-// eliminating per-item cache lookups inside the item loop.
-func (s *Service) resolveGroupFolderTree(ctx context.Context, ns types.NamespaceInfo, group *batchCheckGroup) (*folderTree, error) {
-	// All items in a group share the same action → same resource type → same HasFolderSupport value.
-	// Check folder support once using the first request, then scan items for actual folder usage.
-	first := group.checkReqs[0]
-	t, ok := s.mapper.Get(first.Group, first.Resource)
-	if !ok || !t.HasFolderSupport() {
-		return nil, nil
-	}
-
-	if !group.requiresFreshData {
-		if tree, ok := s.getCachedFolderTree(ctx, ns); ok {
-			return &tree, nil
-		}
-	}
-
-	tree, err := s.buildFolderTree(ctx, ns)
-	if err != nil {
-		return nil, err
-	}
-	return &tree, nil
 }
 
 // getPermissionsForGroup fetches permissions for a batch check group,
@@ -844,7 +814,40 @@ func (s *Service) getUserBasicRole(ctx context.Context, ns types.NamespaceInfo, 
 	return *basicRole, nil
 }
 
-func (s *Service) checkPermission(ctx context.Context, scopeMap map[string]bool, req *checkRequest, tree *folderTree) (bool, error) {
+// folderTreeGetter is a lazily-evaluated, memoized function that returns the folder tree for a namespace.
+// Create one instance per logical call-site (e.g. per batch group or per single Check) so that the tree
+// is fetched at most once even when multiple items share the same getter.
+type folderTreeGetter func() (*folderTree, error)
+
+// newFolderTreeGetter returns a folderTreeGetter that fetches the folder tree at most once.
+// If skipCache is false it tries the cache first before calling buildFolderTree.
+func (s *Service) newFolderTreeGetter(ctx context.Context, ns types.NamespaceInfo, skipCache bool) folderTreeGetter {
+	var (
+		result   *folderTree
+		fetchErr error
+		fetched  bool
+	)
+	return func() (*folderTree, error) {
+		if fetched {
+			return result, fetchErr
+		}
+		fetched = true
+		if !skipCache {
+			if tree, ok := s.getCachedFolderTree(ctx, ns); ok {
+				result = &tree
+				return result, nil
+			}
+		}
+		tree, err := s.buildFolderTree(ctx, ns)
+		fetchErr = err
+		if err == nil {
+			result = &tree
+		}
+		return result, fetchErr
+	}
+}
+
+func (s *Service) checkPermission(ctx context.Context, scopeMap map[string]bool, req *checkRequest, getTree folderTreeGetter) (bool, error) {
 	ctx, span := s.tracer.Start(ctx, "authz_direct_db.service.checkPermission", trace.WithAttributes(
 		attribute.Int("scope_count", len(scopeMap))))
 	defer span.End()
@@ -889,7 +892,7 @@ func (s *Service) checkPermission(ctx context.Context, scopeMap map[string]bool,
 		return false, nil
 	}
 
-	return s.checkInheritedPermissions(ctx, scopeMap, req, tree)
+	return s.checkInheritedPermissions(ctx, scopeMap, req, getTree)
 }
 
 func (s *Service) getScopeMap(permissions []accesscontrol.Permission) map[string]bool {
@@ -910,7 +913,7 @@ func (s *Service) getScopeMap(permissions []accesscontrol.Permission) map[string
 	return permMap
 }
 
-func (s *Service) checkInheritedPermissions(ctx context.Context, scopeMap map[string]bool, req *checkRequest, preResolvedTree *folderTree) (bool, error) {
+func (s *Service) checkInheritedPermissions(ctx context.Context, scopeMap map[string]bool, req *checkRequest, getTree folderTreeGetter) (bool, error) {
 	if req.ParentFolder == "" {
 		return false, nil
 	}
@@ -919,26 +922,24 @@ func (s *Service) checkInheritedPermissions(ctx context.Context, scopeMap map[st
 	defer span.End()
 	ctxLogger := s.logger.FromContext(ctx)
 
-	var tree folderTree
-	if preResolvedTree != nil {
-		tree = *preResolvedTree
-	} else {
-		var ok bool
-		tree, ok = s.getCachedFolderTree(ctx, req.Namespace)
+	tree, err := getTree()
+	if err != nil {
+		ctxLogger.Error("could not get folder tree", "error", err)
+		return false, err
+	}
 
-		// Check cached tree is up to date
-		if !ok || !s.isFolderInTree(tree, req.ParentFolder) {
-			var err error
-			tree, err = s.buildFolderTree(ctx, req.Namespace)
-			if err != nil {
-				ctxLogger.Error("could not build folder and dashboard tree", "error", err)
-				return false, err
-			}
-			if !s.isFolderInTree(tree, req.ParentFolder) {
-				// Not erroring here as the permission might exist but the folder wasn't synchronized yet
-				// Once in mode 5 we can deny access here
-				ctxLogger.Error("parent folder not found in folder tree", "folder", req.ParentFolder)
-			}
+	// If the folder is missing from the tree, try a fresh build to recover from a stale cache.
+	if tree == nil || !s.isFolderInTree(*tree, req.ParentFolder) {
+		fresh, err := s.buildFolderTree(ctx, req.Namespace)
+		if err != nil {
+			ctxLogger.Error("could not build folder and dashboard tree", "error", err)
+			return false, err
+		}
+		tree = &fresh
+		if !s.isFolderInTree(*tree, req.ParentFolder) {
+			// Not erroring here as the permission might exist but the folder wasn't synchronized yet
+			// Once in mode 5 we can deny access here
+			ctxLogger.Error("parent folder not found in folder tree", "folder", req.ParentFolder)
 		}
 	}
 

--- a/pkg/services/authz/rbac/service_test.go
+++ b/pkg/services/authz/rbac/service_test.go
@@ -324,7 +324,8 @@ func TestService_checkPermission(t *testing.T) {
 
 			s.folderCache.Set(context.Background(), folderCacheKey("default"), newFolderTree(tc.folders))
 			tc.check.Namespace = types.NamespaceInfo{Value: "default", OrgID: 1}
-			got, err := s.checkPermission(context.Background(), s.getScopeMap(tc.permissions), &tc.check, nil)
+			ns := types.NamespaceInfo{Value: "default", OrgID: 1}
+			got, err := s.checkPermission(context.Background(), s.getScopeMap(tc.permissions), &tc.check, s.newFolderTreeGetter(context.Background(), ns, false))
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, got)
 		})
@@ -430,7 +431,8 @@ func TestService_checkPermission_folderCacheMissRecovery(t *testing.T) {
 		Namespace:    types.NamespaceInfo{Value: "default", OrgID: 1},
 	}
 
-	got, err := s.checkPermission(ctx, userPermissions, &check, nil)
+	ns := types.NamespaceInfo{Value: "default", OrgID: 1}
+	got, err := s.checkPermission(ctx, userPermissions, &check, s.newFolderTreeGetter(ctx, ns, false))
 	require.NoError(t, err)
 	assert.True(t, got)
 

--- a/pkg/services/authz/rbac/service_test.go
+++ b/pkg/services/authz/rbac/service_test.go
@@ -324,7 +324,7 @@ func TestService_checkPermission(t *testing.T) {
 
 			s.folderCache.Set(context.Background(), folderCacheKey("default"), newFolderTree(tc.folders))
 			tc.check.Namespace = types.NamespaceInfo{Value: "default", OrgID: 1}
-			got, err := s.checkPermission(context.Background(), s.getScopeMap(tc.permissions), &tc.check)
+			got, err := s.checkPermission(context.Background(), s.getScopeMap(tc.permissions), &tc.check, nil)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, got)
 		})
@@ -430,7 +430,7 @@ func TestService_checkPermission_folderCacheMissRecovery(t *testing.T) {
 		Namespace:    types.NamespaceInfo{Value: "default", OrgID: 1},
 	}
 
-	got, err := s.checkPermission(ctx, userPermissions, &check)
+	got, err := s.checkPermission(ctx, userPermissions, &check, nil)
 	require.NoError(t, err)
 	assert.True(t, got)
 
@@ -2413,9 +2413,9 @@ func TestService_BatchCheck(t *testing.T) {
 		require.True(t, resp.Results["check2"].Allowed)
 		require.True(t, resp.Results["check3"].Allowed)
 
-		// Should have called GetUserPermissions only once (plus GetBasicRoles and GetUserIdentifiers once each)
-		// Total calls should be 3: GetUserIdentifiers(1), GetBasicRoles(1), GetUserPermissions(1)
-		assert.LessOrEqual(t, fStore.calls, 3, "Should batch permission lookups efficiently")
+		// Should have called GetUserPermissions only once (plus GetBasicRoles, GetUserIdentifiers, and GetFolders once each)
+		// Total calls should be 4: GetUserIdentifiers(1), GetBasicRoles(1), GetUserPermissions(1), GetFolders(1)
+		assert.LessOrEqual(t, fStore.calls, 4, "Should batch permission lookups efficiently")
 	})
 
 	t.Run("should skip cache when freshness_timestamp is recent", func(t *testing.T) {


### PR DESCRIPTION
This pull request optimizes how folder tree data is fetched and reused during permission checks in the RBAC authorization service. By introducing a lazily-evaluated, memoized function for retrieving the folder tree, the code ensures that the folder structure is fetched at most once per logical operation, which reduces redundant lookups and improves efficiency, especially in batch scenarios. Several method signatures are updated to use this new approach, and related tests are adjusted accordingly.

**Folder tree fetching optimization:**

* Introduced the `folderTreeGetter` type and the `newFolderTreeGetter` method, providing a memoized function to fetch the folder tree only once per check or batch, with optional cache usage.
* Updated `checkPermission` and `checkInheritedPermissions` signatures to accept and use the `folderTreeGetter`, ensuring all permission checks within a logical group share the same folder tree fetch. [[1]](diffhunk://#diff-1e06afd11b3f74ef3062ef3e5bc87f802090bf795543ae096f98b394b52f60e7L812-R850) [[2]](diffhunk://#diff-1e06afd11b3f74ef3062ef3e5bc87f802090bf795543ae096f98b394b52f60e7L857-R895) [[3]](diffhunk://#diff-1e06afd11b3f74ef3062ef3e5bc87f802090bf795543ae096f98b394b52f60e7L878-R916)
* Modified the logic in `checkInheritedPermissions` to use the getter and handle errors, including a fallback to a fresh build if the folder is missing from the tree.

**Batch and single-check integration:**

* Updated both single permission checks and batch group checks to create and pass a shared `folderTreeGetter` instance, ensuring efficient reuse across multiple permission checks. [[1]](diffhunk://#diff-1e06afd11b3f74ef3062ef3e5bc87f802090bf795543ae096f98b394b52f60e7R149-R153) [[2]](diffhunk://#diff-1e06afd11b3f74ef3062ef3e5bc87f802090bf795543ae096f98b394b52f60e7L173-R175) [[3]](diffhunk://#diff-1e06afd11b3f74ef3062ef3e5bc87f802090bf795543ae096f98b394b52f60e7R350) [[4]](diffhunk://#diff-1e06afd11b3f74ef3062ef3e5bc87f802090bf795543ae096f98b394b52f60e7R369-R373)

**Test updates:**

* Adjusted tests to use the new `checkPermission` signature and to expect an additional call for folder fetching, reflecting the new logic. [[1]](diffhunk://#diff-fa0882f881e78af55889afb5e134869a5f118eec3b37a1b2e7c9ab7de6564b89L327-R328) [[2]](diffhunk://#diff-fa0882f881e78af55889afb5e134869a5f118eec3b37a1b2e7c9ab7de6564b89L433-R435) [[3]](diffhunk://#diff-fa0882f881e78af55889afb5e134869a5f118eec3b37a1b2e7c9ab7de6564b89L2416-R2420)