### PR TITLE
Provisioning: add retries to repository integration tests

### DIFF
--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -1812,43 +1812,56 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 		require.Equal(collectT, "someToken", val.DangerouslyExposeAndConsumeValue())
 	}, time.Second*10, time.Second, "Expected repo to be reconciled")
 
-	repoUnstructured, err := helper.Repositories.Resource.Get(ctx, "repo-with-connection", metav1.GetOptions{})
-	require.NoError(t, err, "can get repository")
-	firstReconciledRepo := unstructuredToRepository(t, repoUnstructured)
 	// Setting up main triggering conditions to verify token is re-generated when
-	// needed, even if all other conditions are not triggered
-	now := time.Now()
-	firstReconciledRepo.Status.ObservedGeneration = firstReconciledRepo.Generation
-	firstReconciledRepo.Status.Sync = provisioning.SyncStatus{
-		State:     provisioning.JobStateSuccess,
-		JobID:     firstReconciledRepo.Status.Sync.JobID,
-		Started:   now.UnixMilli(),
-		Finished:  now.UnixMilli(),
-		Scheduled: now.UnixMilli(),
-		LastRef:   firstReconciledRepo.Status.Sync.LastRef,
+	// needed, even if all other conditions are not triggered.
+	// Retries on conflict errors caused by optimistic locking.
+	// TODO: extract this to a helper function
+	var firstReconciledRepo *provisioning.Repository
+	const maxStatusRetries = 5
+	for attempt := range maxStatusRetries {
+		repoUnstructured, err := helper.Repositories.Resource.Get(ctx, "repo-with-connection", metav1.GetOptions{})
+		require.NoError(t, err, "can get repository")
+		firstReconciledRepo = unstructuredToRepository(t, repoUnstructured)
+
+		now := time.Now()
+		firstReconciledRepo.Status.ObservedGeneration = firstReconciledRepo.Generation
+		firstReconciledRepo.Status.Sync = provisioning.SyncStatus{
+			State:     provisioning.JobStateSuccess,
+			JobID:     firstReconciledRepo.Status.Sync.JobID,
+			Started:   now.UnixMilli(),
+			Finished:  now.UnixMilli(),
+			Scheduled: now.UnixMilli(),
+			LastRef:   firstReconciledRepo.Status.Sync.LastRef,
+		}
+		firstReconciledRepo.Status.Health = provisioning.HealthStatus{
+			Healthy: true,
+			Checked: now.UnixMilli(),
+		}
+		firstReconciledRepo.Status.Token = provisioning.TokenStatus{
+			LastUpdated: now.Add(-2 * time.Minute).UnixMilli(),
+			Expiration:  now.Add(-time.Minute).UnixMilli(),
+		}
+		firstReconciledRepo.Status.FieldErrors = []provisioning.ErrorDetails{}
+		firstReconciledRepo.Status.Conditions = []metav1.Condition{
+			{
+				Type:               provisioning.ConditionTypeReady,
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: firstReconciledRepo.Generation,
+				LastTransitionTime: metav1.Time{Time: now},
+				Reason:             provisioning.ReasonAvailable,
+			},
+		}
+		updatedRepo := repositoryToUnstructured(t, firstReconciledRepo)
+		// This should also trigger a reconciliation loop
+		_, err = helper.Repositories.Resource.UpdateStatus(ctx, updatedRepo, metav1.UpdateOptions{})
+		if err == nil {
+			break
+		}
+		if apierrors.IsConflict(err) && attempt < maxStatusRetries-1 {
+			continue
+		}
+		require.NoError(t, err, "failed to update status")
 	}
-	firstReconciledRepo.Status.Health = provisioning.HealthStatus{
-		Healthy: true,
-		Checked: now.UnixMilli(),
-	}
-	firstReconciledRepo.Status.Token = provisioning.TokenStatus{
-		LastUpdated: now.Add(-2 * time.Minute).UnixMilli(),
-		Expiration:  now.Add(-time.Minute).UnixMilli(),
-	}
-	firstReconciledRepo.Status.FieldErrors = []provisioning.ErrorDetails{}
-	firstReconciledRepo.Status.Conditions = []metav1.Condition{
-		{
-			Type:               provisioning.ConditionTypeReady,
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: firstReconciledRepo.Generation,
-			LastTransitionTime: metav1.Time{Time: now},
-			Reason:             provisioning.ReasonAvailable,
-		},
-	}
-	updatedRepo := repositoryToUnstructured(t, firstReconciledRepo)
-	// This should also trigger a reconciliation loop
-	_, err = helper.Repositories.Resource.UpdateStatus(ctx, updatedRepo, metav1.UpdateOptions{})
-	require.NoError(t, err, "failed to update status")
 
 	require.EventuallyWithT(t, func(collectT *assert.CollectT) {
 		repo, err := helper.Repositories.Resource.Get(ctx, "repo-with-connection", metav1.GetOptions{})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add retries to avoid integration tests failing due to optimistic locking. A second retry should work most of the times as there is not a lot of changes ongoing during integration tests, after the first failure, should be straightforward to retry and succeed.

**Why do we need this feature?**

Avoid flaky integration tests.

**Who is this feature for?**

Provisioning feature development.

