### PR TITLE
CI: Use custom setup-node action for better caching

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -18,4 +18,4 @@ runs:
       with:
         node-version-file: '${{ inputs.cwd }}/.nvmrc'
         cache: ${{ inputs.cache == 'true' && 'yarn' || '' }}
-        cache-dependency-path: ${{ inputs.cache == 'true' && format('{0}/yarn.lock', inputs.cwd) || '' }}
+        cache-dependency-path: ${{ inputs.cache == 'true' && format('{0}/yarn.lock', inputs.cwd) || 'false' }}

--- a/.github/workflows/analytics-events-report.yml
+++ b/.github/workflows/analytics-events-report.yml
@@ -17,13 +17,10 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
+        uses: ./.github/actions/setup-node
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+      - name: Install yarn dependencies
+        uses: ./.github/actions/yarn-install
 
       - name: Generate analytics report
         run: yarn analytics-report

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -96,10 +96,8 @@ jobs:
             .prettierrc.js
           fetch-depth: 0
           fetch-tags: true
-      - name: Setup nodejs environment
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
       - name: "Configure git user"
         run: |
           git config --local user.name "github-actions[bot]"

--- a/.github/workflows/core-plugins-build-and-release.yml
+++ b/.github/workflows/core-plugins-build-and-release.yml
@@ -63,11 +63,8 @@ jobs:
           credentials_json: '${{ env.PLUGINS_GOOGLE_CREDENTIALS }}'
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db'
-      - name: Setup nodejs environment
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-          cache: yarn
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
       - name: Find plugin directory
         shell: bash
         id: get_dir
@@ -79,11 +76,10 @@ jobs:
             )" \
           )"
           echo "dir=${dir}" >> "$GITHUB_OUTPUT"
-      - name: Install frontend dependencies
-        shell: bash
-        working-directory: ${{ steps.get_dir.outputs.dir }}
-        run: |
-          yarn install --immutable
+      - name: Install yarn dependencies
+        uses: ./.github/actions/yarn-install
+        with:
+          cwd: ${{ steps.get_dir.outputs.dir }}
       - name: Download grabpl executable
         shell: sh
         working-directory: ${{ steps.get_dir.outputs.dir }}
@@ -164,7 +160,7 @@ jobs:
         if: steps.check_backend.outputs.has_backend == 'true'
         shell: bash
         env:
-          VERSION: ${{ steps.build_frontend.outputs.version }}  
+          VERSION: ${{ steps.build_frontend.outputs.version }}
         run: |
           make build-plugin-go PLUGIN_ID="$PLUGIN_ID"
       - name: package
@@ -178,7 +174,7 @@ jobs:
       - name: Check existing release
         env:
           GCOM_TOKEN: ${{ env.PLUGINS_GCOM_TOKEN }}
-          VERSION: ${{ steps.build_frontend.outputs.version }}  
+          VERSION: ${{ steps.build_frontend.outputs.version }}
           GCOM_API: ${{ env.GCOM_API }}
         run: |
           api_res="$(curl -X 'GET' -H "Authorization: Bearer $GCOM_TOKEN" \
@@ -215,7 +211,7 @@ jobs:
         working-directory: ${{ steps.get_dir.outputs.dir }}
         env:
           GCOM_TOKEN: ${{ env.PLUGINS_GCOM_TOKEN }}
-          VERSION: ${{ steps.build_frontend.outputs.version }}  
+          VERSION: ${{ steps.build_frontend.outputs.version }}
           GCP_BUCKET: ${{ env.GCP_BUCKET }}
           OUTPUT_DIR: ${{ steps.get_dir.outputs.dir }}
           GCOM_API: ${{ env.GCOM_API }}

--- a/.github/workflows/detect-breaking-changes-levitate.yml
+++ b/.github/workflows/detect-breaking-changes-levitate.yml
@@ -122,9 +122,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
 
       - name: Get built packages from pr
         uses: actions/download-artifact@v6

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -155,11 +155,8 @@ jobs:
     - uses: actions/checkout@v5
       with:
         persist-credentials: false
-    - uses: actions/setup-node@v6
-      with:
-        node-version-file: '.nvmrc'
-        cache: 'yarn'
-        cache-dependency-path: 'yarn.lock'
+    - name: Setup Node.js
+      uses: ./.github/actions/setup-node
     - name: Install yarn dependencies
       uses: ./.github/actions/yarn-install
     - name: Free up disk space

--- a/.github/workflows/lint-build-docs.yml
+++ b/.github/workflows/lint-build-docs.yml
@@ -35,10 +35,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
+        uses: ./.github/actions/setup-node
 
       - name: Install yarn dependencies
         uses: ./.github/actions/yarn-install

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -18,7 +18,7 @@ jobs:
     # Run on `grafana/grafana` main branch, or on pull requests to prevent double-running on mirrors
     if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: Detect whether code changed
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-arm64-small
     permissions:
       contents: read
     outputs:
@@ -430,7 +430,7 @@ jobs:
     if: always()
 
     name: All E2E tests complete
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-arm64-small
     steps:
     - name: Placeholder step
       run: echo "This step is intentionally left blank. Check playwright-required-tests job for the actual test results."

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -132,10 +132,8 @@ jobs:
           fetch-depth: '0'
           path: .grafana-main
 
-      - name: Setup nodejs environment
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
       - uses: actions/setup-go@v6.0.0
         with:
           go-version-file: go.mod

--- a/.github/workflows/run-dashboard-search-e2e.yml
+++ b/.github/workflows/run-dashboard-search-e2e.yml
@@ -34,10 +34,8 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
       - run: go version
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
       - name: Cache Node Modules
         id: cache-node-modules
         uses: actions/cache@v4


### PR DESCRIPTION
This PR improves the github actions caching by using our custom `setup-node` action more consistently. This action disables the automatic yarn caching, which is instead provided by our `yarn-install` actions. This is to prevent duplicate caches which eats up our quota, leading to early evictions.

Also while I'm here, I've tried switching some e2e steps over to use cheaper ARM runners.