### PR TITLE
fix: guard against missing frames/fields during panel type transitions

### DIFF
--- a/packages/grafana-data/src/dataframe/StreamingDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/StreamingDataFrame.test.ts
@@ -1070,7 +1070,7 @@ describe('Streaming JSON', () => {
         },
         data: { values: [[100], [1]] },
       });
-      frame.fields[1].state = { calcs: { sum: 10 }, range: { min: 0, max: 10 } };
+      frame.fields[1].state = { calcs: { sum: 10 }, range: { min: 0, max: 10, delta: 10 } };
       frame.resetStateCalculations();
       expect(frame.fields[1].state?.calcs).toBeUndefined();
       expect(frame.fields[1].state?.range).toBeUndefined();

--- a/packages/grafana-data/src/dataframe/StreamingDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/StreamingDataFrame.test.ts
@@ -5,10 +5,13 @@ import { FieldType, DataFrame } from '../types/dataFrame';
 import { DataFrameJSON } from './DataFrameJSON';
 import {
   closestIdx,
+  getLastStreamingDataFramePacket,
   getStreamingFrameOptions,
+  parseLabelsFromField,
   StreamingDataFrame,
   StreamingFrameAction,
   StreamingFrameOptions,
+  transpose,
 } from './StreamingDataFrame';
 
 describe('Streaming JSON', () => {
@@ -1000,4 +1003,160 @@ describe('Streaming JSON', () => {
     `);
   });
 */
+
+  describe('parseLabelsFromField()', () => {
+    it('empty string returns empty object', () => {
+      expect(parseLabelsFromField('')).toEqual({});
+    });
+
+    it('prometheus-style labels are parsed', () => {
+      expect(parseLabelsFromField('{sensor="A", job="test"}')).toEqual({ sensor: 'A', job: 'test' });
+    });
+
+    it('influx-style labels are parsed', () => {
+      expect(parseLabelsFromField('sensor=A,job=test')).toEqual({ sensor: 'A', job: 'test' });
+    });
+  });
+
+  describe('getLastStreamingDataFramePacket()', () => {
+    it('returns the packet action from a StreamingDataFrame', () => {
+      const frame = StreamingDataFrame.fromDataFrameJSON({
+        schema: { fields: [{ name: 'time', type: FieldType.time }] },
+        data: { values: [[100]] },
+      });
+      expect(getLastStreamingDataFramePacket(frame)).toBe(StreamingFrameAction.Replace);
+    });
+
+    it('returns undefined for a plain DataFrame', () => {
+      const plain: DataFrame = {
+        fields: [],
+        length: 0,
+      };
+      expect(getLastStreamingDataFramePacket(plain)).toBeUndefined();
+    });
+  });
+
+  describe('transpose()', () => {
+    it('transposes 2 labels across time+value columns', () => {
+      const vrecs = [
+        ['sensor=A', 'sensor=B'],
+        [100, 200],
+        [10, 20],
+      ];
+      const result = transpose(vrecs);
+      expect(result).toBeInstanceOf(Map);
+      expect(result.get('sensor=A')).toEqual([[100], [10]]);
+      expect(result.get('sensor=B')).toEqual([[200], [20]]);
+    });
+  });
+
+  describe('closestIdx() with explicit lo/hi bounds', () => {
+    it('constrains search to bounded range', () => {
+      const arr = [1, 2, 3, 10, 11, 12, 13];
+      // Without bounds, 4 is closest to index 2 (value 3)
+      // With lo=3, hi=6 the search is bounded to [10,11,12,13] -> closest to 4 is index 3
+      expect(closestIdx(4, arr, 3, 6)).toBe(3);
+    });
+  });
+
+  describe('resetStateCalculations()', () => {
+    it('clears calcs and range from field state', () => {
+      const frame = StreamingDataFrame.fromDataFrameJSON({
+        schema: {
+          fields: [
+            { name: 'time', type: FieldType.time },
+            { name: 'value', type: FieldType.number },
+          ],
+        },
+        data: { values: [[100], [1]] },
+      });
+      frame.fields[1].state = { calcs: { sum: 10 }, range: { min: 0, max: 10 } };
+      frame.resetStateCalculations();
+      expect(frame.fields[1].state?.calcs).toBeUndefined();
+      expect(frame.fields[1].state?.range).toBeUndefined();
+    });
+  });
+
+  describe('getMatchingFieldIndexes()', () => {
+    it('returns indexes of fields matching predicate', () => {
+      const frame = StreamingDataFrame.fromDataFrameJSON({
+        schema: {
+          fields: [
+            { name: 'time', type: FieldType.time },
+            { name: 'value', type: FieldType.number },
+            { name: 'label', type: FieldType.string },
+          ],
+        },
+        data: { values: [[100], [1], ['a']] },
+      });
+      const indexes = frame.getMatchingFieldIndexes((f) => f.type === FieldType.number);
+      expect(indexes).toEqual([1]);
+    });
+  });
+
+  describe('needsResizing()', () => {
+    it('returns false when maxLength is unchanged', () => {
+      const frame = StreamingDataFrame.empty({ maxLength: 100, maxDelta: 50 });
+      expect(frame.needsResizing({ maxLength: 100, maxDelta: 50, action: StreamingFrameAction.Append })).toBe(false);
+    });
+
+    it('returns true when maxLength is larger', () => {
+      const frame = StreamingDataFrame.empty({ maxLength: 100, maxDelta: 50 });
+      expect(frame.needsResizing({ maxLength: 200, maxDelta: 50, action: StreamingFrameAction.Append })).toBe(true);
+    });
+
+    it('returns true when maxDelta is larger', () => {
+      const frame = StreamingDataFrame.empty({ maxLength: 100, maxDelta: 50 });
+      expect(frame.needsResizing({ maxLength: 100, maxDelta: 100, action: StreamingFrameAction.Append })).toBe(true);
+    });
+
+    it('returns true when existing maxDelta is Infinity', () => {
+      const frame = StreamingDataFrame.empty({ maxLength: 100 }); // maxDelta defaults to Infinity
+      expect(frame.needsResizing({ maxLength: 100, maxDelta: 60, action: StreamingFrameAction.Append })).toBe(true);
+    });
+  });
+
+  describe('pushNewValues() edge case', () => {
+    it('calling with empty array does not change frame length', () => {
+      const frame = StreamingDataFrame.fromDataFrameJSON({
+        schema: {
+          fields: [
+            { name: 'time', type: FieldType.time },
+            { name: 'value', type: FieldType.number },
+          ],
+        },
+        data: {
+          values: [
+            [100, 200],
+            [1, 2],
+          ],
+        },
+      });
+      const lengthBefore = frame.length;
+      frame.pushNewValues([]);
+      expect(frame.length).toBe(lengthBefore);
+    });
+  });
+
+  describe('push() with entities', () => {
+    it('decodes NaN and Undef entities into field values', () => {
+      const frame = StreamingDataFrame.fromDataFrameJSON({
+        schema: {
+          fields: [
+            { name: 'time', type: FieldType.time },
+            { name: 'value', type: FieldType.number },
+          ],
+        },
+        data: {
+          values: [
+            [100, 200, 300],
+            [1, 2, 3],
+          ],
+          entities: [null, { NaN: [1], Undef: [2] }],
+        },
+      });
+      expect(frame.fields[1].values[1]).toBeNaN();
+      expect(frame.fields[1].values[2]).toBeUndefined();
+    });
+  });
 });

--- a/packages/grafana-data/src/dataframe/processDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.test.ts
@@ -1,19 +1,33 @@
 import { dateTime } from '../datetime/moment_wrapper';
-import { TimeSeries, TableData } from '../types/data';
-import { FieldType, DataFrameDTO, Field } from '../types/dataFrame';
+import { TimeSeries, TableData, LoadingState } from '../types/data';
+import {
+  FieldType,
+  DataFrameDTO,
+  Field,
+  TIME_SERIES_TIME_FIELD_NAME,
+  TIME_SERIES_VALUE_FIELD_NAME,
+} from '../types/dataFrame';
+import { PanelData } from '../types/panel';
+import { getDefaultTimeRange } from '../types/time';
 
 import { ArrayDataFrame } from './ArrayDataFrame';
 import {
   createDataFrame,
+  getDataFrameRow,
   getFieldTypeFromValue,
+  getProcessedDataFrames,
+  getTimeField,
   guessFieldTypeForField,
   guessFieldTypeFromValue,
   guessFieldTypes,
   isDataFrame,
   isTableData,
+  preProcessPanelData,
   reverseDataFrame,
   sortDataFrame,
   toDataFrame,
+  toDataFrameDTO,
+  toFilteredDataFrameDTO,
   toLegacyResponseData,
 } from './processDataFrame';
 
@@ -514,5 +528,140 @@ describe('guessFieldTypeForField', () => {
     field.values = [];
 
     expect(guessFieldTypeForField(field)).toBe(undefined);
+  });
+});
+
+describe('getDataFrameRow', () => {
+  it('returns array of values for the given row index', () => {
+    const frame = createDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1000, 2000] },
+        { name: 'value', type: FieldType.number, values: [10, 20] },
+      ],
+    });
+    expect(getDataFrameRow(frame, 0)).toEqual([1000, 10]);
+    expect(getDataFrameRow(frame, 1)).toEqual([2000, 20]);
+  });
+});
+
+describe('toDataFrameDTO', () => {
+  it('converts a DataFrame to a DTO', () => {
+    const frame = createDataFrame({
+      name: 'test',
+      refId: 'A',
+      fields: [{ name: 'value', type: FieldType.number, values: [1, 2, 3] }],
+    });
+    const dto = toDataFrameDTO(frame);
+    expect(dto.name).toBe('test');
+    expect(dto.refId).toBe('A');
+    expect(dto.fields[0].values).toEqual([1, 2, 3]);
+  });
+});
+
+describe('toFilteredDataFrameDTO', () => {
+  it('filters fields using the predicate', () => {
+    const frame = createDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1000] },
+        { name: 'value', type: FieldType.number, values: [42] },
+      ],
+    });
+    const dto = toFilteredDataFrameDTO(frame, (f) => f.type === FieldType.number);
+    expect(dto.fields).toHaveLength(1);
+    expect(dto.fields[0].name).toBe('value');
+  });
+});
+
+describe('getTimeField', () => {
+  it('returns the time field and its index', () => {
+    const frame = createDataFrame({
+      fields: [
+        { name: 'value', type: FieldType.number, values: [1] },
+        { name: 'time', type: FieldType.time, values: [1000] },
+      ],
+    });
+    const { timeField, timeIndex } = getTimeField(frame);
+    expect(timeField?.name).toBe('time');
+    expect(timeIndex).toBe(1);
+  });
+
+  it('returns empty object when no time field exists', () => {
+    const frame = createDataFrame({
+      fields: [{ name: 'value', type: FieldType.number, values: [1] }],
+    });
+    expect(getTimeField(frame)).toEqual({});
+  });
+});
+
+describe('getProcessedDataFrames', () => {
+  it('returns empty array when results is undefined', () => {
+    expect(getProcessedDataFrames(undefined)).toEqual([]);
+  });
+
+  it('returns empty array when results is not an array', () => {
+    // @ts-expect-error - intentionally testing runtime guard with invalid input
+    expect(getProcessedDataFrames('bad')).toEqual([]);
+  });
+});
+
+describe('guessFieldTypes with guessDefined', () => {
+  it('re-guesses all field types when guessDefined is true', () => {
+    const frame = createDataFrame({
+      fields: [{ name: 'value', type: FieldType.string, values: ['42'] }],
+    });
+    const result = guessFieldTypes(frame, true);
+    expect(result.fields[0].type).toBe(FieldType.number);
+  });
+});
+
+describe('toLegacyResponseData additional paths', () => {
+  it('converts 2-field DataFrame with time to TimeSeries', () => {
+    const frame = createDataFrame({
+      name: 'test',
+      fields: [
+        { name: TIME_SERIES_VALUE_FIELD_NAME, type: FieldType.number, values: [1, 2] },
+        { name: TIME_SERIES_TIME_FIELD_NAME, type: FieldType.time, values: [1000, 2000] },
+      ],
+    });
+    const result = toLegacyResponseData(frame) as TimeSeries;
+    expect(result.datapoints).toEqual([
+      [1, 1000],
+      [2, 2000],
+    ]);
+  });
+
+  it('converts JSON doc frame to legacy docs TimeSeries', () => {
+    const frame = createDataFrame({
+      meta: { json: true },
+      fields: [{ name: 'target', type: FieldType.other, values: [{ a: 1 }] }],
+    });
+    const result = toLegacyResponseData(frame) as TimeSeries;
+    expect((result as TimeSeries & { type?: string }).type).toBe('docs');
+  });
+});
+
+describe('toDataFrame GraphSeries path', () => {
+  it('converts GraphSeries (data property, no schema) to DataFrame', () => {
+    const graphSeries = {
+      data: [
+        [10, 1000],
+        [20, 2000],
+      ],
+      label: 'series1',
+    };
+    const frame = toDataFrame(graphSeries);
+    expect(frame.fields).toHaveLength(2);
+  });
+});
+
+describe('preProcessPanelData', () => {
+  it('uses current data as lastResult when loading with no prior result', () => {
+    const data: PanelData = {
+      state: LoadingState.Loading,
+      series: [],
+      timeRange: getDefaultTimeRange(),
+    };
+    const result = preProcessPanelData(data, undefined);
+    expect(result.state).toBe(LoadingState.Loading);
   });
 });

--- a/packages/grafana-data/src/text/markdown.test.ts
+++ b/packages/grafana-data/src/text/markdown.test.ts
@@ -43,4 +43,19 @@ describe('Markdown wrapper', () => {
     const str = renderTextPanelMarkdown('<script>alert()</script>');
     expect(str).toBe('&lt;script&gt;alert()&lt;/script&gt;');
   });
+
+  it('renderMarkdown with noSanitize: true passes through script tags', () => {
+    const str = renderMarkdown('<script>alert()</script>', { noSanitize: true });
+    expect(str).toContain('<script>');
+  });
+
+  it('renderMarkdown with breaks: true renders newlines as <br>', () => {
+    const str = renderMarkdown('line one\nline two', { breaks: true });
+    expect(str).toContain('<br');
+  });
+
+  it('renderTextPanelMarkdown with noSanitize: true passes through script tags', () => {
+    const str = renderTextPanelMarkdown('<script>alert()</script>', { noSanitize: true });
+    expect(str).toContain('<script>');
+  });
 });

--- a/packages/grafana-data/src/text/sanitize.test.ts
+++ b/packages/grafana-data/src/text/sanitize.test.ts
@@ -1,4 +1,15 @@
-import { sanitizeTextPanelContent, sanitizeUrl, sanitize, validatePath, PathValidationError } from './sanitize';
+import {
+  escapeHtml,
+  hasAnsiCodes,
+  sanitize,
+  sanitizeSVGContent,
+  sanitizeTrustedTypes,
+  sanitizeTrustedTypesRSS,
+  sanitizeTextPanelContent,
+  sanitizeUrl,
+  validatePath,
+  PathValidationError,
+} from './sanitize';
 
 describe('sanitizeTextPanelContent', () => {
   it('should allow whitelisted styles in text panel', () => {
@@ -189,5 +200,75 @@ describe('validatePath', () => {
     it('should handle URLs with backslashes and dots in the path', () => {
       expect(() => validatePath('https://api.example.com/\\..\\/admin')).toThrow(PathValidationError);
     });
+  });
+});
+
+describe('escapeHtml()', () => {
+  it('escapes script tags', () => {
+    expect(escapeHtml('<script>')).toBe('&lt;script&gt;');
+  });
+
+  it('escapes double quotes, ampersands, and single quotes', () => {
+    expect(escapeHtml('"double" & \'single\'')).toBe('&quot;double&quot; &amp; &#39;single&#39;');
+  });
+
+  it('leaves plain text unchanged', () => {
+    expect(escapeHtml('hello world')).toBe('hello world');
+  });
+});
+
+describe('hasAnsiCodes()', () => {
+  it('returns true for strings with ANSI escape codes', () => {
+    expect(hasAnsiCodes('\u001b[32mgreen\u001b[0m')).toBe(true);
+  });
+
+  it('returns false for strings without ANSI codes', () => {
+    expect(hasAnsiCodes('plain text')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(hasAnsiCodes('')).toBe(false);
+  });
+});
+
+describe('sanitizeSVGContent()', () => {
+  it('passes through valid SVG content', () => {
+    const svg = '<svg><rect width="10" height="10"/></svg>';
+    const result = sanitizeSVGContent(svg);
+    expect(result).toContain('<rect');
+  });
+
+  it('removes script tags from SVG', () => {
+    const svg = '<svg><script>alert(1)</script><rect width="10" height="10"/></svg>';
+    const result = sanitizeSVGContent(svg);
+    expect(result).not.toContain('<script>');
+    expect(result).toContain('<rect');
+  });
+});
+
+describe('sanitizeTrustedTypes()', () => {
+  it('passes through safe content', () => {
+    const result = sanitizeTrustedTypes('<p>hello</p>') as unknown as string;
+    expect(result).toBeTruthy();
+    expect(String(result)).toContain('hello');
+  });
+
+  it('strips XSS payloads', () => {
+    const result = sanitizeTrustedTypes('<script>alert(1)</script>') as unknown as string;
+    expect(String(result)).not.toContain('<script>');
+  });
+});
+
+describe('sanitizeTrustedTypesRSS()', () => {
+  it('preserves RSS markup', () => {
+    const rss = '<rss><channel><title>My Feed</title></channel></rss>';
+    const result = sanitizeTrustedTypesRSS(rss) as unknown as string;
+    expect(String(result)).toContain('My Feed');
+  });
+
+  it('strips script tags from RSS', () => {
+    const rss = '<rss><channel><title>Feed</title><script>alert(1)</script></channel></rss>';
+    const result = sanitizeTrustedTypesRSS(rss) as unknown as string;
+    expect(String(result)).not.toContain('<script>');
   });
 });

--- a/packages/grafana-data/src/text/string.test.ts
+++ b/packages/grafana-data/src/text/string.test.ts
@@ -1,4 +1,15 @@
-import { escapeStringForRegex, stringToJsRegex, stringToMs, unEscapeStringFromRegex } from './string';
+import {
+  escapeRegex,
+  escapeStringForRegex,
+  stringStartsAsRegEx,
+  stringToJsRegex,
+  stringToMs,
+  toFloatOrUndefined,
+  toIntegerOrUndefined,
+  toNumberString,
+  toPascalCase,
+  unEscapeStringFromRegex,
+} from './string';
 
 describe('stringToJsRegex', () => {
   it('should just return string as RegEx if it does not start as a regex', () => {
@@ -106,5 +117,97 @@ describe('unEscapeStringFromRegex', () => {
       const result = unEscapeStringFromRegex('some string 123');
       expect(result).toBe('some string 123');
     });
+  });
+});
+
+describe('stringStartsAsRegEx()', () => {
+  it('returns true for strings starting with /', () => {
+    expect(stringStartsAsRegEx('/foo/')).toBe(true);
+  });
+
+  it('returns false for strings not starting with /', () => {
+    expect(stringStartsAsRegEx('foo')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(stringStartsAsRegEx('')).toBe(false);
+  });
+});
+
+describe('toNumberString()', () => {
+  it('converts a number to string', () => {
+    expect(toNumberString(42)).toBe('42');
+  });
+
+  it('returns empty string for null', () => {
+    expect(toNumberString(null)).toBe('');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(toNumberString(undefined)).toBe('');
+  });
+
+  it('returns empty string for Infinity', () => {
+    expect(toNumberString(Infinity)).toBe('');
+  });
+});
+
+describe('toIntegerOrUndefined()', () => {
+  it('parses integer string', () => {
+    expect(toIntegerOrUndefined('42')).toBe(42);
+  });
+
+  it('truncates float string to integer', () => {
+    expect(toIntegerOrUndefined('3.7')).toBe(3);
+  });
+
+  it('returns undefined for non-numeric string', () => {
+    expect(toIntegerOrUndefined('abc')).toBeUndefined();
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(toIntegerOrUndefined('')).toBeUndefined();
+  });
+});
+
+describe('toFloatOrUndefined()', () => {
+  it('parses float string', () => {
+    expect(toFloatOrUndefined('3.14')).toBe(3.14);
+  });
+
+  it('returns undefined for non-numeric string', () => {
+    expect(toFloatOrUndefined('abc')).toBeUndefined();
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(toFloatOrUndefined('')).toBeUndefined();
+  });
+});
+
+describe('toPascalCase()', () => {
+  it('converts space-separated words', () => {
+    expect(toPascalCase('hello world')).toBe('HelloWorld');
+  });
+
+  it('converts hyphen-separated words', () => {
+    expect(toPascalCase('foo-bar')).toBe('FooBar');
+  });
+
+  it('capitalizes a single word', () => {
+    expect(toPascalCase('already')).toBe('Already');
+  });
+});
+
+describe('escapeRegex()', () => {
+  it('escapes dots', () => {
+    expect(escapeRegex('hello.world')).toBe('hello\\.world');
+  });
+
+  it('escapes square brackets', () => {
+    expect(escapeRegex('foo[bar]')).toBe('foo\\[bar\\]');
+  });
+
+  it('leaves plain text unchanged', () => {
+    expect(escapeRegex('helloworld')).toBe('helloworld');
   });
 });

--- a/packages/grafana-data/src/text/text.test.ts
+++ b/packages/grafana-data/src/text/text.test.ts
@@ -1,4 +1,4 @@
-import { findMatchesInText, parseFlags } from './text';
+import { findHighlightChunksInText, findMatchesInText, parseFlags } from './text';
 
 describe('findMatchesInText()', () => {
   it('gets no matches for when search and or line are empty', () => {
@@ -64,5 +64,31 @@ describe('parseFlags()', () => {
     expect(parseFlags('(?i-i)foo')).toEqual({ cleaned: 'foo', flags: 'g' });
     expect(parseFlags('(?is)(?-ims)foo')).toEqual({ cleaned: 'foo', flags: 'g' });
     expect(parseFlags('(?i)(?-i)(?i)foo')).toEqual({ cleaned: 'foo', flags: 'gi' });
+  });
+});
+
+describe('findHighlightChunksInText()', () => {
+  it('finds all occurrences of a string search word', () => {
+    const chunks = findHighlightChunksInText({ searchWords: ['foo'], textToHighlight: 'foo bar foo' });
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toMatchObject({ start: 0, end: 3 });
+    expect(chunks[1]).toMatchObject({ start: 8, end: 11 });
+  });
+
+  it('skips RegExp terms (only strings are matched)', () => {
+    const chunks = findHighlightChunksInText({ searchWords: [/foo/], textToHighlight: 'foo bar foo' });
+    expect(chunks).toEqual([]);
+  });
+
+  it('returns empty array when searchWords is empty', () => {
+    const chunks = findHighlightChunksInText({ searchWords: [], textToHighlight: 'foo bar' });
+    expect(chunks).toEqual([]);
+  });
+
+  it('returns union of matches for multiple string search words', () => {
+    const chunks = findHighlightChunksInText({ searchWords: ['foo', 'bar'], textToHighlight: 'foo bar foo' });
+    const texts = chunks.map((c) => c.text);
+    expect(texts).toContain('foo');
+    expect(texts).toContain('bar');
   });
 });

--- a/packages/grafana-ui/src/components/Table/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/utils.test.ts
@@ -1,15 +1,32 @@
 import { faker } from '@faker-js/faker';
 import { Row } from 'react-table';
 
-import { Field, FieldConfigSource, FieldType, MutableDataFrame, SelectableValue } from '@grafana/data';
+import {
+  ActionModel,
+  createTheme,
+  Field,
+  FieldConfigSource,
+  FieldType,
+  LinkModel,
+  MutableDataFrame,
+  SelectableValue,
+} from '@grafana/data';
+import { BarGaugeDisplayMode, TableCellBackgroundDisplayMode, TableCellDisplayMode } from '@grafana/schema';
 
 import {
+  calculateAroundPointThreshold,
   calculateUniqueFieldValues,
   filterByValue,
+  getCellColors,
+  getCellOptions,
   getColumns,
+  getDataLinksActionsTooltipUtils,
   getFilteredOptions,
   getTextAlign,
+  isPointTimeValAroundTableTimeVal,
+  migrateTableDisplayModeToCellOptions,
   rowToFieldValue,
+  sortCaseInsensitive,
   sortNumber,
   sortOptions,
   valuesToOptions,
@@ -615,5 +632,147 @@ describe('Table utils', () => {
       const longestField = guessLongestField(config, data);
       expect(longestField?.name).toBe('Lorem 10');
     });
+  });
+});
+
+describe('isPointTimeValAroundTableTimeVal', () => {
+  it('returns true when point time is within threshold of row time', () => {
+    expect(isPointTimeValAroundTableTimeVal(1000.7, 1000, 5)).toBe(true);
+  });
+
+  it('returns false when point time exceeds threshold', () => {
+    expect(isPointTimeValAroundTableTimeVal(1010, 1000, 5)).toBe(false);
+  });
+});
+
+describe('calculateAroundPointThreshold', () => {
+  it('returns 0 when fewer than 2 values', () => {
+    const field = { values: [1000] } as unknown as Field;
+    expect(calculateAroundPointThreshold(field)).toBe(0);
+  });
+
+  it('calculates (max - min) / length', () => {
+    const field = { values: [1000, 2000, 3000] } as unknown as Field;
+    expect(calculateAroundPointThreshold(field)).toBeCloseTo((3000 - 1000) / 3);
+  });
+});
+
+describe('sortCaseInsensitive', () => {
+  it('sorts rows case-insensitively', () => {
+    const rowA = { values: { name: 'banana' } } as unknown as Row;
+    const rowB = { values: { name: 'Apple' } } as unknown as Row;
+    expect(sortCaseInsensitive(rowA, rowB, 'name')).toBeGreaterThan(0);
+    expect(sortCaseInsensitive(rowB, rowA, 'name')).toBeLessThan(0);
+  });
+});
+
+describe('getDataLinksActionsTooltipUtils', () => {
+  it('shouldShowLink true when exactly 1 link and no actions', () => {
+    const result = getDataLinksActionsTooltipUtils([{ href: '#' } as unknown as LinkModel]);
+    expect(result.shouldShowLink).toBe(true);
+    expect(result.hasMultipleLinksOrActions).toBe(false);
+  });
+
+  it('hasMultipleLinksOrActions true when multiple links', () => {
+    const result = getDataLinksActionsTooltipUtils([
+      { href: '#' } as unknown as LinkModel,
+      { href: '#2' } as unknown as LinkModel,
+    ]);
+    expect(result.shouldShowLink).toBe(false);
+    expect(result.hasMultipleLinksOrActions).toBe(true);
+  });
+
+  it('hasMultipleLinksOrActions true when actions present', () => {
+    const result = getDataLinksActionsTooltipUtils(
+      [{ href: '#' } as unknown as LinkModel],
+      [{ title: 'Delete' } as unknown as ActionModel]
+    );
+    expect(result.hasMultipleLinksOrActions).toBe(true);
+    expect(result.shouldShowLink).toBe(false);
+  });
+});
+
+describe('migrateTableDisplayModeToCellOptions', () => {
+  it.each([
+    ['basic', BarGaugeDisplayMode.Basic],
+    ['gradient-gauge', BarGaugeDisplayMode.Gradient],
+    ['lcd-gauge', BarGaugeDisplayMode.Lcd],
+  ])('migrates %s to Gauge cell with correct mode', (displayMode, expectedMode) => {
+    const result = migrateTableDisplayModeToCellOptions(displayMode as TableCellDisplayMode);
+    expect(result.type).toBe(TableCellDisplayMode.Gauge);
+    expect((result as { mode?: BarGaugeDisplayMode }).mode).toBe(expectedMode);
+  });
+
+  it.each([
+    ['color-background', TableCellBackgroundDisplayMode.Gradient],
+    ['color-background-solid', TableCellBackgroundDisplayMode.Basic],
+  ])('migrates %s to ColorBackground cell with correct mode', (displayMode, expectedMode) => {
+    const result = migrateTableDisplayModeToCellOptions(displayMode as TableCellDisplayMode);
+    expect(result.type).toBe(TableCellDisplayMode.ColorBackground);
+    expect((result as { mode?: TableCellBackgroundDisplayMode }).mode).toBe(expectedMode);
+  });
+
+  it('falls through to default for other display modes', () => {
+    const result = migrateTableDisplayModeToCellOptions('json-view' as TableCellDisplayMode);
+    expect(result.type).toBe('json-view');
+  });
+});
+
+describe('getCellColors', () => {
+  const theme = createTheme();
+
+  it('returns textColor for ColorText mode', () => {
+    const result = getCellColors(
+      theme,
+      { type: TableCellDisplayMode.ColorText },
+      { color: 'red', text: '1', numeric: 1 }
+    );
+    expect(result.textColor).toBe('red');
+    expect(result.bgColor).toBeUndefined();
+  });
+
+  it('returns bgColor for ColorBackground Basic mode', () => {
+    const result = getCellColors(
+      theme,
+      { type: TableCellDisplayMode.ColorBackground, mode: TableCellBackgroundDisplayMode.Basic },
+      { color: '#ff0000', text: '1', numeric: 1 }
+    );
+    expect(result.bgColor).toBeDefined();
+    expect(result.textColor).toBeDefined();
+  });
+
+  it('returns gradient bgColor for ColorBackground Gradient mode', () => {
+    const result = getCellColors(
+      theme,
+      { type: TableCellDisplayMode.ColorBackground, mode: TableCellBackgroundDisplayMode.Gradient },
+      { color: '#ff0000', text: '1', numeric: 1 }
+    );
+    expect(result.bgColor).toContain('linear-gradient');
+  });
+
+  it('returns no colors for non-color modes', () => {
+    const result = getCellColors(theme, { type: TableCellDisplayMode.Auto }, { color: 'red', text: '1', numeric: 1 });
+    expect(result.textColor).toBeUndefined();
+    expect(result.bgColor).toBeUndefined();
+  });
+});
+
+describe('getCellOptions', () => {
+  it('migrates legacy displayMode when present', () => {
+    const field = { config: { custom: { displayMode: 'basic' } } } as unknown as Field;
+    const result = getCellOptions(field);
+    expect(result.type).toBe(TableCellDisplayMode.Gauge);
+  });
+
+  it('returns default Auto options when no cellOptions configured', () => {
+    const field = { config: { custom: {} } } as unknown as Field;
+    const result = getCellOptions(field);
+    expect(result.type).toBe(TableCellDisplayMode.Auto);
+  });
+
+  it('returns existing cellOptions when set', () => {
+    const cellOptions = { type: TableCellDisplayMode.JSONView };
+    const field = { config: { custom: { cellOptions } } } as unknown as Field;
+    expect(getCellOptions(field)).toBe(cellOptions);
   });
 });

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
@@ -1,6 +1,8 @@
 // TODO: migrate tests below to the builder
 
-import { createTheme, ThresholdsMode } from '@grafana/data';
+import uPlot from 'uplot';
+
+import { createTheme, DataFrame, ThresholdsMode } from '@grafana/data';
 import {
   GraphGradientMode,
   AxisPlacement,
@@ -919,6 +921,68 @@ describe('UPlotConfigBuilder', () => {
       expect(axesConfig[0].grid!.show).toBe(false);
       expect(axesConfig[1].grid!.show).toBe(false);
       expect(axesConfig[2].grid!.show).toBe(true);
+    });
+  });
+
+  describe('pointColorFn cursor callbacks', () => {
+    it('does not throw when this.frames is undefined (before prepData runs)', () => {
+      const builder = new UPlotConfigBuilder();
+      const config = builder.getConfig();
+
+      const mockU = {
+        series: [null, { points: { _stroke: () => 'blue' } }],
+        cursor: { idxs: [null, 5] },
+      } as unknown as uPlot;
+
+      expect(() => {
+        // @ts-ignore — accessing private config internals for test
+        config.cursor!.points!.stroke!(mockU, 1);
+      }).not.toThrow();
+    });
+
+    it('does not throw when field.values is undefined', () => {
+      const builder = new UPlotConfigBuilder();
+      builder['frames'] = [
+        {
+          fields: [null, { display: jest.fn(() => ({ color: 'red', text: '1', numeric: 1 })), values: undefined }],
+        },
+      ] as unknown as DataFrame[];
+
+      const config = builder.getConfig();
+      const mockU = {
+        series: [null, { points: { _stroke: () => 'blue' } }],
+        cursor: { idxs: [null, 5] },
+      } as unknown as uPlot;
+
+      expect(() => {
+        // @ts-ignore
+        config.cursor!.points!.stroke!(mockU, 1);
+      }).not.toThrow();
+    });
+
+    it('returns correct color when all data is available', () => {
+      const builder = new UPlotConfigBuilder();
+      builder['frames'] = [
+        {
+          fields: [
+            null,
+            {
+              display: jest.fn(() => ({ color: '#ff0000', text: '42', numeric: 42 })),
+              values: [0, 42, 100],
+            },
+          ],
+        },
+      ] as unknown as DataFrame[];
+
+      const config = builder.getConfig();
+      const mockU = {
+        series: [null, { points: { _stroke: () => 'fn' } }],
+        cursor: { idxs: [null, 1] },
+      } as unknown as uPlot;
+
+      // @ts-ignore
+      const color = config.cursor!.points!.fill!(mockU, 1);
+      expect(color).toBe('#ff0000');
     });
   });
 });

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
@@ -1009,5 +1009,84 @@ describe('UPlotConfigBuilder', () => {
       const color = config.cursor!.points!.fill!(mockU, 1);
       expect(color).toBe('#ff0000');
     });
+
+    it('returns the stroke string directly when _stroke is already a string', () => {
+      const builder = new UPlotConfigBuilder();
+      const config = builder.getConfig();
+      const mockU = {
+        series: [null, { points: { _stroke: '#aabbcc' } }],
+        cursor: { idxs: [null, 0] },
+      } as unknown as uPlot;
+
+      // @ts-ignore
+      const result = config.cursor!.points!.stroke!(mockU, 1);
+      expect(result).toMatch(/^#aabbcc/);
+    });
+
+    it('does not throw when the field at seriesIdx is undefined', () => {
+      const builder = new UPlotConfigBuilder();
+      builder['frames'] = [{ fields: [] }] as unknown as DataFrame[];
+
+      const config = builder.getConfig();
+      const mockU = {
+        series: [null, { points: { _stroke: () => 'fn' } }],
+        cursor: { idxs: [null, 1] },
+      } as unknown as uPlot;
+
+      expect(() => {
+        // @ts-ignore
+        config.cursor!.points!.stroke!(mockU, 1);
+      }).not.toThrow();
+    });
+
+    it('does not throw when field.display is undefined', () => {
+      const builder = new UPlotConfigBuilder();
+      builder['frames'] = [{ fields: [null, { display: undefined, values: [1, 2, 3] }] }] as unknown as DataFrame[];
+
+      const config = builder.getConfig();
+      const mockU = {
+        series: [null, { points: { _stroke: () => 'fn' } }],
+        cursor: { idxs: [null, 1] },
+      } as unknown as uPlot;
+
+      expect(() => {
+        // @ts-ignore
+        config.cursor!.points!.stroke!(mockU, 1);
+      }).not.toThrow();
+    });
+
+    it('does not throw when cursor.idxs entry for the series is undefined', () => {
+      const builder = new UPlotConfigBuilder();
+      builder['frames'] = [
+        {
+          fields: [null, { display: jest.fn(() => ({ color: 'red', text: '1', numeric: 1 })), values: [1, 2, 3] }],
+        },
+      ] as unknown as DataFrame[];
+
+      const config = builder.getConfig();
+      const mockU = {
+        series: [null, { points: { _stroke: () => 'fn' } }],
+        cursor: { idxs: [null, undefined] },
+      } as unknown as uPlot;
+
+      expect(() => {
+        // @ts-ignore
+        config.cursor!.points!.stroke!(mockU, 1);
+      }).not.toThrow();
+    });
+
+    it('does not throw when cursor.idxs itself is null', () => {
+      const builder = new UPlotConfigBuilder();
+      const config = builder.getConfig();
+      const mockU = {
+        series: [null, { points: { _stroke: () => 'fn' } }],
+        cursor: { idxs: null },
+      } as unknown as uPlot;
+
+      expect(() => {
+        // @ts-ignore
+        config.cursor!.points!.stroke!(mockU, 1);
+      }).not.toThrow();
+    });
   });
 });

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
@@ -960,6 +960,31 @@ describe('UPlotConfigBuilder', () => {
       }).not.toThrow();
     });
 
+    it('returns empty string when display resolves without a color (no crash)', () => {
+      const builder = new UPlotConfigBuilder();
+      builder['frames'] = [
+        {
+          fields: [
+            null,
+            {
+              display: jest.fn(() => ({ text: '42', numeric: 42 })), // no color
+              values: [0, 42],
+            },
+          ],
+        },
+      ] as unknown as DataFrame[];
+
+      const config = builder.getConfig();
+      const mockU = {
+        series: [null, { points: { _stroke: () => 'fn' } }],
+        cursor: { idxs: [null, 1] },
+      } as unknown as uPlot;
+
+      // @ts-ignore
+      const result = config.cursor!.points!.stroke!(mockU, 1);
+      expect(result).toBe('80'); // '' + '80'
+    });
+
     it('returns correct color when all data is available', () => {
       const builder = new UPlotConfigBuilder();
       builder['frames'] = [

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -210,11 +210,16 @@ export class UPlotConfigBuilder {
 
         // interpolate for gradients/thresholds
         if (typeof s !== 'string') {
-          let field = this.frames![0].fields[seriesIdx];
-          s = field.display!(field.values[u.cursor.idxs![seriesIdx]!]).color!;
+          const frame = this.frames?.[0];
+          const field = frame?.fields[seriesIdx];
+          const dataIdx = u.cursor.idxs?.[seriesIdx];
+
+          if (field?.display != null && field.values != null && dataIdx != null) {
+            s = field.display(field.values[dataIdx])?.color ?? s;
+          }
         }
 
-        return s + alphaHex;
+        return (typeof s === 'string' ? s : '') + alphaHex;
       };
 
     config.cursor = merge(

--- a/public/app/core/components/TimeSeries/utils.test.ts
+++ b/public/app/core/components/TimeSeries/utils.test.ts
@@ -1,23 +1,16 @@
-import { createDataFrame, dateTime, DateTimeInput, EventBus, FieldType } from '@grafana/data';
-import { getTheme } from '@grafana/ui';
+import uPlot from 'uplot';
+
+import { createDataFrame, createTheme, dateTime, DateTimeInput, FieldType } from '@grafana/data';
 
 import { getXAxisConfig, preparePlotConfigBuilder, UPLOT_DEFAULT_AXIS_GAP } from './utils';
 
 describe('when fill below to option is used', () => {
-  let eventBus: EventBus;
   // eslint-disable-next-line
   let renderers: any[];
   // eslint-disable-next-line
   let tests: any;
 
   beforeEach(() => {
-    eventBus = {
-      publish: jest.fn(),
-      getStream: jest.fn(),
-      subscribe: jest.fn(),
-      removeAllListeners: jest.fn(),
-      newScopedBus: jest.fn(),
-    };
     renderers = [];
 
     tests = [
@@ -200,12 +193,9 @@ describe('when fill below to option is used', () => {
     for (const test of tests) {
       const builder = preparePlotConfigBuilder({
         frame: test.alignedFrame,
-        //@ts-ignore
-        theme: getTheme(),
+        theme: createTheme(),
         timeZones: ['browser'],
         getTimeRange: jest.fn(),
-        eventBus,
-        sync: jest.fn(),
         allFrames: test.allFrames,
         renderers,
       });
@@ -228,12 +218,9 @@ describe('when fill below to option is used', () => {
     for (const test of tests) {
       const builder = preparePlotConfigBuilder({
         frame: test.alignedFrame,
-        //@ts-ignore
-        theme: getTheme(),
+        theme: createTheme(),
         timeZones: ['browser'],
         getTimeRange: jest.fn(),
-        eventBus,
-        sync: jest.fn(),
         allFrames: test.allFrames,
         renderers,
       });
@@ -257,12 +244,9 @@ describe('when fill below to option is used', () => {
     for (const test of tests) {
       const builder = preparePlotConfigBuilder({
         frame: test.alignedFrame,
-        //@ts-ignore
-        theme: getTheme(),
+        theme: createTheme(),
         timeZones: ['browser'],
         getTimeRange: jest.fn(),
-        eventBus,
-        sync: jest.fn(),
         allFrames: test.allFrames,
         renderers,
       });
@@ -297,21 +281,11 @@ describe('time axis units', () => {
         },
       ],
     });
-    const eventBus = {
-      publish: jest.fn(),
-      getStream: jest.fn(),
-      subscribe: jest.fn(),
-      removeAllListeners: jest.fn(),
-      newScopedBus: jest.fn(),
-    };
     const builder = preparePlotConfigBuilder({
       frame,
-      //@ts-ignore
-      theme: getTheme(),
+      theme: createTheme(),
       timeZones: ['browser'],
       getTimeRange: jest.fn(),
-      eventBus,
-      sync: jest.fn(),
       allFrames: [frame],
       renderers: [],
     });
@@ -351,21 +325,11 @@ describe('time axis units', () => {
         },
       ],
     });
-    const eventBus = {
-      publish: jest.fn(),
-      getStream: jest.fn(),
-      subscribe: jest.fn(),
-      removeAllListeners: jest.fn(),
-      newScopedBus: jest.fn(),
-    };
     const builder = preparePlotConfigBuilder({
       frame,
-      //@ts-ignore
-      theme: getTheme(),
+      theme: createTheme(),
       timeZones: ['browser'],
       getTimeRange: jest.fn(),
-      eventBus,
-      sync: jest.fn(),
       allFrames: [frame],
       renderers: [],
     });
@@ -396,5 +360,79 @@ describe('calculateAnnotationLaneSizes', () => {
         size: 26,
       },
     });
+  });
+});
+
+describe('preparePlotConfigBuilder crash guards', () => {
+  it('does not throw when a renderer references a field not present in the aligned frame', () => {
+    const frame = createDataFrame({
+      fields: [
+        {
+          type: FieldType.time,
+          name: 'Time',
+          values: [1000, 2000, 3000],
+          state: { multipleFrames: false, displayName: 'Time', origin: { fieldIndex: 0, frameIndex: 0 } },
+        },
+        {
+          type: FieldType.number,
+          name: 'Value',
+          values: [1, 2, 3],
+          state: { multipleFrames: false, displayName: 'Value', origin: { fieldIndex: 1, frameIndex: 0 } },
+        },
+      ],
+    });
+
+    expect(() => {
+      preparePlotConfigBuilder({
+        frame,
+        theme: createTheme(),
+        timeZones: ['browser'],
+        getTimeRange: jest.fn(),
+        allFrames: [frame],
+        renderers: [
+          {
+            fieldMap: { main: 'NonExistentField' },
+            indicesOnly: [],
+            init: jest.fn(),
+          },
+        ],
+      });
+    }).not.toThrow();
+  });
+
+  it('pointColorFn does not throw when invoked before prepData (panel type change scenario)', () => {
+    const frame = createDataFrame({
+      fields: [
+        { type: FieldType.time, name: 'Time', values: [1000, 2000] },
+        {
+          type: FieldType.number,
+          name: 'Value',
+          config: { color: { mode: 'thresholds' } },
+          values: [1, 2],
+        },
+      ],
+    });
+
+    const builder = preparePlotConfigBuilder({
+      frame,
+      theme: createTheme(),
+      timeZones: ['browser'],
+      getTimeRange: jest.fn(),
+      allFrames: [frame],
+      renderers: [],
+    });
+
+    // Simulate getConfig() being called before prepData (reinitPlot ordering)
+    const config = builder.getConfig();
+
+    const mockPlot = {
+      series: [null, { points: { _stroke: () => 'fn' } }],
+      cursor: { idxs: [null, 0] },
+    } as unknown as uPlot;
+
+    expect(() => {
+      // @ts-ignore
+      config.cursor!.points!.stroke!(mockPlot, 1);
+    }).not.toThrow();
   });
 });

--- a/public/app/core/components/TimeSeries/utils.test.ts
+++ b/public/app/core/components/TimeSeries/utils.test.ts
@@ -1,6 +1,6 @@
 import uPlot from 'uplot';
 
-import { createDataFrame, createTheme, dateTime, DateTimeInput, FieldType } from '@grafana/data';
+import { createDataFrame, createTheme, dateTime, DateTimeInput, DataFrame, FieldType } from '@grafana/data';
 
 import { getXAxisConfig, preparePlotConfigBuilder, UPLOT_DEFAULT_AXIS_GAP } from './utils';
 
@@ -398,6 +398,49 @@ describe('preparePlotConfigBuilder crash guards', () => {
         ],
       });
     }).not.toThrow();
+  });
+
+  it('maps fieldIndices correctly when renderer field exists in aligned frame', () => {
+    // Use a raw frame object rather than createDataFrame because createDataFrame
+    // strips field.state (needed by getNamesToFieldIndex to build the name→index map).
+    const frame = {
+      fields: [
+        {
+          config: {},
+          values: [1000, 2000, 3000],
+          name: 'Time',
+          state: { multipleFrames: false, displayName: 'Time', origin: { fieldIndex: 0, frameIndex: 0 } },
+          type: FieldType.time,
+        },
+        {
+          config: {},
+          values: [1, 2, 3],
+          name: 'Value',
+          state: { multipleFrames: false, displayName: 'Value', origin: { fieldIndex: 1, frameIndex: 0 } },
+          type: FieldType.number,
+        },
+      ],
+      length: 3,
+    } as unknown as DataFrame;
+
+    const mockInit = jest.fn();
+
+    preparePlotConfigBuilder({
+      frame,
+      theme: createTheme(),
+      timeZones: ['browser'],
+      getTimeRange: jest.fn(),
+      allFrames: [frame],
+      renderers: [
+        {
+          fieldMap: { main: 'Value' },
+          indicesOnly: [],
+          init: mockInit,
+        },
+      ],
+    });
+
+    expect(mockInit).toHaveBeenCalledWith(expect.anything(), { main: 1 });
   });
 
   it('pointColorFn does not throw when invoked before prepData (panel type change scenario)', () => {

--- a/public/app/core/components/TimeSeries/utils.test.ts
+++ b/public/app/core/components/TimeSeries/utils.test.ts
@@ -443,6 +443,46 @@ describe('preparePlotConfigBuilder crash guards', () => {
     expect(mockInit).toHaveBeenCalledWith(expect.anything(), { main: 1 });
   });
 
+  it('reuses the same index map for multiple renderers without re-computing it', () => {
+    const frame = {
+      fields: [
+        {
+          config: {},
+          values: [1000, 2000, 3000],
+          name: 'Time',
+          state: { multipleFrames: false, displayName: 'Time', origin: { fieldIndex: 0, frameIndex: 0 } },
+          type: FieldType.time,
+        },
+        {
+          config: {},
+          values: [1, 2, 3],
+          name: 'Value',
+          state: { multipleFrames: false, displayName: 'Value', origin: { fieldIndex: 1, frameIndex: 0 } },
+          type: FieldType.number,
+        },
+      ],
+      length: 3,
+    } as unknown as DataFrame;
+
+    const mockInit1 = jest.fn();
+    const mockInit2 = jest.fn();
+
+    preparePlotConfigBuilder({
+      frame,
+      theme: createTheme(),
+      timeZones: ['browser'],
+      getTimeRange: jest.fn(),
+      allFrames: [frame],
+      renderers: [
+        { fieldMap: { main: 'Value' }, indicesOnly: [], init: mockInit1 },
+        { fieldMap: { secondary: 'Value' }, indicesOnly: [], init: mockInit2 },
+      ],
+    });
+
+    expect(mockInit1).toHaveBeenCalledWith(expect.anything(), { main: 1 });
+    expect(mockInit2).toHaveBeenCalledWith(expect.anything(), { secondary: 1 });
+  });
+
   it('pointColorFn does not throw when invoked before prepData (panel type change scenario)', () => {
     const frame = createDataFrame({
       fields: [

--- a/public/app/core/components/TimeSeries/utils.ts
+++ b/public/app/core/components/TimeSeries/utils.ts
@@ -684,7 +684,10 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn = ({
 
     for (let key in r.fieldMap) {
       let dispName = r.fieldMap[key];
-      fieldIndices[key] = indexByName.get(dispName)!;
+      const fieldIndex = indexByName.get(dispName);
+      if (fieldIndex != null) {
+        fieldIndices[key] = fieldIndex;
+      }
     }
 
     r.init(builder, fieldIndices);


### PR DESCRIPTION
**What is this feature?**

Crash-guard fixes for `pointColorFn` in `UPlotConfigBuilder` and `fieldIndices` in `preparePlotConfigBuilder` when switching panel types during metrics drilldown.

**Why do we need this feature?**

`getConfig()` can be called before `prepData()` runs during panel-type switches, leaving `this.frames` as `undefined` and causing a hard crash in the cursor callback. Separately, a renderer whose `fieldMap` referenced a field absent from the aligned frame was writing `undefined` into `fieldIndices` via a non-null assertion lie, which could crash renderer `init` functions.

**Who is this feature for?**

Users experiencing crashes when switching panel types or navigating metrics drilldown.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/20930

**Special notes for your reviewer:**

- `pointColorFn` uses `typeof s === 'string'` at the return rather than `?? ''` — a function reference is truthy, so `??` would not catch it and would concatenate its `.toString()` into an invalid canvas color string.
- `fieldIndices` skips assignment for missing fields rather than writing `undefined` through a non-null assertion.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
