### PR TITLE
[release-12.3.5] Dashboards: Fix start parameter in list versions API for K8s backend

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -1052,6 +1052,116 @@ func TestDashboardVersionsAPIEndpoint(t *testing.T) {
 				assert.Equal(t, anonString, v.CreatedBy)
 			}
 		}, mockSQLStore)
+
+	// Test start parameter
+	t.Run("When calling GET with start and limit query parameters", func(t *testing.T) {
+		testCases := []struct {
+			name          string
+			queryParams   map[string]string
+			mockVersions  []*dashver.DashboardVersionDTO
+			expectedCount int
+			expectedFirst int // expected first version number
+			expectedLast  int // expected last version number
+		}{
+			{
+				name: "with start=0 and limit=2, should return first 2 versions",
+				queryParams: map[string]string{
+					"start": "0",
+					"limit": "2",
+				},
+				mockVersions: []*dashver.DashboardVersionDTO{
+					{Version: 5, CreatedBy: 1},
+					{Version: 4, CreatedBy: 1},
+				},
+				expectedCount: 2,
+				expectedFirst: 5,
+				expectedLast:  4,
+			},
+			{
+				name: "with start=2 and limit=2, should return versions after offset",
+				queryParams: map[string]string{
+					"start": "2",
+					"limit": "2",
+				},
+				mockVersions: []*dashver.DashboardVersionDTO{
+					{Version: 3, CreatedBy: 1},
+					{Version: 2, CreatedBy: 1},
+				},
+				expectedCount: 2,
+				expectedFirst: 3,
+				expectedLast:  2,
+			},
+			{
+				name: "with start=1 and limit=3, should skip first version",
+				queryParams: map[string]string{
+					"start": "1",
+					"limit": "3",
+				},
+				mockVersions: []*dashver.DashboardVersionDTO{
+					{Version: 4, CreatedBy: 1},
+					{Version: 3, CreatedBy: 1},
+					{Version: 2, CreatedBy: 1},
+				},
+				expectedCount: 3,
+				expectedFirst: 4,
+				expectedLast:  2,
+			},
+			{
+				name: "with start=5, should return empty when offset exceeds results",
+				queryParams: map[string]string{
+					"start": "5",
+					"limit": "2",
+				},
+				mockVersions:  []*dashver.DashboardVersionDTO{},
+				expectedCount: 0,
+			},
+			{
+				name: "with only limit, should behave like start=0",
+				queryParams: map[string]string{
+					"limit": "2",
+				},
+				mockVersions: []*dashver.DashboardVersionDTO{
+					{Version: 5, CreatedBy: 1},
+					{Version: 4, CreatedBy: 1},
+				},
+				expectedCount: 2,
+				expectedFirst: 5,
+				expectedLast:  4,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				testFakeDashboardVersionService := dashvertest.NewDashboardVersionServiceFake()
+				testFakeDashboardVersionService.ExpectedListDashboarVersions = tc.mockVersions
+
+				loggedInUserScenarioWithRole(t, "Calling GET on", "GET", "/api/dashboards/uid/test-uid/versions",
+					"/api/dashboards/uid/:uid/versions", org.RoleEditor, func(sc *scenarioContext) {
+						sc.dashboardVersionService = testFakeDashboardVersionService
+						hs := getHS(&usertest.FakeUserService{
+							ExpectedSignedInUser: &user.SignedInUser{Login: "test-user"},
+						})
+						hs.dashboardVersionService = testFakeDashboardVersionService
+						hs.callGetDashboardVersionsWithParams(sc, tc.queryParams)
+
+						assert.Equal(t, http.StatusOK, sc.resp.Code)
+						var resp dashver.DashboardVersionResponseMeta
+						err := json.NewDecoder(sc.resp.Body).Decode(&resp)
+						require.NoError(t, err)
+
+						assert.Equal(t, tc.expectedCount, len(resp.Versions),
+							"unexpected number of versions returned")
+
+						if tc.expectedCount > 0 {
+							assert.Equal(t, tc.expectedFirst, resp.Versions[0].Version,
+								"first version should be %d", tc.expectedFirst)
+							assert.Equal(t, tc.expectedLast, resp.Versions[len(resp.Versions)-1].Version,
+								"last version should be %d", tc.expectedLast)
+						}
+					}, mockSQLStore)
+			})
+		}
+	})
 }
 
 func (hs *HTTPServer) callGetDashboard(sc *scenarioContext) {
@@ -1062,6 +1172,11 @@ func (hs *HTTPServer) callGetDashboard(sc *scenarioContext) {
 func (hs *HTTPServer) callGetDashboardVersions(sc *scenarioContext) {
 	sc.handlerFunc = hs.GetDashboardVersions
 	sc.fakeReqWithParams("GET", sc.url, map[string]string{}).exec()
+}
+
+func (hs *HTTPServer) callGetDashboardVersionsWithParams(sc *scenarioContext, queryParams map[string]string) {
+	sc.handlerFunc = hs.GetDashboardVersions
+	sc.fakeReqWithParams("GET", sc.url, queryParams).exec()
 }
 
 func callPostDashboard(sc *scenarioContext) {

--- a/pkg/services/dashboardversion/dashverimpl/dashver.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver.go
@@ -138,6 +138,7 @@ func (s *Service) List(
 		query.OrgID,
 		query.DashboardUID,
 		int64(query.Limit),
+		int64(query.Start),
 		query.ContinueToken,
 	)
 	if err != nil {
@@ -237,14 +238,26 @@ func (s *Service) getDashboardVersionThroughK8s(
 }
 
 func (s *Service) listDashboardVersionsThroughK8s(
-	ctx context.Context, orgID int64, dashboardUID string, limit int64, continueToken string,
+	ctx context.Context, orgID int64, dashboardUID string, limit int64, start int64, continueToken string,
 ) (*unstructured.UnstructuredList, error) {
 	labelSelector := utils.LabelKeyGetHistory + "=true"
 	fieldSelector := "metadata.name=" + dashboardUID
+
+	// We need to fetch (start + limit) items to be able to skip the first 'start' items
+	// and return 'limit' items after that offset.
+	//
+	// Note: This implementation fetches items in memory and then slices them, which works well
+	// for typical use cases (small offsets, < 100 versions per dashboard), but may be inefficient
+	// for dashboards with many versions (>1000) and large offset values.
+	// K8s doesn't support native offset pagination - it only supports token-based pagination
+	// (Limit + Continue). An alternative would be to skip pages using Continue tokens, but this
+	// adds complexity for minimal practical benefit given typical dashboard version counts.
+	totalToFetch := start + limit
+
 	out, err := s.k8sclient.List(ctx, orgID, v1.ListOptions{
 		LabelSelector: labelSelector,
 		FieldSelector: fieldSelector,
-		Limit:         limit,
+		Limit:         totalToFetch,
 		Continue:      continueToken,
 	})
 	if err != nil {
@@ -258,14 +271,14 @@ func (s *Service) listDashboardVersionsThroughK8s(
 		return nil, dashboards.ErrDashboardNotFound
 	}
 
-	// if k8s returns a continue token, we need to fetch the next page(s) until we either reach the limit or there are no more pages
+	// if k8s returns a continue token, we need to fetch the next page(s) until we either reach the total or there are no more pages
 	continueToken = out.GetContinue()
-	for (len(out.Items) < int(limit)) && (continueToken != "") {
+	for (len(out.Items) < int(totalToFetch)) && (continueToken != "") {
 		tempOut, err := s.k8sclient.List(ctx, orgID, v1.ListOptions{
 			LabelSelector: labelSelector,
 			FieldSelector: fieldSelector,
 			Continue:      continueToken,
-			Limit:         limit - int64(len(out.Items)),
+			Limit:         totalToFetch - int64(len(out.Items)),
 		})
 		if err != nil {
 			return nil, err
@@ -273,6 +286,24 @@ func (s *Service) listDashboardVersionsThroughK8s(
 		out.Items = append(out.Items, tempOut.Items...)
 		continueToken = tempOut.GetContinue()
 	}
+
+	// Apply the offset (start) by skipping the first 'start' items
+	if start > 0 && len(out.Items) > int(start) {
+		out.Items = out.Items[start:]
+	} else if start > 0 {
+		// If start is greater than or equal to the number of items, return empty list
+		out.Items = []unstructured.Unstructured{}
+	}
+
+	// Ensure we don't return more than 'limit' items after applying the offset
+	if int64(len(out.Items)) > limit {
+		out.Items = out.Items[:limit]
+	}
+
+	// Update the continue token on the response to reflect the actual position after all fetched items.
+	// Without this, the response would return the token from the first fetch, causing duplicate items
+	// on subsequent pages when multiple fetches were needed to fill the requested limit.
+	out.SetContinue(continueToken)
 
 	return out, nil
 }

--- a/pkg/services/dashboardversion/dashverimpl/dashver_test.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver_test.go
@@ -3,6 +3,7 @@ package dashverimpl
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -350,6 +351,139 @@ func TestListDashboardVersions(t *testing.T) {
 		query := dashver.ListDashboardVersionsQuery{DashboardID: 42}
 		_, err := dashboardVersionService.List(context.Background(), &query)
 		require.ErrorIs(t, dashboards.ErrDashboardNotFound, err)
+	})
+
+	t.Run("List should respect start parameter to skip versions", func(t *testing.T) {
+		// Helper to create a version object
+		createVersion := func(generation int64) unstructured.Unstructured {
+			return unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{
+					"name":            "uid",
+					"resourceVersion": fmt.Sprintf("%d", 10+generation),
+					"generation":      generation,
+					"labels": map[string]any{
+						utils.LabelKeyDeprecatedInternalID: "42", // nolint:staticcheck
+					},
+				},
+				"spec": map[string]any{},
+			}}
+		}
+
+		// All available versions (5, 4, 3, 2, 1) in descending order
+		allVersions := []unstructured.Unstructured{
+			createVersion(5),
+			createVersion(4),
+			createVersion(3),
+			createVersion(2),
+			createVersion(1),
+		}
+
+		tests := []struct {
+			name             string
+			start            int
+			limit            int
+			k8sReturnsCount  int   // how many items K8s returns (will be min(start+limit, 5))
+			expectedVersions []int // expected version numbers in order
+			expectedCount    int
+		}{
+			{
+				name:             "no offset, get first 2 versions",
+				start:            0,
+				limit:            2,
+				k8sReturnsCount:  2, // K8s returns 2 items (0+2)
+				expectedVersions: []int{5, 4},
+				expectedCount:    2,
+			},
+			{
+				name:             "offset by 2, get next 2 versions",
+				start:            2,
+				limit:            2,
+				k8sReturnsCount:  4, // K8s returns 4 items (2+2)
+				expectedVersions: []int{3, 2},
+				expectedCount:    2,
+			},
+			{
+				name:             "offset by 1, get next 3 versions",
+				start:            1,
+				limit:            3,
+				k8sReturnsCount:  4, // K8s returns 4 items (1+3)
+				expectedVersions: []int{4, 3, 2},
+				expectedCount:    3,
+			},
+			{
+				name:             "offset equals total items, return empty",
+				start:            5,
+				limit:            2,
+				k8sReturnsCount:  5, // K8s returns all 5 items (5+2 requested but only 5 exist)
+				expectedVersions: []int{},
+				expectedCount:    0,
+			},
+			{
+				name:             "offset exceeds total items, return empty",
+				start:            10,
+				limit:            2,
+				k8sReturnsCount:  5, // K8s returns all 5 items (10+2 requested but only 5 exist)
+				expectedVersions: []int{},
+				expectedCount:    0,
+			},
+			{
+				name:             "get all versions",
+				start:            0,
+				limit:            5,
+				k8sReturnsCount:  5, // K8s returns all 5 items (0+5)
+				expectedVersions: []int{5, 4, 3, 2, 1},
+				expectedCount:    5,
+			},
+			{
+				name:             "offset at end, get last version",
+				start:            4,
+				limit:            1,
+				k8sReturnsCount:  5, // K8s returns all 5 items (4+1)
+				expectedVersions: []int{1},
+				expectedCount:    1,
+			},
+			{
+				name:             "offset by 3, limit exceeds remaining items",
+				start:            3,
+				limit:            5,
+				k8sReturnsCount:  5, // K8s returns all 5 items (3+5 requested but only 5 exist)
+				expectedVersions: []int{2, 1},
+				expectedCount:    2,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				dashboardService := dashboards.NewFakeDashboardService(t)
+				dashboardVersionService := Service{dashSvc: dashboardService, features: featuremgmt.WithFeatures()}
+				mockCli := new(client.MockK8sHandler)
+				dashboardVersionService.k8sclient = mockCli
+
+				dashboardService.On("GetDashboardUIDByID", mock.Anything,
+					mock.AnythingOfType("*dashboards.GetDashboardRefByIDQuery")).
+					Return(&dashboards.DashboardRef{UID: "uid"}, nil)
+
+				query := dashver.ListDashboardVersionsQuery{DashboardID: 42, Start: tt.start, Limit: tt.limit}
+				mockCli.On("GetUsersFromMeta", mock.Anything, mock.Anything).Return(map[string]*user.User{}, nil)
+
+				// Mock K8s to return the number of items specified by k8sReturnsCount
+				// This simulates K8s returning items up to the requested limit or all available items
+				k8sResponse := &unstructured.UnstructuredList{
+					Items: allVersions[:tt.k8sReturnsCount],
+				}
+				mockCli.On("List", mock.Anything, mock.Anything, mock.Anything).Return(k8sResponse, nil).Once()
+
+				res, err := dashboardVersionService.List(context.Background(), &query)
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedCount, len(res.Versions), "unexpected number of versions returned")
+
+				// Verify the version numbers match expectations
+				for i, expectedVersion := range tt.expectedVersions {
+					require.Equal(t, expectedVersion, res.Versions[i].Version,
+						"version at index %d should be %d", i, expectedVersion)
+				}
+			})
+		}
 	})
 }
 

--- a/pkg/services/dashboardversion/dashverimpl/dashver_test.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver_test.go
@@ -334,7 +334,7 @@ func TestListDashboardVersions(t *testing.T) {
 		res, err := dashboardVersionService.List(context.Background(), &query)
 		require.Nil(t, err)
 		require.Equal(t, 3, len(res.Versions))
-		require.Equal(t, "t1", res.ContinueToken) // Implementation returns continue token from first page
+		require.Equal(t, "", res.ContinueToken) // Should return token from last fetch (empty = no more pages)
 		mockCli.AssertNumberOfCalls(t, "List", 2)
 	})
 


### PR DESCRIPTION
Backport of #118566 to release-12.3.5

## Original PR Summary

Fixes the `start` parameter not being respected when listing dashboard versions through the Kubernetes backend. The API was ignoring the offset and always returning the same results regardless of the `start` value.

## Problem

Customer reported that the `start` query parameter had no effect when calling `/api/dashboards/uid/:uid/versions`. The parameter is documented as "Version to start from when returning queries" but was not implemented for the K8s backend.

Fixes https://github.com/grafana/support-escalations/issues/20725

## Solution

- Pass the `Start` parameter from `ListDashboardVersionsQuery` to the K8s listing function
- Implement offset logic by:
  - Fetching `(start + limit)` items from K8s
  - Skipping the first `start` items
  - Returning up to `limit` items after applying the offset
- Handle edge cases (start exceeds total items, etc.)

The behavior now matches the SQL implementation which uses `.Limit(limit, start)` for pagination with offset support.

## Backport Notes

- Manually resolved merge conflicts in `pkg/services/dashboardversion/dashverimpl/dashver.go`
- The `listHistoryThroughK8s` function signature was updated to include the `start` parameter
- Offset logic was added before converting to DTO list