### PR TITLE
Provisioning: Add pre-flight resource authorization for bulk delete/move jobs

### DIFF
--- a/pkg/registry/apis/provisioning/jobs.go
+++ b/pkg/registry/apis/provisioning/jobs.go
@@ -9,11 +9,17 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/registry/rest"
 
+	authlib "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/apps/provisioning/pkg/apis/auth"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 )
 
 type JobQueueGetter interface {
@@ -25,6 +31,8 @@ type jobsConnector struct {
 	statusPatcherProvider StatusPatcherProvider
 	jobs                  JobQueueGetter
 	historic              jobs.HistoryReader
+	access                auth.AccessChecker
+	resourcesFactory      resources.RepositoryResourcesFactory
 }
 
 func NewJobsConnector(
@@ -32,12 +40,16 @@ func NewJobsConnector(
 	statusPatcherProvider StatusPatcherProvider,
 	jobs JobQueueGetter,
 	historic jobs.HistoryReader,
+	access auth.AccessChecker,
+	resourcesFactory resources.RepositoryResourcesFactory,
 ) *jobsConnector {
 	return &jobsConnector{
 		repoGetter:            repoGetter,
 		statusPatcherProvider: statusPatcherProvider,
 		jobs:                  jobs,
 		historic:              historic,
+		access:                access,
+		resourcesFactory:      resourcesFactory,
 	}
 }
 
@@ -169,6 +181,13 @@ func (c *jobsConnector) Connect(
 			}
 		}
 
+		if spec.Action == provisioning.JobActionDelete || spec.Action == provisioning.JobActionMove {
+			if err := c.authorizeJobTargets(r.Context(), repo, cfg, spec); err != nil {
+				responder.Error(err)
+				return
+			}
+		}
+
 		job, err := c.jobs.GetJobQueue().Insert(ctx, cfg.Namespace, spec)
 		if err != nil {
 			responder.Error(err)
@@ -208,6 +227,168 @@ var (
 	_ rest.Storage         = (*jobsConnector)(nil)
 	_ rest.StorageMetadata = (*jobsConnector)(nil)
 )
+
+// authorizeJobTargets checks that the requesting user has permission on the resources
+// targeted by a delete or move job. This runs at job creation time while the user's
+// identity is still in the request context, since jobs execute later as the
+// provisioning service identity.
+//
+// For path-based targeting, folder permissions are checked (inheritance covers contents).
+// For ResourceRef-based targeting, each resource is checked individually.
+// Move jobs additionally require create permission on the target folder.
+func (c *jobsConnector) authorizeJobTargets(ctx context.Context, repo repository.Repository, cfg *provisioning.Repository, spec provisioning.JobSpec) error {
+	var paths []string
+	var resourceRefs []provisioning.ResourceRef
+	var targetPath string
+
+	switch spec.Action {
+	case provisioning.JobActionDelete:
+		if spec.Delete != nil {
+			paths = spec.Delete.Paths
+			resourceRefs = spec.Delete.Resources
+		}
+	case provisioning.JobActionMove:
+		if spec.Move != nil {
+			paths = spec.Move.Paths
+			resourceRefs = spec.Move.Resources
+			targetPath = spec.Move.TargetPath
+		}
+	default:
+		return nil
+	}
+
+	if err := c.authorizePaths(ctx, cfg, paths, utils.VerbDelete); err != nil {
+		return err
+	}
+
+	if err := c.authorizeResourceRefs(ctx, repo, cfg, resourceRefs, utils.VerbDelete); err != nil {
+		return err
+	}
+
+	if spec.Action == provisioning.JobActionMove && targetPath != "" {
+		if err := c.authorizeTargetFolder(ctx, cfg, targetPath); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// authorizePaths checks folder-level permissions for path-based job targets.
+// Directory paths check the folder directly; file paths check their parent folder.
+// Checks are deduplicated by folder UID.
+func (c *jobsConnector) authorizePaths(ctx context.Context, cfg *provisioning.Repository, paths []string, verb string) error {
+	checked := make(map[string]struct{})
+
+	for _, p := range paths {
+		folderUID := folderUIDForPath(cfg, p)
+
+		if _, ok := checked[folderUID]; ok {
+			continue
+		}
+		checked[folderUID] = struct{}{}
+
+		if safepath.IsDir(p) {
+			if err := c.access.Check(ctx, authlib.CheckRequest{
+				Group:    resources.FolderResource.Group,
+				Resource: resources.FolderResource.Resource,
+				Name:     folderUID,
+				Verb:     verb,
+			}, folderUID); err != nil {
+				return err
+			}
+		} else {
+			if err := c.access.Check(ctx, authlib.CheckRequest{
+				Group:    resources.DashboardResource.Group,
+				Resource: resources.DashboardResource.Resource,
+				Verb:     verb,
+			}, folderUID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// authorizeResourceRefs checks permissions for ResourceRef-based job targets.
+// Each resource is resolved to its file path, then authorized via its folder.
+func (c *jobsConnector) authorizeResourceRefs(ctx context.Context, repo repository.Repository, cfg *provisioning.Repository, refs []provisioning.ResourceRef, verb string) error {
+	if len(refs) == 0 {
+		return nil
+	}
+
+	rw, ok := repo.(repository.ReaderWriter)
+	if !ok {
+		return apierrors.NewBadRequest("repository does not support resource resolution")
+	}
+
+	repoResources, err := c.resourcesFactory.Client(ctx, rw)
+	if err != nil {
+		return fmt.Errorf("create repository resources client: %w", err)
+	}
+
+	for _, ref := range refs {
+		gvk := schema.GroupVersionKind{
+			Group: ref.Group,
+			Kind:  ref.Kind,
+		}
+
+		filePath, err := repoResources.FindResourcePath(ctx, ref.Name, gvk)
+		if err != nil {
+			return fmt.Errorf("resolve resource %s/%s: %w", ref.Kind, ref.Name, err)
+		}
+
+		folderUID := folderUIDForPath(cfg, filePath)
+
+		if err := c.access.Check(ctx, authlib.CheckRequest{
+			Group:    ref.Group,
+			Resource: gvkToResource(gvk),
+			Name:     ref.Name,
+			Verb:     verb,
+		}, folderUID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// authorizeTargetFolder checks that the user has create permission on the
+// destination folder for move operations.
+func (c *jobsConnector) authorizeTargetFolder(ctx context.Context, cfg *provisioning.Repository, targetPath string) error {
+	parentFolder := ""
+	if targetPath != "" {
+		parentPath := safepath.Dir(targetPath)
+		if parentPath != "" {
+			parentFolder = resources.ParseFolder(parentPath, cfg.Name).ID
+		} else {
+			parentFolder = resources.RootFolder(cfg)
+		}
+	}
+
+	return c.access.Check(ctx, authlib.CheckRequest{
+		Group:    resources.FolderResource.Group,
+		Resource: resources.FolderResource.Resource,
+		Name:     "",
+		Verb:     utils.VerbCreate,
+	}, parentFolder)
+}
+
+// folderUIDForPath derives the Grafana folder UID from a repository file or directory path.
+func folderUIDForPath(cfg *provisioning.Repository, filePath string) string {
+	if safepath.IsDir(filePath) {
+		return resources.ParseFolder(filePath, cfg.Name).ID
+	}
+
+	return resources.ParentFolder(filePath, cfg)
+}
+
+// gvkToResource converts a GroupVersionKind to its plural resource name.
+// This follows the Kubernetes convention of lowercasing the kind and appending "s".
+func gvkToResource(gvk schema.GroupVersionKind) string {
+	return strings.ToLower(gvk.Kind) + "s"
+}
 
 // ValidUUID ensures the ID is valid for a blob.
 // The ID is always a UUID. As such, this checks for something that can resemble a UUID.

--- a/pkg/registry/apis/provisioning/jobs_test.go
+++ b/pkg/registry/apis/provisioning/jobs_test.go
@@ -1,0 +1,401 @@
+package provisioning
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	authlib "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/apps/provisioning/pkg/apis/auth"
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
+)
+
+// readOnlyRepo implements only repository.Repository (not ReaderWriter)
+type readOnlyRepo struct {
+	cfg *provisioning.Repository
+}
+
+func (r *readOnlyRepo) Config() *provisioning.Repository {
+	return r.cfg
+}
+
+func (r *readOnlyRepo) Test(_ context.Context) (*provisioning.TestResults, error) {
+	return nil, nil
+}
+
+func newTestRepo(name, namespace string) *provisioning.Repository {
+	return &provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: provisioning.RepositorySpec{
+			Sync: provisioning.SyncOptions{
+				Target: provisioning.SyncTargetTypeFolder,
+			},
+		},
+	}
+}
+
+func TestAuthorizeJobTargets(t *testing.T) {
+	ctx := context.Background()
+	cfg := newTestRepo("my-repo", "default")
+
+	t.Run("delete with paths - authorized", func(t *testing.T) {
+		accessMock := auth.NewMockAccessChecker(t)
+		accessMock.EXPECT().Check(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		mockRepo := repository.NewMockRepository(t)
+		c := &jobsConnector{access: accessMock}
+
+		spec := provisioning.JobSpec{
+			Action:     provisioning.JobActionDelete,
+			Repository: "my-repo",
+			Delete: &provisioning.DeleteJobOptions{
+				Paths: []string{"team-a/dashboard.json"},
+			},
+		}
+
+		err := c.authorizeJobTargets(ctx, mockRepo, cfg, spec)
+		require.NoError(t, err)
+	})
+
+	t.Run("delete with paths - unauthorized", func(t *testing.T) {
+		accessMock := auth.NewMockAccessChecker(t)
+		accessMock.EXPECT().Check(mock.Anything, mock.Anything, mock.Anything).
+			Return(apierrors.NewForbidden(schema.GroupResource{}, "", nil))
+
+		mockRepo := repository.NewMockRepository(t)
+		c := &jobsConnector{access: accessMock}
+
+		spec := provisioning.JobSpec{
+			Action:     provisioning.JobActionDelete,
+			Repository: "my-repo",
+			Delete: &provisioning.DeleteJobOptions{
+				Paths: []string{"team-a/dashboard.json"},
+			},
+		}
+
+		err := c.authorizeJobTargets(ctx, mockRepo, cfg, spec)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err))
+	})
+
+	t.Run("delete directory path - checks folder permission", func(t *testing.T) {
+		accessMock := auth.NewMockAccessChecker(t)
+
+		folderUID := resources.ParseFolder("team-a/", cfg.Name).ID
+		accessMock.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
+			return req.Group == resources.FolderResource.Group &&
+				req.Resource == resources.FolderResource.Resource &&
+				req.Name == folderUID &&
+				req.Verb == utils.VerbDelete
+		}), folderUID).Return(nil)
+
+		mockRepo := repository.NewMockRepository(t)
+		c := &jobsConnector{access: accessMock}
+
+		spec := provisioning.JobSpec{
+			Action:     provisioning.JobActionDelete,
+			Repository: "my-repo",
+			Delete: &provisioning.DeleteJobOptions{
+				Paths: []string{"team-a/"},
+			},
+		}
+
+		err := c.authorizeJobTargets(ctx, mockRepo, cfg, spec)
+		require.NoError(t, err)
+	})
+
+	t.Run("delete file path - checks dashboard permission in folder", func(t *testing.T) {
+		accessMock := auth.NewMockAccessChecker(t)
+
+		folderUID := resources.ParentFolder("team-a/dashboard.json", cfg)
+		accessMock.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
+			return req.Group == resources.DashboardResource.Group &&
+				req.Resource == resources.DashboardResource.Resource &&
+				req.Verb == utils.VerbDelete
+		}), folderUID).Return(nil)
+
+		mockRepo := repository.NewMockRepository(t)
+		c := &jobsConnector{access: accessMock}
+
+		spec := provisioning.JobSpec{
+			Action:     provisioning.JobActionDelete,
+			Repository: "my-repo",
+			Delete: &provisioning.DeleteJobOptions{
+				Paths: []string{"team-a/dashboard.json"},
+			},
+		}
+
+		err := c.authorizeJobTargets(ctx, mockRepo, cfg, spec)
+		require.NoError(t, err)
+	})
+
+	t.Run("delete deduplicates folder checks", func(t *testing.T) {
+		accessMock := auth.NewMockAccessChecker(t)
+
+		folderUID := resources.ParentFolder("team-a/dash1.json", cfg)
+		accessMock.EXPECT().Check(mock.Anything, mock.Anything, folderUID).Return(nil).Once()
+
+		mockRepo := repository.NewMockRepository(t)
+		c := &jobsConnector{access: accessMock}
+
+		spec := provisioning.JobSpec{
+			Action:     provisioning.JobActionDelete,
+			Repository: "my-repo",
+			Delete: &provisioning.DeleteJobOptions{
+				Paths: []string{"team-a/dash1.json", "team-a/dash2.json"},
+			},
+		}
+
+		err := c.authorizeJobTargets(ctx, mockRepo, cfg, spec)
+		require.NoError(t, err)
+	})
+
+	t.Run("delete with resource refs - authorized", func(t *testing.T) {
+		accessMock := auth.NewMockAccessChecker(t)
+		accessMock.EXPECT().Check(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		mockRepoResources := resources.NewMockRepositoryResources(t)
+		mockRepoResources.EXPECT().FindResourcePath(mock.Anything, "dash-uid", mock.Anything).
+			Return("team-a/dashboard.json", nil)
+
+		mockFactory := resources.NewMockRepositoryResourcesFactory(t)
+		mockFactory.EXPECT().Client(mock.Anything, mock.Anything).Return(mockRepoResources, nil)
+
+		mockRepo := repository.NewMockReaderWriter(t)
+
+		c := &jobsConnector{
+			access:           accessMock,
+			resourcesFactory: mockFactory,
+		}
+
+		spec := provisioning.JobSpec{
+			Action:     provisioning.JobActionDelete,
+			Repository: "my-repo",
+			Delete: &provisioning.DeleteJobOptions{
+				Resources: []provisioning.ResourceRef{
+					{Name: "dash-uid", Kind: "Dashboard", Group: "dashboard.grafana.app"},
+				},
+			},
+		}
+
+		err := c.authorizeJobTargets(ctx, mockRepo, cfg, spec)
+		require.NoError(t, err)
+	})
+
+	t.Run("delete with resource refs - unauthorized", func(t *testing.T) {
+		accessMock := auth.NewMockAccessChecker(t)
+		accessMock.EXPECT().Check(mock.Anything, mock.Anything, mock.Anything).
+			Return(apierrors.NewForbidden(schema.GroupResource{}, "", nil))
+
+		mockRepoResources := resources.NewMockRepositoryResources(t)
+		mockRepoResources.EXPECT().FindResourcePath(mock.Anything, "dash-uid", mock.Anything).
+			Return("team-a/dashboard.json", nil)
+
+		mockFactory := resources.NewMockRepositoryResourcesFactory(t)
+		mockFactory.EXPECT().Client(mock.Anything, mock.Anything).Return(mockRepoResources, nil)
+
+		mockRepo := repository.NewMockReaderWriter(t)
+
+		c := &jobsConnector{
+			access:           accessMock,
+			resourcesFactory: mockFactory,
+		}
+
+		spec := provisioning.JobSpec{
+			Action:     provisioning.JobActionDelete,
+			Repository: "my-repo",
+			Delete: &provisioning.DeleteJobOptions{
+				Resources: []provisioning.ResourceRef{
+					{Name: "dash-uid", Kind: "Dashboard", Group: "dashboard.grafana.app"},
+				},
+			},
+		}
+
+		err := c.authorizeJobTargets(ctx, mockRepo, cfg, spec)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err))
+	})
+
+	t.Run("move job - checks source delete and target create", func(t *testing.T) {
+		accessMock := auth.NewMockAccessChecker(t)
+
+		sourceFolderUID := resources.ParseFolder("team-a/", cfg.Name).ID
+		accessMock.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
+			return req.Verb == utils.VerbDelete && req.Name == sourceFolderUID
+		}), sourceFolderUID).Return(nil)
+
+		accessMock.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
+			return req.Verb == utils.VerbCreate
+		}), mock.Anything).Return(nil)
+
+		mockRepo := repository.NewMockRepository(t)
+		c := &jobsConnector{access: accessMock}
+
+		spec := provisioning.JobSpec{
+			Action:     provisioning.JobActionMove,
+			Repository: "my-repo",
+			Move: &provisioning.MoveJobOptions{
+				Paths:      []string{"team-a/"},
+				TargetPath: "team-b/",
+			},
+		}
+
+		err := c.authorizeJobTargets(ctx, mockRepo, cfg, spec)
+		require.NoError(t, err)
+	})
+
+	t.Run("move job - unauthorized on target folder", func(t *testing.T) {
+		accessMock := auth.NewMockAccessChecker(t)
+
+		sourceFolderUID := resources.ParseFolder("team-a/", cfg.Name).ID
+		accessMock.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
+			return req.Verb == utils.VerbDelete
+		}), sourceFolderUID).Return(nil)
+
+		accessMock.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
+			return req.Verb == utils.VerbCreate
+		}), mock.Anything).Return(apierrors.NewForbidden(schema.GroupResource{}, "", nil))
+
+		mockRepo := repository.NewMockRepository(t)
+		c := &jobsConnector{access: accessMock}
+
+		spec := provisioning.JobSpec{
+			Action:     provisioning.JobActionMove,
+			Repository: "my-repo",
+			Move: &provisioning.MoveJobOptions{
+				Paths:      []string{"team-a/"},
+				TargetPath: "team-b/",
+			},
+		}
+
+		err := c.authorizeJobTargets(ctx, mockRepo, cfg, spec)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err))
+	})
+
+	t.Run("no targets - no error", func(t *testing.T) {
+		accessMock := auth.NewMockAccessChecker(t)
+		mockRepo := repository.NewMockRepository(t)
+		c := &jobsConnector{access: accessMock}
+
+		spec := provisioning.JobSpec{
+			Action:     provisioning.JobActionDelete,
+			Repository: "my-repo",
+			Delete:     &provisioning.DeleteJobOptions{},
+		}
+
+		err := c.authorizeJobTargets(ctx, mockRepo, cfg, spec)
+		require.NoError(t, err)
+	})
+
+	t.Run("nil options - no error", func(t *testing.T) {
+		accessMock := auth.NewMockAccessChecker(t)
+		mockRepo := repository.NewMockRepository(t)
+		c := &jobsConnector{access: accessMock}
+
+		spec := provisioning.JobSpec{
+			Action:     provisioning.JobActionDelete,
+			Repository: "my-repo",
+		}
+
+		err := c.authorizeJobTargets(ctx, mockRepo, cfg, spec)
+		require.NoError(t, err)
+	})
+
+	t.Run("non-delete/move action - skipped", func(t *testing.T) {
+		accessMock := auth.NewMockAccessChecker(t)
+		mockRepo := repository.NewMockRepository(t)
+		c := &jobsConnector{access: accessMock}
+
+		spec := provisioning.JobSpec{
+			Action:     provisioning.JobActionPull,
+			Repository: "my-repo",
+		}
+
+		err := c.authorizeJobTargets(ctx, mockRepo, cfg, spec)
+		require.NoError(t, err)
+	})
+
+	t.Run("resource refs with non-readwriter repo returns error", func(t *testing.T) {
+		accessMock := auth.NewMockAccessChecker(t)
+		roRepo := &readOnlyRepo{cfg: cfg}
+		c := &jobsConnector{access: accessMock}
+
+		spec := provisioning.JobSpec{
+			Action:     provisioning.JobActionDelete,
+			Repository: "my-repo",
+			Delete: &provisioning.DeleteJobOptions{
+				Resources: []provisioning.ResourceRef{
+					{Name: "dash-uid", Kind: "Dashboard", Group: "dashboard.grafana.app"},
+				},
+			},
+		}
+
+		err := c.authorizeJobTargets(ctx, roRepo, cfg, spec)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsBadRequest(err))
+	})
+
+	t.Run("multiple paths across different folders - checks each folder", func(t *testing.T) {
+		accessMock := auth.NewMockAccessChecker(t)
+
+		folderA := resources.ParentFolder("team-a/dash.json", cfg)
+		folderB := resources.ParentFolder("team-b/dash.json", cfg)
+
+		accessMock.EXPECT().Check(mock.Anything, mock.Anything, folderA).Return(nil).Once()
+		accessMock.EXPECT().Check(mock.Anything, mock.Anything, folderB).Return(nil).Once()
+
+		mockRepo := repository.NewMockRepository(t)
+		c := &jobsConnector{access: accessMock}
+
+		spec := provisioning.JobSpec{
+			Action:     provisioning.JobActionDelete,
+			Repository: "my-repo",
+			Delete: &provisioning.DeleteJobOptions{
+				Paths: []string{"team-a/dash.json", "team-b/dash.json"},
+			},
+		}
+
+		err := c.authorizeJobTargets(ctx, mockRepo, cfg, spec)
+		require.NoError(t, err)
+	})
+}
+
+func TestFolderUIDForPath(t *testing.T) {
+	cfg := newTestRepo("my-repo", "default")
+
+	t.Run("directory path returns folder ID", func(t *testing.T) {
+		uid := folderUIDForPath(cfg, "team-a/")
+		expected := resources.ParseFolder("team-a/", cfg.Name).ID
+		assert.Equal(t, expected, uid)
+	})
+
+	t.Run("file path returns parent folder ID", func(t *testing.T) {
+		uid := folderUIDForPath(cfg, "team-a/dashboard.json")
+		expected := resources.ParentFolder("team-a/dashboard.json", cfg)
+		assert.Equal(t, expected, uid)
+	})
+
+	t.Run("root file returns root folder", func(t *testing.T) {
+		uid := folderUIDForPath(cfg, "dashboard.json")
+		expected := resources.RootFolder(cfg)
+		assert.Equal(t, expected, uid)
+	})
+}
+
+func TestGvkToResource(t *testing.T) {
+	assert.Equal(t, "dashboards", gvkToResource(schema.GroupVersionKind{Kind: "Dashboard"}))
+	assert.Equal(t, "folders", gvkToResource(schema.GroupVersionKind{Kind: "Folder"}))
+}

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -696,7 +696,7 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	storage[provisioning.RepositoryResourceInfo.StoragePath("history")] = &historySubresource{
 		repoGetter: b,
 	}
