### PR TITLE
Air: Faster builds with CGO_ENABLED=0, disabled optimizations and fixed SOURCE_DATE_EPOCH

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,7 +1,7 @@
 [build]
 bin = "./bin/grafana-air"
 args_bin = ["server", "-profile", "-profile-addr=127.0.0.1", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
-cmd = "make GO_BUILD_DEV=1 build-air"
+cmd = "make CGO_ENABLED=0 GO_BUILD_GCFLAGS='all=-N -l' SOURCE_DATE_EPOCH=1767222000 GO_BUILD_DEV=1 build-air"
 exclude_regex = ["_test.go", "_gen.go"]
 exclude_unchanged = true
 follow_symlink = true

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILD_NUMBER ?= local
 BUILD_VERSION := $(shell sed -n 's/.*"version": *"\(.*\)".*/\1/p' package.json | sed 's/-pre/-$(BUILD_NUMBER)/')
 BUILD_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
-BUILD_STAMP := $(shell echo $${SOURCE_DATE_EPOCH:-$$(date +%s 2>/dev/null)})
+BUILD_STAMP := $(or $(SOURCE_DATE_EPOCH),$(shell date +%s 2>/dev/null))
 GO_LDFLAGS = -X main.version=$(BUILD_VERSION) \
 	-X main.commit=$(BUILD_COMMIT) \
 	-X main.buildBranch=$(BUILD_BRANCH) \


### PR DESCRIPTION
There were three separate improvements:
- Fixing the build timestamp with `SOURCE_DATE_EPOCH` made incremental rebuilds faster, using a different timestamp on every build is not cache friendly. 

- Explicitly using `CGO_ENABLED=0` decreased build times in general:
```
Benchmark 1: CGO_ENABLED=0 go build -a -o ./bin/grafana1 ./pkg/cmd/grafana
  Time (mean ± σ):     77.583 s ±  0.176 s    [User: 603.266 s, System: 79.937 s]
  Range (min … max):   77.416 s … 77.903 s    10 runs

Benchmark 2: go build -a -o ./bin/grafana2 ./pkg/cmd/grafana
  Time (mean ± σ):     106.098 s ±  4.169 s    [User: 636.559 s, System: 84.545 s]
  Range (min … max):   102.243 s … 112.151 s    10 runs
```

- Disabling optimizations with `'all=-N -l'` further decreases build times, at least on my machine by ~10s on a full build:
```
Benchmark 1: CGO_ENABLED=0 go build -a -tags=arrow_json_stdlib -o ./bin/grafana1 ./pkg/cmd/grafana
  Time (mean ± σ):     76.300 s ±  0.712 s    [User: 594.104 s, System: 79.977 s]
  Range (min … max):   75.529 s … 77.595 s    10 runs

Benchmark 5: CGO_ENABLED=0 go build -a -buildvcs=false -trimpath -tags arrow_json_stdlib -gcflags "all=-N -l" -o ./bin/grafana2 ./pkg/cmd/grafana
  Time (mean ± σ):     64.601 s ±  0.886 s    [User: 445.124 s, System: 74.809 s]
  Range (min … max):   63.063 s … 66.215 s    10 runs
```