### PR TITLE
Alerting: Fix flaky TestIntegrationHAEvaluation

### DIFF
--- a/pkg/tests/api/alerting/high_availability_test.go
+++ b/pkg/tests/api/alerting/high_availability_test.go
@@ -387,12 +387,16 @@ func waitForClusterSettled(t *testing.T, grafanas []*haGrafana) {
 func assertPosition0IsEvaluator(t *testing.T, grafanas []*haGrafana) {
 	t.Helper()
 
-	baselines := make([]int, len(grafanas))
-	for i, g := range grafanas {
-		baselines[i] = getEvalTotal(t, g.Addr)
-	}
-
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		baselines := make([]int, len(grafanas))
+		for i, g := range grafanas {
+			baselines[i] = getEvalTotal(t, g.Addr)
+		}
+
+		// Wait a few seconds to allow for any evaluations to occur.
+		// the evaluation ingterval is 1s, so this should allow for multiple evaluation cycles if the node is evaluating.
+		time.Sleep(3 * time.Second)
+
 		for i, g := range grafanas {
 			pos := getPeerPosition(t, g.Addr)
 			evals := getEvalTotal(t, g.Addr)
@@ -404,7 +408,7 @@ func assertPosition0IsEvaluator(t *testing.T, grafanas []*haGrafana) {
 				assert.False(c, isEvaluating, "position %d node should not be evaluating", pos)
 			}
 		}
-	}, 30*time.Second, 1*time.Second)
+	}, 45*time.Second, 1*time.Second)
 }
 
 // assertIdenticalAlertGroups verifies that all nodes have identical alert groups.


### PR DESCRIPTION
`TestIntegrationHAEvaluation_SingleNodeEvaluates` captured one initial evaluation count per node and then expected non-primary nodes to never go above it. But during startup, a non-primary node can briefly evaluate before peer positions settle. Fix that by capturing the number of evaluations each time and then checking that it did not change for non-primary nodes.