### PR TITLE
Dashboards: Fix N+1 query in GetDashboardsByPluginID and GetDashboards

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/exp/maps"
+	"golang.org/x/sync/errgroup"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -1349,16 +1350,12 @@ func (dr *DashboardServiceImpl) GetDashboardsByPluginID(ctx context.Context, que
 	}
 
 	// search only returns the metadata, need to get the dashboard.Data too
-	results := make([]*dashboards.Dashboard, len(dashs))
+	uids := make([]string, len(dashs))
 	for i, d := range dashs {
-		dash, err := dr.GetDashboard(ctx, &dashboards.GetDashboardQuery{OrgID: d.OrgID, UID: d.UID})
-		if err != nil {
-			return nil, err
-		}
-		results[i] = dash
+		uids[i] = d.UID
 	}
 
-	return results, nil
+	return dr.getDashboardsBatchThroughK8s(ctx, query.OrgID, uids)
 }
 
 // (sometimes) called by the k8s storage engine after creating an object
@@ -1511,16 +1508,12 @@ func (dr *DashboardServiceImpl) GetDashboards(ctx context.Context, query *dashbo
 	}
 
 	// search only returns the metadata, need to get the dashboard.Data too
-	results := make([]*dashboards.Dashboard, len(dashs))
+	uids := make([]string, len(dashs))
 	for i, d := range dashs {
-		dash, err := dr.GetDashboard(ctx, &dashboards.GetDashboardQuery{OrgID: d.OrgID, UID: d.UID})
-		if err != nil {
-			return nil, err
-		}
-		results[i] = dash
+		uids[i] = d.UID
 	}
 
