### PR TITLE
CI: Speed up Playwright e2e tests workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1096,6 +1096,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /scripts/levitate-parse-json-report.js @grafana/grafana-frontend-platform
 /scripts/levitate-show-affected-plugins.js @grafana/grafana-frontend-platform
 /scripts/codemods/explicit-barrel-imports.cjs @grafana/frontend-ops
+/scripts/view-playwright-ci.sh @grafana/grafana-frontend-platform
 
 /scripts/codeowners-manifest/ @grafana/dataviz-squad
 /scripts/test-coverage-by-codeowner.js @grafana/dataviz-squad
@@ -1332,6 +1333,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/pr-test-docker.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/update-schema-types.yml @grafana/grafana-frontend-platform
 /.github/workflows/defaults-ini-docs-reminder.yml @grafana/docs-tooling @jtvdez
+/.github/workflows/pr-build-grafana.yml @grafana/grafana-developer-enablement-squad
 
 # Generated files not requiring owner approval
 /packages/grafana-data/src/types/featureToggles.gen.ts @grafanabot

--- a/.github/actions/change-detection/action.yml
+++ b/.github/actions/change-detection/action.yml
@@ -24,7 +24,7 @@ outputs:
     description: Whether the e2e tests or self have changed in any way
     value: ${{ steps.changed-files.outputs.e2e_any_changed == 'true' ||
       steps.changed-files.outputs.backend_any_changed == 'true' ||
-      steps.changed-files.outputs.frontend_any_changed == 'true' || 'true' }}
+      steps.changed-files.outputs.frontend_any_changed == 'true' }}
   e2e-cloud-plugins:
     description: Whether the cloud plugins code or tests have changed in any way
     value: ${{ steps.changed-files.outputs.e2e_cloud_plugins_any_changed || 'true' }}

--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -120,6 +120,7 @@ runs:
         YARN_NM_MODE: 'hardlinks-local' # Reduce node_modules size
         YARN_INSTALL_STATE_PATH: '.yarn/install-state.gz' # Might speed up resolution step when node_modules present
         YARN_ENABLE_HARDENED_MODE: ${{ (github.event.pull_request.head.repo.fork == true || inputs.hardened-mode == 'true') && '1' || '0' }} # Always enabled for forks; for internal PRs, enabled when hardened-mode is 'true'
+        YARN_ENABLE_HARDENED_MODE: 0
         # Skip big post-install dependencies
         PUPPETEER_SKIP_DOWNLOAD: true
         CYPRESS_INSTALL_BINARY: 0

--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -120,7 +120,6 @@ runs:
         YARN_NM_MODE: 'hardlinks-local' # Reduce node_modules size
         YARN_INSTALL_STATE_PATH: '.yarn/install-state.gz' # Might speed up resolution step when node_modules present
         YARN_ENABLE_HARDENED_MODE: ${{ (github.event.pull_request.head.repo.fork == true || inputs.hardened-mode == 'true') && '1' || '0' }} # Always enabled for forks; for internal PRs, enabled when hardened-mode is 'true'
-        YARN_ENABLE_HARDENED_MODE: 0
         # Skip big post-install dependencies
         PUPPETEER_SKIP_DOWNLOAD: true
         CYPRESS_INSTALL_BINARY: 0

--- a/.github/workflows/pr-build-grafana.yml
+++ b/.github/workflows/pr-build-grafana.yml
@@ -1,0 +1,129 @@
+name: PR build Docker image
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+permissions: {}
+
+jobs:
+  detect-changes:
+    # Gate the whole workflow behind this check
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+    name: Detect whether code changed
+    runs-on: ubuntu-x64-small
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.detect-changes.outputs.frontend == 'true' || steps.detect-changes.outputs.backend == 'true' }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: true # required to get more history in the changed-files action
+          fetch-depth: 2
+      - name: Detect changes
+        id: detect-changes
+        uses: ./.github/actions/change-detection
+        with:
+          self: .github/workflows/pr-build-grafana.yml
+
+  build-grafana:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.changed == 'true'
+    name: Build & Package Grafana
+    runs-on: ubuntu-x64-xlarge
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: grafana/shared-workflows/actions/dockerhub-login@main
+        if: github.event.pull_request.head.repo.fork == false
+      - uses: grafana/shared-workflows/actions/login-to-gar@main
+        if: github.event.pull_request.head.repo.fork == false
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Build Grafana
+        uses: kminehart/dagger-for-github@590bdefcb7f0c1030fce068a2c041c36582262d6
+        env:
+          CACHE_BUILDERS: ${{ github.event.pull_request.head.repo.fork == false }}
+        with:
+          cache-binary: "true"
+          version: 0.18.8
+          verb: run
+          args: go run ./pkg/build/cmd artifacts -a docker:grafana:linux/amd64 --grafana-dir="${PWD}" --cache-builders=${CACHE_BUILDERS} > out.txt
+      - name: Cat built artifact
+        run: cat out.txt
+      - name: Move built artifacts
+        run: |
+          mkdir -p build-dir
+          mv "$(grep 'grafana_.*docker.tar.gz$' out.txt)" build-dir/grafana.docker.tar.gz
+
+      - name: Set artifact name
+        run: echo "artifact=grafana-server-${{github.run_number}}" >> "$GITHUB_OUTPUT"
+        id: artifact
+
+      - name: Upload grafana docker tarball
+        uses: actions/upload-artifact@v7
+        with:
+          retention-days: 1
+          name: grafana-docker-tar-gz
+          path: build-dir/grafana.docker.tar.gz
+
+  push-docker-image:
+    needs:
+      - detect-changes
+      - build-grafana
+    if: needs.detect-changes.outputs.changed == 'true'
+    name: Push PR Docker image
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-x64
+    steps:
+      - id: get-github-token
+        name: "create github app token"
+        uses: grafana/shared-workflows/actions/create-github-app-token@eb02241ed0a92aff205feab8ac3afcdf51c757c8 # create-github-app-token-v0.2.0
+        with:
+          github_app: "delivery-bot-app"
+      - uses: grafana/shared-workflows/actions/login-to-gar@main
+        id: login-to-gar
+        with:
+          registry: 'us-docker.pkg.dev'
+          environment: 'dev'
+      - uses: actions/download-artifact@v8
+        with:
+          name: grafana-docker-tar-gz
+          path: .
+      - name: Load & Push Docker image
+        env:
+          BUILD_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          LOADED_IMAGE_NAME=$(docker load -i grafana.docker.tar.gz | sed 's/Loaded image: //g')
+          VERSION=$(echo "${LOADED_IMAGE_NAME}" | cut -d ':' -f 2 | cut -d '-' -f 1)
+          DOCKER_IMAGE="us-docker.pkg.dev/grafanalabs-dev/docker-grafana-dev/grafana:${VERSION}-${BUILD_ID}"
+          docker tag "${LOADED_IMAGE_NAME}" "${DOCKER_IMAGE}"
+          docker push "${DOCKER_IMAGE}"
+          echo "IMAGE=${DOCKER_IMAGE}" >> "$GITHUB_ENV"
+      - name: Add PR status check
+        env:
+          GH_TOKEN: ${{ steps.get-github-token.outputs.token }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/grafana/grafana/check-runs \
+           -f "name=${IMAGE}" \
+           -f "head_sha=${SHA}" \
+           -f 'status=completed' \
+           -f 'conclusion=neutral' \
+           -f 'output[title]=Docker image' \
+           -f "output[summary]=${IMAGE}" \
+           -f "output[text]=${IMAGE}"

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -152,15 +152,8 @@ jobs:
       - name: Install yarn dependencies
         uses: ./.github/actions/yarn-install
 
-      - name: Get Playwright version
-        id: pw-version
-        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v5
-        with:
-          key: storybook-playwright-${{ steps.pw-version.outputs.version }}
-          path: ~/.cache/ms-playwright
       - name: Install Playwright browsers
-        run: npx playwright install chromium --with-deps
+        run: yarn playwright install chromium --with-deps
 
       - name: Run Storybook and E2E tests
         run: yarn e2e:playwright:storybook
@@ -247,14 +240,8 @@ jobs:
       - name: Install yarn dependencies
         uses: ./.github/actions/yarn-install
 
-      - name: Get Playwright version
-        id: pw-version
-        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v5
-        with:
-          key: playwright-${{ steps.pw-version.outputs.version }}
-          path: ~/.cache/ms-playwright
-      - run: npx playwright install chromium --with-deps
+      - name: Install Playwright browsers
+        run: yarn playwright install chromium --with-deps
 
       - name: Run Playwright tests
         run: yarn e2e:playwright --shard=${{ matrix.shard }}/${{ matrix.shardTotal }} --reporter=dot,blob --output=playwright-test-results

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
       changed: ${{ steps.detect-changes.outputs.e2e }}
       cloud_plugins_changed: ${{ steps.detect-changes.outputs.e2e-cloud-plugins }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: true # required to get more history in the changed-files action
           fetch-depth: 2
@@ -44,7 +44,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -54,7 +54,7 @@ jobs:
           key: "e2e-build-backend-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum', 'go.work', 'go.work.sum', 'pkg/**/*.go', 'apps/**/*.go', '!**_test.go', 'Makefile', 'embed.go') }}"
           path: bin
 
-      - uses: actions/setup-go@v6.0.0
+      - uses: actions/setup-go@v6.3.0
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           go-version-file: 'go.mod'
@@ -64,7 +64,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: make build-go
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: grafana-backend
           path: bin/
@@ -79,7 +79,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -108,7 +108,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn e2e:plugin:build
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: grafana-frontend
           path: |
@@ -119,7 +119,7 @@ jobs:
             !public/locales/
           retention-days: 1
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: grafana-test-plugins
           path: e2e-playwright/test-plugins/
@@ -142,7 +142,7 @@ jobs:
         if: github.event.pull_request.head.repo.fork == false
 
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -182,25 +182,25 @@ jobs:
         shardTotal: [8]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       # Download the grafana artifacts and stitch them together into a standalone prod-ish Grafana distribution
       - name: Download backend artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: grafana-backend
           path: grafana-server/bin
       - name: Fix binary permissions
         run: chmod +x grafana-server/bin/grafana*
       - name: Download frontend artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: grafana-frontend
           path: grafana-server/public
       - name: Download test plugins
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: grafana-test-plugins
           path: grafana-server/data/plugins
@@ -262,14 +262,14 @@ jobs:
           GRAFANA_URL: http://localhost:3001
           CI: true
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: grafana-server-log-${{ matrix.shard }}
           path: grafana-server/grafana.log
           retention-days: 3
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: playwright-blob-${{ matrix.shard }}
@@ -292,7 +292,7 @@ jobs:
       - uses: grafana/shared-workflows/actions/login-to-gar@main
         if: github.event.pull_request.head.repo.fork == false
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -339,7 +339,7 @@ jobs:
 
       - name: Upload HTML report
         id: upload-html
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-html
           path: playwright-report
@@ -367,7 +367,7 @@ jobs:
           echo "  ./scripts/view-playwright-ci.sh $RUN_ID"
           echo ""
           echo "Alternatively, download the test report from $REPORT_URL"
-          echo "And view it locally with:"
+          echo "and view it locally with:"
           echo "  yarn playwright show-report <path-to-unzipped-report>"
           if [ "$FAILED" = "true" ]; then
             exit 1
@@ -388,7 +388,7 @@ jobs:
           repo_secrets: |
             GRAFANA_MISC_STATS_API_KEY=grafana-misc-stats:api_key
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Setup Node.js

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -114,11 +114,14 @@ jobs:
         with:
           name: grafana-frontend
           path: |
-            public/
-            !public/**/*.ts
-            !public/**/*.tsx
+            public/build
+            public/dashboards
+            public/views
+            public/emails
+            public/app/plugins
+            !**/*.ts
+            !**/*.tsx
             !public/**/node_modules/
-            !public/locales/
           retention-days: 1
 
   run-storybook-test:

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -7,16 +7,11 @@ on:
       - main
       - release-*.*.*
 
-# TODO: re-enable this before merging
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.ref }}
-#   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 permissions: {}
-
-env:
-  ACTIONS_STEP_DEBUG: true
-  RUNNER_DEBUG: 1
 
 jobs:
   detect-changes:
@@ -40,11 +35,100 @@ jobs:
         with:
           self: .github/workflows/pr-e2e-tests.yml
 
+  build-backend:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.changed == 'true'
+    name: Build backend
+    runs-on: ubuntu-x64-xlarge
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - uses: actions/cache@v4
+        id: cache
+        with:
+          key: "build-backend-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum', 'go.work', 'go.work.sum', 'pkg/**/*.go', 'apps/**/*.go', '!**_test.go', 'Makefile', 'build.go', 'embed.go') }}"
+          path: bin
+
+      - uses: actions/setup-go@v6.0.0
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Build backend
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: make build-go
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: grafana-backend
+          path: bin/
+          retention-days: 1
+
+  build-frontend:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.changed == 'true'
+    name: Build frontend
+    runs-on: ubuntu-x64-xlarge
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - uses: actions/cache@v4
+        id: cache
+        with:
+          key: "build-frontend-${{ runner.os }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/**', 'public/**', 'plugins-bundled/**', 'e2e-playwright/test-plugins/**', '!**/*.test.ts', '!**/*.test.tsx', 'tsconfig.json', '.browserslistrc', 'nx.json', '.nvmrc') }}"
+          path: |
+            public/build
+            e2e-playwright/test-plugins
+
+      - uses: actions/setup-node@v6
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
+
+      - name: Build frontend
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: make build-js
+
+      - name: Build e2e test plugins
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn e2e:plugin:build
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: grafana-frontend
+          path: |
+            public/
+            !public/**/*.ts
+            !public/**/*.tsx
+          retention-days: 1
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: grafana-test-plugins
+          path: e2e-playwright/test-plugins/
+          retention-days: 1
+
   build-grafana:
     needs: detect-changes
     if: needs.detect-changes.outputs.changed == 'true'
-    name: Build & Package Grafana
+    name: Build Grafana artifacts
     runs-on: ubuntu-x64-xlarge
+    timeout-minutes: 20
     permissions:
       contents: read
       id-token: write
@@ -57,19 +141,7 @@ jobs:
         with:
           persist-credentials: false
 
-      # TODO: add a cleanup workflow to remove the cache when the PR is closed
-      # https://github.com/actions/cache/blob/main/tips-and-workarounds.md#force-deletion-of-caches-overriding-default-cache-eviction-policy
-      # TODO: maybe we could just use the cache to store the build, instead of uploading as an artifact?
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          key: "build-grafana-${{ runner.os }}-${{ hashFiles('yarn.lock', 'public/*',  'packages/*', 'conf/*', 'pkg/**/*.go', '**/go.mod', '**/go.sum', '!**_test.go', '!**.test.ts', '!**.test.tsx', 'Dockerfile') }}"
-          path: |
-            build-dir
-
-      # If no cache hit, build Grafana
-      - name: Build Grafana
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Build all artifacts via Dagger
         uses: kminehart/dagger-for-github@590bdefcb7f0c1030fce068a2c041c36582262d6
         env:
           CACHE_BUILDERS: ${{ github.event.pull_request.head.repo.fork == false }}
@@ -77,81 +149,21 @@ jobs:
           cache-binary: "true"
           version: 0.18.8
           verb: run
-          args: go run ./pkg/build/cmd artifacts -a targz:grafana:linux/amd64 -a docker:grafana:linux/amd64 --grafana-dir="${PWD}" --cache-builders=${CACHE_BUILDERS} > out.txt
-      - name: Cat built artifact
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: cat out.txt
-      - name: Move built artifacts
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p build-dir
-          mv "$(grep 'grafana_.*tar.gz$' out.txt | grep -Fv -m1 'docker')" build-dir/grafana.tar.gz
-          mv "$(grep 'grafana_.*docker.tar.gz$' out.txt)" build-dir/grafana.docker.tar.gz
+          args: go run ./pkg/build/cmd artifacts -a docker:grafana:linux/amd64 --grafana-dir="${PWD}" --cache-builders=${CACHE_BUILDERS} > out.txt
 
-      # If cache hit, validate the artifact is present
-      - name: Validate artifact
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: |
-          if [ ! -f build-dir/grafana.tar.gz ]; then
-            echo "Error: build-dir/grafana.tar.gz not found in cache"
-            exit 1
-          fi
-
-      - name: Set artifact name
-        run: echo "artifact=grafana-server-${{github.run_number}}" >> "$GITHUB_OUTPUT"
-        id: artifact
-
-      - name: Upload grafana.tar.gz
+      - name: Upload grafana tarball
         uses: actions/upload-artifact@v5
         with:
           retention-days: 1
           name: grafana-tar-gz
