### PR TITLE
NavTree: Fix enterprise nav items missing for non-admin users with RBAC

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -213,6 +213,7 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 
 	hs.HooksService.RunIndexDataHooks(&data, c)
 
+	data.NavTree.RemoveEmptyAdminSections()
 	data.NavTree.Sort()
 
 	return &data, nil

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -135,6 +135,19 @@ func (root *NavTreeRoot) Sort() {
 	Sort(root.Children)
 }
 
+// RemoveEmptyAdminSections removes the Users and access section if it has no children
+// (e.g. grafana-auth-app was not injected), then removes the entire Administration
+// section if it ended up empty. This must be called AFTER all hooks have had a chance
+// to add their nav items.
+func (root *NavTreeRoot) RemoveEmptyAdminSections() {
+	if sec := root.FindById(NavIDCfgAccess); sec != nil && len(sec.Children) == 0 {
+		root.RemoveSectionByID(NavIDCfgAccess)
+	}
+	if sec := root.FindById(NavIDCfg); sec != nil && len(sec.Children) == 0 {
+		root.RemoveSectionByID(NavIDCfg)
+	}
+}
+
 func (root *NavTreeRoot) MarshalJSON() ([]byte, error) {
 	return json.Marshal(root.Children)
 }

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -176,14 +176,9 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		return nil, err
 	}
 
-	// remove user access if empty. Happens if grafana-auth-app is not injected
-	if sec := treeRoot.FindById(navtree.NavIDCfgAccess); sec != nil && len(sec.Children) == 0 {
-		treeRoot.RemoveSectionByID(navtree.NavIDCfgAccess)
-	}
-	// double-check and remove admin menu if empty
-	if sec := treeRoot.FindById(navtree.NavIDCfg); sec != nil && len(sec.Children) == 0 {
-		treeRoot.RemoveSectionByID(navtree.NavIDCfg)
-	}
+	// NOTE: empty admin section cleanup is intentionally NOT done here.
+	// It happens in setIndexViewData (pkg/api/index.go) AFTER RunIndexDataHooks,
+	// so enterprise hooks have a chance to add items before empty sections are pruned.
 
 	if c.IsSignedIn {
 		treeRoot.AddSection(&navtree.NavLink{


### PR DESCRIPTION
**What is this feature?**

Fix for enterprise nav items (Secrets Management, Announcement Banners, Recorded Queries, Stats and Licensing) being silently dropped from the Administration sidebar.

**Why do we need this feature?**

There was a timing/ordering issue where empty admin sections were removed before enterprise hooks had a chance to add their items. Users with enterprise RBAC permissions but no OSS admin permissions would see no Administration section, even though they had valid permissions for enterprise features. The pages were accessible via direct URL, but invisible in the sidebar.


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-enterprise/issues/11175
