### PR TITLE
API Clients: Make legacy APIs internal only, and publish to NPM

### DIFF
--- a/packages/grafana-api-clients/README.md
+++ b/packages/grafana-api-clients/README.md
@@ -4,7 +4,45 @@
 
 This package provides reusable clients for Grafana APIs. The implementation is in ALPHA and the package is now published on npm as `@grafana/api-clients`.
 
-# Instructions within `grafana/grafana` repository:
+The clients are auto-generated [RTK Query](https://redux-toolkit.js.org/rtk-query/overview) API clients for Grafana's App Platform APIs.
+
+## Installation
+
+```bash
+yarn add @grafana/api-clients
+```
+
+## Usage
+
+Each API client is available as a separate subpath export, scoped by group and version:
+
+```ts
+import { generatedAPI } from '@grafana/api-clients/rtkq/<group>/<version>';
+```
+
+For example, to use the dashboard API or a hook:
+
+```ts
+import { generatedAPI, useListDashboardsQuery } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
+```
+
+### Adding RTKQ middleware to your Redux store
+
+If you're using this package in the context of the Grafana application, the middleware is already added for all API clients, so you don't need to add it manually.
+If you're using this package for something else, outside of the core Grafana UI, you can add the middleware and reducers to your Redux store by importing the `allMiddleware` and `allReducers` exports.
+
+```ts
+import { allMiddleware, allReducers } from '@grafana/api-clients/rtkq';
+
+const store = configureStore({
+  reducer: {
+    ...allReducers,
+  },
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(...allMiddleware),
+});
+```
+
+# Development (within `grafana/grafana`)
 
 ## Generating RTK Query API Clients
 

--- a/packages/grafana-api-clients/README.md
+++ b/packages/grafana-api-clients/README.md
@@ -1,8 +1,10 @@
 # Grafana API Clients
 
-> **@grafana/api-clients is currently in BETA**.
+> **@grafana/api-clients is currently in ALPHA**.
 
-This package hosts reusable clients for Grafana APIs. The implementation is currently in BETA and not yet published.
+This package provides reusable clients for Grafana APIs. The implementation is in ALPHA and the package is now published on npm as `@grafana/api-clients`.
+
+# Instructions within `grafana/grafana` repository:
 
 ## Generating RTK Query API Clients
 

--- a/packages/grafana-api-clients/package.json
+++ b/packages/grafana-api-clients/package.json
@@ -1,7 +1,6 @@
 {
   "author": "Grafana Labs",
   "license": "Apache-2.0",
-  "private": true,
   "name": "@grafana/api-clients",
   "version": "13.0.0-pre",
   "description": "Grafana API client utilities",

--- a/packages/grafana-api-clients/package.json
+++ b/packages/grafana-api-clients/package.json
@@ -31,6 +31,18 @@
       "import": "./dist/esm/clients/rtkq/index.mjs",
       "require": "./dist/cjs/clients/rtkq/index.cjs"
     },
+    "./rtkq/legacy": {
+      "@grafana-app/source": "./src/clients/rtkq/legacy/index.ts"
+    },
+    "./rtkq/legacy/migrate-to-cloud": {
+      "@grafana-app/source": "./src/clients/rtkq/migrate-to-cloud/index.ts"
+    },
+    "./rtkq/legacy/preferences": {
+      "@grafana-app/source": "./src/clients/rtkq/preferences/user/index.ts"
+    },
+    "./rtkq/legacy/user": {
+      "@grafana-app/source": "./src/clients/rtkq/user/index.ts"
+    },
     "./rtkq/advisor/v0alpha1": {
       "@grafana-app/source": "./src/clients/rtkq/advisor/v0alpha1/index.ts",
       "types": "./dist/types/clients/rtkq/advisor/v0alpha1/index.d.ts",
@@ -66,30 +78,6 @@
       "types": "./dist/types/clients/rtkq/iam/v0alpha1/index.d.ts",
       "import": "./dist/esm/clients/rtkq/iam/v0alpha1/index.mjs",
       "require": "./dist/cjs/clients/rtkq/iam/v0alpha1/index.cjs"
-    },
-    "./rtkq/legacy": {
-      "@grafana-app/source": "./src/clients/rtkq/legacy/index.ts",
-      "types": "./dist/types/clients/rtkq/legacy/index.d.ts",
-      "import": "./dist/esm/clients/rtkq/legacy/index.mjs",
-      "require": "./dist/cjs/clients/rtkq/legacy/index.cjs"
-    },
-    "./rtkq/legacy/migrate-to-cloud": {
-      "@grafana-app/source": "./src/clients/rtkq/migrate-to-cloud/index.ts",
-      "types": "./dist/types/clients/rtkq/migrate-to-cloud/index.d.ts",
-      "import": "./dist/esm/clients/rtkq/migrate-to-cloud/index.mjs",
-      "require": "./dist/cjs/clients/rtkq/migrate-to-cloud/index.cjs"
-    },
-    "./rtkq/legacy/preferences": {
-      "@grafana-app/source": "./src/clients/rtkq/preferences/user/index.ts",
-      "types": "./dist/types/clients/rtkq/preferences/user/index.d.ts",
-      "import": "./dist/esm/clients/rtkq/preferences/user/index.mjs",
-      "require": "./dist/cjs/clients/rtkq/preferences/user/index.cjs"
-    },
-    "./rtkq/legacy/user": {
-      "@grafana-app/source": "./src/clients/rtkq/user/index.ts",
-      "types": "./dist/types/clients/rtkq/user/index.d.ts",
-      "import": "./dist/esm/clients/rtkq/user/index.mjs",
-      "require": "./dist/cjs/clients/rtkq/user/index.cjs"
     },
     "./rtkq/playlist/v1": {
       "@grafana-app/source": "./src/clients/rtkq/playlist/v1/index.ts",

--- a/packages/grafana-api-clients/src/clients/rtkq/index.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/index.ts
@@ -10,16 +10,13 @@ import { generatedAPI as historianAlertingAPIv0alpha1 } from './historian.alerti
 import { generatedAPI as iamAPIv0alpha1 } from './iam/v0alpha1';
 import { generatedAPI as logsdrilldownAPIv1alpha1 } from './logsdrilldown/v1alpha1';
 import { generatedAPI as logsdrilldownAPIv1beta1 } from './logsdrilldown/v1beta1';
-import { generatedAPI as migrateToCloudAPI } from './migrate-to-cloud';
 import { generatedAPI as notificationsAlertingAPIv0alpha1 } from './notifications.alerting/v0alpha1';
 import { generatedAPI as playlistAPIv1 } from './playlist/v1';
-import { generatedAPI as preferencesUserAPI } from './preferences/user';
 import { generatedAPI as preferencesAPIv1alpha1 } from './preferences/v1alpha1';
 import { generatedAPI as provisioningAPIv0alpha1 } from './provisioning/v0alpha1';
 import { generatedAPI as quotasAPIv0alpha1 } from './quotas/v0alpha1';
 import { generatedAPI as rulesAlertingAPIv0alpha1 } from './rules.alerting/v0alpha1';
 import { generatedAPI as shortURLAPIv1beta1 } from './shorturl/v1beta1';
-import { generatedAPI as legacyUserAPI } from './user';
 // PLOP_INJECT_IMPORT
 
 /** RTK Query middleware for all API clients  */
@@ -28,15 +25,12 @@ export const allMiddleware = [
   dashboardAPIv0alpha1.middleware,
   folderAPIv1beta1.middleware,
   iamAPIv0alpha1.middleware,
-  migrateToCloudAPI.middleware,
   playlistAPIv1.middleware,
   collectionsAPIv1alpha1.middleware, // stars
   preferencesAPIv1alpha1.middleware,
-  preferencesUserAPI.middleware, // legacy preferences
   provisioningAPIv0alpha1.middleware,
   shortURLAPIv1beta1.middleware,
   correlationsAPIv0alpha1.middleware,
-  legacyUserAPI.middleware,
   notificationsAlertingAPIv0alpha1.middleware,
   rulesAlertingAPIv0alpha1.middleware,
   historianAlertingAPIv0alpha1.middleware,
@@ -52,15 +46,12 @@ export const allReducers = {
   [dashboardAPIv0alpha1.reducerPath]: dashboardAPIv0alpha1.reducer,
   [folderAPIv1beta1.reducerPath]: folderAPIv1beta1.reducer,
   [iamAPIv0alpha1.reducerPath]: iamAPIv0alpha1.reducer,
-  [migrateToCloudAPI.reducerPath]: migrateToCloudAPI.reducer,
   [playlistAPIv1.reducerPath]: playlistAPIv1.reducer,
   [collectionsAPIv1alpha1.reducerPath]: collectionsAPIv1alpha1.reducer,
   [preferencesAPIv1alpha1.reducerPath]: preferencesAPIv1alpha1.reducer,
-  [preferencesUserAPI.reducerPath]: preferencesUserAPI.reducer,
   [provisioningAPIv0alpha1.reducerPath]: provisioningAPIv0alpha1.reducer,
   [shortURLAPIv1beta1.reducerPath]: shortURLAPIv1beta1.reducer,
   [correlationsAPIv0alpha1.reducerPath]: correlationsAPIv0alpha1.reducer,
-  [legacyUserAPI.reducerPath]: legacyUserAPI.reducer,
   [notificationsAlertingAPIv0alpha1.reducerPath]: notificationsAlertingAPIv0alpha1.reducer,
   [rulesAlertingAPIv0alpha1.reducerPath]: rulesAlertingAPIv0alpha1.reducer,
   [historianAlertingAPIv0alpha1.reducerPath]: historianAlertingAPIv0alpha1.reducer,

--- a/public/app/core/reducers/root.ts
+++ b/public/app/core/reducers/root.ts
@@ -2,7 +2,10 @@ import { ReducersMapObject } from '@reduxjs/toolkit';
 import { AnyAction, combineReducers } from 'redux';
 
 import { allReducers as allApiClientReducers } from '@grafana/api-clients/rtkq';
-import { generatedAPI as legacyAPI } from '@grafana/api-clients/rtkq/legacy';
+import { generatedAPI as migrateToCloudAPI } from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';
+import { generatedAPI as preferencesUserAPI } from '@grafana/api-clients/rtkq/legacy/preferences';
+import { generatedAPI as legacyUserAPI } from '@grafana/api-clients/rtkq/legacy/user';
+import { legacyAPI } from 'app/api/clients/legacy';
 import { scopeAPIv0alpha1 } from 'app/api/clients/scope/v0alpha1';
 import sharedReducers from 'app/core/reducers';
 import ldapReducers from 'app/features/admin/state/reducers';
@@ -49,6 +52,9 @@ const rootReducers = {
   ...supportBundlesReducer,
   ...authConfigReducers,
   [legacyAPI.reducerPath]: legacyAPI.reducer,
+  [migrateToCloudAPI.reducerPath]: migrateToCloudAPI.reducer,
+  [preferencesUserAPI.reducerPath]: preferencesUserAPI.reducer,
+  [legacyUserAPI.reducerPath]: legacyUserAPI.reducer,
   plugins: pluginsReducer,
   [alertingApi.reducerPath]: alertingApi.reducer,
   [publicDashboardApi.reducerPath]: publicDashboardApi.reducer,

--- a/public/app/core/reducers/root.ts
+++ b/public/app/core/reducers/root.ts
@@ -2,10 +2,10 @@ import { ReducersMapObject } from '@reduxjs/toolkit';
 import { AnyAction, combineReducers } from 'redux';
 
 import { allReducers as allApiClientReducers } from '@grafana/api-clients/rtkq';
+import { generatedAPI as legacyAPI } from '@grafana/api-clients/rtkq/legacy';
 import { generatedAPI as migrateToCloudAPI } from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';
 import { generatedAPI as preferencesUserAPI } from '@grafana/api-clients/rtkq/legacy/preferences';
 import { generatedAPI as legacyUserAPI } from '@grafana/api-clients/rtkq/legacy/user';
-import { legacyAPI } from 'app/api/clients/legacy';
 import { scopeAPIv0alpha1 } from 'app/api/clients/scope/v0alpha1';
 import sharedReducers from 'app/core/reducers';
 import ldapReducers from 'app/features/admin/state/reducers';

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -3,6 +3,9 @@ import { setupListeners } from '@reduxjs/toolkit/query';
 import { Middleware } from 'redux';
 
 import { allMiddleware as allApiClientMiddleware } from '@grafana/api-clients/rtkq';
+import { generatedAPI as migrateToCloudAPI } from '@grafana/api-clients/rtkq/legacy/migrate-to-cloud';
+import { generatedAPI as preferencesUserAPI } from '@grafana/api-clients/rtkq/legacy/preferences';
+import { generatedAPI as legacyUserAPI } from '@grafana/api-clients/rtkq/legacy/user';
 import { legacyAPI } from 'app/api/clients/legacy';
 import { scopeAPIv0alpha1 } from 'app/api/clients/scope/v0alpha1';
 import { browseDashboardsAPI } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
@@ -41,6 +44,9 @@ export function configureStore(initialState?: Partial<StoreState>) {
         publicDashboardApi.middleware,
         browseDashboardsAPI.middleware,
         legacyAPI.middleware,
+        migrateToCloudAPI.middleware,
+        preferencesUserAPI.middleware,
+        legacyUserAPI.middleware,
         scopeAPIv0alpha1.middleware,
         ...allApiClientMiddleware,
         ...extraMiddleware

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -38,17 +38,29 @@ export function configureStore(initialState?: Partial<StoreState>) {
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({ thunk: true, serializableCheck: false, immutableCheck: false }).concat(
         listenerMiddleware.middleware,
+
         // older internal alerting API client
         alertingApi.middleware,
-        // other Grafana core APIs
+
+        // API clients that are not in the api-clients package
+        // Anything here is likely to be deprecated
         publicDashboardApi.middleware,
         browseDashboardsAPI.middleware,
+
+        // Legacy API clients that come from the api-clients package
+        // (these are not exported in the same way as we avoid including them in the published package)
         legacyAPI.middleware,
         migrateToCloudAPI.middleware,
         preferencesUserAPI.middleware,
         legacyUserAPI.middleware,
+
+        // Enterprise API clients from the api-clients package
         scopeAPIv0alpha1.middleware,
+
+        // All api-clients from the api-clients package
         ...allApiClientMiddleware,
+
+        // Any additional other middleware, configured from enterprise
         ...extraMiddleware
       ),
     devTools: process.env.NODE_ENV !== 'production',


### PR DESCRIPTION
**What is this feature?**
- Prep @grafana/api-clients for publishing to npm (removing "private": true and updating READMEº
 - Exclude legacy/internal-only API clients (legacy, legacy/migrate-to-cloud, legacy/preferences, legacy/user) from the published package
 - Remove those legacy clients from the shared allMiddleware/allReducers aggregates in @grafana/api-clients/rtkq, since they should not be part of the public package surface
  - Register the legacy client reducers and middleware directly in root.ts and configureStore.ts
