### PR TITLE
Dashboards: Add quick edit options API for panel plugins

### DIFF
--- a/packages/grafana-data/src/panel/PanelPlugin.test.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.test.ts
@@ -1,0 +1,75 @@
+import { getPanelPlugin } from '../../test';
+
+describe('PanelPlugin', () => {
+  describe('setQuickEditPaths', () => {
+    it('should store quick edit paths', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+
+      plugin.setQuickEditPaths(['path1', 'path2']);
+
+      expect(plugin.getQuickEditPaths()).toEqual(['path1', 'path2']);
+    });
+
+    it('should return undefined when no paths are set', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+
+      expect(plugin.getQuickEditPaths()).toBeUndefined();
+    });
+
+    it('should limit paths to maximum of 5', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      plugin.setQuickEditPaths(['path1', 'path2', 'path3', 'path4', 'path5', 'path6', 'path7']);
+
+      expect(plugin.getQuickEditPaths()).toEqual(['path1', 'path2', 'path3', 'path4', 'path5']);
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('setQuickEditPaths received 7 paths'));
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should allow exactly 5 paths without warning', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      plugin.setQuickEditPaths(['path1', 'path2', 'path3', 'path4', 'path5']);
+
+      expect(plugin.getQuickEditPaths()).toEqual(['path1', 'path2', 'path3', 'path4', 'path5']);
+      expect(consoleSpy).not.toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should return this for method chaining', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+
+      const result = plugin.setQuickEditPaths(['path1']);
+
+      expect(result).toBe(plugin);
+    });
+
+    it('should create a copy of the paths array', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+      const paths = ['path1', 'path2'];
+
+      plugin.setQuickEditPaths(paths);
+      paths.push('path3');
+
+      expect(plugin.getQuickEditPaths()).toEqual(['path1', 'path2']);
+    });
+
+    it('should work with setPanelOptions in method chain', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' })
+        .setPanelOptions((builder) => {
+          builder.addSelect({
+            path: 'displayMode',
+            name: 'Display mode',
+            settings: { options: [] },
+          });
+        })
+        .setQuickEditPaths(['displayMode']);
+
+      expect(plugin.getQuickEditPaths()).toEqual(['displayMode']);
+    });
+  });
+});

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -118,6 +118,7 @@ export class PanelPlugin<
 
   private optionsSupplier?: PanelOptionsSupplier<TOptions>;
   private suggestionsSupplier?: VisualizationSuggestionsSupplier<TOptions, TFieldConfigOptions>;
+  private _quickEditPaths?: string[];
 
   panel: ComponentType<PanelProps<TOptions>> | null;
   editor?: ComponentClass<PanelEditorProps<TOptions>>;
