### PR TITLE
Provisioning: Update folder title on sync when it has changed

### DIFF
--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -129,6 +129,7 @@ func (fm *FolderManager) EnsureFolderPathExist(ctx context.Context, filePath str
 // EnsureFolderExists creates the folder if it doesn't exist.
 // If the folder already exists:
 // - it will error if the folder is not owned by this repository
+// - it will update the title if it has changed
 func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, parent string) error {
 	cfg := fm.repo.Config()
 	obj, err := fm.client.Get(ctx, folder.ID, metav1.GetOptions{})
@@ -140,6 +141,21 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 		if current != cfg.Name {
 			return fmt.Errorf("target folder is managed by a different repository (%s)", current)
 		}
+
+		currentTitle, _, _ := unstructured.NestedString(obj.Object, "spec", "title")
+		if currentTitle != folder.Title {
+			ctx, _, err = identity.WithProvisioningIdentity(ctx, cfg.GetNamespace())
+			if err != nil {
+				return fmt.Errorf("unable to use provisioning identity %w", err)
+			}
+			if err := unstructured.SetNestedField(obj.Object, folder.Title, "spec", "title"); err != nil {
+				return fmt.Errorf("set folder title: %w", err)
+			}
+			if _, err := fm.client.Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
+				return fmt.Errorf("update folder title: %w", err)
+			}
+		}
+
 		return nil
 	} else if !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to check if folder exists: %w", err)

--- a/pkg/registry/apis/provisioning/resources/folders_test.go
+++ b/pkg/registry/apis/provisioning/resources/folders_test.go
@@ -237,12 +237,188 @@ func TestEnsureFolderPathExistWithBeforeCreate(t *testing.T) {
 	})
 }
 
