### PR TITLE
QueryEditor: Banner and v1/v2 opt in/out polish

### DIFF
--- a/packages/grafana-data/src/types/icon.ts
+++ b/packages/grafana-data/src/types/icon.ts
@@ -131,6 +131,7 @@ export const availableIconsIndex = {
   'file-export': true,
   'file-landscape-alt': true,
   filter: true,
+  flask: true,
   'filter-plus': true,
   'filter-minus': true,
   flip: true,

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
+import { t } from '@grafana/i18n';
 import {
   SceneComponentProps,
   SceneObjectBase,
@@ -11,7 +12,7 @@ import {
   SceneObjectUrlValues,
   VizPanel,
 } from '@grafana/scenes';
-import { Container, ScrollContainer, TabContent, TabsBar, useStyles2 } from '@grafana/ui';
+import { Button, Container, ScrollContainer, TabContent, TabsBar, useStyles2 } from '@grafana/ui';
 import { getConfig } from 'app/core/config';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getRulesPermissions } from 'app/features/alerting/unified/utils/access-control';
@@ -22,10 +23,14 @@ import { PanelDataPaneNext } from '../PanelEditNext/PanelDataPaneNext';
 import { PanelDataAlertingTab } from './PanelDataAlertingTab';
 import { PanelDataQueriesTab } from './PanelDataQueriesTab';
 import { PanelDataTransformationsTab } from './PanelDataTransformationsTab';
-import { PanelDataPaneTab, TabId } from './types';
+import { PanelDataPaneTab, PanelEditorInterface, TabId } from './types';
 
 function isTabId(value: string): value is TabId {
   return Object.values<string>(TabId).includes(value);
+}
+
+function isPanelEditor(obj: object): obj is PanelEditorInterface {
+  return 'onToggleQueryEditorVersion' in obj && typeof obj.onToggleQueryEditorVersion === 'function';
 }
 
 export interface PanelDataPaneState extends SceneObjectState {
@@ -72,6 +77,12 @@ export class PanelDataPane extends SceneObjectBase<PanelDataPaneState> {
     this.setState({ tab: tab.tabId });
   };
 
+  public onTryNewEditor = () => {
+    if (this.parent && isPanelEditor(this.parent)) {
+      this.parent.onToggleQueryEditorVersion();
+    }
+  };
+
   public getUrlState() {
     return { tab: this.state.tab };
   }
@@ -95,11 +106,26 @@ function PanelDataPaneRendered({ model }: SceneComponentProps<PanelDataPane>) {
   }
 
   const currentTab = tabs.find((t) => t.tabId === tab);
+  const showTryNewEditor = getConfig().featureToggles.queryEditorNext;
 
   return (
     <div className={styles.dataPane} data-testid={selectors.components.PanelEditor.DataPane.content}>
       <TabsBar hideBorder className={styles.tabsBar}>
         {tabs.map((t) => t.renderTab({ active: t.tabId === tab, onChangeTab: () => model.onChangeTab(t) }))}
+        {showTryNewEditor && (
+          <div className={styles.tryNewEditorWrapper}>
+            <Button
+              size="sm"
+              fill="text"
+              icon="flask"
+              variant="primary"
+              onClick={model.onTryNewEditor}
+              tooltip={t('panel-data-pane.try-new-editor.tooltip', 'Switch to the new query editor experience')}
+            >
+              {t('panel-data-pane.try-new-editor.label', 'Try the new editor')}
+            </Button>
+          </div>
+        )}
       </TabsBar>
       <div className={styles.tabBorder}>
         <ScrollContainer>
@@ -152,6 +178,12 @@ function getStyles(theme: GrafanaTheme2) {
     tabsBar: css({
       flexShrink: 0,
       paddingLeft: theme.spacing(2),
+    }),
+    tryNewEditorWrapper: css({
+      marginLeft: 'auto',
+      display: 'flex',
+      alignItems: 'center',
+      paddingRight: theme.spacing(1),
     }),
   };
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/types.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/types.ts
@@ -16,3 +16,7 @@ export interface PanelDataPaneTab extends SceneObject {
   getTabLabel(): string;
   tabId: TabId;
 }
+
+export interface PanelEditorInterface {
+  onToggleQueryEditorVersion: () => void;
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditControls.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditControls.tsx
@@ -3,8 +3,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
-import { Button, InlineSwitch, useStyles2 } from '@grafana/ui';
+import { InlineSwitch, useStyles2 } from '@grafana/ui';
 
 import { PanelEditor } from './PanelEditor';
 
@@ -13,7 +12,7 @@ export interface Props {
 }
 
 export function PanelEditControls({ panelEditor }: Props) {
-  const { tableView, dataPane, useQueryExperienceNext } = panelEditor.useState();
+  const { tableView, dataPane } = panelEditor.useState();
   const styles = useStyles2(getStyles);
 
   if (!dataPane) {
@@ -22,19 +21,6 @@ export function PanelEditControls({ panelEditor }: Props) {
 
   return (
     <div className={styles.container}>
-      {config.featureToggles.queryEditorNext && (
-        <Button
-          onClick={panelEditor.onToggleQueryEditorVersion}
-          tooltip=""
-          variant="primary"
-          fill="text"
-          icon={useQueryExperienceNext ? 'arrow-left' : 'rocket'}
-        >
-          {useQueryExperienceNext
-            ? t('dashboard-scene.panel-edit-controls.back-to-classic', 'Back to classic editor')
-            : t('dashboard-scene.panel-edit-controls.try-new-editor', 'Try new editor')}
-        </Button>
-      )}
       <InlineSwitch
         label={t('dashboard-scene.panel-edit-controls.table-view-label-table-view', 'Table view')}
         showLabel={true}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ExperimentalFeedbackButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ExperimentalFeedbackButton.tsx
@@ -1,0 +1,92 @@
+import { css, cx, keyframes } from '@emotion/css';
+import { useRef } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Button, Dropdown, Menu, useStyles2 } from '@grafana/ui';
+
+import { QUERY_EDITOR_BANNER_FEEDBACK_URL } from '../../constants';
+import { useActionsContext, useQueryEditorUIContext } from '../QueryEditorContext';
+
+export function ExperimentalFeedbackButton() {
+  const { showVersionBanner } = useQueryEditorUIContext();
+  const { onSwitchToClassic } = useActionsContext();
+  const styles = useStyles2(getStyles);
+
+  // Track whether the banner was visible when this component first mounted.
+  // If it was, the user dismissed it in this session — animate the button in.
+  // If it wasn't (already dismissed on load), skip the animation.
+  const bannerWasInitiallyVisible = useRef(showVersionBanner);
+  const shouldAnimate = bannerWasInitiallyVisible.current && !showVersionBanner;
+
+  if (showVersionBanner || !onSwitchToClassic) {
+    return null;
+  }
+
+  const menu = (
+    <Menu>
+      <Menu.Item
+        label={t('query-editor-next.experimental-button.give-feedback', 'Give feedback')}
+        icon="external-link-alt"
+        url={QUERY_EDITOR_BANNER_FEEDBACK_URL}
+        target="_blank"
+      />
+      <Menu.Item
+        label={t('query-editor-next.experimental-button.back-to-classic', 'Go back to classic editor')}
+        icon="arrow-left"
+        onClick={onSwitchToClassic}
+      />
+    </Menu>
+  );
+
+  return (
+    <div className={cx(styles.wrapper, shouldAnimate && styles.animated)}>
+      <Dropdown overlay={menu} placement="bottom-end">
+        <Button
+          size="sm"
+          fill="text"
+          icon="flask"
+          variant="secondary"
+          className={styles.button}
+          tooltip={t('query-editor-next.experimental-button.tooltip', 'Experimental feature options')}
+          aria-label={t('query-editor-next.experimental-button.aria-label', 'Experimental feature options')}
+        />
+      </Dropdown>
+    </div>
+  );
+}
+
+const slideInAndPulse = keyframes({
+  '0%': {
+    opacity: 0,
+    transform: 'translateX(24px) scale(0.6)',
+  },
+  '60%': {
+    opacity: 1,
+    transform: 'translateX(0) scale(1.2)',
+  },
+  '80%': {
+    transform: 'translateX(0) scale(0.9)',
+  },
+  '100%': {
+    opacity: 1,
+    transform: 'translateX(0) scale(1)',
+  },
+});
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  wrapper: css({
+    display: 'flex',
+  }),
+  animated: css({
+    [theme.transitions.handleMotion('no-preference')]: {
+      animation: `${slideInAndPulse} 0.4s ${theme.transitions.easing.easeOut} both`,
+    },
+  }),
+  button: css({
+    color: theme.colors.warning.main,
+    '&:hover': {
+      color: theme.colors.warning.text,
+    },
+  }),
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/HeaderActions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/HeaderActions.tsx
@@ -7,6 +7,7 @@ import { Actions } from '../../Actions';
 import { QueryEditorType } from '../../constants';
 import { useActionsContext, useQueryEditorUIContext } from '../QueryEditorContext';
 
+import { ExperimentalFeedbackButton } from './ExperimentalFeedbackButton';
 import { PluginActions } from './PluginActions';
 import { QueryActionsMenu } from './QueryActionsMenu';
 import { SaveButton } from './SaveButton';
@@ -76,6 +77,7 @@ export function HeaderActions({ containerRef }: HeaderActionsProps) {
           duplicate: 0,
         }}
       />
+      <ExperimentalFeedbackButton />
       {cardType === QueryEditorType.Transformation ? <TransformationActionButtons /> : <QueryActionsMenu />}
     </Stack>
   );

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/QueryActionsMenu.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/QueryActionsMenu.tsx
@@ -1,9 +1,7 @@
-import { css } from '@emotion/css';
 import { useCallback } from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Button, Dropdown, Menu, useStyles2 } from '@grafana/ui';
+import { Button, Dropdown, Menu } from '@grafana/ui';
 import { InspectTab } from 'app/features/inspector/types';
 
 import { PanelInspectDrawer } from '../../../../inspect/PanelInspectDrawer';
@@ -23,8 +21,6 @@ export function QueryActionsMenu() {
     cardType,
   } = useQueryEditorUIContext();
 
-  const styles = useStyles2(getStyles);
-
   const onOpenInspector = useCallback(() => {
     const dashboard = getDashboardSceneFor(panel);
     dashboard.showModal(new PanelInspectDrawer({ panelRef: panel.getRef(), currentTab: InspectTab.Query }));
@@ -43,7 +39,6 @@ export function QueryActionsMenu() {
       overlay={
         <Menu>
           <Menu.Item
-            className={styles.menuItem}
             label={t('query-editor-next.action.duplicate', 'Duplicate {{type}}', { type: typeLabel })}
             icon="copy"
             onClick={() => duplicateQuery(selectedQuery.refId)}
@@ -52,7 +47,6 @@ export function QueryActionsMenu() {
           {/* Data source help (queries only, not expressions) */}
           {hasEditorHelp && !isExpression && (
             <Menu.Item
-              className={styles.menuItem}
               label={
                 showingDatasourceHelp
                   ? t('query-editor-next.action.hide-help', 'Hide data source help')
@@ -65,7 +59,6 @@ export function QueryActionsMenu() {
           )}
 
           <Menu.Item
-            className={styles.menuItem}
             label={t('query-editor-next.action.inspector', 'Query inspector')}
             icon="brackets-curly"
             onClick={onOpenInspector}
@@ -85,9 +78,3 @@ export function QueryActionsMenu() {
     </Dropdown>
   );
 }
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  menuItem: css({
-    fontSize: theme.typography.bodySmall.fontSize,
-  }),
-});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
@@ -93,9 +93,11 @@ export interface QueryEditorUIState {
   pendingTransformation: PendingTransformation | null;
   setPendingTransformation: (pending: PendingTransformation | null) => void;
   finalizePendingTransformation: (transformationId: string) => void;
+  showVersionBanner: boolean;
 }
 
 export interface QueryEditorActions {
+  onSwitchToClassic?: () => void;
   updateQueries: (queries: DataQuery[]) => void;
   updateSelectedQuery: (updatedQuery: DataQuery, originalRefId: string) => void;
   addQuery: (query?: Partial<DataQuery>, afterRefId?: string) => string | undefined;

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
@@ -39,9 +39,13 @@ export function getNextSelectedQueryRefId(
  */
 export function QueryEditorContextWrapper({
   dataPane,
+  onSwitchToClassic,
+  showVersionBanner,
   children,
 }: {
   dataPane: PanelDataPaneNext;
+  onSwitchToClassic?: () => void;
+  showVersionBanner?: boolean;
   children: ReactNode;
 }) {
   const { panelRef, datasource, dsSettings, dsError } = dataPane.useState();
@@ -208,7 +212,7 @@ export function QueryEditorContextWrapper({
         // Clear query and transformation selection when selecting an alert
         setSelectedQueryRefId(null);
         setSelectedTransformationId(null);
-        // Reset transformation-specific UI when switching transformations
+        // Reset transformation-specific UI when switching alerts
         setTransformTogglesState({ showHelp: false, showDebug: false });
         // Abandon pending flows when selecting a card
         clearPendingExpression();
@@ -263,6 +267,7 @@ export function QueryEditorContextWrapper({
         setPendingTransformation(pending);
       },
       finalizePendingTransformation,
+      showVersionBanner: Boolean(showVersionBanner),
     }),
     [
       selectedQuery,
@@ -288,11 +293,13 @@ export function QueryEditorContextWrapper({
       setPendingTransformation,
       finalizePendingTransformation,
       clearPendingTransformation,
+      showVersionBanner,
     ]
   );
 
   const actions = useMemo(
     () => ({
+      onSwitchToClassic,
       updateQueries: dataPane.updateQueries,
       updateSelectedQuery: (updatedQuery: DataQuery, originalRefId: string) => {
         dataPane.updateSelectedQuery(updatedQuery, originalRefId);
@@ -325,7 +332,7 @@ export function QueryEditorContextWrapper({
       updateTransformation: dataPane.updateTransformation,
       reorderTransformations: dataPane.reorderTransformations,
     }),
-    [dataPane, findTransformationIndex, addTransformationAction]
+    [onSwitchToClassic, dataPane, findTransformationIndex, addTransformationAction]
   );
 
   return (

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
@@ -120,6 +120,7 @@ describe('QueryEditorRenderer', () => {
             finalizePendingTransformation: jest.fn(),
             pendingSavedQuery: null,
             setPendingSavedQuery: jest.fn(),
+            showVersionBanner: false,
           }}
           actions={mockActions}
         >

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/testUtils.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/testUtils.tsx
@@ -197,6 +197,7 @@ export function renderWithQueryEditorProvider(children: ReactElement, options: C
     setSelectedAlert: jest.fn(),
     pendingSavedQuery: null,
     setPendingSavedQuery: jest.fn(),
+    showVersionBanner: false,
     ...uiStateOverrides,
   };
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/VizAndDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/VizAndDataPaneNext.tsx
@@ -42,7 +42,11 @@ export function VizAndDataPaneNext({ model }: SceneComponentProps<PanelEditor>) 
         )}
       </div>
       {nextDataPane && (
-        <QueryEditorContextWrapper dataPane={nextDataPane}>
+        <QueryEditorContextWrapper
+          dataPane={nextDataPane}
+          onSwitchToClassic={model.onToggleQueryEditorVersion}
+          showVersionBanner={showBanner}
+        >
           {showBanner && (
             <QueryEditorBanner
               useQueryExperienceNext={model.state.useQueryExperienceNext ?? false}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditorRenderer.tsx
@@ -13,9 +13,7 @@ import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { UnlinkModal } from '../scene/UnlinkModal';
 import { getDashboardSceneFor, getLibraryPanelBehavior } from '../utils/utils';
 
-import { useQueryEditorBanner } from './PanelEditNext/hooks';
 import { PanelEditor } from './PanelEditor';
-import { QueryEditorBanner } from './QueryEditorBanner';
 import { SaveLibraryVizPanelModal } from './SaveLibraryVizPanelModal';
 import { useSnappingSplitter } from './splitter/useSnappingSplitter';
 import { scrollReflowMediaCondition, useScrollReflowLimit } from './useScrollReflowLimit';
@@ -88,7 +86,6 @@ function VizAndDataPane({ model }: SceneComponentProps<PanelEditor>) {
   const libraryPanel = getLibraryPanelBehavior(panel);
   const { controls } = dashboard.useState();
   const styles = useStyles2(getStyles);
-  const { showBanner, dismissBanner } = useQueryEditorBanner();
 
   const isScrollingLayout = useScrollReflowLimit();
 
@@ -136,14 +133,6 @@ function VizAndDataPane({ model }: SceneComponentProps<PanelEditor>) {
         {dataPane && (
           <>
             <div {...splitterProps} />
-            {showBanner && (
-              <QueryEditorBanner
-                useQueryExperienceNext={model.state.useQueryExperienceNext ?? false}
-                onToggle={model.onToggleQueryEditorVersion}
-                onDismiss={dismissBanner}
-                className={styles.bannerWrapper}
-              />
-            )}
             <div
               {...secondaryProps}
               className={cx(secondaryProps.className, isScrollingLayout && styles.fullSizeEditor)}
@@ -280,10 +269,6 @@ function getStyles(theme: GrafanaTheme2) {
       svg: {
         rotate: '-90deg',
       },
-    }),
-    bannerWrapper: css({
-      marginLeft: theme.spacing(2),
-      flexShrink: 0,
     }),
     vizWrapper: css({
       height: '100%',

--- a/public/app/features/dashboard-scene/panel-edit/QueryEditorBanner.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/QueryEditorBanner.test.tsx
@@ -16,14 +16,14 @@ describe('QueryEditorBanner', () => {
     it('shows the upgrade title and "Try it out" button', () => {
       render(<QueryEditorBanner useQueryExperienceNext={false} onToggle={onToggle} onDismiss={onDismiss} />);
 
-      expect(screen.getByText('New editor available!')).toBeInTheDocument();
+      expect(screen.getByText('New editor available')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /try it out/i })).toBeInTheDocument();
     });
 
     it('does not show new-editor-specific content', () => {
       render(<QueryEditorBanner useQueryExperienceNext={false} onToggle={onToggle} onDismiss={onDismiss} />);
 
-      expect(screen.queryByText('Go back to classic')).not.toBeInTheDocument();
+      expect(screen.queryByText('Back to classic')).not.toBeInTheDocument();
     });
 
     it('calls onToggle when "Try it out" is clicked', async () => {
@@ -39,7 +39,7 @@ describe('QueryEditorBanner', () => {
     it('shows the new editor title and "Go back to classic" button', () => {
       render(<QueryEditorBanner useQueryExperienceNext={true} onToggle={onToggle} onDismiss={onDismiss} />);
 
-      expect(screen.getByText('New query editor!')).toBeInTheDocument();
+      expect(screen.getByText('New query editor')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /back to classic/i })).toBeInTheDocument();
     });
 

--- a/public/app/features/dashboard-scene/panel-edit/QueryEditorBanner.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/QueryEditorBanner.tsx
@@ -19,11 +19,11 @@ export function QueryEditorBanner({ useQueryExperienceNext, onToggle, onDismiss,
   return (
     <div className={cx(styles.banner, className)}>
       <div className={styles.left}>
-        <Icon name={useQueryExperienceNext ? 'rocket' : 'bolt'} size="md" className={styles.accentIcon} />
+        <Icon name="flask" size="md" className={styles.accentIcon} />
         <span className={styles.title}>
           {useQueryExperienceNext
-            ? t('dashboard-scene.query-editor-banner.downgrade-title', 'New query editor!')
-            : t('dashboard-scene.query-editor-banner.upgrade-title', 'New editor available!')}
+            ? t('dashboard-scene.query-editor-banner.downgrade-title', 'New query editor')
+            : t('dashboard-scene.query-editor-banner.upgrade-title', 'New editor available')}
         </span>
         <span className={styles.description}>
           {useQueryExperienceNext
@@ -43,7 +43,7 @@ export function QueryEditorBanner({ useQueryExperienceNext, onToggle, onDismiss,
             variant="primary"
             fill="text"
             size="sm"
-            icon="comment-alt"
+            icon="external-link-alt"
             href={QUERY_EDITOR_BANNER_FEEDBACK_URL}
             target="_blank"
             rel="noopener noreferrer"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13459,6 +13459,7 @@
     },
     "edit-query-name": "Edit query name",
     "experimental-button": {
+      "aria-label": "Experimental feature options",
       "back-to-classic": "Go back to classic editor",
       "give-feedback": "Give feedback",
       "tooltip": "Experimental feature options"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6887,10 +6887,8 @@
       "title-delete-all-transformations": "Delete all transformations?"
     },
     "panel-edit-controls": {
-      "back-to-classic": "Back to classic editor",
       "table-view-aria-label-toggletableview": "Toggle table view",
-      "table-view-label-table-view": "Table view",
-      "try-new-editor": "Try new editor"
+      "table-view-label-table-view": "Table view"
     },
     "panel-editor": {
       "text": {
@@ -6940,11 +6938,11 @@
       "description-classic": "Try the improved query editing experience.",
       "description-new": "Welcome to the improved query editing experience.",
       "dismiss": "Dismiss",
-      "downgrade-title": "New query editor!",
+      "downgrade-title": "New query editor",
       "give-feedback": "Give feedback",
       "go-back": "Back to classic",
       "try-it": "Try it out",
-      "upgrade-title": "New editor available!"
+      "upgrade-title": "New editor available"
     },
     "query-variable-editor-form": {
       "description-examples": "Named capture groups can be used to separate the display text and value (<1>see examples</1> ).",
@@ -12026,6 +12024,12 @@
       "could-anything-matching-query": "Could not find anything matching your query"
     }
   },
+  "panel-data-pane": {
+    "try-new-editor": {
+      "label": "Try the new editor",
+      "tooltip": "Switch to the new query editor experience"
+    }
+  },
   "panel-group-by": {
     "button": "Group by",
     "loading": "Loading options",
@@ -13454,6 +13458,11 @@
       "width-of-panel": "Width of panel"
     },
     "edit-query-name": "Edit query name",
+    "experimental-button": {
+      "back-to-classic": "Go back to classic editor",
+      "give-feedback": "Give feedback",
+      "tooltip": "Experimental feature options"
+    },
     "footer": {
       "edit-option": "Edit {{label}}",
       "label": {


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->
Resolves https://github.com/grafana/grafana/issues/119541

As discussed this morning during the UI call. 

## Changes
<!--- Describe your changes in detail -->
* Change icon for “Give feedback” to external
* Remove query view buttons in controls header
* When banner is dismissed, show the beaker in the content header actions
* Update spaceship icon to flask
* Flask button in content header is a menu
   * Give feedback
   * Go back to classic

**In v1**

* Move "Try the editor” button to the right of the query editor tabs.
* No banner for ops, we'll bring the banner back for private preview

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->
N/A

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->
https://github.com/user-attachments/assets/f88ecd5a-bf53-48cc-af6c-aa27b0f2a174

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* Pull it down and try it out 😄 

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable