### PR TITLE
Zanzana: add leader election to MT reconciler for HA deployments

### DIFF
--- a/pkg/services/authz/zanzana/server/reconciler/leader_election.go
+++ b/pkg/services/authz/zanzana/server/reconciler/leader_election.go
@@ -1,0 +1,154 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	clientrest "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+// LeaderElector abstracts the leader election mechanism.
+type LeaderElector interface {
+	// Run blocks, calling fn when this instance acquires leadership.
+	// fn receives a context cancelled when leadership is lost.
+	// Run returns when ctx is cancelled.
+	Run(ctx context.Context, fn func(ctx context.Context)) error
+	// IsLeader returns true if this instance currently holds the lease.
+	IsLeader() bool
+}
+
+// NoopLeaderElector always acts as the leader (single-instance / backward compat).
+type NoopLeaderElector struct{}
+
+// NewNoopLeaderElector returns a NoopLeaderElector that always acts as leader.
+func NewNoopLeaderElector() *NoopLeaderElector {
+	return &NoopLeaderElector{}
+}
+
+// Run calls fn immediately and blocks until ctx is cancelled.
+func (n *NoopLeaderElector) Run(ctx context.Context, fn func(ctx context.Context)) error {
+	fn(ctx)
+	return ctx.Err()
+}
+
+// IsLeader always returns true for the noop implementation.
+func (n *NoopLeaderElector) IsLeader() bool {
+	return true
+}
+
+// KubernetesLeaderElector uses coordination.k8s.io/v1 Lease resources.
+type KubernetesLeaderElector struct {
+	leaseName     string
+	namespace     string
+	identity      string
+	leaseDuration time.Duration
+	renewDeadline time.Duration
+	retryPeriod   time.Duration
+	kubeClient    kubernetes.Interface
+	isLeader      atomic.Bool
+	logger        log.Logger
+}
+
+// NewKubernetesLeaderElector creates a KubernetesLeaderElector from the provided REST config.
+// All string parameters must be non-empty; they are expected to come from reconciler settings.
+func NewKubernetesLeaderElector(
+	restCfg *clientrest.Config,
+	leaseName string,
+	namespace string,
+	identity string,
+	leaseDuration time.Duration,
+	renewDeadline time.Duration,
+	retryPeriod time.Duration,
+	logger log.Logger,
+) (*KubernetesLeaderElector, error) {
+	if leaseName == "" {
+		return nil, fmt.Errorf("leader_election_lease_name must be set")
+	}
+	if namespace == "" {
+		return nil, fmt.Errorf("leader_election_namespace must be set")
+	}
+	if identity == "" {
+		return nil, fmt.Errorf("leader_election_identity must be set")
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	return &KubernetesLeaderElector{
+		leaseName:     leaseName,
+		namespace:     namespace,
+		identity:      identity,
+		leaseDuration: leaseDuration,
+		renewDeadline: renewDeadline,
+		retryPeriod:   retryPeriod,
+		kubeClient:    kubeClient,
+		logger:        logger,
+	}, nil
+}
+
+// Run participates in leader election and calls fn when leadership is acquired.
+// fn receives a context that is cancelled when leadership is lost.
+// Run blocks until ctx is cancelled.
+func (k *KubernetesLeaderElector) Run(ctx context.Context, fn func(ctx context.Context)) error {
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      k.leaseName,
+			Namespace: k.namespace,
+		},
+		Client: k.kubeClient.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: k.identity,
+		},
+	}
+
+	le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		LeaseDuration:   k.leaseDuration,
+		RenewDeadline:   k.renewDeadline,
+		RetryPeriod:     k.retryPeriod,
+		ReleaseOnCancel: true,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				k.logger.Info("Acquired leader lease, starting reconciler loop",
+					"identity", k.identity,
+					"lease", k.leaseName,
+					"namespace", k.namespace,
+				)
+				k.isLeader.Store(true)
+				fn(ctx)
+			},
+			OnStoppedLeading: func() {
+				k.logger.Info("Lost leader lease, stopping reconciler loop",
+					"identity", k.identity,
+				)
+				k.isLeader.Store(false)
+			},
+			OnNewLeader: func(identity string) {
+				if identity != k.identity {
+					k.logger.Info("New leader elected", "leader", identity)
+				}
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create leader elector: %w", err)
+	}
+
+	le.Run(ctx)
+	return ctx.Err()
+}
+
+// IsLeader returns true if this instance currently holds the leader lease.
+func (k *KubernetesLeaderElector) IsLeader() bool {
+	return k.isLeader.Load()
+}

--- a/pkg/services/authz/zanzana/server/reconciler/leader_election.go
+++ b/pkg/services/authz/zanzana/server/reconciler/leader_election.go
@@ -3,7 +3,6 @@ package reconciler
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,8 +20,6 @@ type LeaderElector interface {
 	// fn receives a context cancelled when leadership is lost.
 	// Run returns when ctx is cancelled.
 	Run(ctx context.Context, fn func(ctx context.Context)) error
-	// IsLeader returns true if this instance currently holds the lease.
-	IsLeader() bool
 }
 
 // NoopLeaderElector always acts as the leader (single-instance / backward compat).
@@ -39,11 +36,6 @@ func (n *NoopLeaderElector) Run(ctx context.Context, fn func(ctx context.Context
 	return ctx.Err()
 }
 
-// IsLeader always returns true for the noop implementation.
-func (n *NoopLeaderElector) IsLeader() bool {
-	return true
-}
-
 // KubernetesLeaderElector uses coordination.k8s.io/v1 Lease resources.
 type KubernetesLeaderElector struct {
 	leaseName     string
@@ -53,7 +45,6 @@ type KubernetesLeaderElector struct {
 	renewDeadline time.Duration
 	retryPeriod   time.Duration
 	kubeClient    kubernetes.Interface
-	isLeader      atomic.Bool
 	logger        log.Logger
 }
 
@@ -124,14 +115,12 @@ func (k *KubernetesLeaderElector) Run(ctx context.Context, fn func(ctx context.C
 					"lease", k.leaseName,
 					"namespace", k.namespace,
 				)
-				k.isLeader.Store(true)
 				fn(ctx)
 			},
 			OnStoppedLeading: func() {
 				k.logger.Info("Lost leader lease, stopping reconciler loop",
 					"identity", k.identity,
 				)
-				k.isLeader.Store(false)
 			},
 			OnNewLeader: func(identity string) {
 				if identity != k.identity {
@@ -146,9 +135,4 @@ func (k *KubernetesLeaderElector) Run(ctx context.Context, fn func(ctx context.C
 
 	le.Run(ctx)
 	return ctx.Err()
-}
-
-// IsLeader returns true if this instance currently holds the leader lease.
-func (k *KubernetesLeaderElector) IsLeader() bool {
-	return k.isLeader.Load()
 }

--- a/pkg/services/authz/zanzana/server/reconciler/reconciler.go
+++ b/pkg/services/authz/zanzana/server/reconciler/reconciler.go
@@ -131,8 +131,7 @@ func (r *Reconciler) runLoop(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			r.logger.Info("Reconciler shutting down")
-			close(r.workQueue) // Signal workers to stop
-			wg.Wait()          // Wait for all workers to finish
+			wg.Wait() // Workers exit via ctx.Done(); do not close the shared channel (it may be reused on re-election)
 			return
 		case <-ticker.C:
 			r.queueAllNamespaces(ctx)
@@ -297,11 +296,6 @@ func (r *Reconciler) EnsureNamespace(ctx context.Context, namespace string) erro
 	// no write race with the leader's background loop (the leader cannot be
 	// reconciling a store that doesn't exist yet). In the unlikely event of
 	// overlap the diff is idempotent.
-	if !r.leaderElector.IsLeader() {
-		r.logger.Debug("EnsureNamespace called on non-leader replica, proceeding anyway",
-			"namespace", namespace,
-		)
-	}
 
 	// Create store if it doesn't exist
 	_, err = r.server.GetOrCreateStore(ctx, namespace)

--- a/pkg/services/authz/zanzana/server/reconciler/reconciler.go
+++ b/pkg/services/authz/zanzana/server/reconciler/reconciler.go
@@ -277,6 +277,11 @@ func (r *Reconciler) reconcileNamespace(ctx context.Context, namespace string) e
 	return nil
 }
 
+// EnsureNamespace is not gated by leader election: it is called inline from
+// the authorization request path and must complete before the caller can
+// proceed. It only creates stores for new namespaces. Any overlap with the
+// leader's background reconciliation loop is safe because reconcileNamespace
+// is idempotent.
 func (r *Reconciler) EnsureNamespace(ctx context.Context, namespace string) error {
 	ctx, span := r.tracer.Start(ctx, "reconciler.EnsureNamespace")
 	defer span.End()
@@ -289,13 +294,6 @@ func (r *Reconciler) EnsureNamespace(ctx context.Context, namespace string) erro
 	if store != nil {
 		return nil
 	}
-
-	// EnsureNamespace is not gated by leader election: it is called inline from
-	// the authorization request path and must complete before the caller can
-	// proceed. It only runs reconcileNamespace for truly new stores, so there is
-	// no write race with the leader's background loop (the leader cannot be
-	// reconciling a store that doesn't exist yet). In the unlikely event of
-	// overlap the diff is idempotent.
 
 	// Create store if it doesn't exist
 	_, err = r.server.GetOrCreateStore(ctx, namespace)

--- a/pkg/services/authz/zanzana/server/reconciler/reconciler.go
+++ b/pkg/services/authz/zanzana/server/reconciler/reconciler.go
@@ -28,6 +28,7 @@ type Reconciler struct {
 	logger        log.Logger
 	tracer        tracing.Tracer
 	metrics       *reconcilerMetrics
+	leaderElector LeaderElector
 
 	workQueue chan string
 
@@ -69,6 +70,7 @@ func NewReconciler(
 	logger log.Logger,
 	tracer tracing.Tracer,
 	reg prometheus.Registerer,
+	leaderElector LeaderElector,
 ) *Reconciler {
 	return &Reconciler{
 		server:        srv,
@@ -77,6 +79,7 @@ func NewReconciler(
 		logger:        logger,
 		tracer:        tracer,
 		metrics:       newReconcilerMetrics(reg),
+		leaderElector: leaderElector,
 		workQueue:     make(chan string, cfg.queueSize()),
 	}
 }
@@ -93,8 +96,15 @@ func (r *Reconciler) getGlobalRolePerms() map[string][]*authzextv1.RolePermissio
 	return r.globalRolePerms
 }
 
-// Run starts the reconciler's main loop and worker goroutines.
+// Run starts leader election and delegates to runLoop when leadership is acquired.
 func (r *Reconciler) Run(ctx context.Context) error {
+	r.logger.Info("Starting MT reconciler")
+	return r.leaderElector.Run(ctx, r.runLoop)
+}
+
+// runLoop contains the main reconciliation loop, started when this instance
+// acquires leadership (or immediately for NoopLeaderElector).
+func (r *Reconciler) runLoop(ctx context.Context) {
 	r.logger.Info("Starting Unistore to Zanzana reconciler",
 		"workers", r.cfg.Workers,
 		"interval", r.cfg.Interval,
@@ -123,7 +133,7 @@ func (r *Reconciler) Run(ctx context.Context) error {
 			r.logger.Info("Reconciler shutting down")
 			close(r.workQueue) // Signal workers to stop
 			wg.Wait()          // Wait for all workers to finish
-			return ctx.Err()
+			return
 		case <-ticker.C:
 			r.queueAllNamespaces(ctx)
 		}
@@ -187,12 +197,19 @@ func (r *Reconciler) runWorker(ctx context.Context, workerID int) {
 			status := "success"
 			if err != nil {
 				status = "error"
-				r.logger.Error("Failed to reconcile namespace",
-					"namespace", namespace,
-					"workerID", workerID,
-					"error", err,
-					"duration", elapsed,
-				)
+				if ctx.Err() != nil {
+					r.logger.Warn("Reconciler shutdown during namespace reconciliation",
+						"namespace", namespace,
+						"workerID", workerID,
+					)
+				} else {
+					r.logger.Error("Failed to reconcile namespace",
+						"namespace", namespace,
+						"workerID", workerID,
+						"error", err,
+						"duration", elapsed,
+					)
+				}
 			} else {
 				r.logger.Info("Successfully reconciled namespace",
 					"namespace", namespace,
@@ -272,6 +289,18 @@ func (r *Reconciler) EnsureNamespace(ctx context.Context, namespace string) erro
 
 	if store != nil {
 		return nil
+	}
+
+	// EnsureNamespace is not gated by leader election: it is called inline from
+	// the authorization request path and must complete before the caller can
+	// proceed. It only runs reconcileNamespace for truly new stores, so there is
+	// no write race with the leader's background loop (the leader cannot be
+	// reconciling a store that doesn't exist yet). In the unlikely event of
+	// overlap the diff is idempotent.
+	if !r.leaderElector.IsLeader() {
+		r.logger.Debug("EnsureNamespace called on non-leader replica, proceeding anyway",
+			"namespace", namespace,
+		)
 	}
 
 	// Create store if it doesn't exist

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -178,6 +178,30 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 	var mtReconciler zanzana.MTReconciler
 	if cfg.ZanzanaReconciler.Mode == setting.ZanzanaReconcilerModeMT {
 		reconcilerLogger := log.New("zanzana.mt-reconciler")
+
+		var leaderElector reconciler.LeaderElector
+		if cfg.ZanzanaReconciler.LeaderElectionEnabled {
+			restCfg, err := clientrest.InClusterConfig()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get in-cluster config for leader election: %w", err)
+			}
+			leaderElector, err = reconciler.NewKubernetesLeaderElector(
+				restCfg,
+				cfg.ZanzanaReconciler.LeaderElectionLeaseName,
+				cfg.ZanzanaReconciler.LeaderElectionNamespace,
+				cfg.ZanzanaReconciler.LeaderElectionIdentity,
+				cfg.ZanzanaReconciler.LeaseDuration,
+				cfg.ZanzanaReconciler.RenewDeadline,
+				cfg.ZanzanaReconciler.RetryPeriod,
+				reconcilerLogger,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create leader elector: %w", err)
+			}
+		} else {
+			leaderElector = reconciler.NewNoopLeaderElector()
+		}
+
 		mtReconciler = reconciler.NewReconciler(
 			s,
 			clientFactory,
@@ -190,6 +214,7 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 			reconcilerLogger,
 			tracer,
 			reg,
+			leaderElector,
 		)
 	} else {
 		mtReconciler = reconciler.NewNoopReconciler()

--- a/pkg/setting/settings_zanzana.go
+++ b/pkg/setting/settings_zanzana.go
@@ -68,12 +68,9 @@ type ZanzanaReconcilerSettings struct {
 	// LeaderElectionLeaseName is the name of the Kubernetes Lease object used
 	// for leader election. Default: "zanzana-mt-reconciler".
 	LeaderElectionLeaseName string
-	// LeaderElectionNamespace is the namespace in which the Lease object is
-	// created. Defaults to the value of the POD_NAMESPACE env var, then falls
-	// back to reading /var/run/secrets/kubernetes.io/serviceaccount/namespace.
+	// LeaderElectionNamespace is the namespace in which the Lease object is created.
 	LeaderElectionNamespace string
-	// LeaderElectionIdentity is the unique identity of this instance used in
-	// the Lease object. Defaults to the POD_NAME env var, then os.Hostname().
+	// LeaderElectionIdentity is the unique identity of this instance used in the Lease object.
 	LeaderElectionIdentity string
 	// LeaseDuration is how long a lease is held before it can be acquired by
 	// another candidate. Default: 15s.

--- a/pkg/setting/settings_zanzana.go
+++ b/pkg/setting/settings_zanzana.go
@@ -59,6 +59,30 @@ type ZanzanaReconcilerSettings struct {
 	WriteBatchSize int
 	// Size of the buffered work queue for namespaces.
 	QueueSize int
+
+	// --- HA leader election (standalone mode in K8s) ---
+
+	// LeaderElectionEnabled enables Kubernetes lease-based leader election so
+	// only one replica runs the reconciler loop at a time.
+	LeaderElectionEnabled bool
+	// LeaderElectionLeaseName is the name of the Kubernetes Lease object used
+	// for leader election. Default: "zanzana-mt-reconciler".
+	LeaderElectionLeaseName string
+	// LeaderElectionNamespace is the namespace in which the Lease object is
+	// created. Defaults to the value of the POD_NAMESPACE env var, then falls
+	// back to reading /var/run/secrets/kubernetes.io/serviceaccount/namespace.
+	LeaderElectionNamespace string
+	// LeaderElectionIdentity is the unique identity of this instance used in
+	// the Lease object. Defaults to the POD_NAME env var, then os.Hostname().
+	LeaderElectionIdentity string
+	// LeaseDuration is how long a lease is held before it can be acquired by
+	// another candidate. Default: 15s.
+	LeaseDuration time.Duration
+	// RenewDeadline is the duration the leader retries refreshing leadership
+	// before giving up. Default: 10s.
+	RenewDeadline time.Duration
+	// RetryPeriod is the interval between leader election retries. Default: 2s.
+	RetryPeriod time.Duration
 }
 
 type ZanzanaServerSettings struct {
@@ -348,5 +372,12 @@ func (cfg *Cfg) readZanzanaSettings() {
 	zr.Interval = reconcilerSec.Key("interval").MustDuration(1 * time.Hour)
 	zr.WriteBatchSize = reconcilerSec.Key("write_batch_size").MustInt(100)
 	zr.QueueSize = reconcilerSec.Key("queue_size").MustInt(1000)
+	zr.LeaderElectionEnabled = reconcilerSec.Key("leader_election_enabled").MustBool(false)
+	zr.LeaderElectionLeaseName = reconcilerSec.Key("leader_election_lease_name").MustString("zanzana-mt-reconciler")
+	zr.LeaderElectionNamespace = reconcilerSec.Key("leader_election_namespace").MustString("")
+	zr.LeaderElectionIdentity = reconcilerSec.Key("leader_election_identity").MustString("")
+	zr.LeaseDuration = reconcilerSec.Key("lease_duration").MustDuration(15 * time.Second)
+	zr.RenewDeadline = reconcilerSec.Key("renew_deadline").MustDuration(10 * time.Second)
+	zr.RetryPeriod = reconcilerSec.Key("retry_period").MustDuration(2 * time.Second)
 	cfg.ZanzanaReconciler = zr
 }


### PR DESCRIPTION
## Summary

This is needed so we can run multiple zanzana replicas without any overlap in reconciling loops.

While `k8s.io/client-go/tools/leaderelection` doesn't guarantee a strict leader (multiple leaders could be running at the same time), this is safe, OpenFGA writes are idempotent, so state will not be corrupted. We do want to use it so save API and OpenFGA resources  by not running two leaders simultaneously 99.99% of the time.

## Changes:

- Introduces a `LeaderElector` interface with two implementations: `NoopLeaderElector` (always leader, default) and `KubernetesLeaderElector` (uses `coordination.k8s.io/v1` Lease objects)
- `Reconciler.Run()` delegates to `leaderElector.Run()`, which calls `runLoop` only when this instance holds the lease — follower pods block in the election loop
- `EnsureNamespace` is not gated: it runs inline on the request path and only reconciles truly new stores, so there is no write race with the leader's background loop
- Leader election is off by default; enabled via `leader_election_enabled = true` in `[zanzana.reconciler]`

## Test plan

- [X] Run ST Grafana and verify that the MT reconciler still runs.

Verified using mt-tilt:
- [x] Deploy 2 replicas, verify only one pod logs "Acquired leader lease, starting reconciler loop" and actively reconciles
- [x] Kill the leader pod, verify the follower acquires the lease within `lease_duration` (15s) and resumes reconciliation

🤖 Generated with [Claude Code](https://claude.com/claude-code)