### PR TITLE
Roles: Fix delegated permission check for provisioning

### DIFF
--- a/pkg/apimachinery/identity/context.go
+++ b/pkg/apimachinery/identity/context.go
@@ -160,6 +160,10 @@ var serviceIdentityTokenPermissions = []string{
 	"query.grafana.app:*",
 	"datasource.grafana.app:*",
 	"iam.grafana.app:*",
+	"provisioning.grafana.app/repositories:read",
+	"provisioning.grafana.app/repositories:watch",
+	"provisioning.grafana.app/settings:read",
+	"provisioning.grafana.app/settings:watch",
 	"preferences.grafana.app:*", // user, team, and org preferences
 	"collections.grafana.app:*", // user stars
 	"plugins.grafana.app:*",


### PR DESCRIPTION
This PR adds the necessary provisioning permissions so that basic Viewer/Editor roles and permission checks on rolebindings and roles work: the authlib client can send the Check request to the RBAC server instead of denying [at the gate](https://github.com/grafana/authlib/blob/main/authz/client.go#L166).