### PR TITLE
Dashboard: Keep organization as optional in AnnotationsPermissions

### DIFF
--- a/public/app/types/dashboard.ts
+++ b/public/app/types/dashboard.ts
@@ -101,6 +101,7 @@ export interface AnnotationActions {
 
 export interface AnnotationsPermissions {
   dashboard: AnnotationActions;
+  organization?: AnnotationActions;
 }
 
 export interface SnapshotSpec {


### PR DESCRIPTION
**What is this feature?**

Makes the `organization` property optional in the `AnnotationsPermissions` type to fix a typecheck failure introduced by #119079.

**Why do we need this feature?**

PR #119079 removed the `organization` property from `AnnotationsPermissions`, but enterprise extensions still reference it in test code. This caused typecheck to fail in the full CI environment while passing locally (since extensions are gitignored in OSS). Making the property optional preserves the intent of ignoring organization annotations while maintaining type compatibility.

**Who is this feature for?**

Developers working with Grafana's annotation system and the CI pipeline.

**Which issue(s) does this PR fix?**:

Fixes typecheck failure on main (related to #119079)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.