### PR TITLE
RemoteCache: Add network=unix support for the Redis remote cache

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -231,7 +231,7 @@ type = database
 
 # cache connectionstring options
 # database: will use Grafana primary database.
-# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=0,username=grafana,password=grafanaRocks,ssl=false`. Only addr is required. ssl may be 'true', 'false', or 'insecure'.
+# redis: config like redis server e.g. `network=tcp,addr=127.0.0.1:6379,pool_size=100,db=0,username=grafana,password=grafanaRocks,ssl=false`. Only addr is required. network may be 'tcp' or 'unix'. ssl may be 'true', 'false', or 'insecure'.
 # memcache: 127.0.0.1:11211
 connstr =
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -218,7 +218,7 @@
 
 # cache connectionstring options
 # database: will use Grafana primary database.
-# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=0,username=grafana,password=grafanaRocks,ssl=false`. Only addr is required. ssl may be 'true', 'false', or 'insecure'.
+# redis: config like redis server e.g. `network=tcp,addr=127.0.0.1:6379,pool_size=100,db=0,username=grafana,password=grafanaRocks,ssl=false`. Only addr is required. network may be 'tcp' or 'unix'. ssl may be 'true', 'false', or 'insecure'.
 # memcache: 127.0.0.1:11211
 ;connstr =
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -503,8 +503,9 @@ Leave empty when using `database` and Grafana uses the primary database.
 
 ##### `redis`
 
-Example connection string: `addr=127.0.0.1:6379,pool_size=100,db=0,username=grafana,password=grafanaRocks,ssl=false`
+Example connection string: `network=tcp,addr=127.0.0.1:6379,pool_size=100,db=0,username=grafana,password=grafanaRocks,ssl=false`
 
+- `network` (optional) can be `tcp` or `unix`.
 - `addr` is the host `:` port of the Redis server.
 - `pool_size` (optional) is the number of underlying connections that can be made to Redis.
 - `db` (optional) is the number identifier of the Redis database you want to use.

--- a/pkg/infra/remotecache/redis_storage.go
+++ b/pkg/infra/remotecache/redis_storage.go
@@ -55,6 +55,8 @@ func parseRedisConnStr(connStr string) (*redis.Options, error) {
 				return nil, fmt.Errorf("%v: %w", "value for pool_size in redis connection string must be a number", err)
 			}
 			options.PoolSize = i
+		case "network":
+			options.Network = connVal
 		case "ssl":
 			if connVal != "true" && connVal != "false" && connVal != "insecure" {
 				return nil, fmt.Errorf("ssl must be set to 'true', 'false', or 'insecure' when present")

--- a/pkg/infra/remotecache/redis_storage_test.go
+++ b/pkg/infra/remotecache/redis_storage_test.go
@@ -37,6 +37,15 @@ func Test_parseRedisConnStr(t *testing.T) {
 			},
 			false,
 		},
+		"network unix should parse": {
+			"network=unix,addr=/var/run/redis/redis.sock,pool_size=100",
+			&redis.Options{
+				Addr:     "/var/run/redis/redis.sock",
+				PoolSize: 100,
+				Network:  "unix",
+			},
+			false,
+		},
 		"ssl set to true should result in default TLS configuration with tls set to addr's host": {
 			"addr=grafana.com:6379,ssl=true",
 			&redis.Options{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR adds support for parsing the `network` option in the Redis connection string.

**Why do we need this feature?**

This allows users to configure the Redis remote cache to use Unix domain sockets for better performance and security locally (e.g., `network=unix,addr=/var/run/redis/redis.sock`).

**Who is this feature for?**

For users who run Redis and Grafana on the same machine.

**Which issue(s) does this PR fix?**:

Fixes #99537

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
