### PR TITLE
Frontend: Prevent HTML error pages from showing in UI notifications

### DIFF
--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -431,9 +431,7 @@ export class BackendSrv implements BackendService {
     err.data = err.data ?? { message: 'Unexpected error' };
 
     if (typeof err.data === 'string') {
-      const message = isHtmlResponse(err.data)
-        ? `${err.status} ${err.statusText ?? 'Error'}`
-        : err.data;
+      const message = isHtmlResponse(err.data) ? `${err.status} ${err.statusText ?? 'Error'}` : err.data;
       err.data = {
         message,
         error: err.statusText,

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -431,8 +431,11 @@ export class BackendSrv implements BackendService {
     err.data = err.data ?? { message: 'Unexpected error' };
 
     if (typeof err.data === 'string') {
+      const message = isHtmlResponse(err.data)
+        ? `${err.status} ${err.statusText ?? 'Error'}`
+        : err.data;
       err.data = {
-        message: err.data,
+        message,
         error: err.statusText,
         response: err.data,
       };
@@ -654,6 +657,11 @@ export class BackendSrv implements BackendService {
       showErrorAlert: false,
     });
   }
+}
+
+function isHtmlResponse(value: string): boolean {
+  const trimmed = value.trimStart().toLowerCase();
+  return trimmed.startsWith('<!doctype') || trimmed.startsWith('<html');
 }
 
 // Used for testing and things that really need BackendSrv

--- a/public/app/core/specs/backend_srv.test.ts
+++ b/public/app/core/specs/backend_srv.test.ts
@@ -327,6 +327,70 @@ describe('backendSrv', () => {
       });
     });
 
+    describe('when error response body is HTML', () => {
+      it('should replace HTML body with status-based message', async () => {
+        jest.useFakeTimers();
+        const htmlBody = '<!DOCTYPE html><html><body><h1>502 Bad Gateway</h1></body></html>';
+        const { backendSrv, appEventsMock, expectRequestCallChain } = getTestContext({
+          ok: false,
+          status: 502,
+          statusText: 'Bad Gateway',
+          data: htmlBody,
+        });
+        const url = '/api/dashboard/';
+
+        await backendSrv
+          .request({ url, method: 'GET' })
+          .catch((error) => {
+            expect(error.data.message).toBe('502 Bad Gateway');
+            expect(error.data.response).toBe(htmlBody);
+            expectRequestCallChain({ url, method: 'GET' });
+            jest.advanceTimersByTime(50);
+          })
+          .catch((error) => {
+            expect(appEventsMock.emit).toHaveBeenCalledWith(AppEvents.alertError, [
+              '502 Bad Gateway',
+              '',
+              undefined,
+            ]);
+          });
+      });
+
+      it('should replace HTML body starting with <html> tag', async () => {
+        jest.useFakeTimers();
+        const htmlBody = '<html><body>503 Service Unavailable</body></html>';
+        const { backendSrv, expectRequestCallChain } = getTestContext({
+          ok: false,
+          status: 503,
+          statusText: 'Service Unavailable',
+          data: htmlBody,
+        });
+        const url = '/api/dashboard/';
+
+        await backendSrv.request({ url, method: 'GET' }).catch((error) => {
+          expect(error.data.message).toBe('503 Service Unavailable');
+          expect(error.data.response).toBe(htmlBody);
+          expectRequestCallChain({ url, method: 'GET' });
+        });
+      });
+
+      it('should not replace non-HTML string error bodies', async () => {
+        jest.useFakeTimers();
+        const { backendSrv, expectRequestCallChain } = getTestContext({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+          data: 'some plain text error',
+        });
+        const url = '/api/dashboard/';
+
+        await backendSrv.request({ url, method: 'GET' }).catch((error) => {
+          expect(error.data.message).toBe('some plain text error');
+          expectRequestCallChain({ url, method: 'GET' });
+        });
+      });
+    });
+
     describe('when making an unsuccessful 422 call', () => {
       it('then it should emit Validation failed message', async () => {
         jest.useFakeTimers();

--- a/public/app/core/specs/backend_srv.test.ts
+++ b/public/app/core/specs/backend_srv.test.ts
@@ -348,11 +348,7 @@ describe('backendSrv', () => {
             jest.advanceTimersByTime(50);
           })
           .catch((error) => {
-            expect(appEventsMock.emit).toHaveBeenCalledWith(AppEvents.alertError, [
-              '502 Bad Gateway',
-              '',
-              undefined,
-            ]);
+            expect(appEventsMock.emit).toHaveBeenCalledWith(AppEvents.alertError, ['502 Bad Gateway', '', undefined]);
           });
       });
 


### PR DESCRIPTION
## What is this feature?

Detects when HTTP error responses contain HTML (e.g., from proxies or CDN services returning error pages) and replaces them with clean status-based messages instead of showing raw HTML to users.

## Why do we need this feature?

Sometimes error responses from backend services contain HTML documents (502/503 error pages) rather than JSON messages. Previously these were displayed as escaped HTML tags in UI error notifications and logged to error tracking systems, which is confusing and uninformative.

## Who is this feature for?

All Grafana users who may encounter proxy or CDN errors. This prevents confusing error messages from appearing in the UI.

## Which issue(s) does this PR fix?

Fixes #119590

## Special notes for your reviewer

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.