### PR TITLE
Alerting: Implement matching notifications by labels in historian app.

### DIFF
--- a/apps/alerting/historian/pkg/app/notification/lokireader.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader.go
@@ -75,12 +75,11 @@ func NewLokiReader(cfg config.LokiConfig, reg prometheus.Registerer, logger logg
 // Query retrieves notification history from an external Loki instance.
 // When query.Type is "counts", it returns aggregated counts via a metrics query.
 // Otherwise it returns individual notification entries via a range query.
+//
+// When query.Labels is set, a two-phase cross-stream lookup is performed:
+// first the alerts stream is queried for matching labels to collect UUIDs,
+// then the notifications stream is filtered by those UUIDs.
 func (h *LokiReader) Query(ctx context.Context, query Query) (QueryResult, error) {
-	logql, err := buildQuery(query)
-	if err != nil {
-		return QueryResult{}, err
-	}
-
 	now := time.Now().UTC()
 	from := now.Add(-defaultQueryRange)
 	if query.From != nil {
@@ -98,6 +97,29 @@ func (h *LokiReader) Query(ctx context.Context, query Query) (QueryResult, error
 
 	if limit > maxLimit {
 		return QueryResult{}, fmt.Errorf("%w: limit (%d) over maximum allowed (%d)", ErrInvalidQuery, limit, maxLimit)
+	}
+
+	// Phase 1: If labels are specified, query the alerts stream to collect matching UUIDs.
+	var labelUUIDs []string
+	if query.Labels != nil && len(*query.Labels) > 0 {
+		alertLogql, err := buildAlertLabelQuery(*query.Labels)
+		if err != nil {
+			return QueryResult{}, err
+		}
+		labelUUIDs, err = h.runAlertUUIDQuery(ctx, alertLogql, from, to)
+		if err != nil {
+			return QueryResult{}, err
+		}
+		if len(labelUUIDs) == 0 {
+			// No alerts match the label filter — return empty result.
+			return QueryResult{Entries: []Entry{}, Counts: []Count{}}, nil
+		}
+	}
+
+	// Phase 2: Build and run the notifications query, optionally filtered by UUIDs.
+	logql, err := buildQuery(query, labelUUIDs)
+	if err != nil {
+		return QueryResult{}, err
 	}
 
 	qtype := v0alpha1.CreateNotificationqueryRequestBodyTypeEntries
@@ -361,8 +383,54 @@ func parseLokiAlertEntry(s lokiclient.Sample) (AlertEntry, error) {
 	}, nil
 }
 
+// buildAlertLabelQuery builds a LogQL query against the alerts stream with label matchers.
+// After | json, Loki flattens nested label keys so labels.alertname becomes labels_alertname.
+func buildAlertLabelQuery(labels Matchers) (string, error) {
+	logql := fmt.Sprintf(`{%s=%q}`, historian.LabelFrom, historian.LabelFromValueAlerts)
+	logql += ` | json`
+	for _, matcher := range labels {
+		if !validLabelKeyRegex.MatchString(matcher.Label) {
+			return "", fmt.Errorf("%w: label: %q", ErrInvalidQuery, matcher.Label)
+		}
+		switch matcher.Type {
+		case "=", "!=", "=~", "!~":
+		default:
+			return "", fmt.Errorf("%w: matcher type: %s", ErrInvalidQuery, matcher.Type)
+		}
+		logql += fmt.Sprintf(` | labels_%s %s %q`, matcher.Label, matcher.Type, matcher.Value)
+	}
+	return logql, nil
+}
+
+// buildAlertUUIDMetricsQuery wraps an alert label LogQL query in a
+// sum by (uuid) (count_over_time(...)) aggregation so Loki deduplicates UUIDs server-side.
+func buildAlertUUIDMetricsQuery(logqlInner string, from, to time.Time) string {
+	rangeSeconds := int64(to.Sub(from).Seconds())
+	return fmt.Sprintf(`sum by (uuid) (count_over_time(%s[%ds]))`, logqlInner, rangeSeconds)
+}
+
+// runAlertUUIDQuery runs a metrics query against the alerts stream and extracts
+// the unique UUIDs from the resulting metric labels. Loki performs deduplication
+// server-side via sum by (uuid) (count_over_time(...)).
+func (l *LokiReader) runAlertUUIDQuery(ctx context.Context, logql string, from, to time.Time) ([]string, error) {
+	metricsLogql := buildAlertUUIDMetricsQuery(logql, from, to)
+	r, err := l.client.MetricsQuery(ctx, metricsLogql, to.UnixNano(), maxLimit)
+	if err != nil {
+		return nil, fmt.Errorf("loki metrics query (alert labels): %w", err)
+	}
+	var uuids []string
+	for _, sample := range r.Data.Result {
+		if uuid, ok := sample.Metric["uuid"]; ok && uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids, nil
+}
+
 // buildQuery creates the LogQL to perform the requested query.
-func buildQuery(query Query) (string, error) {
+// If uuids is non-empty, an additional filter is added after | json to match
+// only notifications with one of the given UUIDs.
+func buildQuery(query Query, uuids []string) (string, error) {
 	selectors := []string{
 		fmt.Sprintf(`%s=%q`, historian.LabelFrom, historian.LabelFromValue),
 	}
@@ -407,6 +475,16 @@ func buildQuery(query Query) (string, error) {
 			}
 			logql += fmt.Sprintf(` | groupLabels_%s %s %q`, matcher.Label, matcher.Type, matcher.Value)
 		}
+	}
+
+	// Add UUID filter if specified (used by cross-stream label filtering).
+	// uuid is a JSON field on the notifications stream, so this goes after | json.
+	if len(uuids) > 0 {
+		escaped := make([]string, len(uuids))
+		for i, u := range uuids {
+			escaped[i] = regexp.QuoteMeta(u)
+		}
+		logql += fmt.Sprintf(` | uuid =~ %q`, strings.Join(escaped, "|"))
 	}
 
 	// Add outcome filter if specified.

--- a/apps/alerting/historian/pkg/app/notification/lokireader_test.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -125,6 +126,7 @@ func TestBuildQuery(t *testing.T) {
 	tests := []struct {
 		name     string
 		query    Query
+		uuids    []string
 		expected string
 		experr   error
 	}{
@@ -247,11 +249,36 @@ func TestBuildQuery(t *testing.T) {
 			},
 			experr: ErrInvalidQuery,
 		},
+		{
+			name:  "query with UUID filter",
+			query: Query{},
+			uuids: []string{"uuid-1", "uuid-2"},
+			expected: fmt.Sprintf(`{%s=%q} | json | uuid =~ "uuid-1|uuid-2"`,
+				historian.LabelFrom, historian.LabelFromValue),
+		},
+		{
+			name:  "query with single UUID filter",
+			query: Query{},
+			uuids: []string{"uuid-1"},
+			expected: fmt.Sprintf(`{%s=%q} | json | uuid =~ "uuid-1"`,
+				historian.LabelFrom, historian.LabelFromValue),
+		},
+		{
+			name: "query with UUID filter and other filters",
+			query: Query{
+				RuleUID:  stringPtr("test-rule-uid"),
+				Receiver: stringPtr("email-receiver"),
+				Status:   createStatusPtr(v0alpha1.CreateNotificationqueryRequestNotificationStatusFiring),
+			},
+			uuids: []string{"uuid-1"},
+			expected: fmt.Sprintf(`{%s=%q} | rule_uids =~ "(^|.*,)test-rule-uid($|,.*)" | receiver = "email-receiver" | json | status = "firing" | uuid =~ "uuid-1"`,
+				historian.LabelFrom, historian.LabelFromValue),
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := buildQuery(tt.query)
+			result, err := buildQuery(tt.query, tt.uuids)
 			if tt.experr != nil {
 				require.ErrorIs(t, err, tt.experr)
 			} else {
@@ -626,6 +653,150 @@ func TestBuildAlertQuery(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestBuildAlertLabelQuery(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   Matchers
+		expected string
+		experr   error
+	}{
+		{
+			name:   "single label matcher",
+			labels: Matchers{{Type: "=", Label: "alertname", Value: "HighCPU"}},
+			expected: fmt.Sprintf(`{%s=%q} | json | labels_alertname = "HighCPU"`,
+				historian.LabelFrom, historian.LabelFromValueAlerts),
+		},
+		{
+			name: "multiple label matchers",
+			labels: Matchers{
+				{Type: "=", Label: "alertname", Value: "HighCPU"},
+				{Type: "!=", Label: "severity", Value: "info"},
+				{Type: "=~", Label: "env", Value: "prod|staging"},
+			},
+			expected: fmt.Sprintf(`{%s=%q} | json | labels_alertname = "HighCPU" | labels_severity != "info" | labels_env =~ "prod|staging"`,
+				historian.LabelFrom, historian.LabelFromValueAlerts),
+		},
+		{
+			name:   "invalid label key",
+			labels: Matchers{{Type: "=", Label: "bad key", Value: "bar"}},
+			experr: ErrInvalidQuery,
+		},
+		{
+			name:   "invalid matcher type",
+			labels: Matchers{{Type: "|=", Label: "foo", Value: "bar"}},
+			experr: ErrInvalidQuery,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := buildAlertLabelQuery(tt.labels)
+			if tt.experr != nil {
+				require.ErrorIs(t, err, tt.experr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestBuildAlertUUIDMetricsQuery(t *testing.T) {
+	now := time.Now().UTC()
+	from := now.Add(-6 * time.Hour)
+	rangeSeconds := int64(now.Sub(from).Seconds())
+
+	inner := fmt.Sprintf(`{%s=%q} | json | labels_alertname = "HighCPU"`,
+		historian.LabelFrom, historian.LabelFromValueAlerts)
+	result := buildAlertUUIDMetricsQuery(inner, from, now)
+	expected := fmt.Sprintf(`sum by (uuid) (count_over_time(%s[%ds]))`, inner, rangeSeconds)
+	assert.Equal(t, expected, result)
+}
+
+func TestLokiReader_QueryWithLabels(t *testing.T) {
+	now := time.Now().UTC()
+	testTimestamp := now.Add(-1 * time.Hour)
+
+	makeMetricSample := func(uuid string) lokiclient.MetricSample {
+		ts, _ := json.Marshal(now.Unix())
+		val, _ := json.Marshal("1")
+		return lokiclient.MetricSample{
+			Metric: map[string]string{"uuid": uuid},
+			Value:  lokiclient.MetricSampleValue{ts, val},
+		}
+	}
+
+	// Metrics response with deduplicated UUIDs from the alerts stream.
+	alertMetricsResponse := lokiclient.MetricsQueryRes{
+		Data: lokiclient.MetricsQueryData{
+			Result: []lokiclient.MetricSample{
+				makeMetricSample("uuid-abc"),
+				makeMetricSample("uuid-def"),
+			},
+		},
+	}
+
+	// Create notification entries matching those UUIDs.
+	notificationResponse := createMockLokiResponse(testTimestamp)
+
+	t.Run("labels filter performs two-phase lookup", func(t *testing.T) {
+		mockClient := &mockLokiClient{}
+		// First call: metrics query against alerts stream for UUIDs.
+		mockClient.On("MetricsQuery", mock.Anything, mock.MatchedBy(func(logql string) bool {
+			return strings.Contains(logql, historian.LabelFromValueAlerts) && strings.Contains(logql, "sum by (uuid)")
+		}), mock.Anything, mock.Anything).
+			Return(alertMetricsResponse, nil).Once()
+		// Second call: range query for notifications with UUID filter.
+		mockClient.On("RangeQuery", mock.Anything, mock.MatchedBy(func(logql string) bool {
+			return strings.Contains(logql, historian.LabelFromValue) && strings.Contains(logql, "uuid =~")
+		}), mock.Anything, mock.Anything, mock.Anything).
+			Return(notificationResponse, nil).Once()
+
+		reader := &LokiReader{
+			client: mockClient,
+			logger: &logging.NoOpLogger{},
+		}
+
+		labels := Matchers{{Type: "=", Label: "alertname", Value: "HighCPU"}}
+		result, err := reader.Query(context.Background(), Query{
+			Labels: &labels,
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, result.Entries, 1)
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("labels filter returns empty when no alerts match", func(t *testing.T) {
+		emptyMetricsResponse := lokiclient.MetricsQueryRes{
+			Data: lokiclient.MetricsQueryData{
+				Result: []lokiclient.MetricSample{},
+			},
+		}
+
+		mockClient := &mockLokiClient{}
+		mockClient.On("MetricsQuery", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(emptyMetricsResponse, nil).Once()
+
+		reader := &LokiReader{
+			client: mockClient,
+			logger: &logging.NoOpLogger{},
+		}
+
+		labels := Matchers{{Type: "=", Label: "alertname", Value: "NonExistent"}}
+		result, err := reader.Query(context.Background(), Query{
+			Labels: &labels,
+		})
+
+		require.NoError(t, err)
+		assert.Empty(t, result.Entries)
+		assert.Empty(t, result.Counts)
+		// Only MetricsQuery should be called (for alert UUIDs), not RangeQuery.
+		mockClient.AssertNumberOfCalls(t, "MetricsQuery", 1)
+		mockClient.AssertNumberOfCalls(t, "RangeQuery", 0)
+	})
 }
 
 func TestParseLokiAlertEntry(t *testing.T) {


### PR DESCRIPTION
This is a brute force implementation of finding notifications for a specific set
of alert labels, by finding UUIDs of notifications in the `notify-history-alerts`
stream then using that to filter the lookup. This has the potential to be slow
but is useful enough to warrant implementing; specifically, it will allow finding
notifications for specific alert instances.
