### PR TITLE
unified-storage: make isSnowflake deterministic and fix test flake

### DIFF
--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -972,13 +972,8 @@ func isRowAlreadyExistsError(err error) bool {
 }
 
 // isSnowflake returns whether the argument passed is a snowflake ID (new) or a microsecond timestamp (old).
-// We try to interpret the number as a microsecond timestamp first. If it represents a time in the past,
-// it is considered a microsecond timestamp. Snowflake IDs are much larger integers and would lead
-// to dates in the future if interpreted as a microsecond timestamp.
+// Snowflake IDs always have 19 digits. A 19-digit microsecond timestamp (10^18 µs) would correspond
+// to year ~33658, so any number with fewer than 19 digits is unambiguously a legacy microsecond timestamp.
 func isSnowflake(rv int64) bool {
-	ts := time.UnixMicro(rv)
-	oneHourFromNow := time.Now().Add(time.Hour)
-	isMicroSecRV := ts.Before(oneHourFromNow)
-
-	return !isMicroSecRV
+	return rv >= 1e18
 }


### PR DESCRIPTION
Previously, the `isSnowflake` function was non-deterministic and kind of brittle: it would compare the given `rv` with a timestamp one hour in the future. If the caller passed a microsecond RV 1h01nsec in the future, it would be considered a snowflake even though the actual integer number is still a lot smaller than an actual snowflake ID.

In this commit `isSnowflake` becomes deterministic by checking if the given `rv` has 19 digits (every valid snowflake in the time range we care about has 19 digits). If it doesn't it's considered a legacy microsecond RV.

This was causing some flakes in the KV store's GC tests where a timestamp of "1 hour from now" was being used and led to RVs being considered snowflake IDs _sometimes_.

For reference, these were the flakes:

```
=== RUN   TestIntegrationGarbageCollectionGroupResource/can_garbage_collect_a_deleted_resource
    storage_backend_gc_test.go:170:
                Error Trace:    /Users/rc/src/grafana/grafana/pkg/storage/unified/resource/storage_backend_gc_test.go:170
                Error:          Not equal:
                                expected: 0
                                actual  : 2
                Test:           TestIntegrationGarbageCollectionGroupResource/can_garbage_collect_a_deleted_resource

=== RUN   TestIntegrationGarbageCollectionGroupResource/pagination_does_not_delete_resources_that_were_recreated
    storage_backend_gc_test.go:472:
                Error Trace:    /Users/rc/src/grafana/grafana/pkg/storage/unified/resource/storage_backend_gc_test.go:472
                Error:          Not equal:
                                expected: 2
                                actual  : 7
                Test:           TestIntegrationGarbageCollectionGroupResource/pagination_does_not_delete_resources_that_were_recreated
```