### PR TITLE
QueryEditor: Datasource error when switching views

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.test.ts
@@ -237,24 +237,38 @@ describe('useSelectedQueryDatasource', () => {
       await waitFor(() => expect(result.current.selectedQueryDsData?.datasource).toBe(mockTestDataDatasource));
     });
 
-    it('should not re-fetch when switching between queries that both inherit from the panel', async () => {
-      // Both queries have no explicit datasource — the dep array values are identical
-      // (selectedDsUid: undefined, panelDsUid: 'testdata-uid'), so useAsync should not re-run.
+    it('should re-load the datasource after returning from alerts/transformation view when query has no explicit datasource', async () => {
+      // Regression: switching to alerts or transformation sets selectedQuery=null, which runs the
+      // async fn and caches value=undefined. When returning to the data view, queryA (no explicit
+      // datasource) produced identical uid/type deps as null — so useAsync skipped the reload and
+      // the cached undefined caused a datasource load error. Including refId in the deps fixes this.
       const queryA: DataQuery = { refId: 'A' };
-      const queryB: DataQuery = { refId: 'B' };
+      const queryBWithExplicitDs: DataQuery = { refId: 'B', datasource: { uid: 'prometheus-uid', type: 'prometheus' } };
 
-      const { rerender } = renderHook(({ query }) => useSelectedQueryDatasource(query, mockTestDataSettings), {
-        initialProps: { query: queryA },
-      });
+      const { result, rerender } = renderHook(
+        ({ query, settings }) => useSelectedQueryDatasource(query, settings),
+        { initialProps: { query: queryA as DataQuery | null, settings: mockTestDataSettings } }
+      );
 
-      await waitFor(() => {});
-      const callCountAfterA = (mockGetDataSourceSrv().get as jest.Mock).mock.calls.length;
+      await waitFor(() => expect(result.current.selectedQueryDsLoading).toBe(false));
+      expect(result.current.selectedQueryDsData?.dsSettings.uid).toBe('testdata-uid');
 
-      rerender({ query: queryB });
-      await waitFor(() => {});
-      const callCountAfterB = (mockGetDataSourceSrv().get as jest.Mock).mock.calls.length;
+      // User clicks query B (explicit datasource)
+      rerender({ query: queryBWithExplicitDs, settings: mockTestDataSettings });
+      await waitFor(() => expect(result.current.selectedQueryDsLoading).toBe(false));
+      expect(result.current.selectedQueryDsData?.dsSettings.uid).toBe('prometheus-uid');
 
-      expect(callCountAfterB).toBe(callCountAfterA);
+      // User navigates to alerts/transformation view — selectedQuery becomes null
+      rerender({ query: null, settings: mockTestDataSettings });
+      await waitFor(() => expect(result.current.selectedQueryDsLoading).toBe(false));
+      expect(result.current.selectedQueryDsData).toBeNull();
+
+      // User returns to data view — falls back to queryA (no explicit ds)
+      rerender({ query: queryA, settings: mockTestDataSettings });
+      await waitFor(() => expect(result.current.selectedQueryDsLoading).toBe(false));
+
+      expect(result.current.selectedQueryDsData?.datasource).toBe(mockTestDataDatasource);
+      expect(result.current.selectedQueryDsData?.dsSettings.uid).toBe('testdata-uid');
     });
   });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.test.ts
@@ -245,10 +245,9 @@ describe('useSelectedQueryDatasource', () => {
       const queryA: DataQuery = { refId: 'A' };
       const queryBWithExplicitDs: DataQuery = { refId: 'B', datasource: { uid: 'prometheus-uid', type: 'prometheus' } };
 
-      const { result, rerender } = renderHook(
-        ({ query, settings }) => useSelectedQueryDatasource(query, settings),
-        { initialProps: { query: queryA as DataQuery | null, settings: mockTestDataSettings } }
-      );
+      const { result, rerender } = renderHook(({ query, settings }) => useSelectedQueryDatasource(query, settings), {
+        initialProps: { query: queryA as DataQuery | null, settings: mockTestDataSettings },
+      });
 
       await waitFor(() => expect(result.current.selectedQueryDsLoading).toBe(false));
       expect(result.current.selectedQueryDsData?.dsSettings.uid).toBe('testdata-uid');

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.ts
@@ -52,6 +52,7 @@ export function useSelectedQueryDatasource(
       return undefined;
     }
   }, [
+    selectedQuery?.refId,
     selectedQuery?.datasource?.uid,
     selectedQuery?.datasource?.type,
     panelDsSettings?.uid,


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->
Resolves https://github.com/grafana/grafana/issues/119366

I noticed a weird error. On an unsaved dashboard if you have more than one query, or basically more than one card, if you have any card other than the first card selected, go to alerts view, and come back, you get an error!

When `selectedQuery` is null (alerts view) and when `selectedQuery` is a query with no explicit datasource (unsaved, first query in data view), both produce [undefined, undefined, ...] in the `useAsync` dependency array. `useSelectedQueryDatasource` does no re-run, stale null served as the result → error.

Adding `selectedQuery?.refId` means the deps change whenever the selected query actually changes, so the reload always fires when it should.

## Changes
<!--- Describe your changes in detail -->
* Add `selectedQuery?.refId` to the dep array in `useSelectedQueryDatasource`

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->
N/A

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->

#### Before

https://github.com/user-attachments/assets/c443d2f5-1299-4191-b6f9-645d7f88402f

#### After

https://github.com/user-attachments/assets/fa432d4f-cec6-49f3-b8bc-974b64b5f3ac

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* On main, create a new dashboard
* Add a panel, with two queries and a transformation
* Click on any query other than the first one
* Click on alerts view
* Click back to data view
* Content error!!

* Pull down this branch, this shouldn't happen!

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable