### PR TITLE
APIServer: Propagate original requester service identity

### DIFF
--- a/pkg/apiserver/identity/caller.go
+++ b/pkg/apiserver/identity/caller.go
@@ -1,0 +1,76 @@
+package identity
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/grafana/authlib/types"
+	"k8s.io/apiserver/pkg/audit"
+)
+
+const (
+	// MetadataKeyUpstreamCaller is the gRPC metadata key / HTTP header for the upstream caller's service identity.
+	// It is propagated automatically across service boundaries so that downstream services know who originated the request chain.
+	// The first service to receive the request sets it using the caller's auth token serviceIdentity key.
+	MetadataKeyUpstreamCaller = "x-grafana-upstream-caller-identity"
+
+	// AuditAnnotationUpstreamCaller is the K8s audit annotation key used to record the upstream caller identity on audit events.
+	// This allows audit backends to suppress events initiated by internal callers.
+	AuditAnnotationUpstreamCaller = "grafana.app/upstream-caller-identity"
+
+	// authServiceIdentityKey is the key used by authlib for the recording the service identity.
+	// Duplicated to avoid importing the whole authn package.
+	authServiceIdentityKey = "serviceIdentity"
+)
+
+type upstreamCallerKey struct{}
+
+// UpstreamCallerFromContext returns the upstream caller identity from the context.
+func UpstreamCallerFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(upstreamCallerKey{}).(string)
+	return v
+}
+
+// WithUpstreamCaller stores the upstream caller identity in the context.
+func WithUpstreamCaller(ctx context.Context, caller string) context.Context {
+	return context.WithValue(ctx, upstreamCallerKey{}, caller)
+}
+
+// ResolveUpstreamCaller determines the upstream caller identity for a request.
+// If an upstream caller is already present (from an inbound header/metadata), it is preserved.
+// Otherwise, the caller's service identity is extracted from the auth info.
+func ResolveUpstreamCaller(ctx context.Context, caller string) string {
+	if caller != "" {
+		return caller
+	}
+
+	if authInfo, ok := types.AuthInfoFrom(ctx); ok {
+		if ids, ok := authInfo.GetExtra()[authServiceIdentityKey]; ok && len(ids) > 0 {
+			// There should be only one, but the `Extra` method always returns a slice.
+			return ids[0]
+		}
+	}
+
+	// It's still optional to set the serviceIdentityKey, so we don't need to error out.
+	return ""
+}
+
+// HTTPMiddleware extracts the upstream caller identity from the request header
+// into the context. If the header is absent, it falls back to the authenticated
+// caller's service identity from the auth info.
+//
+// Must be placed in the handler chain AFTER authentication so that auth info is available.
+func HTTPMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if caller := ResolveUpstreamCaller(r.Context(), r.Header.Get(MetadataKeyUpstreamCaller)); caller != "" {
+			ctx := WithUpstreamCaller(r.Context(), caller)
+
+			// Annotate the K8s audit event so the audit backend can make a decision based on it.
+			audit.AddAuditAnnotation(ctx, AuditAnnotationUpstreamCaller, caller)
+
+			r = r.WithContext(ctx)
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/apiserver/identity/caller_test.go
+++ b/pkg/apiserver/identity/caller_test.go
@@ -1,0 +1,77 @@
+package identity
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/authlib/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveUpstreamCaller(t *testing.T) {
+	t.Run("preserves inbound caller (chain preservation)", func(t *testing.T) {
+		ctx := types.WithAuthInfo(t.Context(), &fakeAuthInfo{
+			extra: map[string][]string{authServiceIdentityKey: {"service-b"}},
+		})
+		got := ResolveUpstreamCaller(ctx, "service-a")
+		require.Equal(t, "service-a", got)
+	})
+
+	t.Run("falls back to auth info when no inbound caller", func(t *testing.T) {
+		ctx := types.WithAuthInfo(t.Context(), &fakeAuthInfo{
+			extra: map[string][]string{authServiceIdentityKey: {"service-a"}},
+		})
+		got := ResolveUpstreamCaller(ctx, "")
+		require.Equal(t, "service-a", got)
+	})
+
+	t.Run("returns empty when no auth info and no inbound", func(t *testing.T) {
+		got := ResolveUpstreamCaller(t.Context(), "")
+		require.Equal(t, "", got)
+	})
+}
+
+func TestHTTPMiddleware(t *testing.T) {
+	t.Run("extracts from header", func(t *testing.T) {
+		var got string
+		handler := HTTPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = UpstreamCallerFromContext(r.Context())
+		}))
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set(MetadataKeyUpstreamCaller, "service-a")
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+		require.Equal(t, "service-a", got)
+	})
+
+	t.Run("falls back to auth info", func(t *testing.T) {
+		var got string
+		handler := HTTPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = UpstreamCallerFromContext(r.Context())
+		}))
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		ctx := types.WithAuthInfo(req.Context(), &fakeAuthInfo{
+			extra: map[string][]string{authServiceIdentityKey: {"service-a"}},
+		})
+		req = req.WithContext(ctx)
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+		require.Equal(t, "service-a", got)
+	})
+
+	t.Run("no-op when no header and no auth info", func(t *testing.T) {
+		var got string
+		handler := HTTPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = UpstreamCallerFromContext(r.Context())
+		}))
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+		require.Equal(t, "", got)
+	})
+}
+
+type fakeAuthInfo struct {
+	types.AuthInfo
+	extra map[string][]string
+}
+
+func (f *fakeAuthInfo) GetExtra() map[string][]string { return f.extra }

