### PR TITLE
Alerting: Notification history on contact points page

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1587,4 +1587,9 @@ export interface FeatureToggles {
   * @default false
   */
   analyticsFramework?: boolean;
+  /**
+  * Enables the notification history contact points page drawer
+  * @default false
+  */
+  alertingNotificationHistoryContactPoints?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2514,6 +2514,14 @@ var (
 			HideFromDocs: true,
 			Expression:   "false",
 		},
+		{
+			Name:         "alertingNotificationHistoryContactPoints",
+			Description:  "Enables the notification history contact points page drawer",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaAlertingSquad,
+			HideFromDocs: true,
+			Expression:   "false",
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -312,3 +312,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-02-25,rememberUserOrgForSso,GA,@grafana/identity-access-team,false,false,false
 2026-02-23,dsAbstractionApp,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2026-02-27,analyticsFramework,experimental,@grafana/grafana-frontend-platform,false,false,false
+2026-02-27,alertingNotificationHistoryContactPoints,experimental,@grafana/alerting-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -865,4 +865,8 @@ const (
 	// FlagAnalyticsFramework
 	// Enables new analytics framework
 	FlagAnalyticsFramework = "analyticsFramework"
+
+	// FlagAlertingNotificationHistoryContactPoints
+	// Enables the notification history contact points page drawer
+	FlagAlertingNotificationHistoryContactPoints = "alertingNotificationHistoryContactPoints"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -456,6 +456,20 @@
     },
     {
       "metadata": {
+        "name": "alertingNotificationHistoryContactPoints",
+        "resourceVersion": "1772225621410",
+        "creationTimestamp": "2026-02-27T20:53:41Z"
+      },
+      "spec": {
+        "description": "Enables the notification history contact points page drawer",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingNotificationHistoryGlobal",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2026-02-18T17:05:38Z"

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoint.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoint.test.tsx
@@ -1,0 +1,162 @@
+import { render, screen } from '@testing-library/react';
+
+import { dateTime } from '@grafana/data';
+
+import { NotifierStatus } from '../../types/alerting';
+
+import { ContactPointReceiverTitleRow } from './ContactPoint';
+import { RECEIVER_STATUS_KEY } from './constants';
+import { ReceiverConfigWithMetadata } from './utils';
+
+/**
+ * Tests for ContactPoint component with notification history diagnostics
+ */
+describe('ContactPoint with notification history', () => {
+  describe('ContactPointReceiverTitleRow', () => {
+    it('should render integration name and type', () => {
+      render(<ContactPointReceiverTitleRow name="My Email" type="email" />);
+
+      expect(screen.getByText('My Email')).toBeInTheDocument();
+    });
+
+    it('should render description when provided', () => {
+      render(<ContactPointReceiverTitleRow name="My Email" type="email" description="test@example.com" />);
+
+      expect(screen.getByText('test@example.com')).toBeInTheDocument();
+    });
+  });
+
+  describe('Diagnostic states', () => {
+    const createReceiverWithDiagnostics = (diagnostics: NotifierStatus): ReceiverConfigWithMetadata => {
+      return {
+        type: 'email',
+        disableResolveMessage: false,
+        settings: {},
+        [RECEIVER_STATUS_KEY]: diagnostics,
+      };
+    };
+
+    it('should handle no attempts state', () => {
+      const diagnostics: NotifierStatus = {
+        name: 'email',
+        lastNotifyAttempt: '',
+        lastNotifyAttemptDuration: '',
+        lastNotifyAttemptError: null,
+        totalAttempts: 0,
+        failedAttempts: 0,
+        successAttempts: 0,
+      };
+
+      // Test data structure - actual rendering tested in integration tests
+      expect(diagnostics.totalAttempts).toBe(0);
+      expect(diagnostics.failedAttempts).toBe(0);
+      expect(diagnostics.successAttempts).toBe(0);
+    });
+
+    it('should handle all successful attempts', () => {
+      const diagnostics: NotifierStatus = {
+        name: 'email',
+        lastNotifyAttempt: dateTime().subtract(5, 'minutes').toISOString(),
+        lastNotifyAttemptDuration: '150.00ms',
+        lastNotifyAttemptError: null,
+        totalAttempts: 5,
+        failedAttempts: 0,
+        successAttempts: 5,
+      };
+
+      expect(diagnostics.totalAttempts).toBe(5);
+      expect(diagnostics.successAttempts).toBe(5);
+      expect(diagnostics.failedAttempts).toBe(0);
+    });
+
+    it('should handle all failed attempts', () => {
+      const diagnostics: NotifierStatus = {
+        name: 'email',
+        lastNotifyAttempt: dateTime().subtract(5, 'minutes').toISOString(),
+        lastNotifyAttemptDuration: '50.00ms',
+        lastNotifyAttemptError: 'SMTP connection timeout',
+        totalAttempts: 3,
+        failedAttempts: 3,
+        successAttempts: 0,
+      };
+
+      expect(diagnostics.totalAttempts).toBe(3);
+      expect(diagnostics.failedAttempts).toBe(3);
+      expect(diagnostics.successAttempts).toBe(0);
+      expect(diagnostics.lastNotifyAttemptError).toBe('SMTP connection timeout');
+    });
+
+    it('should handle mixed success/failure attempts', () => {
+      const diagnostics: NotifierStatus = {
+        name: 'email',
+        lastNotifyAttempt: dateTime().subtract(5, 'minutes').toISOString(),
+        lastNotifyAttemptDuration: '150.00ms',
+        lastNotifyAttemptError: 'Connection timeout',
+        totalAttempts: 10,
+        failedAttempts: 3,
+        successAttempts: 7,
+      };
+
+      expect(diagnostics.totalAttempts).toBe(10);
+      expect(diagnostics.failedAttempts).toBe(3);
+      expect(diagnostics.successAttempts).toBe(7);
+      expect(diagnostics.lastNotifyAttemptError).toBe('Connection timeout');
+    });
+
+    it('should identify different states correctly', () => {
+      const noAttempts: NotifierStatus = {
+        name: 'email',
+        lastNotifyAttempt: '',
+        lastNotifyAttemptDuration: '',
+        totalAttempts: 0,
+        failedAttempts: 0,
+        successAttempts: 0,
+      };
+
+      const allFailed: NotifierStatus = {
+        name: 'email',
+        lastNotifyAttempt: dateTime().toISOString(),
+        lastNotifyAttemptDuration: '50ms',
+        lastNotifyAttemptError: 'Error',
+        totalAttempts: 5,
+        failedAttempts: 5,
+        successAttempts: 0,
+      };
+
+      const allSuccess: NotifierStatus = {
+        name: 'email',
+        lastNotifyAttempt: dateTime().toISOString(),
+        lastNotifyAttemptDuration: '150ms',
+        totalAttempts: 5,
+        failedAttempts: 0,
+        successAttempts: 5,
+      };
+
+      const mixed: NotifierStatus = {
+        name: 'email',
+        lastNotifyAttempt: dateTime().toISOString(),
+        lastNotifyAttemptDuration: '150ms',
+        lastNotifyAttemptError: 'Some error',
+        totalAttempts: 10,
+        failedAttempts: 3,
+        successAttempts: 7,
+      };
+
+      // No attempts
+      expect(noAttempts.totalAttempts).toBe(0);
+
+      // All failed
+      const isAllFailed = allFailed.totalAttempts! > 0 && allFailed.failedAttempts === allFailed.totalAttempts;
+      expect(isAllFailed).toBe(true);
+
+      // All success
+      const isAllSuccess = allSuccess.totalAttempts! > 0 && allSuccess.successAttempts === allSuccess.totalAttempts;
+      expect(isAllSuccess).toBe(true);
+
+      // Mixed
+      const isMixed =
+        mixed.totalAttempts! > 0 && mixed.failedAttempts! > 0 && mixed.successAttempts! > 0;
+      expect(isMixed).toBe(true);
+    });
+  });
+});

--- a/public/app/features/alerting/unified/components/contact-points/useContactPoints.notification-history.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/useContactPoints.notification-history.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Integration tests for useContactPoints with notification history
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { TestProvider } from 'test/helpers/TestProvider';
+
+import { setupMswServer } from '../../mockApi';
+import { setupDataSources } from '../../testSetup/datasources';
+
+import { useGrafanaContactPoints } from './useContactPoints';
+
+/**
+ * Tests for useGrafanaContactPoints with notification history API
+ */
+setupMswServer();
+
+beforeAll(() => {
+  setupDataSources();
+});
+
+describe('useGrafanaContactPoints with notification history', () => {
+  it('should fetch notification history for contact points', async () => {
+    const { result } = renderHook(() => useGrafanaContactPoints({ fetchStatuses: true }), {
+      wrapper: TestProvider,
+    });
+
+    await waitFor(
+      () => {
+        expect(result.current.isLoading).toBe(false);
+      },
+      { timeout: 5000 }
+    );
+
+    // Should have contact points data
+    expect(result.current.contactPoints).toBeDefined();
+  });
+
+  it('should not fetch notification history when fetchStatuses is false', async () => {
+    const { result } = renderHook(() => useGrafanaContactPoints({ fetchStatuses: false }), {
+      wrapper: TestProvider,
+    });
+
+    await waitFor(
+      () => {
+        expect(result.current.isLoading).toBe(false);
+      },
+      { timeout: 5000 }
+    );
+
+    expect(result.current.contactPoints).toBeDefined();
+  });
+
+  it('should handle empty contact point list', async () => {
+    const { result } = renderHook(() => useGrafanaContactPoints({ fetchStatuses: true }), {
+      wrapper: TestProvider,
+    });
+
+    await waitFor(
+      () => {
+        expect(result.current.isLoading).toBe(false);
+      },
+      { timeout: 5000 }
+    );
+
+    expect(result.current.contactPoints).toBeDefined();
+    expect(Array.isArray(result.current.contactPoints)).toBe(true);
+  });
+});

--- a/public/app/features/alerting/unified/components/contact-points/useNotificationHistory.test.ts
+++ b/public/app/features/alerting/unified/components/contact-points/useNotificationHistory.test.ts
@@ -1,0 +1,115 @@
+import { transformCountsToIntegrations } from './useNotificationHistory';
+
+describe('useNotificationHistory', () => {
+  describe('transformCountsToIntegrations', () => {
+    const receiverName = 'my-receiver';
+
+    // Helper: build an IntegrationCountsResult from a flat list of integration specs
+    const makeResult = (
+      integrations: Array<{
+        type: string;
+        index: number;
+        success?: number;
+        failed?: number;
+        lastAttempt?: string;
+        duration?: string;
+        error?: string | null;
+      }>
+    ) => {
+      const byKey = new Map();
+      for (const { type, index, success = 0, failed = 0, lastAttempt = '', duration = '', error = null } of integrations) {
+        byKey.set(`${type}:${index}`, {
+          integrationType: type,
+          integrationIndex: index,
+          successCount: success,
+          failedCount: failed,
+          lastNotifyAttempt: lastAttempt,
+          lastNotifyAttemptDuration: duration,
+          lastNotifyAttemptError: error,
+        });
+      }
+      return { byKey };
+    };
+
+    it('returns a single zeroed entry when there are no counts', () => {
+      const result = transformCountsToIntegrations(makeResult([]), receiverName);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        name: receiverName,
+        totalAttempts: 0,
+        failedAttempts: 0,
+        successAttempts: 0,
+        lastNotifyAttempt: '',
+        lastNotifyAttemptDuration: '',
+        lastNotifyAttemptError: null,
+      });
+    });
+
+    it('returns one entry per (type, integrationIndex) pair', () => {
+      // Mirrors the real API: receiver with webhook[0] and email[0] — both integrationIndex=0
+      // because integrationIndex is a per-type occurrence counter, not overall position.
+      const result = transformCountsToIntegrations(
+        makeResult([
+          { type: 'webhook', index: 0, failed: 7, error: 'connection refused' },
+          { type: 'email', index: 0, failed: 7, error: 'SMTP error' },
+        ]),
+        receiverName
+      );
+
+      expect(result).toHaveLength(2);
+
+      const webhook = result.find((r) => r.integrationType === 'webhook');
+      const email = result.find((r) => r.integrationType === 'email');
+
+      expect(webhook).toMatchObject({ integrationType: 'webhook', integrationIndex: 0, totalAttempts: 7, failedAttempts: 7 });
+      expect(email).toMatchObject({ integrationType: 'email', integrationIndex: 0, totalAttempts: 7, failedAttempts: 7 });
+    });
+
+    it('correctly sums success and failed counts into totalAttempts', () => {
+      const result = transformCountsToIntegrations(
+        makeResult([{ type: 'slack', index: 0, success: 3, failed: 2 }]),
+        receiverName
+      );
+
+      expect(result[0]).toMatchObject({ totalAttempts: 5, successAttempts: 3, failedAttempts: 2 });
+    });
+
+    it('handles two integrations of the same type using incrementing integrationIndex', () => {
+      const result = transformCountsToIntegrations(
+        makeResult([
+          { type: 'email', index: 0, success: 5 },
+          { type: 'email', index: 1, failed: 2 },
+        ]),
+        receiverName
+      );
+
+      expect(result).toHaveLength(2);
+      const first = result.find((r) => r.integrationIndex === 0);
+      const second = result.find((r) => r.integrationIndex === 1);
+      expect(first).toMatchObject({ integrationType: 'email', successAttempts: 5 });
+      expect(second).toMatchObject({ integrationType: 'email', failedAttempts: 2 });
+    });
+
+    it('includes lastNotifyAttempt metadata', () => {
+      const result = transformCountsToIntegrations(
+        makeResult([
+          {
+            type: 'webhook',
+            index: 0,
+            success: 1,
+            lastAttempt: '2024-01-01T00:00:00Z',
+            duration: '150.00ms',
+          },
+        ]),
+        receiverName
+      );
+
+      expect(result[0]).toMatchObject({
+        lastNotifyAttempt: '2024-01-01T00:00:00Z',
+        lastNotifyAttemptDuration: '150.00ms',
+        lastNotifyAttemptError: null,
+      });
+    });
+  });
+});

--- a/public/app/features/alerting/unified/components/contact-points/useNotificationHistory.ts
+++ b/public/app/features/alerting/unified/components/contact-points/useNotificationHistory.ts
@@ -1,0 +1,265 @@
+import { useEffect, useRef, useState, useMemo } from 'react';
+
+import {
+  CreateNotificationqueryNotificationCount,
+  generatedAPI as notificationsApi,
+} from '@grafana/api-clients/rtkq/historian.alerting/v0alpha1';
+import { dateTime } from '@grafana/data';
+import { dispatch } from 'app/store/store';
+
+import { ReceiversStateDTO, NotifierStatus } from '../../types/alerting';
+
+const ONE_HOUR_AGO = () => dateTime().subtract(1, 'hour').toISOString();
+const NOW = () => dateTime().toISOString();
+
+interface NotificationHistoryOptions {
+  skip?: boolean;
+  pollingInterval?: number;
+}
+
+// Composite key: "<type>:<integrationIndex>" uniquely identifies an integration within a receiver.
+// The history API's integrationIndex is the 0-based occurrence of that type within the receiver,
+// not the overall position in the integrations array.
+type IntegrationKey = string;
+const integrationKey = (type: string, index: number): IntegrationKey => `${type}:${index}`;
+
+interface IntegrationInfo {
+  integrationType: string;
+  integrationIndex: number;
+  successCount: number;
+  failedCount: number;
+  lastNotifyAttempt: string;
+  lastNotifyAttemptDuration: string;
+  lastNotifyAttemptError: string | null;
+}
+
+interface IntegrationCountsResult {
+  // All integrations keyed by composite "type:index"
+  byKey: Map<IntegrationKey, IntegrationInfo>;
+}
+
+/**
+ * Custom hook to fetch notification status for multiple contact points using the counts API.
+ * Makes two requests per fetch:
+ * 1. A single counts query grouped by receiver, integration, integrationIndex and outcome
+ * 2. One entries query per receiver (limit=100) for the most recent attempt metadata per integration
+ */
+export const useNotificationHistoryForContactPoints = (
+  contactPointNames: string[],
+  options: NotificationHistoryOptions = {}
+): {
+  data?: ReceiversStateDTO[];
+  isLoading: boolean;
+  isError: boolean;
+  error?: unknown;
+} => {
+  const { skip = false, pollingInterval } = options;
+
+  const [receiverData, setReceiverData] = useState<Map<string, IntegrationCountsResult>>(new Map());
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+  const [error, setError] = useState<unknown>(undefined);
+  const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  const fetchNotificationStatus = async () => {
+    if (skip || contactPointNames.length === 0) {
+      return;
+    }
+
+    setIsLoading(true);
+    setIsError(false);
+    setError(undefined);
+
+    const from = ONE_HOUR_AGO();
+    const to = NOW();
+
+    try {
+      // Single counts query for all contact points, grouped by receiver, integration, integrationIndex and outcome
+      const countsResponse = await dispatch(
+        notificationsApi.endpoints.createNotificationquery.initiate({
+          createNotificationqueryRequestBody: {
+            from,
+            to,
+            type: 'counts',
+            groupBy: {
+              receiver: true,
+              integration: true,
+              integrationIndex: true,
+              outcome: true,
+              status: false,
+              error: false,
+            },
+          },
+        })
+      ).unwrap();
+
+      // One entries query per receiver to get the most recent entry per integration index
+      const recentEntriesResults = await Promise.all(
+        contactPointNames.map((receiverName) =>
+          dispatch(
+            notificationsApi.endpoints.createNotificationquery.initiate({
+              createNotificationqueryRequestBody: {
+                from,
+                to,
+                receiver: receiverName,
+                limit: 100,
+              },
+            })
+          )
+            .unwrap()
+            .then((res) => ({ receiverName, entries: res.entries ?? [] }))
+            .catch(() => ({ receiverName, entries: [] }))
+        )
+      );
+
+      const newData = new Map<string, IntegrationCountsResult>();
+
+      for (const receiverName of contactPointNames) {
+        const receiverCounts = (countsResponse.counts ?? []).filter((c) => c.receiver === receiverName);
+        const entries = recentEntriesResults.find((r) => r.receiverName === receiverName)?.entries ?? [];
+
+        const byKey = new Map<IntegrationKey, IntegrationInfo>();
+
+        // Aggregate counts — each count row has a unique (type, integrationIndex, outcome) triple
+        for (const count of receiverCounts) {
+          if (!count.integration) {
+            continue;
+          }
+          const idx = count.integrationIndex ?? 0;
+          const key = integrationKey(count.integration, idx);
+          const existing = byKey.get(key) ?? {
+            integrationType: count.integration,
+            integrationIndex: idx,
+            successCount: 0,
+            failedCount: 0,
+            lastNotifyAttempt: '',
+            lastNotifyAttemptDuration: '',
+            lastNotifyAttemptError: null,
+          };
+          if (count.outcome === 'success') {
+            existing.successCount += count.count;
+          } else if (count.outcome === 'error') {
+            existing.failedCount += count.count;
+          }
+          byKey.set(key, existing);
+        }
+
+        // Enrich with most-recent entry metadata per (type, integrationIndex)
+        const sorted = [...entries].sort(
+          (a, b) => dateTime(b.timestamp).valueOf() - dateTime(a.timestamp).valueOf()
+        );
+        for (const entry of sorted) {
+          if (!entry.integration) {
+            continue;
+          }
+          const idx = entry.integrationIndex ?? 0;
+          const key = integrationKey(entry.integration, idx);
+          const info = byKey.get(key);
+          // Only set once (sorted desc, so first match is most recent)
+          if (info && !info.lastNotifyAttempt) {
+            info.lastNotifyAttempt = entry.timestamp ?? '';
+            info.lastNotifyAttemptDuration =
+              entry.duration != null ? `${(entry.duration / 1_000_000).toFixed(2)}ms` : '';
+            info.lastNotifyAttemptError = entry.error ?? null;
+          }
+        }
+
+        newData.set(receiverName, { byKey });
+      }
+
+      setReceiverData(newData);
+      setIsLoading(false);
+    } catch (err) {
+      setIsError(true);
+      setError(err);
+      setIsLoading(false);
+    }
+  };
+
+  // Initial fetch and polling setup
+  useEffect(() => {
+    if (skip) {
+      return;
+    }
+
+    fetchNotificationStatus();
+
+    if (pollingInterval) {
+      pollingIntervalRef.current = setInterval(() => {
+        fetchNotificationStatus();
+      }, pollingInterval);
+    }
+
+    return () => {
+      if (pollingIntervalRef.current) {
+        clearInterval(pollingIntervalRef.current);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [skip, pollingInterval, JSON.stringify(contactPointNames)]);
+
+  const receiversState = useMemo(() => {
+    if (receiverData.size === 0) {
+      return undefined;
+    }
+
+    const receivers: ReceiversStateDTO[] = [];
+
+    receiverData.forEach((result, receiverName) => {
+      const integrations = transformCountsToIntegrations(result, receiverName);
+      receivers.push({
+        active: true,
+        integrations,
+        name: receiverName,
+      });
+    });
+
+    return receivers;
+  }, [receiverData]);
+
+  return {
+    data: receiversState,
+    isLoading,
+    isError,
+    error,
+  };
+};
+
+/**
+ * Transform aggregated counts result into a NotifierStatus array.
+ * Each entry carries integrationType and integrationIndex (per-type occurrence within the receiver)
+ * so that enhanceContactPointsWithMetadata can match by type + occurrence rather than overall position.
+ */
+export const transformCountsToIntegrations = (
+  result: IntegrationCountsResult,
+  receiverName: string
+): NotifierStatus[] => {
+  const { byKey } = result;
+
+  if (byKey.size === 0) {
+    return [
+      {
+        name: receiverName,
+        lastNotifyAttempt: '',
+        lastNotifyAttemptDuration: '',
+        lastNotifyAttemptError: null,
+        totalAttempts: 0,
+        failedAttempts: 0,
+        successAttempts: 0,
+      },
+    ];
+  }
+
+  return Array.from(byKey.values()).map((info) => ({
+    name: receiverName,
+    integrationType: info.integrationType,
+    integrationIndex: info.integrationIndex,
+    lastNotifyAttempt: info.lastNotifyAttempt,
+    lastNotifyAttemptDuration: info.lastNotifyAttemptDuration,
+    lastNotifyAttemptError: info.lastNotifyAttemptError,
+    totalAttempts: info.successCount + info.failedCount,
+    failedAttempts: info.failedCount,
+    successAttempts: info.successCount,
+  }));
+};
+

--- a/public/app/features/alerting/unified/components/contact-points/utils.ts
+++ b/public/app/features/alerting/unified/components/contact-points/utils.ts
@@ -161,21 +161,39 @@ export function enhanceContactPointsWithMetadata({
       provenance: contactPointProvenance,
       policies:
         alertmanagerConfiguration && usedContactPointsByName && (usedContactPointsByName[contactPoint.name] ?? []),
-      grafana_managed_receiver_configs: receivers.map((receiver, index) => {
-        const isOnCallReceiver = receiver.type === ReceiverTypes.OnCall;
-        // if we don't have alertmanagerConfiguration we can't get the metadata for oncall receivers,
-        // because we don't have the url, as we are not using the alertmanager configuration
-        // but the contact points returned by the read only permissions contact points endpoint (/api/v1/notifications/receivers)
-        return {
-          ...receiver,
-          [RECEIVER_STATUS_KEY]: statusForReceiver?.integrations[index],
-          [RECEIVER_META_KEY]: getNotifierMetadata(notifiers, receiver),
-          // if OnCall plugin is installed, we'll add it to the receiver's plugin metadata
-          [RECEIVER_PLUGIN_META_KEY]: isOnCallReceiver
-            ? getOnCallMetadata(onCallIntegrations, receiver, Boolean(alertmanagerConfiguration), onCallPluginId)
-            : undefined,
-        };
-      }),
+      grafana_managed_receiver_configs: (() => {
+        // Track how many times each integration type has been seen so far,
+        // to compute the per-type occurrence index that the history API uses as integrationIndex.
+        const typeOccurrenceCount = new Map<string, number>();
+        const integrations = statusForReceiver?.integrations ?? [];
+
+        return receivers.map((receiver, index) => {
+          const isOnCallReceiver = receiver.type === ReceiverTypes.OnCall;
+          // if we don't have alertmanagerConfiguration we can't get the metadata for oncall receivers,
+          // because we don't have the url, as we are not using the alertmanager configuration
+          // but the contact points returned by the read only permissions contact points endpoint (/api/v1/notifications/receivers)
+
+          // The history API's integrationIndex is the 0-based occurrence of that type within the receiver,
+          // not the overall position in the integrations array. Track occurrences as we iterate.
+          const typeOccurrence = typeOccurrenceCount.get(receiver.type) ?? 0;
+          typeOccurrenceCount.set(receiver.type, typeOccurrence + 1);
+
+          // Match by type + per-type occurrence index; fall back to overall array position for legacy status data
+          const integrationStatus =
+            integrations.find((s) => s.integrationType === receiver.type && s.integrationIndex === typeOccurrence) ??
+            integrations[index];
+
+          return {
+            ...receiver,
+            [RECEIVER_STATUS_KEY]: integrationStatus,
+            [RECEIVER_META_KEY]: getNotifierMetadata(notifiers, receiver),
+            // if OnCall plugin is installed, we'll add it to the receiver's plugin metadata
+            [RECEIVER_PLUGIN_META_KEY]: isOnCallReceiver
+              ? getOnCallMetadata(onCallIntegrations, receiver, Boolean(alertmanagerConfiguration), onCallPluginId)
+              : undefined,
+          };
+        });
+      })(),
     };
   });
 

--- a/public/app/features/alerting/unified/mockApi.ts
+++ b/public/app/features/alerting/unified/mockApi.ts
@@ -266,3 +266,39 @@ export function setupMswServer() {
 
   return server;
 }
+
+/**
+ * Helper to mock notification history API response
+ */
+export function mockNotificationHistory(
+  server: SetupServer,
+  receiver: string,
+  entries: Array<{
+    timestamp: string;
+    duration?: number;
+    outcome: 'success' | 'error';
+    error?: string;
+    status: 'firing' | 'resolved';
+  }>
+) {
+  server.use(
+    http.post('/api/notifications/query', async ({ request }) => {
+      const body = (await request.json()) as any;
+
+      // Filter entries for the requested receiver
+      const filteredEntries = body.receiver === receiver ? entries : [];
+
+      return HttpResponse.json({
+        entries: filteredEntries.map((entry) => ({
+          receiver,
+          timestamp: entry.timestamp,
+          duration: entry.duration,
+          outcome: entry.outcome,
+          error: entry.error,
+          status: entry.status,
+          groupLabels: {},
+        })),
+      });
+    })
+  );
+}

--- a/public/app/features/alerting/unified/mocks/server/all-handlers.ts
+++ b/public/app/features/alerting/unified/mocks/server/all-handlers.ts
@@ -16,6 +16,7 @@ import templatesK8sHandlers from 'app/features/alerting/unified/mocks/server/han
 import timeIntervalK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/timeIntervals.k8s';
 import receiverTestK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8sReceiverTest';
 import mimirRulerHandlers from 'app/features/alerting/unified/mocks/server/handlers/mimirRuler';
+import notificationHistoryHandlers from 'app/features/alerting/unified/mocks/server/handlers/notificationHistory';
 import pluginsHandlers from 'app/features/alerting/unified/mocks/server/handlers/plugins';
 import allPluginHandlers from 'app/features/alerting/unified/mocks/server/handlers/plugins/all-plugin-handlers';
 import provisioningHandlers from 'app/features/alerting/unified/mocks/server/handlers/provisioning';
@@ -34,6 +35,7 @@ export const alertingHandlers = [
   ...alertmanagerHandlers,
   ...silenceHandlers,
   ...provisioningHandlers,
+  ...notificationHistoryHandlers,
 
   // Kubernetes-style handlers
   ...integrationTypeSchemasK8sHandlers,

--- a/public/app/features/alerting/unified/mocks/server/handlers/notificationHistory.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/notificationHistory.ts
@@ -1,0 +1,20 @@
+import { HttpResponse, http } from 'msw';
+
+import { CreateNotificationqueryResponse } from '@grafana/api-clients/rtkq/historian.alerting/v0alpha1';
+
+/**
+ * Default handler for notification history API
+ * Returns empty notification history by default
+ */
+const notificationHistoryHandlers = [
+  http.post('/apis/historian.alerting.grafana.app/v0alpha1/namespaces/default/notification/query', () => {
+    const response: CreateNotificationqueryResponse = {
+      entries: [],
+      counts: [],
+    };
+
+    return HttpResponse.json(response);
+  }),
+];
+
+export default notificationHistoryHandlers;

--- a/public/app/features/alerting/unified/types/alerting.ts
+++ b/public/app/features/alerting/unified/types/alerting.ts
@@ -211,6 +211,13 @@ export interface NotifierStatus {
   lastNotifyAttemptDuration: string;
   name: string;
   sendResolved?: boolean;
+  // New fields for aggregation from notification history
+  totalAttempts?: number;
+  failedAttempts?: number;
+  successAttempts?: number;
+  // Integration type and index for matching against contact point configs
+  integrationType?: string;
+  integrationIndex?: number;
 }
 
 export interface NotifiersState {


### PR DESCRIPTION
Exposes notification history on the contact points page, which will be invaluable for troubleshooting why contact points aren't working. Key points:

- Gated behind new feature flag `alertingNotificationHistoryContactPoints`
- Makes the per-integration status text clickable to open a drawer with notification history in
- Replaces the use of the receivers status API with notification history
  - (The main advantage here is the status is persistent and not lost on restarts)

[Screencast from 2026-02-27 23-36-46.webm](https://github.com/user-attachments/assets/d1a23279-1e26-4452-b2cf-a24069a0c662)