-	storage[provisioning.RepositoryResourceInfo.StoragePath("jobs")] = NewJobsConnector(b, b, b, jobHistory)
+	storage[provisioning.RepositoryResourceInfo.StoragePath("jobs")] = NewJobsConnector(b, b, b, jobHistory, b.access, b.repositoryResources)
 
 	// Add any extra storage
 	for _, extra := range b.extras {

--- a/pkg/tests/apis/provisioning/jobs_resource_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs_resource_auth_test.go
@@ -1,0 +1,243 @@
+package provisioning
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+func TestIntegrationProvisioning_JobResourceAuthorization(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafana(t)
+	ctx := context.Background()
+
+	const repo = "job-resource-auth-test"
+	testRepo := TestRepo{
+		Name:   repo,
+		Target: "folder",
+		Copies: map[string]string{
+			"testdata/all-panels.json":   "team-a/dashboard1.json",
+			"testdata/text-options.json": "team-b/dashboard2.json",
+		},
+		ExpectedDashboards: 2,
+		ExpectedFolders:    3, // root + team-a + team-b
+	}
+	helper.CreateRepo(t, testRepo)
+
+	t.Run("admin can create delete job for any folder path", func(t *testing.T) {
+		body := asJSON(provisioning.JobSpec{
+			Action: provisioning.JobActionDelete,
+			Delete: &provisioning.DeleteJobOptions{
+				Paths: []string{"team-a/dashboard1.json"},
+			},
+		})
+
+		var statusCode int
+		result := helper.AdminREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.NoError(t, result.Error(), "admin should be able to create delete job")
+		require.Equal(t, http.StatusAccepted, statusCode)
+
+		helper.AwaitJobs(t, repo)
+
+		// Re-add the dashboard for subsequent tests
+		helper.CopyToProvisioningPath(t, "testdata/all-panels.json", "team-a/dashboard1.json")
+		helper.SyncAndWait(t, repo, nil)
+	})
+
+	t.Run("editor can create delete job with default permissions", func(t *testing.T) {
+		// Grant editor broad dashboard permissions
+		helper.SetPermissions(helper.Org1.Editor, []resourcepermissions.SetResourcePermissionCommand{
+			{
+				Actions:           []string{"dashboards:read", "dashboards:write", "dashboards:delete", "dashboards:create"},
+				Resource:          "dashboards",
+				ResourceAttribute: "uid",
+				ResourceID:        "*",
+			},
+			{
+				Actions:           []string{"folders:read", "folders:write", "folders:delete", "folders:create"},
+				Resource:          "folders",
+				ResourceAttribute: "uid",
+				ResourceID:        "*",
+			},
+		})
+
+		body := asJSON(provisioning.JobSpec{
+			Action: provisioning.JobActionDelete,
+			Delete: &provisioning.DeleteJobOptions{
+				Paths: []string{"team-b/dashboard2.json"},
+			},
+		})
+
+		var statusCode int
+		result := helper.EditorREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.NoError(t, result.Error(), "editor with broad permissions should be able to create delete job")
+		require.Equal(t, http.StatusAccepted, statusCode)
+
+		helper.AwaitJobs(t, repo)
+
+		// Re-add the dashboard for subsequent tests
+		helper.CopyToProvisioningPath(t, "testdata/text-options.json", "team-b/dashboard2.json")
+		helper.SyncAndWait(t, repo, nil)
+	})
+
+	t.Run("viewer cannot create delete job", func(t *testing.T) {
+		body := asJSON(provisioning.JobSpec{
+			Action: provisioning.JobActionDelete,
+			Delete: &provisioning.DeleteJobOptions{
+				Paths: []string{"team-a/dashboard1.json"},
+			},
+		})
+
+		var statusCode int
+		result := helper.ViewerREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.Error(t, result.Error(), "viewer should not be able to create delete job")
+		require.Equal(t, http.StatusForbidden, statusCode)
+		require.True(t, apierrors.IsForbidden(result.Error()))
+	})
+
+	t.Run("admin can create move job", func(t *testing.T) {
+		body := asJSON(provisioning.JobSpec{
+			Action: provisioning.JobActionMove,
+			Move: &provisioning.MoveJobOptions{
+				Paths:      []string{"team-a/dashboard1.json"},
+				TargetPath: "team-b/",
+			},
+		})
+
+		var statusCode int
+		result := helper.AdminREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.NoError(t, result.Error(), "admin should be able to create move job")
+		require.Equal(t, http.StatusAccepted, statusCode)
+
+		helper.AwaitJobs(t, repo)
+	})
+
+	t.Run("editor can create move job with permissions", func(t *testing.T) {
+		// Sync to get a consistent state after the admin move
+		helper.SyncAndWait(t, repo, nil)
+
+		// Verify we have dashboards to work with
+		dashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, len(dashboards.Items), 1, "should have at least 1 dashboard")
+
+		// Grant editor broad permissions
+		helper.SetPermissions(helper.Org1.Editor, []resourcepermissions.SetResourcePermissionCommand{
+			{
+				Actions:           []string{"dashboards:read", "dashboards:write", "dashboards:delete", "dashboards:create"},
+				Resource:          "dashboards",
+				ResourceAttribute: "uid",
+				ResourceID:        "*",
+			},
+			{
+				Actions:           []string{"folders:read", "folders:write", "folders:delete", "folders:create"},
+				Resource:          "folders",
+				ResourceAttribute: "uid",
+				ResourceID:        "*",
+			},
+		})
+
+		body := asJSON(provisioning.JobSpec{
+			Action: provisioning.JobActionMove,
+			Move: &provisioning.MoveJobOptions{
+				Paths:      []string{"team-b/"},
+				TargetPath: "archived/",
+			},
+		})
+
+		var statusCode int
+		result := helper.EditorREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.NoError(t, result.Error(), "editor with permissions should be able to create move job")
+		require.Equal(t, http.StatusAccepted, statusCode)
+
+		helper.AwaitJobs(t, repo)
+	})
+
+	t.Run("editor without folder delete permission is rejected", func(t *testing.T) {
+		// Set editor permissions to only have read access -- no delete
+		helper.SetPermissions(helper.Org1.Editor, []resourcepermissions.SetResourcePermissionCommand{
+			{
+				Actions:           []string{"dashboards:read"},
+				Resource:          "dashboards",
+				ResourceAttribute: "uid",
+				ResourceID:        "*",
+			},
+			{
+				Actions:           []string{"folders:read"},
+				Resource:          "folders",
+				ResourceAttribute: "uid",
+				ResourceID:        "*",
+			},
+		})
+
+		body := asJSON(provisioning.JobSpec{
+			Action: provisioning.JobActionDelete,
+			Delete: &provisioning.DeleteJobOptions{
+				Paths: []string{"archived/"},
+			},
+		})
+
+		var statusCode int
+		result := helper.EditorREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.Error(t, result.Error(), "editor without delete permission should be rejected")
+		assert.True(t, apierrors.IsForbidden(result.Error()), "error should be forbidden, got: %v", result.Error())
+	})
+}


