### PR TITLE
chore: add cla-override workflow, which will overwrite failing CLA checks on non-forks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1251,6 +1251,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/backend-unit-tests.yml @grafana/grafana-backend-group
 /.github/workflows/backport-trigger.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/backport-workflow.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/cla-override.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/bump-version.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/release-pr.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/release-comms.yml @grafana/grafana-developer-enablement-squad

--- a/.github/workflows/cla-override.yml
+++ b/.github/workflows/cla-override.yml
@@ -33,7 +33,7 @@ jobs:
           app_id: ${{ vars.DELIVERY_BOT_APP_ID }}
           private_key: ${{ env.GRAFANA_DELIVERY_BOT_APP_PEM }}
           repositories: "[\"grafana\"]"
-          permissions: "{\"contents\": \"write\"}"
+          permissions: "{\"statuses\": \"write\"}"
 
       - name: Wait for CLA check and override
         uses: actions/github-script@v8
@@ -47,7 +47,6 @@ jobs:
             const maxAttempts = 60;
             const intervalMs = 10_000;
 
-            // Wait for the `license/cla` status to show up
             for (let attempt = 1; attempt <= maxAttempts; attempt++) {
               const { data: statuses } = await github.rest.repos.listCommitStatusesForRef({
                 owner,
@@ -66,11 +65,11 @@ jobs:
                 break;
               }
 
-              core.info(`Waiting for '${targetContext}' (attempt ${attempt}/${maxAttempts})...`);
+              const contexts = statuses.map(s => `${s.context} (${s.state})`);
+              core.info(`Waiting for '${targetContext}' (attempt ${attempt}/${maxAttempts}). Current statuses: [${contexts.join(', ')}]`);
               await new Promise(resolve => setTimeout(resolve, intervalMs));
             }
 
-            // Create a new status with the same name and set it to success
             await github.rest.repos.createCommitStatus({
               owner,
               repo,

--- a/.github/workflows/cla-override.yml
+++ b/.github/workflows/cla-override.yml
@@ -1,0 +1,83 @@
+name: Override CLA check
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: cla-override-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  override-cla:
+    # This will fail on forks due to lack of vault access
+    # but also we need to make sure forks have the CLA signed
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: "Get vault secrets"
+        id: vault-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            GRAFANA_DELIVERY_BOT_APP_PEM=delivery-bot-app:PRIVATE_KEY
+
+      - name: "Generate token"
+        id: generate_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        with:
+          app_id: ${{ vars.DELIVERY_BOT_APP_ID }}
+          private_key: ${{ env.GRAFANA_DELIVERY_BOT_APP_PEM }}
+          repositories: "[\"grafana\"]"
+          permissions: "{\"contents\": \"write\"}"
+
+      - name: Wait for CLA check and override
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const sha = context.payload.pull_request.head.sha;
+            const targetContext = 'license/cla';
+            const maxAttempts = 60;
+            const intervalMs = 10_000;
+
+            // Wait for the `license/cla` status to show up
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const { data: statuses } = await github.rest.repos.listCommitStatusesForRef({
+                owner,
+                repo,
+                ref: sha,
+              });
+
+              const claStatus = statuses.find(s => s.context === targetContext);
+              if (claStatus) {
+                core.info(`Found '${targetContext}' with state: ${claStatus.state}`);
+                break;
+              }
+
+              if (attempt === maxAttempts) {
+                core.warning(`'${targetContext}' did not appear after ${maxAttempts} attempts — overriding anyway`);
+                break;
+              }
+
+              core.info(`Waiting for '${targetContext}' (attempt ${attempt}/${maxAttempts})...`);
+              await new Promise(resolve => setTimeout(resolve, intervalMs));
+            }
+
+            // Create a new status with the same name and set it to success
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha,
+              state: 'success',
+              context: targetContext,
+              description: 'CLA check overridden — author is a Grafana org member',
+            });
+
+            core.info(`Set '${targetContext}' to success on ${sha}`);


### PR DESCRIPTION
This will run on non-forks (it will fail on forks without that skip), and overwrite the `license/cla` check.