### PR TITLE
Hackathon: Add AI-powered dashboard editing experience

### DIFF
--- a/public/app/features/dashboard-scene/ai/DashboardAIContextProvider.tsx
+++ b/public/app/features/dashboard-scene/ai/DashboardAIContextProvider.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useMemo } from 'react';
+
+import {
+  useProvidePageContext,
+  createAssistantContextItem,
+  ChatContextItem,
+  newFunctionNamespace,
+  getExposeAssistantFunctionsConfig,
+} from '@grafana/assistant';
+import { getDataSourceRef } from '@grafana/data';
+import { config, getDataSourceSrv } from '@grafana/runtime';
+import { SceneDataTransformer, sceneGraph, SceneQueryRunner, VizPanel, VizPanelMenu } from '@grafana/scenes';
+
+import { getPluginExtensionRegistries } from '../../plugins/extensions/registry/setup';
+import { DashboardDatasourceBehaviour } from '../scene/DashboardDatasourceBehaviour';
+import { DashboardScene } from '../scene/DashboardScene';
+import { VizPanelLinks, VizPanelLinksMenu } from '../scene/PanelLinks';
+import { panelMenuBehavior } from '../scene/PanelMenuBehavior';
+import { VizPanelHeaderActions } from '../scene/VizPanelHeaderActions';
+import { VizPanelSubHeader } from '../scene/VizPanelSubHeader';
+import { setDashboardPanelContext } from '../scene/setDashboardPanelContext';
+import {
+  findVizPanelByKey,
+  getPanelIdForVizPanel,
+  getQueryRunnerFor,
+  getVizPanelKeyForPanelId,
+} from '../utils/utils';
+
+interface DashboardAIContextProviderProps {
+  dashboard: DashboardScene;
+}
+
+function buildPanelContextItems(panels: VizPanel[]): ChatContextItem[] {
+  return panels.map((panel) => {
+    const panelId = getPanelIdForVizPanel(panel);
+    const dataProvider = panel.state.$data;
+    let datasourceInfo: { uid?: string; type?: string } | undefined;
+
+    if (dataProvider instanceof SceneQueryRunner) {
+      const ds = dataProvider.state.datasource;
+      if (ds) {
+        datasourceInfo = { uid: ds.uid, type: ds.type };
+      }
+    }
+
+    return createAssistantContextItem('structured', {
+      title: `Panel: ${panel.state.title || 'Untitled'}`,
+      data: {
+        panelId,
+        title: panel.state.title,
+        description: panel.state.description,
+        pluginId: panel.state.pluginId,
+        ...(datasourceInfo && { datasource: datasourceInfo }),
+      },
+    });
+  });
+}
+
+function buildDatasourceContextItems(panels: VizPanel[]): ChatContextItem[] {
+  const seen = new Set<string>();
+  const items: ChatContextItem[] = [];
+
+  for (const panel of panels) {
+    const dataProvider = panel.state.$data;
+    if (dataProvider instanceof SceneQueryRunner) {
+      const uid = dataProvider.state.datasource?.uid;
+      if (uid && !seen.has(uid)) {
+        seen.add(uid);
+        items.push(
+          createAssistantContextItem('datasource', {
+            datasourceUid: uid,
+          })
+        );
+      }
+    }
+  }
+
+  return items;
+}
+
+function buildVariableContextItems(dashboard: DashboardScene): ChatContextItem[] {
+  const variableSet = sceneGraph.getVariables(dashboard);
+  if (!variableSet) {
+    return [];
+  }
+
+  const variables = variableSet.state.variables;
+  if (variables.length === 0) {
+    return [];
+  }
+
+  return [
+    createAssistantContextItem('structured', {
+      title: 'Dashboard Variables',
+      data: {
+        variables: variables.map((v) => ({
+          name: v.state.name,
+          type: v.state.type,
+          label: v.state.label,
+          value: v.getValue?.(),
+        })),
+      },
+    }),
+  ];
+}
+
+function buildLayoutContextItem(dashboard: DashboardScene): ChatContextItem {
+  const layoutManager = dashboard.state.body;
+
+  return createAssistantContextItem('structured', {
+    title: 'Dashboard Layout',
+    data: {
+      layoutType: layoutManager.descriptor.name,
+      panelCount: layoutManager.getVizPanels().length,
+    },
+  });
+}
+
+function buildDashboardMetadataItem(dashboard: DashboardScene): ChatContextItem {
+  return createAssistantContextItem('structured', {
+    title: `Dashboard: ${dashboard.state.title}`,
+    hidden: true,
+    data: {
+      uid: dashboard.state.uid,
+      title: dashboard.state.title,
+      description: dashboard.state.description,
+      tags: dashboard.state.tags,
+      isEditing: dashboard.state.isEditing,
+      editable: dashboard.state.editable,
+    },
+  });
+}
+
+function useDashboardContextItems(dashboard: DashboardScene): ChatContextItem[] {
+  const { title, description, tags, isEditing, body, uid } = dashboard.useState();
+  const panels = body.getVizPanels();
+
+  return useMemo(() => {
+    const items: ChatContextItem[] = [];
+
+    items.push(buildDashboardMetadataItem(dashboard));
+    items.push(buildLayoutContextItem(dashboard));
+    items.push(...buildPanelContextItems(panels));
+    items.push(...buildDatasourceContextItems(panels));
+    items.push(...buildVariableContextItems(dashboard));
+
+    return items;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dashboard, title, description, tags, isEditing, uid, panels]);
+}
+
+function buildVizPanel(type: string, title: string, datasource?: string, query?: string): VizPanel {
+  const pluginId = type || 'timeseries';
+  const dsSettings = datasource
+    ? getDataSourceSrv().getInstanceSettings(datasource)
+    : getDataSourceSrv().getInstanceSettings(null);
+
+  const queryRunner = dsSettings
+    ? new SceneQueryRunner({
+        queries: [{ refId: 'A', ...(query ? { expr: query, rawSql: query, query } : {}) }],
+        datasource: getDataSourceRef(dsSettings),
+        $behaviors: [new DashboardDatasourceBehaviour({})],
+      })
+    : undefined;
+
+  return new VizPanel({
+    title,
+    pluginId,
+    seriesLimit: config.panelSeriesLimit,
+    titleItems: [new VizPanelLinks({ menu: new VizPanelLinksMenu({}) })],
+    hoverHeaderOffset: 0,
+    $behaviors: [],
+    subHeader: new VizPanelSubHeader({
+      hideNonApplicableDrilldowns: !config.featureToggles.perPanelNonApplicableDrilldowns,
+    }),
+    extendPanelContext: setDashboardPanelContext,
+    menu: new VizPanelMenu({
+      $behaviors: [panelMenuBehavior],
+    }),
+    headerActions: new VizPanelHeaderActions({
+      hideGroupByAction: !config.featureToggles.panelGroupBy,
+    }),
+    $data: queryRunner
+      ? new SceneDataTransformer({ $data: queryRunner, transformations: [] })
+      : undefined,
+  });
+}
+
+function useDashboardFunctions(dashboard: DashboardScene) {
+  useEffect(() => {
+    const dashboardNamespace = newFunctionNamespace('dashboard', {
+      addPanel: (type: string, title: string, datasource?: string, query?: string) => {
+        const vizPanel = buildVizPanel(type, title, datasource, query);
+        dashboard.addPanel(vizPanel);
+      },
+
+      removePanel: (panelId: number) => {
+        const panel = findVizPanelByKey(dashboard, getVizPanelKeyForPanelId(panelId));
+        if (panel) {
+          dashboard.removePanel(panel);
+        }
+      },
+
+      updatePanelQuery: (panelId: number, query: string) => {
+        const panel = findVizPanelByKey(dashboard, getVizPanelKeyForPanelId(panelId));
+        if (!panel) {
+          return;
+        }
+        const queryRunner = getQueryRunnerFor(panel);
+        if (!queryRunner) {
+          return;
+        }
+        const existingQueries = queryRunner.state.queries;
+        const updatedQueries = existingQueries.length > 0
+          ? existingQueries.map((q, i) => (i === 0 ? { ...q, expr: query, rawSql: query, query } : q))
+          : [{ refId: 'A', expr: query, rawSql: query, query }];
+        queryRunner.setState({ queries: updatedQueries });
+        queryRunner.runQueries();
+      },
+
+      setDashboardTitle: (title: string) => {
+        dashboard.setState({ title });
+      },
+
+      setDashboardDescription: (description: string) => {
+        dashboard.setState({ description });
+      },
+    });
+
+    const functionsConfig = getExposeAssistantFunctionsConfig([dashboardNamespace]);
+
+    getPluginExtensionRegistries().then((registries) => {
+      registries.addedFunctionsRegistry.register({
+        pluginId: 'grafana',
+        configs: [functionsConfig],
+      });
+    });
+  }, [dashboard]);
+}
+
+export function DashboardAIContextProvider({ dashboard }: DashboardAIContextProviderProps) {
+  const contextItems = useDashboardContextItems(dashboard);
+
+  const setDashboardContext = useProvidePageContext('/d/*', contextItems);
+  const setNewDashboardContext = useProvidePageContext('/dashboard/new', contextItems);
+
+  useEffect(() => {
+    setDashboardContext(contextItems);
+    setNewDashboardContext(contextItems);
+  }, [contextItems, setDashboardContext, setNewDashboardContext]);
+
+  useDashboardFunctions(dashboard);
+
+  return null;
+}

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
@@ -29,6 +29,7 @@ export interface DashboardEditPaneState extends SceneObjectState {
   redoStack: DashboardEditActionEventPayload[];
   openPane?: DashboardSidebarPaneName;
   isDocked?: boolean;
+  aiMode?: boolean;
 }
 
 export type DashboardSidebarPaneName = 'element' | 'outline' | 'filters' | 'add';
