### PR TITLE
CI: Upgrade Trivy to v0.69.2

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install Trivy
       uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1
       with:
-        version: v0.56.2
+        version: v0.69.2
         cache: true
     - name: Download Trivy DB
       run: |

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   trivy-scan:
     runs-on: ubuntu-22.04
+    env:
+      # renovate: datasource=github-releases depName=trivy packageName=aquasecurity/trivy
+      TRIVY_VERSION: 'v0.69.2'
     steps:
     - uses: actions/checkout@v5
       with:
@@ -22,7 +25,7 @@ jobs:
     - name: Install Trivy
       uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1
       with:
-        version: v0.69.2
+        version: ${{ env.TRIVY_VERSION }}
         cache: true
     - name: Download Trivy DB
       run: |


### PR DESCRIPTION
## Summary
Upgrades aquasecurity/trivy from v0.56.2 to v0.69.2 to address security vulnerability.

## Details
- Upgrades Trivy version in `.github/workflows/trivy-scan.yml`
- Addresses vulnerability documented in [StepSecurity blog post](https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation#attack-6-aquasecuritytrivy---evidence-cleared)
- This unblocks the CI pipeline

## Test plan
- [ ] Verify Trivy scan workflow runs successfully
- [ ] Confirm no new vulnerabilities are reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)