### PR TITLE
Unified search: add search_inject_failures_percent for fault injection

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -642,6 +642,7 @@ type Cfg struct {
 	CACertPath                                 string
 	HttpsSkipVerify                            bool
 	ResourceServerJoinRingTimeout              time.Duration
+	SearchInjectFailuresPercent                int
 	EnableSearch                               bool
 	EnableSearchClient                         bool
 	OverridesFilePath                          string

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -69,6 +69,12 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 		// Helper log to find instances disabling migration
 		cfg.Logger.Info("Unified migration configs enforcement disabled", "storage_type", cfg.UnifiedStorageType(), "disable_data_migrations", cfg.DisableDataMigrations)
 	}
+	cfg.SearchInjectFailuresPercent = section.Key("search_inject_failures_percent").MustInt(0)
+	if cfg.SearchInjectFailuresPercent < 0 {
+		cfg.SearchInjectFailuresPercent = 0
+	} else if cfg.SearchInjectFailuresPercent > 100 {
+		cfg.SearchInjectFailuresPercent = 100
+	}
 	cfg.EnableSearch = section.Key("enable_search").MustBool(true)
 	cfg.EnableSearchClient = section.Key("enable_search_client").MustBool(false)
 	cfg.MaxPageSizeBytes = section.Key("max_page_size_bytes").MustInt(0)

--- a/pkg/setting/setting_unified_storage_test.go
+++ b/pkg/setting/setting_unified_storage_test.go
@@ -78,6 +78,49 @@ func TestCfg_setUnifiedStorageConfig(t *testing.T) {
 		assert.Equal(t, 5, cfg.IndexMinCount)
 	})
 
