### PR TITLE
i18n: Add duplicate-key-check plugin

### DIFF
--- a/i18next.config.ts
+++ b/i18next.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from 'i18next-cli';
 
+import { duplicateKeyCheckPlugin } from './packages/grafana-i18n/src/plugins/duplicate-key-check';
+
 export default defineConfig({
   locales: ['en-US'], // Only en-US is updated - Crowdin will PR with other languages
   extract: {
@@ -8,6 +10,7 @@ export default defineConfig({
       'public/app/extensions/**/*',
       'public/app/plugins/datasource/**/*',
       'packages/*/dist/**/*',
+      'packages/grafana-i18n/src/plugins/__tests__/fixtures/**/*',
     ],
     input: ['public/**/*.{tsx,ts}', 'packages/grafana-ui/**/*.{tsx,ts}', 'packages/grafana-data/**/*.{tsx,ts}'],
     output: 'public/locales/{{language}}/{{namespace}}.json',
@@ -15,4 +18,5 @@ export default defineConfig({
     functions: ['t', '*.t'],
     transComponents: ['Trans'],
   },
+  plugins: [duplicateKeyCheckPlugin({ failOnConflict: true })],
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -35,6 +35,21 @@ const esModules = [
   'earcut',
   'pbf',
   'geotiff',
+  'i18next-cli',
+  'chalk',
+  'ora',
+  'cli-cursor',
+  'restore-cursor',
+  'onetime',
+  'cli-spinners',
+  'log-symbols',
+  'strip-ansi',
+  'ansi-regex',
+  'string-width',
+  'get-east-asian-width',
+  'is-interactive',
+  'is-unicode-supported',
+  'stdin-discarder',
 ].join('|');
 
 module.exports = {

--- a/packages/grafana-i18n/package.json
+++ b/packages/grafana-i18n/package.json
@@ -62,7 +62,9 @@
     "react-i18next": "^15.0.0"
   },
   "devDependencies": {
+    "@swc/core": "^1.0.0",
     "@types/react": "18.3.18",
+    "i18next-cli": "^1.24.22",
     "rollup": "^4.22.4",
     "rollup-plugin-copy": "3.5.0",
     "typescript": "5.9.2"

--- a/packages/grafana-i18n/src/plugins/__tests__/fixtures/advanced-mixed-conflict/src/PageA.tsx
+++ b/packages/grafana-i18n/src/plugins/__tests__/fixtures/advanced-mixed-conflict/src/PageA.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import { Trans } from '../../../../../i18n';
+
+<Trans i18nKey="welcome" values={{ annoName: 'anno.name' }}>
+  {'{{annoName}}'} (Built-in)
+</Trans>;

--- a/packages/grafana-i18n/src/plugins/__tests__/fixtures/advanced-mixed-conflict/src/PageB.tsx
+++ b/packages/grafana-i18n/src/plugins/__tests__/fixtures/advanced-mixed-conflict/src/PageB.tsx
@@ -1,0 +1,3 @@
+import { t } from '../../../../../i18n';
+
+t('welcome', '{{annoName}} (Built-in)', { annoName: 'anno.name', interpolation: { escapeValue: false } });

--- a/packages/grafana-i18n/src/plugins/__tests__/fixtures/mixed-conflict/src/Banner.tsx
+++ b/packages/grafana-i18n/src/plugins/__tests__/fixtures/mixed-conflict/src/Banner.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+import { Trans } from '../../../../../i18n';
+
+<Trans i18nKey="welcome">Welcome</Trans>;

--- a/packages/grafana-i18n/src/plugins/__tests__/fixtures/mixed-conflict/src/Page.tsx
+++ b/packages/grafana-i18n/src/plugins/__tests__/fixtures/mixed-conflict/src/Page.tsx
@@ -1,0 +1,3 @@
+import { t } from '../../../../../i18n';
+
+t('welcome', 'Welcome back');

--- a/packages/grafana-i18n/src/plugins/__tests__/fixtures/namespace-explicit/src/A.tsx
+++ b/packages/grafana-i18n/src/plugins/__tests__/fixtures/namespace-explicit/src/A.tsx
@@ -1,0 +1,3 @@
+import { t } from '../../../../../i18n';
+
+t('common:button.save', 'Save');

--- a/packages/grafana-i18n/src/plugins/__tests__/fixtures/namespace-explicit/src/B.tsx
+++ b/packages/grafana-i18n/src/plugins/__tests__/fixtures/namespace-explicit/src/B.tsx
@@ -1,0 +1,3 @@
+import { t } from '../../../../../i18n';
+
+t('common:button.save', 'Save Changes');

--- a/packages/grafana-i18n/src/plugins/__tests__/fixtures/namespace-explicit/src/C.tsx
+++ b/packages/grafana-i18n/src/plugins/__tests__/fixtures/namespace-explicit/src/C.tsx
@@ -1,0 +1,3 @@
+import { t } from '../../../../../i18n';
+
+t('button.save', 'Save Item');

--- a/packages/grafana-i18n/src/plugins/__tests__/fixtures/no-conflict/src/ButtonA.tsx
+++ b/packages/grafana-i18n/src/plugins/__tests__/fixtures/no-conflict/src/ButtonA.tsx
@@ -1,0 +1,3 @@
+import { t } from '../../../../../i18n';
+
+t('button.save', 'Save');

--- a/packages/grafana-i18n/src/plugins/__tests__/fixtures/no-conflict/src/ButtonB.tsx
+++ b/packages/grafana-i18n/src/plugins/__tests__/fixtures/no-conflict/src/ButtonB.tsx
@@ -1,0 +1,3 @@
+import { t } from '../../../../../i18n';
+
+t('button.save', 'Save');

--- a/packages/grafana-i18n/src/plugins/__tests__/fixtures/no-default/src/Link.tsx
+++ b/packages/grafana-i18n/src/plugins/__tests__/fixtures/no-default/src/Link.tsx
@@ -1,0 +1,3 @@
+import { t } from '../../../../../i18n';
+
+t('nav.home', '');

--- a/packages/grafana-i18n/src/plugins/__tests__/fixtures/simple-t-conflict/src/ButtonA.tsx
+++ b/packages/grafana-i18n/src/plugins/__tests__/fixtures/simple-t-conflict/src/ButtonA.tsx
@@ -1,0 +1,3 @@
+import { t } from '../../../../../i18n';
+
+t('button.save', 'Save');

--- a/packages/grafana-i18n/src/plugins/__tests__/fixtures/simple-t-conflict/src/ButtonB.tsx
+++ b/packages/grafana-i18n/src/plugins/__tests__/fixtures/simple-t-conflict/src/ButtonB.tsx
@@ -1,0 +1,3 @@
+import { t } from '../../../../../i18n';
+
+t('button.save', 'Save Changes');

--- a/packages/grafana-i18n/src/plugins/__tests__/fixtures/trans-conflict/src/PageA.tsx
+++ b/packages/grafana-i18n/src/plugins/__tests__/fixtures/trans-conflict/src/PageA.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+import { Trans } from '../../../../../i18n';
+
+<Trans i18nKey="welcome">Welcome back</Trans>;

--- a/packages/grafana-i18n/src/plugins/__tests__/fixtures/trans-conflict/src/PageB.tsx
+++ b/packages/grafana-i18n/src/plugins/__tests__/fixtures/trans-conflict/src/PageB.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+import { Trans } from '../../../../../i18n';
+
+<Trans i18nKey="welcome">Welcome</Trans>;

--- a/packages/grafana-i18n/src/plugins/__tests__/helpers.test.ts
+++ b/packages/grafana-i18n/src/plugins/__tests__/helpers.test.ts
@@ -1,0 +1,171 @@
+import type { Argument, Expression, JSXElementChild } from '@swc/core';
+
+import { extractDefaultValue, extractJSXTextContent, extractKey, qualify, shouldIgnore } from '../duplicate-key-check';
+
+function stringLitArg(value: string): Argument {
+  return {
+    expression: { type: 'StringLiteral', value, raw: `"${value}"`, span: { start: 0, end: 0, ctxt: 0 } } as Expression,
+  };
+}
+
+function objArg(propValue: string): Argument {
+  return {
+    expression: {
+      type: 'ObjectExpression',
+      properties: [
+        {
+          type: 'KeyValueProperty',
+          key: { type: 'Identifier', value: 'defaultValue', optional: false, span: { start: 0, end: 0, ctxt: 0 } },
+          value: {
+            type: 'StringLiteral',
+            value: propValue,
+            raw: `"${propValue}"`,
+            span: { start: 0, end: 0, ctxt: 0 },
+          },
+          span: { start: 0, end: 0, ctxt: 0 },
+        },
+      ],
+      span: { start: 0, end: 0, ctxt: 0 },
+    },
+  } as unknown as Argument;
+}
+
+describe('extractKey', () => {
+  it('returns value from StringLiteral argument', () => {
+    expect(extractKey(stringLitArg('my.key'))).toBe('my.key');
+  });
+
+  it('returns null for dynamic (Identifier) argument', () => {
+    const arg: Argument = {
+      expression: {
+        type: 'Identifier',
+        value: 'someVar',
+        optional: false,
+        span: { start: 0, end: 0, ctxt: 0 },
+      } as Expression,
+    };
+    expect(extractKey(arg)).toBeNull();
+  });
+
+  it('returns null when argument is missing', () => {
+    expect(extractKey(null)).toBeNull();
+  });
+});
+
+describe('extractDefaultValue', () => {
+  it('returns value from string literal second arg', () => {
+    expect(extractDefaultValue(stringLitArg('Default text'))).toBe('Default text');
+  });
+
+  it('returns value from options object defaultValue property', () => {
+    expect(extractDefaultValue(objArg('Default text'))).toBe('Default text');
+  });
+
+  it('returns null when options object has no defaultValue property', () => {
+    const arg = {
+      expression: {
+        type: 'ObjectExpression',
+        properties: [
+          {
+            type: 'KeyValueProperty',
+            key: { type: 'Identifier', value: 'count', optional: false, span: { start: 0, end: 0, ctxt: 0 } },
+            value: { type: 'NumericLiteral', value: 1, span: { start: 0, end: 0, ctxt: 0 } },
+            span: { start: 0, end: 0, ctxt: 0 },
+          },
+        ],
+        span: { start: 0, end: 0, ctxt: 0 },
+      },
+    } as unknown as Argument;
+    expect(extractDefaultValue(arg)).toBeNull();
+  });
+
+  it('returns null when argument is missing', () => {
+    expect(extractDefaultValue(null)).toBeNull();
+  });
+});
+
+describe('extractJSXTextContent', () => {
+  it('returns trimmed text from JSXText children', () => {
+    const children: JSXElementChild[] = [
+      { type: 'JSXText', value: '  Welcome back  ', raw: '  Welcome back  ', span: { start: 0, end: 0, ctxt: 0 } },
+    ];
+    expect(extractJSXTextContent(children)).toBe('Welcome back');
+  });
+
+  it('concatenates JSXText nodes separated by non-string expressions', () => {
+    const children: JSXElementChild[] = [
+      { type: 'JSXText', value: 'Click ', raw: 'Click ', span: { start: 0, end: 0, ctxt: 0 } },
+      {
+        type: 'JSXExpressionContainer',
+        expression: { type: 'JSXEmptyExpression', span: { start: 0, end: 0, ctxt: 0 } },
+        span: { start: 0, end: 0, ctxt: 0 },
+      },
+      { type: 'JSXText', value: 'to continue', raw: 'to continue', span: { start: 0, end: 0, ctxt: 0 } },
+    ];
+    expect(extractJSXTextContent(children)).toBe('Click to continue');
+  });
+
+  it('includes string literal JSXExpressionContainer values inline', () => {
+    const children: JSXElementChild[] = [
+      {
+        type: 'JSXExpressionContainer',
+        expression: {
+          type: 'StringLiteral',
+          value: '{{annoName}}',
+          raw: '"{{annoName}}"',
+          span: { start: 0, end: 0, ctxt: 0 },
+        },
+        span: { start: 0, end: 0, ctxt: 0 },
+      },
+      { type: 'JSXText', value: ' (Built-in)', raw: ' (Built-in)', span: { start: 0, end: 0, ctxt: 0 } },
+    ];
+    expect(extractJSXTextContent(children)).toBe('{{annoName}} (Built-in)');
+  });
+
+  it('returns null when there are no JSXText or string literal expression children', () => {
+    const children: JSXElementChild[] = [
+      {
+        type: 'JSXExpressionContainer',
+        expression: { type: 'JSXEmptyExpression', span: { start: 0, end: 0, ctxt: 0 } },
+        span: { start: 0, end: 0, ctxt: 0 },
+      },
+    ];
+    expect(extractJSXTextContent(children)).toBeNull();
+  });
+});
+
+describe('qualify', () => {
+  it('prepends defaultNS when no separator present', () => {
+    expect(qualify('my.key', ':', 'translation')).toBe('translation:my.key');
+  });
+
+  it('returns key as-is when separator already present', () => {
+    expect(qualify('common:my.key', ':', 'translation')).toBe('common:my.key');
+  });
+
+  it('returns key as-is when nsSep is false', () => {
+    expect(qualify('my.key', false, 'translation')).toBe('my.key');
+  });
+
+  it('returns key as-is when defNS is false', () => {
+    expect(qualify('my.key', ':', false)).toBe('my.key');
+  });
+});
+
+describe('shouldIgnore', () => {
+  it('returns false when key is not in ignore list', () => {
+    expect(shouldIgnore('translation:button.save', ['common:*'])).toBe(false);
+  });
+
+  it('matches exact key', () => {
+    expect(shouldIgnore('translation:button.save', ['translation:button.save'])).toBe(true);
+  });
+
+  it('matches prefix glob', () => {
+    expect(shouldIgnore('common:button.save', ['common:*'])).toBe(true);
+  });
+
+  it('returns false for non-matching prefix glob', () => {
+    expect(shouldIgnore('translation:button.save', ['common:*'])).toBe(false);
+  });
+});

--- a/packages/grafana-i18n/src/plugins/__tests__/integration.test.ts
+++ b/packages/grafana-i18n/src/plugins/__tests__/integration.test.ts
@@ -1,0 +1,79 @@
+import { extract, type I18nextToolkitConfig } from 'i18next-cli';
+import { join } from 'node:path';
+
+import { duplicateKeyCheckPlugin } from '../duplicate-key-check';
+
+const FIXTURES = join(__dirname, 'fixtures');
+
+async function runFixture(name: string): Promise<string[]> {
+  const reportedConflicts: string[] = [];
+
+  const config: I18nextToolkitConfig = {
+    locales: ['en-US'],
+    extract: {
+      input: [join(FIXTURES, name, 'src/**/*.{ts,tsx}')],
+      output: join(FIXTURES, name, '.out/{{language}}/{{namespace}}.json'),
+      defaultNS: 'grafana',
+      functions: ['t', '*.t'],
+      transComponents: ['Trans'],
+    },
+    plugins: [
+      duplicateKeyCheckPlugin({
+        failOnConflict: false,
+      }),
+    ],
+  };
+
+  const original = console.warn;
+  console.warn = (msg: string) => {
+    const keyMatches = msg.matchAll(/Key: "([^"]+)"/g);
+    for (const m of keyMatches) {
+      reportedConflicts.push(m[1]);
+    }
+  };
+
+  try {
+    await extract(config);
+  } finally {
+    console.warn = original;
+  }
+
+  return reportedConflicts.sort();
+}
+
+describe('duplicate-key-check plugin', () => {
+  it('reports no conflicts when all defaults match', async () => {
+    const conflicts = await runFixture('no-conflict');
+    expect(conflicts).toEqual([]);
+  });
+
+  it('reports conflict for t() calls with different defaults', async () => {
+    const conflicts = await runFixture('simple-t-conflict');
+    expect(conflicts).toEqual(['grafana:button.save']);
+  });
+
+  it('reports conflict for Trans components with different children', async () => {
+    const conflicts = await runFixture('trans-conflict');
+    expect(conflicts).toEqual(['grafana:welcome']);
+  });
+
+  it('reports conflict when t() and Trans disagree on the same key', async () => {
+    const conflicts = await runFixture('mixed-conflict');
+    expect(conflicts).toEqual(['grafana:welcome']);
+  });
+
+  it('reports conflict when t() and Trans disagree on the same key', async () => {
+    const conflicts = await runFixture('advanced-mixed-conflict');
+    expect(conflicts).toEqual([]);
+  });
+
+  it('ignores t() calls with no defaultValue', async () => {
+    const conflicts = await runFixture('no-default');
+    expect(conflicts).toEqual([]);
+  });
+
+  it('handles explicit namespace prefixes and does not cross namespaces', async () => {
+    const conflicts = await runFixture('namespace-explicit');
+    expect(conflicts).toEqual(['common:button.save']);
+  });
+});

--- a/packages/grafana-i18n/src/plugins/duplicate-key-check.ts
+++ b/packages/grafana-i18n/src/plugins/duplicate-key-check.ts
@@ -1,0 +1,258 @@
+import type { CallExpression, JSXAttribute, JSXElement, Node, StringLiteral } from '@swc/core';
+import type { ExtractedKeysMap, I18nextToolkitConfig, Plugin } from 'i18next-cli';
+
+import {
+  isCallExpression,
+  isIdentifier,
+  isJSXAttribute,
+  isJSXElement,
+  isJSXExpressionContainer,
+  isJSXText,
+  isKeyValueProperty,
+  isObjectExpression,
+  isStringLiteral,
+} from './guards';
+import { DuplicateKeyCheckOptions, Occurrence } from './types';
+
+export function getStringValue(expr: StringLiteral | null | undefined): string | null {
+  if (isStringLiteral(expr)) {
+    return expr.value;
+  }
+
+  return null;
+}
+
+export function getCalleeName(callee: CallExpression['callee']): string | null {
+  if (isIdentifier(callee)) {
+    return callee.value;
+  }
+
+  return null;
+}
+
+export function extractKey(arg: { expression: Node } | null | undefined): string | null {
+  if (isStringLiteral(arg?.expression)) {
+    return arg.expression.value;
+  }
+
+  return null;
+}
+
+export function extractDefaultValue(arg: { expression: Node } | null | undefined): string | null {
+  const expr = arg?.expression;
+
+  if (isStringLiteral(expr)) {
+    return expr.value;
+  }
+
+  if (isObjectExpression(expr)) {
+    const prop = expr.properties.find(
+      (p) => isKeyValueProperty(p) && (isIdentifier(p.key) || isStringLiteral(p.key)) && p.key.value === 'defaultValue'
+    );
+
+    if (!prop) {
+      return null;
+    }
+
+    if (isKeyValueProperty(prop) && isStringLiteral(prop.value)) {
+      return prop.value.value;
+    }
+
+    return null;
+  }
+
+  return null;
+}
+
+export function extractJSXTextContent(children: JSXElement['children']): string | null {
+  const parts: string[] = [];
+  for (const child of children) {
+    if (isJSXText(child)) {
+      const normalized = child.value.replace(/\s+/g, ' ');
+      if (normalized.trim()) {
+        parts.push(normalized);
+      }
+      continue;
+    }
+
+    if (isJSXExpressionContainer(child) && isStringLiteral(child.expression)) {
+      parts.push(child.expression.value);
+      continue;
+    }
+  }
+  const combined = parts.join('').trim();
+  return combined || null;
+}
+
+export function qualify(
+  rawKey: string,
+  nsSep: string | false | null | undefined,
+  defNS: string | false | undefined
+): string {
+  const sep = nsSep === undefined || nsSep === null ? ':' : nsSep;
+  const ns = defNS === undefined ? 'translation' : defNS;
+  if (!sep || !ns) {
+    return rawKey;
+  }
+  return rawKey.includes(sep) ? rawKey : `${ns}${sep}${rawKey}`;
+}
+
+export function shouldIgnore(qualifiedKey: string, ignoreKeys: string[]): boolean {
+  return ignoreKeys.some((pattern) => {
+    if (pattern.endsWith('*')) {
+      return qualifiedKey.startsWith(pattern.slice(0, -1));
+    }
+    return qualifiedKey === pattern;
+  });
+}
+
+export function formatConflictReport(conflicts: Array<{ key: string; occurrences: Occurrence[] }>): string {
+  const lines: string[] = [
+    `\n[duplicate-key-check] Found ${conflicts.length} key(s) with conflicting default values:\n`,
+  ];
+
+  for (const { key, occurrences } of conflicts) {
+    lines.push(`  Key: "${key}"`);
+    const byValue = new Map<string, string[]>();
+    for (const occ of occurrences) {
+      const files = byValue.get(occ.value) ?? [];
+      files.push(occ.file);
+      byValue.set(occ.value, files);
+    }
+    for (const [value, files] of byValue.entries()) {
+      lines.push(`    Value: "${value}"`);
+      for (const file of files) {
+        lines.push(`      at ${file}`);
+      }
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+export function duplicateKeyCheckPlugin(options: DuplicateKeyCheckOptions = {}): Plugin {
+  const { failOnConflict = false, conflictThreshold = 2, ignoreKeys = [] } = options;
+
+  let registry = new Map<string, Occurrence[]>();
+  let currentFile = '';
+  let nsSep: string | false | null = ':';
+  let defNS: string | false = 'translation';
+  let tFunctions = new Set<string>(['t']);
+  let transComponents = new Set<string>(['Trans']);
+  let configRead = false;
+
+  function readConfig(config: I18nextToolkitConfig): void {
+    if (configRead) {
+      return;
+    }
+    configRead = true;
+    nsSep = config.extract?.nsSeparator ?? ':';
+    defNS = config.extract?.defaultNS ?? 'translation';
+    transComponents = new Set(config.extract?.transComponents ?? ['Trans']);
+    const fns = config.extract?.functions ?? ['t'];
+    tFunctions = new Set(fns.filter((fn) => !fn.includes('.') && !fn.startsWith('*')));
+  }
+
+  function recordOccurrence(qualifiedKey: string, value: string): void {
+    if (shouldIgnore(qualifiedKey, ignoreKeys)) {
+      return;
+    }
+    const existing = registry.get(qualifiedKey) ?? [];
+    existing.push({ value, file: currentFile });
+    registry.set(qualifiedKey, existing);
+  }
+
+  return {
+    name: 'duplicate-key-check',
+
+    setup() {
+      registry = new Map();
+      currentFile = '';
+      configRead = false;
+    },
+
+    onLoad(code: string, path: string): string {
+      currentFile = path;
+      return code;
+    },
+
+    onVisitNode(node: Node, context) {
+      readConfig(context.config);
+
+      if (isCallExpression(node)) {
+        const calleeName = getCalleeName(node.callee);
+        if (!calleeName || !tFunctions.has(calleeName)) {
+          return;
+        }
+
+        const args = node.arguments;
+        const rawKey = extractKey(args[0] ?? null);
+        const defaultValue = extractDefaultValue(args[1] ?? null);
+        if (!rawKey || !defaultValue) {
+          return;
+        }
+
+        recordOccurrence(qualify(rawKey, nsSep, defNS), defaultValue);
+        return;
+      }
+
+      if (isJSXElement(node)) {
+        if (!isIdentifier(node.opening.name)) {
+          return;
+        }
+
+        const componentName = node.opening.name.value;
+        if (!transComponents.has(componentName)) {
+          return;
+        }
+
+        const i18nKeyAttr = node.opening.attributes.find(
+          (attr): attr is JSXAttribute =>
+            isJSXAttribute(attr) && isIdentifier(attr.name) && attr.name.value === 'i18nKey'
+        );
+
+        if (!i18nKeyAttr?.value) {
+          return;
+        }
+
+        if (!isStringLiteral(i18nKeyAttr.value)) {
+          return;
+        }
+
+        const rawKey = i18nKeyAttr.value.value;
+        const textContent = extractJSXTextContent(node.children);
+        if (!textContent) {
+          return;
+        }
+
+        recordOccurrence(qualify(rawKey, nsSep, defNS), textContent);
+        return;
+      }
+    },
+
+    async onEnd(_keys: ExtractedKeysMap) {
+      const conflicts: Array<{ key: string; occurrences: Occurrence[] }> = [];
+
+      for (const [qualifiedKey, occurrences] of registry.entries()) {
+        const uniqueValues = new Set(occurrences.map((o) => o.value));
+        if (uniqueValues.size >= conflictThreshold) {
+          conflicts.push({ key: qualifiedKey, occurrences });
+        }
+      }
+
+      registry = new Map();
+
+      if (conflicts.length === 0) {
+        return;
+      }
+
+      const report = formatConflictReport(conflicts);
+      if (failOnConflict) {
+        throw new Error(report);
+      } else {
+        console.warn(report);
+      }
+    },
+  };
+}

--- a/packages/grafana-i18n/src/plugins/guards.ts
+++ b/packages/grafana-i18n/src/plugins/guards.ts
@@ -1,0 +1,48 @@
+import type {
+  CallExpression,
+  Identifier,
+  JSXAttribute,
+  JSXElement,
+  JSXExpressionContainer,
+  JSXText,
+  KeyValueProperty,
+  Node,
+  ObjectExpression,
+  StringLiteral,
+} from '@swc/core';
+
+export function isIdentifier(node: Node | null | undefined): node is Identifier {
+  return node?.type === 'Identifier';
+}
+
+export function isStringLiteral(node: Node | null | undefined): node is StringLiteral {
+  return node?.type === 'StringLiteral';
+}
+
+export function isObjectExpression(node: Node | null | undefined): node is ObjectExpression {
+  return node?.type === 'ObjectExpression';
+}
+
+export function isKeyValueProperty(node: Node | null | undefined): node is KeyValueProperty {
+  return node?.type === 'KeyValueProperty';
+}
+
+export function isJSXText(node: Node | null | undefined): node is JSXText {
+  return node?.type === 'JSXText';
+}
+
+export function isJSXExpressionContainer(node: Node | null | undefined): node is JSXExpressionContainer {
+  return node?.type === 'JSXExpressionContainer';
+}
+
+export function isJSXElement(node: Node | null | undefined): node is JSXElement {
+  return node?.type === 'JSXElement';
+}
+
+export function isJSXAttribute(node: Node | null | undefined): node is JSXAttribute {
+  return node?.type === 'JSXAttribute';
+}
+
+export function isCallExpression(node: Node | null | undefined): node is CallExpression {
+  return node?.type === 'CallExpression';
+}

--- a/packages/grafana-i18n/src/plugins/types.ts
+++ b/packages/grafana-i18n/src/plugins/types.ts
@@ -1,0 +1,10 @@
+export interface DuplicateKeyCheckOptions {
+  failOnConflict?: boolean;
+  conflictThreshold?: number;
+  ignoreKeys?: string[];
+}
+
+export interface Occurrence {
+  value: string;
+  file: string;
+}

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
@@ -328,7 +328,9 @@ function ImportWizardContent() {
 
       setTimeout(() => {
         setShowConfirmModal(false);
-        notifyApp.success(t('alerting.import-to-gma.success', 'Successfully imported resources to Grafana Alerting.'));
+        notifyApp.success(
+          t('alerting.import-to-gma.success', 'Successfully imported alert rules to Grafana-managed rules.')
+        );
         locationService.push(ruleListUrl);
       }, 1500);
     } catch (err) {
@@ -337,7 +339,11 @@ function ImportWizardContent() {
         notificationsSource: willImportNotifications ? values.notificationsSource : undefined,
         rulesSource: willImportRules ? values.rulesSource : undefined,
       });
-      notifyApp.error(t('alerting.import-to-gma.error', 'Failed to import resources'), stringifyErrorLike(err));
+      notifyApp.error(
+        t('alerting.import-to-gma.error', 'Failed to import alert rules: {{error}}', {
+          error: stringifyErrorLike(err),
+        })
+      );
     }
   }, [getValues, importNotifications, importRules, rulesFromDatasource, notifyApp]);
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.tsx
@@ -44,10 +44,10 @@ export function LegacyEmptyTransformationsMessage({ onShowPicker }: { onShowPick
     <Box alignItems="center" padding={4}>
       <Stack direction="column" alignItems="center" gap={2}>
         <Text element="h3" textAlignment="center">
-          <Trans i18nKey="transformations.empty.add-transformation-header">Start transforming data</Trans>
+          <Trans i18nKey="transformations.legacy.empty.add-transformation-header">Start transforming data</Trans>
         </Text>
         <Text element="p" textAlignment="center" data-testid={selectors.components.Transforms.noTransformationsMessage}>
-          <Trans i18nKey="transformations.empty.add-transformation-body">
+          <Trans i18nKey="transformations.legacy.empty.add-transformation-body">
             Transformations allow data to be changed in various ways before your visualization is shown.
             <br />
             This includes joining data together, renaming fields, making calculations, formatting data for display, and
@@ -61,7 +61,9 @@ export function LegacyEmptyTransformationsMessage({ onShowPicker }: { onShowPick
           onClick={onShowPicker}
           data-testid={selectors.components.Transforms.addTransformationButton}
         >
-          <Trans i18nKey="dashboard-scene.empty-transformations-message.add-transformation">Add transformation</Trans>
+          <Trans i18nKey="dashboard-scene.legacy.empty-transformations-message.add-transformation">
+            Add transformation
+          </Trans>
         </Button>
       </Stack>
     </Box>
@@ -118,10 +120,10 @@ export function NewEmptyTransformationsMessage(props: EmptyTransformationsProps)
         {showHeaderText && (
           <Stack direction="column" alignItems="start" gap={1}>
             <Text element="h3" textAlignment="start">
-              <Trans i18nKey="transformations.empty.add-transformation-header">Add a Transformation</Trans>
+              <Trans i18nKey="transformations.new.empty.add-transformation-header">Add a Transformation</Trans>
             </Text>
             <Text element="p" textAlignment="start" color="secondary">
-              <Trans i18nKey="transformations.empty.add-transformation-body">
+              <Trans i18nKey="transformations.new.empty.add-transformation-body">
                 Transformations allow data to be changed in various ways before your visualization is shown.
                 <br />
                 This includes joining data together, renaming fields, making calculations, formatting data for display,

--- a/public/app/features/dashboard-scene/scene/dashboard-filters-overview/FiltersOverviewRow.tsx
+++ b/public/app/features/dashboard-scene/scene/dashboard-filters-overview/FiltersOverviewRow.tsx
@@ -103,10 +103,10 @@ export const FilterRow = memo(
         <div className={styles.valueCell}>
           {isMultiOperator ? (
             <MultiCombobox
-              aria-label={t('dashboard.filters-overview.value', 'Value')}
+              aria-label={t('dashboard.filters-overview.multi.value', 'Value')}
               options={(inputValue: string) => getValueOptions(keyValue, operatorValue, inputValue)}
               value={multiValues}
-              placeholder={t('dashboard.filters-overview.value.placeholder', 'Select values')}
+              placeholder={t('dashboard.filters-overview.multi.value.placeholder', 'Select values')}
               isClearable={true}
               onChange={(selections: Array<ComboboxOption<string>>) => {
                 onMultiValuesChange(
@@ -117,10 +117,10 @@ export const FilterRow = memo(
             />
           ) : (
             <Combobox
-              aria-label={t('dashboard.filters-overview.value', 'Value')}
+              aria-label={t('dashboard.filters-overview.single.value', 'Value')}
               options={(inputValue: string) => getValueOptions(keyValue, operatorValue, inputValue)}
               value={singleValue ? { label: singleValue, value: singleValue } : null}
-              placeholder={t('dashboard.filters-overview.value.placeholder', 'Select value')}
+              placeholder={t('dashboard.filters-overview.single.value.placeholder', 'Select value')}
               isClearable={true}
               onChange={(selection: ComboboxOption<string> | null) => {
                 onSingleValueChange(keyValue, selection?.value ?? '');

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/CommunityDashboardSection.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/CommunityDashboardSection.tsx
@@ -303,7 +303,10 @@ export const CommunityDashboardSection = ({ onShowMapping, datasourceType }: Pro
         ) : showError ? (
           <Stack direction="column" alignItems="center" gap={2}>
             <Alert
-              title={t('dashboard-library.community-error-title', 'Error loading community dashboards')}
+              title={t(
+                'dashboard-library.community-dashboard-section.community-error-title',
+                'Error loading community dashboards'
+              )}
               severity="error"
             >
               <Trans i18nKey="dashboard-library.community-error">

--- a/public/app/features/provisioning/Shared/RepositoryList.tsx
+++ b/public/app/features/provisioning/Shared/RepositoryList.tsx
@@ -69,7 +69,7 @@ export function RepositoryList({ items }: Props) {
             {isFreeTierLicense() && (
               <>
                 <br />
-                <Trans i18nKey="provisioning.free-tier-limit.message-connection">
+                <Trans i18nKey="provisioning.folder-repository-list.free-tier-limit.message-connection">
                   Free-tier accounts are limited to 20 resources per folder. To add more resources per folder,
                 </Trans>{' '}
                 <TextLink href={UPGRADE_URL} external>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1627,7 +1627,7 @@
         "label": "Data source",
         "required-message": "Please select a data source"
       },
-      "error": "Failed to import resources",
+      "error": "Failed to import alert rules: {{error}}",
       "group": {
         "description": "Type to search for an existing group",
         "label": "Group"
@@ -1777,7 +1777,7 @@
         "yaml-file": "Rules YAML file",
         "yaml-required": "Please select a file"
       },
-      "success": "Successfully imported resources to Grafana Alerting.",
+      "success": "Successfully imported alert rules to Grafana-managed rules.",
       "target-folder": {
         "description": "The folder to import the rules to",
         "label": "Target folder"
@@ -5440,13 +5440,18 @@
       "empty": "No labels available",
       "groupby": "GroupBy",
       "missing-adhoc": "No ad hoc filters available",
+      "multi": {
+        "value": "Value"
+      },
       "operator": "Operator",
       "search": {
         "aria-label": "Search filters",
         "placeholder": "Search..."
       },
-      "title": "Edit filters",
-      "value": "Value"
+      "single": {
+        "value": "Value"
+      },
+      "title": "Edit filters"
     },
     "gen-aihistory": {
       "aria-label-send-custom-feedback": "Send custom feedback",
@@ -6295,6 +6300,9 @@
       "use-dashboard-button": "Use dashboard",
       "view-template-button": "View template"
     },
+    "community-dashboard-section": {
+      "community-error-title": "Error loading community dashboards"
+    },
     "community-empty-title": "No community dashboards found",
     "community-empty-title-with-datasource": "No {{datasourceType}} community dashboards found",
     "community-error": "Failed to load community dashboards. Please try again.",
@@ -6639,7 +6647,6 @@
       }
     },
     "empty-transformations-message": {
-      "add-transformation": "Add transformation",
       "show-more": "Show more",
       "sql-name": "Transform with SQL",
       "sql-transformation-description": "Manipulate your data using MySQL-like syntax"
@@ -6785,6 +6792,11 @@
         "would-still-dashboard": "Would you still like to save this dashboard?"
       },
       "save-and-overwrite": "Save and overwrite"
+    },
+    "legacy": {
+      "empty-transformations-message": {
+        "add-transformation": "Add transformation"
+      }
     },
     "library-viz-panel-info": {
       "last-edited": "{{timeAgo}} by <person />",
@@ -7340,8 +7352,9 @@
       "title": "Versions"
     }
   },
+  "dashboard.filters-overview.multi.value.placeholder": "Select values",
   "dashboard.filters-overview.operator.placeholder": "Select operator",
-  "dashboard.filters-overview.value.placeholder": "Select values",
+  "dashboard.filters-overview.single.value.placeholder": "Select value",
   "dashboards": {
     "filters-overview": {
       "all-filters": "All filters",
@@ -12672,6 +12685,9 @@
     "folder-repository-list": {
       "all-resources-managed_one": "All {{count}} resources are managed",
       "all-resources-managed_other": "All {{count}} resources are managed",
+      "free-tier-limit": {
+        "message-connection": "Free-tier accounts are limited to 20 resources per folder. To add more resources per folder,"
+      },
       "no-results-matching-your-query": "No results matching your query",
       "partial-managed": "{{managedCount}}/{{resourceCount}} resources managed by Git sync.",
       "placeholder-search": "Search",
@@ -12680,7 +12696,7 @@
     },
     "free-tier-limit": {
       "message": "Free-tier accounts are capped to 1 connection, and 20 resources per folder",
-      "message-connection": "Free-tier accounts are limited to 20 resources per folder. To add more resources per folder,",
+      "message-connection": "Free-tier accounts are limited to 1 connection. To add more connections,",
       "message-resource": "Free-tier accounts are limited to 20 resources per folder. To add more resources,",
       "note": "Note:",
       "upgrade-link": "upgrade your account"
@@ -14657,9 +14673,17 @@
     "no-transformation-editor-title": "Transformation does not have an editor component"
   },
   "transformations": {
-    "empty": {
-      "add-transformation-body": "Transformations allow data to be changed in various ways before your visualization is shown.<br />This includes joining data together, renaming fields, making calculations, formatting data for display, and more.",
-      "add-transformation-header": "Start transforming data"
+    "legacy": {
+      "empty": {
+        "add-transformation-body": "Transformations allow data to be changed in various ways before your visualization is shown.<br />This includes joining data together, renaming fields, making calculations, formatting data for display, and more.",
+        "add-transformation-header": "Start transforming data"
+      }
+    },
+    "new": {
+      "empty": {
+        "add-transformation-body": "Transformations allow data to be changed in various ways before your visualization is shown.<br />This includes joining data together, renaming fields, making calculations, formatting data for display, and more.",
+        "add-transformation-header": "Add a Transformation"
+      }
     }
   },
   "transformers": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3679,11 +3679,13 @@ __metadata:
   resolution: "@grafana/i18n@workspace:packages/grafana-i18n"
   dependencies:
     "@formatjs/intl-durationformat": "npm:^0.7.0"
+    "@swc/core": "npm:^1.0.0"
     "@types/react": "npm:18.3.18"
     "@typescript-eslint/utils": "npm:^8.33.1"
     fast-deep-equal: "npm:^3.1.3"
     i18next: "npm:^25.0.0"
     i18next-browser-languagedetector: "npm:^8.0.0"
+    i18next-cli: "npm:^1.24.22"
     i18next-pseudo: "npm:^2.2.1"
     micro-memoize: "npm:^4.1.2"
     react-i18next: "npm:^15.0.0"
@@ -9748,6 +9750,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-darwin-arm64@npm:1.15.18":
+  version: 1.15.18
+  resolution: "@swc/core-darwin-arm64@npm:1.15.18"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@swc/core-darwin-arm64@npm:1.15.2":
   version: 1.15.2
   resolution: "@swc/core-darwin-arm64@npm:1.15.2"
@@ -9765,6 +9774,13 @@ __metadata:
 "@swc/core-darwin-x64@npm:1.13.3":
   version: 1.13.3
   resolution: "@swc/core-darwin-x64@npm:1.13.3"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core-darwin-x64@npm:1.15.18":
+  version: 1.15.18
+  resolution: "@swc/core-darwin-x64@npm:1.15.18"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -9790,6 +9806,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-arm-gnueabihf@npm:1.15.18":
+  version: 1.15.18
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.15.18"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@swc/core-linux-arm-gnueabihf@npm:1.15.2":
   version: 1.15.2
   resolution: "@swc/core-linux-arm-gnueabihf@npm:1.15.2"
@@ -9807,6 +9830,13 @@ __metadata:
 "@swc/core-linux-arm64-gnu@npm:1.13.3":
   version: 1.13.3
   resolution: "@swc/core-linux-arm64-gnu@npm:1.13.3"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-gnu@npm:1.15.18":
+  version: 1.15.18
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.15.18"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -9832,6 +9862,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-arm64-musl@npm:1.15.18":
+  version: 1.15.18
+  resolution: "@swc/core-linux-arm64-musl@npm:1.15.18"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@swc/core-linux-arm64-musl@npm:1.15.2":
   version: 1.15.2
   resolution: "@swc/core-linux-arm64-musl@npm:1.15.2"
@@ -9849,6 +9886,13 @@ __metadata:
 "@swc/core-linux-x64-gnu@npm:1.13.3":
   version: 1.13.3
   resolution: "@swc/core-linux-x64-gnu@npm:1.13.3"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-gnu@npm:1.15.18":
+  version: 1.15.18
+  resolution: "@swc/core-linux-x64-gnu@npm:1.15.18"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -9874,6 +9918,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-x64-musl@npm:1.15.18":
+  version: 1.15.18
+  resolution: "@swc/core-linux-x64-musl@npm:1.15.18"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@swc/core-linux-x64-musl@npm:1.15.2":
   version: 1.15.2
   resolution: "@swc/core-linux-x64-musl@npm:1.15.2"
@@ -9891,6 +9942,13 @@ __metadata:
 "@swc/core-win32-arm64-msvc@npm:1.13.3":
   version: 1.13.3
   resolution: "@swc/core-win32-arm64-msvc@npm:1.13.3"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-arm64-msvc@npm:1.15.18":
+  version: 1.15.18
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.15.18"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -9916,6 +9974,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-win32-ia32-msvc@npm:1.15.18":
+  version: 1.15.18
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.15.18"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@swc/core-win32-ia32-msvc@npm:1.15.2":
   version: 1.15.2
   resolution: "@swc/core-win32-ia32-msvc@npm:1.15.2"
@@ -9933,6 +9998,13 @@ __metadata:
 "@swc/core-win32-x64-msvc@npm:1.13.3":
   version: 1.13.3
   resolution: "@swc/core-win32-x64-msvc@npm:1.13.3"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-x64-msvc@npm:1.15.18":
+  version: 1.15.18
+  resolution: "@swc/core-win32-x64-msvc@npm:1.15.18"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -10040,6 +10112,52 @@ __metadata:
     "@swc/helpers":
       optional: true
   checksum: 10/55c112b2d3ff098efd1d2d941ec8fc8ddbcd81c53ede67bcaa28d176a711fb39a250a63a627104f0c2f6f764e41f78eeb72edb5300c6d98cbbaf97cce84927a9
+  languageName: node
+  linkType: hard
+
+"@swc/core@npm:^1.0.0":
+  version: 1.15.18
+  resolution: "@swc/core@npm:1.15.18"
+  dependencies:
+    "@swc/core-darwin-arm64": "npm:1.15.18"
+    "@swc/core-darwin-x64": "npm:1.15.18"
+    "@swc/core-linux-arm-gnueabihf": "npm:1.15.18"
+    "@swc/core-linux-arm64-gnu": "npm:1.15.18"
+    "@swc/core-linux-arm64-musl": "npm:1.15.18"
+    "@swc/core-linux-x64-gnu": "npm:1.15.18"
+    "@swc/core-linux-x64-musl": "npm:1.15.18"
+    "@swc/core-win32-arm64-msvc": "npm:1.15.18"
+    "@swc/core-win32-ia32-msvc": "npm:1.15.18"
+    "@swc/core-win32-x64-msvc": "npm:1.15.18"
+    "@swc/counter": "npm:^0.1.3"
+    "@swc/types": "npm:^0.1.25"
+  peerDependencies:
+    "@swc/helpers": ">=0.5.17"
+  dependenciesMeta:
+    "@swc/core-darwin-arm64":
+      optional: true
+    "@swc/core-darwin-x64":
+      optional: true
+    "@swc/core-linux-arm-gnueabihf":
+      optional: true
+    "@swc/core-linux-arm64-gnu":
+      optional: true
+    "@swc/core-linux-arm64-musl":
+      optional: true
+    "@swc/core-linux-x64-gnu":
+      optional: true
+    "@swc/core-linux-x64-musl":
+      optional: true
+    "@swc/core-win32-arm64-msvc":
+      optional: true
+    "@swc/core-win32-ia32-msvc":
+      optional: true
+    "@swc/core-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@swc/helpers":
+      optional: true
+  checksum: 10/ef198b9feb6eee034e3a912c37988ece2885fec35419e8245d467adbc1fc47a5c3e61869d1bdbe6fff76cbd9186ef278120cbb9746d5f7446576f4a7f15c2dcd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What is this PR?

Implements an i18next-cli plugin that detects conflicting i18n keys where the same translation key is used with different default values across the codebase.

## Why do we need this?

Translation keys should be consistent - if the same key (e.g., `grafana:button.save`) is used in multiple places, it should always have the same default string. Inconsistent defaults can lead to:
- Confusion for translators
- Unexpected user-facing text if translations are missing
- Hard-to-debug i18n issues

This plugin catches these issues at extraction time rather than in production.

## How does it work?

The `duplicate-key-check` plugin:
- Tracks all `t()` calls with default values
- Tracks all `<Trans>` components with `i18nKey` and text content
- Handles JSX expression containers with string literals (e.g., `{'{{variable}}'}`)
- Normalizes JSX text whitespace to handle different indentation levels
- Detects when the same key is used with multiple different default values
- Reports conflicts with file locations and both versions of the text
- Can fail the build on conflicts (via `failOnConflict: true` config)

## Test coverage

Includes 26 tests covering:
- Simple `t()` conflicts
- `<Trans>` component conflicts  
- Mixed `t()` and `<Trans>` usage of the same key
- Namespace-scoped keys (e.g., `common:button.save`)
- Keys with no default values (correctly ignored)
- Whitespace normalization across different indentation levels

## Next steps

- [ ] Review the plugin implementation
- [ ] Check test fixture coverage
- [ ] Verify integration with existing i18n pipeline
- [ ] Consider adding to CI/CD to detect conflicts on every PR

FIxes: #118130

🤖 Generated with [Claude Code](https://claude.com/claude-code)