### PR TITLE
ThresholdsEditor: Don't steal focus on mount

### DIFF
--- a/public/app/features/dimensions/editors/ThresholdsEditor/ThresholdsEditor.test.tsx
+++ b/public/app/features/dimensions/editors/ThresholdsEditor/ThresholdsEditor.test.tsx
@@ -167,6 +167,20 @@ describe('ThresholdsEditor', () => {
     expect(screen.getByRole('spinbutton', { name: 'Threshold 2' })).toHaveValue(75);
   });
 
+  it('should not steal focus on mount', () => {
+    setup({
+      thresholds: {
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: '#7EB26D' },
+          { value: 50, color: '#EAB839' },
+        ],
+      },
+    });
+
+    expect(document.body).toHaveFocus();
+  });
+
   it('should exclude invalid steps and render a proper list', () => {
     setup({
       thresholds: {

--- a/public/app/features/dimensions/editors/ThresholdsEditor/ThresholdsEditor.tsx
+++ b/public/app/features/dimensions/editors/ThresholdsEditor/ThresholdsEditor.tsx
@@ -25,10 +25,14 @@ export const ThresholdsEditor = memo(function ThresholdsEditor({ thresholds, onC
     return steps;
   });
   const latestThresholdInputRef = useRef<HTMLInputElement>(null);
+  const isMounted = useRef(false);
   const styles = useStyles2(getStyles);
 
   useEffect(() => {
-    latestThresholdInputRef.current?.focus();
+    if (isMounted.current) {
+      latestThresholdInputRef.current?.focus();
+    }
+    isMounted.current = true;
   }, [steps.length]);
 
   function fireOnChange(newSteps: ThresholdWithKey[]) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- only focus the latest input when the steps change after initial mount
- add a test 

**Why do we need this feature?**

- prevent `ThresholdsEditor` stealing focus on mount

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
