### PR TITLE
docs: add no-animal-violence Vale package for inclusive language checking

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,5 +1,7 @@
 MinAlertLevel = warning
 
+Packages = https://github.com/Open-Paws/vale-no-animal-violence/releases/latest/download/NoAnimalViolence.zip
+
 [*.md]
-BasedOnStyles = Grafana
+BasedOnStyles = Grafana, NoAnimalViolence
 TokenIgnores = (<http[^\n]+>+?), \*\*[^\n]+\*\*


### PR DESCRIPTION
Adds the [no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) Vale package to the docs Vale configuration.

The package flags phrases that normalize violence toward animals and suggests clearer, more professional alternatives. Several are particularly common in observability and infrastructure documentation:

| Phrase | Suggested alternative |
|--------|----------------------|
| "canary deployment" | "progressive rollout" |
| "cattle vs. pets" | "ephemeral vs. persistent" |
| "kill two birds with one stone" | "accomplish two things at once" |
| "monkey patch" | "runtime patch" |
| "guinea pig" | "test subject" |

The alternatives are technically more precise and clearer for international readers.

> **Note**: This may flag some existing phrases in the docs. Those can be fixed as a follow-up, or individual rules can be set to `suggestion` level to reduce noise during the transition.

**Package**: https://github.com/Open-Paws/vale-no-animal-violence (MIT)

**Change**: `.vale.ini` — add `Packages` with the NoAnimalViolence URL and add `NoAnimalViolence` to `BasedOnStyles`