### PR TITLE
Alerting: Add start/end state filters to rule history tab

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1453,11 +1453,6 @@
       "count": 1
     }
   },
-  "public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "public/app/features/alerting/unified/components/rules/state-history/StateHistory.tsx": {
     "no-restricted-syntax": {
       "count": 1

--- a/public/app/features/alerting/unified/components/rules/central-state-history/constants.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/constants.ts
@@ -3,5 +3,7 @@ export const StateFilterValues = {
   firing: 'Alerting',
   normal: 'Normal',
   pending: 'Pending',
+  noData: 'NoData',
+  error: 'Error',
   recovering: 'Recovering',
 } as const;

--- a/public/app/features/alerting/unified/components/rules/central-state-history/constants.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/constants.ts
@@ -3,7 +3,5 @@ export const StateFilterValues = {
   firing: 'Alerting',
   normal: 'Normal',
   pending: 'Pending',
-  noData: 'NoData',
-  error: 'Error',
   recovering: 'Recovering',
 } as const;

--- a/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
@@ -29,8 +29,8 @@ const STATE_FILTER_OPTIONS: Array<SelectableValue<string>> = [
   { label: 'Alerting', value: StateFilterValues.firing },
   { label: 'Normal', value: StateFilterValues.normal },
   { label: 'Pending', value: StateFilterValues.pending },
-  { label: 'NoData', value: StateFilterValues.noData },
-  { label: 'Error', value: StateFilterValues.error },
+  { label: 'NoData', value: 'NoData' },
+  { label: 'Error', value: 'Error' },
   { label: 'Recovering', value: StateFilterValues.recovering },
 ];
 const MAX_TIMELINE_SERIES = 12;
@@ -162,22 +162,24 @@ const LokiStateHistory = ({ ruleUID }: Props) => {
         </Field>
       </Stack>
       {!isEmpty(commonLabels) && (
-        <Stack gap={1} alignItems="center" wrap="wrap">
-          <Stack gap={0.5} alignItems="center" minWidth="fit-content">
-            <Text variant="bodySmall">
-              <Trans i18nKey="alerting.loki-state-history.common-labels">Common labels</Trans>
-            </Text>
-            <Tooltip
-              content={t(
-                'alerting.loki-state-history.tooltip-common-labels',
-                'Common labels are the ones attached to all of the alert instances'
-              )}
-            >
-              <Icon name="info-circle" size="sm" />
-            </Tooltip>
+        <div className={styles.commonLabels}>
+          <Stack gap={1} alignItems="center" wrap="wrap">
+            <Stack gap={0.5} alignItems="center" minWidth="fit-content">
+              <Text variant="bodySmall">
+                <Trans i18nKey="alerting.loki-state-history.common-labels">Common labels</Trans>
+              </Text>
+              <Tooltip
+                content={t(
+                  'alerting.loki-state-history.tooltip-common-labels',
+                  'Common labels are the ones attached to all of the alert instances'
+                )}
+              >
+                <Icon name="info-circle" size="sm" />
+              </Tooltip>
+            </Stack>
+            <AlertLabels labels={fromPairs(commonLabels)} size="sm" />
           </Stack>
-          <AlertLabels labels={fromPairs(commonLabels)} size="sm" />
-        </Stack>
+        </div>
       )}
       {isEmpty(frameSubset) ? (
         <div className={styles.emptyState}>
@@ -190,9 +192,19 @@ const LokiStateHistory = ({ ruleUID }: Props) => {
         </div>
       ) : (
         <>
-          <div className={styles.graphWrapper}>
-            <LogTimelineViewer frames={frameSubset} timeRange={frameTimeRange} />
-          </div>
+          {hasActiveStateFilter ? (
+            <div className={styles.timelineHiddenMessage}>
+              <Text variant="bodySmall" color="secondary">
+                <Trans i18nKey="alerting.loki-state-history.timeline-hidden">
+                  Timeline is hidden when state filters are active
+                </Trans>
+              </Text>
+            </div>
+          ) : (
+            <div className={styles.graphWrapper}>
+              <LogTimelineViewer frames={frameSubset} timeRange={frameTimeRange} />
+            </div>
+          )}
           {hasMoreInstances && (
             <div className={styles.moreInstancesWarning}>
               <Stack direction="row" alignItems="center" gap={1}>
@@ -311,6 +323,13 @@ export const getStyles = (theme: GrafanaTheme2) => ({
 
     display: 'flex',
     flexDirection: 'column',
+  }),
+  commonLabels: css({
+    padding: theme.spacing(1, 0),
+  }),
+  timelineHiddenMessage: css({
+    textAlign: 'center',
+    padding: theme.spacing(1, 0),
   }),
   instancesFilterForm: css({
     flex: 1,

--- a/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
@@ -5,13 +5,14 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { AlertLabels } from '@grafana/alerting/unstable';
-import { DataFrame, GrafanaTheme2, TimeRange, dateTime } from '@grafana/data';
+import { DataFrame, GrafanaTheme2, SelectableValue, TimeRange, dateTime } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Alert, Button, Field, Icon, Input, Label, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Field, Icon, Input, Label, Select, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { stateHistoryApi } from '../../../api/stateHistoryApi';
 import { combineMatcherStrings } from '../../../utils/alertmanager';
 import { PopupCard } from '../../HoverCard';
+import { StateFilterValues } from '../central-state-history/constants';
 
 import { LogRecordViewerByTimestamp } from './LogRecordViewer';
 import { LogTimelineViewer } from './LogTimelineViewer';
@@ -22,11 +23,23 @@ interface Props {
 }
 
 const STATE_HISTORY_POLLING_INTERVAL = 10 * 1000; // 10 seconds
+
+const STATE_FILTER_OPTIONS: Array<SelectableValue<string>> = [
+  { label: 'All', value: StateFilterValues.all },
+  { label: 'Alerting', value: StateFilterValues.firing },
+  { label: 'Normal', value: StateFilterValues.normal },
+  { label: 'Pending', value: StateFilterValues.pending },
+  { label: 'NoData', value: StateFilterValues.noData },
+  { label: 'Error', value: StateFilterValues.error },
+  { label: 'Recovering', value: StateFilterValues.recovering },
+];
 const MAX_TIMELINE_SERIES = 12;
 
 const LokiStateHistory = ({ ruleUID }: Props) => {
   const styles = useStyles2(getStyles);
   const [instancesFilter, setInstancesFilter] = useState('');
+  const [stateFrom, setStateFrom] = useState<string>(StateFilterValues.all);
+  const [stateTo, setStateTo] = useState<string>(StateFilterValues.all);
   const logsRef = useRef<Map<number, HTMLElement>>(new Map<number, HTMLElement>());
 
   const { getValues, setValue, register, handleSubmit } = useForm({ defaultValues: { query: '' } });
@@ -47,6 +60,8 @@ const LokiStateHistory = ({ ruleUID }: Props) => {
       from: queryTimeRange.from.unix(),
       to: queryTimeRange.to.unix(),
       limit: 250,
+      previous: stateFrom !== StateFilterValues.all ? stateFrom : undefined,
+      current: stateTo !== StateFilterValues.all ? stateTo : undefined,
     },
     {
       refetchOnFocus: true,
@@ -74,6 +89,8 @@ const LokiStateHistory = ({ ruleUID }: Props) => {
   const onFilterCleared = useCallback(() => {
     setInstancesFilter('');
     setValue('query', '');
+    setStateFrom(StateFilterValues.all);
+    setStateTo(StateFilterValues.all);
   }, [setInstancesFilter, setValue]);
 
   if (isLoading) {
@@ -100,21 +117,50 @@ const LokiStateHistory = ({ ruleUID }: Props) => {
   }
 
   const hasMoreInstances = frameSubset.length < dataFrames.length;
-  const emptyStateMessage =
-    totalRecordsCount > 0
-      ? `No matches were found for the given filters among the ${totalRecordsCount} instances`
-      : 'No state transitions have occurred in the last 30 days';
+  const hasActiveStateFilter = stateFrom !== StateFilterValues.all || stateTo !== StateFilterValues.all;
+
+  let emptyStateMessage: string;
+  if (totalRecordsCount > 0) {
+    emptyStateMessage = `No matches were found for the given filters among the ${totalRecordsCount} instances`;
+  } else if (hasActiveStateFilter) {
+    emptyStateMessage = t(
+      'alerting.loki-state-history.no-transitions-match-filters',
+      'No state transitions match the selected filters'
+    );
+  } else {
+    emptyStateMessage = 'No state transitions have occurred in the last 30 days';
+  }
 
   return (
     <div className={styles.fullSize}>
-      <form onSubmit={handleSubmit((data) => setInstancesFilter(data.query))}>
-        <SearchFieldInput
-          {...register('query')}
-          showClearFilterSuffix={!!instancesFilter}
-          onClearFilterClick={onFilterCleared}
-        />
-        <input type="submit" hidden />
-      </form>
+      <Stack direction="row" gap={1} alignItems="flex-end">
+        <div className={styles.instancesFilterForm}>
+          <form onSubmit={handleSubmit((data) => setInstancesFilter(data.query))}>
+            <SearchFieldInput
+              {...register('query')}
+              showClearFilterSuffix={!!instancesFilter}
+              onClearFilterClick={onFilterCleared}
+            />
+            <input type="submit" hidden />
+          </form>
+        </div>
+        <Field noMargin label={t('alerting.loki-state-history.start-state', 'Start state')}>
+          <Select
+            options={STATE_FILTER_OPTIONS}
+            value={stateFrom}
+            onChange={(v) => setStateFrom(v.value ?? StateFilterValues.all)}
+            width={18}
+          />
+        </Field>
+        <Field noMargin label={t('alerting.loki-state-history.end-state', 'End state')}>
+          <Select
+            options={STATE_FILTER_OPTIONS}
+            value={stateTo}
+            onChange={(v) => setStateTo(v.value ?? StateFilterValues.all)}
+            width={18}
+          />
+        </Field>
+      </Stack>
       {!isEmpty(commonLabels) && (
         <Stack gap={1} alignItems="center" wrap="wrap">
           <Stack gap={0.5} alignItems="center" minWidth="fit-content">
@@ -136,7 +182,7 @@ const LokiStateHistory = ({ ruleUID }: Props) => {
       {isEmpty(frameSubset) ? (
         <div className={styles.emptyState}>
           {emptyStateMessage}
-          {totalRecordsCount > 0 && (
+          {(totalRecordsCount > 0 || hasActiveStateFilter) && (
             <Button variant="secondary" type="button" onClick={onFilterCleared}>
               <Trans i18nKey="alerting.loki-state-history.clear-filters">Clear filters</Trans>
             </Button>
@@ -200,6 +246,7 @@ const SearchFieldInput = React.forwardRef<HTMLInputElement, SearchFieldInputProp
   ({ showClearFilterSuffix, onClearFilterClick, ...rest }: SearchFieldInputProps, ref) => {
     return (
       <Field
+        noMargin
         label={
           <Label htmlFor="instancesSearchInput">
             <Stack gap={0.5}>
@@ -264,6 +311,10 @@ export const getStyles = (theme: GrafanaTheme2) => ({
 
     display: 'flex',
     flexDirection: 'column',
+  }),
+  instancesFilterForm: css({
+    flex: 1,
+    minWidth: 0,
   }),
   graphWrapper: css({
     padding: `${theme.spacing()} 0`,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1977,6 +1977,7 @@
       "loading": "Loading...",
       "no-transitions-match-filters": "No state transitions match the selected filters",
       "start-state": "Start state",
+      "timeline-hidden": "Timeline is hidden when state filters are active",
       "title-error-fetching-the-state-history": "Error fetching the state history",
       "tooltip-common-labels": "Common labels are the ones attached to all of the alert instances"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1972,8 +1972,11 @@
     "loki-state-history": {
       "clear-filters": "Clear filters",
       "common-labels": "Common labels",
+      "end-state": "End state",
       "error-unable-to-fetch": "Unable to fetch alert state history",
       "loading": "Loading...",
+      "no-transitions-match-filters": "No state transitions match the selected filters",
+      "start-state": "Start state",
       "title-error-fetching-the-state-history": "Error fetching the state history",
       "tooltip-common-labels": "Common labels are the ones attached to all of the alert instances"
     },


### PR DESCRIPTION
**What is this feature?**

Adds "Start state" and "End state" filter dropdowns to the alert rule history tab (`/alerting/grafana/{uid}/view?tab=history`).

Example: https://ephemeral15111821119584alexan.grafana-dev.net/alerting/grafana/eff32tfwsd0jkf/view?tab=history


<details>

<summary>Screenshots</summary>

<img width="1196" height="581" alt="image" src="https://github.com/user-attachments/assets/976ac961-6d79-4201-bdd4-8993de138715" />


<img width="1205" height="542" alt="image" src="https://github.com/user-attachments/assets/22837c6a-5e8d-450a-a78c-aa4790f29d75" />


</details>

**Why do we need this feature?**

The global history page (`/alerting/history`) already has state transition filters (start/end state), but the per-rule history tab only has an instance label filter. The API already supports previous and current state filter parameters, the UI just wasn't exposing them on the rule page.

**Who is this feature for?**

Grafana Alerting users.

**Special notes for your reviewer:**

When the state filters are active, the timeline is hidden since it does not represent the alert state timeline anymore and just looks confusing.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
