### PR TITLE
CI: Disable actions/setup-go cache for integration tests

### DIFF
--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/setup-go@v6.0.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - name: Run tests
         if: matrix.shard != 'profiled'
         env:
@@ -177,7 +177,7 @@ jobs:
         uses: actions/setup-go@v6.0.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - name: Setup MySQL devenv
         run: mysql -h 127.0.0.1 -P 3306 -u root -prootpass < devenv/docker/blocks/mysql_tests/setup.sql
       - name: Run tests
@@ -225,7 +225,7 @@ jobs:
         uses: actions/setup-go@v6.0.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - name: Setup Postgres devenv
         run: psql -p 5432 -h 127.0.0.1 -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
       - name: Run tests
@@ -271,7 +271,7 @@ jobs:
         uses: actions/setup-go@v6.0.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:
@@ -388,7 +388,7 @@ jobs:
         uses: actions/setup-go@v6.0.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:
@@ -441,7 +441,7 @@ jobs:
         uses: actions/setup-go@v6.0.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:


### PR DESCRIPTION
## Summary

- Disable `actions/setup-go` cache for all integration test jobs
- The precompile step (from #119605) already warms the Go build cache within each job, so the GH Actions cache save/restore adds overhead without benefit
- This is an experiment to measure whether removing it improves overall job times

## Comparison

Will compare against recent runs with cache enabled to measure impact.

## Test plan

- [ ] Compare job durations with cache enabled (recent main runs) vs this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)