### PR TITLE
Dashboards: Improve error messages when sending invalid resources to /api/dashboard/db

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -422,16 +422,28 @@ func (hs *HTTPServer) postDashboard(c *contextmodel.ReqContext, cmd dashboards.S
 	// Items with metadata, spec, etc
 	if dashboards.LooksLikeK8sResource(spec) {
 		obj := &unstructured.Unstructured{Object: spec}
-		if strings.HasPrefix(obj.GetAPIVersion(), "dashboard.grafana.app/") {
-			uid, ok, _ := unstructured.NestedString(spec, "uid")
+		apiVersion := obj.GetAPIVersion()
+		switch {
+		case strings.HasPrefix(apiVersion, dashboardsV1.GROUP):
+			if _, ok := spec["spec"]; !ok {
+				return response.Error(http.StatusBadRequest, "The k8s style dashboard must include the dashboard contents in the spec property", nil)
+			}
+			v, ok, _ := unstructured.NestedString(spec, "uid")
 			if ok {
 				delete(obj.Object, "uid")
-				obj.SetName(uid) // overwrite the incoming name -- this can happen from TF providers
+				obj.SetName(v) // overwrite the incoming name -- this can happen from TF providers
+			}
+			_, ok, _ = unstructured.NestedString(spec, "id")
+			if ok {
+				return response.Error(http.StatusBadRequest, "The k8s style dashboard must not include an id on the root element", nil)
 			}
 			hs.log.Warn("DEPRECATION WARNING: Accepting k8s style dashboard in legacy /api/dashboards/db.  Please use the /apis/dashboard.grafana.app/ API to manage this resource", "dashboard", obj.GetName())
 			return hs.saveDashboardViaK8s(c, cmd, obj)
+
+		case apiVersion == "":
+			return response.Error(http.StatusBadRequest, "Dashboard appears to be a k8s style resource, but is missing an explicit apiVersion.", nil)
 		}
-		return response.Error(http.StatusBadRequest, "Dashboard appears to be a full k8s style resource.  Please use the /apis/dashboard.grafana.app/ API to manage this resource", nil)
+		return response.Error(http.StatusBadRequest, "The dashboard payload references a non dashboard apiVersion.  This should be sent to the requested api directly", nil)
 	}
 
 	_, found := spec["title"]
@@ -513,7 +525,7 @@ func (hs *HTTPServer) saveDashboardViaK8s(c *contextmodel.ReqContext, cmd dashbo
 
 	title, _, _ := unstructured.NestedString(obj.Object, "spec", "title")
 	if title == "" {
-		return response.Error(http.StatusBadRequest, "Dashboard is missing required title property", nil)
+		return response.Error(http.StatusBadRequest, "Dashboard spec is missing required title property", nil)
 	}
 
 	ctx := c.Req.Context()
@@ -524,12 +536,12 @@ func (hs *HTTPServer) saveDashboardViaK8s(c *contextmodel.ReqContext, cmd dashbo
 	}
 	client := tmp.Resource(gv.WithResource(dashboardsV1.DASHBOARD_RESOURCE)).Namespace(namespace)
 
+	obj.SetKind("Dashboard") // Writing to the dashboard API
 	obj.SetNamespace(namespace)
 	obj.SetAnnotations(map[string]string{}) // clear any annotations
 	obj.SetLabels(map[string]string{})      // clear any labels
 	delete(obj.Object, "status")
 	delete(obj.Object, "access") // can exist if you copied a /dto object
-	delete(obj.Object, "kind")   // copy from UI may have DashboardWithAccessInfo
 
 	meta, err := utils.MetaAccessor(obj)
 	if err != nil {

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -425,17 +425,16 @@ func (hs *HTTPServer) postDashboard(c *contextmodel.ReqContext, cmd dashboards.S
 		apiVersion := obj.GetAPIVersion()
 		switch {
 		case strings.HasPrefix(apiVersion, dashboardsV1.GROUP):
+			if _, ok, err := unstructured.NestedInt64(spec, "id"); ok || err != nil {
+				return response.Error(http.StatusBadRequest, "The k8s style dashboard must not include an id on the root element", nil)
+			}
 			if _, ok := spec["spec"]; !ok {
 				return response.Error(http.StatusBadRequest, "The k8s style dashboard must include the dashboard contents in the spec property", nil)
 			}
-			v, ok, _ := unstructured.NestedString(spec, "uid")
+			uid, ok, _ := unstructured.NestedString(spec, "uid")
 			if ok {
 				delete(obj.Object, "uid")
-				obj.SetName(v) // overwrite the incoming name -- this can happen from TF providers
-			}
-			_, ok, _ = unstructured.NestedString(spec, "id")
-			if ok {
-				return response.Error(http.StatusBadRequest, "The k8s style dashboard must not include an id on the root element", nil)
+				obj.SetName(uid) // overwrite the incoming name -- this might happen from TF providers
 			}
 			hs.log.Warn("DEPRECATION WARNING: Accepting k8s style dashboard in legacy /api/dashboards/db.  Please use the /apis/dashboard.grafana.app/ API to manage this resource", "dashboard", obj.GetName())
 			return hs.saveDashboardViaK8s(c, cmd, obj)

--- a/pkg/tests/apis/dashboard/dashboards_test.go
+++ b/pkg/tests/apis/dashboard/dashboards_test.go
@@ -275,7 +275,7 @@ func TestIntegrationLegacySupport(t *testing.T) {
 				"apiVersion": "playlist.grafana.app/v2",
 				"spec":       map[string]any{},
 			},
-			expect: "must not include an id on the root element",
+			expect: "dashboard payload references a non dashboard apiVersion",
 		}, {
 			name: "missing title",
 			input: map[string]any{

--- a/pkg/tests/apis/dashboard/dashboards_test.go
+++ b/pkg/tests/apis/dashboard/dashboards_test.go
@@ -227,23 +227,32 @@ func TestIntegrationLegacySupport(t *testing.T) {
 			expect string
 			inK8s  bool
 		}{{
-			name: "with apiVersion",
+			name: "with apiVersion (missing spec)",
 			input: map[string]any{
-				"apiVersion": "v2",
+				"apiVersion": "dashboard.grafana.app/v2",
 			},
-			expect: "Dashboard appears to be a full k8s style resource",
+			expect: "must include the dashboard contents in the spec property",
 		}, {
-			name: "with metadata",
+			name: "id at root",
+			input: map[string]any{
+				"apiVersion": "dashboard.grafana.app/v2",
+				"id":         123,
+			},
+			expect: "must not include an id on the root element",
+		}, {
+			name: "with metadata (missing apiVersion)",
 			input: map[string]any{
 				"metadata": map[string]any{},
+				"spec":     map[string]any{},
 			},
-			expect: "Dashboard appears to be a full k8s style resource",
+			expect: "but is missing an explicit apiVersion",
 		}, {
 			name: "with spec",
 			input: map[string]any{
-				"spec": map[string]any{},
+				"apiVersion": "dashboard.grafana.app/v2",
+				"spec":       map[string]any{},
 			},
-			expect: "Dashboard appears to be a full k8s style resource",
+			expect: "spec is missing required title property",
 		}, {
 			name: "with elements",
 			input: map[string]any{
@@ -260,6 +269,13 @@ func TestIntegrationLegacySupport(t *testing.T) {
 			},
 			expect: "dashboard appears to be in v2 format",
 			inK8s:  true,
+		}, {
+			name: "non dashboard api",
+			input: map[string]any{
+				"apiVersion": "playlist.grafana.app/v2",
+				"spec":       map[string]any{},
+			},
+			expect: "must not include an id on the root element",
 		}, {
 			name: "missing title",
 			input: map[string]any{


### PR DESCRIPTION
With introducing the new dashboard format options, this will certainly cause confusion with people unfamiliar with the new structures.  

This PR adds more clear errors earlier in the request so the correct behavior is more clear.  Specifficallly:
* missing apiVersion
* id at the root element
* missing spec element