### PR TITLE
IAM: Add kind field to TeamBinding subject

### DIFF
--- a/apps/iam/kinds/v0alpha1/teambindingspec.cue
+++ b/apps/iam/kinds/v0alpha1/teambindingspec.cue
@@ -2,6 +2,8 @@ package v0alpha1
 
 TeamBindingSpec: {
 	#Subject: {
+		// kind of the identity
+		kind: "User"
 		// uid of the identity
 		name: string
 	}

--- a/apps/iam/pkg/apis/iam/v0alpha1/teambinding_spec_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/teambinding_spec_gen.go
@@ -4,13 +4,17 @@ package v0alpha1
 
 // +k8s:openapi-gen=true
 type TeamBindingspecSubject struct {
+	// kind of the identity
+	Kind string `json:"kind"`
 	// uid of the identity
 	Name string `json:"name"`
 }
 
 // NewTeamBindingspecSubject creates a new TeamBindingspecSubject object.
 func NewTeamBindingspecSubject() *TeamBindingspecSubject {
-	return &TeamBindingspecSubject{}
+	return &TeamBindingspecSubject{
+		Kind: "User",
+	}
 }
 
 // OpenAPIModelName returns the OpenAPI model name for TeamBindingspecSubject.

--- a/apps/iam/pkg/apis/iam/v0alpha1/zz_openapi_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/zz_openapi_gen.go
@@ -2431,6 +2431,14 @@ func schema_pkg_apis_iam_v0alpha1_TeamBindingspecSubject(ref common.ReferenceCal
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "kind of the identity",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "uid of the identity",
@@ -2440,7 +2448,7 @@ func schema_pkg_apis_iam_v0alpha1_TeamBindingspecSubject(ref common.ReferenceCal
 						},
 					},
 				},
-				Required: []string{"name"},
+				Required: []string{"kind", "name"},
 			},
 		},
 	}

--- a/packages/grafana-api-clients/src/clients/rtkq/iam/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/iam/v0alpha1/endpoints.gen.ts
@@ -2062,6 +2062,8 @@ export type GithubCom1Grafana1Grafana1Pkg1Apis1Iam1V0Alpha1SsoSettingList = {
   metadata?: ListMeta;
 };
 export type TeamBindingspecSubject = {
+  /** kind of the identity */
+  kind: string;
   /** uid of the identity */
   name: string;
 };

--- a/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
@@ -5982,8 +5982,13 @@
       },
       "TeamBindingspecSubject": {
         "type": "object",
-        "required": ["name"],
+        "required": ["kind", "name"],
         "properties": {
+          "kind": {
+            "description": "kind of the identity",
+            "type": "string",
+            "default": ""
+          },
           "name": {
             "description": "uid of the identity",
             "type": "string",

--- a/pkg/registry/apis/iam/authorizer/team_binding_authorizer_test.go
+++ b/pkg/registry/apis/iam/authorizer/team_binding_authorizer_test.go
@@ -20,6 +20,7 @@ func newTeamBinding(teamName, name, subjectName string) *iamv0.TeamBinding {
 				Name: teamName,
 			},
 			Subject: iamv0.TeamBindingspecSubject{
+				Kind: "User",
 				Name: subjectName,
 			},
 		},

--- a/pkg/registry/apis/iam/team_binding_hooks_test.go
+++ b/pkg/registry/apis/iam/team_binding_hooks_test.go
@@ -32,6 +32,7 @@ func TestAfterTeamBindingCreate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-1",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -78,6 +79,7 @@ func TestAfterTeamBindingCreate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-2",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -129,6 +131,7 @@ func TestAfterTeamBindingCreate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-3",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -159,6 +162,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-1",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -175,6 +179,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-1",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -233,6 +238,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-1",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -249,6 +255,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-2",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -306,6 +313,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-1",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -322,6 +330,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-1",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -377,6 +386,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-1",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -393,6 +403,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-2",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -433,6 +444,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-1",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -449,6 +461,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-2",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -472,6 +485,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "", // Empty name will cause server-side error on delete
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -488,6 +502,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-2",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -550,6 +565,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-1",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -566,6 +582,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-1",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -601,6 +618,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-1",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -617,6 +635,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "", // Empty name - should cause early return
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -652,6 +671,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-1",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -668,6 +688,7 @@ func TestBeginTeamBindingUpdate(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-2",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -712,6 +733,7 @@ func TestAfterTeamBindingDelete(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-1",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -757,6 +779,7 @@ func TestAfterTeamBindingDelete(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-2",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -807,6 +830,7 @@ func TestAfterTeamBindingDelete(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-3",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{
@@ -830,6 +854,7 @@ func TestAfterTeamBindingDelete(t *testing.T) {
 			},
 			Spec: iamv0.TeamBindingSpec{
 				Subject: iamv0.TeamBindingspecSubject{
+					Kind: "User",
 					Name: "user-4",
 				},
 				TeamRef: iamv0.TeamBindingTeamRef{

--- a/pkg/registry/apis/iam/teambinding/store.go
+++ b/pkg/registry/apis/iam/teambinding/store.go
@@ -352,6 +352,7 @@ func mapToBindingObject(ns claims.NamespaceInfo, tm legacy.TeamMember) iamv0alph
 				Name: tm.TeamUID,
 			},
 			Subject: iamv0alpha1.TeamBindingspecSubject{
+				Kind: "User",
 				Name: tm.UserUID,
 			},
 			Permission: common.MapTeamPermission(tm.Permission),

--- a/pkg/registry/apis/iam/teambinding/validate.go
+++ b/pkg/registry/apis/iam/teambinding/validate.go
@@ -19,6 +19,10 @@ func ValidateOnCreate(ctx context.Context, obj *iamv0alpha1.TeamBinding) error {
 		return apierrors.NewBadRequest("invalid permission")
 	}
 
+	if obj.Spec.Subject.Kind != "User" {
+		return apierrors.NewBadRequest("subject kind must be User")
+	}
+
 	if obj.Spec.Subject.Name == "" {
 		return apierrors.NewBadRequest("subject is required")
 	}
@@ -38,6 +42,10 @@ func ValidateOnUpdate(ctx context.Context, obj, old *iamv0alpha1.TeamBinding) er
 
 	if obj.Spec.TeamRef.Name != old.Spec.TeamRef.Name {
 		return apierrors.NewBadRequest("teamRef is immutable")
+	}
+
+	if obj.Spec.Subject.Kind != "User" {
+		return apierrors.NewBadRequest("subject kind must be User")
 	}
 
 	if obj.Spec.Subject.Name != old.Spec.Subject.Name {

--- a/pkg/registry/apis/iam/teambinding/validate_test.go
+++ b/pkg/registry/apis/iam/teambinding/validate_test.go
@@ -28,6 +28,7 @@ func TestValidateOnCreate(t *testing.T) {
 			obj: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -39,6 +40,46 @@ func TestValidateOnCreate(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "invalid team binding - invalid subject kind",
+			requester: &identity.StaticRequester{
+				Type:    types.TypeUser,
+				OrgRole: identity.RoleAdmin,
+			},
+			obj: &iamv0alpha1.TeamBinding{
+				Spec: iamv0alpha1.TeamBindingSpec{
+					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "ServiceAccount",
+						Name: "test-user",
+					},
+					TeamRef: iamv0alpha1.TeamBindingTeamRef{
+						Name: "test-team",
+					},
+					Permission: iamv0alpha1.TeamBindingTeamPermissionAdmin,
+				},
+			},
+			want: apierrors.NewBadRequest("subject kind must be User"),
+		},
+		{
+			name: "invalid team binding - empty subject kind",
+			requester: &identity.StaticRequester{
+				Type:    types.TypeUser,
+				OrgRole: identity.RoleAdmin,
+			},
+			obj: &iamv0alpha1.TeamBinding{
+				Spec: iamv0alpha1.TeamBindingSpec{
+					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "",
+						Name: "test-user",
+					},
+					TeamRef: iamv0alpha1.TeamBindingTeamRef{
+						Name: "test-team",
+					},
+					Permission: iamv0alpha1.TeamBindingTeamPermissionAdmin,
+				},
+			},
+			want: apierrors.NewBadRequest("subject kind must be User"),
+		},
+		{
 			name: "invalid team binding - invalid permission",
 			requester: &identity.StaticRequester{
 				Type:    types.TypeUser,
@@ -47,6 +88,7 @@ func TestValidateOnCreate(t *testing.T) {
 			obj: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -66,6 +108,7 @@ func TestValidateOnCreate(t *testing.T) {
 			obj: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -85,6 +128,7 @@ func TestValidateOnCreate(t *testing.T) {
 			obj: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -101,6 +145,7 @@ func TestValidateOnCreate(t *testing.T) {
 			obj: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -139,6 +184,7 @@ func TestValidateOnUpdate(t *testing.T) {
 			old: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -151,6 +197,7 @@ func TestValidateOnUpdate(t *testing.T) {
 			obj: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -163,7 +210,7 @@ func TestValidateOnUpdate(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "valid update - no changes",
+			name: "invalid update - invalid subject kind",
 			requester: &identity.StaticRequester{
 				Type:    types.TypeUser,
 				OrgRole: identity.RoleAdmin,
@@ -171,6 +218,7 @@ func TestValidateOnUpdate(t *testing.T) {
 			old: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -183,6 +231,41 @@ func TestValidateOnUpdate(t *testing.T) {
 			obj: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "ServiceAccount",
+						Name: "test-user",
+					},
+					TeamRef: iamv0alpha1.TeamBindingTeamRef{
+						Name: "test-team",
+					},
+					Permission: iamv0alpha1.TeamBindingTeamPermissionAdmin,
+					External:   false,
+				},
+			},
+			want: apierrors.NewBadRequest("subject kind must be User"),
+		},
+		{
+			name: "valid update - no changes",
+			requester: &identity.StaticRequester{
+				Type:    types.TypeUser,
+				OrgRole: identity.RoleAdmin,
+			},
+			old: &iamv0alpha1.TeamBinding{
+				Spec: iamv0alpha1.TeamBindingSpec{
+					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
+						Name: "test-user",
+					},
+					TeamRef: iamv0alpha1.TeamBindingTeamRef{
+						Name: "test-team",
+					},
+					Permission: iamv0alpha1.TeamBindingTeamPermissionAdmin,
+					External:   false,
+				},
+			},
+			obj: &iamv0alpha1.TeamBinding{
+				Spec: iamv0alpha1.TeamBindingSpec{
+					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -203,6 +286,7 @@ func TestValidateOnUpdate(t *testing.T) {
 			old: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -215,6 +299,7 @@ func TestValidateOnUpdate(t *testing.T) {
 			obj: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -235,6 +320,7 @@ func TestValidateOnUpdate(t *testing.T) {
 			old: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -247,6 +333,7 @@ func TestValidateOnUpdate(t *testing.T) {
 			obj: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user-updated",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -267,6 +354,7 @@ func TestValidateOnUpdate(t *testing.T) {
 			old: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -279,6 +367,7 @@ func TestValidateOnUpdate(t *testing.T) {
 			obj: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -299,6 +388,7 @@ func TestValidateOnUpdate(t *testing.T) {
 			old: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -311,6 +401,7 @@ func TestValidateOnUpdate(t *testing.T) {
 			obj: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -327,6 +418,7 @@ func TestValidateOnUpdate(t *testing.T) {
 			old: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -339,6 +431,7 @@ func TestValidateOnUpdate(t *testing.T) {
 			obj: &iamv0alpha1.TeamBinding{
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "test-user",
 					},
 					TeamRef: iamv0alpha1.TeamBindingTeamRef{

--- a/pkg/services/authz/zanzana/server/reconciler/translators_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/translators_test.go
@@ -135,7 +135,7 @@ func TestTranslateTeamBindingToTuples(t *testing.T) {
 			tb := &iamv0.TeamBinding{
 				ObjectMeta: metav1.ObjectMeta{Name: "tb-test"},
 				Spec: iamv0.TeamBindingSpec{
-					Subject:    iamv0.TeamBindingspecSubject{Name: "user1"},
+					Subject:    iamv0.TeamBindingspecSubject{Kind: "User", Name: "user1"},
 					TeamRef:    iamv0.TeamBindingTeamRef{Name: "teamA"},
 					Permission: tt.permission,
 				},
@@ -1124,7 +1124,7 @@ func TestTranslatedTuplesAreSchemaValid(t *testing.T) {
 				tb := &iamv0.TeamBinding{
 					ObjectMeta: metav1.ObjectMeta{Name: "tb-schema-test"},
 					Spec: iamv0.TeamBindingSpec{
-						Subject:    iamv0.TeamBindingspecSubject{Name: "user1"},
+						Subject:    iamv0.TeamBindingspecSubject{Kind: "User", Name: "user1"},
 						TeamRef:    iamv0.TeamBindingTeamRef{Name: "teamA"},
 						Permission: perm,
 					},

--- a/pkg/services/team/teamapi/team_members_adapter.go
+++ b/pkg/services/team/teamapi/team_members_adapter.go
@@ -262,6 +262,7 @@ func (tapi *TeamAPI) createTeamBindingsForUsers(
 			ObjectMeta: makeMetadata(namespace, user.UID, teamUID),
 			Spec: iamv0alpha1.TeamBindingSpec{
 				Subject: iamv0alpha1.TeamBindingspecSubject{
+					Kind: "User",
 					Name: user.UID,
 				},
 				TeamRef: iamv0alpha1.TeamBindingTeamRef{

--- a/pkg/services/team/teamapi/team_members_adapter_test.go
+++ b/pkg/services/team/teamapi/team_members_adapter_test.go
@@ -128,6 +128,7 @@ func TestCheckAndCreateBindingUpdate(t *testing.T) {
 				},
 				Spec: iamv0alpha1.TeamBindingSpec{
 					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
 						Name: "1",
 					},
 					Permission: iamv0alpha1.TeamBindingTeamPermissionMember,
@@ -258,6 +259,7 @@ func (s *testSetup) mockCreateBinding(userUID string, permission iamv0alpha1.Tea
 		},
 		Spec: iamv0alpha1.TeamBindingSpec{
 			Subject: iamv0alpha1.TeamBindingspecSubject{
+				Kind: "User",
 				Name: userUID,
 			},
 			TeamRef: iamv0alpha1.TeamBindingTeamRef{
@@ -295,6 +297,7 @@ func (s *testSetup) createExistingBinding(userUID string, permission iamv0alpha1
 		},
 		Spec: iamv0alpha1.TeamBindingSpec{
 			Subject: iamv0alpha1.TeamBindingspecSubject{
+				Kind: "User",
 				Name: userUID,
 			},
 			TeamRef: iamv0alpha1.TeamBindingTeamRef{

--- a/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
@@ -6473,9 +6473,15 @@
       "com.github.grafana.grafana.apps.iam.pkg.apis.iam.v0alpha1.TeamBindingspecSubject": {
         "type": "object",
         "required": [
+          "kind",
           "name"
         ],
         "properties": {
+          "kind": {
+            "description": "kind of the identity",
+            "type": "string",
+            "default": ""
+          },
           "name": {
             "description": "uid of the identity",
             "type": "string",


### PR DESCRIPTION
## Summary
- Adds a `kind: string` attribute to the TeamBinding resource's `#Subject` in the CUE schema, currently constrained to `"User"` only
- Ran `make generate` from `apps/iam` to regenerate Go types and OpenAPI schema
- Updated all code constructing `TeamBindingspecSubject` to include `Kind: "User"`
- Added validation in `ValidateOnCreate` and `ValidateOnUpdate` to reject any kind other than `"User"`
- Added test cases for invalid and empty subject kind

## Test plan
- [x] Unit tests pass (`teambinding`, `authorizer`, `teamapi`, `reconciler`)
- [x] Integration tests in `pkg/tests/apis/iam` pass (no TeamBinding-related failures)
- [x] Build compiles successfully


🤖 Generated with [Claude Code](https://claude.com/claude-code)