### PR TITLE
Alerting: Support ruleUID groupBy for historian notification counts

### DIFF
--- a/apps/alerting/historian/kinds/v0alpha1/notification.cue
+++ b/apps/alerting/historian/kinds/v0alpha1/notification.cue
@@ -41,6 +41,7 @@ import (
         status: bool
         outcome: bool
         error: bool
+        ruleUID: bool
     }
 }
 
@@ -91,6 +92,7 @@ import (
     status?: #NotificationStatus
     outcome?: #NotificationOutcome
     error?: string
+    ruleUID?: string
 
     // Count is the number of notification attempts in the time period. Set for counts queries.
     count: int

--- a/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationquery_request_body_types_gen.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationquery_request_body_types_gen.go
@@ -92,6 +92,7 @@ type CreateNotificationqueryRequestV0alpha1BodyGroupBy struct {
 	Status           bool `json:"status"`
 	Outcome          bool `json:"outcome"`
 	Error            bool `json:"error"`
+	RuleUID          bool `json:"ruleUID"`
 }
 
 // NewCreateNotificationqueryRequestV0alpha1BodyGroupBy creates a new CreateNotificationqueryRequestV0alpha1BodyGroupBy object.

--- a/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationquery_response_types_gen.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationquery_response_types_gen.go
@@ -113,6 +113,7 @@ type CreateNotificationqueryNotificationCount struct {
 	Status           *CreateNotificationqueryNotificationStatus  `json:"status,omitempty"`
 	Outcome          *CreateNotificationqueryNotificationOutcome `json:"outcome,omitempty"`
 	Error            *string                                     `json:"error,omitempty"`
+	RuleUID          *string                                     `json:"ruleUID,omitempty"`
 	// Count is the number of notification attempts in the time period. Set for counts queries.
 	Count int64 `json:"count"`
 	// Values is the list of (timestamp, count) pairs in the time series. Set for range_counts queries.

--- a/apps/alerting/historian/pkg/apis/alertinghistorian_manifest.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian_manifest.go
@@ -136,6 +136,11 @@ var appManifestData = app.ManifestData{
 																					Type: []string{"boolean"},
 																				},
 																			},
+																			"ruleUID": {
+																				SchemaProps: spec.SchemaProps{
+																					Type: []string{"boolean"},
+																				},
+																			},
 																			"status": {
 																				SchemaProps: spec.SchemaProps{
 																					Type: []string{"boolean"},
@@ -149,6 +154,7 @@ var appManifestData = app.ManifestData{
 																			"status",
 																			"outcome",
 																			"error",
+																			"ruleUID",
 																		},
 																	},
 																},
@@ -441,6 +447,11 @@ var appManifestData = app.ManifestData{
 									},
 								},
 								"receiver": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"ruleUID": {
 									SchemaProps: spec.SchemaProps{
 										Type: []string{"string"},
 									},

--- a/apps/alerting/historian/pkg/app/notification/lokireader.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader.go
@@ -217,6 +217,11 @@ func (h *LokiReader) QueryAlerts(ctx context.Context, query AlertQuery) (AlertQu
 // topk(sum(count_over_time(...))) aggregation.
 func buildMetricsQuery(logqlInner string, from, to time.Time, limit int64, groupBy QueryGroupBy) string {
 	inner := buildMetricsRangeQuery(logqlInner, to.Sub(from), groupBy)
+	// Skip topk when grouping by RuleUID because the raw rule_uids label contains
+	// comma-separated UIDs that must be exploded client-side before applying topk.
+	if groupBy.RuleUID {
+		return inner
+	}
 	return fmt.Sprintf(`topk(%d, %s)`, limit, inner)
 }
 
@@ -251,6 +256,9 @@ func buildMetricsRangeQuery(logqlInner string, step time.Duration, groupBy Query
 	if groupBy.Error {
 		labels = append(labels, "error")
 	}
+	if groupBy.RuleUID {
+		labels = append(labels, "rule_uids")
+	}
 	sumBy := ""
 	if len(labels) > 0 {
 		sumBy = fmt.Sprintf(" by (%s) ", strings.Join(labels, ","))
@@ -281,12 +289,67 @@ func (h *LokiReader) runMetricsQuery(ctx context.Context, logqlInner string, fro
 		counts = append(counts, count)
 	}
 
+	// When grouping by RuleUID, explode the comma-separated rule_uids into
+	// individual counts, aggregate, and apply client-side topk.
+	if groupBy.RuleUID {
+		counts = explodeRuleUIDCounts(counts, limit)
+	}
+
 	// Sort counts by count (highest first).
 	sort.Slice(counts, func(i, j int) bool {
 		return counts[i].Count > counts[j].Count
 	})
 
 	return counts, nil
+}
+
+// explodeRuleUIDCounts splits counts with comma-separated rule_uids into individual
+// counts per rule UID, aggregates (sums) counts sharing the same (ruleUID + other groupBy
+// dimensions) key, sorts by count descending, and applies the limit (client-side topk).
+func explodeRuleUIDCounts(counts []Count, limit int64) []Count {
+	aggregated := make(map[string]*Count)
+
+	key := func(c Count) string {
+		c0 := c
+		c0.Count = 0
+		b, _ := json.Marshal(c0)
+		return string(b)
+	}
+
+	for _, c := range counts {
+		ruleUIDs := []string{""}
+		if c.RuleUID != nil && *c.RuleUID != "" {
+			ruleUIDs = strings.Split(*c.RuleUID, ",")
+		}
+		for _, uid := range ruleUIDs {
+			entry := c
+			uidCopy := uid
+			entry.RuleUID = &uidCopy
+			k := key(entry)
+			if existing, ok := aggregated[k]; ok {
+				existing.Count += entry.Count
+			} else {
+				aggregated[k] = &entry
+			}
+		}
+	}
+
+	result := make([]Count, 0, len(aggregated))
+	for _, c := range aggregated {
+		result = append(result, *c)
+	}
+
+	// Sort by count descending.
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Count > result[j].Count
+	})
+
+	// Apply limit (client-side topk).
+	if int64(len(result)) > limit {
+		result = result[:limit]
+	}
+
+	return result
 }
 
 // defaultStep returns a sensible default step interval for a range query over the given time range.
@@ -398,6 +461,11 @@ func parseCountLabels(m map[string]string) (Count, error) {
 	}
 	if v, ok := m["error"]; ok {
 		entry.Error = &v
+	}
+	if v, ok := m["rule_uids"]; ok {
+		// Store the raw comma-separated rule_uids string temporarily in the RuleUID
+		// field. The explodeRuleUIDCounts function will split and reaggregate later.
+		entry.RuleUID = &v
 	}
 	return entry, nil
 }

