### PR TITLE
Import Dashboards: Don't add expressions datasource to inputs

### DIFF
--- a/public/app/features/manage-dashboards/import/components/ImportForm.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportForm.tsx
@@ -117,9 +117,6 @@ export function ImportForm({
         </Field>
         {inputs.dataSources &&
           inputs.dataSources.map((input: DataSourceInput, index: number) => {
-            if (input.pluginId === ExpressionDatasourceRef.type) {
-              return null;
-            }
             const dataSourceOption = `dataSources.${index}` as const;
             const current = watchDataSources ?? [];
             return (

--- a/public/app/features/manage-dashboards/import/components/ImportForm.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportForm.tsx
@@ -3,7 +3,6 @@ import { Controller, FieldErrors, UseFormReturn } from 'react-hook-form';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
 import { Button, Field, FormFieldErrors, FormsOnSubmit, Stack, Input, Legend } from '@grafana/ui';
 import { FolderPicker } from 'app/core/components/Select/FolderPicker';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -9,7 +9,7 @@ import { Dashboard, Panel, VariableModel } from '@grafana/schema/dist/esm/veneer
 import { ExportFormat } from 'app/features/dashboard/api/types';
 import { ExportLabel } from 'app/features/dashboard-scene/scene/export/exporters';
 
-import { DashboardInputs, DataSourceInput, ImportDashboardDTO, ImportFormDataV2, InputType } from '../../types';
+import { DashboardInputs, ImportDashboardDTO, ImportFormDataV2, InputType } from '../../types';
 
 import {
   applyV1Inputs,

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -244,8 +244,8 @@ describe('extractV1Inputs', () => {
 
     const result = await extractV1Inputs(dashboard);
 
-    expect(result.dataSources).toHaveLength(2);
-    expect(result.constants).toHaveLength(1);
+    expect(result.dataSources.map((ds) => ds.name)).toEqual(['DS_PROMETHEUS', 'DS_LOKI']);
+    expect(result.constants.map((c) => c.name)).toEqual(['VAR_NAMESPACE']);
   });
 
   it('should handle empty __inputs array', async () => {

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -9,7 +9,7 @@ import { Dashboard, Panel, VariableModel } from '@grafana/schema/dist/esm/veneer
 import { ExportFormat } from 'app/features/dashboard/api/types';
 import { ExportLabel } from 'app/features/dashboard-scene/scene/export/exporters';
 
-import { DashboardInputs, ImportDashboardDTO, ImportFormDataV2, InputType } from '../../types';
+import { DashboardInputs, DataSourceInput, ImportDashboardDTO, ImportFormDataV2, InputType } from '../../types';
 
 import {
   applyV1Inputs,
@@ -213,6 +213,41 @@ describe('extractV1Inputs', () => {
     expect(result.constants).toHaveLength(0);
   });
 
+  it('should skip expressions datasource inputs', async () => {
+    const dashboard = createV1DashboardWithInputs([
+      {
+        name: 'DS_PROMETHEUS',
+        type: InputType.DataSource,
+        label: 'Prometheus',
+        pluginId: 'prometheus',
+      },
+      {
+        name: 'DS_LOKI',
+        type: InputType.DataSource,
+        label: 'Loki',
+        pluginId: 'loki',
+      },
+      {
+        name: 'VAR_NAMESPACE',
+        type: InputType.Constant,
+        label: 'Namespace',
+        value: 'default',
+      },
+      {
+        name: 'DS_EXPRESSION',
+        label: 'Expression',
+        description: '',
+        type: InputType.DataSource,
+        pluginId: '__expr__',
+      },
+    ]);
+
+    const result = await extractV1Inputs(dashboard);
+
+    expect(result.dataSources).toHaveLength(2);
+    expect(result.constants).toHaveLength(1);
+  });
+
   it('should handle empty __inputs array', async () => {
     const dashboard = { title: 'Test Dashboard', __inputs: [] };
     const result = await extractV1Inputs(dashboard);
@@ -264,6 +299,20 @@ describe('extractV2Inputs', () => {
                     {
                       kind: 'PanelQuery',
                       spec: { query: { group: 'prometheus', labels: { [ExportLabel]: 'prom-1' } } },
+                    },
+                    // expression queries shouldn't be added to input, adding this just to prevent regressions
+                    {
+                      kind: 'PanelQuery',
+                      spec: {
+                        query: {
+                          datasource: {
+                            name: '__expr__',
+                          },
+                          group: '__expr__',
+                          spec: {},
+                        },
+                        refId: 'B',
+                      },
                     },
                   ],
                 },

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -1,5 +1,6 @@
 import { DataSourceInstanceSettings, VariableModel } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
+import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
 import { AnnotationQueryKind, Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { Panel } from '@grafana/schema/dist/esm/raw/dashboard/x/Dashboard_types.gen';
 import { AnnotationQuery, Dashboard } from '@grafana/schema/dist/esm/veneer/dashboard.types';
@@ -146,10 +147,13 @@ export async function extractV1Inputs(dashboard: unknown): Promise<DashboardInpu
       };
 
       if (input.type === InputType.DataSource) {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        (inputModel as DataSourceInput).description = getDataSourceDescription(input);
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        inputs.dataSources.push(inputModel as DataSourceInput);
+        // Expression datasources do not need user input
+        if (inputModel.pluginId !== ExpressionDatasourceRef.type) {
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          (inputModel as DataSourceInput).description = getDataSourceDescription(input);
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          inputs.dataSources.push(inputModel as DataSourceInput);
+        }
       } else if (input.type === InputType.Constant) {
         if (!inputModel.info) {
           inputModel.info = 'Specify a string constant';


### PR DESCRIPTION
Fixes a bug in the import flow (originally reported in [Slack](https://raintank-corp.slack.com/archives/C03KVDHTWAH/p1772712526860019)) where datasources were matched to the inputs from the Import form (from v1). However, 'expressions' datasource has no input since it's built-in, so no matches were found, resulting in 
`cannot read type of undefined` error. 

This change makes sure `__inputs` in v1 schema don't get added to the UI for datasource inputs in the first place by checking whether a datasource is not expression. 
Also added a query in the test case for v2 inputs. V2 dsInputs are not extracted from `__inputs`, but from variables, annotations and queries themselves. When the expressions query hits this function, it will be[ filtered out in this line](https://github.com/grafana/grafana/blob/3ad05241e13b19e185a27b2d7cd00001e0f1aa1a/public/app/features/manage-dashboards/import/utils/inputs.ts#L227) because expressions never have a label. Still I added a query in the test case just in case we decide to change that in the future, lmk what you think