### PR TITLE
Provisioning: Fix Pure Git wizard failing with branch not found

### DIFF
--- a/public/app/features/provisioning/utils/data.test.ts
+++ b/public/app/features/provisioning/utils/data.test.ts
@@ -168,6 +168,20 @@ describe('provisioning data mapping', () => {
     });
   });
 
+  describe('empty branch sends empty string for backend auto-detection', () => {
+    it.each(['github', 'gitlab', 'bitbucket', 'git'] as const)(
+      'sends empty branch for %s when branch is not set',
+      (type) => {
+        const formData = makeFormData(type);
+        formData.branch = '';
+        const spec = dataToSpec(formData);
+
+        const providerSpec = spec[type];
+        expect(providerSpec?.branch).toBe('');
+      }
+    );
+  });
+
   describe('local', () => {
     it('maps form data to local spec and filters branch from workflows', () => {
       const formData = makeFormData('local');

--- a/public/app/features/provisioning/utils/data.ts
+++ b/public/app/features/provisioning/utils/data.ts
@@ -25,7 +25,7 @@ export const dataToSpec = (data: RepositoryFormData, connectionName?: string): R
 
   const baseConfig = {
     url: data.url || '',
-    branch: data.branch || (data.type !== 'github' ? 'main' : ''),
+    branch: data.branch || '',
     path: data.path,
   };
 


### PR DESCRIPTION
**What is this feature?**

Fixes the Pure Git provisioning wizard to properly auto-detect the default branch when creating a repository, preventing the "branch not found" error that was blocking users.

**Why do we need this feature?**

When setting up Pure Git through the wizard, the backend test is called before the user reaches the branch selector. The frontend was hardcoding `'main'` as a fallback for empty branch, which failed for repositories using `'master'` or other defaults, permanently blocking users on step 1.


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/119117
