### PR TITLE
Scopes: Add rootScope parameter to scope navigation requests

### DIFF
--- a/public/app/features/scopes/ScopesApiClient.test.ts
+++ b/public/app/features/scopes/ScopesApiClient.test.ts
@@ -624,21 +624,21 @@ describe('ScopesApiClient', () => {
       consoleErrorSpy.mockRestore();
     });
 
-    it('should pass depth option to the endpoint', async () => {
+    it('should pass depth and rootScope options to the endpoint', async () => {
       const mockSubscription = createMockSubscription({ data: { items: [] } });
       (scopeAPIv0alpha1.endpoints.getFindScopeNavigationsResults.initiate as jest.Mock).mockReturnValue(
         mockSubscription
       );
 
-      await apiClient.fetchScopeNavigations(['mimir'], { depth: 1 });
+      await apiClient.fetchScopeNavigations(['mimir'], { depth: 1, rootScope: 'myRoot' });
 
       expect(scopeAPIv0alpha1.endpoints.getFindScopeNavigationsResults.initiate).toHaveBeenCalledWith(
-        expect.objectContaining({ scope: ['mimir'], depth: 1 }),
+        expect.objectContaining({ scope: ['mimir'], depth: 1, rootScope: 'myRoot' }),
         { subscribe: false }
       );
     });
 
-    it('should omit depth when options not provided', async () => {
+    it('should omit depth and rootScope when options not provided', async () => {
       const mockSubscription = createMockSubscription({ data: { items: [] } });
       (scopeAPIv0alpha1.endpoints.getFindScopeNavigationsResults.initiate as jest.Mock).mockReturnValue(
         mockSubscription
@@ -649,25 +649,26 @@ describe('ScopesApiClient', () => {
       const callArgs = (scopeAPIv0alpha1.endpoints.getFindScopeNavigationsResults.initiate as jest.Mock).mock
         .calls[0][0];
       expect(callArgs.depth).toBeUndefined();
+      expect(callArgs.rootScope).toBeUndefined();
     });
   });
 
-  describe('fetchDashboards depth option', () => {
-    it('should pass depth option to the endpoint', async () => {
+  describe('fetchDashboards navigation options', () => {
+    it('should pass depth and rootScope options to the endpoint', async () => {
       const mockSubscription = createMockSubscription({ data: { items: [] } });
       (scopeAPIv0alpha1.endpoints.getFindScopeDashboardBindingsResults.initiate as jest.Mock).mockReturnValue(
         mockSubscription
       );
 
-      await apiClient.fetchDashboards(['grafana'], { depth: 1 });
+      await apiClient.fetchDashboards(['grafana'], { depth: 1, rootScope: 'myRoot' });
 
       expect(scopeAPIv0alpha1.endpoints.getFindScopeDashboardBindingsResults.initiate).toHaveBeenCalledWith(
-        expect.objectContaining({ scope: ['grafana'], depth: 1 }),
+        expect.objectContaining({ scope: ['grafana'], depth: 1, rootScope: 'myRoot' }),
         { subscribe: false }
       );
     });
 
-    it('should omit depth when options not provided', async () => {
+    it('should omit depth and rootScope when options not provided', async () => {
       const mockSubscription = createMockSubscription({ data: { items: [] } });
       (scopeAPIv0alpha1.endpoints.getFindScopeDashboardBindingsResults.initiate as jest.Mock).mockReturnValue(
         mockSubscription
@@ -678,6 +679,7 @@ describe('ScopesApiClient', () => {
       const callArgs = (scopeAPIv0alpha1.endpoints.getFindScopeDashboardBindingsResults.initiate as jest.Mock).mock
         .calls[0][0];
       expect(callArgs.depth).toBeUndefined();
+      expect(callArgs.rootScope).toBeUndefined();
     });
   });
 

--- a/public/app/features/scopes/ScopesApiClient.ts
+++ b/public/app/features/scopes/ScopesApiClient.ts
@@ -8,6 +8,7 @@ import { ScopeNavigation } from './dashboards/types';
 
 export interface NavigationFetchOptions {
   depth?: number;
+  rootScope?: string;
 }
 
 export class ScopesApiClient {

--- a/public/app/features/scopes/dashboards/ScopesDashboardsService.test.ts
+++ b/public/app/features/scopes/dashboards/ScopesDashboardsService.test.ts
@@ -729,7 +729,10 @@ describe('ScopesDashboardsService', () => {
 
       expect(service.state.navigationScope).toBe('navScope1');
       expect(service.state.drawerOpened).toBe(true);
-      expect(mockApiClient.fetchScopeNavigations).toHaveBeenCalledWith(['navScope1'], { depth: 1 });
+      expect(mockApiClient.fetchScopeNavigations).toHaveBeenCalledWith(['navScope1'], {
+        depth: 1,
+        rootScope: 'navScope1',
+      });
     });
 
     it('should clear navigation scope and use fallback scope names', async () => {
@@ -745,7 +748,10 @@ describe('ScopesDashboardsService', () => {
       await service.setNavigationScope('initialScope');
       expect(service.state.navigationScope).toBe('initialScope');
       expect(service.state.drawerOpened).toBe(true);
-      expect(mockApiClient.fetchScopeNavigations).toHaveBeenCalledWith(['initialScope'], { depth: 1 });
+      expect(mockApiClient.fetchScopeNavigations).toHaveBeenCalledWith(['initialScope'], {
+        depth: 1,
+        rootScope: 'initialScope',
+      });
 
       await service.setNavigationScope(undefined, ['fallbackScope1', 'fallbackScope2']);
 
@@ -799,7 +805,10 @@ describe('ScopesDashboardsService', () => {
       await service.setNavigationScope('navScope2');
 
       expect(service.state.navigationScope).toBe('navScope2');
-      expect(mockApiClient.fetchScopeNavigations).toHaveBeenCalledWith(['navScope2'], { depth: 1 });
+      expect(mockApiClient.fetchScopeNavigations).toHaveBeenCalledWith(['navScope2'], {
+        depth: 1,
+        rootScope: 'navScope2',
+      });
     });
 
     it('should update navigation scope when clearing an existing scope', async () => {

--- a/public/app/features/scopes/dashboards/ScopesDashboardsService.ts
+++ b/public/app/features/scopes/dashboards/ScopesDashboardsService.ts
@@ -208,7 +208,12 @@ export class ScopesDashboardsService extends ScopesServiceBase<ScopesDashboardsS
 
       // No depth param: sub-scope expansions fetch one level at a time (on demand).
       // Only the initial fetchDashboards uses depth=1 to prefetch the first expansion.
-      const subScopeItems = await fetchNavigations([subScopeName]);
+      // rootScope gives the backend context to optimize (e.g., skip expensive
+      // dashboard computation for deep sub-nodes).
+      const navigationScope = this.state.navigationScope;
+      const subScopeItems = navigationScope
+        ? await fetchNavigations([subScopeName], { rootScope: navigationScope })
+        : await fetchNavigations([subScopeName]);
 
       // Filter out items that have a subScope matching any subScope already in the path
       // This prevents infinite loops when a subScope returns items with the same subScope
@@ -310,8 +315,12 @@ export class ScopesDashboardsService extends ScopesServiceBase<ScopesDashboardsS
       ? this.apiClient.fetchScopeNavigations
       : this.apiClient.fetchDashboards;
 
-    // depth=1 prefetches next-level sub-scope items so the first expansion is instant
-    const res = await fetchNavigations(forScopeNames, { depth: 1 });
+    // depth=1 prefetches next-level sub-scope items so the first expansion is instant.
+    // rootScope gives the backend context for optimizing sub-scope responses.
+    const res = await fetchNavigations(forScopeNames, {
+      depth: 1,
+      ...(this.state.navigationScope ? { rootScope: this.state.navigationScope } : {}),
+    });
 
     if (isEqual(this.state.forScopeNames, forScopeNames)) {
       const folders = this.groupSuggestedItems(res);


### PR DESCRIPTION
> **Merge order**: Merge #119893 and grafana-enterprise#11210 first, then run codegen, then #119551, then this PR.

## What this PR does / why we need it

Adds a `rootScope` parameter to `scope_navigations` and `scope_dashboard_bindings` API requests. This gives the backend context about which scope the user navigated from, enabling optimization of sub-scope responses (e.g., skipping expensive dashboard-to-scope computation for deep sub-nodes).

**Stacked on**: #119551 (depth parameter)

Ref: [hyperion-planning#523](https://github.com/grafana/hyperion-planning/issues/523)

### Changes

- **ScopesApiClient.ts**: Extended `NavigationFetchOptions` with `rootScope`; both fetch methods spread it into the RTK Query initiate args
- **ScopesDashboardsService.ts**: `fetchDashboards` passes `navigationScope` as `rootScope` when set; `fetchSubScopeItems` also passes `rootScope` when set. Both conditionally omit `rootScope` when `navigationScope` is undefined.
- **Tests**: API client tests for rootScope passthrough and omission; service test assertions updated; integration tests (`dashboardsList.test.ts`) updated

### Backward compatibility

When `rootScope` is omitted (`undefined`), behavior is identical — the param is stripped from the HTTP request. When `navigationScope` is not set, `rootScope` is not included in the options object.

### Related PRs

- grafana-enterprise#11210 — Backend: OpenAPI spec with depth + rootScope params (**merge first**)
- #119893 — Go contract type (`ScopeNavigationOptions`) (**merge first**)
- #119551 — Frontend: depth param (base of this stacked PR, **merge first**)
- #119566 — Frontend: remove stale `name` field

## Test plan

- [x] All 410 scopes tests pass (unit + integration + dashboardsList)
- [ ] CI typecheck will pass after codegen runs post-enterprise merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)