### PR TITLE
Docs: Add Administration permission requirement for GitHub Git Sync

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
@@ -64,7 +64,7 @@ If you want to configure Git Sync for GitHub, you can connect using a **Personal
 
 If you want to configure Git Sync for GitHub and authenticate with a Personal Access Token, sign in to GitHub and [create a new fine-grained personal access token](https://github.com/settings/personal-access-tokens/new) with these permissions:
 
-- **Administration**: Read-only permission (required for validating branch protection rules with the write workflow)
+- **Administration**: Read-only permission (enables validation of branch protection rules against the configured branch when users can push directly to it; may be used in the future to check other repository settings and make the setup process smoother)
 - **Contents**: Read and write permission
 - **Metadata**: Read-only permission
 - **Pull requests**: Read and write permission
@@ -105,7 +105,7 @@ If you want to configure Git Sync for GitHub and authenticate with GitHub App:
 
 Note that your GitHub App must have the following permissions:
 
-- **Administration**: Read-only permission (required for validating branch protection rules with the write workflow)
+- **Administration**: Read-only permission (enables validation of branch protection rules against the configured branch when users can push directly to it; may be used in the future to check other repository settings and make the setup process smoother)
 - **Contents**: Read and write permission
 - **Metadata**: Read-only permission
 - **Pull requests**: Read and write permission

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
@@ -64,6 +64,7 @@ If you want to configure Git Sync for GitHub, you can connect using a **Personal
 
 If you want to configure Git Sync for GitHub and authenticate with a Personal Access Token, sign in to GitHub and [create a new fine-grained personal access token](https://github.com/settings/personal-access-tokens/new) with these permissions:
 
+- **Administration**: Read-only permission (required for validating branch protection rules with the write workflow)
 - **Contents**: Read and write permission
 - **Metadata**: Read-only permission
 - **Pull requests**: Read and write permission
@@ -104,6 +105,7 @@ If you want to configure Git Sync for GitHub and authenticate with GitHub App:
 
 Note that your GitHub App must have the following permissions:
 
+- **Administration**: Read-only permission (required for validating branch protection rules with the write workflow)
 - **Contents**: Read and write permission
 - **Metadata**: Read-only permission
 - **Pull requests**: Read and write permission

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
@@ -80,6 +80,7 @@ To create the GitHub App, follow these steps:
    - Homepage URL: For example, your Grafana Cloud instance URL
 1. Scroll down to the **Webhook** section and uncheck the **Active** box
 1. In the **Permissions** section, go to **Repository permissions** and set these parameters:
+   - **Administration**: Read-only permission (required for validating branch protection rules with the write workflow)
    - **Contents**: Read and write permission
    - **Metadata**: Read-only permission
    - **Pull requests**: Read and write permission

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
@@ -80,7 +80,7 @@ To create the GitHub App, follow these steps:
    - Homepage URL: For example, your Grafana Cloud instance URL
 1. Scroll down to the **Webhook** section and uncheck the **Active** box
 1. In the **Permissions** section, go to **Repository permissions** and set these parameters:
-   - **Administration**: Read-only permission (required for validating branch protection rules with the write workflow)
+   - **Administration**: Read-only permission (enables validation of branch protection rules against the configured branch when users can push directly to it; may be used in the future to check other repository settings and make the setup process smoother)
    - **Contents**: Read and write permission
    - **Metadata**: Read-only permission
    - **Pull requests**: Read and write permission


### PR DESCRIPTION
## Summary

Updates Git Sync documentation to include the **Administration** read permission requirement for GitHub Apps and Personal Access Tokens.

## Why

Git Sync validates branch protection rules and repository rulesets against the configured branch to help users avoid configuration issues. This validation requires GitHub API endpoints that need **Administration** read permissions.

## Changes

Updated two documentation files to add Administration permission:

**1. `set-up-before.md` - GitHub App setup prerequisites**
- Added Administration read-only permission to the required permissions list

**2. `_index.md` - UI setup instructions**
- Added Administration read-only permission to both PAT and GitHub App setup sections

All three locations now include:
```markdown
- **Administration**: Read-only permission (enables validation of branch protection 
  rules against the configured branch when users can push directly to it; may be 
  used in the future to check other repository settings and make the setup process 
  smoother)
```

## Permission Behavior

The Administration read permission is **optional but recommended**:

- ✅ **With permission**: Branch protection rules and rulesets are validated during repository test, preventing configuration issues early
- ⚠️ **Without permission**: Protection checks are skipped gracefully (warning logged), users discover issues when actually pushing

When the permission is missing, Git Sync logs:
```
WARN Skipping branch protection check: token lacks Administration read permission
```

## Future Use

This permission may also be used in the future to:
- Check additional repository settings
- Provide better validation and feedback  
- Make the setup process smoother overall

## Testing

- [x] Verified permission requirements match GitHub API documentation
- [x] Confirmed explanatory text is clear, accurate, and forward-looking
- [x] Checked all locations are updated consistently
- [x] Branch is clean and contains only documentation changes

**Sources:**
- [REST API endpoints for protected branches - GitHub Docs](https://docs.github.com/en/rest/branches/branch-protection)
- [REST API endpoints for rules - GitHub Docs](https://docs.github.com/en/rest/repos/rules)
- [Permissions required for fine-grained personal access tokens - GitHub Docs](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens)