### PR TITLE
Provisioning: Fix flaky FixFolderMetadataDrawer test

### DIFF
--- a/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.test.tsx
+++ b/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.test.tsx
@@ -110,10 +110,13 @@ describe('FixFolderMetadataDrawer', () => {
 
     const { user } = render(<FixFolderMetadataDrawer repositoryName={REPO_NAME} onDismiss={jest.fn()} />);
 
+    // Click opens the Combobox menu, whose stateReducer clears the input.
+    // We must wait for that render before typing, otherwise the new text
+    // appends to the previous value (e.g. "mainfeature-branch").
     const branchInput = await screen.findByRole('combobox', { name: /branch/i });
-    await user.clear(branchInput);
-    await user.type(branchInput, 'feature-branch');
-    await user.keyboard('{Enter}');
+    await user.click(branchInput);
+    await waitFor(() => expect(branchInput).toHaveValue(''));
+    await user.keyboard('feature-branch{Enter}');
 
     await user.click(screen.getByRole('button', { name: /fix folder ids/i }));
 


### PR DESCRIPTION
**What is this feature?**

Fix for a flaky test that fails in CI but passes locally.

**Why do we need this feature?**

The "submits job with custom branch" test uses `user.clear()` on a Downshift-based Combobox, which is unreliable. The stateReducer clears the input when the menu opens, but timing differences between local and CI environments cause `user.type()` to append to the old value instead of replacing it (e.g., "mainfeature-branch" instead of "feature-branch").