@@ -197,6 +198,10 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> {
     this.performAction(action);
 
     this.setState({ redoStack, undoStack: [...this.state.undoStack, action] });
+  }
+
+  public toggleAiMode() {
+    this.setState({ aiMode: !this.state.aiMode });
   }
 
   public enableSelection() {

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
@@ -1,10 +1,12 @@
+import { css } from '@emotion/css';
 import { useCallback, useMemo, useState } from 'react';
 
+import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { t } from '@grafana/i18n';
+import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { sceneGraph, SceneObject, SceneObjectState, sceneUtils, useSceneObjectState } from '@grafana/scenes';
-import { Sidebar } from '@grafana/ui';
+import { Icon, Sidebar, Stack, Switch, Text, useStyles2 } from '@grafana/ui';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 
 import { DashboardScene } from '../scene/DashboardScene';
@@ -32,8 +34,9 @@ export interface Props {
  * Making the EditPane rendering completely standalone (not using editPane.Component) in order to pass custom react props
  */
 export function DashboardEditPaneRenderer({ editPane, dashboard }: Props) {
-  const { selection, openPane } = useSceneObjectState(editPane, { shouldActivateOrKeepAlive: true });
+  const { selection, openPane, aiMode } = useSceneObjectState(editPane, { shouldActivateOrKeepAlive: true });
   const { isEditing, meta, uid } = dashboard.useState();
+  const toggleStyles = useStyles2(getToggleStyles);
   const hasUid = Boolean(uid);
   const isEmbedded = meta.isEmbedded;
   const selectedObject = selection?.getFirstObject();
@@ -90,12 +93,44 @@ export function DashboardEditPaneRenderer({ editPane, dashboard }: Props) {
     <>
       {editableElement && (
         <Sidebar.OpenPane>
-          <ElementEditPane
-            key={selectedObject?.state.key}
-            editPane={editPane}
-            element={editableElement}
-            isNewElement={isNewElement}
-          />
+          <div className={toggleStyles.toggleBar}>
+            <Text
+              color={aiMode ? 'primary' : 'secondary'}
+              weight={aiMode ? 'bold' : 'regular'}
+            >
+              <Trans i18nKey="dashboard.edit-pane.ai-mode-label">AI Assistant</Trans>
+            </Text>
+            <Switch
+              value={!!aiMode}
+              onChange={() => editPane.toggleAiMode()}
+              aria-label={t('dashboard.edit-pane.ai-mode-toggle-aria', 'Toggle AI assistant mode')}
+            />
+            <Text
+              color={aiMode ? 'secondary' : 'primary'}
+              weight={aiMode ? 'regular' : 'bold'}
+            >
+              <Trans i18nKey="dashboard.edit-pane.manual-mode-label">Manual Mode</Trans>
+            </Text>
+          </div>
+          {aiMode ? (
+            <div className={toggleStyles.aiPlaceholder}>
+              <Stack direction="column" alignItems="center" justifyContent="center" gap={2}>
+                <Icon name="ai-sparkle" size="xxl" />
+                <Text color="secondary" textAlignment="center">
+                  <Trans i18nKey="dashboard.edit-pane.ai-placeholder">
+                    AI Assistant chat will appear here
+                  </Trans>
+                </Text>
+              </Stack>
+            </div>
+          ) : (
+            <ElementEditPane
+              key={selectedObject?.state.key}
+              editPane={editPane}
+              element={editableElement}
+              isNewElement={isNewElement}
+            />
+          )}
         </Sidebar.OpenPane>
       )}
       {openPane === 'add' && (
@@ -250,4 +285,25 @@ function RedoButton({ dashboard }: ToolbarActionProps) {
       onClick={() => editPane.redoAction()}
     />
   );
+}
+
+function getToggleStyles(theme: GrafanaTheme2) {
+  return {
+    toggleBar: css({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: theme.spacing(1.5),
+      padding: theme.spacing(1.5, 2),
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
+    }),
+    aiPlaceholder: css({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexGrow: 1,
+      padding: theme.spacing(4),
+      minHeight: '200px',
+    }),
+  };
 }

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -8,6 +8,7 @@ import { Page } from 'app/core/components/Page/Page';
 import { getNavModel } from 'app/core/selectors/navModel';
 import { useSelector } from 'app/types/store';
 
+import { DashboardAIContextProvider } from '../ai/DashboardAIContextProvider';
 import { DashboardEditPaneSplitter } from '../edit-pane/DashboardEditPaneSplitter';
 
 import { DashboardScene } from './DashboardScene';
@@ -97,6 +98,7 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
 
   return (
     <>
+      <DashboardAIContextProvider dashboard={model} />
       {layoutOrchestrator && <layoutOrchestrator.Component model={layoutOrchestrator} />}
       <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Custom}>
         {editPanel && <editPanel.Component model={editPanel} />}

--- a/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.tsx
@@ -1,17 +1,12 @@
-import { css, cx } from '@emotion/css';
-import { useCallback, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom-v5-compat';
+import { css } from '@emotion/css';
+import { useCallback, useState } from 'react';
 
+import { useAssistant } from '@grafana/assistant';
 import { GrafanaTheme2 } from '@grafana/data';
-import { selectors } from '@grafana/e2e-selectors';
-import { Trans } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
-import { Button, useStyles2, Text, Box, Stack, TextLink, Icon } from '@grafana/ui';
+import { Trans, t } from '@grafana/i18n';
+import { Button, Icon, IconButton, useStyles2, Text, Stack } from '@grafana/ui';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
-
-import { BasicProvisionedDashboardsEmptyPage } from '../DashboardLibrary/BasicProvisionedDashboardsEmptyPage';
-import { SuggestedDashboards } from '../DashboardLibrary/SuggestedDashboards';
 
 import { DashboardEmptyExtensionPoint } from './DashboardEmptyExtensionPoint';
 import {
@@ -24,215 +19,87 @@ import {
 interface InternalProps {
   dashboard: DashboardModel | DashboardScene;
   onAddVisualization?: () => void;
-  onAddLibraryPanel?: () => void;
-  onImportDashboard?: () => void;
 }
 
-const InternalDashboardEmpty = ({
-  dashboard,
-  onAddVisualization,
-  onAddLibraryPanel,
-  onImportDashboard,
-}: InternalProps) => {
+const InternalDashboardEmpty = ({ onAddVisualization }: InternalProps) => {
   const styles = useStyles2(getStyles);
-  const [searchParams] = useSearchParams();
-  const dashboardLibraryDatasourceUid = searchParams.get('dashboardLibraryDatasourceUid');
+  const [prompt, setPrompt] = useState('');
+  const { openAssistant } = useAssistant();
 
-  return (
-    <>
-      <Stack alignItems="center" justifyContent="center">
-        <div
-          className={cx(styles.wrapper, {
-            [styles.wrapperMaxWidth]:
-              !(config.featureToggles.dashboardLibrary || config.featureToggles.suggestedDashboards) ||
-              !dashboardLibraryDatasourceUid,
-          })}
-        >
-          {config.featureToggles.dashboardNewLayouts && dashboard instanceof DashboardScene ? (
-            <NewLayoutEmpty
-              dashboard={dashboard}
-              styles={styles}
-              dashboardLibraryDatasourceUid={dashboardLibraryDatasourceUid}
-            />
-          ) : (
-            <OldLayoutEmpty
-              dashboardLibraryDatasourceUid={dashboardLibraryDatasourceUid}
-              onAddVisualization={onAddVisualization}
-              onAddLibraryPanel={onAddLibraryPanel}
-              onImportDashboard={onImportDashboard}
-            />
-          )}
-        </div>
-      </Stack>
-    </>
-  );
-};
-
-const DashboardExtensionsComponents = ({
-  dashboardLibraryDatasourceUid,
-}: {
-  dashboardLibraryDatasourceUid: string | null;
-}) => (
-  <>
-    {/* Suggested Dashboards Section */}
-    {config.featureToggles.suggestedDashboards &&
-      config.featureToggles.dashboardLibrary &&
-      dashboardLibraryDatasourceUid && <SuggestedDashboards datasourceUid={dashboardLibraryDatasourceUid} />}
-
-    {/* Basic Provisioned Dashboards Section that don't include community dashboards */}
-    {config.featureToggles.dashboardLibrary &&
-      !config.featureToggles.suggestedDashboards &&
-      dashboardLibraryDatasourceUid && (
-        <BasicProvisionedDashboardsEmptyPage datasourceUid={dashboardLibraryDatasourceUid} />
-      )}
-  </>
-);
-interface NewLayoutEmptyProps {
-  dashboard: DashboardScene;
-  styles: {
-    wrapper: string;
-    wrapperMaxWidth: string;
-    appsIcon: string;
-  };
-  dashboardLibraryDatasourceUid: string | null;
-}
-
-const NewLayoutEmpty = ({ dashboard, styles, dashboardLibraryDatasourceUid }: NewLayoutEmptyProps) => {
-  const { uid, isEditing, editPane } = dashboard.state;
-  const isEditingNewDashboard = isEditing && !uid;
-
-  // open the edit pane when the dashboard is new and in editing mode
-  // will only happen when the default empty state is shown (not overridden by extension point)
-  useEffect(() => {
-    if (isEditingNewDashboard) {
-      editPane.openPane('add');
+  const handleSubmit = useCallback(() => {
+    if (prompt.trim() && openAssistant) {
+      openAssistant({
+        origin: 'dashboard/empty-state',
+        mode: 'dashboarding',
+        prompt: prompt.trim(),
+        autoSend: true,
+      });
     }
-  }, [isEditingNewDashboard, editPane]);
+  }, [prompt, openAssistant]);
 
   return (
-    <Stack alignItems="stretch" justifyContent="center" gap={4} direction="column">
-      <Box padding={4}>
-        <Box marginBottom={2} paddingX={4} display="flex" justifyContent="center">
-          <Icon name="apps" size="xxl" className={styles.appsIcon} />
-        </Box>
-        <Text element="h1" textAlignment="center" weight="medium">
-          <Trans i18nKey="dashboard.empty.title">New dashboard</Trans>
-        </Text>
-        <Box marginTop={3} paddingX={4}>
-          <Text element="p" textAlignment="center" color="secondary">
-            <Trans i18nKey="dashboard.empty.description">Add a panel to visualize your data</Trans>
-          </Text>
-        </Box>
-      </Box>
-      <DashboardExtensionsComponents dashboardLibraryDatasourceUid={dashboardLibraryDatasourceUid} />
-    </Stack>
-  );
-};
+    <Stack alignItems="center" justifyContent="center">
+      <div className={styles.wrapper}>
+        <Stack direction="column" alignItems="center" gap={3}>
+          <div className={styles.sparkleCircle}>
+            <Icon name="ai-sparkle" size="xxl" className={styles.sparkleIcon} />
+          </div>
 
-interface OldLayoutEmptyProps {
-  dashboardLibraryDatasourceUid: string | null;
-  onAddVisualization?: () => void;
-  onAddLibraryPanel?: () => void;
-  onImportDashboard?: () => void;
-}
-const OldLayoutEmpty = ({
-  dashboardLibraryDatasourceUid,
-  onAddVisualization,
-  onAddLibraryPanel,
-  onImportDashboard,
-}: OldLayoutEmptyProps) => (
-  <Stack alignItems="stretch" justifyContent="center" gap={4} direction="column">
-    <Box borderRadius="lg" borderColor="strong" borderStyle="dashed" padding={4}>
-      <Stack direction="column" alignItems="center" gap={2}>
-        <Text element="h1" textAlignment="center" weight="medium">
-          <Trans i18nKey="dashboard.empty.add-visualization-header">
-            Start your new dashboard by adding a visualization
-          </Trans>
-        </Text>
-        <Box marginBottom={2} paddingX={4}>
+          <Text element="h1" textAlignment="center" weight="medium">
+            <Trans i18nKey="dashboard.empty.ai-welcome-title">Welcome to your dashboard</Trans>
+          </Text>
+
           <Text element="p" textAlignment="center" color="secondary">
-            <Trans i18nKey="dashboard.empty.add-visualization-body">
-              Select a data source and then query and visualize your data with charts, stats and tables or create lists,
-              markdowns and other widgets.
+            <Trans i18nKey="dashboard.empty.ai-welcome-subtitle">
+              What would you like to visualize today?
             </Trans>
           </Text>
-        </Box>
-        <Button
-          size="lg"
-          icon="plus"
-          data-testid={selectors.pages.AddDashboard.itemButton('Create new panel button')}
-          onClick={onAddVisualization}
-          disabled={!onAddVisualization}
-        >
-          <Trans i18nKey="dashboard.empty.add-visualization-button">Add visualization</Trans>
-        </Button>
-      </Stack>
-    </Box>
 
-    <DashboardExtensionsComponents dashboardLibraryDatasourceUid={dashboardLibraryDatasourceUid} />
+          <div className={styles.promptBar}>
+            <IconButton
+              name="plus"
+              size="lg"
+              aria-label={t('dashboard.empty.ai-add-panel-aria', 'Add panel manually')}
+              tooltip={t('dashboard.empty.ai-add-panel-tooltip', 'Add panel')}
+              onClick={onAddVisualization}
+              className={styles.promptButton}
+            />
+            <input
+              className={styles.promptInput}
+              type="text"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder={t('dashboard.empty.ai-prompt-placeholder', 'Server performance metrics')}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  handleSubmit();
+                }
+              }}
+            />
+            <IconButton
+              name="arrow-right"
+              size="lg"
+              aria-label={t('dashboard.empty.ai-submit-aria', 'Submit prompt')}
+              tooltip={t('dashboard.empty.ai-submit-tooltip', 'Submit')}
+              onClick={handleSubmit}
+              className={styles.promptButton}
+            />
+          </div>
 
-    <Stack direction={{ xs: 'column', md: 'row' }} wrap="wrap" gap={4}>
-      <Box borderRadius="lg" borderColor="strong" borderStyle="dashed" padding={3} flex={1}>
-        <Stack direction="column" alignItems="center" gap={1}>
-          <Text element="h3" textAlignment="center" weight="medium">
-            <Trans i18nKey="dashboard.empty.add-library-panel-header">Import panel</Trans>
-          </Text>
-          <Box marginBottom={2}>
-            <Text element="p" textAlignment="center" color="secondary">
-              <Trans i18nKey="dashboard.empty.add-library-panel-body">
-                Add visualizations that are shared with other dashboards.
-              </Trans>
-            </Text>
-          </Box>
-          <Button
-            icon="plus"
-            fill="outline"
-            data-testid={selectors.pages.AddDashboard.itemButton('Add a panel from the panel library button')}
-            onClick={onAddLibraryPanel}
-            disabled={!onAddLibraryPanel}
-          >
-            <Trans i18nKey="dashboard.empty.add-library-panel-button">Add library panel</Trans>
+          <Button icon="apps" fill="text" onClick={onAddVisualization}>
+            <Trans i18nKey="dashboard.empty.ai-add-panel-button">Add a panel</Trans>
           </Button>
         </Stack>
-      </Box>
-      <Box borderRadius="lg" borderColor="strong" borderStyle="dashed" padding={3} flex={1}>
-        <Stack direction="column" alignItems="center" gap={1}>
-          <Text element="h3" textAlignment="center" weight="medium">
-            <Trans i18nKey="dashboard.empty.import-a-dashboard-header">Import a dashboard</Trans>
-          </Text>
-          <Box marginBottom={2}>
-            <Text element="p" textAlignment="center" color="secondary">
-              <Trans i18nKey="dashboard.empty.import-a-dashboard-body">
-                Import dashboards from files or{' '}
-                <TextLink external href="https://grafana.com/grafana/dashboards/">
-                  grafana.com
-                </TextLink>
-                .
-              </Trans>
-            </Text>
-          </Box>
-          <Button
-            icon="upload"
-            fill="outline"
-            data-testid={selectors.pages.AddDashboard.itemButton('Import dashboard button')}
-            onClick={onImportDashboard}
-            disabled={!onImportDashboard}
-          >
-            <Trans i18nKey="dashboard.empty.import-dashboard-button">Import dashboard</Trans>
-          </Button>
-        </Stack>
-      </Box>
+      </div>
     </Stack>
-  </Stack>
-);
+  );
+};
 
 export interface Props {
   dashboard: DashboardModel | DashboardScene;
   canCreate: boolean;
 }
 
-// We pass the default empty UI through to the extension point so that the extension can conditionally render it if needed.
-// For example, an extension might want to render custom UI for a specific experiment cohort, and the default UI for everyone else.
 const DashboardEmpty = (props: Props) => {
   const { isReadOnlyRepo, isProvisioned } = useRepositoryStatus(props);
   const onAddVisualization = useOnAddVisualization({ ...props, isReadOnlyRepo, isProvisioned });
@@ -243,14 +110,9 @@ const DashboardEmpty = (props: Props) => {
     <DashboardEmptyExtensionPoint
       renderDefaultUI={useCallback(
         () => (
-          <InternalDashboardEmpty
-            dashboard={props.dashboard}
-            onAddVisualization={onAddVisualization}
-            onAddLibraryPanel={onAddLibraryPanel}
-            onImportDashboard={onImportDashboard}
-          />
+          <InternalDashboardEmpty dashboard={props.dashboard} onAddVisualization={onAddVisualization} />
         ),
-        [onAddVisualization, onAddLibraryPanel, onImportDashboard, props.dashboard]
+        [onAddVisualization, props.dashboard]
       )}
       onAddVisualization={onAddVisualization}
       onAddLibraryPanel={onAddLibraryPanel}
@@ -264,20 +126,57 @@ export default DashboardEmpty;
 function getStyles(theme: GrafanaTheme2) {
   return {
     wrapper: css({
-      label: 'dashboard-empty-wrapper',
+      display: 'flex',
       flexDirection: 'column',
-      gap: theme.spacing.gridSize * 4,
-      paddingTop: theme.spacing(2),
-
-      [theme.breakpoints.up('sm')]: {
-        paddingTop: theme.spacing(12),
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingTop: theme.spacing(12),
+      width: '100%',
+      maxWidth: '600px',
+    }),
+    sparkleCircle: css({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: '64px',
+      height: '64px',
+      borderRadius: theme.shape.radius.circle,
+      background: theme.colors.background.secondary,
+    }),
+    sparkleIcon: css({
+      color: theme.colors.primary.text,
+    }),
+    promptBar: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+      width: '100%',
+      padding: theme.spacing(0.5, 1),
+      borderRadius: theme.shape.radius.pill,
+      border: `1px solid ${theme.colors.border.medium}`,
+      background: theme.colors.background.primary,
+      [theme.transitions.handleMotion('no-preference')]: {
+        transition: theme.transitions.create('border-color'),
+      },
+      '&:focus-within': {
+        borderColor: theme.colors.primary.border,
       },
     }),
-    wrapperMaxWidth: css({
-      maxWidth: '890px',
+    promptInput: css({
+      flex: 1,
+      border: 'none',
+      outline: 'none',
+      background: 'transparent',
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.fontSize,
+      fontFamily: theme.typography.fontFamily,
+      padding: theme.spacing(1, 0),
+      '&::placeholder': {
+        color: theme.colors.text.disabled,
+      },
     }),
-    appsIcon: css({
-      fill: theme.v1.palette.orange,
+    promptButton: css({
+      flexShrink: 0,
     }),
   };
 }


### PR DESCRIPTION
Three aims:

- Make the empty state an AI input. Adding a panel, using a template or importing a dashboard are secondary options.
- Make the default edit pane behaviour an Assistant chat window. This should be a dedicated dashboard-specific chat pane which behaves like the current edit pane. There should be a toggle to allow users to revert back to the "manual" edit experience in the edit pane
   - If no panel is selected, it takes the whole dashboard as context
   - If a panel (or multiple panels) is selected, it takes those selected panels as context
   - If a dashboard control (e.g. variable) is selected, it takes those elements as context
- Improve the AI-editing animation
   - When creating a new dashboard, use some sort of moving image of a grid to convey that the whole dashboard is being created
   - When editing one or multiple elements, use a circle with moving colours to indicate that the AI magic is working on those panels 

----

Actual changes so far:

Introduce DashboardAIContextProvider that exposes dashboard metadata, panels, datasources, variables, and layout as assistant context items, and registers dashboard mutation functions (addPanel, removePanel, updatePanelQuery, setDashboardTitle, setDashboardDescription) via the assistant function namespace.

Update DashboardEditPane with an aiMode toggle, integrate the AI context provider into DashboardSceneRenderer, and replace the empty dashboard landing page with an AI-first prompt-based interface.