--- a/apps/alerting/historian/pkg/app/notification/lokireader_test.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -1125,6 +1126,24 @@ func TestBuildMetricsQuery(t *testing.T) {
 				`(count_over_time({foo="bar"} | json`+
 				` | label_format outcome="{{ if .error }}error{{ else }}success{{ end }}"[%ds])))`, rangeSeconds),
 		},
+		{
+			name:       "group by ruleUID omits topk and adds rule_uids",
+			logqlInner: `{foo="bar"} | json`,
+			from:       from,
+			to:         now,
+			limit:      100,
+			groupBy:    QueryGroupBy{RuleUID: true},
+			expected:   fmt.Sprintf(`sum by (rule_uids) (count_over_time({foo="bar"} | json[%ds]))`, rangeSeconds),
+		},
+		{
+			name:       "group by ruleUID and receiver omits topk",
+			logqlInner: `{foo="bar"} | json`,
+			from:       from,
+			to:         now,
+			limit:      50,
+			groupBy:    QueryGroupBy{Receiver: true, RuleUID: true},
+			expected:   fmt.Sprintf(`sum by (receiver,rule_uids) (count_over_time({foo="bar"} | json[%ds]))`, rangeSeconds),
+		},
 	}
 
 	for _, tt := range tests {
@@ -1197,6 +1216,14 @@ func TestParseCount(t *testing.T) {
 			want: Count{Count: 1, Error: stringPtr("connection refused")},
 		},
 		{
+			name: "with rule_uids",
+			sample: lokiclient.MetricSample{
+				Metric: map[string]string{"rule_uids": "ruleA,ruleB"},
+				Value:  makeValue("15"),
+			},
+			want: Count{Count: 15, RuleUID: stringPtr("ruleA,ruleB")},
+		},
+		{
 			name: "non-integer count",
 			sample: lokiclient.MetricSample{
 				Metric: map[string]string{},
@@ -1230,6 +1257,7 @@ func TestParseCount(t *testing.T) {
 			assert.Equal(t, tt.want.Status, got.Status)
 			assert.Equal(t, tt.want.Outcome, got.Outcome)
 			assert.Equal(t, tt.want.Error, got.Error)
+			assert.Equal(t, tt.want.RuleUID, got.RuleUID)
 		})
 	}
 }
