### PR TITLE
Alerting: Add ability to query notification counts in historian API

### DIFF
--- a/apps/alerting/historian/kinds/v0alpha1/notification.cue
+++ b/apps/alerting/historian/kinds/v0alpha1/notification.cue
@@ -9,6 +9,9 @@ import (
 #NotificationOutcome: "success" | "error" @cog(kind="enum",memberNames="Success|Error")
 
 #NotificationQuery: {
+    // Type of query to perform (default: entries)
+    type?: "entries" | "counts" @cog(kind="enum",memberNames="Entries|Counts")
+
     // From is the starting timestamp for the query.
     from?: time.Time
     // To is the starting timestamp for the query.
@@ -27,10 +30,21 @@ import (
     groupLabels?: #Matchers
     // Labels optionally filters the entries by matching alert labels.
     labels?: #Matchers
+
+    // GroupBy specifies how to aggregate counts queries.
+    groupBy?: {
+        receiver: bool
+        integration: bool
+        integrationIndex: bool
+        status: bool
+        outcome: bool
+        error: bool
+    }
 }
 
 #NotificationQueryResult: {
     entries: [...#NotificationEntry]
+    counts: [...#NotificationCount]
 }
 
 #NotificationEntry: {
@@ -66,6 +80,18 @@ import (
     pipelineTime: time.Time
     // GroupKey uniquely idenifies the dispatcher alert group.
     groupKey: string
+}
+
+#NotificationCount: {
+    receiver?: string
+    integration?: string
+    integrationIndex?: int
+    status?: #NotificationStatus
+    outcome?: #NotificationOutcome
+    error?: string
+
+    // Count is the number of notification attempts in the time period.
+    count: int
 }
 
 #AlertQuery: {

--- a/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationquery_request_body_types_gen.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationquery_request_body_types_gen.go
@@ -49,6 +49,8 @@ func (CreateNotificationqueryRequestMatcher) OpenAPIModelName() string {
 }
 
 type CreateNotificationqueryRequestBody struct {
+	// Type of query to perform (default: entries)
+	Type *CreateNotificationqueryRequestBodyType `json:"type,omitempty"`
 	// From is the starting timestamp for the query.
 	From *time.Time `json:"from,omitempty"`
 	// To is the starting timestamp for the query.
@@ -67,6 +69,8 @@ type CreateNotificationqueryRequestBody struct {
 	GroupLabels *CreateNotificationqueryRequestMatchers `json:"groupLabels,omitempty"`
 	// Labels optionally filters the entries by matching alert labels.
 	Labels *CreateNotificationqueryRequestMatchers `json:"labels,omitempty"`
+	// GroupBy specifies how to aggregate counts queries.
+	GroupBy *CreateNotificationqueryRequestV0alpha1BodyGroupBy `json:"groupBy,omitempty"`
 }
 
 // NewCreateNotificationqueryRequestBody creates a new CreateNotificationqueryRequestBody object.
@@ -77,6 +81,25 @@ func NewCreateNotificationqueryRequestBody() *CreateNotificationqueryRequestBody
 // OpenAPIModelName returns the OpenAPI model name for CreateNotificationqueryRequestBody.
 func (CreateNotificationqueryRequestBody) OpenAPIModelName() string {
 	return "com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationqueryRequestBody"
+}
+
+type CreateNotificationqueryRequestV0alpha1BodyGroupBy struct {
+	Receiver         bool `json:"receiver"`
+	Integration      bool `json:"integration"`
+	IntegrationIndex bool `json:"integrationIndex"`
+	Status           bool `json:"status"`
+	Outcome          bool `json:"outcome"`
+	Error            bool `json:"error"`
+}
+
+// NewCreateNotificationqueryRequestV0alpha1BodyGroupBy creates a new CreateNotificationqueryRequestV0alpha1BodyGroupBy object.
+func NewCreateNotificationqueryRequestV0alpha1BodyGroupBy() *CreateNotificationqueryRequestV0alpha1BodyGroupBy {
+	return &CreateNotificationqueryRequestV0alpha1BodyGroupBy{}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for CreateNotificationqueryRequestV0alpha1BodyGroupBy.
+func (CreateNotificationqueryRequestV0alpha1BodyGroupBy) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationqueryRequestV0alpha1BodyGroupBy"
 }
 
 type CreateNotificationqueryRequestMatcherType string
@@ -91,4 +114,16 @@ const (
 // OpenAPIModelName returns the OpenAPI model name for CreateNotificationqueryRequestMatcherType.
 func (CreateNotificationqueryRequestMatcherType) OpenAPIModelName() string {
 	return "com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationqueryRequestMatcherType"
+}
+
+type CreateNotificationqueryRequestBodyType string
+
+const (
+	CreateNotificationqueryRequestBodyTypeEntries CreateNotificationqueryRequestBodyType = "entries"
+	CreateNotificationqueryRequestBodyTypeCounts  CreateNotificationqueryRequestBodyType = "counts"
+)
+
+// OpenAPIModelName returns the OpenAPI model name for CreateNotificationqueryRequestBodyType.
+func (CreateNotificationqueryRequestBodyType) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationqueryRequestBodyType"
 }

--- a/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationquery_response_types_gen.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationquery_response_types_gen.go
@@ -106,14 +106,38 @@ func (CreateNotificationqueryNotificationEntryAlert) OpenAPIModelName() string {
 }
 
 // +k8s:openapi-gen=true
+type CreateNotificationqueryNotificationCount struct {
+	Receiver         *string                                     `json:"receiver,omitempty"`
+	Integration      *string                                     `json:"integration,omitempty"`
+	IntegrationIndex *int64                                      `json:"integrationIndex,omitempty"`
+	Status           *CreateNotificationqueryNotificationStatus  `json:"status,omitempty"`
+	Outcome          *CreateNotificationqueryNotificationOutcome `json:"outcome,omitempty"`
+	Error            *string                                     `json:"error,omitempty"`
+	// Count is the number of notification attempts in the time period.
+	Count int64 `json:"count"`
+}
+
+// NewCreateNotificationqueryNotificationCount creates a new CreateNotificationqueryNotificationCount object.
+func NewCreateNotificationqueryNotificationCount() *CreateNotificationqueryNotificationCount {
+	return &CreateNotificationqueryNotificationCount{}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for CreateNotificationqueryNotificationCount.
+func (CreateNotificationqueryNotificationCount) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationqueryNotificationCount"
+}
+
+// +k8s:openapi-gen=true
 type CreateNotificationqueryResponse struct {
 	Entries []CreateNotificationqueryNotificationEntry `json:"entries"`
+	Counts  []CreateNotificationqueryNotificationCount `json:"counts"`
 }
 
 // NewCreateNotificationqueryResponse creates a new CreateNotificationqueryResponse object.
 func NewCreateNotificationqueryResponse() *CreateNotificationqueryResponse {
 	return &CreateNotificationqueryResponse{
 		Entries: []CreateNotificationqueryNotificationEntry{},
+		Counts:  []CreateNotificationqueryNotificationCount{},
 	}
 }
 

--- a/apps/alerting/historian/pkg/apis/alertinghistorian_manifest.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian_manifest.go
@@ -106,6 +106,52 @@ var appManifestData = app.ManifestData{
 																		Description: "From is the starting timestamp for the query.",
 																	},
 																},
+																"groupBy": {
+																	SchemaProps: spec.SchemaProps{
+																		Type:        []string{"object"},
+																		Description: "GroupBy specifies how to aggregate counts queries.",
+																		Properties: map[string]spec.Schema{
+																			"error": {
+																				SchemaProps: spec.SchemaProps{
+																					Type: []string{"boolean"},
+																				},
+																			},
+																			"integration": {
+																				SchemaProps: spec.SchemaProps{
+																					Type: []string{"boolean"},
+																				},
+																			},
+																			"integrationIndex": {
+																				SchemaProps: spec.SchemaProps{
+																					Type: []string{"boolean"},
+																				},
+																			},
+																			"outcome": {
+																				SchemaProps: spec.SchemaProps{
+																					Type: []string{"boolean"},
+																				},
+																			},
+																			"receiver": {
+																				SchemaProps: spec.SchemaProps{
+																					Type: []string{"boolean"},
+																				},
+																			},
+																			"status": {
+																				SchemaProps: spec.SchemaProps{
+																					Type: []string{"boolean"},
+																				},
+																			},
+																		},
+																		Required: []string{
+																			"receiver",
+																			"integration",
+																			"integrationIndex",
+																			"status",
+																			"outcome",
+																			"error",
+																		},
+																	},
+																},
 																"groupLabels": {
 																	SchemaProps: spec.SchemaProps{
 
@@ -159,6 +205,16 @@ var appManifestData = app.ManifestData{
 																		Description: "To is the starting timestamp for the query.",
 																	},
 																},
+																"type": {
+																	SchemaProps: spec.SchemaProps{
+																		Type:        []string{"string"},
+																		Description: "Type of query to perform (default: entries)",
+																		Enum: []interface{}{
+																			"entries",
+																			"counts",
+																		},
+																	},
+																},
 															},
 														}},
 												}},
