### PR TITLE
PanelEdit: Use a simpler method to determine whether panel has changes

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -1,3 +1,4 @@
+import deepEqual from 'fast-deep-equal';
 import * as H from 'history';
 import { debounce } from 'lodash';
 
@@ -25,7 +26,6 @@ import { VizSuggestionsInteractions } from 'app/features/panel/components/VizTyp
 
 import { DashboardEditActionEvent } from '../edit-pane/shared';
 import { DashboardSceneChangeTracker } from '../saving/DashboardSceneChangeTracker';
-import { getPanelChanges } from '../saving/getDashboardChanges';
 import { UNCONFIGURED_PANEL_PLUGIN_ID } from '../scene/UnconfiguredPanel';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { DashboardLayoutItem, isDashboardLayoutItem } from '../scene/types/DashboardLayoutItem';
@@ -193,8 +193,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
   private _setupChangeDetection() {
     const panel = this.state.panelRef.resolve();
     const performSaveModelDiff = () => {
-      const { hasChanges } = getPanelChanges(this._originalSaveModel, vizPanelToPanel(panel));
-      this.setState({ isDirty: hasChanges });
+      this.setState({ isDirty: !deepEqual(this._originalSaveModel, vizPanelToPanel(panel)) });
     };
 
     const performSaveModelDiffDebounced = this.debounceSaveModelDiff

--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.test.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.test.ts
@@ -1,6 +1,6 @@
-import { Dashboard, Panel } from '@grafana/schema';
+import { Dashboard } from '@grafana/schema';
 
-import { adHocVariableFiltersEqual, getRawDashboardChanges, getPanelChanges } from './getDashboardChanges';
+import { adHocVariableFiltersEqual, getRawDashboardChanges } from './getDashboardChanges';
 
 describe('adHocVariableFiltersEqual', () => {
   it('should compare empty filters', () => {
@@ -433,116 +433,5 @@ describe('getDashboardChanges', () => {
     const result = getRawDashboardChanges(initial, changed, false, true, false);
 
     expect(result).toEqual(expectedChanges);
-  });
-});
-
-describe('getPanelChanges', () => {
-  const initial: Panel = {
-    id: 1,
-    type: 'graph',
-    title: 'Panel 1',
-    gridPos: {
-      x: 0,
-      y: 0,
-      w: 12,
-      h: 8,
-    },
-    targets: [
-      {
-        refId: 'A',
-        query: 'query1',
-      },
-    ],
-  };
-
-  it('should return the correct result when no changes', () => {
-    const changed = { ...initial };
-
-    const expectedChanges = {
-      initialSaveModel: {
-        ...initial,
-      },
-      changedSaveModel: {
-        ...changed,
-      },
-      diffs: {},
-      diffCount: 0,
-      hasChanges: false,
-    };
-
-    expect(getPanelChanges(initial, changed)).toEqual(expectedChanges);
-  });
-
-  it('should return the correct result when there is some changes', () => {
-    const changed = {
-      ...initial,
-      title: 'Panel 2',
-      type: 'table',
-      gridPos: {
-        ...initial.gridPos,
-        x: 1,
-      },
-      targets: [
-        {
-          refId: 'A',
-          query: 'query2',
-        },
-      ],
-    } as Panel;
-
-    const expectedChanges = {
-      initialSaveModel: {
-        ...initial,
-      },
-      changedSaveModel: {
-        ...changed,
-      },
-      diffs: {
-        title: [
-          {
-            endLineNumber: 3,
-            op: 'replace',
-            originalValue: 'Panel 1',
-            path: ['title'],
-            startLineNumber: 3,
-            value: 'Panel 2',
-          },
-        ],
-        type: [
-          {
-            endLineNumber: 2,
-            op: 'replace',
-            originalValue: 'graph',
-            path: ['type'],
-            startLineNumber: 2,
-            value: 'table',
-          },
-        ],
-        gridPos: [
-          {
-            endLineNumber: 5,
-            op: 'replace',
-            originalValue: 0,
-            path: ['gridPos', 'x'],
-            startLineNumber: 5,
-            value: 1,
-          },
-        ],
-        targets: [
-          {
-            endLineNumber: 13,
-            op: 'replace',
-            originalValue: 'query1',
-            path: ['targets', '0', 'query'],
-            startLineNumber: 13,
-            value: 'query2',
-          },
-        ],
-      },
-      diffCount: 4,
-      hasChanges: true,
-    };
-
-    expect(getPanelChanges(changed, initial)).toEqual(expectedChanges);
   });
 });

--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 
 import type { AdHocVariableModel, TextBoxVariableModel, TypedVariableModel } from '@grafana/data';
-import { Dashboard, Panel, VariableOption } from '@grafana/schema';
+import { Dashboard, VariableOption } from '@grafana/schema';
 import {
   AdHocFilterWithLabels,
   AdhocVariableSpec,
@@ -282,17 +282,4 @@ export function applyVariableChanges(saveModel: Dashboard, originalSaveModel: Da
   }
 
   return hasVariableValueChanges;
-}
-
-export function getPanelChanges(saveModel: Panel, originalSaveModel: Panel) {
-  const diff = jsonDiff(originalSaveModel, saveModel);
-  const diffCount = Object.values(diff).reduce((acc, cur) => acc + cur.length, 0);
-
-  return {
-    changedSaveModel: saveModel,
-    initialSaveModel: originalSaveModel,
-    diffs: diff,
-    diffCount,
-    hasChanges: diffCount > 0,
-  };
 }


### PR DESCRIPTION
While working on other performance improvements, I noticed this issue in PanelEdit.

The `getPanelChanges` method called [`jsonDiff`](https://github.com/grafana/grafana/blob/e35f65b865ab35d0c43a3a0627b88d303b198706/public/app/features/dashboard-scene/settings/version-history/utils.ts#L21-L61), which performs a JSON Diff using `fast-json-patch` (nice!), but then does a whole bunch of other stuff that PanelEdit doesn't use. It turns out all that serde was costing us when messing with transforms or other changes that mess with the panel json for complex panels. I've updated it to be a simple call to `fast-deep-equal`, which presumably will also stop on the first delta it encounters, which should be faster in all cases. I also deleted the now unused `getPanelChanges` method and tests.

### Testing a complex panel, toggling a transform on and off 5 times (4x slowdown)

#### Before
<img width="679" height="831" alt="Screenshot 2026-03-02 at 3 27 36 PM" src="https://github.com/user-attachments/assets/8447c0cc-f80e-4287-a194-b25946232cfb" />


#### After
<img width="679" height="822" alt="Screenshot 2026-03-02 at 3 19 50 PM" src="https://github.com/user-attachments/assets/a54297e2-4498-4c9c-a3d6-55536cf1658e" />
