### PR TITLE
Alerting: Fix reducer undefined error in alert rule edit

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen } from 'test/test-utils';
+
+import { ReducerID } from '@grafana/data';
+import { EvalFunction } from 'app/features/alerting/state/alertDef';
+import { ClassicCondition, ExpressionQuery } from 'app/features/expressions/types';
+import { AlertQuery } from 'app/types/unified-alerting-dto';
+
+import { mockReduceExpression, mockThresholdExpression } from '../../../mocks';
+
+import { SimpleCondition, SimpleConditionEditor } from './SimpleCondition';
+
+const defaultSimpleCondition: SimpleCondition = {
+  whenField: ReducerID.last,
+  evaluator: { params: [0], type: EvalFunction.IsAbove },
+};
+
+function buildReduceExpressionWithConditions(
+  conditionOverrides?: Array<Partial<ClassicCondition>>
+): AlertQuery<ExpressionQuery> {
+  const conditions = conditionOverrides?.map((override) => ({
+    type: 'query' as const,
+    evaluator: { params: [0], type: EvalFunction.IsAbove },
+    query: { params: ['A'] },
+    ...override,
+  }));
+
+  return mockReduceExpression({
+    expression: 'A',
+    conditions: conditions as ClassicCondition[],
+  });
+}
+
+describe('SimpleConditionEditor', () => {
+  it('should render without crashing when reduce expression conditions have no reducer object', () => {
+    const expressionQueries = [buildReduceExpressionWithConditions([{}]), mockThresholdExpression({ expression: 'B' })];
+
+    expect(() =>
+      render(
+        <SimpleConditionEditor
+          simpleCondition={defaultSimpleCondition}
+          onChange={jest.fn()}
+          expressionQueriesList={expressionQueries}
+          dispatch={jest.fn()}
+        />
+      )
+    ).not.toThrow();
+  });
+
+  it('should render without crashing when reduce expression has empty conditions array', () => {
+    const expressionQueries = [
+      mockReduceExpression({ expression: 'A', conditions: [] }),
+      mockThresholdExpression({ expression: 'B' }),
+    ];
+
+    expect(() =>
+      render(
+        <SimpleConditionEditor
+          simpleCondition={defaultSimpleCondition}
+          onChange={jest.fn()}
+          expressionQueriesList={expressionQueries}
+          dispatch={jest.fn()}
+        />
+      )
+    ).not.toThrow();
+  });
+
+  it('should render without crashing when reduce expression has no conditions', () => {
+    const expressionQueries = [mockReduceExpression({ expression: 'A' }), mockThresholdExpression({ expression: 'B' })];
+
+    expect(() =>
+      render(
+        <SimpleConditionEditor
+          simpleCondition={defaultSimpleCondition}
+          onChange={jest.fn()}
+          expressionQueriesList={expressionQueries}
+          dispatch={jest.fn()}
+        />
+      )
+    ).not.toThrow();
+  });
+
+  it('should dispatch updated expression when changing reducer with missing conditions[0].reducer', async () => {
+    const dispatch = jest.fn();
+    const expressionQueries = [buildReduceExpressionWithConditions([{}]), mockThresholdExpression({ expression: 'B' })];
+
+    const { user } = render(
+      <SimpleConditionEditor
+        simpleCondition={defaultSimpleCondition}
+        onChange={jest.fn()}
+        expressionQueriesList={expressionQueries}
+        dispatch={dispatch}
+      />
+    );
+
+    // The WHEN select renders a react-select input — there is only one combobox in this component
+    const whenSelect = screen.getByRole('combobox');
+    await user.click(whenSelect);
+
+    const meanOption = await screen.findByText('Mean');
+    await user.click(meanOption);
+
+    // Verify dispatch was called — no crash occurred and the expression was updated
+    expect(dispatch).toHaveBeenCalled();
+  });
+
+  it('should render without crashing when threshold expression has empty conditions', () => {
+    const expressionQueries = [
+      mockReduceExpression({ expression: 'A' }),
+      mockThresholdExpression({ expression: 'B', conditions: [] }),
+    ];
+
+    expect(() =>
+      render(
+        <SimpleConditionEditor
+          simpleCondition={defaultSimpleCondition}
+          onChange={jest.fn()}
+          expressionQueriesList={expressionQueries}
+          dispatch={jest.fn()}
+        />
+      )
+    ).not.toThrow();
+  });
+
+  it('should render and function correctly with fully-populated expression data', () => {
+    const expressionQueries = [
+      buildReduceExpressionWithConditions([{ reducer: { params: [], type: 'last' } }]),
+      mockThresholdExpression({ expression: 'B' }),
+    ];
+
+    render(
+      <SimpleConditionEditor
+        simpleCondition={defaultSimpleCondition}
+        onChange={jest.fn()}
+        expressionQueriesList={expressionQueries}
+        dispatch={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Alert condition')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.tsx
@@ -167,9 +167,17 @@ function updateReduceExpression(
 
   const newReduceExpression = reduceExpression
     ? produce(reduceExpression?.model, (draft) => {
-        if (draft && draft.conditions) {
+        if (draft && draft.conditions?.[0]) {
           draft.reducer = reducer;
-          draft.conditions[0].reducer.type = getReducerType(reducer) ?? ReducerID.last;
+          const reducerType = getReducerType(reducer) ?? ReducerID.last;
+          // API-loaded rules may have conditions without a reducer object (e.g. provisioned rules
+          // or rules created by older versions). Backfill it to keep conditions[0].reducer.type
+          // in sync with draft.reducer rather than silently skipping the update.
+          if (!draft.conditions[0].reducer) {
+            draft.conditions[0].reducer = { params: [], type: reducerType };
+          } else {
+            draft.conditions[0].reducer.type = reducerType;
+          }
         }
       })
     : undefined;
@@ -184,7 +192,7 @@ function updateThresholdFunction(
   const thresholdExpression = expressionQueriesList.find((query) => query.model.type === ExpressionQueryType.threshold);
 
   const newThresholdExpression = produce(thresholdExpression, (draft) => {
-    if (draft && draft.model.conditions) {
+    if (draft && draft.model.conditions?.[0]) {
       draft.model.conditions[0].evaluator.type = evaluator;
     }
   });
@@ -200,7 +208,7 @@ function updateThresholdValue(
   const thresholdExpression = expressionQueriesList.find((query) => query.model.type === ExpressionQueryType.threshold);
 
   const newThresholdExpression = produce(thresholdExpression, (draft) => {
-    if (draft && draft.model.conditions) {
+    if (draft && draft.model.conditions?.[0]) {
       draft.model.conditions[0].evaluator.params[index] = value;
     }
   });

--- a/public/app/features/expressions/components/Condition.test.tsx
+++ b/public/app/features/expressions/components/Condition.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from 'test/test-utils';
+
+import { EvalFunction } from 'app/features/alerting/state/alertDef';
+
+import { ClassicCondition } from '../types';
+
+import { Condition } from './Condition';
+
+const baseCondition: ClassicCondition = {
+  type: 'query',
+  evaluator: { params: [0], type: EvalFunction.IsAbove },
+  query: { params: ['A'] },
+  reducer: { params: [], type: 'avg' },
+};
+
+const defaultProps = {
+  onChange: jest.fn(),
+  onRemoveCondition: jest.fn(),
+  index: 0,
+  refIds: [{ value: 'A', label: 'A' }],
+};
+
+describe('Condition', () => {
+  it('should render without crashing when condition.reducer is undefined', () => {
+    const conditionWithoutReducer: ClassicCondition = {
+      ...baseCondition,
+      reducer: undefined,
+    };
+
+    expect(() => render(<Condition {...defaultProps} condition={conditionWithoutReducer} />)).not.toThrow();
+  });
+
+  it('should show the WHEN label when condition.reducer is undefined', () => {
+    const conditionWithoutReducer: ClassicCondition = {
+      ...baseCondition,
+      reducer: undefined,
+    };
+
+    render(<Condition {...defaultProps} condition={conditionWithoutReducer} />);
+
+    // Component should render with no selected reducer value in the Select
+    expect(screen.getByText('WHEN')).toBeInTheDocument();
+  });
+
+  it('should render with the correct reducer selected when condition.reducer exists', () => {
+    render(<Condition {...defaultProps} condition={baseCondition} />);
+
+    expect(screen.getByText('WHEN')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/expressions/components/Condition.tsx
+++ b/public/app/features/expressions/components/Condition.tsx
@@ -95,7 +95,7 @@ export const Condition = ({ condition, index, onChange, onRemoveCondition, refId
             options={reducerFunctions}
             onChange={onReducerFunctionChange}
             width={20}
-            value={reducerFunctions.find((rf) => rf.value === condition.reducer.type)}
+            value={reducerFunctions.find((rf) => rf.value === condition.reducer?.type)}
           />
           <div className={styles.button}>
             <Trans i18nKey="expressions.condition.of">OF</Trans>

--- a/public/app/features/expressions/types.ts
+++ b/public/app/features/expressions/types.ts
@@ -179,7 +179,7 @@ export interface ClassicCondition {
   query: {
     params: string[];
   };
-  reducer: {
+  reducer?: {
     params: [];
     type: ReducerType;
   };

--- a/public/app/features/expressions/utils/expressionTypes.test.ts
+++ b/public/app/features/expressions/utils/expressionTypes.test.ts
@@ -1,0 +1,101 @@
+import { EvalFunction } from 'app/features/alerting/state/alertDef';
+
+import { ClassicCondition, ExpressionQuery, ExpressionQueryType } from '../types';
+
+import { defaultCondition, getDefaults } from './expressionTypes';
+
+describe('getDefaults', () => {
+  describe('classic expression type', () => {
+    it('should create default conditions when conditions is undefined', () => {
+      const query = {
+        type: ExpressionQueryType.classic,
+        refId: 'A',
+      } as ExpressionQuery;
+
+      const result = getDefaults(query);
+      expect(result.conditions).toEqual([defaultCondition]);
+    });
+
+    it('should backfill missing reducer in existing conditions', () => {
+      const query = {
+        type: ExpressionQueryType.classic,
+        refId: 'A',
+        conditions: [
+          {
+            type: 'query',
+            evaluator: { params: [0], type: EvalFunction.IsAbove },
+            query: { params: ['A'] },
+          } satisfies ClassicCondition,
+        ],
+      } as ExpressionQuery;
+
+      const result = getDefaults(query);
+      expect(result.conditions![0].reducer).toEqual({ params: [], type: 'avg' });
+    });
+
+    it('should not overwrite an existing reducer', () => {
+      const query = {
+        type: ExpressionQueryType.classic,
+        refId: 'A',
+        conditions: [
+          {
+            type: 'query',
+            evaluator: { params: [0], type: EvalFunction.IsAbove },
+            query: { params: ['A'] },
+            reducer: { params: [], type: 'max' },
+          },
+        ],
+      } as ExpressionQuery;
+
+      const result = getDefaults(query);
+      expect(result.conditions?.[0].reducer?.type).toBe('max');
+    });
+
+    it('should handle a mix of conditions with and without reducer', () => {
+      const query = {
+        type: ExpressionQueryType.classic,
+        refId: 'A',
+        conditions: [
+          {
+            type: 'query',
+            evaluator: { params: [0], type: EvalFunction.IsAbove },
+            query: { params: ['A'] },
+            reducer: { params: [], type: 'sum' },
+          },
+          {
+            type: 'query',
+            evaluator: { params: [0], type: EvalFunction.IsAbove },
+            query: { params: ['B'] },
+          } satisfies ClassicCondition,
+        ],
+      } as ExpressionQuery;
+
+      const result = getDefaults(query);
+      expect(result.conditions?.[0]?.reducer?.type).toBe('sum');
+      expect(result.conditions?.[1]?.reducer).toEqual({ params: [], type: 'avg' });
+    });
+  });
+
+  describe('reduce expression type', () => {
+    it('should set default reducer when missing', () => {
+      const query = {
+        type: ExpressionQueryType.reduce,
+        refId: 'A',
+      } as ExpressionQuery;
+
+      const result = getDefaults(query);
+      expect(result.reducer).toBe('mean');
+    });
+
+    it('should not overwrite existing reducer', () => {
+      const query = {
+        type: ExpressionQueryType.reduce,
+        refId: 'A',
+        reducer: 'max',
+      } as ExpressionQuery;
+
+      const result = getDefaults(query);
+      expect(result.reducer).toBe('max');
+    });
+  });
+});

--- a/public/app/features/expressions/utils/expressionTypes.ts
+++ b/public/app/features/expressions/utils/expressionTypes.ts
@@ -32,6 +32,15 @@ export const getDefaults = (query: ExpressionQuery) => {
     case ExpressionQueryType.classic:
       if (!query.conditions) {
         query.conditions = [defaultCondition];
+      } else {
+        // API-loaded rules may have conditions without a reducer object (e.g. provisioned
+        // rules or rules created by older versions). Backfill with the default reducer
+        // to prevent downstream components from crashing on undefined access.
+        for (const condition of query.conditions) {
+          if (!condition.reducer) {
+            condition.reducer = { params: [], type: 'avg' };
+          }
+        }
       }
 
       break;


### PR DESCRIPTION
**Problem**
- Observed via ops alert: https://ops.grafana-ops.net/alerting/grafana/cecxa4fbf3jeoa/view?orgId=1
- Alert rules loaded from the API that contain a reduce expression with a conditions array where conditions[0].reducer is absent (e.g. provisioned rules or rules created by older API versions) cause a systematic crash in the simple condition editor. When a user opens such a rule and changes the WHEN (reducer) dropdown, updateReduceExpression attempts to write to conditions[0].reducer.type without guarding against reducer being undefined, throwing TypeError: cannot set properties of undefined (setting 'type') and crashing the component tree
- The same pattern of unguarded conditions[0] access exists as latent bugs in updateThresholdFunction and updateThresholdValue (empty conditions array would crash those too), and in Condition.tsx where condition.reducer.type is read during render without a null guard

**Fix**
- SimpleCondition.tsx: added conditions?.[0] guard in updateReduceExpression, updateThresholdFunction, and updateThresholdValue to handle both undefined and empty conditions arrays; added backfill logic in updateReduceExpression to initialize a missing conditions[0].reducer object from the selected reducer type instead of crashing
- expressionTypes.ts: added a normalization loop in getDefaults for classic expressions that backfills a default reducer object on any condition missing one, providing defense-in-depth before data reaches UI components
- Refactored reducer in ClassicCondition as optional to better reflect the real world data shape
- Condition.tsx: added optional chaining on condition.reducer?.type in the reducer `<Select>` value prop so the component degrades gracefully to an empty selection when reducer is absent


**Reproduction steps**
1. Create the rule with a missing reducer in the reduce expression conditions via the provisioning API:
```
curl -X POST https://<your-grafana>/api/v1/provisioning/alert-rules \
  -H "Content-Type: application/json" \
  -u admin:password \
  -d '{
    "title": "Reproduce reducer bug",
    "ruleGroup": "bug-repro",
    "folderUID": "<folder-uid>",
    "condition": "C",
    "noDataState": "NoData",
    "execErrState": "Error",
    "for": "1m",
    "data": [
      {
        "refId": "A",
        "datasourceUid": "<datasource-uid>",
        "queryType": "",
        "relativeTimeRange": { "from": 600, "to": 0 },
        "model": { "refId": "A" }
      },
      {
        "refId": "B",
        "datasourceUid": "__expr__",
        "queryType": "expression",
        "relativeTimeRange": { "from": 600, "to": 0 },
        "model": {
          "type": "reduce",
          "refId": "B",
          "expression": "A",
          "reducer": "last",
          "conditions": [
            {
              "type": "query",
              "evaluator": { "params": [0], "type": "gt" },
              "query": { "params": ["A"] }
            }
          ]
        }
      },
      {
        "refId": "C",
        "datasourceUid": "__expr__",
        "queryType": "expression",
        "relativeTimeRange": { "from": 600, "to": 0 },
        "model": {
          "type": "threshold",
          "refId": "C",
          "expression": "B",
          "conditions": [
            {
              "type": "query",
              "evaluator": { "params": [0], "type": "gt" },
              "query": { "params": ["B"] },
              "reducer": { "params": [], "type": "last" }
            }
          ]
        }
      }
    ]
  }'
```
2. Navigate to /alerting/{uid}/edit with the UID returned by the API call
3. Toggle Advanced options OFF to enter the simple condition editor
4. Click the WHEN dropdown and select any reducer (e.g. "Mean")
5. Observe that the error "TypeError: cannot set properties of undefined (setting 'type')" error cannot be seen in the console
