### PR TITLE
Prometheus: Respect datasource httpMethod for resource API requests

### DIFF
--- a/pkg/promlib/client/client.go
+++ b/pkg/promlib/client/client.go
@@ -102,9 +102,38 @@ func (c *Client) QueryResource(ctx context.Context, req *backend.CallResourceReq
 	}
 	u.RawQuery = reqUrlParsed.RawQuery
 
-	// We use method from the request, as for resources front end may do a fallback to GET if POST does not work
-	// nad we want to respect that.
-	httpRequest, err := createRequest(ctx, req.Method, u, bytes.NewReader(req.Body))
+	// Use the datasource's configured HTTP method rather than the incoming request method.
+	// External API clients (e.g. mcp-grafana's prometheus/client_golang) always send POST,
+	// which fails for GET-configured datasources. Using c.method ensures the request matches
+	// what the upstream Prometheus server expects.
+	// If the incoming request is GET (e.g. frontend fallback), always respect that regardless
+	// of the configured method, since GET is universally accepted by Prometheus.
+	method := c.method
+	if req.Method == http.MethodGet {
+		method = http.MethodGet
+	}
+
+	var body io.Reader
+	if strings.ToUpper(method) == http.MethodGet {
+		// For GET requests, move any body params to query string
+		if len(req.Body) > 0 {
+			bodyParams, parseErr := url.ParseQuery(string(req.Body))
+			if parseErr == nil {
+				existingQuery := u.Query()
+				for k, vs := range bodyParams {
+					for _, v := range vs {
+						existingQuery.Add(k, v)
+					}
+				}
+				u.RawQuery = existingQuery.Encode()
+			}
+		}
+		body = http.NoBody
+	} else {
+		body = bytes.NewReader(req.Body)
+	}
+
+	httpRequest, err := createRequest(ctx, method, u, body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/promlib/client/client_test.go
+++ b/pkg/promlib/client/client_test.go
@@ -28,17 +28,16 @@ func (doer *MockDoer) Do(req *http.Request) (*http.Response, error) {
 
 func TestClient(t *testing.T) {
 	t.Run("QueryResource", func(t *testing.T) {
-		doer := &MockDoer{}
-		// The method here does not really matter for resource calls
-		client := NewClient(doer, http.MethodGet, "http://localhost:9090", "60s")
+		t.Run("POST-configured client forwards POST request as POST", func(t *testing.T) {
+			doer := &MockDoer{}
+			client := NewClient(doer, http.MethodPost, "http://localhost:9090", "60s")
 
-		t.Run("sends correct POST request", func(t *testing.T) {
 			req := &backend.CallResourceRequest{
 				PluginContext: backend.PluginContext{},
 				Path:          "/api/v1/series",
 				Method:        http.MethodPost,
 				URL:           "/api/v1/series",
-				Body:          []byte("match%5B%5D: ALERTS\nstart: 1655271408\nend: 1655293008"),
+				Body:          []byte("match%5B%5D=ALERTS&start=1655271408&end=1655293008"),
 			}
 			res, err := client.QueryResource(context.Background(), req)
 			defer func() {
@@ -53,11 +52,40 @@ func TestClient(t *testing.T) {
 			require.Equal(t, http.MethodPost, doer.Req.Method)
 			body, err := io.ReadAll(doer.Req.Body)
 			require.NoError(t, err)
-			require.Equal(t, []byte("match%5B%5D: ALERTS\nstart: 1655271408\nend: 1655293008"), body)
+			require.Equal(t, "match%5B%5D=ALERTS&start=1655271408&end=1655293008", string(body))
 			require.Equal(t, "http://localhost:9090/api/v1/series", doer.Req.URL.String())
 		})
 
-		t.Run("sends correct GET request", func(t *testing.T) {
+		t.Run("GET-configured client converts incoming POST to GET", func(t *testing.T) {
+			doer := &MockDoer{}
+			client := NewClient(doer, http.MethodGet, "http://localhost:9090", "60s")
+
+			req := &backend.CallResourceRequest{
+				PluginContext: backend.PluginContext{},
+				Path:          "/api/v1/query",
+				Method:        http.MethodPost,
+				URL:           "/api/v1/query",
+				Body:          []byte("query=up&time=1234567890"),
+			}
+			res, err := client.QueryResource(context.Background(), req)
+			defer func() {
+				if res != nil && res.Body != nil {
+					if err := res.Body.Close(); err != nil {
+						fmt.Println("Error", "err", err)
+					}
+				}
+			}()
+			require.NoError(t, err)
+			require.NotNil(t, doer.Req)
+			require.Equal(t, http.MethodGet, doer.Req.Method)
+			require.Contains(t, doer.Req.URL.RawQuery, "query=up")
+			require.Contains(t, doer.Req.URL.RawQuery, "time=1234567890")
+		})
+
+		t.Run("GET request is always respected regardless of configured method", func(t *testing.T) {
+			doer := &MockDoer{}
+			client := NewClient(doer, http.MethodPost, "http://localhost:9090", "60s")
+
 			req := &backend.CallResourceRequest{
 				PluginContext: backend.PluginContext{},
 				Path:          "/api/v1/series",
@@ -79,6 +107,32 @@ func TestClient(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, []byte{}, body)
 			require.Equal(t, "http://localhost:9090/api/v1/series?match%5B%5D=ALERTS&start=1655272558&end=1655294158", doer.Req.URL.String())
+		})
+
+		t.Run("GET-configured client preserves existing query params when converting POST", func(t *testing.T) {
+			doer := &MockDoer{}
+			client := NewClient(doer, http.MethodGet, "http://localhost:9090", "60s")
+
+			req := &backend.CallResourceRequest{
+				PluginContext: backend.PluginContext{},
+				Path:          "/api/v1/query",
+				Method:        http.MethodPost,
+				URL:           "/api/v1/query?timeout=30",
+				Body:          []byte("query=up"),
+			}
+			res, err := client.QueryResource(context.Background(), req)
+			defer func() {
+				if res != nil && res.Body != nil {
+					if err := res.Body.Close(); err != nil {
+						fmt.Println("Error", "err", err)
+					}
+				}
+			}()
+			require.NoError(t, err)
+			require.NotNil(t, doer.Req)
+			require.Equal(t, http.MethodGet, doer.Req.Method)
+			require.Contains(t, doer.Req.URL.RawQuery, "timeout=30")
+			require.Contains(t, doer.Req.URL.RawQuery, "query=up")
 		})
 	})
 

--- a/pkg/promlib/middleware/force_http_get.go
+++ b/pkg/promlib/middleware/force_http_get.go
@@ -20,6 +20,7 @@ func ForceHttpGet(logger log.Logger) sdkhttpclient.Middleware {
 			if req.Method == http.MethodPost {
 				resp := &http.Response{
 					StatusCode: http.StatusMethodNotAllowed,
+					Body:       http.NoBody,
 				}
 				return resp, nil
 			}

--- a/pkg/promlib/middleware/force_http_get_test.go
+++ b/pkg/promlib/middleware/force_http_get_test.go
@@ -37,8 +37,7 @@ func TestEnsureHttpMethodMiddleware(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, res)
 		require.Equal(t, res.StatusCode, http.StatusMethodNotAllowed)
-		if res.Body != nil {
-			require.NoError(t, res.Body.Close())
-		}
+		require.NotNil(t, res.Body, "Body must not be nil to avoid panics in callers")
+		require.NoError(t, res.Body.Close())
 	})
 }


### PR DESCRIPTION
## Summary

- Fix `QueryResource` to use the datasource's configured `httpMethod` instead of always forwarding the incoming request method
- Fix `ForceHttpGet` middleware to return a response with a non-nil Body, preventing panics in downstream callers
- Add test coverage for POST-to-GET conversion in resource API calls

## Why

External API clients like [mcp-grafana](https://github.com/grafana/mcp-grafana) use the `/api/datasources/uid/{uid}/resources/...` endpoint to query Prometheus datasources. The `prometheus/client_golang` library's `DoGetFallback` always sends POST first, expecting a 405 to trigger a GET retry. For GET-configured datasources, the `ForceHttpGet` middleware correctly returned 405, but with a **nil Body** — causing a panic in `Execute()` that surfaced as a 500 error to callers. The GET fallback never triggered.

Additionally, `QueryResource` always used the incoming request's HTTP method rather than the datasource's configured method, making it impossible for any client to successfully query GET-configured datasources via POST.

## Changes

| File | Change |
|---|---|
| `pkg/promlib/client/client.go` | `QueryResource` now uses `c.method` (configured httpMethod). For GET, POST body params are moved to query string. Incoming GET requests are always respected for frontend fallback compatibility. |
| `pkg/promlib/middleware/force_http_get.go` | Added `Body: http.NoBody` to the 405 response to prevent nil pointer panics. |
| `pkg/promlib/client/client_test.go` | Updated and added tests for POST→GET conversion, param preservation, and method override behavior. |
| `pkg/promlib/middleware/force_http_get_test.go` | Added assertion that response Body is non-nil. |

## Test plan

- [x] All existing `pkg/promlib/client` and `pkg/promlib/middleware` tests pass
- [x] New tests cover: POST-configured forwards POST, GET-configured converts POST→GET, GET always respected, query params preserved during conversion
- [ ] Manual verification: query a GET-configured Prometheus datasource via the resources API with a POST request

Fixes #119686