### PR TITLE
Heatmap panel: fix sparse heatmap native histogram oom loop

### DIFF
--- a/public/app/plugins/panel/heatmap/utils.test.ts
+++ b/public/app/plugins/panel/heatmap/utils.test.ts
@@ -1,3 +1,5 @@
+import uPlot from 'uplot';
+
 import { ScaleDistribution } from '@grafana/schema';
 
 import {
@@ -5,9 +7,70 @@ import {
   boundedMinMax,
   calculateBucketExpansionFactor,
   calculateYSizeDivisor,
+  createSparseYScaleRange,
   toLogBase,
   valuesToFills,
 } from './utils';
+
+// Root cause of Chrome OOM crash (GitHub issue #20873):
+// Native histogram panels produce sparse DataFrameType.HeatmapCells frames. The sparse Y axis is
+// always log scale (base 2). When a panel receives no data, u.data[1] contains empty facet arrays
+// [[], [], [], []]. uPlot passes dataMin=null to the Y scale range function because there are no
+// data points to compute a minimum from. Without the null guard, null coerces to 0 in arithmetic,
+// so rangeLog receives scaleMin=0 on a log-base-2 axis. logAxisSplits then computes:
+//   foundIncr = pow(2, floor(log2(0))) = pow(2, -Infinity) = 0
+// and loops: do { split = 0 + 0 } while (0 <= 0) — forever. Chrome runs out of memory and crashes.
+describe('logAxisSplits OOM crash with empty sparse heatmap data', () => {
+  it('createSparseYScaleRange returns [null, null] for empty histogram panel data', () => {
+    // u.data[1] = [[], [], [], []] represents a native histogram panel with no data.
+    // uPlot passes dataMin=null, dataMax=null to the range function when dataLen=0.
+    // Without the null guard: null * bucketFactor(1) = 0, rangeLog(null, 0, 2, true) = [0, 0],
+    // which sets scale.min=0 and triggers the logAxisSplits infinite loop described above.
+    // With the null guard: returns [null, null] before reaching rangeLog.
+    // Remove the guard and this test fails with [0, 0].
+    const rangeFn = createSparseYScaleRange(ScaleDistribution.Log, 2, 'y_test', false, {});
+    const mockU = {
+      data: [null, [[], [], [], []], []],
+      scales: { y_test: { log: 2 } },
+    } as unknown as uPlot;
+
+    const result = rangeFn(mockU, null as unknown as number, null as unknown as number);
+    expect(result).toEqual([null, null]);
+  });
+
+  it('uPlot sets scale.min=null for empty histogram data — axesCalc skips logAxisSplits', () => {
+    // Proves the fix prevents logAxisSplits from being called in a real uPlot instance.
+    // uPlot axesCalc (uPlot.iife.js line 4799): if (scale.min == null) { return; }
+    // When scale.min is null, axesCalc returns before calling axis.splits, so logAxisSplits
+    // never executes and the infinite loop never starts.
+    // Remove the fix and this test fails: scale.min becomes 0, logAxisSplits is called,
+    // and the test runner throws RangeError: Invalid array length as the array push in the
+    // loop exhausts the JS array size limit. In Chrome the same loop exhausts memory instead.
+    const rangeFn = createSparseYScaleRange(ScaleDistribution.Log, 2, 'y', false, {});
+
+    const container = document.createElement('div');
+    const u = new uPlot(
+      {
+        width: 100,
+        height: 100,
+        scales: {
+          x: { time: false },
+          y: { distr: 3, log: 2, range: rangeFn as unknown as uPlot.Scale['range'] },
+        },
+        axes: [{}, { scale: 'y' }],
+        series: [{}, { scale: 'y' }],
+      },
+      [[], []],
+      container
+    );
+
+    u.setData([[], []]);
+
+    expect(u.scales.y.min).toBeNull();
+
+    u.destroy();
+  });
+});
 
 describe('toLogBase', () => {
   it('returns 10 when value is 10', () => {

--- a/public/app/plugins/panel/heatmap/utils.ts
+++ b/public/app/plugins/panel/heatmap/utils.ts
@@ -79,7 +79,7 @@ export function createSparseYScaleRange(
   yAxisConfig: YAxisConfig
 ): (u: uPlot, dataMin: number, dataMax: number) => [number | null, number | null] {
   return (u, dataMin, dataMax) => {
-    // Guard: when dataMin/dataMax are null (empty panel data), uPlot.rangeLog(null, 0, base, true)
+    // Guard: when dataMin/dataMax are null (empty panel data in native histogram, sparse heatmap), uPlot.rangeLog(null, 0, base, true)
     // returns [0, 0], and logAxisSplits(scaleMin=0, logBase=2) enters an infinite loop
     // (pow(2,-Inf)=0, 0+0=0 forever) → OOM crash. Return [null,null] so uPlot skips logAxisSplits.
     if (dataMin == null || dataMax == null) {

--- a/public/app/plugins/panel/heatmap/utils.ts
+++ b/public/app/plugins/panel/heatmap/utils.ts
@@ -66,6 +66,63 @@ interface PrepConfigOpts {
   rowsFrame?: { yBucketScale?: { type: ScaleDistribution; log?: number; linearThreshold?: number } };
 }
 
+/**
+ * Creates the sparse heatmap Y scale range function.
+ * Exported for testing — verifies the null-data guard that prevents the logAxisSplits OOM infinite loop.
+ * See utils.test.ts: 'logAxisSplits infinite loop with empty sparse heatmap data'.
+ */
+export function createSparseYScaleRange(
+  scaleDistribution: ScaleDistribution,
+  scaleLog: number,
+  yScaleKey: string,
+  isOrdinalY: boolean,
+  yAxisConfig: YAxisConfig
+): (u: uPlot, dataMin: number, dataMax: number) => [number | null, number | null] {
+  return (u, dataMin, dataMax) => {
+    // Guard: when dataMin/dataMax are null (empty panel data), uPlot.rangeLog(null, 0, base, true)
+    // returns [0, 0], and logAxisSplits(scaleMin=0, logBase=2) enters an infinite loop
+    // (pow(2,-Inf)=0, 0+0=0 forever) → OOM crash. Return [null,null] so uPlot skips logAxisSplits.
+    if (dataMin == null || dataMax == null) {
+      return [null, null];
+    }
+
+    const yMinData = u.data[1]?.[1];
+    const yMaxData = u.data[1]?.[2];
+    const yMinValues = Array.isArray(yMinData) ? yMinData : [];
+    const yMaxValues = Array.isArray(yMaxData) ? yMaxData : [];
+
+    // ...but uPlot currently only auto-ranges from the yMin facet data, so we have to grow by 1 extra factor
+    const bucketFactor = calculateBucketExpansionFactor(yMinValues, yMaxValues);
+    dataMax *= bucketFactor;
+
+    let scaleMin: number | null, scaleMax: number | null;
+
+    const isLogScale = scaleDistribution === ScaleDistribution.Log || scaleDistribution === ScaleDistribution.Symlog;
+    [scaleMin, scaleMax] = isLogScale ? uPlot.rangeLog(dataMin, dataMax, scaleLog, true) : [dataMin, dataMax];
+
+    let { min: explicitMin, max: explicitMax } = yAxisConfig;
+
+    if (isLogScale && !isOrdinalY) {
+      let yExp = u.scales[yScaleKey].log!;
+      let log = yExp === 2 ? Math.log2 : Math.log10;
+
+      if (explicitMin != null && explicitMin > 0) {
+        let minLog = log(explicitMin);
+        scaleMin = yExp ** incrRoundDn(minLog, 1);
+      }
+
+      if (explicitMax != null && explicitMax > 0) {
+        let maxLog = log(explicitMax);
+        scaleMax = yExp ** incrRoundUp(maxLog, 1);
+      }
+    } else if (!isOrdinalY) {
+      [scaleMin, scaleMax] = applyExplicitMinMax(scaleMin, scaleMax, explicitMin, explicitMax);
+    }
+
+    return [scaleMin, scaleMax];
+  };
+}
+
 export function prepConfig(opts: PrepConfigOpts) {
   const {
     dataRef,
@@ -242,48 +299,7 @@ export function prepConfig(opts: PrepConfigOpts) {
     range:
       // sparse already accounts for le/ge by explicit yMin & yMax cell bounds, so no need to expand y range
       isSparseHeatmap
-        ? (u, dataMin, dataMax) => {
-            // Extract yMin and yMax arrays
-            const yMinData = u.data[1]?.[1];
-            const yMaxData = u.data[1]?.[2];
-            const yMinValues = Array.isArray(yMinData) ? yMinData : [];
-            const yMaxValues = Array.isArray(yMaxData) ? yMaxData : [];
-
-            // ...but uPlot currently only auto-ranges from the yMin facet data, so we have to grow by 1 extra factor
-            const bucketFactor = calculateBucketExpansionFactor(yMinValues, yMaxValues);
-
-            dataMax *= bucketFactor;
-
-            let scaleMin: number | null, scaleMax: number | null;
-
-            const isLogScale =
-              scaleDistribution === ScaleDistribution.Log || scaleDistribution === ScaleDistribution.Symlog;
-            [scaleMin, scaleMax] = isLogScale ? uPlot.rangeLog(dataMin, dataMax, scaleLog, true) : [dataMin, dataMax];
-
-            let { min: explicitMin, max: explicitMax } = yAxisConfig;
-
-            if (isLogScale && !isOrdinalY) {
-              let yExp = u.scales[yScaleKey].log!;
-              let log = yExp === 2 ? Math.log2 : Math.log10;
-
-              // guard against <= 0
-              if (explicitMin != null && explicitMin > 0) {
-                // snap to magnitude
-                let minLog = log(explicitMin);
-                scaleMin = yExp ** incrRoundDn(minLog, 1);
-              }
-
-              if (explicitMax != null && explicitMax > 0) {
-                let maxLog = log(explicitMax);
-                scaleMax = yExp ** incrRoundUp(maxLog, 1);
-              }
-            } else if (!isOrdinalY) {
-              // Apply explicit min/max for linear scale
-              [scaleMin, scaleMax] = applyExplicitMinMax(scaleMin, scaleMax, explicitMin, explicitMax);
-            }
-
-            return [scaleMin, scaleMax];
-          }
+        ? createSparseYScaleRange(scaleDistribution, scaleLog, yScaleKey, isOrdinalY, yAxisConfig)
         : // dense and ordinal only have one of yMin|yMax|y, so expand range by one cell in the direction of le/ge/unknown
           (u, dataMin, dataMax) => {
             let scaleMin = dataMin,


### PR DESCRIPTION
### Problem

Native histogram panels in the metrics drilldown breakdown view were crashing Chrome tabs (reported in https://github.com/grafana/support-escalations/issues/20873). When a panel received no data, the heatmap would OOM the browser.

### Root cause

Native histograms produce sparse HeatmapCells frames with a log-scale Y axis. When a panel has no data, u.data[1] contains empty facet arrays. uPlot passes dataMin=null to the Y scale range function. Without a null guard, null coerces to 0 in arithmetic, so rangeLog receives scaleMin=0 on a log-base-2 axis. This causes logAxisSplits in uPlot to compute foundIncr = pow(2, -Infinity) = 0 and enter an infinite loop (0 + 0 = 0 forever), exhausting Chrome's memory.

### Fix

In createSparseYScaleRange, return [null, null] early when dataMin or dataMax is null. uPlot treats scale.min=null as no data, axesCalc returns before calling axis.splits, so logAxisSplits never executes.

### Tests

Two tests added that both fail when the fix is removed, second test shows the loop as a rangeError:

- Asserts createSparseYScaleRange returns [null, null] for null data (returns [0, 0] without fix)
- Integration test with a real uPlot instance, without fix, reproduces the crash as RangeError: Invalid array length from logAxisSplits


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
