### PR TITLE
UI: Add noscript fallback message for disabled JavaScript

### DIFF
--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -150,6 +150,26 @@
       </div>
   </div>
 
+    <noscript>
+      <style>
+        .preloader {
+          display: none;
+        }
+
+        .js-required-message {
+          margin: 48px auto;
+          max-width: 720px;
+          padding: 0 16px;
+          font-family: Sans-serif;
+          line-height: 1.5;
+        }
+      </style>
+      <main class="js-required-message">
+        <h1>JavaScript is required to run Grafana</h1>
+        <p>Please enable JavaScript in your browser and reload the page.</p>
+      </main>
+    </noscript>
+
     <div id="reactRoot"></div>
 
     <script nonce="[[.Nonce]]">

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -265,6 +265,26 @@
       </script>
     </div>
 
+    <noscript>
+      <style>
+        .preloader {
+          display: none;
+        }
+
+        .js-required-message {
+          margin: 48px auto;
+          max-width: 720px;
+          padding: 0 16px;
+          font-family: Sans-serif;
+          line-height: 1.5;
+        }
+      </style>
+      <main class="js-required-message">
+        <h1>JavaScript is required to run Grafana</h1>
+        <p>Please enable JavaScript in your browser and reload the page.</p>
+      </main>
+    </noscript>
+
     <div id="reactRoot"></div>
 
     <script nonce="[[.Nonce]]">


### PR DESCRIPTION
**What is this feature?**

This PR adds a `<noscript>` fallback message to Grafana’s two `index.html` files so that users with JavaScript disabled see a clear explanation instead of an infinite loading animation.

Implemented in:
- `public/views/index.html` 
- `pkg/services/frontend/index.html` 

**Why do we need this feature?**

Rn, when JavaScript is disabled, Grafana shows a loading spinner/logo indefinitely, which is confusing and gives no actionable information.  
This change will make the failure mode explicit and also tell users exactly what they need to do to resolve this issue: enable JavaScript and reload the page.

**Who is this feature for?**

Grafana users who have JavaScript disabled (temporarily or by policy) need a clear explanation for why dashboards/pages are not loading.

**Which issue(s) does this PR fix?**:

Fixes #117243

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A)
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New. (Not required for this small UX fallback)

Test Instructions:
- Disable JavaScript for `localhost:3000.`
- Refresh Grafana
- Confirm the new “JavaScript is required to run Grafana” message is shown in both entry paths instead of endless loading
- Re-enable JavaScript and confirm normal app load
