### PR TITLE
Fix resources API to use datasource configured HTTP method

### DIFF
--- a/pkg/promlib/client/client.go
+++ b/pkg/promlib/client/client.go
@@ -102,9 +102,13 @@ func (c *Client) QueryResource(ctx context.Context, req *backend.CallResourceReq
 	}
 	u.RawQuery = reqUrlParsed.RawQuery
 
-	// We use method from the request, as for resources front end may do a fallback to GET if POST does not work
-	// nad we want to respect that.
-	httpRequest, err := createRequest(ctx, req.Method, u, bytes.NewReader(req.Body))
+	// Use the configured datasource method to ensure the request method matches the datasource's configured HTTP method.
+	// This prevents method mismatch errors when the incoming request method differs from the datasource's configured method.
+	bodyReader := bytes.NewReader(req.Body)
+	if strings.ToUpper(c.method) == http.MethodGet {
+		bodyReader = http.NoBody
+	}
+	httpRequest, err := createRequest(ctx, c.method, u, bodyReader)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #119686. The resources API was using the incoming request method instead of the datasource's configured HTTP method, causing 500 errors when there was a method mismatch (e.g., POST request to a GET-configured datasource). Now it uses the datasource's configured method, matching the behavior of query data requests and preventing method mismatch errors.