### PR TITLE
fix(folders): read dual-writer mode dynamically to prevent stale legacy stats

### DIFF
--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -23,7 +23,6 @@ import (
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/services"
-	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	infraDB "github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	secrets "github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
@@ -70,23 +69,14 @@ func ProvideUnifiedStorageClient(opts *Options,
 		GrpcClientKeepaliveTime: apiserverCfg.Key("grpc_client_keepalive_time").MustDuration(0),
 	}, opts.Cfg, opts.Features, opts.DB, opts.Tracer, opts.Reg, opts.Authzc, opts.Docs, storageMetrics, indexMetrics, opts.SecureValues)
 	if err == nil {
-		// Decide whether to disable SQL fallback stats per resource in Mode 5.
-		// Otherwise we would still try to query the legacy SQL database in Mode 5.
-		var disableDashboardsFallback, disableFoldersFallback bool
-		if opts.Cfg != nil {
-			// String are static here, so we don't need to import the packages.
-			foldersMode := opts.Cfg.UnifiedStorage["folders.folder.grafana.app"].DualWriterMode
-			disableFoldersFallback = foldersMode == grafanarest.Mode5
-			dashboardsMode := opts.Cfg.UnifiedStorage["dashboards.dashboard.grafana.app"].DualWriterMode
-			disableDashboardsFallback = dashboardsMode == grafanarest.Mode5
-		}
-
 		// Used to get the folder stats
+		// Pass cfg directly so the federated client reads the current dual-writer mode
+		// at query time, not at creation time. This is important because auto-migration
+		// may set Mode5 after the client is created during startup.
 		client = federated.NewFederatedClient(
 			client, // The original
 			legacysql.NewDatabaseProvider(opts.DB),
-			disableDashboardsFallback,
-			disableFoldersFallback,
+			opts.Cfg,
 		)
 	}
 

