### PR TITLE
Auditing: Skip logging for access policies on default evaluator

### DIFF
--- a/pkg/apiserver/auditing/policy.go
+++ b/pkg/apiserver/auditing/policy.go
@@ -2,7 +2,9 @@ package auditing
 
 import (
 	"slices"
+	"strings"
 
+	"github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
@@ -41,6 +43,13 @@ func (defaultGrafanaPolicyRuleEvaluator) EvaluatePolicyRule(attrs authorizer.Att
 	// Skip auditing if the user is part of the privileged group.
 	// The loopback client uses this group, so requests initiated in `/api/` would be duplicated.
 	if u := attrs.GetUser(); u != nil && slices.Contains(u.GetGroups(), user.SystemPrivilegedGroup) {
+		return audit.RequestAuditConfig{
+			Level: auditinternal.LevelNone,
+		}
+	}
+
+	// Skip auditing if this is an access policy, which is generally used for service-to-service communication.
+	if u := attrs.GetUser(); u != nil && strings.HasPrefix(u.GetUID(), types.TypeAccessPolicy.String()) {
 		return audit.RequestAuditConfig{
 			Level: auditinternal.LevelNone,
 		}

--- a/pkg/apiserver/auditing/policy_test.go
+++ b/pkg/apiserver/auditing/policy_test.go
@@ -3,6 +3,7 @@ package auditing_test
 import (
 	"testing"
 
+	"github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/apiserver/auditing"
 	"github.com/stretchr/testify/require"
@@ -85,5 +86,21 @@ func TestDefaultGrafanaPolicyRuleEvaluator(t *testing.T) {
 
 		config := evaluator.EvaluatePolicyRule(attrs)
 		require.Equal(t, auditinternal.LevelMetadata, config.Level)
+	})
+
+	t.Run("returns audit level none for access policies", func(t *testing.T) {
+		t.Parallel()
+
+		attrs := authorizer.AttributesRecord{
+			ResourceRequest: true,
+			Verb:            utils.VerbGet,
+			User: &user.DefaultInfo{
+				UID:    types.TypeAccessPolicy.String() + ":" + "uuid",
+				Groups: []string{"test-group"},
+			},
+		}
+
+		config := evaluator.EvaluatePolicyRule(attrs)
+		require.Equal(t, auditinternal.LevelNone, config.Level)
 	})
 }


### PR DESCRIPTION
Skips auditing for events that are from an access policy identity