### PR TITLE
Dashboards: Remove dashboard save and get metrics 

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -256,7 +256,6 @@ func (hs *HTTPServer) GetDashboard(c *contextmodel.ReqContext) response.Response
 		Meta:      meta,
 	}
 
-	c.TimeRequest(metrics.MApiDashboardGet)
 	return response.JSON(http.StatusOK, dto)
 }
 
@@ -494,7 +493,6 @@ func (hs *HTTPServer) postDashboard(c *contextmodel.ReqContext, cmd dashboards.S
 		return apierrors.ToDashboardErrorResponse(ctx, hs.pluginStore, saveErr)
 	}
 
-	c.TimeRequest(metrics.MApiDashboardSave)
 	return response.JSON(http.StatusOK, util.DynMap{
 		"status":    "success",
 		"slug":      dashboard.Slug,
@@ -590,7 +588,6 @@ func (hs *HTTPServer) saveDashboardViaK8s(c *contextmodel.ReqContext, cmd dashbo
 	title, _, _ = unstructured.NestedString(dash.Object, "spec", "title")
 	slug := slugify.Slugify(title)
 
-	c.TimeRequest(metrics.MApiDashboardSave)
 	return response.JSON(http.StatusOK, util.DynMap{
 		"status":    "success",
 		"slug":      slug,

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -36,12 +36,6 @@ var (
 	// MApiUserSignUpInvite is a metric amount of users who have been invited
 	MApiUserSignUpInvite prometheus.Counter
 
-	// MApiDashboardSave is a metric summary for dashboard save duration
-	MApiDashboardSave prometheus.Summary
-
-	// MApiDashboardGet is a metric summary for dashboard get duration
-	MApiDashboardGet prometheus.Summary
-
 	// MApiDashboardSearch is a metric summary for dashboard search duration
 	MApiDashboardSearch prometheus.Summary
 
@@ -308,20 +302,6 @@ func init() {
 		Name:      "api_user_signup_invite_total",
 		Help:      "amount of users who have been invited",
 		Namespace: ExporterName,
-	})
-
-	MApiDashboardSave = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "api_dashboard_save_milliseconds",
-		Help:       "summary for dashboard save duration",
-		Objectives: objectiveMap,
-		Namespace:  ExporterName,
-	})
-
-	MApiDashboardGet = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "api_dashboard_get_milliseconds",
-		Help:       "summary for dashboard get duration",
-		Objectives: objectiveMap,
-		Namespace:  ExporterName,
 	})
 
 	MApiDashboardSearch = prometheus.NewSummary(prometheus.SummaryOpts{
@@ -791,8 +771,6 @@ func initMetricVars(reg prometheus.Registerer) {
 		MApiUserSignUpStarted,
 		MApiUserSignUpCompleted,
 		MApiUserSignUpInvite,
-		MApiDashboardSave,
-		MApiDashboardGet,
 		MApiDashboardSearch,
 		MDataSourceProxyReqTimer,
 		MAlertingExecutionTime,


### PR DESCRIPTION
Removing:
* api_dashboard_save_milliseconds
* api_dashboard_get_milliseconds

These are now covered by unified storage dashboard metrics