### PR TITLE
Provisioning: fix undefined runGrafana and TestRepo in files_test.go

### DIFF
--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -1014,11 +1014,11 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 func TestIntegrationProvisioning_CreateFolder_FolderMetadataFlag(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
-	helper := runGrafana(t, withProvisioningFolderMetadata)
+	helper := common.RunGrafana(t, withProvisioningFolderMetadata)
 	ctx := context.Background()
 
 	const repo = "folder-metadata-test-repo"
-	helper.CreateRepo(t, TestRepo{Name: repo, Target: "instance", SkipResourceAssertions: true})
+	helper.CreateRepo(t, common.TestRepo{Name: repo, Target: "instance", SkipResourceAssertions: true})
 
 	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
 


### PR DESCRIPTION
## Summary

Fix typecheck error in `pkg/tests/apis/provisioning/files_test.go` where `runGrafana` and `TestRepo` were referenced without the `common.` package qualifier, causing compilation failures.

## Test plan

- [x] `go vet ./pkg/tests/apis/provisioning/...` passes with no errors for `files_test.go`