### PR TITLE
Provisioning: Auto-generate branch name when only branch workflow is enabled

### DIFF
--- a/public/app/features/provisioning/hooks/useProvisionedDashboardData.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedDashboardData.ts
@@ -9,6 +9,7 @@ import { getIsReadOnlyRepo } from 'app/features/provisioning/utils/repository';
 import { DashboardMeta } from 'app/types/dashboard';
 
 import { getCanPushToConfiguredBranch, getDefaultWorkflow } from '../components/defaults';
+import { generateNewBranchName } from '../components/utils/newBranchName';
 import { generatePath } from '../components/utils/path';
 import { generateTimestamp } from '../components/utils/timestamp';
 import { ProvisionedDashboardFormData } from '../types/form';
@@ -55,8 +56,7 @@ export function useDefaultValues({
 
   return {
     values: {
-      // When workflow is branch, we don't set a default ref, user will select from branches dropdown
-      ref: defaultWorkflow === 'branch' ? '' : (repository?.branch ?? ''),
+      ref: defaultWorkflow === 'branch' ? generateNewBranchName('dashboard') : (repository?.branch ?? ''),
       path: dashboardPath,
       repo: managerIdentity || repository?.name || '',
       comment: '',

--- a/public/app/features/provisioning/hooks/useProvisionedFolderFormData.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedFolderFormData.ts
@@ -4,6 +4,7 @@ import { Folder } from 'app/api/clients/folder/v1beta1';
 import { RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
 import { AnnoKeySourcePath } from 'app/features/apiserver/types';
 import { getCanPushToConfiguredBranch, getDefaultWorkflow } from 'app/features/provisioning/components/defaults';
+import { generateNewBranchName } from 'app/features/provisioning/components/utils/newBranchName';
 import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
 
 import { BaseProvisionedFormData } from '../types/form';
@@ -42,8 +43,7 @@ export function useProvisionedFolderFormData({
     return {
       title: title || '',
       comment: '',
-      // When workflow is branch, we don't set a default ref, user will select from branches dropdown
-      ref: defaultWorkflow === 'branch' ? '' : (repository?.branch ?? ''),
+      ref: defaultWorkflow === 'branch' ? generateNewBranchName('folder') : (repository?.branch ?? ''),
       repo: repository.name || '',
       path: folder?.metadata?.annotations?.[AnnoKeySourcePath] || '',
       workflow: getDefaultWorkflow(repository),


### PR DESCRIPTION
**What is this feature?**

Auto-generates a branch name when the save dialog opens for a dashboard or folder in a repository that has only the "branch" workflow enabled (no direct push to configured branch).

**Why do we need this feature?**

When a repository has only the "branch" workflow, the branch field was left empty, forcing users to manually type a branch name before saving changes. The existing `generateNewBranchName` utility was unused; this fix wires it up to pre-fill the field with names like `dashboard/2026-03-06-abc12`.


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/962