### PR TITLE
Provisioning: enrich connection controller logs with structured context fields

### DIFF
--- a/pkg/registry/apis/provisioning/controller/connection.go
+++ b/pkg/registry/apis/provisioning/controller/connection.go
@@ -132,7 +132,8 @@ func (cc *ConnectionController) processNextWorkItem(ctx context.Context) bool {
 	}
 	defer cc.queue.Done(item)
 
-	logger := logging.FromContext(ctx).With("work_key", item.key)
+	namespace, name, _ := cache.SplitMetaNamespaceKey(item.key)
+	logger := logging.FromContext(ctx).With("work_key", item.key, "namespace", namespace, "connection", name)
 	logger.Info("ConnectionController processing key")
 
 	err := cc.process(ctx, item)
@@ -183,7 +184,8 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 		return err
 	}
 
-	logger = logger.With("connection", conn.Name, "namespace", conn.Namespace)
+	logger = logger.With("namespace", namespace, "connection", name)
+	ctx = logging.Context(ctx, logger)
 
 	// Skip if being deleted
 	if conn.DeletionTimestamp != nil {

--- a/pkg/registry/apis/provisioning/controller/connection_health.go
+++ b/pkg/registry/apis/provisioning/controller/connection_health.go
@@ -163,7 +163,7 @@ func (hc *ConnectionHealthChecker) RefreshHealthWithPatchOps(ctx context.Context
 // refreshHealth performs a comprehensive health check
 // Returns test results, health status, and any error
 func (hc *ConnectionHealthChecker) refreshHealth(ctx context.Context, conn *provisioning.Connection, existingStatus provisioning.HealthStatus) (*provisioning.TestResults, provisioning.HealthStatus, error) {
-	logger := logging.FromContext(ctx).With("connection", conn.GetName(), "namespace", conn.GetNamespace())
+	logger := logging.FromContext(ctx)
 	start := time.Now()
 	outcome := utils.SuccessOutcome
 	defer func() {


### PR DESCRIPTION
## Summary

- Enriches the connection controller logger with `namespace` and `connection` fields after the connection object is fetched, so all downstream log calls (health checks, token refresh) inherit structured context.
- Adds `namespace` and `connection` to `processNextWorkItem` logger so retry/error logs also have structured context.
- Propagates the enriched logger via `logging.Context(ctx, logger)` so downstream functions receive context fields automatically.
- Removes redundant `"connection"` and `"namespace"` fields from the connection health checker's `refreshHealth` logger, since they are now inherited from context.

Companion to #119312 (job driver) and #119495 (repository controller).

## Test plan

- [x] `go build ./pkg/registry/apis/provisioning/controller/...` passes
- [x] `go test ./pkg/registry/apis/provisioning/controller/...` passes
- [ ] Verify log output in dev environment includes new structured fields

Made with [Cursor](https://cursor.com)