### PR TITLE
Inline SecureValues:  noop when removing a value that does not exist

### DIFF
--- a/pkg/storage/unified/apistore/secure.go
+++ b/pkg/storage/unified/apistore/secure.go
@@ -69,7 +69,7 @@ func prepareSecureValues(ctx context.Context, store secret.InlineSecureValueSupp
 			}
 			if val.Remove {
 				if before.Name == "" {
-					return fmt.Errorf("cannot remove secure value '%s', it did not exist in the previous value", k)
+					continue // no-op
 				}
 				delete(secure, k)
 				v.hasChanged = true

--- a/pkg/storage/unified/apistore/secure_test.go
+++ b/pkg/storage/unified/apistore/secure_test.go
@@ -184,7 +184,7 @@ func TestSecureLifecycle(t *testing.T) {
 		// Previous values must exist for remove to execute
 		info := &objectForStorage{}
 		err := prepareSecureValues(context.Background(), secureStore, obj, resourceWithSecureValues(nil), info)
-		require.NotNil(t, err, "should noop when previous value does not exist")
+		require.Nil(t, err, "should noop when previous value does not exist")
 		secureStore.AssertExpectations(t)
 	})
 

--- a/pkg/storage/unified/apistore/secure_test.go
+++ b/pkg/storage/unified/apistore/secure_test.go
@@ -178,14 +178,13 @@ func TestSecureLifecycle(t *testing.T) {
 	t.Run("remove invalid secure values", func(t *testing.T) {
 		secureStore := secret.NewMockInlineSecureValueSupport(t)
 		obj := resourceWithSecureValues(common.InlineSecureValues{
-			"b": common.InlineSecureValue{Remove: true},
+			"b": common.InlineSecureValue{Remove: true}, // b does not exist in previous value
 		})
 
 		// Previous values must exist for remove to execute
 		info := &objectForStorage{}
 		err := prepareSecureValues(context.Background(), secureStore, obj, resourceWithSecureValues(nil), info)
-		require.Error(t, err, "should error when previous secure values does not exist")
-		require.Equal(t, "cannot remove secure value 'b', it did not exist in the previous value", err.Error())
+		require.NotNil(t, err, "should noop when previous value does not exist")
 		secureStore.AssertExpectations(t)
 	})
 


### PR DESCRIPTION
Rather than returning a 500 error when requesting to remove a secure value that does not exist, this ignores the request -- it is already removed.