### PR TITLE
chore: migrate grafana-app-sdk off of CLI flags and to config.cue blocks

### DIFF
--- a/apps/advisor/Makefile
+++ b/apps/advisor/Makefile
@@ -6,11 +6,7 @@ etcd:
 
 .PHONY: generate # Run Grafana App SDK code generation
 generate: install-app-sdk update-app-sdk
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--defencoding=none
+	@$(APP_SDK_BIN) generate --source=./kinds/
 
 .PHONY: run
 run:

--- a/apps/advisor/kinds/config.cue
+++ b/apps/advisor/kinds/config.cue
@@ -1,0 +1,14 @@
+package advisor
+
+config: {
+	codegen: {
+		goGenPath: "./pkg/apis"
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/alerting/historian/Makefile
+++ b/apps/alerting/historian/Makefile
@@ -2,8 +2,4 @@ include ../../sdk.mk
 
 .PHONY: generate # Run Grafana App SDK code generation
 generate: install-app-sdk update-app-sdk
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--defencoding=none
+	@$(APP_SDK_BIN) generate --source=./kinds/

--- a/apps/alerting/historian/kinds/config.cue
+++ b/apps/alerting/historian/kinds/config.cue
@@ -1,0 +1,14 @@
+package kinds
+
+config: {
+	codegen: {
+		goGenPath: "./pkg/apis"
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/alerting/notifications/Makefile
+++ b/apps/alerting/notifications/Makefile
@@ -2,10 +2,5 @@ include ../../sdk.mk
 
 .PHONY: generate # Run Grafana App SDK code generation
 generate: install-app-sdk update-app-sdk
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--genoperatorstate=false \
-		--defencoding=none
+	@$(APP_SDK_BIN) generate --source=./kinds/
 	

--- a/apps/alerting/notifications/kinds/config.cue
+++ b/apps/alerting/notifications/kinds/config.cue
@@ -1,0 +1,15 @@
+package kinds
+
+config: {
+	codegen: {
+		goGenPath:                      "./pkg/apis"
+		enableOperatorStatusGeneration: false
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/alerting/rules/Makefile
+++ b/apps/alerting/rules/Makefile
@@ -5,4 +5,4 @@ generate: do-generate ## Run Grafana App SDK code generation
 
 .PHONY: do-generate
 do-generate: install-app-sdk update-app-sdk
-	@$(APP_SDK_BIN) generate --grouping=group --gogenpath=./pkg/apis --defencoding=yaml --postprocess
+	@$(APP_SDK_BIN) generate --source=./kinds/

--- a/apps/alerting/rules/kinds/config.cue
+++ b/apps/alerting/rules/kinds/config.cue
@@ -1,0 +1,14 @@
+package kinds
+
+config: {
+	codegen: {
+		goGenPath:               "./pkg/apis"
+		enableK8sPostProcessing: true
+	}
+	definitions: {
+		encoding: "yaml"
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/annotation/Makefile
+++ b/apps/annotation/Makefile
@@ -2,8 +2,4 @@ include ../sdk.mk
 
 .PHONY: generate # Run Grafana App SDK code generation
 generate: install-app-sdk update-app-sdk
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--defencoding=none
+	@$(APP_SDK_BIN) generate --source=./kinds/

--- a/apps/annotation/kinds/config.cue
+++ b/apps/annotation/kinds/config.cue
@@ -1,0 +1,14 @@
+package kinds
+
+config: {
+	codegen: {
+		goGenPath: "./pkg/apis"
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/collections/Makefile
+++ b/apps/collections/Makefile
@@ -2,9 +2,4 @@ include ../sdk.mk
 
 .PHONY: generate # Run Grafana App SDK code generation
 generate: install-app-sdk update-app-sdk
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--genoperatorstate=false \
-		--defencoding=none
+	@$(APP_SDK_BIN) generate --source=./kinds/

--- a/apps/collections/kinds/config.cue
+++ b/apps/collections/kinds/config.cue
@@ -1,0 +1,15 @@
+package preferences
+
+config: {
+	codegen: {
+		goGenPath:                      "./pkg/apis"
+		enableOperatorStatusGeneration: false
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/correlations/Makefile
+++ b/apps/correlations/Makefile
@@ -5,12 +5,7 @@ generate: do-generate post-generate-cleanup
 
 .PHONY: do-generate
 do-generate: install-app-sdk update-app-sdk
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--genoperatorstate=false \
-		--defencoding=none
+	@$(APP_SDK_BIN) generate --source=./kinds/
 
 .PHONY: post-generate-cleanup
 post-generate-cleanup: ## Fix TargetSpec OpenAPI schema

--- a/apps/correlations/kinds/config.cue
+++ b/apps/correlations/kinds/config.cue
@@ -1,0 +1,15 @@
+package kinds
+
+config: {
+	codegen: {
+		goGenPath:                      "./pkg/apis"
+		enableOperatorStatusGeneration: false
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/dashboard/Makefile
+++ b/apps/dashboard/Makefile
@@ -10,13 +10,7 @@ generate: do-generate post-generate-cleanup ## Run Grafana App SDK code generati
 
 .PHONY: do-generate
 do-generate: install-app-sdk update-app-sdk ## Run Grafana App SDK code generation
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--tsgenpath=../../packages/grafana-schema/src/schema \
-		--grouping=group \
-		--defencoding=none \
-		--genoperatorstate=false
+	@$(APP_SDK_BIN) generate --source=./kinds/
 
 .PHONY: post-generate-cleanup
 post-generate-cleanup: ## Clean up the generated code

--- a/apps/dashboard/kinds/config.cue
+++ b/apps/dashboard/kinds/config.cue
@@ -1,0 +1,16 @@
+package kinds
+
+config: {
+	codegen: {
+		goGenPath:                      "./pkg/apis"
+		tsGenPath:                      "../../packages/grafana-schema/src/schema"
+		enableOperatorStatusGeneration: false
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/dashvalidator/Makefile
+++ b/apps/dashvalidator/Makefile
@@ -2,8 +2,4 @@ include ../sdk.mk
 
 .PHONY: generate # Run Grafana App SDK code generation
 generate: install-app-sdk update-app-sdk
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--defencoding=none
+	@$(APP_SDK_BIN) generate --source=./kinds/

--- a/apps/dashvalidator/kinds/config.cue
+++ b/apps/dashvalidator/kinds/config.cue
@@ -1,0 +1,14 @@
+package kinds
+
+config: {
+	codegen: {
+		goGenPath: "./pkg/apis"
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/example/Makefile
+++ b/apps/example/Makefile
@@ -2,8 +2,4 @@ include ../sdk.mk
 
 .PHONY: generate # Run Grafana App SDK code generation
 generate: install-app-sdk update-app-sdk
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--defencoding=none
+	@$(APP_SDK_BIN) generate --source=./kinds/

--- a/apps/example/kinds/config.cue
+++ b/apps/example/kinds/config.cue
@@ -1,0 +1,14 @@
+package kinds
+
+config: {
+	codegen: {
+		goGenPath: "./pkg/apis"
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/folder/Makefile
+++ b/apps/folder/Makefile
@@ -2,12 +2,6 @@ include ../sdk.mk
 
 .PHONY: generate
 generate: install-app-sdk update-app-sdk ## Run Grafana App SDK code generation
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--defencoding=none \
-		--genoperatorstate=false \
-		--noschemasinmanifest
+	@$(APP_SDK_BIN) generate --source=./kinds/
 
 	

--- a/apps/folder/kinds/config.cue
+++ b/apps/folder/kinds/config.cue
@@ -1,0 +1,16 @@
+package folder
+
+config: {
+	codegen: {
+		goGenPath:                      "./pkg/apis"
+		enableOperatorStatusGeneration: false
+	}
+	definitions: {
+		manifestSchemas: false
+		genManifest:     false
+		genCRDs:         false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/iam/Makefile
+++ b/apps/iam/Makefile
@@ -2,14 +2,7 @@ include ../sdk.mk
 
 .PHONY: generate
 generate: install-app-sdk update-app-sdk ## Run Grafana App SDK code generation
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--defencoding=none \
-		--noschemasinmanifest \
-		--genoperatorstate=false \
-		--postprocess
+	@$(APP_SDK_BIN) generate --source=./kinds/
 
 .PHONY: deps
 deps:

--- a/apps/iam/kinds/config.cue
+++ b/apps/iam/kinds/config.cue
@@ -1,0 +1,17 @@
+package kinds
+
+config: {
+	codegen: {
+		goGenPath:                      "./pkg/apis"
+		enableOperatorStatusGeneration: false
+		enableK8sPostProcessing:        true
+	}
+	definitions: {
+		manifestSchemas: false
+		genManifest:     false
+		genCRDs:         false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/live/Makefile
+++ b/apps/live/Makefile
@@ -2,12 +2,7 @@ include ../sdk.mk
 
 .PHONY: generate
 generate: install-app-sdk update-app-sdk ## Run Grafana App SDK code generation
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--defencoding=none \
-		--genoperatorstate=false
+	@$(APP_SDK_BIN) generate --source=./kinds/
 
 .PHONY: test
 test: generate

--- a/apps/live/kinds/config.cue
+++ b/apps/live/kinds/config.cue
@@ -1,0 +1,15 @@
+package live
+
+config: {
+	codegen: {
+		goGenPath:                      "./pkg/apis"
+		enableOperatorStatusGeneration: false
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/logsdrilldown/Makefile
+++ b/apps/logsdrilldown/Makefile
@@ -2,8 +2,4 @@ include ../sdk.mk
 
 .PHONY: generate # Run Grafana App SDK code generation
 generate: install-app-sdk update-app-sdk
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--defencoding=none
+	@$(APP_SDK_BIN) generate --source=./kinds/

--- a/apps/logsdrilldown/kinds/config.cue
+++ b/apps/logsdrilldown/kinds/config.cue
@@ -1,0 +1,14 @@
+package kinds
+
+config: {
+	codegen: {
+		goGenPath: "./pkg/apis"
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/playlist/Makefile
+++ b/apps/playlist/Makefile
@@ -2,11 +2,7 @@ include ../sdk.mk
 
 .PHONY: generate # Run Grafana App SDK code generation
 generate: install-app-sdk update-app-sdk
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--defencoding=none
+	@$(APP_SDK_BIN) generate --source=./kinds/
 	@# Remove generated files for v0alpha1 since it's a thin wrapper around v1
 	@rm -f ./pkg/apis/playlist/v0alpha1/playlist_codec_gen.go
 	@rm -f ./pkg/apis/playlist/v0alpha1/playlist_object_gen.go

--- a/apps/playlist/kinds/config.cue
+++ b/apps/playlist/kinds/config.cue
@@ -1,0 +1,14 @@
+package playlist
+
+config: {
+	codegen: {
+		goGenPath: "./pkg/apis"
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/plugins/Makefile
+++ b/apps/plugins/Makefile
@@ -2,11 +2,7 @@ include ../sdk.mk
 
 .PHONY: internal-generate # Run Grafana App SDK code generation
 internal-generate: install-app-sdk update-app-sdk
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--defencoding=none
+	@$(APP_SDK_BIN) generate --source=./kinds/
 
 .PHONY: generate
 generate: internal-generate # copy files to packages/grafana-runtime/src/services/pluginMeta/types

--- a/apps/plugins/kinds/config.cue
+++ b/apps/plugins/kinds/config.cue
@@ -1,0 +1,14 @@
+package plugins
+
+config: {
+	codegen: {
+		goGenPath: "./pkg/apis"
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/preferences/Makefile
+++ b/apps/preferences/Makefile
@@ -2,9 +2,4 @@ include ../sdk.mk
 
 .PHONY: generate # Run Grafana App SDK code generation
 generate: install-app-sdk update-app-sdk
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--genoperatorstate=false \
-		--defencoding=none
+	@$(APP_SDK_BIN) generate --source=./kinds/

--- a/apps/preferences/kinds/config.cue
+++ b/apps/preferences/kinds/config.cue
@@ -1,0 +1,15 @@
+package preferences
+
+config: {
+	codegen: {
+		goGenPath:                      "./pkg/apis"
+		enableOperatorStatusGeneration: false
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/provisioning/Makefile
+++ b/apps/provisioning/Makefile
@@ -2,12 +2,7 @@ include ../sdk.mk
 
 .PHONY: generate # Run Grafana App SDK code generation
 generate: install-app-sdk update-app-sdk
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--genoperatorstate=false \
-		--defencoding=none
+	@$(APP_SDK_BIN) generate --source=./kinds/
 
 .PHONY: build
 build: generate

--- a/apps/provisioning/kinds/config.cue
+++ b/apps/provisioning/kinds/config.cue
@@ -1,0 +1,15 @@
+package repository
+
+config: {
+	codegen: {
+		goGenPath:                      "./pkg/apis"
+		enableOperatorStatusGeneration: false
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/quotas/Makefile
+++ b/apps/quotas/Makefile
@@ -2,8 +2,4 @@ include ../sdk.mk
 
 .PHONY: generate # Run Grafana App SDK code generation
 generate: install-app-sdk update-app-sdk
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--defencoding=none
+	@$(APP_SDK_BIN) generate --source=./kinds/

--- a/apps/quotas/kinds/config.cue
+++ b/apps/quotas/kinds/config.cue
@@ -1,0 +1,14 @@
+package kinds
+
+config: {
+	codegen: {
+		goGenPath: "./pkg/apis"
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/secret/Makefile
+++ b/apps/secret/Makefile
@@ -2,10 +2,4 @@ include ../sdk.mk
 
 .PHONY: generate # Run Grafana App SDK code generation
 generate: install-app-sdk update-app-sdk
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--defencoding=none \
-		--noschemasinmanifest \
-		--postprocess
+	@$(APP_SDK_BIN) generate --source=./kinds/

--- a/apps/secret/kinds/config.cue
+++ b/apps/secret/kinds/config.cue
@@ -1,0 +1,16 @@
+package kinds
+
+config: {
+	codegen: {
+		goGenPath:               "./pkg/apis"
+		enableK8sPostProcessing: true
+	}
+	definitions: {
+		manifestSchemas: false
+		genManifest:     false
+		genCRDs:         false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/apps/shorturl/Makefile
+++ b/apps/shorturl/Makefile
@@ -2,8 +2,4 @@ include ../sdk.mk
 
 .PHONY: generate # Run Grafana App SDK code generation
 generate: install-app-sdk update-app-sdk
-	@$(APP_SDK_BIN) generate \
-		--source=./kinds/ \
-		--gogenpath=./pkg/apis \
-		--grouping=group \
-		--defencoding=none
+	@$(APP_SDK_BIN) generate --source=./kinds/

--- a/apps/shorturl/kinds/config.cue
+++ b/apps/shorturl/kinds/config.cue
@@ -1,0 +1,14 @@
+package kinds
+
+config: {
+	codegen: {
+		goGenPath: "./pkg/apis"
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}

--- a/pkg/services/apiserver/builder/runner/testdata/app/Makefile
+++ b/pkg/services/apiserver/builder/runner/testdata/app/Makefile
@@ -1,3 +1,3 @@
 .PHONY: generate
 generate:
-	@grafana-app-sdk generate -g ./pkg/apis --kindgrouping=group --postprocess --crdencoding none
+	@grafana-app-sdk generate --source=./kinds/

--- a/pkg/services/apiserver/builder/runner/testdata/app/kinds/config.cue
+++ b/pkg/services/apiserver/builder/runner/testdata/app/kinds/config.cue
@@ -1,0 +1,15 @@
+package core
+
+config: {
+	codegen: {
+		goGenPath:               "./pkg/apis"
+		enableK8sPostProcessing: true
+	}
+	definitions: {
+		genManifest: false
+		genCRDs:     false
+	}
+	kinds: {
+		grouping: "group"
+	}
+}


### PR DESCRIPTION
**What is this feature?**

Introduced in grafana-app-sdk recently is a change to define configuration options for apps via a new config cue block, rather than using CLI flags. This migrates all projects off the CLI flags and onto a config cue block.
- PR: https://github.com/grafana/grafana-app-sdk/pull/1130
- Release: https://github.com/grafana/grafana-app-sdk/releases/tag/v0.49.0
- Docs: https://github.com/grafana/grafana-app-sdk/blob/main/docs/code-generation.md#kind-code-generation

**How was it tested?**
Ran `make gen-apps` and all generated code remains intact without unexpected changes.

**Why do we need this feature?**

The CLI flags in the SDK are going to be removed in a future release, so this is in preparation for that.
