### PR TITLE
Register datasources which are children of apps

### DIFF
--- a/pkg/registry/apis/datasource/register.go
+++ b/pkg/registry/apis/datasource/register.go
@@ -331,17 +331,26 @@ func getDatasourcePlugins(pluginSources sources.Registry) ([]plugins.JSONData, e
 			return nil, err
 		}
 		for _, p := range res {
-			if !p.Primary.JSONData.Backend || p.Primary.JSONData.Type != plugins.TypeDataSource {
-				continue
+			if p.Primary.JSONData.Type == plugins.TypeDataSource {
+				if _, found := uniquePlugins[p.Primary.JSONData.ID]; found {
+					backend.Logger.Info("Found duplicate plugin %s when registering API groups.", p.Primary.JSONData.ID)
+					continue
+				}
+
+				uniquePlugins[p.Primary.JSONData.ID] = true
+				pluginJSONs = append(pluginJSONs, p.Primary.JSONData)
 			}
 
-			if _, found := uniquePlugins[p.Primary.JSONData.ID]; found {
-				backend.Logger.Info("Found duplicate plugin %s when registering API groups.", p.Primary.JSONData.ID)
-				continue
+			for _, child := range p.Children {
+				if child.JSONData.Type == plugins.TypeDataSource {
+					if _, found := uniquePlugins[child.JSONData.ID]; found {
+						backend.Logger.Info("Found duplicate plugin %s when registering API groups.", child.JSONData.ID)
+						continue
+					}
+					uniquePlugins[child.JSONData.ID] = true
+					pluginJSONs = append(pluginJSONs, child.JSONData)
+				}
 			}
-
-			uniquePlugins[p.Primary.JSONData.ID] = true
-			pluginJSONs = append(pluginJSONs, p.Primary.JSONData)
 		}
 	}
 	return pluginJSONs, nil


### PR DESCRIPTION
When filtering plugins to find datasources, we were missing datasources that are shipped as children of some app plugins.

This PR checks the child plugins of apps and registers datasources it finds there.

Fixes https://github.com/grafana/grafana-enterprise/issues/11122