### PR TITLE
Provisioning: Add webhook URL field to GitHub features

### DIFF
--- a/public/app/features/provisioning/Config/ConfigFormGithubCollapse.test.tsx
+++ b/public/app/features/provisioning/Config/ConfigFormGithubCollapse.test.tsx
@@ -61,16 +61,12 @@ describe('ConfigFormGithubCollapse', () => {
     jest.clearAllMocks();
   });
 
-  it('still renders collapse when image rendering is not allowed on a public instance', () => {
+  it('returns null when image rendering is not allowed on a public instance', () => {
     jest.spyOn(console, 'warn').mockImplementation(() => {});
-    setup({ imageRenderingAllowed: false, isPublic: true });
+    const { renderResult } = setup({ imageRenderingAllowed: false, isPublic: true });
 
-    expect(screen.getByText('GitHub features')).toBeInTheDocument();
-    expect(
-      screen.queryByRole('checkbox', {
-        name: /Enable dashboard previews in pull requests/i,
-      })
-    ).not.toBeInTheDocument();
+    expect(renderResult.container).toBeEmptyDOMElement();
+    expect(screen.queryByText('GitHub features')).not.toBeInTheDocument();
     jest.spyOn(console, 'warn').mockRestore();
   });
 

--- a/public/app/features/provisioning/Config/ConfigFormGithubCollapse.test.tsx
+++ b/public/app/features/provisioning/Config/ConfigFormGithubCollapse.test.tsx
@@ -61,13 +61,16 @@ describe('ConfigFormGithubCollapse', () => {
     jest.clearAllMocks();
   });
 
-  it('returns null when image rendering is not allowed on a public instance', () => {
-    //Adding this due to React Router Future Flag Warning: React Router will begin wrapping state updates in `React.startTransition` in v7.
+  it('still renders collapse when image rendering is not allowed on a public instance', () => {
     jest.spyOn(console, 'warn').mockImplementation(() => {});
-    const { renderResult } = setup({ imageRenderingAllowed: false, isPublic: true });
+    setup({ imageRenderingAllowed: false, isPublic: true });
 
-    expect(renderResult.container).toBeEmptyDOMElement();
-    expect(screen.queryByText('GitHub features')).not.toBeInTheDocument();
+    expect(screen.getByText('GitHub features')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', {
+        name: /Enable dashboard previews in pull requests/i,
+      })
+    ).not.toBeInTheDocument();
     jest.spyOn(console, 'warn').mockRestore();
   });
 
@@ -91,14 +94,20 @@ describe('ConfigFormGithubCollapse', () => {
     expect(checkbox).toBeDisabled();
   });
 
-  it('disables preview checkbox and shows realtime feedback info on private instances', () => {
+  it('disables preview checkbox and shows learn more link on private instances', () => {
     setup({ isPublic: false, imageRenderingAllowed: true });
 
     const checkbox = screen.getByRole('checkbox', {
       name: /Enable dashboard previews in pull requests/i,
     });
     expect(checkbox).toBeDisabled();
-    expect(screen.getByRole('link', { name: 'Configure webhooks' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Learn more' })).toBeInTheDocument();
+  });
+
+  it('hides learn more link on public instances', () => {
+    setup({ isPublic: true, imageRenderingAllowed: true });
+
+    expect(screen.queryByRole('link', { name: 'Learn more' })).not.toBeInTheDocument();
   });
 
   it('hides preview checkbox when image rendering is not allowed', () => {
@@ -109,5 +118,12 @@ describe('ConfigFormGithubCollapse', () => {
         name: /Enable dashboard previews in pull requests/i,
       })
     ).not.toBeInTheDocument();
+  });
+
+  it('always renders webhook URL field', () => {
+    const { registerMock } = setup({ isPublic: true, imageRenderingAllowed: true });
+
+    expect(screen.getByText('Webhook URL')).toBeInTheDocument();
+    expect(registerMock).toHaveBeenCalledWith('webhook.baseUrl');
   });
 });

--- a/public/app/features/provisioning/Config/ConfigFormGithubCollapse.tsx
+++ b/public/app/features/provisioning/Config/ConfigFormGithubCollapse.tsx
@@ -18,6 +18,11 @@ export function ConfigFormGithubCollapse({ register }: ConfigFormGithubCollapseP
   const hasImageRenderer = checkImageRenderer();
   const imageRenderingAllowed = checkImageRenderingAllowed(settings.data);
 
+  if (!imageRenderingAllowed && isPublic) {
+    // don't display the whole collapse if neither feature is applicable
+    return null;
+  }
+
   return (
     <ControlledCollapse
       label={t('provisioning.config-form-github-collapse.label-git-hub-features', 'GitHub features')}

--- a/public/app/features/provisioning/Config/ConfigFormGithubCollapse.tsx
+++ b/public/app/features/provisioning/Config/ConfigFormGithubCollapse.tsx
@@ -1,7 +1,7 @@
 import { UseFormRegister } from 'react-hook-form';
 
 import { Trans, t } from '@grafana/i18n';
-import { Checkbox, ControlledCollapse, Field, Stack, Text, TextLink } from '@grafana/ui';
+import { Checkbox, ControlledCollapse, Field, Input, Stack, Text, TextLink } from '@grafana/ui';
 import { useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1';
 
 import { checkImageRenderer, checkPublicAccess, checkImageRenderingAllowed } from '../GettingStarted/features';
@@ -17,11 +17,6 @@ export function ConfigFormGithubCollapse({ register }: ConfigFormGithubCollapseP
   const isPublic = checkPublicAccess();
   const hasImageRenderer = checkImageRenderer();
   const imageRenderingAllowed = checkImageRenderingAllowed(settings.data);
-
-  if (!imageRenderingAllowed && isPublic) {
-    // don't display the whole collapse if neither feature is applicable
-    return null;
-  }
 
   return (
     <ControlledCollapse
@@ -59,22 +54,35 @@ export function ConfigFormGithubCollapse({ register }: ConfigFormGithubCollapseP
           </Field>
         )}
 
-        {!isPublic && (
-          <Field
-            noMargin
-            label={t('provisioning.config-form-github-collapse.label-realtime-feedback', 'Realtime feedback')}
-          >
-            <Text variant="bodySmall" color={'secondary'}>
-              <Trans i18nKey={'provisioning.config-form-github-collapse.description-realtime-feedback'}>
-                <TextLink variant={'bodySmall'} href={GETTING_STARTED_URL}>
-                  Configure webhooks
-                </TextLink>{' '}
-                to get instant updates in Grafana as soon as changes are committed. Review and approve changes using
-                pull requests before they go live.
+        <Field
+          noMargin
+          label={t('provisioning.config-form-github-collapse.label-webhook-url', 'Webhook URL')}
+          description={
+            <>
+              <Trans i18nKey="provisioning.config-form-github-collapse.description-webhook-url">
+                Overrides the auto-detected URL for registering webhooks.
               </Trans>
-            </Text>
-          </Field>
-        )}
+              {!isPublic && (
+                <>
+                  {' '}
+                  <TextLink variant="bodySmall" href={GETTING_STARTED_URL}>
+                    <Trans i18nKey="provisioning.config-form-github-collapse.description-webhook-url-learn-more">
+                      Learn more
+                    </Trans>
+                  </TextLink>
+                </>
+              )}
+            </>
+          }
+        >
+          <Input
+            {...register('webhook.baseUrl')}
+            placeholder={t(
+              'provisioning.config-form-github-collapse.placeholder-webhook-url',
+              'https://grafana.example.com'
+            )}
+          />
+        </Field>
       </Stack>
     </ControlledCollapse>
   );

--- a/public/app/features/provisioning/Wizard/FinishStep.tsx
+++ b/public/app/features/provisioning/Wizard/FinishStep.tsx
@@ -130,6 +130,22 @@ export const FinishStep = memo(function FinishStep() {
           />
         </Field>
       )}
+
+      {isGithub && (
+        <Field
+          noMargin
+          label={t('provisioning.finish-step.label-webhook-url', 'Webhook URL')}
+          description={t(
+            'provisioning.finish-step.description-webhook-url',
+            'Overrides the auto-detected URL for registering webhooks.'
+          )}
+        >
+          <Input
+            {...register('repository.webhook.baseUrl')}
+            placeholder={t('provisioning.finish-step.placeholder-webhook-url', 'https://grafana.example.com')}
+          />
+        </Field>
+      )}
     </Stack>
   );
 });

--- a/public/app/features/provisioning/utils/data.test.ts
+++ b/public/app/features/provisioning/utils/data.test.ts
@@ -168,6 +168,40 @@ describe('provisioning data mapping', () => {
     });
   });
 
+  describe('webhook', () => {
+    it('includes webhook baseUrl in spec when provided', () => {
+      const formData = makeFormData('github');
+      formData.webhook = { baseUrl: 'https://grafana.example.com' };
+      const spec = dataToSpec(formData);
+      expect(spec.webhook?.baseUrl).toBe('https://grafana.example.com');
+    });
+
+    it('omits webhook from spec when baseUrl is empty', () => {
+      const formData = makeFormData('github');
+      formData.webhook = { baseUrl: '' };
+      const spec = dataToSpec(formData);
+      expect(spec.webhook).toBeUndefined();
+    });
+
+    it('omits webhook from spec when not set', () => {
+      const spec = dataToSpec(makeFormData('github'));
+      expect(spec.webhook).toBeUndefined();
+    });
+
+    it('reads webhook from spec to form data', () => {
+      const spec: RepositorySpec = {
+        type: 'github',
+        title: 'repo',
+        sync: baseSync,
+        workflows: [],
+        github: { url: 'https://github.com/owner/repo', branch: 'main', path: '' },
+        webhook: { baseUrl: 'https://grafana.example.com' },
+      };
+      const data = specToData(spec);
+      expect(data.webhook?.baseUrl).toBe('https://grafana.example.com');
+    });
+  });
+
   describe('empty branch sends empty string for backend auto-detection', () => {
     it.each(['github', 'gitlab', 'bitbucket', 'git'] as const)(
       'sends empty branch for %s when branch is not set',

--- a/public/app/features/provisioning/utils/data.ts
+++ b/public/app/features/provisioning/utils/data.ts
@@ -23,6 +23,10 @@ export const dataToSpec = (data: RepositoryFormData, connectionName?: string): R
     workflows: getWorkflows(data),
   };
 
+  if (data.webhook?.baseUrl) {
+    spec.webhook = { baseUrl: data.webhook.baseUrl };
+  }
+
   const baseConfig = {
     url: data.url || '',
     branch: data.branch || '',

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12647,9 +12647,11 @@
       "placeholder-my-config": "My config"
     },
     "config-form-github-collapse": {
-      "description-realtime-feedback": "<0>Configure webhooks</0> to get instant updates in Grafana as soon as changes are committed. Review and approve changes using pull requests before they go live.",
+      "description-webhook-url": "Overrides the auto-detected URL for registering webhooks.",
+      "description-webhook-url-learn-more": "Learn more",
       "label-git-hub-features": "GitHub features",
-      "label-realtime-feedback": "Realtime feedback"
+      "label-webhook-url": "Webhook URL",
+      "placeholder-webhook-url": "https://grafana.example.com"
     },
     "connect-page": {
       "subTitle": {
@@ -12798,11 +12800,14 @@
       "description-preview-requirements": "(requires <2>image rendering</2> and public access enabled)",
       "description-read-only": "Resources can't be modified through Grafana.",
       "description-sync-interval": "How often to sync changes from the repository",
+      "description-webhook-url": "Overrides the auto-detected URL for registering webhooks.",
       "error-sync-interval-required": "Sync interval is required",
       "label-enable-previews": "Enable dashboard previews in pull requests",
       "label-generate-dashboard-previews": "Generate Dashboard Previews",
       "label-read-only": "Read only",
-      "label-sync-interval": "Sync Interval (seconds)"
+      "label-sync-interval": "Sync Interval (seconds)",
+      "label-webhook-url": "Webhook URL",
+      "placeholder-webhook-url": "https://grafana.example.com"
     },
     "fix-folder-metadata": {
       "button": "Fix folder IDs"


### PR DESCRIPTION
**What is this feature?**

Adds a webhook URL input field to the provisioning UI that allows users to override the auto-detected base URL for webhook endpoint registration.

**Why do we need this feature?**

Backend PR #119635 introduced webhook configuration support at the API level. This PR implements the corresponding UI to expose the `webhook.baseUrl` field to users in both the provisioning wizard and config form.

Part of https://github.com/grafana/grafana/issues/108664
<img width="952" height="476" alt="Screenshot 2026-03-06 at 13 52 02" src="https://github.com/user-attachments/assets/409448f6-6911-4e5f-8aec-1da7a8e86c23" />

<img width="824" height="241" alt="Screenshot 2026-03-06 at 15 20 01" src="https://github.com/user-attachments/assets/c4f2f612-b16a-4247-b21d-ee92dff7c70f" />

