### PR TITLE
Docs: Clarify DELETE /org/users/:userId deletes orphaned non-admin users

### DIFF
--- a/docs/sources/administration/user-management/manage-org-users/index.md
+++ b/docs/sources/administration/user-management/manage-org-users/index.md
@@ -140,7 +140,7 @@ To copy an invitation link and send it directly to a user, click Copy Invite. Yo
 
 You can remove a user from an organization when they no longer require access to the dashboard or data sources owned by the organization. No longer requiring access to an organization might occur when the user has left your company or has internally moved to another organization.
 
-This action does not remove the user account from the Grafana server.
+If the user belongs to multiple organizations, this action only removes them from the current organization. However, if the user does not belong to any other organization after removal and is not a Grafana Server Admin, the user account is permanently deleted from the Grafana instance.
 
 ### Before you begin
 

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -447,7 +447,11 @@ func (hs *HTTPServer) updateOrgUserHelper(c *contextmodel.ReqContext, cmd org.Up
 
 // swagger:route DELETE /org/users/{user_id} org removeOrgUserForCurrentOrg
 //
-// Delete user in current organization.
+// Remove user from current organization.
+//
+// Removes the user from the current organization. If the user does not belong
+// to any other organization after removal and is not a Grafana Server Admin,
+// the user account will be permanently deleted from the Grafana instance.
 //
 // If you are running Grafana Enterprise and have Fine-grained access control enabled
 // you need to have a permission with action: `org.users:remove` with scope `users:*`.
@@ -473,7 +477,11 @@ func (hs *HTTPServer) RemoveOrgUserForCurrentOrg(c *contextmodel.ReqContext) res
 
 // swagger:route DELETE /orgs/{org_id}/users/{user_id} orgs removeOrgUser
 //
-// Delete user in current organization.
+// Remove user from organization.
+//
+// Removes the user from the specified organization. Unlike the current-org
+// endpoint (DELETE /org/users/{user_id}), this does not delete orphaned
+// user accounts.
 //
 // If you are running Grafana Enterprise and have Fine-grained access control enabled
 // you need to have a permission with action: `org.users:remove` with scope `users:*`.


### PR DESCRIPTION
## What is this PR about?

The documentation and swagger description for `DELETE /org/users/{user_id}` incorrectly state that this endpoint only removes a user from the organization.

In reality, when `ShouldDeleteOrphanedUser` is set to `true` (which is the case for this endpoint), users who do not belong to any other organization **and** are not Grafana Server Admins are **permanently deleted** from the Grafana instance.

The Admin API endpoint (`DELETE /orgs/{org_id}/users/{user_id}`) does **not** set this flag, so it truly only removes the user from the specified org without deleting the account.

### Changes

- Updated swagger route description for `removeOrgUserForCurrentOrg` to document the orphaned user deletion behavior
- Updated swagger route description for `removeOrgUser` (admin endpoint) to clarify it does **not** delete orphaned users
- Updated user-facing docs (`manage-org-users/index.md`) to reflect the actual behavior

### Code references

- `pkg/api/org_users.go:463-472` — `RemoveOrgUserForCurrentOrg` sets `ShouldDeleteOrphanedUser: true`
- `pkg/api/org_users.go:490-502` — `RemoveOrgUser` does **not** set `ShouldDeleteOrphanedUser`
- `pkg/services/org/orgimpl/store.go:739` — orphaned user deletion logic
- `pkg/services/org/orgimpl/store_test.go` — test: *"Removing user from org should delete user completely if in no other org"*

### How was this tested?

Code reading and verification against existing test cases in `store_test.go` that explicitly validate the orphaned user deletion behavior.