@@ -176,6 +232,18 @@ var appManifestData = app.ManifestData{
 																SchemaProps: spec.SchemaProps{
 																	Type: []string{"object"},
 																	Properties: map[string]spec.Schema{
+																		"counts": {
+																			SchemaProps: spec.SchemaProps{
+																				Type: []string{"array"},
+																				Items: &spec.SchemaOrArray{
+																					Schema: &spec.Schema{
+																						SchemaProps: spec.SchemaProps{
+
+																							Ref: spec.MustCreateRef("#/components/schemas/createNotificationqueryNotificationCount"),
+																						}},
+																				},
+																			},
+																		},
 																		"entries": {
 																			SchemaProps: spec.SchemaProps{
 																				Type: []string{"array"},
@@ -191,6 +259,7 @@ var appManifestData = app.ManifestData{
 																	},
 																	Required: []string{
 																		"entries",
+																		"counts",
 																	},
 																}},
 														}},
@@ -330,6 +399,54 @@ var appManifestData = app.ManifestData{
 
 										Ref: spec.MustCreateRef("#/components/schemas/createNotificationqueryMatcher"),
 									}},
+							},
+						},
+					},
+					"createNotificationqueryNotificationCount": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"count": {
+									SchemaProps: spec.SchemaProps{
+										Type:        []string{"integer"},
+										Description: "Count is the number of notification attempts in the time period.",
+									},
+								},
+								"error": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"integration": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"integrationIndex": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"integer"},
+									},
+								},
+								"outcome": {
+									SchemaProps: spec.SchemaProps{
+
+										Ref: spec.MustCreateRef("#/components/schemas/createNotificationqueryNotificationOutcome"),
+									},
+								},
+								"receiver": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"status": {
+									SchemaProps: spec.SchemaProps{
+
+										Ref: spec.MustCreateRef("#/components/schemas/createNotificationqueryNotificationStatus"),
+									},
+								},
+							},
+							Required: []string{
+								"count",
 							},
 						},
 					},

