### PR TITLE
Gauge: Fix regression in default behavior for percentage gauges

### DIFF
--- a/apps/dashboard/pkg/migration/testdata/golden_checksums.json
+++ b/apps/dashboard/pkg/migration/testdata/golden_checksums.json
@@ -72,7 +72,7 @@
   "dev-dashboards-output/panel-gauge/gauge-multi-series.v42.json": "712bd116080613648de9e493d93bb39f83e11d752f93d08e29a7231289bba777",
   "dev-dashboards-output/panel-gauge/gauge_tests.v42.json": "2eade52f43f2859ed93d2148f695e24739c88a41fa80104d90e9d145321e6e10",
   "dev-dashboards-output/panel-gauge/gauge_tests_new.v42.json": "490829d6fa96e833a13f2034762c26b4feb4a85e686c628076009d53fdc84144",
-  "dev-dashboards-output/panel-gauge/gauge_tests_old_to_new.v42.json": "d8eb15ea8655f40754b8d1baba1bf66113dba6865e311ef2f57aff635b88e166",
+  "dev-dashboards-output/panel-gauge/gauge_tests_old_to_new.v42.json": "6cf057d0cf13ead60d8a039662d1d6b320230dbf1de2b2892dd0b3790c158760",
   "dev-dashboards-output/panel-geomap/geomap-color-field.v42.json": "a3dc6a3291a47088a229bea0eca833fd3ff7f227b1d0296a52dbd42d03907124",
   "dev-dashboards-output/panel-geomap/geomap-photo-layer.v42.json": "1b9eca89aeb6244e5eb9415ff4f737b4ae0dafcbf3310213cef60567a3d09f3c",
   "dev-dashboards-output/panel-geomap/geomap-route-layer.v42.json": "ee4f1eefd7664983745b60de7e7d82d2f8f87f7f9007c246497d473c97e51302",

--- a/devenv/dev-dashboards/panel-gauge/gauge_tests_old_to_new.json
+++ b/devenv/dev-dashboards/panel-gauge/gauge_tests_old_to_new.json
@@ -544,9 +544,9 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 7,
+        "w": 3,
         "x": 10,
-        "y": 6
+        "y": 5
       },
       "id": 16,
       "options": {
@@ -620,10 +620,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 7,
-        "x": 10,
-        "y": 11
+        "h": 5,
+        "w": 4,
+        "x": 13,
+        "y": 5
       },
       "id": 17,
       "options": {
@@ -1114,6 +1114,61 @@
         }
       ],
       "title": "neutral value 47 (33 => 41)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "grafana-testdata-datasource"
+      },
+      "description": "should show a green gauge",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 7,
+        "x": 10,
+        "y": 10
+      },
+      "id": 20,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false,
+        "sizing": "auto"
+      },
+      "pluginVersion": "12.3.0-pre",
+      "targets": [
+        {
+          "refId": "A",
+          "scenarioId": "csv_content",
+          "csvContent": "a\n0.95"
+        }
+      ],
+      "title": "Percentage w/ no min/max",
       "type": "gauge"
     }
   ],

--- a/e2e-playwright/panels-suite/gauge.spec.ts
+++ b/e2e-playwright/panels-suite/gauge.spec.ts
@@ -8,6 +8,7 @@ test.use({
 
 const OLD_GAUGES_DASHBOARD_UID = '_5rDmaQiz';
 const NEW_GAUGES_DASHBOARD_UID = 'panel-tests-gauge-new';
+const OLD_TO_NEW_GAUGES_DASHBOARD_UID = 'panel-tests-old-gauge-to-new';
 
 test.describe(
   'Gauge Panel',
@@ -123,6 +124,27 @@ test.describe(
         dashboardPage2.getByGrafanaSelector(selectors.components.Panels.Panel.PanelDataErrorMessage),
         'that the empty text appears'
       ).toHaveText('Data is missing a number field');
+    });
+
+    test('handles percentage units', async ({ gotoDashboardPage, selectors }) => {
+      const dashboardPage = await gotoDashboardPage({
+        uid: OLD_TO_NEW_GAUGES_DASHBOARD_UID,
+        queryParams: new URLSearchParams({ editPanel: '20' }),
+      });
+
+      const gaugeLocator = dashboardPage.getByGrafanaSelector(
+        selectors.components.Panels.Visualization.Gauge.Container
+      );
+
+      await expect(gaugeLocator).toBeVisible();
+
+      const computedColor = await gaugeLocator.evaluate((el) => {
+        const pathsInSVG = el.querySelectorAll('path');
+        return window.getComputedStyle(pathsInSVG[pathsInSVG.length - 1]).stroke;
+      });
+
+      // Assert that the color matches the expected RGB value
+      expect(computedColor).toBe('rgb(115, 191, 105)');
     });
   }
 );

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -560,6 +560,12 @@ export const versionedComponents = {
         Container: {
           '12.4.0': 'data-testid gauge container',
         },
+        Track: {
+          '13.0.0': 'data-testid gauge track',
+        },
+        Bar: {
+          '13.0.0': 'data-testid gauge bar',
+        },
       },
     },
   },

--- a/packages/grafana-ui/src/components/RadialGauge/RadialBar.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialBar.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import { colorManipulator, FALLBACK_COLOR, FieldDisplay } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 
 import { useTheme2 } from '../../themes/ThemeContext';
 
@@ -54,6 +55,7 @@ export function RadialBar({
           roundedBars={roundedBars}
           shape={shape}
           startAngle={startAngle}
+          data-testid={selectors.components.Panels.Visualization.Gauge.Track}
         />
       )}
       {/** Track after value */}
@@ -65,6 +67,7 @@ export function RadialBar({
         roundedBars={roundedBars}
         shape={shape}
         startAngle={startAngle + startValueAngle + endValueAngle}
+        data-testid={selectors.components.Panels.Visualization.Gauge.Track}
       />
       {/** The colored bar */}
       <RadialArcPath
@@ -78,6 +81,7 @@ export function RadialBar({
         roundedBars={roundedBars}
         shape={shape}
         startAngle={startAngle + startValueAngle}
+        data-testid={selectors.components.Panels.Visualization.Gauge.Bar}
         {...colorProps}
       />
     </>

--- a/packages/grafana-ui/src/components/RadialGauge/RadialBarSegmented.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialBarSegmented.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react';
 
 import { FALLBACK_COLOR, FieldDisplay } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 
 import { useTheme2 } from '../../themes/ThemeContext';
 
@@ -67,6 +68,11 @@ export const RadialBarSegmented = memo(
           glowFilter={glowFilter}
           shape={shape}
           startAngle={segmentStartAngle}
+          data-testid={
+            isTrack
+              ? selectors.components.Panels.Visualization.Gauge.Track
+              : selectors.components.Panels.Visualization.Gauge.Bar
+          }
           {...colorProps}
         />
       );

--- a/public/app/plugins/panel/gauge/v2/GaugePanel.tsx
+++ b/public/app/plugins/panel/gauge/v2/GaugePanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback, type JSX } from 'react';
+import { useMemo, type JSX } from 'react';
 
 import {
   DisplayValueAlignmentFactors,
@@ -25,8 +25,6 @@ export function GaugePanel({
   fieldConfig,
   timeZone,
 }: PanelProps<Options>) {
-  const renderComponent = useMemo(() => renderComponentFactory(options), [options]);
-
   const values: FieldDisplay[] = useMemo(() => {
     // TODO: this is carried over from v1, but it really ought to live somewhere inside of the data processing pipeline.
     // Without this, gauges which have percentage units and percentage thresholds will not automatically select a 0-100% min max
@@ -55,23 +53,7 @@ export function GaugePanel({
     });
   }, [data, fieldConfig, options.reduceOptions, options.sparkline, replaceVariables, timeZone]);
 
-  const renderValue = useCallback(
-    (valueProps: VizRepeaterRenderValueProps<FieldDisplay, DisplayValueAlignmentFactors>): JSX.Element => {
-      const { value } = valueProps;
-      const { getLinks, hasLinks } = value;
-
-      if (hasLinks && getLinks) {
-        return (
-          <DataLinksContextMenu links={getLinks} style={{ flexGrow: 1 }}>
-            {(api) => renderComponent(valueProps, api)}
-          </DataLinksContextMenu>
-        );
-      }
-
-      return renderComponent(valueProps, {});
-    },
-    [renderComponent]
-  );
+  const renderValue = useMemo(() => renderValueFactory(options), [options]);
 
   if (values[0]?.display?.text === 'No data') {
     return <PanelDataErrorView panelId={id} fieldConfig={fieldConfig} data={data} needsNumberField />;
@@ -97,7 +79,7 @@ export function GaugePanel({
   );
 }
 
-const renderComponentFactory = (options: Options) => {
+const renderValueFactory = (options: Options) => {
   const renderRadialGauge = (
     {
       width,
@@ -106,7 +88,7 @@ const renderComponentFactory = (options: Options) => {
       alignmentFactors,
       count,
     }: VizRepeaterRenderValueProps<FieldDisplay, DisplayValueAlignmentFactors>,
-    menuProps: DataLinksContextMenuApi
+    menuProps?: DataLinksContextMenuApi
   ): JSX.Element => (
     <RadialGauge
       alignmentFactors={alignmentFactors}
@@ -118,7 +100,7 @@ const renderComponentFactory = (options: Options) => {
       height={height}
       nameManualFontSize={options.text?.titleSize}
       neutral={options.neutral}
-      onClick={menuProps.openMenu}
+      onClick={menuProps?.openMenu}
       roundedBars={options.barShape === 'rounded'}
       segmentCount={options.segmentCount}
       segmentSpacing={options.segmentSpacing}
@@ -132,5 +114,23 @@ const renderComponentFactory = (options: Options) => {
       width={width}
     />
   );
-  return renderRadialGauge;
+
+  const renderValue = (
+    valueProps: VizRepeaterRenderValueProps<FieldDisplay, DisplayValueAlignmentFactors>
+  ): JSX.Element => {
+    const { value } = valueProps;
+    const { getLinks, hasLinks } = value;
+
+    if (hasLinks && getLinks) {
+      return (
+        <DataLinksContextMenu links={getLinks} style={{ flexGrow: 1 }}>
+          {(api) => renderRadialGauge(valueProps, api)}
+        </DataLinksContextMenu>
+      );
+    }
+
+    return renderRadialGauge(valueProps);
+  };
+
+  return renderValue;
 };

--- a/public/app/plugins/panel/gauge/v2/GaugePanel.tsx
+++ b/public/app/plugins/panel/gauge/v2/GaugePanel.tsx
@@ -1,8 +1,9 @@
-import type { JSX } from 'react';
+import { useMemo, useCallback, type JSX } from 'react';
 
 import {
   DisplayValueAlignmentFactors,
   FieldDisplay,
+  getDisplayProcessor,
   getDisplayValueAlignmentFactors,
   getFieldDisplayValues,
   PanelProps,
@@ -24,57 +25,25 @@ export function GaugePanel({
   fieldConfig,
   timeZone,
 }: PanelProps<Options>) {
-  function renderComponent(
-    valueProps: VizRepeaterRenderValueProps<FieldDisplay, DisplayValueAlignmentFactors>,
-    menuProps: DataLinksContextMenuApi
-  ) {
-    const { width, height, value } = valueProps;
+  const renderComponent = useMemo(() => renderComponentFactory(options), [options]);
 
-    return (
-      <RadialGauge
-        alignmentFactors={valueProps.alignmentFactors}
-        barWidthFactor={options.barWidthFactor}
-        endpointMarker={options.endpointMarker !== 'none' ? options.endpointMarker : undefined}
-        glowBar={options.effects?.barGlow}
-        glowCenter={options.effects?.centerGlow}
-        gradient={options.effects?.gradient}
-        height={height}
-        nameManualFontSize={options.text?.titleSize}
-        neutral={options.neutral}
-        onClick={menuProps.openMenu}
-        roundedBars={options.barShape === 'rounded'}
-        segmentCount={options.segmentCount}
-        segmentSpacing={options.segmentSpacing}
-        shape={options.shape}
-        showScaleLabels={options.showThresholdLabels}
-        textMode={options.textMode}
-        thresholdsBar={options.showThresholdMarkers}
-        valueManualFontSize={options.text?.valueSize}
-        values={[value]}
-        vizCount={valueProps.count}
-        width={width}
-      />
-    );
-  }
-
-  function renderValue(
-    valueProps: VizRepeaterRenderValueProps<FieldDisplay, DisplayValueAlignmentFactors>
-  ): JSX.Element {
-    const { value } = valueProps;
-    const { getLinks, hasLinks } = value;
-
-    if (hasLinks && getLinks) {
-      return (
-        <DataLinksContextMenu links={getLinks} style={{ flexGrow: 1 }}>
-          {(api) => renderComponent(valueProps, api)}
-        </DataLinksContextMenu>
-      );
+  const values: FieldDisplay[] = useMemo(() => {
+    // TODO: this is carried over from v1, but it really ought to live somewhere inside of the data processing pipeline.
+    // Without this, gauges which have percentage units and percentage thresholds will not automatically select a 0-100% min max
+    // and their colors will potentially be wrong.
+    for (let frame of data.series) {
+      for (let field of frame.fields) {
+        // Set the Min/Max value automatically for percent and percentunit
+        if (field.config.unit === 'percent' || field.config.unit === 'percentunit') {
+          const min = field.config.min ?? 0;
+          const max = field.config.max ?? (field.config.unit === 'percent' ? 100 : 1);
+          field.state = field.state ?? {};
+          field.state.range = { min, max, delta: max - min };
+          field.display = getDisplayProcessor({ field, theme: config.theme2 });
+        }
+      }
     }
 
-    return renderComponent(valueProps, {});
-  }
-
-  function getValues(): FieldDisplay[] {
     return getFieldDisplayValues({
       fieldConfig,
       reduceOptions: options.reduceOptions,
@@ -84,16 +53,34 @@ export function GaugePanel({
       sparkline: options.sparkline,
       timeZone,
     });
-  }
+  }, [data, fieldConfig, options.reduceOptions, options.sparkline, replaceVariables, timeZone]);
 
-  if (getValues()[0]?.display?.text === 'No data') {
+  const renderValue = useCallback(
+    (valueProps: VizRepeaterRenderValueProps<FieldDisplay, DisplayValueAlignmentFactors>): JSX.Element => {
+      const { value } = valueProps;
+      const { getLinks, hasLinks } = value;
+
+      if (hasLinks && getLinks) {
+        return (
+          <DataLinksContextMenu links={getLinks} style={{ flexGrow: 1 }}>
+            {(api) => renderComponent(valueProps, api)}
+          </DataLinksContextMenu>
+        );
+      }
+
+      return renderComponent(valueProps, {});
+    },
+    [renderComponent]
+  );
+
+  if (values[0]?.display?.text === 'No data') {
     return <PanelDataErrorView panelId={id} fieldConfig={fieldConfig} data={data} needsNumberField />;
   }
 
   return (
     <Stack direction="row" justifyContent="center" alignItems="center" height={'100%'}>
       <VizRepeater
-        getValues={getValues}
+        getValues={() => values}
         renderValue={renderValue}
         width={width}
         height={height}
@@ -109,3 +96,41 @@ export function GaugePanel({
     </Stack>
   );
 }
+
+const renderComponentFactory = (options: Options) => {
+  const renderRadialGauge = (
+    {
+      width,
+      height,
+      value,
+      alignmentFactors,
+      count,
+    }: VizRepeaterRenderValueProps<FieldDisplay, DisplayValueAlignmentFactors>,
+    menuProps: DataLinksContextMenuApi
+  ): JSX.Element => (
+    <RadialGauge
+      alignmentFactors={alignmentFactors}
+      barWidthFactor={options.barWidthFactor}
+      endpointMarker={options.endpointMarker !== 'none' ? options.endpointMarker : undefined}
+      glowBar={options.effects?.barGlow}
+      glowCenter={options.effects?.centerGlow}
+      gradient={options.effects?.gradient}
+      height={height}
+      nameManualFontSize={options.text?.titleSize}
+      neutral={options.neutral}
+      onClick={menuProps.openMenu}
+      roundedBars={options.barShape === 'rounded'}
+      segmentCount={options.segmentCount}
+      segmentSpacing={options.segmentSpacing}
+      shape={options.shape}
+      showScaleLabels={options.showThresholdLabels}
+      textMode={options.textMode}
+      thresholdsBar={options.showThresholdMarkers}
+      valueManualFontSize={options.text?.valueSize}
+      values={[value]}
+      vizCount={count}
+      width={width}
+    />
+  );
+  return renderRadialGauge;
+};


### PR DESCRIPTION
Relates to https://github.com/grafana/support-escalations/issues/20985

In the v1 Gauge, there was a bit of a hack we missed in implementing the new gauge, where if you had percentage values and no min or max set, the gauge would automatically use 0%-100% as the range, which ensured that percentage thresholds worked without setting min and maxes by hand.

This PR adds that to the v2 Gauge, adds a gdev panel to confirm it, and adds an e2e which checks the gdev panel.