### PR TITLE
QueryEditor: Transformation polish for transforms with no options

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/NoOptionsIndicator.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/NoOptionsIndicator.tsx
@@ -4,6 +4,8 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Icon, Stack, useStyles2 } from '@grafana/ui';
 
+import { QUERY_EDITOR_COLORS } from '../constants';
+
 interface NoOptionsIndicatorProps {
   name: string;
 }
@@ -39,7 +41,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     borderRadius: theme.shape.radius.default,
     overflow: 'hidden',
     position: 'relative',
-    background: `color-mix(in srgb, ${theme.colors.success.main} 10%, ${theme.colors.background.secondary} 100%)`,
+    background: `color-mix(in srgb, ${QUERY_EDITOR_COLORS.transformation} 10%, ${theme.colors.background.secondary} 100%)`,
 
     '&::before': {
       content: '""',
@@ -48,11 +50,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
       top: 0,
       bottom: 0,
       width: 3,
-      background: theme.colors.success.main,
+      background: QUERY_EDITOR_COLORS.transformation,
     },
   }),
   icon: css({
-    color: theme.colors.success.text,
+    color: QUERY_EDITOR_COLORS.transformation,
     flexShrink: 0,
   }),
   title: css({

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/NoOptionsIndicator.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/NoOptionsIndicator.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { colorManipulator, GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Icon, Stack, useStyles2 } from '@grafana/ui';
 
@@ -36,9 +36,20 @@ const getStyles = (theme: GrafanaTheme2) => ({
     alignItems: 'center',
     gap: theme.spacing(1.5),
     padding: theme.spacing(2),
-    marginTop: theme.spacing(1),
-    borderLeft: `3px solid ${theme.colors.success.main}`,
-    background: colorManipulator.alpha(theme.colors.success.main, 0.07),
+    borderRadius: theme.shape.radius.default,
+    overflow: 'hidden',
+    position: 'relative',
+    background: `color-mix(in srgb, ${theme.colors.success.main} 10%, ${theme.colors.background.secondary} 100%)`,
+
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      bottom: 0,
+      width: 3,
+      background: theme.colors.success.main,
+    },
   }),
   icon: css({
     color: theme.colors.success.text,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/NoOptionsIndicator.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/NoOptionsIndicator.tsx
@@ -1,0 +1,56 @@
+import { css } from '@emotion/css';
+
+import { colorManipulator, GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Icon, Stack, useStyles2 } from '@grafana/ui';
+
+interface NoOptionsIndicatorProps {
+  name: string;
+}
+
+export function NoOptionsIndicator({ name }: NoOptionsIndicatorProps) {
+  const styles = useStyles2(getStyles);
+  return (
+    <div className={styles.wrapper}>
+      <Icon name="check-circle" size="lg" className={styles.icon} />
+      <Stack direction="column" gap={0.25}>
+        <span className={styles.title}>{t('transformation-editor.no-options.title', 'No options to configure')}</span>
+        <span className={styles.description}>
+          {t(
+            'transformation-editor.no-options.description',
+            '{{name}} will be applied automatically to your data unless the transformation is disabled.',
+            {
+              name,
+              interpolation: { escapeValue: false },
+            }
+          )}
+        </span>
+      </Stack>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  wrapper: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+    padding: theme.spacing(2),
+    marginTop: theme.spacing(1),
+    borderLeft: `3px solid ${theme.colors.success.main}`,
+    background: colorManipulator.alpha(theme.colors.success.main, 0.07),
+  }),
+  icon: css({
+    color: theme.colors.success.text,
+    flexShrink: 0,
+  }),
+  title: css({
+    fontSize: theme.typography.body.fontSize,
+    fontWeight: theme.typography.fontWeightMedium,
+    color: theme.colors.text.primary,
+  }),
+  description: css({
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+  }),
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditor.tsx
@@ -1,8 +1,9 @@
 import { useCallback } from 'react';
 
-import { DataTransformerConfig, DataFrame } from '@grafana/data';
+import { DataTransformerID, DataTransformerConfig, DataFrame } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 
+import { NoOptionsIndicator } from './NoOptionsIndicator';
 import { Transformation } from './types';
 
 interface TransformationEditorProps {
@@ -22,6 +23,10 @@ export function TransformationEditor({ transformation, inputData, onUpdate }: Tr
     [transformConfig, onUpdate]
   );
 
+  const showNoOptions =
+    transformConfig.id === DataTransformerID.seriesToRows ||
+    (transformConfig.id === DataTransformerID.merge && inputData.length > 1);
+
   const Editor = registryItem!.editor!;
 
   return (
@@ -31,6 +36,7 @@ export function TransformationEditor({ transformation, inputData, onUpdate }: Tr
         onChange={handleChange}
         options={{ ...registryItem!.transformation.defaultOptions, ...transformConfig.options }}
       />
+      {showNoOptions && <NoOptionsIndicator name={registryItem?.name ?? ''} />}
     </div>
   );
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14682,6 +14682,12 @@
       "no-data-found-in-response": "No data found in response"
     }
   },
+  "transformation-editor": {
+    "no-options": {
+      "description": "{{name}} will be applied automatically to your data unless the transformation is disabled.",
+      "title": "No options to configure"
+    }
+  },
   "transformation-editor-renderer": {
     "no-transformation-editor-title": "Transformation does not have an editor component"
   },


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->

Resolves https://github.com/grafana/grafana/issues/119434

Two transformation types (merge series/tables and series to rows) don't have any transformation options. So they just render a blank screen in the content section. This looks like a bug!! I'm proposing we add a UI element to let users know the transformation is being applied unless hidden, and that there are just no configurable options. See demo below. 

## Changes
<!--- Describe your changes in detail -->
* Add a custom cool alert thing.

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->
Don't think any

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->

<img width="1383" height="382" alt="image" src="https://github.com/user-attachments/assets/5609a74e-edbf-4fec-9d1c-ad8d4ec68d32" />

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* Pull it down and test it out!

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable