### PR TITLE
Dashboards: Add quick edit options API for panel plugins

### DIFF
--- a/packages/grafana-data/src/panel/PanelPlugin.test.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.test.ts
@@ -1,0 +1,75 @@
+import { getPanelPlugin } from '../../test';
+
+describe('PanelPlugin', () => {
+  describe('setQuickEditPaths', () => {
+    it('should store quick edit paths', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+
+      plugin.setQuickEditPaths(['path1', 'path2']);
+
+      expect(plugin.getQuickEditPaths()).toEqual(['path1', 'path2']);
+    });
+
+    it('should return undefined when no paths are set', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+
+      expect(plugin.getQuickEditPaths()).toBeUndefined();
+    });
+
+    it('should limit paths to maximum of 5', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      plugin.setQuickEditPaths(['path1', 'path2', 'path3', 'path4', 'path5', 'path6', 'path7']);
+
+      expect(plugin.getQuickEditPaths()).toEqual(['path1', 'path2', 'path3', 'path4', 'path5']);
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('setQuickEditPaths received 7 paths'));
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should allow exactly 5 paths without warning', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      plugin.setQuickEditPaths(['path1', 'path2', 'path3', 'path4', 'path5']);
+
+      expect(plugin.getQuickEditPaths()).toEqual(['path1', 'path2', 'path3', 'path4', 'path5']);
+      expect(consoleSpy).not.toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should return this for method chaining', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+
+      const result = plugin.setQuickEditPaths(['path1']);
+
+      expect(result).toBe(plugin);
+    });
+
+    it('should create a copy of the paths array', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+      const paths = ['path1', 'path2'];
+
+      plugin.setQuickEditPaths(paths);
+      paths.push('path3');
+
+      expect(plugin.getQuickEditPaths()).toEqual(['path1', 'path2']);
+    });
+
+    it('should work with setPanelOptions in method chain', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' })
+        .setPanelOptions((builder) => {
+          builder.addSelect({
+            path: 'displayMode',
+            name: 'Display mode',
+            settings: { options: [] },
+          });
+        })
+        .setQuickEditPaths(['displayMode']);
+
+      expect(plugin.getQuickEditPaths()).toEqual(['displayMode']);
+    });
+  });
+});

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -118,6 +118,7 @@ export class PanelPlugin<
 
   private optionsSupplier?: PanelOptionsSupplier<TOptions>;
   private suggestionsSupplier?: VisualizationSuggestionsSupplier<TOptions, TFieldConfigOptions>;
+  private _quickEditPaths?: string[];
 
   panel: ComponentType<PanelProps<TOptions>> | null;
   editor?: ComponentClass<PanelEditorProps<TOptions>>;
