### PR TITLE
Dashboards: Add user events tracking for quick edit options

### DIFF
--- a/packages/grafana-data/src/panel/PanelPlugin.test.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.test.ts
@@ -1,0 +1,75 @@
+import { getPanelPlugin } from '../../test';
+
+describe('PanelPlugin', () => {
+  describe('setQuickEditPaths', () => {
+    it('should store quick edit paths', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+
+      plugin.setQuickEditPaths(['path1', 'path2']);
+
+      expect(plugin.getQuickEditPaths()).toEqual(['path1', 'path2']);
+    });
+
+    it('should return undefined when no paths are set', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+
+      expect(plugin.getQuickEditPaths()).toBeUndefined();
+    });
+
+    it('should limit paths to maximum of 5', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      plugin.setQuickEditPaths(['path1', 'path2', 'path3', 'path4', 'path5', 'path6', 'path7']);
+
+      expect(plugin.getQuickEditPaths()).toEqual(['path1', 'path2', 'path3', 'path4', 'path5']);
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('setQuickEditPaths received 7 paths'));
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should allow exactly 5 paths without warning', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      plugin.setQuickEditPaths(['path1', 'path2', 'path3', 'path4', 'path5']);
+
+      expect(plugin.getQuickEditPaths()).toEqual(['path1', 'path2', 'path3', 'path4', 'path5']);
+      expect(consoleSpy).not.toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should return this for method chaining', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+
+      const result = plugin.setQuickEditPaths(['path1']);
+
+      expect(result).toBe(plugin);
+    });
+
+    it('should create a copy of the paths array', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' });
+      const paths = ['path1', 'path2'];
+
+      plugin.setQuickEditPaths(paths);
+      paths.push('path3');
+
+      expect(plugin.getQuickEditPaths()).toEqual(['path1', 'path2']);
+    });
+
+    it('should work with setPanelOptions in method chain', () => {
+      const plugin = getPanelPlugin({ id: 'test-panel' })
+        .setPanelOptions((builder) => {
+          builder.addSelect({
+            path: 'displayMode',
+            name: 'Display mode',
+            settings: { options: [] },
+          });
+        })
+        .setQuickEditPaths(['displayMode']);
+
+      expect(plugin.getQuickEditPaths()).toEqual(['displayMode']);
+    });
+  });
+});

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -118,6 +118,7 @@ export class PanelPlugin<
 
   private optionsSupplier?: PanelOptionsSupplier<TOptions>;
   private suggestionsSupplier?: VisualizationSuggestionsSupplier<TOptions, TFieldConfigOptions>;
+  private _quickEditPaths?: string[];
 
   panel: ComponentType<PanelProps<TOptions>> | null;
   editor?: ComponentClass<PanelEditorProps<TOptions>>;
@@ -274,6 +275,58 @@ export class PanelPlugin<
    */
   getPanelOptionsSupplier(): PanelOptionsSupplier<TOptions> {
     return this.optionsSupplier ?? (() => {});
+  }
+
+  /**
+   * Define which panel options should appear in the dashboard edit pane
+   * for quick editing without entering the full panel editor.
+   *
+   * This allows users to quickly adjust common settings directly from the
+   * dashboard edit view, reducing the number of clicks needed for frequent
+   * configuration changes.
+   *
+   * @param paths - Array of option paths (max 5) that should be shown in quick edit.
+   *                Paths should match those defined in setPanelOptions.
+   *                Supports nested paths using dot notation (e.g., 'legend.displayMode').
+   *
+   * @example
+   * ```typescript
+   * export const plugin = new PanelPlugin<Options>(MyPanel)
+   *   .setPanelOptions((builder) => {
+   *     builder
+   *       .addSelect({ path: 'displayMode', name: 'Display mode', ... })
+   *       .addRadio({ path: 'orientation', name: 'Orientation', ... })
+   *       .addBooleanSwitch({ path: 'showLegend', name: 'Show legend', ... });
+   *   })
+   *   .setQuickEditPaths(['displayMode', 'orientation']);
+   * ```
+   *
+   * @alpha
+   */
+  setQuickEditPaths(paths: Array<keyof TOptions & string> | string[]) {
+    const MAX_QUICK_EDIT_PATHS = 5;
+
+    if (paths.length > MAX_QUICK_EDIT_PATHS) {
+      console.warn(
+        `PanelPlugin [${this.meta?.id ?? 'unknown'}]: setQuickEditPaths received ${paths.length} paths, ` +
+          `but only ${MAX_QUICK_EDIT_PATHS} are allowed. Extra paths will be ignored.`
+      );
+      this._quickEditPaths = paths.slice(0, MAX_QUICK_EDIT_PATHS);
+    } else {
+      this._quickEditPaths = [...paths];
+    }
+
+    return this;
+  }
+
+  /**
+   * Get the quick edit paths defined for this plugin.
+   *
+   * @returns Array of option paths for quick edit, or undefined if not set.
+   * @alpha
+   */
+  getQuickEditPaths(): string[] | undefined {
+    return this._quickEditPaths;
   }
 
   /**

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1403,6 +1403,11 @@ export interface FeatureToggles {
   */
   heatmapRowsAxisOptions?: boolean;
   /**
+  * Enable quick edit options for panel plugins in the dashboard edit pane
+  * @default false
+  */
+  panelQuickEdit?: boolean;
+  /**
   * Restrict PanelChrome contents with overflow: hidden;
   * @default true
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2213,6 +2213,14 @@ var (
 			Expression:   "false",
 		},
 		{
+			Name:         "panelQuickEdit",
+			Description:  "Enable quick edit options for panel plugins in the dashboard edit pane",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: true,
+			Owner:        grafanaDashboardsSquad,
+			Expression:   "false",
+		},
+		{
 			Name:         "preventPanelChromeOverflow",
 			Description:  "Restrict PanelChrome contents with overflow: hidden;",
 			Stage:        FeatureStagePublicPreview,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -275,6 +275,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-12-02,externalVizSuggestions,experimental,@grafana/dataviz-squad,false,false,true
 2026-03-03,vizLegendSeriesLimit,experimental,@grafana/dataviz-squad,false,false,true
 2025-12-18,heatmapRowsAxisOptions,experimental,@grafana/dataviz-squad,false,false,true
+2026-03-09,panelQuickEdit,experimental,@grafana/dashboards-squad,false,false,true
 2025-10-17,preventPanelChromeOverflow,preview,@grafana/grafana-frontend-platform,false,false,true
 2025-10-31,jaegerEnableGrpcEndpoint,experimental,@grafana/oss-big-tent,false,false,false
 2025-10-17,pluginStoreServiceLoading,experimental,@grafana/plugins-platform-backend,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3266,6 +3266,23 @@
     },
     {
       "metadata": {
+        "name": "panelQuickEdit",
+        "resourceVersion": "1773045630979",
+        "creationTimestamp": "2026-03-09T08:27:57Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-03-09 08:40:30.97947 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enable quick edit options for panel plugins in the dashboard edit pane",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "panelStyleActions",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2026-02-18T17:05:38Z"

--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
@@ -37,6 +37,14 @@ function useEditPaneOptions(this: VizPanelEditableElement, isNewElement: boolean
   const descriptionId = useId();
   const backgroundId = useId();
 
+  const dashboardUid = useMemo(() => {
+    try {
+      return getDashboardSceneFor(panel).state.uid;
+    } catch {
+      return undefined;
+    }
+  }, [panel]);
+
   const panelOptions = useMemo(() => {
     return new OptionsPaneCategoryDescriptor({ title: '', id: 'panel-options' })
       .addItem(
@@ -75,7 +83,7 @@ function useEditPaneOptions(this: VizPanelEditableElement, isNewElement: boolean
   }, [rootId, titleId, panel, descriptionId, backgroundId, isNewElement]);
 
   const isPanelQuickEditEnabled = useBooleanFlagValue('panelQuickEdit', false);
-  const quickEditOptions = useQuickEditOptions({ panel, plugin });
+  const quickEditOptions = useQuickEditOptions({ panel, plugin, dashboardUid });
   const quickEditCategory = isPanelQuickEditEnabled ? quickEditOptions : null;
 
   const layoutCategories = useMemo(

--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
@@ -1,3 +1,4 @@
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useId, useMemo } from 'react';
 
 import { Trans, t } from '@grafana/i18n';
@@ -73,7 +74,9 @@ function useEditPaneOptions(this: VizPanelEditableElement, isNewElement: boolean
       );
   }, [rootId, titleId, panel, descriptionId, backgroundId, isNewElement]);
 
-  const quickEditCategory = useQuickEditOptions({ panel, plugin });
+  const isPanelQuickEditEnabled = useBooleanFlagValue('panelQuickEdit', false);
+  const quickEditOptions = useQuickEditOptions({ panel, plugin });
+  const quickEditCategory = isPanelQuickEditEnabled ? quickEditOptions : null;
 
   const layoutCategories = useMemo(
     () => (isDashboardLayoutItem(layoutElement) && layoutElement.getOptions ? layoutElement.getOptions() : []),

--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
@@ -25,10 +25,12 @@ import { DashboardInteractions } from '../utils/interactions';
 import { getDashboardSceneFor, getPanelIdForVizPanel } from '../utils/utils';
 
 import { MultiSelectedVizPanelsEditableElement } from './MultiSelectedVizPanelsEditableElement';
+import { useQuickEditOptions } from './useQuickEditOptions';
 
 function useEditPaneOptions(this: VizPanelEditableElement, isNewElement: boolean): OptionsPaneCategoryDescriptor[] {
   const panel = this.panel;
   const layoutElement = panel.parent!;
+  const plugin = panel.getPlugin();
   const rootId = useId();
   const titleId = useId();
   const descriptionId = useId();
@@ -71,12 +73,20 @@ function useEditPaneOptions(this: VizPanelEditableElement, isNewElement: boolean
       );
   }, [rootId, titleId, panel, descriptionId, backgroundId, isNewElement]);
 
+  const quickEditCategory = useQuickEditOptions({ panel, plugin });
+
   const layoutCategories = useMemo(
     () => (isDashboardLayoutItem(layoutElement) && layoutElement.getOptions ? layoutElement.getOptions() : []),
     [layoutElement]
   );
 
-  return [panelOptions, ...layoutCategories];
+  const categories: OptionsPaneCategoryDescriptor[] = [panelOptions];
+  if (quickEditCategory) {
+    categories.push(quickEditCategory);
+  }
+  categories.push(...layoutCategories);
+
+  return categories;
 }
 
 export class VizPanelEditableElement implements EditableDashboardElement, BulkActionElement {

--- a/public/app/features/dashboard-scene/edit-pane/editActions.ts
+++ b/public/app/features/dashboard-scene/edit-pane/editActions.ts
@@ -1,0 +1,16 @@
+import { BusEventWithPayload } from '@grafana/data';
+import { SceneObject } from '@grafana/scenes';
+
+export interface DashboardEditActionEventPayload {
+  removedObject?: SceneObject;
+  addedObject?: SceneObject;
+  movedObject?: SceneObject;
+  source: SceneObject;
+  description?: string;
+  perform: () => void;
+  undo: () => void;
+}
+
+export class DashboardEditActionEvent extends BusEventWithPayload<DashboardEditActionEventPayload> {
+  static type = 'dashboard-edit-action';
+}

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
@@ -5,14 +5,8 @@ import { EventBusSrv } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { VizPanel } from '@grafana/scenes';
 
-import { dashboardEditActions } from './shared';
+import { DashboardEditActionEvent } from './editActions';
 import { useQuickEditOptions } from './useQuickEditOptions';
-
-jest.mock('./shared', () => ({
-  dashboardEditActions: {
-    edit: jest.fn(),
-  },
-}));
 
 describe('useQuickEditOptions', () => {
   const createMockPanel = (options: Record<string, unknown> = {}) => {
@@ -30,6 +24,7 @@ describe('useQuickEditOptions', () => {
       onOptionsChange: jest.fn(),
     } as ReturnType<typeof panel.getPanelContext>);
     jest.spyOn(panel, 'onOptionsChange').mockImplementation(jest.fn());
+    jest.spyOn(panel, 'publishEvent').mockImplementation(jest.fn());
 
     return panel;
   };
@@ -182,7 +177,7 @@ describe('useQuickEditOptions', () => {
       jest.clearAllMocks();
     });
 
-    it('should call dashboardEditActions.edit when changing an option', () => {
+    it('should publish DashboardEditActionEvent when changing an option', () => {
       const panel = createMockPanel({ textMode: 'auto' });
       const plugin = createMockPlugin(['textMode']);
 
@@ -196,14 +191,8 @@ describe('useQuickEditOptions', () => {
         rendered.props.onChange('value');
       });
 
-      expect(dashboardEditActions.edit).toHaveBeenCalledTimes(1);
-      expect(dashboardEditActions.edit).toHaveBeenCalledWith(
-        expect.objectContaining({
-          source: panel,
-          perform: expect.any(Function),
-          undo: expect.any(Function),
-        })
-      );
+      expect(panel.publishEvent).toHaveBeenCalledTimes(1);
+      expect(panel.publishEvent).toHaveBeenCalledWith(expect.any(DashboardEditActionEvent), true);
     });
 
     it('should apply new value when perform is called', () => {
@@ -218,8 +207,8 @@ describe('useQuickEditOptions', () => {
         rendered.props.onChange('value');
       });
 
-      const editCall = (dashboardEditActions.edit as jest.Mock).mock.calls[0][0];
-      editCall.perform();
+      const event = (panel.publishEvent as jest.Mock).mock.calls[0][0] as DashboardEditActionEvent;
+      event.payload.perform();
 
       expect(panel.onOptionsChange).toHaveBeenCalledWith({ textMode: 'value' });
     });
@@ -243,8 +232,8 @@ describe('useQuickEditOptions', () => {
         rendered.props.onChange('value');
       });
 
-      const editCall = (dashboardEditActions.edit as jest.Mock).mock.calls[0][0];
-      editCall.undo();
+      const event = (panel.publishEvent as jest.Mock).mock.calls[0][0] as DashboardEditActionEvent;
+      event.payload.undo();
 
       expect(panel.onOptionsChange).toHaveBeenCalledWith({ textMode: 'auto' });
     });

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
 import { EventBusSrv } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
@@ -18,6 +18,7 @@ describe('useQuickEditOptions', () => {
     jest.spyOn(panel, 'interpolate').mockImplementation((value) => value as string);
     jest.spyOn(panel, 'getPanelContext').mockReturnValue({
       eventBus: new EventBusSrv(),
+      eventsScope: 'local',
       onOptionsChange: jest.fn(),
     } as ReturnType<typeof panel.getPanelContext>);
     jest.spyOn(panel, 'onOptionsChange').mockImplementation(jest.fn());

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
@@ -64,6 +64,24 @@ describe('useQuickEditOptions', () => {
           name: 'Conditional option',
           defaultValue: false,
           showIf: (config) => config.showGraph === true,
+        })
+        .addBooleanSwitch({
+          path: 'legend.showLegend',
+          name: 'Visibility',
+          category: ['Legend'],
+          defaultValue: true,
+        })
+        .addSelect({
+          path: 'tooltip.mode',
+          name: 'Mode',
+          category: ['Tooltip'],
+          settings: {
+            options: [
+              { value: 'single', label: 'Single' },
+              { value: 'all', label: 'All' },
+            ],
+          },
+          defaultValue: 'single',
         });
     });
 
@@ -107,10 +125,22 @@ describe('useQuickEditOptions', () => {
     const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
 
     expect(result.current).not.toBeNull();
-    expect(result.current?.props.title).toBe('Quick settings');
+    expect(result.current?.props.title).toBe('Quick edit');
     expect(result.current?.items).toHaveLength(2);
     expect(result.current?.items[0].props.title).toBe('Text mode');
     expect(result.current?.items[1].props.title).toBe('Color mode');
+  });
+
+  it('should include category prefix for nested options', () => {
+    const panel = createMockPanel({ legend: { showLegend: true }, tooltip: { mode: 'single' } });
+    const plugin = createMockPlugin(['legend.showLegend', 'tooltip.mode']);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items).toHaveLength(2);
+    expect(result.current?.items[0].props.title).toBe('Legend Visibility');
+    expect(result.current?.items[1].props.title).toBe('Tooltip Mode');
   });
 
   it('should warn and skip invalid paths', () => {

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
@@ -1,0 +1,170 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { EventBusSrv } from '@grafana/data';
+import { getPanelPlugin } from '@grafana/data/test';
+import { VizPanel } from '@grafana/scenes';
+
+import { useQuickEditOptions } from './useQuickEditOptions';
+
+describe('useQuickEditOptions', () => {
+  const createMockPanel = (options: Record<string, unknown> = {}) => {
+    const panel = new VizPanel({
+      title: 'Test Panel',
+      pluginId: 'stat',
+      options,
+    });
+
+    jest.spyOn(panel, 'useState').mockReturnValue({ options } as ReturnType<typeof panel.useState>);
+    jest.spyOn(panel, 'interpolate').mockImplementation((value) => value as string);
+    jest.spyOn(panel, 'getPanelContext').mockReturnValue({
+      eventBus: new EventBusSrv(),
+      onOptionsChange: jest.fn(),
+    } as ReturnType<typeof panel.getPanelContext>);
+    jest.spyOn(panel, 'onOptionsChange').mockImplementation(jest.fn());
+
+    return panel;
+  };
+
+  const createMockPlugin = (quickEditPaths?: string[]) => {
+    const plugin = getPanelPlugin({ id: 'stat' }).setPanelOptions((builder) => {
+      builder
+        .addSelect({
+          path: 'textMode',
+          name: 'Text mode',
+          settings: {
+            options: [
+              { value: 'auto', label: 'Auto' },
+              { value: 'value', label: 'Value' },
+            ],
+          },
+          defaultValue: 'auto',
+        })
+        .addSelect({
+          path: 'colorMode',
+          name: 'Color mode',
+          settings: {
+            options: [
+              { value: 'none', label: 'None' },
+              { value: 'value', label: 'Value' },
+            ],
+          },
+          defaultValue: 'value',
+        })
+        .addBooleanSwitch({
+          path: 'showGraph',
+          name: 'Show graph',
+          defaultValue: true,
+        })
+        .addBooleanSwitch({
+          path: 'conditionalOption',
+          name: 'Conditional option',
+          defaultValue: false,
+          showIf: (config) => config.showGraph === true,
+        });
+    });
+
+    if (quickEditPaths) {
+      plugin.setQuickEditPaths(quickEditPaths);
+    }
+
+    return plugin;
+  };
+
+  it('should return null when plugin is undefined', () => {
+    const panel = createMockPanel();
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin: undefined }));
+
+    expect(result.current).toBeNull();
+  });
+
+  it('should return null when plugin has no quick edit paths', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin();
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).toBeNull();
+  });
+
+  it('should return null when quick edit paths array is empty', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin([]);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).toBeNull();
+  });
+
+  it('should return category with matching options', () => {
+    const panel = createMockPanel({ textMode: 'value', colorMode: 'none' });
+    const plugin = createMockPlugin(['textMode', 'colorMode']);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.props.title).toBe('Quick settings');
+    expect(result.current?.items).toHaveLength(2);
+    expect(result.current?.items[0].props.title).toBe('Text mode');
+    expect(result.current?.items[1].props.title).toBe('Color mode');
+  });
+
+  it('should warn and skip invalid paths', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin(['textMode', 'invalidPath']);
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items).toHaveLength(1);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Quick edit path "invalidPath" not found'));
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should respect showIf conditions', () => {
+    const panel = createMockPanel({ showGraph: false });
+    const plugin = createMockPlugin(['showGraph', 'conditionalOption']);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items).toHaveLength(1);
+    expect(result.current?.items[0].props.title).toBe('Show graph');
+  });
+
+  it('should show conditional option when condition is met', () => {
+    const panel = createMockPanel({ showGraph: true });
+    const plugin = createMockPlugin(['showGraph', 'conditionalOption']);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items).toHaveLength(2);
+  });
+
+  it('should return null when all paths are invalid', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin(['invalidPath1', 'invalidPath2']);
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).toBeNull();
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should preserve order of paths', () => {
+    const panel = createMockPanel();
+    const plugin = createMockPlugin(['colorMode', 'textMode', 'showGraph']);
+
+    const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.items[0].props.title).toBe('Color mode');
+    expect(result.current?.items[1].props.title).toBe('Text mode');
+    expect(result.current?.items[2].props.title).toBe('Show graph');
+  });
+});

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
@@ -5,8 +5,17 @@ import { EventBusSrv } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { VizPanel } from '@grafana/scenes';
 
+import { DashboardInteractions } from '../utils/interactions';
+
 import { DashboardEditActionEvent } from './editActions';
 import { useQuickEditOptions } from './useQuickEditOptions';
+
+jest.mock('../utils/interactions', () => ({
+  DashboardInteractions: {
+    quickEditOptionChanged: jest.fn(),
+    quickEditOptionUndone: jest.fn(),
+  },
+}));
 
 describe('useQuickEditOptions', () => {
   const createMockPanel = (options: Record<string, unknown> = {}) => {
@@ -266,6 +275,57 @@ describe('useQuickEditOptions', () => {
       event.payload.undo();
 
       expect(panel.onOptionsChange).toHaveBeenCalledWith({ textMode: 'auto' });
+    });
+
+    it('should track telemetry when changing an option', () => {
+      const panel = createMockPanel({ textMode: 'auto' });
+      const plugin = createMockPlugin(['textMode']);
+
+      const { result } = renderHook(() => useQuickEditOptions({ panel, plugin, dashboardUid: 'test-dashboard-uid' }));
+      const item = result.current!.items[0];
+
+      const rendered = item.props.render(item) as React.ReactElement<{ onChange: (value: string) => void }>;
+      act(() => {
+        rendered.props.onChange('value');
+      });
+
+      expect(DashboardInteractions.quickEditOptionChanged).toHaveBeenCalledWith({
+        panelType: 'stat',
+        optionPath: 'textMode',
+        optionName: 'Text mode',
+        source: 'quick_edit',
+        dashboardUid: 'test-dashboard-uid',
+      });
+    });
+
+    it('should track telemetry when undoing a change', () => {
+      const panel = createMockPanel({ textMode: 'auto' });
+      const plugin = createMockPlugin(['textMode']);
+
+      jest.spyOn(panel, 'state', 'get').mockReturnValue({
+        options: { textMode: 'value' },
+        pluginId: 'stat',
+        title: 'Test Panel',
+        fieldConfig: { defaults: {}, overrides: [] },
+      } as unknown as typeof panel.state);
+
+      const { result } = renderHook(() => useQuickEditOptions({ panel, plugin, dashboardUid: 'test-dashboard-uid' }));
+      const item = result.current!.items[0];
+
+      const rendered = item.props.render(item) as React.ReactElement<{ onChange: (value: string) => void }>;
+      act(() => {
+        rendered.props.onChange('value');
+      });
+
+      const event = (panel.publishEvent as jest.Mock).mock.calls[0][0] as DashboardEditActionEvent;
+      event.payload.undo();
+
+      expect(DashboardInteractions.quickEditOptionUndone).toHaveBeenCalledWith({
+        panelType: 'stat',
+        optionPath: 'textMode',
+        optionName: 'Text mode',
+        dashboardUid: 'test-dashboard-uid',
+      });
     });
   });
 });

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.test.tsx
@@ -1,10 +1,18 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
+import React from 'react';
 
 import { EventBusSrv } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { VizPanel } from '@grafana/scenes';
 
+import { dashboardEditActions } from './shared';
 import { useQuickEditOptions } from './useQuickEditOptions';
+
+jest.mock('./shared', () => ({
+  dashboardEditActions: {
+    edit: jest.fn(),
+  },
+}));
 
 describe('useQuickEditOptions', () => {
   const createMockPanel = (options: Record<string, unknown> = {}) => {
@@ -167,5 +175,78 @@ describe('useQuickEditOptions', () => {
     expect(result.current?.items[0].props.title).toBe('Color mode');
     expect(result.current?.items[1].props.title).toBe('Text mode');
     expect(result.current?.items[2].props.title).toBe('Show graph');
+  });
+
+  describe('undo/redo support', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call dashboardEditActions.edit when changing an option', () => {
+      const panel = createMockPanel({ textMode: 'auto' });
+      const plugin = createMockPlugin(['textMode']);
+
+      const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+
+      expect(result.current).not.toBeNull();
+      const item = result.current!.items[0];
+
+      const rendered = item.props.render(item) as React.ReactElement<{ onChange: (value: string) => void }>;
+      act(() => {
+        rendered.props.onChange('value');
+      });
+
+      expect(dashboardEditActions.edit).toHaveBeenCalledTimes(1);
+      expect(dashboardEditActions.edit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: panel,
+          perform: expect.any(Function),
+          undo: expect.any(Function),
+        })
+      );
+    });
+
+    it('should apply new value when perform is called', () => {
+      const panel = createMockPanel({ textMode: 'auto' });
+      const plugin = createMockPlugin(['textMode']);
+
+      const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+      const item = result.current!.items[0];
+
+      const rendered = item.props.render(item) as React.ReactElement<{ onChange: (value: string) => void }>;
+      act(() => {
+        rendered.props.onChange('value');
+      });
+
+      const editCall = (dashboardEditActions.edit as jest.Mock).mock.calls[0][0];
+      editCall.perform();
+
+      expect(panel.onOptionsChange).toHaveBeenCalledWith({ textMode: 'value' });
+    });
+
+    it('should restore old value when undo is called', () => {
+      const panel = createMockPanel({ textMode: 'auto' });
+      const plugin = createMockPlugin(['textMode']);
+
+      jest.spyOn(panel, 'state', 'get').mockReturnValue({
+        options: { textMode: 'value' },
+        pluginId: 'stat',
+        title: 'Test Panel',
+        fieldConfig: { defaults: {}, overrides: [] },
+      } as unknown as typeof panel.state);
+
+      const { result } = renderHook(() => useQuickEditOptions({ panel, plugin }));
+      const item = result.current!.items[0];
+
+      const rendered = item.props.render(item) as React.ReactElement<{ onChange: (value: string) => void }>;
+      act(() => {
+        rendered.props.onChange('value');
+      });
+
+      const editCall = (dashboardEditActions.edit as jest.Mock).mock.calls[0][0];
+      editCall.undo();
+
+      expect(panel.onOptionsChange).toHaveBeenCalledWith({ textMode: 'auto' });
+    });
   });
 });

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
@@ -52,7 +52,7 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
     const allItems = builder.getItems();
 
     const category = new OptionsPaneCategoryDescriptor({
-      title: t('dashboard.quick-edit.category-title', 'Quick settings'),
+      title: t('dashboard.quick-edit.category-title', 'Quick edit'),
       id: 'quick-edit-options',
     });
 
@@ -81,12 +81,16 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
 
       const Editor = item.editor;
       const htmlId = `quick-edit-${item.id}`;
-      const optionName = item.name;
       const optionPath = item.path;
+
+      // Build display name including category for nested options
+      const displayName =
+        item.category && item.category.length > 0 ? `${item.category.join(' > ')} ${item.name}` : item.name;
+      const optionName = displayName;
 
       category.addItem(
         new OptionsPaneItemDescriptor({
-          title: item.name,
+          title: displayName,
           id: htmlId,
           description: item.description,
           render: function renderQuickEditOption() {

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
@@ -2,12 +2,14 @@ import { get as lodashGet } from 'lodash';
 import { useMemo } from 'react';
 
 import { PanelOptionsEditorBuilder, PanelPlugin, StandardEditorContext } from '@grafana/data';
-import { isNestedPanelOptions, NestedValueAccess } from '@grafana/data/internal';
+import { isNestedPanelOptions } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
 import { VizPanel } from '@grafana/scenes';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
+
+import { dashboardEditActions } from './shared';
 
 interface UseQuickEditOptionsProps {
   panel: VizPanel;
@@ -49,14 +51,6 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
 
     const allItems = builder.getItems();
 
-    const access: NestedValueAccess = {
-      getValue: (path) => lodashGet(currentOptions, path),
-      onChange: (path, value) => {
-        const newOptions = setOptionImmutably(currentOptions, path, value);
-        panel.onOptionsChange(newOptions);
-      },
-    };
-
     const category = new OptionsPaneCategoryDescriptor({
       title: t('dashboard.quick-edit.category-title', 'Quick settings'),
       id: 'quick-edit-options',
@@ -87,6 +81,8 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
 
       const Editor = item.editor;
       const htmlId = `quick-edit-${item.id}`;
+      const optionName = item.name;
+      const optionPath = item.path;
 
       category.addItem(
         new OptionsPaneItemDescriptor({
@@ -94,17 +90,26 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
           id: htmlId,
           description: item.description,
           render: function renderQuickEditOption() {
-            return (
-              <Editor
-                value={access.getValue(item.path)}
-                onChange={(value) => {
-                  access.onChange(item.path, value);
-                }}
-                item={item}
-                context={context}
-                id={htmlId}
-              />
-            );
+            const currentValue = lodashGet(currentOptions, optionPath);
+
+            const handleChange = (newValue: unknown) => {
+              const oldValue = currentValue;
+              const newOptions = setOptionImmutably(currentOptions, optionPath, newValue);
+
+              dashboardEditActions.edit({
+                description: t('dashboard.quick-edit.change-option', 'Change {{optionName}}', { optionName }),
+                source: panel,
+                perform: () => {
+                  panel.onOptionsChange(newOptions);
+                },
+                undo: () => {
+                  const revertedOptions = setOptionImmutably(panel.state.options, optionPath, oldValue);
+                  panel.onOptionsChange(revertedOptions);
+                },
+              });
+            };
+
+            return <Editor value={currentValue} onChange={handleChange} item={item} context={context} id={htmlId} />;
           },
         })
       );

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
@@ -9,7 +9,7 @@ import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
 
-import { dashboardEditActions } from './shared';
+import { DashboardEditActionEvent } from './editActions';
 
 interface UseQuickEditOptionsProps {
   panel: VizPanel;
@@ -96,17 +96,20 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
               const oldValue = currentValue;
               const newOptions = setOptionImmutably(currentOptions, optionPath, newValue);
 
-              dashboardEditActions.edit({
-                description: t('dashboard.quick-edit.change-option', 'Change {{optionName}}', { optionName }),
-                source: panel,
-                perform: () => {
-                  panel.onOptionsChange(newOptions);
-                },
-                undo: () => {
-                  const revertedOptions = setOptionImmutably(panel.state.options, optionPath, oldValue);
-                  panel.onOptionsChange(revertedOptions);
-                },
-              });
+              panel.publishEvent(
+                new DashboardEditActionEvent({
+                  description: t('dashboard.quick-edit.change-option', 'Change {{optionName}}', { optionName }),
+                  source: panel,
+                  perform: () => {
+                    panel.onOptionsChange(newOptions);
+                  },
+                  undo: () => {
+                    const revertedOptions = setOptionImmutably(panel.state.options, optionPath, oldValue);
+                    panel.onOptionsChange(revertedOptions);
+                  },
+                }),
+                true
+              );
             };
 
             return <Editor value={currentValue} onChange={handleChange} item={item} context={context} id={htmlId} />;

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
@@ -1,0 +1,119 @@
+import { get as lodashGet } from 'lodash';
+import { useMemo } from 'react';
+
+import { PanelOptionsEditorBuilder, PanelPlugin, StandardEditorContext } from '@grafana/data';
+import { isNestedPanelOptions, NestedValueAccess } from '@grafana/data/internal';
+import { t } from '@grafana/i18n';
+import { VizPanel } from '@grafana/scenes';
+import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
+import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
+
+interface UseQuickEditOptionsProps {
+  panel: VizPanel;
+  plugin: PanelPlugin | undefined;
+}
+
+/**
+ * Hook to build quick edit options for a panel based on the plugin's quickEditPaths.
+ *
+ * Quick edit options appear in the dashboard edit pane, allowing users to modify
+ * common panel settings without entering the full panel editor.
+ *
+ * @returns OptionsPaneCategoryDescriptor with the quick edit options, or null if none are defined
+ */
+export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps): OptionsPaneCategoryDescriptor | null {
+  const { options: currentOptions } = panel.useState();
+
+  return useMemo((): OptionsPaneCategoryDescriptor | null => {
+    if (!plugin) {
+      return null;
+    }
+
+    const quickEditPaths = plugin.getQuickEditPaths();
+    if (!quickEditPaths || quickEditPaths.length === 0) {
+      return null;
+    }
+
+    const supplier = plugin.getPanelOptionsSupplier();
+
+    const context: StandardEditorContext<unknown, unknown> = {
+      data: [],
+      options: currentOptions,
+      replaceVariables: panel.interpolate,
+      eventBus: panel.getPanelContext().eventBus,
+    };
+
+    const builder = new PanelOptionsEditorBuilder();
+    supplier(builder, context);
+
+    const allItems = builder.getItems();
+
+    const access: NestedValueAccess = {
+      getValue: (path) => lodashGet(currentOptions, path),
+      onChange: (path, value) => {
+        const newOptions = setOptionImmutably(currentOptions, path, value);
+        panel.onOptionsChange(newOptions);
+      },
+    };
+
+    const category = new OptionsPaneCategoryDescriptor({
+      title: t('dashboard.quick-edit.category-title', 'Quick settings'),
+      id: 'quick-edit-options',
+    });
+
+    for (const path of quickEditPaths) {
+      const item = allItems.find((opt) => opt.path === path);
+
+      if (!item) {
+        console.warn(
+          `useQuickEditOptions: Quick edit path "${path}" not found in plugin options for "${plugin.meta?.id ?? 'unknown'}". ` +
+            `Make sure the path matches an option defined in setPanelOptions().`
+        );
+        continue;
+      }
+
+      if (isNestedPanelOptions(item)) {
+        console.warn(
+          `useQuickEditOptions: Quick edit path "${path}" refers to a nested options group, which is not supported. ` +
+            `Use paths to individual options instead.`
+        );
+        continue;
+      }
+
+      if (item.showIf && !item.showIf(context.options, context.data, context.annotations)) {
+        continue;
+      }
+
+      const Editor = item.editor;
+      const htmlId = `quick-edit-${item.id}`;
+
+      category.addItem(
+        new OptionsPaneItemDescriptor({
+          title: item.name,
+          id: htmlId,
+          description: item.description,
+          render: function renderQuickEditOption() {
+            return (
+              <Editor
+                value={access.getValue(item.path)}
+                onChange={(value) => {
+                  access.onChange(item.path, value);
+                }}
+                item={item}
+                context={context}
+                id={htmlId}
+              />
+            );
+          },
+        })
+      );
+    }
+
+    if (category.items.length === 0) {
+      return null;
+    }
+
+    return category;
+  }, [panel, plugin, currentOptions]);
+}

