### PR TITLE
Scopes: Add rootScope param for single-call path resolution

### DIFF
--- a/public/app/api/clients/scope/v0alpha1/endpoints.gen.ts
+++ b/public/app/api/clients/scope/v0alpha1/endpoints.gen.ts
@@ -57,6 +57,7 @@ const injectedRtkApi = api
             // Added ahead of codegen — will be included in generated output
             // when the backend OpenAPI spec is updated.
             depth: queryArg.depth,
+            rootScope: queryArg.rootScope,
           },
         }),
         providesTags: ['FindScopeNodeChildrenResults'],
@@ -635,6 +636,8 @@ export type GetFindScopeNodeChildrenResultsApiArg = {
   limit?: number;
   /** Extra levels of descendants beyond direct children. 0 or omitted = direct children only. */
   depth?: number;
+  /** When set, response includes ancestor nodes from rootScope down to parent. */
+  rootScope?: string;
 };
 export type ListScopeDashboardBindingApiResponse = /** status 200 OK */ ScopeDashboardBindingList;
 export type ListScopeDashboardBindingApiArg = {

--- a/public/app/features/scopes/ScopesApiClient.test.ts
+++ b/public/app/features/scopes/ScopesApiClient.test.ts
@@ -474,7 +474,31 @@ describe('ScopesApiClient', () => {
       );
     });
 
-    it('should omit depth when not provided', async () => {
+    it('should pass rootScope to the endpoint', async () => {
+      const mockSubscription = createMockSubscription({
+        data: { items: [] },
+      });
+      (scopeAPIv0alpha1.endpoints.getFindScopeNodeChildrenResults.initiate as jest.Mock).mockReturnValue(
+        mockSubscription
+      );
+
+      await apiClient.fetchNodes({
+        parent: 'leaf-node',
+        rootScope: '',
+        depth: 0,
+      });
+
+      expect(scopeAPIv0alpha1.endpoints.getFindScopeNodeChildrenResults.initiate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parent: 'leaf-node',
+          rootScope: '',
+          depth: 0,
+        }),
+        expect.objectContaining({ forceRefetch: true })
+      );
+    });
+
+    it('should omit depth and rootScope when not provided', async () => {
       const mockSubscription = createMockSubscription({
         data: { items: [] },
       });
@@ -487,6 +511,7 @@ describe('ScopesApiClient', () => {
       const callArgs = (scopeAPIv0alpha1.endpoints.getFindScopeNodeChildrenResults.initiate as jest.Mock).mock
         .calls[0][0];
       expect(callArgs.depth).toBeUndefined();
+      expect(callArgs.rootScope).toBeUndefined();
     });
   });
 

