### PR TITLE
Datasource resources API: return 405 instead of 500 for HTTP method mismatch

### DIFF
--- a/pkg/api/plugin_resource.go
+++ b/pkg/api/plugin_resource.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
+	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 
@@ -37,6 +39,11 @@ func (hs *HTTPServer) callPluginResource(c *contextmodel.ReqContext, pluginID st
 		return
 	}
 
+	if err := validateResourceMethod(c.Req.Method); err != nil {
+		handleCallResourceError(err, c)
+		return
+	}
+
 	req, err := hs.pluginResourceRequest(c)
 	if err != nil {
 		c.JsonApiErr(http.StatusBadRequest, "Failed for create plugin resource request", err)
@@ -65,6 +72,11 @@ func (hs *HTTPServer) callPluginResourceWithDataSource(c *contextmodel.ReqContex
 	err = hs.DataSourceRequestValidator.Validate(ds.URL, ds.JsonData, c.Req)
 	if err != nil {
 		c.JsonApiErr(http.StatusForbidden, "Access denied", err)
+		return
+	}
+
+	if err := validateResourceMethod(c.Req.Method); err != nil {
+		handleCallResourceError(err, c)
 		return
 	}
 
@@ -115,7 +127,42 @@ func (hs *HTTPServer) makePluginResourceRequest(w http.ResponseWriter, req *http
 	return hs.pluginClient.CallResource(req.Context(), crReq, httpSender)
 }
 
+// allowedResourceMethods defines the HTTP methods supported for datasource resource calls.
+var allowedResourceMethods = map[string]bool{
+	http.MethodGet:    true,
+	http.MethodPost:   true,
+	http.MethodPut:    true,
+	http.MethodDelete: true,
+	http.MethodPatch:  true,
+}
+
+// allowedResourceMethodsList returns a sorted, comma-separated list of allowed HTTP methods
+// for use in the Allow response header.
+func allowedResourceMethodsList() string {
+	methods := make([]string, 0, len(allowedResourceMethods))
+	for m := range allowedResourceMethods {
+		methods = append(methods, m)
+	}
+	sort.Strings(methods)
+	return strings.Join(methods, ", ")
+}
+
+// validateResourceMethod checks if the HTTP method is allowed for plugin resource calls.
+// Returns nil if the method is allowed, or an error if the method is not supported.
+func validateResourceMethod(method string) error {
+	if !allowedResourceMethods[method] {
+		return plugins.ErrPluginMethodNotAllowed
+	}
+	return nil
+}
+
 func handleCallResourceError(err error, reqCtx *contextmodel.ReqContext) {
+	if errors.Is(err, plugins.ErrPluginMethodNotAllowed) {
+		reqCtx.Resp.Header().Set("Allow", allowedResourceMethodsList())
+		resp := response.ErrOrFallback(http.StatusMethodNotAllowed, "Method not allowed", err)
+		resp.WriteTo(reqCtx)
+		return
+	}
 	resp := response.ErrOrFallback(http.StatusInternalServerError, "Failed to call resource", err)
 	resp.WriteTo(reqCtx)
 }

--- a/pkg/api/plugin_resource_test.go
+++ b/pkg/api/plugin_resource_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -39,6 +41,7 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch"
 	testdatasource "github.com/grafana/grafana/pkg/tsdb/grafana-testdata-datasource"
 	"github.com/grafana/grafana/pkg/util/testutil"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/grafana/grafana/pkg/web/webtest"
 )
 
@@ -213,4 +216,73 @@ func TestIntegrationCallResource(t *testing.T) {
 		require.NoError(t, resp.Body.Close())
 		require.Equal(t, 500, resp.StatusCode)
 	})
