### PR TITLE
Add dry-run overview log to Unistore KV Garbage Collector

### DIFF
--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -483,10 +483,6 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 					if err != nil {
 						return fmt.Errorf("failed to get keys for resource '%s': %s", dk, err)
 					}
-					// if in dry run mode, log the key to deletet
-					if b.garbageCollection.DryRun {
-						b.log.Info("garbage collection", "key to delete", deleteKey)
-					}
 					keysToDelete = append(keysToDelete, deleteKey)
 				}
 

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -493,16 +493,17 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 				if b.garbageCollection.DryRun {
 					// if in dry run mode, just count the keys to delete
 					totalDryRun += int64(len(keysToDelete))
-				} else {
-					// if not in dry run mode, batch delete the keys
-					err := b.kv.BatchDelete(ctx, kv.DataSection, keysToDelete)
-					if err != nil {
-						return fmt.Errorf("failed to batch delete keys: %s", err)
-					}
-
-					// update the total number of keys deleted
-					keysDeleted = keysDeleted + int64(len(keysToDelete))
+					continue
 				}
+
+				// if not in dry run mode, batch delete the keys
+				err := b.kv.BatchDelete(ctx, kv.DataSection, keysToDelete)
+				if err != nil {
+					return fmt.Errorf("failed to batch delete keys: %s", err)
+				}
+
+				// update the total number of keys deleted
+				keysDeleted = keysDeleted + int64(len(keysToDelete))
 			}
 		}
 

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -415,6 +415,7 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 	start := time.Now()
 
 	totalDeleted := int64(0)
+	totalDryRun := int64(0)
 
 	// get the start and end keys for the list operation based on the resource prefix
 	// for example, for dashboards, the start key will be "unified/data/dashboard.grafana.app/dashboards/"
@@ -482,17 +483,24 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 					if err != nil {
 						return fmt.Errorf("failed to get keys for resource '%s': %s", dk, err)
 					}
-					b.log.Info("garbage collection", "key to delete", deleteKey)
+					// if in dry run mode, log the key to deletet
+					if b.garbageCollection.DryRun {
+						b.log.Info("garbage collection", "key to delete", deleteKey)
+					}
 					keysToDelete = append(keysToDelete, deleteKey)
 				}
 
-				// if not in dry run mode, batch delete the keys
-				if !b.garbageCollection.DryRun {
+				if b.garbageCollection.DryRun {
+					// if in dry run mode, just count the keys to delete
+					totalDryRun += int64(len(keysToDelete))
+				} else {
+					// if not in dry run mode, batch delete the keys
 					err := b.kv.BatchDelete(ctx, kv.DataSection, keysToDelete)
 					if err != nil {
 						return fmt.Errorf("failed to batch delete keys: %s", err)
 					}
 
+					// update the total number of keys deleted
 					keysDeleted = keysDeleted + int64(len(keysToDelete))
 				}
 			}
@@ -514,6 +522,15 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 			"group", group,
 			"resource", resourceName,
 			"rows", totalDeleted,
+			"seconds", time.Since(start).Seconds(),
+		)
+	}
+
+	if totalDryRun > 0 {
+		b.log.Info("garbage collection dry run",
+			"group", group,
+			"resource", resourceName,
+			"rows", totalDryRun,
 			"seconds", time.Since(start).Seconds(),
 		)
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR adds a dry-run mode overview of the SQLKV garbage collector. 

**Why do we need this feature?**

We are going to use this information to compare data with the current SQL Garbage Collector implementation

**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