-          path: build-dir/grafana.tar.gz
+          path: dist/*tar.gz
 
       - name: Upload grafana docker tarball
         uses: actions/upload-artifact@v5
         with:
           retention-days: 1
           name: grafana-docker-tar-gz
-          path: build-dir/grafana.docker.tar.gz
-
-  # TODO: we won't need this when we only have playwright
-  build-e2e-runner:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.changed == 'true'
-    name: Build E2E test runner
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    outputs:
-      artifact: ${{ steps.artifact.outputs.artifact }}
-    steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@main
-        if: github.event.pull_request.head.repo.fork == false
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
-        if: github.event.pull_request.head.repo.fork == false
-      - uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-      - name: Setup Go
-        uses: actions/setup-go@v6.0.0
-        with:
-          go-version-file: go.mod
-          cache: ${{ !github.event.pull_request.head.repo.fork }}
-      - name: Build E2E test runner
-        id: artifact
-        run: |
-          set -euo pipefail
-          # We want a static binary, so we need to set CGO_ENABLED=0
-          CGO_ENABLED=0 go build -o ./e2e-runner ./e2e/
-          echo "artifact=e2e-runner-${{github.run_number}}" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@v5
-        id: upload
-        with:
-          retention-days: 1
-          name: ${{ steps.artifact.outputs.artifact }}
-          path: e2e-runner
+          path: dist/*.docker.tar.gz
 
   push-docker-image:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
@@ -181,7 +193,7 @@ jobs:
           BUILD_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          LOADED_IMAGE_NAME=$(docker load -i grafana.docker.tar.gz | sed 's/Loaded image: //g')
+          LOADED_IMAGE_NAME=$(docker load -i *.docker.tar.gz | sed 's/Loaded image: //g')
           VERSION=$(echo "${LOADED_IMAGE_NAME}" | cut -d ':' -f 2 | cut -d '-' -f 1)
           DOCKER_IMAGE="us-docker.pkg.dev/grafanalabs-dev/docker-grafana-dev/grafana:${VERSION}-${BUILD_ID}"
           docker tag "${LOADED_IMAGE_NAME}" "${DOCKER_IMAGE}"
@@ -205,75 +217,10 @@ jobs:
            -f "output[summary]=${IMAGE}" \
            -f "output[text]=${IMAGE}"
 
-  run-e2e-tests:
-    needs:
-      - build-grafana
-      - build-e2e-runner
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - suite: various-suite (old arch)
-            path: e2e/old-arch/various-suite
-            flags: --flags="--env dashboardScene=false"
-          - suite: dashboards-suite (old arch)
-            path: e2e/old-arch/dashboards-suite
-            flags: --flags="--env dashboardScene=false"
-          - suite: smoke-tests-suite (old arch)
-            path: e2e/old-arch/smoke-tests-suite
-            flags: --flags="--env dashboardScene=false"
-          - suite: panels-suite (old arch)
-            path: e2e/old-arch/panels-suite
-            flags: --flags="--env dashboardScene=false"
-    name: ${{ matrix.suite }}
-    runs-on: ubuntu-x64-large
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@main
-        if: github.event.pull_request.head.repo.fork == false
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
-        if: github.event.pull_request.head.repo.fork == false
-      - uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-      - uses: actions/download-artifact@v6
-        with:
-          name: grafana-tar-gz
-      - uses: actions/download-artifact@v6
-        with:
-          name: ${{ needs.build-e2e-runner.outputs.artifact }}
-      - name: chmod +x
-        run: chmod +x ./e2e-runner
-      - name: Run E2E tests
-        uses: kminehart/dagger-for-github@590bdefcb7f0c1030fce068a2c041c36582262d6
-        with:
-          cache-binary: "true"
-          version: 0.18.8
-          verb: run
-          args: go run ./pkg/build/e2e --package=grafana.tar.gz
-            --suite=${{ matrix.path }}
-            ${{ matrix.flags }}
-      - name: Set suite name
-        id: set-suite-name
-        if: success() || failure()
-        env:
-          SUITE: ${{ matrix.path }}
-        run: |
-          set -euo pipefail
-          echo "suite=$(echo "$SUITE" | sed 's/\//-/g')" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@v5
-        if: success() || failure()
-        with:
-          name: ${{ steps.set-suite-name.outputs.suite }}-${{ github.run_number }}
-          path: videos
-          retention-days: 1
-
   run-storybook-test:
     name: Verify Storybook (Playwright)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: detect-changes
     if: needs.detect-changes.outputs.changed == 'true'
     permissions:
@@ -296,23 +243,37 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      - uses: actions/cache@v4
+        with:
+          key: storybook-yarn-${{ hashFiles('yarn.lock') }}
+          path: |
+            node_modules
+            .yarn/cache
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
+        with:
+          key: storybook-playwright-${{ steps.pw-version.outputs.version }}
+          path: ~/.cache/ms-playwright
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install chromium --with-deps
 
       - name: Run Storybook and E2E tests
         run: yarn e2e:playwright:storybook
 
   run-playwright-tests:
     needs:
-      - build-grafana
+      - build-backend
+      - build-frontend
     name: Playwright E2E tests (${{ matrix.shard }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-x64-large
+    timeout-minutes: 20
     permissions:
       contents: read
-      id-token: write
 
     strategy:
       fail-fast: false
@@ -321,109 +282,80 @@ jobs:
         shardTotal: [8]
 
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@main
-        if: github.event.pull_request.head.repo.fork == false
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
-        if: github.event.pull_request.head.repo.fork == false
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: actions/download-artifact@v6
+
+      # Download pre-built artifacts into the correct locations
+      - uses: actions/download-artifact@v4
         with:
-          name: grafana-tar-gz
-      - name: Run E2E tests
-        uses: kminehart/dagger-for-github@590bdefcb7f0c1030fce068a2c041c36582262d6
+          name: grafana-backend
+          path: bin
+
+      - uses: actions/download-artifact@v4
         with:
-          cache-binary: "true"
-          version: 0.18.8
-          verb: run
-          args: go run ./pkg/build/e2e-playwright --package=grafana.tar.gz --shard=${{ matrix.shard }}/${{ matrix.shardTotal }} --blob-dir=./blob-report
+          name: grafana-frontend
+          path: frontend-artifact
+
+      - run: rsync -a frontend-artifact/ public/
+      - run: rm -rf frontend-artifact
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: grafana-test-plugins
+          path: e2e-playwright/test-plugins
+
+      # Restore execute permissions stripped by actions/upload-artifact
+      - name: Fix binary permissions
+        run: chmod +x bin/grafana*
+
+      - run: tree > tree.txt
+      - uses: actions/upload-artifact@v5
+        with:
+          name: debug-tree-shard-${{ matrix.shard }}
+          path: tree.txt
+          retention-days: 1
+
+      # Start Grafana using existing scripts (handles provisioning, config, etc.)
+      - name: Start Grafana
+        run: |
+          ./scripts/grafana-server/start-server &
+          ./scripts/grafana-server/wait-for-grafana
+        env:
+          PORT: 3001
+
+      # Install test dependencies
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+      - run: yarn install --immutable
+
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
+        with:
+          key: playwright-${{ steps.pw-version.outputs.version }}
+          path: ~/.cache/ms-playwright
+      - run: npx playwright install chromium --with-deps
+
+      # Run tests — Grafana is running natively on localhost:3001
+      - name: Run Playwright tests
+        run: yarn e2e:playwright --shard=${{ matrix.shard }}/${{ matrix.shardTotal }} --reporter=dot,blob --output=playwright-test-results
+        env:
+          GRAFANA_URL: http://localhost:3001
+          CI: true
+
       - uses: actions/upload-artifact@v5
         if: success() || failure()
         with:
           name: playwright-blob-${{ github.run_number }}-${{ matrix.shard }}
-          path: ./blob-report
+          path: blob-report
           retention-days: 1
-
-  run-azure-monitor-e2e:
-    if: needs.detect-changes.outputs.cloud_plugins_changed == 'true' && github.event.pull_request.head.repo.fork == false && github.event_name == 'pull_request'
-    runs-on: ubuntu-x64-large
-    needs:
-      - build-grafana
-      - detect-changes
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@main
-        if: github.event.pull_request.head.repo.fork == false
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
-        if: github.event.pull_request.head.repo.fork == false
-
-      - uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-
-      - uses: grafana/shared-workflows/actions/login-to-gar@login-to-gar-v0.4.0
-        id: login-to-gar
-        with:
-          registry: "us-docker.pkg.dev"
-          environment: "dev"
-
-      - id: pull-docker-image
-        run: |
-          docker pull us-docker.pkg.dev/grafanalabs-dev/docker-oss-plugin-partnerships-dev/e2e-playwright:latest
-
-      - id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
-        with:
-          repo_secrets: |
-            AZURE_SP_APP_ID=cpp-azure-resourcemanager-credentials:application_id
-            AZURE_SP_PASSWORD=cpp-azure-resourcemanager-credentials:application_secret
-            AZURE_TENANT=cpp-azure-resourcemanager-credentials:tenant_id
-
-      - id: deploy-resources
-        env:
-          AZURE_SP_APP_ID: ${{ env.AZURE_SP_APP_ID}}
-          AZURE_SP_PASSWORD: ${{ env.AZURE_SP_PASSWORD}}
-          AZURE_TENANT: ${{ env.AZURE_TENANT }}
-          NAME: ${{ github.ref_name }}
-        run: |
-          docker container run --name cpp-e2e-deploy -e AZURE_SP_APP_ID -e AZURE_SP_PASSWORD -e AZURE_TENANT -e PLAYWRIGHT_CI=true us-docker.pkg.dev/grafanalabs-dev/docker-oss-plugin-partnerships-dev/e2e-playwright:latest ./cpp-e2e/scripts/ci-run-playwright.sh azure "${NAME}" deploy
-
-      - id: extract-creds
-        # see https://github.com/grafana/oss-plugin-partnerships/blob/a77040d0456003cd258668b61d542dc7c75db5b5/e2e/scripts/deploy.sh#L25 for path
-        run: |
-          docker cp cpp-e2e-deploy:/outputs.json /tmp/outputs.json
-
-      - uses: actions/download-artifact@v6
-        with:
-          name: grafana-tar-gz
-
-      - name: Run E2E tests
-        uses: kminehart/dagger-for-github@590bdefcb7f0c1030fce068a2c041c36582262d6
-        with:
-          cache-binary: "true"
-          version: 0.18.8
-          verb: run
-          args: go run ./pkg/build/e2e-playwright --package=grafana.tar.gz --playwright-command="yarn e2e:playwright:cloud-plugins" --cloud-plugin-creds=/tmp/outputs.json
-
-      - name: Destroy resources
-        if: always() && steps.deploy-resources.outcome == 'success'
-        env:
-          AZURE_SP_APP_ID: ${{ env.AZURE_SP_APP_ID }}
-          AZURE_SP_PASSWORD: ${{ env.AZURE_SP_PASSWORD }}
-          AZURE_TENANT: ${{ env.AZURE_TENANT }}
-          NAME: ${{ github.ref_name }}
-        run: |
-          docker container run --name cpp-e2e-destroy -e AZURE_SP_APP_ID -e AZURE_SP_PASSWORD -e AZURE_TENANT us-docker.pkg.dev/grafanalabs-dev/docker-oss-plugin-partnerships-dev/e2e-playwright:latest ./cpp-e2e/scripts/ci-run-playwright.sh azure "${NAME}" destroy
 
   required-playwright-tests:
     needs:
       - run-playwright-tests
-      - run-azure-monitor-e2e
       - run-storybook-test
-      - build-grafana
     if: ${{ !cancelled() }}
     name: All Playwright tests complete
     runs-on: ubuntu-latest
@@ -440,9 +372,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
 
       - name: Download blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@v6
@@ -531,40 +462,10 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
+        uses: ./.github/actions/setup-node
       - name: Install dependencies
         run: yarn install --immutable
       - name: Extract and publish metrics
         run: ./scripts/ci-frontend-metrics.sh | node --experimental-strip-types .github/workflows/scripts/publish-frontend-metrics.mts
         env:
           GRAFANA_MISC_STATS_API_KEY: ${{ env.GRAFANA_MISC_STATS_API_KEY}}
-
-  # This is the job that is actually required by rulesets.
-  # We want to only require one job instead of all the individual tests.
-  # Future work also allows us to start skipping some tests based on changed files.
-  required-e2e-tests:
-    needs:
-      - run-e2e-tests
-      - build-grafana
-      # a11y test is not listed on purpose: it is not an important E2E test.
-      # It is also totally fine to fail right now.
-    # always() is the best function here.
-    # success() || failure() will skip this function if any need is also skipped.
-    # That means conditional test suites will fail the entire requirement check.
-    if: always()
-
-    name: All E2E tests complete
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-
-      - name: Check test suites
-        uses: ./.github/actions/check-jobs
-        with:
-          needs: ${{ toJson(needs) }}
-          failure-message: "One or more E2E test suites have failed"
-          success-message: "All E2E test suites completed successfully"

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -18,7 +18,7 @@ jobs:
     # Run on `grafana/grafana` main branch, or on pull requests to prevent double-running on mirrors
     if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: Detect whether code changed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-small
     permissions:
       contents: read
     outputs:
@@ -127,7 +127,7 @@ jobs:
 
   run-storybook-test:
     name: Verify Storybook (Playwright)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     timeout-minutes: 15
     needs: detect-changes
     if: needs.detect-changes.outputs.changed == 'true'
@@ -282,7 +282,7 @@ jobs:
       - run-storybook-test
     if: ${{ !cancelled() }}
     name: All Playwright tests complete
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-small
     permissions:
       contents: read
       id-token: write
@@ -380,7 +380,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-small
     steps:
       - id: vault-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@main

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -215,14 +215,22 @@ jobs:
           cp -r e2e-playwright/test-plugins/. grafana-server/data/plugins/
 
       # Start Grafana from the standalone directory
-      - name: Start Grafana
+      # The server is immediately backgrounded so it can initialise in parallel while the Playwright browsers are installing 🤓
+      - name: Start Grafana server
         run: |
           grafana-server/bin/grafana server \
             --homepath="$PWD/grafana-server" \
             cfg:server.http_port=3001 \
             > grafana-server/grafana.log 2>&1 &
 
-          # Wait for Grafana to be ready
+          printf "\nThe Grafana server is starting in the background.\n"
+          echo "To view the server logs, wait for this job to complete and downloaded the 'grafana-server-log-${{ matrix.shard }}' artifact."
+
+      - name: Install Playwright browsers
+        run: yarn playwright install chromium --with-deps
+
+      - name: Wait for Grafana server to start
+        run: |
           timeout=180
           elapsed=0
           printf "Waiting for Grafana to start"
@@ -235,10 +243,8 @@ jobs:
             sleep 1
             elapsed=$((elapsed + 1))
           done
-          printf "\nGrafana is ready\n"
-
-      - name: Install Playwright browsers
-        run: yarn playwright install chromium --with-deps
+          printf "\nThe Grafana server is ready\n"
+          echo "To view the server logs, wait for this job to complete and downloaded the 'grafana-server-log-${{ matrix.shard }}' artifact."
 
       - name: Run Playwright tests
         run: yarn e2e:playwright --shard=${{ matrix.shard }}/${{ matrix.shardTotal }} --reporter=dot,blob --output=playwright-test-results

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/cache@v5
         id: cache
         with:
-          key: "e2e-build-frontend-${{ runner.os }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/**', 'public/**', '!**/*.test.ts', '!**/*.test.tsx', 'tsconfig.json', '.browserslistrc', 'nx.json', '.nvmrc') }}"
+          key: "e2e-build-frontend-${{ runner.os }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/**', 'public/**', 'scripts/webpack/**', '!**/*.test.ts', '!**/*.test.tsx', 'tsconfig.json', '.browserslistrc', 'nx.json', 'project.json', '.nvmrc') }}"
           path: |
             public/build
             public/app/plugins/*/*/dist
