### PR TITLE
Gauge: Fix awkward circular gauge cutoff

### DIFF
--- a/packages/grafana-ui/src/components/RadialGauge/RadialArcPath.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialArcPath.tsx
@@ -111,7 +111,13 @@ export const RadialArcPath = memo(
     const vizContent = (
       <>
         {isGradient ? (
-          <foreignObject x={boxX} y={Math.max(boxY, 0)} width={vizWidth} height={vizHeight} mask={`url(#${id})`}>
+          <foreignObject
+            x={boxX}
+            y={Math.max(boxY, 0)}
+            width={Math.max(vizWidth, boxSize)}
+            height={Math.max(vizHeight, boxSize)}
+            mask={`url(#${id})`}
+          >
             <div style={bgDivStyle} />
           </foreignObject>
         ) : (

--- a/packages/grafana-ui/src/components/RadialGauge/ThresholdsBar.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/ThresholdsBar.tsx
@@ -57,11 +57,11 @@ export function ThresholdsBar({
       <g key={i} data-testid="radial-gauge-thresholds-bar">
         <RadialArcPath
           arcLengthDeg={lengthDeg}
-          barEndcaps={shape === 'circle' && roundedBars}
           dimensions={thresholdDimensions}
           fieldDisplay={fieldDisplay}
           glowFilter={glowFilter}
-          roundedBars={roundedBars}
+          barEndcaps={false}
+          roundedBars={false}
           shape={shape}
           startAngle={currentStart}
           {...colorProps}


### PR DESCRIPTION
Fixes #118126. To test, use [debug--2026-03-02 15_51_43.json.txt](https://github.com/user-attachments/files/25694272/debug--2026-03-02.15_51_43.json.txt). Confirmed in Safari and Chrome.

### Before

<img width="1003" height="508" alt="Screenshot 2026-03-02 at 3 54 56 PM" src="https://github.com/user-attachments/assets/7e4c5fc9-78d3-4122-b31e-8345a72fdf1a" />

### After

<img width="1004" height="520" alt="Screenshot 2026-03-02 at 3 52 50 PM" src="https://github.com/user-attachments/assets/1e364c76-f76a-4984-a818-11b94d063fb0" />
