### PR TITLE
QueryEditor: Add missing events for `PanelEditNext`

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/Actions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/Actions.tsx
@@ -74,11 +74,11 @@ export function Actions({
       if (requiresDeleteConfirmation) {
         setShowDeleteConfirmation(true);
       } else {
-        trackCardAction('delete', item.type);
+        trackCardAction('delete', item.type, contentHeader ? 'content_header' : 'sidebar_card');
         onDelete();
       }
     },
-    [requiresDeleteConfirmation, onDelete, handleResetFocus, item.type]
+    [requiresDeleteConfirmation, onDelete, handleResetFocus, item.type, contentHeader]
   );
 
   const handleConfirmDelete = useCallback(() => {
@@ -86,11 +86,11 @@ export function Actions({
       return;
     }
 
-    trackCardAction('delete', item.type);
+    trackCardAction('delete', item.type, contentHeader ? 'content_header' : 'sidebar_card');
     onDelete();
     setShowDeleteConfirmation(false);
     handleResetFocus?.();
-  }, [onDelete, handleResetFocus, item.type]);
+  }, [onDelete, handleResetFocus, item.type, contentHeader]);
 
   const handleDismissModal = useCallback(() => {
     setShowDeleteConfirmation(false);
@@ -111,7 +111,7 @@ export function Actions({
         label: labels.duplicate,
         onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
           e.stopPropagation();
-          trackCardAction('duplicate', item.type);
+          trackCardAction('duplicate', item.type, contentHeader ? 'content_header' : 'sidebar_card');
           onDuplicate();
         },
       },
@@ -127,7 +127,7 @@ export function Actions({
         label: item.isHidden ? labels.show : labels.hide,
         onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
           e.stopPropagation();
-          trackCardAction('toggle_hide', item.type);
+          trackCardAction('toggle_hide', item.type, contentHeader ? 'content_header' : 'sidebar_card');
           onToggleHide();
         },
       },
@@ -146,6 +146,7 @@ export function Actions({
     onDelete,
     handleDelete,
     order,
+    contentHeader,
   ]);
 
   return (

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/Actions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/Actions.tsx
@@ -6,7 +6,7 @@ import { t } from '@grafana/i18n';
 import { Button, ConfirmModal, Icon, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { QUERY_EDITOR_COLORS, QUERY_EDITOR_TYPE_CONFIG, QueryEditorType } from './constants';
-import { trackCardAction } from './tracking';
+import { trackCardAction, CardActionSource } from './tracking';
 
 export interface ActionItem {
   name: string;
@@ -52,6 +52,7 @@ export function Actions({
   const config = QUERY_EDITOR_TYPE_CONFIG[item.type];
   const typeLabel = config.getLabel();
   const requiresDeleteConfirmation = config.deleteConfirmation;
+  const cardActionSource: CardActionSource = contentHeader ? 'content_header' : 'sidebar_card';
 
   const labels = useMemo(
     () => ({
@@ -74,11 +75,11 @@ export function Actions({
       if (requiresDeleteConfirmation) {
         setShowDeleteConfirmation(true);
       } else {
-        trackCardAction('delete', item.type, contentHeader ? 'content_header' : 'sidebar_card');
+        trackCardAction('delete', item.type, cardActionSource);
         onDelete();
       }
     },
-    [requiresDeleteConfirmation, onDelete, handleResetFocus, item.type, contentHeader]
+    [requiresDeleteConfirmation, onDelete, handleResetFocus, item.type, cardActionSource]
   );
 
   const handleConfirmDelete = useCallback(() => {
@@ -86,11 +87,11 @@ export function Actions({
       return;
     }
 
-    trackCardAction('delete', item.type, contentHeader ? 'content_header' : 'sidebar_card');
+    trackCardAction('delete', item.type, cardActionSource);
     onDelete();
     setShowDeleteConfirmation(false);
     handleResetFocus?.();
-  }, [onDelete, handleResetFocus, item.type, contentHeader]);
+  }, [onDelete, handleResetFocus, item.type, cardActionSource]);
 
   const handleDismissModal = useCallback(() => {
     setShowDeleteConfirmation(false);
@@ -111,7 +112,7 @@ export function Actions({
         label: labels.duplicate,
         onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
           e.stopPropagation();
-          trackCardAction('duplicate', item.type, contentHeader ? 'content_header' : 'sidebar_card');
+          trackCardAction('duplicate', item.type, cardActionSource);
           onDuplicate();
         },
       },
@@ -127,7 +128,7 @@ export function Actions({
         label: item.isHidden ? labels.show : labels.hide,
         onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
           e.stopPropagation();
-          trackCardAction('toggle_hide', item.type, contentHeader ? 'content_header' : 'sidebar_card');
+          trackCardAction('toggle_hide', item.type, cardActionSource);
           onToggleHide();
         },
       },
@@ -146,7 +147,7 @@ export function Actions({
     onDelete,
     handleDelete,
     order,
-    contentHeader,
+    cardActionSource,
   ]);
 
   return (

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Footer/QueryEditorFooter.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Footer/QueryEditorFooter.tsx
@@ -6,6 +6,7 @@ import { t, Trans } from '@grafana/i18n';
 import { Button, Icon, Stack, useStyles2 } from '@grafana/ui';
 
 import { FOOTER_HEIGHT, getQueryEditorColors, TIME_OPTION_PLACEHOLDER } from '../../constants';
+import { trackQueryOptionsToggle } from '../../tracking';
 import { useDatasourceContext, useQueryEditorUIContext, useQueryRunnerContext } from '../QueryEditorContext';
 import { QueryOptionField } from '../types';
 
@@ -71,10 +72,13 @@ export function QueryEditorFooter() {
 
     // Don't focus interval since it's read-only
     if (fieldId && fieldId !== QueryOptionField.interval) {
+      trackQueryOptionsToggle(true);
       openSidebar(fieldId);
     } else if (!isQueryOptionsOpen) {
+      trackQueryOptionsToggle(true);
       openSidebar();
     } else {
+      trackQueryOptionsToggle(false);
       closeSidebar();
     }
   };

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/EditableQueryName.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/EditableQueryName.tsx
@@ -6,6 +6,8 @@ import { t } from '@grafana/i18n';
 import { DataQuery } from '@grafana/schema';
 import { useStyles2, Input, FieldValidationMessage, Icon, Text } from '@grafana/ui';
 
+import { trackRenameInitiated } from '../../tracking';
+
 interface EditableQueryNameProps {
   query: DataQuery;
   queries: DataQuery[];
@@ -24,6 +26,7 @@ export function EditableQueryName({ query, queries, onQueryUpdate }: EditableQue
   );
 
   const onEditQuery = () => {
+    trackRenameInitiated();
     setIsEditing(true);
     setValidationError(null);
   };

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.tsx
@@ -7,6 +7,7 @@ import { ScrollContainer, useStyles2 } from '@grafana/ui';
 
 import { SegmentedToggle, SegmentedToggleProps } from '../../SegmentedToggle';
 import { QueryEditorType, SidebarSize } from '../../constants';
+import { trackSidebarViewChange } from '../../tracking';
 import { useAlertingContext, useQueryEditorUIContext } from '../QueryEditorContext';
 import { EMPTY_ALERT } from '../types';
 
@@ -26,6 +27,7 @@ export const Sidebar = memo(function Sidebar({ sidebarSize, setSidebarSize }: Si
   const { alertRules, loading } = useAlertingContext();
 
   const handleViewChange = (view: QueryEditorType) => {
+    trackSidebarViewChange(view);
     setSelectedAlert(view === QueryEditorType.Alert ? (alertRules[0] ?? EMPTY_ALERT) : null);
   };
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarHeaderActions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SidebarHeaderActions.tsx
@@ -6,6 +6,7 @@ import { t } from '@grafana/i18n';
 import { IconButton, useStyles2 } from '@grafana/ui';
 
 import { getQueryEditorColors, SidebarSize } from '../../constants';
+import { trackSidebarSizeToggle } from '../../tracking';
 
 interface SidebarHeaderActionsProps {
   sidebarSize: SidebarSize;
@@ -24,7 +25,10 @@ export function SidebarHeaderActions({ sidebarSize, setSidebarSize, children }: 
           name={isMini ? 'maximize-left' : 'compress-alt-left'}
           size="sm"
           variant="secondary"
-          onClick={() => setSidebarSize(isMini ? SidebarSize.Full : SidebarSize.Mini)}
+          onClick={() => {
+            trackSidebarSizeToggle(isMini ? 'expand' : 'collapse');
+            setSidebarSize(isMini ? SidebarSize.Full : SidebarSize.Mini);
+          }}
           aria-label={t('query-editor-next.sidebar.toggle-size', 'Toggle sidebar size')}
         />
         {children}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
@@ -112,10 +112,6 @@ export function trackFeedbackClick() {
   });
 }
 
-// ---------------------------------------------------------------------------
-// Sidebar
-// ---------------------------------------------------------------------------
-
 export function trackSidebarSizeToggle(direction: 'expand' | 'collapse') {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {
     action: 'toggle_sidebar_size',
@@ -130,20 +126,12 @@ export function trackSidebarViewChange(view: QueryEditorType) {
   });
 }
 
-// ---------------------------------------------------------------------------
-// Query options footer
-// ---------------------------------------------------------------------------
-
 export function trackQueryOptionsToggle(open: boolean) {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {
     action: 'toggle_query_options',
     open,
   });
 }
-
-// ---------------------------------------------------------------------------
-// Rename
-// ---------------------------------------------------------------------------
 
 export function trackRenameInitiated() {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
@@ -57,10 +57,15 @@ export function trackAddTransformationInitiated(source: AddCardSource) {
   });
 }
 
-export function trackCardAction(action: 'delete' | 'toggle_hide' | 'duplicate', itemType: QueryEditorType) {
+export function trackCardAction(
+  action: 'delete' | 'toggle_hide' | 'duplicate',
+  itemType: QueryEditorType,
+  source: 'content_header' | 'sidebar_card'
+) {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {
     action,
     item_type: itemType,
+    source,
   });
 }
 
@@ -104,5 +109,45 @@ export function trackBannerDismiss() {
 export function trackFeedbackClick() {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {
     action: 'click_feedback_link',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Sidebar
+// ---------------------------------------------------------------------------
+
+export function trackSidebarSizeToggle(direction: 'expand' | 'collapse') {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action: 'toggle_sidebar_size',
+    direction,
+  });
+}
+
+export function trackSidebarViewChange(view: QueryEditorType) {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action: 'change_sidebar_view',
+    view,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Query options footer
+// ---------------------------------------------------------------------------
+
+export function trackQueryOptionsToggle(open: boolean) {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action: 'toggle_query_options',
+    open,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Rename
+// ---------------------------------------------------------------------------
+
+export function trackRenameInitiated() {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action: 'rename_initiated',
+    item_type: QueryEditorType.Query,
   });
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
@@ -57,10 +57,12 @@ export function trackAddTransformationInitiated(source: AddCardSource) {
   });
 }
 
+export type CardActionSource = 'content_header' | 'sidebar_card';
+
 export function trackCardAction(
   action: 'delete' | 'toggle_hide' | 'duplicate',
   itemType: QueryEditorType,
-  source: 'content_header' | 'sidebar_card'
+  source: CardActionSource
 ) {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {
     action,

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -172,7 +172,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     borderTop: `1px solid ${theme.colors.border.weak}`,
   }),
   boxNestedExpanded: css({
-    marginBottom: theme.spacing(2),
+    marginBottom: theme.spacing(3),
   }),
   title: css({
     flexGrow: 1,
@@ -189,7 +189,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   header: css({
     display: 'flex',
     alignItems: 'center',
-    padding: theme.spacing(0.5, 1.5),
+    padding: theme.spacing(1, 1.5),
     color: theme.colors.text.primary,
     fontWeight: theme.typography.fontWeightMedium,
     cursor: 'pointer',
@@ -204,10 +204,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     color: theme.colors.text.primary,
   }),
   headerNested: css({
-    padding: theme.spacing(0.5, 0, 0.5, 0),
+    padding: theme.spacing(1, 0),
   }),
   body: css({
-    padding: theme.spacing(1, 2, 1, 2),
+    padding: theme.spacing(1.5, 2),
   }),
   titleDisabled: css({
     color: theme.colors.text.disabled,

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -172,7 +172,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     borderTop: `1px solid ${theme.colors.border.weak}`,
   }),
   boxNestedExpanded: css({
-    marginBottom: theme.spacing(3),
+    marginBottom: theme.spacing(2),
   }),
   title: css({
     flexGrow: 1,
@@ -189,7 +189,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   header: css({
     display: 'flex',
     alignItems: 'center',
-    padding: theme.spacing(1, 1.5),
+    padding: theme.spacing(0.5, 1.5),
     color: theme.colors.text.primary,
     fontWeight: theme.typography.fontWeightMedium,
     cursor: 'pointer',
@@ -204,10 +204,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     color: theme.colors.text.primary,
   }),
   headerNested: css({
-    padding: theme.spacing(1, 0),
+    padding: theme.spacing(0.5, 0, 0.5, 0),
   }),
   body: css({
-    padding: theme.spacing(1.5, 2),
+    padding: theme.spacing(1, 2, 1, 2),
   }),
   titleDisabled: css({
     color: theme.colors.text.disabled,


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->

This PR supplements #117267 and is a follow-up to #119458. It adds some missing `reportInteraction` event tracking to the v2 panel edit experience (`PanelEditNext`).

## Changes
<!--- Describe your changes in detail -->

### New tracking

- Sidebar expand/collapse
- Data/Alert view toggle
- Query options toggle
- Rename initiated

### Fixes to existing tracking

- Card actions (duplicate/hide/delete) now include source (`'content_header' | 'sidebar_card'`)
- Query actions menu now reports correct `item_type` for expressions (was hardcoded to query)
- Saved query: `open_saved_query_picker` fires on drawer open; `add_query` fires only on successful selection (not on cancel)

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->

Inherently low risk...`reportInteraction` is fire-and-forget and cannot affect rendering or data flow.

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->

N/A

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->

I'll borrow from the Testing Instructions section in #119458:

> Testing this locally doesn't feel valuable to me. Feedback on the code would be great, and then I suggest that we use the events to build a dashboard. The dashboarding process will help us understand if events & payloads need to be adjusted further.

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable