### PR TITLE
Alerting: Remove unnecessary dingding secure fields patching logic

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/grafana/alerting/models"
 	alertingNotify "github.com/grafana/alerting/notify"
 	"github.com/grafana/alerting/notify/nfstatus"
 	alertingTemplates "github.com/grafana/alerting/templates"
@@ -445,14 +444,6 @@ func (am *alertmanager) applyConfig(ctx context.Context, cfg *apimodels.Postable
 		return false, nil
 	}
 
-	receivers := alertingNotify.PostableAPIReceiversToAPIReceivers(amConfig.Receivers)
-	for _, recv := range receivers {
-		err = patchNewSecureFields(ctx, recv, alertingNotify.DecodeSecretsFromBase64, am.decryptFn)
-		if err != nil {
-			return false, err
-		}
-	}
-
 	am.logger.Info("Applying new configuration to Alertmanager", "configHash", fmt.Sprintf("%x", configHash))
 	err = am.Base.ApplyConfig(alertingNotify.NotificationsConfiguration{
 		RoutingTree:       amConfig.Route.AsAMRoute(),
@@ -460,7 +451,7 @@ func (am *alertmanager) applyConfig(ctx context.Context, cfg *apimodels.Postable
 		MuteTimeIntervals: amConfig.MuteTimeIntervals,
 		TimeIntervals:     amConfig.TimeIntervals,
 		Templates:         templates,
-		Receivers:         receivers,
+		Receivers:         alertingNotify.PostableAPIReceiversToAPIReceivers(amConfig.Receivers),
 		Limits:            am.dynamicLimits,
 		Raw:               rawConfig,
 		Hash:              configHash,
@@ -471,50 +462,6 @@ func (am *alertmanager) applyConfig(ctx context.Context, cfg *apimodels.Postable
 
 	am.updateConfigMetrics(cfg, len(rawConfig))
 	return true, nil
-}
-
-func patchNewSecureFields(ctx context.Context, api *alertingNotify.APIReceiver, decode alertingNotify.DecodeSecretsFn, decrypt alertingNotify.GetDecryptedValueFn) error {
-	for _, integration := range api.Integrations {
-		switch integration.Type {
-		case "dingding":
-			err := patchSettingsFromSecureSettings(ctx, integration, "url", decode, decrypt)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-func patchSettingsFromSecureSettings(ctx context.Context, integration *models.IntegrationConfig, key string, decode alertingNotify.DecodeSecretsFn, decrypt alertingNotify.GetDecryptedValueFn) error {
-	if _, ok := integration.SecureSettings[key]; !ok {
-		return nil
-	}
-	decoded, err := decode(integration.SecureSettings)
-	if err != nil {
-		return err
-	}
-	settings := map[string]any{}
-	err = json.Unmarshal(integration.Settings, &settings)
-	if err != nil {
-		return err
-	}
-	currentValue, ok := settings[key]
-	currentString := ""
-	if ok {
-		currentString, _ = currentValue.(string)
-	}
-	secretValue := decrypt(ctx, decoded, key, currentString)
-	if secretValue == currentString {
-		return nil
-	}
-	settings[key] = secretValue
-	data, err := json.Marshal(settings)
-	if err != nil {
-		return err
-	}
-	integration.Settings = data
-	return nil
 }
 
 // PutAlerts receives the alerts and then sends them through the corresponding route based on whenever the alert has a receiver embedded or not

--- a/pkg/services/ngalert/notifier/testreceivers.go
+++ b/pkg/services/ngalert/notifier/testreceivers.go
@@ -26,17 +26,12 @@ func (am *alertmanager) TestReceivers(ctx context.Context, c apimodels.TestRecei
 				SecureSettings:        gr.SecureSettings,
 			})
 		}
-		recv := &alertingNotify.APIReceiver{
+		receivers = append(receivers, &alertingNotify.APIReceiver{
 			ConfigReceiver: r.Receiver,
 			ReceiverConfig: models.ReceiverConfig{
 				Integrations: integrations,
 			},
-		}
-		err := patchNewSecureFields(ctx, recv, alertingNotify.DecodeSecretsFromBase64, am.decryptFn)
-		if err != nil {
-			return nil, 0, err
-		}
-		receivers = append(receivers, recv)
+		})
 	}
 	a := &alertingNotify.PostableAlert{}
 	if c.Alert != nil {


### PR DESCRIPTION
Remove `patchNewSecureFields` and `patchSettingsFromSecureSettings` functions as they are no longer needed.

`grafana/alerting` now reads from [both settings and secureSettings](https://github.com/grafana/alerting/blob/77a1e2f35be87bebc41a0bf634f336282f0b9b53/receivers/dingding/v1/config.go#L30).