@@ -274,6 +275,58 @@ export class PanelPlugin<
    */
   getPanelOptionsSupplier(): PanelOptionsSupplier<TOptions> {
     return this.optionsSupplier ?? (() => {});
+  }
+
+  /**
+   * Define which panel options should appear in the dashboard edit pane
+   * for quick editing without entering the full panel editor.
+   *
+   * This allows users to quickly adjust common settings directly from the
+   * dashboard edit view, reducing the number of clicks needed for frequent
+   * configuration changes.
+   *
+   * @param paths - Array of option paths (max 5) that should be shown in quick edit.
+   *                Paths should match those defined in setPanelOptions.
+   *                Supports nested paths using dot notation (e.g., 'legend.displayMode').
+   *
+   * @example
+   * ```typescript
+   * export const plugin = new PanelPlugin<Options>(MyPanel)
+   *   .setPanelOptions((builder) => {
+   *     builder
+   *       .addSelect({ path: 'displayMode', name: 'Display mode', ... })
+   *       .addRadio({ path: 'orientation', name: 'Orientation', ... })
+   *       .addBooleanSwitch({ path: 'showLegend', name: 'Show legend', ... });
+   *   })
+   *   .setQuickEditPaths(['displayMode', 'orientation']);
+   * ```
+   *
+   * @alpha
+   */
+  setQuickEditPaths(paths: Array<keyof TOptions & string> | string[]) {
+    const MAX_QUICK_EDIT_PATHS = 5;
+
+    if (paths.length > MAX_QUICK_EDIT_PATHS) {
+      console.warn(
+        `PanelPlugin [${this.meta?.id ?? 'unknown'}]: setQuickEditPaths received ${paths.length} paths, ` +
+          `but only ${MAX_QUICK_EDIT_PATHS} are allowed. Extra paths will be ignored.`
+      );
+      this._quickEditPaths = paths.slice(0, MAX_QUICK_EDIT_PATHS);
+    } else {
+      this._quickEditPaths = [...paths];
+    }
+
+    return this;
+  }
+
+  /**
+   * Get the quick edit paths defined for this plugin.
+   *
+   * @returns Array of option paths for quick edit, or undefined if not set.
+   * @alpha
+   */
+  getQuickEditPaths(): string[] | undefined {
+    return this._quickEditPaths;
   }
 
   /**

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1403,6 +1403,11 @@ export interface FeatureToggles {
   */
   heatmapRowsAxisOptions?: boolean;
   /**
+  * Enable quick edit options for panel plugins in the dashboard edit pane
+  * @default false
+  */
+  panelQuickEdit?: boolean;
+  /**
   * Restrict PanelChrome contents with overflow: hidden;
   * @default true
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2213,6 +2213,14 @@ var (
 			Expression:   "false",
 		},
 		{
+			Name:         "panelQuickEdit",
+			Description:  "Enable quick edit options for panel plugins in the dashboard edit pane",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: true,
+			Owner:        grafanaDashboardsSquad,
+			Expression:   "false",
+		},
+		{
 			Name:         "preventPanelChromeOverflow",
 			Description:  "Restrict PanelChrome contents with overflow: hidden;",
 			Stage:        FeatureStagePublicPreview,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -275,6 +275,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-12-02,externalVizSuggestions,experimental,@grafana/dataviz-squad,false,false,true
 2026-03-03,vizLegendSeriesLimit,experimental,@grafana/dataviz-squad,false,false,true
 2025-12-18,heatmapRowsAxisOptions,experimental,@grafana/dataviz-squad,false,false,true
+2026-03-09,panelQuickEdit,experimental,@grafana/dashboards-squad,false,false,true
 2025-10-17,preventPanelChromeOverflow,preview,@grafana/grafana-frontend-platform,false,false,true
 2025-10-31,jaegerEnableGrpcEndpoint,experimental,@grafana/oss-big-tent,false,false,false
 2025-10-17,pluginStoreServiceLoading,experimental,@grafana/plugins-platform-backend,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3266,6 +3266,23 @@
     },
     {
       "metadata": {
+        "name": "panelQuickEdit",
+        "resourceVersion": "1773045630979",
+        "creationTimestamp": "2026-03-09T08:27:57Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-03-09 08:40:30.97947 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enable quick edit options for panel plugins in the dashboard edit pane",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "panelStyleActions",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2026-02-18T17:05:38Z"

--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
@@ -1,3 +1,4 @@
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useId, useMemo } from 'react';
 
 import { Trans, t } from '@grafana/i18n';
@@ -73,7 +74,9 @@ function useEditPaneOptions(this: VizPanelEditableElement, isNewElement: boolean
       );
   }, [rootId, titleId, panel, descriptionId, backgroundId, isNewElement]);
 
-  const quickEditCategory = useQuickEditOptions({ panel, plugin });
+  const isPanelQuickEditEnabled = useBooleanFlagValue('panelQuickEdit', false);
+  const quickEditOptions = useQuickEditOptions({ panel, plugin });
+  const quickEditCategory = isPanelQuickEditEnabled ? quickEditOptions : null;
 
   const layoutCategories = useMemo(
     () => (isDashboardLayoutItem(layoutElement) && layoutElement.getOptions ? layoutElement.getOptions() : []),

--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
@@ -25,10 +25,12 @@ import { DashboardInteractions } from '../utils/interactions';
 import { getDashboardSceneFor, getPanelIdForVizPanel } from '../utils/utils';
 
 import { MultiSelectedVizPanelsEditableElement } from './MultiSelectedVizPanelsEditableElement';
+import { useQuickEditOptions } from './useQuickEditOptions';
 
 function useEditPaneOptions(this: VizPanelEditableElement, isNewElement: boolean): OptionsPaneCategoryDescriptor[] {
   const panel = this.panel;
   const layoutElement = panel.parent!;
+  const plugin = panel.getPlugin();
   const rootId = useId();
   const titleId = useId();
   const descriptionId = useId();
@@ -71,12 +73,20 @@ function useEditPaneOptions(this: VizPanelEditableElement, isNewElement: boolean
       );
   }, [rootId, titleId, panel, descriptionId, backgroundId, isNewElement]);
 
+  const quickEditCategory = useQuickEditOptions({ panel, plugin });
+
   const layoutCategories = useMemo(
     () => (isDashboardLayoutItem(layoutElement) && layoutElement.getOptions ? layoutElement.getOptions() : []),
     [layoutElement]
   );
 
-  return [panelOptions, ...layoutCategories];
+  const categories: OptionsPaneCategoryDescriptor[] = [panelOptions];
+  if (quickEditCategory) {
+    categories.push(quickEditCategory);
+  }
+  categories.push(...layoutCategories);
+
+  return categories;
 }
 
 export class VizPanelEditableElement implements EditableDashboardElement, BulkActionElement {

--- a/public/app/features/dashboard-scene/edit-pane/editActions.ts
+++ b/public/app/features/dashboard-scene/edit-pane/editActions.ts
@@ -1,0 +1,16 @@
+import { BusEventWithPayload } from '@grafana/data';
+import { SceneObject } from '@grafana/scenes';
+
+export interface DashboardEditActionEventPayload {
+  removedObject?: SceneObject;
+  addedObject?: SceneObject;
+  movedObject?: SceneObject;
+  source: SceneObject;
+  description?: string;
+  perform: () => void;
+  undo: () => void;
+}
+
+export class DashboardEditActionEvent extends BusEventWithPayload<DashboardEditActionEventPayload> {
+  static type = 'dashboard-edit-action';
+}

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
@@ -5,14 +5,8 @@ import { EventBusSrv } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { VizPanel } from '@grafana/scenes';
 
-import { dashboardEditActions } from './shared';
+import { DashboardEditActionEvent } from './editActions';
 import { useQuickEditOptions } from './useQuickEditOptions';
-
-jest.mock('./shared', () => ({
-  dashboardEditActions: {
-    edit: jest.fn(),
-  },
-}));
 
 describe('useQuickEditOptions', () => {
   const createMockPanel = (options: Record<string, unknown> = {}) => {
@@ -30,6 +24,7 @@ describe('useQuickEditOptions', () => {
       onOptionsChange: jest.fn(),
     } as ReturnType<typeof panel.getPanelContext>);
     jest.spyOn(panel, 'onOptionsChange').mockImplementation(jest.fn());
+    jest.spyOn(panel, 'publishEvent').mockImplementation(jest.fn());
 
     return panel;
   };
@@ -182,7 +177,7 @@ describe('useQuickEditOptions', () => {
       jest.clearAllMocks();
     });
 
-    it('should call dashboardEditActions.edit when changing an option', () => {
+    it('should publish DashboardEditActionEvent when changing an option', () => {
       const panel = createMockPanel({ textMode: 'auto' });
       const plugin = createMockPlugin(['textMode']);
 
@@ -196,14 +191,8 @@ describe('useQuickEditOptions', () => {
         rendered.props.onChange('value');
       });
 
-      expect(dashboardEditActions.edit).toHaveBeenCalledTimes(1);
-      expect(dashboardEditActions.edit).toHaveBeenCalledWith(
-        expect.objectContaining({
-          source: panel,
-          perform: expect.any(Function),
-          undo: expect.any(Function),
-        })
-      );
+      expect(panel.publishEvent).toHaveBeenCalledTimes(1);
+      expect(panel.publishEvent).toHaveBeenCalledWith(expect.any(DashboardEditActionEvent), true);
     });
 
     it('should apply new value when perform is called', () => {
@@ -218,8 +207,8 @@ describe('useQuickEditOptions', () => {
         rendered.props.onChange('value');
       });
 
-      const editCall = (dashboardEditActions.edit as jest.Mock).mock.calls[0][0];
-      editCall.perform();
+      const event = (panel.publishEvent as jest.Mock).mock.calls[0][0] as DashboardEditActionEvent;
+      event.payload.perform();
 
       expect(panel.onOptionsChange).toHaveBeenCalledWith({ textMode: 'value' });
     });
@@ -243,8 +232,8 @@ describe('useQuickEditOptions', () => {
         rendered.props.onChange('value');
       });
 
-      const editCall = (dashboardEditActions.edit as jest.Mock).mock.calls[0][0];
-      editCall.undo();
+      const event = (panel.publishEvent as jest.Mock).mock.calls[0][0] as DashboardEditActionEvent;
+      event.payload.undo();
 
       expect(panel.onOptionsChange).toHaveBeenCalledWith({ textMode: 'auto' });
     });

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
 import { EventBusSrv } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
@@ -18,6 +18,7 @@ describe('useQuickEditOptions', () => {
     jest.spyOn(panel, 'interpolate').mockImplementation((value) => value as string);
     jest.spyOn(panel, 'getPanelContext').mockReturnValue({
       eventBus: new EventBusSrv(),
+      eventsScope: 'local',
       onOptionsChange: jest.fn(),
     } as ReturnType<typeof panel.getPanelContext>);
     jest.spyOn(panel, 'onOptionsChange').mockImplementation(jest.fn());

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
@@ -64,6 +64,24 @@ describe('useQuickEditOptions', () => {
           name: 'Conditional option',
           defaultValue: false,
           showIf: (config) => config.showGraph === true,
+        })
+        .addBooleanSwitch({
+          path: 'legend.showLegend',
+          name: 'Visibility',
+          category: ['Legend'],
+          defaultValue: true,
+        })
+        .addSelect({
+          path: 'tooltip.mode',
+          name: 'Mode',
+          category: ['Tooltip'],
+          settings: {
+            options: [
+              { value: 'single', label: 'Single' },
+              { value: 'all', label: 'All' },
+            ],
+          },
+          defaultValue: 'single',
         });
     });
 
@@ -107,10 +125,22 @@ describe('useQuickEditOptions', () => {
     const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
 
     expect(result.current).not.toBeNull();
-    expect(result.current?.props.title).toBe('Quick settings');
+    expect(result.current?.props.title).toBe('Quick edit');
     expect(result.current?.items).toHaveLength(2);
     expect(result.current?.items[0].props.title).toBe('Text mode');
     expect(result.current?.items[1].props.title).toBe('Color mode');
+  });
+
+  it('should include category prefix for nested options', () => {
+    const panel = createMockPanel({ legend: { showLegend: true }, tooltip: { mode: 'single' } });
+    const plugin = createMockPlugin(['legend.showLegend', 'tooltip.mode']);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items).toHaveLength(2);
+    expect(result.current?.items[0].props.title).toBe('Legend Visibility');
+    expect(result.current?.items[1].props.title).toBe('Tooltip Mode');
   });
 
   it('should warn and skip invalid paths', () => {

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
@@ -1,0 +1,170 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { EventBusSrv } from '@grafana/data';
+import { getPanelPlugin } from '@grafana/data/test';
+import { VizPanel } from '@grafana/scenes';
+
+import { useQuickEditOptions } from './useQuickEditOptions';
+
+describe('useQuickEditOptions', () => {
+  const createMockPanel = (options: Record<string, unknown> = {}) => {
+    const panel = new VizPanel({
+      title: 'Test Panel',
+      pluginId: 'stat',
+      options,
+    });
+
+    jest.spyOn(panel, 'useState').mockReturnValue({ options } as ReturnType<typeof panel.useState>);
+    jest.spyOn(panel, 'interpolate').mockImplementation((value) => value as string);
+    jest.spyOn(panel, 'getPanelContext').mockReturnValue({
+      eventBus: new EventBusSrv(),
+      onOptionsChange: jest.fn(),
+    } as ReturnType<typeof panel.getPanelContext>);
+    jest.spyOn(panel, 'onOptionsChange').mockImplementation(jest.fn());
+
+    return panel;
+  };
+
+  const createMockPlugin = (quickEditPaths?: string[]) => {
+    const plugin = getPanelPlugin({ id: 'stat' }).setPanelOptions((builder) => {
+      builder
+        .addSelect({
+          path: 'textMode',
+          name: 'Text mode',
+          settings: {
+            options: [
+              { value: 'auto', label: 'Auto' },
+              { value: 'value', label: 'Value' },
+            ],
+          },
+          defaultValue: 'auto',
+        })
+        .addSelect({
+          path: 'colorMode',
+          name: 'Color mode',
+          settings: {
+            options: [
+              { value: 'none', label: 'None' },
+              { value: 'value', label: 'Value' },
+            ],
+          },
+          defaultValue: 'value',
+        })
+        .addBooleanSwitch({
+          path: 'showGraph',
+          name: 'Show graph',
+          defaultValue: true,
+        })
+        .addBooleanSwitch({
+          path: 'conditionalOption',
+          name: 'Conditional option',
+          defaultValue: false,
+          showIf: (config) => config.showGraph === true,
+        });
+    });
+
+    if (quickEditPaths) {
+      plugin.setQuickEditPaths(quickEditPaths);
+    }
+
+    return plugin;
+  };
+
+  it('should return null when plugin is undefined', () => {
+    const panel = createMockPanel();
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin: undefined }));
+
+    expect(result.current).toBeNull();
+  });
+
+  it('should return null when plugin has no quick edit paths', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin();
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).toBeNull();
+  });
+
+  it('should return null when quick edit paths array is empty', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin([]);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).toBeNull();
+  });
+
+  it('should return category with matching options', () => {
+    const panel = createMockPanel({ textMode: 'value', colorMode: 'none' });
+    const plugin = createMockPlugin(['textMode', 'colorMode']);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.props.title).toBe('Quick settings');
+    expect(result.current?.items).toHaveLength(2);
+    expect(result.current?.items[0].props.title).toBe('Text mode');
+    expect(result.current?.items[1].props.title).toBe('Color mode');
+  });
+
+  it('should warn and skip invalid paths', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin(['textMode', 'invalidPath']);
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items).toHaveLength(1);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Quick edit path "invalidPath" not found'));
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should respect showIf conditions', () => {
+    const panel = createMockPanel({ showGraph: false });
+    const plugin = createMockPlugin(['showGraph', 'conditionalOption']);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items).toHaveLength(1);
+    expect(result.current?.items[0].props.title).toBe('Show graph');
+  });
+
+  it('should show conditional option when condition is met', () => {
+    const panel = createMockPanel({ showGraph: true });
+    const plugin = createMockPlugin(['showGraph', 'conditionalOption']);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items).toHaveLength(2);
+  });
+
+  it('should return null when all paths are invalid', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin(['invalidPath1', 'invalidPath2']);
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).toBeNull();
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should preserve order of paths', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin(['colorMode', 'textMode', 'showGraph']);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items[0].props.title).toBe('Color mode');
+    expect(result.current?.items[1].props.title).toBe('Text mode');
+    expect(result.current?.items[2].props.title).toBe('Show graph');
+  });
+});

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
@@ -1,10 +1,18 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
+import React from 'react';
 
 import { EventBusSrv } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { VizPanel } from '@grafana/scenes';
 
+import { dashboardEditActions } from './shared';
 import { useQuickEditOptions } from './useQuickEditOptions';
+
+jest.mock('./shared', () => ({
+  dashboardEditActions: {
+    edit: jest.fn(),
+  },
+}));
 
 describe('useQuickEditOptions', () => {
   const createMockPanel = (options: Record<string, unknown> = {}) => {
@@ -167,5 +175,78 @@ describe('useQuickEditOptions', () => {
     expect(result.current?.items[0].props.title).toBe('Color mode');
     expect(result.current?.items[1].props.title).toBe('Text mode');
     expect(result.current?.items[2].props.title).toBe('Show graph');
+  });
+
+  describe('undo/redo support', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call dashboardEditActions.edit when changing an option', () => {
+      const panel = createMockPanel({ textMode: 'auto' });
+      const plugin = createMockPlugin(['textMode']);
+
+      const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+      expect(result.current).not.toBeNull();
+      const item = result.current!.items[0];
+
+      const rendered = item.props.render(item) as React.ReactElement<{ onChange: (value: string) => void }>;
+      act(() => {
+        rendered.props.onChange('value');
+      });
+
+      expect(dashboardEditActions.edit).toHaveBeenCalledTimes(1);
+      expect(dashboardEditActions.edit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: panel,
+          perform: expect.any(Function),
+          undo: expect.any(Function),
+        })
+      );
+    });
+
+    it('should apply new value when perform is called', () => {
+      const panel = createMockPanel({ textMode: 'auto' });
+      const plugin = createMockPlugin(['textMode']);
+
+      const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+      const item = result.current!.items[0];
+
+      const rendered = item.props.render(item) as React.ReactElement<{ onChange: (value: string) => void }>;
+      act(() => {
+        rendered.props.onChange('value');
+      });
+
+      const editCall = (dashboardEditActions.edit as jest.Mock).mock.calls[0][0];
+      editCall.perform();
+
+      expect(panel.onOptionsChange).toHaveBeenCalledWith({ textMode: 'value' });
+    });
+
+    it('should restore old value when undo is called', () => {
+      const panel = createMockPanel({ textMode: 'auto' });
+      const plugin = createMockPlugin(['textMode']);
+
+      jest.spyOn(panel, 'state', 'get').mockReturnValue({
+        options: { textMode: 'value' },
+        pluginId: 'stat',
+        title: 'Test Panel',
+        fieldConfig: { defaults: {}, overrides: [] },
+      } as unknown as typeof panel.state);
+
+      const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+      const item = result.current!.items[0];
+
+      const rendered = item.props.render(item) as React.ReactElement<{ onChange: (value: string) => void }>;
+      act(() => {
+        rendered.props.onChange('value');
+      });
+
+      const editCall = (dashboardEditActions.edit as jest.Mock).mock.calls[0][0];
+      editCall.undo();
+
+      expect(panel.onOptionsChange).toHaveBeenCalledWith({ textMode: 'auto' });
+    });
   });
 });

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
@@ -52,7 +52,7 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
     const allItems = builder.getItems();
 
     const category = new OptionsPaneCategoryDescriptor({
-      title: t('dashboard.quick-edit.category-title', 'Quick settings'),
+      title: t('dashboard.quick-edit.category-title', 'Quick edit'),
       id: 'quick-edit-options',
     });
 
@@ -81,12 +81,16 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
 
       const Editor = item.editor;
       const htmlId = `quick-edit-${item.id}`;
-      const optionName = item.name;
       const optionPath = item.path;
+
+      // Build display name including category for nested options
+      const displayName =
+        item.category && item.category.length > 0 ? `${item.category.join(' > ')} ${item.name}` : item.name;
+      const optionName = displayName;
 
       category.addItem(
         new OptionsPaneItemDescriptor({
-          title: item.name,
+          title: displayName,
           id: htmlId,
           description: item.description,
           render: function renderQuickEditOption() {

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
@@ -2,12 +2,14 @@ import { get as lodashGet } from 'lodash';
 import { useMemo } from 'react';
 
 import { PanelOptionsEditorBuilder, PanelPlugin, StandardEditorContext } from '@grafana/data';
-import { isNestedPanelOptions, NestedValueAccess } from '@grafana/data/internal';
+import { isNestedPanelOptions } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
 import { VizPanel } from '@grafana/scenes';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
+
+import { dashboardEditActions } from './shared';
 
 interface UseQuickEditOptionsProps {
   panel: VizPanel;
@@ -49,14 +51,6 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
 
     const allItems = builder.getItems();
 
-    const access: NestedValueAccess = {
-      getValue: (path) => lodashGet(currentOptions, path),
-      onChange: (path, value) => {
-        const newOptions = setOptionImmutably(currentOptions, path, value);
-        panel.onOptionsChange(newOptions);
-      },
-    };
-
     const category = new OptionsPaneCategoryDescriptor({
       title: t('dashboard.quick-edit.category-title', 'Quick settings'),
       id: 'quick-edit-options',
@@ -87,6 +81,8 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
 
       const Editor = item.editor;
       const htmlId = `quick-edit-${item.id}`;
+      const optionName = item.name;
+      const optionPath = item.path;
 
       category.addItem(
         new OptionsPaneItemDescriptor({
@@ -94,17 +90,26 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
           id: htmlId,
           description: item.description,
           render: function renderQuickEditOption() {
-            return (
-              <Editor
-                value={access.getValue(item.path)}
-                onChange={(value) => {
-                  access.onChange(item.path, value);
-                }}
-                item={item}
-                context={context}
-                id={htmlId}
-              />
-            );
+            const currentValue = lodashGet(currentOptions, optionPath);
+
+            const handleChange = (newValue: unknown) => {
+              const oldValue = currentValue;
+              const newOptions = setOptionImmutably(currentOptions, optionPath, newValue);
+
+              dashboardEditActions.edit({
+                description: t('dashboard.quick-edit.change-option', 'Change {{optionName}}', { optionName }),
+                source: panel,
+                perform: () => {
+                  panel.onOptionsChange(newOptions);
+                },
+                undo: () => {
+                  const revertedOptions = setOptionImmutably(panel.state.options, optionPath, oldValue);
+                  panel.onOptionsChange(revertedOptions);
+                },
+              });
+            };
+
+            return <Editor value={currentValue} onChange={handleChange} item={item} context={context} id={htmlId} />;
           },
         })
       );

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
@@ -9,7 +9,7 @@ import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
 
-import { dashboardEditActions } from './shared';
+import { DashboardEditActionEvent } from './editActions';
 
 interface UseQuickEditOptionsProps {
   panel: VizPanel;
@@ -96,17 +96,20 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
               const oldValue = currentValue;
               const newOptions = setOptionImmutably(currentOptions, optionPath, newValue);
 
-              dashboardEditActions.edit({
-                description: t('dashboard.quick-edit.change-option', 'Change {{optionName}}', { optionName }),
-                source: panel,
-                perform: () => {
-                  panel.onOptionsChange(newOptions);
-                },
-                undo: () => {
-                  const revertedOptions = setOptionImmutably(panel.state.options, optionPath, oldValue);
-                  panel.onOptionsChange(revertedOptions);
-                },
-              });
+              panel.publishEvent(
+                new DashboardEditActionEvent({
+                  description: t('dashboard.quick-edit.change-option', 'Change {{optionName}}', { optionName }),
+                  source: panel,
+                  perform: () => {
+                    panel.onOptionsChange(newOptions);
+                  },
+                  undo: () => {
+                    const revertedOptions = setOptionImmutably(panel.state.options, optionPath, oldValue);
+                    panel.onOptionsChange(revertedOptions);
+                  },
+                }),
+                true
+              );
             };
 
             return <Editor value={currentValue} onChange={handleChange} item={item} context={context} id={htmlId} />;

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
@@ -1,0 +1,119 @@
+import { get as lodashGet } from 'lodash';
+import { useMemo } from 'react';
+
+import { PanelOptionsEditorBuilder, PanelPlugin, StandardEditorContext } from '@grafana/data';
+import { isNestedPanelOptions, NestedValueAccess } from '@grafana/data/internal';
+import { t } from '@grafana/i18n';
+import { VizPanel } from '@grafana/scenes';
+import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
+import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
+
+interface UseQuickEditOptionsProps {
+  panel: VizPanel;
+  plugin: PanelPlugin | undefined;
+}
+
+/**
+ * Hook to build quick edit options for a panel based on the plugin's quickEditPaths.
+ *
+ * Quick edit options appear in the dashboard edit pane, allowing users to modify
+ * common panel settings without entering the full panel editor.
+ *
+ * @returns OptionsPaneCategoryDescriptor with the quick edit options, or null if none are defined
+ */
+export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps): OptionsPaneCategoryDescriptor | null {
+  const { options: currentOptions } = panel.useState();
+
+  return useMemo((): OptionsPaneCategoryDescriptor | null => {
+    if (!plugin) {
+      return null;
+    }
+
+    const quickEditPaths = plugin.getQuickEditPaths();
+    if (!quickEditPaths || quickEditPaths.length === 0) {
+      return null;
+    }
+
+    const supplier = plugin.getPanelOptionsSupplier();
+
+    const context: StandardEditorContext<unknown, unknown> = {
+      data: [],
+      options: currentOptions,
+      replaceVariables: panel.interpolate,
+      eventBus: panel.getPanelContext().eventBus,
+    };
+
+    const builder = new PanelOptionsEditorBuilder();
+    supplier(builder, context);
+
+    const allItems = builder.getItems();
+
+    const access: NestedValueAccess = {
+      getValue: (path) => lodashGet(currentOptions, path),
+      onChange: (path, value) => {
+        const newOptions = setOptionImmutably(currentOptions, path, value);
+        panel.onOptionsChange(newOptions);
+      },
+    };
+
+    const category = new OptionsPaneCategoryDescriptor({
+      title: t('dashboard.quick-edit.category-title', 'Quick settings'),
+      id: 'quick-edit-options',
+    });
+
+    for (const path of quickEditPaths) {
+      const item = allItems.find((opt) => opt.path === path);
+
+      if (!item) {
+        console.warn(
+          `useQuickEditOptions: Quick edit path "${path}" not found in plugin options for "${plugin.meta?.id ?? 'unknown'}". ` +
+            `Make sure the path matches an option defined in setPanelOptions().`
+        );
+        continue;
+      }
+
+      if (isNestedPanelOptions(item)) {
+        console.warn(
+          `useQuickEditOptions: Quick edit path "${path}" refers to a nested options group, which is not supported. ` +
+            `Use paths to individual options instead.`
+        );
+        continue;
+      }
+
+      if (item.showIf && !item.showIf(context.options, context.data, context.annotations)) {
+        continue;
+      }
+
+      const Editor = item.editor;
+      const htmlId = `quick-edit-${item.id}`;
+
+      category.addItem(
+        new OptionsPaneItemDescriptor({
+          title: item.name,
+          id: htmlId,
+          description: item.description,
+          render: function renderQuickEditOption() {
+            return (
+              <Editor
+                value={access.getValue(item.path)}
+                onChange={(value) => {
+                  access.onChange(item.path, value);
+                }}
+                item={item}
+                context={context}
+                id={htmlId}
+              />
+            );
+          },
+        })
+      );
+    }
+
+    if (category.items.length === 0) {
+      return null;
+    }
+
+    return category;
+  }, [panel, plugin, currentOptions]);
+}