--- a/public/app/features/scopes/ScopesApiClient.ts
+++ b/public/app/features/scopes/ScopesApiClient.ts
@@ -133,9 +133,16 @@ export class ScopesApiClient {
    * @param {string|undefined} options.query A query string to filter the nodes, or undefined for no filtering.
    * @param {number|undefined} options.limit The maximum number of nodes to fetch, defaults to 1000 if undefined. Must be between 1 and 10000.
    * @param {number|undefined} options.depth Extra levels of descendants to return beyond direct children. 0 or undefined = direct children only. 1 = children + grandchildren.
+   * @param {string|undefined} options.rootScope When set, response includes ancestor nodes from rootScope down to parent for path reconstruction.
    * @return {Promise<ScopeNode[]>} A promise that resolves to a map of fetched nodes. Returns an empty object if an error occurs.
    */
-  async fetchNodes(options: { parent?: string; query?: string; limit?: number; depth?: number }): Promise<ScopeNode[]> {
+  async fetchNodes(options: {
+    parent?: string;
+    query?: string;
+    limit?: number;
+    depth?: number;
+    rootScope?: string;
+  }): Promise<ScopeNode[]> {
     const limit = options.limit ?? 1000;
 
     if (!(0 < limit && limit <= 10000)) {
@@ -149,6 +156,7 @@ export class ScopesApiClient {
           query: options.query,
           limit,
           depth: options.depth,
+          rootScope: options.rootScope,
         },
         { subscribe: false, forceRefetch: true } // Froce refetch for search. Revisit this when necessary
       )

--- a/public/app/features/scopes/selector/ScopesSelectorService.test.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.test.ts
@@ -2592,9 +2592,15 @@ describe('ScopesSelectorService', () => {
       await service.changeScopes(['service-scope'], undefined, 'service-node');
       await service.open();
 
+      // All ancestor nodes should be cached from the single rootScope call
       expect(service.state.nodes['region']).toEqual(rootContainer);
       expect(service.state.nodes['cluster']).toEqual(midContainer);
       expect(service.state.nodes['service-node']).toEqual(leafNode);
+
+      // Verify rootScope was used (fetchNodes called with rootScope param)
+      expect(apiClient.fetchNodes).toHaveBeenCalledWith(
+        expect.objectContaining({ parent: 'service-node', rootScope: '', depth: 0 })
+      );
     });
 
     it('should prefer defaultPath over rootScope when available', async () => {

--- a/public/app/features/scopes/selector/ScopesSelectorService.test.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.test.ts
@@ -2521,4 +2521,155 @@ describe('ScopesSelectorService', () => {
       expect(fetchNodesSpy).toHaveBeenCalledWith({ parent: '', query: '' });
     });
   });
+
+  describe('rootScope path resolution', () => {
+    const rootContainer: ScopeNode = {
+      metadata: { name: 'region' },
+      spec: {
+        nodeType: 'container',
+        title: 'Region',
+        parentName: '',
+        linkType: undefined,
+        linkId: undefined,
+      },
+    };
+
+    const midContainer: ScopeNode = {
+      metadata: { name: 'cluster' },
+      spec: {
+        nodeType: 'container',
+        title: 'Cluster',
+        parentName: 'region',
+        linkType: undefined,
+        linkId: undefined,
+      },
+    };
+
+    const leafNode: ScopeNode = {
+      metadata: { name: 'service-node' },
+      spec: {
+        nodeType: 'leaf',
+        title: 'Service',
+        parentName: 'cluster',
+        linkType: 'scope',
+        linkId: 'service-scope',
+      },
+    };
+
+    const scopeWithoutDefaultPath: Scope = {
+      metadata: { name: 'service-scope' },
+      spec: {
+        title: 'Service Scope',
+        filters: [],
+      },
+    };
+
+    it('should use rootScope to resolve path in a single API call', async () => {
+      apiClient.fetchNodes = jest.fn().mockImplementation((options: { parent?: string; rootScope?: string }) => {
+        if (options.parent === 'service-node' && options.rootScope === '') {
+          return Promise.resolve([rootContainer, midContainer, leafNode]);
+        }
+        if (options.parent === '') {
+          return Promise.resolve([rootContainer]);
+        }
+        return Promise.resolve([]);
+      });
+
+      apiClient.fetchMultipleScopes = jest.fn().mockResolvedValue([scopeWithoutDefaultPath]);
+      apiClient.fetchScopeNode = jest.fn().mockImplementation((id: string) => {
+        if (id === 'service-node') {
+          return Promise.resolve(leafNode);
+        }
+        if (id === 'cluster') {
+          return Promise.resolve(midContainer);
+        }
+        if (id === 'region') {
+          return Promise.resolve(rootContainer);
+        }
+        return Promise.resolve(undefined);
+      });
+
+      await service.changeScopes(['service-scope'], undefined, 'service-node');
+      await service.open();
+
+      expect(service.state.nodes['region']).toEqual(rootContainer);
+      expect(service.state.nodes['cluster']).toEqual(midContainer);
+      expect(service.state.nodes['service-node']).toEqual(leafNode);
+    });
+
+    it('should prefer defaultPath over rootScope when available', async () => {
+      const scopeWithDefaultPath: Scope = {
+        metadata: { name: 'service-scope' },
+        spec: {
+          title: 'Service Scope',
+          filters: [],
+          defaultPath: ['region', 'cluster', 'service-node'],
+        },
+      };
+
+      apiClient.fetchNodes = jest.fn().mockImplementation((options: { parent?: string }) => {
+        if (options.parent === '') {
+          return Promise.resolve([rootContainer]);
+        }
+        if (options.parent === 'region') {
+          return Promise.resolve([midContainer]);
+        }
+        return Promise.resolve([]);
+      });
+
+      apiClient.fetchMultipleScopes = jest.fn().mockResolvedValue([scopeWithDefaultPath]);
+      apiClient.fetchMultipleScopeNodes = jest.fn().mockResolvedValue([rootContainer, midContainer, leafNode]);
+      apiClient.fetchScopeNode = jest.fn().mockImplementation((id: string) => {
+        if (id === 'service-node') {
+          return Promise.resolve(leafNode);
+        }
+        return Promise.resolve(undefined);
+      });
+
+      await service.changeScopes(['service-scope'], undefined, 'service-node');
+
+      const fetchNodesSpy = jest.spyOn(apiClient, 'fetchNodes');
+      fetchNodesSpy.mockClear();
+
+      await service.open();
+
+      // Should NOT have called fetchNodes with rootScope — defaultPath was used instead
+      const rootScopeCalls = fetchNodesSpy.mock.calls.filter(
+        (call) => call[0] && 'rootScope' in call[0] && call[0].rootScope !== undefined
+      );
+      expect(rootScopeCalls).toHaveLength(0);
+    });
+
+    it('should fall back to recursive walk when rootScope returns empty', async () => {
+      apiClient.fetchNodes = jest.fn().mockImplementation((options: { parent?: string; rootScope?: string }) => {
+        if (options.rootScope === '') {
+          return Promise.resolve([]);
+        }
+        if (options.parent === '') {
+          return Promise.resolve([rootContainer]);
+        }
+        return Promise.resolve([]);
+      });
+
+      apiClient.fetchMultipleScopes = jest.fn().mockResolvedValue([scopeWithoutDefaultPath]);
+      apiClient.fetchScopeNode = jest.fn().mockImplementation((id: string) => {
+        if (id === 'service-node') {
+          return Promise.resolve(leafNode);
+        }
+        if (id === 'cluster') {
+          return Promise.resolve(midContainer);
+        }
+        if (id === 'region') {
+          return Promise.resolve(rootContainer);
+        }
+        return Promise.resolve(undefined);
+      });
+
+      await service.changeScopes(['service-scope'], undefined, 'service-node');
+      await service.open();
+
+      // Should still resolve the path via recursive getScopeNode calls
+      expect(apiClient.fetchScopeNode).toHaveBeenCalledWith('service-node');
+    });
+  });
 });

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -145,8 +145,27 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       return await this.getScopeNodes(scope.spec.defaultPath);
     }
 
