### PR TITLE
RRC Patch Slow: Support k8s resource inside /api/dashboards/db

### DIFF
--- a/apps/provisioning/pkg/connection/github/client.go
+++ b/apps/provisioning/pkg/connection/github/client.go
@@ -14,9 +14,7 @@ import (
 
 // API errors that we need to convey after parsing real GH errors (or faking them).
 var (
-	//lint:ignore ST1005 this is not punctuation
-	ErrAuthentication = apierrors.NewUnauthorized("authentication failed")
-	//lint:ignore ST1005 this is not punctuation
+	ErrAuthentication     = apierrors.NewUnauthorized("authentication failed")
 	ErrServiceUnavailable = apierrors.NewServiceUnavailable("github is unavailable")
 
 	ErrNotFound            = errors.New("not found")

--- a/apps/provisioning/pkg/repository/github/client.go
+++ b/apps/provisioning/pkg/repository/github/client.go
@@ -12,9 +12,8 @@ import (
 
 // API errors that we need to convey after parsing real GH errors (or faking them).
 var (
-	ErrResourceNotFound = errors.New("the resource does not exist")
-	ErrUnauthorized     = errors.New("unauthorized")
-	//lint:ignore ST1005 this is not punctuation
+	ErrResourceNotFound   = errors.New("the resource does not exist")
+	ErrUnauthorized       = errors.New("unauthorized")
 	ErrServiceUnavailable = apierrors.NewServiceUnavailable("github is unavailable")
 	ErrTooManyItems       = errors.New("maximum number of items exceeded")
 )

--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -399,6 +399,31 @@ type SaveDashboardDTO struct {
 	Dashboard *Dashboard
 }
 
+func LooksLikeK8sResource(data map[string]any) bool {
+	if _, ok := data["apiVersion"]; ok {
+		return true
+	}
+	if _, ok := data["metadata"]; ok {
+		return true
+	}
+	if _, ok := data["spec"]; ok {
+		return true
+	}
+	return false
+}
+
+const LooksLikeV2SpecMessage = "dashboard appears to be in v2 format. Please use the /apis/dashboard.grafana.app/v2 API"
+
+func LooksLikeV2Spec(data map[string]any) bool {
+	if _, ok := data["elements"]; ok {
+		return true
+	}
+	if _, ok := data["layout"]; ok {
+		return true
+	}
+	return false
+}
+
 type DashboardSearchProjection struct {
 	ID          int64  `xorm:"id"`
 	UID         string `xorm:"uid"`

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -18,6 +18,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 
 	claims "github.com/grafana/authlib/types"
@@ -2327,7 +2328,32 @@ func (dr *DashboardServiceImpl) UnstructuredToLegacyDashboard(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	return dr.unstructuredToLegacyDashboardWithUsers(item, orgID, users)
+
+	dash, err := dr.unstructuredToLegacyDashboardWithUsers(item, orgID, users)
+	if err != nil {
+		return nil, err
+	}
+
+	// The requested version
+	gv, _ := schema.ParseGroupVersion(item.GetAPIVersion())
+	if gv.Version != "" {
+		dash.APIVersion = gv.Version
+	}
+
+	// Use the old payload if we could not convert to the the requested version
+	conversion, ok, _ := unstructured.NestedMap(item.Object, "status", "conversion")
+	if ok && conversion != nil {
+		failed, _, _ := unstructured.NestedBool(conversion, "failed")
+		if failed {
+			dash.APIVersion, _, _ = unstructured.NestedString(conversion, "storedVersion")
+			body, ok, _ := unstructured.NestedMap(conversion, "source")
+			if ok {
+				dash.Data = simplejson.NewFromAny(body)
+			}
+		}
+	}
+
+	return dash, nil
 }
 
 func (dr *DashboardServiceImpl) unstructuredToLegacyDashboardWithUsers(item *unstructured.Unstructured, orgID int64, users map[string]*user.User) (*dashboards.Dashboard, error) {

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -2222,10 +2222,7 @@ func runDashboardHttpTest(t *testing.T, ctx TestContext, foreignOrgCtx TestConte
 							"spec": {
 								"title": "%s",
 								"schemaVersion": 42,
-								"layout": {
-									"kind": "GridLayout",
-									"items": []
-								}
+								"panels": []
 							}
 						}`, metadata, dashboardTitle)
 

--- a/pkg/tests/apis/dashboard/testdata/dashboard-test-v2.yaml
+++ b/pkg/tests/apis/dashboard/testdata/dashboard-test-v2.yaml
@@ -1,4 +1,4 @@
-apiVersion: dashboard.grafana.app/v2alpha1
+apiVersion: dashboard.grafana.app/v2beta1
 kind: Dashboard
 metadata:
   name: test-v2


### PR DESCRIPTION
Cherry-pick of https://github.com/grafana/grafana/pull/118946 and https://github.com/grafana/grafana/pull/118665 into the slow channel