### PR TITLE
ContextMenu: fix data links overflow with floating-ui size middleware

### DIFF
--- a/packages/grafana-ui/src/components/ContextMenu/ContextMenu.test.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/ContextMenu.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+import { Menu } from '../Menu/Menu';
+
+import { ContextMenu } from './ContextMenu';
+
+describe('ContextMenu', () => {
+  const originalInnerHeight = window.innerHeight;
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: originalInnerHeight,
+    });
+  });
+
+  it('constrains height and keeps the menu scrollable when content exceeds viewport height', async () => {
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 120,
+    });
+
+    render(
+      <ContextMenu
+        x={100}
+        y={110}
+        renderMenuItems={() =>
+          Array.from({ length: 40 }, (_, index) => <Menu.Item key={index} label={`Menu item ${index}`} />)
+        }
+      />
+    );
+
+    const menu = await screen.findByRole('menu');
+    const floatingElement = menu.parentElement?.parentElement?.parentElement as HTMLDivElement;
+
+    await waitFor(() => {
+      expect(floatingElement.style.getPropertyValue('--context-menu-max-height')).not.toBe('');
+      expect(floatingElement.style.maxHeight).not.toBe('');
+    });
+
+    const maxHeight = parseFloat(floatingElement.style.getPropertyValue('--context-menu-max-height'));
+    expect(maxHeight).toBeLessThanOrEqual(window.innerHeight);
+    expect(floatingElement.style.overflowY).toBe('auto');
+    expect(getComputedStyle(menu.parentElement as HTMLElement).overflowY).toBe('auto');
+  });
+});

--- a/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
@@ -1,11 +1,14 @@
-import { useRef, useState, useLayoutEffect } from 'react';
+import { autoUpdate, offset, size, useFloating, useMergeRefs } from '@floating-ui/react';
+import { useLayoutEffect, useMemo, useRef } from 'react';
 import * as React from 'react';
 import { useClickAway } from 'react-use';
 
 import { selectors } from '@grafana/e2e-selectors';
 
+import { getPositioningMiddleware } from '../../utils/floating';
 import { Menu } from '../Menu/Menu';
 import { Portal } from '../Portal/Portal';
+import { ScrollContainer } from '../ScrollContainer/ScrollContainer';
 
 export interface ContextMenuProps {
   /** Starting horizontal position for the menu */
@@ -29,28 +32,58 @@ export interface ContextMenuProps {
  */
 export const ContextMenu = React.memo(
   ({ x, y, onClose, focusOnOpen = true, renderMenuItems, renderHeader }: ContextMenuProps) => {
+    const floatingRef = useRef<HTMLDivElement | null>(null);
     const menuRef = useRef<HTMLDivElement>(null);
-    const [positionStyles, setPositionStyles] = useState({});
+
+    const OFFSET = 5;
+    const middleware = useMemo(
+      () => [
+        offset(OFFSET),
+        ...getPositioningMiddleware('bottom-start'),
+        size({
+          padding: OFFSET,
+          apply({ availableHeight, elements }) {
+            const maxHeight = `${Math.max(0, availableHeight)}px`;
+            elements.floating.style.maxHeight = maxHeight;
+            elements.floating.style.overflowY = 'auto';
+            elements.floating.style.overflowX = 'hidden';
+            elements.floating.style.setProperty('--context-menu-max-height', maxHeight);
+          },
+        }),
+      ],
+      []
+    );
+
+    const { refs, floatingStyles } = useFloating({
+      placement: 'bottom-start',
+      middleware,
+      whileElementsMounted: autoUpdate,
+      strategy: 'fixed',
+    });
+
+    const virtualReference = useMemo(
+      () => ({
+        getBoundingClientRect: () => ({
+          x,
+          y,
+          width: 0,
+          height: 0,
+          top: y,
+          right: x,
+          bottom: y,
+          left: x,
+        }),
+      }),
+      [x, y]
+    );
 
     useLayoutEffect(() => {
-      const menuElement = menuRef.current;
-      if (menuElement) {
-        const rect = menuElement.getBoundingClientRect();
-        const OFFSET = 5;
-        const collisions = {
-          right: window.innerWidth < x + rect.width,
-          bottom: window.innerHeight < y + rect.height + OFFSET,
-        };
+      refs.setReference(virtualReference);
+    }, [refs, virtualReference]);
 
-        setPositionStyles({
-          position: 'fixed',
-          left: collisions.right ? x - rect.width - OFFSET : x - OFFSET,
-          top: Math.max(0, collisions.bottom ? y - rect.height - OFFSET : y + OFFSET),
-        });
-      }
-    }, [x, y]);
+    const mergedFloatingRef = useMergeRefs([floatingRef, refs.setFloating]);
 
-    useClickAway(menuRef, () => {
+    useClickAway(floatingRef, () => {
       onClose?.();
     });
     const header = renderHeader?.();
@@ -70,17 +103,27 @@ export const ContextMenu = React.memo(
 
     return (
       <Portal>
-        <Menu
-          header={header}
-          ref={menuRef}
-          style={positionStyles}
-          ariaLabel={selectors.components.Menu.MenuComponent('Context')}
-          onOpen={onOpen}
-          onClick={onClose}
-          onKeyDown={onKeyDown}
+        <div
+          ref={mergedFloatingRef}
+          style={floatingStyles}
         >
-          {menuItems}
-        </Menu>
+          <ScrollContainer
+            maxHeight="var(--context-menu-max-height, 100vh)"
+            overflowY="auto"
+            overflowX="hidden"
+          >
+            <Menu
+              header={header}
+              ref={menuRef}
+              ariaLabel={selectors.components.Menu.MenuComponent('Context')}
+              onOpen={onOpen}
+              onClick={onClose}
+              onKeyDown={onKeyDown}
+            >
+              {menuItems}
+            </Menu>
+          </ScrollContainer>
+        </div>
       </Portal>
     );
   }


### PR DESCRIPTION
**What is this feature?**
Adds viewport-constrained scrolling to the ContextMenu so data links that extend beyond the screen edge are scrollable instead of clipped.

**Why do we need this feature?**
When panels like Stat or Graph have many data links configured, the context menu silently overflows the viewport, users can't reach links rendered off-screen.

**Who is this feature for?**
Grafana users who configure multiple data links on Stat, Graph, and other non-Table panel types.

**Which issue(s) does this PR fix?**
Fixes #115608 (ContextMenu path, Table panel path covered in separate PR)

**Special notes for your reviewer:**
- Uses existing `@floating-ui/react` `size` middleware to compute available viewport height dynamically, no new dependencies added
- Works correctly for both downward rendering and upward-flip scenarios
- Used `useMergeRefs` to combine refs idiomatically, no read-only ref mutation
- New `ContextMenu.test.tsx` added (no prior test file existed) verifying scrollable behavior when content exceeds viewport height
- 143 test suites pass

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated.
