### PR TITLE
CI: Run tests with arrow_json_stdlib build tag to reduce build times

### DIFF
--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -248,16 +248,7 @@ jobs:
     # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
     needs: detect-changes
     if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && needs.detect-changes.outputs.changed == 'true')
-    strategy:
-      matrix:
-        # We don't need more than this since it has to wait for the other tests.
-        shard: [
-          1/4, 2/4, 3/4, 4/4,
-          profiled,
-        ]
-      fail-fast: false
-
-    name: Sqlite Enterprise (${{ matrix.shard }})
+    name: Sqlite Enterprise
     runs-on: ubuntu-x64-large-io
     permissions:
       contents: read
@@ -277,90 +268,14 @@ jobs:
         with:
           github-app-name: 'grafana-ci-bot'
       - name: Run tests
-        if: matrix.shard != 'profiled'
-        env:
-          SHARD: ${{ matrix.shard }}
-          CGO_ENABLED: 0
-          SKIP_PACKAGES: |-
-            pkg/tests/apis/folder
-            pkg/tests/apis/dashboard
         run: |
-          set -euo pipefail
-          # Build regex pattern like: pkg1$|pkg2$|pkg3$
-          SKIP_PATTERN=$(echo "$SKIP_PACKAGES" | sed '/^$/d' | sed 's|.*|&$|' | paste -sd '|' -)
-          readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N "$SHARD" -d - | grep -Ev "($SKIP_PATTERN)")"
-          go test -tags=enterprise -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
-      - name: Run profiled tests
-        id: run-profiled-tests
-        if: matrix.shard == 'profiled'
-        env:
-          CGO_ENABLED: 0
-          PROFILED_PACKAGES: |-
-            pkg/tests/apis/folder
-            pkg/tests/apis/dashboard
-        run: |
-          set -euo pipefail
-          # Build regex pattern line: pkg1$|pkg2$|pkg3$
-          PROFILE_PATTERN=$(echo "$PROFILED_PACKAGES" | sed '/^$/d' | sed 's|.*|&$|' | paste -sd '|' -)
-          readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | grep -E "($PROFILE_PATTERN)")"
-          if [ ${#PACKAGES[@]} -eq 0 ]; then
-            echo "⚠️  No profiled packages found"
-            exit 0
-          fi
-          mkdir -p profiles
-          EXIT_CODE=0
-          # Run each profiled package sequentially
-          for full_pkg in "${PACKAGES[@]}"; do
-            # Build valid file name
-            pkg_name=$(basename "$full_pkg" | tr '/' '_' | tr '.' '_')
-            echo "📦 Running $full_pkg"
-            set +e
-            go test -tags=enterprise -timeout=8m -run '^TestIntegration' \
-              -outputdir=profiles \
-              -cpuprofile="cpu_${pkg_name}.prof" \
-              -memprofile="mem_${pkg_name}.prof" \
-              -trace="trace_${pkg_name}.out" \
-              "$full_pkg" 2>&1 | tee "profiles/test_${pkg_name}.log"
-            TEST_EXIT=$?
-            set -e
-            if [ $TEST_EXIT -ne 0 ]; then
-              echo "❌ $full_pkg failed with exit code $TEST_EXIT"
-              EXIT_CODE=1
-            else
-              echo "✅ $full_pkg passed"
-            fi
-          done
-          # Set output for artifact upload
-          if [ $EXIT_CODE -ne 0 ]; then
-            echo "upload_artifacts=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "upload_artifacts=false" >> "$GITHUB_OUTPUT"
-          fi
-          exit $EXIT_CODE
-      - name: Output test profiles and traces
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v4
-        if: matrix.shard == 'profiled' && !cancelled() && steps.run-profiled-tests.outputs.upload_artifacts == 'true'
-        with:
-          name: integration-test-profiles-sqlite-${{ github.run_number }}
-          path: profiles/
-          retention-days: 7
-          if-no-files-found: ignore
+          CGO_ENABLED=0 go test -tags=enterprise -p $(nproc) -parallel $(nproc) -timeout=8m -run '^TestIntegration' ./...
 
   mysql-enterprise:
     # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
     needs: detect-changes
     if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && needs.detect-changes.outputs.changed == 'true')
-    strategy:
-      matrix:
-        shard: [
-           1/16,  2/16,  3/16,  4/16,
-           5/16,  6/16,  7/16,  8/16,
-           9/16, 10/16, 11/16, 12/16,
-          13/16, 14/16, 15/16, 16/16,
-        ]
-      fail-fast: false
-
-    name: MySQL Enterprise (${{ matrix.shard }})
+    name: MySQL Enterprise
     runs-on: ubuntu-x64-large-io
     permissions:
       contents: read
@@ -396,31 +311,14 @@ jobs:
       - name: Setup MySQL devenv
         run: mysql -h 127.0.0.1 -P 3306 -u root -prootpass < devenv/docker/blocks/mysql_tests/setup.sql
       - name: Run tests
-        env:
-          SHARD: ${{ matrix.shard }}
         run: |
-          set -euo pipefail
-          readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
-          echo "Precompiling, no tests will be run"
-          CGO_ENABLED=0 go test -tags=enterprise -run='^$' "${PACKAGES[@]}"
-          echo "Running tests now"
-          CGO_ENABLED=0 go test -p=1 -tags=enterprise -timeout=12m -run '^TestIntegration' "${PACKAGES[@]}"
+          CGO_ENABLED=0 go test -tags=enterprise -p $(nproc) -parallel $(nproc) -timeout=12m -run '^TestIntegration' ./...
 
   postgres-enterprise:
     # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
     needs: detect-changes
     if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && needs.detect-changes.outputs.changed == 'true')
