### PR TITLE
Matchers, Transforms: Ensure labels are connected to some fields for a11y and e2es

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2866,11 +2866,6 @@
       "count": 1
     }
   },
-  "public/app/features/transformers/editors/GroupToNestedTableTransformerEditor.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "public/app/features/transformers/editors/ReduceTransformerEditor.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1

--- a/packages/grafana-ui/src/components/MatchersUI/FieldNameByRegexMatcherEditor.tsx
+++ b/packages/grafana-ui/src/components/MatchersUI/FieldNameByRegexMatcherEditor.tsx
@@ -9,7 +9,7 @@ import { Input } from '../Input/Input';
 import { MatcherUIProps, FieldMatcherUIRegistryItem } from './types';
 
 export const FieldNameByRegexMatcherEditor = memo<MatcherUIProps<string>>((props) => {
-  const { options, onChange } = props;
+  const { id, options, onChange } = props;
 
   const onBlur = useCallback(
     (e: React.FocusEvent<HTMLInputElement>) => {
@@ -20,6 +20,7 @@ export const FieldNameByRegexMatcherEditor = memo<MatcherUIProps<string>>((props
 
   return (
     <Input
+      id={id}
       placeholder={t('grafana-ui.field-name-by-regex-matcher.input-placeholder', 'Enter regular expression')}
       defaultValue={options}
       onBlur={onBlur}

--- a/packages/grafana-ui/src/components/MatchersUI/FieldNamesMatcherEditor.tsx
+++ b/packages/grafana-ui/src/components/MatchersUI/FieldNamesMatcherEditor.tsx
@@ -10,7 +10,7 @@ import { MatcherUIProps, FieldMatcherUIRegistryItem } from './types';
 import { useFieldDisplayNames, useSelectOptions, frameHasName } from './utils';
 
 export const FieldNamesMatcherEditor = memo<MatcherUIProps<ByNamesMatcherOptions>>((props) => {
-  const { data, options, onChange: onChangeFromProps } = props;
+  const { id, data, options, onChange: onChangeFromProps } = props;
   const { readOnly, prefix } = options;
   const names = useFieldDisplayNames(data);
   const selectOptions = useSelectOptions(names, undefined);
@@ -37,10 +37,10 @@ export const FieldNamesMatcherEditor = memo<MatcherUIProps<ByNamesMatcherOptions
 
   if (readOnly) {
     const displayNames = (options.names ?? []).join(', ');
-    return <Input value={displayNames} readOnly={true} disabled={true} prefix={prefix} />;
+    return <Input id={id} value={displayNames} readOnly={true} disabled={true} prefix={prefix} />;
   }
 
-  return <MultiSelect value={options.names} options={selectOptions} onChange={onChange} />;
+  return <MultiSelect inputId={id} value={options.names} options={selectOptions} onChange={onChange} />;
 });
 FieldNamesMatcherEditor.displayName = 'FieldNameMatcherEditor';
 

--- a/packages/grafana-ui/src/components/MatchersUI/FieldValueMatcher.tsx
+++ b/packages/grafana-ui/src/components/MatchersUI/FieldValueMatcher.tsx
@@ -36,7 +36,7 @@ function isBooleanReducer(r: ReducerID) {
   return r === ReducerID.allIsNull || r === ReducerID.allIsZero;
 }
 
-export const FieldValueMatcherEditor = ({ options, onChange }: Props) => {
+export const FieldValueMatcherEditor = ({ id, options, onChange }: Props) => {
   const styles = useStyles2(getStyles);
   const reducer = useMemo(() => fieldReducers.selectOptions([options?.reducer]), [options?.reducer]);
 
@@ -68,6 +68,7 @@ export const FieldValueMatcherEditor = ({ options, onChange }: Props) => {
   return (
     <div className={styles.spot}>
       <Select
+        inputId={id}
         value={reducer.current}
         options={reducer.options}
         onChange={onSetReducer}
@@ -83,7 +84,12 @@ export const FieldValueMatcherEditor = ({ options, onChange }: Props) => {
             width={19}
           />
 
-          <Input type="number" value={opts.value} onChange={onChangeValue} />
+          <Input
+            type="number"
+            value={opts.value}
+            aria-label={t('grafana-ui.field-value-matcher.reducer-value-label', 'Reducer value')}
+            onChange={onChangeValue}
+          />
         </>
       )}
     </div>

--- a/packages/grafana-ui/src/components/MatchersUI/FieldsByFrameRefIdMatcher.tsx
+++ b/packages/grafana-ui/src/components/MatchersUI/FieldsByFrameRefIdMatcher.tsx
@@ -234,7 +234,7 @@ function getFramesDescription(frames: DataFrame[]): string {
 export const getFieldsByFrameRefIdItem: () => FieldMatcherUIRegistryItem<string> = () => ({
   id: FieldMatcherID.byFrameRefID,
   component: (props: MatcherUIProps<string>) => {
-    return <RefIDPicker value={props.options} data={props.data} onChange={props.onChange} />;
+    return <RefIDPicker id={props.id} value={props.options} data={props.data} onChange={props.onChange} />;
   },
   matcher: fieldMatchers.get(FieldMatcherID.byFrameRefID),
   name: t('grafana-ui.matchers-ui.name-fields-by-query', 'Fields returned by query'),

--- a/public/app/features/transformers/configFromQuery/ConfigFromQueryTransformerEditor.tsx
+++ b/public/app/features/transformers/configFromQuery/ConfigFromQueryTransformerEditor.tsx
@@ -79,6 +79,7 @@ export function ConfigFromQueryTransformerEditor({ input, onChange, options }: P
           className={styles.matcherOptions}
         >
           <matcherUI.component
+            id={matcherUI.id}
             matcher={matcherUI.matcher}
             data={input}
             options={currentMatcher.options}

--- a/public/app/features/transformers/editors/GroupToNestedTableTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupToNestedTableTransformerEditor.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useCallback } from 'react';
+import { useCallback, useId } from 'react';
 
 import {
   DataTransformerID,
@@ -89,7 +89,7 @@ export const GroupToNestedTableTransformerEditor = ({
   const showCalcAlert = hasAggregation && !hasGrouping;
 
   return (
-    <Stack direction="column">
+    <Stack gap={1} direction="column">
       {showCalcAlert && (
         <Alert
           title={t(
@@ -118,6 +118,7 @@ export const GroupToNestedTableTransformerEditor = ({
           'transformers.group-to-nested-table-transformer-editor.description-show-field-names',
           'If enabled nested tables will show field names as a table header'
         )}
+        noMargin
       >
         <Switch value={showHeaders} onChange={onShowFieldNamesChange} />
       </Field>
@@ -128,6 +129,7 @@ export const GroupToNestedTableTransformerEditor = ({
 export const GroupByFieldConfiguration = ({ fieldName, config, onConfigChange }: FieldProps) => {
   const theme = useTheme2();
   const styles = getStyles(theme);
+  const id = useId();
   const onChange = useCallback(
     (value: SelectableValue<GroupByOperationID | null>) => {
       onConfigChange({
@@ -150,10 +152,11 @@ export const GroupByFieldConfiguration = ({ fieldName, config, onConfigChange }:
   ];
 
   return (
-    <InlineField className={styles.label} label={fieldName} grow shrink>
+    <InlineField className={styles.label} label={fieldName} grow shrink htmlFor={id}>
       <Stack gap={0.5} direction="row" wrap={false}>
         <div className={styles.operation}>
           <Select
+            inputId={id}
             options={options}
             value={config?.operation}
             placeholder={t('transformers.group-by-field-configuration.placeholder-ignored', 'Ignored')}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9819,6 +9819,7 @@
     },
     "field-value-matcher": {
       "operator-label": "Comparison operator",
+      "reducer-value-label": "Reducer value",
       "select-field-placeholder": "Select field reducer"
     },
     "file-dropzone": {


### PR DESCRIPTION
These changes were made in the context of #117047, where we needed labels to be properly connected with the fields they represent for e2e tests to work correctly. These changes also just make sense from an a11y perspective.

To test: I think clicking the label and seeing the field get focused is a good test for these label hookups. If you click all 6 of these in main, they don't focus the field.

https://github.com/user-attachments/assets/1cfc9f5d-25df-43ea-bccb-2e70fb50327e