### PR TITLE
Add authorization and scoped actions for alerting routes

### DIFF
--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -479,9 +479,19 @@ const (
 	ActionAlertingReceiversPermissionsRead  = "receivers.permissions:read"
 	ActionAlertingReceiversPermissionsWrite = "receivers.permissions:write"
 
-	// Alerting routes policies actions
+	// Alerting routes policies actions (legacy, unscoped - kept for backward compatibility)
 	ActionAlertingRoutesRead  = "alert.notifications.routes:read"
 	ActionAlertingRoutesWrite = "alert.notifications.routes:write"
+
+	// Alerting managed routes actions (new, scoped per-resource)
+	ActionAlertingManagedRoutesRead   = "alert.notifications.routes.managed:read"
+	ActionAlertingManagedRoutesWrite  = "alert.notifications.routes.managed:write"
+	ActionAlertingManagedRoutesCreate = "alert.notifications.routes.managed:create"
+	ActionAlertingManagedRoutesDelete = "alert.notifications.routes.managed:delete"
+
+	// Alerting routes permissions actions
+	ActionAlertingRoutesPermissionsRead  = "routes.permissions:read"
+	ActionAlertingRoutesPermissionsWrite = "routes.permissions:write"
 
 	// External alerting rule actions. We can only narrow it down to writes or reads, as we don't control the atomicity in the external system.
 	ActionAlertingRuleExternalWrite = "alert.rules.external:write"

--- a/pkg/services/ngalert/accesscontrol/routes.go
+++ b/pkg/services/ngalert/accesscontrol/routes.go
@@ -1,0 +1,312 @@
+package accesscontrol
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
+)
+
+var (
+	// Legacy actions — grant access to the default route only, not to other managed routes.
+	legacyReadRoutePermissions = ac.EvalAny(
+		ac.EvalPermission(ac.ActionAlertingNotificationsRead), // Legacy system-wide action.
+		ac.EvalPermission(ac.ActionAlertingRoutesRead),        // Legacy route-specific action.
+	)
+	legacyWriteRoutePermissions = ac.EvalAny(
+		ac.EvalPermission(ac.ActionAlertingNotificationsWrite), // Legacy system-wide action.
+		ac.EvalPermission(ac.ActionAlertingRoutesWrite),        // Legacy route-specific action.
+	)
+
+	// Provisioning actions — like legacy, grant access to the default route only, not to other managed routes.
+	provisioningReadRoutePermissions = ac.EvalAny(
+		ac.EvalPermission(ac.ActionAlertingProvisioningRead),              // Global provisioning action. Org scope.
+		ac.EvalPermission(ac.ActionAlertingNotificationsProvisioningRead), // Notifications provisioning action. Org scope.
+	)
+	provisioningWriteRoutePermissions = ac.EvalAny(
+		ac.EvalPermission(ac.ActionAlertingProvisioningWrite),              // Global provisioning action. Org scope.
+		ac.EvalPermission(ac.ActionAlertingNotificationsProvisioningWrite), // Notifications provisioning action. Org scope.
+	)
+
+	// Read
+
+	// Asserts pre-conditions for read access to routes (new scoped action only; legacy is added via extendAccessControl).
+	readRoutesPreConditionsEval = ac.EvalPermission(ac.ActionAlertingManagedRoutesRead)
+
+	// Asserts read-only access to all routes. Legacy/provisioning actions do NOT grant access to all managed routes.
+	readAllRoutesEval = ac.EvalPermission(ac.ActionAlertingManagedRoutesRead, models.ScopeRoutesAll)
+
+	// Asserts read-only access to a specific route (new scoped action only; legacy is added via extendAccessControl).
+	readRouteEval = func(name string) ac.Evaluator {
+		return ac.EvalPermission(ac.ActionAlertingManagedRoutesRead, models.ScopeRoutesProvider.GetResourceScopeUID(name))
+	}
+
+	// Create
+
+	// Asserts create access to routes. Create is org-level only; legacy/provisioning actions do NOT grant create.
+	createRoutesEval = ac.EvalPermission(ac.ActionAlertingManagedRoutesCreate)
+
+	// Update
+
+	// Asserts pre-conditions for update access to routes (new scoped action only; legacy is added via extendAccessControl).
+	updateRoutesPreConditionsEval = ac.EvalPermission(ac.ActionAlertingManagedRoutesWrite)
+
+	// Asserts update access to all routes. Legacy/provisioning actions do NOT grant access to all managed routes.
+	updateAllRoutesEval = ac.EvalPermission(ac.ActionAlertingManagedRoutesWrite, models.ScopeRoutesAll)
+
+	// Asserts update access to a specific route (new scoped action only; legacy is added via extendAccessControl).
+	updateRouteEval = func(name string) ac.Evaluator {
+		return ac.EvalPermission(ac.ActionAlertingManagedRoutesWrite, models.ScopeRoutesProvider.GetResourceScopeUID(name))
+	}
+
+	// Delete
+
+	// Asserts pre-conditions for delete access to routes (new scoped action only; legacy is added via extendAccessControl).
+	deleteRoutesPreConditionsEval = ac.EvalPermission(ac.ActionAlertingManagedRoutesDelete)
+
+	// Asserts delete access to all routes. Legacy/provisioning actions do NOT grant access to all managed routes.
+	deleteAllRoutesEval = ac.EvalPermission(ac.ActionAlertingManagedRoutesDelete, models.ScopeRoutesAll)
+
+	// Asserts delete access to a specific route (new scoped action only; legacy is added via extendAccessControl).
+	deleteRouteEval = func(name string) ac.Evaluator {
+		return ac.EvalPermission(ac.ActionAlertingManagedRoutesDelete, models.ScopeRoutesProvider.GetResourceScopeUID(name))
+	}
+
+	// Admin (permissions management)
+
+	// Asserts pre-conditions for resource permissions access to routes.
+	permissionsRoutesPreConditionsEval = ac.EvalAll(
+		ac.EvalPermission(ac.ActionAlertingRoutesPermissionsRead),
+		ac.EvalPermission(ac.ActionAlertingRoutesPermissionsWrite),
+	)
+
+	// Asserts resource permissions access to all routes.
+	permissionsAllRoutesEval = ac.EvalAll(
+		ac.EvalPermission(ac.ActionAlertingRoutesPermissionsRead, models.ScopeRoutesAll),
+		ac.EvalPermission(ac.ActionAlertingRoutesPermissionsWrite, models.ScopeRoutesAll),
+	)
+
+	// Asserts resource permissions access to a specific route.
+	permissionsRouteEval = func(name string) ac.Evaluator {
+		return ac.EvalAll(
+			ac.EvalPermission(ac.ActionAlertingRoutesPermissionsRead, models.ScopeRoutesProvider.GetResourceScopeUID(name)),
+			ac.EvalPermission(ac.ActionAlertingRoutesPermissionsWrite, models.ScopeRoutesProvider.GetResourceScopeUID(name)),
+		)
+	}
+)
+
+// defaultRouteOnly builds an actionAccess extension that applies the given evaluator only to the default route.
+// It satisfies the pre-condition (user can access the default route) but does NOT satisfy the all-routes evaluator.
+func defaultRouteOnly[T models.Identified](eval ac.Evaluator) actionAccess[T] {
+	return actionAccess[T]{
+		authorizeSome: eval,                  // satisfies pre-condition — user can access at least the default route
+		authorizeAll:  ac.EvalPermission(""), // never satisfied — does NOT grant access to all routes
+		authorizeOne: func(route models.Identified) ac.Evaluator {
+			if route.GetUID() == legacy_storage.UserDefinedRoutingTreeName {
+				return eval
+			}
+			return ac.EvalPermission("") // never satisfied — does not apply to non-default routes
+		},
+	}
+}
+
+type RouteAccess[T models.Identified] struct {
+	read        actionAccess[T]
+	create      actionAccess[T]
+	update      actionAccess[T]
+	delete      actionAccess[T]
+	permissions actionAccess[T]
+}
+
+// NewRouteAccess creates a new RouteAccess service. If includeProvisioningActions is true, the service will also
+// accept provisioning-specific permissions for the default route (alert.provisioning:read/write and
+// alert.notifications.provisioning:read/write). Like legacy permissions, provisioning permissions only grant access to
+// the default route, not to other managed routes.
+func NewRouteAccess[T models.Identified](a ac.AccessControl, includeProvisioningActions bool) *RouteAccess[T] {
+	routeAccess := &RouteAccess[T]{
+		read: actionAccess[T]{
+			genericService: genericService{
+				ac: a,
+			},
+			resource:      "route",
+			action:        "read",
+			authorizeSome: readRoutesPreConditionsEval,
+			authorizeOne: func(route models.Identified) ac.Evaluator {
+				return readRouteEval(route.GetUID())
+			},
+			authorizeAll: readAllRoutesEval,
+		},
+		create: actionAccess[T]{
+			genericService: genericService{
+				ac: a,
+			},
+			resource:      "route",
+			action:        "create",
+			authorizeSome: createRoutesEval,
+			authorizeOne: func(route models.Identified) ac.Evaluator {
+				return createRoutesEval
+			},
+			authorizeAll: createRoutesEval,
+		},
+		update: actionAccess[T]{
+			genericService: genericService{
+				ac: a,
+			},
+			resource:      "route",
+			action:        "update",
+			authorizeSome: updateRoutesPreConditionsEval,
+			authorizeOne: func(route models.Identified) ac.Evaluator {
+				return updateRouteEval(route.GetUID())
+			},
+			authorizeAll: updateAllRoutesEval,
+		},
+		delete: actionAccess[T]{
+			genericService: genericService{
+				ac: a,
+			},
+			resource:      "route",
+			action:        "delete",
+			authorizeSome: deleteRoutesPreConditionsEval,
+			authorizeOne: func(route models.Identified) ac.Evaluator {
+				return deleteRouteEval(route.GetUID())
+			},
+			authorizeAll: deleteAllRoutesEval,
+		},
+		permissions: actionAccess[T]{
+			genericService: genericService{
+				ac: a,
+			},
+			resource:      "route",
+			action:        "admin",
+			authorizeSome: permissionsRoutesPreConditionsEval,
+			authorizeOne: func(route models.Identified) ac.Evaluator {
+				return permissionsRouteEval(route.GetUID())
+			},
+			authorizeAll: permissionsAllRoutesEval,
+		},
+	}
+
+	// Legacy permissions apply to the default route only.
+	extendAccessControl(&routeAccess.read, ac.EvalAny, defaultRouteOnly[T](legacyReadRoutePermissions))
+	extendAccessControl(&routeAccess.update, ac.EvalAny, defaultRouteOnly[T](legacyWriteRoutePermissions))
+	extendAccessControl(&routeAccess.delete, ac.EvalAny, defaultRouteOnly[T](legacyWriteRoutePermissions))
+
+	// Provisioning permissions also apply to the default route only (same as legacy).
+	if includeProvisioningActions {
+		extendAccessControl(&routeAccess.read, ac.EvalAny, defaultRouteOnly[T](provisioningReadRoutePermissions))
+		extendAccessControl(&routeAccess.update, ac.EvalAny, defaultRouteOnly[T](provisioningWriteRoutePermissions))
+		extendAccessControl(&routeAccess.delete, ac.EvalAny, defaultRouteOnly[T](provisioningWriteRoutePermissions))
+	}
+
+	// Write, delete, and permissions management should require read permissions.
+	extendAccessControl(&routeAccess.update, ac.EvalAll, routeAccess.read)
+	extendAccessControl(&routeAccess.delete, ac.EvalAll, routeAccess.read)
+	extendAccessControl(&routeAccess.permissions, ac.EvalAll, routeAccess.read)
+
+	return routeAccess
+}
+
+// FilterRead filters the given list of routes based on the read access control permissions of the user.
+func (s RouteAccess[T]) FilterRead(ctx context.Context, user identity.Requester, routes ...T) ([]T, error) {
+	return s.read.Filter(ctx, user, routes...)
+}
+
+// AuthorizeRead checks if user has access to read a route.
+func (s RouteAccess[T]) AuthorizeRead(ctx context.Context, user identity.Requester, route T) error {
+	return s.read.Authorize(ctx, user, route)
+}
+
+// HasRead checks if user has access to read a route.
+func (s RouteAccess[T]) HasRead(ctx context.Context, user identity.Requester, route T) (bool, error) {
+	return s.read.Has(ctx, user, route)
+}
+
+// AuthorizeReadSome checks if user has access to read some routes.
+func (s RouteAccess[T]) AuthorizeReadSome(ctx context.Context, user identity.Requester) error {
+	return s.read.AuthorizePreConditions(ctx, user)
+}
+
+// AuthorizeCreate checks if user has access to create routes.
+func (s RouteAccess[T]) AuthorizeCreate(ctx context.Context, user identity.Requester) error {
+	return s.create.AuthorizeAll(ctx, user)
+}
+
+// AuthorizeUpdate checks if user has access to update a route.
+func (s RouteAccess[T]) AuthorizeUpdate(ctx context.Context, user identity.Requester, route T) error {
+	return s.update.Authorize(ctx, user, route)
+}
+
+// AuthorizeDelete checks if user has access to delete a route.
+func (s RouteAccess[T]) AuthorizeDelete(ctx context.Context, user identity.Requester, route T) error {
+	return s.delete.Authorize(ctx, user, route)
+}
+
+// AuthorizeDeleteByUID checks if user has access to delete a route by name.
+func (s RouteAccess[T]) AuthorizeDeleteByUID(ctx context.Context, user identity.Requester, name string) error {
+	return s.delete.Authorize(ctx, user, identified{uid: name})
+}
+
+// AuthorizeUpdateByUID checks if user has access to update a route by name.
+func (s RouteAccess[T]) AuthorizeUpdateByUID(ctx context.Context, user identity.Requester, name string) error {
+	return s.update.Authorize(ctx, user, identified{uid: name})
+}
+
+// AuthorizeReadByUID checks if user has access to read a route by name.
+func (s RouteAccess[T]) AuthorizeReadByUID(ctx context.Context, user identity.Requester, name string) error {
+	return s.read.Authorize(ctx, user, identified{uid: name})
+}
+
+// Access returns the permission sets for a slice of routes.
+func (s RouteAccess[T]) Access(ctx context.Context, user identity.Requester, routes ...T) (map[string]models.RoutePermissionSet, error) {
+	basePerms := models.NewRoutePermissionSet()
+
+	if err := s.permissions.AuthorizePreConditions(ctx, user); err != nil {
+		basePerms.Set(models.RoutePermissionAdmin, false)
+	} else if err := s.permissions.AuthorizeAll(ctx, user); err == nil {
+		basePerms.Set(models.RoutePermissionAdmin, true)
+	}
+
+	if err := s.update.AuthorizePreConditions(ctx, user); err != nil {
+		basePerms.Set(models.RoutePermissionWrite, false)
+	} else if err := s.update.AuthorizeAll(ctx, user); err == nil {
+		basePerms.Set(models.RoutePermissionWrite, true)
+	}
+
+	if err := s.delete.AuthorizePreConditions(ctx, user); err != nil {
+		basePerms.Set(models.RoutePermissionDelete, false)
+	} else if err := s.delete.AuthorizeAll(ctx, user); err == nil {
+		basePerms.Set(models.RoutePermissionDelete, true)
+	}
+
+	if basePerms.AllSet() {
+		result := make(map[string]models.RoutePermissionSet, len(routes))
+		for _, r := range routes {
+			result[r.GetUID()] = basePerms.Clone()
+		}
+		return result, nil
+	}
+
+	result := make(map[string]models.RoutePermissionSet, len(routes))
+	for _, r := range routes {
+		permSet := basePerms.Clone()
+		if _, ok := permSet.Has(models.RoutePermissionAdmin); !ok {
+			err := s.permissions.authorize(ctx, user, r)
+			permSet.Set(models.RoutePermissionAdmin, err == nil)
+		}
+
+		if _, ok := permSet.Has(models.RoutePermissionWrite); !ok {
+			err := s.update.authorize(ctx, user, r)
+			permSet.Set(models.RoutePermissionWrite, err == nil)
+		}
+
+		if _, ok := permSet.Has(models.RoutePermissionDelete); !ok {
+			err := s.delete.authorize(ctx, user, r)
+			permSet.Set(models.RoutePermissionDelete, err == nil)
+		}
+
+		result[r.GetUID()] = permSet
+	}
+	return result, nil
+}