@@ -274,6 +275,58 @@ export class PanelPlugin<
    */
   getPanelOptionsSupplier(): PanelOptionsSupplier<TOptions> {
     return this.optionsSupplier ?? (() => {});
+  }
+
+  /**
+   * Define which panel options should appear in the dashboard edit pane
+   * for quick editing without entering the full panel editor.
+   *
+   * This allows users to quickly adjust common settings directly from the
+   * dashboard edit view, reducing the number of clicks needed for frequent
+   * configuration changes.
+   *
+   * @param paths - Array of option paths (max 5) that should be shown in quick edit.
+   *                Paths should match those defined in setPanelOptions.
+   *                Supports nested paths using dot notation (e.g., 'legend.displayMode').
+   *
+   * @example
+   * ```typescript
+   * export const plugin = new PanelPlugin<Options>(MyPanel)
+   *   .setPanelOptions((builder) => {
+   *     builder
+   *       .addSelect({ path: 'displayMode', name: 'Display mode', ... })
+   *       .addRadio({ path: 'orientation', name: 'Orientation', ... })
+   *       .addBooleanSwitch({ path: 'showLegend', name: 'Show legend', ... });
+   *   })
+   *   .setQuickEditPaths(['displayMode', 'orientation']);
+   * ```
+   *
+   * @alpha
+   */
+  setQuickEditPaths(paths: Array<keyof TOptions & string> | string[]) {
+    const MAX_QUICK_EDIT_PATHS = 5;
+
+    if (paths.length > MAX_QUICK_EDIT_PATHS) {
+      console.warn(
+        `PanelPlugin [${this.meta?.id ?? 'unknown'}]: setQuickEditPaths received ${paths.length} paths, ` +
+          `but only ${MAX_QUICK_EDIT_PATHS} are allowed. Extra paths will be ignored.`
+      );
+      this._quickEditPaths = paths.slice(0, MAX_QUICK_EDIT_PATHS);
+    } else {
+      this._quickEditPaths = [...paths];
+    }
+
+    return this;
+  }
+
+  /**
+   * Get the quick edit paths defined for this plugin.
+   *
+   * @returns Array of option paths for quick edit, or undefined if not set.
+   * @alpha
+   */
+  getQuickEditPaths(): string[] | undefined {
+    return this._quickEditPaths;
   }
 
   /**

--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
@@ -25,10 +25,12 @@ import { DashboardInteractions } from '../utils/interactions';
 import { getDashboardSceneFor, getPanelIdForVizPanel } from '../utils/utils';
 
 import { MultiSelectedVizPanelsEditableElement } from './MultiSelectedVizPanelsEditableElement';
+import { useQuickEditOptions } from './useQuickEditOptions';
 
 function useEditPaneOptions(this: VizPanelEditableElement, isNewElement: boolean): OptionsPaneCategoryDescriptor[] {
   const panel = this.panel;
   const layoutElement = panel.parent!;
+  const plugin = panel.getPlugin();
   const rootId = useId();
   const titleId = useId();
   const descriptionId = useId();
@@ -71,12 +73,20 @@ function useEditPaneOptions(this: VizPanelEditableElement, isNewElement: boolean
       );
   }, [rootId, titleId, panel, descriptionId, backgroundId, isNewElement]);
 
+  const quickEditCategory = useQuickEditOptions({ panel, plugin });
+
   const layoutCategories = useMemo(
     () => (isDashboardLayoutItem(layoutElement) && layoutElement.getOptions ? layoutElement.getOptions() : []),
     [layoutElement]
   );
 
-  return [panelOptions, ...layoutCategories];
+  const categories: OptionsPaneCategoryDescriptor[] = [panelOptions];
+  if (quickEditCategory) {
+    categories.push(quickEditCategory);
+  }
+  categories.push(...layoutCategories);
+
+  return categories;
 }
 
 export class VizPanelEditableElement implements EditableDashboardElement, BulkActionElement {

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
@@ -5,12 +5,21 @@ import { EventBusSrv } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { VizPanel } from '@grafana/scenes';
 
+import { DashboardInteractions } from '../utils/interactions';
+
 import { dashboardEditActions } from './shared';
 import { useQuickEditOptions } from './useQuickEditOptions';
 
 jest.mock('./shared', () => ({
   dashboardEditActions: {
     edit: jest.fn(),
+  },
+}));
+
+jest.mock('../utils/interactions', () => ({
+  DashboardInteractions: {
+    quickEditOptionChanged: jest.fn(),
+    quickEditOptionUndone: jest.fn(),
   },
 }));
 
@@ -247,6 +256,63 @@ describe('useQuickEditOptions', () => {
       editCall.undo();
 
       expect(panel.onOptionsChange).toHaveBeenCalledWith({ textMode: 'auto' });
+    });
+  });
+
+  describe('user events', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should report interaction when option is changed', () => {
+      const panel = createMockPanel({ textMode: 'auto' });
+      const plugin = createMockPlugin(['textMode']);
+
+      const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+      const item = result.current!.items[0];
+
+      const rendered = item.props.render(item) as React.ReactElement<{ onChange: (value: string) => void }>;
+      act(() => {
+        rendered.props.onChange('value');
+      });
+
+      expect(DashboardInteractions.quickEditOptionChanged).toHaveBeenCalledWith({
+        panelType: 'stat',
+        optionPath: 'textMode',
+        optionName: 'Text mode',
+        source: 'quick_edit',
+        dashboardUid: undefined,
+      });
+    });
+
+    it('should report interaction when option is undone', () => {
+      const panel = createMockPanel({ textMode: 'auto' });
+      const plugin = createMockPlugin(['textMode']);
+
+      jest.spyOn(panel, 'state', 'get').mockReturnValue({
+        options: { textMode: 'value' },
+        pluginId: 'stat',
+        title: 'Test Panel',
+        fieldConfig: { defaults: {}, overrides: [] },
+      } as unknown as typeof panel.state);
+
+      const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+      const item = result.current!.items[0];
+
+      const rendered = item.props.render(item) as React.ReactElement<{ onChange: (value: string) => void }>;
+      act(() => {
+        rendered.props.onChange('value');
+      });
+
+      const editCall = (dashboardEditActions.edit as jest.Mock).mock.calls[0][0];
+      editCall.undo();
+
+      expect(DashboardInteractions.quickEditOptionUndone).toHaveBeenCalledWith({
+        panelType: 'stat',
+        optionPath: 'textMode',
+        optionName: 'Text mode',
+        dashboardUid: undefined,
+      });
     });
   });
 });

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
 import { EventBusSrv } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
@@ -18,6 +18,7 @@ describe('useQuickEditOptions', () => {
     jest.spyOn(panel, 'interpolate').mockImplementation((value) => value as string);
     jest.spyOn(panel, 'getPanelContext').mockReturnValue({
       eventBus: new EventBusSrv(),
+      eventsScope: 'local',
       onOptionsChange: jest.fn(),
     } as ReturnType<typeof panel.getPanelContext>);
     jest.spyOn(panel, 'onOptionsChange').mockImplementation(jest.fn());

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
@@ -1,0 +1,170 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { EventBusSrv } from '@grafana/data';
+import { getPanelPlugin } from '@grafana/data/test';
+import { VizPanel } from '@grafana/scenes';
+
+import { useQuickEditOptions } from './useQuickEditOptions';
+
+describe('useQuickEditOptions', () => {
+  const createMockPanel = (options: Record<string, unknown> = {}) => {
+    const panel = new VizPanel({
+      title: 'Test Panel',
+      pluginId: 'stat',
+      options,
+    });
+
+    jest.spyOn(panel, 'useState').mockReturnValue({ options } as ReturnType<typeof panel.useState>);
+    jest.spyOn(panel, 'interpolate').mockImplementation((value) => value as string);
+    jest.spyOn(panel, 'getPanelContext').mockReturnValue({
+      eventBus: new EventBusSrv(),
+      onOptionsChange: jest.fn(),
+    } as ReturnType<typeof panel.getPanelContext>);
+    jest.spyOn(panel, 'onOptionsChange').mockImplementation(jest.fn());
+
+    return panel;
+  };
+
+  const createMockPlugin = (quickEditPaths?: string[]) => {
+    const plugin = getPanelPlugin({ id: 'stat' }).setPanelOptions((builder) => {
+      builder
+        .addSelect({
+          path: 'textMode',
+          name: 'Text mode',
+          settings: {
+            options: [
+              { value: 'auto', label: 'Auto' },
+              { value: 'value', label: 'Value' },
+            ],
+          },
+          defaultValue: 'auto',
+        })
+        .addSelect({
+          path: 'colorMode',
+          name: 'Color mode',
+          settings: {
+            options: [
+              { value: 'none', label: 'None' },
+              { value: 'value', label: 'Value' },
+            ],
+          },
+          defaultValue: 'value',
+        })
+        .addBooleanSwitch({
+          path: 'showGraph',
+          name: 'Show graph',
+          defaultValue: true,
+        })
+        .addBooleanSwitch({
+          path: 'conditionalOption',
+          name: 'Conditional option',
+          defaultValue: false,
+          showIf: (config) => config.showGraph === true,
+        });
+    });
+
+    if (quickEditPaths) {
+      plugin.setQuickEditPaths(quickEditPaths);
+    }
+
+    return plugin;
+  };
+
+  it('should return null when plugin is undefined', () => {
+    const panel = createMockPanel();
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin: undefined }));
+
+    expect(result.current).toBeNull();
+  });
+
+  it('should return null when plugin has no quick edit paths', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin();
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).toBeNull();
+  });
+
+  it('should return null when quick edit paths array is empty', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin([]);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).toBeNull();
+  });
+
+  it('should return category with matching options', () => {
+    const panel = createMockPanel({ textMode: 'value', colorMode: 'none' });
+    const plugin = createMockPlugin(['textMode', 'colorMode']);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.props.title).toBe('Quick settings');
+    expect(result.current?.items).toHaveLength(2);
+    expect(result.current?.items[0].props.title).toBe('Text mode');
+    expect(result.current?.items[1].props.title).toBe('Color mode');
+  });
+
+  it('should warn and skip invalid paths', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin(['textMode', 'invalidPath']);
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items).toHaveLength(1);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Quick edit path "invalidPath" not found'));
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should respect showIf conditions', () => {
+    const panel = createMockPanel({ showGraph: false });
+    const plugin = createMockPlugin(['showGraph', 'conditionalOption']);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items).toHaveLength(1);
+    expect(result.current?.items[0].props.title).toBe('Show graph');
+  });
+
+  it('should show conditional option when condition is met', () => {
+    const panel = createMockPanel({ showGraph: true });
+    const plugin = createMockPlugin(['showGraph', 'conditionalOption']);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items).toHaveLength(2);
+  });
+
+  it('should return null when all paths are invalid', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin(['invalidPath1', 'invalidPath2']);
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).toBeNull();
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should preserve order of paths', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin(['colorMode', 'textMode', 'showGraph']);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items[0].props.title).toBe('Color mode');
+    expect(result.current?.items[1].props.title).toBe('Text mode');
+    expect(result.current?.items[2].props.title).toBe('Show graph');
+  });
+});

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
@@ -1,10 +1,18 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
+import React from 'react';
 
 import { EventBusSrv } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { VizPanel } from '@grafana/scenes';
 
+import { dashboardEditActions } from './shared';
 import { useQuickEditOptions } from './useQuickEditOptions';
+
+jest.mock('./shared', () => ({
+  dashboardEditActions: {
+    edit: jest.fn(),
+  },
+}));
 
 describe('useQuickEditOptions', () => {
   const createMockPanel = (options: Record<string, unknown> = {}) => {
@@ -167,5 +175,78 @@ describe('useQuickEditOptions', () => {
     expect(result.current?.items[0].props.title).toBe('Color mode');
     expect(result.current?.items[1].props.title).toBe('Text mode');
     expect(result.current?.items[2].props.title).toBe('Show graph');
+  });
+
+  describe('undo/redo support', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call dashboardEditActions.edit when changing an option', () => {
+      const panel = createMockPanel({ textMode: 'auto' });
+      const plugin = createMockPlugin(['textMode']);
+
+      const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+      expect(result.current).not.toBeNull();
+      const item = result.current!.items[0];
+
+      const rendered = item.props.render(item) as React.ReactElement<{ onChange: (value: string) => void }>;
+      act(() => {
+        rendered.props.onChange('value');
+      });
+
+      expect(dashboardEditActions.edit).toHaveBeenCalledTimes(1);
+      expect(dashboardEditActions.edit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: panel,
+          perform: expect.any(Function),
+          undo: expect.any(Function),
+        })
+      );
+    });
+
+    it('should apply new value when perform is called', () => {
+      const panel = createMockPanel({ textMode: 'auto' });
+      const plugin = createMockPlugin(['textMode']);
+
+      const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+      const item = result.current!.items[0];
+
+      const rendered = item.props.render(item) as React.ReactElement<{ onChange: (value: string) => void }>;
+      act(() => {
+        rendered.props.onChange('value');
+      });
+
+      const editCall = (dashboardEditActions.edit as jest.Mock).mock.calls[0][0];
+      editCall.perform();
+
+      expect(panel.onOptionsChange).toHaveBeenCalledWith({ textMode: 'value' });
+    });
+
+    it('should restore old value when undo is called', () => {
+      const panel = createMockPanel({ textMode: 'auto' });
+      const plugin = createMockPlugin(['textMode']);
+
+      jest.spyOn(panel, 'state', 'get').mockReturnValue({
+        options: { textMode: 'value' },
+        pluginId: 'stat',
+        title: 'Test Panel',
+        fieldConfig: { defaults: {}, overrides: [] },
+      } as unknown as typeof panel.state);
+
+      const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+      const item = result.current!.items[0];
+
+      const rendered = item.props.render(item) as React.ReactElement<{ onChange: (value: string) => void }>;
+      act(() => {
+        rendered.props.onChange('value');
+      });
+
+      const editCall = (dashboardEditActions.edit as jest.Mock).mock.calls[0][0];
+      editCall.undo();
+
+      expect(panel.onOptionsChange).toHaveBeenCalledWith({ textMode: 'auto' });
+    });
   });
 });

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
@@ -2,12 +2,14 @@ import { get as lodashGet } from 'lodash';
 import { useMemo } from 'react';
 
 import { PanelOptionsEditorBuilder, PanelPlugin, StandardEditorContext } from '@grafana/data';
-import { isNestedPanelOptions, NestedValueAccess } from '@grafana/data/internal';
+import { isNestedPanelOptions } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
 import { VizPanel } from '@grafana/scenes';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
+
+import { dashboardEditActions } from './shared';
 
 interface UseQuickEditOptionsProps {
   panel: VizPanel;
@@ -49,14 +51,6 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
 
     const allItems = builder.getItems();
 
-    const access: NestedValueAccess = {
-      getValue: (path) => lodashGet(currentOptions, path),
-      onChange: (path, value) => {
-        const newOptions = setOptionImmutably(currentOptions, path, value);
-        panel.onOptionsChange(newOptions);
-      },
-    };
-
     const category = new OptionsPaneCategoryDescriptor({
       title: t('dashboard.quick-edit.category-title', 'Quick settings'),
       id: 'quick-edit-options',
@@ -87,6 +81,8 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
 
       const Editor = item.editor;
       const htmlId = `quick-edit-${item.id}`;
+      const optionName = item.name;
+      const optionPath = item.path;
 
       category.addItem(
         new OptionsPaneItemDescriptor({
@@ -94,17 +90,26 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
           id: htmlId,
           description: item.description,
           render: function renderQuickEditOption() {
-            return (
-              <Editor
-                value={access.getValue(item.path)}
-                onChange={(value) => {
-                  access.onChange(item.path, value);
-                }}
-                item={item}
-                context={context}
-                id={htmlId}
-              />
-            );
+            const currentValue = lodashGet(currentOptions, optionPath);
+
+            const handleChange = (newValue: unknown) => {
+              const oldValue = currentValue;
+              const newOptions = setOptionImmutably(currentOptions, optionPath, newValue);
+
+              dashboardEditActions.edit({
+                description: t('dashboard.quick-edit.change-option', 'Change {{optionName}}', { optionName }),
+                source: panel,
+                perform: () => {
+                  panel.onOptionsChange(newOptions);
+                },
+                undo: () => {
+                  const revertedOptions = setOptionImmutably(panel.state.options, optionPath, oldValue);
+                  panel.onOptionsChange(revertedOptions);
+                },
+              });
+            };
+
+            return <Editor value={currentValue} onChange={handleChange} item={item} context={context} id={htmlId} />;
           },
         })
       );

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
@@ -9,7 +9,19 @@ import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
 
+import { DashboardInteractions } from '../utils/interactions';
+import { getDashboardSceneFor } from '../utils/utils';
+
 import { dashboardEditActions } from './shared';
+
+function getDashboardUid(panel: VizPanel): string | undefined {
+  try {
+    const dashboard = getDashboardSceneFor(panel);
+    return dashboard.state.uid;
+  } catch {
+    return undefined;
+  }
+}
 
 interface UseQuickEditOptionsProps {
   panel: VizPanel;
@@ -95,6 +107,16 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
             const handleChange = (newValue: unknown) => {
               const oldValue = currentValue;
               const newOptions = setOptionImmutably(currentOptions, optionPath, newValue);
+              const panelType = plugin.meta?.id ?? 'unknown';
+              const dashboardUid = getDashboardUid(panel);
+
+              DashboardInteractions.quickEditOptionChanged({
+                panelType,
+                optionPath,
+                optionName,
+                source: 'quick_edit',
+                dashboardUid,
+              });
 
               dashboardEditActions.edit({
                 description: t('dashboard.quick-edit.change-option', 'Change {{optionName}}', { optionName }),
@@ -103,6 +125,12 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
                   panel.onOptionsChange(newOptions);
                 },
                 undo: () => {
+                  DashboardInteractions.quickEditOptionUndone({
+                    panelType,
+                    optionPath,
+                    optionName,
+                    dashboardUid,
+                  });
                   const revertedOptions = setOptionImmutably(panel.state.options, optionPath, oldValue);
                   panel.onOptionsChange(revertedOptions);
                 },

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
@@ -1,0 +1,119 @@
+import { get as lodashGet } from 'lodash';
+import { useMemo } from 'react';
+
+import { PanelOptionsEditorBuilder, PanelPlugin, StandardEditorContext } from '@grafana/data';
+import { isNestedPanelOptions, NestedValueAccess } from '@grafana/data/internal';
+import { t } from '@grafana/i18n';
+import { VizPanel } from '@grafana/scenes';
+import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
+import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
+
+interface UseQuickEditOptionsProps {
+  panel: VizPanel;
+  plugin: PanelPlugin | undefined;
+}
+
+/**
+ * Hook to build quick edit options for a panel based on the plugin's quickEditPaths.
+ *
+ * Quick edit options appear in the dashboard edit pane, allowing users to modify
+ * common panel settings without entering the full panel editor.
+ *
+ * @returns OptionsPaneCategoryDescriptor with the quick edit options, or null if none are defined
+ */
+export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps): OptionsPaneCategoryDescriptor | null {
+  const { options: currentOptions } = panel.useState();
+
+  return useMemo((): OptionsPaneCategoryDescriptor | null => {
+    if (!plugin) {
+      return null;
+    }
+
+    const quickEditPaths = plugin.getQuickEditPaths();
+    if (!quickEditPaths || quickEditPaths.length === 0) {
+      return null;
+    }
+
+    const supplier = plugin.getPanelOptionsSupplier();
+
+    const context: StandardEditorContext<unknown, unknown> = {
+      data: [],
+      options: currentOptions,
+      replaceVariables: panel.interpolate,
+      eventBus: panel.getPanelContext().eventBus,
+    };
+
+    const builder = new PanelOptionsEditorBuilder();
+    supplier(builder, context);
+
+    const allItems = builder.getItems();
+
+    const access: NestedValueAccess = {
+      getValue: (path) => lodashGet(currentOptions, path),
+      onChange: (path, value) => {
+        const newOptions = setOptionImmutably(currentOptions, path, value);
+        panel.onOptionsChange(newOptions);
+      },
+    };
+
+    const category = new OptionsPaneCategoryDescriptor({
+      title: t('dashboard.quick-edit.category-title', 'Quick settings'),
+      id: 'quick-edit-options',
+    });
+
+    for (const path of quickEditPaths) {
+      const item = allItems.find((opt) => opt.path === path);
+
+      if (!item) {
+        console.warn(
+          `useQuickEditOptions: Quick edit path "${path}" not found in plugin options for "${plugin.meta?.id ?? 'unknown'}". ` +
+            `Make sure the path matches an option defined in setPanelOptions().`
+        );
+        continue;
+      }
+
+      if (isNestedPanelOptions(item)) {
+        console.warn(
+          `useQuickEditOptions: Quick edit path "${path}" refers to a nested options group, which is not supported. ` +
+            `Use paths to individual options instead.`
+        );
+        continue;
+      }
+
+      if (item.showIf && !item.showIf(context.options, context.data, context.annotations)) {
+        continue;
+      }
+
+      const Editor = item.editor;
+      const htmlId = `quick-edit-${item.id}`;
+
+      category.addItem(
+        new OptionsPaneItemDescriptor({
+          title: item.name,
+          id: htmlId,
+          description: item.description,
+          render: function renderQuickEditOption() {
+            return (
+              <Editor
+                value={access.getValue(item.path)}
+                onChange={(value) => {
+                  access.onChange(item.path, value);
+                }}
+                item={item}
+                context={context}
+                id={htmlId}
+              />
+            );
+          },
+        })
+      );
+    }
+
+    if (category.items.length === 0) {
+      return null;
+    }
+
+    return category;
+  }, [panel, plugin, currentOptions]);
+}

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -287,6 +287,48 @@ export const DashboardInteractions = {
     const properties = { item, action, context };
     reportDashboardInteraction('move_item', properties);
   },
