### PR TITLE
annotations: add support for metadata.generateName

### DIFF
--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,6 +35,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/apiserver/appinstaller"
 	grafrequest "github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 var (
@@ -337,6 +339,18 @@ func (s *k8sRESTAdapter) Create(ctx context.Context,
 	if !ok {
 		return nil, fmt.Errorf("expected annotation")
 	}
+
+	// Validate either name or generateName is provided
+	if resource.Name == "" && resource.GenerateName == "" {
+		return nil, apierrors.NewBadRequest("metadata.name or metadata.generateName is required")
+	}
+
+	// If generateName is provided, generate a unique name using the provided prefix
+	if resource.GenerateName != "" {
+		resource.Name = resource.GenerateName + util.GenerateShortUID()
+		resource.GenerateName = ""
+	}
+
 	return s.store.Create(ctx, resource)
 }
 

--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -348,7 +348,6 @@ func (s *k8sRESTAdapter) Create(ctx context.Context,
 	// If generateName is provided, generate a unique name using the provided prefix
 	if resource.GenerateName != "" {
 		resource.Name = resource.GenerateName + util.GenerateShortUID()
-		resource.GenerateName = ""
 	}
 
 	return s.store.Create(ctx, resource)

--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -345,8 +345,8 @@ func (s *k8sRESTAdapter) Create(ctx context.Context,
 		return nil, apierrors.NewBadRequest("metadata.name or metadata.generateName is required")
 	}
 
-	// If generateName is provided, generate a unique name using the provided prefix
-	if resource.GenerateName != "" {
+	// If a name is empty and generateName is not, generate a unique name using the provided prefix
+	if resource.Name == "" && resource.GenerateName != "" {
 		resource.Name = resource.GenerateName + util.GenerateShortUID()
 	}
 

--- a/pkg/registry/apps/annotation/register_test.go
+++ b/pkg/registry/apps/annotation/register_test.go
@@ -1,0 +1,116 @@
+package annotation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestK8sRESTAdapter_Create_GenerateName(t *testing.T) {
+	ctx := t.Context()
+
+	cfg := &setting.Cfg{}
+	nsMapper := request.GetNamespaceMapper(cfg)
+
+	store := NewMemoryStore()
+	adapter := &k8sRESTAdapter{
+		store:  store,
+		mapper: nsMapper,
+	}
+
+	t.Run("should generate name from generateName", func(t *testing.T) {
+		anno := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-anno-",
+				Namespace:    "default",
+			},
+			Spec: annotationV0.AnnotationSpec{
+				Text: "test annotation",
+				Time: 12345,
+			},
+		}
+
+		created, err := adapter.Create(ctx, anno, nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, created)
+
+		result := created.(*annotationV0.Annotation)
+
+		// Name should start with the generateName prefix and have a random suffix appended
+		assert.True(t, strings.HasPrefix(result.Name, "test-anno-"),
+			"expected name to start with prefix 'test-anno-', got: %s", result.Name)
+		assert.Greater(t, len(result.Name), len("test-anno-"),
+			"expected name to have random suffix appended")
+	})
+
+	t.Run("should accept explicit name", func(t *testing.T) {
+		anno := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-annotation-name",
+				Namespace: "default",
+			},
+			Spec: annotationV0.AnnotationSpec{
+				Text: "test annotation with explicit name",
+				Time: 12345,
+			},
+		}
+
+		created, err := adapter.Create(ctx, anno, nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, created)
+
+		result := created.(*annotationV0.Annotation)
+		assert.Equal(t, "my-annotation-name", result.Name,
+			"expected name to match the provided name")
+	})
+
+	t.Run("should reject when both name and generateName are empty", func(t *testing.T) {
+		anno := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+			},
+			Spec: annotationV0.AnnotationSpec{
+				Text: "test annotation",
+				Time: 12345,
+			},
+		}
+
+		_, err := adapter.Create(ctx, anno, nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "metadata.name or metadata.generateName is required",
+			"expected error message about missing name/generateName")
+	})
+
+	t.Run("generateName takes precedence over name", func(t *testing.T) {
+		anno := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:         "my-annotation-name",
+				GenerateName: "generated-",
+				Namespace:    "default",
+			},
+			Spec: annotationV0.AnnotationSpec{
+				Text: "test annotation",
+				Time: 12345,
+			},
+		}
+
+		created, err := adapter.Create(ctx, anno, nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, created)
+
+		result := created.(*annotationV0.Annotation)
+
+		// When both are provided, generateName takes priority
+		assert.True(t, strings.HasPrefix(result.Name, "generated-"),
+			"expected name to be generated from generateName prefix")
+		assert.NotEqual(t, "my-annotation-name", result.Name,
+			"explicit name should be overridden when generateName is present")
+	})
+}

--- a/pkg/registry/apps/annotation/register_test.go
+++ b/pkg/registry/apps/annotation/register_test.go
@@ -88,10 +88,10 @@ func TestK8sRESTAdapter_Create_GenerateName(t *testing.T) {
 			"expected error message about missing name/generateName")
 	})
 
-	t.Run("generateName takes precedence over name", func(t *testing.T) {
+	t.Run("name takes precedence over generateName", func(t *testing.T) {
 		anno := &annotationV0.Annotation{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:         "my-annotation-name",
+				Name:         "my-special-name",
 				GenerateName: "generated-",
 				Namespace:    "default",
 			},
@@ -107,10 +107,8 @@ func TestK8sRESTAdapter_Create_GenerateName(t *testing.T) {
 
 		result := created.(*annotationV0.Annotation)
 
-		// When both are provided, generateName takes priority
-		assert.True(t, strings.HasPrefix(result.Name, "generated-"),
-			"expected name to be generated from generateName prefix")
-		assert.NotEqual(t, "my-annotation-name", result.Name,
-			"explicit name should be overridden when generateName is present")
+		// When both are provided, name takes priority
+		assert.Equal(t, "my-special-name", result.Name,
+			"expected name to match the provided name, not the generateName")
 	})
 }


### PR DESCRIPTION
Adds support for `metadata.generateName` to the new Annotations App Platform API and validates that either `metadata.name` or `metadata.generateName` are provided when creating annotations.

_Note: This will not impact the names generated for annotations served from legacy sql storage as they are named according to the pattern `a-<database_id>`, with the name being derived from the ID in the database._