### PR TITLE
Folders: Default maxNestedFolderDepth to 4 when unset

### DIFF
--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -185,6 +185,10 @@ func (b *FolderAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.API
 		}
 	}
 
+	if b.maxNestedFolderDepth <= 0 {
+		b.maxNestedFolderDepth = setting.DefaultMaxNestedFolderDepth
+	}
+
 	storage := map[string]rest.Storage{}
 	storage[resourceInfo.StoragePath()] = b.storage
 

--- a/pkg/setting/setting_folder.go
+++ b/pkg/setting/setting_folder.go
@@ -5,21 +5,21 @@ import (
 )
 
 const maxNestedFolderDepth = 7
-const defaultMaxNestedFolderDepth = 4
+const DefaultMaxNestedFolderDepth = 4
 
 func maxDeptFolderSettings(iniFile *ini.File) int {
 	if iniFile == nil {
-		return defaultMaxNestedFolderDepth
+		return DefaultMaxNestedFolderDepth
 	}
 
 	folderSection := iniFile.Section("folder")
-	cfgMaxNestedFolderDepth := folderSection.Key("max_nested_folder_depth").MustInt(defaultMaxNestedFolderDepth)
+	cfgMaxNestedFolderDepth := folderSection.Key("max_nested_folder_depth").MustInt(DefaultMaxNestedFolderDepth)
 	if cfgMaxNestedFolderDepth > maxNestedFolderDepth {
 		cfgMaxNestedFolderDepth = maxNestedFolderDepth
 	}
 
 	if cfgMaxNestedFolderDepth <= 0 {
-		cfgMaxNestedFolderDepth = defaultMaxNestedFolderDepth
+		cfgMaxNestedFolderDepth = DefaultMaxNestedFolderDepth
 	}
 
 	return cfgMaxNestedFolderDepth

--- a/pkg/setting/setting_folder_test.go
+++ b/pkg/setting/setting_folder_test.go
@@ -18,26 +18,26 @@ func TestMaxDeptFolderSettings(t *testing.T) {
 		{
 			name:     "returns default when ini file is nil",
 			noFile:   true,
-			expected: defaultMaxNestedFolderDepth,
+			expected: DefaultMaxNestedFolderDepth,
 		},
 		{
 			name:     "returns default when key is absent",
-			expected: defaultMaxNestedFolderDepth,
+			expected: DefaultMaxNestedFolderDepth,
 		},
 		{
 			name:     "returns default when value is not a valid integer",
 			iniValue: strp("notanint"),
-			expected: defaultMaxNestedFolderDepth,
+			expected: DefaultMaxNestedFolderDepth,
 		},
 		{
 			name:     "returns default when value is zero",
 			iniValue: strp("0"),
-			expected: defaultMaxNestedFolderDepth,
+			expected: DefaultMaxNestedFolderDepth,
 		},
 		{
 			name:     "returns default when value is negative",
 			iniValue: strp("-1"),
-			expected: defaultMaxNestedFolderDepth,
+			expected: DefaultMaxNestedFolderDepth,
 		},
 		{
 			name:     "returns configured value when within range (3)",


### PR DESCRIPTION
## Summary

- The MT apiserver constructs `FolderAPIBuilder` via `NewAPIService`, which does not set `maxNestedFolderDepth`. This leaves it at Go's zero value (`0`), causing all nested folder creation to fail with `"folder max depth exceeded, max depth is 0"`.
- Adds a guard in `UpdateAPIGroupInfo` that defaults `maxNestedFolderDepth` to `4` (the original hardcoded value before https://github.com/grafana/grafana/pull/118592 made it configurable) when the value is `<= 0`.
- Exports `DefaultMaxNestedFolderDepth` from the `setting` package so the constant is reusable.

### Follow-up

The MT folder apiserver (`grafana-enterprise`) should also be updated to pass the `max_nested_folder_depth` setting through to `NewAPIService` when possible, so it respects the configured value rather than always falling back to the default.

## Test plan

- [x] Existing `TestMaxDeptFolderSettings` tests pass (renamed constant).
- [x] Existing `TestValidateCreate`, `TestValidateUpdate`, and `TestFolderAPIBuilder_Validate_*` tests all pass.
- [ ] Verify nested folder creation works in the MT apiserver (no more "max depth is 0" error).

Made with [Cursor](https://cursor.com)