-    // 2. Fall back to calculating path from scopeNodeId
+    // 2. Use rootScope to fetch all ancestors in a single API call.
+    // After populating the nodes cache, getNodePath resolves entirely from cache (zero API calls).
     if (scopeNodeId) {
+      const ancestorNodes = await this.apiClient.fetchNodes({
+        parent: scopeNodeId,
+        rootScope: '',
+        depth: 0,
+      });
+
+      if (ancestorNodes.length > 0) {
+        const newNodes = { ...this.state.nodes };
+        for (const node of ancestorNodes) {
+          newNodes[node.metadata.name] = node;
+        }
+        this.updateState({ nodes: newNodes });
+
+        // All ancestors are now cached — getNodePath will resolve without API calls
+        return await this.getNodePath(scopeNodeId);
+      }
+
+      // 3. Fallback: recursive parent walk (N sequential API calls)
       return await this.getNodePath(scopeNodeId);
     }
 

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -137,7 +137,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
    * @param scopeNodeId - Optional scope node ID to fall back to if no defaultPath
    * @returns Promise resolving to array of ScopeNode objects representing the path
    */
-  private async getPathForScope(scopeId: string, scopeNodeId?: string): Promise<ScopeNode[]> {
+  private async getPathForScope(scopeId: string | undefined, scopeNodeId?: string): Promise<ScopeNode[]> {
     // 1. Check if scope has defaultPath (preferred method)
     const scope = this.state.scopes[scopeId];
     if (scope?.spec.defaultPath && scope.spec.defaultPath.length > 0) {
@@ -177,17 +177,9 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
     tree: TreeNode,
     scopeId?: string
   ): Promise<{ path: ScopeNode[]; tree: TreeNode }> => {
-    let nodePath: ScopeNode[];
-
-    // Check if scope has defaultPath for optimized resolution
-    const scope = scopeId ? this.state.scopes[scopeId] : undefined;
-    if (scope?.spec.defaultPath && scope.spec.defaultPath.length > 0) {
-      // Use batch-fetched defaultPath (most efficient)
-      nodePath = await this.getPathForScope(scopeId!, scopeNodeId);
-    } else {
-      // Fall back to node-based path resolution
-      nodePath = await this.getNodePath(scopeNodeId);
-    }
+    // getPathForScope handles the full resolution chain:
+    // defaultPath (if scopeId provided) → rootScope (single call) → recursive walk (fallback)
+    const nodePath = await this.getPathForScope(scopeId, scopeNodeId);
 
     const newTree = insertPathNodesIntoTree(tree, nodePath);
 


### PR DESCRIPTION
## What this PR does / why we need it

Adds a `rootScope` parameter to `scope_node_children` API requests, enabling single-call ancestor path resolution. Instead of N sequential `getScopeNode` API calls to walk from a leaf node to root, a single `fetchNodes` call with `rootScope=''` returns all ancestor nodes, populating the cache so the existing recursive `getNodePath` resolves with zero additional calls.

**Stacked on**: #119463 (depth parameter)

### Changes

- **endpoints.gen.ts**: Added `rootScope` to query params and API arg type
- **ScopesApiClient.ts**: Added `rootScope` to `fetchNodes` options, passed through to endpoint
- **ScopesSelectorService.ts**:
  - `getPathForScope` uses `rootScope=''` to fetch all ancestors in one call; falls back to recursive walk if response is empty
  - `getPathForScope` signature widened to accept `undefined` scopeId
  - `resolvePathToRoot` now routes through `getPathForScope` for all callers (including URL-restoration via `ScopesService`), ensuring the rootScope optimization activates on initial page load — not just when opening the selector drawer
- **Tests**: 4 new tests covering rootScope path resolution, defaultPath preference, recursive walk fallback, and fetchNodes call assertion

### Resolution strategy (3 tiers)

1. **defaultPath** (if scope has it) — batch fetch, most efficient
2. **rootScope** (single API call) — populates cache, then `getNodePath` resolves from cache
3. **Recursive walk** (fallback) — N sequential `getScopeNode` calls, existing behavior

### Backward compatibility

When `rootScope` is omitted (all existing callers except `getPathForScope`), behavior is identical to before. If the backend doesn't support `rootScope` yet, it returns an empty response and the fallback recursive walk activates.

## Which issue(s) this PR fixes

Ref: [hyperion-planning#523](https://github.com/grafana/hyperion-planning/issues/523)

## Test plan

- [ ] Opening selector with applied scope triggers rootScope API call
- [ ] URL restoration (page load with scopes in URL) uses rootScope optimization
- [ ] Scope with defaultPath does NOT trigger rootScope call
- [ ] Empty rootScope response falls back to recursive walk without error
- [ ] Existing scope selector behavior unchanged when backend ignores rootScope param

🤖 Generated with [Claude Code](https://claude.com/claude-code)