### PR TITLE
Elasticsearch: Move the ref update out of render body into a `useEffect` in `ElasticsearchVariableEditor.tsx`

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.tsx
@@ -46,7 +46,10 @@ const FieldMapping = (props: FieldMappingProps) => {
 
   // Track the actual query content to avoid re-querying when only meta changes
   const queryRef = useRef(query);
-  queryRef.current = query;
+
+  useEffect(() => {
+    queryRef.current = query;
+  });
 
   // Only re-run the query when the query content changes, not when meta (valueField/textField) changes
   const queryKey = useMemo(


### PR DESCRIPTION
Ports a fix from https://github.com/grafana/grafana-elasticsearch-datasource/pull/100, this caused errors in the externalised data source pipeline but didn't in the `grafana/grafana` pipeline for some reason.