-    strategy:
-      matrix:
-        shard: [
-           1/16,  2/16,  3/16,  4/16,
-           5/16,  6/16,  7/16,  8/16,
-           9/16, 10/16, 11/16, 12/16,
-          13/16, 14/16, 15/16, 16/16,
-        ]
-      fail-fast: false
-
-    name: Postgres Enterprise (${{ matrix.shard }})
+    name: Postgres Enterprise
     runs-on: ubuntu-x64-large-io
     permissions:
       contents: read
@@ -449,15 +347,8 @@ jobs:
       - name: Setup Postgres devenv
         run: psql -p 5432 -h 127.0.0.1 -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
       - name: Run tests
-        env:
-          SHARD: ${{ matrix.shard }}
         run: |
-          set -euo pipefail
-          readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
-          echo "Precompiling, no tests will be run"
-          CGO_ENABLED=0 go test -tags=enterprise -run='^$' "${PACKAGES[@]}"
-          echo "Running tests now"
-          CGO_ENABLED=0 go test -p=1 -tags=enterprise -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
+          CGO_ENABLED=0 go test -tags=enterprise -p $(nproc) -parallel $(nproc) -timeout=12m -run '^TestIntegration' ./...
       - name: Cleanup Postgres
         if: always()
         run: |


### PR DESCRIPTION
In theory building with the `arrow_json_stdlib` flag removes compilation of `goccy/go-json` package, which can be slow:
```
goccy/go-json/internal/encoder/vm - 12.54s
goccy/go-json/internal/encoder/vm_indent - 6.67s
goccy/go-json/internal/encoder/vm_color_indent - 3.77s
goccy/go-json/internal/encoder/vm_color - 2.95s
```

All add up to almost 26s on my machine, and hopefully in CI the improvements are notable. In theory we don't care that the JSON package is slower for the Arrow package, because there aren't many tests and I don't believe it will interfere with anything else.

One missing thing is whether this is the only place importing this JSON package. I couldn't find any else, and when recompiling with the `arrow_json_stdlib` tag, the JSON package no longer showed up in the timings.