### PR TITLE
Alerting: Set a default NegotiatedSerializer in historian app client.

### DIFF
--- a/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/client.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/grafana/grafana-app-sdk/k8s"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 )
@@ -24,6 +25,11 @@ func NewClient(cfg rest.Config, namespace string) (*Client, error) {
 	cfg.GroupVersion = &schema.GroupVersion{
 		Group:   APIGroup,
 		Version: APIVersion,
+	}
+
+	// If the caller didn't pass one, specify a reasonable default.
+	if cfg.NegotiatedSerializer == nil {
+		cfg.NegotiatedSerializer = &k8s.GenericNegotiatedSerializer{}
 	}
 
 	client, err := rest.RESTClientFor(&cfg)

--- a/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/client_test.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/client_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 )
 
@@ -20,9 +19,6 @@ func newTestClient(t *testing.T, handler http.Handler) *Client {
 	cfg := rest.Config{
 		Host:    srv.URL,
 		APIPath: "/apis",
-		ContentConfig: rest.ContentConfig{
-			NegotiatedSerializer: &fakeNegotiatedSerializer{},
-		},
 	}
 	client, err := NewClient(cfg, "test-ns")
 	require.NoError(t, err)
@@ -61,14 +57,4 @@ func TestHistorianClient_NotificationsQueryAlerts(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "POST", gotMethod)
 	require.Equal(t, "/apis/historian.alerting.grafana.app/v0alpha1/namespaces/test-ns/notifications/queryalerts", gotPath)
-}
-
-type fakeNegotiatedSerializer struct{}
-
-func (f *fakeNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo { return nil }
-func (f *fakeNegotiatedSerializer) EncoderForVersion(serializer runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
-	return serializer
-}
-func (f *fakeNegotiatedSerializer) DecoderToVersion(serializer runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
-	return serializer
 }


### PR DESCRIPTION
Hides a bit of complexity from the caller by providiing a default, but allowing
customization if needed. Use the same as clients from the registry use by default.
