### PR TITLE
Dashboards: Shorten template dashboard modal description to "Get started"

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.tsx
@@ -116,9 +116,7 @@ export const TemplateDashboardModal = () => {
     >
       <div className={styles.stickyHeader}>
         <Text element="p">
-          <Trans i18nKey="dashboard-library.template-dashboard-modal.description">
-            Get started with Grafana templates using sample data. Connect your data to power them with real metrics.
-          </Trans>
+          <Trans i18nKey="dashboard-library.template-dashboard-modal.description">Get started</Trans>
         </Text>
       </div>
       <Box direction="column" gap={4} display="flex">


### PR DESCRIPTION
## Summary

- Simplifies the description text in `TemplateDashboardModal` from the verbose _"Get started with Grafana templates using sample data. Connect your data to power them with real metrics."_ to the concise _"Get started"_
- The change reduces visual noise in the modal, making the UI cleaner and more focused

## Test plan

- [ ] Open the template dashboards modal (via quick add button, command palette, or browse dashboards page)
- [ ] Verify the description now reads "Get started" instead of the previous longer text
- [ ] Confirm modal layout and other functionality remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)