### PR TITLE
Barchart: auto-calculate time axis label spacing to prevent overlap

### DIFF
--- a/public/app/plugins/panel/barchart/bars.ts
+++ b/public/app/plugins/panel/barchart/bars.ts
@@ -10,7 +10,7 @@ import {
   VizLegendOptions,
 } from '@grafana/schema';
 import { measureText } from '@grafana/ui';
-import { timeUnitSize, StackingGroup, preparePlotData2 } from '@grafana/ui/internal';
+import { UPLOT_AXIS_FONT_SIZE, timeUnitSize, StackingGroup, preparePlotData2 } from '@grafana/ui/internal';
 
 const intervals = systemDateFormats.interval;
 
@@ -150,11 +150,10 @@ export function getConfig(opts: BarsOptions, theme: GrafanaTheme2) {
   const xSplits: Axis.Splits | undefined = (u) => Array.from(u.data[0].map((v, i) => i));
 
   const hFilter: Axis.Filter | undefined =
-    xSpacing === 0
+    xSpacing === 0 && !opts.xTimeAuto
       ? undefined
       : (u, splits) => {
-          // hSpacing?
-          const dim = u.bbox.width;
+          const dim = isXHorizontal ? u.bbox.width : u.bbox.height;
           const _dir = dir * (isXHorizontal ? 1 : -1);
 
           let dataLen = splits.length;
@@ -163,12 +162,47 @@ export function getConfig(opts: BarsOptions, theme: GrafanaTheme2) {
           let skipMod = 0;
 
           let cssDim = dim / uPlot.pxRatio;
-          let maxTicks = Math.abs(Math.floor(cssDim / xSpacing));
+
+          let effectiveSpacing = xSpacing;
+
+          // when xSpacing is 0 (default) and data is time-based, auto-calculate
+          // minimum spacing from actual label width to prevent overlapping labels
+          if (effectiveSpacing === 0 && opts.xTimeAuto) {
+            const data = u.data[0];
+            const timeRange = (data[data.length - 1] ?? 0) - (data[0] ?? 0);
+            const approxIncr = dataLen > 1 ? timeRange / (dataLen - 1) : timeRange;
+
+            let format = intervals.year;
+            if (approxIncr < timeUnitSize.second) {
+              format = intervals.millisecond;
+            } else if (approxIncr < timeUnitSize.minute) {
+              format = intervals.second;
+            } else if (approxIncr < timeUnitSize.hour) {
+              format = intervals.minute;
+            } else if (approxIncr < timeUnitSize.day) {
+              format = intervals.hour;
+            } else if (approxIncr < timeUnitSize.month) {
+              format = intervals.day;
+            } else if (approxIncr < timeUnitSize.year) {
+              format = intervals.month;
+            }
+
+            if (isXHorizontal) {
+              const sampleLabel = dateTimeFormat(data[data.length - 1] ?? Date.now(), { format, timeZone });
+              const labelWidth = measureText(sampleLabel, UPLOT_AXIS_FONT_SIZE).width;
+              effectiveSpacing = labelWidth + 18;
+            } else {
+              // vertical axis: labels stack top-to-bottom, spacing is driven by font height not text width
+              effectiveSpacing = UPLOT_AXIS_FONT_SIZE + 8;
+            }
+          }
+
+          let maxTicks = Math.abs(Math.floor(cssDim / effectiveSpacing));
 
           skipMod = dataLen < maxTicks ? 0 : Math.ceil(dataLen / maxTicks);
 
           let splits2 = splits.map((v, i) => {
-            let shouldSkip = skipMod !== 0 && (xSpacing > 0 ? i : lastIdx - i) % skipMod > 0;
+            let shouldSkip = skipMod !== 0 && (effectiveSpacing > 0 ? i : lastIdx - i) % skipMod > 0;
             return shouldSkip ? null : v;
           });
 

--- a/public/app/plugins/panel/barchart/utils.test.ts
+++ b/public/app/plugins/panel/barchart/utils.test.ts
@@ -259,4 +259,131 @@ describe('BarChart utils', () => {
       expect(info.series[0].fields[2].config.unit).toBeUndefined();
     });
   });
+
+  describe('auto-spacing for time axis labels', () => {
+    function makeTimeFrame(timestamps: number[], fieldConfig?: { unit?: string }) {
+      const df = new MutableDataFrame({
+        refId: 'A',
+        fields: [
+          { name: 'time', type: FieldType.time, values: timestamps, config: fieldConfig ?? {} },
+          { name: 'value', type: FieldType.number, values: timestamps.map((_, i) => (i + 1) * 10) },
+        ],
+      });
+      df.fields.forEach((f) => (f.config.custom = f.config.custom ?? {}));
+      return df;
+    }
+
+    function getXAxisFilter(opts: { timestamps?: number[]; xTickLabelSpacing?: number; orientation?: VizOrientation; timeFieldConfig?: { unit?: string }; fieldType?: FieldType }) {
+      const isString = opts.fieldType === FieldType.string;
+      const df = isString
+        ? (() => {
+            const d = new MutableDataFrame({
+              refId: 'A',
+              fields: [
+                { name: 'category', type: FieldType.string, values: (opts.timestamps ?? []).map((_, i) => `cat${i}`) },
+                { name: 'value', type: FieldType.number, values: (opts.timestamps ?? []).map((_, i) => (i + 1) * 10) },
+              ],
+            });
+            d.fields.forEach((f) => (f.config.custom = f.config.custom ?? {}));
+            return d;
+          })()
+        : makeTimeFrame(opts.timestamps ?? [1609459200000, 1609545600000, 1609632000000], opts.timeFieldConfig);
+
+      const info = prepSeries([df], fieldConfig, StackingMode.None, createTheme());
+      const result = prepConfig({
+        ...config,
+        options: { ...config.options, xTickLabelSpacing: opts.xTickLabelSpacing ?? 0 },
+        series: info.series,
+        orientation: opts.orientation ?? VizOrientation.Auto,
+      }).builder.getConfig();
+
+      return result.axes![0].filter as ((self: any, splits: number[]) => (number | null)[]) | undefined;
+    }
+
+    // Mock uPlot instance for invoking the filter function directly
+    function mockUPlot(data: number[][], bboxWidth: number, bboxHeight: number) {
+      return { data, bbox: { width: bboxWidth, height: bboxHeight } };
+    }
+
+    it('should produce a filter when xTickLabelSpacing is 0 and field is time without time: unit', () => {
+      const filter = getXAxisFilter({});
+      expect(filter).toBeDefined();
+    });
+
+    it('should not produce a filter when time field has time: unit prefix', () => {
+      const filter = getXAxisFilter({ timeFieldConfig: { unit: 'time:YYYY-MM-DD' } });
+      expect(filter).toBeUndefined();
+    });
+
+    it('should not produce a filter for string fields with xTickLabelSpacing 0', () => {
+      const filter = getXAxisFilter({ fieldType: FieldType.string, timestamps: [1, 2, 3] });
+      expect(filter).toBeUndefined();
+    });
+
+    it('should produce a filter for both horizontal and vertical bar orientations', () => {
+      const hFilter = getXAxisFilter({ orientation: VizOrientation.Vertical });
+      const vFilter = getXAxisFilter({ orientation: VizOrientation.Horizontal });
+      expect(hFilter).toBeDefined();
+      expect(vFilter).toBeDefined();
+    });
+
+    it('should keep all ticks when chart is wide enough to fit them', () => {
+      // 3 daily timestamps — labels are short (e.g. "01/01"), chart is very wide
+      const timestamps = [1609459200000, 1609545600000, 1609632000000];
+      const filter = getXAxisFilter({ timestamps })!;
+      const splits = [0, 1, 2];
+      const u = mockUPlot([timestamps], 2000, 400);
+
+      const result = filter(u, splits);
+      // All ticks should be kept (no nulls) when there's plenty of space
+      expect(result.filter((v) => v !== null)).toHaveLength(3);
+    });
+
+    it('should skip ticks when chart is too narrow to fit all labels', () => {
+      // Generate many daily timestamps so labels must overlap on a narrow chart
+      const dayMs = 24 * 60 * 60 * 1000;
+      const start = 1609459200000; // 2021-01-01
+      const timestamps = Array.from({ length: 30 }, (_, i) => start + i * dayMs);
+      const filter = getXAxisFilter({ timestamps })!;
+
+      const splits = timestamps.map((_, i) => i);
+      // 100px is far too narrow for 30 day-level labels
+      const u = mockUPlot([timestamps], 100, 400);
+
+      const result = filter(u, splits);
+      const keptTicks = result.filter((v) => v !== null);
+      // Some ticks must be filtered out
+      expect(keptTicks.length).toBeGreaterThan(0);
+      expect(keptTicks.length).toBeLessThan(timestamps.length);
+    });
+
+    it('should use font-height-based spacing for vertical axis (horizontal bars)', () => {
+      // With horizontal bars, the x-axis is vertical — spacing is based on font height not label width.
+      // A narrow bbox height should still cause tick skipping with enough data points.
+      const dayMs = 24 * 60 * 60 * 1000;
+      const start = 1609459200000;
+      const timestamps = Array.from({ length: 20 }, (_, i) => start + i * dayMs);
+      const filter = getXAxisFilter({ timestamps, orientation: VizOrientation.Horizontal })!;
+
+      const splits = timestamps.map((_, i) => i);
+      // Vertical axis: bbox.height is the relevant dimension; make it small
+      const u = mockUPlot([timestamps], 400, 80);
+
+      const result = filter(u, splits);
+      const keptTicks = result.filter((v) => v !== null);
+      expect(keptTicks.length).toBeGreaterThan(0);
+      expect(keptTicks.length).toBeLessThan(timestamps.length);
+    });
+
+    it('should handle a single data point without error', () => {
+      const timestamps = [1609459200000];
+      const filter = getXAxisFilter({ timestamps })!;
+      const splits = [0];
+      const u = mockUPlot([timestamps], 400, 400);
+
+      const result = filter(u, splits);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(0);
+    });
+  });
 });

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -327,7 +327,7 @@ export const prepConfig = ({ series, totalSeries, color, orientation, options, t
     placement: xFieldAxisPlacement,
     label: frame.fields[0]?.config.custom?.axisLabel,
     splits: config.xSplits,
-    filter: vizOrientation.xOri === 0 ? config.hFilter : undefined,
+    filter: config.hFilter,
     values: config.xValues,
     timeZone,
     grid: { show: false },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Barchart: auto-calculate time axis label spacing to prevent overlap on mobile.

When xTickLabelSpacing is 0 (default "None") and the bar chart has time-based x-axis data, labels overlap on narrow/mobile screens. This adds auto-spacing that measures actual label width and filters ticks accordingly, matching the behavior already available via the manual spacing options.

Also fixes the filter for horizontal bar mode (narrow screens): the label filter is now always applied regardless of axis orientation, and uses the correct dimension (height for vertical axis, width for horizontal axis).

**Why do we need this feature?**

Makes the axis readable on small-screen devices. Validated on a Grafana instance I manage:

<img width="702" height="610" alt="grafana-axis-fix" src="https://github.com/user-attachments/assets/53ad2b83-4390-4e78-981b-1f10f01912a7" />

**Which issue(s) does this PR fix?**: Fixes #107758

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
