### PR TITLE
Scopes: Add depth parameter to scope node fetching

### DIFF
--- a/public/app/api/clients/scope/v0alpha1/endpoints.gen.ts
+++ b/public/app/api/clients/scope/v0alpha1/endpoints.gen.ts
@@ -54,6 +54,9 @@ const injectedRtkApi = api
             query: queryArg.query,
             names: queryArg.names,
             limit: queryArg.limit,
+            // Added ahead of codegen — will be included in generated output
+            // when the backend OpenAPI spec is updated.
+            depth: queryArg.depth,
           },
         }),
         providesTags: ['FindScopeNodeChildrenResults'],
@@ -630,6 +633,8 @@ export type GetFindScopeNodeChildrenResultsApiArg = {
   query?: string;
   names?: string[];
   limit?: number;
+  /** Extra levels of descendants beyond direct children. 0 or omitted = direct children only. */
+  depth?: number;
 };
 export type ListScopeDashboardBindingApiResponse = /** status 200 OK */ ScopeDashboardBindingList;
 export type ListScopeDashboardBindingApiArg = {

--- a/public/app/features/scopes/ScopesApiClient.test.ts
+++ b/public/app/features/scopes/ScopesApiClient.test.ts
@@ -447,6 +447,47 @@ describe('ScopesApiClient', () => {
         expect(expectedNodes).toContainEqual(node);
       });
     });
