### PR TITLE
Alerting: Fix long text overflow in rule details sidebar

### DIFF
--- a/public/app/features/alerting/unified/components/common/DetailText.tsx
+++ b/public/app/features/alerting/unified/components/common/DetailText.tsx
@@ -5,8 +5,6 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Box, ClipboardButton, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
 
-import ConditionalWrap from '../ConditionalWrap';
-
 type DetailTextProps = {
   id: string;
   label: string;
@@ -59,12 +57,15 @@ export const DetailText = ({
           {label}
         </Text>
         <Text aria-labelledby={id} color="primary" variant={monospace ? 'code' : 'body'}>
-          <ConditionalWrap
-            shouldWrap={Boolean(tooltipValue)}
-            wrap={(children) => <Tooltip content={tooltipValue!}>{children}</Tooltip>}
-          >
+          {tooltipValue ? (
+            <Tooltip content={tooltipValue}>
+              <span>
+                <Value>{value}</Value>
+              </span>
+            </Tooltip>
+          ) : (
             <Value>{value}</Value>
-          </ConditionalWrap>
+          )}
           {showCopyButton && (
             <ClipboardButton
               aria-label={copyToClipboardLabel}

--- a/public/app/features/alerting/unified/components/common/DetailText.tsx
+++ b/public/app/features/alerting/unified/components/common/DetailText.tsx
@@ -1,7 +1,9 @@
+import { css } from '@emotion/css';
 import type { JSX } from 'react';
 
+import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Box, ClipboardButton, Stack, Text, Tooltip } from '@grafana/ui';
+import { Box, ClipboardButton, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
 
 import ConditionalWrap from '../ConditionalWrap';
 
@@ -28,6 +30,18 @@ type ConditionalProps =
     }
   | { showCopyButton?: never; copyValue?: never };
 
+const Value = ({ children }: { children: React.ReactNode }) => {
+  const styles = useStyles2(getStyles);
+  return <span className={styles.value}>{children}</span>;
+};
+
+const getStyles = (_theme: GrafanaTheme2) => ({
+  value: css({
+    overflowWrap: 'break-word',
+    wordBreak: 'break-word',
+  }),
+});
+
 export const DetailText = ({
   id,
   label,
@@ -49,7 +63,7 @@ export const DetailText = ({
             shouldWrap={Boolean(tooltipValue)}
             wrap={(children) => <Tooltip content={tooltipValue!}>{children}</Tooltip>}
           >
-            <span>{value}</span>
+            <Value>{value}</Value>
           </ConditionalWrap>
           {showCopyButton && (
             <ClipboardButton

--- a/public/app/features/alerting/unified/components/rule-viewer/Details.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/Details.tsx
@@ -354,5 +354,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: 'grid',
     gap: theme.spacing(4),
     gridTemplateColumns: '1fr',
+    overflowWrap: 'break-word',
+    wordBreak: 'break-word',
   }),
 });


### PR DESCRIPTION
**What is this feature?**

Fix long text values (e.g. URLs in annotations) overflowing horizontally in the rule details sidebar. Content now wraps instead of causing a horizontal scrollbar.

**Why do we need this feature?**

Long annotation values like URLs were causing the entire details panel to scroll horizontally, making it hard to read other content on the page.

**Who is this feature for?**

Users who view alert rule details that contain long annotations or other long text values.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.