### PR TITLE
DynamicDashboards: Improve copy/paste of custom grid panels

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -1,5 +1,6 @@
+import { AppEvents } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
+import { config, getAppEvents } from '@grafana/runtime';
 import {
   SceneComponentProps,
   SceneObject,
@@ -135,7 +136,18 @@ export class AutoGridLayoutManager
   }
 
   public pastePanel() {
-    const panel = getAutoGridItemFromClipboard(getDashboardSceneFor(this));
+    let panel;
+
+    try {
+      panel = getAutoGridItemFromClipboard(getDashboardSceneFor(this));
+    } catch (error) {
+      getAppEvents().publish({
+        type: AppEvents.alertError.name,
+        payload: error instanceof Error ? [error.message, String(error.cause)] : [String(error)],
+      });
+      return;
+    }
+
     if (config.featureToggles.dashboardNewLayouts) {
       dashboardEditActions.edit({
         description: t('dashboard.edit-actions.paste-panel', 'Paste panel'),

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -1,9 +1,9 @@
 import { css, cx } from '@emotion/css';
 
-import { GrafanaTheme2 } from '@grafana/data';
+import { AppEvents, GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
+import { config, getAppEvents } from '@grafana/runtime';
 import {
   SceneObjectState,
   SceneGridLayout,
@@ -187,7 +187,17 @@ export class DefaultGridLayoutManager
 
   public pastePanel() {
     const emptySpace = findSpaceForNewPanel(this.state.grid);
-    const newGridItem = getDashboardGridItemFromClipboard(getDashboardSceneFor(this), emptySpace);
+    let newGridItem;
+
+    try {
+      newGridItem = getDashboardGridItemFromClipboard(getDashboardSceneFor(this), emptySpace);
+    } catch (error) {
+      getAppEvents().publish({
+        type: AppEvents.alertError.name,
+        payload: error instanceof Error ? [error.message, String(error.cause)] : [String(error)],
+      });
+      return;
+    }
 
     if (config.featureToggles.dashboardNewLayouts) {
       dashboardEditActions.edit({

--- a/public/app/features/dashboard-scene/scene/layouts-shared/paste.test.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/paste.test.ts
@@ -2,6 +2,7 @@ import { store } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils } from '@grafana/runtime';
 import { SceneTimeRange } from '@grafana/scenes';
+import { AutoGridLayoutItemKind, GridLayoutItemKind } from '@grafana/schema/dist/esm/schema/dashboard/v2beta1';
 import { LS_PANEL_COPY_KEY } from 'app/core/constants';
 
 import { DashboardScene } from '../DashboardScene';
@@ -23,7 +24,7 @@ function buildDashboardScene(): DashboardScene {
   });
 }
 
-function buildAutoGridClipboard(): PanelStore {
+function buildAutoGridClipboard(): PanelStore & { gridItem: AutoGridLayoutItemKind } {
   return {
     elements: {
       'panel-42': {
@@ -48,12 +49,16 @@ function buildAutoGridClipboard(): PanelStore {
       spec: {
         element: { kind: 'ElementReference', name: 'panel-42' },
         repeat: { mode: 'variable', value: 'testVarAuto' },
+        conditionalRendering: {
+          kind: 'ConditionalRenderingGroup',
+          spec: { condition: 'and', visibility: 'hide', items: [] },
+        },
       },
     },
   };
 }
 
-function buildGridLayoutClipboard(): PanelStore {
+function buildCustomGridLayoutClipboard(): PanelStore & { gridItem: GridLayoutItemKind } {
   return {
     elements: {
       'panel-43': {
@@ -98,35 +103,31 @@ describe('getAutoGridItemFromClipboard()', () => {
     store.delete(LS_PANEL_COPY_KEY);
   });
 
-  test('if the clipboard contains an AutoGridLayoutItem, it returns an AutoGridItem ', () => {
-    const { scene } = setup(buildAutoGridClipboard());
+  it.each([
+    { name: 'AutoGridLayoutItem', buildClipboard: buildAutoGridClipboard },
+    { name: 'GridLayoutItem', buildClipboard: buildCustomGridLayoutClipboard },
+  ])('if the clipboard contains a $name, it returns an AutoGridItem', ({ buildClipboard }) => {
+    const { scene } = setup(buildClipboard());
 
     const result = getAutoGridItemFromClipboard(scene);
 
     expect(result).toBeInstanceOf(AutoGridItem);
   });
 
-  test('if the clipboard contains a GridLayoutItem, it returns an AutoGridItem', () => {
-    const { scene } = setup(buildGridLayoutClipboard());
-
-    const result = getAutoGridItemFromClipboard(scene);
-
-    expect(result).toBeInstanceOf(AutoGridItem);
-  });
-
-  test('preserves the grid item key and variableName, as well as the panel title and pluginId', () => {
+  test('preserves the grid item key, variableName and conditionalRendering, as well as the panel title and pluginId', () => {
     const { scene } = setup(buildAutoGridClipboard());
 
     const result = getAutoGridItemFromClipboard(scene);
 
     expect(result.state.key).toBe('grid-item-1');
     expect(result.state.variableName).toBe('testVarAuto');
+    expect(result.state.conditionalRendering!.state.visibility).toBe('hide');
     expect(result.state.body.state.title).toBe('Test Panel 42');
     expect(result.state.body.state.pluginId).toBe('timeseries');
   });
 
   test('the returned VizPanel is parented to the AutoGridItem, not to the deserialized grid item', () => {
-    const { scene } = setup(buildGridLayoutClipboard());
+    const { scene } = setup(buildCustomGridLayoutClipboard());
 
     const result = getAutoGridItemFromClipboard(scene);
 
@@ -139,16 +140,11 @@ describe('getDashboardGridItemFromClipboard()', () => {
     store.delete(LS_PANEL_COPY_KEY);
   });
 
-  test('if the clipboard contains a GridLayoutItem, it returns a DashboardGridItem', () => {
-    const { scene } = setup(buildGridLayoutClipboard());
-
-    const result = getDashboardGridItemFromClipboard(scene, null);
-
-    expect(result).toBeInstanceOf(DashboardGridItem);
-  });
-
-  test('if the clipboard contains an AutoGridLayoutItem, it returns a DashboardGridItem', () => {
-    const { scene } = setup(buildAutoGridClipboard());
+  it.each([
+    { name: 'GridLayoutItem', buildClipboard: buildCustomGridLayoutClipboard },
+    { name: 'AutoGridLayoutItem', buildClipboard: buildAutoGridClipboard },
+  ])('if the clipboard contains a $name, it returns a DashboardGridItem', ({ buildClipboard }) => {
+    const { scene } = setup(buildClipboard());
 
     const result = getDashboardGridItemFromClipboard(scene, null);
 
@@ -156,7 +152,7 @@ describe('getDashboardGridItemFromClipboard()', () => {
   });
 
   test('preserves the grid item key and variableName, as well as the panel title and pluginId', () => {
-    const { scene } = setup(buildGridLayoutClipboard());
+    const { scene } = setup(buildCustomGridLayoutClipboard());
 
     const result = getDashboardGridItemFromClipboard(scene, null);
 
@@ -172,5 +168,34 @@ describe('getDashboardGridItemFromClipboard()', () => {
     const result = getDashboardGridItemFromClipboard(scene, null);
 
     expect(result.state.body.parent).toBe(result);
+  });
+
+  describe('when the clipboard contains a GridLayoutItem', () => {
+    test('uses gridCell position but preserves the clipboard dimensions', () => {
+      const customGridLayout = buildCustomGridLayoutClipboard();
+      const { scene } = setup(customGridLayout);
+      const gridCell = { x: 1, y: 2, width: 3, height: 4 };
+
+      const result = getDashboardGridItemFromClipboard(scene, gridCell);
+
+      expect(result.state.x).toBe(gridCell.x);
+      expect(result.state.y).toBe(gridCell.y);
+      expect(result.state.width).toBe(customGridLayout.gridItem.spec.width);
+      expect(result.state.height).toBe(customGridLayout.gridItem.spec.height);
+    });
+  });
+
+  describe('when the clipboard contains an AutoGridLayoutItem', () => {
+    test('uses gridCell for both position and dimensions', () => {
+      const { scene } = setup(buildAutoGridClipboard());
+      const gridCell = { x: 5, y: 6, width: 7, height: 8 };
+
+      const result = getDashboardGridItemFromClipboard(scene, gridCell);
+
+      expect(result.state.x).toBe(gridCell.x);
+      expect(result.state.y).toBe(gridCell.y);
+      expect(result.state.width).toBe(gridCell.width);
+      expect(result.state.height).toBe(gridCell.height);
+    });
   });
 });

--- a/public/app/features/dashboard-scene/scene/layouts-shared/paste.test.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/paste.test.ts
@@ -5,6 +5,7 @@ import { SceneTimeRange } from '@grafana/scenes';
 import { AutoGridLayoutItemKind, GridLayoutItemKind } from '@grafana/schema/dist/esm/schema/dashboard/v2beta1';
 import { LS_PANEL_COPY_KEY } from 'app/core/constants';
 
+import { ConditionalRenderingVariable } from '../../conditional-rendering/conditions/ConditionalRenderingVariable';
 import { DashboardScene } from '../DashboardScene';
 import { AutoGridItem } from '../layout-auto-grid/AutoGridItem';
 import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
@@ -27,11 +28,11 @@ function buildDashboardScene(): DashboardScene {
 function buildAutoGridClipboard(): PanelStore & { gridItem: AutoGridLayoutItemKind } {
   return {
     elements: {
-      'panel-42': {
+      'panel-auto-grid': {
         kind: 'Panel',
         spec: {
           id: 42,
-          title: 'Test Panel 42',
+          title: 'Test Panel Auto Grid',
           description: '',
           links: [],
           data: { kind: 'QueryGroup', spec: { queries: [], transformations: [], queryOptions: {} } },
@@ -47,25 +48,34 @@ function buildAutoGridClipboard(): PanelStore & { gridItem: AutoGridLayoutItemKi
     gridItem: {
       kind: 'AutoGridLayoutItem',
       spec: {
-        element: { kind: 'ElementReference', name: 'panel-42' },
+        element: { kind: 'ElementReference', name: 'panel-auto-grid' },
         repeat: { mode: 'variable', value: 'testVarAuto' },
         conditionalRendering: {
           kind: 'ConditionalRenderingGroup',
-          spec: { condition: 'and', visibility: 'hide', items: [] },
+          spec: {
+            condition: 'and',
+            visibility: 'hide',
+            items: [
+              {
+                kind: 'ConditionalRenderingVariable',
+                spec: { variable: 'testVarAuto', operator: 'equals', value: '42' },
+              },
+            ],
+          },
         },
       },
     },
   };
 }
 
-function buildCustomGridLayoutClipboard(): PanelStore & { gridItem: GridLayoutItemKind } {
+function buildCustomGridClipboard(): PanelStore & { gridItem: GridLayoutItemKind } {
   return {
     elements: {
-      'panel-43': {
+      'panel-custom-grid': {
         kind: 'Panel',
         spec: {
           id: 43,
-          title: 'Test Panel 43',
+          title: 'Test Panel Custom Grid',
           description: '',
           links: [],
           data: { kind: 'QueryGroup', spec: { queries: [], transformations: [], queryOptions: {} } },
@@ -85,7 +95,7 @@ function buildCustomGridLayoutClipboard(): PanelStore & { gridItem: GridLayoutIt
         y: 10,
         width: 12,
         height: 8,
-        element: { kind: 'ElementReference', name: 'panel-43' },
+        element: { kind: 'ElementReference', name: 'panel-custom-grid' },
         repeat: { mode: 'variable', value: 'testVarGrid' },
       },
     },
@@ -93,109 +103,161 @@ function buildCustomGridLayoutClipboard(): PanelStore & { gridItem: GridLayoutIt
 }
 
 function setup(panelStore: PanelStore) {
-  const scene = buildDashboardScene();
+  const dashboardScene = buildDashboardScene();
   store.set(LS_PANEL_COPY_KEY, JSON.stringify(panelStore));
-  return { scene };
+  return { dashboardScene };
 }
 
-describe('getAutoGridItemFromClipboard()', () => {
+describe('getAutoGridItemFromClipboard(dashboardScene)', () => {
   afterEach(() => {
     store.delete(LS_PANEL_COPY_KEY);
   });
 
   it.each([
     { name: 'AutoGridLayoutItem', buildClipboard: buildAutoGridClipboard },
-    { name: 'GridLayoutItem', buildClipboard: buildCustomGridLayoutClipboard },
+    { name: 'GridLayoutItem', buildClipboard: buildCustomGridClipboard },
   ])('if the clipboard contains a $name, it returns an AutoGridItem', ({ buildClipboard }) => {
-    const { scene } = setup(buildClipboard());
+    const { dashboardScene } = setup(buildClipboard());
 
-    const result = getAutoGridItemFromClipboard(scene);
+    const result = getAutoGridItemFromClipboard(dashboardScene);
 
     expect(result).toBeInstanceOf(AutoGridItem);
   });
 
-  test('preserves the grid item key, variableName and conditionalRendering, as well as the panel title and pluginId', () => {
-    const { scene } = setup(buildAutoGridClipboard());
+  describe('when the item from clipboard is an AutoGridItem', () => {
+    test('preserves the grid item key, variableName and conditionalRendering, as well as panel properties (title and pluginId)', () => {
+      const { dashboardScene } = setup(buildAutoGridClipboard());
 
-    const result = getAutoGridItemFromClipboard(scene);
+      const result = getAutoGridItemFromClipboard(dashboardScene);
 
-    expect(result.state.key).toBe('grid-item-1');
-    expect(result.state.variableName).toBe('testVarAuto');
-    expect(result.state.conditionalRendering!.state.visibility).toBe('hide');
-    expect(result.state.body.state.title).toBe('Test Panel 42');
-    expect(result.state.body.state.pluginId).toBe('timeseries');
+      expect(result.state.key).toBe('grid-item-1');
+      expect(result.state.variableName).toBe('testVarAuto');
+
+      const { visibility, conditions } = result.state.conditionalRendering!.state;
+      expect(visibility).toBe('hide');
+      expect(conditions[0]).toBeInstanceOf(ConditionalRenderingVariable);
+      expect((conditions[0] as ConditionalRenderingVariable).state).toEqual(
+        expect.objectContaining({
+          variable: 'testVarAuto',
+          operator: '=',
+          value: '42',
+        })
+      );
+
+      expect(result.state.body.state.title).toBe('Test Panel Auto Grid');
+      expect(result.state.body.state.pluginId).toBe('timeseries');
+    });
   });
 
-  test('the returned VizPanel is parented to the AutoGridItem, not to the deserialized grid item', () => {
-    const { scene } = setup(buildCustomGridLayoutClipboard());
+  describe('when the item from clipboard is not an AutoGridItem', () => {
+    test('the returned VizPanel is parented to the AutoGridItem, not to the deserialized grid item', () => {
+      const { dashboardScene } = setup(buildCustomGridClipboard());
 
-    const result = getAutoGridItemFromClipboard(scene);
+      const result = getAutoGridItemFromClipboard(dashboardScene);
 
-    expect(result.state.body.parent).toBe(result);
+      expect(result.state.body.parent).toBe(result);
+    });
+
+    test('preserves the grid item key and variableName, as well as panel properties (title and pluginId)', () => {
+      const { dashboardScene } = setup(buildCustomGridClipboard());
+
+      const result = getAutoGridItemFromClipboard(dashboardScene);
+
+      expect(result.state.key).toBe('grid-item-1');
+      expect(result.state.variableName).toBe('testVarGrid');
+
+      const { visibility, conditions } = result.state.conditionalRendering!.state;
+      expect(visibility).toBe('show');
+      expect(conditions).toEqual([]);
+
+      expect(result.state.body.state.title).toBe('Test Panel Custom Grid');
+      expect(result.state.body.state.pluginId).toBe('table');
+    });
   });
 });
 
-describe('getDashboardGridItemFromClipboard()', () => {
+describe('getDashboardGridItemFromClipboard(dashboardScene, gridCell)', () => {
   afterEach(() => {
     store.delete(LS_PANEL_COPY_KEY);
   });
 
   it.each([
-    { name: 'GridLayoutItem', buildClipboard: buildCustomGridLayoutClipboard },
+    { name: 'GridLayoutItem', buildClipboard: buildCustomGridClipboard },
     { name: 'AutoGridLayoutItem', buildClipboard: buildAutoGridClipboard },
   ])('if the clipboard contains a $name, it returns a DashboardGridItem', ({ buildClipboard }) => {
-    const { scene } = setup(buildClipboard());
+    const { dashboardScene } = setup(buildClipboard());
 
-    const result = getDashboardGridItemFromClipboard(scene, null);
+    const result = getDashboardGridItemFromClipboard(dashboardScene, null);
 
     expect(result).toBeInstanceOf(DashboardGridItem);
   });
 
-  test('preserves the grid item key and variableName, as well as the panel title and pluginId', () => {
-    const { scene } = setup(buildCustomGridLayoutClipboard());
+  describe('when the item from clipboard is a DashboardGridItem and gridCell is not null', () => {
+    test('reposition the item to the grid cell, while preserving the grid item key and variableName, as well as panel properties (title and pluginId)', () => {
+      const { dashboardScene } = setup(buildCustomGridClipboard());
 
-    const result = getDashboardGridItemFromClipboard(scene, null);
-
-    expect(result.state.key).toBe('grid-item-1');
-    expect(result.state.variableName).toBe('testVarGrid');
-    expect(result.state.body.state.title).toBe('Test Panel 43');
-    expect(result.state.body.state.pluginId).toBe('table');
-  });
-
-  test('the returned VizPanel is parented to the DashboardGridItem, not to the deserialized grid item', () => {
-    const { scene } = setup(buildAutoGridClipboard());
-
-    const result = getDashboardGridItemFromClipboard(scene, null);
-
-    expect(result.state.body.parent).toBe(result);
-  });
-
-  describe('when the clipboard contains a GridLayoutItem', () => {
-    test('uses gridCell position but preserves the clipboard dimensions', () => {
-      const customGridLayout = buildCustomGridLayoutClipboard();
-      const { scene } = setup(customGridLayout);
-      const gridCell = { x: 1, y: 2, width: 3, height: 4 };
-
-      const result = getDashboardGridItemFromClipboard(scene, gridCell);
+      const gridCell = { x: 1, y: 2, width: 0, height: 0 };
+      const result = getDashboardGridItemFromClipboard(dashboardScene, gridCell);
 
       expect(result.state.x).toBe(gridCell.x);
       expect(result.state.y).toBe(gridCell.y);
-      expect(result.state.width).toBe(customGridLayout.gridItem.spec.width);
-      expect(result.state.height).toBe(customGridLayout.gridItem.spec.height);
+      expect(result.state.width).toBeGreaterThan(0);
+      expect(result.state.height).toBeGreaterThan(0);
+
+      expect(result.state.key).toBe('grid-item-1');
+      expect(result.state.variableName).toBe('testVarGrid');
+
+      expect(result.state.body.state.title).toBe('Test Panel Custom Grid');
+      expect(result.state.body.state.pluginId).toBe('table');
     });
   });
 
-  describe('when the clipboard contains an AutoGridLayoutItem', () => {
-    test('uses gridCell for both position and dimensions', () => {
-      const { scene } = setup(buildAutoGridClipboard());
-      const gridCell = { x: 5, y: 6, width: 7, height: 8 };
+  describe('when the item from clipboard is not a DashboardGridItem', () => {
+    test('the returned VizPanel is parented to the DashboardGridItem, not to the deserialized grid item', () => {
+      const { dashboardScene } = setup(buildCustomGridClipboard());
 
-      const result = getDashboardGridItemFromClipboard(scene, gridCell);
+      const result = getDashboardGridItemFromClipboard(dashboardScene, null);
 
-      expect(result.state.x).toBe(gridCell.x);
-      expect(result.state.y).toBe(gridCell.y);
-      expect(result.state.width).toBe(gridCell.width);
-      expect(result.state.height).toBe(gridCell.height);
+      expect(result.state.body.parent).toBe(result);
+    });
+
+    describe('if gridCell is not null', () => {
+      test('uses it for both position and dimensions, while preserving the grid item key and variableName, as well as panel properties (title and pluginId)', () => {
+        const { dashboardScene } = setup(buildAutoGridClipboard());
+        const gridCell = { x: 5, y: 6, width: 7, height: 8 };
+
+        const result = getDashboardGridItemFromClipboard(dashboardScene, gridCell);
+
+        expect(result.state.x).toBe(gridCell.x);
+        expect(result.state.y).toBe(gridCell.y);
+        expect(result.state.width).toBe(gridCell.width);
+        expect(result.state.height).toBe(gridCell.height);
+
+        expect(result.state.key).toBe('grid-item-1');
+        expect(result.state.variableName).toBe('testVarAuto');
+
+        expect(result.state.body.state.title).toBe('Test Panel Auto Grid');
+        expect(result.state.body.state.pluginId).toBe('timeseries');
+      });
+    });
+
+    describe('if gridCell is null', () => {
+      test('does not set any position or dimensions', () => {
+        const { dashboardScene } = setup(buildAutoGridClipboard());
+
+        const result = getDashboardGridItemFromClipboard(dashboardScene, null);
+
+        expect(result.state.x).toBeUndefined();
+        expect(result.state.y).toBeUndefined();
+        expect(result.state.width).toBeUndefined();
+        expect(result.state.height).toBeUndefined();
+
+        expect(result.state.key).toBe('grid-item-1');
+        expect(result.state.variableName).toBe('testVarAuto');
+
+        expect(result.state.body.state.title).toBe('Test Panel Auto Grid');
+        expect(result.state.body.state.pluginId).toBe('timeseries');
+      });
     });
   });
 });

--- a/public/app/features/dashboard-scene/scene/layouts-shared/paste.test.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/paste.test.ts
@@ -174,6 +174,27 @@ describe('getAutoGridItemFromClipboard(dashboardScene)', () => {
       expect(result.state.body.state.pluginId).toBe('table');
     });
   });
+
+  test('throws when deserialization fails', () => {
+    const clipboard = { ...buildAutoGridClipboard(), elements: {} };
+    const { dashboardScene } = setup(clipboard);
+
+    expect.assertions(4);
+
+    try {
+      getAutoGridItemFromClipboard(dashboardScene);
+    } catch (error) {
+      const thrown = error as Error;
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(thrown.message).toBe('Error pasting panel from clipboard, please try to copy again.');
+
+      expect(thrown.cause).toBeInstanceOf(Error);
+      expect((thrown.cause as Error).message).toBe(
+        'Panel with uid panel-auto-grid not found in the dashboard elements'
+      );
+    }
+  });
 });
 
 describe('getDashboardGridItemFromClipboard(dashboardScene, gridCell)', () => {
@@ -259,5 +280,26 @@ describe('getDashboardGridItemFromClipboard(dashboardScene, gridCell)', () => {
         expect(result.state.body.state.pluginId).toBe('timeseries');
       });
     });
+  });
+
+  test('throws when deserialization fails', () => {
+    const clipboard = { ...buildCustomGridClipboard(), elements: {} };
+    const { dashboardScene } = setup(clipboard);
+
+    expect.assertions(4);
+
+    try {
+      getAutoGridItemFromClipboard(dashboardScene);
+    } catch (error) {
+      const thrown = error as Error;
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(thrown.message).toBe('Error pasting panel from clipboard, please try to copy again.');
+
+      expect(thrown.cause).toBeInstanceOf(Error);
+      expect((thrown.cause as Error).message).toBe(
+        'Panel with uid panel-custom-grid not found in the dashboard elements'
+      );
+    }
   });
 });

--- a/public/app/features/dashboard-scene/scene/layouts-shared/paste.test.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/paste.test.ts
@@ -1,0 +1,176 @@
+import { store } from '@grafana/data';
+import { getPanelPlugin } from '@grafana/data/test';
+import { setPluginImportUtils } from '@grafana/runtime';
+import { SceneTimeRange } from '@grafana/scenes';
+import { LS_PANEL_COPY_KEY } from 'app/core/constants';
+
+import { DashboardScene } from '../DashboardScene';
+import { AutoGridItem } from '../layout-auto-grid/AutoGridItem';
+import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
+import { DashboardGridItem } from '../layout-default/DashboardGridItem';
+
+import { PanelStore, getAutoGridItemFromClipboard, getDashboardGridItemFromClipboard } from './paste';
+
+setPluginImportUtils({
+  importPanelPlugin: (id: string) => Promise.resolve(getPanelPlugin({})),
+  getPanelPluginFromCache: (id: string) => undefined,
+});
+
+function buildDashboardScene(): DashboardScene {
+  return new DashboardScene({
+    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+    body: AutoGridLayoutManager.createEmpty(),
+  });
+}
+
+function buildAutoGridClipboard(): PanelStore {
+  return {
+    elements: {
+      'panel-42': {
+        kind: 'Panel',
+        spec: {
+          id: 42,
+          title: 'Test Panel 42',
+          description: '',
+          links: [],
+          data: { kind: 'QueryGroup', spec: { queries: [], transformations: [], queryOptions: {} } },
+          vizConfig: {
+            kind: 'VizConfig',
+            group: 'timeseries',
+            version: '13.0.0',
+            spec: { options: {}, fieldConfig: { defaults: {}, overrides: [] } },
+          },
+        },
+      },
+    },
+    gridItem: {
+      kind: 'AutoGridLayoutItem',
+      spec: {
+        element: { kind: 'ElementReference', name: 'panel-42' },
+        repeat: { mode: 'variable', value: 'testVarAuto' },
+      },
+    },
+  };
+}
+
+function buildGridLayoutClipboard(): PanelStore {
+  return {
+    elements: {
+      'panel-43': {
+        kind: 'Panel',
+        spec: {
+          id: 43,
+          title: 'Test Panel 43',
+          description: '',
+          links: [],
+          data: { kind: 'QueryGroup', spec: { queries: [], transformations: [], queryOptions: {} } },
+          vizConfig: {
+            kind: 'VizConfig',
+            group: 'table',
+            version: '13.0.0',
+            spec: { options: {}, fieldConfig: { defaults: {}, overrides: [] } },
+          },
+        },
+      },
+    },
+    gridItem: {
+      kind: 'GridLayoutItem',
+      spec: {
+        x: 5,
+        y: 10,
+        width: 12,
+        height: 8,
+        element: { kind: 'ElementReference', name: 'panel-43' },
+        repeat: { mode: 'variable', value: 'testVarGrid' },
+      },
+    },
+  };
+}
+
+function setup(panelStore: PanelStore) {
+  const scene = buildDashboardScene();
+  store.set(LS_PANEL_COPY_KEY, JSON.stringify(panelStore));
+  return { scene };
+}
+
+describe('getAutoGridItemFromClipboard()', () => {
+  afterEach(() => {
+    store.delete(LS_PANEL_COPY_KEY);
+  });
+
+  test('if the clipboard contains an AutoGridLayoutItem, it returns an AutoGridItem ', () => {
+    const { scene } = setup(buildAutoGridClipboard());
+
+    const result = getAutoGridItemFromClipboard(scene);
+
+    expect(result).toBeInstanceOf(AutoGridItem);
+  });
+
+  test('if the clipboard contains a GridLayoutItem, it returns an AutoGridItem', () => {
+    const { scene } = setup(buildGridLayoutClipboard());
+
+    const result = getAutoGridItemFromClipboard(scene);
+
+    expect(result).toBeInstanceOf(AutoGridItem);
+  });
+
+  test('preserves the grid item key and variableName, as well as the panel title and pluginId', () => {
+    const { scene } = setup(buildAutoGridClipboard());
+
+    const result = getAutoGridItemFromClipboard(scene);
+
+    expect(result.state.key).toBe('grid-item-1');
+    expect(result.state.variableName).toBe('testVarAuto');
+    expect(result.state.body.state.title).toBe('Test Panel 42');
+    expect(result.state.body.state.pluginId).toBe('timeseries');
+  });
+
+  test('the returned VizPanel is parented to the AutoGridItem, not to the deserialized grid item', () => {
+    const { scene } = setup(buildGridLayoutClipboard());
+
+    const result = getAutoGridItemFromClipboard(scene);
+
+    expect(result.state.body.parent).toBe(result);
+  });
+});
+
+describe('getDashboardGridItemFromClipboard()', () => {
+  afterEach(() => {
+    store.delete(LS_PANEL_COPY_KEY);
+  });
+
+  test('if the clipboard contains a GridLayoutItem, it returns a DashboardGridItem', () => {
+    const { scene } = setup(buildGridLayoutClipboard());
+
+    const result = getDashboardGridItemFromClipboard(scene, null);
+
+    expect(result).toBeInstanceOf(DashboardGridItem);
+  });
+
+  test('if the clipboard contains an AutoGridLayoutItem, it returns a DashboardGridItem', () => {
+    const { scene } = setup(buildAutoGridClipboard());
+
+    const result = getDashboardGridItemFromClipboard(scene, null);
+
+    expect(result).toBeInstanceOf(DashboardGridItem);
+  });
+
+  test('preserves the grid item key and variableName, as well as the panel title and pluginId', () => {
+    const { scene } = setup(buildGridLayoutClipboard());
+
+    const result = getDashboardGridItemFromClipboard(scene, null);
+
+    expect(result.state.key).toBe('grid-item-1');
+    expect(result.state.variableName).toBe('testVarGrid');
+    expect(result.state.body.state.title).toBe('Test Panel 43');
+    expect(result.state.body.state.pluginId).toBe('table');
+  });
+
+  test('the returned VizPanel is parented to the DashboardGridItem, not to the deserialized grid item', () => {
+    const { scene } = setup(buildAutoGridClipboard());
+
+    const result = getDashboardGridItemFromClipboard(scene, null);
+
+    expect(result.state.body.parent).toBe(result);
+  });
+});

--- a/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
@@ -55,25 +55,25 @@ export function getRowFromClipboard(scene: DashboardScene): RowItem {
   try {
     row = deserializeRow(jsonObj.row, jsonObj.elements, false, panelIdGenerator);
   } catch (error) {
-    throw new Error('Error pasting row from clipboard, please try to copy again');
+    throw new Error(`Error pasting row from clipboard. Please try to copy again.`, { cause: error });
   }
-
   return row;
 }
 
 export function getTabFromClipboard(scene: DashboardScene): TabItem {
   const jsonData = store.get(LS_TAB_COPY_KEY);
+
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const jsonObj: TabStore = JSON.parse(jsonData) as TabStore;
   clearClipboard();
   const panelIdGenerator = dashboardSceneGraph.getPanelIdGenerator(scene);
+
   let tab;
   try {
     tab = deserializeTab(jsonObj.tab, jsonObj.elements, false, panelIdGenerator);
   } catch (error) {
-    throw new Error('Error pasting tab from clipboard, please try to copy again');
+    throw new Error(`Error pasting tab from clipboard. Please try to copy again.`, { cause: error });
   }
-
   return tab;
 }
 
@@ -89,9 +89,8 @@ function getGridItemFromClipboard(scene: DashboardScene) {
         ? deserializeGridItem(gridItem, elements, dashboardSceneGraph.getPanelIdGenerator(scene))
         : deserializeAutoGridItem(gridItem, elements, dashboardSceneGraph.getPanelIdGenerator(scene));
   } catch (error) {
-    throw new Error('Error pasting panel from clipboard, please try to copy again');
+    throw new Error('Error pasting panel from clipboard, please try to copy again.', { cause: error });
   }
-
   return deserializedGridItem;
 }
 

--- a/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
@@ -1,4 +1,5 @@
 import { store } from '@grafana/data';
+import { VizPanel } from '@grafana/scenes';
 import {
   AutoGridLayoutItemKind,
   Spec as DashboardV2Spec,
@@ -77,36 +78,35 @@ export function getTabFromClipboard(scene: DashboardScene): TabItem {
   return tab;
 }
 
-export function getPanelFromClipboard(scene: DashboardScene): DashboardGridItem | AutoGridItem {
+interface ClipboardGridItem {
+  body: VizPanel;
+  key: string;
+  variableName?: string;
+}
+
+// Deserializes the clipboard data into a layout-agnostic grid item representation,
+// detaching the VizPanel so callers can safely parent it into the correct grid item type.
+function getGridItemFromClipboard(scene: DashboardScene): ClipboardGridItem {
   const jsonData = store.get(LS_PANEL_COPY_KEY);
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const { elements, gridItem }: PanelStore = JSON.parse(jsonData) as PanelStore;
 
-  if (gridItem.kind === 'GridLayoutItem') {
-    return deserializeGridItem(gridItem, elements, dashboardSceneGraph.getPanelIdGenerator(scene));
-  }
-  return deserializeAutoGridItem(gridItem, elements, dashboardSceneGraph.getPanelIdGenerator(scene));
+  const deserializedGridItem =
+    gridItem.kind === 'GridLayoutItem'
+      ? deserializeGridItem(gridItem, elements, dashboardSceneGraph.getPanelIdGenerator(scene))
+      : deserializeAutoGridItem(gridItem, elements, dashboardSceneGraph.getPanelIdGenerator(scene));
+
+  const { body, key, variableName } = deserializedGridItem.state;
+  body.clearParent();
+  return { body, key: key!, variableName };
 }
 
 export function getAutoGridItemFromClipboard(scene: DashboardScene): AutoGridItem {
-  const panel = getPanelFromClipboard(scene);
-  if (panel instanceof AutoGridItem) {
-    return panel;
-  }
-  // Convert to AutoGridItem
-  return new AutoGridItem({ body: panel.state.body, key: panel.state.key, variableName: panel.state.variableName });
+  const { body, key, variableName } = getGridItemFromClipboard(scene);
+  return new AutoGridItem({ body, key, variableName });
 }
 
 export function getDashboardGridItemFromClipboard(scene: DashboardScene, gridCell: GridCell | null): DashboardGridItem {
-  const panel = getPanelFromClipboard(scene);
-  if (panel instanceof DashboardGridItem) {
-    return panel;
-  }
-  // Convert to DashboardGridItem
-  return new DashboardGridItem({
-    ...gridCell,
-    body: panel.state.body,
-    key: panel.state.key,
-    variableName: panel.state.variableName,
-  });
+  const { body, key, variableName } = getGridItemFromClipboard(scene);
+  return new DashboardGridItem({ ...gridCell, body, key, variableName });
 }

--- a/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
@@ -110,8 +110,8 @@ export function getAutoGridItemFromClipboard(scene: DashboardScene): AutoGridIte
   });
 }
 
-// Always uses gridCell for positioning so pasting behaves like adding a new panel via findSpaceForNewPanel,
-// rather than reusing the clipboard's original coordinates which could overlap existing panels.
+// Uses gridCell for placement to avoid overlaps with existing panels.
+// If the deserialized item is a DashboardGridItem (GridLayoutItem in clipboard), preserve its width/height.
 export function getDashboardGridItemFromClipboard(scene: DashboardScene, gridCell: GridCell | null): DashboardGridItem {
   const deserializedGridItem = getGridItemFromClipboard(scene);
 

--- a/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
@@ -1,5 +1,4 @@
 import { store } from '@grafana/data';
-import { VizPanel } from '@grafana/scenes';
 import {
   AutoGridLayoutItemKind,
   Spec as DashboardV2Spec,
@@ -78,35 +77,59 @@ export function getTabFromClipboard(scene: DashboardScene): TabItem {
   return tab;
 }
 
-interface ClipboardGridItem {
-  body: VizPanel;
-  key: string;
-  variableName?: string;
-}
-
-// Deserializes the clipboard data into a layout-agnostic grid item representation,
-// detaching the VizPanel so callers can safely parent it into the correct grid item type.
-function getGridItemFromClipboard(scene: DashboardScene): ClipboardGridItem {
+function getGridItemFromClipboard(scene: DashboardScene) {
   const jsonData = store.get(LS_PANEL_COPY_KEY);
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const { elements, gridItem }: PanelStore = JSON.parse(jsonData) as PanelStore;
 
-  const deserializedGridItem =
-    gridItem.kind === 'GridLayoutItem'
-      ? deserializeGridItem(gridItem, elements, dashboardSceneGraph.getPanelIdGenerator(scene))
-      : deserializeAutoGridItem(gridItem, elements, dashboardSceneGraph.getPanelIdGenerator(scene));
+  let deserializedGridItem;
+  try {
+    deserializedGridItem =
+      gridItem.kind === 'GridLayoutItem'
+        ? deserializeGridItem(gridItem, elements, dashboardSceneGraph.getPanelIdGenerator(scene))
+        : deserializeAutoGridItem(gridItem, elements, dashboardSceneGraph.getPanelIdGenerator(scene));
+  } catch (error) {
+    throw new Error('Error pasting panel from clipboard, please try to copy again');
+  }
 
-  const { body, key, variableName } = deserializedGridItem.state;
-  body.clearParent();
-  return { body, key: key!, variableName };
+  return deserializedGridItem;
 }
 
 export function getAutoGridItemFromClipboard(scene: DashboardScene): AutoGridItem {
-  const { body, key, variableName } = getGridItemFromClipboard(scene);
-  return new AutoGridItem({ body, key, variableName });
+  const deserializedGridItem = getGridItemFromClipboard(scene);
+  if (deserializedGridItem instanceof AutoGridItem) {
+    return deserializedGridItem;
+  }
+
+  deserializedGridItem.state.body.clearParent();
+
+  return new AutoGridItem({
+    key: deserializedGridItem.state.key,
+    body: deserializedGridItem.state.body,
+    variableName: deserializedGridItem.state.variableName,
+  });
 }
 
+// Always uses gridCell for positioning so pasting behaves like adding a new panel via findSpaceForNewPanel,
+// rather than reusing the clipboard's original coordinates which could overlap existing panels.
 export function getDashboardGridItemFromClipboard(scene: DashboardScene, gridCell: GridCell | null): DashboardGridItem {
-  const { body, key, variableName } = getGridItemFromClipboard(scene);
-  return new DashboardGridItem({ ...gridCell, body, key, variableName });
+  const deserializedGridItem = getGridItemFromClipboard(scene);
+
+  deserializedGridItem.state.body.clearParent();
+
+  const gridProps =
+    deserializedGridItem instanceof DashboardGridItem
+      ? {
+          ...gridCell,
+          width: deserializedGridItem.state.width,
+          height: deserializedGridItem.state.height,
+        }
+      : gridCell;
+
+  return new DashboardGridItem({
+    ...gridProps,
+    key: deserializedGridItem.state.key,
+    body: deserializedGridItem.state.body,
+    variableName: deserializedGridItem.state.variableName,
+  });
 }

--- a/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
@@ -110,24 +110,21 @@ export function getAutoGridItemFromClipboard(scene: DashboardScene): AutoGridIte
   });
 }
 
-// Uses gridCell for placement to avoid overlaps with existing panels.
-// If the deserialized item is a DashboardGridItem (GridLayoutItem in clipboard), preserve its width/height.
 export function getDashboardGridItemFromClipboard(scene: DashboardScene, gridCell: GridCell | null): DashboardGridItem {
   const deserializedGridItem = getGridItemFromClipboard(scene);
 
+  if (deserializedGridItem instanceof DashboardGridItem) {
+    if (gridCell) {
+      // reposition to the given grid cell to avoid overlapping existing items
+      deserializedGridItem.setState({ x: gridCell.x, y: gridCell.y });
+    }
+    return deserializedGridItem;
+  }
+
   deserializedGridItem.state.body.clearParent();
 
-  const gridProps =
-    deserializedGridItem instanceof DashboardGridItem
-      ? {
-          ...gridCell,
-          width: deserializedGridItem.state.width,
-          height: deserializedGridItem.state.height,
-        }
-      : gridCell;
-
   return new DashboardGridItem({
-    ...gridProps,
+    ...gridCell,
     key: deserializedGridItem.state.key,
     body: deserializedGridItem.state.body,
     variableName: deserializedGridItem.state.variableName,


### PR DESCRIPTION
While testing https://github.com/grafana/grafana/pull/119305, I noticed console warnings that occured after pasting a panel across tabs/rows that used different layout types (e.g., `GridLayout` → `AutoGrid`):

<img width="445" height="" alt="image" src="https://github.com/user-attachments/assets/d627fffb-c318-4b9a-9d26-d7532d1196e8" />

**Problem:**
When pasting a panel, [`getPanelFromClipboard`](https://github.com/grafana/grafana/blob/main/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts#L80) deserializes the clipboard data into a grid item that becomes the `VizPanel`'s parent. If the target layout requires a different grid item type, the conversion functions (`getAutoGridItemFromClipboard` / `getDashboardGridItemFromClipboard`) pass that same `VizPanel` to a new grid item constructor, triggering the warning because it already has a parent.

**Solution:**
This PR updates `getPanelFromClipboard` to return a plain object `{ body, key, variableName }` instead of a `SceneObject`. The deserialized grid item stays internal and the `VizPanel` is detached via `clearParent()` before being returned. Callers now always construct the correct grid item type directly — no `instanceof` checks or conversion branches needed.

**Opportunity for improvement:**
When pasting into a `DefaultGridLayout` from a same-type clipboard, the panel previously kept its original grid position, potentially overlapping existing panels. It now always uses the position computed by `findSpaceForNewPanel`, consistent with cross-layout pastes.
