### PR TITLE
Suggested Fields: Add support for any logging source

### DIFF
--- a/public/app/features/logs/components/fieldSelector/ActiveFields.tsx
+++ b/public/app/features/logs/components/fieldSelector/ActiveFields.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 
 import { Field } from './Field';
@@ -53,14 +54,24 @@ export const ActiveFields = ({ activeFields, clear, fields, reorder, suggestedFi
     [activeFields, suggestedFields]
   );
 
+  const toggleSelectedField = useCallback(
+    (key: string) => {
+      toggle(key);
+      reportInteraction('logs_field_selector_suggested_field_clicked');
+    },
+    [toggle]
+  );
+
   if (active.length || suggested.length) {
     return (
       <>
         <div className={styles.columnHeader}>
           <Trans i18nKey="explore.logs-table-multi-select.selected-fields">Selected fields</Trans>
-          <button onClick={clear} className={styles.columnHeaderButton}>
-            <Trans i18nKey="explore.logs-table-multi-select.reset">Reset</Trans>
-          </button>
+          {active.length > 0 && (
+            <button onClick={clear} className={styles.columnHeaderButton}>
+              <Trans i18nKey="explore.logs-table-multi-select.reset">Reset</Trans>
+            </button>
+          )}
         </div>
         <DragDropContext onDragEnd={onDragEnd}>
           <Droppable droppableId="order-fields" direction="vertical">
@@ -108,7 +119,7 @@ export const ActiveFields = ({ activeFields, clear, fields, reorder, suggestedFi
             <div className={styles.columnWrapper}>
               {suggested.map((field) => (
                 <div className={styles.wrap} key={field.name}>
-                  <Field field={field} toggle={toggle} />
+                  <Field field={field} toggle={toggleSelectedField} />
                 </div>
               ))}
             </div>

--- a/public/app/features/logs/components/fieldSelector/FieldSelector.test.tsx
+++ b/public/app/features/logs/components/fieldSelector/FieldSelector.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { DataFrame, FieldType, store, toDataFrame } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { FieldNameMetaStore } from 'app/features/explore/Logs/LogsTableWrap';
 
 import { createLogLine } from '../mocks/logRow';
@@ -162,6 +163,60 @@ describe('LogListFieldSelector', () => {
 
     expect(onClickShowField).toHaveBeenCalledWith('level');
     expect(onClickHideField).toHaveBeenCalledWith('service');
+  });
+
+  test('should show suggested fields for any logging source when feature toggle is on', () => {
+    const originalToggle = config.featureToggles.otelLogsFormatting;
+    try {
+      config.featureToggles.otelLogsFormatting = true;
+
+      const logsWithGenericFields: LogListModel[] = [
+        createLogLine({
+          uid: '1',
+          entry: 'log 1',
+          labels: { service_name: 'frontend', message: 'hello', app: 'web' },
+        }),
+        createLogLine({
+          uid: '2',
+          entry: 'log 2',
+          labels: { service_name: 'backend', message: 'world' },
+        }),
+      ];
+
+      const dataFramesWithGenericFields: DataFrame[] = [
+        toDataFrame({
+          fields: [
+            { name: 'timestamp', type: FieldType.time, values: [1, 2] },
+            { name: 'body', type: FieldType.string, values: ['log 1', 'log 2'] },
+            {
+              name: 'labels',
+              type: FieldType.other,
+              values: [
+                { service_name: 'frontend', message: 'hello', app: 'web' },
+                { service_name: 'backend', message: 'world' },
+              ],
+            },
+          ],
+        }),
+      ];
+
+      render(
+        <LogListContext.Provider value={{ ...defaultContextValue, displayedFields: [] }}>
+          <LogListFieldSelector
+            containerElement={containerElement}
+            logs={logsWithGenericFields}
+            dataFrames={dataFramesWithGenericFields}
+          />
+        </LogListContext.Provider>
+      );
+
+      expect(screen.getByText('Suggested')).toBeInTheDocument();
+      expect(screen.getAllByText('service_name').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('message').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('app').length).toBeGreaterThan(0);
+    } finally {
+      config.featureToggles.otelLogsFormatting = originalToggle;
+    }
   });
 });
 

--- a/public/app/features/logs/components/otel/formats.test.ts
+++ b/public/app/features/logs/components/otel/formats.test.ts
@@ -4,9 +4,7 @@ import { createLogLine } from '../mocks/logRow';
 import {
   getDisplayedFieldsForLogs,
   getOtelAttributesField,
-  getSuggestedFieldsForAnyLogs,
   getSuggestedFieldsForLogs,
-  getSuggestedOTelDisplayFormat,
   identifyOTelLanguage,
   identifyOTelLanguages,
   OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME,

--- a/public/app/features/logs/components/otel/formats.test.ts
+++ b/public/app/features/logs/components/otel/formats.test.ts
@@ -4,7 +4,13 @@ import { createLogLine } from '../mocks/logRow';
 import {
   getDisplayedFieldsForLogs,
   getOtelAttributesField,
+  getSuggestedFieldsForAnyLogs,
+  getSuggestedFieldsForLogs,
+  getSuggestedOTelDisplayFormat,
+  identifyOTelLanguage,
+  identifyOTelLanguages,
   OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME,
+  OTEL_LANGUAGE_UNKNOWN,
   OTEL_PROBE_FIELD,
 } from './formats';
 
@@ -115,5 +121,122 @@ describe('getOtelAttributesField', () => {
     });
 
     expect(getOtelAttributesField(log, false)).toEqual('vcs_ref_head_name=main field=value');
+  });
+});
+
+describe('identifyOTelLanguage', () => {
+  test('returns undefined when OTel probe field is not present', () => {
+    const log = createLogLine({ labels: { place: 'luna' }, entry: 'msg' });
+    expect(identifyOTelLanguage(log)).toBeUndefined();
+  });
+
+  test('returns telemetry_sdk_language when OTel probe is present', () => {
+    const log = createLogLine({
+      labels: { [OTEL_PROBE_FIELD]: '1', telemetry_sdk_language: 'go' },
+      entry: 'msg',
+    });
+    expect(identifyOTelLanguage(log)).toBe('go');
+  });
+
+  test('returns OTEL_LANGUAGE_UNKNOWN when OTel probe is present but no telemetry_sdk_language', () => {
+    const log = createLogLine({
+      labels: { [OTEL_PROBE_FIELD]: '1', exception_type: 'err' },
+      entry: 'msg',
+    });
+    expect(identifyOTelLanguage(log)).toBe(OTEL_LANGUAGE_UNKNOWN);
+  });
+
+  test('returns otelLanguage when set on log', () => {
+    const log = createLogLine({
+      labels: { [OTEL_PROBE_FIELD]: '1', telemetry_sdk_language: 'php' },
+      entry: 'msg',
+    });
+    log.otelLanguage = 'java';
+    expect(identifyOTelLanguage(log)).toBe('java');
+  });
+});
+
+describe('identifyOTelLanguages', () => {
+  test('returns empty array for non-OTel logs', () => {
+    const logs = [
+      createLogLine({ labels: { a: '1' }, entry: 'msg' }),
+      createLogLine({ labels: { b: '2' }, entry: 'msg' }),
+    ];
+    expect(identifyOTelLanguages(logs)).toEqual([]);
+  });
+
+  test('returns unique languages from OTel logs', () => {
+    const logs = [
+      createLogLine({
+        labels: { [OTEL_PROBE_FIELD]: '1', telemetry_sdk_language: 'go' },
+        entry: 'msg',
+      }),
+      createLogLine({
+        labels: { [OTEL_PROBE_FIELD]: '1', telemetry_sdk_language: 'go' },
+        entry: 'msg',
+      }),
+      createLogLine({
+        labels: { [OTEL_PROBE_FIELD]: '1', telemetry_sdk_language: 'php' },
+        entry: 'msg',
+      }),
+    ];
+    expect(identifyOTelLanguages(logs)).toEqual(['go', 'php']);
+  });
+});
+
+describe('getSuggestedFieldsForLogs', () => {
+  test('returns only suggested fields that appear in logs for non-OTel logs', () => {
+    const logs = [
+      createLogLine({ labels: { service_name: 'svc', message: 'hello' }, entry: 'log 1' }),
+      createLogLine({ labels: { app: 'web' }, entry: 'log 2' }),
+    ];
+    const result = getSuggestedFieldsForLogs(logs);
+    expect(result).toContain('service_name');
+    expect(result).toContain('message');
+    expect(result).toContain('app');
+    expect(result).not.toContain('traceID');
+    expect(result).not.toContain('trace_id');
+    expect(result).not.toContain('environment');
+    expect(result).not.toContain('error');
+    expect(result).not.toContain('scope_name');
+    expect(result).not.toContain('msg');
+  });
+
+  test('includes body and OTel attributes when OTel is detected (they are in OTel suggested set)', () => {
+    const logs = [
+      createLogLine({
+        labels: { [OTEL_PROBE_FIELD]: '1' },
+        entry: 'log',
+      }),
+    ];
+    const result = getSuggestedFieldsForLogs(logs);
+    expect(result).toContain(LOG_LINE_BODY_FIELD_NAME);
+    expect(result).toContain(OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME);
+  });
+
+  test('returns generic and OTel suggested fields when OTel is detected', () => {
+    const logs = [
+      createLogLine({
+        labels: {
+          [OTEL_PROBE_FIELD]: '1',
+          service_name: 'svc',
+          thread_name: 'main',
+          exception_type: 'Error',
+        },
+        entry: 'log',
+      }),
+    ];
+    const result = getSuggestedFieldsForLogs(logs);
+    expect(result).toContain('service_name');
+    expect(result).toContain('thread_name');
+    expect(result).toContain('exception_type');
+    expect(result).toContain(LOG_LINE_BODY_FIELD_NAME);
+    expect(result).toContain(OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME);
+  });
+
+  test('returns empty array when logs have none of the suggested fields (non-OTel)', () => {
+    const logs = [createLogLine({ labels: { custom_label: 'x' }, entry: 'log' })];
+    const result = getSuggestedFieldsForLogs(logs);
+    expect(result).toEqual([]);
   });
 });

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -66,11 +66,12 @@ function getDisplayFormatForLanguage(language: string) {
  * Given a list of logs, return a list of suggested fields to display for the user.
  */
 export function getSuggestedFieldsForLogs(logs: LogListModel[] | LogRowModel[]): string[] {
+  const suggestedFields = getSuggestedFieldsForAnyLogs();
+
   const languages = identifyOTelLanguages(logs);
-  if (!languages.length) {
-    return [];
-  }
-  const fields = getSuggestedOTelDisplayFormat();
+  const otelFields = languages.length ? getSuggestedOTelDisplayFormat() : [];
+
+  const fields = [...suggestedFields, ...otelFields];
 
   return fields.filter(
     (field) =>
@@ -78,6 +79,10 @@ export function getSuggestedFieldsForLogs(logs: LogListModel[] | LogRowModel[]):
       field === OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME ||
       logs.some((log) => log.labels[field] !== undefined)
   );
+}
+
+export function getSuggestedFieldsForAnyLogs() {
+  return ['app', 'scope_name', 'service_name', 'message', 'msg', 'traceID', 'trace_id', 'environment', 'error'];
 }
 
 export function getSuggestedOTelDisplayFormat() {

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -71,7 +71,7 @@ export function getSuggestedFieldsForLogs(logs: LogListModel[] | LogRowModel[]):
   const languages = identifyOTelLanguages(logs);
   const otelFields = languages.length ? getSuggestedOTelDisplayFormat() : [];
 
-  const fields = [...suggestedFields, ...otelFields];
+  const fields = [...new Set([...suggestedFields, ...otelFields])];
 
   return fields.filter(
     (field) =>
@@ -82,7 +82,7 @@ export function getSuggestedFieldsForLogs(logs: LogListModel[] | LogRowModel[]):
 }
 
 export function getSuggestedFieldsForAnyLogs() {
-  return ['app', 'scope_name', 'service_name', 'message', 'msg', 'traceID', 'trace_id', 'environment', 'error'];
+  return ['app', 'service_name', 'message', 'msg', 'traceID', 'trace_id', 'environment', 'error'];
 }
 
 export function getSuggestedOTelDisplayFormat() {


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/119475

This PR updates suggested fields to be present for any logging source, not just logs identified as OpenTelemetry logs.

The motivation arises from 1) wanting to include any log for this feature and 2) getting knowledge of commonly used displayed fields, that are potentially relevant to any user.

<img width="233" height="836" alt="imagen" src="https://github.com/user-attachments/assets/2b1cf2a3-3aa7-4d72-8a36-f50dbb7c53cf" />

### How to test

Given any source of logs, if these logs contain any of the updated suggested fields, it should offer them in the Field Selector component of the Logs panel.

Since the Logs Table is currently undergoing an update, this will be implemented specifically there.