--- a/pkg/registry/apis/secret/decrypt/grpc_client.go
+++ b/pkg/registry/apis/secret/decrypt/grpc_client.go
@@ -26,6 +26,7 @@ import (
 	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/apps/secret/pkg/decrypt"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
+	"github.com/grafana/grafana/pkg/services/grpcserver/interceptors"
 )
 
 type GRPCDecryptClient struct {
@@ -82,7 +83,11 @@ func NewGRPCDecryptClientWithTLS(
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponentialWithJitter(time.Second, 0.5)),
 		grpc_retry.WithCodes(codes.ResourceExhausted, codes.Unavailable),
 	)
-	opts = append(opts, grpc.WithUnaryInterceptor(retryInterceptor))
+	opts = append(opts, grpc.WithChainUnaryInterceptor(
+		// Set the original service identity requester in the metadata, if present.
+		interceptors.CallerUnaryClientInterceptor(),
+		retryInterceptor,
+	))
 
 	conn, err := grpc.NewClient(address, opts...)
 	if err != nil {

--- a/pkg/registry/apis/secret/inline/grpc_client.go
+++ b/pkg/registry/apis/secret/inline/grpc_client.go
@@ -19,6 +19,7 @@ import (
 	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
+	"github.com/grafana/grafana/pkg/services/grpcserver/interceptors"
 )
 
 type GRPCInlineClient struct {
@@ -57,6 +58,9 @@ func NewGRPCInlineClient(tokenExchanger authnlib.TokenExchanger, tracer trace.Tr
 		// This reduces the number of requests made to the DNS servers.
 		opts = append(opts, grpc.WithDisableServiceConfig())
 	}
+
+	// Set the original service identity requester in the metadata, if present.
+	opts = append(opts, grpc.WithChainUnaryInterceptor(interceptors.CallerUnaryClientInterceptor()))
 
 	conn, err := grpc.NewClient(address, opts...)
 	if err != nil {

--- a/pkg/services/grpcserver/interceptors/caller.go
+++ b/pkg/services/grpcserver/interceptors/caller.go
@@ -1,0 +1,85 @@
+package interceptors
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/grafana/grafana/pkg/apiserver/identity"
+)
+
+// CallerUnaryServerInterceptor extracts the upstream caller identity from inbound gRPC metadata
+// into the context. If the metadata key is absent, it falls back to the authenticated
+// caller's service identity from the auth info.
+//
+// Must be placed in the interceptor chain AFTER authentication so that auth info is available.
+func CallerUnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		var inbound string
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			if vals := md.Get(identity.MetadataKeyUpstreamCaller); len(vals) > 0 {
+				inbound = vals[0]
+			}
+		}
+		if caller := identity.ResolveUpstreamCaller(ctx, inbound); caller != "" {
+			ctx = identity.WithUpstreamCaller(ctx, caller)
+		}
+		return handler(ctx, req)
+	}
+}
+
+// CallerStreamServerInterceptor is the streaming equivalent of CallerUnaryServerInterceptor.
+func CallerStreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx := ss.Context()
+		var inbound string
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			if vals := md.Get(identity.MetadataKeyUpstreamCaller); len(vals) > 0 {
+				inbound = vals[0]
+			}
+		}
+		if caller := identity.ResolveUpstreamCaller(ctx, inbound); caller != "" {
+			ss = &callerServerStream{ServerStream: ss, ctx: identity.WithUpstreamCaller(ctx, caller)}
+		}
+		return handler(srv, ss)
+	}
+}
+
+type callerServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (w *callerServerStream) Context() context.Context { return w.ctx }
+
+// CallerUnaryClientInterceptor propagates the upstream caller identity from the context
+// to outgoing gRPC metadata. It preserves existing metadata if already set.
+func CallerUnaryClientInterceptor() grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		ctx = appendUpstreamCallerToOutgoingMD(ctx)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+// CallerStreamClientInterceptor is the streaming equivalent of CallerUnaryClientInterceptor.
+func CallerStreamClientInterceptor() grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		ctx = appendUpstreamCallerToOutgoingMD(ctx)
+		return streamer(ctx, desc, cc, method, opts...)
+	}
+}
+
+func appendUpstreamCallerToOutgoingMD(ctx context.Context) context.Context {
+	caller := identity.UpstreamCallerFromContext(ctx)
+	if caller == "" {
+		return ctx
+	}
+	// Don't override if already set in outgoing metadata, we need to preserver the original service that set it.
+	if md, ok := metadata.FromOutgoingContext(ctx); ok {
+		if vals := md.Get(identity.MetadataKeyUpstreamCaller); len(vals) > 0 {
+			return ctx
+		}
+	}
+	return metadata.AppendToOutgoingContext(ctx, identity.MetadataKeyUpstreamCaller, caller)
+}

