### PR TITLE
fix(folders): set maxNestedFolderDepth in NewAPIService for multi-tenant environments

### DIFF
--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -96,13 +96,14 @@ func RegisterAPIService(cfg *setting.Cfg,
 	return builder
 }
 
-func NewAPIService(ac authlib.AccessClient, searcher resource.ResourceClient, features featuremgmt.FeatureToggles, zanzanaClient zanzana.Client, resourcePermissionsSvc *dynamic.NamespaceableResourceInterface) *FolderAPIBuilder {
+func NewAPIService(ac authlib.AccessClient, searcher resource.ResourceClient, features featuremgmt.FeatureToggles, zanzanaClient zanzana.Client, resourcePermissionsSvc *dynamic.NamespaceableResourceInterface, maxNestedFolderDepth int) *FolderAPIBuilder {
 	return &FolderAPIBuilder{
 		features:               features,
 		accessClient:           ac,
 		searcher:               searcher,
 		permissionStore:        reconcilers.NewZanzanaPermissionStore(zanzanaClient),
 		resourcePermissionsSvc: resourcePermissionsSvc,
+		maxNestedFolderDepth:   maxNestedFolderDepth,
 	}
 }
 

--- a/pkg/setting/setting_folder.go
+++ b/pkg/setting/setting_folder.go
@@ -5,21 +5,21 @@ import (
 )
 
 const maxNestedFolderDepth = 7
-const defaultMaxNestedFolderDepth = 4
+const DefaultMaxNestedFolderDepth = 4
 
 func maxDeptFolderSettings(iniFile *ini.File) int {
 	if iniFile == nil {
-		return defaultMaxNestedFolderDepth
+		return DefaultMaxNestedFolderDepth
 	}
 
 	folderSection := iniFile.Section("folder")
-	cfgMaxNestedFolderDepth := folderSection.Key("max_nested_folder_depth").MustInt(defaultMaxNestedFolderDepth)
+	cfgMaxNestedFolderDepth := folderSection.Key("max_nested_folder_depth").MustInt(DefaultMaxNestedFolderDepth)
 	if cfgMaxNestedFolderDepth > maxNestedFolderDepth {
 		cfgMaxNestedFolderDepth = maxNestedFolderDepth
 	}
 
 	if cfgMaxNestedFolderDepth <= 0 {
-		cfgMaxNestedFolderDepth = defaultMaxNestedFolderDepth
+		cfgMaxNestedFolderDepth = DefaultMaxNestedFolderDepth
 	}
 
 	return cfgMaxNestedFolderDepth

--- a/pkg/setting/setting_folder_test.go
+++ b/pkg/setting/setting_folder_test.go
@@ -18,26 +18,26 @@ func TestMaxDeptFolderSettings(t *testing.T) {
 		{
 			name:     "returns default when ini file is nil",
 			noFile:   true,
-			expected: defaultMaxNestedFolderDepth,
+			expected: DefaultMaxNestedFolderDepth,
 		},
 		{
 			name:     "returns default when key is absent",
-			expected: defaultMaxNestedFolderDepth,
+			expected: DefaultMaxNestedFolderDepth,
 		},
 		{
 			name:     "returns default when value is not a valid integer",
 			iniValue: strp("notanint"),
-			expected: defaultMaxNestedFolderDepth,
+			expected: DefaultMaxNestedFolderDepth,
 		},
 		{
 			name:     "returns default when value is zero",
 			iniValue: strp("0"),
-			expected: defaultMaxNestedFolderDepth,
+			expected: DefaultMaxNestedFolderDepth,
 		},
 		{
 			name:     "returns default when value is negative",
 			iniValue: strp("-1"),
-			expected: defaultMaxNestedFolderDepth,
+			expected: DefaultMaxNestedFolderDepth,
 		},
 		{
 			name:     "returns configured value when within range (3)",


### PR DESCRIPTION
## Summary
- PR #118592 replaced the hardcoded `folder.MaxNestedFolderDepth` constant with a configurable `cfg.MaxNestedFolderDepth` but missed the `NewAPIService` constructor used by the multi-tenant enterprise folder service
- The `maxNestedFolderDepth` field defaulted to Go's zero value (`0`), causing every nested folder create/update to fail with `"folder max depth exceeded, max depth is 0"`
- Sets `maxNestedFolderDepth` using `setting.NewCfg().MaxNestedFolderDepth` (default: 4), consistent with how tests already handle this

## Test plan
- [x] `go build ./pkg/registry/apis/folders/...` compiles successfully
- [x] `go test ./pkg/registry/apis/folders/... -short` passes
- [ ] Verify in cloud MT environment that nested folder creation no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)