### PR TITLE
Provisioning: add nested folders metadata file and block non-GET operations on metadata files

### DIFF
--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -2,6 +2,7 @@ package provisioning
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -218,6 +219,13 @@ func (c *filesConnector) handleDirectoryListing(ctx context.Context, name string
 
 // handleMethodRequest routes the request to the appropriate handler based on HTTP method.
 func (c *filesConnector) handleMethodRequest(ctx context.Context, r *http.Request, opts resources.DualWriteOptions, isDir bool, dualReadWriter *resources.DualReadWriter) (*provisioning.ResourceWrapper, error) {
+	if c.folderMetadataEnabled && r.Method != http.MethodGet && resources.IsFolderMetadataFile(opts.Path) {
+		return nil, apierrors.NewForbidden(
+			provisioning.RepositoryResourceInfo.GroupResource(),
+			opts.Path,
+			errors.New("folder metadata is managed by the system and cannot be modified directly"),
+		)
+	}
 	switch r.Method {
 	case http.MethodGet:
 		return c.handleGet(ctx, opts, dualReadWriter)

--- a/pkg/registry/apis/provisioning/files_test.go
+++ b/pkg/registry/apis/provisioning/files_test.go
@@ -228,7 +228,7 @@ func TestHandleMethodRequest_FolderMetadataGuard(t *testing.T) {
 				// Guard does not fire; code reaches nil dualReadWriter and panics.
 				require.Panics(t, func() {
 					//nolint:errcheck
-					connector.handleMethodRequest(context.Background(), req, opts, false, nil)
+					_, _ = connector.handleMethodRequest(context.Background(), req, opts, false, nil)
 				}, "guard must not intercept; code should proceed past the guard")
 			}
 		})

--- a/pkg/registry/apis/provisioning/files_test.go
+++ b/pkg/registry/apis/provisioning/files_test.go
@@ -1,10 +1,14 @@
 package provisioning
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	provisioningapi "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -153,6 +157,79 @@ func TestCheckQuota(t *testing.T) {
 				assert.True(t, apierrors.IsForbidden(err), "error should be Forbidden, got: %v", err)
 			} else {
 				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestHandleMethodRequest_FolderMetadataGuard(t *testing.T) {
+	tests := []struct {
+		name            string
+		method          string
+		path            string
+		flagEnabled     bool
+		expectForbidden bool
+	}{
+		{
+			name:            "POST _folder.json flag on",
+			method:          http.MethodPost,
+			path:            "folder/_folder.json",
+			flagEnabled:     true,
+			expectForbidden: true,
+		},
+		{
+			name:            "PUT _folder.json flag on",
+			method:          http.MethodPut,
+			path:            "folder/_folder.json",
+			flagEnabled:     true,
+			expectForbidden: true,
+		},
+		{
+			name:            "DELETE _folder.json flag on",
+			method:          http.MethodDelete,
+			path:            "folder/_folder.json",
+			flagEnabled:     true,
+			expectForbidden: true,
+		},
+		{
+			name:            "GET _folder.json flag on",
+			method:          http.MethodGet,
+			path:            "folder/_folder.json",
+			flagEnabled:     true,
+			expectForbidden: false,
+		},
+		{
+			name:            "POST _folder.json flag off",
+			method:          http.MethodPost,
+			path:            "folder/_folder.json",
+			flagEnabled:     false,
+			expectForbidden: false,
+		},
+		{
+			name:            "POST regular file flag on",
+			method:          http.MethodPost,
+			path:            "folder/dashboard.json",
+			flagEnabled:     true,
+			expectForbidden: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			connector := &filesConnector{folderMetadataEnabled: tc.flagEnabled}
+			req := httptest.NewRequest(tc.method, "/", nil)
+			opts := resources.DualWriteOptions{Path: tc.path}
+
+			if tc.expectForbidden {
+				_, err := connector.handleMethodRequest(context.Background(), req, opts, false, nil)
+				require.Error(t, err)
+				assert.True(t, apierrors.IsForbidden(err))
+			} else {
+				// Guard does not fire; code reaches nil dualReadWriter and panics.
+				require.Panics(t, func() {
+					//nolint:errcheck
+					connector.handleMethodRequest(context.Background(), req, opts, false, nil)
+				}, "guard must not intercept; code should proceed past the guard")
 			}
 		})
 	}

--- a/pkg/registry/apis/provisioning/resources/dualwriter.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter.go
@@ -171,15 +171,25 @@ func (r *DualReadWriter) CreateFolder(ctx context.Context, opts DualWriteOptions
 		return nil, fmt.Errorf("unable to use provisioning identity: %w", err)
 	}
 
-	// When the feature flag is enabled, write a _folder.json with a stable UID
-	// for this folder only. Intermediate ancestor folders are not given a
-	// _folder.json automatically — they receive one only when explicitly created.
+	// When the feature flag is enabled, write folder metadata for every path segment
+	// (ancestor and leaf), skipping any segment that already has one.
 	var stableUID string
 	if r.folderMetadataEnabled {
-		uid := util.GenerateShortUID()
-		manifest := NewFolderManifest(uid, safepath.Base(opts.Path))
-		var err error
-		stableUID, err = WriteFolderMetadata(ctx, r.repo, opts.Path, manifest, opts.Ref, opts.Message)
+		err = safepath.Walk(ctx, opts.Path, func(ctx context.Context, segPath string) error {
+			folderPath := segPath + "/"
+			existing, readErr := ReadFolderMetadata(ctx, r.repo, folderPath, opts.Ref)
+			if readErr == nil {
+				// _folder.json already exists; reuse its UID for this segment
+				stableUID = existing.Name
+				return nil
+			}
+			// Not found or unreadable: write a new _folder.json
+			uid := util.GenerateShortUID()
+			manifest := NewFolderManifest(uid, safepath.Base(folderPath))
+			var writeErr error
+			stableUID, writeErr = WriteFolderMetadata(ctx, r.repo, folderPath, manifest, opts.Ref, opts.Message)
+			return writeErr
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/registry/apis/provisioning/resources/dualwriter.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter.go
@@ -2,8 +2,10 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -175,20 +177,33 @@ func (r *DualReadWriter) CreateFolder(ctx context.Context, opts DualWriteOptions
 	// (ancestor and leaf), skipping any segment that already has one.
 	var stableUID string
 	if r.folderMetadataEnabled {
+		leafPath := strings.TrimSuffix(opts.Path, "/")
 		err = safepath.Walk(ctx, opts.Path, func(ctx context.Context, segPath string) error {
 			folderPath := segPath + "/"
 			existing, readErr := ReadFolderMetadata(ctx, r.repo, folderPath, opts.Ref)
 			if readErr == nil {
-				// _folder.json already exists; reuse its UID for this segment
+				if segPath == leafPath {
+					return apierrors.NewAlreadyExists(
+						provisioning.RepositoryResourceInfo.GroupResource(),
+						opts.Path,
+					)
+				}
+				// Ancestor already has folder metadata; reuse its UID
 				stableUID = existing.Name
 				return nil
 			}
-			// Not found or unreadable: write a new _folder.json
+			if !errors.Is(readErr, repository.ErrFileNotFound) {
+				return fmt.Errorf("failed to read folder metadata for %q: %w", folderPath, readErr)
+			}
+			// Not found: write a new folder metadata file
 			uid := util.GenerateShortUID()
 			manifest := NewFolderManifest(uid, safepath.Base(folderPath))
 			var writeErr error
 			stableUID, writeErr = WriteFolderMetadata(ctx, r.repo, folderPath, manifest, opts.Ref, opts.Message)
-			return writeErr
+			if writeErr != nil {
+				return fmt.Errorf("failed to write folder metadata for %q: %w", folderPath, writeErr)
+			}
+			return nil
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/registry/apis/provisioning/resources/dualwriter_test.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter_test.go
@@ -298,6 +298,7 @@ func TestCreateFolder(t *testing.T) {
 		setup       func(t *testing.T) (*DualReadWriter, DualWriteOptions)
 		wantErr     bool
 		errContains string
+		errCheck    func(t *testing.T, err error)
 		check       func(t *testing.T, result *provisioning.ResourceWrapper)
 	}{
 		{
@@ -412,6 +413,38 @@ func TestCreateFolder(t *testing.T) {
 				return dw, DualWriteOptions{Path: "newfolder/"}
 			},
 			wantErr: true,
+		},
+		{
+			name: "error: flag enabled, leaf already has _folder.json returns AlreadyExists",
+			setup: func(t *testing.T) (*DualReadWriter, DualWriteOptions) {
+				rw := repository.NewMockReaderWriter(t)
+				rw.On("Config").Return(newTestRepoConfig("test-repo"))
+				existing := NewFolderManifest("existing-uid", "newfolder")
+				existingData, _ := json.Marshal(existing)
+				rw.On("Read", mock.Anything, "newfolder/_folder.json", "").Return(&repository.FileInfo{Data: existingData}, nil)
+				accessMock := auth.NewMockAccessChecker(t)
+				accessMock.On("Check", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				dw := &DualReadWriter{repo: rw, access: accessMock, folderMetadataEnabled: true}
+				return dw, DualWriteOptions{Path: "newfolder/"}
+			},
+			wantErr: true,
+			errCheck: func(t *testing.T, err error) {
+				assert.True(t, apierrors.IsAlreadyExists(err), "expected AlreadyExists, got: %v", err)
+			},
+		},
+		{
+			name: "error: flag enabled, read error other than not-found is propagated",
+			setup: func(t *testing.T) (*DualReadWriter, DualWriteOptions) {
+				rw := repository.NewMockReaderWriter(t)
+				rw.On("Config").Return(newTestRepoConfig("test-repo"))
+				rw.On("Read", mock.Anything, "newfolder/_folder.json", "").Return(nil, fmt.Errorf("network error"))
+				accessMock := auth.NewMockAccessChecker(t)
+				accessMock.On("Check", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				dw := &DualReadWriter{repo: rw, access: accessMock, folderMetadataEnabled: true}
+				return dw, DualWriteOptions{Path: "newfolder/"}
+			},
+			wantErr:     true,
+			errContains: "failed to read folder metadata",
 		},
 		{
 			name: "sync enabled, flag disabled: GetFolder not found → no Upsert",
@@ -586,6 +619,9 @@ func TestCreateFolder(t *testing.T) {
 				require.Error(t, err)
 				if tt.errContains != "" {
 					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				if tt.errCheck != nil {
+					tt.errCheck(t, err)
 				}
 				return
 			}

--- a/pkg/registry/apis/provisioning/resources/dualwriter_test.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter_test.go
@@ -322,6 +322,7 @@ func TestCreateFolder(t *testing.T) {
 				config := newTestRepoConfig("test-repo")
 				rw := repository.NewMockReaderWriter(t)
 				rw.On("Config").Return(config)
+				rw.On("Read", mock.Anything, "newfolder/_folder.json", "").Return(nil, repository.ErrFileNotFound)
 				var capturedUID string
 				rw.On("Create", mock.Anything, "newfolder/_folder.json", "", mock.MatchedBy(func(b []byte) bool {
 					var res folders.Folder
@@ -403,6 +404,7 @@ func TestCreateFolder(t *testing.T) {
 			setup: func(t *testing.T) (*DualReadWriter, DualWriteOptions) {
 				rw := repository.NewMockReaderWriter(t)
 				rw.On("Config").Return(newTestRepoConfig("test-repo"))
+				rw.On("Read", mock.Anything, "newfolder/_folder.json", "").Return(nil, repository.ErrFileNotFound)
 				rw.On("Create", mock.Anything, "newfolder/_folder.json", "", mock.Anything, "").Return(fmt.Errorf("repo error"))
 				accessMock := auth.NewMockAccessChecker(t)
 				accessMock.On("Check", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -498,6 +500,7 @@ func TestCreateFolder(t *testing.T) {
 				config := newSyncEnabledConfig("test-repo")
 				rw := repository.NewMockReaderWriter(t)
 				rw.On("Config").Return(config)
+				rw.On("Read", mock.Anything, "newfolder/_folder.json", "").Return(nil, repository.ErrFileNotFound)
 				rw.On("Create", mock.Anything, "newfolder/_folder.json", "", mock.Anything, "").Return(nil)
 				accessMock := auth.NewMockAccessChecker(t)
 				accessMock.On("Check", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -529,6 +532,7 @@ func TestCreateFolder(t *testing.T) {
 				config := newSyncEnabledConfig("test-repo")
 				rw := repository.NewMockReaderWriter(t)
 				rw.On("Config").Return(config)
+				rw.On("Read", mock.Anything, "newfolder/_folder.json", "").Return(nil, repository.ErrFileNotFound)
 				rw.On("Create", mock.Anything, "newfolder/_folder.json", "", mock.Anything, "").Return(nil)
 				accessMock := auth.NewMockAccessChecker(t)
 				accessMock.On("Check", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -668,14 +672,22 @@ func TestMoveDirectory_FolderMetadata(t *testing.T) {
 }
 
 func TestCreateFolder_Nested_FolderMetadata(t *testing.T) {
-	t.Run("flag enabled: nested folder creates _folder.json only for the leaf, not the parent", func(t *testing.T) {
+	t.Run("flag enabled: nested folder creates _folder.json for every segment", func(t *testing.T) {
 		config := newTestRepoConfig("test-repo")
 		rw := repository.NewMockReaderWriter(t)
 		rw.On("Config").Return(config)
 		accessMock := auth.NewMockAccessChecker(t)
 		accessMock.On("Check", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-		// Only the leaf _folder.json should be created.
+		// Parent: not found → create
+		rw.On("Read", mock.Anything, "parent/_folder.json", "").Return(nil, repository.ErrFileNotFound)
+		rw.On("Create", mock.Anything, "parent/_folder.json", "", mock.MatchedBy(func(b []byte) bool {
+			var f folders.Folder
+			return json.Unmarshal(b, &f) == nil && f.Name != "" && f.Spec.Title == "parent"
+		}), "").Return(nil)
+
+		// Child (leaf): not found → create
+		rw.On("Read", mock.Anything, "parent/child/_folder.json", "").Return(nil, repository.ErrFileNotFound)
 		rw.On("Create", mock.Anything, "parent/child/_folder.json", "", mock.MatchedBy(func(b []byte) bool {
 			var f folders.Folder
 			return json.Unmarshal(b, &f) == nil && f.Name != "" && f.Spec.Title == "child"
@@ -686,9 +698,36 @@ func TestCreateFolder_Nested_FolderMetadata(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
-		// Verify parent/_folder.json was never created.
+		rw.AssertExpectations(t)
+	})
+
+	t.Run("flag enabled: skips existing parent _folder.json, creates child", func(t *testing.T) {
+		config := newTestRepoConfig("test-repo")
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Config").Return(config)
+		accessMock := auth.NewMockAccessChecker(t)
+		accessMock.On("Check", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		// Parent: already exists → skip (no Create call)
+		existingParent := NewFolderManifest("existing-parent-uid", "parent")
+		existingData, _ := json.Marshal(existingParent)
+		rw.On("Read", mock.Anything, "parent/_folder.json", "").
+			Return(&repository.FileInfo{Data: existingData}, nil)
+
+		// Child: not found → create
+		rw.On("Read", mock.Anything, "parent/child/_folder.json", "").Return(nil, repository.ErrFileNotFound)
+		rw.On("Create", mock.Anything, "parent/child/_folder.json", "", mock.MatchedBy(func(b []byte) bool {
+			var f folders.Folder
+			return json.Unmarshal(b, &f) == nil && f.Name != "" && f.Spec.Title == "child"
+		}), "").Return(nil)
+
+		dw := &DualReadWriter{repo: rw, access: accessMock, folderMetadataEnabled: true}
+		result, err := dw.CreateFolder(context.Background(), DualWriteOptions{Path: "parent/child/"})
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		rw.AssertExpectations(t)
 		rw.AssertNotCalled(t, "Create", mock.Anything, "parent/_folder.json",
 			mock.Anything, mock.Anything, mock.Anything)
-		rw.AssertExpectations(t)
 	})
 }

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -1057,27 +1057,32 @@ func TestIntegrationProvisioning_CreateFolder_FolderMetadataFlag(t *testing.T) {
 		require.NoError(t, err, "Grafana folder should exist with the stable UID from _folder.json")
 	})
 
-	t.Run("nested creation writes _folder.json only for the leaf", func(t *testing.T) {
+	t.Run("nested creation writes _folder.json for every folder in the path", func(t *testing.T) {
 		resp := postFolder(t, "parent-folder/child-folder/")
 		// nolint:errcheck
 		defer resp.Body.Close()
 		require.Equal(t, http.StatusOK, resp.StatusCode, "creating nested folder should succeed")
 
-		_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "parent-folder/_folder.json")
-		require.Error(t, err, "parent _folder.json should not exist — only the directly-created folder gets one")
+		// Parent must have _folder.json
+		parentWrap, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "parent-folder/_folder.json")
+		require.NoError(t, err, "parent _folder.json should exist")
+		parentUID, _, _ := unstructured.NestedString(parentWrap.Object, "resource", "file", "metadata", "name")
+		require.NotEmpty(t, parentUID)
 
+		// Child must have _folder.json
 		childWrap, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "parent-folder/child-folder/_folder.json")
-		require.NoError(t, err, "child _folder.json should be readable via the files endpoint")
+		require.NoError(t, err, "child _folder.json should exist")
+		childUID, _, _ := unstructured.NestedString(childWrap.Object, "resource", "file", "metadata", "name")
+		require.NotEmpty(t, childUID)
+		require.NotEqual(t, parentUID, childUID, "each folder gets a distinct UID")
 
 		childAPIVersion, _, _ := unstructured.NestedString(childWrap.Object, "resource", "file", "apiVersion")
 		require.Equal(t, "folder.grafana.app/v1beta1", childAPIVersion)
-		childUID, _, _ := unstructured.NestedString(childWrap.Object, "resource", "file", "metadata", "name")
-		require.NotEmpty(t, childUID, "child _folder.json should contain a non-empty stable UID")
 		childTitle, _, _ := unstructured.NestedString(childWrap.Object, "resource", "file", "spec", "title")
 		require.Equal(t, "child-folder", childTitle)
 
 		_, err = helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
-		require.NoError(t, err, "child Grafana folder should exist with the stable UID from _folder.json")
+		require.NoError(t, err, "child Grafana folder should exist with the stable UID")
 	})
 
 	t.Run("child created inside existing managed folder gets its own _folder.json", func(t *testing.T) {
@@ -1112,5 +1117,71 @@ func TestIntegrationProvisioning_CreateFolder_FolderMetadataFlag(t *testing.T) {
 		require.NoError(t, err, "parent Grafana folder should exist")
 		_, err = helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child Grafana folder should exist")
+	})
+}
+
+func TestIntegrationProvisioning_FolderMetadataFileProtection(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := common.RunGrafana(t, withProvisioningFolderMetadata)
+	ctx := context.Background()
+
+	const repo = "folder-protection-test-repo"
+	helper.CreateRepo(t, common.TestRepo{Name: repo, Target: "instance", SkipResourceAssertions: true})
+
+	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+	filesURL := func(filePath string) string {
+		return fmt.Sprintf("http://admin:admin@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/%s",
+			addr, repo, filePath)
+	}
+
+	// Create a managed folder so its _folder.json exists for PUT/DELETE tests.
+	req, err := http.NewRequest(http.MethodPost, filesURL("protected-folder/"), nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	// nolint:errcheck
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "setup: creating protected-folder should succeed")
+
+	t.Run("POST to _folder.json is blocked", func(t *testing.T) {
+		body := []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"some-uid"},"spec":{"title":"attempt"}}`)
+		req, err := http.NewRequest(http.MethodPost, filesURL("new-folder/_folder.json"), bytes.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode, "direct POST to _folder.json must be blocked")
+	})
+
+	t.Run("PUT to existing _folder.json is blocked", func(t *testing.T) {
+		body := []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"tampered-uid"},"spec":{"title":"tampered"}}`)
+		req, err := http.NewRequest(http.MethodPut, filesURL("protected-folder/_folder.json"), bytes.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode, "PUT to _folder.json must be blocked")
+	})
+
+	t.Run("DELETE of _folder.json is blocked", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodDelete, filesURL("protected-folder/_folder.json"), nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode, "DELETE of _folder.json must be blocked")
+	})
+
+	t.Run("GET of _folder.json is still allowed", func(t *testing.T) {
+		wrapObj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "protected-folder/_folder.json")
+		require.NoError(t, err, "_folder.json must remain readable")
+		uid, _, _ := unstructured.NestedString(wrapObj.Object, "resource", "file", "metadata", "name")
+		require.NotEmpty(t, uid)
 	})
 }

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -1085,6 +1085,18 @@ func TestIntegrationProvisioning_CreateFolder_FolderMetadataFlag(t *testing.T) {
 		require.NoError(t, err, "child Grafana folder should exist with the stable UID")
 	})
 
+	t.Run("duplicate folder creation returns 409 Conflict", func(t *testing.T) {
+		resp := postFolder(t, "duplicate-folder/")
+		// nolint:errcheck
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, "first creation should succeed")
+
+		resp2 := postFolder(t, "duplicate-folder/")
+		// nolint:errcheck
+		defer resp2.Body.Close()
+		require.Equal(t, http.StatusConflict, resp2.StatusCode, "second creation should return 409 Conflict")
+	})
+
 	t.Run("child created inside existing managed folder gets its own _folder.json", func(t *testing.T) {
 		resp := postFolder(t, "managed-parent/")
 		// nolint:errcheck


### PR DESCRIPTION
**What is this feature?**

This PR builds on the provisioningFolderMetadata feature flag work (which introduced `_folder.json` as a stable-UID anchor for managed folders) with two improvements:

1. Nested folder creation now writes `_folder.json` for every path segment;
    - **Before**: When a user called `POST /files/parent/child/`, only `child/_folder.json` was written. The intermediate `parent/` folder got no metadata file, so its UID was unstable - generated fresh on every update;
    - **After**: `CreateFolder` in `dualwriter.go` walks each segment of the requested path using `safepath.Walk`. For each segment it first tries to read an existing `_folder.json`; if one is already there it reuses that UID (idempotent), and if not it creates a new one. This means every folder in the hierarchy - ancestors and leaf alike - gets a stable UID anchored in the repository;
2. `_folder.json` is now write-protected via the files API.
    - A guard was added at the top of `handleMethodRequest` in `files.go`;

**Why do we need this feature?**

1. When multiple folders are created as part of `/files` endpoint call, all folders need a stable UID;
2. `_folder.json` files are managed entirely by the system; letting users overwrite or delete them would corrupt the stable-UID contract.

**Who is this feature for?**

Users of GitSync

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/900

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
