### PR TITLE
fix: handle maxOpenConns=0 in postgres datasource

### DIFF
--- a/packages/grafana-sql/src/components/configuration/ConnectionLimits.tsx
+++ b/packages/grafana-sql/src/components/configuration/ConnectionLimits.tsx
@@ -44,7 +44,7 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
   // When the maximum number of connections is changed
   // see if we have the automatic idle option enabled
   const onMaxConnectionsChanged = (number?: number) => {
-    if (autoIdle && number) {
+    if (autoIdle && number !== undefined) {
       updateJsonData({
         maxOpenConns: number,
         maxIdleConns: number,

--- a/packages/grafana-sql/src/components/configuration/MaxOpenConnectionsField.tsx
+++ b/packages/grafana-sql/src/components/configuration/MaxOpenConnectionsField.tsx
@@ -29,7 +29,7 @@ export function MaxOpenConnectionsField({ labelWidth, onMaxConnectionsChanged, j
                     The maximum number of open connections to the database. If <i>Max idle connections</i> is greater
                     than 0 and the <i>Max open connections</i> is less than <i>Max idle connections</i>, then
                     <i>Max idle connections</i> will be reduced to match the <i>Max open connections</i> limit. If set
-                    to 0, there is no limit on the number of open connections.
+                    to 0, the driver default is used.
                   </Trans>
                 </span>
               }

--- a/packages/grafana-sql/src/components/configuration/NumberInput.tsx
+++ b/packages/grafana-sql/src/components/configuration/NumberInput.tsx
@@ -14,6 +14,7 @@ export function NumberInput({ value, defaultValue, onChange, width }: NumberInpu
   return (
     <Input
       type="number"
+      min={0}
       placeholder={String(defaultValue)}
       value={isEmpty ? '' : value}
       onChange={(e) => {

--- a/packages/grafana-sql/src/locales/en-US/grafana-sql.json
+++ b/packages/grafana-sql/src/locales/en-US/grafana-sql.json
@@ -14,7 +14,7 @@
         "content-auto-max-idle": "If enabled, automatically set the number of <i>Maximum idle connections</i> to the same value as<i> Max open connections</i>. If the number of maximum open connections is not set it will be set to the default ({{defaultMaxIdle}}).",
         "content-max-idle": "The maximum number of connections in the idle connection pool.If <i>Max open connections</i> is greater than 0 but less than the <i>Max idle connections</i>, then the <i>Max idle connections</i> will be reduced to match the <i>Max open connections</i> limit. If set to 0, no idle connections are retained.",
         "content-max-lifetime": "The maximum amount of time in seconds a connection may be reused. If set to 0, connections are reused forever.",
-        "content-max-open": "The maximum number of open connections to the database. If <i>Max idle connections</i> is greater than 0 and the <i>Max open connections</i> is less than <i>Max idle connections</i>, then<i>Max idle connections</i> will be reduced to match the <i>Max open connections</i> limit. If set to 0, there is no limit on the number of open connections.",
+        "content-max-open": "The maximum number of open connections to the database. If <i>Max idle connections</i> is greater than 0 and the <i>Max open connections</i> is less than <i>Max idle connections</i>, then<i>Max idle connections</i> will be reduced to match the <i>Max open connections</i> limit. If set to 0, the driver default is used.",
         "max-idle": "Max idle",
         "max-lifetime": "Max lifetime",
         "max-open": "Max open",

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres.go
@@ -56,8 +56,12 @@ func newPostgres(ctx context.Context, userFacingDefaultError string, rowLimit in
 	}
 
 	queryResultTransformer := postgresQueryResultTransformer{}
-	pgxConf.MaxConnLifetime = time.Duration(config.DSInfo.JsonData.ConnMaxLifetime) * time.Second
-	pgxConf.MaxConns = int32(config.DSInfo.JsonData.MaxOpenConns)
+	if config.DSInfo.JsonData.ConnMaxLifetime > 0 {
+		pgxConf.MaxConnLifetime = time.Duration(config.DSInfo.JsonData.ConnMaxLifetime) * time.Second
+	}
+	if config.DSInfo.JsonData.MaxOpenConns > 0 {
+		pgxConf.MaxConns = int32(config.DSInfo.JsonData.MaxOpenConns)
+	}
 
 	p, err := pgxpool.NewWithConfig(ctx, pgxConf)
 	if err != nil {

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
@@ -12,12 +12,75 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/tsdb/grafana-postgresql-datasource/sqleng"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
+
+func TestPgxPoolConfigWithZeroMaxConns(t *testing.T) {
+	connStr := "user='test' host='localhost' dbname='test' sslmode='disable'"
+	pgxConf, err := pgxpool.ParseConfig(connStr)
+	require.NoError(t, err)
+
+	defaultMaxConns := pgxConf.MaxConns
+
+	tests := []struct {
+		name            string
+		maxOpenConns    int
+		connMaxLifetime int
+		expectMaxConns  int32
+		expectLifetime  time.Duration
+	}{
+		{
+			name:            "zero maxOpenConns uses pgxpool default",
+			maxOpenConns:    0,
+			connMaxLifetime: 600,
+			expectMaxConns:  defaultMaxConns,
+			expectLifetime:  600 * time.Second,
+		},
+		{
+			name:            "negative maxOpenConns uses pgxpool default",
+			maxOpenConns:    -1,
+			connMaxLifetime: 600,
+			expectMaxConns:  defaultMaxConns,
+			expectLifetime:  600 * time.Second,
+		},
+		{
+			name:            "positive maxOpenConns is applied",
+			maxOpenConns:    10,
+			connMaxLifetime: 600,
+			expectMaxConns:  10,
+			expectLifetime:  600 * time.Second,
+		},
+		{
+			name:            "zero connMaxLifetime uses pgxpool default",
+			maxOpenConns:    10,
+			connMaxLifetime: 0,
+			expectMaxConns:  10,
+			expectLifetime:  pgxConf.MaxConnLifetime,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := pgxpool.ParseConfig(connStr)
+			require.NoError(t, err)
+
+			if tt.connMaxLifetime > 0 {
+				cfg.MaxConnLifetime = time.Duration(tt.connMaxLifetime) * time.Second
+			}
+			if tt.maxOpenConns > 0 {
+				cfg.MaxConns = int32(tt.maxOpenConns)
+			}
+
+			assert.Equal(t, tt.expectMaxConns, cfg.MaxConns)
+			assert.Equal(t, tt.expectLifetime, cfg.MaxConnLifetime)
+		})
+	}
+}
 
 // Test generateConnectionString.
 func TestIntegrationGenerateConnectionString(t *testing.T) {


### PR DESCRIPTION
Fixes #119810

When `maxOpenConns` is set to 0 (meaning "unlimited" in `database/sql`), the value was passed directly to pgxpool which requires `MaxConns >= 1`, causing connection failures.

Now we skip setting `MaxConns` and `MaxConnLifetime` when their configured values are <= 0, letting pgxpool use its own defaults instead.

Also adds unit tests for the zero/negative value cases.