### PR TITLE
unified-storage: add search benchmark along with actual storage implementation

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -1380,6 +1380,7 @@ func (b *testDocumentBuilder) BuildDocument(ctx context.Context, key *resourcepb
 		Title: title,
 		Tags:  tags,
 		Fields: map[string]interface{}{
+			"title": title,
 			"value": val,
 		},
 	}, nil

--- a/pkg/storage/unified/sql/test/benchmark_test.go
+++ b/pkg/storage/unified/sql/test/benchmark_test.go
@@ -1,10 +1,15 @@
 package test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/search"
 	test "github.com/grafana/grafana/pkg/storage/unified/testing"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -17,4 +22,31 @@ func TestIntegrationBenchmarkSQLStorageBackend(t *testing.T) {
 	}
 	backend := newTestBackend(t, true, 2*time.Millisecond, min(max(10, opts.Concurrency), 100))
 	test.RunStorageBackendBenchmark(t, backend, opts)
+}
+
+func TestIntegrationBenchmarkSQLStorageAndSearch(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	opts := test.DefaultBenchmarkOptions(t)
+	if db.IsTestDbSQLite() {
+		opts.Concurrency = 1
+	}
+	backend := newTestBackend(t, true, 2*time.Millisecond, min(max(10, opts.Concurrency), 100))
+	searchBackend, err := search.NewBleveBackend(search.BleveOptions{
+		Root:                   t.TempDir(),
+		FileThreshold:          0,
+		IndexMinUpdateInterval: opts.IndexMinUpdateInterval,
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(searchBackend.Stop)
+	groupsResources := make(map[string]string, opts.NumResourceTypes)
+	for i := 0; i < opts.NumResourceTypes; i++ {
+		groupsResources[fmt.Sprintf("group-%d", i)] = fmt.Sprintf("resource-%d", i)
+	}
+	searchOpts := resource.SearchOptions{
+		Backend: searchBackend,
+		Resources: &resource.TestDocumentBuilderSupplier{
+			GroupsResources: groupsResources,
+		},
+	}
+	test.RunStorageAndSearchBenchmark(t, backend, searchOpts, opts)
 }

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,13 +20,14 @@ import (
 
 // BenchmarkOptions configures the benchmark parameters
 type BenchmarkOptions struct {
-	NumResources       int // total number of resources to write
-	Concurrency        int // number of concurrent writers
-	NumNamespaces      int // number of different namespaces
-	NumGroups          int // number of different groups
-	NumResourceTypes   int // number of different resource types
-	NumHistoryVersions int // history depth per resource for list seed (default 10)
-	NumListIterations  int // number of List calls to measure (default 100)
+	NumResources           int           // total number of resources to write
+	Concurrency            int           // number of concurrent writers
+	NumNamespaces          int           // number of different namespaces
+	NumGroups              int           // number of different groups
+	NumResourceTypes       int           // number of different resource types
+	NumHistoryVersions     int           // history depth per resource for list seed (default 10)
+	NumListIterations      int           // number of List calls to measure (default 100)
+	IndexMinUpdateInterval time.Duration // minimum time between index updates (default 0, no throttle)
 }
 
 // DefaultBenchmarkOptions returns the default benchmark options
@@ -42,21 +44,34 @@ func DefaultBenchmarkOptions(t *testing.T) *BenchmarkOptions {
 		return defaultVal
 	}
 
+	envOrDefaultDuration := func(name string, defaultVal time.Duration) time.Duration {
+		envVar := fmt.Sprintf("US_BACKEND_BENCH_%s", name)
+		if str := os.Getenv(envVar); str != "" {
+			dur, err := time.ParseDuration(str)
+			require.NoError(t, err)
+
+			return dur
+		}
+
+		return defaultVal
+	}
+
 	return &BenchmarkOptions{
-		NumResources:       envOrDefault("RESOURCES", 1000),
-		Concurrency:        envOrDefault("CONCURRENCY", 50),
-		NumNamespaces:      envOrDefault("NAMESPACES", 1),
-		NumGroups:          envOrDefault("GROUPS", 1),
-		NumResourceTypes:   envOrDefault("RESOURCE_TYPES", 1),
-		NumHistoryVersions: envOrDefault("HISTORY_VERSIONS", 10),
-		NumListIterations:  envOrDefault("LIST_ITERATIONS", 100),
+		NumResources:           envOrDefault("RESOURCES", 1000),
+		Concurrency:            envOrDefault("CONCURRENCY", 50),
+		NumNamespaces:          envOrDefault("NAMESPACES", 1),
+		NumGroups:              envOrDefault("GROUPS", 1),
+		NumResourceTypes:       envOrDefault("RESOURCE_TYPES", 1),
+		NumHistoryVersions:     envOrDefault("HISTORY_VERSIONS", 10),
+		NumListIterations:      envOrDefault("LIST_ITERATIONS", 100),
+		IndexMinUpdateInterval: envOrDefaultDuration("INDEX_MIN_UPDATE_INTERVAL", 100*time.Millisecond),
 	}
 }
 
 func (opts *BenchmarkOptions) String() string {
 	return fmt.Sprintf(
-		"Workers=%d, Resources=%d, Namespaces=%d, Groups=%d, Resource Types=%d, History Versions=%d, List Iterations=%d",
-		opts.Concurrency, opts.NumResources, opts.NumNamespaces, opts.NumGroups, opts.NumResourceTypes, opts.NumHistoryVersions, opts.NumListIterations,
+		"Workers=%d, Resources=%d, Namespaces=%d, Groups=%d, Resource Types=%d, History Versions=%d, List Iterations=%d, Index Min Update Interval=%v",
+		opts.Concurrency, opts.NumResources, opts.NumNamespaces, opts.NumGroups, opts.NumResourceTypes, opts.NumHistoryVersions, opts.NumListIterations, opts.IndexMinUpdateInterval,
 	)
 }
 
@@ -75,7 +90,7 @@ func (r BenchmarkResult) String() string {
 
 	fmt.Fprintf(&out, "Total Duration: %v\n", r.TotalDuration)
 	fmt.Fprintf(&out, "Req Count: %d\n", r.ReqCount)
-	fmt.Fprintf(&out, "Throughput: %.2f writes/sec\n", r.Throughput)
+	fmt.Fprintf(&out, "Throughput: %.2f reqs/sec\n", r.Throughput)
 	fmt.Fprintf(&out, "P50 Latency: %v\n", r.P50Latency)
 	fmt.Fprintf(&out, "P90 Latency: %v\n", r.P90Latency)
 	fmt.Fprintf(&out, "P99 Latency: %v\n", r.P99Latency)
@@ -441,6 +456,242 @@ func runSearchBackendBenchmarkWriteThroughput(ctx context.Context, backend resou
 		P90Latency:    latencies[len(latencies)*90/100],
 		P99Latency:    latencies[len(latencies)*99/100],
 	}, nil
+}
+
+// StorageAndSearchBenchmarkResults aggregates results of a combined storage + search benchmark run.
+type StorageAndSearchBenchmarkResults struct {
+	WriteResults  BenchmarkResult
+	SearchResults BenchmarkResult
+}
+
+func (r StorageAndSearchBenchmarkResults) String() string {
+	return fmt.Sprintf(
+		"WRITES:\n%s\n\nSEARCHES:\n%s\n",
+		r.WriteResults, r.SearchResults,
+	)
+}
+
+// runStorageAndSearchBenchmark runs a benchmark that writes to storage while
+// periodically searching through an index kept up-to-date from that storage.
+// It also exercises our ability to search-after-write for every resource written
+// during the benchmark.
+func runStorageAndSearchBenchmark(
+	t *testing.T,
+	backend resource.StorageBackend,
+	searchOpts resource.SearchOptions,
+	opts *BenchmarkOptions,
+) *StorageAndSearchBenchmarkResults {
+	ctx := t.Context()
+
+	const benchNamespace = "bench-search-ns"
+
+	// Discover group/resource pairs from the configured document builders
+	builders, err := searchOpts.Resources.GetDocumentBuilders()
+	require.NoError(t, err)
+	require.NotEmpty(t, builders, "search options must have at least one document builder")
+
+	type groupResource struct {
+		group    string
+		resource string
+	}
+	pairs := make([]groupResource, len(builders))
+	for i, b := range builders {
+		t.Logf("using group=%s resource=%s", b.GroupResource.Group, b.GroupResource.Resource)
+		pairs[i] = groupResource{group: b.GroupResource.Group, resource: b.GroupResource.Resource}
+	}
+
+	searchServer, err := resource.NewSearchServer(resource.ResourceServerOptions{
+		Backend: backend,
+		Search:  searchOpts,
+	})
+	require.NoError(t, err)
+
+	type searchJob struct {
+		group    string
+		resource string
+		title    string
+		idx      int // index into searchLatencies
+	}
+
+	searchCh := make(chan searchJob, opts.NumResources)
+	searchLatencies := make([]time.Duration, opts.NumResources)
+
+	// Dispatcher goroutine: reads from searchCh and spawns a search goroutine per write.
+	var dispatcherDone sync.WaitGroup
+	searchG, searchCtx := errgroup.WithContext(ctx)
+	dispatcherDone.Go(func() {
+		for job := range searchCh {
+			req := &resourcepb.ResourceSearchRequest{
+				Options: &resourcepb.ListOptions{
+					Key: &resourcepb.ResourceKey{
+						Namespace: benchNamespace,
+						Group:     job.group,
+						Resource:  job.resource,
+					},
+				},
+				Query: job.title,
+				QueryFields: []*resourcepb.ResourceSearchRequest_QueryField{
+					{
+						Name: "title",
+						Type: resourcepb.QueryFieldType_KEYWORD,
+					},
+				},
+				Limit: 10,
+			}
+			idx := job.idx
+			searchG.Go(func() error {
+				start := time.Now()
+				resp, err := searchServer.Search(searchCtx, req)
+				searchLatencies[idx] = time.Since(start)
+				if err != nil {
+					return fmt.Errorf(
+						"search failed for %s/%s %s: %w",
+						req.Options.Key.Group, req.Options.Key.Resource, req.Options.Key.Name, err,
+					)
+				}
+				if resp.TotalHits != 1 {
+					return fmt.Errorf(
+						"expected 1 hit for %s/%s %s, got %d",
+						req.Options.Key.Group, req.Options.Key.Resource, req.Query, resp.TotalHits,
+					)
+				}
+				return nil
+			})
+		}
+	})
+
+	// Background goroutine: continuously issues wildcard searches across all
+	// group/resource pairs to exercise index updates while writes are in flight.
+	bgSearchCtx, bgSearchCancel := context.WithCancel(ctx)
+	defer bgSearchCancel()
+	var bgSearchDone sync.WaitGroup
+	bgSearchDone.Go(func() {
+		for i := 0; ; i++ {
+			select {
+			case <-bgSearchCtx.Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+			pair := pairs[i%len(pairs)]
+			_, err := searchServer.Search(bgSearchCtx, &resourcepb.ResourceSearchRequest{
+				Options: &resourcepb.ListOptions{
+					Key: &resourcepb.ResourceKey{
+						Namespace: benchNamespace,
+						Group:     pair.group,
+						Resource:  pair.resource,
+					},
+				},
+				Query: "*",
+				Limit: 10,
+			})
+			if err != nil && bgSearchCtx.Err() == nil {
+				t.Errorf("background search failed for %s/%s: %v", pair.group, pair.resource, err)
+				return
+			}
+		}
+	})
+
+	// Start write workers — distribute across group/resource pairs like the storage benchmark.
+	// After each write, send a search job through the channel.
+	jobs := make(chan int, opts.NumResources)
+	writeLatencies := make([]time.Duration, opts.NumResources)
+	for i := 0; i < opts.NumResources; i++ {
+		jobs <- i
+	}
+	close(jobs)
+
+	g, groupCtx := errgroup.WithContext(ctx)
+	writeStart := time.Now()
+	value := strings.Repeat("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", 20) // ~1.21 KiB
+
+	for workerID := 0; workerID < opts.Concurrency; workerID++ {
+		g.Go(func() error {
+			for jobID := range jobs {
+				pair := pairs[jobID%len(pairs)]
+				name := fmt.Sprintf("item-%d", jobID)
+				title := fmt.Sprintf("%s %d", name, time.Now().Unix())
+				opStart := time.Now()
+				_, err := WriteEvent(groupCtx, backend, name, resourcepb.WatchEvent_ADDED,
+					WithGroup(pair.group),
+					WithResource(pair.resource),
+					WithNamespace(benchNamespace),
+					WithValueAndTitle(value, title),
+				)
+				if err != nil {
+					return err
+				}
+				writeLatencies[jobID] = time.Since(opStart)
+				// Sleep to simulate what the resource server does to
+				// provide search-after-write guarantees to the caller.
+				if opts.IndexMinUpdateInterval > 0 {
+					time.Sleep(opts.IndexMinUpdateInterval)
+				}
+				// Make sure we are able to search the resource just created.
+				searchCh <- searchJob{
+					group:    pair.group,
+					resource: pair.resource,
+					title:    title,
+					idx:      jobID,
+				}
+			}
+			return nil
+		})
+	}
+
+	require.NoError(t, g.Wait())
+	writeDuration := time.Since(writeStart)
+
+	// Wait for dispatcher to finish spawning, then for all searches to complete
+	close(searchCh)
+	dispatcherDone.Wait()
+	require.NoError(t, searchG.Wait())
+	searchDuration := time.Since(writeStart)
+
+	// Stop background search goroutine
+	bgSearchCancel()
+	bgSearchDone.Wait()
+
+	// Compute write results
+	slices.Sort(writeLatencies)
+	writeResult := BenchmarkResult{
+		TotalDuration: writeDuration,
+		ReqCount:      opts.NumResources,
+		Throughput:    float64(opts.NumResources) / writeDuration.Seconds(),
+		P50Latency:    writeLatencies[len(writeLatencies)*50/100],
+		P90Latency:    writeLatencies[len(writeLatencies)*90/100],
+		P99Latency:    writeLatencies[len(writeLatencies)*99/100],
+	}
+
+	// Compute search results
+	slices.Sort(searchLatencies)
+	searchResult := BenchmarkResult{
+		TotalDuration: searchDuration,
+		ReqCount:      opts.NumResources,
+		Throughput:    float64(opts.NumResources) / searchDuration.Seconds(),
+		P50Latency:    searchLatencies[opts.NumResources*50/100],
+		P90Latency:    searchLatencies[opts.NumResources*90/100],
+		P99Latency:    searchLatencies[opts.NumResources*99/100],
+	}
+
+	return &StorageAndSearchBenchmarkResults{
+		WriteResults:  writeResult,
+		SearchResults: searchResult,
+	}
+}
+
+// RunStorageAndSearchBenchmark runs a benchmark that combines storage writes with search.
+func RunStorageAndSearchBenchmark(
+	t *testing.T,
+	backend resource.StorageBackend,
+	searchOpts resource.SearchOptions,
+	opts *BenchmarkOptions,
+) {
+	results := runStorageAndSearchBenchmark(t, backend, searchOpts, opts)
+
+	t.Logf("Benchmark Configuration: %s", opts)
+	t.Logf("")
+	t.Logf("Benchmark Results:")
+	t.Logf("\n%s", results)
 }
 
 // RunSearchBackendBenchmark runs a benchmark test for a search backend implementation

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -27,7 +27,7 @@ type BenchmarkOptions struct {
 	NumResourceTypes       int           // number of different resource types
 	NumHistoryVersions     int           // history depth per resource for list seed (default 10)
 	NumListIterations      int           // number of List calls to measure (default 100)
-	IndexMinUpdateInterval time.Duration // minimum time between index updates (default 0, no throttle)
+	IndexMinUpdateInterval time.Duration // minimum time between index updates (default 100ms)
 }
 
 // DefaultBenchmarkOptions returns the default benchmark options

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -483,7 +483,9 @@ func runStorageAndSearchBenchmark(
 ) *StorageAndSearchBenchmarkResults {
 	ctx := t.Context()
 
-	const benchNamespace = "bench-search-ns"
+	if opts.NumGroups != opts.NumResourceTypes {
+		t.Logf("WARNING: benchmark only supports NumGroups=NumResourceTypes, one resource type per group")
+	}
 
 	// Discover group/resource pairs from the configured document builders
 	builders, err := searchOpts.Resources.GetDocumentBuilders()
@@ -507,10 +509,11 @@ func runStorageAndSearchBenchmark(
 	require.NoError(t, err)
 
 	type searchJob struct {
-		group    string
-		resource string
-		title    string
-		idx      int // index into searchLatencies
+		namespace string
+		group     string
+		resource  string
+		title     string
+		idx       int // index into searchLatencies
 	}
 
 	searchCh := make(chan searchJob, opts.NumResources)
@@ -524,7 +527,7 @@ func runStorageAndSearchBenchmark(
 			req := &resourcepb.ResourceSearchRequest{
 				Options: &resourcepb.ListOptions{
 					Key: &resourcepb.ResourceKey{
-						Namespace: benchNamespace,
+						Namespace: job.namespace,
 						Group:     job.group,
 						Resource:  job.resource,
 					},
@@ -573,10 +576,11 @@ func runStorageAndSearchBenchmark(
 			case <-time.After(50 * time.Millisecond):
 			}
 			pair := pairs[i%len(pairs)]
+			namespace := fmt.Sprintf("ns-%d", i%opts.NumNamespaces)
 			_, err := searchServer.Search(bgSearchCtx, &resourcepb.ResourceSearchRequest{
 				Options: &resourcepb.ListOptions{
 					Key: &resourcepb.ResourceKey{
-						Namespace: benchNamespace,
+						Namespace: namespace,
 						Group:     pair.group,
 						Resource:  pair.resource,
 					},
@@ -608,13 +612,14 @@ func runStorageAndSearchBenchmark(
 		g.Go(func() error {
 			for jobID := range jobs {
 				pair := pairs[jobID%len(pairs)]
+				namespace := fmt.Sprintf("ns-%d", jobID%opts.NumNamespaces)
 				name := fmt.Sprintf("item-%d", jobID)
 				title := fmt.Sprintf("%s %d", name, time.Now().Unix())
 				opStart := time.Now()
 				_, err := WriteEvent(groupCtx, backend, name, resourcepb.WatchEvent_ADDED,
 					WithGroup(pair.group),
 					WithResource(pair.resource),
-					WithNamespace(benchNamespace),
+					WithNamespace(namespace),
 					WithValueAndTitle(value, title),
 				)
 				if err != nil {
@@ -628,10 +633,11 @@ func runStorageAndSearchBenchmark(
 				}
 				// Make sure we are able to search the resource just created.
 				searchCh <- searchJob{
-					group:    pair.group,
-					resource: pair.resource,
-					title:    title,
-					idx:      jobID,
+					namespace: namespace,
+					group:     pair.group,
+					resource:  pair.resource,
+					title:     title,
+					idx:       jobID,
 				}
 			}
 			return nil

--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -1254,16 +1254,21 @@ func WithFolder(folder string) WriteEventOption {
 
 // WithValue sets the value for the write event
 func WithValue(value string) WriteEventOption {
+	return WithValueAndTitle(value, "")
+}
+
+func WithValueAndTitle(value, title string) WriteEventOption {
 	return func(o *WriteEventOptions) {
 		u := unstructured.Unstructured{
 			Object: map[string]any{
 				"apiVersion": o.Group + "/v1",
 				"kind":       o.Resource,
 				"metadata": map[string]any{
-					"name":      "name",
-					"namespace": "ns",
+					"name":      o.Name,
+					"namespace": o.Namespace,
 				},
 				"spec": map[string]any{
+					"title": title,
 					"value": value,
 				},
 			},
@@ -1273,6 +1278,7 @@ func WithValue(value string) WriteEventOption {
 }
 
 type WriteEventOptions struct {
+	Name       string
 	Namespace  string
 	Group      string
 	Resource   string
@@ -1284,6 +1290,7 @@ type WriteEventOptions struct {
 func WriteEvent(ctx context.Context, store resource.StorageBackend, name string, action resourcepb.WatchEvent_Type, opts ...WriteEventOption) (int64, error) {
 	// Default options
 	options := WriteEventOptions{
+		Name:      name,
 		Namespace: "namespace",
 		Group:     "group",
 		Resource:  "resource",

--- a/pkg/storage/unified/testing/storage_backend_test.go
+++ b/pkg/storage/unified/testing/storage_backend_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/search"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
@@ -48,6 +49,37 @@ func TestIntegrationBenchmarkSQLKVStorageBackend(t *testing.T) {
 			backend, dbConn := NewTestSqlKvBackend(t, t.Context(), withRvManager)
 			dbConn.SqlDB().SetMaxOpenConns(min(max(10, opts.Concurrency), 100))
 			RunStorageBackendBenchmark(t, backend, opts)
+		})
+	}
+}
+
+func TestIntegrationBenchmarkSQLKVStorageAndSearch(t *testing.T) {
+	for _, withRvManager := range []bool{true, false} {
+		t.Run(fmt.Sprintf("rvmanager=%t", withRvManager), func(t *testing.T) {
+			testutil.SkipIntegrationTestInShortMode(t)
+			opts := DefaultBenchmarkOptions(t)
+			if db.IsTestDbSQLite() {
+				opts.Concurrency = 1
+			}
+			backend, _ := NewTestSqlKvBackend(t, t.Context(), withRvManager)
+			searchBackend, err := search.NewBleveBackend(search.BleveOptions{
+				Root:                   t.TempDir(),
+				FileThreshold:          0,
+				IndexMinUpdateInterval: opts.IndexMinUpdateInterval,
+			}, nil)
+			require.NoError(t, err)
+			t.Cleanup(searchBackend.Stop)
+			groupsResources := make(map[string]string, opts.NumResourceTypes)
+			for i := 0; i < opts.NumResourceTypes; i++ {
+				groupsResources[fmt.Sprintf("group-%d", i)] = fmt.Sprintf("resource-%d", i)
+			}
+			searchOpts := resource.SearchOptions{
+				Backend: searchBackend,
+				Resources: &resource.TestDocumentBuilderSupplier{
+					GroupsResources: groupsResources,
+				},
+			}
+			RunStorageAndSearchBenchmark(t, backend, searchOpts, opts)
 		})
 	}
 }

--- a/pkg/storage/unified/testing/storage_backend_test.go
+++ b/pkg/storage/unified/testing/storage_backend_test.go
@@ -56,6 +56,7 @@ func TestIntegrationBenchmarkSQLKVStorageBackend(t *testing.T) {
 func TestIntegrationBenchmarkSQLKVStorageAndSearch(t *testing.T) {
 	for _, withRvManager := range []bool{true, false} {
 		t.Run(fmt.Sprintf("rvmanager=%t", withRvManager), func(t *testing.T) {
+			t.Skip("skipping until https://github.com/grafana/search-and-storage-team/issues/659 is fixed")
 			testutil.SkipIntegrationTestInShortMode(t)
 			opts := DefaultBenchmarkOptions(t)
 			if db.IsTestDbSQLite() {


### PR DESCRIPTION
This PR adds a benchmark creating resources in parallel and having a continuous stream of search requests. It also verifies that search is able to find resources that have just been created (search-after-write).

NOTE: the sqlkv version of the benchmark is currently skipped due to https://github.com/grafana/search-and-storage-team/issues/659. It will be unskipped in a future PR along with a fix.

Results for creating 10,000 resources:

**sqlkv** (`US_BACKEND_BENCH_RESOURCES=10000 GRAFANA_TEST_DB=mysql go test -v -count=1 -run TestIntegrationBenchmarkSQLKVStorageAndSearch ./pkg/storage/unified/testing/`)

_Note: manually unskipped and ignoring not found errors_

```
=== RUN   TestIntegrationBenchmarkSQLKVStorageAndSearch/rvmanager=true
benchmark.go:692: Benchmark Configuration: Workers=50, Resources=10000, Namespaces=1, Groups=1, Resource Types=1, History Versions=10, List Iterations=100, Index Min Update Interval=100ms
    benchmark.go:693:
    benchmark.go:694: Benchmark Results:
    benchmark.go:695:
        WRITES:
        Total Duration: 24.171592125s
        Req Count: 10000
        Throughput: 413.71 reqs/sec
        P50 Latency: 18.199958ms
        P90 Latency: 28.299667ms
        P99 Latency: 87.350292ms


        SEARCHES:
        Total Duration: 24.182907542s
        Req Count: 10000
        Throughput: 413.52 reqs/sec
        P50 Latency: 69.792µs
        P90 Latency: 39.756666ms
        P99 Latency: 50.628458ms

=== RUN   TestIntegrationBenchmarkSQLKVStorageAndSearch/rvmanager=false
benchmark.go:692: Benchmark Configuration: Workers=50, Resources=10000, Namespaces=1, Groups=1, Resource Types=1, History Versions=10, List Iterations=100, Index Min Update Interval=100ms
    benchmark.go:693:
    benchmark.go:694: Benchmark Results:
    benchmark.go:695:
        WRITES:
        Total Duration: 21.015078125s
        Req Count: 10000
        Throughput: 475.85 reqs/sec
        P50 Latency: 4.447ms
        P90 Latency: 7.859583ms
        P99 Latency: 14.932833ms


        SEARCHES:
        Total Duration: 21.0286815s
        Req Count: 10000
        Throughput: 475.54 reqs/sec
        P50 Latency: 37.554834ms
        P90 Latency: 55.267917ms
        P99 Latency: 64.723625ms
```


**sql backend** (`US_BACKEND_BENCH_RESOURCES=10000 GRAFANA_TEST_DB=mysql go test -v -count=1 -run TestIntegrationBenchmarkSQLStorageAndSearch ./pkg/storage/unified/sql/test/`)

```
=== RUN   TestIntegrationBenchmarkSQLStorageAndSearch
    benchmark.go:499: using group=group-0 resource=resource-0
    benchmark.go:692: Benchmark Configuration: Workers=50, Resources=10000, Namespaces=1, Groups=1, Resource Types=1, History Versions=10, List Iterations=100, Index Min Update Interval=100ms
    benchmark.go:693:
    benchmark.go:694: Benchmark Results:
    benchmark.go:695:
        WRITES:
        Total Duration: 43.034710792s
        Req Count: 10000
        Throughput: 232.37 reqs/sec
        P50 Latency: 106.469917ms
        P90 Latency: 148.877125ms
        P99 Latency: 170.846375ms


        SEARCHES:
        Total Duration: 43.059100375s
        Req Count: 10000
        Throughput: 232.24 reqs/sec
        P50 Latency: 21.958458ms
        P90 Latency: 34.063708ms
        P99 Latency: 50.774917ms
```