### PR TITLE
Dashboard: handle rows.Err() in rowsWrapper

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -455,6 +455,9 @@ func (r *rowsWrapper) Next() bool {
 	var err error
 
 	// breaks after first readable value
+	defer func() {
+		r.err = errors.Join(r.err, r.rows.Err())
+	}()
 	for r.rows.Next() {
 		r.count++
 

--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards_test.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -516,6 +517,110 @@ func TestParseLibraryPanelRow(t *testing.T) {
 		updatedTimestamp, err := meta.GetUpdatedTimestamp()
 		require.NoError(t, err)
 		require.Nil(t, updatedTimestamp)
+	})
+}
+
+func TestRowsWrapper_PropagatesRowsErr(t *testing.T) {
+	mockDB, smock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() {
+		_ = mockDB.Close()
+	}()
+
+	provisioner := provisioning.NewProvisioningServiceMock(context.Background())
+	provisioner.GetDashboardProvisionerResolvedPathFunc = func(name string) string { return "provisioner" }
+	store := &dashboardSqlAccess{
+		namespacer:   func(_ int64) string { return "default" },
+		provisioning: provisioner,
+		log:          log.New("test"),
+	}
+
+	columns := []string{"orgId", "dashboard_id", "name", "title", "folder_uid", "deleted", "plugin_id", "origin_name", "origin_path", "origin_hash", "origin_ts", "created", "createdBy", "createdByID", "updated", "updatedBy", "updatedByID", "version", "message", "data", "api_version"}
+	timestamp := time.Now()
+
+	t.Run("rows.Err after partial iteration is surfaced via Error()", func(t *testing.T) {
+		// Simulate: first row succeeds, second row triggers a rows.Err()
+		simulatedErr := fmt.Errorf("connection reset by peer")
+		rows := sqlmock.NewRows(columns).
+			AddRow(1, int64(1), "uid1", "Dashboard 1", "folder1", nil, "", "", "", "", 0, timestamp, "creator", 0, timestamp, "updater", 0, int64(1), "msg", []byte(`{"key":"value"}`), "v0alpha1").
+			RowError(1, simulatedErr). // error on second row
+			AddRow(1, int64(2), "uid2", "Dashboard 2", "folder1", nil, "", "", "", "", 0, timestamp, "creator", 0, timestamp, "updater", 0, int64(1), "msg", []byte(`{"key":"value"}`), "v0alpha1")
+
+		smock.ExpectQuery("SELECT").WillReturnRows(rows)
+		sqlRows, err := mockDB.Query("SELECT")
+		require.NoError(t, err)
+
+		wrapper := &rowsWrapper{
+			rows:    sqlRows,
+			a:       store,
+			history: false,
+		}
+		defer func() {
+			_ = wrapper.Close()
+		}()
+
+		// First call should succeed
+		require.True(t, wrapper.Next())
+		require.NoError(t, wrapper.Error())
+		require.Equal(t, "uid1", wrapper.Name())
+
+		// Second call should return false and surface the rows.Err()
+		require.False(t, wrapper.Next())
+		require.Error(t, wrapper.Error())
+		require.ErrorContains(t, wrapper.Error(), "connection reset by peer")
+	})
+
+	t.Run("rows.Err on first row surfaces error and returns no rows", func(t *testing.T) {
+		// Simulate: error on the very first row — migration would see 0 rows
+		simulatedErr := fmt.Errorf("database is locked")
+		rows := sqlmock.NewRows(columns).
+			RowError(0, simulatedErr).
+			AddRow(1, int64(1), "uid1", "Dashboard 1", "folder1", nil, "", "", "", "", 0, timestamp, "creator", 0, timestamp, "updater", 0, int64(1), "msg", []byte(`{"key":"value"}`), "v0alpha1")
+
+		smock.ExpectQuery("SELECT").WillReturnRows(rows)
+		sqlRows, err := mockDB.Query("SELECT")
+		require.NoError(t, err)
+
+		wrapper := &rowsWrapper{
+			rows:    sqlRows,
+			a:       store,
+			history: false,
+		}
+		defer func() {
+			_ = wrapper.Close()
+		}()
+
+		// First call should return false (error on first row)
+		require.False(t, wrapper.Next())
+		// The error from rows.Err() must be surfaced
+		require.Error(t, wrapper.Error(), "rows.Err() must be propagated to wrapper.Error()")
+		require.ErrorContains(t, wrapper.Error(), "database is locked")
+	})
+
+	t.Run("no error when all rows are consumed successfully", func(t *testing.T) {
+		rows := sqlmock.NewRows(columns).
+			AddRow(1, int64(1), "uid1", "Dashboard 1", "folder1", nil, "", "", "", "", 0, timestamp, "creator", 0, timestamp, "updater", 0, int64(1), "msg", []byte(`{"key":"value"}`), "v0alpha1").
+			AddRow(1, int64(2), "uid2", "Dashboard 2", "folder1", nil, "", "", "", "", 0, timestamp, "creator", 0, timestamp, "updater", 0, int64(1), "msg", []byte(`{"key":"value"}`), "v0alpha1")
+
+		smock.ExpectQuery("SELECT").WillReturnRows(rows)
+		sqlRows, err := mockDB.Query("SELECT")
+		require.NoError(t, err)
+
+		wrapper := &rowsWrapper{
+			rows:    sqlRows,
+			a:       store,
+			history: false,
+		}
+		defer func() {
+			_ = wrapper.Close()
+		}()
+
+		require.True(t, wrapper.Next())
+		require.NoError(t, wrapper.Error())
+		require.True(t, wrapper.Next())
+		require.NoError(t, wrapper.Error())
+		require.False(t, wrapper.Next())
+		require.NoError(t, wrapper.Error(), "no error expected when all rows consumed successfully")
 	})
 }
 


### PR DESCRIPTION
**What is this feature?**

Fixes missing error handling in `rowsWrapper`. 

**Why do we need this feature?**

Allows us to see the errors on dashboard and folders migration logic. We have seen reports of migration failure on count validation due to no rows being imported:

```
logger=storage.unified.migration_runner.folders-dashboards t=2026-03-02T15:17:07.205852098+01:00 level=info msg="Migration progress" org_id=1 count=-2 message="finished dashboards... (0)"
...
logger=unifiedstorage-migrator t=2026-03-03T08:37:39.718875357Z level=error msg="Executing migration failed" id="folders and dashboards migration" error="migration validation failed for org 8 (org-8): validator CountValidator failed: count mismatch for dashboards.dashboard.grafana.app in namespace org-8: legacy has 3, unified has 0, rejected 0" duration=3m35.64343857s
```

**Who is this feature for?**

OSS users upgrading to 12.4.0 (and future versions)

**Which issue(s) does this PR fix?**:

Ticket: https://github.com/grafana/grafana/issues/119312

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
