### PR TITLE
Jaeger: forward request context on HTTP calls so auth headers are sent

### DIFF
--- a/pkg/tsdb/jaeger/callresource.go
+++ b/pkg/tsdb/jaeger/callresource.go
@@ -31,13 +31,14 @@ func (s *Service) withDatasourceHandlerFunc(getHandler func(d *datasourceInfo) h
 
 func getServicesHandler(ds *datasourceInfo) http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
-		cfg := backend.GrafanaConfigFromContext(r.Context())
+		ctx := r.Context()
+		cfg := backend.GrafanaConfigFromContext(ctx)
 		var services []string
 		var err error
 		if cfg.FeatureToggles().IsEnabled("jaegerEnableGrpcEndpoint") {
-			services, err = ds.JaegerClient.GrpcServices()
+			services, err = ds.JaegerClient.GrpcServices(ctx)
 		} else {
-			services, err = ds.JaegerClient.Services()
+			services, err = ds.JaegerClient.Services(ctx)
 		}
 		writeResponse(services, err, rw, ds.JaegerClient.logger)
 	}
@@ -45,14 +46,15 @@ func getServicesHandler(ds *datasourceInfo) http.HandlerFunc {
 
 func getOperationsHandler(ds *datasourceInfo) http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
-		cfg := backend.GrafanaConfigFromContext(r.Context())
+		ctx := r.Context()
+		cfg := backend.GrafanaConfigFromContext(ctx)
 		service := strings.TrimSpace(r.PathValue("service"))
 		var operations []string
 		var err error
 		if cfg.FeatureToggles().IsEnabled("jaegerEnableGrpcEndpoint") {
-			operations, err = ds.JaegerClient.GrpcOperations(service)
+			operations, err = ds.JaegerClient.GrpcOperations(ctx, service)
 		} else {
-			operations, err = ds.JaegerClient.Operations(service)
+			operations, err = ds.JaegerClient.Operations(ctx, service)
 		}
 		writeResponse(operations, err, rw, ds.JaegerClient.logger)
 	}

