### PR TITLE
Dynamic dashboards: Fixes for panels with expressions

### DIFF
--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
@@ -1,3 +1,4 @@
+import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
 import {
   defaultDataQueryKind,
   defaultPanelSpec,
@@ -197,6 +198,23 @@ describe('getPanelDataSource', () => {
     },
   });
 
+  const createQueryWithExpressionDatasource = (refId = 'A'): PanelQueryKind => ({
+    kind: 'PanelQuery',
+    spec: {
+      refId,
+      hidden: false,
+      query: {
+        kind: 'DataQuery',
+        version: defaultDataQueryKind().version,
+        group: ExpressionDatasourceRef.type,
+        datasource: {
+          name: ExpressionDatasourceRef.uid,
+        },
+        spec: {},
+      },
+    },
+  });
+
   it('should return undefined when panel has no queries', () => {
     const panel = createPanelWithQueries([]);
 
@@ -277,7 +295,6 @@ describe('getPanelDataSource', () => {
 
     expect(result).toEqual({ type: 'mixed', uid: MIXED_DATASOURCE_NAME });
   });
-
   it('should return undefined when queries have no explicit datasource name but same type', () => {
     const panel = createPanelWithQueries([
       createQueryWithoutDatasourceName('prometheus', 'A'),
@@ -298,6 +315,17 @@ describe('getPanelDataSource', () => {
     const result = getPanelDataSource(panel);
 
     expect(result).toEqual({ type: 'mixed', uid: MIXED_DATASOURCE_NAME });
+  });
+
+  it('should return datasource if expression is mixed with other datasource', () => {
+    const panel = createPanelWithQueries([
+      createQuery('prometheus-uid', 'prometheus', 'A'),
+      createQueryWithExpressionDatasource('B'),
+    ]);
+
+    const result = getPanelDataSource(panel);
+
+    expect(result).toBeUndefined();
   });
 });
 

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -1,5 +1,6 @@
 import { getNextRefId } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
 import {
   SceneDataProvider,
   SceneDataQuery,
@@ -251,8 +252,9 @@ export function getPanelDataSource(panel: PanelKind): DataSourceRef | undefined 
   const firstDatasource = datasources[0];
 
   // Check if queries use different datasources
+  // don't include expressions in this check since they don't have a datasource and shouldn't trigger mixed mode on their own
   const isMixedDatasource = datasources.some(
-    (ds) => ds?.uid !== firstDatasource?.uid || ds?.type !== firstDatasource?.type
+    (ds) => isNotExpressionDatasource(ds) && (ds?.uid !== firstDatasource?.uid || ds?.type !== firstDatasource?.type)
   );
 
   if (isMixedDatasource) {
@@ -437,4 +439,8 @@ export function getElement(
   scene: DashboardScene
 ): DashboardV2Spec['elements'] {
   return createElements([vizPanelToSchemaV2(gridItem.state.body, scene.serializer.getDSReferencesMapping())], scene);
+}
+
+function isNotExpressionDatasource(ds: DataSourceRef | undefined): boolean {
+  return ds?.type !== ExpressionDatasourceRef.type && ds?.uid !== ExpressionDatasourceRef.uid;
 }

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -22,7 +22,6 @@ import {
   replaceDatasourcesInDashboard,
   DatasourceMappings,
 } from './inputs';
-import { create } from 'lodash';
 
 // Mock external dependencies
 jest.mock('@grafana/runtime', () => ({

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -9,11 +9,12 @@ import { Dashboard, Panel, VariableModel } from '@grafana/schema/dist/esm/veneer
 import { ExportFormat } from 'app/features/dashboard/api/types';
 import { ExportLabel } from 'app/features/dashboard-scene/scene/export/exporters';
 
-import { DashboardInputs, ImportDashboardDTO, ImportFormDataV2, InputType } from '../../types';
+import { DashboardInputs, DataSourceInput, ImportDashboardDTO, ImportFormDataV2, InputType } from '../../types';
 
 import {
   applyV1Inputs,
   applyV2Inputs,
+  checkUserInputMatch,
   detectExportFormat,
   extractV1Inputs,
   extractV2Inputs,
@@ -21,6 +22,7 @@ import {
   replaceDatasourcesInDashboard,
   DatasourceMappings,
 } from './inputs';
+import { create } from 'lodash';
 
 // Mock external dependencies
 jest.mock('@grafana/runtime', () => ({
@@ -925,5 +927,83 @@ describe('replaceDatasourcesInDashboard', () => {
       expect(getPanelQueryDatasourceName(result, 'panel-variable')).toBe('${ds}');
       expect(getPanelQueryDatasourceName(result, 'panel-hardcoded')).toBe('new-loki-uid');
     });
+  });
+});
+
+describe('checkUserInputMatch', () => {
+  const datasourceInputs: DataSourceInput[] = [
+    {
+      name: 'DS_TESTDATA_DB',
+      label: 'TestData DB',
+      description: '',
+      type: InputType.DataSource,
+      pluginId: 'grafana-testdata-datasource',
+      info: '',
+      value: '',
+    },
+    {
+      name: 'DS_EXPRESSION',
+      label: 'Expression',
+      description: '',
+      type: InputType.DataSource,
+      pluginId: '__expr__',
+      info: '',
+      value: '',
+    },
+    {
+      name: 'DS_GRAFANACLOUD_PROM',
+      label: 'Grafana Cloud Prometheus',
+      description: '',
+      type: InputType.DataSource,
+      pluginId: 'prometheus',
+      info: '',
+      value: '',
+    },
+  ];
+
+  const createUserInputDatasource = (uid: string, name: string, type: string): DataSourceInstanceSettings =>
+    ({ uid, name, type }) as DataSourceInstanceSettings;
+
+  // come from InputForm.tsx - expressions are never included
+  const defaultUserDsInputs: DataSourceInstanceSettings[] = [
+    createUserInputDatasource('testdata-uid', 'TestData DB', 'grafana-testdata-datasource'),
+    createUserInputDatasource('testdata-uid-2', 'TestData DB 2', 'grafana-testdata-datasource'),
+    createUserInputDatasource('prom-uid', 'Prometheus', 'prometheus'),
+  ];
+
+  it('returns user datasource when templateized UID matches Prometheus ds input and form has matching type', () => {
+    const result = checkUserInputMatch('${DS_GRAFANACLOUD_PROM}', datasourceInputs, defaultUserDsInputs);
+    expect(result).toBeDefined();
+    expect(result?.uid).toBe('prom-uid');
+    expect(result?.type).toBe('prometheus');
+  });
+
+  it('returns undefined when templateized UID is an expression', () => {
+    const result = checkUserInputMatch('${DS_EXPRESSION}', datasourceInputs, defaultUserDsInputs);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when templateized UID has no matching input name', () => {
+    const userDsInputs = [createUserInputDatasource('prom-uid', 'Prometheus', 'prometheus')];
+    const result = checkUserInputMatch('${DS_UNKNOWN_INPUT}', datasourceInputs, userDsInputs);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when input exists but form has no datasource of that pluginId', () => {
+    const userDsInputs = [createUserInputDatasource('loki-uid', 'Loki', 'loki')];
+    const result = checkUserInputMatch('${DS_TESTDATA_DB}', datasourceInputs, userDsInputs);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when datasourceInputs is empty', () => {
+    const userDsInputs = [createUserInputDatasource('testdata-uid', 'TestData DB', 'grafana-testdata-datasource')];
+    const result = checkUserInputMatch('${DS_TESTDATA_DB}', [], userDsInputs);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns first matching user datasource when form has multiple of same pluginId', () => {
+    const result = checkUserInputMatch('${DS_TESTDATA_DB}', datasourceInputs, defaultUserDsInputs);
+    expect(result).toBeDefined();
+    expect(result?.uid).toBe('testdata-uid');
   });
 });

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -489,14 +489,14 @@ function replaceElementDatasources(
   );
 }
 
-function checkUserInputMatch(
+export function checkUserInputMatch(
   templateizedUid: string,
   datasourceInputs: DataSourceInput[],
   userDsInputs: DataSourceInstanceSettings[]
 ) {
   const dsName = templateizedUid.replace(/\$\{(.*)\}/, '$1');
   const input = datasourceInputs?.find((ds) => ds.name === dsName);
-  const userInput = input && userDsInputs.find((ds) => ds.type === input.pluginId);
+  const userInput = input && userDsInputs.find((ds) => !!ds && ds.type === input.pluginId);
   return userInput;
 }
 


### PR DESCRIPTION
This fixes two bugs: 
1. `inputs.ts` bug in the import flow (originally reported in [Slack](https://raintank-corp.slack.com/archives/C03KVDHTWAH/p1772712526860019)) where datasources were matched to the inputs from the Import form. However, 'expressions' datasource has no input since it's built-in, so no matches were found, resulting in 
`cannot read type of undefined` error. This fix checks that datasource is defined, otherwise returns null
2. bug with ad hoc filters and expressions ([this ticket](https://github.com/grafana/grafana/issues/119492)) where the issue is in getPanelDatasource function that returns `Mixed` datasource for panels with expressions. This causes the query runner not recognize the panel as Cube datasource, which won't update it after adhoc filter update. It should return the original datasource and ignore the expression. This is it with the fix:

https://github.com/user-attachments/assets/e74714ad-d05c-436b-a073-63bcabd958da

