### PR TITLE
Dashboards: Resolve display names by identity in version history

### DIFF
--- a/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
@@ -187,6 +187,36 @@ describe('VersionsEditView', () => {
       expect(rows[2]).toHaveTextContent('Bhaskar Surroy');
     });
 
+    it('should use createdBy annotation as fallback for initial version without updatedBy', async () => {
+      mockListDashboardHistory.mockResolvedValue({
+        metadata: { continue: '' },
+        items: [
+          createTestResource(2, '2024-01-02T00:00:00Z', 'user:uid-editor'),
+          createTestResourceWithCreatedByOnly(1, '2024-01-01T00:00:00Z', 'user:uid-creator'),
+        ],
+      });
+
+      mockUseGetDisplayMappingQuery.mockReturnValue({
+        data: {
+          keys: ['user:uid-editor', 'user:uid-creator'],
+          display: [
+            { identity: { type: 'user', name: 'uid-creator' }, displayName: 'Creator User' },
+            { identity: { type: 'user', name: 'uid-editor' }, displayName: 'Editor User' },
+          ],
+        },
+      });
+
+      const { versionsView } = await buildTestScene();
+      render(<versionsView.Component model={versionsView} />);
+
+      expect(await screen.findByText('Editor User')).toBeInTheDocument();
+      expect(screen.getByText('Creator User')).toBeInTheDocument();
+
+      const rows = screen.getAllByRole('row');
+      expect(rows[1]).toHaveTextContent('Editor User');
+      expect(rows[2]).toHaveTextContent('Creator User');
+    });
+
     it('should fall back to raw key when user is not found in display data', async () => {
       mockListDashboardHistory.mockResolvedValue({
         metadata: { continue: '' },
@@ -215,6 +245,23 @@ function createTestResource(version: number, created: string, updatedBy = 'admin
       creationTimestamp: created,
       annotations: {
         'grafana.app/updatedBy': updatedBy,
+        'grafana.app/message': '',
+      },
+    },
+    spec: { version },
+  };
+}
+
+function createTestResourceWithCreatedByOnly(version: number, created: string, createdBy: string) {
+  return {
+    apiVersion: 'v1beta1',
+    kind: 'Dashboard',
+    metadata: {
+      name: '_U4zObQMz',
+      generation: version,
+      creationTimestamp: created,
+      annotations: {
+        'grafana.app/createdBy': createdBy,
         'grafana.app/message': '',
       },
     },

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
@@ -1,3 +1,7 @@
+import { render as RTLRender, screen } from '@testing-library/react';
+import * as React from 'react';
+import { TestProvider } from 'test/helpers/TestProvider';
+
 import { SceneTimeRange } from '@grafana/scenes';
 import { VERSIONS_FETCH_LIMIT } from 'app/features/dashboard/types/revisionModels';
 
@@ -6,12 +10,22 @@ import { activateFullSceneTree } from '../utils/test-utils';
 
 import { VersionsEditView } from './VersionsEditView';
 
+function render(component: React.ReactNode) {
+  return RTLRender(<TestProvider>{component}</TestProvider>);
+}
+
 const mockListDashboardHistory = jest.fn();
 
 jest.mock('app/features/dashboard/api/dashboard_api', () => ({
   getDashboardAPI: () => ({
     listDashboardHistory: mockListDashboardHistory,
   }),
+}));
+
+const mockUseGetDisplayMappingQuery = jest.fn();
+
+jest.mock('app/api/clients/iam/v0alpha1', () => ({
+  useGetDisplayMappingQuery: (...args: unknown[]) => mockUseGetDisplayMappingQuery(...args),
 }));
 
 describe('VersionsEditView', () => {
@@ -132,9 +146,66 @@ describe('VersionsEditView', () => {
       expect(versionsView.continueToken).toBe('');
     });
   });
+
+  describe('Display name resolution', () => {
+    beforeEach(() => {
+      mockUseGetDisplayMappingQuery.mockReset();
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should map display names by identity, not array index', async () => {
+      mockListDashboardHistory.mockResolvedValue({
+        metadata: { continue: '' },
+        items: [
+          createTestResource(2, '2024-01-02T00:00:00Z', 'user:uid-ryan'),
+          createTestResource(1, '2024-01-01T00:00:00Z', 'user:uid-bhaskar'),
+        ],
+      });
+
+      mockUseGetDisplayMappingQuery.mockReturnValue({
+        data: {
+          keys: ['user:uid-ryan', 'user:uid-bhaskar'],
+          display: [
+            { identity: { type: 'user', name: 'uid-bhaskar' }, displayName: 'Bhaskar Surroy' },
+            { identity: { type: 'user', name: 'uid-ryan' }, displayName: 'Ryan Brown' },
+          ],
+        },
+      });
+
+      const { versionsView } = await buildTestScene();
+      render(<versionsView.Component model={versionsView} />);
+
+      expect(await screen.findByText('Ryan Brown')).toBeInTheDocument();
+      expect(screen.getByText('Bhaskar Surroy')).toBeInTheDocument();
+
+      const rows = screen.getAllByRole('row');
+      // row 0 is the header; row 1 is version 2 (Ryan), row 2 is version 1 (Bhaskar)
+      expect(rows[1]).toHaveTextContent('Ryan Brown');
+      expect(rows[2]).toHaveTextContent('Bhaskar Surroy');
+    });
+
+    it('should fall back to raw key when user is not found in display data', async () => {
+      mockListDashboardHistory.mockResolvedValue({
+        metadata: { continue: '' },
+        items: [createTestResource(1, '2024-01-01T00:00:00Z', 'user:uid-unknown')],
+      });
+
+      mockUseGetDisplayMappingQuery.mockReturnValue({
+        data: { keys: ['user:uid-unknown'], display: [], invalidKeys: ['user:uid-unknown'] },
+      });
+
+      const { versionsView } = await buildTestScene();
+      render(<versionsView.Component model={versionsView} />);
+
+      expect(await screen.findByText('user:uid-unknown')).toBeInTheDocument();
+    });
+  });
 });
 
-function createTestResource(version: number, created: string) {
+function createTestResource(version: number, created: string, updatedBy = 'admin') {
   return {
     apiVersion: 'v1beta1',
     kind: 'Dashboard',
@@ -143,7 +214,7 @@ function createTestResource(version: number, created: string) {
       generation: version,
       creationTimestamp: created,
       annotations: {
-        'grafana.app/updatedBy': 'admin',
+        'grafana.app/updatedBy': updatedBy,
         'grafana.app/message': '',
       },
     },

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -8,7 +8,13 @@ import { SceneComponentProps, SceneObjectBase, sceneGraph } from '@grafana/scene
 import { Alert, Spinner, Stack } from '@grafana/ui';
 import { useGetDisplayMappingQuery } from 'app/api/clients/iam/v0alpha1';
 import { Page } from 'app/core/components/Page/Page';
-import { AnnoKeyMessage, AnnoKeyUpdatedBy, AnnoKeyUpdatedTimestamp, Resource } from 'app/features/apiserver/types';
+import {
+  AnnoKeyCreatedBy,
+  AnnoKeyMessage,
+  AnnoKeyUpdatedBy,
+  AnnoKeyUpdatedTimestamp,
+  Resource,
+} from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import {
   DecoratedRevisionModel,
@@ -127,7 +133,7 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
           item.metadata.annotations?.[AnnoKeyUpdatedTimestamp] ??
           item.metadata.creationTimestamp ??
           new Date().toISOString(),
-        createdBy: item.metadata.annotations?.[AnnoKeyUpdatedBy] ?? '',
+        createdBy: item.metadata.annotations?.[AnnoKeyUpdatedBy] ?? item.metadata.annotations?.[AnnoKeyCreatedBy] ?? '',
         message: item.metadata.annotations?.[AnnoKeyMessage] ?? '',
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         data: item.spec as object,
@@ -197,14 +203,19 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
   const { data: displayData } = useGetDisplayMappingQuery(userKeys.length > 0 ? { key: userKeys } : skipToken);
   const isLoadingUserDisplayNames = userKeys.length > 0 && !displayData;
 
-  // Here replacing raw user ids with human readable names
   const versionsWithDisplayNames = useMemo(() => {
     if (!displayData) {
       return model.versions;
     }
+    const displayMap = new Map<string, string>();
+    for (const item of displayData.display) {
+      displayMap.set(`${item.identity.type}:${item.identity.name}`, item.displayName);
+      if (item.internalId) {
+        displayMap.set(String(item.internalId), item.displayName);
+      }
+    }
     return model.versions.map((version) => {
-      const idx = version.createdBy ? displayData.keys.indexOf(version.createdBy) : -1;
-      const displayName = idx >= 0 ? displayData.display[idx]?.displayName : undefined;
+      const displayName = version.createdBy ? displayMap.get(version.createdBy) : undefined;
       return displayName ? { ...version, createdBy: displayName } : version;
     });
   }, [model.versions, displayData]);


### PR DESCRIPTION
Fixes #119219

*Problem*

The "Updated By" column in the dashboard version history page shows wrong user names when multiple users have edited a dashboard. The names appear swapped or shuffled across versions. This affects both UI-saved and API-saved dashboards.

The frontend resolves user identity keys to display names via the IAM display API (`/display`). The response contains `keys` (in request order) and `display` (ordered by `u.id ASC` in the database). The code used an index-based lookup between these two misaligned arrays, mapping the wrong display name to the wrong user key.

*Solution*

Replace the index-based array lookup with an identity-based `Map` using each display item's `identity` field (`type:name`). Also add an `internalId` fallback for legacy numeric keys.

*How to test*

1. Create a dashboard and save a few versions as User A
2. Log in as User B (with a different/higher DB ID) and save a new version
3. Open Settings > Versions -- each version should show the correct user name 