### PR TITLE
QueryEditor: Fix segmented toggle bug

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueryEditorSidebar.tsx
@@ -32,6 +32,8 @@ export const QueryEditorSidebar = memo(function QueryEditorSidebar({
     setSelectedAlert(view === QueryEditorType.Alert ? (alertRules[0] ?? EMPTY_ALERT) : null);
   };
 
+  const toggleValue = cardType === QueryEditorType.Alert ? QueryEditorType.Alert : QueryEditorType.Query;
+
   const alertsLabel = loading
     ? t('query-editor-next.sidebar.alerts-loading', 'Alerts')
     : t('query-editor-next.sidebar.alerts', 'Alerts ({{count}})', { count: alertRules.length });
@@ -46,7 +48,7 @@ export const QueryEditorSidebar = memo(function QueryEditorSidebar({
       <SidebarHeaderActions sidebarSize={sidebarSize} setSidebarSize={setSidebarSize}>
         <SegmentedToggle
           options={viewOptions}
-          value={cardType}
+          value={toggleValue}
           onChange={handleViewChange}
           aria-label={t('query-editor-next.sidebar.view-toggle', 'View')}
           showBackground={false}


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->
There was a bug where if you clicked on a transformation, or expression, the state of the segmented toggle button got borked.

## Changes
<!--- Describe your changes in detail -->
* Base the state either on alert or query view basically.

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->

#### Before

https://github.com/user-attachments/assets/cc2bf51f-6101-46bc-aaa0-fee9cc902d51

#### After

https://github.com/user-attachments/assets/2c3aedc2-af05-439f-9ac8-ddba0a5e7847

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* Pull it down make sure it works!

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable