### PR TITLE
Accessibility: Add `aria-pressed` state to "Show only overrides" button

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelOptionsPane.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelOptionsPane.test.tsx
@@ -1,11 +1,18 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from 'test/test-utils';
+
 import { PanelPlugin } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
+import { VizPanel } from '@grafana/scenes';
 import { OptionFilter } from 'app/features/dashboard/components/PanelEditor/OptionsPaneOptions';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 
 import { DashboardScene } from '../scene/DashboardScene';
+import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
 import { DashboardModelCompatibilityWrapper } from '../utils/DashboardModelCompatibilityWrapper';
+import { activateFullSceneTree } from '../utils/test-utils';
 import { findVizPanelByKey } from '../utils/utils';
 import * as utils from '../utils/utils';
 
@@ -14,12 +21,39 @@ import { testDashboard } from './testfiles/testDashboard';
 
 jest.spyOn(utils, 'getDashboardSceneFor').mockReturnValue(new DashboardScene({}));
 
+const pluginWithFieldConfig = getPanelPlugin({
+  id: 'TestPanel',
+}).useFieldConfig({
+  useCustomConfig: (b) => {
+    b.addBooleanSwitch({
+      name: 'CustomBool',
+      path: 'CustomBool',
+    });
+  },
+});
+
 let pluginToLoad: PanelPlugin | undefined;
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getPluginImportUtils: () => ({
-    getPanelPluginFromCache: jest.fn(() => pluginToLoad),
+    getPanelPluginFromCache: jest.fn(() => pluginToLoad ?? pluginWithFieldConfig),
+  }),
+}));
+
+jest.mock('@grafana/runtime/internal', () => ({
+  ...jest.requireActual('@grafana/runtime/internal'),
+  useListedPanelPluginMetas: jest.fn().mockReturnValue({
+    loading: false,
+    error: undefined,
+    value: [
+      {
+        id: 'TestPanel',
+        name: 'Test Panel',
+        sort: 0,
+        info: { logos: { small: '' } },
+      },
+    ],
   }),
 }));
 
@@ -189,6 +223,39 @@ describe('PanelOptionsPane', () => {
       });
 
       expect(mockOnFieldConfigChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Show only overrides button', () => {
+    it('Should set aria-pressed correctly when toggling', async () => {
+      const panel = new VizPanel({
+        key: 'panel-1',
+        pluginId: 'TestPanel',
+        title: 'Test',
+        fieldConfig: { defaults: {}, overrides: [] },
+      });
+
+      new DashboardGridItem({ body: panel });
+
+      const optionsPane = new PanelOptionsPane({
+        panelRef: panel.getRef(),
+        searchQuery: '',
+        listMode: OptionFilter.All,
+      });
+
+      activateFullSceneTree(optionsPane);
+      panel.activate();
+
+      render(<optionsPane.Component model={optionsPane} />);
+
+      const overridesButton = screen.getByRole('button', { name: 'Show only overrides' });
+      expect(overridesButton).toHaveAttribute('aria-pressed', 'false');
+
+      await userEvent.click(overridesButton);
+      expect(overridesButton).toHaveAttribute('aria-pressed', 'true');
+
+      await userEvent.click(overridesButton);
+      expect(overridesButton).toHaveAttribute('aria-pressed', 'false');
     });
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelOptionsPane.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelOptionsPane.tsx
@@ -205,6 +205,7 @@ function PanelOptionsPaneComponent({ model }: SceneComponentProps<PanelOptionsPa
                   onClick={() => {
                     model.onSetListMode(onlyOverrides ? OptionFilter.All : OptionFilter.Overrides);
                   }}
+                  aria-pressed={onlyOverrides}
                 />
               )}
               <Button


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- adds the `aria-pressed` state to the "Show only overrides" button
- adds a unit test to prevent regressions

**Why do we need this feature?**

- better a11y

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/118776

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
