### PR TITLE
GlobalRoles: Prevent role refs and permission omittion

### DIFF
--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -871,8 +871,14 @@ func (b *IdentityAccessManagementAPIBuilder) validateCreate(ctx context.Context,
 	case *iamv0.ExternalGroupMapping:
 		return b.externalGroupMappingApiInstaller.ValidateOnCreate(ctx, typedObj)
 	case *iamv0.Role:
+		if err := ValidateRoleSpec(typedObj); err != nil {
+			return err
+		}
 		return b.roleApiInstaller.ValidateOnCreate(ctx, typedObj)
 	case *iamv0.GlobalRole:
+		if err := ValidateGlobalRoleSpec(typedObj); err != nil {
+			return err
+		}
 		return b.globalRoleApiInstaller.ValidateOnCreate(ctx, typedObj)
 	case *iamv0.TeamLBACRule:
 		return b.teamLBACApiInstaller.ValidateOnCreate(ctx, typedObj)
@@ -908,11 +914,17 @@ func (b *IdentityAccessManagementAPIBuilder) validateUpdate(ctx context.Context,
 		if !ok {
 			return fmt.Errorf("expected old object to be a Role, got %T", oldObj)
 		}
+		if err := ValidateRoleSpec(typedObj); err != nil {
+			return err
+		}
 		return b.roleApiInstaller.ValidateOnUpdate(ctx, oldRoleObj, typedObj)
 	case *iamv0.GlobalRole:
 		oldGlobalRoleObj, ok := oldObj.(*iamv0.GlobalRole)
 		if !ok {
 			return fmt.Errorf("expected old object to be a GlobalRole, got %T", oldObj)
+		}
+		if err := ValidateGlobalRoleSpec(typedObj); err != nil {
+			return err
 		}
 		return b.globalRoleApiInstaller.ValidateOnUpdate(ctx, oldGlobalRoleObj, typedObj)
 	case *iamv0.TeamLBACRule:

--- a/pkg/registry/apis/iam/role_spec_validate.go
+++ b/pkg/registry/apis/iam/role_spec_validate.go
@@ -1,0 +1,32 @@
+package iam
+
+import (
+	"fmt"
+	"strings"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+)
+
+// Global roles cannot reference other roles or omit permissions
+func ValidateGlobalRoleSpec(gr *iamv0.GlobalRole) error {
+	if len(gr.Spec.RoleRefs) > 0 {
+		return fmt.Errorf("global roles cannot have roleRefs defined")
+	}
+	if len(gr.Spec.PermissionsOmitted) > 0 {
+		return fmt.Errorf("global roles cannot have permissionsOmitted defined")
+	}
+	return nil
+}
+
+// Role refs may only reference a basic global role
+func ValidateRoleSpec(r *iamv0.Role) error {
+	for _, ref := range r.Spec.RoleRefs {
+		if ref.Kind != string(iamv0.RoleBindingSpecRoleRefKindGlobalRole) {
+			return fmt.Errorf("role refs may only reference a global basic role (kind must be GlobalRole), got kind %q", ref.Kind)
+		}
+		if !strings.HasPrefix(ref.Name, "basic_") {
+			return fmt.Errorf("role refs may only reference a global basic role, got name %q", ref.Name)
+		}
+	}
+	return nil
+}

--- a/pkg/registry/apis/iam/role_spec_validate_test.go
+++ b/pkg/registry/apis/iam/role_spec_validate_test.go
@@ -1,0 +1,167 @@
+package iam
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+)
+
+func TestValidateGlobalRoleSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		gr      *iamv0.GlobalRole
+		wantErr bool
+	}{
+		{
+			name: "no roleRefs allowed",
+			gr: &iamv0.GlobalRole{
+				Spec: iamv0.GlobalRoleSpec{
+					RoleRefs: []iamv0.GlobalRolespecRoleRef{
+						{Kind: "GlobalRole", Name: "basic_viewer"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty roleRefs allowed",
+			gr: &iamv0.GlobalRole{
+				Spec: iamv0.GlobalRoleSpec{
+					RoleRefs: []iamv0.GlobalRolespecRoleRef{},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "nil roleRefs allowed",
+			gr: &iamv0.GlobalRole{
+				Spec: iamv0.GlobalRoleSpec{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "permissionsOmitted not allowed",
+			gr: &iamv0.GlobalRole{
+				Spec: iamv0.GlobalRoleSpec{
+					PermissionsOmitted: []iamv0.GlobalRolespecPermission{
+						{Action: "dashboards:read", Scope: "dashboards:*"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty permissionsOmitted allowed",
+			gr: &iamv0.GlobalRole{
+				Spec: iamv0.GlobalRoleSpec{
+					PermissionsOmitted: []iamv0.GlobalRolespecPermission{},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateGlobalRoleSpec(tt.gr)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateRoleSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		r       *iamv0.Role
+		wantErr bool
+	}{
+		{
+			name: "no roleRefs allowed",
+			r: &iamv0.Role{
+				Spec: iamv0.RoleSpec{
+					RoleRefs: nil,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty roleRefs allowed",
+			r: &iamv0.Role{
+				Spec: iamv0.RoleSpec{
+					RoleRefs: []iamv0.RolespecRoleRef{},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "GlobalRole Viewer allowed",
+			r: &iamv0.Role{
+				Spec: iamv0.RoleSpec{
+					RoleRefs: []iamv0.RolespecRoleRef{
+						{Kind: "GlobalRole", Name: "basic_viewer"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "GlobalRole Editor allowed",
+			r: &iamv0.Role{
+				Spec: iamv0.RoleSpec{
+					RoleRefs: []iamv0.RolespecRoleRef{
+						{Kind: "GlobalRole", Name: "basic_editor"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Role kind not allowed",
+			r: &iamv0.Role{
+				Spec: iamv0.RoleSpec{
+					RoleRefs: []iamv0.RolespecRoleRef{
+						{Kind: "Role", Name: "custom-role"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "CoreRole kind not allowed",
+			r: &iamv0.Role{
+				Spec: iamv0.RoleSpec{
+					RoleRefs: []iamv0.RolespecRoleRef{
+						{Kind: "CoreRole", Name: "Viewer"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-basic role name not allowed",
+			r: &iamv0.Role{
+				Spec: iamv0.RoleSpec{
+					RoleRefs: []iamv0.RolespecRoleRef{
+						{Kind: "GlobalRole", Name: "CustomRole"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRoleSpec(tt.r)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
This PR prevents GlobalRoles from being created with role refs or omitted permissions. 

It also prevents Roles from referencing anything other than basic global roles for now.

Closes https://github.com/grafana/identity-access-team/issues/1958