### PR TITLE
Alerting: Add frontend name validation for notification policies

### DIFF
--- a/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.tsx
@@ -19,6 +19,7 @@ import {
   stringToSelectableValue,
   stringsToSelectableValues,
 } from '../../utils/amroutes';
+import { validateRbacEntityName } from '../../utils/k8s/utils';
 import { makeAMLink } from '../../utils/misc';
 
 import { PromDurationInput } from './PromDurationInput';
@@ -81,18 +82,15 @@ export const AmRootRouteForm = ({
           >
             <Input
               {...register('name', {
-                required: true,
-                validate: (value) => {
-                  if (!value || value.trim().length === 0) {
-                    return t('alerting.am-root-route-form.validate-name', 'Name is required');
-                  }
-                  if (existingPolicyNames?.includes(value.trim())) {
-                    return t(
-                      'alerting.am-root-route-form.validate-name-duplicate',
-                      'A notification policy with this name already exists'
-                    );
-                  }
-                  return true;
+                validate: {
+                  format: (value) => validateRbacEntityName(value)?.message ?? true,
+                  duplicate: (value) =>
+                    existingPolicyNames?.includes((value ?? '').trim())
+                      ? t(
+                          'alerting.am-root-route-form.validate-name-duplicate',
+                          'A notification policy with this name already exists'
+                        )
+                      : true,
                 },
               })}
               className={styles.input}

--- a/public/app/features/alerting/unified/utils/k8s/utils.test.ts
+++ b/public/app/features/alerting/unified/utils/k8s/utils.test.ts
@@ -1,7 +1,7 @@
 import { KnownProvenance } from '../../types/knownProvenance';
 
 import { K8sAnnotations } from './constants';
-import { canTestEntity, encodeFieldSelector, isProvisionedResource } from './utils';
+import { canTestEntity, encodeFieldSelector, isProvisionedResource, validateRbacEntityName } from './utils';
 
 describe('encodeFieldSelector', () => {
   it('should escape backslashes', () => {
@@ -90,5 +90,32 @@ describe('canTestEntity', () => {
   it('should return false when metadata is undefined', () => {
     const entity = {};
     expect(canTestEntity(entity)).toBe(false);
+  });
+});
+
+describe('validateRbacEntityName', () => {
+  it('returns an error for an empty name', () => {
+    expect(validateRbacEntityName('')?.message).toContain('required');
+  });
+
+  it('returns an error when name contains a colon', () => {
+    expect(validateRbacEntityName('my:route')?.message).toContain(':');
+  });
+
+  it('returns an error when name exceeds 40 characters', () => {
+    expect(validateRbacEntityName('a'.repeat(41))?.message).toContain('longer than 40');
+  });
+
+  it('returns an error when name is not a valid DNS subdomain', () => {
+    expect(validateRbacEntityName('My_Route')?.message).toContain('DNS subdomain'); // uppercase + underscore
+    expect(validateRbacEntityName('-leading-hyphen')?.message).toContain('DNS subdomain');
+    expect(validateRbacEntityName('trailing-hyphen-')?.message).toContain('DNS subdomain');
+    expect(validateRbacEntityName('.leading-dot')?.message).toContain('DNS subdomain');
+    expect(validateRbacEntityName('trailing-dot.')?.message).toContain('DNS subdomain');
+    expect(validateRbacEntityName('illegal@chars!')?.message).toContain('DNS subdomain');
+  });
+
+  it('returns undefined for a valid name', () => {
+    expect(validateRbacEntityName('my-route.1')).toBeUndefined();
   });
 });

--- a/public/app/features/alerting/unified/utils/k8s/utils.ts
+++ b/public/app/features/alerting/unified/utils/k8s/utils.ts
@@ -74,6 +74,47 @@ export function isImportedResource(provenance?: string): boolean {
   return provenance === KnownProvenance.ConvertedPrometheus;
 }
 
+// Maximum allowed length for an RBAC-managed entity name, matching the backend's UIDMaxLength.
+const MAX_NAME_LENGTH = 40;
+
+// DNS1123 subdomain: lowercase alphanumeric, hyphens and dots; must start and end with alphanumeric.
+// Equivalent to the Kubernetes k8s.io/apimachinery IsDNS1123Subdomain check used by the backend.
+const DNS1123_SUBDOMAIN_REGEX = /^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/;
+
+/**
+ * Validates the name of an RBAC-managed entity (e.g. a routing tree), mirroring the backend rules:
+ *  1. Non-empty after trimming whitespace
+ *  2. No colon character (confuses RBAC)
+ *  3. At most 40 characters
+ *  4. Must be a valid DNS1123 subdomain (lowercase, alphanumeric, hyphens, dots; no underscores or uppercase)
+ *  5. Optionally, not already present in existingNames
+ *
+ * Returns an Error when invalid, or undefined when valid.
+ */
+export function validateRbacEntityName(name?: string): Error | undefined {
+  const trimmed = (name ?? '').trim();
+
+  if (trimmed.length === 0) {
+    return new Error('Name is required');
+  }
+
+  if (trimmed.includes(':')) {
+    return new Error("Name cannot contain ':'");
+  }
+
+  if (trimmed.length > MAX_NAME_LENGTH) {
+    return new Error(`Name cannot be longer than ${MAX_NAME_LENGTH} characters`);
+  }
+
+  if (!DNS1123_SUBDOMAIN_REGEX.test(trimmed)) {
+    return new Error(
+      'Name must be a valid DNS subdomain: lowercase alphanumeric characters, hyphens and dots only, and must start and end with an alphanumeric character'
+    );
+  }
+
+  return undefined;
+}
+
 export function receiverConfigToK8sIntegration(config: GrafanaManagedReceiverConfig): ReceiverIntegration {
   return {
     uid: config.uid,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -674,7 +674,6 @@
       "message": {
         "required": "Required."
       },
-      "validate-name": "Name is required",
       "validate-name-duplicate": "A notification policy with this name already exists"
     },
     "am-routes-expanded-form": {


### PR DESCRIPTION
**What is this feature?**

Adds a reusable `validateRbacEntityName` utility to `utils/k8s/utils.ts` and wires it into the \"New notification policy\" form. The validator mirrors the backend rules introduced in #119516:

1. Non-empty after trimming whitespace
2. No colon character (confuses RBAC)
3. At most 40 characters (matching `UIDMaxLength`)
4. Must be a valid DNS1123 subdomain — lowercase alphanumeric, hyphens and dots only, must start and end with an alphanumeric character

The duplicate-name check is kept as a separate `validate` rule in the form, since it is a contextual check (depends on fetched data) rather than a structural one.

**Why do we need this feature?**

The backend now rejects non-conforming names on create (#119516). Without frontend validation, users would submit the form and receive an opaque server error. This surfaces the constraints upfront with a clear, actionable message.

**Who is this feature for?**

Grafana operators creating notification policies (routing trees) via the UI.

**Which issue(s) does this PR fix?**:

Relates to #119516

**Special notes for your reviewer:**

- Validation only applies on **create** — the name field is not shown when editing an existing policy, which matches backend behaviour (`validateManagedRouteName` is only called from `CreateManagedRoute`, not `UpdateNamedRoute`).
- The `alerting.am-root-route-form.validate-name` i18n key is removed because the empty-name message is now produced by the shared utility rather than an inline translated string. The duplicate key is retained and still uses `t()`.
- `validateRbacEntityName` is intentionally placed in `utils/k8s/utils.ts` and kept generic — it is designed to be reused for other RBAC-managed k8s entities beyond routing trees.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.