--- a/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useQuickEditOptions.tsx
@@ -9,11 +9,14 @@ import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
 
+import { DashboardInteractions } from '../utils/interactions';
+
 import { DashboardEditActionEvent } from './editActions';
 
 interface UseQuickEditOptionsProps {
   panel: VizPanel;
   plugin: PanelPlugin | undefined;
+  dashboardUid?: string;
 }
 
 /**
@@ -24,7 +27,11 @@ interface UseQuickEditOptionsProps {
  *
  * @returns OptionsPaneCategoryDescriptor with the quick edit options, or null if none are defined
  */
-export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps): OptionsPaneCategoryDescriptor | null {
+export function useQuickEditOptions({
+  panel,
+  plugin,
+  dashboardUid,
+}: UseQuickEditOptionsProps): OptionsPaneCategoryDescriptor | null {
   const { options: currentOptions } = panel.useState();
 
   return useMemo((): OptionsPaneCategoryDescriptor | null => {
@@ -99,6 +106,15 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
             const handleChange = (newValue: unknown) => {
               const oldValue = currentValue;
               const newOptions = setOptionImmutably(currentOptions, optionPath, newValue);
+              const panelType = plugin.meta?.id ?? 'unknown';
+
+              DashboardInteractions.quickEditOptionChanged({
+                panelType,
+                optionPath,
+                optionName,
+                source: 'quick_edit',
+                dashboardUid,
+              });
 
               panel.publishEvent(
                 new DashboardEditActionEvent({
@@ -108,6 +124,12 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
                     panel.onOptionsChange(newOptions);
                   },
                   undo: () => {
+                    DashboardInteractions.quickEditOptionUndone({
+                      panelType,
+                      optionPath,
+                      optionName,
+                      dashboardUid,
+                    });
                     const revertedOptions = setOptionImmutably(panel.state.options, optionPath, oldValue);
                     panel.onOptionsChange(revertedOptions);
                   },
@@ -127,5 +149,5 @@ export function useQuickEditOptions({ panel, plugin }: UseQuickEditOptionsProps)
     }
 
     return category;
-  }, [panel, plugin, currentOptions]);
+  }, [panel, plugin, currentOptions, dashboardUid]);
 }

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
@@ -22,6 +22,7 @@ import { makeExportableV1, makeExportableV2 } from '../scene/export/exporters';
 import { getVariablesCompatibility } from '../utils/getVariablesCompatibility';
 import { getVizPanelKeyForPanelId } from '../utils/utils';
 
+import type { DashboardTrackingInfo, DynamicDashboardsTrackingInformation } from './dashboardTrackingTypes';
 import { transformSceneToSaveModel } from './transformSceneToSaveModel';
 import { transformSceneToSaveModelSchemaV2 } from './transformSceneToSaveModelSchemaV2';
 
@@ -60,31 +61,6 @@ export interface DashboardSceneSerializerLike<T, M, I = T, E = T | { error: unkn
   getDSReferencesMapping: () => DSReferencesMapping;
   makeExportableExternally: (s: DashboardScene) => Promise<E | { error: unknown }>;
   getK8SMetadata: () => Partial<ObjectMeta> | undefined;
-}
-
-export interface DashboardTrackingInfo {
-  uid?: string;
-  title?: string;
-  schemaVersion: number;
-  panels_count: number;
-  rowCount?: number;
-  settings_nowdelay?: number;
-  settings_livenow?: boolean;
-}
-
-export interface DynamicDashboardsTrackingInformation {
-  panelCount: number;
-  rowCount: number;
-  tabCount: number;
-  templateVariableCount: number;
-  maxNestingLevel: number;
-  conditionalRenderRulesCount: number;
-  autoLayoutCount: number;
-  customGridLayoutCount: number;
-  rowsLayoutCount: number;
-  tabsLayoutCount: number;
-  dashStructure: string;
-  panelsByDatasourceType: Record<string, number>;
 }
 
 interface DynamicDashboardTrackingInformationStructureNode {

--- a/public/app/features/dashboard-scene/serialization/dashboardTrackingTypes.ts
+++ b/public/app/features/dashboard-scene/serialization/dashboardTrackingTypes.ts
@@ -1,0 +1,30 @@
+/**
+ * Types for dashboard tracking/analytics.
+ * These are extracted to a separate file to avoid circular dependencies
+ * when importing in interactions.ts
+ */
+
+export interface DashboardTrackingInfo {
+  uid?: string;
+  title?: string;
+  schemaVersion: number;
+  panels_count: number;
+  rowCount?: number;
+  settings_nowdelay?: number;
+  settings_livenow?: boolean;
+}
+
+export interface DynamicDashboardsTrackingInformation {
+  panelCount: number;
+  rowCount: number;
+  tabCount: number;
+  templateVariableCount: number;
+  maxNestingLevel: number;
+  conditionalRenderRulesCount: number;
+  autoLayoutCount: number;
+  customGridLayoutCount: number;
+  rowsLayoutCount: number;
+  tabsLayoutCount: number;
+  dashStructure: string;
+  panelsByDatasourceType: Record<string, number>;
+}

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -1,6 +1,6 @@
 import { config, reportInteraction } from '@grafana/runtime';
 
-import { DashboardTrackingInfo, DynamicDashboardsTrackingInformation } from '../serialization/DashboardSceneSerializer';
+import { DashboardTrackingInfo, DynamicDashboardsTrackingInformation } from '../serialization/dashboardTrackingTypes';
 
 let isScenesContextSet = false;
 
@@ -286,6 +286,48 @@ export const DashboardInteractions = {
   trackMoveItem: (item: 'panel' | 'row' | 'tab', action: 'drag' | 'drop', context: { isCrossLayout: boolean }) => {
     const properties = { item, action, context };
     reportDashboardInteraction('move_item', properties);
+  },
+
+  /**
+   * Track when a user changes a panel option that is configured for quick edit.
+   * This event is fired both from quick edit sidebar and from the full panel editor,
+   * differentiated by the `source` property.
+   *
+   * Event name: `dashboards_quick_edit_option_changed`
+   *
+   * @param properties.panelType - The panel plugin ID (e.g., 'stat', 'timeseries', 'table')
+   * @param properties.optionPath - The option path that was changed (e.g., 'textMode', 'legend.showLegend')
+   * @param properties.optionName - Human-readable name of the option (e.g., 'Text mode', 'Show legend'). Optional, not available in panel editor context.
+   * @param properties.source - Where the change was made: 'quick_edit' (sidebar) or 'panel_editor' (full editor)
+   * @param properties.dashboardUid - UID of the dashboard being edited (undefined if not available)
+   */
+  quickEditOptionChanged: (properties: {
+    panelType: string;
+    optionPath: string;
+    optionName?: string;
+    source: 'quick_edit' | 'panel_editor';
+    dashboardUid?: string;
+  }) => {
+    reportDashboardInteraction('quick_edit_option_changed', properties);
+  },
+
+  /**
+   * Track when a user undoes a quick edit change via Ctrl+Z / Cmd+Z.
+   *
+   * Event name: `dashboards_quick_edit_option_undone`
+   *
+   * @param properties.panelType - The panel plugin ID (e.g., 'stat', 'timeseries', 'table')
+   * @param properties.optionPath - The option path that was undone (e.g., 'textMode', 'legend.showLegend')
+   * @param properties.optionName - Human-readable name of the option (e.g., 'Text mode', 'Show legend')
+   * @param properties.dashboardUid - UID of the dashboard being edited (undefined if not available)
+   */
+  quickEditOptionUndone: (properties: {
+    panelType: string;
+    optionPath: string;
+    optionName: string;
+    dashboardUid?: string;
+  }) => {
+    reportDashboardInteraction('quick_edit_option_undone', properties);
   },
 };
 

--- a/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.test.ts
@@ -222,6 +222,7 @@ describe('getVisualizationOptions', () => {
         meta: { skipDataQuery: false },
         getPanelOptionsSupplier: jest.fn,
         fieldConfigRegistry: customFieldRegistry,
+        getQuickEditPaths: () => [],
       } as unknown as PanelPlugin;
 
       const vizOptions = getVisualizationOptions2({
@@ -284,6 +285,7 @@ describe('getVisualizationOptions', () => {
         meta: { skipDataQuery: false },
         getPanelOptionsSupplier: jest.fn,
         fieldConfigRegistry: customFieldRegistry,
+        getQuickEditPaths: () => [],
       } as unknown as PanelPlugin;
 
       const vizOptions = getVisualizationOptions2({
@@ -335,6 +337,7 @@ describe('getVisualizationOptions', () => {
         meta: { skipDataQuery: false },
         getPanelOptionsSupplier: jest.fn,
         fieldConfigRegistry: customFieldRegistry,
+        getQuickEditPaths: () => [],
       } as unknown as PanelPlugin;
     };
 

--- a/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx
@@ -16,6 +16,8 @@ import { VizPanel } from '@grafana/scenes';
 import { Input } from '@grafana/ui';
 import { LibraryVizPanelInfo } from 'app/features/dashboard-scene/panel-edit/LibraryVizPanelInfo';
 import { LibraryPanelBehavior } from 'app/features/dashboard-scene/scene/LibraryPanelBehavior';
+import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
+import { getDashboardSceneFor } from 'app/features/dashboard-scene/utils/utils';
 import { getDataLinksVariableSuggestions } from 'app/features/panel/panellinks/link_srv';
 
 import { OptionsPaneCategoryDescriptor } from './OptionsPaneCategoryDescriptor';
@@ -224,6 +226,7 @@ export function getVisualizationOptions2(props: OptionPaneRenderProps2): Options
   };
 
   const currentOptions = panel.state.options;
+  const quickEditPaths = plugin.getQuickEditPaths() ?? [];
   const access: NestedValueAccess = {
     getValue: (path) => lodashGet(currentOptions, path),
     onChange: (path, value) => {
@@ -232,6 +235,22 @@ export function getVisualizationOptions2(props: OptionPaneRenderProps2): Options
           viz_type: plugin.meta.id,
           feature_type: 'time_comparison',
           option_type: value ? 'toggle_enabled' : 'toggle_disabled',
+        });
+      }
+
+      if (quickEditPaths.includes(path)) {
+        let dashboardUid: string | undefined;
+        try {
+          dashboardUid = getDashboardSceneFor(panel).state.uid;
+        } catch {
+          // Dashboard may not be available in all contexts
+        }
+
+        DashboardInteractions.quickEditOptionChanged({
+          panelType: plugin.meta.id,
+          optionPath: path,
+          source: 'panel_editor',
+          dashboardUid,
         });
       }
 

--- a/public/app/plugins/panel/stat/module.test.ts
+++ b/public/app/plugins/panel/stat/module.test.ts
@@ -1,0 +1,9 @@
+import { plugin } from './module';
+
+describe('Stat panel plugin', () => {
+  it('should have textMode, colorMode, and graphMode as quick edit options', () => {
+    const quickEditPaths = plugin.getQuickEditPaths();
+
+    expect(quickEditPaths).toEqual(['textMode', 'colorMode', 'graphMode']);
+  });
+});

--- a/public/app/plugins/panel/stat/module.tsx
+++ b/public/app/plugins/panel/stat/module.tsx
@@ -138,4 +138,5 @@ export const plugin = new PanelPlugin<Options>(StatPanel)
   .setNoPadding()
   .setPanelChangeHandler(statPanelChangedHandler)
   .setSuggestionsSupplier(statSuggestionsSupplier)
-  .setMigrationHandler(sharedSingleStatMigrationHandler);
+  .setMigrationHandler(sharedSingleStatMigrationHandler)
+  .setQuickEditPaths(['textMode', 'colorMode', 'graphMode']);

--- a/public/app/plugins/panel/stat/module.tsx
+++ b/public/app/plugins/panel/stat/module.tsx
@@ -138,5 +138,4 @@ export const plugin = new PanelPlugin<Options>(StatPanel)
   .setNoPadding()
   .setPanelChangeHandler(statPanelChangedHandler)
   .setSuggestionsSupplier(statSuggestionsSupplier)
-  .setMigrationHandler(sharedSingleStatMigrationHandler)
-  .setQuickEditPaths(['textMode', 'colorMode', 'graphMode']);
+  .setMigrationHandler(sharedSingleStatMigrationHandler);

--- a/public/app/plugins/panel/table/module.test.ts
+++ b/public/app/plugins/panel/table/module.test.ts
@@ -1,0 +1,9 @@
+import { plugin } from './module';
+
+describe('Table panel plugin', () => {
+  it('should have cellHeight and enablePagination as quick edit options', () => {
+    const quickEditPaths = plugin.getQuickEditPaths();
+
+    expect(quickEditPaths).toEqual(['cellHeight', 'enablePagination']);
+  });
+});

--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -126,4 +126,5 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TablePanel)
   .setPanelOptions((builder) => {
     addTableCustomPanelOptions(builder);
   })
-  .setSuggestionsSupplier(tableSuggestionsSupplier);
+  .setSuggestionsSupplier(tableSuggestionsSupplier)
+  .setQuickEditPaths(['cellHeight', 'enablePagination']);

--- a/public/app/plugins/panel/text/TextPanel.test.tsx
+++ b/public/app/plugins/panel/text/TextPanel.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { dateTime, LoadingState, EventBusSrv } from '@grafana/data';
 
 import { Props, TextPanel } from './TextPanel';
+import { plugin } from './module';
 import { TextMode } from './panelcfg.gen';
 
 const replaceVariablesMock = jest.fn();
@@ -161,5 +162,11 @@ describe('TextPanel', () => {
     expect(screen.getByTestId('TextPanel-converted-content').innerHTML).toEqual(
       'We begin by a simple sentence.\n```This is a code block\n```'
     );
+  });
+
+  it('should have mode and content as quick edit options', () => {
+    const quickEditPaths = plugin.getQuickEditPaths();
+
+    expect(quickEditPaths).toEqual(['mode', 'content']);
   });
 });

--- a/public/app/plugins/panel/text/module.tsx
+++ b/public/app/plugins/panel/text/module.tsx
@@ -66,4 +66,5 @@ export const plugin = new PanelPlugin<Options>(TextPanel)
     ds.fieldCount === 0 && !config.featureToggles.newVizSuggestions
       ? [{ cardOptions: { imgSrc: icnTextPanelSvg } }]
       : []
-  );
+  )
+  .setQuickEditPaths(['mode', 'content']);

--- a/public/app/plugins/panel/timeseries/module.test.ts
+++ b/public/app/plugins/panel/timeseries/module.test.ts
@@ -1,0 +1,9 @@
+import { plugin } from './module';
+
+describe('Timeseries panel plugin', () => {
+  it('should have legend.showLegend and legend.calcs as quick edit options', () => {
+    const quickEditPaths = plugin.getQuickEditPaths();
+
+    expect(quickEditPaths).toEqual(['legend.showLegend', 'legend.calcs']);
+  });
+});

--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -28,4 +28,5 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TimeSeriesPanel)
     });
   })
   .setSuggestionsSupplier(timeseriesSuggestionsSupplier)
