### PR TITLE
Alerting: Use the new k8s API instead of the legacy GET config endpoint for inhibit rules alert

### DIFF
--- a/public/app/features/alerting/unified/components/InhibitionRulesAlert.test.tsx
+++ b/public/app/features/alerting/unified/components/InhibitionRulesAlert.test.tsx
@@ -1,29 +1,31 @@
-import { produce } from 'immer';
+import { HttpResponse, http } from 'msw';
 import { render, screen, waitFor } from 'test/test-utils';
 
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
-import { makeAllAlertmanagerConfigFetchFail } from 'app/features/alerting/unified/mocks/server/configure';
-import {
-  getAlertmanagerConfig,
-  setAlertmanagerConfig,
-} from 'app/features/alerting/unified/mocks/server/entities/alertmanagers';
+import { ALERTING_API_SERVER_BASE_URL, getK8sResponse } from 'app/features/alerting/unified/mocks/server/utils';
 import { GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
 import { DOCS_URL_INHIBITION_RULES } from 'app/features/alerting/unified/utils/docs';
 
 import { InhibitionRulesAlert } from './InhibitionRulesAlert';
 
-setupMswServer();
+const server = setupMswServer();
+
+function setInhibitionRulesResponse(items: Array<{ name: string; equal?: string[] }>) {
+  const k8sItems = items.map((item) => ({
+    apiVersion: 'notifications.alerting.grafana.app/v0alpha1',
+    kind: 'InhibitionRule',
+    metadata: { name: item.name, namespace: 'default' },
+    spec: { equal: item.equal ?? ['alertname'] },
+  }));
+
+  server.use(
+    http.get(`${ALERTING_API_SERVER_BASE_URL}/namespaces/:namespace/inhibitionrules`, () =>
+      HttpResponse.json(getK8sResponse('InhibitionRuleList', k8sItems))
+    )
+  );
+}
 
 describe('InhibitionRulesAlert', () => {
-  beforeEach(() => {
-    // Reset to a config without inhibition rules by default
-    const config = getAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);
-    const configWithoutInhibitRules = produce(config, (draft) => {
-      draft.alertmanager_config.inhibit_rules = [];
-    });
-    setAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME, configWithoutInhibitRules);
-  });
-
   it('should not render when there are no inhibition rules', async () => {
     const { container } = render(<InhibitionRulesAlert alertmanagerSourceName={GRAFANA_RULES_SOURCE_NAME} />);
 
@@ -33,17 +35,7 @@ describe('InhibitionRulesAlert', () => {
   });
 
   it('should render alert when inhibition rules are configured', async () => {
-    const config = getAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);
-    const configWithInhibitRules = produce(config, (draft) => {
-      draft.alertmanager_config.inhibit_rules = [
-        {
-          source_match: { severity: 'critical' },
-          target_match: { severity: 'warning' },
-          equal: ['alertname'],
-        },
-      ];
-    });
-    setAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME, configWithInhibitRules);
+    setInhibitionRulesResponse([{ name: 'rule-1' }]);
 
     render(<InhibitionRulesAlert alertmanagerSourceName={GRAFANA_RULES_SOURCE_NAME} />);
 
@@ -53,17 +45,7 @@ describe('InhibitionRulesAlert', () => {
   });
 
   it('should include a link to documentation', async () => {
-    const config = getAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);
-    const configWithInhibitRules = produce(config, (draft) => {
-      draft.alertmanager_config.inhibit_rules = [
-        {
-          source_match: { severity: 'critical' },
-          target_match: { severity: 'warning' },
-          equal: ['alertname'],
-        },
-      ];
-    });
-    setAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME, configWithInhibitRules);
+    setInhibitionRulesResponse([{ name: 'rule-1' }]);
 
     render(<InhibitionRulesAlert alertmanagerSourceName={GRAFANA_RULES_SOURCE_NAME} />);
 
@@ -80,10 +62,24 @@ describe('InhibitionRulesAlert', () => {
     });
   });
 
-  it('should not render when fetching config fails', async () => {
-    makeAllAlertmanagerConfigFetchFail();
+  it('should not render when fetching inhibition rules fails', async () => {
+    server.use(
+      http.get(`${ALERTING_API_SERVER_BASE_URL}/namespaces/:namespace/inhibitionrules`, () =>
+        HttpResponse.json({ message: 'error' }, { status: 500 })
+      )
+    );
 
     const { container } = render(<InhibitionRulesAlert alertmanagerSourceName={GRAFANA_RULES_SOURCE_NAME} />);
+
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  it('should not render for non-Grafana alertmanager sources', async () => {
+    setInhibitionRulesResponse([{ name: 'rule-1' }]);
+
+    const { container } = render(<InhibitionRulesAlert alertmanagerSourceName="some-external-am" />);
 
     await waitFor(() => {
       expect(container).toBeEmptyDOMElement();

--- a/public/app/features/alerting/unified/hooks/useHasInhibitionRules.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useHasInhibitionRules.test.tsx
@@ -1,28 +1,34 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { produce } from 'immer';
+import { HttpResponse, http } from 'msw';
 import { getWrapper } from 'test/test-utils';
 
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
-import {
-  getAlertmanagerConfig,
-  setAlertmanagerConfig,
-} from 'app/features/alerting/unified/mocks/server/entities/alertmanagers';
+import { ALERTING_API_SERVER_BASE_URL, getK8sResponse } from 'app/features/alerting/unified/mocks/server/utils';
 import { GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
 
 import { useHasInhibitionRules } from './useHasInhibitionRules';
 
-setupMswServer();
+const server = setupMswServer();
 
 const wrapper = () => getWrapper({ renderWithRouter: true });
 
+function setInhibitionRulesResponse(items: Array<{ name: string; equal?: string[] }>) {
+  const k8sItems = items.map((item) => ({
+    apiVersion: 'notifications.alerting.grafana.app/v0alpha1',
+    kind: 'InhibitionRule',
+    metadata: { name: item.name, namespace: 'default' },
+    spec: { equal: item.equal ?? ['alertname'] },
+  }));
+
+  server.use(
+    http.get(`${ALERTING_API_SERVER_BASE_URL}/namespaces/:namespace/inhibitionrules`, () =>
+      HttpResponse.json(getK8sResponse('InhibitionRuleList', k8sItems))
+    )
+  );
+}
+
 describe('useHasInhibitionRules', () => {
-  it('should return false when no inhibition rules are configured', async () => {
-    const config = getAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);
-    const configWithoutInhibitRules = produce(config, (draft) => {
-      draft.alertmanager_config.inhibit_rules = [];
-    });
-    setAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME, configWithoutInhibitRules);
-
+  it('should return false when no inhibition rules exist', async () => {
     const { result } = renderHook(() => useHasInhibitionRules(GRAFANA_RULES_SOURCE_NAME), { wrapper: wrapper() });
 
     await waitFor(() => {
@@ -32,34 +38,8 @@ describe('useHasInhibitionRules', () => {
     expect(result.current.hasInhibitionRules).toBe(false);
   });
 
-  it('should return false when inhibit_rules is undefined', async () => {
-    const config = getAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);
-    const configWithUndefinedInhibitRules = produce(config, (draft) => {
-      delete (draft.alertmanager_config as Record<string, unknown>).inhibit_rules;
-    });
-    setAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME, configWithUndefinedInhibitRules);
-
-    const { result } = renderHook(() => useHasInhibitionRules(GRAFANA_RULES_SOURCE_NAME), { wrapper: wrapper() });
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current.hasInhibitionRules).toBe(false);
-  });
-
-  it('should return true when inhibition rules are configured', async () => {
-    const config = getAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);
-    const configWithInhibitRules = produce(config, (draft) => {
-      draft.alertmanager_config.inhibit_rules = [
-        {
-          source_match: { severity: 'critical' },
-          target_match: { severity: 'warning' },
-          equal: ['alertname'],
-        },
-      ];
-    });
-    setAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME, configWithInhibitRules);
+  it('should return true when inhibition rules exist', async () => {
+    setInhibitionRulesResponse([{ name: 'rule-1', equal: ['alertname'] }]);
 
     const { result } = renderHook(() => useHasInhibitionRules(GRAFANA_RULES_SOURCE_NAME), { wrapper: wrapper() });
 
@@ -73,7 +53,6 @@ describe('useHasInhibitionRules', () => {
   it('should return isLoading true while loading', async () => {
     const { result } = renderHook(() => useHasInhibitionRules(GRAFANA_RULES_SOURCE_NAME), { wrapper: wrapper() });
 
-    // Initially should be loading
     expect(result.current.isLoading).toBe(true);
 
     await waitFor(() => {
@@ -83,6 +62,32 @@ describe('useHasInhibitionRules', () => {
 
   it('should return false when alertmanagerSourceName is undefined', async () => {
     const { result } = renderHook(() => useHasInhibitionRules(undefined), { wrapper: wrapper() });
+
+    expect(result.current.hasInhibitionRules).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should return false for non-Grafana alertmanager sources', async () => {
+    setInhibitionRulesResponse([{ name: 'rule-1' }]);
+
+    const { result } = renderHook(() => useHasInhibitionRules('some-external-alertmanager'), { wrapper: wrapper() });
+
+    expect(result.current.hasInhibitionRules).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should return false when the API call fails', async () => {
+    server.use(
+      http.get(`${ALERTING_API_SERVER_BASE_URL}/namespaces/:namespace/inhibitionrules`, () =>
+        HttpResponse.json({ message: 'error' }, { status: 500 })
+      )
+    );
+
+    const { result } = renderHook(() => useHasInhibitionRules(GRAFANA_RULES_SOURCE_NAME), { wrapper: wrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
 
     expect(result.current.hasInhibitionRules).toBe(false);
   });

--- a/public/app/features/alerting/unified/hooks/useHasInhibitionRules.ts
+++ b/public/app/features/alerting/unified/hooks/useHasInhibitionRules.ts
@@ -1,19 +1,20 @@
-import { useMemo } from 'react';
+import { generatedAPI } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
 
-import { useAlertmanagerConfig } from './useAlertmanagerConfig';
+import { GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 
 /**
- * Hook to detect if the selected Alertmanager has inhibition rules configured.
- * @param alertmanagerSourceName - The name of the Alertmanager datasource
- * @returns An object with `hasInhibitionRules` boolean and `isLoading` state
+ * Hook to detect if the Grafana Alertmanager has inhibition rules configured,
+ * using the k8s API for inhibition rules.
+ *
+ * Only fetches when the selected alertmanager is the Grafana-managed one,
+ * since the k8s API only manages Grafana alertmanager inhibition rules.
  */
 export function useHasInhibitionRules(alertmanagerSourceName: string | undefined) {
-  const { data: config, isLoading } = useAlertmanagerConfig(alertmanagerSourceName);
+  const isGrafanaAlertmanager = alertmanagerSourceName === GRAFANA_RULES_SOURCE_NAME;
 
-  const hasInhibitionRules = useMemo(() => {
-    const rules = config?.alertmanager_config?.inhibit_rules;
-    return Array.isArray(rules) && rules.length > 0;
-  }, [config]);
+  const { data, isLoading } = generatedAPI.useListInhibitionRuleQuery({}, { skip: !isGrafanaAlertmanager });
 
-  return { hasInhibitionRules, isLoading };
+  const hasInhibitionRules = isGrafanaAlertmanager && Array.isArray(data?.items) && data.items.length > 0;
+
+  return { hasInhibitionRules, isLoading: isGrafanaAlertmanager && isLoading };
 }

--- a/public/app/features/alerting/unified/mocks/server/all-handlers.ts
+++ b/public/app/features/alerting/unified/mocks/server/all-handlers.ts
@@ -9,6 +9,7 @@ import datasourcesHandlers from 'app/features/alerting/unified/mocks/server/hand
 import evalHandlers from 'app/features/alerting/unified/mocks/server/handlers/eval';
 import folderHandlers from 'app/features/alerting/unified/mocks/server/handlers/folders';
 import grafanaRulerHandlers from 'app/features/alerting/unified/mocks/server/handlers/grafanaRuler';
+import inhibitionRulesK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/inhibitionRules.k8s';
 import integrationTypeSchemasK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/integrationTypeSchemas.k8s';
 import receiverK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/receivers.k8s';
 import routingTreeK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/routingtrees.k8s';
@@ -36,6 +37,7 @@ export const alertingHandlers = [
   ...provisioningHandlers,
 
   // Kubernetes-style handlers
+  ...inhibitionRulesK8sHandlers,
   ...integrationTypeSchemasK8sHandlers,
   ...timeIntervalK8sHandlers,
   ...receiverK8sHandlers,

--- a/public/app/features/alerting/unified/mocks/server/handlers/k8s/inhibitionRules.k8s.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/k8s/inhibitionRules.k8s.ts
@@ -1,0 +1,14 @@
+import { HttpResponse, http } from 'msw';
+
+import { InhibitionRuleList } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
+import { ALERTING_API_SERVER_BASE_URL, getK8sResponse } from 'app/features/alerting/unified/mocks/server/utils';
+
+const emptyInhibitionRuleList = getK8sResponse<InhibitionRuleList['items'][number]>('InhibitionRuleList', []);
+
+const listNamespacedInhibitionRuleHandler = () =>
+  http.get<{ namespace: string }>(`${ALERTING_API_SERVER_BASE_URL}/namespaces/:namespace/inhibitionrules`, () => {
+    return HttpResponse.json(emptyInhibitionRuleList);
+  });
+
+const handlers = [listNamespacedInhibitionRuleHandler()];
+export default handlers;


### PR DESCRIPTION
**What is this feature?**

This PR changes the `InhibitionRulesAlert` warning to use the new k8s API instead of the legacy GET config endpoint.

### Problem

The inhibition rules warning added in #116568 relies on `useAlertmanagerConfig`, which fetches the full alertmanager configuration from the legacy `GET /api/alertmanager/{uid}/config/api/v1/alerts` endpoint. This has two issues:

1. **Wrong data source**: Inhibition rules support was added via a new k8s resource, and the `inhibit_rules` field in the legacy config endpoint does not reflect these new rules. The warning was checking a field that would never be populated by the new mechanism.
2. **Unnecessary load**: The hook is used on 4 pages (alert rule detail, alertmanager config, active notifications, notification policies), each triggering a full config fetch with `refetchOnMountOrArgChange: true`, contributing to increased traffic on the legacy config endpoint.

### Solution

Replaced the data fetching in `useHasInhibitionRules` to use the auto-generated k8s API client (`useListInhibitionRuleQuery` from `@grafana/api-clients`), which calls:


**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1450

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
