### PR TITLE
chore: fix repo url

### DIFF
--- a/packages/grafana-openapi/package.json
+++ b/packages/grafana-openapi/package.json
@@ -13,7 +13,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "git+http://github.com/grafana/grafana.git",
+    "url": "http://github.com/grafana/grafana.git",
     "directory": "packages/grafana-openapi"
   },
   "exports": {


### PR DESCRIPTION
**What is this feature?**

This pull request includes a minor update to the `packages/grafana-openapi/package.json` file, specifically correcting the repository URL by removing the unnecessary `git+` prefix. 

- Updated the `repository.url` field in `package.json` to remove the `git+` protocol prefix, ensuring consistency with standard URL formats.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
