### PR TITLE
Alerting: Add multi-select support to RoutingTreeSelector

### DIFF
--- a/packages/grafana-alerting/src/grafana/notificationPolicies/components/RoutingTreeSelector/RoutingTreeSelector.mdx
+++ b/packages/grafana-alerting/src/grafana/notificationPolicies/components/RoutingTreeSelector/RoutingTreeSelector.mdx
@@ -15,6 +15,27 @@ function MyComponent() {
 }
 ```
 
+## Multi select
+
+Use the `multi` prop to allow selecting multiple routing trees. The `onChange` callback receives an array of `RoutingTree` objects and `value` accepts an array of tree names.
+
+```tsx
+import { RoutingTreeSelector } from '@grafana/alerting/unstable';
+import type { RoutingTree } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
+
+function MyComponent() {
+  const [selected, setSelected] = useState<string[]>([]);
+
+  return (
+    <RoutingTreeSelector
+      multi
+      value={selected}
+      onChange={(trees) => setSelected(trees.map((t) => t.metadata.name ?? ''))}
+    />
+  );
+}
+```
+
 ## With routing preview
 
 Combine with `useMatchInstancesToSpecificRouteTree` to preview which routes match a set of labels:

--- a/packages/grafana-alerting/src/grafana/notificationPolicies/components/RoutingTreeSelector/RoutingTreeSelector.story.tsx
+++ b/packages/grafana-alerting/src/grafana/notificationPolicies/components/RoutingTreeSelector/RoutingTreeSelector.story.tsx
@@ -54,6 +54,24 @@ export const SingleDefaultTree: Story = {
   render: StoryRenderFn,
 };
 
+const MultiSelectRenderFn: StoryFn<RoutingTreeSelectorProps> = (args) => {
+  const id = useId();
+  return (
+    <Field noMargin label="Select notification policies">
+      <RoutingTreeSelector {...args} multi value={[]} onChange={() => {}} id={id} />
+    </Field>
+  );
+};
+
+export const MultiSelect: Story = {
+  parameters: {
+    msw: {
+      handlers: simpleRoutingTreesListScenario,
+    },
+  },
+  render: MultiSelectRenderFn,
+};
+
 export const WithError: Story = {
   parameters: {
     msw: {

--- a/packages/grafana-alerting/src/grafana/notificationPolicies/components/RoutingTreeSelector/RoutingTreeSelector.test.tsx
+++ b/packages/grafana-alerting/src/grafana/notificationPolicies/components/RoutingTreeSelector/RoutingTreeSelector.test.tsx
@@ -147,6 +147,36 @@ describe('clearable behavior', () => {
   });
 });
 
+describe('multi select', () => {
+  it('should show all options and allow selecting multiple trees', async () => {
+    const onChangeHandler = jest.fn();
+
+    const { user } = render(<RoutingTreeSelector multi value={[]} onChange={onChangeHandler} />);
+    await user.click(screen.getByRole('combobox'));
+
+    const options = await screen.findAllByRole('option');
+    expect(options).toHaveLength(simpleRoutingTreesList.items.length);
+
+    // Select first custom tree
+    await user.click(await screen.findByRole('option', { name: /team-platform/i }));
+
+    expect(onChangeHandler).toHaveBeenCalledWith([
+      expect.objectContaining({
+        metadata: expect.objectContaining({ name: 'team-platform' }),
+      }),
+    ]);
+  });
+
+  it('should show pre-selected value as a pill', async () => {
+    const onChangeHandler = jest.fn();
+
+    render(<RoutingTreeSelector multi value={[USER_DEFINED_TREE_NAME]} onChange={onChangeHandler} />);
+
+    // MultiCombobox renders selected values as pills
+    expect(await screen.findByText(/default policy/i)).toBeInTheDocument();
+  });
+});
+
 describe('error handling', () => {
   beforeEach(() => {
     server.use(...routingTreeWithErrorScenario);


### PR DESCRIPTION
**What is this feature?**

Adds a `multi` prop to `RoutingTreeSelector` in the `@grafana/alerting` package, enabling selection of multiple notification policy trees via a `MultiCombobox`.

**Why do we need this feature?**

The multi-policy notification policies view needs to allow users to filter by multiple routing trees simultaneously.

**Who is this feature for?**

Developers building features on top of the `@grafana/alerting` package that need to present a multi-select routing tree picker.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.