### PR TITLE
DynamicDashboards: Fix duplicate rows within tabs, enable duplicate row containing tabs

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.test.ts
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.test.ts
@@ -8,16 +8,57 @@ import { AutoGridLayout } from './AutoGridLayout';
 import { AutoGridLayoutManager } from './AutoGridLayoutManager';
 
 describe('AutoGridLayoutManager', () => {
-  it('can remove panel', () => {
-    const { manager, panel1 } = setup();
+  describe('removePanel', () => {
+    it('can remove panel', () => {
+      const { manager, panel1 } = setup();
 
-    manager.subscribeToEvent(DashboardEditActionEvent, (event) => {
-      event.payload.perform();
+      manager.subscribeToEvent(DashboardEditActionEvent, (event) => {
+        event.payload.perform();
+      });
+
+      manager.removePanel(panel1);
+
+      expect(manager.state.layout.state.children.length).toBe(1);
+    });
+  });
+
+  describe('duplicate', () => {
+    it('returns a new AutoGridLayoutManager instance', () => {
+      const { manager } = setup();
+
+      const duplicated = manager.duplicate() as AutoGridLayoutManager;
+
+      expect(duplicated).toBeInstanceOf(AutoGridLayoutManager);
+      expect(duplicated).not.toBe(manager);
+      expect(duplicated.state.key).not.toBe(manager.state.key);
     });
 
-    manager.removePanel(panel1);
+    it('deep-clones all children', () => {
+      const { manager, gridItems } = setup();
 
-    expect(manager.state.layout.state.children.length).toBe(1);
+      const duplicated = manager.duplicate() as AutoGridLayoutManager;
+
+      const clonedChildren = duplicated.state.layout.state.children;
+
+      expect(clonedChildren.length).toBe(2);
+
+      expect(clonedChildren[0]).not.toBe(gridItems[0]);
+      expect(clonedChildren[0].state.body).not.toBe(gridItems[0].state.body);
+
+      expect(clonedChildren[1]).not.toBe(gridItems[1]);
+      expect(clonedChildren[1].state.body).not.toBe(gridItems[1].state.body);
+    });
+
+    describe('when grid items contain panels', () => {
+      it('assigns unique sequential panel keys, starting after the highest existing id', () => {
+        const { manager } = setup();
+
+        const duplicated = manager.duplicate() as AutoGridLayoutManager;
+
+        const panelKeys = duplicated.getVizPanels().map((p) => p.state.key);
+        expect(panelKeys).toEqual(['panel-3', 'panel-4']);
+      });
+    });
   });
 });
 
@@ -31,7 +72,7 @@ function setup() {
 
   const panel2 = new VizPanel({
     title: 'Panel A',
-    key: 'panel-1',
+    key: 'panel-2',
     pluginId: 'table',
     $data: new SceneQueryRunner({ key: 'data-query-runner', queries: [{ refId: 'A' }] }),
   });
@@ -51,9 +92,12 @@ function setup() {
     }),
   ];
 
-  const manager = new AutoGridLayoutManager({ layout: new AutoGridLayout({ children: gridItems }) });
+  const manager = new AutoGridLayoutManager({
+    key: 'test-AutoGridLayoutManager',
+    layout: new AutoGridLayout({ children: gridItems }),
+  });
 
   new DashboardScene({ body: manager });
 
-  return { manager, panel1, panel2 };
+  return { manager, gridItems, panel1, panel2 };
 }

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -14,7 +14,7 @@ import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/Pan
 
 import { dashboardEditActions, NewObjectAddedToCanvasEvent } from '../../edit-pane/shared';
 import { serializeAutoGridLayout } from '../../serialization/layoutSerializers/AutoGridLayoutSerializer';
-import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
+import { dashboardSceneGraph, PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 import { trackDropItemCrossLayout } from '../../utils/tracking';
 import {
   forceRenderChildren,
@@ -187,7 +187,7 @@ export class AutoGridLayoutManager
   }
 
   // panelIdGenerator is a shared counter to ensure unique panel IDs across siblings.
-  public duplicate(panelIdGenerator?: () => number): DashboardLayoutManager {
+  public duplicate(panelIdGenerator?: PanelIdGenerator): DashboardLayoutManager {
     const children = this.state.layout.state.children;
     const clonedChildren: AutoGridItem[] = [];
 

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -186,23 +186,23 @@ export class AutoGridLayoutManager
     });
   }
 
-  public duplicate(): DashboardLayoutManager {
+  // panelIdGenerator is a shared counter to ensure unique panel IDs across siblings.
+  public duplicate(panelIdGenerator?: () => number): DashboardLayoutManager {
     const children = this.state.layout.state.children;
     const clonedChildren: AutoGridItem[] = [];
 
     if (children.length) {
-      let panelId = dashboardSceneGraph.getNextPanelId(children[0].state.body);
+      const nextId = panelIdGenerator ?? dashboardSceneGraph.getPanelIdGenerator(children[0].state.body);
 
       children.forEach((child) => {
         const clone = child.clone({
           key: undefined,
           body: child.state.body.clone({
-            key: getVizPanelKeyForPanelId(panelId),
+            key: getVizPanelKeyForPanelId(nextId()),
           }),
         });
 
         clonedChildren.push(clone);
-        panelId++;
       });
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.test.tsx
@@ -211,6 +211,69 @@ describe('DefaultGridLayoutManager', () => {
       expect(gridRow.state.children.length).toBe(3);
     });
   });
+
+  describe('duplicate', () => {
+    it('returns a new DefaultGridLayoutManager instance', () => {
+      const { manager } = setup();
+
+      const duplicated = manager.duplicate() as DefaultGridLayoutManager;
+
+      expect(duplicated).toBeInstanceOf(DefaultGridLayoutManager);
+      expect(duplicated).not.toBe(manager);
+      expect(duplicated.state.key).not.toBe(manager.state.key);
+    });
+
+    it('deep-clones all children', () => {
+      const { manager, grid } = setup();
+      const originalChildren = grid.state.children;
+
+      const duplicated = manager.duplicate() as DefaultGridLayoutManager;
+      const clonedChildren = duplicated.state.grid.state.children;
+
+      expect(clonedChildren.length).toBe(originalChildren.length);
+
+      expect(clonedChildren[0]).not.toBe(originalChildren[0]);
+      expect((clonedChildren[0] as DashboardGridItem).state.body).not.toBe(
+        (originalChildren[0] as DashboardGridItem).state.body
+      );
+
+      expect(clonedChildren[1]).not.toBe(originalChildren[1]);
+      expect((clonedChildren[1] as DashboardGridItem).state.body).not.toBe(
+        (originalChildren[1] as DashboardGridItem).state.body
+      );
+
+      expect(clonedChildren[2]).not.toBe(originalChildren[2]);
+    });
+
+    describe('when grid items contain panels', () => {
+      it('assigns unique sequential panel keys, starting after the highest existing id', () => {
+        const gridItems = [
+          new DashboardGridItem({
+            key: 'griditem-1',
+            body: new VizPanel({
+              key: 'panel-39',
+              title: 'Panel A',
+              pluginId: 'table',
+            }),
+          }),
+          new DashboardGridItem({
+            key: 'griditem-2',
+            body: new VizPanel({
+              key: 'panel-40',
+              title: 'Panel B',
+              pluginId: 'table',
+            }),
+          }),
+        ];
+        const { manager } = setup({ gridItems });
+
+        const duplicated = manager.duplicate() as DefaultGridLayoutManager;
+
+        const panelKeys = duplicated.getVizPanels().map((p) => p.state.key);
+        expect(panelKeys).toEqual(['panel-41', 'panel-42']);
+      });
+    });
+  });
 });
 
 interface TestOptions {

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -31,7 +31,7 @@ import {
 } from '../../edit-pane/shared';
 import { serializeDefaultGridLayout } from '../../serialization/layoutSerializers/DefaultGridLayoutSerializer';
 import { isRepeatCloneOrChildOf } from '../../utils/clone';
-import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
+import { dashboardSceneGraph, PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 import { getTestIdForLayout } from '../../utils/test-utils';
 import {
   forceRenderChildren,
@@ -326,7 +326,7 @@ export class DefaultGridLayoutManager
   }
 
   // panelIdGenerator is a shared counter to ensure unique panel IDs across siblings.
-  public duplicate(panelIdGenerator?: () => number): DashboardLayoutManager {
+  public duplicate(panelIdGenerator?: PanelIdGenerator): DashboardLayoutManager {
     const children = this.state.grid.state.children;
     const hasGridItem = children.find((child) => child instanceof DashboardGridItem);
     const clonedChildren: SceneGridItemLike[] = [];

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -325,25 +325,26 @@ export class DefaultGridLayoutManager
     });
   }
 
-  public duplicate(): DashboardLayoutManager {
+  // panelIdGenerator is a shared counter to ensure unique panel IDs across siblings.
+  public duplicate(panelIdGenerator?: () => number): DashboardLayoutManager {
     const children = this.state.grid.state.children;
     const hasGridItem = children.find((child) => child instanceof DashboardGridItem);
     const clonedChildren: SceneGridItemLike[] = [];
 
     if (children.length) {
-      let panelId = hasGridItem ? dashboardSceneGraph.getNextPanelId(hasGridItem.state.body) : 1;
+      const nextId =
+        panelIdGenerator ?? dashboardSceneGraph.getPanelIdGenerator(hasGridItem ? hasGridItem.state.body : this);
 
       children.forEach((child) => {
         if (child instanceof DashboardGridItem) {
           const clone = child.clone({
             key: undefined,
             body: child.state.body.clone({
-              key: getVizPanelKeyForPanelId(panelId),
+              key: getVizPanelKeyForPanelId(nextId()),
             }),
           });
 
           clonedChildren.push(clone);
-          panelId++;
         } else {
           clonedChildren.push(child.clone({ key: undefined }));
         }

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -168,8 +168,10 @@ export class RowItem
     this.getParentLayout().duplicateRow(this);
   }
 
-  public duplicate(): RowItem {
-    return this.clone({ key: undefined, layout: this.getLayout().duplicate() });
+  // panelIdGenerator is a shared sequential counter created by the parent layout
+  // we forward id to ensure sibling tabs never produce duplicate panel IDs
+  public duplicate(panelIdGenerator?: () => number): RowItem {
+    return this.clone({ key: undefined, layout: this.getLayout().duplicate(panelIdGenerator) });
   }
 
   public serialize(): RowsLayoutRowKind {

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -22,6 +22,7 @@ import { ConditionalRenderingGroup } from '../../conditional-rendering/group/Con
 import { dashboardEditActions } from '../../edit-pane/shared';
 import { serializeRow } from '../../serialization/layoutSerializers/RowsLayoutSerializer';
 import { getElements } from '../../serialization/layoutSerializers/utils';
+import { PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 import { trackDropItemCrossLayout } from '../../utils/tracking';
 import { getDashboardSceneFor } from '../../utils/utils';
 import { AutoGridItem } from '../layout-auto-grid/AutoGridItem';
@@ -170,7 +171,7 @@ export class RowItem
 
   // panelIdGenerator is a shared sequential counter created by the parent layout
   // we forward id to ensure sibling tabs never produce duplicate panel IDs
-  public duplicate(panelIdGenerator?: () => number): RowItem {
+  public duplicate(panelIdGenerator?: PanelIdGenerator): RowItem {
     return this.clone({ key: undefined, layout: this.getLayout().duplicate(panelIdGenerator) });
   }
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.test.tsx
@@ -1,6 +1,10 @@
+import { SceneGridLayout, VizPanel } from '@grafana/scenes';
+
 import { dashboardEditActions } from '../../edit-pane/shared';
 import { DashboardScene } from '../DashboardScene';
 import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
+import { DashboardGridItem } from '../layout-default/DashboardGridItem';
+import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
 
 import { RowItem } from './RowItem';
 import { RowsLayoutManager } from './RowsLayoutManager';
@@ -31,8 +35,8 @@ jest.mock('../layouts-shared/utils', () => ({
   }),
 }));
 
-function buildRowsLayoutManager() {
-  const rowsLayoutManager = new RowsLayoutManager({ rows: [] });
+function buildRowsLayoutManager(rows: RowItem[] = []) {
+  const rowsLayoutManager = new RowsLayoutManager({ key: 'test-RowsLayoutManager', rows });
   new DashboardScene({ body: rowsLayoutManager });
   return rowsLayoutManager;
 }
@@ -168,6 +172,77 @@ describe('RowsLayoutManager', () => {
         expect(parent.state.body).toBe(rowsLayoutManager);
         expect(rowsLayoutManager.state.rows).toHaveLength(1);
         expect(rowsLayoutManager.state.rows[0]).toBe(row);
+      });
+    });
+  });
+
+  describe('duplicate', () => {
+    it('should return a new RowsLayoutManager instance', () => {
+      const rowsLayoutManager = buildRowsLayoutManager();
+
+      const duplicated = rowsLayoutManager.duplicate() as RowsLayoutManager;
+
+      expect(duplicated).toBeInstanceOf(RowsLayoutManager);
+      expect(duplicated).not.toBe(rowsLayoutManager);
+      expect(duplicated.state.key).not.toBe(rowsLayoutManager.state.key);
+    });
+
+    it('should duplicate each row', () => {
+      const rows = [new RowItem({ title: 'Row 1' }), new RowItem({ title: 'Row 2' }), new RowItem({ title: 'Row 3' })];
+      const rowDuplicateSpies = rows.map((row) => jest.spyOn(row, 'duplicate'));
+      const rowsLayoutManager = buildRowsLayoutManager(rows);
+
+      const duplicated = rowsLayoutManager.duplicate() as RowsLayoutManager;
+
+      expect(rowDuplicateSpies[0]).toHaveBeenCalledTimes(1);
+      expect(rowDuplicateSpies[1]).toHaveBeenCalledTimes(1);
+      expect(rowDuplicateSpies[2]).toHaveBeenCalledTimes(1);
+
+      expect(duplicated.state.rows.length).toBe(3);
+      expect(duplicated.state.rows[0]).not.toBe(rows[0]);
+      expect(duplicated.state.rows[1]).not.toBe(rows[1]);
+      expect(duplicated.state.rows[2]).not.toBe(rows[2]);
+    });
+
+    describe('when rows contain panels', () => {
+      it('should assign unique panel keys across all rows, starting after the highest existing id', () => {
+        const rowsLayoutManager = buildRowsLayoutManager([
+          new RowItem({
+            title: 'Row 1',
+            layout: new DefaultGridLayoutManager({
+              grid: new SceneGridLayout({
+                children: [
+                  new DashboardGridItem({
+                    body: new VizPanel({ key: 'panel-1', title: 'Panel A' }),
+                  }),
+                  new DashboardGridItem({
+                    body: new VizPanel({ key: 'panel-2', title: 'Panel B' }),
+                  }),
+                ],
+              }),
+            }),
+          }),
+          new RowItem({
+            title: 'Row 2',
+            layout: new DefaultGridLayoutManager({
+              grid: new SceneGridLayout({
+                children: [
+                  new DashboardGridItem({
+                    body: new VizPanel({ key: 'panel-3', title: 'Panel C', pluginId: 'table' }),
+                  }),
+                  new DashboardGridItem({
+                    body: new VizPanel({ key: 'panel-4', title: 'Panel D', pluginId: 'table' }),
+                  }),
+                ],
+              }),
+            }),
+          }),
+        ]);
+
+        const duplicated = rowsLayoutManager.duplicate();
+
+        const panelKeys = duplicated.getVizPanels().map((p) => p.state.key);
+        expect(panelKeys).toEqual(['panel-5', 'panel-6', 'panel-7', 'panel-8']);
       });
     });
   });

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -13,7 +13,7 @@ import { Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.
 
 import { dashboardEditActions, ObjectsReorderedOnCanvasEvent } from '../../edit-pane/shared';
 import { serializeRowsLayout } from '../../serialization/layoutSerializers/RowsLayoutSerializer';
-import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
+import { dashboardSceneGraph, PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 import { getDashboardSceneFor } from '../../utils/utils';
 import { AutoGridItem } from '../layout-auto-grid/AutoGridItem';
 import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
@@ -119,7 +119,7 @@ export class RowsLayoutManager
   }
 
   // a single panel ID generator is shared across all rows to ensure that each gets a unique range of panel IDs
-  public duplicate(panelIdGenerator?: () => number): DashboardLayoutManager {
+  public duplicate(panelIdGenerator?: PanelIdGenerator): DashboardLayoutManager {
     const gen = panelIdGenerator ?? dashboardSceneGraph.getPanelIdGenerator(this);
     const newRows = this.state.rows.map((row) => row.duplicate(gen));
     return this.clone({ rows: newRows, key: undefined });

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -13,6 +13,7 @@ import { Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.
 
 import { dashboardEditActions, ObjectsReorderedOnCanvasEvent } from '../../edit-pane/shared';
 import { serializeRowsLayout } from '../../serialization/layoutSerializers/RowsLayoutSerializer';
+import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import { getDashboardSceneFor } from '../../utils/utils';
 import { AutoGridItem } from '../layout-auto-grid/AutoGridItem';
 import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
@@ -117,8 +118,10 @@ export class RowsLayoutManager
     return this.clone({});
   }
 
-  public duplicate(): DashboardLayoutManager {
-    const newRows = this.state.rows.map((row) => row.duplicate());
+  // a single panel ID generator is shared across all rows to ensure that each gets a unique range of panel IDs
+  public duplicate(panelIdGenerator?: () => number): DashboardLayoutManager {
+    const gen = panelIdGenerator ?? dashboardSceneGraph.getPanelIdGenerator(this);
+    const newRows = this.state.rows.map((row) => row.duplicate(gen));
     return this.clone({ rows: newRows, key: undefined });
   }
 

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -181,8 +181,10 @@ export class TabItem
     this.getParentLayout().duplicateTab(this);
   }
 
-  public duplicate(): TabItem {
-    return this.clone({ key: undefined, layout: this.getLayout().duplicate() });
+  // panelIdGenerator is a shared sequential counter created by the parent layout
+  // we forward id to ensure sibling tabs never produce duplicate panel IDs
+  public duplicate(panelIdGenerator?: () => number): TabItem {
+    return this.clone({ key: undefined, layout: this.getLayout().duplicate(panelIdGenerator) });
   }
 
   public onChangeTitle(title: string) {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -22,6 +22,7 @@ import { ConditionalRenderingGroup } from '../../conditional-rendering/group/Con
 import { dashboardEditActions } from '../../edit-pane/shared';
 import { serializeTab } from '../../serialization/layoutSerializers/TabsLayoutSerializer';
 import { getElements } from '../../serialization/layoutSerializers/utils';
+import { PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 import { trackDropItemCrossLayout } from '../../utils/tracking';
 import { getDashboardSceneFor } from '../../utils/utils';
 import { AutoGridItem } from '../layout-auto-grid/AutoGridItem';
@@ -183,7 +184,7 @@ export class TabItem
 
   // panelIdGenerator is a shared sequential counter created by the parent layout
   // we forward id to ensure sibling tabs never produce duplicate panel IDs
-  public duplicate(panelIdGenerator?: () => number): TabItem {
+  public duplicate(panelIdGenerator?: PanelIdGenerator): TabItem {
     return this.clone({ key: undefined, layout: this.getLayout().duplicate(panelIdGenerator) });
   }
 

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
@@ -1,8 +1,9 @@
-import { VizPanel } from '@grafana/scenes';
+import { SceneGridLayout, VizPanel } from '@grafana/scenes';
 
 import { dashboardEditActions } from '../../edit-pane/shared';
 import { DashboardScene } from '../DashboardScene';
 import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
+import { DashboardGridItem } from '../layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
 import { RowItem } from '../layout-rows/RowItem';
 import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
@@ -33,8 +34,8 @@ jest.mock('../../edit-pane/shared', () => ({
   ObjectsReorderedOnCanvasEvent: jest.fn().mockImplementation(() => ({})),
 }));
 
-function buildTabsLayoutManager(tabs: TabItem[]) {
-  const tabsLayoutManager = new TabsLayoutManager({ tabs });
+function buildTabsLayoutManager(tabs: TabItem[] = []) {
+  const tabsLayoutManager = new TabsLayoutManager({ key: 'test-TabsLayoutManager', tabs });
   new DashboardScene({ body: tabsLayoutManager });
   return tabsLayoutManager;
 }
@@ -417,6 +418,77 @@ describe('TabsLayoutManager', () => {
       expect(tabsManager.state.tabs).toHaveLength(2);
       expect(tabsManager.state.tabs[0].state.title).toBe('New row');
       expect(tabsManager.state.tabs[1].state.title).toBe('New tab');
+    });
+  });
+
+  describe('duplicate', () => {
+    it('should return a new TabsLayoutManager instance', () => {
+      const tabsLayoutManager = buildTabsLayoutManager();
+
+      const duplicated = tabsLayoutManager.duplicate() as TabsLayoutManager;
+
+      expect(duplicated).toBeInstanceOf(TabsLayoutManager);
+      expect(duplicated).not.toBe(tabsLayoutManager);
+      expect(duplicated.state.key).not.toBe(tabsLayoutManager.state.key);
+    });
+
+    it('should duplicate each tab', () => {
+      const tabs = [new TabItem({ title: 'Tab 1' }), new TabItem({ title: 'Tab 2' }), new TabItem({ title: 'Tab 3' })];
+      const tabDuplicateSpies = tabs.map((row) => jest.spyOn(row, 'duplicate'));
+      const tabsLayoutManager = buildTabsLayoutManager(tabs);
+
+      const duplicated = tabsLayoutManager.duplicate() as TabsLayoutManager;
+
+      expect(tabDuplicateSpies[0]).toHaveBeenCalledTimes(1);
+      expect(tabDuplicateSpies[1]).toHaveBeenCalledTimes(1);
+      expect(tabDuplicateSpies[2]).toHaveBeenCalledTimes(1);
+
+      expect(duplicated.state.tabs.length).toBe(3);
+      expect(duplicated.state.tabs[0]).not.toBe(tabs[0]);
+      expect(duplicated.state.tabs[1]).not.toBe(tabs[1]);
+      expect(duplicated.state.tabs[2]).not.toBe(tabs[2]);
+    });
+
+    describe('when tabs contain panels', () => {
+      it('should assign unique panel keys across all tabs, starting after the highest existing id', () => {
+        const tabsLayoutManager = buildTabsLayoutManager([
+          new TabItem({
+            title: 'Tab 1',
+            layout: new DefaultGridLayoutManager({
+              grid: new SceneGridLayout({
+                children: [
+                  new DashboardGridItem({
+                    body: new VizPanel({ key: 'panel-1', title: 'Panel A' }),
+                  }),
+                  new DashboardGridItem({
+                    body: new VizPanel({ key: 'panel-2', title: 'Panel B' }),
+                  }),
+                ],
+              }),
+            }),
+          }),
+          new TabItem({
+            title: 'Tab 2',
+            layout: new DefaultGridLayoutManager({
+              grid: new SceneGridLayout({
+                children: [
+                  new DashboardGridItem({
+                    body: new VizPanel({ key: 'panel-3', title: 'Panel C', pluginId: 'table' }),
+                  }),
+                  new DashboardGridItem({
+                    body: new VizPanel({ key: 'panel-4', title: 'Panel D', pluginId: 'table' }),
+                  }),
+                ],
+              }),
+            }),
+          }),
+        ]);
+
+        const duplicated = tabsLayoutManager.duplicate();
+
+        const panelKeys = duplicated.getVizPanels().map((p) => p.state.key);
+        expect(panelKeys).toEqual(['panel-5', 'panel-6', 'panel-7', 'panel-8']);
+      });
     });
   });
 });

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -12,6 +12,7 @@ import { Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.
 
 import { dashboardEditActions, ObjectsReorderedOnCanvasEvent } from '../../edit-pane/shared';
 import { serializeTabsLayout } from '../../serialization/layoutSerializers/TabsLayoutSerializer';
+import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import { getDashboardSceneFor } from '../../utils/utils';
 import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
@@ -73,9 +74,11 @@ export class TabsLayoutManager
     });
   }
 
-  public duplicate(): DashboardLayoutManager {
-    // Maybe not needed, depending on if we want nested tabs or tabs within rows
-    throw new Error('Method not implemented.');
+  // a single panel ID generator is shared across all tabs to ensure that each gets a unique range of panel IDs.
+  public duplicate(panelIdGenerator?: () => number): DashboardLayoutManager {
+    const gen = panelIdGenerator ?? dashboardSceneGraph.getPanelIdGenerator(this);
+    const newTabs = this.state.tabs.map((tab) => tab.duplicate(gen));
+    return this.clone({ tabs: newTabs, key: undefined });
   }
 
   public duplicateTab(tab: TabItem) {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -12,7 +12,7 @@ import { Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.
 
 import { dashboardEditActions, ObjectsReorderedOnCanvasEvent } from '../../edit-pane/shared';
 import { serializeTabsLayout } from '../../serialization/layoutSerializers/TabsLayoutSerializer';
-import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
+import { dashboardSceneGraph, PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 import { getDashboardSceneFor } from '../../utils/utils';
 import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
@@ -75,7 +75,7 @@ export class TabsLayoutManager
   }
 
   // a single panel ID generator is shared across all tabs to ensure that each gets a unique range of panel IDs.
-  public duplicate(panelIdGenerator?: () => number): DashboardLayoutManager {
+  public duplicate(panelIdGenerator?: PanelIdGenerator): DashboardLayoutManager {
     const gen = panelIdGenerator ?? dashboardSceneGraph.getPanelIdGenerator(this);
     const newTabs = this.state.tabs.map((tab) => tab.duplicate(gen));
     return this.clone({ tabs: newTabs, key: undefined });

--- a/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
@@ -48,7 +48,7 @@ export function getRowFromClipboard(scene: DashboardScene): RowItem {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const jsonObj: RowStore = JSON.parse(jsonData) as RowStore;
   clearClipboard();
-  const panelIdGenerator = getPanelIdGenerator(dashboardSceneGraph.getNextPanelId(scene));
+  const panelIdGenerator = dashboardSceneGraph.getPanelIdGenerator(scene);
 
   let row;
   // We don't control the local storage content, so if it's out of sync with the code all bets are off.
@@ -66,7 +66,7 @@ export function getTabFromClipboard(scene: DashboardScene): TabItem {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const jsonObj: TabStore = JSON.parse(jsonData) as TabStore;
   clearClipboard();
-  const panelIdGenerator = getPanelIdGenerator(dashboardSceneGraph.getNextPanelId(scene));
+  const panelIdGenerator = dashboardSceneGraph.getPanelIdGenerator(scene);
   let tab;
   try {
     tab = deserializeTab(jsonObj.tab, jsonObj.elements, false, panelIdGenerator);
@@ -83,9 +83,9 @@ export function getPanelFromClipboard(scene: DashboardScene): DashboardGridItem 
   const { elements, gridItem }: PanelStore = JSON.parse(jsonData) as PanelStore;
 
   if (gridItem.kind === 'GridLayoutItem') {
-    return deserializeGridItem(gridItem, elements, getPanelIdGenerator(dashboardSceneGraph.getNextPanelId(scene)));
+    return deserializeGridItem(gridItem, elements, dashboardSceneGraph.getPanelIdGenerator(scene));
   }
-  return deserializeAutoGridItem(gridItem, elements, getPanelIdGenerator(dashboardSceneGraph.getNextPanelId(scene)));
+  return deserializeAutoGridItem(gridItem, elements, dashboardSceneGraph.getPanelIdGenerator(scene));
 }
 
 export function getAutoGridItemFromClipboard(scene: DashboardScene): AutoGridItem {
@@ -109,9 +109,4 @@ export function getDashboardGridItemFromClipboard(scene: DashboardScene, gridCel
     key: panel.state.key,
     variableName: panel.state.variableName,
   });
-}
-
-function getPanelIdGenerator(start: number) {
-  let id = start;
-  return () => id++;
 }

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
@@ -73,9 +73,11 @@ export interface DashboardLayoutManager<S = {}> extends SceneObject {
   cloneLayout(ancestorKey: string, isSource: boolean): DashboardLayoutManager;
 
   /**
-   * Duplicate, like clone but with new keys
+   * Duplicate, like clone but with new keys.
+   * @param panelIdGenerator Optional sequential ID generator shared across
+   *   sibling layouts to prevent duplicate panel IDs.
    */
-  duplicate(): DashboardLayoutManager;
+  duplicate(panelIdGenerator?: () => number): DashboardLayoutManager;
 
   /**
    * Paste a panel from the clipboard

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
@@ -2,6 +2,8 @@ import { SceneObject, VizPanel } from '@grafana/scenes';
 import { Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
+import { PanelIdGenerator } from '../../utils/dashboardSceneGraph';
+
 import { LayoutRegistryItem } from './LayoutRegistryItem';
 
 /**
@@ -77,7 +79,7 @@ export interface DashboardLayoutManager<S = {}> extends SceneObject {
    * @param panelIdGenerator Optional sequential ID generator shared across
    *   sibling layouts to prevent duplicate panel IDs.
    */
-  duplicate(panelIdGenerator?: () => number): DashboardLayoutManager;
+  duplicate(panelIdGenerator?: PanelIdGenerator): DashboardLayoutManager;
 
   /**
    * Paste a panel from the clipboard

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/AutoGridLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/AutoGridLayoutSerializer.ts
@@ -15,7 +15,7 @@ import {
   getTemplateColumnsTemplate,
   AutoGridLayoutManager,
 } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
-import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
+import { dashboardSceneGraph, PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 import { getGridItemKeyForPanelId } from '../../utils/utils';
 
 import { buildLibraryPanel, buildVizPanel, getConditionalRendering } from './utils';
@@ -107,7 +107,7 @@ export function deserializeAutoGridLayout(
   layout: DashboardV2Spec['layout'],
   elements: DashboardV2Spec['elements'],
   preload: boolean,
-  panelIdGenerator?: () => number
+  panelIdGenerator?: PanelIdGenerator
 ): AutoGridLayoutManager {
   if (layout.kind !== 'AutoGridLayout') {
     throw new Error('Invalid layout kind');
@@ -154,7 +154,7 @@ function serializeAutoGridRowHeight(rowHeight: AutoGridRowHeight) {
 export function deserializeAutoGridItem(
   item: AutoGridLayoutItemKind,
   elements: DashboardV2Spec['elements'],
-  panelIdGenerator?: () => number
+  panelIdGenerator?: PanelIdGenerator
 ): AutoGridItem {
   const panel = elements[item.spec.element.name];
   if (!panel) {

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/DefaultGridLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/DefaultGridLayoutSerializer.ts
@@ -13,7 +13,7 @@ import {
 import { DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
 import { getIsLazy } from '../../scene/layouts-shared/utils';
-import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
+import { dashboardSceneGraph, PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 import { calculateGridItemDimensions, isLibraryPanel } from '../../utils/utils';
 
 import { buildLibraryPanel, buildVizPanel } from './utils';
@@ -34,7 +34,7 @@ export function deserializeDefaultGridLayout(
   layout: DashboardV2Spec['layout'],
   elements: DashboardV2Spec['elements'],
   preload: boolean,
-  panelIdGenerator?: () => number
+  panelIdGenerator?: PanelIdGenerator
 ): DefaultGridLayoutManager {
   if (layout.kind !== 'GridLayout') {
     throw new Error('Invalid layout kind');
@@ -191,7 +191,7 @@ function repeaterToLayoutItems(repeater: DashboardGridItem, isSnapshot = false):
 function createSceneGridLayoutForItems(
   layout: GridLayoutKind,
   elements: Record<string, Element>,
-  panelIdGenerator?: () => number
+  panelIdGenerator?: PanelIdGenerator
 ): SceneGridItemLike[] {
   const gridItems = layout.spec.items;
 
@@ -233,7 +233,7 @@ function buildGridItem(
 export function deserializeGridItem(
   item: GridLayoutItemKind,
   elements: DashboardV2Spec['elements'],
-  panelIdGenerator?: () => number
+  panelIdGenerator?: PanelIdGenerator
 ): DashboardGridItem {
   const panel = elements[item.spec.element.name];
 

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.ts
@@ -2,6 +2,7 @@ import { Spec as DashboardV2Spec, RowsLayoutRowKind } from '@grafana/schema/apis
 
 import { RowItem } from '../../scene/layout-rows/RowItem';
 import { RowsLayoutManager } from '../../scene/layout-rows/RowsLayoutManager';
+import { PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 
 import { layoutDeserializerRegistry } from './layoutSerializerRegistry';
 import { getConditionalRendering } from './utils';
@@ -66,7 +67,7 @@ export function deserializeRowsLayout(
   layout: DashboardV2Spec['layout'],
   elements: DashboardV2Spec['elements'],
   preload: boolean,
-  panelIdGenerator?: () => number
+  panelIdGenerator?: PanelIdGenerator
 ): RowsLayoutManager {
   if (layout.kind !== 'RowsLayout') {
     throw new Error('Invalid layout kind');
@@ -79,7 +80,7 @@ export function deserializeRow(
   row: RowsLayoutRowKind,
   elements: DashboardV2Spec['elements'],
   preload: boolean,
-  panelIdGenerator?: () => number
+  panelIdGenerator?: PanelIdGenerator
 ): RowItem {
   const layout = row.spec.layout;
 

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.ts
@@ -2,6 +2,7 @@ import { Spec as DashboardV2Spec, TabsLayoutTabKind } from '@grafana/schema/apis
 
 import { TabItem } from '../../scene/layout-tabs/TabItem';
 import { TabsLayoutManager } from '../../scene/layout-tabs/TabsLayoutManager';
+import { PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 
 import { layoutDeserializerRegistry } from './layoutSerializerRegistry';
 import { getConditionalRendering } from './utils';
@@ -46,7 +47,7 @@ export function deserializeTabsLayout(
   layout: DashboardV2Spec['layout'],
   elements: DashboardV2Spec['elements'],
   preload: boolean,
-  panelIdGenerator?: () => number
+  panelIdGenerator?: PanelIdGenerator
 ): TabsLayoutManager {
   if (layout.kind !== 'TabsLayout') {
     throw new Error('Invalid layout kind');
@@ -63,7 +64,7 @@ export function deserializeTab(
   tab: TabsLayoutTabKind,
   elements: DashboardV2Spec['elements'],
   preload: boolean,
-  panelIdGenerator?: () => number
+  panelIdGenerator?: PanelIdGenerator
 ): TabItem {
   const layout = tab.spec.layout;
 

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/layoutSerializerRegistry.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/layoutSerializerRegistry.ts
@@ -2,6 +2,7 @@ import { Registry, RegistryItem } from '@grafana/data';
 import { Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 
 import { DashboardLayoutManager } from '../../scene/types/DashboardLayoutManager';
+import { PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 
 import { deserializeAutoGridLayout } from './AutoGridLayoutSerializer';
 import { deserializeDefaultGridLayout } from './DefaultGridLayoutSerializer';
@@ -13,7 +14,7 @@ interface LayoutSerializerRegistryItem extends RegistryItem {
     layout: DashboardV2Spec['layout'],
     elements: DashboardV2Spec['elements'],
     preload: boolean,
-    panelIdGenerator?: () => number
+    panelIdGenerator?: PanelIdGenerator
   ) => DashboardLayoutManager;
 }
 

--- a/public/app/features/dashboard-scene/utils/dashboardSceneGraph.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardSceneGraph.ts
@@ -50,11 +50,13 @@ export function getNextPanelId(scene: SceneObject): number {
   return max + 1;
 }
 
+export type PanelIdGenerator = () => number;
+
 /**
  * Returns a sequential ID generator seeded from the current max panel ID.
  * Shared across sibling layouts to prevent duplicate panel IDs during duplication.
  */
-export function getPanelIdGenerator(scene: SceneObject): () => number {
+export function getPanelIdGenerator(scene: SceneObject): PanelIdGenerator {
   let id = getNextPanelId(scene);
   return () => id++;
 }

--- a/public/app/features/dashboard-scene/utils/dashboardSceneGraph.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardSceneGraph.ts
@@ -50,6 +50,15 @@ export function getNextPanelId(scene: SceneObject): number {
   return max + 1;
 }
 
+/**
+ * Returns a sequential ID generator seeded from the current max panel ID.
+ * Shared across sibling layouts to prevent duplicate panel IDs during duplication.
+ */
+export function getPanelIdGenerator(scene: SceneObject): () => number {
+  let id = getNextPanelId(scene);
+  return () => id++;
+}
+
 function getDataLayers(scene: DashboardScene): DashboardDataLayerSet {
   const data = sceneGraph.getData(scene);
 
@@ -100,5 +109,6 @@ export const dashboardSceneGraph = {
   getCursorSync,
   getLayoutManagerFor,
   getNextPanelId,
+  getPanelIdGenerator,
   getElementIdentifierForVizPanel,
 };


### PR DESCRIPTION
This PR fixes a bug where duplicate panel IDs are generated after duplicating a tab containing multiple rows.

From a user perspective, after duplicating a tab with rows, some panels in the duplicated tab appear as clones of panels from other rows instead of being faithful copies. 

**Root cause:**
Each row's inner layout (`DefaultGridLayoutManager`, `AutoGridLayoutManager`) independently calls `getNextPanelId()`, which walks up to the Scene root to find the current max panel ID. Since cloned panels from earlier rows aren't attached to the scene tree yet, every row sees the same max and starts assigning from the same ID.

**Fix:**
This PR introduces a shared `getPanelIdGenerator()` function that returns a sequential counter closure (mirroring the existing pattern used by the [paste/deserialization path](https://github.com/grafana/grafana/blob/main/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts)). The generator is created once by the parent layout and threaded through `duplicate()` to all children, guaranteeing unique IDs across siblings. 

Bug reported in Slack, also fixes: https://github.com/grafana/grafana/issues/119466