--- a/pkg/storage/unified/federated/client.go
+++ b/pkg/storage/unified/federated/client.go
@@ -5,18 +5,18 @@ import (
 
 	"google.golang.org/grpc"
 
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
-func NewFederatedClient(base resource.ResourceClient, sql legacysql.LegacyDatabaseProvider, disableDashboardsFallback bool, disableFoldersFallback bool) resource.ResourceClient {
+func NewFederatedClient(base resource.ResourceClient, sql legacysql.LegacyDatabaseProvider, cfg *setting.Cfg) resource.ResourceClient {
 	return &federatedClient{
 		ResourceClient: base,
 		stats: &LegacyStatsGetter{
-			SQL:                          sql,
-			DisableSQLFallbackDashboards: disableDashboardsFallback,
-			DisableSQLFallbackFolders:    disableFoldersFallback,
+			SQL: sql,
+			Cfg: cfg,
 		},
 	}
 }

--- a/pkg/storage/unified/federated/stats.go
+++ b/pkg/storage/unified/federated/stats.go
@@ -6,16 +6,31 @@ import (
 
 	claims "github.com/grafana/authlib/types"
 
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
 // Read stats from legacy SQL
 type LegacyStatsGetter struct {
-	SQL                          legacysql.LegacyDatabaseProvider
-	DisableSQLFallbackDashboards bool
-	DisableSQLFallbackFolders    bool
+	SQL legacysql.LegacyDatabaseProvider
+	Cfg *setting.Cfg
+}
+
+func (s *LegacyStatsGetter) isDashboardsFallbackDisabled() bool {
+	if s.Cfg == nil {
+		return false
+	}
+	return s.Cfg.UnifiedStorage["dashboards.dashboard.grafana.app"].DualWriterMode == grafanarest.Mode5
+}
+
+func (s *LegacyStatsGetter) isFoldersFallbackDisabled() bool {
+	if s.Cfg == nil {
+		return false
+	}
+	return s.Cfg.UnifiedStorage["folders.folder.grafana.app"].DualWriterMode == grafanarest.Mode5
 }
 
 func (s *LegacyStatsGetter) GetStats(ctx context.Context, in *resourcepb.ResourceStatsRequest) (*resourcepb.ResourceStatsResponse, error) {
@@ -66,7 +81,7 @@ func (s *LegacyStatsGetter) GetStats(ctx context.Context, in *resourcepb.Resourc
 		}
 
 		// Legacy dashboard table
-		if !s.DisableSQLFallbackDashboards {
+		if !s.isDashboardsFallbackDisabled() {
 			err = fn("dashboard", "org_id=? AND folder_uid=? AND is_folder=false", group, "dashboards", true)
 			if err != nil {
 				return err
@@ -74,7 +89,7 @@ func (s *LegacyStatsGetter) GetStats(ctx context.Context, in *resourcepb.Resourc
 		}
 
 		// Legacy folder table
-		if !s.DisableSQLFallbackFolders {
+		if !s.isFoldersFallbackDisabled() {
 			err = fn("folder", "org_id=? AND parent_uid=?", group, "folders", true)
 			if err != nil {
 				return err

--- a/pkg/storage/unified/federated/stats_test.go
+++ b/pkg/storage/unified/federated/stats_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
+	rest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -21,6 +22,7 @@ import (
 	ngalertstore "github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
@@ -116,6 +118,16 @@ func TestIntegrationDirectSQLStats(t *testing.T) {
 		SQL: legacysql.NewDatabaseProvider(db),
 	}
 
+	// Helper to create a cfg with specific dual-writer modes
+	cfgWithModes := func(dashboardsMode, foldersMode int) *setting.Cfg {
+		return &setting.Cfg{
+			UnifiedStorage: map[string]setting.UnifiedStorageConfig{
+				"dashboards.dashboard.grafana.app": {DualWriterMode: rest.DualWriterMode(dashboardsMode)},
+				"folders.folder.grafana.app":       {DualWriterMode: rest.DualWriterMode(foldersMode)},
+			},
+		}
+	}
+
 	t.Run("GetStatsForFolder1", func(t *testing.T) {
 		ctx := context.Background()
 		ctx = request.WithNamespace(ctx, "default")
@@ -155,9 +167,8 @@ func TestIntegrationDirectSQLStats(t *testing.T) {
 		ctx = request.WithNamespace(ctx, "default")
 
 		store := &LegacyStatsGetter{
-			SQL:                          legacysql.NewDatabaseProvider(db),
-			DisableSQLFallbackDashboards: true,
-			DisableSQLFallbackFolders:    false,
+			SQL: legacysql.NewDatabaseProvider(db),
+			Cfg: cfgWithModes(5, 0), // dashboards Mode5, folders Mode0
 		}
 
 		stats, err := store.GetStats(ctx, &resourcepb.ResourceStatsRequest{
@@ -185,9 +196,8 @@ func TestIntegrationDirectSQLStats(t *testing.T) {
 		ctx = request.WithNamespace(ctx, "default")
 
 		store := &LegacyStatsGetter{
-			SQL:                          legacysql.NewDatabaseProvider(db),
-			DisableSQLFallbackDashboards: false,
-			DisableSQLFallbackFolders:    true,
+			SQL: legacysql.NewDatabaseProvider(db),
+			Cfg: cfgWithModes(0, 5), // dashboards Mode0, folders Mode5
 		}
 
 		stats, err := store.GetStats(ctx, &resourcepb.ResourceStatsRequest{
@@ -215,9 +225,8 @@ func TestIntegrationDirectSQLStats(t *testing.T) {
 		ctx = request.WithNamespace(ctx, "default")
 
 		store := &LegacyStatsGetter{
-			SQL:                          legacysql.NewDatabaseProvider(db),
-			DisableSQLFallbackDashboards: true,
-			DisableSQLFallbackFolders:    true,
+			SQL: legacysql.NewDatabaseProvider(db),
+			Cfg: cfgWithModes(5, 5), // both Mode5
 		}
 
 		stats, err := store.GetStats(ctx, &resourcepb.ResourceStatsRequest{
@@ -278,5 +287,52 @@ func TestIntegrationDirectSQLStats(t *testing.T) {
 				"resource": "library_elements"
 			}
 		]`, string(jj))
+	})
+
+	// Verify that changing the cfg mode dynamically affects the stats query.
+	// This is the key behavior for the fix: auto-migration sets Mode5 after the
+	// LegacyStatsGetter is created, and the getter must pick up the change.
+	t.Run("DynamicModeChange", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = request.WithNamespace(ctx, "default")
+
+		cfg := cfgWithModes(0, 0) // start with Mode0 for both
+		store := &LegacyStatsGetter{
+			SQL: legacysql.NewDatabaseProvider(db),
+			Cfg: cfg,
+		}
+
+		// With Mode0, legacy dashboard stats should be returned
+		stats, err := store.GetStats(ctx, &resourcepb.ResourceStatsRequest{
+			Namespace: "default",
+			Folder:    folder1UID,
+		})
+		require.NoError(t, err)
+		var hasDashboards bool
+		for _, s := range stats.Stats {
+			if s.Resource == "dashboards" {
+				hasDashboards = true
+			}
+		}
+		require.True(t, hasDashboards, "dashboards stats should be present in Mode0")
+
+		// Simulate auto-migration setting Mode5 after client creation
+		cfg.UnifiedStorage["dashboards.dashboard.grafana.app"] = setting.UnifiedStorageConfig{
+			DualWriterMode: rest.Mode5,
+		}
+
+		// Now legacy dashboard stats should be skipped
+		stats, err = store.GetStats(ctx, &resourcepb.ResourceStatsRequest{
+			Namespace: "default",
+			Folder:    folder1UID,
+		})
+		require.NoError(t, err)
+		hasDashboards = false
+		for _, s := range stats.Stats {
+			if s.Resource == "dashboards" {
+				hasDashboards = true
+			}
+		}
+		require.False(t, hasDashboards, "dashboards stats should be disabled after Mode5 is set")
 	})
 }


### PR DESCRIPTION
## Summary

Fixes #119488 — "Folders: Can't delete empty folder in 12.4.0"

After upgrading to 12.4 from a prior version, users cannot delete folders that appear empty. The root cause is a **timing issue** between the federated client creation and auto-migration:

1. During wire DI, the `LegacyStatsGetter` captured `DisableSQLFallbackDashboards` as a static boolean — always `false` because Mode5 hasn't been set yet
2. Auto-migration runs later during service startup and sets Mode5, but the boolean was already captured
3. When deleting a folder, `validateOnDelete` → `GetStats()` always appended legacy SQL dashboard counts (stale records from pre-migration that were never cleaned up)
4. This caused "folder is not empty" even though the dashboard was already deleted from unified storage

The fix replaces the static booleans with a `*setting.Cfg` pointer, reading the dual-writer mode at query time so auto-migration changes are picked up immediately.

## Changes

- **`federated/stats.go`**: Replace `DisableSQLFallbackDashboards`/`DisableSQLFallbackFolders` booleans with `*setting.Cfg` and dynamic mode-checking methods
- **`federated/client.go`**: Update `NewFederatedClient` to accept `*setting.Cfg` instead of two booleans
- **`client.go`**: Simplify call site, remove eagerly-computed boolean logic
- **`federated/stats_test.go`**: Update existing tests + add `DynamicModeChange` test verifying the fix

## Test plan

- [x] All existing `TestIntegrationDirectSQLStats` tests pass
- [x] New `DynamicModeChange` test verifies that changing cfg mode after `LegacyStatsGetter` creation is reflected in subsequent `GetStats` calls
- [ ] Manual verification: upgrade from 12.3 → 12.4, create folder+dashboard in 12.3, delete dashboard then folder in 12.4