### PR TITLE
Transforms: GroupBy should handle displayName more elegantly

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
@@ -5,7 +5,13 @@ import { mockTransformationsRegistry } from '../../utils/tests/mockTransformatio
 import { ReducerID } from '../fieldReducer';
 import { transformDataFrame } from '../transformDataFrame';
 
-import { GroupByOperationID, groupByTransformer, GroupByTransformerOptions, shouldCalculateField } from './groupBy';
+import {
+  GroupByOperationID,
+  groupByTransformer,
+  GroupByTransformerOptions,
+  groupValuesByKey,
+  shouldCalculateField,
+} from './groupBy';
 import { DataTransformerID } from './ids';
 
 // returns a simple group by / reducer pair
@@ -558,5 +564,26 @@ describe('shouldCalculateField()', () => {
       fields: { testField: { aggregations, operation } },
     };
     expect(shouldCalculateField(field, options)).toBe(expected);
+  });
+});
+
+describe('groupValuesByKey', () => {
+  it('should set the displayName but not the name', () => {
+    const testSeries = toDataFrame({
+      name: 'A',
+      fields: [{ name: 'message', type: FieldType.string, values: ['A', 'A'], config: { displayName: 'MyMessage' } }],
+    });
+
+    const result = groupValuesByKey(testSeries, [testSeries.fields[0]]);
+
+    expect(result.get('A')).toMatchObject({
+      MyMessage: {
+        name: 'message',
+        type: FieldType.string,
+        values: ['A', 'A'],
+        config: expect.objectContaining({ displayName: 'MyMessage' }),
+        state: expect.objectContaining({ displayName: 'MyMessage' }),
+      },
+    });
   });
 });

--- a/packages/grafana-data/src/transformations/transformers/groupBy.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.ts
@@ -185,9 +185,10 @@ export function groupValuesByKey(frame: DataFrame, groupByFields: Field[]) {
 
       if (!valuesByField[fieldName]) {
         valuesByField[fieldName] = {
-          name: fieldName,
+          name: field.name,
           type: field.type,
-          config: { ...field.config },
+          config: { ...field.config, displayName: fieldName },
+          state: { ...field.state, displayName: fieldName },
           values: [],
         };
       }

--- a/packages/grafana-data/src/transformations/transformers/groupToNestedTable.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupToNestedTable.test.ts
@@ -55,8 +55,30 @@ describe('GroupToSubframe transformer', () => {
                 meta: { custom: { noHeader: false } },
                 length: 1,
                 fields: [
-                  { name: 'time', type: 'time', config: {}, values: [3000] },
-                  { name: 'values', type: 'string', config: {}, values: [1] },
+                  {
+                    name: 'time',
+                    type: 'time',
+                    config: {
+                      displayName: 'time',
+                    },
+                    state: {
+                      displayName: 'time',
+                      multipleFrames: false,
+                    },
+                    values: [3000],
+                  },
+                  {
+                    name: 'values',
+                    type: 'string',
+                    config: {
+                      displayName: 'values',
+                    },
+                    state: {
+                      displayName: 'values',
+                      multipleFrames: false,
+                    },
+                    values: [1],
+                  },
                 ],
               },
             ],
@@ -68,13 +90,25 @@ describe('GroupToSubframe transformer', () => {
                   {
                     name: 'time',
                     type: 'time',
-                    config: {},
+                    config: {
+                      displayName: 'time',
+                    },
+                    state: {
+                      displayName: 'time',
+                      multipleFrames: false,
+                    },
                     values: [4000, 5000],
                   },
                   {
                     name: 'values',
                     type: 'string',
-                    config: {},
+                    config: {
+                      displayName: 'values',
+                    },
+                    state: {
+                      displayName: 'values',
+                      multipleFrames: false,
+                    },
                     values: [2, 2],
                   },
                 ],
@@ -88,13 +122,25 @@ describe('GroupToSubframe transformer', () => {
                   {
                     name: 'time',
                     type: 'time',
-                    config: {},
+                    config: {
+                      displayName: 'time',
+                    },
+                    state: {
+                      displayName: 'time',
+                      multipleFrames: false,
+                    },
                     values: [6000, 7000, 8000],
                   },
                   {
                     name: 'values',
                     type: 'string',
-                    config: {},
+                    config: {
+                      displayName: 'values',
+                    },
+                    state: {
+                      displayName: 'values',
+                      multipleFrames: false,
+                    },
                     values: [3, 3, 3],
                   },
                 ],
@@ -147,9 +193,9 @@ describe('GroupToSubframe transformer', () => {
         },
         {
           name: 'values (sum)',
-          values: [1, 4, 9],
           type: FieldType.number,
           config: {},
+          values: [1, 4, 9],
         },
         {
           config: {},
@@ -164,19 +210,37 @@ describe('GroupToSubframe transformer', () => {
                   {
                     name: 'time',
                     type: 'time',
-                    config: {},
+                    config: {
+                      displayName: 'time',
+                    },
+                    state: {
+                      displayName: 'time',
+                      multipleFrames: false,
+                    },
                     values: [3000],
                   },
                   {
                     name: 'intVal',
                     type: 'number',
-                    config: {},
+                    config: {
+                      displayName: 'intVal',
+                    },
+                    state: {
+                      displayName: 'intVal',
+                      multipleFrames: false,
+                    },
                     values: [1],
                   },
                   {
                     name: 'floatVal',
                     type: 'number',
-                    config: {},
+                    config: {
+                      displayName: 'floatVal',
+                    },
+                    state: {
+                      displayName: 'floatVal',
+                      multipleFrames: false,
+                    },
                     values: [1.1],
                   },
                 ],
@@ -190,19 +254,37 @@ describe('GroupToSubframe transformer', () => {
                   {
                     name: 'time',
                     type: 'time',
-                    config: {},
+                    config: {
+                      displayName: 'time',
+                    },
+                    state: {
+                      displayName: 'time',
+                      multipleFrames: false,
+                    },
                     values: [4000, 5000],
                   },
                   {
                     name: 'intVal',
                     type: 'number',
-                    config: {},
+                    config: {
+                      displayName: 'intVal',
+                    },
+                    state: {
+                      displayName: 'intVal',
+                      multipleFrames: false,
+                    },
                     values: [2, 3],
                   },
                   {
                     name: 'floatVal',
                     type: 'number',
-                    config: {},
+                    config: {
+                      displayName: 'floatVal',
+                    },
+                    state: {
+                      displayName: 'floatVal',
+                      multipleFrames: false,
+                    },
                     values: [2.3, 3.6],
                   },
                 ],
@@ -216,19 +298,37 @@ describe('GroupToSubframe transformer', () => {
                   {
                     name: 'time',
                     type: 'time',
-                    config: {},
+                    config: {
+                      displayName: 'time',
+                    },
+                    state: {
+                      displayName: 'time',
+                      multipleFrames: false,
+                    },
                     values: [6000, 7000, 8000],
                   },
                   {
                     name: 'intVal',
                     type: 'number',
-                    config: {},
+                    config: {
+                      displayName: 'intVal',
+                    },
+                    state: {
+                      displayName: 'intVal',
+                      multipleFrames: false,
+                    },
                     values: [4, 5, 6],
                   },
                   {
                     name: 'floatVal',
                     type: 'number',
-                    config: {},
+                    config: {
+                      displayName: 'floatVal',
+                    },
+                    state: {
+                      displayName: 'floatVal',
+                      multipleFrames: false,
+                    },
                     values: [4.8, 5.7, 6.9],
                   },
                 ],


### PR DESCRIPTION
This was discovered when putting #117047 together. Without this update, the if a field is renamed during transformations, the matcher which shows the original field name fails to work when a field is created by "Group to nested fields" (which uses "Group by". (I'm talking about the "base field name" thing in the matcher on the right in this screenshot.)

<img width="1717" height="714" alt="Screenshot 2026-03-05 at 7 34 12 PM" src="https://github.com/user-attachments/assets/e9b6af66-2ea5-4807-a4f5-7383a8a73863" />
