### PR TITLE
Provisioning: fixing provisioning integration tests

### DIFF
--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -1014,11 +1014,11 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 func TestIntegrationProvisioning_CreateFolder_FolderMetadataFlag(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
-	helper := runGrafana(t, withProvisioningFolderMetadata)
+	helper := common.RunGrafana(t, withProvisioningFolderMetadata)
 	ctx := context.Background()
 
 	const repo = "folder-metadata-test-repo"
-	helper.CreateRepo(t, TestRepo{Name: repo, Target: "instance", SkipResourceAssertions: true})
+	helper.CreateRepo(t, common.TestRepo{Name: repo, Target: "instance", SkipResourceAssertions: true})
 
 	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
 


### PR DESCRIPTION
**What is this feature?**

A recent change that was added before https://github.com/grafana/grafana/pull/119128 was merged broke the integration tests added by the latter PR. 
This PR fixes it

**Why do we need this feature?**

To have working integration tests. 

**Who is this feature for?**

Developers of grafana/grafana.

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/pull/119128 and https://github.com/grafana/git-ui-sync-project/issues/900

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
