### PR TITLE
Dashboards: Skip snapshot variable type during serialization

### DIFF
--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.test.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.test.ts
@@ -26,6 +26,7 @@ import {
 } from '@grafana/scenes';
 import { DataSourceRef, VariableHide, VariableRefresh } from '@grafana/schema';
 
+import { SnapshotVariable } from './custom-variables/SnapshotVariable';
 import { sceneVariablesSetToSchemaV2Variables, sceneVariablesSetToVariables } from './sceneVariablesSetToVariables';
 
 const runRequestMock = jest.fn().mockReturnValue(
@@ -893,6 +894,23 @@ describe('sceneVariablesSetToVariables', () => {
     });
   });
 
+  it('should skip SnapshotVariable during serialization', () => {
+    const variable = new SnapshotVariable({
+      name: 'test',
+      label: 'test-label',
+      value: 'foo',
+      text: 'foo',
+      options: [],
+      isMulti: false,
+    });
+    const set = new SceneVariableSet({
+      variables: [variable],
+    });
+
+    const result = sceneVariablesSetToVariables(set);
+    expect(result).toHaveLength(0);
+  });
+
   it('should handle SwitchVariable with "true" value', () => {
     const variable = new SwitchVariable({
       name: 'test',
@@ -1618,6 +1636,23 @@ describe('sceneVariablesSetToVariables', () => {
 
         expect(() => sceneVariablesSetToSchemaV2Variables(set)).toThrow('Unsupported variable type');
       });
+    });
+
+    it('should skip SnapshotVariable during serialization', () => {
+      const variable = new SnapshotVariable({
+        name: 'test',
+        label: 'test-label',
+        value: 'foo',
+        text: 'foo',
+        options: [],
+        isMulti: false,
+      });
+      const set = new SceneVariableSet({
+        variables: [variable],
+      });
+
+      const result = sceneVariablesSetToSchemaV2Variables(set);
+      expect(result).toHaveLength(0);
     });
 
     it('should handle SwitchVariable with true value', () => {

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -253,7 +253,7 @@ export function sceneVariablesSetToVariables(set: SceneVariables, keepQueryOptio
           },
         ],
       });
-    } else if (variable.state.type === 'system') {
+    } else if (variable.state.type === 'system' || variable.state.type === 'snapshot') {
       // Not persisted
     } else {
       throw new Error('Unsupported variable type');
@@ -591,7 +591,7 @@ export function sceneVariablesSetToSchemaV2Variables(
         },
       };
       variables.push(switchVariable);
-    } else if (variable.state.type === 'system') {
+    } else if (variable.state.type === 'system' || variable.state.type === 'snapshot') {
       // Do nothing
     } else {
       throw new Error('Unsupported variable type: ' + variable.state.type);


### PR DESCRIPTION
  **Summary**

  - Fix "Unsupported variable type" error thrown when navigating away from a snapshot dashboard that contains template variables
  - sceneVariablesSetToVariables and sceneVariablesSetToSchemaV2Variables now skip SnapshotVariable (type 'snapshot') during serialization, just like SystemVariable (type 'system') is already skipped

  **Details**

In k8s, when a snapshot with template variables is loaded, the original variables are replaced with SnapshotVariable instances (type 'snapshot'). These are read-only, runtime-only variables that should never be persisted.

  When navigating away from the snapshot, templateSrv.getVariables() calls getVariablesCompatibility() → sceneVariablesSetToVariables(), which iterates all variables in the scene. Since 'snapshot' was not handled, it fell through to the throw new Error('Unsupported variable type') branch, crashing the app.

  The fix adds 'snapshot' alongside 'system' in both the v1 and v2 serialization functions so these variables are silently skipped.

  **Test plan**

  - Added unit tests for SnapshotVariable being skipped in both sceneVariablesSetToVariables and sceneVariablesSetToSchemaV2Variables
  - Manual: Open a snapshot with template variables → navigate away via breadcrumb or sidebar → no crash

**Special notes for your reviewer:**
Create a snapshot from a dashboard that contains template variables using these feature flags:

```
kubernetesSnapshots = true

[unified_storage.snapshots.dashboard.grafana.app]
dualWriterMode = 0
```

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