-  .setDataSupport({ annotations: true, alertStates: true });
+  .setDataSupport({ annotations: true, alertStates: true })
+  .setQuickEditPaths(['legend.showLegend', 'legend.calcs']);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5859,7 +5859,7 @@
       "try-again-later": "Try again later"
     },
     "quick-edit": {
-      "category-title": "Quick settings",
+      "category-title": "Quick edit",
       "change-option": "Change {{optionName}}"
     },
     "remove-panel": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5858,6 +5858,9 @@
       "paused": "This dashboard has been paused by the administrator",
       "try-again-later": "Try again later"
     },
+    "quick-edit": {
+      "category-title": "Quick settings"
+    },
     "remove-panel": {
       "text": {
         "remove-panel": "Are you sure you want to remove this panel?"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5859,7 +5859,8 @@
       "try-again-later": "Try again later"
     },
     "quick-edit": {
-      "category-title": "Quick settings"
+      "category-title": "Quick settings",
+      "change-option": "Change {{optionName}}"
     },
     "remove-panel": {
       "text": {


### PR DESCRIPTION
Made-with: Cursor

Builds on https://github.com/grafana/grafana/pull/119802

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

## What is this feature?

Track when users change panel options that are configured for quick edit. Events are fired from both the quick edit sidebar and the full panel editor, differentiated by the `source` property to enable comparison analytics.

Events tracked:
- dashboards_quick_edit_option_changed: option was modified
- dashboards_quick_edit_option_undone: change was undone via Ctrl+Z/Cmd+Z

Extract DashboardTrackingInfo and DynamicDashboardsTrackingInformation to a separate file to avoid circular dependencies.


## Why do we need this feature?

To measure the impact of the new quick edit feature 


## Who is this feature for?

Dashboards Edit squad mainly - when rolling out and afterward to keep an eye on adoptions.
DataViz could have use for it to - to iterate on which options should be made quick edits for their panel types


## Analytics
### Events

#### `dashboards_quick_edit_option_changed`
Fired when a user changes a panel option that is configured for quick edit. Tracked from both the quick edit sidebar and the full panel editor.

| Property | Type | Required | Description |
|----------|------|----------|-------------|
| `panelType` | string | Yes | The panel plugin ID (e.g., `stat`, `timeseries`, `table`) |
| `optionPath` | string | Yes | The option path that was changed (e.g., `textMode`, `legend.showLegend`) |
| `optionName` | string | No | Human-readable name of the option (e.g., `Text mode`). Only available when `source` is `quick_edit`. |
| `source` | string | Yes | Where the change was made: `quick_edit` (sidebar) or `panel_editor` (full editor) |
| `dashboardUid` | string | No | UID of the dashboard being edited |

#### `dashboards_quick_edit_option_undone`
Fired when a user undoes a quick edit change via Ctrl+Z / Cmd+Z. Only tracked from the quick edit sidebar (undo not supported in panel editor).

| Property | Type | Required | Description |
|----------|------|----------|-------------|
| `panelType` | string | Yes | The panel plugin ID (e.g., `stat`, `timeseries`, `table`) |
| `optionPath` | string | Yes | The option path that was undone (e.g., `textMode`, `legend.showLegend`) |
| `optionName` | string | Yes | Human-readable name of the option (e.g., `Text mode`) |
| `dashboardUid` | string | No | UID of the dashboard being edited |

### Additional Context

Both events automatically include the following properties via `DashboardInteractions`:

| Property | Description |
|----------|-------------|
| `scenesView` | `true` when in scenes context |
| `isDynamicDashboard` | `true` when `dashboardNewLayouts` feature toggle is enabled |


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
