### PR TITLE
Alerting: Alerting List Dashboard Panel Improvements

### DIFF
--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -13,6 +13,7 @@ import {
   BigValueGraphMode,
   BigValueJustifyMode,
   BigValueTextMode,
+  Link,
   LoadingPlaceholder,
   ScrollContainer,
   useStyles2,
@@ -313,9 +314,9 @@ function StatView({
   if (enhancementsEnabled) {
     const href = buildAlertingListUrl(options, dashboardUid);
     return (
-      <a href={href} className={styles.statLink}>
+      <Link href={href} className={styles.statLink}>
         {bigValue}
-      </a>
+      </Link>
     );
   }
 

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -45,10 +45,10 @@ import { AlertingAction, useAlertingAbility } from '../../../features/alerting/u
 import { getAlertingRule } from '../../../features/alerting/unified/utils/rules';
 import { AlertingRule, CombinedRuleWithLocation } from '../../../types/unified-alerting';
 
-import { GroupMode, SortOrder, StateFilter, UnifiedAlertListOptions, ViewMode } from './types';
+import { GroupMode, SortOrder, STAT_THRESHOLDS_DEFAULT, StateFilter, UnifiedAlertListOptions, ViewMode } from './types';
 import GroupedModeView from './unified-alerting/GroupedView';
 import UngroupedModeView from './unified-alerting/UngroupedView';
-import { filterAlerts } from './util';
+import { buildAlertingListUrl, filterAlerts, getStatDisplayValue } from './util';
 
 function getStateList(state: StateFilter) {
   const reducer = (list: string[], [stateKey, value]: [string, boolean]) => {
@@ -239,15 +239,13 @@ function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
       {havePreviousResults && (
         <section>
           {props.options.viewMode === ViewMode.Stat && (
-            <BigValue
-              colorMode={BigValueColorMode.None}
+            <StatView
+              rules={rules}
               width={props.width}
               height={props.height}
-              graphMode={BigValueGraphMode.None}
-              textMode={BigValueTextMode.Auto}
-              justifyMode={BigValueJustifyMode.Auto}
-              theme={config.theme2}
-              value={{ text: `${rules.length}`, numeric: rules.length }}
+              options={parsedOptions}
+              dashboardUid={options.dashboardAlerts ? dashboardRef.current?.uid : undefined}
+              styles={styles}
             />
           )}
           {props.options.viewMode === ViewMode.List && props.options.groupMode === GroupMode.Custom && (
@@ -268,6 +266,60 @@ function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
       {renderLoading && <LoadingPlaceholder text={t('alertlist.unified-alert-list.text-loading', 'Loading...')} />}
     </ScrollContainer>
   );
+}
+
+function StatView({
+  rules,
+  width,
+  height,
+  options,
+  dashboardUid,
+  styles,
+}: {
+  rules: CombinedRuleWithLocation[];
+  width: number;
+  height: number;
+  options: UnifiedAlertListOptions;
+  dashboardUid?: string;
+  styles: ReturnType<typeof getStyles>;
+}) {
+  const enhancementsEnabled = Boolean(config.featureToggles.alertingAlertListPanelEnhancements);
+
+  const displayValue = enhancementsEnabled
+    ? getStatDisplayValue(
+        rules.length,
+        options.statColorMode ?? BigValueColorMode.None,
+        options.statThresholds ?? STAT_THRESHOLDS_DEFAULT,
+        options.statValueMappings ?? [],
+        config.theme2
+      )
+    : { text: `${rules.length}`, numeric: rules.length };
+
+  const colorMode = enhancementsEnabled ? (options.statColorMode ?? BigValueColorMode.None) : BigValueColorMode.None;
+
+  const bigValue = (
+    <BigValue
+      colorMode={colorMode}
+      width={width}
+      height={height}
+      graphMode={BigValueGraphMode.None}
+      textMode={BigValueTextMode.Auto}
+      justifyMode={BigValueJustifyMode.Auto}
+      theme={config.theme2}
+      value={displayValue}
+    />
+  );
+
+  if (enhancementsEnabled) {
+    const href = buildAlertingListUrl(options, dashboardUid);
+    return (
+      <a href={href} className={styles.statLink}>
+        {bigValue}
+      </a>
+    );
+  }
+
+  return bigValue;
 }
 
 function sortRules(sortOrder: SortOrder, rules: CombinedRuleWithLocation[]) {
@@ -462,6 +514,15 @@ export const getStyles = (theme: GrafanaTheme2) => ({
   }),
   hidden: css({
     display: 'none',
+  }),
+  statLink: css({
+    display: 'block',
+    width: '100%',
+    height: '100%',
+    textDecoration: 'none',
+    '&:hover': {
+      textDecoration: 'none',
+    },
   }),
 });
 

--- a/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
@@ -127,7 +127,6 @@ const defaultOptions: UnifiedAlertListOptions = {
   statColorMode: BigValueColorMode.None,
   statThresholds: STAT_THRESHOLDS_DEFAULT,
   statValueMappings: [],
-  datasourceRef: null,
 };
 
 const defaultProps: PanelProps<UnifiedAlertListOptions> = {

--- a/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
@@ -3,8 +3,16 @@ import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { byRole, byText } from 'testing-library-selector';
 
-import { FieldConfigSource, getDefaultTimeRange, LoadingState, PanelProps, PluginExtensionTypes } from '@grafana/data';
-import { TimeRangeUpdatedEvent, usePluginLinks } from '@grafana/runtime';
+import {
+  FieldConfigSource,
+  getDefaultTimeRange,
+  LoadingState,
+  PanelProps,
+  PluginExtensionTypes,
+  ThresholdsMode,
+} from '@grafana/data';
+import { config, TimeRangeUpdatedEvent, usePluginLinks } from '@grafana/runtime';
+import { BigValueColorMode } from '@grafana/ui';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 import { mockPromRulesApiResponse } from 'app/features/alerting/unified/mocks/grafanaRulerApi';
 import { mockRulerRulesApiResponse } from 'app/features/alerting/unified/mocks/rulerApi';
@@ -26,7 +34,7 @@ import { GRAFANA_RULES_SOURCE_NAME } from '../../../features/alerting/unified/ut
 import { AccessControlAction } from '../../../types/accessControl';
 
 import { UnifiedAlertListPanel } from './UnifiedAlertList';
-import { GroupMode, SortOrder, UnifiedAlertListOptions, ViewMode } from './types';
+import { GroupMode, SortOrder, STAT_THRESHOLDS_DEFAULT, UnifiedAlertListOptions, ViewMode } from './types';
 import * as utils from './util';
 
 const grafanaRuleMock = {
@@ -116,6 +124,10 @@ const defaultOptions: UnifiedAlertListOptions = {
   datasource: 'grafana',
   viewMode: ViewMode.List,
   showInactiveAlerts: false,
+  statColorMode: BigValueColorMode.None,
+  statThresholds: STAT_THRESHOLDS_DEFAULT,
+  statValueMappings: [],
+  datasourceRef: null,
 };
 
 const defaultProps: PanelProps<UnifiedAlertListOptions> = {
@@ -281,5 +293,105 @@ describe('UnifiedAlertList', () => {
     // The subscription should be re-created after the useEffect re-runs.
     await waitFor(() => expect(subscribeMock).toHaveBeenCalledTimes(2));
     expect(subscribeMock.mock.calls[1][0]).toEqual(TimeRangeUpdatedEvent);
+  });
+
+  describe('stat mode with feature flag off', () => {
+    beforeEach(() => {
+      config.featureToggles.alertingAlertListPanelEnhancements = false;
+      jest.spyOn(defaultProps, 'replaceVariables').mockReturnValue('');
+    });
+
+    it('renders plain stat value without link when flag is off', async () => {
+      renderPanel({
+        viewMode: ViewMode.Stat,
+        dashboardAlerts: false,
+        alertName: '',
+        datasource: GRAFANA_RULES_SOURCE_NAME,
+        folder: undefined,
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('stat mode with feature flag on', () => {
+    beforeEach(() => {
+      config.featureToggles.alertingAlertListPanelEnhancements = true;
+      jest.spyOn(defaultProps, 'replaceVariables').mockReturnValue('');
+    });
+
+    afterEach(() => {
+      config.featureToggles.alertingAlertListPanelEnhancements = false;
+    });
+
+    it('renders stat value wrapped in a link when flag is on', async () => {
+      renderPanel({
+        viewMode: ViewMode.Stat,
+        dashboardAlerts: false,
+        alertName: '',
+        datasource: GRAFANA_RULES_SOURCE_NAME,
+        folder: undefined,
+        statColorMode: BigValueColorMode.None,
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+      });
+
+      const link = screen.getByRole('link');
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', expect.stringContaining('/alerting/list'));
+    });
+
+    it('uses variable-expanded options when building the stat link', async () => {
+      jest
+        .spyOn(defaultProps, 'replaceVariables')
+        .mockImplementation((value: string) => (value === '$alert' ? 'cpu-high' : ''));
+
+      renderPanel({
+        viewMode: ViewMode.Stat,
+        dashboardAlerts: false,
+        alertName: '$alert',
+        datasource: GRAFANA_RULES_SOURCE_NAME,
+        folder: undefined,
+        statColorMode: BigValueColorMode.None,
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+      });
+
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute('href', expect.stringContaining('cpu-high'));
+    });
+
+    it('renders stat value with threshold color when colorMode is Value', async () => {
+      renderPanel({
+        viewMode: ViewMode.Stat,
+        dashboardAlerts: false,
+        alertName: '',
+        datasource: GRAFANA_RULES_SOURCE_NAME,
+        folder: undefined,
+        statColorMode: BigValueColorMode.Value,
+        statThresholds: {
+          mode: ThresholdsMode.Absolute,
+          steps: [
+            { value: -Infinity, color: 'green' },
+            { value: 5, color: 'red' },
+          ],
+        },
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+      });
+
+      const link = screen.getByRole('link');
+      expect(link).toBeInTheDocument();
+    });
   });
 });

--- a/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
@@ -1,6 +1,5 @@
-import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Provider } from 'react-redux';
+import { render, screen, waitFor } from 'test/test-utils';
 import { byRole, byText } from 'testing-library-selector';
 
 import {
@@ -170,11 +169,7 @@ const renderPanel = (options: Partial<UnifiedAlertListOptions> = defaultOptions)
 
   const props = { ...defaultProps, options: { ...defaultOptions, ...options } };
 
-  return render(
-    <Provider store={store}>
-      <UnifiedAlertListPanel {...props} />
-    </Provider>
-  );
+  return render(<UnifiedAlertListPanel {...props} />, { store });
 };
 
 describe('UnifiedAlertList', () => {
@@ -266,11 +261,7 @@ describe('UnifiedAlertList', () => {
       stateFilter: { firing: true, pending: false, noData: false, normal: true, error: false, recovering: false },
     };
 
-    const { rerender } = render(
-      <Provider store={store}>
-        <UnifiedAlertListPanel {...{ ...defaultProps, options: initialOptions }} />
-      </Provider>
-    );
+    const { rerender } = render(<UnifiedAlertListPanel {...{ ...defaultProps, options: initialOptions }} />, { store });
 
     await waitFor(() => expect(subscribeMock).toHaveBeenCalledTimes(1));
     expect(subscribeMock.mock.calls[0][0]).toEqual(TimeRangeUpdatedEvent);
@@ -280,11 +271,7 @@ describe('UnifiedAlertList', () => {
       stateFilter: { firing: true, pending: true, noData: true, normal: true, error: true, recovering: true },
     };
 
-    rerender(
-      <Provider store={store}>
-        <UnifiedAlertListPanel {...{ ...defaultProps, options: updatedOptions }} />
-      </Provider>
-    );
+    rerender(<UnifiedAlertListPanel {...{ ...defaultProps, options: updatedOptions }} />);
 
     // The old subscription should be cleaned up
     await waitFor(() => expect(unsubscribeMock).toHaveBeenCalled());

--- a/public/app/plugins/panel/alertlist/module.tsx
+++ b/public/app/plugins/panel/alertlist/module.tsx
@@ -1,8 +1,10 @@
-import { DataSourceInstanceSettings, PanelPlugin } from '@grafana/data';
+import { DataSourceInstanceSettings, PanelPlugin, standardEditorsRegistry, ThresholdsMode } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { Button, Stack } from '@grafana/ui';
+import { config } from '@grafana/runtime';
+import { BigValueColorMode, Button, Stack } from '@grafana/ui';
 import { NestedFolderPicker } from 'app/core/components/NestedFolderPicker/NestedFolderPicker';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
+import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 
 import {
   GRAFANA_DATASOURCE_NAME,
@@ -11,220 +13,314 @@ import {
 
 import { GroupBy } from './GroupByWithLoading';
 import { UnifiedAlertListPanel } from './UnifiedAlertList';
-import { GroupMode, SortOrder, UnifiedAlertListOptions, ViewMode } from './types';
+import { GroupMode, SortOrder, STAT_THRESHOLDS_DEFAULT, UnifiedAlertListOptions, ViewMode } from './types';
 
-const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertListPanel).setPanelOptions((builder) => {
-  const optionsCategory = [t('alertlist.category-options', 'Options')];
-  const filterCategory = [t('alertlist.category-filter', 'Filter')];
-  const alertStateCategory = [t('alertlist.category-alert-state-filter', 'Alert state filter')];
-  builder
-    .addRadio({
-      path: 'viewMode',
-      name: t('alertlist.name-view-mode', 'View mode'),
-      description: t('alertlist.description-view-mode', 'Toggle between list view and stat view'),
-      defaultValue: ViewMode.List,
-      settings: {
-        options: [
-          { label: t('alertlist.view-mode-options.label-list', 'List'), value: ViewMode.List },
-          { label: t('alertlist.view-mode-options.label-stat', 'Stat'), value: ViewMode.Stat },
-        ],
-      },
-      category: optionsCategory,
-    })
-    .addRadio({
-      path: 'groupMode',
-      name: t('alertlist.name-group-mode', 'Group mode'),
-      description: t('alertlist.description-group-mode', 'How alert instances should be grouped'),
-      defaultValue: GroupMode.Default,
-      settings: {
-        options: [
-          {
-            value: GroupMode.Default,
-            label: t('alertlist.group-mode-options.label-default-grouping', 'Default grouping'),
-          },
-          {
-            value: GroupMode.Custom,
-            label: t('alertlist.group-mode-options.label-custom-grouping', 'Custom grouping'),
-          },
-        ],
-      },
-      category: optionsCategory,
-    })
-    .addCustomEditor({
-      path: 'groupBy',
-      name: t('alertlist.name-group-by', 'Group by'),
-      description: t('alertlist.description-group-by', 'Filter alerts using label querying'),
-      id: 'groupBy',
-      defaultValue: [],
-      showIf: (options) => options.groupMode === GroupMode.Custom,
-      category: optionsCategory,
-      editor: (props) => {
-        return (
-          <GroupBy
-            id={props.id ?? 'groupBy'}
-            defaultValue={props.value.map((value: string) => ({ label: value, value }))}
-            onChange={props.onChange}
-            dataSource={props.context.options.datasource}
-          />
-        );
-      },
-    })
-    .addNumberInput({
-      name: t('alertlist.name-max-items', 'Max items'),
-      path: 'maxItems',
-      description: t('alertlist.description-max-items', 'Maximum alerts to display'),
-      defaultValue: 20,
-      showIf: (options) => options.groupMode !== GroupMode.Custom,
-      category: optionsCategory,
-    })
-    .addSelect({
-      name: t('alertlist.name-sort-order', 'Sort order'),
-      path: 'sortOrder',
-      description: t('alertlist.description-sort-order', 'Sort order of alerts and alert instances'),
-      settings: {
-        options: [
-          {
-            label: t('alertlist.sort-order-options.label-alphabetical-asc', 'Alphabetical (asc)'),
-            value: SortOrder.AlphaAsc,
-          },
-          {
-            label: t('alertlist.sort-order-options.label-alphabetical-desc', 'Alphabetical (desc)'),
-            value: SortOrder.AlphaDesc,
-          },
-          { label: t('alertlist.sort-order-options.label-importance', 'Importance'), value: SortOrder.Importance },
-          { label: t('alertlist.sort-order-options.label-time-asc', 'Time (asc)'), value: SortOrder.TimeAsc },
-          { label: t('alertlist.sort-order-options.label-time-desc', 'Time (desc)'), value: SortOrder.TimeDesc },
-        ],
-      },
-      defaultValue: SortOrder.AlphaAsc,
-      category: optionsCategory,
-    })
-    .addBooleanSwitch({
-      path: 'dashboardAlerts',
-      name: t('alertlist.name-alerts-linked-to-dashboard', 'Alerts linked to this dashboard'),
-      description: t('alertlist.descriptino-alerts-linked-to-dashboard', 'Only show alerts linked to this dashboard'),
-      defaultValue: false,
-      category: optionsCategory,
-    })
-    .addTextInput({
-      path: 'alertName',
-      name: t('alertlist.name-alert-name', 'Alert name'),
-      description: t('alertlist.description-alert-name', 'Filter for alerts containing this text'),
-      defaultValue: '',
-      category: filterCategory,
-    })
-    .addTextInput({
-      path: 'alertInstanceLabelFilter',
-      name: t('alertlist.name-alert-instance-label', 'Alert instance label'),
-      description: t(
-        'alertlist.description-alert-instance-label',
-        'Filter alert instances using label querying, ex: {severity="critical", instance=~"cluster-us-.+"}'
-      ),
-      defaultValue: '',
-      category: filterCategory,
-    })
-    .addCustomEditor({
-      path: 'datasource',
-      name: t('alertlist.name-datasource', 'Datasource'),
-      description: t('alertlist.description-datasource', 'Filter from alert source'),
-      id: 'datasource',
-      defaultValue: null,
-      editor: function RenderDatasourcePicker({ id, ...props }) {
-        return (
-          <Stack gap={1}>
-            <DataSourcePicker
-              {...props}
-              inputId={id}
-              type={SUPPORTED_RULE_SOURCE_TYPES}
-              noDefault
-              current={props.value}
-              onChange={(ds: DataSourceInstanceSettings) => {
-                // If we're changing the datasource, clear the folder selection
-                // as otherwise we might still be accidentally filtering out alerts
-                if (ds.uid !== 'grafana') {
-                  props.context.options.folder = null;
-                }
-                return props.onChange(ds.name);
-              }}
+const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertListPanel)
+  .setPanelOptions((builder) => {
+    const optionsCategory = [t('alertlist.category-options', 'Options')];
+    const filterCategory = [t('alertlist.category-filter', 'Filter')];
+    const alertStateCategory = [t('alertlist.category-alert-state-filter', 'Alert state filter')];
+    builder
+      .addRadio({
+        path: 'viewMode',
+        name: t('alertlist.name-view-mode', 'View mode'),
+        description: t('alertlist.description-view-mode', 'Toggle between list view and stat view'),
+        defaultValue: ViewMode.List,
+        settings: {
+          options: [
+            { label: t('alertlist.view-mode-options.label-list', 'List'), value: ViewMode.List },
+            { label: t('alertlist.view-mode-options.label-stat', 'Stat'), value: ViewMode.Stat },
+          ],
+        },
+        category: optionsCategory,
+      })
+      .addRadio({
+        path: 'groupMode',
+        name: t('alertlist.name-group-mode', 'Group mode'),
+        description: t('alertlist.description-group-mode', 'How alert instances should be grouped'),
+        defaultValue: GroupMode.Default,
+        settings: {
+          options: [
+            {
+              value: GroupMode.Default,
+              label: t('alertlist.group-mode-options.label-default-grouping', 'Default grouping'),
+            },
+            {
+              value: GroupMode.Custom,
+              label: t('alertlist.group-mode-options.label-custom-grouping', 'Custom grouping'),
+            },
+          ],
+        },
+        category: optionsCategory,
+      })
+      .addCustomEditor({
+        path: 'groupBy',
+        name: t('alertlist.name-group-by', 'Group by'),
+        description: t('alertlist.description-group-by', 'Filter alerts using label querying'),
+        id: 'groupBy',
+        defaultValue: [],
+        showIf: (options) => options.groupMode === GroupMode.Custom,
+        category: optionsCategory,
+        editor: (props) => {
+          return (
+            <GroupBy
+              id={props.id ?? 'groupBy'}
+              defaultValue={props.value.map((value: string) => ({ label: value, value }))}
+              onChange={props.onChange}
+              dataSource={props.context.options.datasource}
             />
-            <Button variant="secondary" onClick={() => props.onChange(null)}>
-              <Trans i18nKey="alertlist.unified-alert-list.clear">Clear</Trans>
-            </Button>
-          </Stack>
-        );
-      },
-      category: filterCategory,
-    })
-    .addCustomEditor({
-      showIf: (options) => options.datasource === GRAFANA_DATASOURCE_NAME || !Boolean(options.datasource),
-      path: 'folder',
-      name: t('alertlist.name-folder', 'Folder'),
-      description: t(
-        'alertlist.description-folder',
-        'Filter for alerts in the selected folder (for Grafana-managed alert rules only)'
-      ),
-      id: 'folder',
-      defaultValue: null,
-      editor: function RenderFolderPicker(props) {
-        return (
-          <NestedFolderPicker
-            clearable
-            showRootFolder={false}
-            {...props}
-            onChange={(uid, title) => props.onChange({ uid, title })}
-            value={props.value?.uid}
-            permission="view"
-          />
-        );
-      },
-      category: filterCategory,
-    })
-    .addBooleanSwitch({
-      path: 'showInactiveAlerts',
-      name: t('alertlist.name-show-inactive-alerts', 'Show alerts with 0 instances'),
-      description: t(
-        'alertlist.description-show-inactive-alerts',
-        'Include alert rules which have 0 (zero) instances. Because these rules have no instances, they remain hidden if the Alert instance label filter is configured.'
-      ),
-      defaultValue: false,
-      category: filterCategory,
-    })
-    .addBooleanSwitch({
-      path: 'stateFilter.firing',
-      name: t('alertlist.name-firing', 'Alerting / Firing'),
-      defaultValue: true,
-      category: alertStateCategory,
-    })
-    .addBooleanSwitch({
-      path: 'stateFilter.pending',
-      name: t('alertlist.name-pending', 'Pending'),
-      defaultValue: true,
-      category: alertStateCategory,
-    })
-    .addBooleanSwitch({
-      path: 'stateFilter.recovering',
-      name: t('alertlist.name-recovering', 'Recovering'),
-      defaultValue: true,
-      category: alertStateCategory,
-    })
-    .addBooleanSwitch({
-      path: 'stateFilter.noData',
-      name: t('alertlist.name-no-data', 'No Data'),
-      defaultValue: false,
-      category: alertStateCategory,
-    })
-    .addBooleanSwitch({
-      path: 'stateFilter.normal',
-      name: t('alertlist.name-normal', 'Normal'),
-      defaultValue: false,
-      category: alertStateCategory,
-    })
-    .addBooleanSwitch({
-      path: 'stateFilter.error',
-      name: t('alertlist.name-error', 'Error'),
-      defaultValue: true,
-      category: alertStateCategory,
-    });
-});
+          );
+        },
+      })
+      .addNumberInput({
+        name: t('alertlist.name-max-items', 'Max items'),
+        path: 'maxItems',
+        description: t('alertlist.description-max-items', 'Maximum alerts to display'),
+        defaultValue: 20,
+        showIf: (options) => options.groupMode !== GroupMode.Custom,
+        category: optionsCategory,
+      })
+      .addSelect({
+        name: t('alertlist.name-sort-order', 'Sort order'),
+        path: 'sortOrder',
+        description: t('alertlist.description-sort-order', 'Sort order of alerts and alert instances'),
+        settings: {
+          options: [
+            {
+              label: t('alertlist.sort-order-options.label-alphabetical-asc', 'Alphabetical (asc)'),
+              value: SortOrder.AlphaAsc,
+            },
+            {
+              label: t('alertlist.sort-order-options.label-alphabetical-desc', 'Alphabetical (desc)'),
+              value: SortOrder.AlphaDesc,
+            },
+            { label: t('alertlist.sort-order-options.label-importance', 'Importance'), value: SortOrder.Importance },
+            { label: t('alertlist.sort-order-options.label-time-asc', 'Time (asc)'), value: SortOrder.TimeAsc },
+            { label: t('alertlist.sort-order-options.label-time-desc', 'Time (desc)'), value: SortOrder.TimeDesc },
+          ],
+        },
+        defaultValue: SortOrder.AlphaAsc,
+        category: optionsCategory,
+      })
+      .addBooleanSwitch({
+        path: 'dashboardAlerts',
+        name: t('alertlist.name-alerts-linked-to-dashboard', 'Alerts linked to this dashboard'),
+        description: t('alertlist.descriptino-alerts-linked-to-dashboard', 'Only show alerts linked to this dashboard'),
+        defaultValue: false,
+        category: optionsCategory,
+      })
+      .addTextInput({
+        path: 'alertName',
+        name: t('alertlist.name-alert-name', 'Alert name'),
+        description: t('alertlist.description-alert-name', 'Filter for alerts containing this text'),
+        defaultValue: '',
+        category: filterCategory,
+      })
+      .addTextInput({
+        path: 'alertInstanceLabelFilter',
+        name: t('alertlist.name-alert-instance-label', 'Alert instance label'),
+        description: t(
+          'alertlist.description-alert-instance-label',
+          'Filter alert instances using label querying, ex: {severity="critical", instance=~"cluster-us-.+"}'
+        ),
+        defaultValue: '',
+        category: filterCategory,
+      })
+      .addCustomEditor({
+        path: 'datasource',
+        name: t('alertlist.name-datasource', 'Datasource'),
+        description: t('alertlist.description-datasource', 'Filter from alert source'),
+        id: 'datasource',
+        defaultValue: null,
+        editor: function RenderDatasourcePicker({ id, ...props }) {
+          return (
+            <Stack gap={1}>
+              <DataSourcePicker
+                {...props}
+                inputId={id}
+                type={SUPPORTED_RULE_SOURCE_TYPES}
+                noDefault
+                current={props.value}
+                onChange={(ds: DataSourceInstanceSettings) => {
+                  if (ds.uid !== 'grafana') {
+                    props.context.options.folder = null;
+                  }
+                  return props.onChange(ds.name);
+                }}
+              />
+              <Button variant="secondary" onClick={() => props.onChange(null)}>
+                <Trans i18nKey="alertlist.unified-alert-list.clear">Clear</Trans>
+              </Button>
+            </Stack>
+          );
+        },
+        category: filterCategory,
+      })
+      .addCustomEditor({
+        showIf: (options) => options.datasource === GRAFANA_DATASOURCE_NAME || !Boolean(options.datasource),
+        path: 'folder',
+        name: t('alertlist.name-folder', 'Folder'),
+        description: t(
+          'alertlist.description-folder',
+          'Filter for alerts in the selected folder (for Grafana-managed alert rules only)'
+        ),
+        id: 'folder',
+        defaultValue: null,
+        editor: function RenderFolderPicker(props) {
+          return (
+            <NestedFolderPicker
+              clearable
+              showRootFolder={false}
+              {...props}
+              onChange={(uid, title) => props.onChange({ uid, title })}
+              value={props.value?.uid}
+              permission="view"
+            />
+          );
+        },
+        category: filterCategory,
+      })
+      .addBooleanSwitch({
+        path: 'showInactiveAlerts',
+        name: t('alertlist.name-show-inactive-alerts', 'Show alerts with 0 instances'),
+        description: t(
+          'alertlist.description-show-inactive-alerts',
+          'Include alert rules which have 0 (zero) instances. Because these rules have no instances, they remain hidden if the Alert instance label filter is configured.'
+        ),
+        defaultValue: false,
+        category: filterCategory,
+      })
+      .addBooleanSwitch({
+        path: 'stateFilter.firing',
+        name: t('alertlist.name-firing', 'Alerting / Firing'),
+        defaultValue: true,
+        category: alertStateCategory,
+      })
+      .addBooleanSwitch({
+        path: 'stateFilter.pending',
+        name: t('alertlist.name-pending', 'Pending'),
+        defaultValue: true,
+        category: alertStateCategory,
+      })
+      .addBooleanSwitch({
+        path: 'stateFilter.recovering',
+        name: t('alertlist.name-recovering', 'Recovering'),
+        defaultValue: true,
+        category: alertStateCategory,
+      })
+      .addBooleanSwitch({
+        path: 'stateFilter.noData',
+        name: t('alertlist.name-no-data', 'No Data'),
+        defaultValue: false,
+        category: alertStateCategory,
+      })
+      .addBooleanSwitch({
+        path: 'stateFilter.normal',
+        name: t('alertlist.name-normal', 'Normal'),
+        defaultValue: false,
+        category: alertStateCategory,
+      })
+      .addBooleanSwitch({
+        path: 'stateFilter.error',
+        name: t('alertlist.name-error', 'Error'),
+        defaultValue: true,
+        category: alertStateCategory,
+      });
+
+    if (config.featureToggles.alertingAlertListPanelEnhancements) {
+      const statCategory = [t('alertlist.category-stat-styles', 'Stat styles')];
+
+      builder
+        .addSelect({
+          path: 'statColorMode',
+          name: t('alertlist.name-stat-color-mode', 'Color mode'),
+          description: t(
+            'alertlist.description-stat-color-mode',
+            'Control how the stat value or background is colored'
+          ),
+          defaultValue: BigValueColorMode.None,
+          showIf: (options) => options.viewMode === ViewMode.Stat,
+          settings: {
+            options: [
+              { value: BigValueColorMode.None, label: t('alertlist.stat-color-mode.label-none', 'None') },
+              { value: BigValueColorMode.Value, label: t('alertlist.stat-color-mode.label-value', 'Value') },
+              {
+                value: BigValueColorMode.Background,
+                label: t('alertlist.stat-color-mode.label-background-gradient', 'Background Gradient'),
+              },
+              {
+                value: BigValueColorMode.BackgroundSolid,
+                label: t('alertlist.stat-color-mode.label-background-solid', 'Background Solid'),
+              },
+            ],
+          },
+          category: statCategory,
+        })
+        .addCustomEditor({
+          id: 'statThresholds',
+          path: 'statThresholds',
+          name: t('alertlist.name-stat-thresholds', 'Thresholds'),
+          description: t(
+            'alertlist.description-stat-thresholds',
+            'Define thresholds to color the stat value based on the alert count'
+          ),
+          defaultValue: STAT_THRESHOLDS_DEFAULT,
+          showIf: (options) => options.viewMode === ViewMode.Stat && options.statColorMode !== BigValueColorMode.None,
+          editor: standardEditorsRegistry.get('thresholds').editor,
+          category: statCategory,
+        })
+        .addCustomEditor({
+          id: 'statValueMappings',
+          path: 'statValueMappings',
+          name: t('alertlist.name-stat-value-mappings', 'Value mappings'),
+          description: t(
+            'alertlist.description-stat-value-mappings',
+            'Modify the display text based on the alert count'
+          ),
+          defaultValue: [],
+          showIf: (options) => options.viewMode === ViewMode.Stat,
+          editor: standardEditorsRegistry.get('mappings').editor,
+          category: statCategory,
+        });
+    }
+  })
+  .setMigrationHandler((panel) => {
+    if (
+      config.featureToggles.alertingAlertListPanelEnhancements &&
+      panel.options.datasource &&
+      typeof panel.options.datasource === 'string' &&
+      !panel.options.datasourceRef
+    ) {
+      try {
+        const ds = getDatasourceSrv().getInstanceSettings(panel.options.datasource);
+        if (ds) {
+          panel.options.datasourceRef = { type: ds.type, uid: ds.uid };
+        }
+      } catch {
+        // datasource may not be resolvable at migration time
+      }
+    }
+
+    if (!panel.options.statColorMode) {
+      panel.options.statColorMode = BigValueColorMode.None;
+    }
+    if (!panel.options.statThresholds) {
+      panel.options.statThresholds = {
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: 'green' },
+          { value: 80, color: 'red' },
+        ],
+      };
+    }
+    if (!panel.options.statValueMappings) {
+      panel.options.statValueMappings = [];
+    }
+    if (panel.options.datasourceRef === undefined) {
+      panel.options.datasourceRef = null;
+    }
+
+    return panel.options;
+  });
 
 export const plugin = unifiedAlertList;

--- a/public/app/plugins/panel/alertlist/module.tsx
+++ b/public/app/plugins/panel/alertlist/module.tsx
@@ -4,7 +4,6 @@ import { config } from '@grafana/runtime';
 import { BigValueColorMode, Button, Stack } from '@grafana/ui';
 import { NestedFolderPicker } from 'app/core/components/NestedFolderPicker/NestedFolderPicker';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
-import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 
 import {
   GRAFANA_DATASOURCE_NAME,
@@ -285,22 +284,6 @@ const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertLi
     }
   })
   .setMigrationHandler((panel) => {
-    if (
-      config.featureToggles.alertingAlertListPanelEnhancements &&
-      panel.options.datasource &&
-      typeof panel.options.datasource === 'string' &&
-      !panel.options.datasourceRef
-    ) {
-      try {
-        const ds = getDatasourceSrv().getInstanceSettings(panel.options.datasource);
-        if (ds) {
-          panel.options.datasourceRef = { type: ds.type, uid: ds.uid };
-        }
-      } catch {
-        // datasource may not be resolvable at migration time
-      }
-    }
-
     if (!panel.options.statColorMode) {
       panel.options.statColorMode = BigValueColorMode.None;
     }
@@ -315,9 +298,6 @@ const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertLi
     }
     if (!panel.options.statValueMappings) {
       panel.options.statValueMappings = [];
-    }
-    if (panel.options.datasourceRef === undefined) {
-      panel.options.datasourceRef = null;
     }
 
     return panel.options;

--- a/public/app/plugins/panel/alertlist/types.ts
+++ b/public/app/plugins/panel/alertlist/types.ts
@@ -46,7 +46,6 @@ export interface UnifiedAlertListOptions {
   statColorMode: BigValueColorMode;
   statThresholds: ThresholdsConfig;
   statValueMappings: ValueMapping[];
-  datasourceRef: { type: string; uid: string } | null;
 }
 
 export const STAT_THRESHOLDS_DEFAULT: ThresholdsConfig = {

--- a/public/app/plugins/panel/alertlist/types.ts
+++ b/public/app/plugins/panel/alertlist/types.ts
@@ -1,3 +1,6 @@
+import { ThresholdsConfig, ThresholdsMode, ValueMapping } from '@grafana/data';
+import { BigValueColorMode } from '@grafana/ui';
+
 export enum SortOrder {
   AlphaAsc = 1,
   AlphaDesc,
@@ -40,4 +43,16 @@ export interface UnifiedAlertListOptions {
   datasource: string;
   viewMode: ViewMode;
   showInactiveAlerts: boolean;
+  statColorMode: BigValueColorMode;
+  statThresholds: ThresholdsConfig;
+  statValueMappings: ValueMapping[];
+  datasourceRef: { type: string; uid: string } | null;
 }
+
+export const STAT_THRESHOLDS_DEFAULT: ThresholdsConfig = {
+  mode: ThresholdsMode.Absolute,
+  steps: [
+    { value: -Infinity, color: 'green' },
+    { value: 80, color: 'red' },
+  ],
+};

--- a/public/app/plugins/panel/alertlist/util.test.tsx
+++ b/public/app/plugins/panel/alertlist/util.test.tsx
@@ -1,9 +1,11 @@
+import { createTheme, MappingType, ThresholdsMode } from '@grafana/data';
+import { BigValueColorMode } from '@grafana/ui';
 import { mockAlertWithState as withState } from 'app/features/alerting/unified/mocks';
 import { Alert } from 'app/types/unified-alerting';
 import { GrafanaAlertState } from 'app/types/unified-alerting-dto';
 
-import { GroupMode, SortOrder, UnifiedAlertListOptions, ViewMode } from './types';
-import { filterAlerts } from './util';
+import { GroupMode, SortOrder, STAT_THRESHOLDS_DEFAULT, UnifiedAlertListOptions, ViewMode } from './types';
+import { buildAlertingListUrl, filterAlerts, getStatDisplayValue } from './util';
 
 const defaultOption: UnifiedAlertListOptions = {
   maxItems: 2,
@@ -19,6 +21,10 @@ const defaultOption: UnifiedAlertListOptions = {
   datasource: 'Alertmanager',
   viewMode: ViewMode.List,
   showInactiveAlerts: false,
+  statColorMode: BigValueColorMode.None,
+  statThresholds: STAT_THRESHOLDS_DEFAULT,
+  statValueMappings: [],
+  datasourceRef: null,
 };
 
 const alerts: Alert[] = [
@@ -72,5 +78,266 @@ describe('filterAlerts', () => {
     const result = filterAlerts(options, alerts);
 
     expect(result.length).toBe(1);
+  });
+});
+
+describe('getStatDisplayValue', () => {
+  const theme = createTheme();
+  const thresholds = {
+    mode: ThresholdsMode.Absolute as const,
+    steps: [
+      { value: -Infinity, color: 'green' },
+      { value: 3, color: 'orange' },
+      { value: 10, color: 'red' },
+    ],
+  };
+
+  it('returns the count as text with no color when colorMode is None', () => {
+    const result = getStatDisplayValue(5, BigValueColorMode.None, thresholds, [], theme);
+    expect(result.text).toBe('5');
+    expect(result.numeric).toBe(5);
+    expect(result.color).toBeUndefined();
+  });
+
+  it('returns threshold color when colorMode is Value', () => {
+    const result = getStatDisplayValue(5, BigValueColorMode.Value, thresholds, [], theme);
+    expect(result.text).toBe('5');
+    expect(result.color).toBeDefined();
+  });
+
+  it('returns green for count below first threshold step', () => {
+    const result = getStatDisplayValue(0, BigValueColorMode.Value, thresholds, [], theme);
+    expect(result.color).toBeDefined();
+  });
+
+  it('returns last threshold color for large counts', () => {
+    const result = getStatDisplayValue(999, BigValueColorMode.Value, thresholds, [], theme);
+    expect(result.color).toBeDefined();
+  });
+
+  it('applies value mappings to display text', () => {
+    const mappings = [
+      {
+        type: MappingType.ValueToText as const,
+        options: {
+          '0': { text: 'All Clear', color: 'green' },
+        },
+      },
+    ];
+    const result = getStatDisplayValue(0, BigValueColorMode.Value, thresholds, mappings, theme);
+    expect(result.text).toBe('All Clear');
+  });
+
+  it('applies range mapping for matching count', () => {
+    const mappings = [
+      {
+        type: MappingType.RangeToText as const,
+        options: {
+          from: 1,
+          to: 100,
+          result: { text: 'Active Alerts', color: 'yellow' },
+        },
+      },
+    ];
+    const result = getStatDisplayValue(5, BigValueColorMode.Value, thresholds, mappings, theme);
+    expect(result.text).toBe('Active Alerts');
+  });
+
+  it('falls back to count when no mapping matches', () => {
+    const mappings = [
+      {
+        type: MappingType.ValueToText as const,
+        options: {
+          '99': { text: 'Special' },
+        },
+      },
+    ];
+    const result = getStatDisplayValue(5, BigValueColorMode.Value, thresholds, mappings, theme);
+    expect(result.text).toBe('5');
+  });
+
+  it('handles empty thresholds gracefully', () => {
+    const emptyThresholds = { mode: ThresholdsMode.Absolute as const, steps: [] };
+    const result = getStatDisplayValue(5, BigValueColorMode.Value, emptyThresholds, [], theme);
+    expect(result.text).toBe('5');
+    expect(result.numeric).toBe(5);
+  });
+});
+
+describe('buildAlertingListUrl', () => {
+  it('returns a bare alerting list URL when no filters are active', () => {
+    const options: UnifiedAlertListOptions = {
+      ...defaultOption,
+      alertName: '',
+      datasource: '',
+      stateFilter: {
+        firing: false,
+        pending: false,
+        noData: false,
+        normal: false,
+        error: false,
+        recovering: false,
+      },
+    };
+    const url = buildAlertingListUrl(options);
+    expect(url).toContain('/alerting/list');
+  });
+
+  it('includes rule filter for alert name', () => {
+    const options: UnifiedAlertListOptions = {
+      ...defaultOption,
+      alertName: 'cpu-high',
+      datasource: '',
+      stateFilter: {
+        firing: false,
+        pending: false,
+        noData: false,
+        normal: false,
+        error: false,
+        recovering: false,
+      },
+    };
+    const url = buildAlertingListUrl(options);
+    expect(url).toContain('rule');
+    expect(url).toContain('cpu-high');
+  });
+
+  it('includes datasource filter', () => {
+    const options: UnifiedAlertListOptions = {
+      ...defaultOption,
+      alertName: '',
+      datasource: 'prometheus',
+      stateFilter: {
+        firing: false,
+        pending: false,
+        noData: false,
+        normal: false,
+        error: false,
+        recovering: false,
+      },
+    };
+    const url = buildAlertingListUrl(options);
+    expect(url).toContain('datasource');
+    expect(url).toContain('prometheus');
+  });
+
+  it('includes state filters for firing and pending', () => {
+    const options: UnifiedAlertListOptions = {
+      ...defaultOption,
+      alertName: '',
+      datasource: '',
+      stateFilter: {
+        firing: true,
+        pending: true,
+        noData: false,
+        normal: false,
+        error: false,
+        recovering: false,
+      },
+    };
+    const url = buildAlertingListUrl(options);
+    expect(url).toContain('state');
+    expect(url).toContain('firing');
+    expect(url).toContain('pending');
+  });
+
+  it('includes recovering state in the query', () => {
+    const options: UnifiedAlertListOptions = {
+      ...defaultOption,
+      alertName: '',
+      datasource: '',
+      stateFilter: {
+        firing: false,
+        pending: false,
+        noData: false,
+        normal: false,
+        error: false,
+        recovering: true,
+      },
+    };
+    const url = buildAlertingListUrl(options);
+    expect(url).toContain('recovering');
+  });
+
+  it('includes namespace filter when folder is selected', () => {
+    const options: UnifiedAlertListOptions = {
+      ...defaultOption,
+      alertName: '',
+      datasource: '',
+      folder: { uid: 'folder-1', title: 'Operations' },
+      stateFilter: {
+        firing: false,
+        pending: false,
+        noData: false,
+        normal: false,
+        error: false,
+        recovering: false,
+      },
+    };
+    const url = buildAlertingListUrl(options);
+    expect(url).toContain('namespace');
+    expect(url).toContain('Operations');
+  });
+
+  it('includes label filter when alert instance label filter is set', () => {
+    const options: UnifiedAlertListOptions = {
+      ...defaultOption,
+      alertName: '',
+      datasource: '',
+      alertInstanceLabelFilter: '{severity="critical"}',
+      stateFilter: {
+        firing: false,
+        pending: false,
+        noData: false,
+        normal: false,
+        error: false,
+        recovering: false,
+      },
+    };
+    const url = buildAlertingListUrl(options);
+    expect(url).toContain('label');
+    expect(url).toContain('severity');
+  });
+
+  it('includes dashboard filter when dashboardAlerts is enabled', () => {
+    const options: UnifiedAlertListOptions = {
+      ...defaultOption,
+      dashboardAlerts: true,
+      alertName: '',
+      datasource: '',
+      stateFilter: {
+        firing: false,
+        pending: false,
+        noData: false,
+        normal: false,
+        error: false,
+        recovering: false,
+      },
+    };
+    const url = buildAlertingListUrl(options, 'dashboard-uid');
+    expect(url).toContain('dashboard');
+    expect(url).toContain('dashboard-uid');
+  });
+
+  it('combines multiple filters in a single search query', () => {
+    const options: UnifiedAlertListOptions = {
+      ...defaultOption,
+      alertName: 'my-alert',
+      datasource: 'grafana',
+      stateFilter: {
+        firing: true,
+        pending: false,
+        noData: false,
+        normal: false,
+        error: true,
+        recovering: false,
+      },
+    };
+    const url = buildAlertingListUrl(options);
+    expect(url).toContain('rule');
+    expect(url).toContain('my-alert');
+    expect(url).toContain('datasource');
+    expect(url).toContain('firing');
+    expect(url).toContain('error');
   });
 });

--- a/public/app/plugins/panel/alertlist/util.test.tsx
+++ b/public/app/plugins/panel/alertlist/util.test.tsx
@@ -160,7 +160,7 @@ describe('getStatDisplayValue', () => {
     const result = getStatDisplayValue(5, BigValueColorMode.Value, emptyThresholds, [], theme);
     expect(result.text).toBe('5');
     expect(result.numeric).toBe(5);
-    expect(result.color).toBeUndefined();
+    expect(result.color).toBeDefined();
   });
 });
 

--- a/public/app/plugins/panel/alertlist/util.test.tsx
+++ b/public/app/plugins/panel/alertlist/util.test.tsx
@@ -24,7 +24,6 @@ const defaultOption: UnifiedAlertListOptions = {
   statColorMode: BigValueColorMode.None,
   statThresholds: STAT_THRESHOLDS_DEFAULT,
   statValueMappings: [],
-  datasourceRef: null,
 };
 
 const alerts: Alert[] = [
@@ -161,6 +160,7 @@ describe('getStatDisplayValue', () => {
     const result = getStatDisplayValue(5, BigValueColorMode.Value, emptyThresholds, [], theme);
     expect(result.text).toBe('5');
     expect(result.numeric).toBe(5);
+    expect(result.color).toBeUndefined();
   });
 });
 

--- a/public/app/plugins/panel/alertlist/util.ts
+++ b/public/app/plugins/panel/alertlist/util.ts
@@ -1,8 +1,19 @@
 import { isEmpty } from 'lodash';
 
-import { Labels } from '@grafana/data';
+import {
+  DisplayValue,
+  FieldType,
+  getActiveThreshold,
+  getDisplayProcessor,
+  GrafanaTheme2,
+  Labels,
+  ThresholdsConfig,
+  ValueMapping,
+} from '@grafana/data';
+import { BigValueColorMode } from '@grafana/ui';
 import { labelsMatchMatchers } from 'app/features/alerting/unified/utils/alertmanager';
 import { parsePromQLStyleMatcherLooseSafe } from 'app/features/alerting/unified/utils/matchers';
+import { createListFilterLink } from 'app/features/alerting/unified/utils/navigation';
 import { Alert, hasAlertState } from 'app/types/unified-alerting';
 import { GrafanaAlertState, PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 
@@ -39,4 +50,85 @@ export function filterAlerts(
       (alertInstanceLabelFilter ? hasLabelFilter(options.alertInstanceLabelFilter, alert.labels) : true)
     );
   });
+}
+
+export function getStatDisplayValue(
+  count: number,
+  colorMode: BigValueColorMode,
+  thresholds: ThresholdsConfig,
+  valueMappings: ValueMapping[],
+  theme: GrafanaTheme2
+): DisplayValue {
+  const display = getDisplayProcessor({
+    field: {
+      type: FieldType.number,
+      config: {
+        thresholds,
+        mappings: valueMappings,
+      },
+    },
+    theme,
+  });
+
+  const displayValue = display(count);
+
+  if (colorMode === BigValueColorMode.None) {
+    return { ...displayValue, color: undefined };
+  }
+
+  if (!displayValue.color) {
+    const activeStep = getActiveThreshold(count, thresholds.steps);
+    return { ...displayValue, color: activeStep.color };
+  }
+
+  return displayValue;
+}
+
+export function buildAlertingListUrl(options: UnifiedAlertListOptions, dashboardUid?: string): string {
+  const filters: Array<[string, string]> = [];
+
+  if (options.alertName) {
+    filters.push(['rule', options.alertName]);
+  }
+  if (options.datasource) {
+    filters.push(['datasource', options.datasource]);
+  }
+
+  const { stateFilter } = options;
+  if (stateFilter.firing) {
+    filters.push(['state', 'firing']);
+  }
+  if (stateFilter.pending) {
+    filters.push(['state', 'pending']);
+  }
+  if (stateFilter.normal) {
+    filters.push(['state', 'inactive']);
+  }
+  if (stateFilter.noData) {
+    filters.push(['state', 'nodata']);
+  }
+  if (stateFilter.error) {
+    filters.push(['state', 'error']);
+  }
+  if (stateFilter.recovering) {
+    filters.push(['state', 'recovering']);
+  }
+
+  if (options.folder?.title) {
+    filters.push(['namespace', options.folder.title]);
+  }
+
+  if (options.alertInstanceLabelFilter) {
+    filters.push(['label', options.alertInstanceLabelFilter]);
+  }
+
+  if (options.dashboardAlerts && dashboardUid) {
+    filters.push(['dashboard', dashboardUid]);
+  }
+
+  if (filters.length === 0) {
+    return createListFilterLink([]);
+  }
+
+  return createListFilterLink(filters);
 }

--- a/public/app/plugins/panel/alertlist/util.ts
+++ b/public/app/plugins/panel/alertlist/util.ts
@@ -77,8 +77,11 @@ export function getStatDisplayValue(
   }
 
   if (!displayValue.color) {
-    const activeStep = getActiveThreshold(count, thresholds.steps);
-    return { ...displayValue, color: activeStep.color };
+    if (thresholds.steps.length > 0) {
+      const activeStep = getActiveThreshold(count, thresholds.steps);
+      return { ...displayValue, color: activeStep.color };
+    }
+    return displayValue;
   }
 
   return displayValue;
@@ -124,10 +127,6 @@ export function buildAlertingListUrl(options: UnifiedAlertListOptions, dashboard
 
   if (options.dashboardAlerts && dashboardUid) {
     filters.push(['dashboard', dashboardUid]);
-  }
-
-  if (filters.length === 0) {
-    return createListFilterLink([]);
   }
 
   return createListFilterLink(filters);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3614,6 +3614,7 @@
     "category-alert-state-filter": "Alert state filter",
     "category-filter": "Filter",
     "category-options": "Options",
+    "category-stat-styles": "Stat styles",
     "descriptino-alerts-linked-to-dashboard": "Only show alerts linked to this dashboard",
     "description-alert-instance-label": "Filter alert instances using label querying, ex: {severity=\"critical\", instance=~\"cluster-us-.+\"}",
     "description-alert-name": "Filter for alerts containing this text",
@@ -3624,6 +3625,9 @@
     "description-max-items": "Maximum alerts to display",
     "description-show-inactive-alerts": "Include alert rules which have 0 (zero) instances. Because these rules have no instances, they remain hidden if the Alert instance label filter is configured.",
     "description-sort-order": "Sort order of alerts and alert instances",
+    "description-stat-color-mode": "Control how the stat value or background is colored",
+    "description-stat-thresholds": "Define thresholds to color the stat value based on the alert count",
+    "description-stat-value-mappings": "Modify the display text based on the alert count",
     "description-view-mode": "Toggle between list view and stat view",
     "group-by": {
       "aria-label-group-by-label-keys": "group by label keys",
@@ -3649,6 +3653,9 @@
     "name-recovering": "Recovering",
     "name-show-inactive-alerts": "Show alerts with 0 instances",
     "name-sort-order": "Sort order",
+    "name-stat-color-mode": "Color mode",
+    "name-stat-thresholds": "Thresholds",
+    "name-stat-value-mappings": "Value mappings",
     "name-view-mode": "View mode",
     "sort-order-options": {
       "label-alphabetical-asc": "Alphabetical (asc)",
@@ -3656,6 +3663,12 @@
       "label-importance": "Importance",
       "label-time-asc": "Time (asc)",
       "label-time-desc": "Time (desc)"
+    },
+    "stat-color-mode": {
+      "label-background-gradient": "Background Gradient",
+      "label-background-solid": "Background Solid",
+      "label-none": "None",
+      "label-value": "Value"
     },
     "ungrouped-mode-view": {
       "active-for": "for <1>{{duration}}</1>",


### PR DESCRIPTION
**What is this feature?**
This PR adds some changes to the alert list dashboard component:
- Added clickable link in stat mode that navigates to /alerting/list with matching filters
- Added threshould based coloring in stat mode
- Added value mappings in stat mode
- Added datasource reference by UID instead of name string (with migration for backward compatibility)


https://github.com/user-attachments/assets/675238e3-0123-46fe-8498-1049129f9d00



**Why do we need this feature?**

To add more usability to the alert list panel particularly in "stat" mode, making it more valuable for users

**Who is this feature for?**

Alerting users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/96965

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
