### PR TITLE
Folders: Export MaxNestedFolderDepth and add depth param to NewAPIService

### DIFF
--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -96,13 +96,14 @@ func RegisterAPIService(cfg *setting.Cfg,
 	return builder
 }
 
-func NewAPIService(ac authlib.AccessClient, searcher resource.ResourceClient, features featuremgmt.FeatureToggles, zanzanaClient zanzana.Client, resourcePermissionsSvc *dynamic.NamespaceableResourceInterface) *FolderAPIBuilder {
+func NewAPIService(ac authlib.AccessClient, searcher resource.ResourceClient, features featuremgmt.FeatureToggles, zanzanaClient zanzana.Client, resourcePermissionsSvc *dynamic.NamespaceableResourceInterface, maxNestedFolderDepth int) *FolderAPIBuilder {
 	return &FolderAPIBuilder{
 		features:               features,
 		accessClient:           ac,
 		searcher:               searcher,
 		permissionStore:        reconcilers.NewZanzanaPermissionStore(zanzanaClient),
 		resourcePermissionsSvc: resourcePermissionsSvc,
+		maxNestedFolderDepth:   maxNestedFolderDepth,
 	}
 }
 

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -185,6 +185,10 @@ func (b *FolderAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.API
 		}
 	}
 
+	if b.maxNestedFolderDepth <= 0 {
+		b.maxNestedFolderDepth = setting.DefaultMaxNestedFolderDepth
+	}
+
 	storage := map[string]rest.Storage{}
 	storage[resourceInfo.StoragePath()] = b.storage
 

--- a/pkg/setting/setting_folder.go
+++ b/pkg/setting/setting_folder.go
@@ -5,21 +5,21 @@ import (
 )
 
 const maxNestedFolderDepth = 7
-const defaultMaxNestedFolderDepth = 4
+const DefaultMaxNestedFolderDepth = 4
 
 func maxDeptFolderSettings(iniFile *ini.File) int {
 	if iniFile == nil {
-		return defaultMaxNestedFolderDepth
+		return DefaultMaxNestedFolderDepth
 	}
 
 	folderSection := iniFile.Section("folder")
-	cfgMaxNestedFolderDepth := folderSection.Key("max_nested_folder_depth").MustInt(defaultMaxNestedFolderDepth)
+	cfgMaxNestedFolderDepth := folderSection.Key("max_nested_folder_depth").MustInt(DefaultMaxNestedFolderDepth)
 	if cfgMaxNestedFolderDepth > maxNestedFolderDepth {
 		cfgMaxNestedFolderDepth = maxNestedFolderDepth
 	}
 
 	if cfgMaxNestedFolderDepth <= 0 {
-		cfgMaxNestedFolderDepth = defaultMaxNestedFolderDepth
+		cfgMaxNestedFolderDepth = DefaultMaxNestedFolderDepth
 	}
 
 	return cfgMaxNestedFolderDepth

--- a/pkg/setting/setting_folder.go
+++ b/pkg/setting/setting_folder.go
@@ -4,7 +4,7 @@ import (
 	"gopkg.in/ini.v1"
 )
 
-const maxNestedFolderDepth = 7
+const MaxNestedFolderDepth = 7
 const DefaultMaxNestedFolderDepth = 4
 
 func maxDeptFolderSettings(iniFile *ini.File) int {
@@ -14,8 +14,8 @@ func maxDeptFolderSettings(iniFile *ini.File) int {
 
 	folderSection := iniFile.Section("folder")
 	cfgMaxNestedFolderDepth := folderSection.Key("max_nested_folder_depth").MustInt(DefaultMaxNestedFolderDepth)
-	if cfgMaxNestedFolderDepth > maxNestedFolderDepth {
-		cfgMaxNestedFolderDepth = maxNestedFolderDepth
+	if cfgMaxNestedFolderDepth > MaxNestedFolderDepth {
+		cfgMaxNestedFolderDepth = MaxNestedFolderDepth
 	}
 
 	if cfgMaxNestedFolderDepth <= 0 {

--- a/pkg/setting/setting_folder_test.go
+++ b/pkg/setting/setting_folder_test.go
@@ -52,12 +52,12 @@ func TestMaxDeptFolderSettings(t *testing.T) {
 		{
 			name:     "returns configured value when equals max",
 			iniValue: strp("7"),
-			expected: maxNestedFolderDepth,
+			expected: MaxNestedFolderDepth,
 		},
 		{
 			name:     "clamps to max when value exceeds max",
 			iniValue: strp("100"),
-			expected: maxNestedFolderDepth,
+			expected: MaxNestedFolderDepth,
 		},
 	}
 

--- a/pkg/setting/setting_folder_test.go
+++ b/pkg/setting/setting_folder_test.go
@@ -18,26 +18,26 @@ func TestMaxDeptFolderSettings(t *testing.T) {
 		{
 			name:     "returns default when ini file is nil",
 			noFile:   true,
-			expected: defaultMaxNestedFolderDepth,
+			expected: DefaultMaxNestedFolderDepth,
 		},
 		{
 			name:     "returns default when key is absent",
-			expected: defaultMaxNestedFolderDepth,
+			expected: DefaultMaxNestedFolderDepth,
 		},
 		{
 			name:     "returns default when value is not a valid integer",
 			iniValue: strp("notanint"),
-			expected: defaultMaxNestedFolderDepth,
+			expected: DefaultMaxNestedFolderDepth,
 		},
 		{
 			name:     "returns default when value is zero",
 			iniValue: strp("0"),
-			expected: defaultMaxNestedFolderDepth,
+			expected: DefaultMaxNestedFolderDepth,
 		},
 		{
 			name:     "returns default when value is negative",
 			iniValue: strp("-1"),
-			expected: defaultMaxNestedFolderDepth,
+			expected: DefaultMaxNestedFolderDepth,
 		},
 		{
 			name:     "returns configured value when within range (3)",


### PR DESCRIPTION
## Summary

- Exports `MaxNestedFolderDepth` (7) from the `setting` package so the hard ceiling constant is available to the MT apiserver.
- Adds a `maxNestedFolderDepth int` parameter to `folders.NewAPIService` so callers (the MT apiserver) can pass the configured depth through explicitly.

This builds on https://github.com/grafana/grafana/pull/119221 which added the zero-guard safety net.

### Companion PRs

- **Enterprise**: Adds `--max-nested-folder-depth` and `--max-folder-depth-limit` CLI flags to the MT apiserver factory and passes them through to `NewAPIService`.
- **Deployment tools**: Wires both flags into the `grafana-folder` deployment config with defaults (4 and 7).

## Test plan

- [x] `TestMaxDeptFolderSettings` passes with exported constant.
- [x] All folder validation tests (`TestValidateCreate`, `TestValidateUpdate`, `TestFolderAPIBuilder_Validate_*`) pass.

Made with [Cursor](https://cursor.com)