### PR TITLE
Folders: Fix dashboard load failure when user lacks folder access with foldersAppPlatformAPI enabled

### DIFF
--- a/public/app/api/clients/folder/v1beta1/hooks.test.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.test.ts
@@ -16,6 +16,7 @@ import {
   useGetFolderQueryFacade,
   useDeleteMultipleFoldersMutationFacade,
   useMoveMultipleFoldersMutationFacade,
+  getFolderByUidFacade,
 } from './hooks';
 import { setupCreateFolder, setupUpdateFolder } from './test-utils';
 
@@ -46,6 +47,7 @@ const dispatchMockFn = jest.fn();
 jest.mock('../../../../types/store', () => {
   return {
     ...jest.requireActual('../../../../types/store'),
+    dispatch: (...args: unknown[]) => dispatchMockFn(...args),
     useDispatch: () => dispatchMockFn,
   };
 });
@@ -287,5 +289,44 @@ describe.each([
 
       expect(await screen.findByText('Folder updated')).toBeInTheDocument();
     });
+  });
+});
+
+describe('getFolderByUidFacade', () => {
+  afterEach(() => {
+    config.featureToggles = originalToggles;
+    dispatchMockFn.mockReset();
+  });
+
+  it('throws the original error with HTTP status when folder API returns 403 and foldersAppPlatformAPI is enabled', async () => {
+    config.featureToggles.foldersAppPlatformAPI = true;
+
+    const fetchError = { status: 403, data: { message: 'Forbidden' } };
+    dispatchMockFn
+      .mockResolvedValueOnce({ error: fetchError, data: undefined })
+      .mockResolvedValueOnce({ error: fetchError, data: undefined })
+      .mockResolvedValueOnce({ error: fetchError, data: undefined });
+
+    await expect(getFolderByUidFacade('some-folder-uid')).rejects.toHaveProperty('status', 403);
+  });
+
+  it('throws the original error with HTTP status when folder API returns 403 and foldersAppPlatformAPI is disabled', async () => {
+    config.featureToggles.foldersAppPlatformAPI = false;
+
+    const fetchError = { status: 403, data: { message: 'Forbidden' } };
+    dispatchMockFn.mockResolvedValueOnce({ error: fetchError, data: undefined });
+
+    await expect(getFolderByUidFacade('some-folder-uid')).rejects.toHaveProperty('status', 403);
+  });
+
+  it('throws a generic error when all responses are undefined and no error is available', async () => {
+    config.featureToggles.foldersAppPlatformAPI = true;
+
+    dispatchMockFn
+      .mockResolvedValueOnce({ data: undefined })
+      .mockResolvedValueOnce({ data: undefined })
+      .mockResolvedValueOnce({ data: undefined });
+
+    await expect(getFolderByUidFacade('some-folder-uid')).rejects.toThrow('One of the folder responses is undefined');
   });
 });

--- a/public/app/api/clients/folder/v1beta1/hooks.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.ts
@@ -150,7 +150,8 @@ export async function getFolderByUidFacade(uid: string) {
     const [legacyFolderResponse, folderResponse, parentsResponse] = responses;
 
     if (!folderResponse?.data || !legacyFolderResponse?.data || !parentsResponse?.data) {
-      throw new Error('One of the folder responses is undefined');
+      const error = legacyFolderResponse?.error || ('error' in parentsResponse ? parentsResponse.error : undefined);
+      throw error || new Error('One of the folder responses is undefined');
     }
 
     const userKeys = getUserKeys(folderResponse.data);

--- a/public/app/api/clients/folder/v1beta1/hooks.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.ts
@@ -150,7 +150,13 @@ export async function getFolderByUidFacade(uid: string) {
     const [legacyFolderResponse, folderResponse, parentsResponse] = responses;
 
     if (!folderResponse?.data || !legacyFolderResponse?.data || !parentsResponse?.data) {
-      const error = legacyFolderResponse?.error || ('error' in parentsResponse ? parentsResponse.error : undefined);
+      // Throw the original error (with HTTP status) so callers can detect e.g. 403 and
+      // gracefully continue — this handles the case when a user has access to a dashboard
+      // but not to the containing folder.
+      const error =
+        ('error' in folderResponse ? folderResponse.error : undefined) ||
+        legacyFolderResponse?.error ||
+        ('error' in parentsResponse ? parentsResponse.error : undefined);
       throw error || new Error('One of the folder responses is undefined');
     }
 


### PR DESCRIPTION
When `foldersAppPlatformAPI` is enabled, `getFolderByUidFacade` makes 3 parallel folder API calls. If the user has dashboard-level access but no folder access, all 3 return 403 with `data: undefined`. The function then throws `new Error('One of the folder responses is undefined')` — a plain `Error` with no HTTP status.

The callers in `v1.ts`/`v2.ts` use `getStatusFromError(e)` to detect 403 and gracefully continue without folder metadata. But `getStatusFromError` returns `undefined` for `Error` instances, so `undefined !== 403` causes it to throw `"Failed to load folder"` and abort the dashboard load.

**Fix**: Throw the original `FetchError` from the RTK Query response (which carries `status: 403`) instead of a generic `Error`. This restores the 403 detection that PR #109160 relies on, and the dashboard renders normally without folder metadata.