@@ -1369,6 +1397,13 @@ func TestBuildMetricsRangeQuery(t *testing.T) {
 			step:       step,
 			groupBy:    QueryGroupBy{Outcome: true},
 			expected:   `sum by (outcome) (count_over_time({foo="bar"} | json | label_format outcome="{{ if .error }}error{{ else }}success{{ end }}"[60s]))`,
+		},
+		{
+			name:       "group by ruleUID adds rule_uids to by clause",
+			logqlInner: `{foo="bar"} | json`,
+			step:       step,
+			groupBy:    QueryGroupBy{RuleUID: true},
+			expected:   `sum by (rule_uids) (count_over_time({foo="bar"} | json[60s]))`,
 		},
 	}
 
@@ -1560,6 +1595,133 @@ func createMockAlertLokiResponse(timestamp time.Time) lokiclient.QueryRes {
 				},
 			},
 		},
+	}
+}
+
+func TestExplodeRuleUIDCounts(t *testing.T) {
+	tests := []struct {
+		name   string
+		counts []Count
+		limit  int64
+		want   []Count
+	}{
+		{
+			name:   "empty input",
+			counts: []Count{},
+			limit:  10,
+			want:   []Count{},
+		},
+		{
+			name: "single rule_uid no splitting needed",
+			counts: []Count{
+				{RuleUID: stringPtr("ruleA"), Count: 5},
+			},
+			limit: 10,
+			want: []Count{
+				{RuleUID: stringPtr("ruleA"), Count: 5},
+			},
+		},
+		{
+			name: "comma-separated rule_uids are split",
+			counts: []Count{
+				{RuleUID: stringPtr("ruleA,ruleB"), Count: 10},
+			},
+			limit: 10,
+			want: []Count{
+				{RuleUID: stringPtr("ruleA"), Count: 10},
+				{RuleUID: stringPtr("ruleB"), Count: 10},
+			},
+		},
+		{
+			name: "aggregation across multiple entries",
+			counts: []Count{
+				{RuleUID: stringPtr("ruleA,ruleB"), Count: 10},
+				{RuleUID: stringPtr("ruleB,ruleC"), Count: 5},
+			},
+			limit: 10,
+			want: []Count{
+				{RuleUID: stringPtr("ruleB"), Count: 15},
+				{RuleUID: stringPtr("ruleA"), Count: 10},
+				{RuleUID: stringPtr("ruleC"), Count: 5},
+			},
+		},
+		{
+			name: "limit is applied after aggregation",
+			counts: []Count{
+				{RuleUID: stringPtr("ruleA,ruleB"), Count: 10},
+				{RuleUID: stringPtr("ruleB,ruleC"), Count: 5},
+			},
+			limit: 2,
+			want: []Count{
+				{RuleUID: stringPtr("ruleB"), Count: 15},
+				{RuleUID: stringPtr("ruleA"), Count: 10},
+			},
+		},
+		{
+			name: "preserves other groupBy fields",
+			counts: []Count{
+				{RuleUID: stringPtr("ruleA,ruleB"), Receiver: stringPtr("email"), Count: 7},
+			},
+			limit: 10,
+			want: []Count{
+				{RuleUID: stringPtr("ruleA"), Receiver: stringPtr("email"), Count: 7},
+				{RuleUID: stringPtr("ruleB"), Receiver: stringPtr("email"), Count: 7},
+			},
+		},
+		{
+			name: "aggregation with other dimensions",
+			counts: []Count{
+				{RuleUID: stringPtr("ruleA"), Receiver: stringPtr("email"), Count: 3},
+				{RuleUID: stringPtr("ruleA"), Receiver: stringPtr("slack"), Count: 5},
+			},
+			limit: 10,
+			want: []Count{
+				{RuleUID: stringPtr("ruleA"), Receiver: stringPtr("slack"), Count: 5},
+				{RuleUID: stringPtr("ruleA"), Receiver: stringPtr("email"), Count: 3},
+			},
+		},
+		{
+			name: "nil rule_uids treated as empty",
+			counts: []Count{
+				{Count: 10},
+			},
+			limit: 10,
+			want: []Count{
+				{Count: 10},
+			},
+		},
+	}
+
+	derefStr := func(p *string) string {
+		if p == nil {
+			return ""
+		}
+		return *p
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := explodeRuleUIDCounts(tt.counts, tt.limit)
+			require.Len(t, got, len(tt.want))
+			// Sort tied counts by ruleUID for deterministic comparison.
+			sort.SliceStable(got, func(i, j int) bool {
+				if got[i].Count != got[j].Count {
+					return got[i].Count > got[j].Count
+				}
+				return derefStr(got[i].RuleUID) < derefStr(got[j].RuleUID)
+			})
+			sort.SliceStable(tt.want, func(i, j int) bool {
+				if tt.want[i].Count != tt.want[j].Count {
+					return tt.want[i].Count > tt.want[j].Count
+				}
+				return derefStr(tt.want[i].RuleUID) < derefStr(tt.want[j].RuleUID)
+			})
+			for i := range tt.want {
+				assert.Equal(t, tt.want[i].Count, got[i].Count, "index %d count", i)
+				assert.Equal(t, derefStr(tt.want[i].RuleUID), derefStr(got[i].RuleUID), "index %d ruleUID", i)
+				assert.Equal(t, derefStr(tt.want[i].Receiver), derefStr(got[i].Receiver), "index %d receiver", i)
+			}
+		})
 	}
 }
 

