### PR TITLE
Alerting: Fix alert list panel dashboard refresh subscription issue

### DIFF
--- a/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
@@ -14,6 +14,7 @@ import { PromRuleGroupDTO, PromRulesResponse, RulerGrafanaRuleDTO } from 'app/ty
 
 import { contextSrv } from '../../../core/services/context_srv';
 import {
+  grantUserPermissions,
   mockPromAlert,
   mockPromAlertingRule,
   mockPromRuleGroup,
@@ -22,6 +23,7 @@ import {
   mockUnifiedAlertingStore,
 } from '../../../features/alerting/unified/mocks';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../../features/alerting/unified/utils/datasource';
+import { AccessControlAction } from '../../../types/accessControl';
 
 import { UnifiedAlertListPanel } from './UnifiedAlertList';
 import { GroupMode, SortOrder, UnifiedAlertListOptions, ViewMode } from './types';
@@ -226,5 +228,60 @@ describe('UnifiedAlertList', () => {
     renderPanel();
 
     expect(screen.getByRole('alert', { name: 'Permission required' })).toBeInTheDocument();
+  });
+
+  it('should re-subscribe to dashboard refresh after useEffect dependencies change', async () => {
+    grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingRuleExternalRead]);
+
+    const unsubscribeMock = jest.fn();
+    const subscribeMock = jest.fn().mockReturnValue({ unsubscribe: unsubscribeMock });
+    const dashboardMock = {
+      id: 1,
+      formatDate: (time: number) => new Date(time).toISOString(),
+      events: { subscribe: subscribeMock },
+    };
+
+    const dashSrv: unknown = { getCurrent: () => dashboardMock };
+    setDashboardSrv(dashSrv as DashboardSrv);
+
+    jest.spyOn(defaultProps, 'replaceVariables').mockReturnValue('');
+
+    const store = mockUnifiedAlertingStore(grafanaRuleMock);
+
+    const initialOptions: UnifiedAlertListOptions = {
+      ...defaultOptions,
+      dashboardAlerts: false,
+      alertName: '',
+      stateFilter: { firing: true, pending: false, noData: false, normal: true, error: false, recovering: false },
+    };
+
+    const { rerender } = render(
+      <Provider store={store}>
+        <UnifiedAlertListPanel {...{ ...defaultProps, options: initialOptions }} />
+      </Provider>
+    );
+
+    await waitFor(() => expect(subscribeMock).toHaveBeenCalledTimes(1));
+    expect(subscribeMock.mock.calls[0][0]).toEqual(TimeRangeUpdatedEvent);
+
+    const updatedOptions: UnifiedAlertListOptions = {
+      ...initialOptions,
+      stateFilter: { firing: true, pending: true, noData: true, normal: true, error: true, recovering: true },
+    };
+
+    rerender(
+      <Provider store={store}>
+        <UnifiedAlertListPanel {...{ ...defaultProps, options: updatedOptions }} />
+      </Provider>
+    );
+
+    // The old subscription should be cleaned up
+    await waitFor(() => expect(unsubscribeMock).toHaveBeenCalled());
+
+    // The subscription should be re-created after the useEffect re-runs.
+    // BUG: With the current code, `dashboard` is a local `let` variable set by useEffectOnce.
+    // On re-render, it resets to `undefined`, so `dashboard?.events.subscribe(...)` is never called.
+    await waitFor(() => expect(subscribeMock).toHaveBeenCalledTimes(2));
+    expect(subscribeMock.mock.calls[1][0]).toEqual(TimeRangeUpdatedEvent);
   });
 });

--- a/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
@@ -279,8 +279,6 @@ describe('UnifiedAlertList', () => {
     await waitFor(() => expect(unsubscribeMock).toHaveBeenCalled());
 
     // The subscription should be re-created after the useEffect re-runs.
-    // BUG: With the current code, `dashboard` is a local `let` variable set by useEffectOnce.
-    // On re-render, it resets to `undefined`, so `dashboard?.events.subscribe(...)` is never called.
     await waitFor(() => expect(subscribeMock).toHaveBeenCalledTimes(2));
     expect(subscribeMock.mock.calls[1][0]).toEqual(TimeRangeUpdatedEvent);
   });


### PR DESCRIPTION
**What is this fix?**

In `public/app/plugins/panel/alertlist/UnifiedAlertList.tsx`, the dashboard reference was stored in a local let variable and set via useEffectOnce. 
When the effect responsible for subscribing to the dashboard events and fetching the initial data runs due to a dependency change, the dashboard variable had already been re-declared as undefined by the new render, so the call for `dashboard?.events.subscribe` failed silently and the event subscription was lost.

**Changes**
- Stored dashboard in a useRef instead of a local let
- Split event subscription and data fetch into separate effects to avoid unecessary unsubscribe/resubscribe cycles


https://github.com/user-attachments/assets/e7794777-110e-4a84-afb7-5606468c9b47


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #118548

**How to test these changes**

- Step 1: Create test alert rule
  1. Go to Alerting > Alert rules > New alert rule
  2. Set the rule type to Grafana-managed
  3. Add a query using the TestData datasource with the "Random Walk" scenario
  4. Add a Reduce expression (e.g., Last) and a Threshold expression (e.g., IS ABOVE 0 — this will always fire)
  5. Set the evaluation interval to something short (e.g., every 10s, for 0s)
  6. Save the rule and wait for it to start firing

- Step 2: Create dashboard with alert list
  1. Create a new dashboard
  2. Add an Alert list panel
  3. In the panel options:
    - Under Filter, enable all alert states (Firing, Pending, Normal, Recovering)
    - Optionally set a datasource filter to "Grafana" if needed
    - Disable "Dashboard alerts only" so you see all alerts
  4. Set the dashboard auto-refresh to something frequent (e.g., 5s or 10s)
  5. Save the dashboard

- Step 3: Trigger new instances
  1. In a separate browser tab, create a second alert rule that will also appear in the alert list
   
- Step 4: Observe
  1. Go back to the dashboard tab, the new alert should show up after the auto-refresh interval
