### PR TITLE
ToolbarButton: Fix text overflow causing overlap with adjacent elements

### DIFF
--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
@@ -252,6 +252,9 @@ const getStyles = (theme: GrafanaTheme2) => {
     contentWithIcon: css({
       display: 'none',
       paddingLeft: theme.spacing(1),
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      minWidth: 0,
 
       [`@media ${mediaUp(theme.v1.breakpoints.md)}`]: {
         display: 'block',


### PR DESCRIPTION
Fixes #119789

## What is this feature?

This PR fixes a UI issue where the German translation of the "Refresh" button text ("Aktualisieren") was overlapping with the adjacent refresh rate dropdown in the dashboard toolbar.

## Why do we need this feature?

In Grafana 12.4, users with German locale enabled noticed that the Refresh button text was overflowing and overlapping with the refresh interval dropdown. This was caused by longer translated text not being properly constrained within the button's content area.

The root cause was that the `contentWithIcon` style in `ToolbarButton` component allowed text content to expand without any overflow handling, causing it to overlap with adjacent elements in button groups.

## Who is this feature for?

This fix benefits all users who use Grafana with non-English locales where translations may be longer than the original English text, particularly:
- German users (de-DE)
- Any locale with longer button text translations

## Changes

- Added `overflow: hidden` to prevent text from overflowing the button content area
- Added `textOverflow: ellipsis` to show ellipsis (...) when text is truncated
- Added `minWidth: 0` to allow flexbox to properly shrink the content when needed (required for text-overflow to work in flex containers)

**File changed:**
- `packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx`

## Testing

The fix was implemented by adding CSS properties that are standard for handling text overflow:
1. `overflow: hidden` - hides content that overflows the element's box
2. `textOverflow: ellipsis` - displays an ellipsis when text overflows
3. `minWidth: 0` - allows flex items to shrink below their minimum content size

These changes ensure that when button text is too long for the available space, it will be truncated with an ellipsis instead of overflowing into adjacent elements.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A - this is a bug fix)
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc. (N/A - this is a bug fix)

## Diff stats

```
 packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx | 3 +++
 1 file changed, 3 insertions(+)
```