### PR TITLE
Docs: Git Sync - Save from UI.

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -48,6 +48,7 @@ To do so, follow these steps:
    - Select the provisioned folder you want to save the dashboard in.
    - Fill in the rest of the fields accordingly.
 1. Click **Save**.
+1. In your synced GitHub repository, merge the branch with the dashboard you want to save.
 
 ## Add a dashboard with Grafana CLI
 

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -35,7 +35,7 @@ Git Sync is under development, and traditional operations like moving or copying
 - [Export the dashboard with Grafana CLI](#add-a-dashboard-with-grafana-cli)
 - [Copy the dashboard as JSON and commit to the repository](#add-a-dashboard-via-json-export)
 
-## Provision an existing dashboard from the Grafana UI
+## Add an existing dashboard from the Grafana UI
 
 You can save a copy of dashboard directly from the Grafana UI to your provisioned folder.
 
@@ -44,7 +44,7 @@ To do so, follow these steps:
 1. Make sure the dashboard is in **Editable** mode.
 1. Select **Save** or **Save as** from the top-right corner.
 1. In the menu:
-   - Type in the name of the branch of the provisioned repository you want to work in. Committing directly to `main` is not supported.
+   - Type in the name of the branch of the provisioned repository you want to work in, or create a new branch. Committing directly to `main` is not supported.
    - Select the provisioned folder you want to save the dashboard in.
    - Fill in the rest of the fields accordingly.
 1. Click **Save**.

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -29,15 +29,15 @@ Git Sync is available in [public preview](https://grafana.com/docs/release-life-
 
 {{< /admonition >}}
 
-Git Sync is under development, and traditional operations like moving or saving a dashboard to a provisioned folder are not fully supported for resources already existing in Grafana. Git Sync doesn't offer any built-in functionality to easily export resources from Grafana in bulk. However, the following options are available:
+Git Sync is under development, and traditional operations like moving or copying a dashboard to a provisioned folder are not fully supported for resources already existing in Grafana. Git Sync doesn't offer any built-in functionality to easily export resources from Grafana in bulk. However, the following options are available:
 
-- [Save a dashboard from the Grafana UI](#save-a-dashboard-from-the-grafana-ui)
+- [Provision an existing dashboard from the Grafana UI](#provision-an-existing-dashboard-from-the-grafana-ui)
 - [Export the dashboard with Grafana CLI](#add-a-dashboard-with-grafana-cli)
 - [Copy the dashboard as JSON and commit to the repository](#add-a-dashboard-via-json-export)
 
-## Save a dashboard from the Grafana UI
+## Provision an existing dashboard from the Grafana UI
 
-You can save any dashboard directly from the Grafana UI to your provisioned folder.
+You can save a copy of dashboard directly from the Grafana UI to your provisioned folder.
 
 To do so, follow these steps:
 
@@ -51,7 +51,7 @@ To do so, follow these steps:
 
 ## Add a dashboard with Grafana CLI
 
-You can export an existing dashboard with the [Grafana CLI](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/). Use the CLI to download the resources you want to sync from Grafana, and then commit and push those files to your provisioned Git repository. Git Sync will then detect the commit, and synchronize with Grafana.
+You can also export an existing dashboard with the [Grafana CLI](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/). Use the CLI to download the resources you want to sync from Grafana, and then commit and push those files to your provisioned Git repository. Git Sync will then detect the commit, and synchronize with Grafana.
 
 To do so, follow these steps:
 

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -32,26 +32,26 @@ Git Sync is available in [public preview](https://grafana.com/docs/release-life-
 Git Sync is under development, and traditional operations like moving or saving a dashboard to a provisioned folder are not fully supported for resources already existing in Grafana. Git Sync doesn't offer any built-in functionality to easily export resources from Grafana in bulk. However, the following options are available:
 
 - [Save a dashboard from the Grafana UI](#save-a-dashboard-from-the-grafana-ui)
-- [Export the dashboard with Grafana CLI](#add-a-dashboard-with-grafana-cli) 
+- [Export the dashboard with Grafana CLI](#add-a-dashboard-with-grafana-cli)
 - [Copy the dashboard as JSON and commit to the repository](#add-a-dashboard-via-json-export)
 
 ## Save a dashboard from the Grafana UI
 
-You can save any dashboard directly from the Grafana UI to your provisioned folder. 
+You can save any dashboard directly from the Grafana UI to your provisioned folder.
 
 To do so, follow these steps:
 
 1. Make sure the dashboard is in **Editable** mode.
 1. Select **Save** or **Save as** from the top-right corner.
 1. In the menu:
-   - Type in the name of the branch of the provisioned repository you want to work in. Commiting directly to `main` is not supported.
+   - Type in the name of the branch of the provisioned repository you want to work in. Committing directly to `main` is not supported.
    - Select the provisioned folder you want to save the dashboard in.
    - Fill in the rest of the fields accordingly.
-1. Click **Save**.   
+1. Click **Save**.
 
 ## Add a dashboard with Grafana CLI
 
-You can export an existing dashboard with the [Grafana CLI](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/). Use the CLI to download the resources you want to sync from Grafana, and then commit and push those files to your privisioned Git repository. Git Sync will then detect the commit, and synchronize with Grafana. 
+You can export an existing dashboard with the [Grafana CLI](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/). Use the CLI to download the resources you want to sync from Grafana, and then commit and push those files to your provisioned Git repository. Git Sync will then detect the commit, and synchronize with Grafana.
 
 To do so, follow these steps:
 

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -44,11 +44,12 @@ To do so, follow these steps:
 1. Make sure the dashboard is in **Editable** mode.
 1. Select **Save** or **Save as** from the top-right corner.
 1. In the menu:
-   - Type in the name of the branch of the provisioned repository you want to work in, or create a new branch. Committing directly to `main` is not supported.
-   - Select the provisioned folder you want to save the dashboard in.
+   - **Target folder**: Select the provisioned folder from your Grafana UI where you want to save the dashboard in. 
+   - **Branch**: Type in the name of the branch of the provisioned repository you want to work in, or create a new branch. Committing directly to `main` is not supported.
+   - **Folder**: Type in the folder in your sync repository, if any.
    - Fill in the rest of the fields accordingly.
 1. Click **Save**.
-1. In your synced GitHub repository, merge the branch with the dashboard you want to save.
+1. In your synced GitHub repository, merge the branch with the dashboard you want to sync.
 
 ## Add a dashboard with Grafana CLI
 

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -23,30 +23,37 @@ aliases:
 
 {{< admonition type="caution" >}}
 
-Git Sync is available in [public preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud, and is an [experimental feature](https://grafana.com/docs/release-life-cycle/) in Grafana v12 for open source and Enterprise editions. Documentation and support is available **based on the different tiers** but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided.
+Git Sync is available in [public preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud, and is an [experimental feature](https://grafana.com/docs/release-life-cycle/) in Grafana v12 for open source and Enterprise editions. Documentation and support is available based on the different tiers but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided.
 
 **Git Sync is under development.** Refer to [Usage and performance limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits) for more information. [Contact Grafana](https://grafana.com/help/) for support or to report any issues you encounter and help us improve this feature.
 
 {{< /admonition >}}
 
-Git Sync is under development, and traditional operations like `import`, `copy`, `move`, or `save` to a provisioned folder are not yet supported for dashboards already existing in Grafana. To use Git Sync with existing dashboards you must export them to the repository first.
+Git Sync is under development, and traditional operations like moving or saving a dashboard to a provisioned folder are not fully supported for resources already existing in Grafana. Git Sync doesn't offer any built-in functionality to easily export resources from Grafana in bulk. However, the following options are available:
 
-Currently, Git Sync doesn't offer any built-in functionality to easily export resources from Grafana in bulk. However, the following options are available:
-
-- [Export the dashboard with Grafana CLI](#add-a-dashboard-with-grafana-cli) (recommended)
+- [Save a dashboard from the Grafana UI](#save-a-dashboard-from-the-grafana-ui)
+- [Export the dashboard with Grafana CLI](#add-a-dashboard-with-grafana-cli) 
 - [Copy the dashboard as JSON and commit to the repository](#add-a-dashboard-via-json-export)
 
-{{< admonition type="caution" >}}
+## Save a dashboard from the Grafana UI
 
-Refer to [Known limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits/) before using Git Sync.
+You can save any dashboard directly from the Grafana UI to your provisioned folder. 
 
-{{< /admonition >}}
+To do so, follow these steps:
+
+1. Make sure the dashboard is in **Editable** mode.
+1. Select **Save** or **Save as** from the top-right corner.
+1. In the menu:
+   - Type in the name of the branch of the provisioned repository you want to work in. Commiting directly to `main` is not supported.
+   - Select the provisioned folder you want to save the dashboard in.
+   - Fill in the rest of the fields accordingly.
+1. Click **Save**.   
 
 ## Add a dashboard with Grafana CLI
 
-You can export an existing dashboard with the [Grafana CLI](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/) and commit it to your Git repository.
+You can export an existing dashboard with the [Grafana CLI](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/). Use the CLI to download the resources you want to sync from Grafana, and then commit and push those files to your privisioned Git repository. Git Sync will then detect the commit, and synchronize with Grafana. 
 
-Use `grafanactl` to download the resources you want to sync from Grafana, and then commit and push those files to the repository. Git Sync will then detect the commit, and synchronize with Grafana. To do so, follow these steps:
+To do so, follow these steps:
 
 1. Set up the `grafanactl` context to point to your instance as documented in [Defining contexts](https://grafana.github.io/grafanactl/configuration/#defining-contexts).
 1. Pull the resources you want to sync from the instance to your local repository:
@@ -74,9 +81,9 @@ See more at [Manage resources with Grafana CLI](https://grafana.github.io/grafan
 
 To add an existing dashboard to Git Sync via JSON export, you need to:
 
-1. Export the dashboard as JSON
-1. Convert it to the Custom Resource Definition (CRD) format required by the Grafana App Platform
-1. Commit the converted file to your Git repository
+1. Export the dashboard as JSON.
+1. Convert it to the Custom Resource Definition (CRD) format required by the Grafana App Platform.
+1. Commit the converted file to your Git repository.
 
 ### Required JSON format
 
@@ -98,6 +105,6 @@ The structure includes:
 - `metadata`: Contains the dashboard identifier `uid`. You can find the identifier in the dahsboard's URL or in the exported JSON
 - `spec`: Wraps your original dashboard JSON
 
-## Edit Git-managed dashboards
+## Work with Git-managed dashboards
 
 After you've saved a dashboard in Git, it'll be synchronized automatically, and you'll be able to work with it as any other provisioned resource. Refer to [Work with provisioned dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/provision-resources/provisioned-dashboards/) for more information.

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -44,7 +44,7 @@ To do so, follow these steps:
 1. Make sure the dashboard is in **Editable** mode.
 1. Select **Save** or **Save as** from the top-right corner.
 1. In the menu:
-   - **Target folder**: Select the provisioned folder from your Grafana UI where you want to save the dashboard in. 
+   - **Target folder**: Select the provisioned folder from your Grafana UI where you want to save the dashboard in.
    - **Branch**: Type in the name of the branch of the provisioned repository you want to work in, or create a new branch. Committing directly to `main` is not supported.
    - **Folder**: Type in the folder in your sync repository, if any.
    - Fill in the rest of the fields accordingly.

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -31,7 +31,7 @@ Git Sync is available in [public preview](https://grafana.com/docs/release-life-
 
 Git Sync is under development, and traditional operations like moving or copying a dashboard to a provisioned folder are not fully supported for resources already existing in Grafana. Git Sync doesn't offer any built-in functionality to easily export resources from Grafana in bulk. However, the following options are available:
 
-- [Provision an existing dashboard from the Grafana UI](#provision-an-existing-dashboard-from-the-grafana-ui)
+- [Export an existing dashboard from the Grafana UI as a copy](#provision-an-existing-dashboard-from-the-grafana-ui)
 - [Export the dashboard with Grafana CLI](#add-a-dashboard-with-grafana-cli)
 - [Copy the dashboard as JSON and commit to the repository](#add-a-dashboard-via-json-export)
 

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code.md
@@ -35,7 +35,7 @@ For more information, refer to the following documents:
 
 - [Repository resource](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/key-concepts#git-sync-repository-resource) and [Connection resource](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/key-concepts#git-sync-repository-resource) overview
 - [Dashboard CRD Format](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/export-resources/)
-- [`grafanactl` documentation](https://grafana.github.io/grafanactl/)
+- [Grafana CLI documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/)
 
 ## Set up Git Sync as code with the Grafana CLI
 


### PR DESCRIPTION
Covers https://github.com/grafana/git-ui-sync-project/issues/961.
Preview - https://deploy-preview-grafana-119732-zb444pucvq-vp.a.run.app/docs/grafana/latest/as-code/observability-as-code/git-sync/export-resources/
