### PR TITLE
Provisioning: Improve job processing logs with repository and connection context

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
@@ -254,6 +254,15 @@ func (r *Repository) Path() string {
 	return ""
 }
 
+// ConnectionName returns the name of the connection referenced by this repository,
+// or an empty string if the repository does not use a connection.
+func (r *Repository) ConnectionName() string {
+	if r.Spec.Connection != nil {
+		return r.Spec.Connection.Name
+	}
+	return ""
+}
+
 type ConnectionInfo struct {
 	Name string `json:"name"`
 }

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types_test.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types_test.go
@@ -6,6 +6,54 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 )
 
+func TestRepository_ConnectionName(t *testing.T) {
+	tests := []struct {
+		name string
+		repo v0alpha1.Repository
+		want string
+	}{
+		{
+			name: "no connection",
+			repo: v0alpha1.Repository{
+				Spec: v0alpha1.RepositorySpec{
+					Type: v0alpha1.GitHubRepositoryType,
+				},
+			},
+			want: "",
+		},
+		{
+			name: "with connection",
+			repo: v0alpha1.Repository{
+				Spec: v0alpha1.RepositorySpec{
+					Type: v0alpha1.GitHubRepositoryType,
+					Connection: &v0alpha1.ConnectionInfo{
+						Name: "my-github-connection",
+					},
+				},
+			},
+			want: "my-github-connection",
+		},
+		{
+			name: "local repository without connection",
+			repo: v0alpha1.Repository{
+				Spec: v0alpha1.RepositorySpec{
+					Type: v0alpha1.LocalRepositoryType,
+				},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.repo.ConnectionName()
+			if got != tt.want {
+				t.Errorf("ConnectionName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRepositoryType_IsGit(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/registry/apis/provisioning/jobs/delete/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/delete/worker.go
@@ -41,7 +41,7 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 		return errors.New("missing delete settings")
 	}
 
-	logger := logging.FromContext(ctx).With("job", job.GetName(), "namespace", job.GetNamespace())
+	logger := logging.FromContext(ctx)
 	opts := *job.Spec.Delete
 	paths := opts.Paths
 	start := time.Now()

--- a/pkg/registry/apis/provisioning/jobs/delete/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/delete/worker.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
@@ -41,7 +43,16 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 		return errors.New("missing delete settings")
 	}
 
-	logger := logging.FromContext(ctx)
+	logger := logging.FromContext(ctx).With("options", job.Spec.Delete)
+	ctx = logging.Context(ctx, logger)
+	ctx, span := tracing.Start(ctx, "provisioning.delete.process")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("delete.ref", job.Spec.Delete.Ref),
+		attribute.Int("delete.paths_count", len(job.Spec.Delete.Paths)),
+		attribute.Int("delete.resources_count", len(job.Spec.Delete.Resources)),
+	)
+
 	opts := *job.Spec.Delete
 	paths := opts.Paths
 	start := time.Now()

--- a/pkg/registry/apis/provisioning/jobs/delete/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/delete/worker.go
@@ -38,7 +38,7 @@ func (w *Worker) IsSupported(ctx context.Context, job provisioning.Job) bool {
 	return job.Spec.Action == provisioning.JobActionDelete
 }
 
-func (w *Worker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) error {
+func (w *Worker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) (processErr error) {
 	if job.Spec.Delete == nil {
 		return errors.New("missing delete settings")
 	}
@@ -46,7 +46,12 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 	logger := logging.FromContext(ctx).With("options", job.Spec.Delete)
 	ctx = logging.Context(ctx, logger)
 	ctx, span := tracing.Start(ctx, "provisioning.delete.process")
-	defer span.End()
+	defer func() {
+		if processErr != nil {
+			_ = tracing.Error(span, processErr)
+		}
+		span.End()
+	}()
 	span.SetAttributes(
 		attribute.String("delete.ref", job.Spec.Delete.Ref),
 		attribute.Int("delete.paths_count", len(job.Spec.Delete.Paths)),

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -242,9 +242,10 @@ func (d *jobDriver) claimAndProcessOneJob(ctx context.Context) error {
 	}()
 
 	// Save the finished job
-	err = d.historicJobs.WriteJob(ctx, d.currentJob.DeepCopy())
-	if err != nil {
+	if err = d.historicJobs.WriteJob(ctx, d.currentJob.DeepCopy()); err != nil {
 		logger.Warn("failed to write historic job", "error", err)
+	} else {
+		logger.Debug("historic job saved")
 	}
 
 	// Mark the job as completed.

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -367,9 +367,12 @@ func (d *jobDriver) processJob(ctx context.Context, recorder JobProgressRecorder
 
 		r := repo.Config()
 		connName := r.ConnectionName()
-		logger = logger.With("connection", connName)
+		logger = logger.With("connection", connName, "repository_type", r.Spec.Type)
 		ctx = logging.Context(ctx, logger)
-		span.SetAttributes(attribute.String("job.connection", connName))
+		span.SetAttributes(
+			attribute.String("job.connection", connName),
+			attribute.String("job.repository_type", string(r.Spec.Type)),
+		)
 
 		if r.DeletionTimestamp != nil && !r.DeletionTimestamp.IsZero() {
 			logger.Info("repository marked for deletion - skip job",

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -372,7 +372,7 @@ func (d *jobDriver) processJob(ctx context.Context, recorder JobProgressRecorder
 		ctx = logging.Context(ctx, logger)
 		span.SetAttributes(
 			attribute.String("job.connection", connName),
-			attribute.String("job.repository_type", string(r.Spec.Type)),
+			attribute.String("repository.type", string(r.Spec.Type)),
 		)
 
 		if r.DeletionTimestamp != nil && !r.DeletionTimestamp.IsZero() {

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -174,7 +174,7 @@ func (d *jobDriver) claimAndProcessOneJob(ctx context.Context) error {
 	defer rollback()
 
 	namespace := claimedJob.GetNamespace()
-	logger = logger.With("job", claimedJob.GetName(), "namespace", namespace, "repository", claimedJob.Spec.Repository)
+	logger = logger.With("job", claimedJob.GetName(), "namespace", namespace, "repository", claimedJob.Spec.Repository, "action", claimedJob.Spec.Action)
 	ctx = logging.Context(ctx, logger)
 	d.currentJob = claimedJob
 

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -366,10 +366,10 @@ func (d *jobDriver) processJob(ctx context.Context, recorder JobProgressRecorder
 		}
 
 		r := repo.Config()
-		if connName := r.ConnectionName(); connName != "" {
-			logger = logger.With("connection", connName)
-			ctx = logging.Context(ctx, logger)
-		}
+		connName := r.ConnectionName()
+		logger = logger.With("connection", connName)
+		ctx = logging.Context(ctx, logger)
+		span.SetAttributes(attribute.String("job.connection", connName))
 
 		if r.DeletionTimestamp != nil && !r.DeletionTimestamp.IsZero() {
 			logger.Info("repository marked for deletion - skip job",

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -174,7 +174,7 @@ func (d *jobDriver) claimAndProcessOneJob(ctx context.Context) error {
 	defer rollback()
 
 	namespace := claimedJob.GetNamespace()
-	logger = logger.With("job", claimedJob.GetName(), "namespace", namespace)
+	logger = logger.With("job", claimedJob.GetName(), "namespace", namespace, "repository", claimedJob.Spec.Repository)
 	ctx = logging.Context(ctx, logger)
 	d.currentJob = claimedJob
 
@@ -366,6 +366,11 @@ func (d *jobDriver) processJob(ctx context.Context, recorder JobProgressRecorder
 		}
 
 		r := repo.Config()
+		if connName := r.ConnectionName(); connName != "" {
+			logger = logger.With("connection", connName)
+			ctx = logging.Context(ctx, logger)
+		}
+
 		if r.DeletionTimestamp != nil && !r.DeletionTimestamp.IsZero() {
 			logger.Info("repository marked for deletion - skip job",
 				"name", r.Name,

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -376,8 +376,6 @@ func (d *jobDriver) processJob(ctx context.Context, recorder JobProgressRecorder
 
 		if r.DeletionTimestamp != nil && !r.DeletionTimestamp.IsZero() {
 			logger.Info("repository marked for deletion - skip job",
-				"name", r.Name,
-				"namespace", r.Namespace,
 				"deletionTimestamp", r.DeletionTimestamp,
 			)
 			return nil

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -208,12 +208,11 @@ func (d *jobDriver) claimAndProcessOneJob(ctx context.Context) error {
 
 	// Process the job with lease loss detection
 	err = d.processJobWithLeaseCheck(jobctx, recorder, leaseExpired)
-	end := time.Now()
-	logger.Debug("job processed", "duration", end.Sub(recorder.Started()), "error", err)
+	duration := time.Since(recorder.Started())
 
 	// Check if parent context was cancelled (graceful shutdown)
 	if ctx.Err() != nil {
-		logger.Debug("context cancel - job will retry")
+		logger.Warn("context cancelled - job will retry", "duration", duration)
 		// Don't complete the job - let it be retried by another worker
 		d.mu.Lock()
 		d.currentJob = nil
@@ -229,6 +228,9 @@ func (d *jobDriver) claimAndProcessOneJob(ctx context.Context) error {
 	// Record job processing error on span
 	if err != nil {
 		span.RecordError(err)
+		logger.Error("job failed", "duration", duration, "error", err)
+	} else {
+		logger.Info("job complete", "duration", duration)
 	}
 
 	// Complete the job
@@ -242,7 +244,6 @@ func (d *jobDriver) claimAndProcessOneJob(ctx context.Context) error {
 	// Save the finished job
 	err = d.historicJobs.WriteJob(ctx, d.currentJob.DeepCopy())
 	if err != nil {
-		// We're not going to return this as it is not critical. Not ideal, but not critical.
 		logger.Warn("failed to write historic job", "error", err)
 	}
 
@@ -251,7 +252,6 @@ func (d *jobDriver) claimAndProcessOneJob(ctx context.Context) error {
 		span.RecordError(err)
 		return apifmt.Errorf("failed to complete job '%s' in '%s': %w", d.currentJob.GetName(), d.currentJob.GetNamespace(), err)
 	}
-	logger.Info("job complete")
 
 	return nil
 }

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -368,7 +368,7 @@ func (d *jobDriver) processJob(ctx context.Context, recorder JobProgressRecorder
 
 		r := repo.Config()
 		connName := r.ConnectionName()
-		logger = logger.With("connection", connName, "repository_type", r.Spec.Type)
+		logger = logger.With("connection", connName, "repositoryType", r.Spec.Type)
 		ctx = logging.Context(ctx, logger)
 		span.SetAttributes(
 			attribute.String("job.connection", connName),

--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -59,7 +59,7 @@ func (r *ExportWorker) IsSupported(ctx context.Context, job provisioning.Job) bo
 }
 
 // Process will start a job
-func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) error {
+func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) (processErr error) {
 	if !r.enabled {
 		return fmt.Errorf("export functionality is disabled by configuration")
 	}
@@ -72,7 +72,12 @@ func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, 
 	logger := logging.FromContext(ctx).With("options", options)
 	ctx = logging.Context(ctx, logger)
 	ctx, span := tracing.Start(ctx, "provisioning.export.process")
-	defer span.End()
+	defer func() {
+		if processErr != nil {
+			_ = tracing.Error(span, processErr)
+		}
+		span.End()
+	}()
 	span.SetAttributes(
 		attribute.String("export.branch", options.Branch),
 		attribute.String("export.folder", options.Folder),

--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/grafana/grafana-app-sdk/logging"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
@@ -66,7 +69,16 @@ func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, 
 		return errors.New("missing export settings")
 	}
 
-	logger := logging.FromContext(ctx)
+	logger := logging.FromContext(ctx).With("options", options)
+	ctx = logging.Context(ctx, logger)
+	ctx, span := tracing.Start(ctx, "provisioning.export.process")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("export.branch", options.Branch),
+		attribute.String("export.folder", options.Folder),
+		attribute.String("export.path", options.Path),
+	)
+
 	start := time.Now()
 	outcome := utils.ErrorOutcome
 	resourcesExported := 0

--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -66,7 +66,7 @@ func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, 
 		return errors.New("missing export settings")
 	}
 
-	logger := logging.FromContext(ctx).With("job", job.GetName(), "namespace", job.GetNamespace())
+	logger := logging.FromContext(ctx)
 	start := time.Now()
 	outcome := utils.ErrorOutcome
 	resourcesExported := 0

--- a/pkg/registry/apis/provisioning/jobs/export/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker_test.go
@@ -145,9 +145,9 @@ func TestExportWorker_ProcessFailedToCreateClients(t *testing.T) {
 
 	mockClients := resources.NewMockClientFactory(t)
 
-	mockClients.On("Clients", context.Background(), "test-namespace").Return(nil, errors.New("failed to create clients"))
+	mockClients.On("Clients", mock.Anything, "test-namespace").Return(nil, errors.New("failed to create clients"))
 	mockStageFn := NewMockWrapWithStageFn(t)
-	mockStageFn.On("Execute", context.Background(), mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, cloneOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
+	mockStageFn.On("Execute", mock.Anything, mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, cloneOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(repo, true)
 	})
 
@@ -179,11 +179,11 @@ func TestExportWorker_ProcessNotReaderWriter(t *testing.T) {
 
 	resourceClients := resources.NewMockResourceClients(t)
 	mockClients := resources.NewMockClientFactory(t)
-	mockClients.On("Clients", context.Background(), "test-namespace").Return(resourceClients, nil)
+	mockClients.On("Clients", mock.Anything, "test-namespace").Return(resourceClients, nil)
 	mockProgress := jobs.NewMockJobProgressRecorder(t)
 
 	mockStageFn := NewMockWrapWithStageFn(t)
-	mockStageFn.On("Execute", context.Background(), mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, cloneOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
+	mockStageFn.On("Execute", mock.Anything, mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, cloneOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(repo, true)
 	})
 
@@ -213,14 +213,14 @@ func TestExportWorker_ProcessRepositoryResourcesError(t *testing.T) {
 
 	resourceClients := resources.NewMockResourceClients(t)
 	mockClients := resources.NewMockClientFactory(t)
-	mockClients.On("Clients", context.Background(), "test-namespace").Return(resourceClients, nil)
+	mockClients.On("Clients", mock.Anything, "test-namespace").Return(resourceClients, nil)
 
 	mockRepoResources := resources.NewMockRepositoryResourcesFactory(t)
-	mockRepoResources.On("Client", context.Background(), mockRepo).Return(nil, fmt.Errorf("failed to create repository resources client"))
+	mockRepoResources.On("Client", mock.Anything, mockRepo).Return(nil, fmt.Errorf("failed to create repository resources client"))
 
 	mockProgress := jobs.NewMockJobProgressRecorder(t)
 	mockStageFn := NewMockWrapWithStageFn(t)
-	mockStageFn.On("Execute", context.Background(), mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
+	mockStageFn.On("Execute", mock.Anything, mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(repo, true)
 	})
 	r := NewExportWorker(mockClients, mockRepoResources, nil, nil, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)

--- a/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/grafana/grafana-app-sdk/logging"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 )
 
@@ -24,18 +27,19 @@ func (w *Worker) IsSupported(_ context.Context, job provisioning.Job) bool {
 }
 
 func (w *Worker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) error {
-	logger := logging.FromContext(ctx)
-
-	// Get options, defaulting to empty if not provided
 	options := job.Spec.FixFolderMetadata
 	if options == nil {
 		options = &provisioning.FixFolderMetadataJobOptions{}
 	}
 
-	// Use the specified ref, or empty string to use repository's default branch
-	ref := options.Ref
+	logger := logging.FromContext(ctx).With("options", options)
+	ctx = logging.Context(ctx, logger)
+	ctx, span := tracing.Start(ctx, "provisioning.fixfoldermetadata.process")
+	defer span.End()
+	span.SetAttributes(attribute.String("fixfoldermetadata.ref", options.Ref))
 
-	logger.Info("starting folder metadata fix job", "ref", ref)
+	ref := options.Ref
+	logger.Info("starting folder metadata fix job")
 	if ref == "" {
 		progress.SetMessage(ctx, "Creating marker commit on default branch")
 	} else {

--- a/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker.go
@@ -24,7 +24,7 @@ func (w *Worker) IsSupported(_ context.Context, job provisioning.Job) bool {
 }
 
 func (w *Worker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) error {
-	logger := logging.FromContext(ctx).With("job", job.GetName(), "namespace", job.GetNamespace())
+	logger := logging.FromContext(ctx)
 
 	// Get options, defaulting to empty if not provided
 	options := job.Spec.FixFolderMetadata

--- a/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker.go
@@ -26,7 +26,7 @@ func (w *Worker) IsSupported(_ context.Context, job provisioning.Job) bool {
 	return job.Spec.Action == provisioning.JobActionFixFolderMetadata
 }
 
-func (w *Worker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) error {
+func (w *Worker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) (processErr error) {
 	options := job.Spec.FixFolderMetadata
 	if options == nil {
 		options = &provisioning.FixFolderMetadataJobOptions{}
@@ -35,7 +35,12 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 	logger := logging.FromContext(ctx).With("options", options)
 	ctx = logging.Context(ctx, logger)
 	ctx, span := tracing.Start(ctx, "provisioning.fixfoldermetadata.process")
-	defer span.End()
+	defer func() {
+		if processErr != nil {
+			_ = tracing.Error(span, processErr)
+		}
+		span.End()
+	}()
 	span.SetAttributes(attribute.String("fixfoldermetadata.ref", options.Ref))
 
 	ref := options.Ref

--- a/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker_test.go
@@ -63,26 +63,26 @@ func TestWorker_Process(t *testing.T) {
 		}
 
 		// Expect staging to be called with empty ref (repository determines default)
-		mockRepo.MockStageableRepository.EXPECT().Stage(ctx, mock.MatchedBy(func(opts repository.StageOptions) bool {
+		mockRepo.MockStageableRepository.EXPECT().Stage(mock.Anything, mock.MatchedBy(func(opts repository.StageOptions) bool {
 			return opts.Ref == "" &&
 				opts.Mode == repository.StageModeCommitOnlyOnce &&
 				strings.Contains(opts.CommitOnlyOnceMessage, "Fix folder metadata")
 		})).Return(mockStaged, nil)
 
 		// Expect a marker file to be written with empty ref
-		mockStaged.EXPECT().Write(ctx, mock.MatchedBy(func(path string) bool {
+		mockStaged.EXPECT().Write(mock.Anything, mock.MatchedBy(func(path string) bool {
 			return strings.HasPrefix(path, ".grafana/folder-metadata-fixed-")
 		}), "", mock.Anything, mock.Anything).Return(nil)
 
 		// Expect push to be called
-		mockStaged.EXPECT().Push(ctx).Return(nil)
+		mockStaged.EXPECT().Push(mock.Anything).Return(nil)
 
 		// Expect cleanup
-		mockStaged.EXPECT().Remove(ctx).Return(nil)
+		mockStaged.EXPECT().Remove(mock.Anything).Return(nil)
 
 		// Expect progress updates with "default branch" message
-		mockProgress.EXPECT().SetMessage(ctx, "Creating marker commit on default branch").Return()
-		mockProgress.EXPECT().SetFinalMessage(ctx, "Folder metadata fixed on default branch").Return()
+		mockProgress.EXPECT().SetMessage(mock.Anything, "Creating marker commit on default branch").Return()
+		mockProgress.EXPECT().SetFinalMessage(mock.Anything, "Folder metadata fixed on default branch").Return()
 
 		err := w.Process(ctx, mockRepo, job, mockProgress)
 		require.NoError(t, err)
@@ -114,22 +114,22 @@ func TestWorker_Process(t *testing.T) {
 		}
 
 		// Expect staging to be called with custom ref
-		mockRepo.MockStageableRepository.EXPECT().Stage(ctx, mock.MatchedBy(func(opts repository.StageOptions) bool {
+		mockRepo.MockStageableRepository.EXPECT().Stage(mock.Anything, mock.MatchedBy(func(opts repository.StageOptions) bool {
 			return opts.Ref == customRef
 		})).Return(mockStaged, nil)
 
 		// Expect a marker file to be written
-		mockStaged.EXPECT().Write(ctx, mock.Anything, customRef, mock.Anything, mock.Anything).Return(nil)
+		mockStaged.EXPECT().Write(mock.Anything, mock.Anything, customRef, mock.Anything, mock.Anything).Return(nil)
 
 		// Expect push to be called
-		mockStaged.EXPECT().Push(ctx).Return(nil)
+		mockStaged.EXPECT().Push(mock.Anything).Return(nil)
 
 		// Expect cleanup
-		mockStaged.EXPECT().Remove(ctx).Return(nil)
+		mockStaged.EXPECT().Remove(mock.Anything).Return(nil)
 
 		// Expect progress updates
-		mockProgress.EXPECT().SetMessage(ctx, fmt.Sprintf("Creating marker commit on branch %s", customRef)).Return()
-		mockProgress.EXPECT().SetFinalMessage(ctx, fmt.Sprintf("Folder metadata fixed on branch %s", customRef)).Return()
+		mockProgress.EXPECT().SetMessage(mock.Anything, fmt.Sprintf("Creating marker commit on branch %s", customRef)).Return()
+		mockProgress.EXPECT().SetFinalMessage(mock.Anything, fmt.Sprintf("Folder metadata fixed on branch %s", customRef)).Return()
 
 		err := w.Process(ctx, mockRepo, job, mockProgress)
 		require.NoError(t, err)
@@ -170,16 +170,16 @@ func TestWorker_Process(t *testing.T) {
 			NewPullRequestURL: "https://github.com/test/repo/compare/feature-branch",
 		}
 
-		mockRepo.MockStageableRepository.EXPECT().Stage(ctx, mock.Anything).Return(mockStaged, nil)
-		mockStaged.EXPECT().Write(ctx, mock.Anything, customRef, mock.Anything, mock.Anything).Return(nil)
-		mockStaged.EXPECT().Push(ctx).Return(nil)
-		mockStaged.EXPECT().Remove(ctx).Return(nil)
-		mockProgress.EXPECT().SetMessage(ctx, fmt.Sprintf("Creating marker commit on branch %s", customRef)).Return()
-		mockProgress.EXPECT().SetFinalMessage(ctx, fmt.Sprintf("Folder metadata fixed on branch %s", customRef)).Return()
+		mockRepo.MockStageableRepository.EXPECT().Stage(mock.Anything, mock.Anything).Return(mockStaged, nil)
+		mockStaged.EXPECT().Write(mock.Anything, mock.Anything, customRef, mock.Anything, mock.Anything).Return(nil)
+		mockStaged.EXPECT().Push(mock.Anything).Return(nil)
+		mockStaged.EXPECT().Remove(mock.Anything).Return(nil)
+		mockProgress.EXPECT().SetMessage(mock.Anything, fmt.Sprintf("Creating marker commit on branch %s", customRef)).Return()
+		mockProgress.EXPECT().SetFinalMessage(mock.Anything, fmt.Sprintf("Folder metadata fixed on branch %s", customRef)).Return()
 
 		// Expect RefURLs to be called with the custom ref and SetRefURLs to be called with the result
-		mockRepo.MockRepositoryWithURLs.EXPECT().RefURLs(ctx, customRef).Return(expectedURLs, nil)
-		mockProgress.EXPECT().SetRefURLs(ctx, expectedURLs).Return()
+		mockRepo.MockRepositoryWithURLs.EXPECT().RefURLs(mock.Anything, customRef).Return(expectedURLs, nil)
+		mockProgress.EXPECT().SetRefURLs(mock.Anything, expectedURLs).Return()
 
 		err := w.Process(ctx, mockRepo, job, mockProgress)
 		require.NoError(t, err)
@@ -208,15 +208,15 @@ func TestWorker_Process(t *testing.T) {
 		}
 
 		// Expect staging with empty ref (repository determines default)
-		mockRepo.MockStageableRepository.EXPECT().Stage(ctx, mock.MatchedBy(func(opts repository.StageOptions) bool {
+		mockRepo.MockStageableRepository.EXPECT().Stage(mock.Anything, mock.MatchedBy(func(opts repository.StageOptions) bool {
 			return opts.Ref == ""
 		})).Return(mockStaged, nil)
 
-		mockStaged.EXPECT().Write(ctx, mock.Anything, "", mock.Anything, mock.Anything).Return(nil)
-		mockStaged.EXPECT().Push(ctx).Return(nil)
-		mockStaged.EXPECT().Remove(ctx).Return(nil)
-		mockProgress.EXPECT().SetMessage(ctx, "Creating marker commit on default branch").Return()
-		mockProgress.EXPECT().SetFinalMessage(ctx, "Folder metadata fixed on default branch").Return()
+		mockStaged.EXPECT().Write(mock.Anything, mock.Anything, "", mock.Anything, mock.Anything).Return(nil)
+		mockStaged.EXPECT().Push(mock.Anything).Return(nil)
+		mockStaged.EXPECT().Remove(mock.Anything).Return(nil)
+		mockProgress.EXPECT().SetMessage(mock.Anything, "Creating marker commit on default branch").Return()
+		mockProgress.EXPECT().SetFinalMessage(mock.Anything, "Folder metadata fixed on default branch").Return()
 
 		err := w.Process(ctx, mockRepo, job, mockProgress)
 		require.NoError(t, err)

--- a/pkg/registry/apis/provisioning/jobs/loki_history.go
+++ b/pkg/registry/apis/provisioning/jobs/loki_history.go
@@ -67,7 +67,7 @@ func (h *LokiJobHistory) WriteJob(ctx context.Context, job *provisioning.Job) er
 	writeCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	logger.Debug("Saving job history to Loki", "namespace", jobCopy.Namespace, "repository", jobCopy.Spec.Repository, "job", jobCopy.Name)
+	logger.Debug("Saving job history to Loki")
 
 	if err := h.client.Push(writeCtx, []loki.Stream{stream}); err != nil {
 		logger.Error("Failed to save job history to Loki", "error", err)

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 
+	"github.com/grafana/grafana-app-sdk/logging"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 )
 
@@ -46,6 +48,11 @@ func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repositor
 	if options == nil {
 		return errors.New("missing migrate settings")
 	}
+
+	logger := logging.FromContext(ctx).With("options", options)
+	ctx = logging.Context(ctx, logger)
+	ctx, span := tracing.Start(ctx, "provisioning.migrate.process")
+	defer span.End()
 
 	progress.SetTotal(ctx, 10) // will show a progress bar
 	rw, ok := repo.(repository.ReaderWriter)

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker.go
@@ -39,7 +39,7 @@ func (w *MigrationWorker) IsSupported(ctx context.Context, job provisioning.Job)
 	return job.Spec.Action == provisioning.JobActionMigrate
 }
 
-func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) error {
+func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) (processErr error) {
 	if !w.enabled {
 		return errors.New("migrate functionality is disabled by configuration")
 	}
@@ -52,7 +52,12 @@ func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repositor
 	logger := logging.FromContext(ctx).With("options", options)
 	ctx = logging.Context(ctx, logger)
 	ctx, span := tracing.Start(ctx, "provisioning.migrate.process")
-	defer span.End()
+	defer func() {
+		if processErr != nil {
+			_ = tracing.Error(span, processErr)
+		}
+		span.End()
+	}()
 
 	progress.SetTotal(ctx, 10) // will show a progress bar
 	rw, ok := repo.(repository.ReaderWriter)

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker_test.go
@@ -181,7 +181,7 @@ func TestMigrationWorker_ConfigurationDisabled(t *testing.T) {
 
 			// Set up mock expectations for when enabled
 			if tt.enabled {
-				mockMigrator.On("Migrate", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockMigrator.On("Migrate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			}
 
 			// Create migration worker
@@ -207,7 +207,7 @@ func TestMigrationWorker_ConfigurationDisabled(t *testing.T) {
 
 			// Create mock progress recorder
 			progress := jobs.NewMockJobProgressRecorder(t)
-			progress.On("SetTotal", context.Background(), 10).Maybe()
+			progress.On("SetTotal", mock.Anything, 10).Maybe()
 
 			// Process the job
 			err := worker.Process(context.Background(), mockRepo, job, progress)

--- a/pkg/registry/apis/provisioning/jobs/move/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/move/worker.go
@@ -39,7 +39,7 @@ func (w *Worker) IsSupported(ctx context.Context, job provisioning.Job) bool {
 	return job.Spec.Action == provisioning.JobActionMove
 }
 
-func (w *Worker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) error {
+func (w *Worker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) (processErr error) {
 	if job.Spec.Move == nil {
 		return errors.New("missing move settings")
 	}
@@ -47,7 +47,12 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 	logger := logging.FromContext(ctx).With("options", job.Spec.Move)
 	ctx = logging.Context(ctx, logger)
 	ctx, span := tracing.Start(ctx, "provisioning.move.process")
-	defer span.End()
+	defer func() {
+		if processErr != nil {
+			_ = tracing.Error(span, processErr)
+		}
+		span.End()
+	}()
 	span.SetAttributes(
 		attribute.String("move.ref", opts.Ref),
 		attribute.String("move.target_path", opts.TargetPath),

--- a/pkg/registry/apis/provisioning/jobs/move/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/move/worker.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
@@ -42,7 +44,17 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 		return errors.New("missing move settings")
 	}
 	opts := *job.Spec.Move
-	logger := logging.FromContext(ctx)
+	logger := logging.FromContext(ctx).With("options", job.Spec.Move)
+	ctx = logging.Context(ctx, logger)
+	ctx, span := tracing.Start(ctx, "provisioning.move.process")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("move.ref", opts.Ref),
+		attribute.String("move.target_path", opts.TargetPath),
+		attribute.Int("move.paths_count", len(opts.Paths)),
+		attribute.Int("move.resources_count", len(opts.Resources)),
+	)
+
 	outcome := utils.ErrorOutcome
 	start := time.Now()
 	resourcesMoved := 0

--- a/pkg/registry/apis/provisioning/jobs/move/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/move/worker.go
@@ -42,7 +42,7 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 		return errors.New("missing move settings")
 	}
 	opts := *job.Spec.Move
-	logger := logging.FromContext(ctx).With("job", job.GetName(), "namespace", job.GetNamespace())
+	logger := logging.FromContext(ctx)
 	outcome := utils.ErrorOutcome
 	start := time.Now()
 	resourcesMoved := 0

--- a/pkg/registry/apis/provisioning/jobs/sync/sync.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/sync.go
@@ -69,7 +69,7 @@ func (r *syncer) Sync(ctx context.Context, repo repository.ReaderWriter, options
 		}
 
 		if quotas.IsQuotaExceeded(cfg.Status.Conditions) {
-			logger.Info("repository is over quota, running full sync", "repository", cfg.Name)
+			logger.Info("repository is over quota, running full sync")
 		}
 	}
 	progress.SetMessage(ctx, "full sync")

--- a/pkg/registry/apis/provisioning/jobs/sync/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker.go
@@ -70,7 +70,7 @@ func (r *SyncWorker) IsSupported(ctx context.Context, job provisioning.Job) bool
 
 func (r *SyncWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) error {
 	cfg := repo.Config()
-	logger := logging.FromContext(ctx).With("job", job.GetName(), "namespace", job.GetNamespace())
+	logger := logging.FromContext(ctx)
 	ctx, span := r.tracer.Start(ctx, "provisioning.sync.process",
 		trace.WithAttributes(
 			attribute.String("job.name", job.GetName()),

--- a/pkg/registry/apis/provisioning/jobs/sync/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker.go
@@ -70,7 +70,8 @@ func (r *SyncWorker) IsSupported(ctx context.Context, job provisioning.Job) bool
 
 func (r *SyncWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) error {
 	cfg := repo.Config()
-	logger := logging.FromContext(ctx)
+	logger := logging.FromContext(ctx).With("options", job.Spec.Pull)
+	ctx = logging.Context(ctx, logger)
 	ctx, span := r.tracer.Start(ctx, "provisioning.sync.process",
 		trace.WithAttributes(
 			attribute.String("job.name", job.GetName()),
@@ -78,6 +79,7 @@ func (r *SyncWorker) Process(ctx context.Context, repo repository.Repository, jo
 			attribute.String("job.action", string(job.Spec.Action)),
 			attribute.String("repository.name", cfg.Name),
 			attribute.String("repository.namespace", cfg.Namespace),
+			attribute.Bool("sync.incremental", job.Spec.Pull != nil && job.Spec.Pull.Incremental),
 		),
 	)
 	defer span.End()

--- a/pkg/registry/apis/provisioning/jobs/sync/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker.go
@@ -183,7 +183,7 @@ func (r *SyncWorker) Process(ctx context.Context, repo repository.Repository, jo
 		syncStatus.LastRef = currentRef
 	} else {
 		if isQuotaWarning {
-			logger.Info("repository is over quota, preserving lastRef", "repository", cfg.Name)
+			logger.Info("repository is over quota, preserving lastRef")
 		}
 		syncStatus.LastRef = lastRef
 	}

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
@@ -98,7 +98,7 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 		return apierrors.NewBadRequest("missing spec.pr")
 	}
 
-	logger := logging.FromContext(ctx).With("pr", opts.PR, "repo", repo.Config().GetName(), "namespace", job.GetNamespace())
+	logger := logging.FromContext(ctx).With("pr", opts.PR)
 
 	if opts.Ref == "" {
 		logger.Debug("missing spec.ref")

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
@@ -86,7 +86,7 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 	repo repository.Repository,
 	job provisioning.Job,
 	progress jobs.JobProgressRecorder,
-) error {
+) (processErr error) {
 	cfg := repo.Config().Spec
 	opts := job.Spec.PullRequest
 	startTime := time.Now()
@@ -103,7 +103,12 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 	logger := logging.FromContext(ctx).With("options", opts)
 	ctx = logging.Context(ctx, logger)
 	ctx, span := tracing.Start(ctx, "provisioning.pullrequest.process")
-	defer span.End()
+	defer func() {
+		if processErr != nil {
+			_ = tracing.Error(span, processErr)
+		}
+		span.End()
+	}()
 	span.SetAttributes(
 		attribute.Int("pr.number", opts.PR),
 		attribute.String("pr.ref", opts.Ref),

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
@@ -98,7 +100,15 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 		return apierrors.NewBadRequest("missing spec.pr")
 	}
 
-	logger := logging.FromContext(ctx).With("pr", opts.PR)
+	logger := logging.FromContext(ctx).With("options", opts)
+	ctx = logging.Context(ctx, logger)
+	ctx, span := tracing.Start(ctx, "provisioning.pullrequest.process")
+	defer span.End()
+	span.SetAttributes(
+		attribute.Int("pr.number", opts.PR),
+		attribute.String("pr.ref", opts.Ref),
+		attribute.String("pr.hash", opts.Hash),
+	)
 
 	if opts.Ref == "" {
 		logger.Debug("missing spec.ref")


### PR DESCRIPTION
Part: https://github.com/grafana/git-ui-sync-project/issues/940

## Summary

Improve job processing observability by enriching logs and traces with consistent context fields across all job types.

### Logger context (all job logs now include)

- `namespace` -- already present, unchanged
- `repository` -- added at claim time from job spec
- `action` -- added at claim time from job spec
- `connection` -- added after repo fetch (empty string if not applicable)
- `repositoryType` -- added after repo fetch (e.g. github, git, local)

### Job options logging

Each worker now logs its full options object as a single `options` field:
- **sync**: `SyncJobOptions` (incremental)
- **export**: `ExportJobOptions` (branch, folder, path, message)
- **delete**: `DeleteJobOptions` (ref, paths, resources)
- **move**: `MoveJobOptions` (ref, targetPath, paths, resources)
- **fix-folder-metadata**: `FixFolderMetadataJobOptions` (ref)
- **migrate**: `MigrateJobOptions` (message)
- **pull-request**: `PullRequestJobOptions` (pr, ref, hash, url)

### Tracing improvements

- Added `repository.type` and `job.connection` span attributes in the job driver
- Added dedicated trace spans to workers that were missing them: export, delete, move, fix-folder-metadata, migrate, pull-request
- All new spans record errors via `tracing.Error` (sets span status + exception) using named returns and deferred closures
- Added relevant job option attributes to each worker span

### Log level fixes

- **"job processed"** was `Debug` with unconditional `error=<nil>` on success. Replaced with `Error` "job failed" (with error) on failure and `Info` "job complete" (with duration) on success
- **"context cancelled - job will retry"** promoted from `Debug` to `Warn`
- Added `Debug` "historic job saved" to confirm history writes

### Cleanup

- Removed redundant `job`/`namespace`/`repository` fields from individual worker loggers and log call sites (already in context from driver)
- Added `Repository.ConnectionName()` helper method to v0alpha1 types with unit tests

## Test plan

- [x] `go test ./apps/provisioning/pkg/apis/provisioning/v0alpha1/...` passes
- [x] `go build ./pkg/registry/apis/provisioning/jobs/...` compiles
- [x] `go build ./pkg/registry/apis/provisioning/webhooks/...` compiles
- [x] Verify logs in a running instance show all context fields
- [x] Verify traces show error status on failed jobs