### PR TITLE
Provisioning: enrich repository controller logs with structured context fields

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
@@ -194,15 +194,6 @@ func (r *Repository) Branch() string {
 	return ""
 }
 
-// ConnectionName returns the connection name if the repository references one,
-// or an empty string otherwise.
-func (r *Repository) ConnectionName() string {
-	if r.Spec.Connection != nil {
-		return r.Spec.Connection.Name
-	}
-	return ""
-}
-
 // URL returns the URL for git-based repositories
 // or an empty string for local repositories
 func (r *Repository) URL() string {

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
@@ -194,6 +194,15 @@ func (r *Repository) Branch() string {
 	return ""
 }
 
+// ConnectionName returns the connection name if the repository references one,
+// or an empty string otherwise.
+func (r *Repository) ConnectionName() string {
+	if r.Spec.Connection != nil {
+		return r.Spec.Connection.Name
+	}
+	return ""
+}
+
 // URL returns the URL for git-based repositories
 // or an empty string for local repositories
 func (r *Repository) URL() string {

--- a/pkg/registry/apis/provisioning/controller/health.go
+++ b/pkg/registry/apis/provisioning/controller/health.go
@@ -236,7 +236,7 @@ func (hc *RepositoryHealthChecker) RefreshTimestamp(ctx context.Context, repo *p
 // refreshHealth performs a comprehensive health check
 // Returns test results, health status, and any error
 func (hc *RepositoryHealthChecker) refreshHealth(ctx context.Context, repo repository.Repository, existingStatus provisioning.HealthStatus) (*provisioning.TestResults, provisioning.HealthStatus, error) {
-	logger := logging.FromContext(ctx).With("repo", repo.Config().GetName(), "namespace", repo.Config().GetNamespace())
+	logger := logging.FromContext(ctx)
 	start := time.Now()
 	outcome := utils.SuccessOutcome
 	defer func() {

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -235,8 +235,8 @@ func (rc *RepositoryController) processNextWorkItem(ctx context.Context) bool {
 	}
 	defer rc.queue.Done(item)
 
-	// TODO: should we move tracking work to trace ids instead?
-	logger := logging.FromContext(ctx).With("work_key", item.key)
+	namespace, name, _ := cache.SplitMetaNamespaceKey(item.key)
+	logger := logging.FromContext(ctx).With("work_key", item.key, "namespace", namespace, "repository", name)
 	logger.Info("RepositoryController processing key")
 
 	err := rc.processFn(item)
@@ -414,10 +414,7 @@ func (rc *RepositoryController) determineSyncStrategy(
 		logger.Info("skip sync as it's disabled")
 		return nil
 	case isBlocked:
-		logger.Info("skip sync for repository over quota",
-			"repository", obj.Name,
-			"namespace", obj.Namespace,
-		)
+		logger.Info("skip sync for repository over quota")
 		return nil
 	case !healthStatus.Healthy:
 		logger.Info("skip sync for unhealthy repository")
@@ -572,6 +569,14 @@ func (rc *RepositoryController) process(item *queueItem) error {
 		return err
 	}
 
+	logger = logger.With(
+		"namespace", namespace,
+		"repository", name,
+		"repositoryType", string(obj.Spec.Type),
+		"connection", obj.ConnectionName(),
+	)
+	ctx = logging.Context(ctx, logger)
+
 	ctx, _, err = identity.WithProvisioningIdentity(ctx, namespace)
 	if err != nil {
 		return err
@@ -618,7 +623,7 @@ func (rc *RepositoryController) process(item *queueItem) error {
 	case isCurrentlyBlocked && isOverQuota:
 		logger.Info("repository blocked and over quota, reconciling but skipping sync")
 	case !isCurrentlyBlocked && isOverQuota:
-		logger.Info("namespace over quota, blocking repository", "namespace", namespace, "max_repositories", newQuota.MaxRepositories)
+		logger.Info("namespace over quota, blocking repository", "max_repositories", newQuota.MaxRepositories)
 	case hasSpecChanged:
 		logger.Info("spec changed", "Generation", obj.Generation, "ObservedGeneration", obj.Status.ObservedGeneration)
 	case shouldResync:
@@ -656,23 +661,17 @@ func (rc *RepositoryController) process(item *queueItem) error {
 	}
 
 	if shouldGenerateToken {
-		logger.Info("updating token for repository", "connection", obj.Spec.Connection.Name)
+		logger.Info("updating token for repository")
 
 		c, err := rc.client.Connections(obj.Namespace).Get(ctx, obj.Spec.Connection.Name, v1.GetOptions{})
 		if err != nil {
-			logger.Error("retrieving connection",
-				"connection", obj.Spec.Connection.Name,
-				"error", err,
-			)
+			logger.Error("retrieving connection", "error", err)
 			return err
 		}
 
 		token, tokenOps, err := rc.generateRepositoryToken(ctx, obj, c)
 		if err != nil {
-			logger.Error("generating token for repository",
-				"connection", obj.Spec.Connection.Name,
-				"error", err,
-			)
+			logger.Error("generating token for repository", "error", err)
 			return err
 		}
 


### PR DESCRIPTION
## Summary

- Enriches the repository controller logger with `namespace`, `repository`, `repositoryType`, and `connection` fields after the repository object is fetched, so all downstream log calls (health checks, sync strategy, hooks, token generation) inherit structured context.
- Adds `namespace` and `repository` to `processNextWorkItem` logger so retry/error logs also have structured context.
- Removes redundant field arguments from ~7 downstream log sites that were manually passing fields already present in the logger context (e.g., `"connection"` in token logs, `"namespace"` in quota logs, `"repo"`/`"namespace"` in health checks).
- Adds `ConnectionName()` helper method to the `Repository` type for consistent connection name access.

Companion to #119312 which did the same for the job driver.

## Test plan

- [x] `go build ./pkg/registry/apis/provisioning/controller/...` passes
- [x] `go test ./pkg/registry/apis/provisioning/controller/...` passes
- [x] Verify log output in dev environment includes new structured fields