### PR TITLE
IAM: Handle NULL team_member.external column to fix dashboard loading

### DIFF
--- a/pkg/registry/apis/iam/legacy/team_binding.go
+++ b/pkg/registry/apis/iam/legacy/team_binding.go
@@ -2,7 +2,7 @@ package legacy
 
 import (
 	"context"
-	"database/sql"
+	stdsql "database/sql"
 	"fmt"
 	"time"
 
@@ -119,9 +119,13 @@ func (s *legacySQLStore) ListTeamBindings(ctx context.Context, ns claims.Namespa
 
 	for rows.Next() {
 		m := TeamMember{}
-		err = rows.Scan(&m.ID, &m.UID, &m.TeamUID, &m.TeamID, &m.UserUID, &m.UserID, &m.Created, &m.Updated, &m.Permission, &m.External)
+		var nullableExternal stdsql.NullBool
+		err = rows.Scan(&m.ID, &m.UID, &m.TeamUID, &m.TeamID, &m.UserUID, &m.UserID, &m.Created, &m.Updated, &m.Permission, &nullableExternal)
 		if err != nil {
 			return res, err
+		}
+		if nullableExternal.Valid {
+			m.External = nullableExternal.Bool
 		}
 
 		res.Bindings = append(res.Bindings, m)
@@ -437,8 +441,12 @@ func (s *legacySQLStore) DeleteTeamMember(ctx context.Context, ns claims.Namespa
 	return nil
 }
 
-func scanMember(rows *sql.Rows) (TeamMember, error) {
+func scanMember(rows *stdsql.Rows) (TeamMember, error) {
 	m := TeamMember{}
-	err := rows.Scan(&m.ID, &m.UID, &m.TeamUID, &m.TeamID, &m.UserUID, &m.UserID, &m.Name, &m.Email, &m.Username, &m.External, &m.Created, &m.Updated, &m.Permission)
+	var nullableExternal stdsql.NullBool
+	err := rows.Scan(&m.ID, &m.UID, &m.TeamUID, &m.TeamID, &m.UserUID, &m.UserID, &m.Name, &m.Email, &m.Username, &nullableExternal, &m.Created, &m.Updated, &m.Permission)
+	if nullableExternal.Valid {
+		m.External = nullableExternal.Bool
+	}
 	return m, err
 }

--- a/pkg/registry/apis/iam/legacy/user.go
+++ b/pkg/registry/apis/iam/legacy/user.go
@@ -2,6 +2,7 @@ package legacy
 
 import (
 	"context"
+	stdsql "database/sql"
 	"errors"
 	"fmt"
 	"text/template"
@@ -267,10 +268,11 @@ func (s *legacySQLStore) ListUserTeams(ctx context.Context, ns claims.NamespaceI
 	for rows.Next() {
 		t := UserTeam{}
 
-		// regression: team_member.permission has been nulled in some instances
-		// Team memberships created before the permission column was added will have a NULL value
+		// regression: team_member.permission and team_member.external have been nulled in some instances
+		// Team memberships created before the permission/external columns were added will have NULL values
 		var nullablePermission *int64
-		err := rows.Scan(&t.ID, &t.UID, &t.Name, &nullablePermission, &t.External)
+		var nullableExternal stdsql.NullBool
+		err := rows.Scan(&t.ID, &t.UID, &t.Name, &nullablePermission, &nullableExternal)
 		if err != nil {
 			return nil, err
 		}
@@ -280,6 +282,10 @@ func (s *legacySQLStore) ListUserTeams(ctx context.Context, ns claims.NamespaceI
 		} else {
 			// treat NULL as member permission
 			t.Permission = team.PermissionType(0)
+		}
+
+		if nullableExternal.Valid {
+			t.External = nullableExternal.Bool
 		}
 
 		res.Items = append(res.Items, t)


### PR DESCRIPTION
## Summary
- Fix `team_member.external` column scan failure when the column contains NULL values
- The column was defined as `Nullable` in the DB migration but was scanned directly into a Go `bool`, causing `sql.Scan` errors
- Use `sql.NullBool` for scanning, matching the existing pattern used for `is_provisioned` in `team.go`
- This caused "could not get user teams" errors and prevented all dashboards from loading after upgrading to v12.4

Fixes #119313