### PR TITLE
 Plugin E2E: Add more tests + agents.md

### DIFF
--- a/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/AGENTS.md
+++ b/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/AGENTS.md
@@ -1,0 +1,55 @@
+# plugin-e2e API Tests - Agent Instructions
+
+## Purpose
+
+These tests verify that `@grafana/plugin-e2e` fixtures, page models and matchers remain compatible with the latest Grafana UI. They are **not** plugin tests - they are forward-compatibility canaries. If a Grafana UI change breaks a selector or interaction pattern that `@grafana/plugin-e2e` depends on, these tests catch it before it ships.
+
+## What to do when a test breaks
+
+A failing test here means a Grafana UI change broke the `@grafana/plugin-e2e` testing API. This affects every plugin that uses `@grafana/plugin-e2e` for end-to-end testing. **Do not delete or skip the test** - that defeats its purpose. Instead, follow these steps in order:
+
+### 1. Reuse the existing e2e selector in your new UI
+
+This is the preferred fix. The `@grafana/plugin-e2e` package locates UI elements using selectors defined in `packages/grafana-e2e-selectors/src/selectors/` (see [pages.ts](../../../packages/grafana-e2e-selectors/src/selectors/pages.ts) and [components.ts](../../../packages/grafana-e2e-selectors/src/selectors/components.ts)). If you changed or replaced a UI element, apply the same `data-testid` or `aria-label` selector that the old element used. This requires no changes outside the Grafana repo.
+
+For example, if you rebuilt the "Add panel" button, make sure the new button still uses the same selector value that the old one did. The test will pass without any other changes.
+
+### 2. Add a new version to the selector
+
+If the element still exists but its selector value legitimately needs to change (e.g. the `data-testid` was renamed for good reason), add a new versioned entry to the selector object. See [packages/grafana-e2e-selectors/src/selectors/README.md](../../../packages/grafana-e2e-selectors/src/selectors/README.md) for how versioned selectors work.
+
+```typescript
+// example: selector value changed in Grafana 12.5.0
+const components = {
+  PanelEditor: {
+    content: {
+      '12.5.0': 'data-testid New panel editor content',
+      '11.1.0': 'data-testid Panel editor content',
+      '9.5.0': 'Panel editor content',
+    },
+  },
+};
+```
+
+**Important rules for selectors:**
+
+- Never delete selectors. Even if unused in the Grafana repo, they may be used by external plugins.
+- Only create new selectors for genuinely new UI. If you're changing existing UI that already has a selector, reuse it.
+- Prefer string selectors over function selectors.
+
+### 3. Raise a PR in plugin-e2e (last resort)
+
+If the UI changed so fundamentally that no existing selector can be reused (e.g. an entirely new interaction flow replaced an old one), you may need to update `@grafana/plugin-e2e` itself. In this case:
+
+1. Raise a PR in [grafana/plugin-tools](https://github.com/grafana/plugin-tools) to update the affected page model or fixture in `@grafana/plugin-e2e`.
+2. Follow the [contributing guide for fixing broken test scenarios](https://github.com/grafana/plugin-tools/blob/main/packages/plugin-e2e/CONTRIBUTING.md#how-to-fix-broken-test-scenarios-after-changes-in-grafana).
+3. Once the new `@grafana/plugin-e2e` version is published and updated in the Grafana repo, update the test here if needed.
+
+This should be rare. Most UI changes can be handled by steps 1 or 2.
+
+## Reference
+
+- **E2E selectors**: `packages/grafana-e2e-selectors/src/selectors/` ([README](../../../packages/grafana-e2e-selectors/src/selectors/README.md))
+- **`@grafana/plugin-e2e` API types**: `node_modules/@grafana/plugin-e2e/dist/index.d.ts`
+- **Contributing guide**: [How to fix broken test scenarios after changes in Grafana](https://github.com/grafana/plugin-tools/blob/main/packages/plugin-e2e/CONTRIBUTING.md#how-to-fix-broken-test-scenarios-after-changes-in-grafana)
+- **Playwright config**: `playwright.config.ts` (projects `admin` and `viewer`)

--- a/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/appPage.spec.ts
+++ b/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/appPage.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@grafana/plugin-e2e';
+
+import { formatExpectError } from '../errors';
+
+const EXTENSIONS_TEST_APP = 'grafana-extensionstest-app';
+
+test.describe(
+  'plugin-e2e-api-tests admin',
+  {
+    tag: ['@plugins'],
+  },
+  () => {
+    test.describe('gotoAppConfigPage', () => {
+      test('should navigate to app config page', async ({ gotoAppConfigPage, page }) => {
+        const configPage = await gotoAppConfigPage({ pluginId: EXTENSIONS_TEST_APP });
+        await expect(page.url(), formatExpectError('Expected URL to contain app config path')).toContain(
+          `/plugins/${EXTENSIONS_TEST_APP}`
+        );
+      });
+    });
+
+    test.describe('gotoAppPage', () => {
+      test('should navigate to app page with default path', async ({ gotoAppPage, page }) => {
+        const appPage = await gotoAppPage({ pluginId: EXTENSIONS_TEST_APP });
+        await expect(page.url(), formatExpectError('Expected URL to contain app page path')).toContain(
+          `/a/${EXTENSIONS_TEST_APP}`
+        );
+      });
+
+      test('should navigate to app page with custom path', async ({ gotoAppPage, page }) => {
+        const appPage = await gotoAppPage({ pluginId: EXTENSIONS_TEST_APP, path: '/added-links' });
+        await expect(page.url(), formatExpectError('Expected URL to contain the custom app page path')).toContain(
+          `/a/${EXTENSIONS_TEST_APP}/added-links`
+        );
+      });
+    });
+
+    test.describe('AppPage', () => {
+      test('goto should navigate to a specific app page path', async ({ gotoAppPage, page }) => {
+        const appPage = await gotoAppPage({ pluginId: EXTENSIONS_TEST_APP });
+        await appPage.goto({ path: '/exposed-components' });
+        await expect(page.url(), formatExpectError('Expected URL to contain the navigated path')).toContain(
+          `/a/${EXTENSIONS_TEST_APP}/exposed-components`
+        );
+      });
+    });
+  }
+);

--- a/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/colorPicker.spec.ts
+++ b/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/colorPicker.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@grafana/plugin-e2e';
+
+import { formatExpectError } from '../errors';
+
+const TEST_PANEL_VIZ_NAME = 'Grafana E2ETest Panel';
+
+test.describe(
+  'plugin-e2e-api-tests admin',
+  {
+    tag: ['@plugins'],
+  },
+  () => {
+    test.describe('ColorPicker', () => {
+      test('should select a color using hex value', async ({ panelEditPage }) => {
+        await panelEditPage.setVisualization(TEST_PANEL_VIZ_NAME);
+        const customOptions = panelEditPage.getCustomOptions('Grafana E2ETest Panel');
+        const colorPicker = customOptions.getColorPicker('Circle color');
+
+        await colorPicker.selectOption('#FF5733');
+        await expect(
+          colorPicker,
+          formatExpectError('Expected color picker to have the selected hex color')
+        ).toHaveColor('#FF5733');
+      });
+
+      test('should select a color using rgb value', async ({ panelEditPage }) => {
+        await panelEditPage.setVisualization(TEST_PANEL_VIZ_NAME);
+        const customOptions = panelEditPage.getCustomOptions('Grafana E2ETest Panel');
+        const colorPicker = customOptions.getColorPicker('Circle color');
+
+        await colorPicker.selectOption('rgb(0, 128, 255)');
+        await expect(
+          colorPicker,
+          formatExpectError('Expected color picker to have the selected rgb color')
+        ).toHaveColor('rgb(0, 128, 255)');
+      });
+    });
+  }
+);

--- a/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/colorPicker.spec.ts
+++ b/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/colorPicker.spec.ts
@@ -20,7 +20,7 @@ test.describe(
         await expect(
           colorPicker,
           formatExpectError('Expected color picker to have the selected hex color')
-        ).toHaveColor('#FF5733');
+        ).toHaveColor('#ff5733');
       });
 
       test('should select a color using rgb value', async ({ panelEditPage }) => {
@@ -32,7 +32,7 @@ test.describe(
         await expect(
           colorPicker,
           formatExpectError('Expected color picker to have the selected rgb color')
-        ).toHaveColor('rgb(0, 128, 255)');
+        ).toHaveColor('#0080ff');
       });
     });
   }

--- a/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/dashboard.spec.ts
+++ b/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/dashboard.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@grafana/plugin-e2e';
 
+import { formatExpectError } from '../errors';
+
 const REACT_TABLE_DASHBOARD = { uid: 'U_bZIMRMk' };
 
 test.describe(
@@ -18,6 +20,21 @@ test.describe(
       const panelEditPage = await dashboardPage.addPanel();
       await expect(panelEditPage.panel.locator).toBeVisible();
       await expect(page.url()).toContain('editPanel');
+    });
+
+    test('getPanelById should return a panel by its id', async ({ gotoDashboardPage }) => {
+      const dashboardPage = await gotoDashboardPage(REACT_TABLE_DASHBOARD);
+      const panel = dashboardPage.getPanelById('4');
+      await expect(
+        panel.locator,
+        formatExpectError('Expected panel with id 4 to be visible on the dashboard')
+      ).toBeVisible();
+    });
+
+    test('refreshDashboard should refresh the dashboard', async ({ gotoDashboardPage }) => {
+      const dashboardPage = await gotoDashboardPage(REACT_TABLE_DASHBOARD);
+      // refreshDashboard clicks the refresh button - it should not throw
+      await dashboardPage.refreshDashboard();
     });
   }
 );

--- a/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelEditPage.spec.ts
+++ b/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelEditPage.spec.ts
@@ -210,5 +210,49 @@ test.describe(
       await panelEditPage.backToDashboard();
       await expect(page.url()).not.toContain('editPanel');
     });
