### PR TITLE
chore: remove cloud-home-app condition from getAppPluginsToPreloadSync

### DIFF
--- a/public/app/features/plugins/extensions/appUtils.tsx
+++ b/public/app/features/plugins/extensions/appUtils.tsx
@@ -147,8 +147,5 @@ export function getAppPluginsToPreloadSync(apps: AppPluginConfig[]): AppPluginCo
     apps
   );
 
-  // TODO(@MattIPv4): cloud-home-app is deprecated and should not be preloaded
-  return apps.filter((app) => {
-    return app.id !== 'cloud-home-app' && (app.preload || dashboardPanelMenuPluginIds.includes(app.id));
-  });
+  return apps.filter((app) => app.preload || dashboardPanelMenuPluginIds.includes(app.id));
 }


### PR DESCRIPTION
**What is this feature?**

Removes the filter for cloud-home-app, which was introduced in #117017 as an interim solution, now that cloud-home-app has been fully deprovisioned from Grafana Cloud (https://grafana.com/whats-new/2026-03-02-removing-the-legacy-grafana-cloud-home-plugin/).

**Why do we need this feature?**

Clean code, condition no longer needed.

**Who is this feature for?**

Cloud.

**Which issue(s) does this PR fix?**:

cc https://github.com/grafana/hg-cloud-home-admin/issues/996 (🔐)