### PR TITLE
UI: Use buttons on EntityNotFound pages

### DIFF
--- a/public/app/core/components/PageNotFound/EntityNotFound.tsx
+++ b/public/app/core/components/PageNotFound/EntityNotFound.tsx
@@ -2,8 +2,8 @@ import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { Trans } from '@grafana/i18n';
-import { EmptyState, TextLink, useStyles2 } from '@grafana/ui';
+import { Trans, t } from '@grafana/i18n';
+import { Stack, EmptyState, LinkButton, useStyles2 } from '@grafana/ui';
 
 export interface Props {
   /**
@@ -18,13 +18,29 @@ export function EntityNotFound({ entity = 'Page' }: Props) {
 
   return (
     <div className={styles.container} data-testid={selectors.components.EntityNotFound.container}>
-      <EmptyState message={`${entity} not found`} variant="not-found">
+      <EmptyState
+        message={t('entity-not-found.title', '{{entity}} not found', { entity })}
+        variant="not-found"
+        button={
+          <Stack direction="row" gap={2}>
+            <LinkButton icon="arrow-left" href="/">
+              <Trans i18nKey="entity-not-found.home-link">Back to Home</Trans>
+            </LinkButton>
+
+            <LinkButton
+              icon="question-circle"
+              href="https://community.grafana.com"
+              target="_blank"
+              rel="noreferrer"
+              variant="secondary"
+            >
+              <Trans i18nKey="entity-not-found.community-link">Community Help</Trans>
+            </LinkButton>
+          </Stack>
+        }
+      >
         <Trans i18nKey="entity-not-found.description">
-          We&apos;re looking but can&apos;t seem to find this {{ lowerCaseEntity }}. Try returning{' '}
-          <TextLink href="/">home</TextLink> or seeking help on the{' '}
-          <TextLink href="https://community.grafana.com" external>
-            community site.
-          </TextLink>
+          We&apos;re looking but can&apos;t seem to find this {{ lowerCaseEntity }}. Please check the URL and try again.
         </Trans>
       </EmptyState>
     </div>

--- a/public/app/core/components/PageNotFound/PageNotFound.tsx
+++ b/public/app/core/components/PageNotFound/PageNotFound.tsx
@@ -1,4 +1,5 @@
 import { PageLayoutType } from '@grafana/data';
+import { t } from '@grafana/i18n';
 
 import { Page } from '../Page/Page';
 
@@ -6,7 +7,11 @@ import { EntityNotFound } from './EntityNotFound';
 
 export function PageNotFound() {
   return (
-    <Page navId="home" layout={PageLayoutType.Canvas} pageNav={{ text: 'Page not found' }}>
+    <Page
+      navId="home"
+      layout={PageLayoutType.Canvas}
+      pageNav={{ text: t('entity-not-found.title', '{{entity}} not found', { entity: 'Page' }) }}
+    >
       <EntityNotFound entity="Page" />
     </Page>
   );

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7811,7 +7811,10 @@
     "pro-tip": "ProTip: {{proTip}}"
   },
   "entity-not-found": {
-    "description": "We're looking but can't seem to find this {{lowerCaseEntity}}. Try returning <4>home</4> or seeking help on the <7>community site.</7>"
+    "community-link": "Community Help",
+    "description": "We're looking but can't seem to find this {{lowerCaseEntity}}. Please check the URL and try again.",
+    "home-link": "Back to Home",
+    "title": "{{entity}} not found"
   },
   "errors": {
     "dashboard-settings": {


### PR DESCRIPTION
**What is this feature?**

- Updates the EntityNotFound pages to use buttons for `Home` + `Community Help` instead of inline links.
- Updates the EntityNotFound pages to use translated text for their titles.

**Why do we need this feature?**

Makes the call-to-actions for the page much more visible and immediately obvious to the user when they've ended up lost.

**Who is this feature for?**

All (lost) users.

**Which issue(s) does this PR fix?**:

Tangentially related to https://github.com/grafana/hg-cloud-home-admin/issues/996 (🔐), where the old Grafana Cloud homepage plugin is going to be removed, so the App EntityNotFound page will start having more eyes on it for a while.

**Special notes for your reviewer:**

| Before | After |
|-|-|
| <img width="1920" height="1008" alt="image" src="https://github.com/user-attachments/assets/d69e8ff3-f2ce-4a72-9785-623c4d864d9a" /> | <img width="1920" height="1008" alt="image" src="https://github.com/user-attachments/assets/560a00f9-5852-46df-8d95-bc21c16f9bee" /> |
| <img width="1920" height="1008" alt="image" src="https://github.com/user-attachments/assets/5d998442-c89a-46d7-956d-dc5e2348c0bd" /> | <img width="1920" height="1008" alt="image" src="https://github.com/user-attachments/assets/effe5e7b-a4a3-40f1-8cdc-78982eefd288" /> |