### PR TITLE
Alerting: Use historian range queries for Notifications page panel.

### DIFF
--- a/public/app/features/alerting/unified/notifications/NotificationsRuntimeDataSource.test.ts
+++ b/public/app/features/alerting/unified/notifications/NotificationsRuntimeDataSource.test.ts
@@ -4,7 +4,7 @@ import {
   isNotificationOutcome,
   isNotificationStatus,
   matcherToAPIFormat,
-  notificationsToDataFrame,
+  rangeCountsToDataFrame,
 } from './NotificationsRuntimeDataSource';
 
 describe('isNotificationStatus', () => {
@@ -57,9 +57,9 @@ describe('matcherToAPIFormat', () => {
   });
 });
 
-describe('notificationsToDataFrame', () => {
-  it('should return empty DataFrame when no entries', () => {
-    const result = notificationsToDataFrame({ entries: [] });
+describe('rangeCountsToDataFrame', () => {
+  it('should return empty DataFrame when no range counts', () => {
+    const result = rangeCountsToDataFrame([]);
 
     expect(result.length).toBe(0);
     expect(result.fields).toHaveLength(2);
@@ -71,87 +71,45 @@ describe('notificationsToDataFrame', () => {
     expect(result.fields[1].values).toEqual([]);
   });
 
-  it('should group entries by 10-second intervals', () => {
-    const entries = [
-      makeEntry('2025-01-01T00:00:01Z'), // interval 0
-      makeEntry('2025-01-01T00:00:05Z'), // interval 0 (same 10s bucket)
-      makeEntry('2025-01-01T00:00:15Z'), // interval 10000
-      makeEntry('2025-01-01T00:00:35Z'), // interval 30000
-      makeEntry('2025-01-01T00:00:37Z'), // interval 30000 (same 10s bucket)
+  it('should convert range count timestamps from seconds to milliseconds', () => {
+    const rangeCounts = [
+      {
+        count: 0,
+        values: [
+          { timestamp: 1735689600, count: 5 }, // 2025-01-01T00:00:00Z in seconds
+          { timestamp: 1735689660, count: 3 }, // +60s
+          { timestamp: 1735689720, count: 8 }, // +120s
+        ],
+      },
     ];
 
-    const result = notificationsToDataFrame({ entries });
+    const result = rangeCountsToDataFrame(rangeCounts);
 
-    expect(result.fields[0].name).toBe('time');
-    expect(result.fields[1].name).toBe('value');
-
-    // Should have 3 time buckets
     expect(result.length).toBe(3);
-
-    // Bucket at 0s: 2 entries
-    const bucket0 = Math.floor(new Date('2025-01-01T00:00:01Z').getTime() / 10000) * 10000;
-    const bucket10 = Math.floor(new Date('2025-01-01T00:00:15Z').getTime() / 10000) * 10000;
-    const bucket30 = Math.floor(new Date('2025-01-01T00:00:35Z').getTime() / 10000) * 10000;
-
-    expect(result.fields[0].values).toEqual([bucket0, bucket10, bucket30]);
-    expect(result.fields[1].values).toEqual([2, 1, 2]);
+    expect(result.fields[0].values).toEqual([1735689600 * 1000, 1735689660 * 1000, 1735689720 * 1000]);
+    expect(result.fields[1].values).toEqual([5, 3, 8]);
   });
 
-  it('should handle a single entry', () => {
-    const entries = [makeEntry('2025-01-01T12:00:00Z')];
+  it('should use the first series when multiple range counts are returned', () => {
+    const rangeCounts = [
+      { count: 0, values: [{ timestamp: 1000, count: 10 }] },
+      { count: 0, values: [{ timestamp: 2000, count: 20 }] },
+    ];
 
-    const result = notificationsToDataFrame({ entries });
+    const result = rangeCountsToDataFrame(rangeCounts);
 
     expect(result.length).toBe(1);
-    expect(result.fields[1].values).toEqual([1]);
+    expect(result.fields[0].values).toEqual([1000 * 1000]);
+    expect(result.fields[1].values).toEqual([10]);
   });
 
-  it('should handle undefined entries gracefully', () => {
-    const result = notificationsToDataFrame({ entries: undefined as unknown as [] });
+  it('should handle a range count series with no values', () => {
+    const rangeCounts = [{ count: 0, values: [] }];
+
+    const result = rangeCountsToDataFrame(rangeCounts);
 
     expect(result.length).toBe(0);
-    expect(result.fields).toHaveLength(2);
     expect(result.fields[0].values).toEqual([]);
     expect(result.fields[1].values).toEqual([]);
   });
-
-  it('should produce one bucket per entry when timestamps are in different intervals', () => {
-    const entries = [
-      makeEntry('2025-01-01T00:01:00Z'),
-      makeEntry('2025-01-01T00:00:05Z'),
-      makeEntry('2025-01-01T00:00:30Z'),
-    ];
-
-    const result = notificationsToDataFrame({ entries });
-
-    // 3 entries in 3 different 10s buckets → 3 buckets each with count 1
-    expect(result.length).toBe(3);
-    expect(result.fields[1].values).toEqual([1, 1, 1]);
-
-    // Buckets follow insertion order (order entries appear)
-    const bucket60 = Math.floor(new Date('2025-01-01T00:01:00Z').getTime() / 10000) * 10000;
-    const bucket0 = Math.floor(new Date('2025-01-01T00:00:05Z').getTime() / 10000) * 10000;
-    const bucket30 = Math.floor(new Date('2025-01-01T00:00:30Z').getTime() / 10000) * 10000;
-    expect(result.fields[0].values).toEqual([bucket60, bucket0, bucket30]);
-  });
 });
-
-function makeEntry(timestamp: string) {
-  return {
-    timestamp,
-    uuid: 'test-uuid',
-    receiver: 'slack',
-    integration: 'slack',
-    integrationIndex: 0,
-    status: 'firing' as const,
-    outcome: 'success' as const,
-    groupLabels: { alertname: 'test' },
-    ruleUIDs: [],
-    alertCount: 1,
-    alerts: [],
-    retry: false,
-    duration: 100,
-    pipelineTime: timestamp,
-    groupKey: 'test-group',
-  };
-}

--- a/public/app/features/alerting/unified/notifications/NotificationsRuntimeDataSource.ts
+++ b/public/app/features/alerting/unified/notifications/NotificationsRuntimeDataSource.ts
@@ -1,9 +1,8 @@
-import { groupBy } from 'lodash';
 import { useEffect, useMemo } from 'react';
 
 import {
   CreateNotificationqueryMatcher,
-  CreateNotificationqueryNotificationEntry,
+  CreateNotificationqueryNotificationCount,
   CreateNotificationqueryNotificationOutcome,
   CreateNotificationqueryNotificationStatus,
   CreateNotificationqueryResponse,
@@ -82,10 +81,7 @@ interface NotificationsAPIQuery extends DataQuery {
   labelFilter?: string;
 }
 
-// Use the generated type from the API client
-type NotificationEntry = CreateNotificationqueryNotificationEntry;
-
-const GROUPING_INTERVAL = 10 * 1000; // 10 seconds
+type NotificationRangeCount = CreateNotificationqueryNotificationCount;
 
 /**
  * This class is a runtime datasource that fetches notification events from the notifications API.
@@ -116,16 +112,17 @@ class NotificationsAPIDatasource extends RuntimeDataSource<NotificationsAPIQuery
       groupLabels = matchers.map(matcherToAPIFormat);
     }
 
-    const notificationResult = await getNotifications(
+    const rangeCounts = await getNotificationsRangeCounts(
       from,
       to,
       isNotificationStatus(statusFilter) ? statusFilter : undefined,
       isNotificationOutcome(outcomeFilter) ? outcomeFilter : undefined,
       receiverFilter && receiverFilter !== 'all' ? receiverFilter : undefined,
-      groupLabels
+      groupLabels,
+      Math.round(request.intervalMs / 1000)
     );
 
-    const dataFrame = notificationsToDataFrame(notificationResult);
+    const dataFrame = rangeCountsToDataFrame(rangeCounts);
 
     return {
       data: [dataFrame],
@@ -216,15 +213,45 @@ export const getNotifications = async (
 };
 
 /**
- * Convert notification entries to a DataFrame for visualization.
- * Groups notifications by time interval and counts them.
+ * Fetch notification range counts from the notifications API for graph visualization.
  */
-export function notificationsToDataFrame(notificationResult: { entries: NotificationEntry[] }): DataFrame {
-  // Extract entries from API response (properly typed from the generated client)
-  const entriesArray = notificationResult.entries ?? [];
+export const getNotificationsRangeCounts = async (
+  from: string,
+  to: string,
+  status?: CreateNotificationqueryNotificationStatus,
+  outcome?: CreateNotificationqueryNotificationOutcome,
+  receiver?: string,
+  groupLabels?: CreateNotificationqueryMatcher[],
+  step?: number
+): Promise<NotificationRangeCount[]> => {
+  const result = await dispatch(
+    notificationsApi.endpoints.createNotificationquery.initiate(
+      {
+        createNotificationqueryRequestBody: {
+          type: 'range_counts',
+          from: from,
+          to: to,
+          status: status,
+          outcome: outcome,
+          receiver: receiver,
+          groupLabels: groupLabels || [],
+          step: step,
+        },
+      },
+      // @ts-expect-error forceRefetch is a valid RTK Query initiate option but not included in generated types
+      { forceRefetch: Boolean(getTimeSrv().getAutoRefreshInteval().interval) }
+    )
+  ).unwrap();
 
-  if (entriesArray.length === 0) {
-    // Return empty DataFrame
+  return result.counts ?? [];
+};
+
+/**
+ * Convert notification range counts to a DataFrame for graph visualization.
+ * Each range count series becomes a separate data frame series with timestamps in milliseconds.
+ */
+export function rangeCountsToDataFrame(rangeCounts: NotificationRangeCount[]): DataFrame {
+  if (rangeCounts.length === 0) {
     return {
       fields: [
         {
@@ -244,28 +271,23 @@ export function notificationsToDataFrame(notificationResult: { entries: Notifica
     };
   }
 
-  // Extract timestamps and convert from ISO strings to milliseconds
-  const timestamps = entriesArray.map((entry) => new Date(entry.timestamp).getTime());
+  // Use the first (and typically only) series from the range counts.
+  // The range_counts query without groupBy returns a single aggregated series.
+  const series = rangeCounts[0];
+  const values = series.values ?? [];
 
-  // Group timestamps by interval
-  const groupedTimestamps = groupBy(
-    timestamps,
-    (time: number) => Math.floor(time / GROUPING_INTERVAL) * GROUPING_INTERVAL
-  );
-
-  // Create time field with grouped time values
   const timeField: Field = {
     name: 'time',
     type: FieldType.time,
-    values: Object.keys(groupedTimestamps).map(Number),
+    // Timestamps from Loki are Unix epoch seconds; convert to milliseconds for Grafana
+    values: values.map((v) => v.timestamp * 1000),
     config: { displayName: 'Time' },
   };
 
-  // Create count field with count of notifications in each group
   const countField: Field = {
     name: 'value',
     type: FieldType.number,
-    values: Object.values(groupedTimestamps).map((group) => group.length),
+    values: values.map((v) => v.count),
     config: {},
   };
 


### PR DESCRIPTION
The backend exposes an API to perform range queries on notifcation history data,
allowing the panel in the notifications page to render properly (and faster)
instead of rendering from the raw entries returned.