@@ -107,6 +107,8 @@ jobs:
 
       - name: Build frontend
         if: steps.cache.outputs.cache-hit != 'true'
+        env:
+          NO_SOURCEMAP: '1' # Don't generate sourcemaps for CI builds to speed up webpack + packaging
         run: make build-js
 
       - name: Upload frontend build artifacts

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -86,19 +86,19 @@ jobs:
       - uses: actions/cache@v4
         id: cache
         with:
-          key: "build-frontend-${{ runner.os }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/**', 'public/**', 'plugins-bundled/**', 'e2e-playwright/test-plugins/**', '!**/*.test.ts', '!**/*.test.tsx', 'tsconfig.json', '.browserslistrc', 'nx.json', '.nvmrc') }}"
+          key: "build-frontend-${{ runner.os }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/**', 'public/**', 'e2e-playwright/test-plugins/**', '!**/*.test.ts', '!**/*.test.tsx', 'tsconfig.json', '.browserslistrc', 'nx.json', '.nvmrc') }}"
           path: |
             public/build
+            public/app/plugins/*/*/dist
             e2e-playwright/test-plugins
 
-      - uses: actions/setup-node@v6
+      - name: Setup Node.js
         if: steps.cache.outputs.cache-hit != 'true'
-        with:
-          node-version-file: '.nvmrc'
+        uses: ./.github/actions/setup-node
 
-      - name: Install dependencies
+      - name: Install yarn dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn install --immutable
+        uses: ./.github/actions/yarn-install
 
       - name: Build frontend
         if: steps.cache.outputs.cache-hit != 'true'
@@ -116,6 +116,7 @@ jobs:
             !public/**/*.ts
             !public/**/*.tsx
             !public/**/node_modules/
+            !public/locales/
           retention-days: 1
 
       - uses: actions/upload-artifact@v5
@@ -149,100 +150,6 @@ jobs:
           path: grafana-misc/
           retention-days: 1
 
-  build-grafana:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.changed == 'true'
-    name: Build Grafana artifacts
-    runs-on: ubuntu-x64-xlarge
-    timeout-minutes: 20
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@main
-        if: github.event.pull_request.head.repo.fork == false
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
-        if: github.event.pull_request.head.repo.fork == false
-      - uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-
-      - name: Build all artifacts via Dagger
-        uses: kminehart/dagger-for-github@590bdefcb7f0c1030fce068a2c041c36582262d6
-        env:
-          CACHE_BUILDERS: ${{ github.event.pull_request.head.repo.fork == false }}
-        with:
-          cache-binary: "true"
-          version: 0.18.8
-          verb: run
-          args: go run ./pkg/build/cmd artifacts -a docker:grafana:linux/amd64 --grafana-dir="${PWD}" --cache-builders=${CACHE_BUILDERS} > out.txt
-
-      - name: Upload grafana tarball
-        uses: actions/upload-artifact@v5
-        with:
-          retention-days: 1
-          name: grafana-tar-gz
-          path: dist/*tar.gz
-
-      - name: Upload grafana docker tarball
-        uses: actions/upload-artifact@v5
-        with:
-          retention-days: 1
-          name: grafana-docker-tar-gz
-          path: dist/*.docker.tar.gz
-
-  push-docker-image:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
-    permissions:
-      contents: read
-      id-token: write
-    runs-on: ubuntu-latest
-    needs:
-      - build-grafana
-    steps:
-      - id: get-github-token
-        name: "create github app token"
-        uses: grafana/shared-workflows/actions/create-github-app-token@eb02241ed0a92aff205feab8ac3afcdf51c757c8 # create-github-app-token-v0.2.0
-        with:
-          github_app: "delivery-bot-app"
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
-        id: login-to-gar
-        with:
-          registry: 'us-docker.pkg.dev'
-          environment: 'dev'
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
-        with:
-          name: grafana-docker-tar-gz
-          path: .
-      - name: Load & Push Docker image
-        env:
-          BUILD_ID: ${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          LOADED_IMAGE_NAME=$(docker load -i *.docker.tar.gz | sed 's/Loaded image: //g')
-          VERSION=$(echo "${LOADED_IMAGE_NAME}" | cut -d ':' -f 2 | cut -d '-' -f 1)
-          DOCKER_IMAGE="us-docker.pkg.dev/grafanalabs-dev/docker-grafana-dev/grafana:${VERSION}-${BUILD_ID}"
-          docker tag "${LOADED_IMAGE_NAME}" "${DOCKER_IMAGE}"
-          docker push "${DOCKER_IMAGE}"
-          echo "IMAGE=${DOCKER_IMAGE}" >> "$GITHUB_ENV"
-      - name: Add PR status check
-        env:
-          GH_TOKEN: ${{ steps.get-github-token.outputs.token }}
-          SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/grafana/grafana/check-runs \
-           -f "name=${IMAGE}" \
-           -f "head_sha=${SHA}" \
-           -f 'status=completed' \
-           -f 'conclusion=neutral' \
-           -f 'output[title]=Docker image' \
-           -f "output[summary]=${IMAGE}" \
-           -f "output[text]=${IMAGE}"
-
   run-storybook-test:
     name: Verify Storybook (Playwright)
     runs-on: ubuntu-latest
@@ -265,18 +172,10 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
+        uses: ./.github/actions/setup-node
 
-      - uses: actions/cache@v4
-        with:
-          key: storybook-yarn-${{ hashFiles('yarn.lock') }}
-          path: |
-            node_modules
-            .yarn/cache
-      - name: Install dependencies
-        run: yarn install --immutable
+      - name: Install yarn dependencies
+        uses: ./.github/actions/yarn-install
 
       - name: Get Playwright version
         id: pw-version
@@ -313,33 +212,30 @@ jobs:
         with:
           persist-credentials: false
 
-      # Download backend binaries → grafana-server/bin/
-      - uses: actions/download-artifact@v4
+      ##
+      # Download the grafana artifacts and stitch them together into a standalone prod-ish Grafana distribution
+      ##
+      - name: Download backend artifacts
+        uses: actions/download-artifact@v4
         with:
           name: grafana-backend
           path: grafana-server/bin
-
-      # Restore execute permissions stripped by actions/upload-artifact
       - name: Fix binary permissions
         run: chmod +x grafana-server/bin/grafana*
-
-      # Download frontend assets → grafana-server/public/
-      - uses: actions/download-artifact@v4
+      - name: Download frontend artifacts
+        uses: actions/download-artifact@v4
         with:
           name: grafana-frontend
           path: grafana-server/public
-
-      # Download test plugins → grafana-server/data/plugins/
+      - name: Download misc artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: grafana-misc
+          path: grafana-server
       - uses: actions/download-artifact@v4
         with:
           name: grafana-test-plugins
           path: grafana-server/data/plugins
-
-      # Download misc files (conf/, tools/, plugins-bundled/) → grafana-server/
-      - uses: actions/download-artifact@v4
-        with:
-          name: grafana-misc
-          path: grafana-server
 
       # Apply E2E test configuration on top of the production-mirrored distribution
       - name: Configure for E2E testing
@@ -350,13 +246,6 @@ jobs:
           cp devenv/dashboards.yaml grafana-server/conf/provisioning/dashboards/
           cp devenv/alert_rules.yaml grafana-server/conf/provisioning/alerting/
           cp devenv/plugins.yaml grafana-server/conf/provisioning/plugins/
-
-      - run: tree grafana-server > tree.txt
-      - uses: actions/upload-artifact@v5
-        with:
-          name: debug-tree-shard-${{ matrix.shard }}
-          path: tree.txt
-          retention-days: 1
 
       # Start Grafana from the standalone directory
       - name: Start Grafana
@@ -381,10 +270,10 @@ jobs:
           done
           printf "\nGrafana is ready\n"
 
-      # Install test dependencies
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
-      - run: yarn install --immutable
+      - name: Install yarn dependencies
+        uses: ./.github/actions/yarn-install
 
       - name: Get Playwright version
         id: pw-version
@@ -395,7 +284,6 @@ jobs:
           path: ~/.cache/ms-playwright
       - run: npx playwright install chromium --with-deps
 
-      # Run tests — Grafana is running standalone on localhost:3001
       - name: Run Playwright tests
         run: yarn e2e:playwright --shard=${{ matrix.shard }}/${{ matrix.shardTotal }} --reporter=dot,blob --output=playwright-test-results
         env:
@@ -527,8 +415,10 @@ jobs:
           persist-credentials: false
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
-      - name: Install dependencies
-        run: yarn install --immutable
+        with:
+          cache: 'false' # Don't use setup-node's built in caching, we'll handle it in the yarn-install step
+      - name: Install yarn dependencies
+        uses: ./.github/actions/yarn-install
       - name: Extract and publish metrics
         run: ./scripts/ci-frontend-metrics.sh | node --experimental-strip-types .github/workflows/scripts/publish-frontend-metrics.mts
         env:

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -44,17 +44,20 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout repo
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      - uses: actions/cache@v5
+      - name: Cache backend build
+        uses: actions/cache@v5
         id: cache
         with:
           key: "e2e-build-backend-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum', 'go.work', 'go.work.sum', 'pkg/**/*.go', 'apps/**/*.go', '!**_test.go', 'Makefile', 'embed.go') }}"
           path: bin
 
-      - uses: actions/setup-go@v6.3.0
+      - name: Setup Go
+        uses: actions/setup-go@v6.3.0
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           go-version-file: 'go.mod'
@@ -64,7 +67,8 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: make build-go
 
-      - uses: actions/upload-artifact@v7
+      - name: Upload backend build artifacts
+        uses: actions/upload-artifact@v7
         with:
           name: grafana-backend
           path: bin/
@@ -79,18 +83,19 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout repo
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      - uses: actions/cache@v5
+      - name: Cache frontend build
+        uses: actions/cache@v5
         id: cache
         with:
-          key: "e2e-build-frontend-${{ runner.os }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/**', 'public/**', 'e2e-playwright/test-plugins/**', '!**/*.test.ts', '!**/*.test.tsx', 'tsconfig.json', '.browserslistrc', 'nx.json', '.nvmrc') }}"
+          key: "e2e-build-frontend-${{ runner.os }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/**', 'public/**', '!**/*.test.ts', '!**/*.test.tsx', 'tsconfig.json', '.browserslistrc', 'nx.json', '.nvmrc') }}"
           path: |
             public/build
             public/app/plugins/*/*/dist
