### PR TITLE
fix: disable migrations when target is not all or core

### DIFF
--- a/pkg/storage/unified/migrations/service.go
+++ b/pkg/storage/unified/migrations/service.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
@@ -55,11 +56,24 @@ func ProvideUnifiedStorageMigrationService(
 	}
 }
 
+func isTargetEligibleForMigrations(targets []string) bool {
+	return slices.Contains(targets, "all") || slices.Contains(targets, "core")
+}
+
+func (p *UnifiedStorageMigrationServiceImpl) shouldSkipMigrations() bool {
+	return p.cfg.DisableDataMigrations ||
+		p.cfg.UnifiedStorageType() != "unified" ||
+		!isTargetEligibleForMigrations(p.cfg.Target)
+}
+
 func (p *UnifiedStorageMigrationServiceImpl) Run(ctx context.Context) error {
-	// skip migrations if disabled in config or storage type is not "unified"
-	if p.cfg.DisableDataMigrations || p.cfg.UnifiedStorageType() != "unified" {
+	if p.shouldSkipMigrations() {
 		metrics.MUnifiedStorageMigrationStatus.Set(1)
-		logger.Info("Data migrations are disabled, skipping", "disableDataMigrations", p.cfg.DisableDataMigrations, "unifiedStorageType", p.cfg.UnifiedStorageType())
+		logger.Info("Data migrations are disabled, skipping",
+			"disableDataMigrations", p.cfg.DisableDataMigrations,
+			"unifiedStorageType", p.cfg.UnifiedStorageType(),
+			"target", p.cfg.Target,
+		)
 		return nil
 	}
 

--- a/pkg/storage/unified/migrations/service.go
+++ b/pkg/storage/unified/migrations/service.go
@@ -60,14 +60,14 @@ func isTargetEligibleForMigrations(targets []string) bool {
 	return slices.Contains(targets, "all") || slices.Contains(targets, "core")
 }
 
-func (p *UnifiedStorageMigrationServiceImpl) shouldSkipMigrations() bool {
-	return p.cfg.DisableDataMigrations ||
-		p.cfg.UnifiedStorageType() != "unified" ||
-		!isTargetEligibleForMigrations(p.cfg.Target)
+func (p *UnifiedStorageMigrationServiceImpl) shouldRunMigrations() bool {
+	return !p.cfg.DisableDataMigrations &&
+		p.cfg.UnifiedStorageType() == "unified" &&
+		isTargetEligibleForMigrations(p.cfg.Target)
 }
 
 func (p *UnifiedStorageMigrationServiceImpl) Run(ctx context.Context) error {
-	if p.shouldSkipMigrations() {
+	if !p.shouldRunMigrations() {
 		metrics.MUnifiedStorageMigrationStatus.Set(1)
 		logger.Info("Data migrations are disabled, skipping",
 			"disableDataMigrations", p.cfg.DisableDataMigrations,

--- a/pkg/storage/unified/migrations/service_test.go
+++ b/pkg/storage/unified/migrations/service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/metrics"
@@ -34,6 +35,18 @@ func TestUnifiedStorageMigrationServiceImpl_Run_SkipsMigrations(t *testing.T) {
 				cfg.DisableDataMigrations = true
 			},
 		},
+		{
+			name: "target is not all or core",
+			cfgFunc: func(cfg *setting.Cfg) {
+				cfg.Target = []string{"storage-server"}
+			},
+		},
+		{
+			name: "target is empty",
+			cfgFunc: func(cfg *setting.Cfg) {
+				cfg.Target = []string{}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -52,6 +65,28 @@ func TestUnifiedStorageMigrationServiceImpl_Run_SkipsMigrations(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, float64(1), testutil.ToFloat64(metrics.MUnifiedStorageMigrationStatus))
 			migrator.AssertNotCalled(t, "Migrate")
+		})
+	}
+}
+
+func TestIsTargetEligibleForMigrations(t *testing.T) {
+	tests := []struct {
+		name     string
+		targets  []string
+		expected bool
+	}{
+		{name: "all target", targets: []string{"all"}, expected: true},
+		{name: "core target", targets: []string{"core"}, expected: true},
+		{name: "all among multiple targets", targets: []string{"storage-server", "all"}, expected: true},
+		{name: "core among multiple targets", targets: []string{"storage-server", "core"}, expected: true},
+		{name: "storage-server only", targets: []string{"storage-server"}, expected: false},
+		{name: "empty targets", targets: []string{}, expected: false},
+		{name: "other target", targets: []string{"search-server-distributor"}, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isTargetEligibleForMigrations(tt.targets))
 		})
 	}
 }


### PR DESCRIPTION
Disable unified storage migrations when the grafana target is not `all` or `core`. This would enable us to get rid of the `disable_data_migrations` usage from the storage/search servers and other services that do not rely on the default targets.

Ticket: https://github.com/grafana/search-and-storage-team/issues/660