### PR TITLE
Gauge: Remove min/max applied by suggestions

### DIFF
--- a/public/app/plugins/panel/gauge/v2/suggestions.test.ts
+++ b/public/app/plugins/panel/gauge/v2/suggestions.test.ts
@@ -148,30 +148,4 @@ describe('GaugePanel Suggestions', () => {
       }
     });
   });
-
-  it('figures out a suitable min and max for gauges', () => {
-    const suggestions = gaugeSuggestionsSupplier(
-      getPanelDataSummary([
-        {
-          length: 1,
-          fields: [
-            {
-              name: 'value',
-              type: FieldType.number,
-              config: {},
-              values: [40, 50, 60, 70, 80, 90],
-              state: { calcs: { min: 40, max: 90 } },
-            },
-          ],
-        },
-      ])
-    );
-    if (!Array.isArray(suggestions)) {
-      throw new Error('expected suggestions to be an array');
-    }
-    for (const suggestion of suggestions) {
-      expect(suggestion.fieldConfig?.defaults?.min).toBe(35);
-      expect(suggestion.fieldConfig?.defaults?.max).toBe(95);
-    }
-  });
 });

--- a/public/app/plugins/panel/gauge/v2/suggestions.ts
+++ b/public/app/plugins/panel/gauge/v2/suggestions.ts
@@ -42,32 +42,10 @@ export const gaugeSuggestionsSupplier: VisualizationSuggestionsSupplier<Options,
     return;
   }
 
-  const suggestedRange = dataSummary.rawFrames?.reduce(
-    ([min, max], frame) => {
-      let newMin = min;
-      let newMax = max;
-      for (const f of frame.fields) {
-        if (f.type === FieldType.number) {
-          newMin = Math.min(newMin, f.state?.calcs?.min ?? Infinity);
-          newMax = Math.max(newMax, f.state?.calcs?.max ?? -Infinity);
-        }
-      }
-      return [newMin, newMax];
-    },
-    [Infinity, -Infinity]
-  );
-
-  let fieldConfig: FieldConfigSource<Partial<GraphFieldConfig>> | undefined = undefined;
-  if (suggestedRange && suggestedRange.every(isFinite)) {
-    const delta = suggestedRange[1] - suggestedRange[0];
-    fieldConfig = {
-      defaults: {
-        min: Math.floor(suggestedRange[0] - delta * 0.1),
-        max: Math.ceil(suggestedRange[1] + delta * 0.1),
-      },
-      overrides: [],
-    };
-  }
+  const fieldConfig: FieldConfigSource<Partial<GraphFieldConfig>> = {
+    defaults: {},
+    overrides: [],
+  };
 
   const suggestions: Array<VisualizationSuggestion<Options, GraphFieldConfig>> = [
     {


### PR DESCRIPTION
After trying this for a few weeks, I think this suggested range thing is just kind of awkward and it worked better without it.