### PR TITLE
Fixed pyroscope label for github actions

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -184,7 +184,7 @@
       "pkg/tsdb/grafana-pyroscope-datasource/**/*"
     ],
     "action": "updateLabel",
-    "addLabel": "datasource/grafana-pyroscope"
+    "addLabel": "datasource/Pyroscope"
   },
   {
     "type": "changedfiles",


### PR DESCRIPTION
We recently renamed the pyroscope label `datasource/grafana-pyroscope` to `datasource/Pyroscope` and so updating/fixing the corresponding auto label actions.