### PR TITLE
Alerting: Fix rule label/annotation key template failure fallback

### DIFF
--- a/pkg/services/ngalert/api/api_ruler_validation_test.go
+++ b/pkg/services/ngalert/api/api_ruler_validation_test.go
@@ -1122,3 +1122,14 @@ func TestValidateRuleNodeReservedLabels(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateRuleNodeEmptyLabelKey(t *testing.T) {
+	cfg := config(t)
+	limits := makeLimits(cfg)
+
+	r := validRule()
+	r.Labels = map[string]string{"": "true"}
+	_, err := ValidateRuleNode(&r, util.GenerateShortUID(), cfg.BaseInterval*time.Duration(rand.Int63n(10)+1), rand.Int63(), randFolder().UID, limits)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "label key cannot be empty")
+}

--- a/pkg/services/ngalert/api/validation/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/validation/api_ruler_validation.go
@@ -193,6 +193,9 @@ func validateRecordingRuleFields(in *apimodels.PostableExtendedRuleNode, newRule
 
 func validateLabels(l map[string]string) error {
 	for key := range l {
+		if key == "" {
+			return fmt.Errorf("label key cannot be empty")
+		}
 		if _, ok := ngmodels.LabelsUserCannotSpecify[key]; ok {
 			return fmt.Errorf("system reserved labels cannot be defined in the rule. Label %s is the reserved", key)
 		}

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -18,6 +18,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/state/template"
 )
 
+const emptyLabelKeyPrefix = "__empty_label_key__"
+
 type ruleStates struct {
 	states map[data.Fingerprint]*State
 }
@@ -217,14 +219,19 @@ func expand(ctx context.Context, log log.Logger, name string, original map[strin
 		expanded = make(map[string]string, len(original))
 	)
 	for k, v := range original {
+		safeKey := k
+		if safeKey == "" {
+			safeKey = emptyLabelKeyPrefix
+			log.Warn("Rule contains empty label key, using fallback key", "fallbackKey", safeKey)
+		}
 		result, err := template.Expand(ctx, name, v, data, externalURL, evaluatedAt)
 		if err != nil {
 			log.Error("Error in expanding template", "error", err)
 			errs = errors.Join(errs, err)
 			// keep the original template on error
-			expanded[k] = v
+			expanded[safeKey] = v
 		} else {
-			expanded[k] = result
+			expanded[safeKey] = result
 		}
 	}
 	return expanded, errs

--- a/pkg/services/ngalert/state/cache_test.go
+++ b/pkg/services/ngalert/state/cache_test.go
@@ -115,6 +115,24 @@ func Test_expand(t *testing.T) {
 		require.True(t, errors.As(err, &expandErr))
 		require.EqualError(t, expandErr, "failed to expand template '{{- $labels := .Labels -}}{{- $values := .Values -}}{{- $value := .Value -}}The instance has been down for {{ $value minutes, please check the instance is online': error parsing template __alert_test: template: __alert_test:1: function \"minutes\" not defined")
 	})
+
+	t.Run("templated label key is not expanded", func(t *testing.T) {
+		templatedKey := `{{ with (index $labels "instance") }}key-{{.}}{{ end }}`
+		original := map[string]string{templatedKey: "{{ $labels.instance }}"}
+		data := template.Data{Labels: map[string]string{"instance": "host1"}}
+
+		results, err := expand(ctx, logger, "test", original, data, nil, time.Now())
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{templatedKey: "host1"}, results)
+	})
+
+	t.Run("empty label key uses fallback key", func(t *testing.T) {
+		original := map[string]string{"": "value"}
+
+		results, err := expand(ctx, logger, "test", original, template.Data{}, nil, time.Now())
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{emptyLabelKeyPrefix: "value"}, results)
+	})
 }
 
 func Test_mergeLabels(t *testing.T) {

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -370,6 +370,54 @@ func TestIntegrationDashboardAnnotations(t *testing.T) {
 	}, time.Second, 100*time.Millisecond, "unexpected annotations")
 }
 
+func TestIntegrationProcessEvalResultsTemplatedLabelKeysAreNotExpanded(t *testing.T) {
+	tutil.SkipIntegrationTestInShortMode(t)
+
+	evaluationTime, err := time.Parse("2006-01-02", "2022-02-02")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ng, dbstore := tests.SetupTestEnv(t, 1)
+
+	cfg := state.ManagerCfg{
+		Metrics:       metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
+		ExternalURL:   nil,
+		InstanceStore: ng.InstanceStore,
+		Images:        &state.NoopImageService{},
+		Clock:         clock.New(),
+		Historian:     &state.FakeHistorian{},
+		Tracer:        tracing.InitializeTracerForTest(),
+		Log:           log.New("ngalert.state.manager"),
+	}
+	st := state.NewManager(cfg, state.NewNoopPersister())
+
+	const mainOrgID int64 = 1
+
+	templatedKeyOne := `{{ with (index $labels "missing_key") }}{{.}}{{ end }}`
+	templatedKeyTwo := `{{ $labels. }}`
+
+	rule := tests.CreateTestAlertRuleWithLabels(t, ctx, dbstore, 600, mainOrgID, map[string]string{
+		templatedKeyOne: "empty-key-value",
+		templatedKeyTwo: "error-key-value",
+	})
+
+	st.Warm(ctx, dbstore, dbstore, ng.InstanceStore)
+	_ = st.ProcessEvalResults(ctx, evaluationTime, rule, eval.Results{{
+		Instance:    data.Labels{"instance_label": "test-value"},
+		State:       eval.Alerting,
+		EvaluatedAt: evaluationTime,
+	}}, data.Labels{
+		"alertname": rule.Title,
+	}, nil)
+
+	states := st.GetStatesForRuleUID(ctx, mainOrgID, rule.UID)
+	require.Len(t, states, 1)
+
+	labels := states[0].Labels
+	require.Equal(t, "empty-key-value", labels[templatedKeyOne])
+	require.Equal(t, "error-key-value", labels[templatedKeyTwo])
+}
+
 func TestProcessEvalResults(t *testing.T) {
 	evaluationDuration := 10 * time.Millisecond
 	evaluationInterval := 10 * time.Second


### PR DESCRIPTION
**What is this feature?**

This PR fixes alert rule label/annotation key handling for empty keys in unified alerting.

- Adds fallback during expansion for literal empty keys by replacing `""` with a built-in key (`__empty_label_key__`) so alerts are still processed instead of being rejected later.
- Adds rule validation to reject empty label keys at rule creation/update time.
- Updates and adds tests for the above behavior and clarifies that labels are not template expanded with a test.

**Why do we need this feature?**

We saw alert instances being dropped/rejected when label keys were empty. This can happen with existing malformed rules and previously allowed invalid inputs. The result is confusing failures during state persistence/sending.

This change makes behavior deterministic:
- Prevent new invalid empty keys via validation.
- Safely handle existing empty-key rules with a fallback key at expansion time.

**Who is this feature for?**

Grafana Alerting users and operators running Grafana-managed alert rules, especially instances affected by malformed/empty rule label keys.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