+
+    test.describe('getVisualizationName', () => {
+      test('should return the current visualization name', async ({ panelEditPage }) => {
+        await panelEditPage.setVisualization(TABLE_VIZ_NAME);
+        await expect(
+          panelEditPage.getVisualizationName(),
+          formatExpectError('Expected getVisualizationName to return the current visualization')
+        ).toHaveText(TABLE_VIZ_NAME);
+      });
+
+      test('should update after changing visualization', async ({ panelEditPage }) => {
+        await panelEditPage.setVisualization(TABLE_VIZ_NAME);
+        await expect(panelEditPage.getVisualizationName()).toHaveText(TABLE_VIZ_NAME);
+        await panelEditPage.setVisualization(TIME_SERIES_VIZ_NAME);
+        await expect(
+          panelEditPage.getVisualizationName(),
+          formatExpectError('Expected visualization name to update after changing visualization')
+        ).toHaveText(TIME_SERIES_VIZ_NAME);
+      });
+    });
+
+    test.describe('PanelEditOptionsGroup', () => {
+      test('should expand and collapse options group', async ({ panelEditPage }) => {
+        await panelEditPage.setVisualization(TIME_SERIES_VIZ_NAME);
+        const graphStyles = panelEditPage.getCustomOptions('Graph styles');
+
+        await expect(
+          await graphStyles.isExpanded(),
+          formatExpectError('Expected Graph styles options group to be expanded by default')
+        ).toBe(true);
+
+        await graphStyles.collapse();
+        await expect(
+          await graphStyles.isExpanded(),
+          formatExpectError('Expected Graph styles options group to be collapsed')
+        ).toBe(false);
+
+        await graphStyles.expand();
+        await expect(
+          await graphStyles.isExpanded(),
+          formatExpectError('Expected Graph styles options group to be expanded after expanding')
+        ).toBe(true);
+      });
+    });
   }
 );