--- a/pkg/tsdb/jaeger/client.go
+++ b/pkg/tsdb/jaeger/client.go
@@ -40,7 +40,15 @@ func (j *JaegerClient) doGet(ctx context.Context, rawURL string) (*http.Response
 	if err != nil {
 		return nil, err
 	}
-	return j.httpClient.Do(req)
+	res, err := j.httpClient.Do(req)
+	if err != nil {
+		j.logger.Error("Jaeger request failed", "error", err)
+		return nil, err
+	}
+	if res != nil && res.StatusCode/100 != 2 {
+		j.logger.Warn("Jaeger request returned non-2xx status", "status", res.StatusCode, "statusText", res.Status)
+	}
+	return res, nil
 }
 
 func (j *JaegerClient) Services(ctx context.Context) ([]string, error) {

--- a/pkg/tsdb/jaeger/client.go
+++ b/pkg/tsdb/jaeger/client.go
@@ -33,7 +33,17 @@ func New(hc *http.Client, logger log.Logger, settings backend.DataSourceInstance
 	return client, nil
 }
 
-func (j *JaegerClient) Services() ([]string, error) {
+// doGet performs a GET request with the given context so that contextual HTTP middleware
+// (e.g. Forward OAuth Identity, x-grafana-id) can attach headers to the outgoing request.
+func (j *JaegerClient) doGet(ctx context.Context, rawURL string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	return j.httpClient.Do(req)
+}
+
+func (j *JaegerClient) Services(ctx context.Context) ([]string, error) {
 	var response types.ServicesResponse
 	services := []string{}
 
@@ -42,7 +52,7 @@ func (j *JaegerClient) Services() ([]string, error) {
 		return services, backend.DownstreamErrorf("failed to join url: %w", err)
 	}
 
-	res, err := j.httpClient.Get(u)
+	res, err := j.doGet(ctx, u)
 	if err != nil {
 		return services, err
 	}
@@ -61,7 +71,7 @@ func (j *JaegerClient) Services() ([]string, error) {
 	return services, err
 }
 
-func (j *JaegerClient) Operations(s string) ([]string, error) {
+func (j *JaegerClient) Operations(ctx context.Context, s string) ([]string, error) {
 	var response types.ServicesResponse
 	operations := []string{}
 
@@ -70,7 +80,7 @@ func (j *JaegerClient) Operations(s string) ([]string, error) {
 		return operations, backend.DownstreamErrorf("failed to join url: %w", err)
 	}
 
-	res, err := j.httpClient.Get(u)
+	res, err := j.doGet(ctx, u)
 	if err != nil {
 		return operations, err
 	}
@@ -89,7 +99,7 @@ func (j *JaegerClient) Operations(s string) ([]string, error) {
 	return operations, err
 }
 
-func (j *JaegerClient) Search(query *JaegerQuery, start, end int64) (*data.Frame, error) {
+func (j *JaegerClient) Search(ctx context.Context, query *JaegerQuery, start, end int64) (*data.Frame, error) {
 	u, err := url.JoinPath(j.url, "/api/traces")
 	if err != nil {
 		return nil, backend.DownstreamErrorf("failed to join url path: %w", err)
@@ -147,7 +157,7 @@ func (j *JaegerClient) Search(query *JaegerQuery, start, end int64) (*data.Frame
 	}
 
 	jaegerURL.RawQuery = urlQuery.Encode()
-	resp, err := j.httpClient.Get(jaegerURL.String())
+	resp, err := j.doGet(ctx, jaegerURL.String())
 	if err != nil {
 		if backend.IsDownstreamHTTPError(err) {
 			return nil, backend.DownstreamError(err)
@@ -217,7 +227,7 @@ func (j *JaegerClient) Trace(ctx context.Context, traceID string, start, end int
 		}
 	}
 
-	res, err := j.httpClient.Get(traceUrl)
+	res, err := j.doGet(ctx, traceUrl)
 	if err != nil {
 		if backend.IsDownstreamHTTPError(err) {
 			return nil, backend.DownstreamError(err)
@@ -276,7 +286,7 @@ func (j *JaegerClient) Dependencies(ctx context.Context, start, end int64) (type
 	parsedURL.RawQuery = query.Encode()
 	u = parsedURL.String()
 
-	res, err := j.httpClient.Get(u)
+	res, err := j.doGet(ctx, u)
 	if err != nil {
 		if backend.IsDownstreamHTTPError(err) {
 			return dependencies, backend.DownstreamError(err)

--- a/pkg/tsdb/jaeger/client_test.go
+++ b/pkg/tsdb/jaeger/client_test.go
@@ -67,7 +67,7 @@ func TestJaegerClient_Services(t *testing.T) {
 			client, err := New(server.Client(), log.NewNullLogger(), settings)
 			assert.NoError(t, err)
 
-			services, err := client.Services()
+			services, err := client.Services(context.Background())
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -159,7 +159,7 @@ func TestJaegerClient_Operations(t *testing.T) {
 			client, err := New(server.Client(), log.NewNullLogger(), settings)
 			assert.NoError(t, err)
 
-			operations, err := client.Operations(tt.service)
+			operations, err := client.Operations(context.Background(), tt.service)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -265,7 +265,7 @@ func TestJaegerClient_Search(t *testing.T) {
 
 			client, err := New(server.Client(), log.NewNullLogger(), settings)
 			assert.NoError(t, err)
-			traces, err := client.Search(tt.query, tt.start, tt.end)
+			traces, err := client.Search(context.Background(), tt.query, tt.start, tt.end)
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/pkg/tsdb/jaeger/client_test.go
+++ b/pkg/tsdb/jaeger/client_test.go
@@ -1,7 +1,6 @@
 package jaeger
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -67,7 +66,7 @@ func TestJaegerClient_Services(t *testing.T) {
 			client, err := New(server.Client(), log.NewNullLogger(), settings)
 			assert.NoError(t, err)
 
-			services, err := client.Services(context.Background())
+			services, err := client.Services(t.Context())
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -159,7 +158,7 @@ func TestJaegerClient_Operations(t *testing.T) {
 			client, err := New(server.Client(), log.NewNullLogger(), settings)
 			assert.NoError(t, err)
 
-			operations, err := client.Operations(context.Background(), tt.service)
+			operations, err := client.Operations(t.Context(), tt.service)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -265,7 +264,7 @@ func TestJaegerClient_Search(t *testing.T) {
 
 			client, err := New(server.Client(), log.NewNullLogger(), settings)
 			assert.NoError(t, err)
-			traces, err := client.Search(context.Background(), tt.query, tt.start, tt.end)
+			traces, err := client.Search(t.Context(), tt.query, tt.start, tt.end)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -379,7 +378,7 @@ func TestJaegerClient_Trace(t *testing.T) {
 			client, err := New(server.Client(), log.NewNullLogger(), settings)
 			assert.NoError(t, err)
 
-			trace, err := client.Trace(context.Background(), tt.traceId, tt.start, tt.end, "A")
+			trace, err := client.Trace(t.Context(), tt.traceId, tt.start, tt.end, "A")
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -491,7 +490,7 @@ func TestJaegerClient_Dependencies(t *testing.T) {
 			client, err := New(server.Client(), log.NewNullLogger(), settings)
 			assert.NoError(t, err)
 
-			dependencies, err := client.Dependencies(context.Background(), tt.start, tt.end)
+			dependencies, err := client.Dependencies(t.Context(), tt.start, tt.end)
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/pkg/tsdb/jaeger/grpc_client.go
+++ b/pkg/tsdb/jaeger/grpc_client.go
@@ -16,7 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/jaeger/utils"
 )
 
-func (j *JaegerClient) GrpcServices() ([]string, error) {
+func (j *JaegerClient) GrpcServices(ctx context.Context) ([]string, error) {
 	var response types.GrpcServicesResponse
 	services := []string{}
 
@@ -25,7 +25,7 @@ func (j *JaegerClient) GrpcServices() ([]string, error) {
 		return services, backend.DownstreamErrorf("failed to join url: %w", err)
 	}
 
-	res, err := j.httpClient.Get(u)
+	res, err := j.doGet(ctx, u)
 	if err != nil {
 		if backend.IsDownstreamHTTPError(err) {
 			return services, backend.DownstreamError(err)
@@ -55,7 +55,7 @@ func (j *JaegerClient) GrpcServices() ([]string, error) {
 	return services, nil
 }
 
-func (j *JaegerClient) GrpcOperations(s string) ([]string, error) {
+func (j *JaegerClient) GrpcOperations(ctx context.Context, s string) ([]string, error) {
 	var response types.GrpcOperationsResponse
 	operations := []string{}
 
@@ -73,7 +73,7 @@ func (j *JaegerClient) GrpcOperations(s string) ([]string, error) {
 	urlQuery.Set("service", s)
 	jaegerURL.RawQuery = urlQuery.Encode()
 
-	res, err := j.httpClient.Get(jaegerURL.String())
+	res, err := j.doGet(ctx, jaegerURL.String())
 	if err != nil {
 		if backend.IsDownstreamHTTPError(err) {
 			return operations, backend.DownstreamError(err)
@@ -109,7 +109,7 @@ func (j *JaegerClient) GrpcOperations(s string) ([]string, error) {
 
 // Note that this and all functionality around search is not yet being used. Once Jaeger adds support for attributes and limit parameters
 // we will be able to start using this and routing traffic to the new API based on the feature flag.
-func (j *JaegerClient) GrpcSearch(query *JaegerQuery, start, end time.Time) (*data.Frame, error) {
+func (j *JaegerClient) GrpcSearch(ctx context.Context, query *JaegerQuery, start, end time.Time) (*data.Frame, error) {
 	u, err := url.JoinPath(j.url, "/api/v3/traces")
 	if err != nil {
 		return nil, backend.DownstreamErrorf("failed to join url path: %w", err)
@@ -159,7 +159,7 @@ func (j *JaegerClient) GrpcSearch(query *JaegerQuery, start, end time.Time) (*da
 	jaegerURL.RawQuery = urlQuery.Encode()
 	// jaeger will not be able to process the request if the time is encoded, all other parameters are encoded except for the start and end time
 	jaegerURL.RawQuery += fmt.Sprintf("&query.start_time_min=%s&query.start_time_max=%s", start.Format(time.RFC3339Nano), end.Format(time.RFC3339Nano))
-	resp, err := j.httpClient.Get(jaegerURL.String())
+	resp, err := j.doGet(ctx, jaegerURL.String())
 	if err != nil {
 		if backend.IsDownstreamHTTPError(err) {
 			return nil, backend.DownstreamError(err)
@@ -231,7 +231,7 @@ func (j *JaegerClient) GrpcTrace(ctx context.Context, traceID string, start, end
 		}
 	}
 
-	res, err := j.httpClient.Get(traceUrl)
+	res, err := j.doGet(ctx, traceUrl)
 	if err != nil {
 		if backend.IsDownstreamHTTPError(err) {
 			return nil, backend.DownstreamError(err)

--- a/pkg/tsdb/jaeger/grpc_client_test.go
+++ b/pkg/tsdb/jaeger/grpc_client_test.go
@@ -69,7 +69,7 @@ func TestJaegerGrpcClient_Services(t *testing.T) {
 			client, err := New(server.Client(), log.NewNullLogger(), settings)
 			assert.NoError(t, err)
 
-			services, err := client.GrpcServices()
+			services, err := client.GrpcServices(context.Background())
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -387,7 +387,7 @@ func TestJaegerGrpcClient_Operations(t *testing.T) {
 			client, err := New(server.Client(), log.NewNullLogger(), settings)
 			assert.NoError(t, err)
 
-			operations, err := client.GrpcOperations(tt.service)
+			operations, err := client.GrpcOperations(context.Background(), tt.service)
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/pkg/tsdb/jaeger/jaeger.go
+++ b/pkg/tsdb/jaeger/jaeger.go
@@ -93,9 +93,9 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 
 	var servicesErr error
 	if cfg.FeatureToggles().IsEnabled("jaegerEnableGrpcEndpoint") {
-		_, servicesErr = client.JaegerClient.GrpcServices()
+		_, servicesErr = client.JaegerClient.GrpcServices(ctx)
 	} else {
-		_, servicesErr = client.JaegerClient.Services()
+		_, servicesErr = client.JaegerClient.Services(ctx)
 	}
 
 	if servicesErr != nil {

--- a/pkg/tsdb/jaeger/querydata.go
+++ b/pkg/tsdb/jaeger/querydata.go
@@ -51,7 +51,7 @@ func queryData(ctx context.Context, dsInfo *datasourceInfo, req *backend.QueryDa
 		// Handle "Search" query type
 		if query.QueryType == "search" {
 			// TODO: enable routing to gRPC when ready, currently pending on: https://github.com/jaegertracing/jaeger/issues/7594
-			frames, err := dsInfo.JaegerClient.Search(&query, q.TimeRange.From.UnixMicro(), q.TimeRange.To.UnixMicro())
+			frames, err := dsInfo.JaegerClient.Search(ctx, &query, q.TimeRange.From.UnixMicro(), q.TimeRange.To.UnixMicro())
 			if err != nil {
 				response.Responses[q.RefID] = backend.ErrorResponseWithErrorSource(err)
 				continue


### PR DESCRIPTION
After the Jaeger backend migration, the datasource uses the backend for health checks and queries. The backend was issuing HTTP requests without the request context, so the middleware that adds auth/identity headers never ran on those requests.

Gateways that require a JWT then responded with plain-text errors (e.g. "JWT required") instead of JSON. We tried to decode that as JSON and failed with `invalid character 'J' looking for beginning of value`.

**Change:** Use the request context for all outbound HTTP calls in the Jaeger backend. The existing HTTP client middleware then attaches the correct headers so gateways receive the JWT again.
