### PR TITLE
Dashboard Import: fix multiple import issues

### DIFF
--- a/public/app/features/manage-dashboards/import/components/DashboardImportK8s.tsx
+++ b/public/app/features/manage-dashboards/import/components/DashboardImportK8s.tsx
@@ -62,7 +62,8 @@ export function DashboardImportK8s({ queryParams }: Props) {
       const response = await getBackendSrv().get(`/api/gnet/dashboards/${id}`);
       const dashboard = response.json;
       const format = detectExportFormat(dashboard);
-      const inputs = format === ExportFormat.V2Resource ? extractV2Inputs(dashboard) : await extractV1Inputs(dashboard);
+      const inputs =
+        format === ExportFormat.V2Resource ? await extractV2Inputs(dashboard) : await extractV1Inputs(dashboard);
 
       setState({
         status: LoadingState.Done,
@@ -116,7 +117,8 @@ export function DashboardImportK8s({ queryParams }: Props) {
       const format = detectExportFormat(json);
       // Unwrap k8s resource to get the spec, or use as-is for classic dashboards
       const dashboard = isDashboardV2Resource(json) || isDashboardV1Resource(json) ? json.spec : json;
-      const inputs = format === ExportFormat.V2Resource ? extractV2Inputs(dashboard) : await extractV1Inputs(dashboard);
+      const inputs =
+        format === ExportFormat.V2Resource ? await extractV2Inputs(dashboard) : await extractV1Inputs(dashboard);
 
       setState({
         status: LoadingState.Done,

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -23,11 +23,14 @@ import {
 } from './inputs';
 
 // Mock external dependencies
+const mockGetDataSourceSrv = {
+  getList: jest.fn().mockReturnValue([{ uid: 'ds-1', name: 'Prometheus', type: 'prometheus' }]),
+  get: jest.fn().mockResolvedValue({ meta: { builtIn: false } }),
+};
+
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: () => ({
-    getList: jest.fn().mockReturnValue([{ uid: 'ds-1', name: 'Prometheus', type: 'prometheus' }]),
-  }),
+  getDataSourceSrv: () => mockGetDataSourceSrv,
 }));
 
 jest.mock('../../../library-panels/state/api', () => ({
@@ -225,8 +228,8 @@ describe('extractV1Inputs', () => {
 });
 
 describe('extractV2Inputs', () => {
-  it('should return empty inputs for non-object dashboard', () => {
-    expect(extractV2Inputs(null)).toEqual(emptyInputs);
+  it('should return empty inputs for non-object dashboard', async () => {
+    expect(await extractV2Inputs(null)).toEqual(emptyInputs);
   });
 
   it.each([
@@ -277,18 +280,18 @@ describe('extractV2Inputs', () => {
         },
       },
     ],
-  ])('should collect datasource types from %s', (_source, dashboard) => {
-    const result = extractV2Inputs(dashboard);
+  ])('should collect datasource types from %s', async (_source, dashboard) => {
+    const result = await extractV2Inputs(dashboard);
     expect(result.dataSources).toHaveLength(1);
     expect(result.dataSources[0].pluginId).toBe('prometheus');
   });
 
-  it('should handle empty dashboard gracefully', () => {
-    const result = extractV2Inputs({});
+  it('should handle empty dashboard gracefully', async () => {
+    const result = await extractV2Inputs({});
     expect(result).toEqual(emptyInputs);
   });
 
-  it('should keep distinct datasource labels', () => {
+  it('should keep distinct datasource labels', async () => {
     const dashboard = {
       elements: {},
       variables: [
@@ -306,14 +309,14 @@ describe('extractV2Inputs', () => {
       ],
     };
 
-    const result = extractV2Inputs(dashboard);
+    const result = await extractV2Inputs(dashboard);
 
     expect(result.dataSources).toHaveLength(3);
     expect(result.dataSources.map((ds) => ds.name)).toEqual(['prom-1', 'prom-2', 'prom-3']);
     expect(result.dataSources.map((ds) => ds.pluginId)).toEqual(['prometheus', 'prometheus', 'prometheus']);
   });
 
-  it('should collect multiple different datasource types', () => {
+  it('should collect multiple different datasource types', async () => {
     const dashboard = {
       elements: {},
       variables: [
@@ -328,7 +331,7 @@ describe('extractV2Inputs', () => {
       ],
     };
 
-    const result = extractV2Inputs(dashboard);
+    const result = await extractV2Inputs(dashboard);
 
     expect(result.dataSources).toHaveLength(2);
     expect(result.dataSources.map((ds) => ds.pluginId)).toContain('prometheus');
@@ -344,8 +347,49 @@ describe('extractV2Inputs', () => {
       'panels without QueryGroup data',
       { elements: { 'panel-1': { kind: 'Panel', spec: { data: { kind: 'Snapshot', spec: {} } } } } },
     ],
-  ])('should skip %s', (_name, dashboard) => {
-    expect(extractV2Inputs(dashboard).dataSources).toHaveLength(0);
+  ])('should skip %s', async (_name, dashboard) => {
+    expect((await extractV2Inputs(dashboard)).dataSources).toHaveLength(0);
+  });
+
+  it('should skip built-in datasources', async () => {
+    mockGetDataSourceSrv.get.mockResolvedValueOnce({ meta: { builtIn: true } });
+
+    const dashboard = {
+      elements: {},
+      variables: [
+        {
+          kind: 'QueryVariable',
+          spec: { name: 'myvar', query: { group: 'grafana', labels: { [ExportLabel]: 'grafana-1' } } },
+        },
+      ],
+    };
+
+    const result = await extractV2Inputs(dashboard);
+    expect(result.dataSources).toHaveLength(0);
+  });
+
+  it('should keep non-built-in datasources and skip built-in ones', async () => {
+    mockGetDataSourceSrv.get
+      .mockResolvedValueOnce({ meta: { builtIn: false } })
+      .mockResolvedValueOnce({ meta: { builtIn: true } });
+
+    const dashboard = {
+      elements: {},
+      variables: [
+        {
+          kind: 'QueryVariable',
+          spec: { name: 'promvar', query: { group: 'prometheus', labels: { [ExportLabel]: 'prom-1' } } },
+        },
+        {
+          kind: 'QueryVariable',
+          spec: { name: 'grafvar', query: { group: 'grafana', labels: { [ExportLabel]: 'grafana-1' } } },
+        },
+      ],
+    };
+
+    const result = await extractV2Inputs(dashboard);
+    expect(result.dataSources).toHaveLength(1);
+    expect(result.dataSources[0].pluginId).toBe('prometheus');
   });
 });
 

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -95,6 +95,10 @@ interface DatasourceVariableModel {
   current?: { value?: string; text?: string; selected?: boolean };
 }
 
+interface ConstantVariableModel extends VariableModel {
+  query?: string;
+}
+
 // Removed duplicate constants - now defined at top of file
 
 describe('extractV1Inputs', () => {
@@ -407,6 +411,95 @@ describe('applyV1Inputs', () => {
 
     const dsVariable = result.templating?.list?.[1] as DatasourceVariableModel;
     expect(dsVariable.current?.value).toBe('ds-uid');
+  });
+
+  it('replaces constant variable query, current, and options with user-provided values', () => {
+    const dashboard = {
+      title: 'old',
+      uid: 'old',
+      templating: {
+        list: [
+          {
+            type: 'constant',
+            name: 'timezone',
+            query: '${VAR_TIMEZONE}',
+            current: { text: '${VAR_TIMEZONE}', value: '${VAR_TIMEZONE}', selected: false },
+            options: [{ text: '${VAR_TIMEZONE}', value: '${VAR_TIMEZONE}', selected: false }],
+          },
+          {
+            type: 'constant',
+            name: 'url',
+            query: '${VAR_URL}',
+            current: { text: '${VAR_URL}', value: '${VAR_URL}', selected: false },
+            options: [{ text: '${VAR_URL}', value: '${VAR_URL}', selected: false }],
+          },
+        ],
+      },
+    } as unknown as Dashboard;
+
+    const inputs: DashboardInputs = {
+      dataSources: [],
+      constants: [
+        { name: 'VAR_TIMEZONE', label: 'Timezone', info: '', value: 'UTC', type: InputType.Constant },
+        { name: 'VAR_URL', label: 'URL', info: '', value: 'http://default', type: InputType.Constant },
+      ],
+      libraryPanels: [],
+    };
+
+    const form: ImportDashboardDTO = {
+      title: 'Test',
+      uid: 'test-uid',
+      gnetId: '',
+      constants: ['Europe/Berlin', 'http://my-app:7070'],
+      dataSources: [],
+      elements: [],
+      folder: { uid: 'folder' },
+    };
+
+    const result = applyV1Inputs(dashboard, inputs, form);
+
+    const vars = result.templating?.list as ConstantVariableModel[];
+    expect(vars[0].query).toBe('Europe/Berlin');
+    expect(vars[0].current?.text).toBe('Europe/Berlin');
+    expect(vars[0].current?.value).toBe('Europe/Berlin');
+    expect(vars[0].options?.[0].text).toBe('Europe/Berlin');
+    expect(vars[1].query).toBe('http://my-app:7070');
+    expect(vars[1].current?.text).toBe('http://my-app:7070');
+    expect(vars[1].current?.value).toBe('http://my-app:7070');
+  });
+
+  it('replaces target datasource UIDs in panels with built-in datasources like Mixed', () => {
+    const dashboard = {
+      title: 'old',
+      uid: 'old',
+      panels: [
+        {
+          datasource: { type: 'datasource', uid: '-- Mixed --' },
+          targets: [
+            { datasource: { type: 'grafana-bigquery-datasource', uid: '${DS}' }, refId: 'A' },
+            { datasource: { type: 'grafana-athena-datasource', uid: '${DS}' }, refId: 'B' },
+          ],
+        },
+      ],
+    } as unknown as Dashboard;
+
+    const form: ImportDashboardDTO = {
+      title: 'new-title',
+      uid: 'new-uid',
+      gnetId: '',
+      constants: [],
+      dataSources: [{ uid: 'ds-uid', type: 'prometheus', name: 'My DS' } as DataSourceInstanceSettings],
+      elements: [],
+      folder: { uid: 'folder' },
+    };
+
+    const result = applyV1Inputs(dashboard, sampleV1Inputs, form);
+
+    expect(result.panels?.[0].datasource?.uid).toBe('-- Mixed --');
+
+    const panel = result.panels?.[0] as PanelWithTargets;
+    expect(panel.targets?.[0].datasource?.uid).toBe('ds-uid');
+    expect(panel.targets?.[1].datasource?.uid).toBe('ds-uid');
   });
 });
 

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -12,6 +12,7 @@ import { LibraryElementExport } from '../../../dashboard/components/DashExportMo
 import { getLibraryPanel } from '../../../library-panels/state/api';
 import { LibraryElementKind } from '../../../library-panels/types';
 import {
+  DashboardInput,
   DashboardInputs,
   DataSourceInput,
   ImportDashboardDTO,
@@ -262,7 +263,7 @@ function getDataSourceDescription(input: Record<string, unknown>): string {
  */
 export function applyV1Inputs(
   dashboard: Dashboard,
-  inputs: { dataSources: DataSourceInput[] },
+  inputs: { dataSources: DataSourceInput[]; constants?: DashboardInput[] },
   form: ImportDashboardDTO
 ): Dashboard {
   const annotations = (dashboard.annotations?.list ?? []).map((annotation: AnnotationQuery) => {
@@ -522,46 +523,67 @@ function processAnnotation(
 }
 
 function processPanel(panel: Panel, inputs: { dataSources: DataSourceInput[] }, form: ImportDashboardDTO): Panel {
-  if (panel.datasource && panel.datasource.uid && panel.datasource.uid.startsWith('$')) {
-    const userInput = checkUserInputMatch(panel.datasource.uid, inputs.dataSources, form.dataSources);
-
-    const queries = panel.targets?.map((target) => {
-      if (target.datasource && hasUid(target.datasource) && target.datasource.uid.startsWith('$')) {
-        const userInput = checkUserInputMatch(target.datasource.uid, inputs.dataSources, form.dataSources);
-        if (userInput) {
-          return {
-            ...target,
-            datasource: {
-              ...target.datasource,
-              uid: userInput.uid,
-            },
-          };
-        }
+  const queries = panel.targets?.map((target) => {
+    if (target.datasource && hasUid(target.datasource) && target.datasource.uid.startsWith('$')) {
+      const userInput = checkUserInputMatch(target.datasource.uid, inputs.dataSources, form.dataSources);
+      if (userInput) {
+        return {
+          ...target,
+          datasource: {
+            ...target.datasource,
+            uid: userInput.uid,
+          },
+        };
       }
-      return target;
-    });
-
-    if (userInput) {
-      return {
-        ...panel,
-        targets: queries,
-        datasource: {
-          ...panel.datasource,
-          uid: userInput.uid,
-        },
-      };
     }
-  }
+    return target;
+  });
 
-  return panel;
+  const panelDs =
+    panel.datasource && panel.datasource.uid && panel.datasource.uid.startsWith('$')
+      ? checkUserInputMatch(panel.datasource.uid, inputs.dataSources, form.dataSources)
+      : undefined;
+
+  return {
+    ...panel,
+    ...(queries && { targets: queries }),
+    ...(panelDs && {
+      datasource: {
+        ...panel.datasource,
+        uid: panelDs.uid,
+      },
+    }),
+  };
 }
 
 function processVariable(
   variable: VariableModel,
-  inputs: { dataSources: DataSourceInput[] },
+  inputs: { dataSources: DataSourceInput[]; constants?: DashboardInput[] },
   form: ImportDashboardDTO
 ) {
   const variableType = variable.type;
+
+  if (variableType === 'constant' && 'query' in variable && typeof variable.query === 'string' && inputs.constants) {
+    for (let i = 0; i < inputs.constants.length; i++) {
+      const placeholder = '${' + inputs.constants[i].name + '}';
+      if (variable.query === placeholder) {
+        const resolved = form.constants[i] ?? inputs.constants[i].value;
+        const current = 'current' in variable && isRecord(variable.current) ? variable.current : {};
+        const option =
+          'options' in variable && Array.isArray(variable.options) && isRecord(variable.options[0])
+            ? variable.options[0]
+            : {};
+
+        return {
+          ...variable,
+          query: resolved,
+          current: { ...current, text: resolved, value: resolved },
+          options: [{ ...option, text: resolved, value: resolved }],
+        };
+      }
+    }
+  }
+
   if (variableType === 'query' && 'datasource' in variable && isRecord(variable.datasource)) {
     const datasourceUid = variable.datasource.uid;
     if (typeof datasourceUid === 'string' && datasourceUid.startsWith('$')) {

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -169,7 +169,7 @@ export async function extractV1Inputs(dashboard: unknown): Promise<DashboardInpu
 /**
  * Extract inputs from a v2 dashboard spec
  */
-export function extractV2Inputs(dashboard: unknown): DashboardInputs {
+export async function extractV2Inputs(dashboard: unknown): Promise<DashboardInputs> {
   const inputs: DashboardInputs = {
     dataSources: [],
     constants: [],
@@ -232,6 +232,15 @@ export function extractV2Inputs(dashboard: unknown): DashboardInputs {
   }
 
   for (const [label, dsType] of Object.entries(dsTypes)) {
+    try {
+      const datasource = await getDataSourceSrv().get({ type: dsType });
+      if (datasource.meta?.builtIn) {
+        continue;
+      }
+    } catch {
+      // datasource not found, still add it as an input so the user can pick one
+    }
+
     const dsInfo = getDataSourceSrv().getList({ pluginId: dsType });
     inputs.dataSources.push({
       name: label,


### PR DESCRIPTION
**What is this feature?**

1. **Constant template variables not resolved:** `__inputs` of type constant (e.g. ${VAR_INVERTERPORTALTITLE}) were passed through as literal placeholders instead of being substituted with user-provided values. 

2. **Mixed datasource panels losing target datasources:** Panels with -- Mixed -- as the top-level datasource had their per-target datasource placeholders (e.g. ${DS_BIGQUERY}) skipped because target processing was gated behind the panel-level uid.startsWith('$') check. 

3. **Built-in datasources detected as user inputs (v2)**: extractV2Inputs did not filter built-in datasources, causing them to appear as configurable inputs during v2 import. 


Fixes: #119494
