### PR TITLE
Chore: Reenable a11y tests, remove from @acceptance, add documentation

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -243,6 +243,8 @@ make test-go-integration-postgres
   - Unzip.
   - Run `yarn playwright show-report <reportLocation>`
 
+- There are also a set of acceptance tests that can be run with `yarn e2e:acceptance`. These tests should run against a Grafana instance with the default configuration (e.g. no provisioned dashboards/datasources), and are used to verify our cloud/on-prem images are working as expected.
+
 If you are curious about other commands, you can see the full list in [the Playwright documentation](https://playwright.dev/docs/test-cli#all-options).
 
 ## Configure Grafana for development

--- a/e2e-playwright/smoke-tests-suite/accessibility.spec.ts
+++ b/e2e-playwright/smoke-tests-suite/accessibility.spec.ts
@@ -11,10 +11,10 @@ interface A11yTestCase {
   ignoredRules?: string[];
 }
 
-test.describe.skip(
+test.describe(
   'A11y smokescreen',
   {
-    tag: ['@acceptance', '@a11y'],
+    tag: ['@a11y'],
   },
   () => {
     (


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- reenables the a11y tests in playwright
- removes them from the `@acceptance` tag as they require certain panels/dashboards to be present

**Why do we need this feature?**

- so build verification works correctly

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
