### PR TITLE
Database: Add stats collector from Prometheus library

### DIFF
--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -330,11 +330,13 @@ func (ss *SQLStore) initEngine(engine *xorm.Engine) error {
 	}
 
 	// TODO(@macabu/2026-03-04): Remove on G14 as these metrics are the same as the ones above.
-	if err := prometheus.Register(sqlstats.NewStatsCollector("grafana", db)); err != nil {
-		ss.log.Warn("Failed to register 'sqlstats' sqlstore stats collector", "error", err)
-	}
-	if err := prometheus.Register(newSQLStoreMetrics(db)); err != nil {
-		ss.log.Warn("Failed to register 'Grafana legacy' sqlstore metrics", "error", err)
+	if ss.cfg.DatabaseRegisterDeprecatedMetrics {
+		if err := prometheus.Register(sqlstats.NewStatsCollector("grafana", db)); err != nil {
+			ss.log.Warn("Failed to register 'sqlstats' sqlstore stats collector", "error", err)
+		}
+		if err := prometheus.Register(newSQLStoreMetrics(db)); err != nil {
+			ss.log.Warn("Failed to register 'Grafana legacy' sqlstore metrics", "error", err)
+		}
 	}
 
 	ss.engine = engine

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 
 	"github.com/grafana/grafana/pkg/util/sqlite"
 	"github.com/grafana/grafana/pkg/util/xorm"
@@ -324,14 +325,16 @@ func (ss *SQLStore) initEngine(engine *xorm.Engine) error {
 	// initialize and register metrics wrapper around the *sql.DB
 	db := engine.DB().DB
 
-	// register the go_sql_stats_connections_* metrics
-	if err := prometheus.Register(sqlstats.NewStatsCollector("grafana", db)); err != nil {
-		ss.log.Warn("Failed to register sqlstore stats collector", "error", err)
+	if err := prometheus.Register(collectors.NewDBStatsCollector(db, "grafana")); err != nil {
+		ss.log.Warn("Failed to register 'Prometheus collector' sqlstore stats collector", "error", err)
 	}
 
-	// TODO: deprecate/remove these metrics
+	// TODO(@macabu/2026-03-04): Remove on G14 as these metrics are the same as the ones above.
+	if err := prometheus.Register(sqlstats.NewStatsCollector("grafana", db)); err != nil {
+		ss.log.Warn("Failed to register 'sqlstats' sqlstore stats collector", "error", err)
+	}
 	if err := prometheus.Register(newSQLStoreMetrics(db)); err != nil {
-		ss.log.Warn("Failed to register sqlstore metrics", "error", err)
+		ss.log.Warn("Failed to register 'Grafana legacy' sqlstore metrics", "error", err)
 	}
 
 	ss.engine = engine

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -568,6 +568,9 @@ type Cfg struct {
 	// sqlstore package and HTTP middlewares.
 	DatabaseInstrumentQueries bool
 
+	// DatabaseRegisterDeprecatedMetrics decides whether to register the deprecated `grafana_database_conn_*` and `go_sql_stats_*` metrics.
+	DatabaseRegisterDeprecatedMetrics bool
+
 	// Public dashboards
 	PublicDashboardsEnabled bool
 
@@ -1500,6 +1503,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 
 	databaseSection := iniFile.Section("database")
 	cfg.DatabaseInstrumentQueries = databaseSection.Key("instrument_queries").MustBool(false)
+	cfg.DatabaseRegisterDeprecatedMetrics = databaseSection.Key("register_deprecated_metrics").MustBool(true)
 
 	logSection := iniFile.Section("log")
 	cfg.UserFacingDefaultError = logSection.Key("user_facing_default_error").MustString("please inspect Grafana server log for details")

--- a/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dlmiddlecote/sqlstats"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 
@@ -118,9 +119,14 @@ func (p *resourceDBProvider) initDB(ctx context.Context) (db.DB, error) {
 	)
 
 	if p.registerMetrics {
+		if err := prometheus.Register(collectors.NewDBStatsCollector(p.engine.DB().DB, "unified_storage")); err != nil {
+			p.log.Warn("Failed to register 'Prometheus collector' unified storage sql stats collector", "error", err)
+		}
+
+		// TODO(@macabu/2026-03-04): Remove on G14 as these metrics are the same as the ones above.
 		err := prometheus.Register(sqlstats.NewStatsCollector("unified_storage", p.engine.DB().DB))
 		if err != nil {
-			p.log.Warn("Failed to register unified storage sql stats collector", "error", err)
+			p.log.Warn("Failed to register 'sqlstats' unified storage sql stats collector", "error", err)
 		}
 	}
 	_ = p.logQueries // TODO: configure SQL logging

--- a/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
@@ -124,9 +124,11 @@ func (p *resourceDBProvider) initDB(ctx context.Context) (db.DB, error) {
 		}
 
 		// TODO(@macabu/2026-03-04): Remove on G14 as these metrics are the same as the ones above.
-		err := prometheus.Register(sqlstats.NewStatsCollector("unified_storage", p.engine.DB().DB))
-		if err != nil {
-			p.log.Warn("Failed to register 'sqlstats' unified storage sql stats collector", "error", err)
+		if p.cfg.DatabaseRegisterDeprecatedMetrics {
+			err := prometheus.Register(sqlstats.NewStatsCollector("unified_storage", p.engine.DB().DB))
+			if err != nil {
+				p.log.Warn("Failed to register 'sqlstats' unified storage sql stats collector", "error", err)
+			}
 		}
 	}
 	_ = p.logQueries // TODO: configure SQL logging


### PR DESCRIPTION
**What is this feature?**

Adds a new series of metrics for the DB using Prometheus' `collectors` package, which is better standardized.

This also deprecates the other two ways we expose DB metrics (with an explicit deprecation on the docs), so we can remove those metrics in G14.

**Why do we need this feature?**

Cleaning up and using a more standard metric name.

**Who is this feature for?**

Operators

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