+func TestEnsureFolderExists_TitleUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	newRepo := func(t *testing.T) (*repository.MockReaderWriter, *provisioning.Repository) {
+		cfg := &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "repo-a",
+				Namespace: "default",
+			},
+			Spec: provisioning.RepositorySpec{
+				Sync: provisioning.SyncOptions{
+					Target: provisioning.SyncTargetTypeFolder,
+				},
+			},
+		}
+
+		repo := repository.NewMockReaderWriter(t)
+		repo.On("Config").Return(cfg)
+		return repo, cfg
+	}
+
+	managedFolder := func(name, title, managerIdentity string) *unstructured.Unstructured {
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "folder.grafana.app/v1beta1",
+				"kind":       "Folder",
+				"metadata": map[string]interface{}{
+					"name":      name,
+					"namespace": "default",
+					"annotations": map[string]interface{}{
+						"grafana.app/managerId": managerIdentity,
+					},
+				},
+				"spec": map[string]interface{}{
+					"title": title,
+				},
+			},
+		}
+		return obj
+	}
+
+	t.Run("does not update when title is the same", func(t *testing.T) {
+		repo, cfg := newRepo(t)
+		tree := resources.NewEmptyFolderTree()
+
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return managedFolder(name, "Same Title", cfg.Name), nil
+			},
+		}
+
+		fm := resources.NewFolderManager(repo, client, tree)
+		err := fm.EnsureFolderExists(ctx, resources.Folder{
+			ID:    "folder-id",
+			Title: "Same Title",
+			Path:  "",
+		}, "")
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"folder-id"}, client.getCalls)
+		require.Empty(t, client.updateCalls, "should not call update when title is unchanged")
+	})
+
+	t.Run("updates title when it has changed", func(t *testing.T) {
+		repo, cfg := newRepo(t)
+		tree := resources.NewEmptyFolderTree()
+
+		var updatedObj *unstructured.Unstructured
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return managedFolder(name, "Old Title", cfg.Name), nil
+			},
+			updateFn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				updatedObj = obj.DeepCopy()
+				return obj, nil
+			},
+		}
+
+		fm := resources.NewFolderManager(repo, client, tree)
+		err := fm.EnsureFolderExists(ctx, resources.Folder{
+			ID:    "folder-id",
+			Title: "New Title",
+			Path:  "",
+		}, "")
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"folder-id"}, client.getCalls)
+		require.Equal(t, []string{"folder-id"}, client.updateCalls)
+
+		newTitle, _, _ := unstructured.NestedString(updatedObj.Object, "spec", "title")
+		require.Equal(t, "New Title", newTitle, "the updated object should have the new title")
+	})
+
+	t.Run("returns error when update fails", func(t *testing.T) {
+		repo, cfg := newRepo(t)
+		tree := resources.NewEmptyFolderTree()
+
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return managedFolder(name, "Old Title", cfg.Name), nil
+			},
+			updateFn: func(_ *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				return nil, fmt.Errorf("conflict")
+			},
+		}
+
+		fm := resources.NewFolderManager(repo, client, tree)
+		err := fm.EnsureFolderExists(ctx, resources.Folder{
+			ID:    "folder-id",
+			Title: "New Title",
+			Path:  "",
+		}, "")
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "update folder title")
+		require.Equal(t, []string{"folder-id"}, client.updateCalls)
+	})
+
+	t.Run("errors when folder is not managed by a repository", func(t *testing.T) {
+		repo, _ := newRepo(t)
+		tree := resources.NewEmptyFolderTree()
+
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":        name,
+							"annotations": map[string]interface{}{},
+						},
+						"spec": map[string]interface{}{
+							"title": "Some Title",
+						},
+					},
+				}
+				return obj, nil
+			},
+		}
+
+		fm := resources.NewFolderManager(repo, client, tree)
+		err := fm.EnsureFolderExists(ctx, resources.Folder{
+			ID:    "folder-id",
+			Title: "New Title",
+			Path:  "",
+		}, "")
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "not managed by a repository")
+		require.Empty(t, client.updateCalls)
+	})
+
+	t.Run("errors when folder is managed by a different repository", func(t *testing.T) {
+		repo, _ := newRepo(t)
+		tree := resources.NewEmptyFolderTree()
+
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return managedFolder(name, "Title", "other-repo"), nil
+			},
+		}
+
+		fm := resources.NewFolderManager(repo, client, tree)
+		err := fm.EnsureFolderExists(ctx, resources.Folder{
+			ID:    "folder-id",
+			Title: "New Title",
+			Path:  "",
+		}, "")
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "managed by a different repository (other-repo)")
+		require.Empty(t, client.updateCalls)
+	})
+}
+
 type fakeDynamicResourceClient struct {
 	getFn    func(name string) (*unstructured.Unstructured, error)
 	createFn func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
+	updateFn func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
 
 	getCalls    []string
 	createCalls []string
+	updateCalls []string
 }
 
 func (f *fakeDynamicResourceClient) Create(_ context.Context, obj *unstructured.Unstructured, _ metav1.CreateOptions, _ ...string) (*unstructured.Unstructured, error) {
@@ -253,8 +429,12 @@ func (f *fakeDynamicResourceClient) Create(_ context.Context, obj *unstructured.
 	return obj, nil
 }
 
-func (f *fakeDynamicResourceClient) Update(context.Context, *unstructured.Unstructured, metav1.UpdateOptions, ...string) (*unstructured.Unstructured, error) {
-	panic("unexpected call to Update")
+func (f *fakeDynamicResourceClient) Update(_ context.Context, obj *unstructured.Unstructured, _ metav1.UpdateOptions, _ ...string) (*unstructured.Unstructured, error) {
+	f.updateCalls = append(f.updateCalls, obj.GetName())
+	if f.updateFn != nil {
+		return f.updateFn(obj)
+	}
+	return obj, nil
 }
 
 func (f *fakeDynamicResourceClient) UpdateStatus(context.Context, *unstructured.Unstructured, metav1.UpdateOptions) (*unstructured.Unstructured, error) {

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -2613,3 +2613,62 @@ func TestIntegrationProvisioning_ConcurrentRepositoryCreation(t *testing.T) {
 
 	t.Logf("Successfully created %d repositories concurrently without deadlocks", numRepos)
 }
+
+func TestIntegrationProvisioning_FolderTitleUpdatesOnSync(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafana(t)
+	ctx := context.Background()
+
+	const repoName = "folder-title-update-test"
+	const initialTitle = "Initial Folder Title"
+	const updatedTitle = "Updated Folder Title"
+
+	helper.CreateRepo(t, TestRepo{
+		Name:               repoName,
+		Target:             "folder",
+		Copies:             map[string]string{"testdata/all-panels.json": "all-panels.json"},
+		ExpectedDashboards: 1,
+		ExpectedFolders:    1,
+		Values: map[string]any{
+			"Title": initialTitle,
+		},
+	})
+
+	// Verify the root folder has the initial title.
+	// The root folder for a folder-sync repo has the same name as the repository.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		folderObj, err := helper.Folders.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		if !assert.NoError(collect, err, "should be able to get the root folder") {
+			return
+		}
+		title, _, _ := unstructured.NestedString(folderObj.Object, "spec", "title")
+		assert.Equal(collect, initialTitle, title, "folder should have the initial title")
+	}, waitTimeoutDefault, waitIntervalDefault, "root folder should have initial title")
+
+	// Update the repository spec.title to a new value.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		repoObj, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		if !assert.NoError(collect, err, "should be able to get repository") {
+			return
+		}
+		err = unstructured.SetNestedField(repoObj.Object, updatedTitle, "spec", "title")
+		require.NoError(t, err, "should be able to set new title")
+
+		_, err = helper.Repositories.Resource.Update(ctx, repoObj, metav1.UpdateOptions{})
+		assert.NoError(collect, err, "should be able to update repository title")
+	}, waitTimeoutDefault, waitIntervalDefault, "should update repository title")
+
+	// Trigger a sync, which calls EnsureFolderExists for the root folder.
+	helper.SyncAndWait(t, repoName, nil)
+
+	// Verify the root folder title was updated.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		folderObj, err := helper.Folders.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		if !assert.NoError(collect, err, "should be able to get the root folder") {
+			return
+		}
+		title, _, _ := unstructured.NestedString(folderObj.Object, "spec", "title")
+		assert.Equal(collect, updatedTitle, title, "folder title should be updated after sync")
+	}, waitTimeoutDefault, waitIntervalDefault, "root folder title should be updated after sync")
+}


### PR DESCRIPTION
## Summary

- Fixes a bug where changing a repository's `spec.title` did not update the provisioned root folder's title on subsequent syncs.
- In `EnsureFolderExists`, after confirming folder ownership, the code now compares the current title with the expected one and updates it if they differ.
- Adds integration test `TestIntegrationProvisioning_FolderTitleUpdatesOnSync` that verifies the folder title is updated after changing the repository title and triggering a sync.

Closes https://github.com/grafana/git-ui-sync-project/issues/948

## Test plan

- [ ] Integration test `TestIntegrationProvisioning_FolderTitleUpdatesOnSync` passes
- [ ] Existing provisioning integration tests still pass (no regressions in folder creation/deletion)
- [ ] Manual test: create a folder-sync repository, change `spec.title`, trigger sync, verify folder title updates

Made with [Cursor](https://cursor.com)