+}
+
+func TestValidateResourceMethod(t *testing.T) {
+	tests := []struct {
+		name      string
+		method    string
+		expectErr bool
+	}{
+		{name: "GET is allowed", method: http.MethodGet, expectErr: false},
+		{name: "POST is allowed", method: http.MethodPost, expectErr: false},
+		{name: "PUT is allowed", method: http.MethodPut, expectErr: false},
+		{name: "DELETE is allowed", method: http.MethodDelete, expectErr: false},
+		{name: "PATCH is allowed", method: http.MethodPatch, expectErr: false},
+		{name: "OPTIONS is not allowed", method: http.MethodOptions, expectErr: true},
+		{name: "HEAD is not allowed", method: http.MethodHead, expectErr: true},
+		{name: "TRACE is not allowed", method: http.MethodTrace, expectErr: true},
+		{name: "CONNECT is not allowed", method: http.MethodConnect, expectErr: true},
+		{name: "custom method is not allowed", method: "CUSTOM", expectErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateResourceMethod(tc.method)
+			if tc.expectErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, plugins.ErrPluginMethodNotAllowed)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAllowedResourceMethodsList(t *testing.T) {
+	result := allowedResourceMethodsList()
+	require.Equal(t, "DELETE, GET, PATCH, POST, PUT", result)
+}
+
+func TestHandleCallResourceErrorMethodNotAllowed(t *testing.T) {
+	rec := httptest.NewRecorder()
+	reqCtx := &contextmodel.ReqContext{
+		Context: &web.Context{
+			Resp: web.NewResponseWriter(http.MethodGet, rec),
+			Req:  httptest.NewRequest(http.MethodOptions, "/", nil),
+		},
+	}
+	handleCallResourceError(plugins.ErrPluginMethodNotAllowed, reqCtx)
+
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	require.Equal(t, "DELETE, GET, PATCH, POST, PUT", rec.Header().Get("Allow"))
+
+	var body map[string]interface{}
+	err := json.NewDecoder(rec.Body).Decode(&body)
+	require.NoError(t, err)
+	require.Contains(t, body["message"], "Method not allowed")
+}
+
+func TestHandleCallResourceErrorGeneric(t *testing.T) {
+	rec := httptest.NewRecorder()
+	reqCtx := &contextmodel.ReqContext{
+		Context: &web.Context{
+			Resp: web.NewResponseWriter(http.MethodGet, rec),
+			Req:  httptest.NewRequest(http.MethodGet, "/", nil),
+		},
+	}
+	handleCallResourceError(errors.New("something went wrong"), reqCtx)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Empty(t, rec.Header().Get("Allow"))
 }

--- a/pkg/apimachinery/errutil/errors.go
+++ b/pkg/apimachinery/errutil/errors.go
@@ -82,6 +82,13 @@ func UnsupportedMediaType(msgID string, opts ...BaseOpt) Base {
 	return NewBase(StatusUnsupportedMediaType, msgID, opts...)
 }
 
+// MethodNotAllowed initializes a new [Base] error with reason StatusMethodNotAllowed
+// that is used to construct [Error]. The msgID is passed to the caller
+// to serve as the base for user facing error messages.
+func MethodNotAllowed(msgID string, opts ...BaseOpt) Base {
+	return NewBase(StatusMethodNotAllowed, msgID, opts...)
+}
+
 // Conflict initializes a new [Base] error with reason StatusConflict
 // that is used to construct [Error]. The msgID is passed to the caller
 // to serve as the base for user facing error messages.

--- a/pkg/apimachinery/errutil/status.go
+++ b/pkg/apimachinery/errutil/status.go
@@ -29,6 +29,10 @@ const (
 	// contained instructions.
 	// HTTP status code 422.
 	StatusUnprocessableEntity CoreStatus = "Unprocessable Entity"
+	// StatusMethodNotAllowed means that the HTTP method used is not
+	// supported for the requested resource.
+	// HTTP status code 405.
+	StatusMethodNotAllowed CoreStatus = CoreStatus(metav1.StatusReasonMethodNotAllowed)
 	// StatusUnsupportedMediaType means that the server does not support
 	// the request payload's media type.
 	// HTTP status code 415.
@@ -111,6 +115,8 @@ func (s CoreStatus) HTTPStatus() int {
 		return http.StatusGatewayTimeout
 	case StatusUnprocessableEntity:
 		return http.StatusUnprocessableEntity
+	case StatusMethodNotAllowed:
+		return http.StatusMethodNotAllowed
 	case StatusUnsupportedMediaType:
 		return http.StatusUnsupportedMediaType
 	case StatusConflict:
@@ -142,6 +148,8 @@ func (s CoreStatus) LogLevel() LogLevel {
 	case StatusNotFound:
 		return LevelInfo
 	case StatusTimeout:
+		return LevelInfo
+	case StatusMethodNotAllowed:
 		return LevelInfo
 	case StatusUnsupportedMediaType:
 		return LevelInfo

--- a/pkg/plugins/errors.go
+++ b/pkg/plugins/errors.go
@@ -24,6 +24,11 @@ var (
 	// ErrMethodNotImplemented error returned when a plugin method is not implemented.
 	ErrMethodNotImplemented = errMethodNotImplementedBase.Errorf("method not implemented")
 
+	errMethodNotAllowedBase = errutil.MethodNotAllowed("plugin.methodNotAllowed",
+		errutil.WithPublicMessage("Method not allowed"))
+	// ErrPluginMethodNotAllowed error returned when a plugin does not support the HTTP method.
+	ErrPluginMethodNotAllowed = errMethodNotAllowedBase.Errorf("method not allowed")
+
 	// ErrPluginHealthCheck error returned when a plugin fails its health check.
 	// Exposed as a base error to wrap it with plugin error.
 	ErrPluginHealthCheck = errutil.Internal("plugin.healthCheck",


### PR DESCRIPTION
Fixes datasource resource API to return 405 Method Not Allowed with Allow header instead of 500 when unsupported HTTP methods are used. Closes #119686