+
+  /**
+   * Track when a user changes a panel option that is configured for quick edit.
+   * This event is fired both from quick edit sidebar and from the full panel editor,
+   * differentiated by the `source` property.
+   *
+   * Event name: `dashboards_quick_edit_option_changed`
+   *
+   * @param properties.panelType - The panel plugin ID (e.g., 'stat', 'timeseries', 'table')
+   * @param properties.optionPath - The option path that was changed (e.g., 'textMode', 'legend.showLegend')
+   * @param properties.optionName - Human-readable name of the option (e.g., 'Text mode', 'Show legend'). Optional, not available in panel editor context.
+   * @param properties.source - Where the change was made: 'quick_edit' (sidebar) or 'panel_editor' (full editor)
+   * @param properties.dashboardUid - UID of the dashboard being edited (undefined if not available)
+   */
+  quickEditOptionChanged: (properties: {
+    panelType: string;
+    optionPath: string;
+    optionName?: string;
+    source: 'quick_edit' | 'panel_editor';
+    dashboardUid?: string;
+  }) => {
+    reportDashboardInteraction('quick_edit_option_changed', properties);
+  },
+
+  /**
+   * Track when a user undoes a quick edit change via Ctrl+Z / Cmd+Z.
+   *
+   * Event name: `dashboards_quick_edit_option_undone`
+   *
+   * @param properties.panelType - The panel plugin ID (e.g., 'stat', 'timeseries', 'table')
+   * @param properties.optionPath - The option path that was undone (e.g., 'textMode', 'legend.showLegend')
+   * @param properties.optionName - Human-readable name of the option (e.g., 'Text mode', 'Show legend')
+   * @param properties.dashboardUid - UID of the dashboard being edited (undefined if not available)
+   */
+  quickEditOptionUndone: (properties: {
+    panelType: string;
+    optionPath: string;
+    optionName: string;
+    dashboardUid?: string;
+  }) => {
+    reportDashboardInteraction('quick_edit_option_undone', properties);
+  },
 };
 
 const reportDashboardInteraction = (

--- a/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.test.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
   EventBusSrv,
   FieldConfigOptionsRegistry,
@@ -6,12 +8,20 @@ import {
   getDefaultTimeRange,
   LoadingState,
   PanelPlugin,
+  PanelOptionsEditorBuilder,
   Registry,
   toDataFrame,
 } from '@grafana/data';
 import { VizPanel } from '@grafana/scenes';
+import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
 
 import { getStandardEditorContext, getVisualizationOptions2 } from './getVisualizationOptions';
+
+jest.mock('app/features/dashboard-scene/utils/interactions', () => ({
+  DashboardInteractions: {
+    quickEditOptionChanged: jest.fn(),
+  },
+}));
 
 describe('getVisualizationOptions', () => {
   describe('getStandardEditorContext', () => {
@@ -221,6 +231,7 @@ describe('getVisualizationOptions', () => {
       const plugin = {
         meta: { skipDataQuery: false },
         getPanelOptionsSupplier: jest.fn,
+        getQuickEditPaths: () => [],
         fieldConfigRegistry: customFieldRegistry,
       } as unknown as PanelPlugin;
 
@@ -283,6 +294,7 @@ describe('getVisualizationOptions', () => {
       const plugin = {
         meta: { skipDataQuery: false },
         getPanelOptionsSupplier: jest.fn,
+        getQuickEditPaths: () => [],
         fieldConfigRegistry: customFieldRegistry,
       } as unknown as PanelPlugin;
 
@@ -334,6 +346,7 @@ describe('getVisualizationOptions', () => {
       return {
         meta: { skipDataQuery: false },
         getPanelOptionsSupplier: jest.fn,
+        getQuickEditPaths: () => [],
         fieldConfigRegistry: customFieldRegistry,
       } as unknown as PanelPlugin;
     };
@@ -396,6 +409,145 @@ describe('getVisualizationOptions', () => {
       expect(showIfSpy.mock.calls.length).toEqual(1);
       expect(showIfSpy.mock.calls[0][0].displayName).toBe('default');
       expect(showIfSpy.mock.calls[0][2][0].fields[0].config.displayName).toBe('annotation');
+    });
+
+    describe('quick edit telemetry', () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
+
+      const createPluginWithQuickEdit = (quickEditPaths: string[]) => {
+        const customFieldRegistry: FieldConfigOptionsRegistry = new Registry<FieldConfigPropertyItem>(() => []);
+
+        const plugin = {
+          meta: { id: 'test-panel', skipDataQuery: false },
+          getPanelOptionsSupplier: () => (builder: PanelOptionsEditorBuilder<{}>) => {
+            builder.addSelect({
+              path: 'testOption',
+              name: 'Test Option',
+              settings: { options: [] },
+            });
+            builder.addSelect({
+              path: 'otherOption',
+              name: 'Other Option',
+              settings: { options: [] },
+            });
+          },
+          getQuickEditPaths: () => quickEditPaths,
+          fieldConfigRegistry: customFieldRegistry,
+        } as unknown as PanelPlugin;
+
+        return plugin;
+      };
+
+      it('should track option change when path is in quickEditPaths', () => {
+        const panel = new VizPanel({
+          title: 'Test Panel',
+          pluginId: 'test-panel',
+          key: 'panel-1',
+          options: { testOption: 'initial' },
+        });
+
+        // Mock onOptionsChange to avoid full plugin setup
+        panel.onOptionsChange = jest.fn();
+
+        const plugin = createPluginWithQuickEdit(['testOption']);
+
+        const vizOptions = getVisualizationOptions2({
+          panel,
+          eventBus: new EventBusSrv(),
+          plugin,
+          instanceState: {},
+        });
+
+        // Find the testOption item and trigger onChange
+        const category = vizOptions.find((c) => c.items.some((i) => i.props.title === 'Test Option'));
+        const item = category?.items.find((i) => i.props.title === 'Test Option');
+
+        // Render the item to get the onChange handler
+        const rendered = item?.props.render(item) as React.ReactElement<{ onChange: (value: string) => void }>;
+        rendered?.props.onChange('newValue');
+
+        expect(DashboardInteractions.quickEditOptionChanged).toHaveBeenCalledWith({
+          panelType: 'test-panel',
+          optionPath: 'testOption',
+          source: 'panel_editor',
+          dashboardUid: undefined,
+        });
+      });
+
+      it('should not track option change when path is not in quickEditPaths', () => {
+        const panel = new VizPanel({
+          title: 'Test Panel',
+          pluginId: 'test-panel',
+          key: 'panel-1',
+          options: { otherOption: 'initial' },
+        });
+
+        // Mock onOptionsChange to avoid full plugin setup
+        panel.onOptionsChange = jest.fn();
+
+        const plugin = createPluginWithQuickEdit(['testOption']); // otherOption is NOT in quickEditPaths
+
+        const vizOptions = getVisualizationOptions2({
+          panel,
+          eventBus: new EventBusSrv(),
+          plugin,
+          instanceState: {},
+        });
+
+        // Find the otherOption item and trigger onChange
+        const category = vizOptions.find((c) => c.items.some((i) => i.props.title === 'Other Option'));
+        const item = category?.items.find((i) => i.props.title === 'Other Option');
+
+        // Render the item to get the onChange handler
+        const rendered = item?.props.render(item) as React.ReactElement<{ onChange: (value: string) => void }>;
+        rendered?.props.onChange('newValue');
+
+        expect(DashboardInteractions.quickEditOptionChanged).not.toHaveBeenCalled();
+      });
+
+      it('should not track when plugin has no quickEditPaths', () => {
+        const panel = new VizPanel({
+          title: 'Test Panel',
+          pluginId: 'test-panel',
+          key: 'panel-1',
+          options: { testOption: 'initial' },
+        });
+
+        // Mock onOptionsChange to avoid full plugin setup
+        panel.onOptionsChange = jest.fn();
+
+        const customFieldRegistry: FieldConfigOptionsRegistry = new Registry<FieldConfigPropertyItem>(() => []);
+
+        const plugin = {
+          meta: { id: 'test-panel', skipDataQuery: false },
+          getPanelOptionsSupplier: () => (builder: PanelOptionsEditorBuilder<{}>) => {
+            builder.addSelect({
+              path: 'testOption',
+              name: 'Test Option',
+              settings: { options: [] },
+            });
+          },
+          getQuickEditPaths: () => undefined,
+          fieldConfigRegistry: customFieldRegistry,
+        } as unknown as PanelPlugin;
+
+        const vizOptions = getVisualizationOptions2({
+          panel,
+          eventBus: new EventBusSrv(),
+          plugin,
+          instanceState: {},
+        });
+
+        const category = vizOptions.find((c) => c.items.some((i) => i.props.title === 'Test Option'));
+        const item = category?.items.find((i) => i.props.title === 'Test Option');
+
+        const rendered = item?.props.render(item) as React.ReactElement<{ onChange: (value: string) => void }>;
+        rendered?.props.onChange('newValue');
+
+        expect(DashboardInteractions.quickEditOptionChanged).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.test.ts
@@ -12,10 +12,16 @@ import {
   Registry,
   toDataFrame,
 } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 import { VizPanel } from '@grafana/scenes';
 import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
 
 import { getStandardEditorContext, getVisualizationOptions2 } from './getVisualizationOptions';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
 
 jest.mock('app/features/dashboard-scene/utils/interactions', () => ({
   DashboardInteractions: {
@@ -409,6 +415,212 @@ describe('getVisualizationOptions', () => {
       expect(showIfSpy.mock.calls.length).toEqual(1);
       expect(showIfSpy.mock.calls[0][0].displayName).toBe('default');
       expect(showIfSpy.mock.calls[0][2][0].fields[0].config.displayName).toBe('annotation');
+    });
+
+    it('should call getItemsCount when property has it', () => {
+      const getItemsCountSpy = jest.fn().mockReturnValue(5);
+
+      const property1: FieldConfigPropertyItem = {
+        id: 'custom.property1',
+        path: 'property1',
+        isCustom: true,
+        process: (value) => value,
+        shouldApply: () => true,
+        override: jest.fn(),
+        editor: jest.fn(),
+        name: 'Property 1',
+        getItemsCount: getItemsCountSpy,
+      };
+
+      const customFieldRegistry: FieldConfigOptionsRegistry = new Registry<FieldConfigPropertyItem>(() => {
+        return [property1];
+      });
+
+      const plugin = {
+        meta: { skipDataQuery: false, id: 'test-panel' },
+        getPanelOptionsSupplier: jest.fn,
+        getQuickEditPaths: () => [],
+        fieldConfigRegistry: customFieldRegistry,
+      } as unknown as PanelPlugin;
+
+      const vizPanel = new VizPanel({
+        title: 'Panel A',
+        pluginId: 'test-panel',
+        key: 'panel-12',
+        fieldConfig: {
+          defaults: { custom: { property1: 'test-value' } },
+          overrides: [],
+        },
+      });
+
+      getVisualizationOptions2({
+        panel: vizPanel,
+        eventBus: new EventBusSrv(),
+        plugin: plugin,
+        instanceState: {},
+      });
+
+      expect(getItemsCountSpy).toHaveBeenCalledWith('test-value');
+    });
+
+    it('should render field config editor and return React element', () => {
+      const MockEditor = ({ value, onChange }: { value: unknown; onChange: (v: unknown) => void }) => {
+        return React.createElement('input', {
+          value: value as string,
+          onChange: (e: { target: { value: unknown } }) => onChange(e.target.value),
+        });
+      };
+
+      const property1: FieldConfigPropertyItem = {
+        id: 'custom.property1',
+        path: 'property1',
+        isCustom: true,
+        process: (value) => value,
+        shouldApply: () => true,
+        override: jest.fn(),
+        editor: MockEditor as FieldConfigPropertyItem['editor'],
+        name: 'Property 1',
+      };
+
+      const customFieldRegistry: FieldConfigOptionsRegistry = new Registry<FieldConfigPropertyItem>(() => {
+        return [property1];
+      });
+
+      const plugin = {
+        meta: { skipDataQuery: false, id: 'test-panel' },
+        getPanelOptionsSupplier: jest.fn,
+        getQuickEditPaths: () => [],
+        fieldConfigRegistry: customFieldRegistry,
+      } as unknown as PanelPlugin;
+
+      const vizPanel = new VizPanel({
+        title: 'Panel A',
+        pluginId: 'test-panel',
+        key: 'panel-12',
+        fieldConfig: {
+          defaults: { custom: { property1: 'initial-value' } },
+          overrides: [],
+        },
+      });
+
+      vizPanel.onFieldConfigChange = jest.fn();
+
+      const vizOptions = getVisualizationOptions2({
+        panel: vizPanel,
+        eventBus: new EventBusSrv(),
+        plugin: plugin,
+        instanceState: {},
+      });
+
+      const category = vizOptions.find((c) => c.items.some((i) => i.props.title === 'Property 1'));
+      const item = category?.items.find((i) => i.props.title === 'Property 1');
+
+      // Call render to trigger the render function and get the React element
+      const rendered = item?.props.render(item);
+
+      // Verify it returns a React element
+      expect(rendered).toBeDefined();
+      expect(React.isValidElement(rendered)).toBe(true);
+
+      // Extract onChange from the rendered element's props and trigger it
+      const renderedElement = rendered as React.ReactElement<{ onChange: (v: unknown) => void }>;
+      renderedElement.props.onChange('new-value');
+
+      expect(vizPanel.onFieldConfigChange).toHaveBeenCalled();
+    });
+
+    describe('timeCompare tracking', () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should track panel_setting_interaction when timeCompare is enabled', () => {
+        const panel = new VizPanel({
+          title: 'Test Panel',
+          pluginId: 'test-panel',
+          key: 'panel-1',
+          options: { timeCompare: false },
+        });
+
+        panel.onOptionsChange = jest.fn();
+
+        const customFieldRegistry: FieldConfigOptionsRegistry = new Registry<FieldConfigPropertyItem>(() => []);
+
+        const plugin = {
+          meta: { id: 'test-panel', skipDataQuery: false },
+          getPanelOptionsSupplier: () => (builder: PanelOptionsEditorBuilder<{}>) => {
+            builder.addBooleanSwitch({
+              path: 'timeCompare',
+              name: 'Time Compare',
+            });
+          },
+          getQuickEditPaths: () => [],
+          fieldConfigRegistry: customFieldRegistry,
+        } as unknown as PanelPlugin;
+
+        const vizOptions = getVisualizationOptions2({
+          panel,
+          eventBus: new EventBusSrv(),
+          plugin,
+          instanceState: {},
+        });
+
+        const category = vizOptions.find((c) => c.items.some((i) => i.props.title === 'Time Compare'));
+        const item = category?.items.find((i) => i.props.title === 'Time Compare');
+
+        const rendered = item?.props.render(item) as React.ReactElement<{ onChange: (value: boolean) => void }>;
+        rendered?.props.onChange(true);
+
+        expect(reportInteraction).toHaveBeenCalledWith('panel_setting_interaction', {
+          viz_type: 'test-panel',
+          feature_type: 'time_comparison',
+          option_type: 'toggle_enabled',
+        });
+      });
+
+      it('should track panel_setting_interaction when timeCompare is disabled', () => {
+        const panel = new VizPanel({
+          title: 'Test Panel',
+          pluginId: 'test-panel',
+          key: 'panel-1',
+          options: { timeCompare: true },
+        });
+
+        panel.onOptionsChange = jest.fn();
+
+        const customFieldRegistry: FieldConfigOptionsRegistry = new Registry<FieldConfigPropertyItem>(() => []);
+
+        const plugin = {
+          meta: { id: 'test-panel', skipDataQuery: false },
+          getPanelOptionsSupplier: () => (builder: PanelOptionsEditorBuilder<{}>) => {
+            builder.addBooleanSwitch({
+              path: 'timeCompare',
+              name: 'Time Compare',
+            });
+          },
+          getQuickEditPaths: () => [],
+          fieldConfigRegistry: customFieldRegistry,
+        } as unknown as PanelPlugin;
+
+        const vizOptions = getVisualizationOptions2({
+          panel,
+          eventBus: new EventBusSrv(),
+          plugin,
+          instanceState: {},
+        });
+
+        const category = vizOptions.find((c) => c.items.some((i) => i.props.title === 'Time Compare'));
+        const item = category?.items.find((i) => i.props.title === 'Time Compare');
+
+        const rendered = item?.props.render(item) as React.ReactElement<{ onChange: (value: boolean) => void }>;
+        rendered?.props.onChange(false);
+
+        expect(reportInteraction).toHaveBeenCalledWith('panel_setting_interaction', {
+          viz_type: 'test-panel',
+          feature_type: 'time_comparison',
+          option_type: 'toggle_disabled',
+        });
+      });
     });
 
     describe('quick edit telemetry', () => {

--- a/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx
@@ -16,6 +16,8 @@ import { VizPanel } from '@grafana/scenes';
 import { Input } from '@grafana/ui';
 import { LibraryVizPanelInfo } from 'app/features/dashboard-scene/panel-edit/LibraryVizPanelInfo';
 import { LibraryPanelBehavior } from 'app/features/dashboard-scene/scene/LibraryPanelBehavior';
+import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
+import { getDashboardSceneFor } from 'app/features/dashboard-scene/utils/utils';
 import { getDataLinksVariableSuggestions } from 'app/features/panel/panellinks/link_srv';
 
 import { OptionsPaneCategoryDescriptor } from './OptionsPaneCategoryDescriptor';
@@ -223,6 +225,7 @@ export function getVisualizationOptions2(props: OptionPaneRenderProps2): Options
     }));
   };
 
+  const quickEditPaths = plugin.getQuickEditPaths() ?? [];
   const currentOptions = panel.state.options;
   const access: NestedValueAccess = {
     getValue: (path) => lodashGet(currentOptions, path),
@@ -232,6 +235,23 @@ export function getVisualizationOptions2(props: OptionPaneRenderProps2): Options
           viz_type: plugin.meta.id,
           feature_type: 'time_comparison',
           option_type: value ? 'toggle_enabled' : 'toggle_disabled',
+        });
+      }
+
+      // Track changes to options that are also available in quick edit
+      if (quickEditPaths.includes(path)) {
+        let dashboardUid: string | undefined;
+        try {
+          dashboardUid = getDashboardSceneFor(panel).state.uid;
+        } catch {
+          // Panel may not be attached to a dashboard
+        }
+
+        DashboardInteractions.quickEditOptionChanged({
+          panelType: plugin.meta.id,
+          optionPath: path,
+          source: 'panel_editor',
+          dashboardUid,
         });
       }
 

--- a/public/app/plugins/panel/stat/module.test.ts
+++ b/public/app/plugins/panel/stat/module.test.ts
@@ -1,0 +1,9 @@
+import { plugin } from './module';
+
+describe('Stat panel plugin', () => {
+  it('should have textMode, colorMode, and graphMode as quick edit options', () => {
+    const quickEditPaths = plugin.getQuickEditPaths();
+
+    expect(quickEditPaths).toEqual(['textMode', 'colorMode', 'graphMode']);
+  });
+});

--- a/public/app/plugins/panel/stat/module.tsx
+++ b/public/app/plugins/panel/stat/module.tsx
@@ -138,4 +138,5 @@ export const plugin = new PanelPlugin<Options>(StatPanel)
   .setNoPadding()
   .setPanelChangeHandler(statPanelChangedHandler)
   .setSuggestionsSupplier(statSuggestionsSupplier)
-  .setMigrationHandler(sharedSingleStatMigrationHandler);
+  .setMigrationHandler(sharedSingleStatMigrationHandler)
+  .setQuickEditPaths(['textMode', 'colorMode', 'graphMode']);

--- a/public/app/plugins/panel/table/module.test.ts
+++ b/public/app/plugins/panel/table/module.test.ts
@@ -1,0 +1,9 @@
+import { plugin } from './module';
+
+describe('Table panel plugin', () => {
+  it('should have cellHeight and enablePagination as quick edit options', () => {
+    const quickEditPaths = plugin.getQuickEditPaths();
+
+    expect(quickEditPaths).toEqual(['cellHeight', 'enablePagination']);
+  });
+});

--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -126,4 +126,5 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TablePanel)
   .setPanelOptions((builder) => {
     addTableCustomPanelOptions(builder);
   })
-  .setSuggestionsSupplier(tableSuggestionsSupplier);
+  .setSuggestionsSupplier(tableSuggestionsSupplier)
+  .setQuickEditPaths(['cellHeight', 'enablePagination']);

--- a/public/app/plugins/panel/text/TextPanel.test.tsx
+++ b/public/app/plugins/panel/text/TextPanel.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { dateTime, LoadingState, EventBusSrv } from '@grafana/data';
 
 import { Props, TextPanel } from './TextPanel';
+import { plugin } from './module';
 import { TextMode } from './panelcfg.gen';
 
 const replaceVariablesMock = jest.fn();
@@ -161,5 +162,11 @@ describe('TextPanel', () => {
     expect(screen.getByTestId('TextPanel-converted-content').innerHTML).toEqual(
       'We begin by a simple sentence.\n```This is a code block\n```'
     );
+  });
+
+  it('should have mode and content as quick edit options', () => {
+    const quickEditPaths = plugin.getQuickEditPaths();
+
+    expect(quickEditPaths).toEqual(['mode', 'content']);
   });
 });

--- a/public/app/plugins/panel/text/module.tsx
+++ b/public/app/plugins/panel/text/module.tsx
@@ -66,4 +66,5 @@ export const plugin = new PanelPlugin<Options>(TextPanel)
     ds.fieldCount === 0 && !config.featureToggles.newVizSuggestions
       ? [{ cardOptions: { imgSrc: icnTextPanelSvg } }]
       : []
-  );
+  )
+  .setQuickEditPaths(['mode', 'content']);

--- a/public/app/plugins/panel/timeseries/module.test.ts
+++ b/public/app/plugins/panel/timeseries/module.test.ts
@@ -1,0 +1,9 @@
+import { plugin } from './module';
+
+describe('Timeseries panel plugin', () => {
+  it('should have legend.showLegend and legend.calcs as quick edit options', () => {
+    const quickEditPaths = plugin.getQuickEditPaths();
+
+    expect(quickEditPaths).toEqual(['legend.showLegend', 'legend.calcs']);
+  });
+});

--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -28,4 +28,5 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TimeSeriesPanel)
     });
   })
   .setSuggestionsSupplier(timeseriesSuggestionsSupplier)
