### PR TITLE
Dashboards: Fix infinite spinner on repeating rows when $_all resolves to empty options

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRepeater.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRepeater.test.tsx
@@ -79,7 +79,7 @@ describe('RowItemRepeater', () => {
       expect(stateUpdates).toBe(1);
     });
 
-    it('Should render source tab instead of infinite spinner when $__all is selected and variable returns no options', async () => {
+    it('Should render source row instead of infinite spinner when $__all is selected and variable returns no options', async () => {
       const { rowToRepeat } = renderScene({ variableQueryTime: 0 }, []);
 
       await waitFor(() => {

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRepeater.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRepeater.test.tsx
@@ -79,6 +79,15 @@ describe('RowItemRepeater', () => {
       expect(stateUpdates).toBe(1);
     });
 
+    it('Should render source tab instead of infinite spinner when $__all is selected and variable returns no options', async () => {
+      const { rowToRepeat } = renderScene({ variableQueryTime: 0 }, []);
+
+      await waitFor(() => {
+        expect(rowToRepeat.state.repeatedRows).toBeDefined();
+        expect(rowToRepeat.state.repeatedRows).toHaveLength(0);
+      });
+    });
+
     it('Should handle removing repeats', async () => {
       const { rowToRepeat } = renderScene({ variableQueryTime: 0 });
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRepeater.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRepeater.tsx
@@ -125,11 +125,11 @@ export function performRowRepeats(variable: MultiValueVariable, row: RowItem, co
 /**
  * Get previous variable values given the current repeated state
  */
-function getPrevRepeatValues(mainRow: RowItem, varName: string): VariableValueSingle[] {
+function getPrevRepeatValues(mainRow: RowItem, varName: string): VariableValueSingle[] | undefined {
   const values: VariableValueSingle[] = [];
 
   if (!mainRow.state.repeatedRows) {
-    return [];
+    return undefined;
   }
 
   function collectVariableValue(row: RowItem) {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRepeater.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRepeater.test.tsx
@@ -79,6 +79,15 @@ describe('TabItemRepeater', () => {
       expect(stateUpdates).toBe(1);
     });
 
+    it('Should render source tab instead of infinite spinner when $__all is selected and variable returns no options', async () => {
+      const { tabToRepeat } = renderScene({ variableQueryTime: 0 }, []);
+
+      await waitFor(() => {
+        expect(tabToRepeat.state.repeatedTabs).toBeDefined();
+        expect(tabToRepeat.state.repeatedTabs).toHaveLength(0);
+      });
+    });
+
     it('Should handle removing repeats', async () => {
       const { tabToRepeat } = renderScene({ variableQueryTime: 0 });
 

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRepeater.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRepeater.tsx
@@ -104,11 +104,11 @@ export function performTabRepeats(variable: MultiValueVariable, tab: TabItem, co
 /**
  * Get previous variable values given the current repeated state
  */
-function getPrevRepeatValues(mainTab: TabItem, varName: string): VariableValueSingle[] {
+function getPrevRepeatValues(mainTab: TabItem, varName: string): VariableValueSingle[] | undefined {
   const values: VariableValueSingle[] = [];
 
   if (!mainTab.state.repeatedTabs) {
-    return [];
+    return undefined;
   }
 
   function collectVariableValue(tab: TabItem) {

--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -1113,8 +1113,8 @@ describe('ResponseTransformers', () => {
           refId: q.spec.refId,
           hide: q.spec.hidden,
           datasource: {
-            type: q.spec.query.spec.group,
-            uid: q.spec.query.spec.datasource?.uid,
+            type: q.spec.query.group,
+            uid: q.spec.query.datasource?.name,
           },
           ...q.spec.query.spec,
         };

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -989,8 +989,8 @@ function getVariablesV1(vars: DashboardV2Spec['variables']): VariableModel[] {
               ? v.spec.query.spec[LEGACY_STRING_VALUE_KEY]
               : v.spec.query.spec,
           datasource: {
-            type: v.spec.query?.spec.group,
-            uid: v.spec.query?.spec.datasource?.name,
+            type: v.spec.query?.group,
+            uid: v.spec.query?.datasource?.name,
           },
           sort: transformSortVariableToEnumV1(v.spec.sort),
           refresh: transformVariableRefreshToEnumV1(v.spec.refresh),
@@ -1199,8 +1199,8 @@ function transformV2PanelToV1Panel(
           refId: q.spec.refId,
           hide: q.spec.hidden,
           datasource: {
-            uid: q.spec.query.spec.datasource?.uid,
-            type: q.spec.query.spec.group,
+            uid: q.spec.query.datasource?.name,
+            type: q.spec.query.group,
           },
           ...q.spec.query.spec,
         };


### PR DESCRIPTION
**What is this feature?**

This PR fixes two issue

1. **Fix infinite spinner on repeating rows/tabs when variable options are empty:** `getPrevRepeatValues` now returns `undefined` instead of `[]` when `repeatedRows`/`repeatedTabs` has never been initialized. This helps avoid a case where `$__all` returns an empty array (when variable options are empty), which matches the previous uninitialized state (`[]`), causing `isEqual([], [])` to skip initialization entirely and leaving the repeater stuck on an infinite spinner.

2. **Fix incorrect datasource property paths in v2 -> v1 response transformation:** The v2 -> v1 conversion was accessing `spec.query.spec.datasource` and `spec.query.spec.group` instead of the correct `spec.query.datasource` and `spec.query.group`, causing datasource references to be lost for both panel queries and query variables.


