### PR TITLE
Fix pkgs-with-tests-named.sh matching tests from subdirectories

### DIFF
--- a/.github/actions/change-detection/action.yml
+++ b/.github/actions/change-detection/action.yml
@@ -78,6 +78,7 @@ runs:
             - '.github/actions/change-detection/**'
             - '**.cue'
             - 'devenv/docker/blocks/*_tests/**'
+            - 'scripts/ci/backend-tests/**'
             - 'kindsv2/**'
             - '${{ inputs.self }}'
           frontend:

--- a/scripts/ci/backend-tests/pkgs-with-tests-named.sh
+++ b/scripts/ci/backend-tests/pkgs-with-tests-named.sh
@@ -60,7 +60,7 @@ fi
 readarray -t PACKAGES <<< "$(go list -f '{{.Dir}}' -e "${dirs[@]}")"
 
 for i in "${!PACKAGES[@]}"; do
-    readarray -t PKG_FILES <<< "$(find "${PACKAGES[$i]}" -type f -name '*_test.go')"
+    readarray -t PKG_FILES <<< "$(find "${PACKAGES[$i]}" -maxdepth 1 -type f -name '*_test.go')"
     if [ ${#PKG_FILES[@]} -eq 0 ] || [ ${#PKG_FILES[@]} -eq 1 ] && [ -z "${PKG_FILES[0]}" ]; then
         unset "PACKAGES[$i]"
         continue


### PR DESCRIPTION
## Summary
- `scripts/ci/backend-tests/pkgs-with-tests-named.sh` uses `find` to locate `*_test.go` files for each package, but `find` is recursive by default
- This causes packages to be incorrectly included in results when the matching test function (e.g. `TestIntegration*`) only exists in a subdirectory package
- For example, `pkg/extensions/apiserver/registry/iam/globalrole` was included because `TestIntegration*` functions exist in its `legacy/` subdirectory, not in the package itself
- Fix: add `-maxdepth 1` to the `find` command to match Go's package semantics (only files in the same directory belong to a package)

## Test plan
- [x] Run `./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration` and verify `globalrole` no longer appears (its `legacy/` subdirectory should still appear)
- [x] Verify the script still correctly finds packages that do have matching test functions