### PR TITLE
Scopes: Remove unused name field from find endpoint generated types

### DIFF
--- a/packages/grafana-openapi/src/scripts/process-specs.ts
+++ b/packages/grafana-openapi/src/scripts/process-specs.ts
@@ -33,15 +33,6 @@ function processOpenAPISpec(spec: OpenAPIV3.Document) {
       pathItem.parameters = filterNamespaceParameters(pathItem.parameters);
     }
 
-    // Remove the `name` path parameter from /find/* endpoints.
-    // K8s codegen adds it to all connect-type endpoints, but /find/* paths
-    // don't contain {name} so the parameter is unused.
-    if (newPathKey.startsWith('/find/') && Array.isArray(pathItem.parameters)) {
-      pathItem.parameters = pathItem.parameters.filter(
-        (param) => !('in' in param && param.in === 'path' && 'name' in param && param.name === 'name')
-      );
-    }
-
     for (const method of Object.keys(pathItem)) {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const operation = pathItem[method as keyof OpenAPIV3.PathItemObject];

--- a/public/app/api/clients/scope/v0alpha1/endpoints.gen.ts
+++ b/public/app/api/clients/scope/v0alpha1/endpoints.gen.ts
@@ -611,15 +611,11 @@ export type GetApiResourcesApiResponse = /** status 200 OK */ ApiResourceList;
 export type GetApiResourcesApiArg = void;
 export type GetFindScopeDashboardBindingsResultsApiResponse = /** status 200 OK */ FindScopeDashboardBindingsResults;
 export type GetFindScopeDashboardBindingsResultsApiArg = {
-  /** name of the FindScopeDashboardBindingsResults */
-  name: string;
   /** A scope name (id) to match against, this parameter may be repeated */
   scope?: string[];
 };
 export type GetFindScopeNavigationsResultsApiResponse = /** status 200 OK */ FindScopeNavigationsResults;
 export type GetFindScopeNavigationsResultsApiArg = {
-  /** name of the FindScopeNavigationsResults */
-  name: string;
   /** A scope name (id) to match against, this parameter may be repeated */
   scope?: string[];
 };

--- a/public/app/features/scopes/ScopesApiClient.ts
+++ b/public/app/features/scopes/ScopesApiClient.ts
@@ -196,10 +196,8 @@ export class ScopesApiClient {
 
   public fetchDashboards = async (scopeNames: string[]): Promise<ScopeDashboardBinding[]> => {
     const subscription = dispatch(
-      // Note: `name` is required by generated types but ignored by the query builder (codegen bug)
       scopeAPIv0alpha1.endpoints.getFindScopeDashboardBindingsResults.initiate(
         {
-          name: '',
           scope: scopeNames,
         },
         { subscribe: false }
@@ -232,10 +230,8 @@ export class ScopesApiClient {
 
   public fetchScopeNavigations = async (scopeNames: string[]): Promise<ScopeNavigation[]> => {
     const subscription = dispatch(
-      // Note: `name` is required by generated types but ignored by the query builder (codegen bug)
       scopeAPIv0alpha1.endpoints.getFindScopeNavigationsResults.initiate(
         {
-          name: '',
           scope: scopeNames,
         },
         { subscribe: false }


### PR DESCRIPTION
## What this PR does / why we need it

Two changes to clean up the spurious `name` field on scope find endpoint types:

### 1. Remove stale `name` from generated types

Removes the `name: string` field from `GetFindScopeDashboardBindingsResultsApiArg` and `GetFindScopeNavigationsResultsApiArg` in the generated scope endpoint types, and removes the `name: ''` workarounds in `ScopesApiClient`.

The `process-specs.ts` fix from #119182 correctly strips the `name` path parameter during spec processing, but the generated TypeScript types were never regenerated after that fix, leaving them stale.

### 2. Revert process-specs.ts workaround

Removes the `/find/*` name path parameter stripping from `process-specs.ts`. The root cause is now fixed in the enterprise `PostProcessOpenAPI` (grafana-enterprise#11210), which correctly sets path-level parameters on the find navigation endpoints, preventing `{name}` from appearing in the generated OpenAPI spec.

### Related PRs

- grafana-enterprise#11210 — Root cause fix in `PostProcessOpenAPI`
- #119893 — Go contract type (`ScopeNavigationOptions`)

Fixes: grafana/hyperion-planning#526

## Test plan

- [x] All 410 scopes tests pass
- [x] `gofmt` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)