### PR TITLE
Explore Logs: update lokiShardSplitting to the new GOFF feature flags

### DIFF
--- a/public/app/features/explore/Logs/Logs.test.tsx
+++ b/public/app/features/explore/Logs/Logs.test.tsx
@@ -1,7 +1,10 @@
+import { OpenFeatureProvider } from '@openfeature/react-sdk';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ComponentProps } from 'react';
 import { Provider } from 'react-redux';
+
+import { getTestFeatureFlagClient } from '@grafana/test-utils/unstable';
 
 import {
   DataFrame,
@@ -155,7 +158,9 @@ describe('Logs', () => {
 
     const rendered = render(
       <Provider store={fakeStore}>
-        {getComponent(partialProps, dataFrame ? dataFrame : getMockLokiFrame(), logs)}
+        <OpenFeatureProvider client={getTestFeatureFlagClient()}>
+          {getComponent(partialProps, dataFrame ? dataFrame : getMockLokiFrame(), logs)}
+        </OpenFeatureProvider>
       </Provider>
     );
     return { ...rendered, store: fakeStore };
@@ -190,17 +195,18 @@ describe('Logs', () => {
     });
     render(
       <Provider store={store}>
-        <Logs
-          exploreId={'left'}
-          splitOpen={() => undefined}
-          logsVolumeEnabled={true}
-          onSetLogsVolumeEnabled={() => null}
-          onClickFilterLabel={() => null}
-          onClickFilterOutLabel={() => null}
-          logsVolumeData={undefined}
-          loadLogsVolumeData={() => undefined}
-          logRows={[]}
-          onStartScanning={scanningStarted}
+        <OpenFeatureProvider client={getTestFeatureFlagClient()}>
+          <Logs
+            exploreId={'left'}
+            splitOpen={() => undefined}
+            logsVolumeEnabled={true}
+            onSetLogsVolumeEnabled={() => null}
+            onClickFilterLabel={() => null}
+            onClickFilterOutLabel={() => null}
+            logsVolumeData={undefined}
+            loadLogsVolumeData={() => undefined}
+            logRows={[]}
+            onStartScanning={scanningStarted}
           timeZone={'utc'}
           width={50}
           loading={false}
@@ -221,6 +227,7 @@ describe('Logs', () => {
           eventBus={new EventBusSrv()}
           isFilterLabelActive={jest.fn()}
         />
+        </OpenFeatureProvider>
       </Provider>
     );
     const button = screen.getByRole('button', {
@@ -238,18 +245,19 @@ describe('Logs', () => {
     });
     render(
       <Provider store={store}>
-        <Logs
-          exploreId={'left'}
-          splitOpen={() => undefined}
-          logsVolumeEnabled={true}
-          onSetLogsVolumeEnabled={() => null}
-          onClickFilterLabel={() => null}
-          onClickFilterOutLabel={() => null}
-          logsVolumeData={undefined}
-          loadLogsVolumeData={() => undefined}
-          logRows={[]}
-          scanning={true}
-          timeZone={'utc'}
+        <OpenFeatureProvider client={getTestFeatureFlagClient()}>
+          <Logs
+            exploreId={'left'}
+            splitOpen={() => undefined}
+            logsVolumeEnabled={true}
+            onSetLogsVolumeEnabled={() => null}
+            onClickFilterLabel={() => null}
+            onClickFilterOutLabel={() => null}
+            logsVolumeData={undefined}
+            loadLogsVolumeData={() => undefined}
+            logRows={[]}
+            scanning={true}
+            timeZone={'utc'}
           width={50}
           loading={false}
           loadingState={LoadingState.Done}
@@ -269,6 +277,7 @@ describe('Logs', () => {
           eventBus={new EventBusSrv()}
           isFilterLabelActive={jest.fn()}
         />
+        </OpenFeatureProvider>
       </Provider>
     );
 
@@ -288,18 +297,19 @@ describe('Logs', () => {
     });
     render(
       <Provider store={store}>
-        <Logs
-          exploreId={'left'}
-          splitOpen={() => undefined}
-          logsVolumeEnabled={true}
-          onSetLogsVolumeEnabled={() => null}
-          onClickFilterLabel={() => null}
-          onClickFilterOutLabel={() => null}
-          logsVolumeData={undefined}
-          loadLogsVolumeData={() => undefined}
-          logRows={[]}
-          scanning={true}
-          onStopScanning={scanningStopped}
+        <OpenFeatureProvider client={getTestFeatureFlagClient()}>
+          <Logs
+            exploreId={'left'}
+            splitOpen={() => undefined}
+            logsVolumeEnabled={true}
+            onSetLogsVolumeEnabled={() => null}
+            onClickFilterLabel={() => null}
+            onClickFilterOutLabel={() => null}
+            logsVolumeData={undefined}
+            loadLogsVolumeData={() => undefined}
+            logRows={[]}
+            scanning={true}
+            onStopScanning={scanningStopped}
           timeZone={'utc'}
           width={50}
           loading={false}
@@ -320,6 +330,7 @@ describe('Logs', () => {
           eventBus={new EventBusSrv()}
           isFilterLabelActive={jest.fn()}
         />
+        </OpenFeatureProvider>
       </Provider>
     );
 
@@ -368,8 +379,20 @@ describe('Logs', () => {
       const panelState = { logs: { id: '1' } };
       const { rerender, store } = setup({ loading: false, panelState });
 
-      rerender(<Provider store={store}>{getComponent({ loading: true, exploreId: 'right', panelState })}</Provider>);
-      rerender(<Provider store={store}>{getComponent({ loading: false, exploreId: 'right', panelState })}</Provider>);
+      rerender(
+        <Provider store={store}>
+          <OpenFeatureProvider client={getTestFeatureFlagClient()}>
+            {getComponent({ loading: true, exploreId: 'right', panelState })}
+          </OpenFeatureProvider>
+        </Provider>
+      );
+      rerender(
+        <Provider store={store}>
+          <OpenFeatureProvider client={getTestFeatureFlagClient()}>
+            {getComponent({ loading: false, exploreId: 'right', panelState })}
+          </OpenFeatureProvider>
+        </Provider>
+      );
 
       expect(fakeChangePanelState).toHaveBeenCalledWith('right', 'logs', { logs: {} });
     });

--- a/public/app/features/explore/Logs/Logs.test.tsx
+++ b/public/app/features/explore/Logs/Logs.test.tsx
@@ -207,26 +207,26 @@ describe('Logs', () => {
             loadLogsVolumeData={() => undefined}
             logRows={[]}
             onStartScanning={scanningStarted}
-          timeZone={'utc'}
-          width={50}
-          loading={false}
-          loadingState={LoadingState.Done}
-          absoluteRange={{
-            from: toUtc('2019-01-01 10:00:00').valueOf(),
-            to: toUtc('2019-01-01 16:00:00').valueOf(),
-          }}
-          range={{
-            from: toUtc('2019-01-01 10:00:00'),
-            to: toUtc('2019-01-01 16:00:00'),
-            raw: { from: 'now-1h', to: 'now' },
-          }}
-          onChangeTime={() => {}}
-          getFieldLinks={() => {
-            return [];
-          }}
-          eventBus={new EventBusSrv()}
-          isFilterLabelActive={jest.fn()}
-        />
+            timeZone={'utc'}
+            width={50}
+            loading={false}
+            loadingState={LoadingState.Done}
+            absoluteRange={{
+              from: toUtc('2019-01-01 10:00:00').valueOf(),
+              to: toUtc('2019-01-01 16:00:00').valueOf(),
+            }}
+            range={{
+              from: toUtc('2019-01-01 10:00:00'),
+              to: toUtc('2019-01-01 16:00:00'),
+              raw: { from: 'now-1h', to: 'now' },
+            }}
+            onChangeTime={() => {}}
+            getFieldLinks={() => {
+              return [];
+            }}
+            eventBus={new EventBusSrv()}
+            isFilterLabelActive={jest.fn()}
+          />
         </OpenFeatureProvider>
       </Provider>
     );
@@ -258,25 +258,25 @@ describe('Logs', () => {
             logRows={[]}
             scanning={true}
             timeZone={'utc'}
-          width={50}
-          loading={false}
-          loadingState={LoadingState.Done}
-          absoluteRange={{
-            from: toUtc('2019-01-01 10:00:00').valueOf(),
-            to: toUtc('2019-01-01 16:00:00').valueOf(),
-          }}
-          range={{
-            from: toUtc('2019-01-01 10:00:00'),
-            to: toUtc('2019-01-01 16:00:00'),
-            raw: { from: 'now-1h', to: 'now' },
-          }}
-          onChangeTime={() => {}}
-          getFieldLinks={() => {
-            return [];
-          }}
-          eventBus={new EventBusSrv()}
-          isFilterLabelActive={jest.fn()}
-        />
+            width={50}
+            loading={false}
+            loadingState={LoadingState.Done}
+            absoluteRange={{
+              from: toUtc('2019-01-01 10:00:00').valueOf(),
+              to: toUtc('2019-01-01 16:00:00').valueOf(),
+            }}
+            range={{
+              from: toUtc('2019-01-01 10:00:00'),
+              to: toUtc('2019-01-01 16:00:00'),
+              raw: { from: 'now-1h', to: 'now' },
+            }}
+            onChangeTime={() => {}}
+            getFieldLinks={() => {
+              return [];
+            }}
+            eventBus={new EventBusSrv()}
+            isFilterLabelActive={jest.fn()}
+          />
         </OpenFeatureProvider>
       </Provider>
     );
@@ -310,26 +310,26 @@ describe('Logs', () => {
             logRows={[]}
             scanning={true}
             onStopScanning={scanningStopped}
-          timeZone={'utc'}
-          width={50}
-          loading={false}
-          loadingState={LoadingState.Done}
-          absoluteRange={{
-            from: toUtc('2019-01-01 10:00:00').valueOf(),
-            to: toUtc('2019-01-01 16:00:00').valueOf(),
-          }}
-          range={{
-            from: toUtc('2019-01-01 10:00:00'),
-            to: toUtc('2019-01-01 16:00:00'),
-            raw: { from: 'now-1h', to: 'now' },
-          }}
-          onChangeTime={() => {}}
-          getFieldLinks={() => {
-            return [];
-          }}
-          eventBus={new EventBusSrv()}
-          isFilterLabelActive={jest.fn()}
-        />
+            timeZone={'utc'}
+            width={50}
+            loading={false}
+            loadingState={LoadingState.Done}
+            absoluteRange={{
+              from: toUtc('2019-01-01 10:00:00').valueOf(),
+              to: toUtc('2019-01-01 16:00:00').valueOf(),
+            }}
+            range={{
+              from: toUtc('2019-01-01 10:00:00'),
+              to: toUtc('2019-01-01 16:00:00'),
+              raw: { from: 'now-1h', to: 'now' },
+            }}
+            onChangeTime={() => {}}
+            getFieldLinks={() => {
+              return [];
+            }}
+            eventBus={new EventBusSrv()}
+            isFilterLabelActive={jest.fn()}
+          />
         </OpenFeatureProvider>
       </Provider>
     );

--- a/public/app/features/explore/Logs/Logs.test.tsx
+++ b/public/app/features/explore/Logs/Logs.test.tsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import { ComponentProps } from 'react';
 import { Provider } from 'react-redux';
 
-
 import {
   DataFrame,
   EventBusSrv,

--- a/public/app/features/explore/Logs/Logs.test.tsx
+++ b/public/app/features/explore/Logs/Logs.test.tsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import { ComponentProps } from 'react';
 import { Provider } from 'react-redux';
 
-import { getTestFeatureFlagClient } from '@grafana/test-utils/unstable';
 
 import {
   DataFrame,
@@ -20,6 +19,7 @@ import {
 } from '@grafana/data';
 import { mockTransformationsRegistry, organizeFieldsTransformer } from '@grafana/data/internal';
 import { config } from '@grafana/runtime';
+import { getTestFeatureFlagClient } from '@grafana/test-utils/unstable';
 import { extractFieldsTransformer } from 'app/features/transformers/extractFields/extractFields';
 import { LokiQueryDirection } from 'app/plugins/datasource/loki/dataquery.gen';
 import { configureStore } from 'app/store/configureStore';

--- a/public/app/features/explore/Logs/LogsVolumePanelList.test.tsx
+++ b/public/app/features/explore/Logs/LogsVolumePanelList.test.tsx
@@ -1,7 +1,9 @@
+import { OpenFeatureProvider } from '@openfeature/react-sdk';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { DataQueryResponse, LoadingState, EventBusSrv, LogRowModel, arrayToDataFrame, DataTopic } from '@grafana/data';
+import { getTestFeatureFlagClient } from '@grafana/test-utils/unstable';
 import { createLogLine } from 'app/features/logs/components/mocks/logRow';
 
 import * as logUtils from '../../logs/utils';
@@ -17,7 +19,8 @@ jest.mock('../Graph/ExploreGraph', () => {
 
 function renderPanel(logsVolumeData?: DataQueryResponse, onLoadLogsVolume = () => {}, logs: LogRowModel[] = []) {
   render(
-    <LogsVolumePanelList
+    <OpenFeatureProvider client={getTestFeatureFlagClient()}>
+      <LogsVolumePanelList
       absoluteRange={{ from: 0, to: 1 }}
       timeZone="timeZone"
       splitOpen={() => {}}
@@ -29,6 +32,7 @@ function renderPanel(logsVolumeData?: DataQueryResponse, onLoadLogsVolume = () =
       eventBus={new EventBusSrv()}
       logs={logs}
     />
+    </OpenFeatureProvider>
   );
 }
 

--- a/public/app/features/explore/Logs/LogsVolumePanelList.test.tsx
+++ b/public/app/features/explore/Logs/LogsVolumePanelList.test.tsx
@@ -21,17 +21,17 @@ function renderPanel(logsVolumeData?: DataQueryResponse, onLoadLogsVolume = () =
   render(
     <OpenFeatureProvider client={getTestFeatureFlagClient()}>
       <LogsVolumePanelList
-      absoluteRange={{ from: 0, to: 1 }}
-      timeZone="timeZone"
-      splitOpen={() => {}}
-      width={100}
-      onUpdateTimeRange={() => {}}
-      logsVolumeData={logsVolumeData}
-      onLoadLogsVolume={onLoadLogsVolume}
-      onDisplayedSeriesChanged={() => null}
-      eventBus={new EventBusSrv()}
-      logs={logs}
-    />
+        absoluteRange={{ from: 0, to: 1 }}
+        timeZone="timeZone"
+        splitOpen={() => {}}
+        width={100}
+        onUpdateTimeRange={() => {}}
+        logsVolumeData={logsVolumeData}
+        onLoadLogsVolume={onLoadLogsVolume}
+        onDisplayedSeriesChanged={() => null}
+        eventBus={new EventBusSrv()}
+        logs={logs}
+      />
     </OpenFeatureProvider>
   );
 }

--- a/public/app/features/explore/Logs/LogsVolumePanelList.tsx
+++ b/public/app/features/explore/Logs/LogsVolumePanelList.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { flatten, groupBy, mapValues, sortBy } from 'lodash';
 import { useCallback, useMemo } from 'react';
 import * as React from 'react';
@@ -21,7 +22,6 @@ import {
   TimeZone,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { Button, InlineField, Alert, useStyles2, SeriesVisibilityChangeMode } from '@grafana/ui';
 
 import {
@@ -118,6 +118,7 @@ export const LogsVolumePanelList = ({
   }, [logs, logsVolumeData?.data]);
 
   const styles = useStyles2(getStyles);
+  const lokiShardSplitting = useBooleanFlagValue('lokiShardSplitting', false);
 
   const numberOfLogVolumes = Object.keys(logVolumes).length;
 
@@ -127,7 +128,7 @@ export const LogsVolumePanelList = ({
   });
 
   const canShowPartialData =
-    config.featureToggles.lokiShardSplitting && logsVolumeData && logsVolumeData.data.length > 0;
+    lokiShardSplitting && logsVolumeData && logsVolumeData.data.length > 0;
   const timeoutError = isTimeoutErrorResponse(logsVolumeData);
   const maxBytesError = isMaxBytesErrorResponse(logsVolumeData);
   const queryTooLargeError = timeoutError || maxBytesError;

--- a/public/app/features/explore/Logs/LogsVolumePanelList.tsx
+++ b/public/app/features/explore/Logs/LogsVolumePanelList.tsx
@@ -127,8 +127,7 @@ export const LogsVolumePanelList = ({
     return !isLogsVolumeLimited(data) && zoomRatio && zoomRatio < 1;
   });
 
-  const canShowPartialData =
-    lokiShardSplitting && logsVolumeData && logsVolumeData.data.length > 0;
+  const canShowPartialData = lokiShardSplitting && logsVolumeData && logsVolumeData.data.length > 0;
   const timeoutError = isTimeoutErrorResponse(logsVolumeData);
   const maxBytesError = isMaxBytesErrorResponse(logsVolumeData);
   const queryTooLargeError = timeoutError || maxBytesError;

--- a/public/app/features/explore/spec/helper/setup.tsx
+++ b/public/app/features/explore/spec/helper/setup.tsx
@@ -1,3 +1,4 @@
+import { OpenFeatureProvider } from '@openfeature/react-sdk';
 import { ByRoleMatcher, waitFor, within } from '@testing-library/dom';
 import { render, screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
@@ -10,6 +11,8 @@ import { Provider } from 'react-redux';
 import { Route, Router } from 'react-router-dom';
 import { of } from 'rxjs';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
+
+import { getTestFeatureFlagClient } from '@grafana/test-utils/unstable';
 
 import {
   DataSourceApi,
@@ -197,33 +200,35 @@ export function setupExplore(options?: SetupOptions): {
 
   const { unmount, container } = render(
     <Provider store={storeState}>
-      <GrafanaContext.Provider value={contextMock}>
-        <Router history={history}>
-          <QueriesDrawerContextProvider>
-            <FinalProvider>
-              {options?.withAppChrome ? (
-                <KBarProvider>
-                  <AppChrome>
-                    <Route
-                      path="/explore"
-                      exact
-                      render={(props) => (
-                        <GrafanaRoute {...props} route={{ component: ExplorePage, path: '/explore' }} />
-                      )}
-                    />
-                  </AppChrome>
-                </KBarProvider>
-              ) : (
-                <Route
-                  path="/explore"
-                  exact
-                  render={(props) => <GrafanaRoute {...props} route={{ component: ExplorePage, path: '/explore' }} />}
-                />
-              )}
-            </FinalProvider>
-          </QueriesDrawerContextProvider>
-        </Router>
-      </GrafanaContext.Provider>
+      <OpenFeatureProvider client={getTestFeatureFlagClient()}>
+        <GrafanaContext.Provider value={contextMock}>
+          <Router history={history}>
+            <QueriesDrawerContextProvider>
+              <FinalProvider>
+                {options?.withAppChrome ? (
+                  <KBarProvider>
+                    <AppChrome>
+                      <Route
+                        path="/explore"
+                        exact
+                        render={(props) => (
+                          <GrafanaRoute {...props} route={{ component: ExplorePage, path: '/explore' }} />
+                        )}
+                      />
+                    </AppChrome>
+                  </KBarProvider>
+                ) : (
+                  <Route
+                    path="/explore"
+                    exact
+                    render={(props) => <GrafanaRoute {...props} route={{ component: ExplorePage, path: '/explore' }} />}
+                  />
+                )}
+              </FinalProvider>
+            </QueriesDrawerContextProvider>
+          </Router>
+        </GrafanaContext.Provider>
+      </OpenFeatureProvider>
     </Provider>
   );
 

--- a/public/app/features/explore/spec/helper/setup.tsx
+++ b/public/app/features/explore/spec/helper/setup.tsx
@@ -12,7 +12,6 @@ import { Route, Router } from 'react-router-dom';
 import { of } from 'rxjs';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
-
 import {
   DataSourceApi,
   DataSourceInstanceSettings,

--- a/public/app/features/explore/spec/helper/setup.tsx
+++ b/public/app/features/explore/spec/helper/setup.tsx
@@ -12,7 +12,6 @@ import { Route, Router } from 'react-router-dom';
 import { of } from 'rxjs';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
-import { getTestFeatureFlagClient } from '@grafana/test-utils/unstable';
 
 import {
   DataSourceApi,
@@ -35,6 +34,7 @@ import {
   setPluginLinksHook,
 } from '@grafana/runtime';
 import { DataSourceRef } from '@grafana/schema';
+import { getTestFeatureFlagClient } from '@grafana/test-utils/unstable';
 import { AppChrome } from 'app/core/components/AppChrome/AppChrome';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
 import { GrafanaRoute } from 'app/core/navigation/GrafanaRoute';

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
+import { getFeatureFlagClient } from '@grafana/runtime/internal';
 import { InlineField, Input, Stack } from '@grafana/ui';
 
 import { LokiQueryType, LokiQueryDirection } from '../dataquery.gen';
@@ -34,7 +35,7 @@ export const queryDirections: Array<SelectableValue<LokiQueryDirection>> = [
   },
 ];
 
-if (config.featureToggles.lokiShardSplitting) {
+if (getFeatureFlagClient().getBooleanValue('lokiShardSplitting', false)) {
   queryDirections.push({
     value: LokiQueryDirection.Scan,
     label: 'Scan',

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -47,6 +47,7 @@ import {
 import { t } from '@grafana/i18n';
 import { Duration } from '@grafana/lezer-logql';
 import { BackendSrvRequest, config, DataSourceWithBackend, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
+import { getFeatureFlagClient } from '@grafana/runtime/internal';
 import { DataQuery } from '@grafana/schema';
 
 import LanguageProvider from './LanguageProvider';
@@ -362,7 +363,7 @@ export class LokiDatasource
       return this.runLiveQueryThroughBackend(fixedRequest);
     }
 
-    if (config.featureToggles.lokiShardSplitting && requestSupportsSharding(fixedRequest.targets)) {
+    if (getFeatureFlagClient().getBooleanValue('lokiShardSplitting', false) && requestSupportsSharding(fixedRequest.targets)) {
       return runShardSplitQuery(this, fixedRequest);
     } else if (config.featureToggles.lokiQuerySplitting && requestSupportsSplitting(fixedRequest.targets)) {
       return runSplitQuery(this, fixedRequest);

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -363,7 +363,10 @@ export class LokiDatasource
       return this.runLiveQueryThroughBackend(fixedRequest);
     }
 
-    if (getFeatureFlagClient().getBooleanValue('lokiShardSplitting', false) && requestSupportsSharding(fixedRequest.targets)) {
+    if (
+      getFeatureFlagClient().getBooleanValue('lokiShardSplitting', false) &&
+      requestSupportsSharding(fixedRequest.targets)
+    ) {
       return runShardSplitQuery(this, fixedRequest);
     } else if (config.featureToggles.lokiQuerySplitting && requestSupportsSplitting(fixedRequest.targets)) {
       return runSplitQuery(this, fixedRequest);

--- a/public/app/plugins/datasource/loki/jest-setup.js
+++ b/public/app/plugins/datasource/loki/jest-setup.js
@@ -1,1 +1,18 @@
 import '@grafana/plugin-configs/jest/jest-setup';
+
+// Polyfills for MSW (used by setTestFlags in querySplitting.test.ts)
+import 'whatwg-fetch';
+
+const globalObj = typeof globalThis !== 'undefined' ? globalThis : global;
+if (typeof globalObj.BroadcastChannel === 'undefined') {
+  globalObj.BroadcastChannel = class BroadcastChannel {
+    constructor() {}
+    postMessage() {}
+    close() {}
+    addEventListener() {}
+    removeEventListener() {}
+    dispatchEvent() {
+      return true;
+    }
+  };
+}

--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -2,6 +2,7 @@ import { of } from 'rxjs';
 
 import { DataQueryError, DataQueryRequest, DataQueryResponse, dateTime, LoadingState } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { LokiQueryType, LokiQueryDirection } from './dataquery.gen';
 import { LokiDatasource } from './datasource';
@@ -17,7 +18,6 @@ jest.mock('uuid', () => ({
   v4: jest.fn().mockReturnValue('uuid'),
 }));
 
-const originalShardingFlagState = config.featureToggles.lokiShardSplitting;
 const originalLokiQueryLimitsContextState = config.featureToggles.lokiQueryLimitsContext;
 const originalErr = console.error;
 beforeEach(() => {
@@ -28,12 +28,11 @@ beforeAll(() => {
   jest.spyOn(global, 'setTimeout').mockImplementation((callback) => {
     callback();
   });
-  config.featureToggles.lokiShardSplitting = false;
+  setTestFlags({ lokiShardSplitting: false });
   config.featureToggles.lokiQueryLimitsContext = true;
 });
 afterAll(() => {
   jest.mocked(global.setTimeout).mockReset();
-  config.featureToggles.lokiShardSplitting = originalShardingFlagState;
   config.featureToggles.lokiQueryLimitsContext = originalLokiQueryLimitsContextState;
   console.error = originalErr;
 });

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
@@ -2,7 +2,8 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { CoreApp, LogSortOrderChangeEvent, LogsSortOrder, store } from '@grafana/data';
-import { config, getAppEvents } from '@grafana/runtime';
+import { getAppEvents } from '@grafana/runtime';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { LokiQueryType, LokiQueryDirection } from '../../dataquery.gen';
 import { createLokiDatasource } from '../../mocks/datasource';
@@ -12,19 +13,12 @@ import { LokiQueryBuilderOptions, Props } from './LokiQueryBuilderOptions';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
-  config: {
-    ...jest.requireActual('@grafana/runtime').config,
-    featureToggles: {
-      ...jest.requireActual('@grafana/runtime').featureToggles,
-      lokiShardSplitting: true,
-    },
-  },
   getAppEvents: jest.fn(),
 }));
 
 const subscribeMock = jest.fn();
 beforeAll(() => {
-  config.featureToggles.lokiShardSplitting = true;
+  setTestFlags({ lokiShardSplitting: true });
   subscribeMock.mockImplementation(() => ({ unsubscribe: jest.fn() }));
   jest.mocked(getAppEvents).mockReturnValue({
     publish: jest.fn(),


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

https://github.com/grafana/logs-drilldown/issues/1704
Update lokiShardSplitting to use the GOFF implmentation

**Testing**
[feature_toggles]
lokiShardSplitting = true
run against grafanacloud-dev-logs for last 30 days
<img width="1732" height="1006" alt="Screenshot 2026-02-27 at 12 56 11 PM" src="https://github.com/user-attachments/assets/1856b194-db71-4f4e-a5d0-2f98d2daedec" />


**Why do we need this feature?**

Users are using the lokiShardSplitting and it's been turned on ad-hoc for some. It needs to continue on in the new feature flag system.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