+	t.Run("search_inject_failures_percent", func(t *testing.T) {
+		setSectionKey := func(cfg *Cfg, key, value string) {
+			section := cfg.Raw.Section("unified_storage")
+			_, err := section.NewKey(key, value)
+			assert.NoError(t, err)
+		}
+
+		t.Run("defaults to 0", func(t *testing.T) {
+			cfg := NewCfg()
+			err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+			assert.NoError(t, err)
+			cfg.setUnifiedStorageConfig()
+			assert.Equal(t, 0, cfg.SearchInjectFailuresPercent)
+		})
+
+		t.Run("reads configured value", func(t *testing.T) {
+			cfg := NewCfg()
+			err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+			assert.NoError(t, err)
+			setSectionKey(cfg, "search_inject_failures_percent", "50")
+			cfg.setUnifiedStorageConfig()
+			assert.Equal(t, 50, cfg.SearchInjectFailuresPercent)
+		})
+
+		t.Run("clamps negative to 0", func(t *testing.T) {
+			cfg := NewCfg()
+			err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+			assert.NoError(t, err)
+			setSectionKey(cfg, "search_inject_failures_percent", "-10")
+			cfg.setUnifiedStorageConfig()
+			assert.Equal(t, 0, cfg.SearchInjectFailuresPercent)
+		})
+
+		t.Run("clamps over 100 to 100", func(t *testing.T) {
+			cfg := NewCfg()
+			err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+			assert.NoError(t, err)
+			setSectionKey(cfg, "search_inject_failures_percent", "200")
+			cfg.setUnifiedStorageConfig()
+			assert.Equal(t, 100, cfg.SearchInjectFailuresPercent)
+		})
+	})
+
 	t.Run("read unified_storage configs with defaults", func(t *testing.T) {
 		cfg := NewCfg()
 		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -255,6 +255,10 @@ func (s *searchServer) ListManagedObjects(ctx context.Context, req *resourcepb.L
 	ctx, span := tracer.Start(ctx, "resource.searchServer.ListManagedObjects")
 	defer span.End()
 
+	if s.injectFailuresPercent > 0 && rand.Intn(100) < s.injectFailuresPercent {
+		return nil, fmt.Errorf("injected search failure")
+	}
+
 	if req.NextPageToken != "" {
 		return &resourcepb.ListManagedObjectsResponse{
 			Error: NewBadRequestError("multiple pages not yet supported"),
@@ -339,6 +343,10 @@ func (s *searchServer) logStats(ctx context.Context, stats *SearchStats, span tr
 func (s *searchServer) CountManagedObjects(ctx context.Context, req *resourcepb.CountManagedObjectsRequest) (*resourcepb.CountManagedObjectsResponse, error) {
 	ctx, span := tracer.Start(ctx, "resource.searchServer.CountManagedObjects")
 	defer span.End()
+
+	if s.injectFailuresPercent > 0 && rand.Intn(100) < s.injectFailuresPercent {
+		return nil, fmt.Errorf("injected search failure")
+	}
 
 	stats := NewSearchStats("CountManagedObjects")
 	defer s.logStats(ctx, stats, span, "namespace", req.Namespace)
@@ -455,6 +463,10 @@ func (s *searchServer) Search(ctx context.Context, req *resourcepb.ResourceSearc
 func (s *searchServer) GetStats(ctx context.Context, req *resourcepb.ResourceStatsRequest) (*resourcepb.ResourceStatsResponse, error) {
 	ctx, span := tracer.Start(ctx, "resource.searchServer.GetStats")
 	defer span.End()
+
+	if s.injectFailuresPercent > 0 && rand.Intn(100) < s.injectFailuresPercent {
+		return nil, fmt.Errorf("injected search failure")
+	}
 
 	if req.Namespace == "" {
 		return &resourcepb.ResourceStatsResponse{

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"math/rand"
 	"slices"
 	"strings"
 	"sync"
@@ -157,6 +158,8 @@ type searchServer struct {
 	rebuildQueue   *debouncer.Queue[rebuildRequest]
 	rebuildWorkers int
 
+	injectFailuresPercent int
+
 	backendDiagnostics resourcepb.DiagnosticsServer
 }
 
@@ -198,9 +201,10 @@ func newSearchServer(opts SearchOptions, storage StorageBackend, access types.Ac
 		indexMetrics:   indexMetrics,
 		ownsIndexFn:    ownsIndexFn,
 
-		dashboardIndexMaxAge: opts.DashboardIndexMaxAge,
-		maxIndexAge:          opts.MaxIndexAge,
-		minBuildVersion:      opts.MinBuildVersion,
+		dashboardIndexMaxAge:  opts.DashboardIndexMaxAge,
+		maxIndexAge:           opts.MaxIndexAge,
+		minBuildVersion:       opts.MinBuildVersion,
+		injectFailuresPercent: opts.InjectFailuresPercent,
 	}
 
 	s.rebuildQueue = debouncer.NewQueue(combineRebuildRequests)
@@ -393,6 +397,10 @@ func (s *searchServer) CountManagedObjects(ctx context.Context, req *resourcepb.
 func (s *searchServer) Search(ctx context.Context, req *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {
 	ctx, span := tracer.Start(ctx, "resource.searchServer.Search")
 	defer span.End()
+
+	if s.injectFailuresPercent > 0 && rand.Intn(100) < s.injectFailuresPercent {
+		return nil, fmt.Errorf("injected search failure")
+	}
 
 	if req.Options.Key.Namespace == "" || req.Options.Key.Group == "" || req.Options.Key.Resource == "" {
 		return &resourcepb.ResourceSearchResponse{

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -163,6 +163,15 @@ type searchServer struct {
 	backendDiagnostics resourcepb.DiagnosticsServer
 }
 
+// maybeInjectFailure returns an error for a configured percentage of calls.
+// Returns nil when failure injection is disabled or the call is not selected.
+func (s *searchServer) maybeInjectFailure() error {
+	if s.injectFailuresPercent > 0 && rand.Intn(100) < s.injectFailuresPercent {
+		return fmt.Errorf("injected search failure")
+	}
+	return nil
+}
+
 var (
 	_ resourcepb.ResourceIndexServer      = (*searchServer)(nil)
 	_ resourcepb.ManagedObjectIndexServer = (*searchServer)(nil)
@@ -255,8 +264,8 @@ func (s *searchServer) ListManagedObjects(ctx context.Context, req *resourcepb.L
 	ctx, span := tracer.Start(ctx, "resource.searchServer.ListManagedObjects")
 	defer span.End()
 
-	if s.injectFailuresPercent > 0 && rand.Intn(100) < s.injectFailuresPercent {
-		return nil, fmt.Errorf("injected search failure")
+	if err := s.maybeInjectFailure(); err != nil {
+		return nil, err
 	}
 
 	if req.NextPageToken != "" {
@@ -344,8 +353,8 @@ func (s *searchServer) CountManagedObjects(ctx context.Context, req *resourcepb.
 	ctx, span := tracer.Start(ctx, "resource.searchServer.CountManagedObjects")
 	defer span.End()
 
-	if s.injectFailuresPercent > 0 && rand.Intn(100) < s.injectFailuresPercent {
-		return nil, fmt.Errorf("injected search failure")
+	if err := s.maybeInjectFailure(); err != nil {
+		return nil, err
 	}
 
 	stats := NewSearchStats("CountManagedObjects")
@@ -406,8 +415,8 @@ func (s *searchServer) Search(ctx context.Context, req *resourcepb.ResourceSearc
 	ctx, span := tracer.Start(ctx, "resource.searchServer.Search")
 	defer span.End()
 
-	if s.injectFailuresPercent > 0 && rand.Intn(100) < s.injectFailuresPercent {
-		return nil, fmt.Errorf("injected search failure")
+	if err := s.maybeInjectFailure(); err != nil {
+		return nil, err
 	}
 
 	if req.Options.Key.Namespace == "" || req.Options.Key.Group == "" || req.Options.Key.Resource == "" {
@@ -464,8 +473,8 @@ func (s *searchServer) GetStats(ctx context.Context, req *resourcepb.ResourceSta
 	ctx, span := tracer.Start(ctx, "resource.searchServer.GetStats")
 	defer span.End()
 
-	if s.injectFailuresPercent > 0 && rand.Intn(100) < s.injectFailuresPercent {
-		return nil, fmt.Errorf("injected search failure")
+	if err := s.maybeInjectFailure(); err != nil {
+		return nil, err
 	}
 
 	if req.Namespace == "" {

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -954,20 +954,6 @@ func TestMaybeInjectFailure(t *testing.T) {
 		}
 	})
 
-	t.Run("fails approximately at configured rate", func(t *testing.T) {
-		s := &searchServer{injectFailuresPercent: 50}
-		failures := 0
-		const iterations = 10000
-		for i := 0; i < iterations; i++ {
-			if s.maybeInjectFailure() != nil {
-				failures++
-			}
-		}
-		// With 50% rate over 10000 iterations, expect roughly 5000 failures.
-		// Allow a wide margin (40%-60%) to avoid flaky tests.
-		require.Greater(t, failures, 4000, "expected at least 40%% failures")
-		require.Less(t, failures, 6000, "expected at most 60%% failures")
-	})
 }
 
 func TestSearchValidatesNegativeLimitAndOffset(t *testing.T) {

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -937,6 +937,39 @@ func TestRebuildIndexesForResource(t *testing.T) {
 	require.Equal(t, 0, support.rebuildQueue.Len())
 }
 
+func TestMaybeInjectFailure(t *testing.T) {
+	t.Run("disabled when percent is 0", func(t *testing.T) {
+		s := &searchServer{injectFailuresPercent: 0}
+		for i := 0; i < 1000; i++ {
+			require.NoError(t, s.maybeInjectFailure())
+		}
+	})
+
+	t.Run("always fails when percent is 100", func(t *testing.T) {
+		s := &searchServer{injectFailuresPercent: 100}
+		for i := 0; i < 100; i++ {
+			err := s.maybeInjectFailure()
+			require.Error(t, err)
+			require.Equal(t, "injected search failure", err.Error())
+		}
+	})
+
+	t.Run("fails approximately at configured rate", func(t *testing.T) {
+		s := &searchServer{injectFailuresPercent: 50}
+		failures := 0
+		const iterations = 10000
+		for i := 0; i < iterations; i++ {
+			if s.maybeInjectFailure() != nil {
+				failures++
+			}
+		}
+		// With 50% rate over 10000 iterations, expect roughly 5000 failures.
+		// Allow a wide margin (40%-60%) to avoid flaky tests.
+		require.Greater(t, failures, 4000, "expected at least 40%% failures")
+		require.Less(t, failures, 6000, "expected at most 60%% failures")
+	})
+}
+
 func TestSearchValidatesNegativeLimitAndOffset(t *testing.T) {
 	opts := SearchOptions{
 		Backend: &mockSearchBackend{},

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -953,7 +953,6 @@ func TestMaybeInjectFailure(t *testing.T) {
 			require.Equal(t, "injected search failure", err.Error())
 		}
 	})
-
 }
 
 func TestSearchValidatesNegativeLimitAndOffset(t *testing.T) {

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -226,6 +226,9 @@ type SearchOptions struct {
 	// Minimum time between index updates. This is also used as a delay after a successful write operation, to guarantee
 	// that subsequent search will observe the effect of the writing.
 	IndexMinUpdateInterval time.Duration
+
+	// Percentage of search requests that should fail immediately (0-100). 0 = disabled, 100 = all requests fail.
+	InjectFailuresPercent int
 }
 
 type ResourceServerOptions struct {

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -63,6 +63,7 @@ func NewSearchOptions(
 			MaxIndexAge:            cfg.MaxFileIndexAge,
 			MinBuildVersion:        minVersion,
 			IndexMinUpdateInterval: cfg.IndexMinUpdateInterval,
+			InjectFailuresPercent:  cfg.SearchInjectFailuresPercent,
 		}, nil
 	}
 	return resource.SearchOptions{


### PR DESCRIPTION
## Summary
- Adds a hidden `search_inject_failures_percent` config option under `[unified_storage]` (not in defaults.ini) that causes a configurable percentage of search requests to fail immediately
- Applies to all query methods on `ResourceIndexServer` (`Search`, `GetStats`) and `ManagedObjectIndexServer` (`CountManagedObjects`, `ListManagedObjects`)
- Values are clamped to 0-100; default is 0 (disabled)
- Useful for testing error handling and resilience of search consumers

## Test plan
- [x] Unit tests for config parsing (default, explicit value, negative clamping, over-100 clamping)
- [x] Unit tests for `maybeInjectFailure` (0% never fails, 100% always fails)
- [x] Verify setting `search_inject_failures_percent = 100` in `custom.ini` causes all search requests to fail
- [x] Verify default (no setting) has no impact on search behavior
