### PR TITLE
Docs: restore SQL expressions regex compatibility limitations

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -243,6 +243,7 @@ During conversion:
 ### Regular expression compatibility
 
 Regular expressions in SQL expressions aren't fully compatible with MySQL standards.
+This is because Grafana runs SQL expressions in a CGo-free configuration, which uses regular expression behavior that differs from MySQL in some cases.
 
 SQL expressions that use regular expression functions have limitations such as:
 
@@ -251,6 +252,8 @@ SQL expressions that use regular expression functions have limitations such as:
 - Differences in handling carriage return (`\r`) characters.
 
 There may be other minor differences as well.
+
+For implementation context, refer to the [`go-mysql-server` regex compatibility notes](https://github.com/grafana/go-mysql-server/blob/main/README.md).
 
 ### Schema changes and missing data
 

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -240,10 +240,9 @@ During conversion:
 - Grafana supports certain data sources. Refer to [compatible data sources](#compatible-data-sources) for a current list.
 - Autocomplete is available, but column/field autocomplete is only available after enabling the `sqlExpressionsColumnAutoComplete` feature toggle, which is provided on an experimental basis.
 
-### Regular expression compatibility
+### Regular expression limitations in SQL expressions
 
-Regular expressions in SQL expressions aren't fully compatible with MySQL standards.
-This is because Grafana runs SQL expressions in a CGo-free configuration, which uses regular expression behavior that differs from MySQL in some cases.
+SQL expressions in Grafana use the `go-mysql-server` SQL engine. Full MySQL regular expression compatibility in that engine depends on CGo, but Grafana is built without CGo.
 
 SQL expressions that use regular expression functions have limitations such as:
 
@@ -253,7 +252,7 @@ SQL expressions that use regular expression functions have limitations such as:
 
 There may be other minor differences as well.
 
-For implementation context, refer to the [`go-mysql-server` regex compatibility notes](https://github.com/grafana/go-mysql-server/blob/main/README.md).
+For implementation context, refer to the [`go-mysql-server` regular expression compatibility notes](https://github.com/grafana/go-mysql-server/blob/main/README.md).
 
 ### Schema changes and missing data
 

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -242,7 +242,7 @@ During conversion:
 
 ### Regular expression limitations in SQL expressions
 
-SQL expressions in Grafana use the `go-mysql-server` SQL engine. Full MySQL regular expression compatibility in that engine depends on `cgo`, but Grafana is built without `cgo`.
+SQL expressions depend on a third-party SQL engine that uses `cgo` by default for full regular expression compatibility with MySQL. However, Grafana is built without `cgo`, which limits regular expression support.
 
 SQL expressions that use regular expression functions have limitations such as:
 

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -240,6 +240,18 @@ During conversion:
 - Grafana supports certain data sources. Refer to [compatible data sources](#compatible-data-sources) for a current list.
 - Autocomplete is available, but column/field autocomplete is only available after enabling the `sqlExpressionsColumnAutoComplete` feature toggle, which is provided on an experimental basis.
 
+### Regular expression compatibility
+
+Regular expressions in SQL expressions aren't fully compatible with MySQL standards.
+
+SQL expressions that use regular expression functions have limitations such as:
+
+- Lack of back-references.
+- No before/after text matching.
+- Differences in handling carriage return (`\r`) characters.
+
+There may be other minor differences as well.
+
 ### Schema changes and missing data
 
 SQL expressions have known limitations that may cause queries to fail or return unexpected results. These constraints are inherent to how the feature is implemented and should be understood when building queries.

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -242,7 +242,7 @@ During conversion:
 
 ### Regular expression limitations in SQL expressions
 
-SQL expressions in Grafana use the `go-mysql-server` SQL engine. Full MySQL regular expression compatibility in that engine depends on CGo, but Grafana is built without CGo.
+SQL expressions in Grafana use the `go-mysql-server` SQL engine. Full MySQL regular expression compatibility in that engine depends on `cgo`, but Grafana is built without `cgo`.
 
 SQL expressions that use regular expression functions have limitations such as:
 


### PR DESCRIPTION
## Summary
- Re-add the SQL expressions regular expression compatibility note under Known limitations. This (the version in the first commit) was added in PR #112289, but reverted in #113050, and then our next attempt #113104 forgot to add these docs once again.
- Document the currently observed caveats: no back-references, no before/after text matching, and carriage-return handling differences.
- Clarify that these regex differences are tied to Grafana's CGo-free SQL expressions configuration.
- Add a breadcrumb to implementation context in the Grafana `go-mysql-server` fork README.

## Context
- Initial dependency/docs update: https://github.com/grafana/grafana/pull/112289
- Revert due to Mac build issues: https://github.com/grafana/grafana/pull/113050
- Follow-up using Grafana GMS fork: https://github.com/grafana/grafana/pull/113104

## Test plan
- [x] Verify the regex compatibility section appears in `docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md` under **Known limitations**.
- [x] Confirm only docs content changed in this PR.
- [ ] Optional: preview docs site rendering for heading/formatting.