### PR TITLE
fix(unified): skip migrations for other storage types

### DIFF
--- a/pkg/storage/unified/migrations/service.go
+++ b/pkg/storage/unified/migrations/service.go
@@ -56,10 +56,10 @@ func ProvideUnifiedStorageMigrationService(
 }
 
 func (p *UnifiedStorageMigrationServiceImpl) Run(ctx context.Context) error {
-	// skip migrations if disabled in config
-	if p.cfg.DisableDataMigrations {
+	// skip migrations if disabled in config or storage type is not "unified"
+	if p.cfg.DisableDataMigrations || p.cfg.UnifiedStorageType() != "unified" {
 		metrics.MUnifiedStorageMigrationStatus.Set(1)
-		logger.Info("Data migrations are disabled, skipping")
+		logger.Info("Data migrations are disabled, skipping", "disableDataMigrations", p.cfg.DisableDataMigrations, "unifiedStorageType", p.cfg.UnifiedStorageType())
 		return nil
 	}
 

--- a/pkg/storage/unified/migrations/service_test.go
+++ b/pkg/storage/unified/migrations/service_test.go
@@ -1,0 +1,57 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/metrics"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestUnifiedStorageMigrationServiceImpl_Run_SkipsMigrations(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfgFunc func(cfg *setting.Cfg)
+	}{
+		{
+			name: "storage type is unified-grpc",
+			cfgFunc: func(cfg *setting.Cfg) {
+				cfg.Raw.Section("grafana-apiserver").Key("storage_type").SetValue("unified-grpc")
+			},
+		},
+		{
+			name: "storage type is unified-kv-grpc",
+			cfgFunc: func(cfg *setting.Cfg) {
+				cfg.Raw.Section("grafana-apiserver").Key("storage_type").SetValue("unified-kv-grpc")
+			},
+		},
+		{
+			name: "data migrations disabled",
+			cfgFunc: func(cfg *setting.Cfg) {
+				cfg.DisableDataMigrations = true
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := setting.NewCfg()
+			tt.cfgFunc(cfg)
+
+			migrator := NewMockUnifiedMigrator(t)
+
+			svc := &UnifiedStorageMigrationServiceImpl{
+				cfg:      cfg,
+				migrator: migrator,
+			}
+
+			err := svc.Run(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, float64(1), testutil.ToFloat64(metrics.MUnifiedStorageMigrationStatus))
+			migrator.AssertNotCalled(t, "Migrate")
+		})
+	}
+}


### PR DESCRIPTION
**What is this feature?**

For now we support only `unified` (default) storage-type for migrations.

**Why do we need this feature?**

Avoid migration on other storage-types.

**Who is this feature for?**

`unified-kv-grpc` storage-type users

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