-  .setDataSupport({ annotations: true, alertStates: true });
+  .setDataSupport({ annotations: true, alertStates: true })
+  .setQuickEditPaths(['legend.showLegend', 'legend.calcs']);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5858,6 +5858,9 @@
       "paused": "This dashboard has been paused by the administrator",
       "try-again-later": "Try again later"
     },
+    "quick-edit": {
+      "category-title": "Quick settings"
+    },
     "remove-panel": {
       "text": {
         "remove-panel": "Are you sure you want to remove this panel?"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5859,7 +5859,8 @@
       "try-again-later": "Try again later"
     },
     "quick-edit": {
-      "category-title": "Quick settings"
+      "category-title": "Quick settings",
+      "change-option": "Change {{optionName}}"
     },
     "remove-panel": {
       "text": {


### PR DESCRIPTION
_Made-with: Cursor_

**Note** : This is the full feature, for ease of review we can use:
1. PR 1 : With changes to core API creating the quick edit function
2. PR 2 : DataViz changes to test out the feature with 4 common panel types
3. PR 3 : Instrumentation of user events 

<!--

4. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

## What is this feature?

Introduces a new PanelPlugin API that allows visualization plugins to expose commonly used options directly in the dashboard edit sidebar. 
This is proposal 3 in the [design doc](https://docs.google.com/document/d/1hdon8dQpPDS1-syR7v3KohzG4Rfl65jD4cxaTNeldvE/edit?tab=t.3gfcb7n7nvpq#heading=h.fl933pk1iwl)

- Add setQuickEditPaths() and getQuickEditPaths() to PanelPlugin
- Add useQuickEditOptions hook for rendering quick edit options
- Integrate quick edit options into VizPanelEditableElement
- Add example usage to stat panel (textMode, colorMode, graphMode)
- Add unit tests for new API and hook

To illustrate the feature, this PR adds quick edits to 4 panels: Stat, Timeseries, Table & Text which are some of the top used panels. 
**Note to DataViz team**: feel free to be opinionated about which panels should include the feature, and which options whould be quick edits 😊 

## Why do we need this feature?

This reduces the number of clicks needed to adjust frequent panel settings by eliminating the need to enter the full panel editor.

## Who is this feature for?

- New editors - only a select few, most commonly used, options will be shown at first. It will be less overwhelming.
- Experienced editors - saves them a click for the most common actions

## Which issue(s) does this PR fix?

None, this is a hackathon project

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

## Analytics
### Events

#### `dashboards_quick_edit_option_changed`
Fired when a user changes a panel option that is configured for quick edit. Tracked from both the quick edit sidebar and the full panel editor.

| Property | Type | Required | Description |
|----------|------|----------|-------------|
| `panelType` | string | Yes | The panel plugin ID (e.g., `stat`, `timeseries`, `table`) |
| `optionPath` | string | Yes | The option path that was changed (e.g., `textMode`, `legend.showLegend`) |
| `optionName` | string | No | Human-readable name of the option (e.g., `Text mode`). Only available when `source` is `quick_edit`. |
| `source` | string | Yes | Where the change was made: `quick_edit` (sidebar) or `panel_editor` (full editor) |
| `dashboardUid` | string | No | UID of the dashboard being edited |

#### `dashboards_quick_edit_option_undone`
Fired when a user undoes a quick edit change via Ctrl+Z / Cmd+Z. Only tracked from the quick edit sidebar (undo not supported in panel editor).

| Property | Type | Required | Description |
|----------|------|----------|-------------|
| `panelType` | string | Yes | The panel plugin ID (e.g., `stat`, `timeseries`, `table`) |
| `optionPath` | string | Yes | The option path that was undone (e.g., `textMode`, `legend.showLegend`) |
| `optionName` | string | Yes | Human-readable name of the option (e.g., `Text mode`) |
| `dashboardUid` | string | No | UID of the dashboard being edited |

### Additional Context

Both events automatically include the following properties via `DashboardInteractions`:

| Property | Description |
|----------|-------------|
| `scenesView` | `true` when in scenes context |
| `isDynamicDashboard` | `true` when `dashboardNewLayouts` feature toggle is enabled |


## Special notes for your reviewer:

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