### PR DESCRIPTION
## Summary

- Adds pre-flight permission checks to the jobs endpoint for bulk delete and move operations. When a user queues a delete or move job, the endpoint now validates that the user has the required permissions (e.g., `dashboards:delete`, `folders:delete`, `folders:create`) on the targeted resources **before** inserting the job into the queue.
- Previously, only route-level authorization (Editor+) was enforced. The job would execute later as the provisioning service identity with no per-resource checks. Now folder-level permissions are verified at job creation time, consistent with how the `/files` endpoint authorizes operations.
- Path-based targets derive the folder UID from the file path and deduplicate checks by folder (leveraging Grafana's permission inheritance). ResourceRef-based targets resolve each resource via `FindResourcePath`, then check via the folder. Move jobs additionally verify `create` permission on the target folder.

Closes https://github.com/grafana/git-ui-sync-project/issues/714

## Test plan

- [x] Unit tests for authorization logic (15 test cases covering authorized/unauthorized, path vs ResourceRef, deduplication, move source+target, edge cases)
- [x] Integration tests for job creation with different permission levels (admin, editor with/without permissions, viewer)
- [ ] Manual testing: create a delete job as an editor with restricted folder permissions and verify 403
- [ ] Manual testing: create a move job targeting a folder the user can't write to and verify 403
- [ ] Verify existing delete/move job tests still pass (`go test ./pkg/tests/apis/provisioning/ -run "TestIntegrationProvisioning_DeleteJob|TestIntegrationProvisioning_MoveJob"`)


Made with [Cursor](https://cursor.com)