### PR TITLE
Enhance RBAC settings with local folder cache TTL support

### DIFF
--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -91,7 +91,10 @@ func ProvideAuthZClient(
 	default:
 		sql := legacysql.NewDatabaseProvider(db)
 
-		rbacSettings := rbac.Settings{CacheTTL: authCfg.cacheTTL}
+		rbacSettings := rbac.Settings{
+			CacheTTL:            authCfg.cacheTTL,
+			LocalFolderCacheTTL: authCfg.localFolderCacheTTL,
+		}
 		if cfg != nil {
 			rbacSettings.AnonOrgRole = cfg.Anonymous.OrgRole
 		}
@@ -302,7 +305,7 @@ func RegisterRBACAuthZService(
 		tracer,
 		reg,
 		cache,
-		rbac.Settings{CacheTTL: cfg.CacheTTL}, // anonymous org role can only be set in-proc
+		rbac.Settings{CacheTTL: cfg.CacheTTL, LocalFolderCacheTTL: cfg.LocalFolderCacheTTL}, // anonymous org role can only be set in-proc
 	)
 
 	srv := handler.GetServer()

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -90,11 +90,7 @@ func ProvideAuthZClient(
 		return rbacClient, err
 	default:
 		sql := legacysql.NewDatabaseProvider(db)
-
-		rbacSettings := rbac.Settings{
-			CacheTTL:            authCfg.cacheTTL,
-			LocalFolderCacheTTL: authCfg.localFolderCacheTTL,
-		}
+		rbacSettings := rbac.Settings{CacheTTL: authCfg.cacheTTL}
 		if cfg != nil {
 			rbacSettings.AnonOrgRole = cfg.Anonymous.OrgRole
 		}

--- a/pkg/services/authz/rbac/cache.go
+++ b/pkg/services/authz/rbac/cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/grafana/authlib/cache"
@@ -53,24 +54,50 @@ type cacheWrap[T any] interface {
 	Get(ctx context.Context, key string) (T, bool)
 	Set(ctx context.Context, key string, value T)
 }
+type localEntry[T any] struct {
+	value     T
+	expiresAt time.Time
+}
+
 type cacheWrapImpl[T any] struct {
 	cache  cache.Cache
 	logger log.Logger
 	tracer tracing.Tracer
 	ttl    time.Duration
+
+	// When localTTL > 0 an in-memory L1 layer sits in front of the remote
+	// cache to avoid round-trips and JSON deserialization on hot paths.
+	localTTL time.Duration
+	mu       sync.RWMutex
+	local    map[string]localEntry[T]
 }
 
-// cacheWrap is a wrapper around the authlib Cache that provides typed Get and Set methods
-// it handles encoding/decoding for a specific type.
-func newCacheWrap[T any](cache cache.Cache, logger log.Logger, tracer tracing.Tracer, ttl time.Duration) cacheWrap[T] {
+// newCacheWrap creates a typed cache around the authlib Cache.
+// An optional localTTL enables an in-memory L1 layer when the backing cache
+// is remote (e.g. memcached); set to 0 (or omit) to disable.
+func newCacheWrap[T any](cache cache.Cache, logger log.Logger, tracer tracing.Tracer, ttl time.Duration, localTTL ...time.Duration) cacheWrap[T] {
 	if ttl == 0 {
 		logger.Info("cache ttl is 0, using noop cache")
 		return &noopCache[T]{}
 	}
-	return &cacheWrapImpl[T]{cache: cache, logger: logger, tracer: tracer, ttl: ttl}
+	w := &cacheWrapImpl[T]{cache: cache, logger: logger, tracer: tracer, ttl: ttl}
+	if len(localTTL) > 0 && localTTL[0] > 0 {
+		w.localTTL = localTTL[0]
+		w.local = make(map[string]localEntry[T])
+	}
+	return w
 }
 
 func (c *cacheWrapImpl[T]) Get(ctx context.Context, key string) (T, bool) {
+	if c.localTTL > 0 {
+		c.mu.RLock()
+		entry, ok := c.local[key]
+		c.mu.RUnlock()
+		if ok && time.Now().Before(entry.expiresAt) {
+			return entry.value, true
+		}
+	}
+
 	ctx, span := c.tracer.Start(ctx, "cacheWrap.Get")
 	defer span.End()
 	span.SetAttributes(attribute.Bool("hit", false))
@@ -92,10 +119,23 @@ func (c *cacheWrapImpl[T]) Get(ctx context.Context, key string) (T, bool) {
 	}
 
 	span.SetAttributes(attribute.Bool("hit", true))
+
+	if c.localTTL > 0 {
+		c.mu.Lock()
+		c.local[key] = localEntry[T]{value: value, expiresAt: time.Now().Add(c.localTTL)}
+		c.mu.Unlock()
+	}
+
 	return value, true
 }
 
 func (c *cacheWrapImpl[T]) Set(ctx context.Context, key string, value T) {
+	if c.localTTL > 0 {
+		c.mu.Lock()
+		c.local[key] = localEntry[T]{value: value, expiresAt: time.Now().Add(c.localTTL)}
+		c.mu.Unlock()
+	}
+
 	ctx, span := c.tracer.Start(ctx, "cacheWrap.Set")
 	defer span.End()
 	logger := c.logger.FromContext(ctx)

--- a/pkg/services/authz/rbac/cache.go
+++ b/pkg/services/authz/rbac/cache.go
@@ -93,8 +93,13 @@ func (c *cacheWrapImpl[T]) Get(ctx context.Context, key string) (T, bool) {
 		c.mu.RLock()
 		entry, ok := c.local[key]
 		c.mu.RUnlock()
-		if ok && time.Now().Before(entry.expiresAt) {
-			return entry.value, true
+		if ok {
+			if time.Now().Before(entry.expiresAt) {
+				return entry.value, true
+			}
+			c.mu.Lock()
+			delete(c.local, key)
+			c.mu.Unlock()
 		}
 	}
 

--- a/pkg/services/authz/rbac/cache_test.go
+++ b/pkg/services/authz/rbac/cache_test.go
@@ -18,15 +18,14 @@ func newTestCache() libcache.Cache {
 }
 
 func TestCacheWrap_LocalTTL(t *testing.T) {
-	c := newCacheWrap[string](newTestCache(), log.NewNopLogger(), tracing.NewNoopTracerService(), 30*time.Second, 50*time.Millisecond)
+	remote := newTestCache()
+	c := newCacheWrap[string](remote, log.NewNopLogger(), tracing.NewNoopTracerService(), 30*time.Second, 50*time.Millisecond)
 	ctx := context.Background()
 
-	// Miss returns zero value
 	v, ok := c.Get(ctx, "key")
 	assert.False(t, ok)
 	assert.Equal(t, "", v)
 
-	// Set populates both local and remote
 	c.Set(ctx, "key", "value1")
 
 	v, ok = c.Get(ctx, "key")
@@ -34,7 +33,7 @@ func TestCacheWrap_LocalTTL(t *testing.T) {
 	assert.Equal(t, "value1", v)
 
 	// Overwrite remote directly — local should still serve stale value until TTL expires
-	c.(*cacheWrapImpl[string]).cache.Set(ctx, "key", []byte(`"value2"`), 5*time.Minute)
+	remote.Set(ctx, "key", []byte(`"value2"`), 5*time.Minute)
 
 	v, ok = c.Get(ctx, "key")
 	require.True(t, ok)
@@ -49,13 +48,14 @@ func TestCacheWrap_LocalTTL(t *testing.T) {
 }
 
 func TestCacheWrap_NoLocalTTL(t *testing.T) {
-	c := newCacheWrap[string](newTestCache(), log.NewNopLogger(), tracing.NewNoopTracerService(), 30*time.Second)
+	remote := newTestCache()
+	c := newCacheWrap[string](remote, log.NewNopLogger(), tracing.NewNoopTracerService(), 30*time.Second)
 	ctx := context.Background()
 
 	c.Set(ctx, "key", "value1")
 
 	// Overwrite remote directly — should be visible immediately without local layer
-	c.(*cacheWrapImpl[string]).cache.Set(ctx, "key", []byte(`"value2"`), 5*time.Minute)
+	remote.Set(ctx, "key", []byte(`"value2"`), 5*time.Minute)
 
 	v, ok := c.Get(ctx, "key")
 	require.True(t, ok)

--- a/pkg/services/authz/rbac/cache_test.go
+++ b/pkg/services/authz/rbac/cache_test.go
@@ -1,0 +1,63 @@
+package rbac
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	libcache "github.com/grafana/authlib/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+)
+
+func newTestCache() libcache.Cache {
+	return libcache.NewLocalCache(libcache.Config{Expiry: 5 * time.Minute, CleanupInterval: 5 * time.Minute})
+}
+
+func TestCacheWrap_LocalTTL(t *testing.T) {
+	c := newCacheWrap[string](newTestCache(), log.NewNopLogger(), tracing.NewNoopTracerService(), 30*time.Second, 50*time.Millisecond)
+	ctx := context.Background()
+
+	// Miss returns zero value
+	v, ok := c.Get(ctx, "key")
+	assert.False(t, ok)
+	assert.Equal(t, "", v)
+
+	// Set populates both local and remote
+	c.Set(ctx, "key", "value1")
+
+	v, ok = c.Get(ctx, "key")
+	require.True(t, ok)
+	assert.Equal(t, "value1", v)
+
+	// Overwrite remote directly — local should still serve stale value until TTL expires
+	c.(*cacheWrapImpl[string]).cache.Set(ctx, "key", []byte(`"value2"`), 5*time.Minute)
+
+	v, ok = c.Get(ctx, "key")
+	require.True(t, ok)
+	assert.Equal(t, "value1", v, "should still return locally cached value")
+
+	// After local TTL expires, should pick up the new remote value
+	time.Sleep(60 * time.Millisecond)
+
+	v, ok = c.Get(ctx, "key")
+	require.True(t, ok)
+	assert.Equal(t, "value2", v, "should return updated remote value after local expiry")
+}
+
+func TestCacheWrap_NoLocalTTL(t *testing.T) {
+	c := newCacheWrap[string](newTestCache(), log.NewNopLogger(), tracing.NewNoopTracerService(), 30*time.Second)
+	ctx := context.Background()
+
+	c.Set(ctx, "key", "value1")
+
+	// Overwrite remote directly — should be visible immediately without local layer
+	c.(*cacheWrapImpl[string]).cache.Set(ctx, "key", []byte(`"value2"`), 5*time.Minute)
+
+	v, ok := c.Get(ctx, "key")
+	require.True(t, ok)
+	assert.Equal(t, "value2", v, "without local TTL changes should be visible immediately")
+}

--- a/pkg/services/authz/rbac/cache_test.go
+++ b/pkg/services/authz/rbac/cache_test.go
@@ -33,7 +33,7 @@ func TestCacheWrap_LocalTTL(t *testing.T) {
 	assert.Equal(t, "value1", v)
 
 	// Overwrite remote directly — local should still serve stale value until TTL expires
-	remote.Set(ctx, "key", []byte(`"value2"`), 5*time.Minute)
+	require.NoError(t, remote.Set(ctx, "key", []byte(`"value2"`), 5*time.Minute))
 
 	v, ok = c.Get(ctx, "key")
 	require.True(t, ok)
@@ -55,7 +55,7 @@ func TestCacheWrap_NoLocalTTL(t *testing.T) {
 	c.Set(ctx, "key", "value1")
 
 	// Overwrite remote directly — should be visible immediately without local layer
-	remote.Set(ctx, "key", []byte(`"value2"`), 5*time.Minute)
+	require.NoError(t, remote.Set(ctx, "key", []byte(`"value2"`), 5*time.Minute))
 
 	v, ok := c.Get(ctx, "key")
 	require.True(t, ok)

--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -68,6 +68,9 @@ type Settings struct {
 	// CacheTTL is the time to live for the permission cache entries.
 	// Set to 0 to disable caching.
 	CacheTTL time.Duration
+	// LocalFolderCacheTTL, when non-zero, adds an in-memory L1 cache in front
+	// of the remote folder cache to reduce round-trips and deserialization cost.
+	LocalFolderCacheTTL time.Duration
 }
 
 func NewService(
@@ -99,7 +102,7 @@ func NewService(
 		permDenialCache: newCacheWrap[bool](cache, logger, tracer, settings.CacheTTL),
 		userTeamCache:   newCacheWrap[[]int64](cache, logger, tracer, settings.CacheTTL),
 		basicRoleCache:  newCacheWrap[store.BasicRole](cache, logger, tracer, settings.CacheTTL),
-		folderCache:     newCacheWrap[folderTree](cache, logger, tracer, settings.CacheTTL),
+		folderCache:     newCacheWrap[folderTree](cache, logger, tracer, settings.CacheTTL, settings.LocalFolderCacheTTL),
 		teamIDCache:     newCacheWrap[map[int64]string](cache, logger, tracer, longCacheTTL),
 		sf:              new(singleflight.Group),
 	}

--- a/pkg/services/authz/rbac_settings.go
+++ b/pkg/services/authz/rbac_settings.go
@@ -32,7 +32,8 @@ type authzClientSettings struct {
 	tokenExchangeURL string
 	tokenNamespace   string
 
-	cacheTTL time.Duration
+	cacheTTL            time.Duration
+	localFolderCacheTTL time.Duration
 }
 
 func readAuthzClientSettings(cfg *setting.Cfg) (*authzClientSettings, error) {
@@ -47,6 +48,7 @@ func readAuthzClientSettings(cfg *setting.Cfg) (*authzClientSettings, error) {
 	s := &authzClientSettings{}
 	// Cache duration applies to the server cache in proc, so it's relevant for both modes.
 	s.cacheTTL = authzSection.Key("cache_ttl").MustDuration(30 * time.Second)
+	s.localFolderCacheTTL = authzSection.Key("local_folder_cache_ttl").MustDuration(0)
 
 	s.mode = mode
 	if s.mode == clientModeInproc {
@@ -70,8 +72,9 @@ func readAuthzClientSettings(cfg *setting.Cfg) (*authzClientSettings, error) {
 }
 
 type RBACServerSettings struct {
-	Folder   FolderAPISettings
-	CacheTTL time.Duration
+	Folder              FolderAPISettings
+	CacheTTL            time.Duration
+	LocalFolderCacheTTL time.Duration
 }
 
 type FolderAPISettings struct {

--- a/pkg/services/authz/rbac_settings.go
+++ b/pkg/services/authz/rbac_settings.go
@@ -32,8 +32,7 @@ type authzClientSettings struct {
 	tokenExchangeURL string
 	tokenNamespace   string
 
-	cacheTTL            time.Duration
-	localFolderCacheTTL time.Duration
+	cacheTTL time.Duration
 }
 
 func readAuthzClientSettings(cfg *setting.Cfg) (*authzClientSettings, error) {
@@ -48,7 +47,6 @@ func readAuthzClientSettings(cfg *setting.Cfg) (*authzClientSettings, error) {
 	s := &authzClientSettings{}
 	// Cache duration applies to the server cache in proc, so it's relevant for both modes.
 	s.cacheTTL = authzSection.Key("cache_ttl").MustDuration(30 * time.Second)
-	s.localFolderCacheTTL = authzSection.Key("local_folder_cache_ttl").MustDuration(0)
 
 	s.mode = mode
 	if s.mode == clientModeInproc {


### PR DESCRIPTION
Add optional in-memory L1 cache for the folder tree in authz.

The folder tree is fetched on every authorization check but changes rarely. When the backing cache is remote (e.g. memcached), each lookup pays a network round-trip and JSON deserialization cost.

This PR adds a localTTL option to cacheWrapImpl that keeps a short-lived in-memory copy in front of the remote cache.

It is configured via the local_folder_cache_ttl setting in the [authorization] INI section (defaults to 0, disabled).
For the gRPC server path, it can be set via RBACServerSettings.LocalFolderCacheTTL.

```
[authorization]
local_folder_cache_ttl = 5s
[authorization]local_folder_cache_ttl = 5s
```