### PR TITLE
Gauge: Use textPath to have nicer rounded label text

### DIFF
--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.test.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.test.tsx
@@ -35,6 +35,13 @@ describe('RadialGauge', () => {
       expect(screen.getByLabelText('Threshold 85')).toBeInTheDocument();
     });
 
+    it('should render labels for a circle gauge', () => {
+      render(<RadialGaugeExample showScaleLabels shape="circle" />);
+
+      expect(screen.getByRole('img')).toBeInTheDocument();
+      expect(screen.getByLabelText('Threshold 85')).toBeInTheDocument();
+    });
+
     it('should render labels including neutral', () => {
       render(<RadialGaugeExample showScaleLabels neutral={50} />);
 

--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
@@ -249,7 +249,6 @@ export function RadialGauge(props: RadialGaugeProps) {
               theme={theme}
               dimensions={dimensions}
               startAngle={startAngle}
-              endAngle={endAngle}
               neutral={neutral}
             />
           );

--- a/packages/grafana-ui/src/components/RadialGauge/RadialScaleLabels.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialScaleLabels.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useId, useMemo } from 'react';
 
 import { FieldDisplay, GrafanaTheme2, Threshold, ThresholdsMode } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -6,7 +6,7 @@ import { t } from '@grafana/i18n';
 import { measureText } from '../../utils/measureText';
 
 import { RadialGaugeDimensions } from './types';
-import { getFieldConfigMinMax, toCartesian } from './utils';
+import { getFieldConfigMinMax, toRad } from './utils';
 
 interface RadialScaleLabelsProps {
   fieldDisplay: FieldDisplay;
@@ -23,7 +23,7 @@ interface RadialScaleLabelsProps {
 interface RadialScaleLabel {
   value: number;
   labelValue?: string;
-  pos: { x: number; y: number; transform: string };
+  startOffset: number;
   label: string;
 }
 
@@ -41,11 +41,10 @@ export const RadialScaleLabels = memo(
     theme,
     dimensions,
     startAngle,
-    endAngle,
     angleRange,
     neutral: rawNeutral,
   }: RadialScaleLabelsProps) => {
-    const { centerX, centerY, scaleLabelsFontSize, scaleLabelsRadius } = dimensions;
+    const { centerX, centerY, scaleLabelsFontSize, scaleLabelsRadius, barWidth } = dimensions;
     const [min, max] = getFieldConfigMinMax(fieldDisplay);
     const thresholds = rawThresholds.filter(
       (threshold) =>
@@ -67,38 +66,63 @@ export const RadialScaleLabels = memo(
     const textLineHeight = scaleLabelsFontSize * LINE_HEIGHT_FACTOR;
     const radius = scaleLabelsRadius - textLineHeight;
 
+    const pathId = useId();
+    const labelsPath = useMemo(() => {
+      let endAngle = angleRange;
+      if (endAngle >= 360) {
+        endAngle = 359.99;
+      }
+      const startRadians = toRad(startAngle);
+      const endRadians = toRad(startAngle + endAngle);
+      const largeArc = endAngle > 180 ? 1 : 0;
+      const x1 = centerX + radius * Math.cos(startRadians);
+      const y1 = centerY + radius * Math.sin(startRadians);
+      const x2 = centerX + radius * Math.cos(endRadians);
+      const y2 = centerY + radius * Math.sin(endRadians);
+      return `M ${x1} ${y1} A ${radius} ${radius} 0 ${largeArc} 1 ${x2} ${y2}`;
+    }, [centerX, centerY, radius, startAngle, angleRange]);
+
+    const pathLength = (angleRange / 360) * 2 * Math.PI * radius;
+
+    // For full circle, add extra space for labels near the top (12 o'clock) to avoid crowding
+    const isFullCircle = angleRange >= 360;
+
     const minLabelValue = allValues.reduce((min, value) => Math.min(value, min), allValues[0]);
     const maxLabelValue = allValues.reduce((max, value) => Math.max(value, max), allValues[0]);
 
-    function getTextPosition(text: string, value: number) {
+    function getStartOffset(text: string, value: number): number {
       const isLast = value === maxLabelValue;
       const isFirst = value === minLabelValue;
 
-      let valueDeg = ((value - min) / (max - min)) * angleRange;
-      let finalAngle = startAngle + valueDeg;
+      const fraction = (value - min) / (max - min);
+      let offset = fraction * pathLength;
 
-      // Now adjust the final angle based on the label text width and the labels position on the arc
-      let measure = measureText(text, fontSize, theme.typography.fontWeightMedium);
-      let textWidthAngle = (measure.width / (2 * Math.PI * radius)) * angleRange;
+      const measure = measureText(text, fontSize, theme.typography.fontWeightMedium);
 
-      // the centering is different for gauge or circle shapes for some reason
-      finalAngle -= endAngle < 180 ? textWidthAngle : textWidthAngle / 2;
-
-      // For circle gauges we need to shift the first label more
-      if (isFirst) {
-        finalAngle += textWidthAngle;
+      // labels at the beginning and end of the path need to be adjusted to avoid clipping
+      if (isFullCircle) {
+        // For full circle: nudge labels near the top at the end of the circle
+        // counter-clockwise along the path to create extra space at 12 o'clock
+        const padding = measure.width / 1.5;
+        if (isFirst) {
+          offset += padding;
+        } else if (isLast) {
+          offset -= padding;
+        }
+      } else {
+        const halfWidth = measure.width / 2;
+        // for non-circle, avoid clipping the bottom:
+        // keep first label's start at least halfWidth from path start
+        if (isFirst && offset - halfWidth < 0) {
+          offset += halfWidth;
+        }
+        // Keep last label's end at least halfWidth before path end
+        if (isLast && offset + halfWidth > pathLength) {
+          offset -= halfWidth;
+        }
       }
 
-      // Remove a bit of the angle for the last label to avoid clipping.
-      // for circles, we shift it over the entire width of the label.
-      // for arcs, we shift by half the label width.
-      if (isLast) {
-        finalAngle -= endAngle === 360 ? textWidthAngle : textWidthAngle / 2;
-      }
-
-      const position = toCartesian(centerX, centerY, radius, finalAngle);
-
-      return { ...position, transform: `rotate(${finalAngle}, ${position.x}, ${position.y})` };
+      return offset;
     }
 
     const labels: RadialScaleLabel[] = thresholds.map((threshold) => {
@@ -107,7 +131,7 @@ export const RadialScaleLabels = memo(
       return {
         value: resolvedValue,
         labelValue: labelText,
-        pos: getTextPosition(labelText, resolvedValue),
+        startOffset: getStartOffset(labelText, resolvedValue),
         label: t(`gauge.threshold`, 'Threshold {{value}}', { value: labelText }),
       };
     });
@@ -115,24 +139,27 @@ export const RadialScaleLabels = memo(
     if (neutral !== undefined) {
       labels.push({
         value: neutral,
-        pos: getTextPosition(String(neutral), neutral),
+        startOffset: getStartOffset(String(neutral), neutral),
         label: t(`gauge.neutral`, 'Neutral {{value}}', { value: neutral }),
       });
     }
 
     return (
       <g>
+        <defs>
+          <path id={pathId} d={labelsPath} fill="none" strokeWidth={barWidth} />
+        </defs>
         {labels.map((label) => (
           <text
             key={label.label}
-            x={label.pos.x}
-            y={label.pos.y}
             fontSize={fontSize}
             fill={theme.colors.text.primary}
-            transform={label.pos.transform}
+            textAnchor="middle"
             aria-label={label.label}
           >
-            {label.labelValue ?? label.value}
+            <textPath href={`#${pathId}`} startOffset={label.startOffset}>
+              {label.labelValue ?? label.value}
+            </textPath>
           </text>
         ))}
       </g>

--- a/packages/grafana-ui/src/components/RadialGauge/RadialScaleLabels.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialScaleLabels.tsx
@@ -6,7 +6,7 @@ import { t } from '@grafana/i18n';
 import { measureText } from '../../utils/measureText';
 
 import { RadialGaugeDimensions } from './types';
-import { getFieldConfigMinMax, toRad } from './utils';
+import { getFieldConfigMinMax, drawRadialArcPath } from './utils';
 
 interface RadialScaleLabelsProps {
   fieldDisplay: FieldDisplay;
@@ -67,20 +67,10 @@ export const RadialScaleLabels = memo(
     const radius = scaleLabelsRadius - textLineHeight;
 
     const pathId = useId();
-    const labelsPath = useMemo(() => {
-      let endAngle = angleRange;
-      if (endAngle >= 360) {
-        endAngle = 359.99;
-      }
-      const startRadians = toRad(startAngle);
-      const endRadians = toRad(startAngle + endAngle);
-      const largeArc = endAngle > 180 ? 1 : 0;
-      const x1 = centerX + radius * Math.cos(startRadians);
-      const y1 = centerY + radius * Math.sin(startRadians);
-      const x2 = centerX + radius * Math.cos(endRadians);
-      const y2 = centerY + radius * Math.sin(endRadians);
-      return `M ${x1} ${y1} A ${radius} ${radius} 0 ${largeArc} 1 ${x2} ${y2}`;
-    }, [centerX, centerY, radius, startAngle, angleRange]);
+    const labelsPath = useMemo(
+      () => drawRadialArcPath(startAngle, angleRange, radius, centerX, centerY),
+      [centerX, centerY, radius, startAngle, angleRange]
+    );
 
     const pathLength = (angleRange / 360) * 2 * Math.PI * radius;
 

--- a/packages/grafana-ui/src/components/RadialGauge/RadialScaleLabels.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialScaleLabels.tsx
@@ -15,7 +15,6 @@ interface RadialScaleLabelsProps {
   thresholdsMode: ThresholdsMode;
   dimensions: RadialGaugeDimensions;
   startAngle: number;
-  endAngle: number;
   angleRange: number;
   neutral?: number;
 }
@@ -88,14 +87,15 @@ export const RadialScaleLabels = memo(
       if (isFullCircle) {
         // For full circle: nudge labels near the top at the end of the circle
         // counter-clockwise along the path to create extra space at 12 o'clock
-        const padding = measure.width / 1.5;
+        const paddingFactor = 0.375; // 3/8 of the label width - a bit of trial-and-error showed this was a good value to use.
+        const padding = measure.width * paddingFactor;
         if (isFirst) {
           offset += padding;
         } else if (isLast) {
           offset -= padding;
         }
       } else {
-        const halfWidth = measure.width / 2;
+        const halfWidth = measure.width * 0.5;
         // for non-circle, avoid clipping the bottom:
         // keep first label's start at least halfWidth from path start
         if (isFirst && offset - halfWidth < 0) {

--- a/packages/grafana-ui/src/components/RadialGauge/RadialScaleLabels.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialScaleLabels.tsx
@@ -1,4 +1,4 @@
-import { memo, useId, useMemo } from 'react';
+import { memo, useId } from 'react';
 
 import { FieldDisplay, GrafanaTheme2, Threshold, ThresholdsMode } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -44,6 +44,8 @@ export const RadialScaleLabels = memo(
     angleRange,
     neutral: rawNeutral,
   }: RadialScaleLabelsProps) => {
+    const pathId = useId();
+
     const { centerX, centerY, scaleLabelsFontSize, scaleLabelsRadius, barWidth } = dimensions;
     const [min, max] = getFieldConfigMinMax(fieldDisplay);
     const thresholds = rawThresholds.filter(
@@ -65,16 +67,9 @@ export const RadialScaleLabels = memo(
     const fontSize = scaleLabelsFontSize;
     const textLineHeight = scaleLabelsFontSize * LINE_HEIGHT_FACTOR;
     const radius = scaleLabelsRadius - textLineHeight;
-
-    const pathId = useId();
-    const labelsPath = useMemo(
-      () => drawRadialArcPath(startAngle, angleRange, radius, centerX, centerY),
-      [centerX, centerY, radius, startAngle, angleRange]
-    );
-
+    const labelsPath = drawRadialArcPath(startAngle, angleRange, radius, centerX, centerY);
     const pathLength = (angleRange / 360) * 2 * Math.PI * radius;
 
-    // For full circle, add extra space for labels near the top (12 o'clock) to avoid crowding
     const isFullCircle = angleRange >= 360;
 
     const minLabelValue = allValues.reduce((min, value) => Math.min(value, min), allValues[0]);

--- a/packages/grafana-ui/src/components/RadialGauge/__snapshots__/utils.test.ts.snap
+++ b/packages/grafana-ui/src/components/RadialGauge/__snapshots__/utils.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RadialGauge utils drawRadialArcPath should draw correct path for full circle 1`] = `"M 0 -80 A 80 80 0 1 1 -0.01 -80"`;
+
 exports[`RadialGauge utils drawRadialArcPath should draw correct path for half arc 1`] = `"M 0 -80 A 80 80 0 0 1 0 80"`;
 
 exports[`RadialGauge utils drawRadialArcPath should draw correct path for narrow radius 1`] = `"M 0 -50 A 50 50 0 0 1 0 50"`;

--- a/packages/grafana-ui/src/components/RadialGauge/__snapshots__/utils.test.ts.snap
+++ b/packages/grafana-ui/src/components/RadialGauge/__snapshots__/utils.test.ts.snap
@@ -7,3 +7,5 @@ exports[`RadialGauge utils drawRadialArcPath should draw correct path for narrow
 exports[`RadialGauge utils drawRadialArcPath should draw correct path for quarter arc 1`] = `"M 0 -80 A 80 80 0 0 1 80 0"`;
 
 exports[`RadialGauge utils drawRadialArcPath should draw correct path for three quarter arc 1`] = `"M 0 -80 A 80 80 0 1 1 -80 0"`;
+
+exports[`RadialGauge utils drawRadialArcPath should draw correct path for with offset 1`] = `"M 80 0 A 80 80 0 0 1 160 80"`;

--- a/packages/grafana-ui/src/components/RadialGauge/utils.test.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.test.ts
@@ -341,6 +341,7 @@ describe('RadialGauge utils', () => {
       { description: 'quarter arc', startAngle: 0, endAngle: 90 },
       { description: 'half arc', startAngle: 0, endAngle: 180 },
       { description: 'three quarter arc', startAngle: 0, endAngle: 270 },
+      { description: 'full circle', startAngle: 0, endAngle: 360 },
       { description: 'narrow radius', startAngle: 0, endAngle: 180, radius: 50 },
       { description: 'with offset', startAngle: 0, endAngle: 90, xOffset: 80, yOffset: 80 },
     ])(`should draw correct path for $description`, ({ startAngle, endAngle, radius = 80, xOffset, yOffset }) => {

--- a/packages/grafana-ui/src/components/RadialGauge/utils.test.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.test.ts
@@ -342,8 +342,9 @@ describe('RadialGauge utils', () => {
       { description: 'half arc', startAngle: 0, endAngle: 180 },
       { description: 'three quarter arc', startAngle: 0, endAngle: 270 },
       { description: 'narrow radius', startAngle: 0, endAngle: 180, radius: 50 },
-    ])(`should draw correct path for $description`, ({ startAngle, endAngle, radius = 80 }) => {
-      const path = drawRadialArcPath(startAngle, endAngle, radius);
+      { description: 'with offset', startAngle: 0, endAngle: 90, xOffset: 80, yOffset: 80 },
+    ])(`should draw correct path for $description`, ({ startAngle, endAngle, radius = 80, xOffset, yOffset }) => {
+      const path = drawRadialArcPath(startAngle, endAngle, radius, xOffset, yOffset);
       expect(path).toMatchSnapshot();
     });
 

--- a/packages/grafana-ui/src/components/RadialGauge/utils.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.ts
@@ -211,7 +211,13 @@ export function toCartesian(centerX: number, centerY: number, radius: number, an
   };
 }
 
-export function drawRadialArcPath(startAngle: number, endAngle: number, radius: number): string {
+export function drawRadialArcPath(
+  startAngle: number,
+  endAngle: number,
+  radius: number,
+  xOffset = 0,
+  yOffset = 0
+): string {
   // For some reason a 100% full arc cannot be rendered
   if (endAngle >= 360) {
     endAngle = 359.99;
@@ -224,10 +230,10 @@ export function drawRadialArcPath(startAngle: number, endAngle: number, radius: 
 
   const MAX_DECIMALS = 2;
 
-  const x1 = parseFloat((radius * Math.cos(startRadians)).toFixed(MAX_DECIMALS));
-  const y1 = parseFloat((radius * Math.sin(startRadians)).toFixed(MAX_DECIMALS));
-  const x2 = parseFloat((radius * Math.cos(endRadians)).toFixed(MAX_DECIMALS));
-  const y2 = parseFloat((radius * Math.sin(endRadians)).toFixed(MAX_DECIMALS));
+  const x1 = xOffset + parseFloat((radius * Math.cos(startRadians)).toFixed(MAX_DECIMALS));
+  const y1 = yOffset + parseFloat((radius * Math.sin(startRadians)).toFixed(MAX_DECIMALS));
+  const x2 = xOffset + parseFloat((radius * Math.cos(endRadians)).toFixed(MAX_DECIMALS));
+  const y2 = yOffset + parseFloat((radius * Math.sin(endRadians)).toFixed(MAX_DECIMALS));
 
   return `M ${x1} ${y1} A ${radius} ${radius} 0 ${largeArc} 1 ${x2} ${y2}`;
 }


### PR DESCRIPTION
From internal feedback on the new gauge. This updates the radial text to use the `textPath` svg element along the circular path

### Before
<img width="686" height="357" alt="Screenshot 2026-03-05 at 4 56 16 PM" src="https://github.com/user-attachments/assets/87603cd4-6204-475e-9373-9f124896766b" />
<img width="688" height="357" alt="Screenshot 2026-03-05 at 4 56 29 PM" src="https://github.com/user-attachments/assets/508d9015-175b-4d43-98e4-2f43c45e5805" />

### After
<img width="684" height="357" alt="Screenshot 2026-03-05 at 4 57 00 PM" src="https://github.com/user-attachments/assets/d4a12603-681c-4cf0-8581-dfd0836ee58c" />
<img width="690" height="369" alt="Screenshot 2026-03-05 at 4 55 43 PM" src="https://github.com/user-attachments/assets/204a98c9-ac48-4233-b239-1083a3d09398" />
