### PR TITLE
Docs: Removed refURIs from TestData

### DIFF
--- a/docs/sources/datasources/testdata/_index.md
+++ b/docs/sources/datasources/testdata/_index.md
@@ -17,25 +17,14 @@ labels:
 menuTitle: TestData
 title: TestData data source
 weight: 1500
-refs:
-  panels-visualizations:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/
-  data-source-management:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/
 ---
 
 # TestData data source
 
-Grafana ships with a TestData data source, which creates simulated time series data for any [panel](ref:panels-visualizations).
+Grafana ships with a TestData data source, which creates simulated time series data for any [panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/).
 You can use it to build your own fake and random time series data and render it in any panel, which helps you verify dashboard functionality since you can safely and easily share the data.
 
-For instructions on how to add a data source to Grafana, refer to the [administration documentation](ref:data-source-management).
+For instructions on how to add a data source to Grafana, refer to the [administration documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/).
 Only users with the organization administrator role can add data sources.
 
 ## Configure the data source


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

As part of the project to externalize Grafana core data sources, Ref URIs must be removed because ref URI linking won't work in an external repo.

EPIC for reference: https://github.com/grafana/grafana/issues/117718

Why do we need this feature?

See above

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