-	return results, nil
+	return dr.getDashboardsBatchThroughK8s(ctx, query.OrgID, uids)
 }
 
 func (dr *DashboardServiceImpl) getDashboardsSharedWithUser(ctx context.Context, user identity.Requester) ([]*dashboards.DashboardRef, error) {
@@ -1896,6 +1889,93 @@ func (dr *DashboardServiceImpl) CleanUpDashboard(ctx context.Context, dashboardU
 // -----------------------------------------------------------------------------------------
 // Dashboard k8s functions
 // -----------------------------------------------------------------------------------------
+
+// getDashboardsBatchThroughK8s fetches multiple dashboards concurrently by their UIDs.
+// This avoids the N+1 query problem of calling getDashboardThroughK8s in a loop.
+func (dr *DashboardServiceImpl) getDashboardsBatchThroughK8s(ctx context.Context, orgID int64, uids []string) ([]*dashboards.Dashboard, error) {
+	if len(uids) == 0 {
+		return []*dashboards.Dashboard{}, nil
+	}
+
+	// Concurrently fetch all dashboards via K8s Get
+	const maxConcurrentGets = 10
+	items := make([]*unstructured.Unstructured, len(uids))
+	errs := make([]error, len(uids))
+
+	var g errgroup.Group
+	g.SetLimit(maxConcurrentGets)
+
+	for i, uid := range uids {
+		i := i
+		uid := uid
+		g.Go(func() error {
+			out, err := dr.k8sclient.Get(ctx, uid, orgID, v1.GetOptions{}, "")
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					errs[i] = dashboards.ErrDashboardNotFound
+					return nil
+				}
+				errs[i] = err
+				return nil
+			}
+			if out == nil {
+				errs[i] = dashboards.ErrDashboardNotFound
+				return nil
+			}
+			items[i] = out
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	for _, err := range errs {
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Batch-resolve users for all items at once instead of per-item
+	unstructuredItems := make([]unstructured.Unstructured, len(items))
+	for i, item := range items {
+		unstructuredItems[i] = *item
+	}
+	users, err := dr.getUsersForList(ctx, unstructuredItems, orgID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert all items to legacy dashboards
+	results := make([]*dashboards.Dashboard, len(items))
+	for i, item := range items {
+		dash, err := dr.unstructuredToLegacyDashboardWithUsers(item, orgID, users)
+		if err != nil {
+			return nil, err
+		}
+
+		// Handle version conversion status (same logic as UnstructuredToLegacyDashboard)
+		gv, _ := schema.ParseGroupVersion(item.GetAPIVersion())
+		if gv.Version != "" {
+			dash.APIVersion = gv.Version
+		}
+		conversion, ok, _ := unstructured.NestedMap(item.Object, "status", "conversion")
+		if ok && conversion != nil {
+			failed, _, _ := unstructured.NestedBool(conversion, "failed")
+			if failed {
+				dash.APIVersion, _, _ = unstructured.NestedString(conversion, "storedVersion")
+				body, ok, _ := unstructured.NestedMap(conversion, "source")
+				if ok {
+					dash.Data = simplejson.NewFromAny(body)
+				}
+			}
+		}
+
+		results[i] = dash
+	}
+
+	return results, nil
+}
 
 func (dr *DashboardServiceImpl) getDashboardThroughK8s(ctx context.Context, query *dashboards.GetDashboardQuery) (*dashboards.Dashboard, error) {
 	// get uid if not passed in

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -1050,6 +1051,61 @@ func TestGetDashboardsByPluginID(t *testing.T) {
 	k8sCliMock.AssertExpectations(t)
 }
 
+func TestGetDashboardsByPluginIDReturnsFirstErrorByUIDOrder(t *testing.T) {
+	service := &DashboardServiceImpl{
+		cfg: setting.NewCfg(),
+	}
+	query := &dashboards.GetDashboardsByPluginIDQuery{
+		PluginID: "testing",
+		OrgID:    1,
+	}
+
+	ctx, k8sCliMock := setupK8sDashboardTests(service)
+	k8sCliMock.On("GetNamespace", mock.Anything, mock.Anything).Return("default")
+	k8sCliMock.On("Search", mock.Anything, mock.Anything, mock.MatchedBy(func(req *resourcepb.ResourceSearchRequest) bool {
+		return ( // gofmt comment helper
+		req.Options.Fields[0].Key == "manager.kind" && req.Options.Fields[0].Values[0] == string(utils.ManagerKindPlugin) &&
+			req.Options.Fields[1].Key == "manager.id" && req.Options.Fields[1].Values[0] == "testing")
+	})).Return(&resourcepb.ResourceSearchResponse{
+		Results: &resourcepb.ResourceTable{
+			Columns: []*resourcepb.ResourceTableColumnDefinition{
+				{Name: "title", Type: resourcepb.ResourceTableColumnDefinition_STRING},
+				{Name: "folder", Type: resourcepb.ResourceTableColumnDefinition_STRING},
+			},
+			Rows: []*resourcepb.ResourceTableRow{
+				{
+					Key: &resourcepb.ResourceKey{Name: "uid1", Resource: "dashboard"},
+					Cells: [][]byte{
+						[]byte("Dashboard 1"),
+						[]byte(""),
+					},
+				},
+				{
+					Key: &resourcepb.ResourceKey{Name: "uid2", Resource: "dashboard"},
+					Cells: [][]byte{
+						[]byte("Dashboard 2"),
+						[]byte(""),
+					},
+				},
+			},
+		},
+		TotalHits: 2,
+	}, nil)
+
+	// Ensure uid2 fails first in wall-clock time; service should still return uid1's error by uid order.
+	k8sCliMock.On("Get", mock.Anything, "uid1", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(mock.Arguments) { time.Sleep(25 * time.Millisecond) }).
+		Return(nil, nil)
+	secondErr := errors.New("unexpected get failure")
+	k8sCliMock.On("Get", mock.Anything, "uid2", mock.Anything, mock.Anything, mock.Anything).Return(nil, secondErr)
+
+	_, err := service.GetDashboardsByPluginID(ctx, query)
+	require.Error(t, err)
+	require.ErrorIs(t, err, dashboards.ErrDashboardNotFound)
+	require.NotErrorIs(t, err, secondErr)
+	k8sCliMock.AssertExpectations(t)
+}
+
 func TestSetDefaultPermissionsWhenSavingFolderForProvisionedDashboards(t *testing.T) {
 	fakeStore := dashboards.FakeDashboardStore{}
 	defer fakeStore.AssertExpectations(t)
@@ -1614,6 +1670,61 @@ func TestGetDashboards(t *testing.T) {
 	result, err = service.GetDashboards(ctx, queryByUIDs)
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
+	k8sCliMock.AssertExpectations(t)
+}
+
+func TestGetDashboardsReturnsErrorWhenSingleGetFails(t *testing.T) {
+	service := &DashboardServiceImpl{
+		cfg: setting.NewCfg(),
+	}
+
+	queryByUIDs := &dashboards.GetDashboardsQuery{
+		DashboardUIDs: []string{"uid1", "uid2"},
+		OrgID:         1,
+	}
+	uid1Unstructured := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"name":       "uid1",
+			"generation": int64(1),
+		},
+		"spec": map[string]any{
+			"title": "Dashboard 1",
+		},
+	}}
+
+	ctx, k8sCliMock := setupK8sDashboardTests(service)
+	k8sCliMock.On("GetNamespace", mock.Anything, mock.Anything).Return("default")
+	k8sCliMock.On("Search", mock.Anything, mock.Anything, mock.Anything).Return(&resourcepb.ResourceSearchResponse{
+		Results: &resourcepb.ResourceTable{
+			Columns: []*resourcepb.ResourceTableColumnDefinition{
+				{Name: "title", Type: resourcepb.ResourceTableColumnDefinition_STRING},
+				{Name: "folder", Type: resourcepb.ResourceTableColumnDefinition_STRING},
+			},
+			Rows: []*resourcepb.ResourceTableRow{
+				{
+					Key: &resourcepb.ResourceKey{Name: "uid1", Resource: "dashboard"},
+					Cells: [][]byte{
+						[]byte("Dashboard 1"),
+						[]byte(""),
+					},
+				},
+				{
+					Key: &resourcepb.ResourceKey{Name: "uid2", Resource: "dashboard"},
+					Cells: [][]byte{
+						[]byte("Dashboard 2"),
+						[]byte(""),
+					},
+				},
+			},
+		},
+		TotalHits: 2,
+	}, nil)
+	k8sCliMock.On("Get", mock.Anything, "uid1", mock.Anything, mock.Anything, mock.Anything).Return(uid1Unstructured, nil)
+	k8sCliMock.On("Get", mock.Anything, "uid2", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+
+	_, err := service.GetDashboards(ctx, queryByUIDs)
+	require.Error(t, err)
+	require.ErrorIs(t, err, dashboards.ErrDashboardNotFound)
 	k8sCliMock.AssertExpectations(t)
 }
 


### PR DESCRIPTION
**What is this feature?**

Replaces serial per-dashboard K8s Get calls in `GetDashboardsByPluginID` and `GetDashboards` with a new `getDashboardsBatchThroughK8s` method that fetches dashboards concurrently (up to 10 in parallel via `errgroup`) and batch-resolves user metadata in a single call.

**Why do we need this feature?**

Both `GetDashboardsByPluginID` and `GetDashboards` had an N+1 query problem: after the initial search returned N dashboard metadata entries, each dashboard was fetched individually in a serial loop. Every iteration made an independent K8s API call plus 2 additional DB queries to resolve the created-by/updated-by users. For a result set of 100 dashboards, this meant ~300 serial round-trips.

With this fix, the same 100 dashboards are fetched with up to 10 concurrent K8s Get calls + 1 batched user resolution query, significantly reducing latency.

**Who is this feature for?**

Grafana operators and users with large numbers of dashboards, particularly those using plugin-provisioned dashboards or querying multiple dashboards at once. The improvement is most noticeable in multi-tenant or large-scale deployments.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- The new `getDashboardsBatchThroughK8s` method mirrors the concurrency pattern already used in `K8sClientWithFallback.fetchWithVersion` (see client.go).
- User metadata resolution is batched via the existing `getUsersForList` helper (same approach used in `processDashboardBatch`).
- Version conversion fallback logic (for dashboards stored in a different API version) is preserved in the batch path.
- No new feature toggle — this is a pure internal optimization with no behavioral change.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.