--- a/pkg/services/grpcserver/interceptors/caller_test.go
+++ b/pkg/services/grpcserver/interceptors/caller_test.go
@@ -1,0 +1,116 @@
+package interceptors
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/authlib/types"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/grafana/grafana/pkg/apiserver/identity"
+)
+
+func TestCallerUnaryServerInterceptor(t *testing.T) {
+	interceptor := CallerUnaryServerInterceptor()
+
+	t.Run("extracts from metadata", func(t *testing.T) {
+		md := metadata.New(map[string]string{identity.MetadataKeyUpstreamCaller: "service-a"})
+		ctx := metadata.NewIncomingContext(t.Context(), md)
+
+		var got string
+		_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{}, func(ctx context.Context, _ any) (any, error) {
+			got = identity.UpstreamCallerFromContext(ctx)
+			return nil, nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, "service-a", got)
+	})
+
+	t.Run("falls back to auth info", func(t *testing.T) {
+		ctx := types.WithAuthInfo(t.Context(), &fakeAuthInfo{
+			extra: map[string][]string{"serviceIdentity": {"service-a"}},
+		})
+
+		var got string
+		_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{}, func(ctx context.Context, _ any) (any, error) {
+			got = identity.UpstreamCallerFromContext(ctx)
+			return nil, nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, "service-a", got)
+	})
+
+	t.Run("preserves inbound over auth info (chain preservation)", func(t *testing.T) {
+		ctx := types.WithAuthInfo(t.Context(), &fakeAuthInfo{
+			extra: map[string][]string{"serviceIdentity": {"service-b"}},
+		})
+		md := metadata.New(map[string]string{identity.MetadataKeyUpstreamCaller: "service-a"})
+		ctx = metadata.NewIncomingContext(ctx, md)
+
+		var got string
+		_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{}, func(ctx context.Context, _ any) (any, error) {
+			got = identity.UpstreamCallerFromContext(ctx)
+			return nil, nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, "service-a", got)
+	})
+
+	t.Run("no-op when no metadata and no auth info", func(t *testing.T) {
+		var got string
+		_, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{}, func(ctx context.Context, _ any) (any, error) {
+			got = identity.UpstreamCallerFromContext(ctx)
+			return nil, nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, "", got)
+	})
+}
+
+func TestCallerUnaryClientInterceptor(t *testing.T) {
+	interceptor := CallerUnaryClientInterceptor()
+
+	t.Run("propagates from context to outgoing metadata", func(t *testing.T) {
+		ctx := identity.WithUpstreamCaller(t.Context(), "service-a")
+
+		var gotMD metadata.MD
+		err := interceptor(ctx, "/test", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			gotMD, _ = metadata.FromOutgoingContext(ctx)
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"service-a"}, gotMD.Get(identity.MetadataKeyUpstreamCaller))
+	})
+
+	t.Run("preserves existing outgoing metadata", func(t *testing.T) {
+		ctx := identity.WithUpstreamCaller(t.Context(), "service-b")
+		ctx = metadata.AppendToOutgoingContext(ctx, identity.MetadataKeyUpstreamCaller, "service-a")
+
+		var gotMD metadata.MD
+		err := interceptor(ctx, "/test", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			gotMD, _ = metadata.FromOutgoingContext(ctx)
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"service-a"}, gotMD.Get(identity.MetadataKeyUpstreamCaller))
+	})
+
+	t.Run("no-op when no caller in context", func(t *testing.T) {
+		var gotMD metadata.MD
+		err := interceptor(t.Context(), "/test", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			gotMD, _ = metadata.FromOutgoingContext(ctx)
+			return nil
+		})
+		require.NoError(t, err)
+		require.Empty(t, gotMD.Get(identity.MetadataKeyUpstreamCaller))
+	})
+}
+
+type fakeAuthInfo struct {
+	types.AuthInfo
+	extra map[string][]string
+}
+
+func (f *fakeAuthInfo) GetExtra() map[string][]string { return f.extra }

