### PR TITLE
A11y: Add aria-expanded to expand/collapse buttons

### DIFF
--- a/e2e-playwright/various-suite/navigation.spec.ts
+++ b/e2e-playwright/various-suite/navigation.spec.ts
@@ -29,7 +29,7 @@ test.describe(
       const undockButton = page.getByRole('button', { name: 'Undock menu' });
       await undockButton.click();
 
-      const openMenuButton = page.getByRole('button', { name: 'Open menu' });
+      const openMenuButton = page.getByRole('button', { name: 'Main menu' });
       await openMenuButton.click();
 
       const dockButton = page.getByRole('button', { name: 'Dock menu' });
@@ -45,7 +45,7 @@ test.describe(
       await undockButton.click();
 
       // Navigate
-      const openMenuButton = page.getByRole('button', { name: 'Open menu' });
+      const openMenuButton = page.getByRole('button', { name: 'Main menu' });
       await openMenuButton.click();
 
       const administrationLink = page.getByRole('link', { name: 'Administration' });

--- a/packages/grafana-ui/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/Dropdown.test.tsx
@@ -28,4 +28,24 @@ describe('Dropdown', () => {
     await userEvent.click(button);
     expect(screen.queryByText('View settings')).toBeVisible();
   });
+
+  it('sets aria-expanded on the trigger button', async () => {
+    const menu = (
+      <Menu>
+        <Menu.Item label="View settings" />
+      </Menu>
+    );
+
+    render(
+      <Dropdown overlay={menu}>
+        <Button>Toggle</Button>
+      </Dropdown>
+    );
+
+    const button = screen.getByRole('button', { name: 'Toggle' });
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
 });

--- a/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
@@ -88,6 +88,7 @@ export const Dropdown = React.memo(({ children, overlay, placement, offset, root
       {React.cloneElement(children, {
         ref: refs.setReference,
         ...getReferenceProps(),
+        'aria-expanded': show,
       })}
       {show && (
         <Portal root={root}>

--- a/public/app/core/components/AppChrome/AppChrome.test.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.test.tsx
@@ -96,7 +96,7 @@ describe('AppChrome', () => {
     const skipLink = await screen.findByRole('link', { name: 'Skip to main content' });
     expect(skipLink).toHaveFocus();
     await userEvent.keyboard('{tab}');
-    expect(await screen.findByRole('button', { name: 'Open menu' })).toHaveFocus();
+    expect(await screen.findByRole('button', { name: 'Main menu' })).toHaveFocus();
   });
 
   it('should not render a skip link if the page is chromeless', async () => {

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.test.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.test.tsx
@@ -19,6 +19,7 @@ describe('ExtensionToolbarItemButton', () => {
     const button = screen.getByTestId('extension-toolbar-button-open');
     expect(button).toBeInTheDocument();
     expect(button).toHaveAttribute('aria-label', 'Open AI assistants and sidebar apps');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
   });
 
   it('renders open button with custom tooltip when title is provided', () => {
@@ -27,6 +28,7 @@ describe('ExtensionToolbarItemButton', () => {
     const button = screen.getByTestId('extension-toolbar-button-open');
     expect(button).toBeInTheDocument();
     expect(button).toHaveAttribute('aria-label', 'Open Test App');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
   });
 
   it('renders close button with custom tooltip when isOpen is true', () => {
@@ -35,6 +37,7 @@ describe('ExtensionToolbarItemButton', () => {
     const button = screen.getByTestId('extension-toolbar-button-close');
     expect(button).toBeInTheDocument();
     expect(button).toHaveAttribute('aria-label', 'Close Test App');
+    expect(button).toHaveAttribute('aria-expanded', 'true');
   });
 
   it('calls onClick handler when button is clicked', () => {

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
@@ -46,6 +46,7 @@ function ExtensionToolbarItemButtonComponent(
       iconOnly
       data-testid={`extension-toolbar-button-${isOpen ? 'close' : 'open'}`}
       variant={isOpen ? 'active' : 'default'}
+      aria-expanded={isOpen}
       onClick={onClick}
       tooltip={tooltip}
     />

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
@@ -46,6 +46,7 @@ export function MegaMenuHeader({ handleDockedMenu, onClose }: Props) {
         variant="secondary"
       />
       <IconButton
+        aria-label={t('navigation.megamenu.close', 'Close menu')}
         tooltip={t('navigation.megamenu.close', 'Close menu')}
         name="times"
         onClick={onClose}

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
@@ -121,6 +121,7 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick, onPin, isPi
                       sectionName: link.text,
                     })
               }
+              aria-expanded={Boolean(sectionExpanded)}
               className={styles.collapseButton}
               onClick={() => setSectionExpanded(!sectionExpanded)}
               name={getIconName(Boolean(sectionExpanded))}

--- a/public/app/core/components/AppChrome/TopBar/HelpTopBarButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/HelpTopBarButton.tsx
@@ -49,6 +49,7 @@ export const HelpTopBarButton = memo(function HelpTopBarButton({ isSmallScreen }
       iconOnly
       icon="question-circle"
       aria-label={t('navigation.help.aria-label', 'Help')}
+      aria-expanded={isOpen}
       variant={isOpen ? 'active' : 'default'}
       tooltip={
         isOpen

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -71,7 +71,8 @@ export const SingleTopBar = memo(function SingleTopBar({
               narrow
               id={MEGA_MENU_TOGGLE_ID}
               onClick={onToggleMegaMenu}
-              tooltip={t('navigation.megamenu.open', 'Open menu')}
+              tooltip={t('navigation.megamenu.open', 'Main menu')}
+              aria-expanded={state.megaMenuOpen}
             >
               <Stack gap={0} alignItems="center">
                 <Icon name="bars" size="xl" />

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11744,7 +11744,7 @@
       "dialog-label": "Navigation",
       "dock": "Dock menu",
       "list-label": "Navigation",
-      "open": "Open menu",
+      "open": "Main menu",
       "undock": "Undock menu"
     },
     "megamenu-item": {


### PR DESCRIPTION
**What is this feature?**

Adds `aria-expanded` attribute to expand/collapse buttons across the Grafana UI to announce state changes to screen readers, per WAI-ARIA disclosure pattern.

**Why do we need this feature?**

Screen readers were not announcing expanded/collapsed state changes when users activated expand/collapse buttons. The `aria-expanded` attribute programmatically communicates state to assistive technologies, meeting WCAG 4.1.2 (Name, Role, Value) requirements.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/117828

**Special notes for your reviewer:**

- Dropdown component now automatically sets `aria-expanded` on all dropdown triggers (Help, Profile buttons)