### PR TITLE
Alerting: Add NoData and Error to central history state filters

### DIFF
--- a/public/app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistoryScene.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistoryScene.tsx
@@ -93,7 +93,7 @@ export const CentralAlertHistoryScene = ({
         'End state:'
       ),
       hide: VariableHide.dontHide,
-      query: `All : ${StateFilterValues.all}, To Firing : ${StateFilterValues.firing},To Normal : ${StateFilterValues.normal},To Pending : ${StateFilterValues.pending},To Recovering : ${StateFilterValues.recovering}`,
+      query: `All : ${StateFilterValues.all}, To Firing : ${StateFilterValues.firing},To Normal : ${StateFilterValues.normal},To Pending : ${StateFilterValues.pending},To NoData : ${StateFilterValues.noData},To Error : ${StateFilterValues.error},To Recovering : ${StateFilterValues.recovering}`,
     });
 
     //custom variable for filtering by the previous state
@@ -105,7 +105,7 @@ export const CentralAlertHistoryScene = ({
         'Start state:'
       ),
       hide: VariableHide.dontHide,
-      query: `All : ${StateFilterValues.all}, From Firing : ${StateFilterValues.firing},From Normal : ${StateFilterValues.normal},From Pending : ${StateFilterValues.pending},From Recovering : ${StateFilterValues.recovering}`,
+      query: `All : ${StateFilterValues.all}, From Firing : ${StateFilterValues.firing},From Normal : ${StateFilterValues.normal},From Pending : ${StateFilterValues.pending},From NoData : ${StateFilterValues.noData},From Error : ${StateFilterValues.error},From Recovering : ${StateFilterValues.recovering}`,
     });
 
     return new EmbeddedScene({

--- a/public/app/features/alerting/unified/components/rules/central-state-history/constants.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/constants.ts
@@ -3,5 +3,7 @@ export const StateFilterValues = {
   firing: 'Alerting',
   normal: 'Normal',
   pending: 'Pending',
+  noData: 'NoData',
+  error: 'Error',
   recovering: 'Recovering',
 } as const;


### PR DESCRIPTION
**What is this feature?**

The backend accepts 6 states (Normal, Alerting, Pending, NoData, Error, Recovering) but the state filter dropdowns on the global history page only included 4. Add the missing NoData and Error options.

Examples: 
- [To Error](https://ephemeral15111821119587alexan.grafana-dev.net/alerting/history?var-STATE_FILTER_FROM=all&var-STATE_FILTER_TO=Error&from=2026-03-06T07:40:08.922Z&to=2026-03-06T07:45:42.895Z&timezone=browser)
- [To NoData](https://ephemeral15111821119587alexan.grafana-dev.net/alerting/history?var-STATE_FILTER_FROM=all&var-STATE_FILTER_TO=NoData&from=2026-03-06T07:40:08.922Z&to=2026-03-06T07:45:42.895Z&timezone=browser)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