--- a/pkg/services/grpcserver/service.go
+++ b/pkg/services/grpcserver/service.go
@@ -80,11 +80,13 @@ func provideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, authe
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
 		interceptors.LoggingUnaryInterceptor(s.logger, s.cfg.EnableLogging), // needs to be registered after tracing interceptor to get trace id
 		middleware.UnaryServerInstrumentInterceptor(grpcRequestDuration),
+		interceptors.CallerUnaryServerInterceptor(),
 	}
 	streamInterceptors := []grpc.StreamServerInterceptor{
 		interceptors.TracingStreamInterceptor(tracer),
 		interceptors.LoggingStreamInterceptor(s.logger, s.cfg.EnableLogging),
 		middleware.StreamServerInstrumentInterceptor(grpcRequestDuration),
+		interceptors.CallerStreamServerInterceptor(),
 	}
 
 	if authenticator != nil {


### PR DESCRIPTION
This adds a new metadata/header that keeps track of the initial service that initiated a request in a chain.

It assumes that all the services in the chain will be auth-ed and include a serviceIdentity key that can be extracted from the token claims.

And it also provides the helpers for both HTTP and gRPC servers to extract and pass forward this information.

The interceptor+wiring for the gRPC server is done in this PR, for the middleware+wiring for the HTTP server is here https://github.com/grafana/grafana-enterprise/pull/11183.

For HTTP, we can simply rely on the auth info being present in the context, and automatically add an audit annotation as HTTP requests will fall through to the Grafana/K8s Audit Backend for processing audit events.

For gRPC, it is a bit different, since it is not handled by the Grafana/K8s Audit Backend, and so we need to instrument the clients manually. That is an acceptable trade-off as the feature is not supported out-of-the-box for gRPC yet.