--- a/packages/grafana-api-clients/src/clients/rtkq/historian.alerting/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/historian.alerting/v0alpha1/endpoints.gen.ts
@@ -629,6 +629,7 @@ export type CreateNotificationqueryNotificationCount = {
   integrationIndex?: number;
   outcome?: CreateNotificationqueryNotificationOutcome;
   receiver?: string;
+  ruleUID?: string;
   status?: CreateNotificationqueryNotificationStatus;
   /** Values is the list of (timestamp, count) pairs in the time series. Set for range_counts queries. */
   values: CreateNotificationqueryNotificationRangeValue[];
@@ -703,6 +704,7 @@ export type CreateNotificationqueryRequestBody = {
     integrationIndex: boolean;
     outcome: boolean;
     receiver: boolean;
+    ruleUID: boolean;
     status: boolean;
   };
   /** GroupLabels optionally filters the entries by matching group labels. */

--- a/packages/grafana-openapi/src/apis/historian.alerting.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/historian.alerting.grafana.app-v0alpha1.json
@@ -1155,6 +1155,9 @@
           "receiver": {
             "type": "string"
           },
+          "ruleUID": {
+            "type": "string"
+          },
           "status": {
             "$ref": "#/components/schemas/CreateNotificationqueryNotificationStatus"
           },
@@ -1339,7 +1342,7 @@
           "groupBy": {
             "description": "GroupBy specifies how to aggregate counts queries.",
             "type": "object",
-            "required": ["receiver", "integration", "integrationIndex", "status", "outcome", "error"],
+            "required": ["receiver", "integration", "integrationIndex", "status", "outcome", "error", "ruleUID"],
             "properties": {
               "error": {
                 "type": "boolean"
@@ -1354,6 +1357,9 @@
                 "type": "boolean"
               },
               "receiver": {
+                "type": "boolean"
+              },
+              "ruleUID": {
                 "type": "boolean"
               },
               "status": {

--- a/pkg/tests/apis/openapi_snapshots/historian.alerting.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/historian.alerting.grafana.app-v0alpha1.json
@@ -1252,6 +1252,9 @@
           "receiver": {
             "type": "string"
           },
+          "ruleUID": {
+            "type": "string"
+          },
           "status": {
             "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.historian.pkg.apis.alertinghistorian.v0alpha1.CreateNotificationqueryNotificationStatus"
           },
@@ -1457,7 +1460,8 @@
               "integrationIndex",
               "status",
               "outcome",
-              "error"
+              "error",
+              "ruleUID"
             ],
             "properties": {
               "error": {
@@ -1473,6 +1477,9 @@
                 "type": "boolean"
               },
               "receiver": {
+                "type": "boolean"
+              },
+              "ruleUID": {
                 "type": "boolean"
               },
               "status": {


### PR DESCRIPTION
Add support for grouping notification counts by rule UID. This is a bit fiddly
as a notification can be fore multiple rule UIDs, and in Loki we store this as
a `rule_uids` structured meta data field being comma-separated values. This
make using Loki to do the whole query impossible.

Instead, we get Loki to group by `rule_uids`, and then expand the counts
ourselves, and them apply the topk. This does have the potential to explode
the result set combinatorially so we may have to consider changing the Loki
format, however it will work well for anyone grouping by e.g. alertname.
