### PR TITLE
CI: Add metrics to track OpenFeature migration progress

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,6 +69,8 @@
 /.bra.toml @grafana/grafana-backend-group
 /.golangci.yml @grafana/grafana-backend-group
 /scripts/modowners/ @grafana/grafana-backend-services-squad
+/scripts/featureflag-analysis/ @grafana/grafana-backend-services-squad
+/.github/workflows/featureflag-migration-metrics.yml @grafana/grafana-backend-services-squad
 /scripts/go-workspace @grafana/grafana-app-platform-squad
 /scripts/ci/backend-tests @grafana/grafana-operator-experience-squad
 /hack/ @grafana/grafana-app-platform-squad

--- a/.github/workflows/featureflag-migration-metrics.yml
+++ b/.github/workflows/featureflag-migration-metrics.yml
@@ -1,0 +1,48 @@
+name: Feature Flag Migration Metrics
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # Daily at 6am UTC
+  workflow_dispatch:
+
+jobs:
+  publish-metrics:
+    name: Publish feature flag migration metrics
+    runs-on: ubuntu-latest
+    if: github.repository == 'grafana/grafana'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - id: vault-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            GRAFANA_MISC_STATS_API_KEY=grafana-misc-stats:api_key
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Enterprise
+        uses: ./.github/actions/setup-enterprise
+        with:
+          github-app-name: 'grafana-ci-bot'
+
+      - name: Analyze and publish metrics
+        run: |
+          AUTH=$(echo -n "6371:${GRAFANA_MISC_STATS_API_KEY}" | base64 | tr -d '\n')
+          go run ./scripts/featureflag-analysis/ . ../grafana-enterprise/src | curl -sf \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Basic ${AUTH}" \
+            -d @- \
+            "https://graphite-us-central1.grafana.net/metrics"
+        env:
+          GRAFANA_MISC_STATS_API_KEY: ${{ env.GRAFANA_MISC_STATS_API_KEY }}

--- a/.github/workflows/featureflag-migration-metrics.yml
+++ b/.github/workflows/featureflag-migration-metrics.yml
@@ -1,6 +1,9 @@
 name: Feature Flag Migration Metrics
 
 on:
+  push:
+    branches:
+      - undef1nd/openfeature-migration-metrics
   schedule:
     - cron: '0 6 * * *' # Daily at 6am UTC
   workflow_dispatch:

--- a/.github/workflows/featureflag-migration-metrics.yml
+++ b/.github/workflows/featureflag-migration-metrics.yml
@@ -1,9 +1,6 @@
 name: Feature Flag Migration Metrics
 
 on:
-  push:
-    branches:
-      - undef1nd/openfeature-migration-metrics
   schedule:
     - cron: '0 6 * * *' # Daily at 6am UTC
   workflow_dispatch:

--- a/scripts/featureflag-analysis/analyzer.go
+++ b/scripts/featureflag-analysis/analyzer.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type migrationStatus string
+
+const (
+	statusMigrated    migrationStatus = "migrated"
+	statusPartial     migrationStatus = "partial"
+	statusNotMigrated migrationStatus = "not_migrated"
+	statusNoUsage     migrationStatus = "no_usage"
+)
+
+type flagInfo struct {
+	Name  string
+	Owner string
+}
+
+// fileIndex holds the content of files that match each broad pattern.
+// We walk the repo once and store file contents in memory so per-flag
+// lookups are fast string searches rather than repeated disk reads.
+type fileIndex struct {
+	beOld map[string]string // Go files containing "IsEnabled"
+	beNew map[string]string // Go files containing "openfeature"
+	feOld map[string]string // TS/TSX files containing "featureToggles" or "getFeatureToggle"
+	feNew map[string]string // TS/TSX files containing "useBooleanFlagValue" or "getFeatureFlagClient"
+}
+
+func buildIndex(roots []string) (fileIndex, error) {
+	idx := fileIndex{
+		beOld: make(map[string]string),
+		beNew: make(map[string]string),
+		feOld: make(map[string]string),
+		feNew: make(map[string]string),
+	}
+
+	for _, root := range roots {
+		// Go files under pkg/
+		if err := filepath.Walk(filepath.Join(root, "pkg"), func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() || !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return nil
+			}
+			s := string(content)
+			if strings.Contains(s, "IsEnabled") {
+				idx.beOld[path] = s
+			}
+			if strings.Contains(s, "openfeature") {
+				idx.beNew[path] = s
+			}
+			return nil
+		}); err != nil {
+			return idx, err
+		}
+
+		// TS/TSX files under public/ and packages/
+		for _, dir := range []string{
+			filepath.Join(root, "public"),
+			filepath.Join(root, "packages"),
+		} {
+			if _, err := os.Stat(dir); os.IsNotExist(err) {
+				continue
+			}
+			if err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if info.IsDir() {
+					return nil
+				}
+				if !strings.HasSuffix(path, ".ts") && !strings.HasSuffix(path, ".tsx") {
+					return nil
+				}
+				content, err := os.ReadFile(path)
+				if err != nil {
+					return nil
+				}
+				s := string(content)
+				if strings.Contains(s, "featureToggles") || strings.Contains(s, "getFeatureToggle") {
+					idx.feOld[path] = s
+				}
+				if strings.Contains(s, "useBooleanFlagValue") || strings.Contains(s, "getFeatureFlagClient") {
+					idx.feNew[path] = s
+				}
+				return nil
+			}); err != nil {
+				return idx, err
+			}
+		}
+	}
+
+	return idx, nil
+}
+
+func classifyFlag(name string, idx fileIndex) migrationStatus {
+	flagConst := "Flag" + strings.ToUpper(name[:1]) + name[1:]
+
+	// BE: string literal "flagName" or Go constant FlagXxx
+	beOld := containsAny(idx.beOld, `"`+name+`"`, flagConst)
+	beNew := containsAny(idx.beNew, `"`+name+`"`, flagConst)
+
+	// FE old: property access config.featureToggles.flagName — match as whole word
+	// to avoid false positives from substrings (e.g. "alert" in "alertingBacktesting")
+	wbRe := regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\b`)
+	feOld := containsPattern(idx.feOld, wbRe)
+
+	// FE new: quoted string literal 'flagName' or "flagName"
+	feNew := containsAny(idx.feNew, `'`+name+`'`, `"`+name+`"`)
+
+	return classify(beOld, beNew, feOld, feNew)
+}
+
+// classify is a pure function so it can be unit tested independently.
+func classify(beOld, beNew, feOld, feNew bool) migrationStatus {
+	beUsed := beOld || beNew
+	feUsed := feOld || feNew
+
+	beMigrated := beUsed && !beOld
+	feMigrated := feUsed && !feOld
+
+	switch {
+	case !beUsed && !feUsed:
+		return statusNoUsage
+	case beUsed && feUsed:
+		if beMigrated && feMigrated {
+			return statusMigrated
+		}
+		if beMigrated || feMigrated {
+			return statusPartial
+		}
+		return statusNotMigrated
+	case beUsed:
+		if beMigrated {
+			return statusMigrated
+		}
+		return statusNotMigrated
+	default: // feUsed only
+		if feMigrated {
+			return statusMigrated
+		}
+		return statusNotMigrated
+	}
+}
+
+func containsAny(files map[string]string, patterns ...string) bool {
+	for _, content := range files {
+		for _, p := range patterns {
+			if strings.Contains(content, p) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func containsPattern(files map[string]string, re *regexp.Regexp) bool {
+	for _, content := range files {
+		if re.MatchString(content) {
+			return true
+		}
+	}
+	return false
+}

--- a/scripts/featureflag-analysis/analyzer_test.go
+++ b/scripts/featureflag-analysis/analyzer_test.go
@@ -4,9 +4,9 @@ import "testing"
 
 func TestClassify(t *testing.T) {
 	tests := []struct {
-		name                    string
+		name                       string
 		beOld, beNew, feOld, feNew bool
-		want                    migrationStatus
+		want                       migrationStatus
 	}{
 		// No usage
 		{"not used anywhere", false, false, false, false, statusNoUsage},

--- a/scripts/featureflag-analysis/analyzer_test.go
+++ b/scripts/featureflag-analysis/analyzer_test.go
@@ -1,0 +1,41 @@
+package main
+
+import "testing"
+
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		name                    string
+		beOld, beNew, feOld, feNew bool
+		want                    migrationStatus
+	}{
+		// No usage
+		{"not used anywhere", false, false, false, false, statusNoUsage},
+
+		// BE only
+		{"BE only — not migrated", true, false, false, false, statusNotMigrated},
+		{"BE only — migrated", false, true, false, false, statusMigrated},
+		{"BE only — both patterns (in progress)", true, true, false, false, statusNotMigrated},
+
+		// FE only
+		{"FE only — not migrated", false, false, true, false, statusNotMigrated},
+		{"FE only — migrated", false, false, false, true, statusMigrated},
+		{"FE only — both patterns (in progress)", false, false, true, true, statusNotMigrated},
+
+		// Both BE and FE
+		{"both — fully migrated", false, true, false, true, statusMigrated},
+		{"both — BE done FE not", false, true, true, false, statusPartial},
+		{"both — FE done BE not", true, false, false, true, statusPartial},
+		{"both — neither done", true, false, true, false, statusNotMigrated},
+		{"both — neither done, BE in progress", true, true, true, false, statusNotMigrated},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classify(tt.beOld, tt.beNew, tt.feOld, tt.feNew)
+			if got != tt.want {
+				t.Errorf("classify(beOld=%v, beNew=%v, feOld=%v, feNew=%v) = %q, want %q",
+					tt.beOld, tt.beNew, tt.feOld, tt.feNew, got, tt.want)
+			}
+		})
+	}
+}

--- a/scripts/featureflag-analysis/main.go
+++ b/scripts/featureflag-analysis/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type graphiteMetric struct {
+	Name     string `json:"name"`
+	Value    int    `json:"value"`
+	Interval int    `json:"interval"`
+	MType    string `json:"mtype"`
+	Time     int64  `json:"time"`
+}
+
+func main() {
+	roots := []string{"."}
+	if len(os.Args) > 1 {
+		roots = os.Args[1:]
+	}
+
+	flags, err := readFlags(filepath.Join(roots[0], "pkg/services/featuremgmt/toggles_gen.csv"))
+	if err != nil {
+		log.Fatalf("reading flags: %v", err)
+	}
+
+	fmt.Fprintln(os.Stderr, "Building file index...")
+	idx, err := buildIndex(roots)
+	if err != nil {
+		log.Fatalf("building index: %v", err)
+	}
+	fmt.Fprintf(os.Stderr, "Indexed: beOld=%d beNew=%d feOld=%d feNew=%d files\n",
+		len(idx.beOld), len(idx.beNew), len(idx.feOld), len(idx.feNew))
+
+	counts := map[migrationStatus]int{}
+	byStatus := map[migrationStatus][]string{}
+	for _, f := range flags {
+		s := classifyFlag(f.Name, idx)
+		counts[s]++
+		byStatus[s] = append(byStatus[s], f.Name)
+	}
+
+	total := len(flags)
+	fmt.Fprintf(os.Stderr, "Total: %d | Migrated: %d | Partial: %d | Not migrated: %d | No usage: %d\n",
+		total, counts[statusMigrated], counts[statusPartial], counts[statusNotMigrated], counts[statusNoUsage])
+	fmt.Fprintf(os.Stderr, "No usage: %v\n", byStatus[statusNoUsage])
+
+	ts := time.Now().Unix()
+	metrics := []graphiteMetric{
+		{"grafana.ci-code.featureflags.total", total, 86400, "gauge", ts},
+		{"grafana.ci-code.featureflags.migrated", counts[statusMigrated], 86400, "gauge", ts},
+		{"grafana.ci-code.featureflags.partial", counts[statusPartial], 86400, "gauge", ts},
+		{"grafana.ci-code.featureflags.not_migrated", counts[statusNotMigrated], 86400, "gauge", ts},
+		{"grafana.ci-code.featureflags.no_usage", counts[statusNoUsage], 86400, "gauge", ts},
+	}
+
+	if err := json.NewEncoder(os.Stdout).Encode(metrics); err != nil {
+		log.Fatalf("encoding output: %v", err)
+	}
+}
+
+func readFlags(csvPath string) ([]flagInfo, error) {
+	f, err := os.Open(csvPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	records, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		return nil, err
+	}
+
+	var flags []flagInfo
+	for i, row := range records {
+		if i == 0 || len(row) < 4 {
+			continue
+		}
+		flags = append(flags, flagInfo{Name: row[1], Owner: row[3]})
+	}
+	return flags, nil
+}


### PR DESCRIPTION
  - Adds a Go tool (scripts/featureflag-analysis/) that walks the repo and determines each feature flag's migration status
  - Adds a GitHub Actions workflow that publishes counts to Graphite under
  `grafana.ci-code.featureflags.*`. Run daily via cron.
  - Flag is `migrated` if every side it's used on (backend and/or frontend) uses the new OpenFeature API; `partial` if used on both sides but only one has migrated; `not_migrated` if no side has migrated; `no_usage` if no call sites found
