### PR TITLE
Alerting: Filter alert label query by rule_uid structured metadata

### DIFF
--- a/apps/alerting/historian/pkg/app/notification/lokireader.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader.go
@@ -103,7 +103,7 @@ func (h *LokiReader) Query(ctx context.Context, query Query) (QueryResult, error
 	// Phase 1: If labels are specified, query the alerts stream to collect matching UUIDs.
 	var labelUUIDs []string
 	if query.Labels != nil && len(*query.Labels) > 0 {
-		alertLogql, err := buildAlertLabelQuery(*query.Labels)
+		alertLogql, err := buildAlertLabelQuery(query.RuleUID, *query.Labels)
 		if err != nil {
 			return QueryResult{}, err
 		}
@@ -482,9 +482,19 @@ func parseLokiAlertEntry(s lokiclient.Sample) (AlertEntry, error) {
 }
 
 // buildAlertLabelQuery builds a LogQL query against the alerts stream with label matchers.
+// When ruleUID is provided, a structured metadata filter is added before JSON parsing
+// so Loki can discard non-matching entries without deserializing the log line.
 // After | json, Loki flattens nested label keys so labels.alertname becomes labels_alertname.
-func buildAlertLabelQuery(labels Matchers) (string, error) {
+func buildAlertLabelQuery(ruleUID *string, labels Matchers) (string, error) {
 	logql := fmt.Sprintf(`{%s=%q}`, historian.LabelFrom, historian.LabelFromValueAlerts)
+
+	if ruleUID != nil && *ruleUID != "" {
+		if !validRuleUIDRegex.MatchString(*ruleUID) {
+			return "", fmt.Errorf("%w: rule uid: %q", ErrInvalidQuery, *ruleUID)
+		}
+		logql += fmt.Sprintf(` | rule_uid = %q`, *ruleUID)
+	}
+
 	logql += ` | json`
 	for _, matcher := range labels {
 		if !validLabelKeyRegex.MatchString(matcher.Label) {

--- a/apps/alerting/historian/pkg/app/notification/lokireader_test.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader_test.go
@@ -663,14 +663,22 @@ func TestBuildAlertQuery(t *testing.T) {
 func TestBuildAlertLabelQuery(t *testing.T) {
 	tests := []struct {
 		name     string
+		ruleUID  *string
 		labels   Matchers
 		expected string
 		experr   error
 	}{
 		{
-			name:   "single label matcher",
+			name:   "single label matcher without rule uid",
 			labels: Matchers{{Type: "=", Label: "alertname", Value: "HighCPU"}},
 			expected: fmt.Sprintf(`{%s=%q} | json | labels_alertname = "HighCPU"`,
+				historian.LabelFrom, historian.LabelFromValueAlerts),
+		},
+		{
+			name:    "single label matcher with rule uid",
+			ruleUID: stringPtr("test-rule-uid"),
+			labels:  Matchers{{Type: "=", Label: "alertname", Value: "HighCPU"}},
+			expected: fmt.Sprintf(`{%s=%q} | rule_uid = "test-rule-uid" | json | labels_alertname = "HighCPU"`,
 				historian.LabelFrom, historian.LabelFromValueAlerts),
 		},
 		{
@@ -684,6 +692,16 @@ func TestBuildAlertLabelQuery(t *testing.T) {
 				historian.LabelFrom, historian.LabelFromValueAlerts),
 		},
 		{
+			name:    "multiple label matchers with rule uid",
+			ruleUID: stringPtr("my-rule"),
+			labels: Matchers{
+				{Type: "=", Label: "alertname", Value: "HighCPU"},
+				{Type: "!=", Label: "severity", Value: "info"},
+			},
+			expected: fmt.Sprintf(`{%s=%q} | rule_uid = "my-rule" | json | labels_alertname = "HighCPU" | labels_severity != "info"`,
+				historian.LabelFrom, historian.LabelFromValueAlerts),
+		},
+		{
 			name:   "invalid label key",
 			labels: Matchers{{Type: "=", Label: "bad key", Value: "bar"}},
 			experr: ErrInvalidQuery,
@@ -693,11 +711,24 @@ func TestBuildAlertLabelQuery(t *testing.T) {
 			labels: Matchers{{Type: "|=", Label: "foo", Value: "bar"}},
 			experr: ErrInvalidQuery,
 		},
+		{
+			name:    "invalid rule uid",
+			ruleUID: stringPtr("bad uid!"),
+			labels:  Matchers{{Type: "=", Label: "alertname", Value: "HighCPU"}},
+			experr:  ErrInvalidQuery,
+		},
+		{
+			name:    "empty rule uid is ignored",
+			ruleUID: stringPtr(""),
+			labels:  Matchers{{Type: "=", Label: "alertname", Value: "HighCPU"}},
+			expected: fmt.Sprintf(`{%s=%q} | json | labels_alertname = "HighCPU"`,
+				historian.LabelFrom, historian.LabelFromValueAlerts),
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := buildAlertLabelQuery(tt.labels)
+			result, err := buildAlertLabelQuery(tt.ruleUID, tt.labels)
 			if tt.experr != nil {
 				require.ErrorIs(t, err, tt.experr)
 			} else {


### PR DESCRIPTION
**What is this feature?**
## Summary
- Adds `rule_uid` structured metadata filter to the Phase 1 alert label query (`buildAlertLabelQuery`), so Loki can discard non-matching entries **before** JSON parsing
- Previously, the query used only `{from="notify-history-alerts"}` as stream selector, forcing Loki to scan and deserialize the entire alerts stream — causing timeouts on instances with high notification history volume
- The alerts stream already writes `rule_uid` as structured metadata (see `historian.go:162`), this change simply takes advantage of it

## Context

When the `notification/query` endpoint receives a `labels` filter (e.g. from the triage drawer), it runs a two-phase lookup:

1. **Phase 1**: MetricsQuery against the alerts stream to find UUIDs matching the label filter
2. **Phase 2**: RangeQuery against the notifications stream filtered by those UUIDs

Phase 1 was slow because the LogQL had no way to narrow down before `| json`:

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