--- a/apps/alerting/historian/pkg/app/notification/lokireader.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -43,6 +44,7 @@ var (
 
 type lokiClient interface {
 	RangeQuery(ctx context.Context, logQL string, start, end, limit int64) (lokiclient.QueryRes, error)
+	MetricsQuery(ctx context.Context, logQL string, ts int64, limit int64) (lokiclient.MetricsQueryRes, error)
 }
 
 type LokiReader struct {
@@ -70,7 +72,9 @@ func NewLokiReader(cfg config.LokiConfig, reg prometheus.Registerer, logger logg
 	}
 }
 
-// Query retrieves notification history entries from an external Loki instance.
+// Query retrieves notification history from an external Loki instance.
+// When query.Type is "counts", it returns aggregated counts via a metrics query.
+// Otherwise it returns individual notification entries via a range query.
 func (h *LokiReader) Query(ctx context.Context, query Query) (QueryResult, error) {
 	logql, err := buildQuery(query)
 	if err != nil {
@@ -96,19 +100,46 @@ func (h *LokiReader) Query(ctx context.Context, query Query) (QueryResult, error
 		return QueryResult{}, fmt.Errorf("%w: limit (%d) over maximum allowed (%d)", ErrInvalidQuery, limit, maxLimit)
 	}
 
-	entries, err := h.runQuery(ctx, logql, from, to, limit)
-	if err != nil {
-		return QueryResult{}, err
+	qtype := v0alpha1.CreateNotificationqueryRequestBodyTypeEntries
+	if query.Type != nil {
+		qtype = *query.Type
 	}
 
-	// Prune entries to the requested limit
-	if int64(len(entries)) > limit {
-		entries = entries[:limit]
-	}
+	switch qtype {
+	case v0alpha1.CreateNotificationqueryRequestBodyTypeEntries:
+		entries, err := h.runQuery(ctx, logql, from, to, limit)
+		if err != nil {
+			return QueryResult{}, err
+		}
 
-	return QueryResult{
-		Entries: entries,
-	}, nil
+		// Prune entries to the requested limit.
+		if int64(len(entries)) > limit {
+			entries = entries[:limit]
+		}
+
+		return QueryResult{Entries: entries}, nil
+
+	case v0alpha1.CreateNotificationqueryRequestBodyTypeCounts:
+		// Default to no grouping (all false).
+		groupBy := QueryGroupBy{}
+		if query.GroupBy != nil {
+			groupBy = *query.GroupBy
+		}
+		counts, err := h.runMetricsQuery(ctx, logql, from, to, limit, groupBy)
+		if err != nil {
+			return QueryResult{}, err
+		}
+
+		// Prune counts to the requested limit.
+		if int64(len(counts)) > limit {
+			counts = counts[:limit]
+		}
+
+		return QueryResult{Counts: counts}, nil
+
+	default:
+		return QueryResult{}, fmt.Errorf("%w: unknown query type (%s)", ErrInvalidQuery, string(qtype))
+	}
 }
 
 // QueryAlerts retrieves individual alert entries from an external Loki instance.
@@ -150,6 +181,115 @@ func (h *LokiReader) QueryAlerts(ctx context.Context, query AlertQuery) (AlertQu
 	return AlertQueryResult{
 		Alerts: alerts,
 	}, nil
+}
+
+// buildMetricsQuery constructs the LogQL metrics query that wraps a log filter in a
+// topk(sum(count_over_time(...))) aggregation.
+func buildMetricsQuery(logqlInner string, from, to time.Time, limit int64, groupBy QueryGroupBy) string {
+	// Additional expressions for the inner query if needed.
+	logqlInnerExtra := ""
+
+	// If grouping by outcome, create a field based on whether error is empty.
+	if groupBy.Outcome {
+		logqlInnerExtra += ` | label_format outcome="{{ if .error }}error{{ else }}success{{ end }}"`
+	}
+
+	// Optionally add the grouping, if any.
+	var labels []string
+	if groupBy.Receiver {
+		labels = append(labels, "receiver")
+	}
+	if groupBy.Integration {
+		labels = append(labels, "integration")
+	}
+	if groupBy.IntegrationIndex {
+		labels = append(labels, "integrationIdx")
+	}
+	if groupBy.Status {
+		labels = append(labels, "status")
+	}
+	if groupBy.Outcome {
+		labels = append(labels, "outcome")
+	}
+	if groupBy.Error {
+		labels = append(labels, "error")
+	}
+	sumBy := ""
+	if len(labels) > 0 {
+		sumBy = fmt.Sprintf(" by (%s) ", strings.Join(labels, ","))
+	}
+
+	rangeSeconds := int64(to.Sub(from).Seconds())
+	return fmt.Sprintf(`topk(%d, sum%s(count_over_time(%s%s[%ds])))`,
+		limit, sumBy, logqlInner, logqlInnerExtra, rangeSeconds)
+}
+
+// runMetricsQuery executes a sum(count_over_time(...)) instant query against Loki and
+// converts the metric samples into Count values.
+func (h *LokiReader) runMetricsQuery(ctx context.Context, logqlInner string, from, to time.Time, limit int64, groupBy QueryGroupBy) ([]Count, error) {
+	logql := buildMetricsQuery(logqlInner, from, to, limit, groupBy)
+
+	res, err := h.client.MetricsQuery(ctx, logql, to.UnixNano(), limit)
+	if err != nil {
+		return nil, fmt.Errorf("loki metrics query: %w", err)
+	}
+
+	counts := make([]Count, 0, len(res.Data.Result))
+	for _, sample := range res.Data.Result {
+		count, err := parseCount(sample)
+		if err != nil {
+			h.logger.Warn("Ignoring metric sample", "err", err)
+			continue
+		}
+		counts = append(counts, count)
+	}
+
+	// Sort counts by count (highest first).
+	sort.Slice(counts, func(i, j int) bool {
+		return counts[i].Count > counts[j].Count
+	})
+
+	return counts, nil
+}
+
+// parseCount converts a single Loki MetricSample into a Count.
+func parseCount(sample lokiclient.MetricSample) (Count, error) {
+	countStr, err := sample.Value.Value()
+	if err != nil {
+		return Count{}, fmt.Errorf("unparseable value: %w", err)
+	}
+	count, err := strconv.ParseInt(countStr, 10, 64)
+	if err != nil {
+		return Count{}, fmt.Errorf("non-integer count %q: %w", countStr, err)
+	}
+
+	entry := Count{Count: count}
+	m := sample.Metric
+	if v, ok := m["receiver"]; ok {
+		entry.Receiver = &v
+	}
+	if v, ok := m["integration"]; ok {
+		entry.Integration = &v
+	}
+	if v, ok := m["integrationIdx"]; ok {
+		i, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return Count{}, fmt.Errorf("non-integer integrationIdx %q: %w", v, err)
+		}
+		entry.IntegrationIndex = &i
+	}
+	if v, ok := m["status"]; ok {
+		s := Status(v)
+		entry.Status = &s
+	}
+	if v, ok := m["outcome"]; ok {
+		o := Outcome(v)
+		entry.Outcome = &o
+	}
+	if v, ok := m["error"]; ok {
+		entry.Error = &v
+	}
+	return entry, nil
 }
 
 // buildAlertQuery creates the LogQL to perform the requested alert query.

--- a/apps/alerting/historian/pkg/app/notification/lokireader.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader.go
@@ -112,11 +112,6 @@ func (h *LokiReader) Query(ctx context.Context, query Query) (QueryResult, error
 			return QueryResult{}, err
 		}
 
-		// Prune entries to the requested limit.
-		if int64(len(entries)) > limit {
-			entries = entries[:limit]
-		}
-
 		return QueryResult{Entries: entries}, nil
 
 	case v0alpha1.CreateNotificationqueryRequestBodyTypeCounts:
@@ -128,11 +123,6 @@ func (h *LokiReader) Query(ctx context.Context, query Query) (QueryResult, error
 		counts, err := h.runMetricsQuery(ctx, logql, from, to, limit, groupBy)
 		if err != nil {
 			return QueryResult{}, err
-		}
-
-		// Prune counts to the requested limit.
-		if int64(len(counts)) > limit {
-			counts = counts[:limit]
 		}
 
 		return QueryResult{Counts: counts}, nil

--- a/apps/alerting/historian/pkg/app/notification/lokireader_test.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader_test.go
@@ -28,6 +28,11 @@ func (m *mockLokiClient) RangeQuery(ctx context.Context, logQL string, start, en
 	return args.Get(0).(lokiclient.QueryRes), args.Error(1)
 }
 
+func (m *mockLokiClient) MetricsQuery(ctx context.Context, logQL string, ts int64, limit int64) (lokiclient.MetricsQueryRes, error) {
+	args := m.Called(ctx, logQL, ts, limit)
+	return args.Get(0).(lokiclient.MetricsQueryRes), args.Error(1)
+}
+
 func TestLokiReader_Query(t *testing.T) {
 	now := time.Now().UTC()
 	testTimestamp := now.Add(-1 * time.Hour)
@@ -739,6 +744,289 @@ func TestParseLokiAlertEntry(t *testing.T) {
 	}
 }
 
+func TestLokiReader_Query_Counts(t *testing.T) {
+	now := time.Now().UTC()
+	queryTypeCounts := v0alpha1.CreateNotificationqueryRequestBodyTypeCounts
+
+	makeMetricSample := func(count string, metric map[string]string) lokiclient.MetricSample {
+		ts, _ := json.Marshal(float64(now.UnixNano()) / 1e9)
+		val, _ := json.Marshal(count)
+		return lokiclient.MetricSample{
+			Metric: metric,
+			Value:  lokiclient.MetricSampleValue{ts, val},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		query         Query
+		lokiResponse  lokiclient.MetricsQueryRes
+		responseError error
+		experr        error
+		validateFn    func(t *testing.T, result QueryResult)
+	}{
+		{
+			name: "successful counts query with results",
+			query: Query{
+				Type:    &queryTypeCounts,
+				RuleUID: stringPtr("test-rule-uid"),
+				GroupBy: &QueryGroupBy{Receiver: true},
+			},
+			lokiResponse: lokiclient.MetricsQueryRes{
+				Data: lokiclient.MetricsQueryData{
+					Result: []lokiclient.MetricSample{
+						makeMetricSample("42", map[string]string{"receiver": "email"}),
+					},
+				},
+			},
+			validateFn: func(t *testing.T, result QueryResult) {
+				require.Len(t, result.Counts, 1)
+				assert.Equal(t, int64(42), result.Counts[0].Count)
+				require.NotNil(t, result.Counts[0].Receiver)
+				assert.Equal(t, "email", *result.Counts[0].Receiver)
+			},
+		},
+		{
+			name: "counts query with over max limit",
+			query: Query{
+				Type:  &queryTypeCounts,
+				Limit: int64Ptr(1001),
+			},
+			lokiResponse: lokiclient.MetricsQueryRes{},
+			experr:       ErrInvalidQuery,
+		},
+		{
+			name: "counts query loki error is propagated",
+			query: Query{
+				Type:    &queryTypeCounts,
+				RuleUID: stringPtr("test-rule-uid"),
+			},
+			lokiResponse:  lokiclient.MetricsQueryRes{},
+			responseError: fmt.Errorf("loki unavailable"),
+			experr:        fmt.Errorf("loki unavailable"),
+		},
+		{
+			name: "counts sorted by count descending",
+			query: Query{
+				Type:    &queryTypeCounts,
+				GroupBy: &QueryGroupBy{Receiver: true},
+			},
+			lokiResponse: lokiclient.MetricsQueryRes{
+				Data: lokiclient.MetricsQueryData{
+					Result: []lokiclient.MetricSample{
+						makeMetricSample("5", map[string]string{"receiver": "slack"}),
+						makeMetricSample("20", map[string]string{"receiver": "email"}),
+						makeMetricSample("10", map[string]string{"receiver": "pagerduty"}),
+					},
+				},
+			},
+			validateFn: func(t *testing.T, result QueryResult) {
+				require.Len(t, result.Counts, 3)
+				assert.Equal(t, int64(20), result.Counts[0].Count)
+				assert.Equal(t, int64(10), result.Counts[1].Count)
+				assert.Equal(t, int64(5), result.Counts[2].Count)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockLokiClient{}
+			mockClient.On("MetricsQuery", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				Return(tt.lokiResponse, tt.responseError)
+
+			reader := &LokiReader{
+				client: mockClient,
+				logger: &logging.NoOpLogger{},
+			}
+
+			result, err := reader.Query(context.Background(), tt.query)
+			if tt.experr != nil {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.validateFn != nil {
+				tt.validateFn(t, result)
+			}
+
+			mockClient.AssertExpectations(t)
+		})
+	}
+}
+
+func TestBuildMetricsQuery(t *testing.T) {
+	now := time.Now().UTC()
+	from := now.Add(-6 * time.Hour)
+	rangeSeconds := int64(now.Sub(from).Seconds())
+
+	tests := []struct {
+		name       string
+		logqlInner string
+		from       time.Time
+		to         time.Time
+		limit      int64
+		groupBy    QueryGroupBy
+		expected   string
+	}{
+		{
+			name:       "no grouping",
+			logqlInner: `{foo="bar"} | json`,
+			from:       from,
+			to:         now,
+			limit:      100,
+			groupBy:    QueryGroupBy{},
+			expected:   fmt.Sprintf(`topk(100, sum(count_over_time({foo="bar"} | json[%ds])))`, rangeSeconds),
+		},
+		{
+			name:       "group by receiver",
+			logqlInner: `{foo="bar"} | json`,
+			from:       from,
+			to:         now,
+			limit:      100,
+			groupBy:    QueryGroupBy{Receiver: true},
+			expected:   fmt.Sprintf(`topk(100, sum by (receiver) (count_over_time({foo="bar"} | json[%ds])))`, rangeSeconds),
+		},
+		{
+			name:       "group by receiver and status",
+			logqlInner: `{foo="bar"} | json`,
+			from:       from,
+			to:         now,
+			limit:      50,
+			groupBy:    QueryGroupBy{Receiver: true, Status: true},
+			expected:   fmt.Sprintf(`topk(50, sum by (receiver,status) (count_over_time({foo="bar"} | json[%ds])))`, rangeSeconds),
+		},
+		{
+			name:       "group by outcome adds label_format",
+			logqlInner: `{foo="bar"} | json`,
+			from:       from,
+			to:         now,
+			limit:      100,
+			groupBy:    QueryGroupBy{Outcome: true},
+			expected: fmt.Sprintf(`topk(100, sum by (outcome) (count_over_time({foo="bar"} | json`+
+				` | label_format outcome="{{ if .error }}error{{ else }}success{{ end }}"[%ds])))`, rangeSeconds),
+		},
+		{
+			name:       "group by all fields",
+			logqlInner: `{foo="bar"} | json`,
+			from:       from,
+			to:         now,
+			limit:      100,
+			groupBy:    QueryGroupBy{Receiver: true, Integration: true, IntegrationIndex: true, Status: true, Outcome: true, Error: true},
+			expected: fmt.Sprintf(`topk(100, sum by (receiver,integration,integrationIdx,status,outcome,error) `+
+				`(count_over_time({foo="bar"} | json`+
+				` | label_format outcome="{{ if .error }}error{{ else }}success{{ end }}"[%ds])))`, rangeSeconds),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildMetricsQuery(tt.logqlInner, tt.from, tt.to, tt.limit, tt.groupBy)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseCount(t *testing.T) {
+	makeValue := func(count string) lokiclient.MetricSampleValue {
+		ts, _ := json.Marshal(1234567890.0)
+		val, _ := json.Marshal(count)
+		return lokiclient.MetricSampleValue{ts, val}
+	}
+
+	tests := []struct {
+		name    string
+		sample  lokiclient.MetricSample
+		wantErr bool
+		want    Count
+	}{
+		{
+			name: "count only",
+			sample: lokiclient.MetricSample{
+				Metric: map[string]string{},
+				Value:  makeValue("42"),
+			},
+			want: Count{Count: 42},
+		},
+		{
+			name: "with receiver",
+			sample: lokiclient.MetricSample{
+				Metric: map[string]string{"receiver": "email"},
+				Value:  makeValue("10"),
+			},
+			want: Count{Count: 10, Receiver: stringPtr("email")},
+		},
+		{
+			name: "with integration and integrationIdx",
+			sample: lokiclient.MetricSample{
+				Metric: map[string]string{"integration": "slack", "integrationIdx": "2"},
+				Value:  makeValue("5"),
+			},
+			want: Count{Count: 5, Integration: stringPtr("slack"), IntegrationIndex: int64Ptr(2)},
+		},
+		{
+			name: "with status",
+			sample: lokiclient.MetricSample{
+				Metric: map[string]string{"status": "firing"},
+				Value:  makeValue("7"),
+			},
+			want: Count{Count: 7, Status: countStatusPtr("firing")},
+		},
+		{
+			name: "with outcome",
+			sample: lokiclient.MetricSample{
+				Metric: map[string]string{"outcome": "success"},
+				Value:  makeValue("3"),
+			},
+			want: Count{Count: 3, Outcome: countOutcomePtr("success")},
+		},
+		{
+			name: "with error",
+			sample: lokiclient.MetricSample{
+				Metric: map[string]string{"error": "connection refused"},
+				Value:  makeValue("1"),
+			},
+			want: Count{Count: 1, Error: stringPtr("connection refused")},
+		},
+		{
+			name: "non-integer count",
+			sample: lokiclient.MetricSample{
+				Metric: map[string]string{},
+				Value:  makeValue("not-a-number"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-integer integrationIdx",
+			sample: lokiclient.MetricSample{
+				Metric: map[string]string{"integrationIdx": "bad"},
+				Value:  makeValue("1"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCount(tt.sample)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want.Count, got.Count)
+			assert.Equal(t, tt.want.Receiver, got.Receiver)
+			assert.Equal(t, tt.want.Integration, got.Integration)
+			assert.Equal(t, tt.want.IntegrationIndex, got.IntegrationIndex)
+			assert.Equal(t, tt.want.Status, got.Status)
+			assert.Equal(t, tt.want.Outcome, got.Outcome)
+			assert.Equal(t, tt.want.Error, got.Error)
+		})
+	}
+}
+
 // Helper functions
 
 func stringPtr(s string) *string {
@@ -835,6 +1123,14 @@ func createMockAlertLokiResponse(timestamp time.Time) lokiclient.QueryRes {
 			},
 		},
 	}
+}
+
+func countStatusPtr(s v0alpha1.CreateNotificationqueryNotificationStatus) *v0alpha1.CreateNotificationqueryNotificationStatus {
+	return &s
+}
+
+func countOutcomePtr(o v0alpha1.CreateNotificationqueryNotificationOutcome) *v0alpha1.CreateNotificationqueryNotificationOutcome {
+	return &o
 }
 
 func createLokiEntryJSONWithNilLabels(t *testing.T, timestamp time.Time) string {

--- a/apps/alerting/historian/pkg/app/notification/lokireader_test.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader_test.go
@@ -749,7 +749,7 @@ func TestLokiReader_Query_Counts(t *testing.T) {
 	queryTypeCounts := v0alpha1.CreateNotificationqueryRequestBodyTypeCounts
 
 	makeMetricSample := func(count string, metric map[string]string) lokiclient.MetricSample {
-		ts, _ := json.Marshal(float64(now.UnixNano()) / 1e9)
+		ts, _ := json.Marshal(now.Unix())
 		val, _ := json.Marshal(count)
 		return lokiclient.MetricSample{
 			Metric: metric,

--- a/apps/alerting/historian/pkg/app/notification/notification.go
+++ b/apps/alerting/historian/pkg/app/notification/notification.go
@@ -143,6 +143,7 @@ func (n *Notification) QueryHandler(ctx context.Context, writer app.CustomRouteR
 
 	n.logger.Debug("Notification history query success",
 		"entries", len(response.Entries),
+		"counts", len(response.Counts),
 		"duration", time.Since(start))
 
 	writer.Header().Add("Content-Type", "application/json")

--- a/apps/alerting/historian/pkg/app/notification/types.go
+++ b/apps/alerting/historian/pkg/app/notification/types.go
@@ -32,3 +32,7 @@ type AlertQuery = v0alpha1.CreateNotificationsqueryalertsRequestBody
 type AlertQueryResult = v0alpha1.CreateNotificationsqueryalertsResponse
 
 type AlertEntry = v0alpha1.CreateNotificationsqueryalertsNotificationEntryAlert
+
+type QueryGroupBy = v0alpha1.CreateNotificationqueryRequestV0alpha1BodyGroupBy
+
+type Count = v0alpha1.CreateNotificationqueryNotificationCount

--- a/packages/grafana-api-clients/src/clients/rtkq/historian.alerting/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/historian.alerting/v0alpha1/endpoints.gen.ts
@@ -613,6 +613,18 @@ export type Status = {
   status?: string;
 };
 export type Patch = object;
+export type CreateNotificationqueryNotificationOutcome = 'success' | 'error';
+export type CreateNotificationqueryNotificationStatus = 'firing' | 'resolved';
+export type CreateNotificationqueryNotificationCount = {
+  /** Count is the number of notification attempts in the time period. */
+  count: number;
+  error?: string;
+  integration?: string;
+  integrationIndex?: number;
+  outcome?: CreateNotificationqueryNotificationOutcome;
+  receiver?: string;
+  status?: CreateNotificationqueryNotificationStatus;
+};
 export type CreateNotificationqueryNotificationEntryAlert = {
   annotations: {
     [key: string]: string;
@@ -627,8 +639,6 @@ export type CreateNotificationqueryNotificationEntryAlert = {
   startsAt: string;
   status: string;
 };
-export type CreateNotificationqueryNotificationOutcome = 'success' | 'error';
-export type CreateNotificationqueryNotificationStatus = 'firing' | 'resolved';
 export type CreateNotificationqueryNotificationEntry = {
   /** AlertCount is the total number of alerts included in the notification. */
   alertCount: number;
@@ -666,6 +676,7 @@ export type CreateNotificationqueryNotificationEntry = {
   uuid: string;
 };
 export type CreateNotificationqueryResponse = {
+  counts: CreateNotificationqueryNotificationCount[];
   entries: CreateNotificationqueryNotificationEntry[];
 };
 export type CreateNotificationqueryMatcher = {
@@ -677,6 +688,15 @@ export type CreateNotificationqueryMatchers = CreateNotificationqueryMatcher[];
 export type CreateNotificationqueryRequestBody = {
   /** From is the starting timestamp for the query. */
   from?: string;
+  /** GroupBy specifies how to aggregate counts queries. */
+  groupBy?: {
+    error: boolean;
+    integration: boolean;
+    integrationIndex: boolean;
+    outcome: boolean;
+    receiver: boolean;
+    status: boolean;
+  };
   /** GroupLabels optionally filters the entries by matching group labels. */
   groupLabels?: CreateNotificationqueryMatchers;
   /** Labels optionally filters the entries by matching alert labels. */
@@ -693,6 +713,8 @@ export type CreateNotificationqueryRequestBody = {
   status?: CreateNotificationqueryNotificationStatus;
   /** To is the starting timestamp for the query. */
   to?: string;
+  /** Type of query to perform (default: entries) */
+  type?: 'entries' | 'counts';
 };
 export type CreateNotificationsqueryalertsNotificationEntryAlert = {
   annotations: {

--- a/packages/grafana-openapi/src/apis/historian.alerting.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/historian.alerting.grafana.app-v0alpha1.json
@@ -1132,6 +1132,34 @@
           "$ref": "#/components/schemas/CreateNotificationqueryMatcher"
         }
       },
+      "CreateNotificationqueryNotificationCount": {
+        "type": "object",
+        "required": ["count"],
+        "properties": {
+          "count": {
+            "description": "Count is the number of notification attempts in the time period.",
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          },
+          "integration": {
+            "type": "string"
+          },
+          "integrationIndex": {
+            "type": "integer"
+          },
+          "outcome": {
+            "$ref": "#/components/schemas/CreateNotificationqueryNotificationOutcome"
+          },
+          "receiver": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/CreateNotificationqueryNotificationStatus"
+          }
+        }
+      },
       "CreateNotificationqueryNotificationEntry": {
         "type": "object",
         "required": [
@@ -1286,6 +1314,31 @@
             "type": "string",
             "format": "date-time"
           },
+          "groupBy": {
+            "description": "GroupBy specifies how to aggregate counts queries.",
+            "type": "object",
+            "required": ["receiver", "integration", "integrationIndex", "status", "outcome", "error"],
+            "properties": {
+              "error": {
+                "type": "boolean"
+              },
+              "integration": {
+                "type": "boolean"
+              },
+              "integrationIndex": {
+                "type": "boolean"
+              },
+              "outcome": {
+                "type": "boolean"
+              },
+              "receiver": {
+                "type": "boolean"
+              },
+              "status": {
+                "type": "boolean"
+              }
+            }
+          },
           "groupLabels": {
             "description": "GroupLabels optionally filters the entries by matching group labels.",
             "allOf": [
@@ -1334,13 +1387,24 @@
             "description": "To is the starting timestamp for the query.",
             "type": "string",
             "format": "date-time"
+          },
+          "type": {
+            "description": "Type of query to perform (default: entries)",
+            "type": "string",
+            "enum": ["entries", "counts"]
           }
         }
       },
       "CreateNotificationqueryResponse": {
         "type": "object",
-        "required": ["entries"],
+        "required": ["entries", "counts"],
         "properties": {
+          "counts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateNotificationqueryNotificationCount"
+            }
+          },
           "entries": {
             "type": "array",
             "items": {

--- a/pkg/tests/apis/openapi_snapshots/historian.alerting.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/historian.alerting.grafana.app-v0alpha1.json
@@ -1226,6 +1226,36 @@
           "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationqueryMatcher"
         }
       },
+      "com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationqueryNotificationCount": {
+        "type": "object",
+        "required": [
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "description": "Count is the number of notification attempts in the time period.",
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          },
+          "integration": {
+            "type": "string"
+          },
+          "integrationIndex": {
+            "type": "integer"
+          },
+          "outcome": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationqueryNotificationOutcome"
+          },
+          "receiver": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationqueryNotificationStatus"
+          }
+        }
+      },
       "com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationqueryNotificationEntry": {
         "type": "object",
         "required": [
@@ -1392,6 +1422,38 @@
             "type": "string",
             "format": "date-time"
           },
+          "groupBy": {
+            "description": "GroupBy specifies how to aggregate counts queries.",
+            "type": "object",
+            "required": [
+              "receiver",
+              "integration",
+              "integrationIndex",
+              "status",
+              "outcome",
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "type": "boolean"
+              },
+              "integration": {
+                "type": "boolean"
+              },
+              "integrationIndex": {
+                "type": "boolean"
+              },
+              "outcome": {
+                "type": "boolean"
+              },
+              "receiver": {
+                "type": "boolean"
+              },
+              "status": {
+                "type": "boolean"
+              }
+            }
+          },
           "groupLabels": {
             "description": "GroupLabels optionally filters the entries by matching group labels.",
             "allOf": [
@@ -1440,15 +1502,30 @@
             "description": "To is the starting timestamp for the query.",
             "type": "string",
             "format": "date-time"
+          },
+          "type": {
+            "description": "Type of query to perform (default: entries)",
+            "type": "string",
+            "enum": [
+              "entries",
+              "counts"
+            ]
           }
         }
       },
       "com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationqueryResponse": {
         "type": "object",
         "required": [
-          "entries"
+          "entries",
+          "counts"
         ],
         "properties": {
+          "counts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationqueryNotificationCount"
+            }
+          },
           "entries": {
             "type": "array",
             "items": {


### PR DESCRIPTION
The query API now accepts type=counts with a groupBy parameter, returning
aggregated notification attempt counts broken down by dimensions such as
receiver, status, and outcome, rather than individual log entries. This enables
use cases like showing per-receiver success/failure totals on a status page
without retrieving and paginating through raw notification history.

The rationale behind sharing the API endpoint instead of making a new one:
- The query parameters are identical, just what data returns is different.
- The code generator creates a separate Go type for each endpoint, making
  it hard to reuse the types in code.
