### PR TITLE
QueryEditor: Fix error state for `QueryEditorRenderer`

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { useState } from 'react';
 
-import { DataSourceApi, DataSourceJsonData } from '@grafana/data';
+import { DataQueryError, DataSourceApi, DataSourceJsonData, getDefaultTimeRange, LoadingState } from '@grafana/data';
 import { VizPanel } from '@grafana/scenes';
 import { DataQuery } from '@grafana/schema';
 
@@ -22,7 +22,7 @@ jest.mock('app/features/query/components/QueryEditorRow', () => ({
 }));
 
 jest.mock('app/features/query/components/QueryErrorAlert', () => ({
-  QueryErrorAlert: () => null,
+  QueryErrorAlert: ({ error }: { error: DataQueryError }) => <div data-testid="query-error-alert">{error.message}</div>,
 }));
 
 interface TestQuery extends DataQuery {
@@ -133,5 +133,23 @@ describe('QueryEditorRenderer', () => {
 
     // Must show series-b, not the stale series-a value from query A's editor instance
     expect(screen.getByTestId('query-editor-legend')).toHaveTextContent('series-b');
+  });
+
+  it('shows an error when the query has an error', () => {
+    renderWithQueryEditorProvider(<QueryEditorRenderer />, {
+      queries: [queryA, queryB],
+      selectedQuery: queryA,
+      uiStateOverrides: { selectedQueryDsData },
+      qrState: {
+        data: {
+          state: LoadingState.Error,
+          series: [],
+          timeRange: getDefaultTimeRange(),
+          errors: [{ message: 'Error!!', refId: queryA.refId }],
+        },
+      },
+    });
+
+    expect(screen.getByText('Error!!')).toBeInTheDocument();
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
@@ -10,9 +10,10 @@ import { QueryErrorAlert } from 'app/features/query/components/QueryErrorAlert';
 import { useActionsContext, useQueryEditorUIContext, useQueryRunnerContext } from './QueryEditorContext';
 
 export function QueryEditorRenderer() {
-  const { queries, data, queryError } = useQueryRunnerContext();
+  const { queries, data } = useQueryRunnerContext();
   const { selectedQuery, selectedQueryDsData, selectedQueryDsLoading } = useQueryEditorUIContext();
   const { updateSelectedQuery, addQuery, runQueries } = useActionsContext();
+  const error = data?.errors?.find((e) => e.refId === selectedQuery?.refId);
 
   const selectedRefId = selectedQuery?.refId;
 
@@ -97,7 +98,7 @@ export function QueryEditorRenderer() {
           range={filteredData?.timeRange}
         />
       </DataSourcePluginContextProvider>
-      {queryError && <QueryErrorAlert error={queryError} />}
+      {error && <QueryErrorAlert error={error} />}
     </>
   );
 }


### PR DESCRIPTION
## Description
`QueryEditorRenderer` was using `queryError` from our context to surface the error state but that is not working correctly on initial render. This fixes it by using the `data.errors` array.

## Demo
<img width="1308" height="414" alt="CleanShot 2026-03-02 at 15 04 49" src="https://github.com/user-attachments/assets/e18c4156-a779-41b9-a091-572c78c3c00a" />

## Testing Instructions
* Create a new dashboard
* Change the datasource of the first query to be something that will error, (ie `gdev-influxdb-flux` errors for me)
* On main, you won't get the error in the query editor content, but on this branch you should. 

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable