### PR TITLE
QueryEditor: Add event tracking to new panel editing experience

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/Actions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/Actions.tsx
@@ -6,6 +6,7 @@ import { t } from '@grafana/i18n';
 import { Button, ConfirmModal, Icon, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { QUERY_EDITOR_COLORS, QUERY_EDITOR_TYPE_CONFIG, QueryEditorType } from './constants';
+import { trackCardAction } from './tracking';
 
 export interface ActionItem {
   name: string;
@@ -73,10 +74,11 @@ export function Actions({
       if (requiresDeleteConfirmation) {
         setShowDeleteConfirmation(true);
       } else {
+        trackCardAction('delete', item.type);
         onDelete();
       }
     },
-    [requiresDeleteConfirmation, onDelete, handleResetFocus]
+    [requiresDeleteConfirmation, onDelete, handleResetFocus, item.type]
   );
 
   const handleConfirmDelete = useCallback(() => {
@@ -84,10 +86,11 @@ export function Actions({
       return;
     }
 
+    trackCardAction('delete', item.type);
     onDelete();
     setShowDeleteConfirmation(false);
     handleResetFocus?.();
-  }, [onDelete, handleResetFocus]);
+  }, [onDelete, handleResetFocus, item.type]);
 
   const handleDismissModal = useCallback(() => {
     setShowDeleteConfirmation(false);
@@ -108,6 +111,7 @@ export function Actions({
         label: labels.duplicate,
         onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
           e.stopPropagation();
+          trackCardAction('duplicate', item.type);
           onDuplicate();
         },
       },
@@ -123,6 +127,7 @@ export function Actions({
         label: item.isHidden ? labels.show : labels.hide,
         onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
           e.stopPropagation();
+          trackCardAction('toggle_hide', item.type);
           onToggleHide();
         },
       },
@@ -137,6 +142,7 @@ export function Actions({
     labels.remove,
     onToggleHide,
     item.isHidden,
+    item.type,
     onDelete,
     handleDelete,
     order,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/ExpressionTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/ExpressionTypePicker.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 import { Card, Text, useStyles2, useTheme2 } from '@grafana/ui';
 import { ExpressionQueryType, expressionTypes } from 'app/features/expressions/types';
 
@@ -26,7 +27,18 @@ export function ExpressionTypePicker() {
         const label = item.label ?? '';
 
         return (
-          <Card key={item.value} onClick={() => finalizePendingExpression(item.value)} noMargin>
+          <Card
+            key={item.value}
+            onClick={() => {
+              reportInteraction('dashboards_expression_interaction', {
+                action: 'add_expression',
+                expression_type: item.value,
+                context: 'panel_query_section',
+              });
+              finalizePendingExpression(item.value);
+            }}
+            noMargin
+          >
             <Card.Heading>{label}</Card.Heading>
             <Card.Description>
               <Text variant="bodySmall">{item.description ?? ''}</Text>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { ChangeEvent, useMemo, useState } from 'react';
+import { ChangeEvent, useEffect, useMemo, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -9,6 +9,11 @@ import config from 'app/core/config';
 import { SqlExpressionsBanner } from 'app/features/dashboard/components/TransformationsEditor/SqlExpressions/SqlExpressionsBanner';
 import { TransformationCard } from 'app/features/dashboard/components/TransformationsEditor/TransformationCard';
 
+import {
+  trackTransformationFilterChanged,
+  trackTransformationSearch,
+  trackTransformationSelected,
+} from '../../tracking';
 import { useQueryEditorUIContext, useQueryRunnerContext } from '../QueryEditorContext';
 
 import { useTransformationSearchAndFilter } from './useTransformationSearchAndFilter';
@@ -31,6 +36,13 @@ export function TransformationTypePicker() {
     onSearchKeyDown,
     allTransformationsCount,
   } = useTransformationSearchAndFilter(finalizePendingTransformation);
+
+  useEffect(() => {
+    trackTransformationSearch(search, filteredTransformations.length);
+    return () => {
+      trackTransformationSearch.cancel();
+    };
+  }, [search, filteredTransformations.length]);
 
   const searchBoxSuffix = useMemo(() => {
     if (filteredTransformations.length === allTransformationsCount) {
@@ -78,14 +90,21 @@ export function TransformationTypePicker() {
         <FilterPill
           label={t('dashboard.transformation-picker-ng.view-all', 'View all')}
           selected={selectedFilter === null}
-          onClick={() => setSelectedFilter(null)}
+          onClick={() => {
+            setSelectedFilter(null);
+            trackTransformationFilterChanged(null);
+          }}
         />
         {categories.map(({ slug, label }) => (
           <FilterPill
             key={slug}
             label={label}
             selected={selectedFilter === slug}
-            onClick={() => setSelectedFilter(selectedFilter === slug ? null : slug)}
+            onClick={() => {
+              const next = selectedFilter === slug ? null : slug;
+              setSelectedFilter(next);
+              trackTransformationFilterChanged(next);
+            }}
           />
         ))}
       </Stack>
@@ -102,7 +121,10 @@ export function TransformationTypePicker() {
               key={item.id}
               transform={item}
               data={data?.series ?? []}
-              onClick={(id) => finalizePendingTransformation(id)}
+              onClick={(id) => {
+                trackTransformationSelected(id);
+                finalizePendingTransformation(id);
+              }}
               showIllustrations={showIllustrations}
               fullWidth
             />

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { ChangeEvent, useEffect, useMemo, useState } from 'react';
+import { ChangeEvent, useMemo, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -33,13 +33,6 @@ export function TransformationTypePicker() {
     allTransformationsCount,
   } = useTransformationSearchAndFilter(finalizePendingTransformation);
 
-  useEffect(() => {
-    trackTransformationSearch(search, filteredTransformations.length);
-    return () => {
-      trackTransformationSearch.cancel();
-    };
-  }, [search, filteredTransformations.length]);
-
   const searchBoxSuffix = useMemo(() => {
     if (filteredTransformations.length === allTransformationsCount) {
       return null;
@@ -70,7 +63,10 @@ export function TransformationTypePicker() {
             'dashboard.transformation-picker-ng.placeholder-search-for-transformation',
             'Search for transformation'
           )}
-          onChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => setSearch(value)}
+          onChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
+            setSearch(value);
+            trackTransformationSearch(value);
+          }}
           onKeyDown={onSearchKeyDown}
           suffix={searchBoxSuffix}
         />

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
@@ -9,11 +9,7 @@ import config from 'app/core/config';
 import { SqlExpressionsBanner } from 'app/features/dashboard/components/TransformationsEditor/SqlExpressions/SqlExpressionsBanner';
 import { TransformationCard } from 'app/features/dashboard/components/TransformationsEditor/TransformationCard';
 
-import {
-  trackTransformationFilterChanged,
-  trackTransformationSearch,
-  trackTransformationSelected,
-} from '../../tracking';
+import { trackTransformationFilterChanged, trackTransformationSearch } from '../../tracking';
 import { useQueryEditorUIContext, useQueryRunnerContext } from '../QueryEditorContext';
 
 import { useTransformationSearchAndFilter } from './useTransformationSearchAndFilter';
@@ -121,10 +117,7 @@ export function TransformationTypePicker() {
               key={item.id}
               transform={item}
               data={data?.series ?? []}
-              onClick={(id) => {
-                trackTransformationSelected(id);
-                finalizePendingTransformation(id);
-              }}
+              onClick={(id) => finalizePendingTransformation(id)}
               showIllustrations={showIllustrations}
               fullWidth
             />

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/QueryActionsMenu.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/QueryActionsMenu.tsx
@@ -9,6 +9,7 @@ import { InspectTab } from 'app/features/inspector/types';
 import { PanelInspectDrawer } from '../../../../inspect/PanelInspectDrawer';
 import { getDashboardSceneFor } from '../../../../utils/utils';
 import { QUERY_EDITOR_TYPE_CONFIG, QueryEditorType } from '../../constants';
+import { trackQueryMenuAction } from '../../tracking';
 import { useActionsContext, usePanelContext, useQueryEditorUIContext } from '../QueryEditorContext';
 
 export function QueryActionsMenu() {
@@ -46,7 +47,10 @@ export function QueryActionsMenu() {
             className={styles.menuItem}
             label={t('query-editor-next.action.duplicate', 'Duplicate {{type}}', { type: typeLabel })}
             icon="copy"
-            onClick={() => duplicateQuery(selectedQuery.refId)}
+            onClick={() => {
+              trackQueryMenuAction('duplicate');
+              duplicateQuery(selectedQuery.refId);
+            }}
           />
 
           {/* Data source help (queries only, not expressions) */}
@@ -59,7 +63,10 @@ export function QueryActionsMenu() {
                   : t('query-editor-next.action.show-help', 'Show data source help')
               }
               icon="question-circle"
-              onClick={toggleDatasourceHelp}
+              onClick={() => {
+                trackQueryMenuAction('toggle_datasource_help');
+                toggleDatasourceHelp();
+              }}
               active={showingDatasourceHelp}
             />
           )}
@@ -68,7 +75,10 @@ export function QueryActionsMenu() {
             className={styles.menuItem}
             label={t('query-editor-next.action.inspector', 'Query inspector')}
             icon="brackets-curly"
-            onClick={onOpenInspector}
+            onClick={() => {
+              trackQueryMenuAction('open_inspector');
+              onOpenInspector();
+            }}
           />
         </Menu>
       }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/QueryActionsMenu.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/QueryActionsMenu.tsx
@@ -48,7 +48,7 @@ export function QueryActionsMenu() {
             label={t('query-editor-next.action.duplicate', 'Duplicate {{type}}', { type: typeLabel })}
             icon="copy"
             onClick={() => {
-              trackQueryMenuAction('duplicate');
+              trackQueryMenuAction('duplicate', cardType);
               duplicateQuery(selectedQuery.refId);
             }}
           />
@@ -64,7 +64,7 @@ export function QueryActionsMenu() {
               }
               icon="question-circle"
               onClick={() => {
-                trackQueryMenuAction('toggle_datasource_help');
+                trackQueryMenuAction('toggle_datasource_help', cardType);
                 toggleDatasourceHelp();
               }}
               active={showingDatasourceHelp}
@@ -76,7 +76,7 @@ export function QueryActionsMenu() {
             label={t('query-editor-next.action.inspector', 'Query inspector')}
             icon="brackets-curly"
             onClick={() => {
-              trackQueryMenuAction('open_inspector');
+              trackQueryMenuAction('open_inspector', cardType);
               onOpenInspector();
             }}
           />

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/TransformationActionButtons.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/TransformationActionButtons.tsx
@@ -4,6 +4,7 @@ import { FrameMatcherID } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Button, Stack } from '@grafana/ui';
 
+import { trackTransformationToolAction } from '../../tracking';
 import { useActionsContext, useQueryEditorUIContext, useQueryRunnerContext } from '../QueryEditorContext';
 
 export function TransformationActionButtons() {
@@ -70,7 +71,10 @@ export function TransformationActionButtons() {
           fill="text"
           icon="question-circle"
           variant={transformToggles.showHelp ? 'primary' : 'secondary'}
-          onClick={transformToggles.toggleHelp}
+          onClick={() => {
+            trackTransformationToolAction('toggle_help');
+            transformToggles.toggleHelp();
+          }}
           tooltip={helpLabel}
           aria-label={helpLabel}
         />
@@ -82,7 +86,10 @@ export function TransformationActionButtons() {
           fill="text"
           icon="filter"
           variant={isFilterActive ? 'primary' : 'secondary'}
-          onClick={handleFilterToggle}
+          onClick={() => {
+            trackTransformationToolAction('toggle_filter');
+            handleFilterToggle();
+          }}
           tooltip={filterLabel}
           aria-label={filterLabel}
         />
@@ -93,7 +100,10 @@ export function TransformationActionButtons() {
         fill="text"
         icon="bug"
         variant={transformToggles.showDebug ? 'primary' : 'secondary'}
-        onClick={transformToggles.toggleDebug}
+        onClick={() => {
+          trackTransformationToolAction('toggle_debug');
+          transformToggles.toggleDebug();
+        }}
         tooltip={t('query-editor-next.action.transformation-debug', 'Debug')}
         aria-label={t('query-editor-next.action.transformation-debug', 'Debug')}
       />

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -10,7 +10,12 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { useQueryLibraryContext } from 'app/features/explore/QueryLibrary/QueryLibraryContext';
 import { AccessControlAction } from 'app/types/accessControl';
 
-import { trackAddExpressionInitiated, trackAddQuery, trackAddTransformationInitiated } from '../../tracking';
+import {
+  trackAddExpressionInitiated,
+  trackAddQuery,
+  trackAddTransformationInitiated,
+  trackOpenSavedQueryPicker,
+} from '../../tracking';
 import { useActionsContext, useQueryEditorUIContext } from '../QueryEditorContext';
 
 function getButtonAriaLabel(variant: 'query' | 'transformation', afterId?: string) {
@@ -81,10 +86,14 @@ export const AddCardButton = ({ variant, afterId, onAdd, alwaysVisible = false }
             label={t('query-editor-next.sidebar.add-saved-query', 'Add saved query')}
             icon="book-open"
             onClick={() => {
-              trackAddQuery('saved_query', afterId ? 'inline' : 'section_header');
+              const cardSource = afterId ? 'inline' : 'section_header';
+              trackOpenSavedQueryPicker(cardSource);
               setPendingSavedQuery({ insertAfter: afterId ?? '' });
               openDrawer({
-                onSelectQuery: (query) => addAndSelectQuery(query),
+                onSelectQuery: (query) => {
+                  trackAddQuery('saved_query', cardSource);
+                  addAndSelectQuery(query);
+                },
                 options: { context: CoreApp.PanelEditor },
               });
             }}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -72,7 +72,7 @@ export const AddCardButton = ({ variant, afterId, onAdd, alwaysVisible = false }
           label={t('query-editor-next.sidebar.add-query', 'Add query')}
           icon="question-circle"
           onClick={() => {
-            trackAddQuery('new_query');
+            trackAddQuery('new_query', afterId ? 'inline' : 'section_header');
             addAndSelectQuery();
           }}
         />
@@ -81,7 +81,7 @@ export const AddCardButton = ({ variant, afterId, onAdd, alwaysVisible = false }
             label={t('query-editor-next.sidebar.add-saved-query', 'Add saved query')}
             icon="book-open"
             onClick={() => {
-              trackAddQuery('saved_query');
+              trackAddQuery('saved_query', afterId ? 'inline' : 'section_header');
               setPendingSavedQuery({ insertAfter: afterId ?? '' });
               openDrawer({
                 onSelectQuery: (query) => addAndSelectQuery(query),
@@ -94,7 +94,7 @@ export const AddCardButton = ({ variant, afterId, onAdd, alwaysVisible = false }
           label={t('query-editor-next.sidebar.add-expression', 'Add expression')}
           icon="calculator-alt"
           onClick={() => {
-            trackAddExpressionInitiated();
+            trackAddExpressionInitiated(afterId ? 'inline' : 'section_header');
             setPendingExpression({ insertAfter: afterId ?? '' });
             onAdd?.();
           }}
@@ -114,7 +114,7 @@ export const AddCardButton = ({ variant, afterId, onAdd, alwaysVisible = false }
   );
 
   const handleTransformationClick = useCallback(() => {
-    trackAddTransformationInitiated();
+    trackAddTransformationInitiated(afterId ? 'inline' : 'section_header');
     setPendingTransformation({ insertAfter: afterId });
     onAdd?.();
   }, [afterId, setPendingTransformation, onAdd]);

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -10,6 +10,7 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { useQueryLibraryContext } from 'app/features/explore/QueryLibrary/QueryLibraryContext';
 import { AccessControlAction } from 'app/types/accessControl';
 
+import { trackAddExpressionInitiated, trackAddQuery, trackAddTransformationInitiated } from '../../tracking';
 import { useActionsContext, useQueryEditorUIContext } from '../QueryEditorContext';
 
 function getButtonAriaLabel(variant: 'query' | 'transformation', afterId?: string) {
@@ -70,13 +71,17 @@ export const AddCardButton = ({ variant, afterId, onAdd, alwaysVisible = false }
         <Menu.Item
           label={t('query-editor-next.sidebar.add-query', 'Add query')}
           icon="question-circle"
-          onClick={() => addAndSelectQuery()}
+          onClick={() => {
+            trackAddQuery('new_query');
+            addAndSelectQuery();
+          }}
         />
         {queryLibraryEnabled && canReadQueries && (
           <Menu.Item
             label={t('query-editor-next.sidebar.add-saved-query', 'Add saved query')}
             icon="book-open"
             onClick={() => {
+              trackAddQuery('saved_query');
               setPendingSavedQuery({ insertAfter: afterId ?? '' });
               openDrawer({
                 onSelectQuery: (query) => addAndSelectQuery(query),
@@ -89,6 +94,7 @@ export const AddCardButton = ({ variant, afterId, onAdd, alwaysVisible = false }
           label={t('query-editor-next.sidebar.add-expression', 'Add expression')}
           icon="calculator-alt"
           onClick={() => {
+            trackAddExpressionInitiated();
             setPendingExpression({ insertAfter: afterId ?? '' });
             onAdd?.();
           }}
@@ -108,6 +114,7 @@ export const AddCardButton = ({ variant, afterId, onAdd, alwaysVisible = false }
   );
 
   const handleTransformationClick = useCallback(() => {
+    trackAddTransformationInitiated();
     setPendingTransformation({ insertAfter: afterId });
     onAdd?.();
   }, [afterId, setPendingTransformation, onAdd]);

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/useSidebarDragAndDrop.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/useSidebarDragAndDrop.ts
@@ -1,6 +1,7 @@
 import { DropResult } from '@hello-pangea/dnd';
 import { useCallback } from 'react';
 
+import { trackReorder } from '../../tracking';
 import {
   useActionsContext,
   usePanelContext,
@@ -36,6 +37,7 @@ export function useSidebarDragAndDrop() {
         return;
       }
       const { startIndex, endIndex } = drop;
+      trackReorder('query');
       updateQueries(reorder(queries, startIndex, endIndex));
       setSelectedQuery(queries[startIndex]);
     },
@@ -50,6 +52,7 @@ export function useSidebarDragAndDrop() {
       }
       const { startIndex, endIndex } = drop;
       const draggedTransformation = transformations[startIndex];
+      trackReorder('transformation');
       reorderTransformations(reorder(transformations, startIndex, endIndex).map((t) => t.transformConfig));
       setSelectedTransformation({
         ...draggedTransformation,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
@@ -10,12 +10,11 @@ import { QueryEditorType } from './constants';
  */
 const EVENT_PANEL_EDIT_NEXT = 'grafana_panel_edit_next_interaction';
 
-export const trackTransformationSearch = debounce((query: string, resultCount: number) => {
+export const trackTransformationSearch = debounce((query: string) => {
   if (query) {
     reportInteraction(EVENT_PANEL_EDIT_NEXT, {
       action: 'search_transformations',
       query,
-      result_count: resultCount,
     });
   }
 }, 300);

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
@@ -37,6 +37,13 @@ export function trackAddQuery(querySource: 'saved_query' | 'new_query', cardSour
   });
 }
 
+export function trackOpenSavedQueryPicker(source: AddCardSource) {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action: 'open_saved_query_picker',
+    source,
+  });
+}
+
 export function trackAddExpressionInitiated(source: AddCardSource) {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {
     action: 'add_expression_initiated',
@@ -65,10 +72,13 @@ export function trackTransformationToolAction(action: 'toggle_help' | 'toggle_fi
   });
 }
 
-export function trackQueryMenuAction(action: 'duplicate' | 'toggle_datasource_help' | 'open_inspector') {
+export function trackQueryMenuAction(
+  action: 'duplicate' | 'toggle_datasource_help' | 'open_inspector',
+  itemType: QueryEditorType.Query | QueryEditorType.Expression
+) {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {
     action,
-    item_type: QueryEditorType.Query,
+    item_type: itemType,
   });
 }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
@@ -14,13 +14,6 @@ const EVENT_PANEL_EDIT_NEXT = 'grafana_panel_edit_next_interaction';
 // Transformation picker
 // ---------------------------------------------------------------------------
 
-export function trackTransformationSelected(transformationId: string) {
-  reportInteraction('grafana_panel_transformations_clicked', {
-    type: transformationId,
-    context: 'transformation_picker',
-  });
-}
-
 export const trackTransformationSearch = debounce((query: string, resultCount: number) => {
   if (query) {
     reportInteraction(EVENT_PANEL_EDIT_NEXT, {
@@ -42,22 +35,27 @@ export function trackTransformationFilterChanged(filter: string | null) {
 // Add card buttons (sidebar)
 // ---------------------------------------------------------------------------
 
-export function trackAddQuery(source: 'saved_query' | 'new_query') {
+type AddCardSource = 'section_header' | 'inline';
+
+export function trackAddQuery(querySource: 'saved_query' | 'new_query', cardSource: AddCardSource) {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {
     action: 'add_query',
+    source: querySource,
+    card_source: cardSource,
+  });
+}
+
+export function trackAddExpressionInitiated(source: AddCardSource) {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action: 'add_expression_initiated',
     source,
   });
 }
 
-export function trackAddExpressionInitiated() {
-  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
-    action: 'add_expression_initiated',
-  });
-}
-
-export function trackAddTransformationInitiated() {
+export function trackAddTransformationInitiated(source: AddCardSource) {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {
     action: 'add_transformation_initiated',
+    source,
   });
 }
 
@@ -102,5 +100,28 @@ export function trackReorder(itemType: 'query' | 'transformation') {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {
     action: 'reorder',
     item_type: itemType,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Editor version banner
+// ---------------------------------------------------------------------------
+
+export function trackEditorVersionToggle(direction: 'upgrade' | 'downgrade') {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action: 'toggle_editor_version',
+    direction,
+  });
+}
+
+export function trackBannerDismiss() {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action: 'dismiss_version_banner',
+  });
+}
+
+export function trackFeedbackClick() {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action: 'click_feedback_link',
   });
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
@@ -10,10 +10,6 @@ import { QueryEditorType } from './constants';
  */
 const EVENT_PANEL_EDIT_NEXT = 'grafana_panel_edit_next_interaction';
 
-// ---------------------------------------------------------------------------
-// Transformation picker
-// ---------------------------------------------------------------------------
-
 export const trackTransformationSearch = debounce((query: string, resultCount: number) => {
   if (query) {
     reportInteraction(EVENT_PANEL_EDIT_NEXT, {
@@ -30,10 +26,6 @@ export function trackTransformationFilterChanged(filter: string | null) {
     filter: filter ?? 'view_all',
   });
 }
-
-// ---------------------------------------------------------------------------
-// Add card buttons (sidebar)
-// ---------------------------------------------------------------------------
 
 type AddCardSource = 'section_header' | 'inline';
 
@@ -59,20 +51,12 @@ export function trackAddTransformationInitiated(source: AddCardSource) {
   });
 }
 
-// ---------------------------------------------------------------------------
-// Card management actions (delete / hide / duplicate)
-// ---------------------------------------------------------------------------
-
 export function trackCardAction(action: 'delete' | 'toggle_hide' | 'duplicate', itemType: QueryEditorType) {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {
     action,
     item_type: itemType,
   });
 }
-
-// ---------------------------------------------------------------------------
-// Transformation toolbar buttons
-// ---------------------------------------------------------------------------
 
 export function trackTransformationToolAction(action: 'toggle_help' | 'toggle_filter' | 'toggle_debug') {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {
@@ -81,10 +65,6 @@ export function trackTransformationToolAction(action: 'toggle_help' | 'toggle_fi
   });
 }
 
-// ---------------------------------------------------------------------------
-// Query actions menu
-// ---------------------------------------------------------------------------
-
 export function trackQueryMenuAction(action: 'duplicate' | 'toggle_datasource_help' | 'open_inspector') {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {
     action,
@@ -92,20 +72,12 @@ export function trackQueryMenuAction(action: 'duplicate' | 'toggle_datasource_he
   });
 }
 
-// ---------------------------------------------------------------------------
-// Drag-and-drop reorder
-// ---------------------------------------------------------------------------
-
 export function trackReorder(itemType: 'query' | 'transformation') {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {
     action: 'reorder',
     item_type: itemType,
   });
 }
-
-// ---------------------------------------------------------------------------
-// Editor version banner
-// ---------------------------------------------------------------------------
 
 export function trackEditorVersionToggle(direction: 'upgrade' | 'downgrade') {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
@@ -74,7 +74,7 @@ export function trackTransformationToolAction(action: 'toggle_help' | 'toggle_fi
 
 export function trackQueryMenuAction(
   action: 'duplicate' | 'toggle_datasource_help' | 'open_inspector',
-  itemType: QueryEditorType.Query | QueryEditorType.Expression
+  itemType: QueryEditorType
 ) {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {
     action,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
@@ -1,0 +1,106 @@
+import { debounce } from 'lodash';
+
+import { reportInteraction } from '@grafana/runtime';
+
+import { QueryEditorType } from './constants';
+
+/**
+ * Single event name for all v2 panel-edit interactions that don't already
+ * have an established v1 event.  Discriminated by `action` + `item_type`.
+ */
+const EVENT_PANEL_EDIT_NEXT = 'grafana_panel_edit_next_interaction';
+
+// ---------------------------------------------------------------------------
+// Transformation picker
+// ---------------------------------------------------------------------------
+
+export function trackTransformationSelected(transformationId: string) {
+  reportInteraction('grafana_panel_transformations_clicked', {
+    type: transformationId,
+    context: 'transformation_picker',
+  });
+}
+
+export const trackTransformationSearch = debounce((query: string, resultCount: number) => {
+  if (query) {
+    reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+      action: 'search_transformations',
+      query,
+      result_count: resultCount,
+    });
+  }
+}, 300);
+
+export function trackTransformationFilterChanged(filter: string | null) {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action: 'filter_transformations',
+    filter: filter ?? 'view_all',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Add card buttons (sidebar)
+// ---------------------------------------------------------------------------
+
+export function trackAddQuery(source: 'saved_query' | 'new_query') {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action: 'add_query',
+    source,
+  });
+}
+
+export function trackAddExpressionInitiated() {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action: 'add_expression_initiated',
+  });
+}
+
+export function trackAddTransformationInitiated() {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action: 'add_transformation_initiated',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Card management actions (delete / hide / duplicate)
+// ---------------------------------------------------------------------------
+
+export function trackCardAction(action: 'delete' | 'toggle_hide' | 'duplicate', itemType: QueryEditorType) {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action,
+    item_type: itemType,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Transformation toolbar buttons
+// ---------------------------------------------------------------------------
+
+export function trackTransformationToolAction(action: 'toggle_help' | 'toggle_filter' | 'toggle_debug') {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action,
+    item_type: QueryEditorType.Transformation,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Query actions menu
+// ---------------------------------------------------------------------------
+
+export function trackQueryMenuAction(action: 'duplicate' | 'toggle_datasource_help' | 'open_inspector') {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action,
+    item_type: QueryEditorType.Query,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Drag-and-drop reorder
+// ---------------------------------------------------------------------------
+
+export function trackReorder(itemType: 'query' | 'transformation') {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action: 'reorder',
+    item_type: itemType,
+  });
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -41,6 +41,7 @@ import { DataProviderSharer } from './PanelDataPane/DataProviderSharer';
 import { PanelDataPane } from './PanelDataPane/PanelDataPane';
 import { PanelDataPaneNext } from './PanelEditNext/PanelDataPaneNext';
 import { PanelEditorRendererNext } from './PanelEditNext/PanelEditorRendererNext';
+import { trackEditorVersionToggle } from './PanelEditNext/tracking';
 import { PanelEditorRenderer } from './PanelEditorRenderer';
 import { PanelOptionsPane } from './PanelOptionsPane';
 
@@ -411,6 +412,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
    */
   public onToggleQueryEditorVersion = () => {
     const newUseQueryExperienceNext = !this.state.useQueryExperienceNext;
+    trackEditorVersionToggle(newUseQueryExperienceNext ? 'upgrade' : 'downgrade');
     const dataPane = PanelDataPane.createFor(this.getPanel(), newUseQueryExperienceNext);
 
     this.setState({

--- a/public/app/features/dashboard-scene/panel-edit/QueryEditorBanner.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/QueryEditorBanner.tsx
@@ -5,6 +5,7 @@ import { t } from '@grafana/i18n';
 import { Button, Icon, IconButton, LinkButton, useStyles2 } from '@grafana/ui';
 
 import { QUERY_EDITOR_BANNER_FEEDBACK_URL, getQueryEditorBannerColors } from './PanelEditNext/constants';
+import { trackBannerDismiss, trackFeedbackClick } from './PanelEditNext/tracking';
 
 interface Props {
   useQueryExperienceNext: boolean;
@@ -47,6 +48,7 @@ export function QueryEditorBanner({ useQueryExperienceNext, onToggle, onDismiss,
             href={QUERY_EDITOR_BANNER_FEEDBACK_URL}
             target="_blank"
             rel="noopener noreferrer"
+            onClick={trackFeedbackClick}
           >
             {t('dashboard-scene.query-editor-banner.give-feedback', 'Give feedback')}
           </LinkButton>
@@ -64,7 +66,10 @@ export function QueryEditorBanner({ useQueryExperienceNext, onToggle, onDismiss,
           name="times"
           size="md"
           tooltip={t('dashboard-scene.query-editor-banner.dismiss', 'Dismiss')}
-          onClick={onDismiss}
+          onClick={() => {
+            trackBannerDismiss();
+            onDismiss();
+          }}
           className={styles.closeButton}
           aria-label={t('dashboard-scene.query-editor-banner.dismiss', 'Dismiss')}
         />


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->

This PR closes #117267. It adds `reportInteraction` event tracking to the v2 panel editing experience (`PanelEditNext`).

## Changes
<!--- Describe your changes in detail -->
- New `PanelEditNext/tracking.ts` centralizes all v2-specific helpers under a single event name, `grafana_panel_edit_next_interaction`.
- V1 parity: `ExpressionTypePicker` fires `dashboards_expression_interaction` on expression selection (matches v1 `PanelDataQueriesTab` behavior)
- New event reporting coverage for:
  - add card (query/expression/transformation)
  - card actions (duplicate/hide/delete)
  - transformation picker (search, category filter)
  - transformation toolbar (help/filter/debug)
  - query actions menu
  - drag-and-drop reorder
  - editor version toggle
  - banner dismiss
  - feedback link click
- Transformation add/edit/delete events are already covered by `PanelDataPaneNext` (#118560) and are not duplicated

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->

Inherently low risk...`reportInteraction` is fire-and-forget and cannot affect rendering or data flow.

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->

N/A

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->

Testing this locally doesn't feel valuable to me. Feedback on the code would be great, and then I suggest that we use the events to build a dashboard. The dashboarding process will help us understand if events & payloads need to be adjusted further.

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable