### PR TITLE
Log Line Details: Use small font size when the option is enabled in the panel or controls

### DIFF
--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -14,6 +14,7 @@ import { LogLineDetailsComponent } from './LogLineDetailsComponent';
 import { useLogListContext } from './LogListContext';
 import { LogListModel } from './processing';
 import { LOG_LIST_MIN_WIDTH } from './virtualization';
+import { LogListFontSize } from './LogList';
 
 export interface Props {
   containerElement: HTMLDivElement;
@@ -29,9 +30,9 @@ export type LogLineDetailsMode = 'inline' | 'sidebar';
 
 export const LogLineDetails = memo(
   ({ containerElement, focusLogLine, logs, timeRange, timeZone, showControls, showFieldSelector }: Props) => {
-    const { noInteractions, logOptionsStorageKey } = useLogListContext();
+    const { noInteractions, fontSize, logOptionsStorageKey } = useLogListContext();
     const { detailsWidth, setDetailsWidth } = useLogDetailsContext();
-    const styles = useStyles2(getStyles, 'sidebar', showControls);
+    const styles = useStyles2(getStyles, 'sidebar', showControls, fontSize);
     const dragStyles = useStyles2(getDragStyles);
     const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -154,9 +155,9 @@ export interface InlineLogLineDetailsProps {
 }
 
 export const InlineLogLineDetails = memo(({ logs, log, onResize, timeRange, timeZone }: InlineLogLineDetailsProps) => {
-  const { app, noInteractions } = useLogListContext();
+  const { app, fontSize, noInteractions } = useLogListContext();
   const { detailsWidth } = useLogDetailsContext();
-  const styles = useStyles2(getStyles, 'inline');
+  const styles = useStyles2(getStyles, 'inline', undefined, fontSize);
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -198,7 +199,12 @@ InlineLogLineDetails.displayName = 'InlineLogLineDetails';
 
 export const LOG_LINE_DETAILS_HEIGHT = 45;
 
-const getStyles = (theme: GrafanaTheme2, mode: LogLineDetailsMode, showControls?: boolean) => ({
+const getStyles = (
+  theme: GrafanaTheme2,
+  mode: LogLineDetailsMode,
+  showControls: boolean | undefined,
+  fontSize: LogListFontSize
+) => ({
   inlineWrapper: css({
     gridColumn: '1 / -1',
     height: `${LOG_LINE_DETAILS_HEIGHT}vh`,
@@ -211,6 +217,8 @@ const getStyles = (theme: GrafanaTheme2, mode: LogLineDetailsMode, showControls?
     borderRadius: theme.shape.radius.default,
     height: '100%',
     overflow: 'auto',
+    fontSize: fontSize === 'small' ? theme.typography.bodySmall.fontSize : undefined,
+    lineHeight: fontSize === 'small' ? theme.typography.bodySmall.lineHeight : undefined,
   }),
   container: css({
     backgroundColor: theme.colors.background.elevated,
@@ -221,6 +229,8 @@ const getStyles = (theme: GrafanaTheme2, mode: LogLineDetailsMode, showControls?
     boxShadow: theme.shadows.z3,
     height: '100%',
     overflow: 'auto',
+    fontSize: fontSize === 'small' ? theme.typography.bodySmall.fontSize : undefined,
+    lineHeight: fontSize === 'small' ? theme.typography.bodySmall.lineHeight : undefined,
   }),
   scrollContainer: css({
     overflow: 'auto',

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -11,10 +11,10 @@ import { getFieldSelectorWidth } from '../fieldSelector/fieldSelectorUtils';
 
 import { getDetailsScrollPosition, saveDetailsScrollPosition, useLogDetailsContext } from './LogDetailsContext';
 import { LogLineDetailsComponent } from './LogLineDetailsComponent';
+import { LogListFontSize } from './LogList';
 import { useLogListContext } from './LogListContext';
 import { LogListModel } from './processing';
 import { LOG_LIST_MIN_WIDTH } from './virtualization';
-import { LogListFontSize } from './LogList';
 
 export interface Props {
   containerElement: HTMLDivElement;
@@ -77,10 +77,10 @@ LogLineDetails.displayName = 'LogLineDetails';
 
 const LogLineDetailsTabs = memo(
   ({ focusLogLine, logs, timeRange, timeZone }: Pick<Props, 'focusLogLine' | 'logs' | 'timeRange' | 'timeZone'>) => {
-    const { app, noInteractions, wrapLogMessage } = useLogListContext();
+    const { app, fontSize, noInteractions, wrapLogMessage } = useLogListContext();
     const { currentLog, setCurrentLog, showDetails, toggleDetails } = useLogDetailsContext();
 
-    const styles = useStyles2(getStyles, 'sidebar');
+    const styles = useStyles2(getStyles, 'sidebar', undefined, fontSize);
 
     useEffect(() => {
       // When wrapping is enabled and details is in sidebar mode, the logs panel width changes and the

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -15,6 +15,7 @@ import { FieldDef } from '../logParser';
 import { OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME } from '../otel/formats';
 
 import { useLogDetailsContext } from './LogDetailsContext';
+import { LogListFontSize } from './LogList';
 import { useLogListContext } from './LogListContext';
 import { LogListModel, getNormalizedFieldName } from './processing';
 
@@ -27,7 +28,8 @@ interface LogLineDetailsFieldsProps {
 }
 
 export const LogLineDetailsFields = memo(({ disableActions, fields, log, logs, search }: LogLineDetailsFieldsProps) => {
-  const styles = useStyles2(getFieldsStyles);
+  const { fontSize } = useLogListContext();
+  const styles = useStyles2(getFieldsStyles, fontSize);
   const getLogs = useCallback(() => logs, [logs]);
   const filteredFields = useMemo(() => (search ? filterFields(fields, search) : fields), [fields, search]);
 
@@ -74,7 +76,8 @@ interface LogLineDetailsLabelFieldsProps {
 }
 
 export const LogLineDetailsLabelFields = ({ fields, log, logs, search }: LogLineDetailsLabelFieldsProps) => {
-  const styles = useStyles2(getFieldsStyles);
+  const { fontSize } = useLogListContext();
+  const styles = useStyles2(getFieldsStyles, fontSize);
   const getLogs = useCallback(() => logs, [logs]);
   const filteredFields = useMemo(() => (search ? filterLabels(fields, search) : fields), [fields, search]);
 
@@ -101,11 +104,11 @@ export const LogLineDetailsLabelFields = ({ fields, log, logs, search }: LogLine
   );
 };
 
-const getFieldsStyles = (theme: GrafanaTheme2) => ({
+const getFieldsStyles = (theme: GrafanaTheme2, fontSize: LogListFontSize) => ({
   fieldsTable: css({
     display: 'grid',
     gap: theme.spacing(1),
-    gridTemplateColumns: `${theme.spacing(11.5)} fit-content(30%) 1fr`,
+    gridTemplateColumns: `${fontSize === 'small' ? theme.spacing(10) : theme.spacing(11.5)} fit-content(30%) 1fr`,
   }),
   fieldsTableNoActions: css({
     display: 'grid',

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -6,7 +6,7 @@ import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { CoreApp, Field, fuzzySearch, GrafanaTheme2, IconName, LinkModel, LogLabelStatsModel } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { ClipboardButton, DataLinkButton, IconButton, useStyles2 } from '@grafana/ui';
+import { ClipboardButton, DataLinkButton, IconButton, IconSize, useStyles2 } from '@grafana/ui';
 
 import { logRowToSingleRowDataFrame } from '../../logsModel';
 import { calculateLogsLabelStats, calculateStats } from '../../utils';
@@ -138,6 +138,7 @@ export const LogLineDetailsField = ({
   const [showFieldsStats, setShowFieldStats] = useState(false);
   const [fieldCount, setFieldCount] = useState(0);
   const [fieldStats, setFieldStats] = useState<LogLabelStatsModel[] | null>(null);
+  const { fontSize } = useLogListContext();
   const {
     app,
     displayedFields,
@@ -271,6 +272,7 @@ export const LogLineDetailsField = ({
               {onClickFilterLabel && fieldSupportsFilters && (
                 <AsyncIconButton
                   name="search-plus"
+                  size={fontSize === 'small' ? 'sm' : undefined}
                   onClick={filterLabel}
                   // We purposely want to pass a new function on every render to allow the active state to be updated when log details remains open between updates.
                   isActive={labelFilterActive}
@@ -280,6 +282,7 @@ export const LogLineDetailsField = ({
               {onClickFilterOutLabel && fieldSupportsFilters && (
                 <IconButton
                   name="search-minus"
+                  size={fontSize === 'small' ? 'sm' : undefined}
                   tooltip={
                     app === CoreApp.Explore && log.dataFrame?.refId
                       ? t('logs.log-line-details.fields.filter-out-query', 'Filter out value in query {{query}}', {
@@ -293,6 +296,7 @@ export const LogLineDetailsField = ({
               {singleKey && displayedFields.includes(keys[0]) && (
                 <IconButton
                   variant="primary"
+                  size={fontSize === 'small' ? 'sm' : undefined}
                   tooltip={t('logs.log-line-details.fields.toggle-field-button.hide-this-field', 'Hide this field')}
                   name="eye"
                   onClick={hideField}
@@ -305,12 +309,14 @@ export const LogLineDetailsField = ({
                     'Show this field instead of the message'
                   )}
                   name="eye"
+                  size={fontSize === 'small' ? 'sm' : undefined}
                   onClick={showField}
                 />
               )}
               <IconButton
                 variant={showFieldsStats ? 'primary' : 'secondary'}
                 name="signal"
+                size={fontSize === 'small' ? 'sm' : undefined}
                 tooltip={t('logs.log-line-details.fields.adhoc-statistics', 'Ad-hoc statistics')}
                 className={styles.statsIcon}
                 disabled={!singleKey}
@@ -527,6 +533,7 @@ export const SingleValue = ({ value: originalValue, prettifyJSON }: { value: str
 interface AsyncIconButtonProps extends Pick<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onClick'> {
   name: IconName;
   isActive(): Promise<boolean>;
+  size?: IconSize;
   tooltipSuffix: string;
 }
 


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/114314 . This PR applies the small font size to Log Details when the option has been selected either in the controls or in the panel options.

> [!IMPORTANT]
> The small font size is applied to those elements that the Logs Panel directly controls. It has no effect on standard Grafana UI elements such as inputs and collapsible sections.


Demo:

https://github.com/user-attachments/assets/e232855d-afde-4fae-8af3-6e57a35cd928