-            e2e-playwright/test-plugins
 
       - name: Setup Node.js
         if: steps.cache.outputs.cache-hit != 'true'
@@ -104,11 +109,8 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: make build-js
 
-      - name: Build e2e test plugins
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn e2e:plugin:build
-
-      - uses: actions/upload-artifact@v7
+      - name: Upload frontend build artifacts
+        uses: actions/upload-artifact@v7
         with:
           name: grafana-frontend
           path: |
@@ -117,12 +119,6 @@ jobs:
             !public/**/*.tsx
             !public/**/node_modules/
             !public/locales/
-          retention-days: 1
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: grafana-test-plugins
-          path: e2e-playwright/test-plugins/
           retention-days: 1
 
   run-storybook-test:
@@ -179,6 +175,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+      - name: Install yarn dependencies
+        uses: ./.github/actions/yarn-install
+
+      # It's quicker to build them in each test shard then prebuild and upload/download them as artifacts
+      - name: Build test plugins
+        run: yarn e2e:plugin:build
+
       # Download the grafana artifacts and stitch them together into a standalone prod-ish Grafana distribution
       - name: Download backend artifacts
         uses: actions/download-artifact@v8
@@ -192,11 +197,6 @@ jobs:
         with:
           name: grafana-frontend
           path: grafana-server/public
-      - name: Download test plugins
-        uses: actions/download-artifact@v8
-        with:
-          name: grafana-test-plugins
-          path: grafana-server/data/plugins
       - name: Copy misc server files
         run: |
           cp -r conf/ grafana-server
@@ -211,6 +211,8 @@ jobs:
           cp devenv/dashboards.yaml grafana-server/conf/provisioning/dashboards/
           cp devenv/alert_rules.yaml grafana-server/conf/provisioning/alerting/
           cp devenv/plugins.yaml grafana-server/conf/provisioning/plugins/
+          mkdir -p grafana-server/data/plugins
+          cp -r e2e-playwright/test-plugins/. grafana-server/data/plugins/
 
       # Start Grafana from the standalone directory
       - name: Start Grafana
@@ -234,11 +236,6 @@ jobs:
             elapsed=$((elapsed + 1))
           done
           printf "\nGrafana is ready\n"
-
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-node
-      - name: Install yarn dependencies
-        uses: ./.github/actions/yarn-install
 
       - name: Install Playwright browsers
         run: yarn playwright install chromium --with-deps

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -48,10 +48,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache
         with:
-          key: "build-backend-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum', 'go.work', 'go.work.sum', 'pkg/**/*.go', 'apps/**/*.go', '!**_test.go', 'Makefile', 'build.go', 'embed.go') }}"
+          key: "e2e-build-backend-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum', 'go.work', 'go.work.sum', 'pkg/**/*.go', 'apps/**/*.go', '!**_test.go', 'Makefile', 'embed.go') }}"
           path: bin
 
       - uses: actions/setup-go@v6.0.0
@@ -83,10 +83,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache
         with:
-          key: "build-frontend-${{ runner.os }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/**', 'public/**', 'e2e-playwright/test-plugins/**', '!**/*.test.ts', '!**/*.test.tsx', 'tsconfig.json', '.browserslistrc', 'nx.json', '.nvmrc') }}"
+          key: "e2e-build-frontend-${{ runner.os }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/**', 'public/**', 'e2e-playwright/test-plugins/**', '!**/*.test.ts', '!**/*.test.tsx', 'tsconfig.json', '.browserslistrc', 'nx.json', '.nvmrc') }}"
           path: |
             public/build
             public/app/plugins/*/*/dist
@@ -125,31 +125,6 @@ jobs:
           path: e2e-playwright/test-plugins/
           retention-days: 1
 
-  build-misc:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.changed == 'true'
-    name: Prepare misc files
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-
-      - name: Prepare misc distribution files
-        run: |
-          mkdir grafana-misc
-          cp -r conf grafana-misc/
-          cp -r tools grafana-misc/
-
-      - uses: actions/upload-artifact@v5
-        with:
-          name: grafana-misc
-          path: grafana-misc/
-          retention-days: 1
-
   run-storybook-test:
     name: Verify Storybook (Playwright)
     runs-on: ubuntu-latest
@@ -180,7 +155,7 @@ jobs:
       - name: Get Playwright version
         id: pw-version
         run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           key: storybook-playwright-${{ steps.pw-version.outputs.version }}
           path: ~/.cache/ms-playwright
@@ -194,7 +169,6 @@ jobs:
     needs:
       - build-backend
       - build-frontend
