### PR TITLE
QueryEditor: Migrate to OpenFeature

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -100,13 +101,13 @@ export class PanelDataPane extends SceneObjectBase<PanelDataPaneState> {
 function PanelDataPaneRendered({ model }: SceneComponentProps<PanelDataPane>) {
   const { tab, tabs } = model.useState();
   const styles = useStyles2(getStyles);
+  const showTryNewEditor = useBooleanFlagValue('queryEditorNext', false);
 
   if (!tabs || !tabs.length) {
     return;
   }
 
   const currentTab = tabs.find((t) => t.tabId === tab);
-  const showTryNewEditor = getConfig().featureToggles.queryEditorNext;
 
   return (
     <div className={styles.dataPane} data-testid={selectors.components.PanelEditor.DataPane.content}>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.ts
@@ -1,8 +1,8 @@
 import { css, cx } from '@emotion/css';
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { RefObject, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useLocalStorage, useSessionStorage } from 'react-use';
 
-import { config } from '@grafana/runtime';
 import { getDragStyles, useStyles2, useTheme2 } from '@grafana/ui';
 import { MIN_SUGGESTIONS_PANE_WIDTH } from 'app/features/panel/suggestions/constants';
 
@@ -123,7 +123,8 @@ export function useRatioResize({
 
 export function useQueryEditorBanner() {
   const [dismissed, setDismissed] = useSessionStorage(QUERY_EDITOR_BANNER_DISMISSED_KEY, false);
-  const showBanner = Boolean(config.featureToggles.queryEditorNext) && !dismissed;
+  const isQueryEditorNextEnabled = useBooleanFlagValue('queryEditorNext', false);
+  const showBanner = isQueryEditorNextEnabled && !dismissed;
   const dismissBanner = useCallback(() => setDismissed(true), [setDismissed]);
 
   return { showBanner, dismissBanner };

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
@@ -14,6 +14,7 @@ import {
   SceneVariableSet,
   VizPanel,
 } from '@grafana/scenes';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
@@ -332,11 +333,11 @@ describe('PanelEditor', () => {
   describe('Query editor version toggle', () => {
     describe('when queryEditorNext feature toggle is enabled', () => {
       beforeEach(() => {
-        config.featureToggles.queryEditorNext = true;
+        setTestFlags({ queryEditorNext: true });
       });
 
       afterEach(() => {
-        config.featureToggles.queryEditorNext = false;
+        setTestFlags({});
       });
 
       it('should use the v2 query editor experience by default', async () => {
@@ -365,7 +366,7 @@ describe('PanelEditor', () => {
 
     describe('when queryEditorNext feature toggle is disabled', () => {
       beforeEach(() => {
-        config.featureToggles.queryEditorNext = false;
+        setTestFlags({});
       });
 
       it('should use the v1 query editor experience', async () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -4,6 +4,7 @@ import { debounce } from 'lodash';
 import { NavIndex, PanelPlugin } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, locationService } from '@grafana/runtime';
+import { getFeatureFlagClient } from '@grafana/runtime/internal';
 import {
   NewSceneObjectAddedEvent,
   PanelBuilders,
@@ -419,7 +420,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
 
 export function buildPanelEditScene(panel: VizPanel, isNewPanel = false): PanelEditor {
   return new PanelEditor({
-    useQueryExperienceNext: config.featureToggles.queryEditorNext,
+    useQueryExperienceNext: getFeatureFlagClient().getBooleanValue('queryEditorNext', false),
     isInitializing: true,
     panelRef: panel.getRef(),
     isNewPanel,


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->
Resolves https://github.com/grafana/grafana/issues/119252
Migrate from classic grafana feature toggles to OpenFeature. It's purely a FE change.

We might in the future look to use string values instead of booleans, but that's TBD.

## Changes
<!--- Describe your changes in detail -->
* Change the FE code

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->
Probably none?

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* Check out the documentation here: https://github.com/grafana/grafana/blob/main/contribute/feature-toggles.md#frontend

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable