### PR TITLE
fix(explore): guard against empty transformer output

### DIFF
--- a/public/app/features/explore/utils/decorators.test.ts
+++ b/public/app/features/explore/utils/decorators.test.ts
@@ -22,6 +22,7 @@ import {
   decorateWithFrameTypeMetadata,
   decorateWithGraphResult,
   decorateWithLogsResult,
+  decorateWithRawPrometheusResult,
   decorateWithTableResult,
 } from './decorators';
 
@@ -333,6 +334,46 @@ describe('decorateWithTableResult', () => {
     const panelData = createExplorePanelData({ error: {}, tableFrames: [table, emptyTable] });
     const panelResult = await lastValueFrom(decorateWithTableResult(panelData));
     expect(panelResult.tableResult).not.toBeNull();
+  });
+});
+
+describe('decorateWithRawPrometheusResult', () => {
+  it('returns null when passed empty rawPrometheusFrames', async () => {
+    const panelData = createExplorePanelData({ rawPrometheusFrames: [] });
+    const panelResult = await lastValueFrom(decorateWithRawPrometheusResult(panelData));
+    expect(panelResult.rawPrometheusResult).toBeNull();
+  });
+
+  it('processes rawPrometheusFrames and sets display processor', async () => {
+    const rawFrame = toDataFrame({
+      name: 'raw',
+      refId: 'A',
+      meta: { preferredVisualisationType: 'rawPrometheus' },
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [100, 200, 300] },
+        { name: 'value', type: FieldType.number, values: [1, 2, 3] },
+      ],
+    });
+    const panelData = createExplorePanelData({ rawPrometheusFrames: [rawFrame] });
+    const panelResult = await lastValueFrom(decorateWithRawPrometheusResult(panelData));
+    expect(panelResult.rawPrometheusResult).not.toBeNull();
+    expect(panelResult.rawPrometheusResult?.fields[0].display).toBeDefined();
+  });
+
+  it('processes non-timeseries rawPrometheusFrames via mergeTransformer', async () => {
+    const nonTimeseriesFrame = toDataFrame({
+      name: 'raw-non-ts',
+      refId: 'A',
+      meta: { preferredVisualisationType: 'rawPrometheus' },
+      fields: [
+        { name: 'label', type: FieldType.string, values: ['instance1', 'instance2'] },
+        { name: 'value', type: FieldType.number, values: [10, 20] },
+      ],
+    });
+    const panelData = createExplorePanelData({ rawPrometheusFrames: [nonTimeseriesFrame] });
+    const panelResult = await lastValueFrom(decorateWithRawPrometheusResult(panelData));
+    expect(panelResult.rawPrometheusResult).not.toBeNull();
+    expect(panelResult.rawPrometheusResult?.fields[0].display).toBeDefined();
   });
 });
 

--- a/public/app/features/explore/utils/decorators.ts
+++ b/public/app/features/explore/utils/decorators.ts
@@ -244,6 +244,10 @@ export const decorateWithRawPrometheusResult = (data: ExplorePanelData): Observa
 
   return transformer.pipe(
     map((frames) => {
+      if (!frames || frames.length === 0) {
+        return { ...data, rawPrometheusResult: null };
+      }
+
       const frame = frames[0];
 
       // set display processor


### PR DESCRIPTION
**What is this feature?**

Bug fix. Guards against a `TypeError` crash in `decorateWithRawPrometheusResult` when the join/merge transformer returns an empty frames array.

**Why do we need this feature?**

Clicking the Table toggle in Explore for certain Prometheus queries throws `TypeError: undefined is not an object (evaluating 'Nt.id')`. The decorator called `frames[0]` unconditionally after running frames through `joinByFieldTransformer` or `mergeTransformer`. When the transformer returns `[]` (e.g. no common join field across frames), `frames[0]` is `undefined` and the subsequent field iteration crashes.

**Who is this feature for?**

Explore users querying Prometheus with instant queries that return frames the join transformer can't merge.

**Which issue(s) does this PR fix?**:

Fixes #119657

**Special notes for your reviewer:**

- One-line guard added at `decorators.ts:247` — returns `rawPrometheusResult: null` when transformer output is empty.
- Tests added for `decorateWithRawPrometheusResult`: empty frames early-return, timeseries path (joinByFieldTransformer), and non-timeseries path (mergeTransformer).
- The exact condition that triggers the guard (transformer returning `[]` for non-empty input) requires mocking the transformer to reproduce in unit tests; not added to avoid over-engineering.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.
