### PR TITLE
Provisioning: SynchonizeStep useEffect causing max depth udpate fix

### DIFF
--- a/public/app/features/provisioning/Job/JobContent.tsx
+++ b/public/app/features/provisioning/Job/JobContent.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { Trans, t } from '@grafana/i18n';
 import { ControlledCollapse, Spinner, Stack, Text } from '@grafana/ui';
@@ -22,27 +22,26 @@ export interface JobContentProps {
 }
 
 export function JobContent({ jobType, job, isFinishedJob = false, onStatusChange, onRetry }: JobContentProps) {
-  const lastReportedStateRef = useRef<string>();
-
-  const { state, message, progress, summary } = job?.status || {};
+  const { state, message, progress, summary, errors, warnings } = job?.status || {};
   const repoName = job?.metadata?.labels?.['provisioning.grafana.app/repository'];
   const pullRequestURL = job?.status?.url?.newPullRequestURL;
+  const messages = useMemo(
+    () => getJobMessages({ state, message, errors, warnings }),
+    [state, message, errors, warnings]
+  );
 
   // Update step status based on job state.
-  // Guard with lastReportedStateRef to avoid re-reporting the same state,
-  // which would create new objects on each call and trigger infinite re-render loops.
+  // Use deconstructed fields from job status to avoid effect churn from whole-object dependency changes.
   useEffect(() => {
-    if (!state || state === lastReportedStateRef.current) {
+    if (!state) {
       return;
     }
-    lastReportedStateRef.current = state;
 
     switch (state) {
       case 'success':
         onStatusChange?.({ status: 'success' });
         break;
       case 'warning': {
-        const messages = getJobMessages(job?.status ?? {});
         onStatusChange?.({
           status: 'warning',
           warning: {
@@ -53,7 +52,6 @@ export function JobContent({ jobType, job, isFinishedJob = false, onStatusChange
         break;
       }
       case 'error': {
-        const messages = getJobMessages(job?.status ?? {});
         const warningInfo = messages.warning
           ? {
               title: t('provisioning.job-status.status.title-warning-running-job', 'Job completed with warnings'),
@@ -81,7 +79,7 @@ export function JobContent({ jobType, job, isFinishedJob = false, onStatusChange
       default:
         break;
     }
-  }, [state, message, job, onStatusChange, onRetry]);
+  }, [state, messages, onStatusChange, onRetry]);
 
   if (!job?.status) {
     return null;

--- a/public/app/features/provisioning/Job/JobContent.tsx
+++ b/public/app/features/provisioning/Job/JobContent.tsx
@@ -22,59 +22,56 @@ export interface JobContentProps {
 }
 
 export function JobContent({ jobType, job, isFinishedJob = false, onStatusChange, onRetry }: JobContentProps) {
-  const errorSetRef = useRef(false);
+  const lastReportedStateRef = useRef<string>();
 
   const { state, message, progress, summary } = job?.status || {};
   const repoName = job?.metadata?.labels?.['provisioning.grafana.app/repository'];
   const pullRequestURL = job?.status?.url?.newPullRequestURL;
 
-  // Update step status based on job state
+  // Update step status based on job state.
+  // Guard with lastReportedStateRef to avoid re-reporting the same state,
+  // which would create new objects on each call and trigger infinite re-render loops.
   useEffect(() => {
-    if (!state) {
+    if (!state || state === lastReportedStateRef.current) {
       return;
     }
+    lastReportedStateRef.current = state;
 
     switch (state) {
       case 'success':
         onStatusChange?.({ status: 'success' });
         break;
       case 'warning': {
-        if (!errorSetRef.current) {
-          const messages = getJobMessages(job?.status ?? {});
-          onStatusChange?.({
-            status: 'warning',
-            warning: {
-              title: t('provisioning.job-status.status.title-warning-running-job', 'Job completed with warnings'),
-              message: messages.warning,
-            },
-          });
-          errorSetRef.current = true;
-        }
+        const messages = getJobMessages(job?.status ?? {});
+        onStatusChange?.({
+          status: 'warning',
+          warning: {
+            title: t('provisioning.job-status.status.title-warning-running-job', 'Job completed with warnings'),
+            message: messages.warning,
+          },
+        });
         break;
       }
       case 'error': {
-        if (!errorSetRef.current) {
-          const messages = getJobMessages(job?.status ?? {});
-          const warningInfo = messages.warning
-            ? {
-                title: t('provisioning.job-status.status.title-warning-running-job', 'Job completed with warnings'),
-                message: messages.warning,
-              }
-            : undefined;
-          onStatusChange?.({
-            status: 'error',
-            error: {
-              title: t('provisioning.job-status.status.title-error-running-job', 'Error running job'),
-              message: messages.error,
-            },
-            warning: warningInfo,
-            action: onRetry && {
-              label: t('provisioning.job-status.retry-action', 'Retry'),
-              onClick: onRetry,
-            },
-          });
-          errorSetRef.current = true;
-        }
+        const messages = getJobMessages(job?.status ?? {});
+        const warningInfo = messages.warning
+          ? {
+              title: t('provisioning.job-status.status.title-warning-running-job', 'Job completed with warnings'),
+              message: messages.warning,
+            }
+          : undefined;
+        onStatusChange?.({
+          status: 'error',
+          error: {
+            title: t('provisioning.job-status.status.title-error-running-job', 'Error running job'),
+            message: messages.error,
+          },
+          warning: warningInfo,
+          action: onRetry && {
+            label: t('provisioning.job-status.retry-action', 'Retry'),
+            onClick: onRetry,
+          },
+        });
         break;
       }
       case 'working':


### PR DESCRIPTION
**What is this feature?**

Bug fix provisioning synchronize step `JobContent` component is having React useEffect max depth error. 

**Root cause:** The useEffect in JobContent depends on job (which gets new references from the RTK Query watch subscription as progress updates) and onRetry (which is retryJob from SynchronizeStep, recreated on every render since it's not memoized). Each time the effect runs during working/pending state, it calls onStatusChange?.({ status: 'running' }) with a new object. 

<img width="2444" height="1312" alt="image" src="https://github.com/user-attachments/assets/20d45a29-c1a2-4628-948f-65d1fd99a031" />


**Why do we need this feature?**

Precent max depth update from React

**Who is this feature for?**

Git sync users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/965

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
