### PR TITLE
Dashboards: Add quickEdit flag for panel option editors

### DIFF
--- a/packages/grafana-data/src/types/options.ts
+++ b/packages/grafana-data/src/types/options.ts
@@ -57,7 +57,17 @@ export interface OptionEditorConfig<TOptions, TSettings = any, TValue = any> {
    * When true, this option will appear in the dashboard edit pane for quick editing
    * without entering the full panel editor.
    *
-   * Only the first 5 options with `quickEdit: true` will be shown.
+   * **Behavior:**
+   * - Only the first 5 options with `quickEdit: true` will be shown
+   * - Options appear in the order they are added to the builder
+   * - A console warning is logged if more than 5 options have `quickEdit: true`
+   *
+   * **Shared option builders:**
+   * When using shared builders like `commonOptionsBuilder.addLegendOptions()`, any
+   * `quickEdit` flags set in those builders will apply to ALL panels using them.
+   * The order depends on when the shared builder is called relative to panel-specific
+   * options. If a shared builder adds 2 quickEdit options and a panel adds 4 more,
+   * only the first 5 (based on builder order) will be shown.
    *
    * @alpha
    */

--- a/packages/grafana-data/src/types/options.ts
+++ b/packages/grafana-data/src/types/options.ts
@@ -52,4 +52,14 @@ export interface OptionEditorConfig<TOptions, TSettings = any, TValue = any> {
    * Function that enables configuration of when option editor should be shown based on current panel option properties.
    */
   showIf?: (currentOptions: TOptions, data?: DataFrame[], annotations?: DataFrame[]) => boolean | undefined;
+
+  /**
+   * When true, this option will appear in the dashboard edit pane for quick editing
+   * without entering the full panel editor.
+   *
+   * Only the first 5 options with `quickEdit: true` will be shown.
+   *
+   * @alpha
+   */
+  quickEdit?: boolean;
 }

--- a/packages/grafana-ui/src/options/builder/legend.tsx
+++ b/packages/grafana-ui/src/options/builder/legend.tsx
@@ -18,6 +18,7 @@ export function addLegendOptions<T extends OptionsWithLegend>(
       path: 'legend.showLegend',
       name: t('grafana-ui.builder.legend.name-visibility', 'Visibility'),
       category,
+      quickEdit: true,
       description: '',
       defaultValue: showLegend,
     })
@@ -75,6 +76,7 @@ export function addLegendOptions<T extends OptionsWithLegend>(
       path: 'legend.calcs',
       name: t('grafana-ui.builder.legend.name-values', 'Values'),
       category,
+      quickEdit: true,
       description: t('grafana-ui.builder.legend.description-values', 'Select values or calculations to show in legend'),
       editor: standardEditorsRegistry.get('stats-picker').editor,
       defaultValue: [],

--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
@@ -25,10 +25,12 @@ import { DashboardInteractions } from '../utils/interactions';
 import { getDashboardSceneFor, getPanelIdForVizPanel } from '../utils/utils';
 
 import { MultiSelectedVizPanelsEditableElement } from './MultiSelectedVizPanelsEditableElement';
+import { useQuickEditOptions } from './useQuickEditOptions';
 
 function useEditPaneOptions(this: VizPanelEditableElement, isNewElement: boolean): OptionsPaneCategoryDescriptor[] {
   const panel = this.panel;
   const layoutElement = panel.parent!;
+  const plugin = panel.getPlugin();
   const rootId = useId();
   const titleId = useId();
   const descriptionId = useId();
@@ -71,12 +73,20 @@ function useEditPaneOptions(this: VizPanelEditableElement, isNewElement: boolean
       );
   }, [rootId, titleId, panel, descriptionId, backgroundId, isNewElement]);
 
+  const quickEditCategory = useQuickEditOptions({ panel, plugin });
+
   const layoutCategories = useMemo(
     () => (isDashboardLayoutItem(layoutElement) && layoutElement.getOptions ? layoutElement.getOptions() : []),
     [layoutElement]
   );
 
-  return [panelOptions, ...layoutCategories];
+  const categories: OptionsPaneCategoryDescriptor[] = [panelOptions];
+  if (quickEditCategory) {
+    categories.push(quickEditCategory);
+  }
+  categories.push(...layoutCategories);
+
+  return categories;
 }
 
 export class VizPanelEditableElement implements EditableDashboardElement, BulkActionElement {

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
@@ -159,4 +159,133 @@ describe('useQuickEditOptions', () => {
     expect(result.current?.items[1].props.title).toBe('Option 3');
     expect(result.current?.items[2].props.title).toBe('Option 5');
   });
+
+  describe('Panel-specific quick edit configurations', () => {
+    it('should show quick edit options for stat panel (textMode, colorMode, graphMode)', () => {
+      const panel = createMockPanel();
+      const plugin = getPanelPlugin({ id: 'stat' }).setPanelOptions((builder) => {
+        builder
+          .addSelect({
+            path: 'textMode',
+            name: 'Text mode',
+            quickEdit: true,
+            settings: { options: [{ value: 'auto', label: 'Auto' }] },
+          })
+          .addSelect({
+            path: 'colorMode',
+            name: 'Color mode',
+            quickEdit: true,
+            settings: { options: [{ value: 'value', label: 'Value' }] },
+          })
+          .addRadio({
+            path: 'graphMode',
+            name: 'Graph mode',
+            quickEdit: true,
+            settings: { options: [{ value: 'none', label: 'None' }] },
+          })
+          .addRadio({
+            path: 'justifyMode',
+            name: 'Text alignment',
+            settings: { options: [{ value: 'auto', label: 'Auto' }] },
+          });
+      });
+
+      const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+      expect(result.current).not.toBeNull();
+      expect(result.current?.items).toHaveLength(3);
+      expect(result.current?.items.map((i) => i.props.title)).toEqual(['Text mode', 'Color mode', 'Graph mode']);
+    });
+
+    it('should show quick edit options for text panel (mode, content)', () => {
+      const panel = createMockPanel();
+      const plugin = getPanelPlugin({ id: 'text' }).setPanelOptions((builder) => {
+        builder
+          .addRadio({
+            path: 'mode',
+            name: 'Mode',
+            quickEdit: true,
+            settings: { options: [{ value: 'markdown', label: 'Markdown' }] },
+          })
+          .addSelect({
+            path: 'code.language',
+            name: 'Language',
+            settings: { options: [{ value: 'plaintext', label: 'Plain text' }] },
+          })
+          .addCustomEditor({
+            id: 'content',
+            path: 'content',
+            name: 'Content',
+            quickEdit: true,
+            editor: () => null,
+          });
+      });
+
+      const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+      expect(result.current).not.toBeNull();
+      expect(result.current?.items).toHaveLength(2);
+      expect(result.current?.items.map((i) => i.props.title)).toEqual(['Mode', 'Content']);
+    });
+
+    it('should show quick edit options for table panel (cellHeight, enablePagination)', () => {
+      const panel = createMockPanel();
+      const plugin = getPanelPlugin({ id: 'table' }).setPanelOptions((builder) => {
+        builder
+          .addBooleanSwitch({
+            path: 'showHeader',
+            name: 'Show table header',
+          })
+          .addRadio({
+            path: 'cellHeight',
+            name: 'Cell height',
+            quickEdit: true,
+            settings: { options: [{ value: 'sm', label: 'Small' }] },
+          })
+          .addCustomEditor({
+            id: 'enablePagination',
+            path: 'enablePagination',
+            name: 'Enable pagination',
+            quickEdit: true,
+            editor: () => null,
+          });
+      });
+
+      const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+      expect(result.current).not.toBeNull();
+      expect(result.current?.items).toHaveLength(2);
+      expect(result.current?.items.map((i) => i.props.title)).toEqual(['Cell height', 'Enable pagination']);
+    });
+
+    it('should show quick edit options for timeseries panel (legend visibility, legend values)', () => {
+      const panel = createMockPanel();
+      const plugin = getPanelPlugin({ id: 'timeseries' }).setPanelOptions((builder) => {
+        builder
+          .addBooleanSwitch({
+            path: 'legend.showLegend',
+            name: 'Visibility',
+            quickEdit: true,
+          })
+          .addRadio({
+            path: 'legend.displayMode',
+            name: 'Mode',
+            settings: { options: [{ value: 'list', label: 'List' }] },
+          })
+          .addCustomEditor({
+            id: 'legend.calcs',
+            path: 'legend.calcs',
+            name: 'Values',
+            quickEdit: true,
+            editor: () => null,
+          });
+      });
+
+      const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+      expect(result.current).not.toBeNull();
+      expect(result.current?.items).toHaveLength(2);
+      expect(result.current?.items.map((i) => i.props.title)).toEqual(['Visibility', 'Values']);
+    });
+  });
 });

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
@@ -1,0 +1,162 @@
+import { renderHook } from '@testing-library/react';
+
+import { EventBusSrv } from '@grafana/data';
+import { getPanelPlugin } from '@grafana/data/test';
+import { VizPanel } from '@grafana/scenes';
+
+import { useQuickEditOptions } from './useQuickEditOptions';
+
+describe('useQuickEditOptions', () => {
+  const createMockPanel = (options: Record<string, unknown> = {}) => {
+    const panel = new VizPanel({
+      title: 'Test Panel',
+      pluginId: 'stat',
+      options,
+    });
+
+    jest.spyOn(panel, 'useState').mockReturnValue({ options } as ReturnType<typeof panel.useState>);
+    jest.spyOn(panel, 'interpolate').mockImplementation((value) => value as string);
+    jest.spyOn(panel, 'getPanelContext').mockReturnValue({
+      eventBus: new EventBusSrv(),
+      onOptionsChange: jest.fn(),
+    } as ReturnType<typeof panel.getPanelContext>);
+    jest.spyOn(panel, 'onOptionsChange').mockImplementation(jest.fn());
+
+    return panel;
+  };
+
+  const createMockPlugin = (optionsWithQuickEdit: Array<{ path: string; name: string; quickEdit?: boolean }>) => {
+    const plugin = getPanelPlugin({ id: 'stat' }).setPanelOptions((builder) => {
+      for (const opt of optionsWithQuickEdit) {
+        builder.addSelect({
+          path: opt.path,
+          name: opt.name,
+          quickEdit: opt.quickEdit,
+          settings: {
+            options: [
+              { value: 'option1', label: 'Option 1' },
+              { value: 'option2', label: 'Option 2' },
+            ],
+          },
+          defaultValue: 'option1',
+        });
+      }
+    });
+
+    return plugin;
+  };
+
+  it('should return null when plugin is undefined', () => {
+    const panel = createMockPanel();
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin: undefined }));
+
+    expect(result.current).toBeNull();
+  });
+
+  it('should return null when no options have quickEdit: true', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin([
+      { path: 'textMode', name: 'Text mode', quickEdit: false },
+      { path: 'colorMode', name: 'Color mode' },
+    ]);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).toBeNull();
+  });
+
+  it('should return category with options that have quickEdit: true', () => {
+    const panel = createMockPanel({ textMode: 'option1', colorMode: 'option2' });
+    const plugin = createMockPlugin([
+      { path: 'textMode', name: 'Text mode', quickEdit: true },
+      { path: 'colorMode', name: 'Color mode', quickEdit: true },
+      { path: 'graphMode', name: 'Graph mode', quickEdit: false },
+    ]);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.props.title).toBe('Quick settings');
+    expect(result.current?.items).toHaveLength(2);
+    expect(result.current?.items[0].props.title).toBe('Text mode');
+    expect(result.current?.items[1].props.title).toBe('Color mode');
+  });
+
+  it('should limit to maximum of 5 options with warning', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin([
+      { path: 'opt1', name: 'Option 1', quickEdit: true },
+      { path: 'opt2', name: 'Option 2', quickEdit: true },
+      { path: 'opt3', name: 'Option 3', quickEdit: true },
+      { path: 'opt4', name: 'Option 4', quickEdit: true },
+      { path: 'opt5', name: 'Option 5', quickEdit: true },
+      { path: 'opt6', name: 'Option 6', quickEdit: true },
+      { path: 'opt7', name: 'Option 7', quickEdit: true },
+    ]);
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items).toHaveLength(5);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('has 7 options with quickEdit: true'));
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should allow exactly 5 options without warning', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin([
+      { path: 'opt1', name: 'Option 1', quickEdit: true },
+      { path: 'opt2', name: 'Option 2', quickEdit: true },
+      { path: 'opt3', name: 'Option 3', quickEdit: true },
+      { path: 'opt4', name: 'Option 4', quickEdit: true },
+      { path: 'opt5', name: 'Option 5', quickEdit: true },
+    ]);
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items).toHaveLength(5);
+    expect(consoleSpy).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should preserve order of options as defined', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin([
+      { path: 'colorMode', name: 'Color mode', quickEdit: true },
+      { path: 'textMode', name: 'Text mode', quickEdit: true },
+      { path: 'graphMode', name: 'Graph mode', quickEdit: true },
+    ]);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items[0].props.title).toBe('Color mode');
+    expect(result.current?.items[1].props.title).toBe('Text mode');
+    expect(result.current?.items[2].props.title).toBe('Graph mode');
+  });
+
+  it('should mix quickEdit: true and false options correctly', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin([
+      { path: 'opt1', name: 'Option 1', quickEdit: true },
+      { path: 'opt2', name: 'Option 2', quickEdit: false },
+      { path: 'opt3', name: 'Option 3', quickEdit: true },
+      { path: 'opt4', name: 'Option 4' }, // undefined = false
+      { path: 'opt5', name: 'Option 5', quickEdit: true },
+    ]);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items).toHaveLength(3);
+    expect(result.current?.items[0].props.title).toBe('Option 1');
+    expect(result.current?.items[1].props.title).toBe('Option 3');
+    expect(result.current?.items[2].props.title).toBe('Option 5');
+  });
+});

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
@@ -1,0 +1,122 @@
+import { get as lodashGet } from 'lodash';
+import { useMemo } from 'react';
+
+import { PanelOptionsEditorBuilder, PanelPlugin, StandardEditorContext } from '@grafana/data';
+import { isNestedPanelOptions, NestedValueAccess } from '@grafana/data/internal';
+import { t } from '@grafana/i18n';
+import { VizPanel } from '@grafana/scenes';
+import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
+import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
+
+const MAX_QUICK_EDIT_OPTIONS = 5;
+
+interface UseQuickEditOptionsProps {
+  panel: VizPanel;
+  plugin: PanelPlugin | undefined;
+}
+
+/**
+ * Hook to build quick edit options for a panel based on options marked with `quickEdit: true`.
+ *
+ * Quick edit options appear in the dashboard edit pane, allowing users to modify
+ * common panel settings without entering the full panel editor.
+ *
+ * Only the first 5 options with `quickEdit: true` will be shown.
+ *
+ * @returns OptionsPaneCategoryDescriptor with the quick edit options, or null if none are defined
+ */
+export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps): OptionsPaneCategoryDescriptor | null {
+  const { options: currentOptions } = panel.useState();
+
+  return useMemo((): OptionsPaneCategoryDescriptor | null => {
+    if (!plugin) {
+      return null;
+    }
+
+    const supplier = plugin.getPanelOptionsSupplier();
+
+    const context: StandardEditorContext<unknown, unknown> = {
+      data: [],
+      options: currentOptions,
+      replaceVariables: panel.interpolate,
+      eventBus: panel.getPanelContext().eventBus,
+    };
+
+    const builder = new PanelOptionsEditorBuilder();
+    supplier(builder, context);
+
+    const allItems = builder.getItems();
+
+    // Filter to only items with quickEdit: true
+    const quickEditItems = allItems.filter((item) => {
+      if (isNestedPanelOptions(item)) {
+        return false;
+      }
+      return item.quickEdit === true;
+    });
+
+    if (quickEditItems.length === 0) {
+      return null;
+    }
+
+    // Warn if more than MAX_QUICK_EDIT_OPTIONS are defined
+    if (quickEditItems.length > MAX_QUICK_EDIT_OPTIONS) {
+      console.warn(
+        `useQuickEditOptions: Plugin "${plugin.meta?.id ?? 'unknown'}" has ${quickEditItems.length} options with quickEdit: true, ` +
+          `but only ${MAX_QUICK_EDIT_OPTIONS} are allowed. Extra options will be ignored.`
+      );
+    }
+
+    const itemsToShow = quickEditItems.slice(0, MAX_QUICK_EDIT_OPTIONS);
+
+    const access: NestedValueAccess = {
+      getValue: (path) => lodashGet(currentOptions, path),
+      onChange: (path, value) => {
+        const newOptions = setOptionImmutably(currentOptions, path, value);
+        panel.onOptionsChange(newOptions);
+      },
+    };
+
+    const category = new OptionsPaneCategoryDescriptor({
+      title: t('dashboard.quick-edit.category-title', 'Quick settings'),
+      id: 'quick-edit-options',
+    });
+
+    for (const item of itemsToShow) {
+      if (item.showIf && !item.showIf(context.options, context.data, context.annotations)) {
+        continue;
+      }
+
+      const Editor = item.editor;
+      const htmlId = `quick-edit-${item.id}`;
+
+      category.addItem(
+        new OptionsPaneItemDescriptor({
+          title: item.name,
+          id: htmlId,
+          description: item.description,
+          render: function renderQuickEditOption() {
+            return (
+              <Editor
+                value={access.getValue(item.path)}
+                onChange={(value) => {
+                  access.onChange(item.path, value);
+                }}
+                item={item}
+                context={context}
+                id={htmlId}
+              />
+            );
+          },
+        })
+      );
+    }
+
+    if (category.items.length === 0) {
+      return null;
+    }
+
+    return category;
+  }, [panel, plugin, currentOptions]);
+}

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
@@ -22,7 +22,12 @@ interface UseQuickEditOptionsProps {
  * Quick edit options appear in the dashboard edit pane, allowing users to modify
  * common panel settings without entering the full panel editor.
  *
- * Only the first 5 options with `quickEdit: true` will be shown.
+ * **Behavior:**
+ * - Only the first 5 options with `quickEdit: true` will be shown
+ * - Options appear in the order they are added to the builder via `setPanelOptions()`
+ * - Shared builders (e.g., `commonOptionsBuilder.addLegendOptions()`) contribute to the
+ *   same pool of quickEdit options, in the order they are called
+ * - A console warning is logged if more than 5 options have `quickEdit: true`
  *
  * @returns OptionsPaneCategoryDescriptor with the quick edit options, or null if none are defined
  */

--- a/public/app/plugins/panel/stat/module.tsx
+++ b/public/app/plugins/panel/stat/module.tsx
@@ -30,6 +30,7 @@ export const plugin = new PanelPlugin<Options>(StatPanel)
         name: t('stat.name-text-mode', 'Text mode'),
         description: t('stat.description-text-mode', 'Control if name and value is displayed or just name'),
         category: mainCategory,
+        quickEdit: true,
         settings: {
           options: [
             { value: BigValueTextMode.Auto, label: t('stat.text-mode-options.label-auto', 'Auto') },
@@ -64,6 +65,7 @@ export const plugin = new PanelPlugin<Options>(StatPanel)
         name: t('stat.name-color-modcolor-mode-options.label', 'Color mode'),
         defaultValue: BigValueColorMode.Value,
         category: mainCategory,
+        quickEdit: true,
         settings: {
           options: [
             { value: BigValueColorMode.None, label: t('stat.color-mode-options.label-none', 'None') },
@@ -84,6 +86,7 @@ export const plugin = new PanelPlugin<Options>(StatPanel)
         name: t('stat.name-graph-mode', 'Graph mode'),
         description: t('stat.description-graph-mode', 'Stat panel graph / sparkline mode'),
         category: mainCategory,
+        quickEdit: true,
         defaultValue: defaultOptions.graphMode,
         settings: {
           options: [

--- a/public/app/plugins/panel/text/module.tsx
+++ b/public/app/plugins/panel/text/module.tsx
@@ -16,6 +16,7 @@ export const plugin = new PanelPlugin<Options>(TextPanel)
         path: 'mode',
         name: t('text.name-mode', 'Mode'),
         category,
+        quickEdit: true,
         settings: {
           options: [
             { value: TextMode.Markdown, label: t('text.mode-options.label-markdown', 'Markdown') },
@@ -57,6 +58,7 @@ export const plugin = new PanelPlugin<Options>(TextPanel)
         path: 'content',
         name: t('text.name-content', 'Content'),
         category,
+        quickEdit: true,
         editor: TextPanelEditor,
         defaultValue: defaultOptions.content,
       });


### PR DESCRIPTION
Made-with: Cursor

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Introduces a `quickEdit` flag on panel option configurations that allows plugin authors to mark specific options for display in the dashboard edit sidebar. 
This is proposal 2 in the [design doc](https://docs.google.com/document/d/1hdon8dQpPDS1-syR7v3KohzG4Rfl65jD4cxaTNeldvE/edit?tab=t.3gfcb7n7nvpq#heading=h.fl933pk1iwl)

- Add `quickEdit?: boolean` to OptionEditorConfig interface
- Add useQuickEditOptions hook to filter and render flagged options
- Integrate quick edit options into VizPanelEditableElement
- Add example usage to stat panel (textMode, colorMode, graphMode)
- Add unit tests for the hook (max 5 options, ordering, filtering)

**Why do we need this feature?**

This reduces clicks needed for common configuration changes by showing frequently-used options without entering the full panel editor.

**Who is this feature for?**

- New editors - only a select few, most commonly used, options will be shown at first. It will be less overwhelming.
- Experienced editors - saves them a click for the most common actions

**Which issue(s) does this PR fix?**:

None, this is a hackathon

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
