### PR TITLE
CloudWatch Logs: Fetch all log groups with pagination and sort alphabetically

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
@@ -111,7 +111,7 @@ describe('LogGroupsSelector', () => {
     expect(screen.getByText('Log group name prefix')).toBeInTheDocument();
     await userEvent.type(screen.getByLabelText('log group search'), 'something');
     await waitFor(() => screen.getByDisplayValue('something'));
-    expect(fetchLogGroups).toBeCalledWith({ accountId: 'all', logGroupPattern: 'something' });
+    expect(fetchLogGroups).toBeCalledWith({ accountId: 'all', logGroupPattern: 'something', listAllLogGroups: true });
   });
 
   it('calls fetchLogGroups with an account when selected', async () => {
@@ -140,7 +140,7 @@ describe('LogGroupsSelector', () => {
     expect(screen.getByText('Loading...')).toBeInTheDocument();
     secondCall.resolve();
     await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
-    expect(fetchLogGroups).toBeCalledWith({ accountId: 'account-id123', logGroupPattern: '' });
+    expect(fetchLogGroups).toBeCalledWith({ accountId: 'account-id123', logGroupPattern: '', listAllLogGroups: true });
   });
 
   it('shows a log group as checked after the user checks it', async () => {
@@ -187,9 +187,7 @@ describe('LogGroupsSelector', () => {
     ]);
   });
 
-  const labelText =
-    'Only the first 50 results can be shown. If you do not see an expected log group, try narrowing down your search.';
-  it('should not display max result info label in case less than 50 logs groups are being displayed', async () => {
+  it('should not display info label in case less than 50 logs groups are being displayed', async () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
@@ -197,16 +195,16 @@ describe('LogGroupsSelector', () => {
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
-    expect(screen.queryByText(labelText)).not.toBeInTheDocument();
+    expect(screen.queryByText(/log groups found/)).not.toBeInTheDocument();
     defer.resolve();
-    await waitFor(() => expect(screen.queryByText(labelText)).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText(/log groups found/)).not.toBeInTheDocument());
   });
 
-  it('should display max result info label in case 50 or more logs groups are being displayed', async () => {
+  it('should display info label with count when 50 or more logs groups are being displayed', async () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
-      return Array(50).map((i) => ({
+      return Array.from({ length: 50 }, (_, i) => ({
         value: {
           arn: `logGroup${i}`,
           name: `logGroup${i}`,
@@ -215,9 +213,9 @@ describe('LogGroupsSelector', () => {
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
-    expect(screen.queryByText(labelText)).not.toBeInTheDocument();
+    expect(screen.queryByText(/log groups found/)).not.toBeInTheDocument();
     defer.resolve();
-    await waitFor(() => expect(screen.getByText(labelText)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/50 log groups found/)).toBeInTheDocument());
   });
 
   it('should display log groups counter label', async () => {

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
@@ -89,15 +89,16 @@ export const LogGroupsSelector = ({
       const possibleLogGroups = await fetchLogGroups({
         logGroupPattern: searchTerm,
         accountId: accountId,
+        listAllLogGroups: true,
       });
-      setSelectableLogGroups(
-        possibleLogGroups.map((lg) => ({
-          arn: lg.value.arn,
-          name: lg.value.name,
-          accountId: lg.accountId,
-          accountLabel: lg.accountId ? accountNameById[lg.accountId] : undefined,
-        }))
-      );
+      const mapped = possibleLogGroups.map((lg) => ({
+        arn: lg.value.arn,
+        name: lg.value.name,
+        accountId: lg.accountId,
+        accountLabel: lg.accountId ? accountNameById[lg.accountId] : undefined,
+      }));
+      mapped.sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
+      setSelectableLogGroups(mapped);
     } catch (err) {
       setSelectableLogGroups([]);
     }
@@ -149,12 +150,12 @@ export const LogGroupsSelector = ({
         </div>
         <Space layout="block" v={2} />
         <div>
-          {!isLoading && selectableLogGroups.length >= 25 && (
+          {!isLoading && selectableLogGroups.length >= 50 && (
             <>
               <div className={styles.limitLabel}>
                 <Icon name="info-circle"></Icon>
-                Only the first 50 results can be shown. If you do not see an expected log group, try narrowing down your
-                search.
+                {selectableLogGroups.length} log groups found. If you do not see an expected log group, try narrowing
+                down your search.
                 <p>
                   A{' '}
                   <TextLink


### PR DESCRIPTION
## Summary
- Enable `listAllLogGroups: true` in the log group selector modal so the backend paginates through all available CloudWatch log groups via `NextToken`, removing the 50-result limit
- Sort fetched log groups alphabetically for easier discovery
- Update the info banner to show the actual count (e.g. "150 log groups found") instead of the static "Only the first 50 results can be shown"

## Motivation
Resolves #118097 — Users monitoring log groups from multiple AWS accounts could only see the first 50 log groups in the selector modal, with no way to access the rest. The backend already supported full pagination via `listAllLogGroups` (used by template variables), but the selector UI wasn't using it.

## Changes
- `LogGroupsSelector.tsx`: Pass `listAllLogGroups: true` to `fetchLogGroups`, sort results alphabetically, update info banner text and threshold
- `LogGroupsSelector.test.tsx`: Update test assertions for new `listAllLogGroups` param, dynamic count label, and fix `Array(50).map` → `Array.from` bug

## Test plan
- [x] Updated existing tests to match new behavior
- [x] Info banner now shows only when ≥50 log groups are returned (was ≥25)
- [x] Info banner shows actual count instead of static message
- [x] Search and account filter calls include `listAllLogGroups: true`