--- a/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/timeRange.spec.ts
+++ b/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/timeRange.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@grafana/plugin-e2e';
+
+import { formatExpectError } from '../errors';
+
+const REACT_TABLE_DASHBOARD = { uid: 'U_bZIMRMk' };
+
+test.describe(
+  'plugin-e2e-api-tests admin',
+  {
+    tag: ['@plugins'],
+  },
+  () => {
+    test.describe('dashboard time range', () => {
+      test('should set relative time range on existing dashboard', async ({ gotoDashboardPage }) => {
+        const dashboardPage = await gotoDashboardPage(REACT_TABLE_DASHBOARD);
+        await dashboardPage.timeRange.set({ from: 'now-6h', to: 'now' });
+        await expect(
+          dashboardPage.ctx.page.getByLabel('Time range selected'),
+          formatExpectError('Expected time range picker to display the selected relative time range')
+        ).toContainText('Last 6 hours');
+      });
+
+      test('should set absolute time range on existing dashboard', async ({ gotoDashboardPage }) => {
+        const dashboardPage = await gotoDashboardPage(REACT_TABLE_DASHBOARD);
+        await dashboardPage.timeRange.set({ from: '2025-01-01 00:00:00', to: '2025-01-01 23:59:59' });
+        await expect(
+          dashboardPage.ctx.page.getByLabel('Time range selected'),
+          formatExpectError('Expected time range picker to display the selected absolute time range')
+        ).toBeVisible();
+      });
+
+      test('should set time range with time zone on existing dashboard', async ({ gotoDashboardPage }) => {
+        const dashboardPage = await gotoDashboardPage(REACT_TABLE_DASHBOARD);
+        await dashboardPage.timeRange.set({ from: 'now-1h', to: 'now', zone: 'Europe/Stockholm' });
+        await expect(
+          dashboardPage.ctx.page.getByLabel('Time range selected'),
+          formatExpectError('Expected time range picker to display the selected time range with time zone')
+        ).toContainText('Last 1 hour');
+      });
+    });
+
+    test.describe('panel edit time range', () => {
+      test('should set relative time range on panel edit page', async ({ panelEditPage }) => {
+        await panelEditPage.timeRange.set({ from: 'now-12h', to: 'now' });
+        await expect(
+          panelEditPage.ctx.page.getByLabel('Time range selected'),
+          formatExpectError('Expected time range picker to display the selected relative time range')
+        ).toContainText('Last 12 hours');
+      });
+    });
+  }
+);

--- a/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/variablePage.spec.ts
+++ b/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/variablePage.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@grafana/plugin-e2e';
+
+import { formatExpectError } from '../errors';
+
+test.describe(
+  'plugin-e2e-api-tests admin',
+  {
+    tag: ['@plugins'],
+  },
+  () => {
+    test.describe('VariablePage', () => {
+      test('clickAddNew should navigate to variable edit page', async ({ variablePage }) => {
+        await variablePage.goto();
+        const variableEditPage = await variablePage.clickAddNew();
+        await expect(
+          variableEditPage.ctx.page.url(),
+          formatExpectError('Expected URL to contain the new variable path')
+        ).toContain('variables');
+      });
+    });
+  }
+);

--- a/e2e-playwright/test-plugins/grafana-test-panel/module.ts
+++ b/e2e-playwright/test-plugins/grafana-test-panel/module.ts
@@ -20,6 +20,12 @@ export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setPanelOption
       name: t('panel.options.showSeriesCount.name', 'Show series counter'),
       defaultValue: false,
     })
+    .addColorPicker({
+      path: 'circleColor',
+      name: t('panel.options.circleColor.name', 'Circle color'),
+      description: t('panel.options.circleColor.description', 'Color of the circle'),
+      defaultValue: 'red',
+    })
     .addRadio({
       path: 'seriesCountSize',
       defaultValue: 'sm',

--- a/e2e-playwright/test-plugins/grafana-test-panel/types.ts
+++ b/e2e-playwright/test-plugins/grafana-test-panel/types.ts
@@ -4,4 +4,5 @@ export interface SimpleOptions {
   text: string;
   showSeriesCount: boolean;
   seriesCountSize: SeriesSize;
+  circleColor: string;
 }

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@emotion/eslint-plugin": "11.12.0",
     "@grafana/eslint-config": "8.2.0",
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules",
-    "@grafana/plugin-e2e": "3.4.0",
+    "@grafana/plugin-e2e": "3.4.5-canary.2527.22939830405.0",
     "@grafana/test-utils": "workspace:*",
     "@manypkg/get-packages": "^3.0.0",
     "@npmcli/package-json": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@emotion/eslint-plugin": "11.12.0",
     "@grafana/eslint-config": "8.2.0",
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules",
-    "@grafana/plugin-e2e": "3.4.5-canary.2527.22939830405.0",
+    "@grafana/plugin-e2e": "3.4.5-canary.2527.22944441661.0",
     "@grafana/test-utils": "workspace:*",
     "@manypkg/get-packages": "^3.0.0",
     "@npmcli/package-json": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@emotion/eslint-plugin": "11.12.0",
     "@grafana/eslint-config": "8.2.0",
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules",
-    "@grafana/plugin-e2e": "3.4.6-canary.2527.22956446261.0",
+    "@grafana/plugin-e2e": "3.4.7",
     "@grafana/test-utils": "workspace:*",
     "@manypkg/get-packages": "^3.0.0",
     "@npmcli/package-json": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@emotion/eslint-plugin": "11.12.0",
     "@grafana/eslint-config": "8.2.0",
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules",
-    "@grafana/plugin-e2e": "3.4.5-canary.2527.22944441661.0",
+    "@grafana/plugin-e2e": "3.4.6-canary.2527.22956446261.0",
     "@grafana/test-utils": "workspace:*",
     "@manypkg/get-packages": "^3.0.0",
     "@npmcli/package-json": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3730,11 +3730,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/plugin-e2e@npm:3.4.5-canary.2527.22939830405.0":
-  version: 3.4.5-canary.2527.22939830405.0
-  resolution: "@grafana/plugin-e2e@npm:3.4.5-canary.2527.22939830405.0"
+"@grafana/plugin-e2e@npm:3.4.5-canary.2527.22944441661.0":
+  version: 3.4.5-canary.2527.22944441661.0
+  resolution: "@grafana/plugin-e2e@npm:3.4.5-canary.2527.22944441661.0"
   dependencies:
-    "@grafana/e2e-selectors": "npm:13.0.0-22732949497"
+    "@grafana/e2e-selectors": "npm:13.0.0-22898798261"
     semver: "npm:^7.5.4"
     uuid: "npm:^13.0.0"
     yaml: "npm:^2.3.4"
@@ -3744,7 +3744,7 @@ __metadata:
   peerDependenciesMeta:
     "@axe-core/playwright":
       optional: true
-  checksum: 10/af2f29509cc28d0543af47477a6fab37a731ff393dd907fbc6b54cfd92d5f64a471f4e26c76075b06a9ba8b23a0988c6e44c581056a2d47731834fc090703b7d
+  checksum: 10/68b2ba549eeacc2537998a4c7f0ed7bf6c44bc7ab57bcf417a0940603b588d132dd10b9393c6b5ddc098e528a40bee59f812cd05afa00c9f7b382aa5fd1c6f08
   languageName: node
   linkType: hard
 
@@ -20111,7 +20111,7 @@ __metadata:
     "@grafana/llm": "npm:1.0.3"
     "@grafana/monaco-logql": "npm:^0.0.8"
     "@grafana/o11y-ds-frontend": "workspace:*"
-    "@grafana/plugin-e2e": "npm:3.4.5-canary.2527.22939830405.0"
+    "@grafana/plugin-e2e": "npm:3.4.5-canary.2527.22944441661.0"
     "@grafana/plugin-ui": "npm:^0.13.1"
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3730,9 +3730,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/plugin-e2e@npm:3.4.5-canary.2527.22944441661.0":
-  version: 3.4.5-canary.2527.22944441661.0
-  resolution: "@grafana/plugin-e2e@npm:3.4.5-canary.2527.22944441661.0"
+"@grafana/plugin-e2e@npm:3.4.6-canary.2527.22956446261.0":
+  version: 3.4.6-canary.2527.22956446261.0
+  resolution: "@grafana/plugin-e2e@npm:3.4.6-canary.2527.22956446261.0"
   dependencies:
     "@grafana/e2e-selectors": "npm:13.0.0-22898798261"
     semver: "npm:^7.5.4"
@@ -3744,7 +3744,7 @@ __metadata:
   peerDependenciesMeta:
     "@axe-core/playwright":
       optional: true
-  checksum: 10/68b2ba549eeacc2537998a4c7f0ed7bf6c44bc7ab57bcf417a0940603b588d132dd10b9393c6b5ddc098e528a40bee59f812cd05afa00c9f7b382aa5fd1c6f08
+  checksum: 10/21d9bd2ed468b09354777d10d811e09aff0b4ecded80c77dc2a68bad721d7edb04e05c2a5b8a6b1a25fa9d456d2eea15026d33e5ee5ca9547cb032758d51f430
   languageName: node
   linkType: hard
 
@@ -20111,7 +20111,7 @@ __metadata:
     "@grafana/llm": "npm:1.0.3"
     "@grafana/monaco-logql": "npm:^0.0.8"
     "@grafana/o11y-ds-frontend": "workspace:*"
-    "@grafana/plugin-e2e": "npm:3.4.5-canary.2527.22944441661.0"
+    "@grafana/plugin-e2e": "npm:3.4.6-canary.2527.22956446261.0"
     "@grafana/plugin-ui": "npm:^0.13.1"
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3730,11 +3730,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/plugin-e2e@npm:3.4.6-canary.2527.22956446261.0":
-  version: 3.4.6-canary.2527.22956446261.0
-  resolution: "@grafana/plugin-e2e@npm:3.4.6-canary.2527.22956446261.0"
+"@grafana/plugin-e2e@npm:3.4.7":
+  version: 3.4.7
+  resolution: "@grafana/plugin-e2e@npm:3.4.7"
   dependencies:
-    "@grafana/e2e-selectors": "npm:13.0.0-22898798261"
+    "@grafana/e2e-selectors": "npm:13.0.0-22967232448"
     semver: "npm:^7.5.4"
     uuid: "npm:^13.0.0"
     yaml: "npm:^2.3.4"
@@ -3744,7 +3744,7 @@ __metadata:
   peerDependenciesMeta:
     "@axe-core/playwright":
       optional: true
-  checksum: 10/21d9bd2ed468b09354777d10d811e09aff0b4ecded80c77dc2a68bad721d7edb04e05c2a5b8a6b1a25fa9d456d2eea15026d33e5ee5ca9547cb032758d51f430
+  checksum: 10/da5aa668882d7d827c94f837a21c4764c1417830b1759f8e17a75664e1df341b22167586ed52c8a715ea0365de1267e1f60d335bd3f469532566ad5515036f64
   languageName: node
   linkType: hard
 
@@ -20111,7 +20111,7 @@ __metadata:
     "@grafana/llm": "npm:1.0.3"
     "@grafana/monaco-logql": "npm:^0.0.8"
     "@grafana/o11y-ds-frontend": "workspace:*"
-    "@grafana/plugin-e2e": "npm:3.4.6-canary.2527.22956446261.0"
+    "@grafana/plugin-e2e": "npm:3.4.7"
     "@grafana/plugin-ui": "npm:^0.13.1"
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3730,19 +3730,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/plugin-e2e@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@grafana/plugin-e2e@npm:3.4.0"
+"@grafana/plugin-e2e@npm:3.4.5-canary.2527.22939830405.0":
+  version: 3.4.5-canary.2527.22939830405.0
+  resolution: "@grafana/plugin-e2e@npm:3.4.5-canary.2527.22939830405.0"
   dependencies:
-    "@grafana/e2e-selectors": "npm:12.4.0-21983999378"
+    "@grafana/e2e-selectors": "npm:13.0.0-22732949497"
     semver: "npm:^7.5.4"
     uuid: "npm:^13.0.0"
     yaml: "npm:^2.3.4"
   peerDependencies:
     "@axe-core/playwright": ^4.11.1
     "@playwright/test": ^1.52.0
-    axe-core: ^4.11.1
-  checksum: 10/61c46fa4d39202deec7eba598a481a172b86a67ac1e788a4c7a23dc54f625526ad18cfe5d2697a0f2abb1b4a4c4b1283fdfdee1e766227cc739b83dea851a2c5
+  peerDependenciesMeta:
+    "@axe-core/playwright":
+      optional: true
+  checksum: 10/af2f29509cc28d0543af47477a6fab37a731ff393dd907fbc6b54cfd92d5f64a471f4e26c76075b06a9ba8b23a0988c6e44c581056a2d47731834fc090703b7d
   languageName: node
   linkType: hard
 
@@ -20109,7 +20111,7 @@ __metadata:
     "@grafana/llm": "npm:1.0.3"
     "@grafana/monaco-logql": "npm:^0.0.8"
     "@grafana/o11y-ds-frontend": "workspace:*"
-    "@grafana/plugin-e2e": "npm:3.4.0"
+    "@grafana/plugin-e2e": "npm:3.4.5-canary.2527.22939830405.0"
     "@grafana/plugin-ui": "npm:^0.13.1"
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"


### PR DESCRIPTION
**What is this feature?**

This PR adds more e2e tests for plugin-e2e. Also adds an `AGENTS.md` explaining how to fix breakages. 

**Why do we need this feature?**

These APIs depend on Grafana UI selectors and interaction patterns. Without forward-compat tests, a Grafana UI change could silently break plugin e2e testing for every plugin author using `@grafana/plugin-e2e`.

**Who is this feature for?**

Plugin devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