-      - build-misc
     name: Playwright E2E tests (${{ matrix.shard }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-x64-large
     timeout-minutes: 20
@@ -212,9 +186,7 @@ jobs:
         with:
           persist-credentials: false
 
-      ##
       # Download the grafana artifacts and stitch them together into a standalone prod-ish Grafana distribution
-      ##
       - name: Download backend artifacts
         uses: actions/download-artifact@v4
         with:
@@ -227,15 +199,15 @@ jobs:
         with:
           name: grafana-frontend
           path: grafana-server/public
-      - name: Download misc artifacts
+      - name: Download test plugins
         uses: actions/download-artifact@v4
-        with:
-          name: grafana-misc
-          path: grafana-server
-      - uses: actions/download-artifact@v4
         with:
           name: grafana-test-plugins
           path: grafana-server/data/plugins
+      - name: Copy misc server files
+        run: |
+          cp -r conf/ grafana-server
+          cp -r tools/ grafana-server
 
       # Apply E2E test configuration on top of the production-mirrored distribution
       - name: Configure for E2E testing
@@ -278,7 +250,7 @@ jobs:
       - name: Get Playwright version
         id: pw-version
         run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           key: playwright-${{ steps.pw-version.outputs.version }}
           path: ~/.cache/ms-playwright
@@ -293,16 +265,16 @@ jobs:
       - uses: actions/upload-artifact@v5
         if: always()
         with:
-          name: grafana-server-log-${{ github.run_number }}-${{ matrix.shard }}
+          name: grafana-server-log-${{ matrix.shard }}
           path: grafana-server/grafana.log
           retention-days: 3
 
       - uses: actions/upload-artifact@v5
         if: success() || failure()
         with:
-          name: playwright-blob-${{ github.run_number }}-${{ matrix.shard }}
+          name: playwright-blob-${{ matrix.shard }}
           path: blob-report
-          retention-days: 1
+          retention-days: 3
 
   required-playwright-tests:
     needs:
@@ -369,7 +341,7 @@ jobs:
         id: upload-html
         uses: actions/upload-artifact@v5
         with:
-          name: playwright-html-${{ github.run_number }}
+          name: playwright-html
           path: playwright-report
           retention-days: 7
 
@@ -386,12 +358,18 @@ jobs:
         env:
           FAILED: ${{ steps.check-jobs.outputs.any-failed }}
           REPORT_URL: ${{ steps.upload-html.outputs.artifact-url }}
+          RUN_ID: ${{ github.run_id }}
         # sed removes the leading `../../src/` from the paths
         run: |
           npx playwright merge-reports --reporter list ./blobs | sed 's|\(\.\./\)\{1,\}src/|/|g'
+          echo ""
+          echo "Run the following command to view the results locally:"
+          echo "  ./scripts/view-playwright-ci.sh $RUN_ID"
+          echo ""
+          echo "Alternatively, download the test report from $REPORT_URL"
+          echo "And view it locally with:"
+          echo "  yarn playwright show-report <path-to-unzipped-report>"
           if [ "$FAILED" = "true" ]; then
-            echo ""
-            echo "Download the test report from $REPORT_URL"
             exit 1
           fi
 

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -112,7 +112,8 @@ jobs:
         with:
           name: grafana-frontend
           path: |
-            public/
+            public/build/
+            public/app/plugins/
             !public/**/*.ts
             !public/**/*.tsx
           retention-days: 1
@@ -121,6 +122,31 @@ jobs:
         with:
           name: grafana-test-plugins
           path: e2e-playwright/test-plugins/
+          retention-days: 1
+
+  build-misc:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.changed == 'true'
+    name: Prepare misc files
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Prepare misc distribution files
+        run: |
+          mkdir grafana-misc
+          cp -r conf grafana-misc/
+          cp -r tools grafana-misc/
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: grafana-misc
+          path: grafana-misc/
           retention-days: 1
 
   build-grafana:
@@ -269,6 +295,7 @@ jobs:
     needs:
       - build-backend
       - build-frontend
+      - build-misc
     name: Playwright E2E tests (${{ matrix.shard }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-x64-large
     timeout-minutes: 20
@@ -286,43 +313,73 @@ jobs:
         with:
           persist-credentials: false
 
-      # Download pre-built artifacts into the correct locations
+      # Download backend binaries → grafana-server/bin/
       - uses: actions/download-artifact@v4
         with:
           name: grafana-backend
-          path: bin
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: grafana-frontend
-          path: frontend-artifact
-
-      - run: rsync -a frontend-artifact/ public/
-      - run: rm -rf frontend-artifact
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: grafana-test-plugins
-          path: e2e-playwright/test-plugins
+          path: grafana-server/bin
 
       # Restore execute permissions stripped by actions/upload-artifact
       - name: Fix binary permissions
-        run: chmod +x bin/grafana*
+        run: chmod +x grafana-server/bin/grafana*
 
-      - run: tree > tree.txt
+      # Download frontend assets → grafana-server/public/
+      - uses: actions/download-artifact@v4
+        with:
+          name: grafana-frontend
+          path: grafana-server/public
+
+      # Download test plugins → grafana-server/data/plugins/
+      - uses: actions/download-artifact@v4
+        with:
+          name: grafana-test-plugins
+          path: grafana-server/data/plugins
+
+      # Download misc files (conf/, tools/, plugins-bundled/) → grafana-server/
+      - uses: actions/download-artifact@v4
+        with:
+          name: grafana-misc
+          path: grafana-server
+
+      # Apply E2E test configuration on top of the production-mirrored distribution
+      - name: Configure for E2E testing
+        run: |
+          mkdir -p grafana-server/conf/provisioning/{datasources,dashboards,alerting,plugins}
+          cp scripts/grafana-server/custom.ini grafana-server/conf/custom.ini
+          cp devenv/datasources.yaml grafana-server/conf/provisioning/datasources/
+          cp devenv/dashboards.yaml grafana-server/conf/provisioning/dashboards/
+          cp devenv/alert_rules.yaml grafana-server/conf/provisioning/alerting/
+          cp devenv/plugins.yaml grafana-server/conf/provisioning/plugins/
+
+      - run: tree grafana-server > tree.txt
       - uses: actions/upload-artifact@v5
         with:
           name: debug-tree-shard-${{ matrix.shard }}
           path: tree.txt
           retention-days: 1
 
-      # Start Grafana using existing scripts (handles provisioning, config, etc.)
+      # Start Grafana from the standalone directory
       - name: Start Grafana
         run: |
-          ./scripts/grafana-server/start-server &
-          ./scripts/grafana-server/wait-for-grafana
-        env:
-          PORT: 3001
+          grafana-server/bin/grafana server \
+            --homepath="$PWD/grafana-server" \
+            cfg:server.http_port=3001 \
+            > grafana-server/grafana.log 2>&1 &
+
+          # Wait for Grafana to be ready
+          timeout=180
+          elapsed=0
+          printf "Waiting for Grafana to start"
+          while ! curl -s -f http://localhost:3001/health > /dev/null 2>&1; do
+            if [ $elapsed -ge $timeout ]; then
+              printf "\nTimeout after %d seconds waiting for Grafana\n" "$timeout"
+              exit 1
+            fi
+            printf "."
+            sleep 1
+            elapsed=$((elapsed + 1))
+          done
+          printf "\nGrafana is ready\n"
 
       # Install test dependencies
       - name: Setup Node.js
@@ -338,12 +395,19 @@ jobs:
           path: ~/.cache/ms-playwright
       - run: npx playwright install chromium --with-deps
 
-      # Run tests — Grafana is running natively on localhost:3001
+      # Run tests — Grafana is running standalone on localhost:3001
       - name: Run Playwright tests
         run: yarn e2e:playwright --shard=${{ matrix.shard }}/${{ matrix.shardTotal }} --reporter=dot,blob --output=playwright-test-results
         env:
           GRAFANA_URL: http://localhost:3001
           CI: true
+
+      - uses: actions/upload-artifact@v5
+        if: always()
+        with:
+          name: grafana-server-log-${{ github.run_number }}-${{ matrix.shard }}
+          path: grafana-server/grafana.log
+          retention-days: 3
 
       - uses: actions/upload-artifact@v5
         if: success() || failure()

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -254,6 +254,16 @@ jobs:
           GRAFANA_URL: http://localhost:3001
           CI: true
 
+      - name: Show failure instructions
+        if: failure()
+        env:
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          echo "Tests in this shard failed."
+          echo ""
+          echo "View combined logs and HTML report in the 'All Playwright tests complete' job once all tests finish."
+          exit 1
+
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -251,14 +251,14 @@ jobs:
         with:
           name: grafana-server-log-${{ matrix.shard }}
           path: grafana-server/grafana.log
-          retention-days: 3
+          retention-days: 7
 
       - uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: playwright-blob-${{ matrix.shard }}
           path: blob-report
-          retention-days: 3
+          retention-days: 1
 
   required-playwright-tests:
     needs:
@@ -271,11 +271,6 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@main
-        if: github.event.pull_request.head.repo.fork == false
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
-        if: github.event.pull_request.head.repo.fork == false
-
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
@@ -302,24 +297,6 @@ jobs:
 
       - name: Merge into HTML Report
         run: npx playwright merge-reports --reporter html ./blobs
-
-      - name: Merge into JSON Report
-        env:
-          PLAYWRIGHT_JSON_OUTPUT_NAME: /tmp/playwright-results.json
-        run: npx playwright merge-reports --reporter=json ./blobs
-
-      - name: Bench report
-        run: |
-          docker run --rm \
-            --volume="/tmp/playwright-results.json:/home/bench/tests/playwright-results.json" \
-            us-docker.pkg.dev/grafanalabs-global/docker-grafana-bench-prod/grafana-bench:v0.5.1 report \
-              --grafana-url "http://localhost:3000" \
-              --grafana-version "CI- ${{ github.sha }}" \
-              --test-suite-name "FrontendCore" \
-              --report-input playwright \
-              --report-output log \
-              --log-level DEBUG \
-              /home/bench/tests/playwright-results.json
 
       - name: Upload HTML report
         id: upload-html
@@ -356,6 +333,93 @@ jobs:
           if [ "$FAILED" = "true" ]; then
             exit 1
           fi
+
+  report-playwright-bench:
+    needs:
+      - run-playwright-tests
+    if: ${{ !cancelled() }}
+    name: Report Playwright benchmarks
+    runs-on: ubuntu-x64-small
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: grafana/shared-workflows/actions/login-to-gar@main
+        if: github.event.pull_request.head.repo.fork == false
+
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Download blob reports from GitHub Actions Artifacts
+        uses: actions/download-artifact@v6
+        with:
+          path: blobs
+          pattern: playwright-blob-*
+          merge-multiple: true
+
+      - name: Merge into JSON Report
+        env:
+          PLAYWRIGHT_JSON_OUTPUT_NAME: /tmp/playwright-results.json
+        run: npx playwright merge-reports --reporter=json ./blobs
+
+      - name: Bench report
+        run: |
+          docker run --rm \
+            --volume="/tmp/playwright-results.json:/home/bench/tests/playwright-results.json" \
+            us-docker.pkg.dev/grafanalabs-global/docker-grafana-bench-prod/grafana-bench:v1.0.1 report \
+              --service grafana \
+              --service-url "http://localhost:3000" \
+              --service-version "CI-${{ github.sha }}" \
+              --suite-name "FrontendCore" \
+              --run-stage ci \
+              --report-input playwright \
+              --report-output log \
+              --log-level DEBUG \
+              /home/bench/tests/playwright-results.json
+
+  report-playwright-bench-no-checkout:
+    needs:
+      - run-playwright-tests
+    if: ${{ !cancelled() }}
+    name: Report Playwright benchmarks (no repo checkout)
+    runs-on: ubuntu-x64-small
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: grafana/shared-workflows/actions/login-to-gar@main
+        if: github.event.pull_request.head.repo.fork == false
+
+      - name: Download blob reports from GitHub Actions Artifacts
+        uses: actions/download-artifact@v6
+        with:
+          path: blobs
+          pattern: playwright-blob-*
+          merge-multiple: true
+
+      - name: Merge into JSON Report
+        env:
+          PLAYWRIGHT_JSON_OUTPUT_NAME: /tmp/playwright-results.json
+        run: npx playwright merge-reports --reporter=json ./blobs
+
+      - name: Bench report
+        run: |
+          docker run --rm \
+            --volume="/tmp/playwright-results.json:/home/bench/tests/playwright-results.json" \
+            us-docker.pkg.dev/grafanalabs-global/docker-grafana-bench-prod/grafana-bench:v1.0.1 report \
+              --service grafana \
+              --service-url "http://localhost:3000" \
+              --service-version "CI-${{ github.sha }}" \
+              --suite-name "FrontendCore" \
+              --run-stage ci \
+              --report-input playwright \
+              --report-output log \
+              --log-level DEBUG \
+              /home/bench/tests/playwright-results.json
 
   publish-metrics:
     name: Publish metrics

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -401,3 +401,16 @@ jobs:
         run: ./scripts/ci-frontend-metrics.sh | node --experimental-strip-types .github/workflows/scripts/publish-frontend-metrics.mts
         env:
           GRAFANA_MISC_STATS_API_KEY: ${{ env.GRAFANA_MISC_STATS_API_KEY}}
+
+  # 'All E2E tests complete' is still a required check. To help with this transition, we keep
+  # a placeholder job to avoid needing to remove the required check from github yet.
+  required-e2e-tests:
+    needs:
+      - required-playwright-tests
+    if: always()
+
+    name: All E2E tests complete
+    runs-on: ubuntu-x64-small
+    steps:
+    - name: Placeholder step
+      run: echo "This step is intentionally left blank. Check playwright-required-tests job for the actual test results."

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -112,10 +112,10 @@ jobs:
         with:
           name: grafana-frontend
           path: |
-            public/build/
-            public/app/plugins/
+            public/
             !public/**/*.ts
             !public/**/*.tsx
+            !public/**/node_modules/
           retention-days: 1
 
       - uses: actions/upload-artifact@v5

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -279,13 +279,6 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-node
-
       - name: Download blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@v6
         with:
@@ -316,7 +309,7 @@ jobs:
 
       - name: Check test suites
         id: check-jobs
-        uses: ./.github/actions/check-jobs
+        uses: grafana/grafana/.github/actions/check-jobs@main
         continue-on-error: true # Failure will be reported on Show test results step
         with:
           needs: ${{ toJson(needs) }}
@@ -352,56 +345,6 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
-        if: github.event.pull_request.head.repo.fork == false
-
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-node
-
-      - name: Download blob reports from GitHub Actions Artifacts
-        uses: actions/download-artifact@v6
-        with:
-          path: blobs
-          pattern: playwright-blob-*
-          merge-multiple: true
-
-      - name: Merge into JSON Report
-        env:
-          PLAYWRIGHT_JSON_OUTPUT_NAME: /tmp/playwright-results.json
-        run: npx playwright merge-reports --reporter=json ./blobs
-
-      - name: Bench report
-        run: |
-          docker run --rm \
-            --volume="/tmp/playwright-results.json:/home/bench/tests/playwright-results.json" \
-            us-docker.pkg.dev/grafanalabs-global/docker-grafana-bench-prod/grafana-bench:v1.0.1 report \
-              --service grafana \
-              --service-url "http://localhost:3000" \
-              --service-version "CI-${{ github.sha }}" \
-              --suite-name "FrontendCore" \
-              --run-stage ci \
-              --report-input playwright \
-              --report-output log \
-              --log-level DEBUG \
-              /home/bench/tests/playwright-results.json
-
-  report-playwright-bench-no-checkout:
-    needs:
-      - run-playwright-tests
-    if: ${{ !cancelled() }}
-    name: Report Playwright benchmarks (no repo checkout)
-    runs-on: ubuntu-x64-small
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
-        if: github.event.pull_request.head.repo.fork == false
-
       - name: Download blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@v6
         with:
@@ -462,7 +405,7 @@ jobs:
   # a placeholder job to avoid needing to remove the required check from github yet.
   required-e2e-tests:
     needs:
-      - required-playwright-tests
+      - run-playwright-tests
     if: always()
 
     name: All E2E tests complete

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -114,14 +114,11 @@ jobs:
         with:
           name: grafana-frontend
           path: |
-            public/build
-            public/dashboards
-            public/views
-            public/emails
-            public/app/plugins
+            public/
             !**/*.ts
             !**/*.tsx
             !public/**/node_modules/
+            !public/locales/
           retention-days: 1
 
   run-storybook-test:

--- a/e2e-playwright/dashboards-suite/dashboard-timepicker.spec.ts
+++ b/e2e-playwright/dashboards-suite/dashboard-timepicker.spec.ts
@@ -44,11 +44,13 @@ test.describe(
       // Set user preferences for timezone
       await page.goto('/profile');
       await page.getByTestId(selectors.components.TimeZonePicker.containerV2).click();
+      await page.keyboard.type('Tokyo');
       await page.getByRole('option', { name: 'Asia/Tokyo' }).click();
       await page.getByTestId(selectors.components.UserProfile.preferencesSaveButton).click();
       // wait for the page to reload before trying to navigate, otherwise this can cause flakes
       // see e.g. https://github.com/microsoft/playwright/issues/21451#issuecomment-1502251404
       await page.waitForURL('/profile');
+      await page.waitForLoadState('networkidle');
 
       // Open dashboard with time range from 8th to end of 10th.
       // Will be Tokyo time because of above preference

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,9 +23,8 @@ export function withAuth(project: Project): Project {
 export const baseConfig: PlaywrightTestConfig<PluginOptions, {}> = {
   fullyParallel: true,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 4 : undefined,
   reporter: [
     ['html'], // pretty
     ['./e2e-playwright/utils/axe-a11y/reporter.ts'], // accessibility reporter

--- a/scripts/view-playwright-ci.sh
+++ b/scripts/view-playwright-ci.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUN_NUMBER="${1:-}"
+
+if [ -z "$RUN_NUMBER" ]; then
+  BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+  echo "No run ID provided, looking up latest run for branch '$BRANCH'..."
+  RUN_NUMBER="$(gh run list --workflow=pr-e2e-tests.yml --branch="$BRANCH" --limit=1 --json databaseId --jq '.[0].databaseId')"
+  if [ -z "$RUN_NUMBER" ]; then
+    echo "Error: No runs found for branch '$BRANCH'"
+    exit 1
+  fi
+  echo "Using run $RUN_NUMBER"
+fi
+
+DEST="/tmp/playwright-html-${RUN_NUMBER}"
+
+echo "Downloading artifact playwright-html from run $RUN_NUMBER"
+gh run download "$RUN_NUMBER"  --name playwright-html --dir "$DEST"
+
+echo "Opening report..."
+yarn playwright show-report "$DEST"

--- a/scripts/webpack/webpack.prod.js
+++ b/scripts/webpack/webpack.prod.js
@@ -30,7 +30,7 @@ const envConfig = getEnvConfig();
 module.exports = (env = {}) =>
   merge(common(env), {
     mode: 'production',
-    devtool: 'source-map',
+    devtool: process.env.NO_SOURCEMAP === '1' ? false : 'source-map',
 
     entry: {
       dark: './public/sass/grafana.dark.scss',


### PR DESCRIPTION
**What is this feature?**

This replaces the Dagger-based build system for Playwright E2E tests with native make commands and GitHub Actions caching. The E2E CI workflow now builds the backend and frontend directly, assembles a standalone Grafana server directory, and runs tests against it — without requiring Docker or Dagger at all.

A new separate workflow (pr-docker-image.yml) is extracted to handle building and pushing the Docker image for PRs, keeping that Dagger-based path intact for that specific use case.

**Why do we need this feature?**

The previous Dagger-based approach was slow, opaque, and complex. It required spinning up a full Docker image to run e2e tests and had significant cold-start overhead as it was difficult to cache the inner workings of it. By switching to native make builds with proper cache keys, CI runs should be significantly faster:

- Backend and frontend builds are cached independently to avoid rebuilding things that haven't changed
- Improved yarn/node_modules caching via unified yarn-install composite action
- The old pkg/build/e2e-playwright and pkg/build/e2e Dagger pipeline code (~800 lines of Go) is deleted entirely as it's no longer needed for e2e.
- A `scripts/view-playwright-report.sh` script is added to make it easier to download and inspect CI test reports locally — the failure message now prints instructions for using it
- Removed old cypress dashboards old-arch E2E tests which required the dagger workflow

Initial testing has E2E tests running more than 50% faster 🎉 from ~30 mins to ~15 mins. I expect this time to go down further once we remove the double webpack build for react 19.


<img width="1211" height="692" alt="Screenshot 2026-03-04 at 7 06 02 pm" src="https://github.com/user-attachments/assets/402a4ea4-549e-42c9-8e5d-18daadb34f3a" />


**Who is this feature for?**

Grafana contributors and the CI infrastructure — faster feedback loops on PRs.

**Which issue(s) does this PR fix?**

Fixes #

**Special notes for your reviewer:**

- The push-docker-image job and the old run-azure-monitor-e2e job are moved to the new pr-docker-image.yml workflow, so Docker image building still works for non-fork PRs