--- a/public/app/plugins/panel/stat/module.tsx
+++ b/public/app/plugins/panel/stat/module.tsx
@@ -138,4 +138,5 @@ export const plugin = new PanelPlugin<Options>(StatPanel)
   .setNoPadding()
   .setPanelChangeHandler(statPanelChangedHandler)
   .setSuggestionsSupplier(statSuggestionsSupplier)
-  .setMigrationHandler(sharedSingleStatMigrationHandler);
+  .setMigrationHandler(sharedSingleStatMigrationHandler)
+  .setQuickEditPaths(['textMode', 'colorMode', 'graphMode']);

--- a/public/app/plugins/panel/stat/module.tsx
+++ b/public/app/plugins/panel/stat/module.tsx
@@ -138,5 +138,4 @@ export const plugin = new PanelPlugin<Options>(StatPanel)
   .setNoPadding()
   .setPanelChangeHandler(statPanelChangedHandler)
   .setSuggestionsSupplier(statSuggestionsSupplier)
-  .setMigrationHandler(sharedSingleStatMigrationHandler)
-  .setQuickEditPaths(['textMode', 'colorMode', 'graphMode']);
+  .setMigrationHandler(sharedSingleStatMigrationHandler);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5859,7 +5859,7 @@
       "try-again-later": "Try again later"
     },
     "quick-edit": {
-      "category-title": "Quick settings",
+      "category-title": "Quick edit",
       "change-option": "Change {{optionName}}"
     },
     "remove-panel": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5858,6 +5858,9 @@
       "paused": "This dashboard has been paused by the administrator",
       "try-again-later": "Try again later"
     },
