### PR TITLE
Alerting: Add frontend only feature flag alertingAlertListPanelEnhancements

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -649,6 +649,11 @@ export interface FeatureToggles {
   */
   alertingListViewV2?: boolean;
   /**
+  * Enables enhanced stat mode for the Alert List panel with thresholds, value mappings, and linking
+  * @default false
+  */
+  alertingAlertListPanelEnhancements?: boolean;
+  /**
   * Enables the new Alerting navigation structure with improved menu grouping
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1017,6 +1017,14 @@ var (
 			Expression:   "false",
 		},
 		{
+			Name:         "alertingAlertListPanelEnhancements",
+			Description:  "Enables enhanced stat mode for the Alert List panel with thresholds, value mappings, and linking",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: true,
+			Owner:        grafanaAlertingSquad,
+			Expression:   "false",
+		},
+		{
 			Name:         "alertingNavigationV2",
 			Description:  "Enables the new Alerting navigation structure with improved menu grouping",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -125,6 +125,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-10-28,dashboardTemplates,preview,@grafana/sharing-squad,false,false,false
 2026-02-18,dashboardTemplatesAssistantButton,experimental,@grafana/sharing-squad,false,false,true
 2024-05-24,alertingListViewV2,privatePreview,@grafana/alerting-squad,false,false,true
+2026-03-02,alertingAlertListPanelEnhancements,experimental,@grafana/alerting-squad,false,false,true
 2026-01-14,alertingNavigationV2,experimental,@grafana/alerting-squad,false,false,false
 2025-12-19,alertingSavedSearches,experimental,@grafana/alerting-squad,false,false,true
 2026-01-29,alertingTriageSavedSearches,experimental,@grafana/alerting-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -174,6 +174,20 @@
     },
     {
       "metadata": {
+        "name": "alertingAlertListPanelEnhancements",
+        "resourceVersion": "1772477753403",
+        "creationTimestamp": "2026-03-02T18:55:53Z"
+      },
+      "spec": {
+        "description": "Enables enhanced stat mode for the Alert List panel with thresholds, value mappings, and linking",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingAlertsActivityBanner",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2026-02-18T17:05:38Z"


### PR DESCRIPTION
**What is this feature?**

This PR adds a frontend only feature flag `alertingAlertListPanelEnhancements` to be used with frontend changes 

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/grafana/issues/96965
