### PR TITLE
QueryEditor: Update SidebarCard error state

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarCard.tsx
@@ -181,6 +181,10 @@ function getStyles(
     },
   });
 
+  const cardBorder = !!item.error
+    ? `1px solid color-mix(in srgb, ${QUERY_EDITOR_COLORS.error} 50%, transparent)`
+    : `1px solid ${isSelected ? borderColor : theme.colors.border.medium}`;
+
   return {
     cardContentIcons: css({
       display: 'flex',
@@ -245,7 +249,7 @@ function getStyles(
       cursor: 'pointer',
 
       overflow: 'hidden',
-      border: `1px solid ${isSelected ? borderColor : theme.colors.border.medium}`,
+      border: cardBorder,
       boxShadow: isSelected ? `0 0 4px 0 color-mix(in srgb, ${borderColor} 40%, transparent)` : 'none',
       '&::before': {
         content: '""',


### PR DESCRIPTION
## Description
Updates SidebarCard error state to always have a red border. This dims the border if its not selected.

## Demo
<img width="1352" height="1134" alt="CleanShot 2026-03-04 at 16 00 57" src="https://github.com/user-attachments/assets/b2a6fb21-7154-4402-8d21-dc2150d1ee70" />


## Testing Instructions
* Pull down and test it

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable