### PR TITLE
Graphite: Correctly set name for metric name variable queries

### DIFF
--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -10,6 +10,7 @@ import {
   DataQueryResponse,
   dateMath,
   dateTime,
+  FieldType,
   getFrameDisplayName,
   MetricFindValue,
   PluginType,
@@ -1577,6 +1578,52 @@ describe('graphiteDatasource', () => {
       expect(requestOptions.url).toBe('/api/datasources/proxy/1/render');
       expect(data[0].text).toBe('apps.backend.backend_01');
       expect(data[1].text).toBe('apps.backend.backend_02');
+    });
+
+    it('should return metric names when queryType is GraphiteQueryType.MetricName in backend mode', async () => {
+      config.featureToggles.graphiteBackendMode = true;
+
+      const backendResponse: DataQueryResponse = {
+        data: [
+          {
+            fields: [
+              { name: 'time', type: FieldType.time, values: [1, 2], config: {} },
+              {
+                name: 'value',
+                type: FieldType.number,
+                values: [10, 12],
+                config: { displayNameFromDS: 'apps.backend.backend_01' },
+              },
+            ],
+            length: 2,
+          },
+          {
+            fields: [
+              { name: 'time', type: FieldType.time, values: [1, 2], config: {} },
+              {
+                name: 'value',
+                type: FieldType.number,
+                values: [10, 12],
+                config: { displayNameFromDS: 'apps.backend.backend_02' },
+              },
+            ],
+            length: 2,
+          },
+        ],
+      };
+      jest.spyOn(ctx.ds, 'query').mockReturnValue(of(backendResponse));
+
+      const variableQuery: GraphiteQuery = {
+        queryType: GraphiteQueryType.MetricName,
+        target: 'apps.backend.*',
+        refId: 'A',
+        datasource: ctx.ds,
+      };
+      const data = await ctx.ds.metricFindQuery(variableQuery);
+      expect(data[0].text).toBe('apps.backend.backend_01');
+      expect(data[1].text).toBe('apps.backend.backend_02');
+
+      config.featureToggles.graphiteBackendMode = false;
     });
   });
 

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -768,11 +768,19 @@ export class GraphiteDatasource
           expandable: false,
         }));
     } else if (queryType === GraphiteQueryType.MetricName) {
-      result = data.data.map((series) => ({
-        text: series.name,
-        value: series.name,
-        expandable: false,
-      }));
+      if (config.featureToggles.graphiteBackendMode) {
+        result = data.data.map((series: DataFrame) => {
+          const valueField = series.fields.find((f) => f.name === 'value');
+          const name = valueField?.config.displayNameFromDS || '';
+          return { text: name, value: name, expandable: false };
+        });
+      } else {
+        result = data.data.map((series) => ({
+          text: series.name,
+          value: series.name,
+          expandable: false,
+        }));
+      }
     } else {
       result = [];
     }


### PR DESCRIPTION
Graphite metric name queries that run through the backend need to have the series name utilised correctly as data frame construction has changed.

This PR fixes the setting of the `text` and `value` fields by using the `displayNameFromDS` value.

Fixes #119497