+
+    it('should pass depth to the endpoint', async () => {
+      const expectedNodes = MOCK_NODES.slice(0, 3);
+      const mockSubscription = createMockSubscription({
+        data: { items: expectedNodes },
+      });
+      (scopeAPIv0alpha1.endpoints.getFindScopeNodeChildrenResults.initiate as jest.Mock).mockReturnValue(
+        mockSubscription
+      );
+
+      const result = await apiClient.fetchNodes({
+        parent: 'applications',
+        depth: 1,
+      });
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(3);
+      expect(scopeAPIv0alpha1.endpoints.getFindScopeNodeChildrenResults.initiate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parent: 'applications',
+          depth: 1,
+          limit: 1000,
+        }),
+        expect.objectContaining({ forceRefetch: true })
+      );
+    });
+
+    it('should omit depth when not provided', async () => {
+      const mockSubscription = createMockSubscription({
+        data: { items: [] },
+      });
+      (scopeAPIv0alpha1.endpoints.getFindScopeNodeChildrenResults.initiate as jest.Mock).mockReturnValue(
+        mockSubscription
+      );
+
+      await apiClient.fetchNodes({ parent: 'test' });
+
+      const callArgs = (scopeAPIv0alpha1.endpoints.getFindScopeNodeChildrenResults.initiate as jest.Mock).mock
+        .calls[0][0];
+      expect(callArgs.depth).toBeUndefined();
+    });
   });
 
   describe('fetchDashboards', () => {

--- a/public/app/features/scopes/ScopesApiClient.ts
+++ b/public/app/features/scopes/ScopesApiClient.ts
@@ -132,9 +132,10 @@ export class ScopesApiClient {
    * @param {string|undefined} options.parent The parent node identifier to fetch children for, or undefined if no parent scope is required.
    * @param {string|undefined} options.query A query string to filter the nodes, or undefined for no filtering.
    * @param {number|undefined} options.limit The maximum number of nodes to fetch, defaults to 1000 if undefined. Must be between 1 and 10000.
+   * @param {number|undefined} options.depth Extra levels of descendants to return beyond direct children. 0 or undefined = direct children only. 1 = children + grandchildren.
    * @return {Promise<ScopeNode[]>} A promise that resolves to a map of fetched nodes. Returns an empty object if an error occurs.
    */
-  async fetchNodes(options: { parent?: string; query?: string; limit?: number }): Promise<ScopeNode[]> {
+  async fetchNodes(options: { parent?: string; query?: string; limit?: number; depth?: number }): Promise<ScopeNode[]> {
     const limit = options.limit ?? 1000;
 
     if (!(0 < limit && limit <= 10000)) {
@@ -147,6 +148,7 @@ export class ScopesApiClient {
           parent: options.parent,
           query: options.query,
           limit,
+          depth: options.depth,
         },
         { subscribe: false, forceRefetch: true } // Froce refetch for search. Revisit this when necessary
       )

--- a/public/app/features/scopes/selector/ScopesSelectorService.test.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.test.ts
@@ -2355,25 +2355,25 @@ describe('ScopesSelectorService', () => {
       },
     };
 
-    const grandchild1: ScopeNode = {
-      metadata: { name: 'grandchild-1' },
+    const level2Leaf1: ScopeNode = {
+      metadata: { name: 'level2-leaf-1' },
       spec: {
-        linkId: 'gc-scope-1',
+        linkId: 'l2-scope-1',
         linkType: 'scope',
         parentName: 'child-container',
         nodeType: 'leaf',
-        title: 'Grandchild 1',
+        title: 'Level 2 Leaf 1',
       },
     };
 
-    const grandchild2: ScopeNode = {
-      metadata: { name: 'grandchild-2' },
+    const level2Leaf2: ScopeNode = {
+      metadata: { name: 'level2-leaf-2' },
       spec: {
-        linkId: 'gc-scope-2',
+        linkId: 'l2-scope-2',
         linkType: 'scope',
         parentName: 'child-container',
         nodeType: 'leaf',
-        title: 'Grandchild 2',
+        title: 'Level 2 Leaf 2',
       },
     };
 
@@ -2382,13 +2382,13 @@ describe('ScopesSelectorService', () => {
         if (options.parent === '') {
           return Promise.resolve([containerNode]);
         } else if (options.parent === 'container' && options.depth === 1) {
-          // depth=1: return children + grandchildren (flat)
-          return Promise.resolve([childContainer, grandchild1, grandchild2]);
+          // depth=1: return children + next level (flat)
+          return Promise.resolve([childContainer, level2Leaf1, level2Leaf2]);
         } else if (options.parent === 'container') {
           // depth=0/undefined: return direct children only
           return Promise.resolve([childContainer]);
         } else if (options.parent === 'child-container') {
-          return Promise.resolve([grandchild1, grandchild2]);
+          return Promise.resolve([level2Leaf1, level2Leaf2]);
         }
         return Promise.resolve([]);
       });
@@ -2416,19 +2416,19 @@ describe('ScopesSelectorService', () => {
       const containerTree = service.state.tree?.children?.['container'];
       expect(containerTree?.children?.['child-container']).toBeDefined();
 
-      // Grandchildren should NOT appear at the expanded level
-      expect(containerTree?.children?.['grandchild-1']).toBeUndefined();
-      expect(containerTree?.children?.['grandchild-2']).toBeUndefined();
+      // Deeper descendants should NOT appear at the expanded level
+      expect(containerTree?.children?.['level2-leaf-1']).toBeUndefined();
+      expect(containerTree?.children?.['level2-leaf-2']).toBeUndefined();
     });
 
-    it('should pre-populate grandchildren under their parent in the tree', async () => {
+    it('should pre-populate descendants under their parent in the tree', async () => {
       await service.toggleExpandedNode('container');
 
       const childContainerTree = service.state.tree?.children?.['container']?.children?.['child-container'];
 
-      // Grandchildren should be pre-populated under child-container
-      expect(childContainerTree?.children?.['grandchild-1']).toBeDefined();
-      expect(childContainerTree?.children?.['grandchild-2']).toBeDefined();
+      // Level 2 nodes should be pre-populated under child-container
+      expect(childContainerTree?.children?.['level2-leaf-1']).toBeDefined();
+      expect(childContainerTree?.children?.['level2-leaf-2']).toBeDefined();
       expect(childContainerTree?.childrenLoaded).toBe(true);
     });
 
@@ -2436,8 +2436,8 @@ describe('ScopesSelectorService', () => {
       await service.toggleExpandedNode('container');
 
       expect(service.state.nodes['child-container']).toEqual(childContainer);
-      expect(service.state.nodes['grandchild-1']).toEqual(grandchild1);
-      expect(service.state.nodes['grandchild-2']).toEqual(grandchild2);
+      expect(service.state.nodes['level2-leaf-1']).toEqual(level2Leaf1);
+      expect(service.state.nodes['level2-leaf-2']).toEqual(level2Leaf2);
     });
 
     it('should skip API call when expanding a node with prefetched children', async () => {
@@ -2455,6 +2455,44 @@ describe('ScopesSelectorService', () => {
 
       // But the node should be expanded
       expect(service.state.tree?.children?.['container']?.children?.['child-container']?.expanded).toBe(true);
+    });
+
+    it('should handle multi-level depth recursively (depth=2)', async () => {
+      // Build a 4-level tree: root → L1 container → L2 container → L3 leaf
+      const l1Container: ScopeNode = {
+        metadata: { name: 'l1' },
+        spec: { linkId: '', linkType: undefined, parentName: '', nodeType: 'container', title: 'L1' },
+      };
+      const l2Container: ScopeNode = {
+        metadata: { name: 'l2' },
+        spec: { linkId: '', linkType: undefined, parentName: 'l1', nodeType: 'container', title: 'L2' },
+      };
+      const l3Leaf: ScopeNode = {
+        metadata: { name: 'l3' },
+        spec: { linkId: 'l3-scope', linkType: 'scope', parentName: 'l2', nodeType: 'leaf', title: 'L3' },
+      };
+
+      apiClient.fetchNodes = jest.fn().mockImplementation((options: { parent?: string; depth?: number }) => {
+        if (options.parent === '') {
+          return Promise.resolve([l1Container]);
+        } else if (options.parent === 'l1' && options.depth === 1) {
+          // depth=1 from l1: returns l2 + l3 (flat, 2 extra levels)
+          return Promise.resolve([l2Container, l3Leaf]);
+        }
+        return Promise.resolve([]);
+      });
+
+      await service.filterNode('', '');
+      await service.toggleExpandedNode('l1');
+
+      // L2 should be a direct child of L1
+      const l1Tree = service.state.tree?.children?.['l1'];
+      expect(l1Tree?.children?.['l2']).toBeDefined();
+      expect(l1Tree?.children?.['l2']?.childrenLoaded).toBe(true);
+
+      // L3 should be nested under L2, not under L1
+      expect(l1Tree?.children?.['l3']).toBeUndefined();
+      expect(l1Tree?.children?.['l2']?.children?.['l3']).toBeDefined();
     });
 
     it('should not pass depth when filtering (search)', async () => {

--- a/public/app/features/scopes/selector/ScopesSelectorService.test.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.test.ts
@@ -2331,4 +2331,156 @@ describe('ScopesSelectorService', () => {
       expect(service.state.nodes['non-existent']).toBeUndefined();
     });
   });
+
+  describe('depth prefetch', () => {
+    const containerNode: ScopeNode = {
+      metadata: { name: 'container' },
+      spec: {
+        linkId: '',
+        linkType: undefined,
+        parentName: '',
+        nodeType: 'container',
+        title: 'Container',
+      },
+    };
+
+    const childContainer: ScopeNode = {
+      metadata: { name: 'child-container' },
+      spec: {
+        linkId: '',
+        linkType: undefined,
+        parentName: 'container',
+        nodeType: 'container',
+        title: 'Child Container',
+      },
+    };
+
+    const grandchild1: ScopeNode = {
+      metadata: { name: 'grandchild-1' },
+      spec: {
+        linkId: 'gc-scope-1',
+        linkType: 'scope',
+        parentName: 'child-container',
+        nodeType: 'leaf',
+        title: 'Grandchild 1',
+      },
+    };
+
+    const grandchild2: ScopeNode = {
+      metadata: { name: 'grandchild-2' },
+      spec: {
+        linkId: 'gc-scope-2',
+        linkType: 'scope',
+        parentName: 'child-container',
+        nodeType: 'leaf',
+        title: 'Grandchild 2',
+      },
+    };
+
+    beforeEach(async () => {
+      apiClient.fetchNodes = jest.fn().mockImplementation((options: { parent?: string; depth?: number }) => {
+        if (options.parent === '') {
+          return Promise.resolve([containerNode]);
+        } else if (options.parent === 'container' && options.depth === 1) {
+          // depth=1: return children + grandchildren (flat)
+          return Promise.resolve([childContainer, grandchild1, grandchild2]);
+        } else if (options.parent === 'container') {
+          // depth=0/undefined: return direct children only
+          return Promise.resolve([childContainer]);
+        } else if (options.parent === 'child-container') {
+          return Promise.resolve([grandchild1, grandchild2]);
+        }
+        return Promise.resolve([]);
+      });
+
+      // Load root nodes
+      await service.filterNode('', '');
+    });
+
+    it('should pass depth=1 to fetchNodes when expanding a node', async () => {
+      const fetchNodesSpy = jest.spyOn(apiClient, 'fetchNodes');
+
+      await service.toggleExpandedNode('container');
+
+      expect(fetchNodesSpy).toHaveBeenCalledWith({
+        parent: 'container',
+        query: undefined,
+        depth: 1,
+      });
+    });
+
+    it('should separate direct children from descendants in tree', async () => {
+      await service.toggleExpandedNode('container');
+
+      // Direct child should appear at the expanded level
+      const containerTree = service.state.tree?.children?.['container'];
+      expect(containerTree?.children?.['child-container']).toBeDefined();
+
+      // Grandchildren should NOT appear at the expanded level
+      expect(containerTree?.children?.['grandchild-1']).toBeUndefined();
+      expect(containerTree?.children?.['grandchild-2']).toBeUndefined();
+    });
+
+    it('should pre-populate grandchildren under their parent in the tree', async () => {
+      await service.toggleExpandedNode('container');
+
+      const childContainerTree = service.state.tree?.children?.['container']?.children?.['child-container'];
+
+      // Grandchildren should be pre-populated under child-container
+      expect(childContainerTree?.children?.['grandchild-1']).toBeDefined();
+      expect(childContainerTree?.children?.['grandchild-2']).toBeDefined();
+      expect(childContainerTree?.childrenLoaded).toBe(true);
+    });
+
+    it('should cache all returned nodes including descendants', async () => {
+      await service.toggleExpandedNode('container');
+
+      expect(service.state.nodes['child-container']).toEqual(childContainer);
+      expect(service.state.nodes['grandchild-1']).toEqual(grandchild1);
+      expect(service.state.nodes['grandchild-2']).toEqual(grandchild2);
+    });
+
+    it('should skip API call when expanding a node with prefetched children', async () => {
+      // Expand container (prefetches child-container's children)
+      await service.toggleExpandedNode('container');
+
+      const fetchNodesSpy = jest.spyOn(apiClient, 'fetchNodes');
+      fetchNodesSpy.mockClear();
+
+      // Expand child-container — its children were already prefetched
+      await service.toggleExpandedNode('child-container');
+
+      // No API call should be made
+      expect(fetchNodesSpy).not.toHaveBeenCalled();
+
+      // But the node should be expanded
+      expect(service.state.tree?.children?.['container']?.children?.['child-container']?.expanded).toBe(true);
+    });
+
+    it('should not pass depth when filtering (search)', async () => {
+      const fetchNodesSpy = jest.spyOn(apiClient, 'fetchNodes');
+      fetchNodesSpy.mockClear();
+
+      await service.filterNode('container', 'search-query');
+
+      // filterNode should NOT pass depth
+      expect(fetchNodesSpy).toHaveBeenCalledWith({
+        parent: 'container',
+        query: 'search-query',
+      });
+    });
+
+    it('should not pass depth when collapsing', async () => {
+      await service.toggleExpandedNode('container');
+
+      const fetchNodesSpy = jest.spyOn(apiClient, 'fetchNodes');
+      fetchNodesSpy.mockClear();
+
+      // Collapse
+      await service.toggleExpandedNode('container');
+
+      // Should reload parent's children without depth
+      expect(fetchNodesSpy).toHaveBeenCalledWith({ parent: '', query: '' });
+    });
+  });
 });

--- a/public/app/features/scopes/selector/ScopesSelectorService.test.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.test.ts
@@ -2457,7 +2457,7 @@ describe('ScopesSelectorService', () => {
       expect(service.state.tree?.children?.['container']?.children?.['child-container']?.expanded).toBe(true);
     });
 
-    it('should handle multi-level depth recursively (depth=2)', async () => {
+    it('should recursively nest descendants from flat depth response', async () => {
       // Build a 4-level tree: root → L1 container → L2 container → L3 leaf
       const l1Container: ScopeNode = {
         metadata: { name: 'l1' },

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -295,6 +295,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
 
       // Recursively builds a TreeNode with pre-populated descendants from the
       // depth response. Works for any depth level, not just one.
+      const visited = new Set<string>();
       const buildTreeWithDescendants = (nodeId: string, existing?: TreeNode): TreeNode => {
         const base: TreeNode = existing ?? {
           expanded: false,
@@ -302,6 +303,11 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
           query: '',
           children: undefined,
         };
+
+        if (visited.has(nodeId)) {
+          return base;
+        }
+        visited.add(nodeId);
 
         const nodeDescendants = childrenByParent.get(nodeId);
         if (!nodeDescendants || nodeDescendants.length === 0) {

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -206,8 +206,12 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
         if (parentNode) {
           await this.loadNodeChildren(parentPath, parentNode, parentNode.query);
         }
+      } else if (nodeToToggle.childrenLoaded && nodeToToggle.children) {
+        // Children already available (e.g., prefetched via depth) — skip API call.
+        // The tree was already updated with expanded: true above.
       } else {
-        await this.loadNodeChildren(path, nodeToToggle);
+        // Prefetch one extra level (grandchildren) so the next expansion is instant
+        await this.loadNodeChildren(path, nodeToToggle, undefined, 1);
       }
       // Catch and throw error so we can ensure the profiler is stopped
       // todo: leverage component-level
@@ -248,16 +252,29 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
     }
   };
 
-  private loadNodeChildren = async (path: string[], treeNode: TreeNode, query?: string) => {
+  private loadNodeChildren = async (path: string[], treeNode: TreeNode, query?: string, depth?: number) => {
     this.updateState({ loadingNodeName: treeNode.scopeNodeId });
 
-    const childNodes = await this.apiClient.fetchNodes({ parent: treeNode.scopeNodeId, query });
+    const allNodes = await this.apiClient.fetchNodes({ parent: treeNode.scopeNodeId, query, depth });
 
     const newNodes = { ...this.state.nodes };
-
-    for (const node of childNodes) {
+    for (const node of allNodes) {
       newNodes[node.metadata.name] = node;
     }
+
+    // Group nodes by parent to handle multi-level responses (depth > 0).
+    // When depth is 0 or undefined, all nodes share the same parent and this is equivalent
+    // to the previous flat iteration.
+    const childrenByParent = new Map<string, ScopeNode[]>();
+    for (const node of allNodes) {
+      const parent = node.spec.parentName ?? '';
+      if (!childrenByParent.has(parent)) {
+        childrenByParent.set(parent, []);
+      }
+      childrenByParent.get(parent)!.push(node);
+    }
+
+    const directChildren = childrenByParent.get(treeNode.scopeNodeId) ?? [];
 
     const newTree = modifyTreeNodeAtPath(this.state.tree, path, (treeNode) => {
       // Preserve existing children that have nested structure (from insertPathNodesIntoTree)
@@ -276,21 +293,47 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       // Start with preserved children, then add/update with fetched children
       treeNode.children = { ...childrenToPreserve };
 
-      for (const node of childNodes) {
-        // If this child was preserved, merge with fetched data
-        if (childrenToPreserve[node.metadata.name]) {
-          treeNode.children[node.metadata.name] = {
-            ...childrenToPreserve[node.metadata.name],
+      for (const node of directChildren) {
+        const nodeId = node.metadata.name;
+
+        if (childrenToPreserve[nodeId]) {
+          treeNode.children[nodeId] = {
+            ...childrenToPreserve[nodeId],
             // Update query but keep nested children
             query: query || '',
           };
         } else {
           // New child from API
-          treeNode.children[node.metadata.name] = {
+          treeNode.children[nodeId] = {
             expanded: false,
-            scopeNodeId: node.metadata.name,
+            scopeNodeId: nodeId,
             query: query || '',
             children: undefined,
+          };
+        }
+
+        // Pre-populate descendants from depth response so subsequent expansions
+        // can skip the API call entirely.
+        const descendants = childrenByParent.get(nodeId);
+        if (descendants && descendants.length > 0) {
+          const existingGrandchildren = treeNode.children[nodeId].children || {};
+          const grandchildren: Record<string, TreeNode> = { ...existingGrandchildren };
+
+          for (const desc of descendants) {
+            if (!grandchildren[desc.metadata.name]) {
+              grandchildren[desc.metadata.name] = {
+                expanded: false,
+                scopeNodeId: desc.metadata.name,
+                query: '',
+                children: undefined,
+              };
+            }
+          }
+
+          treeNode.children[nodeId] = {
+            ...treeNode.children[nodeId],
+            children: grandchildren,
+            childrenLoaded: true,
           };
         }
       }

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -210,7 +210,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
         // Children already available (e.g., prefetched via depth) — skip API call.
         // The tree was already updated with expanded: true above.
       } else {
-        // Prefetch one extra level (grandchildren) so the next expansion is instant
+        // depth=1 fetches one extra level of descendants so the next expansion is instant
         await this.loadNodeChildren(path, nodeToToggle, undefined, 1);
       }
       // Catch and throw error so we can ensure the profiler is stopped

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -293,49 +293,43 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       // Start with preserved children, then add/update with fetched children
       treeNode.children = { ...childrenToPreserve };
 
+      // Recursively builds a TreeNode with pre-populated descendants from the
+      // depth response. Works for any depth level, not just one.
+      const buildTreeWithDescendants = (nodeId: string, existing?: TreeNode): TreeNode => {
+        const base: TreeNode = existing ?? {
+          expanded: false,
+          scopeNodeId: nodeId,
+          query: '',
+          children: undefined,
+        };
+
+        const nodeDescendants = childrenByParent.get(nodeId);
+        if (!nodeDescendants || nodeDescendants.length === 0) {
+          return base;
+        }
+
+        const existingChildren = base.children || {};
+        const children: Record<string, TreeNode> = { ...existingChildren };
+
+        for (const desc of nodeDescendants) {
+          children[desc.metadata.name] = buildTreeWithDescendants(
+            desc.metadata.name,
+            existingChildren[desc.metadata.name]
+          );
+        }
+
+        return { ...base, children, childrenLoaded: true };
+      };
+
       for (const node of directChildren) {
         const nodeId = node.metadata.name;
 
-        if (childrenToPreserve[nodeId]) {
-          treeNode.children[nodeId] = {
-            ...childrenToPreserve[nodeId],
-            // Update query but keep nested children
-            query: query || '',
-          };
-        } else {
-          // New child from API
-          treeNode.children[nodeId] = {
-            expanded: false,
-            scopeNodeId: nodeId,
-            query: query || '',
-            children: undefined,
-          };
-        }
+        const preserved = childrenToPreserve[nodeId];
+        const base: TreeNode = preserved
+          ? { ...preserved, query: query || '' }
+          : { expanded: false, scopeNodeId: nodeId, query: query || '', children: undefined };
 
-        // Pre-populate descendants from depth response so subsequent expansions
-        // can skip the API call entirely.
-        const descendants = childrenByParent.get(nodeId);
-        if (descendants && descendants.length > 0) {
-          const existingGrandchildren = treeNode.children[nodeId].children || {};
-          const grandchildren: Record<string, TreeNode> = { ...existingGrandchildren };
-
-          for (const desc of descendants) {
-            if (!grandchildren[desc.metadata.name]) {
-              grandchildren[desc.metadata.name] = {
-                expanded: false,
-                scopeNodeId: desc.metadata.name,
-                query: '',
-                children: undefined,
-              };
-            }
-          }
-
-          treeNode.children[nodeId] = {
-            ...treeNode.children[nodeId],
-            children: grandchildren,
-            childrenLoaded: true,
-          };
-        }
+        treeNode.children[nodeId] = buildTreeWithDescendants(nodeId, base);
       }
       // Set loaded to true if node is a container
       treeNode.childrenLoaded = true;


### PR DESCRIPTION
## What this PR does / why we need it

Adds a `depth` parameter to `scope_node_children` API requests, enabling prefetch of extra tree levels when expanding scope nodes. This reduces API round-trips — expanding a node with `depth=1` fetches its children and their children in a single call, so the next expansion is instant (no API call needed).

### Changes

- **endpoints.gen.ts**: Added `depth` to query params and API arg type (ahead of codegen — will be replaced when backend OpenAPI spec is updated)
- **ScopesApiClient.ts**: Added `depth` to `fetchNodes` options, passed through to RTK Query endpoint
- **ScopesSelectorService.ts**:
  - `loadNodeChildren` accepts `depth`, groups multi-level flat responses by `parentName`, recursively builds tree nodes at each level via `buildTreeWithDescendants`
  - `toggleExpandedNode` passes `depth: 1` when expanding; skips API call entirely for nodes whose children were already prefetched
  - Circular reference protection matches existing `getNodePath` pattern
- **Tests**: 9 new tests covering parameter passthrough, tree structure correctness, node caching, prefetch skip optimization, recursive N-level nesting, and no-depth on filter/collapse

### Backward compatibility

When `depth` is omitted (all existing callers), behavior is identical to before — `undefined` is stripped from the HTTP request, and the `childrenByParent` grouping degenerates to the previous flat iteration.

## Which issue(s) this PR fixes

Ref: [hyperion-planning#523](https://github.com/grafana/hyperion-planning/issues/523)

## Test plan

- [ ] Expanding a scope node sends `depth=1` in the request
- [ ] Multi-level response places nodes at correct tree levels (not flattened)
- [ ] Expanding a prefetched child shows no loading spinner / API call
- [ ] Search (filterNode) does NOT send depth
- [ ] Collapsing and re-expanding works correctly
- [ ] Existing scope selector behavior unchanged when backend ignores depth param

🤖 Generated with [Claude Code](https://claude.com/claude-code)