+    "quick-edit": {
+      "category-title": "Quick settings"
+    },
     "remove-panel": {
       "text": {
         "remove-panel": "Are you sure you want to remove this panel?"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5859,7 +5859,8 @@
       "try-again-later": "Try again later"
     },
     "quick-edit": {
-      "category-title": "Quick settings"
+      "category-title": "Quick settings",
+      "change-option": "Change {{optionName}}"
     },
     "remove-panel": {
       "text": {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

This is step 1 of https://github.com/grafana/grafana/pull/119741

**What is this feature?**

Introduces a new PanelPlugin API that allows visualization plugins to expose commonly used options directly in the dashboard edit sidebar.
This is proposal 3 in the [design doc](https://docs.google.com/document/d/1hdon8dQpPDS1-syR7v3KohzG4Rfl65jD4cxaTNeldvE/edit?tab=t.3gfcb7n7nvpq#heading=h.fl933pk1iwl)

- Add setQuickEditPaths() and getQuickEditPaths() to PanelPlugin
- Add useQuickEditOptions hook for rendering quick edit options
- Integrate quick edit options into VizPanelEditableElement
- Add unit tests for new API and hook

**Why do we need this feature?**

This reduces the number of clicks needed to adjust frequent panel settings by eliminating the need to enter the full panel editor.

**Who is this feature for?**

New editors - only a select few, most commonly used, options will be shown at first. It will be less overwhelming.
Experienced editors - saves them a click for the most common actions

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

None, this is a hackathon PR

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
