### PR TITLE
Browse Dashboards: Update QuotaLimitBanner to use Alert action prop

### DIFF
--- a/public/app/features/browse-dashboards/components/QuotaLimitBanner.test.tsx
+++ b/public/app/features/browse-dashboards/components/QuotaLimitBanner.test.tsx
@@ -67,8 +67,7 @@ async function expectNoAlert() {
 
 const errorAlert = { name: /hit your storage limits/i };
 const warningAlert = { name: /nearing your storage limits/i };
-// Alert's buttonContent button gets aria-label="Close alert" (hardcoded in Alert component)
-const extensionButton = { name: /close alert/i };
+const extensionButton = { name: /request quota extension/i };
 
 describe('QuotaLimitBanner', () => {
   testWithFeatureToggles({ enable: ['kubernetesUnifiedStorageQuotas'] });
@@ -199,7 +198,7 @@ describe('QuotaLimitBanner', () => {
       const { user } = render(<QuotaLimitBanner />);
       expect(await screen.findByRole('alert', warningAlert)).toBeInTheDocument();
 
-      await user.click(screen.getByRole('button', { name: /dismiss/i }));
+      await user.click(screen.getByRole('button', { name: /close alert/i }));
       expect(screen.queryByRole('alert', warningAlert)).not.toBeInTheDocument();
     });
 
@@ -208,7 +207,7 @@ describe('QuotaLimitBanner', () => {
       const { user } = render(<QuotaLimitBanner />);
       expect(await screen.findByRole('alert', warningAlert)).toBeInTheDocument();
 
-      await user.click(screen.getByRole('button', { name: /dismiss/i }));
+      await user.click(screen.getByRole('button', { name: /close alert/i }));
       const stored = store.getObject<Record<string, boolean>>(DISMISS_STORAGE_KEY);
       expect(stored).toEqual(expect.objectContaining({ dashboards: true }));
     });

--- a/public/app/features/browse-dashboards/components/QuotaLimitBanner.tsx
+++ b/public/app/features/browse-dashboards/components/QuotaLimitBanner.tsx
@@ -1,9 +1,8 @@
-import { css } from '@emotion/css';
 import { useState } from 'react';
 
-import { GrafanaTheme2, store } from '@grafana/data';
+import { store } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { Alert, IconButton, useStyles2 } from '@grafana/ui';
+import { Alert, Button } from '@grafana/ui';
 
 import { isFreeTierLicense } from '../../provisioning/utils/isFreeTierLicense';
 import { type ResourceStatus, useQuotaLimits } from '../hooks/useQuotaLimits';
@@ -36,7 +35,6 @@ function formatDetail(resource: ResourceStatus): string {
 }
 
 export function QuotaLimitBanner() {
-  const styles = useStyles2(getStyles);
   const { resources, isLoading, allQueriesFailed, featureEnabled } = useQuotaLimits();
   const [dismissed, setDismissed] = useState<DismissedMap>(
     () => store.getObject<DismissedMap>(DISMISS_STORAGE_KEY) ?? {}
@@ -64,12 +62,11 @@ export function QuotaLimitBanner() {
     window.open(QUOTA_EXTENSION_URL, '_blank');
   };
 
-  const extensionProps = isPaying
-    ? {
-        onRemove: handleRequestExtension,
-        buttonContent: t('browse-dashboards.quota-banner.request-extension', 'Request quota extension'),
-      }
-    : {};
+  const extensionAction = isPaying ? (
+    <Button variant="primary" onClick={handleRequestExtension}>
+      {t('browse-dashboards.quota-banner.request-extension', 'Request quota extension')}
+    </Button>
+  ) : undefined;
 
   return (
     <>
@@ -77,7 +74,7 @@ export function QuotaLimitBanner() {
         <Alert
           severity="error"
           title={t('browse-dashboards.quota-banner.at-limit-title', "You've hit your storage limits")}
-          {...extensionProps}
+          action={extensionAction}
         >
           {atLimitResources.map((r) => formatDetail(r)).join(' ')}{' '}
           <Trans i18nKey="browse-dashboards.quota-banner.at-limit-body">
@@ -89,30 +86,15 @@ export function QuotaLimitBanner() {
         <Alert
           severity="warning"
           title={t('browse-dashboards.quota-banner.nearing-title', "You're nearing your storage limits")}
-          {...extensionProps}
+          action={extensionAction}
+          onRemove={handleDismiss}
         >
           {nearingResources.map((r) => formatDetail(r)).join(' ')}{' '}
           <Trans i18nKey="browse-dashboards.quota-banner.nearing-body">
             New resources can&apos;t be created once the limit is reached. Clean up unused resources to free up space.
           </Trans>
-          {/* Alert doesn't support showing both buttonContent and a close icon, so we position dismiss manually */}
-          <div className={styles.dismiss}>
-            <IconButton
-              aria-label={t('browse-dashboards.quota-banner.dismiss', 'Dismiss')}
-              name="times"
-              onClick={handleDismiss}
-            />
-          </div>
         </Alert>
       )}
     </>
   );
 }
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  dismiss: css({
-    position: 'absolute',
-    top: theme.spacing(0.5),
-    right: theme.spacing(0.25),
-  }),
-});

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4183,7 +4183,6 @@
     "quota-banner": {
       "at-limit-body": "Clean up unused resources to free up space.",
       "at-limit-title": "You've hit your storage limits",
-      "dismiss": "Dismiss",
       "nearing-body": "New resources can't be created once the limit is reached. Clean up unused resources to free up space.",
       "nearing-title": "You're nearing your storage limits",
       "request-extension": "Request quota extension",


### PR DESCRIPTION
**What is this feature?**

Updates the `QuotaLimitBanner` component to use the newly-added `action` prop from the Alert component (PR #118673) for rendering the "Request quota extension" button.

**Why do we need this feature?**

The previous implementation used `onRemove` + `buttonContent` to display the action button, which forced an incorrect `aria-label="Close alert"` and required a workaround to simultaneously show both a custom action button and a dismiss (X) icon. The new `action` prop renders the button with proper semantics and allows both buttons to coexist.

**Which issue(s) does this PR fix?**:

Fixes #119272

**Special notes for your reviewer:**

<img width="1389" height="273" alt="Screenshot 2026-03-02 at 9 45 32" src="https://github.com/user-attachments/assets/1f91e004-2ae5-4325-931a-b0bccf255cf2" />

<img width="1380" height="261" alt="Screenshot 2026-03-02 at 9 47 21" src="https://github.com/user-attachments/assets/dc79cc0f-dc05-495f-a0c3-11e2b6666859" />

