### PR TITLE
Transformations: add tooltip to Conditions field in Filter by Values editor

### DIFF
--- a/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.tsx
@@ -128,6 +128,10 @@ export const FilterByValueTransformerEditor = (props: TransformerUIProps<FilterB
         <InlineField
           label={t('transformers.filter-by-value-transformer-editor.label-conditions', 'Conditions')}
           labelWidth={16}
+          tooltip={t(
+            'transformers.filter-by-value-transformer-editor.tooltip-conditions',
+            'When multiple conditions are present, choose whether a row must match all conditions ("Match all") or at least one condition ("Match any") to be included or excluded.'
+          )}
         >
           <div className="width-15">
             <RadioButtonGroup options={filterMatch} value={options.match} onChange={onChangeMatch} fullWidth />


### PR DESCRIPTION
## What this PR does / why we need it

The Conditions radio group (Match all / Match any) appears when there are 2+ filters in the Filter by Values transformation. The options were not self-explanatory — users couldn't tell what "all" or "any" referred to without more context.

This PR adds a tooltip to the Conditions InlineField label that explains:
- **Match all**: the row is kept only if every condition passes (logical AND)
- **Match any**: the row is kept if at least one condition passes (logical OR)

The Conditions field is already hidden when there is 0 or 1 filter (so the tooltip is only visible in the multi-condition scenario where it matters most).

## Which issue(s) this PR closes

Closes #97239

## Checklist

- [x] Documentation updated if necessary
- [x] No breaking changes