### PR TITLE
Alerting: Add thin typed client for using historian custom routes.

### DIFF
--- a/apps/alerting/historian/go.mod
+++ b/apps/alerting/historian/go.mod
@@ -14,6 +14,7 @@ require (
 	go.opentelemetry.io/otel v1.40.0
 	go.opentelemetry.io/otel/trace v1.40.0
 	k8s.io/apimachinery v0.35.1
+	k8s.io/client-go v0.35.1
 	k8s.io/kube-openapi v0.0.0-20251125145642-4e65d59e963e
 )
 
@@ -177,7 +178,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.35.1 // indirect
 	k8s.io/apiextensions-apiserver v0.35.1 // indirect
-	k8s.io/client-go v0.35.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/client.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/client.go
@@ -1,0 +1,78 @@
+package v0alpha1
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+)
+
+// Note that this file is currently hand written, custom routes do not generate clients:
+// https://github.com/grafana/grafana-app-sdk/issues/1277
+
+// Client is a thin typed wrapper around a namespaced rest.Interface
+type Client struct {
+	client    rest.Interface
+	namespace string
+}
+
+// NewClient creates a Client for a for a specific namespace.
+func NewClient(cfg rest.Config, namespace string) (*Client, error) {
+	cfg.GroupVersion = &schema.GroupVersion{
+		Group:   APIGroup,
+		Version: APIVersion,
+	}
+
+	client, err := rest.RESTClientFor(&cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{client: client, namespace: namespace}, nil
+}
+
+// NotificationQuery invokes POST /notification/query.
+func (h *Client) NotificationQuery(ctx context.Context, body CreateNotificationqueryRequestBody) (*CreateNotificationqueryResponse, error) {
+	var resp CreateNotificationqueryResponse
+	if err := h.post(ctx, "/notification/query", body, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// NotificationsQueryAlerts invokes POST /notifications/queryalerts.
+func (h *Client) NotificationsQueryAlerts(ctx context.Context, body CreateNotificationsqueryalertsRequestBody) (*CreateNotificationsqueryalertsResponse, error) {
+	var resp CreateNotificationsqueryalertsResponse
+	if err := h.post(ctx, "/notifications/queryalerts", body, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (h *Client) post(ctx context.Context, path string, body any, resp any) error {
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal [%s]: %w", path, err)
+	}
+	result := h.client.Post().
+		Namespace(h.namespace).
+		Suffix(path).
+		SetHeader("Content-Type", "application/json").
+		Body(bytes.NewReader(encoded)).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return fmt.Errorf("request [%s]: %w", path, err)
+	}
+	raw, err := result.Raw()
+	if err != nil {
+		// Should be caught above, but check anyway.
+		return fmt.Errorf("request [%s]: %w", path, err)
+	}
+	if err := json.Unmarshal(raw, resp); err != nil {
+		return fmt.Errorf("unmarshal [%s]: %w", path, err)
+	}
+	return nil
+}

--- a/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/client_test.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/client_test.go
@@ -1,0 +1,74 @@
+package v0alpha1
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+)
+
+func newTestClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	cfg := rest.Config{
+		Host:    srv.URL,
+		APIPath: "/apis",
+		ContentConfig: rest.ContentConfig{
+			NegotiatedSerializer: &fakeNegotiatedSerializer{},
+		},
+	}
+	client, err := NewClient(cfg, "test-ns")
+	require.NoError(t, err)
+	return client
+}
+
+func TestHistorianClient_NotificationQuery(t *testing.T) {
+	var gotPath string
+	var gotMethod string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		resp := CreateNotificationqueryResponse{}
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	client := newTestClient(t, handler)
+	_, err := client.NotificationQuery(context.Background(), CreateNotificationqueryRequestBody{})
+	require.NoError(t, err)
+	require.Equal(t, "POST", gotMethod)
+	require.Equal(t, "/apis/historian.alerting.grafana.app/v0alpha1/namespaces/test-ns/notification/query", gotPath)
+}
+
+func TestHistorianClient_NotificationsQueryAlerts(t *testing.T) {
+	var gotPath string
+	var gotMethod string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		resp := CreateNotificationsqueryalertsResponse{}
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	client := newTestClient(t, handler)
+	_, err := client.NotificationsQueryAlerts(context.Background(), CreateNotificationsqueryalertsRequestBody{})
+	require.NoError(t, err)
+	require.Equal(t, "POST", gotMethod)
+	require.Equal(t, "/apis/historian.alerting.grafana.app/v0alpha1/namespaces/test-ns/notifications/queryalerts", gotPath)
+}
+
+type fakeNegotiatedSerializer struct{}
+
+func (f *fakeNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo { return nil }
+func (f *fakeNegotiatedSerializer) EncoderForVersion(serializer runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return serializer
+}
+func (f *fakeNegotiatedSerializer) DecoderToVersion(serializer runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return serializer
+}

--- a/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/client_test.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/client_test.go
@@ -36,7 +36,7 @@ func TestHistorianClient_NotificationQuery(t *testing.T) {
 		gotPath = r.URL.Path
 		gotMethod = r.Method
 		resp := CreateNotificationqueryResponse{}
-		json.NewEncoder(w).Encode(resp)
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
 	})
 
 	client := newTestClient(t, handler)
@@ -53,7 +53,7 @@ func TestHistorianClient_NotificationsQueryAlerts(t *testing.T) {
 		gotPath = r.URL.Path
 		gotMethod = r.Method
 		resp := CreateNotificationsqueryalertsResponse{}
-		json.NewEncoder(w).Encode(resp)
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
 	})
 
 	client := newTestClient(t, handler)


### PR DESCRIPTION
Client code is only generated for Kinds currently, not custom routes, so for the
time being, add a thin hand written client wrapping a rest.Interface.

See https://github.com/grafana/grafana-app-sdk/issues/1277
