### PR TITLE
Suggestions: Fix panel title when the flag is enabled

### DIFF
--- a/public/app/features/dashboard-scene/scene/UnconfiguredPanel.tsx
+++ b/public/app/features/dashboard-scene/scene/UnconfiguredPanel.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { CoreApp, GrafanaTheme2, PanelPlugin, PanelProps } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -19,7 +19,6 @@ import {
   useStyles2,
 } from '@grafana/ui';
 
-import { NEW_PANEL_TITLE } from '../../dashboard/utils/dashboard';
 import { DashboardInteractions } from '../utils/interactions';
 import { findVizPanelByKey, getVizPanelKeyForPanelId } from '../utils/utils';
 
@@ -63,18 +62,6 @@ function UnconfiguredPanelComp(props: PanelProps) {
 
     dashboard.onShowAddLibraryPanelDrawer(panel.getRef());
   };
-
-  useEffect(() => {
-    if (!panel || !config.featureToggles.newVizSuggestions) {
-      return;
-    }
-
-    if (panelContext.app === CoreApp.PanelEditor) {
-      panel.setState({ title: '' });
-    } else if (!panel.state.title) {
-      panel.setState({ title: NEW_PANEL_TITLE });
-    }
-  }, [panel, panelContext.app]);
 
   const MenuActions = () => (
     <Menu>

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -268,10 +268,7 @@ export function getDefaultPluginId(): string {
 export function getDefaultVizPanel(): VizPanel {
   const defaultPluginId = getDefaultPluginId();
 
-  const newPanelTitle =
-    config.featureToggles.newVizSuggestions && defaultPluginId === UNCONFIGURED_PANEL_PLUGIN_ID
-      ? ''
-      : t('dashboard.new-panel-title', 'New panel');
+  const newPanelTitle = t('dashboard.new-panel-title', 'New panel');
 
   const datasourceSettings = getDataSourceSrv().getInstanceSettings(null);
 


### PR DESCRIPTION
The empty panel title made sense in the old flow but not with the current flow, so I removed the logic altogether. This behavior is now on par with dynamic dashboards.

Before

https://github.com/user-attachments/assets/a97e15ab-21e8-40cc-b9f9-54a24c79c970



After


https://github.com/user-attachments/assets/ae77af40-9435-46a1-9c8f-f5569386c950


To test:

- With `newVizSuggestions` flag enabled-
- Create a new panel
- Add a title
- Click configure
- Title should not dissapear



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