--- a/pkg/services/ngalert/accesscontrol/routes_test.go
+++ b/pkg/services/ngalert/accesscontrol/routes_test.go
@@ -1,0 +1,1075 @@
+package accesscontrol
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
+	"github.com/grafana/grafana/pkg/services/org"
+)
+
+type testRoute struct {
+	name string
+}
+
+func (r testRoute) GetUID() string {
+	return r.name
+}
+
+func TestRouteAccess(t *testing.T) {
+	defaultRoute := testRoute{name: legacy_storage.UserDefinedRoutingTreeName}
+	route1 := testRoute{name: "route-1"}
+	route2 := testRoute{name: "route-2"}
+
+	allRoutes := []testRoute{defaultRoute, route1, route2}
+
+	permissions := func(perms ...models.RoutePermission) models.RoutePermissionSet {
+		set := models.NewRoutePermissionSet()
+		for _, v := range models.RoutePermissions() {
+			set.Set(v, false)
+		}
+		for _, v := range perms {
+			set.Set(v, true)
+		}
+		return set
+	}
+
+	newEmptyUser := func(permissions ...ac.Permission) identity.Requester {
+		return ac.BackgroundUser("test", orgID, org.RoleNone, permissions)
+	}
+
+	newViewUser := func(permissions ...ac.Permission) identity.Requester {
+		return ac.BackgroundUser("test", orgID, org.RoleNone, append([]ac.Permission{
+			{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesAll},
+		}, permissions...))
+	}
+
+	testCases := []struct {
+		name     string
+		user     identity.Requester
+		expected map[string]models.RoutePermissionSet
+	}{
+		// Legacy route-specific read (alert.notifications.routes:read) — only grants access to default route.
+		{
+			name: "legacy routes:read grants no elevated permissions on any route",
+			user: newEmptyUser(ac.Permission{Action: ac.ActionAlertingRoutesRead}),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(),
+				route2.name:       permissions(),
+			},
+		},
+		// Legacy system-wide read (alert.notifications:read) — only grants access to default route.
+		{
+			name: "legacy notifications:read grants no elevated permissions on any route",
+			user: newEmptyUser(ac.Permission{Action: ac.ActionAlertingNotificationsRead}),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(),
+				route2.name:       permissions(),
+			},
+		},
+		// Legacy write covers update and delete but ONLY for the default route.
+		{
+			name: "legacy routes:write with routes:read grants write+delete only on default route",
+			user: newEmptyUser(
+				ac.Permission{Action: ac.ActionAlertingRoutesRead},
+				ac.Permission{Action: ac.ActionAlertingRoutesWrite},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(models.RoutePermissionWrite, models.RoutePermissionDelete),
+				route1.name:       permissions(),
+				route2.name:       permissions(),
+			},
+		},
+		{
+			name: "legacy notifications:write with notifications:read grants write+delete only on default route",
+			user: newEmptyUser(
+				ac.Permission{Action: ac.ActionAlertingNotificationsRead},
+				ac.Permission{Action: ac.ActionAlertingNotificationsWrite},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(models.RoutePermissionWrite, models.RoutePermissionDelete),
+				route1.name:       permissions(),
+				route2.name:       permissions(),
+			},
+		},
+		{
+			name: "legacy routes:write without read grants nothing",
+			user: newEmptyUser(ac.Permission{Action: ac.ActionAlertingRoutesWrite}),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(),
+				route2.name:       permissions(),
+			},
+		},
+		{
+			name: "global scoped reader grants no elevated permissions",
+			user: newEmptyUser(ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesAll}),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(),
+				route2.name:       permissions(),
+			},
+		},
+		{
+			name: "global scoped writer grants write but no delete",
+			user: newViewUser(ac.Permission{Action: ac.ActionAlertingManagedRoutesWrite, Scope: models.ScopeRoutesAll}),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(models.RoutePermissionWrite),
+				route1.name:       permissions(models.RoutePermissionWrite),
+				route2.name:       permissions(models.RoutePermissionWrite),
+			},
+		},
+		{
+			name: "per-route scoped writer grants per-route write",
+			user: newViewUser(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesWrite, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(models.RoutePermissionWrite),
+				route2.name:       permissions(),
+			},
+		},
+		{
+			name: "per-route scoped writer requires read",
+			user: newEmptyUser(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesWrite, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(),
+				route2.name:       permissions(),
+			},
+		},
+		// New scoped delete.
+		{
+			name: "global scoped deleter grants delete but no write",
+			user: newViewUser(ac.Permission{Action: ac.ActionAlertingManagedRoutesDelete, Scope: models.ScopeRoutesAll}),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(models.RoutePermissionDelete),
+				route1.name:       permissions(models.RoutePermissionDelete),
+				route2.name:       permissions(models.RoutePermissionDelete),
+			},
+		},
+		{
+			name: "per-route scoped deleter grants per-route delete",
+			user: newViewUser(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesDelete, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesDelete, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route2.name)},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(models.RoutePermissionDelete),
+				route2.name:       permissions(models.RoutePermissionDelete),
+			},
+		},
+		{
+			name: "per-route scoped deleter requires read",
+			user: newEmptyUser(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesDelete, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(),
+				route2.name:       permissions(),
+			},
+		},
+		// Admin (permissions management).
+		{
+			name: "route read permissions alone cannot admin",
+			user: newViewUser(ac.Permission{Action: ac.ActionAlertingRoutesPermissionsRead, Scope: models.ScopeRoutesAll}),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(),
+				route2.name:       permissions(),
+			},
+		},
+		{
+			name: "route write permissions alone cannot admin",
+			user: newViewUser(ac.Permission{Action: ac.ActionAlertingRoutesPermissionsWrite, Scope: models.ScopeRoutesAll}),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(),
+				route2.name:       permissions(),
+			},
+		},
+		{
+			name: "global route read+write permissions can admin all routes",
+			user: newViewUser(
+				ac.Permission{Action: ac.ActionAlertingRoutesPermissionsRead, Scope: models.ScopeRoutesAll},
+				ac.Permission{Action: ac.ActionAlertingRoutesPermissionsWrite, Scope: models.ScopeRoutesAll},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(models.RoutePermissionAdmin),
+				route1.name:       permissions(models.RoutePermissionAdmin),
+				route2.name:       permissions(models.RoutePermissionAdmin),
+			},
+		},
+		{
+			name: "per-route read+write permissions grant per-route admin",
+			user: newViewUser(
+				ac.Permission{Action: ac.ActionAlertingRoutesPermissionsRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+				ac.Permission{Action: ac.ActionAlertingRoutesPermissionsWrite, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(models.RoutePermissionAdmin),
+				route2.name:       permissions(),
+			},
+		},
+		{
+			name: "per-route admin requires read",
+			user: newEmptyUser(
+				ac.Permission{Action: ac.ActionAlertingRoutesPermissionsRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+				ac.Permission{Action: ac.ActionAlertingRoutesPermissionsWrite, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(),
+				route2.name:       permissions(),
+			},
+		},
+		// Mixed: legacy + new scoped.
+		{
+			// Scoped write requires scoped read (enforced by extendAccessControl).
+			// Legacy routes:read only covers the default route, so scoped write on route-1 without scoped read grants nothing on route-1.
+			name: "legacy routes:read + scoped write without scoped read grants nothing on scoped route",
+			user: newEmptyUser(
+				ac.Permission{Action: ac.ActionAlertingRoutesRead},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesWrite, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(),
+				route2.name:       permissions(),
+			},
+		},
+		{
+			// Scoped delete also requires scoped read. Legacy routes:read only covers default.
+			name: "legacy routes:read + scoped read+delete grants delete only on scoped route",
+			user: newEmptyUser(
+				ac.Permission{Action: ac.ActionAlertingRoutesRead},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route2.name)},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesDelete, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route2.name)},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(),
+				route2.name:       permissions(models.RoutePermissionDelete),
+			},
+		},
+		{
+			// Legacy routes:write grants write/delete on default. Scoped permissions + scoped read grant admin on route-1.
+			name: "legacy routes:write + scoped read+admin grants full write on default + admin on scoped route",
+			user: newEmptyUser(
+				ac.Permission{Action: ac.ActionAlertingRoutesRead},
+				ac.Permission{Action: ac.ActionAlertingRoutesWrite},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+				ac.Permission{Action: ac.ActionAlertingRoutesPermissionsRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+				ac.Permission{Action: ac.ActionAlertingRoutesPermissionsWrite, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(models.RoutePermissionWrite, models.RoutePermissionDelete),
+				route1.name:       permissions(models.RoutePermissionAdmin),
+				route2.name:       permissions(),
+			},
+		},
+		{
+			// Scoped read + scoped write on route-1 grants write on route-1 (not on default without write).
+			// Note: legacy routes:write (ActionAlertingRoutesWrite) is a different action from managed:write
+			// (ActionAlertingManagedRoutesWrite) and does NOT grant write on non-default routes.
+			name: "scoped read+write on route1 grants write on route1 (legacy write does not apply to non-default)",
+			user: newEmptyUser(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesWrite, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesDelete, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(models.RoutePermissionWrite, models.RoutePermissionDelete),
+				route2.name:       permissions(),
+			},
+		},
+		// Verify legacy actions do NOT satisfy "all" evaluators.
+		{
+			name: "legacy routes:read does not grant write-all or delete-all",
+			user: newEmptyUser(
+				ac.Permission{Action: ac.ActionAlertingRoutesRead},
+				ac.Permission{Action: ac.ActionAlertingRoutesWrite},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				// write/delete only on default, not on other managed routes
+				defaultRoute.name: permissions(models.RoutePermissionWrite, models.RoutePermissionDelete),
+				route1.name:       permissions(),
+				route2.name:       permissions(),
+			},
+		},
+		// Overlapping global + per-route scoped permissions.
+		{
+			name: "global read + per-route write grants write only on scoped route",
+			user: newViewUser(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesWrite, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(models.RoutePermissionWrite),
+				route2.name:       permissions(),
+			},
+		},
+		{
+			name: "global read + per-route delete on route1 does not grant delete on route2",
+			user: newViewUser(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesDelete, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(models.RoutePermissionDelete),
+				route2.name:       permissions(),
+			},
+		},
+		{
+			name: "global read + per-route write and delete on different routes",
+			user: newViewUser(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesWrite, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesDelete, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route2.name)},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(models.RoutePermissionWrite),
+				route2.name:       permissions(models.RoutePermissionDelete),
+			},
+		},
+		{
+			name: "global read + per-route admin on route1 + per-route write on route2",
+			user: newViewUser(
+				ac.Permission{Action: ac.ActionAlertingRoutesPermissionsRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+				ac.Permission{Action: ac.ActionAlertingRoutesPermissionsWrite, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesWrite, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route2.name)},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(),
+				route1.name:       permissions(models.RoutePermissionAdmin),
+				route2.name:       permissions(models.RoutePermissionWrite),
+			},
+		},
+		{
+			name: "global write + per-route delete on route1 grants write everywhere but delete only on route1",
+			user: newViewUser(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesWrite, Scope: models.ScopeRoutesAll},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesDelete, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+			),
+			expected: map[string]models.RoutePermissionSet{
+				defaultRoute.name: permissions(models.RoutePermissionWrite),
+				route1.name:       permissions(models.RoutePermissionWrite, models.RoutePermissionDelete),
+				route2.name:       permissions(models.RoutePermissionWrite),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			svc := NewRouteAccess[testRoute](&recordingAccessControlFake{}, false)
+
+			actual, err := svc.Access(context.Background(), testCase.user, allRoutes...)
+
+			assert.NoError(t, err)
+			assert.Equalf(t, testCase.expected, actual, "expected: %v, actual: %v", testCase.expected, actual)
+		})
+	}
+}
+
+func TestRouteAccessFilterRead(t *testing.T) {
+	defaultRoute := testRoute{name: legacy_storage.UserDefinedRoutingTreeName}
+	route1 := testRoute{name: "route-1"}
+	route2 := testRoute{name: "route-2"}
+
+	allRoutes := []testRoute{defaultRoute, route1, route2}
+
+	user := func(perms ...ac.Permission) identity.Requester {
+		return ac.BackgroundUser("test", orgID, org.RoleNone, perms)
+	}
+
+	testCases := []struct {
+		name                string
+		user                identity.Requester
+		includeProvisioning bool
+		expected            []testRoute
+	}{
+		{
+			name:     "legacy routes:read can read only default route",
+			user:     user(ac.Permission{Action: ac.ActionAlertingRoutesRead}),
+			expected: []testRoute{defaultRoute},
+		},
+		{
+			name:     "legacy notifications:read can read only default route",
+			user:     user(ac.Permission{Action: ac.ActionAlertingNotificationsRead}),
+			expected: []testRoute{defaultRoute},
+		},
+		{
+			name:     "global scoped reader can read all routes",
+			user:     user(ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesAll}),
+			expected: allRoutes,
+		},
+		{
+			name: "per-route scoped reader can read specific routes",
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route2.name)},
+			),
+			expected: []testRoute{route1, route2},
+		},
+		{
+			name: "legacy read + scoped read gives default + scoped routes",
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingRoutesRead},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+			),
+			expected: []testRoute{defaultRoute, route1},
+		},
+		{
+			name:     "user without read permissions gets empty list",
+			user:     user(),
+			expected: nil,
+		},
+		// Provisioning permissions — default route only.
+		{
+			name:                "provisioning:read can read only default route",
+			user:                user(ac.Permission{Action: ac.ActionAlertingProvisioningRead}),
+			includeProvisioning: true,
+			expected:            []testRoute{defaultRoute},
+		},
+		{
+			name:                "notifications provisioning:read can read only default route",
+			user:                user(ac.Permission{Action: ac.ActionAlertingNotificationsProvisioningRead}),
+			includeProvisioning: true,
+			expected:            []testRoute{defaultRoute},
+		},
+		{
+			name: "provisioning:read + scoped read gives default + scoped routes",
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingProvisioningRead},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+			),
+			includeProvisioning: true,
+			expected:            []testRoute{defaultRoute, route1},
+		},
+		{
+			name:                "provisioning:read has no effect when provisioning actions disabled",
+			user:                user(ac.Permission{Action: ac.ActionAlertingProvisioningRead}),
+			includeProvisioning: false,
+			expected:            nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			svc := NewRouteAccess[testRoute](&recordingAccessControlFake{}, testCase.includeProvisioning)
+
+			actual, err := svc.FilterRead(context.Background(), testCase.user, allRoutes...)
+
+			if testCase.expected == nil {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, testCase.expected, actual)
+			}
+		})
+	}
+}
+
+func TestRouteAccessAuthorizeLegacy(t *testing.T) {
+	defaultRoute := testRoute{name: legacy_storage.UserDefinedRoutingTreeName}
+	route1 := testRoute{name: "route-1"}
+
+	user := func(perms ...ac.Permission) identity.Requester {
+		return ac.BackgroundUser("test", orgID, org.RoleNone, perms)
+	}
+
+	testCases := []struct {
+		name      string
+		authorize func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error
+		user      identity.Requester
+		expectErr bool
+	}{
+		// AuthorizeCreate — legacy actions do NOT grant create.
+		{
+			name: "legacy routes:write cannot create",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeCreate(ctx, user)
+			},
+			user:      user(ac.Permission{Action: ac.ActionAlertingRoutesWrite}),
+			expectErr: true,
+		},
+		{
+			name: "legacy notifications:write cannot create",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeCreate(ctx, user)
+			},
+			user:      user(ac.Permission{Action: ac.ActionAlertingNotificationsWrite}),
+			expectErr: true,
+		},
+		{
+			name: "reader cannot create",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeCreate(ctx, user)
+			},
+			user:      user(ac.Permission{Action: ac.ActionAlertingRoutesRead}),
+			expectErr: true,
+		},
+		// AuthorizeUpdate — legacy actions only apply to the default route.
+		{
+			name: "legacy routes:write can update default route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeUpdate(ctx, user, defaultRoute)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingRoutesRead},
+				ac.Permission{Action: ac.ActionAlertingRoutesWrite},
+			),
+			expectErr: false,
+		},
+		{
+			name: "legacy notifications:write can update default route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeUpdate(ctx, user, defaultRoute)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingNotificationsRead},
+				ac.Permission{Action: ac.ActionAlertingNotificationsWrite},
+			),
+			expectErr: false,
+		},
+		{
+			name: "legacy routes:write cannot update non-default managed route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeUpdate(ctx, user, route1)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingRoutesRead},
+				ac.Permission{Action: ac.ActionAlertingRoutesWrite},
+			),
+			expectErr: true,
+		},
+		// AuthorizeDelete — legacy actions only apply to the default route.
+		{
+			name: "legacy routes:write can delete default route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeDelete(ctx, user, defaultRoute)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingRoutesRead},
+				ac.Permission{Action: ac.ActionAlertingRoutesWrite},
+			),
+			expectErr: false,
+		},
+		{
+			name: "legacy notifications:write can delete default route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeDelete(ctx, user, defaultRoute)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingNotificationsRead},
+				ac.Permission{Action: ac.ActionAlertingNotificationsWrite},
+			),
+			expectErr: false,
+		},
+		{
+			name: "legacy routes:write cannot delete non-default managed route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeDelete(ctx, user, route1)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingRoutesRead},
+				ac.Permission{Action: ac.ActionAlertingRoutesWrite},
+			),
+			expectErr: true,
+		},
+		{
+			name: "legacy notifications:write cannot delete non-default managed route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeDelete(ctx, user, route1)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingNotificationsRead},
+				ac.Permission{Action: ac.ActionAlertingNotificationsWrite},
+			),
+			expectErr: true,
+		},
+		// Mixed: legacy + scoped on the default route.
+		{
+			// Legacy read satisfies read, new scoped write satisfies update — both combine for the default route.
+			name: "legacy routes:read + scoped managed:write can update default route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeUpdate(ctx, user, defaultRoute)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingRoutesRead},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesWrite, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(defaultRoute.name)},
+			),
+			expectErr: false,
+		},
+		{
+			// New scoped read satisfies read, legacy write satisfies update on the default route.
+			name: "scoped managed:read + legacy routes:write can update default route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeUpdate(ctx, user, defaultRoute)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(defaultRoute.name)},
+				ac.Permission{Action: ac.ActionAlertingRoutesWrite},
+			),
+			expectErr: false,
+		},
+		{
+			// Legacy write also covers delete on the default route; scoped read satisfies the read prerequisite.
+			name: "scoped managed:read + legacy routes:write can delete default route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeDelete(ctx, user, defaultRoute)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(defaultRoute.name)},
+				ac.Permission{Action: ac.ActionAlertingRoutesWrite},
+			),
+			expectErr: false,
+		},
+		{
+			// Scoped write requires scoped read. Legacy routes:read only covers the default route,
+			// so scoped write on route-1 without scoped read grants nothing on route-1.
+			name: "legacy routes:read + scoped managed:write requires scoped read on non-default route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeUpdate(ctx, user, route1)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingRoutesRead},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesWrite, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+			),
+			expectErr: true,
+		},
+		// Verify legacy actions do NOT satisfy "all routes" evaluators.
+		{
+			name: "legacy routes:read does not satisfy readAll evaluator",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.read.AuthorizeAll(ctx, user)
+			},
+			user:      user(ac.Permission{Action: ac.ActionAlertingRoutesRead}),
+			expectErr: true,
+		},
+		{
+			name: "legacy routes:write does not satisfy updateAll evaluator",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.update.AuthorizeAll(ctx, user)
+			},
+			user:      user(ac.Permission{Action: ac.ActionAlertingRoutesWrite}),
+			expectErr: true,
+		},
+		{
+			name: "legacy routes:write does not satisfy deleteAll evaluator",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.delete.AuthorizeAll(ctx, user)
+			},
+			user:      user(ac.Permission{Action: ac.ActionAlertingRoutesWrite}),
+			expectErr: true,
+		},
+		{
+			name: "legacy notifications:read does not satisfy readAll evaluator",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.read.AuthorizeAll(ctx, user)
+			},
+			user:      user(ac.Permission{Action: ac.ActionAlertingNotificationsRead}),
+			expectErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			svc := NewRouteAccess[testRoute](&recordingAccessControlFake{}, false)
+
+			err := testCase.authorize(svc, context.Background(), testCase.user)
+
+			if testCase.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRouteAccessAuthorizeScoped(t *testing.T) {
+	route1 := testRoute{name: "route-1"}
+	route2 := testRoute{name: "route-2"}
+
+	user := func(perms ...ac.Permission) identity.Requester {
+		return ac.BackgroundUser("test", orgID, org.RoleNone, perms)
+	}
+
+	testCases := []struct {
+		name      string
+		authorize func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error
+		user      identity.Requester
+		expectErr bool
+	}{
+		// AuthorizeCreate.
+		{
+			name: "scoped creator can create",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeCreate(ctx, user)
+			},
+			user:      user(ac.Permission{Action: ac.ActionAlertingManagedRoutesCreate}),
+			expectErr: false,
+		},
+		{
+			name: "user without create action cannot create",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeCreate(ctx, user)
+			},
+			user:      user(ac.Permission{Action: ac.ActionAlertingManagedRoutesWrite, Scope: models.ScopeRoutesAll}),
+			expectErr: true,
+		},
+		// AuthorizeRead.
+		{
+			name: "scoped managed:read can read scoped route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeRead(ctx, user, route1)
+			},
+			user:      user(ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)}),
+			expectErr: false,
+		},
+		{
+			name: "global managed:read can read any route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeRead(ctx, user, route2)
+			},
+			user:      user(ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesAll}),
+			expectErr: false,
+		},
+		{
+			name: "user without managed:read cannot read route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeRead(ctx, user, route1)
+			},
+			user:      user(),
+			expectErr: true,
+		},
+		{
+			name: "scoped managed:read on other route cannot read route1",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeRead(ctx, user, route1)
+			},
+			user:      user(ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route2.name)}),
+			expectErr: true,
+		},
+		// AuthorizeUpdate.
+		{
+			name: "scoped writer can update scoped route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeUpdate(ctx, user, route1)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesWrite, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+			),
+			expectErr: false,
+		},
+		{
+			name: "global writer can update any route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeUpdate(ctx, user, route2)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesAll},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesWrite, Scope: models.ScopeRoutesAll},
+			),
+			expectErr: false,
+		},
+		{
+			name: "scoped writer cannot update unscoped route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeUpdate(ctx, user, route1)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesAll},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesWrite, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route2.name)},
+			),
+			expectErr: true,
+		},
+		{
+			name: "scoped write without read cannot update",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeUpdate(ctx, user, route1)
+			},
+			user:      user(ac.Permission{Action: ac.ActionAlertingManagedRoutesWrite, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)}),
+			expectErr: true,
+		},
+		// AuthorizeDelete.
+		{
+			name: "scoped deleter can delete scoped route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeDelete(ctx, user, route1)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesDelete, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+			),
+			expectErr: false,
+		},
+		{
+			name: "global deleter can delete any route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeDelete(ctx, user, route2)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesAll},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesDelete, Scope: models.ScopeRoutesAll},
+			),
+			expectErr: false,
+		},
+		{
+			name: "scoped deleter cannot delete unscoped route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeDelete(ctx, user, route1)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesAll},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesDelete, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route2.name)},
+			),
+			expectErr: true,
+		},
+		{
+			name: "scoped delete without read cannot delete",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeDelete(ctx, user, route1)
+			},
+			user:      user(ac.Permission{Action: ac.ActionAlertingManagedRoutesDelete, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)}),
+			expectErr: true,
+		},
+		{
+			name: "managed:write does not grant delete",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeDelete(ctx, user, route1)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesRead, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+				ac.Permission{Action: ac.ActionAlertingManagedRoutesWrite, Scope: models.ScopeRoutesProvider.GetResourceScopeUID(route1.name)},
+			),
+			expectErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			svc := NewRouteAccess[testRoute](&recordingAccessControlFake{}, false)
+
+			err := testCase.authorize(svc, context.Background(), testCase.user)
+
+			if testCase.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRouteAccessAuthorizeProvisioning(t *testing.T) {
+	defaultRoute := testRoute{name: legacy_storage.UserDefinedRoutingTreeName}
+	route1 := testRoute{name: "route-1"}
+
+	user := func(perms ...ac.Permission) identity.Requester {
+		return ac.BackgroundUser("test", orgID, org.RoleNone, perms)
+	}
+
+	testCases := []struct {
+		name                string
+		authorize           func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error
+		user                identity.Requester
+		includeProvisioning bool
+		expectErr           bool
+	}{
+		// Provisioning read grants access to the default route only.
+		{
+			name: "provisioning:read can read default route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeRead(ctx, user, defaultRoute)
+			},
+			user:                user(ac.Permission{Action: ac.ActionAlertingProvisioningRead}),
+			includeProvisioning: true,
+			expectErr:           false,
+		},
+		{
+			name: "provisioning:read cannot read non-default managed route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeRead(ctx, user, route1)
+			},
+			user:                user(ac.Permission{Action: ac.ActionAlertingProvisioningRead}),
+			includeProvisioning: true,
+			expectErr:           true,
+		},
+		{
+			name: "notifications provisioning:read can read default route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeRead(ctx, user, defaultRoute)
+			},
+			user:                user(ac.Permission{Action: ac.ActionAlertingNotificationsProvisioningRead}),
+			includeProvisioning: true,
+			expectErr:           false,
+		},
+		{
+			name: "notifications provisioning:read cannot read non-default managed route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeRead(ctx, user, route1)
+			},
+			user:                user(ac.Permission{Action: ac.ActionAlertingNotificationsProvisioningRead}),
+			includeProvisioning: true,
+			expectErr:           true,
+		},
+		// Provisioning write + read grants update/delete on default route only.
+		{
+			name: "provisioning read+write can update default route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeUpdate(ctx, user, defaultRoute)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingProvisioningRead},
+				ac.Permission{Action: ac.ActionAlertingProvisioningWrite},
+			),
+			includeProvisioning: true,
+			expectErr:           false,
+		},
+		{
+			name: "provisioning read+write cannot update non-default managed route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeUpdate(ctx, user, route1)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingProvisioningRead},
+				ac.Permission{Action: ac.ActionAlertingProvisioningWrite},
+			),
+			includeProvisioning: true,
+			expectErr:           true,
+		},
+		{
+			name: "provisioning read+write can delete default route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeDelete(ctx, user, defaultRoute)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingProvisioningRead},
+				ac.Permission{Action: ac.ActionAlertingProvisioningWrite},
+			),
+			includeProvisioning: true,
+			expectErr:           false,
+		},
+		{
+			name: "provisioning read+write cannot delete non-default managed route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeDelete(ctx, user, route1)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingProvisioningRead},
+				ac.Permission{Action: ac.ActionAlertingProvisioningWrite},
+			),
+			includeProvisioning: true,
+			expectErr:           true,
+		},
+		{
+			name: "notifications provisioning read+write can update default route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeUpdate(ctx, user, defaultRoute)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingNotificationsProvisioningRead},
+				ac.Permission{Action: ac.ActionAlertingNotificationsProvisioningWrite},
+			),
+			includeProvisioning: true,
+			expectErr:           false,
+		},
+		{
+			name: "notifications provisioning read+write cannot update non-default managed route",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeUpdate(ctx, user, route1)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingNotificationsProvisioningRead},
+				ac.Permission{Action: ac.ActionAlertingNotificationsProvisioningWrite},
+			),
+			includeProvisioning: true,
+			expectErr:           true,
+		},
+		// Provisioning write alone (without provisioning read) cannot update — read is still required.
+		{
+			name: "provisioning:write alone cannot update default route (read required)",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeUpdate(ctx, user, defaultRoute)
+			},
+			user:                user(ac.Permission{Action: ac.ActionAlertingProvisioningWrite}),
+			includeProvisioning: true,
+			expectErr:           true,
+		},
+		// Provisioning permissions do NOT satisfy the "all routes" evaluators.
+		{
+			name: "provisioning:read does not satisfy readAll evaluator",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.read.AuthorizeAll(ctx, user)
+			},
+			user:                user(ac.Permission{Action: ac.ActionAlertingProvisioningRead}),
+			includeProvisioning: true,
+			expectErr:           true,
+		},
+		{
+			name: "provisioning read+write does not satisfy updateAll evaluator",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.update.AuthorizeAll(ctx, user)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingProvisioningRead},
+				ac.Permission{Action: ac.ActionAlertingProvisioningWrite},
+			),
+			includeProvisioning: true,
+			expectErr:           true,
+		},
+		{
+			name: "provisioning read+write does not satisfy deleteAll evaluator",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.delete.AuthorizeAll(ctx, user)
+			},
+			user: user(
+				ac.Permission{Action: ac.ActionAlertingProvisioningRead},
+				ac.Permission{Action: ac.ActionAlertingProvisioningWrite},
+			),
+			includeProvisioning: true,
+			expectErr:           true,
+		},
+		// Without includeProvisioningActions, provisioning actions have no effect.
+		{
+			name: "provisioning:read has no effect when provisioning actions disabled",
+			authorize: func(svc *RouteAccess[testRoute], ctx context.Context, user identity.Requester) error {
+				return svc.AuthorizeRead(ctx, user, defaultRoute)
+			},
+			user:                user(ac.Permission{Action: ac.ActionAlertingProvisioningRead}),
+			includeProvisioning: false,
+			expectErr:           true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			svc := NewRouteAccess[testRoute](&recordingAccessControlFake{}, testCase.includeProvisioning)
+
+			err := testCase.authorize(svc, context.Background(), testCase.user)
+
+			if testCase.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/services/ngalert/models/accesscontrol.go
+++ b/pkg/services/ngalert/models/accesscontrol.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	ScopeReceiversRoot       = "receivers"
+	ScopeRoutesRoot          = "routes"
 	ScopeInhibitionRulesRoot = "inhibition-rules"
 	AlertRolesGroup          = "Alerting"
 
@@ -24,6 +25,8 @@ const (
 var (
 	ScopeReceiversProvider       = ReceiverScopeProvider{accesscontrol.NewScopeProvider(ScopeReceiversRoot)}
 	ScopeReceiversAll            = ScopeReceiversProvider.GetResourceAllScope()
+	ScopeRoutesProvider          = RouteScopeProvider{accesscontrol.NewScopeProvider(ScopeRoutesRoot)}
+	ScopeRoutesAll               = ScopeRoutesProvider.GetResourceAllScope()
 	ScopeInhibitionRulesProvider = accesscontrol.NewScopeProvider(ScopeInhibitionRulesRoot)
 	ScopeInhibitionRulesAll      = ScopeInhibitionRulesProvider.GetResourceAllScope()
 )
@@ -50,4 +53,12 @@ func (p ReceiverScopeProvider) GetResourceIDFromUID(uid string) string {
 	h := sha1.New()
 	h.Write([]byte(uid))
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+type RouteScopeProvider struct {
+	accesscontrol.ScopeProvider
+}
+
+func (p RouteScopeProvider) GetResourceScopeUID(uid string) string {
+	return p.ScopeProvider.GetResourceScopeUID(uid)
 }

--- a/pkg/services/ngalert/models/permissions.go
+++ b/pkg/services/ngalert/models/permissions.go
@@ -36,6 +36,31 @@ func NewReceiverPermissionSet() ReceiverPermissionSet {
 	return NewPermissionSet(ReceiverPermissions())
 }
 
+// RoutePermission is a type for representing permission to perform a route action.
+type RoutePermission string
+
+const (
+	RoutePermissionAdmin  RoutePermission = "admin"
+	RoutePermissionWrite  RoutePermission = "write"
+	RoutePermissionDelete RoutePermission = "delete"
+)
+
+// RoutePermissions returns all possible route permissions.
+func RoutePermissions() []RoutePermission {
+	return []RoutePermission{
+		RoutePermissionAdmin,
+		RoutePermissionWrite,
+		RoutePermissionDelete,
+	}
+}
+
+// RoutePermissionSet represents a set of permissions for a route.
+type RoutePermissionSet = PermissionSet[RoutePermission]
+
+func NewRoutePermissionSet() RoutePermissionSet {
+	return NewPermissionSet(RoutePermissions())
+}
+
 // PermissionSet represents a set of permissions on a resource.
 type PermissionSet[T ~string] struct {
 	set map[T]bool


### PR DESCRIPTION
This PR adds new scoped RBAC actions for managed routes:

- scoped `alert.notifications.routes.managed:read|write|delete`
- scoped `routes.permissions:read|write`
- non-scoped `alert.notifications.routes.managed:create`

NOTE: neither of permissions are wired to APIs.

Adds a routes authz service that implements authorization logic that is backward compatible with legacy permissions:
- the legacy permissions (`alert.provisioning:read|write`,  `alert.notifications.provisioning:read|write`, `alert.notifications:read|write`, `alert.notifications.routes:read|write`) grant access to only the default route and does not grant create permissions.
- similar to receiver's authz service implementation, Route service supports two modes: include\exclude provisioning permissions. This is needed to apply the current semantics that grants access to provisioning API to regular permissions but not wise versa. 