### PR TITLE
Provisioning: wait for repo reconciliation in provisioning integration test to avoid race conditions

### DIFF
--- a/pkg/tests/apis/provisioning/files_quota_test.go
+++ b/pkg/tests/apis/provisioning/files_quota_test.go
@@ -216,6 +216,7 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 1})
 		helper.TriggerRepositoryReconciliation(t, repo)
+		helper.WaitForResourceQuotaLimit(t, repo, 1)
 		helper.SyncAndWait(t, repo, nil)
 		// Wait for quota condition to show exceeded
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaExceeded)

--- a/pkg/tests/apis/provisioning/helper_test.go
+++ b/pkg/tests/apis/provisioning/helper_test.go
@@ -651,6 +651,22 @@ func (h *provisioningTestHelper) CreateRepo(t *testing.T, repo TestRepo) {
 	}
 }
 
+// WaitForResourceQuotaLimit waits until the repository's Status.Quota.MaxResourcesPerRepository
+// matches the expected limit.
+func (h *provisioningTestHelper) WaitForResourceQuotaLimit(t *testing.T, repoName string, expectedLimit int64) {
+	t.Helper()
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		repoObj, err := h.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
+		if !assert.NoError(collect, err, "failed to get repository") {
+			return
+		}
+
+		repo := unstructuredToRepository(t, repoObj)
+		assert.Equal(collect, expectedLimit, repo.Status.Quota.MaxResourcesPerRepository,
+			"repository quota limit not yet updated by controller")
+	}, waitTimeoutDefault, waitIntervalDefault, "Status.Quota.MaxResourcesPerRepository should be %d", expectedLimit)
+}
+
 // WaitForQuotaReconciliation waits for the repository's quota condition to match the expected reason.
 // It uses the typed Repository object and the quotas package to check conditions.
 func (h *provisioningTestHelper) WaitForQuotaReconciliation(t *testing.T, repoName string, expectedReason string) {

--- a/pkg/tests/apis/provisioning/quota_test.go
+++ b/pkg/tests/apis/provisioning/quota_test.go
@@ -96,6 +96,7 @@ func TestIntegrationProvisioning_QuotaCondition(t *testing.T) {
 
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
 		helper.TriggerRepositoryReconciliation(t, repo)
+		helper.WaitForResourceQuotaLimit(t, repo, 2)
 		helper.SyncAndWait(t, repo, nil)
 
 		// Wait for the repository to be synced and check the Quota condition

--- a/pkg/tests/apis/provisioning/sync_quota_test.go
+++ b/pkg/tests/apis/provisioning/sync_quota_test.go
@@ -47,6 +47,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		// 1 folder + 2 dashboards = 3 resources, new limit 2 → exceeded
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
 		helper.TriggerRepositoryReconciliation(t, repo)
+		helper.WaitForResourceQuotaLimit(t, repo, 2)
 		helper.SyncAndWait(t, repo, nil)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaExceeded)
 
@@ -137,6 +138,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		// 1 folder + 2 dashboards = 3 resources, new limit 2 → exceeded
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
 		helper.TriggerRepositoryReconciliation(t, testRepo.Name)
+		helper.WaitForResourceQuotaLimit(t, repo, 2)
 		helper.SyncAndWait(t, repo, nil)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaExceeded)
 
@@ -405,6 +407,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		// 1 folder + 3 dashboards = 4 resources, new limit 3 → exceeded
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 3})
 		helper.TriggerRepositoryReconciliation(t, repo)
+		helper.WaitForResourceQuotaLimit(t, repo, 3)
 		helper.SyncAndWait(t, repo, nil)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaExceeded)
 
@@ -452,6 +455,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		// 1 folder + 3 dashboards = 4 resources, new limit 1 → exceeded
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 1})
 		helper.TriggerRepositoryReconciliation(t, repo)
+		helper.WaitForResourceQuotaLimit(t, repo, 1)
 		helper.SyncAndWait(t, repo, nil)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaExceeded)
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Integration test that update quota condition should wait for the repository reconciliation (a.k.a. quota update) before proceeding. 

**Why do we need this feature?**

If wait does not happen, there is a chance that the pull jobs tested don't see the updated quota in the repository, treating it as unlimited or any other previous condition, making the integration test to randomly fail.

**Who is this feature for?**

Integration tests for provisioning.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer:**

Please check that:
- [ x ] It works as expected from a user's perspective.
- [ x ] If this is a pre-GA feature, it is behind a feature toggle.
- [ x ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
