### PR TITLE
Provisioning: add some integration tests, checking for folder metadata restrictions

### DIFF
--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -1285,6 +1285,40 @@ func TestIntegrationProvisioning_FolderMetadataFileProtection(t *testing.T) {
 		uid, _, _ := unstructured.NestedString(wrapObj.Object, "resource", "file", "metadata", "name")
 		require.NotEmpty(t, uid)
 	})
+
+	t.Run("POST to root _folder.json is blocked", func(t *testing.T) {
+		body := []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"root-uid"},"spec":{"title":"root"}}`)
+		req, err := http.NewRequest(http.MethodPost, filesURL("_folder.json"), bytes.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode, "direct POST to root _folder.json must be blocked")
+	})
+
+	t.Run("PUT to root _folder.json is blocked", func(t *testing.T) {
+		body := []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"root-uid"},"spec":{"title":"root"}}`)
+		req, err := http.NewRequest(http.MethodPut, filesURL("_folder.json"), bytes.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode, "PUT to root _folder.json must be blocked")
+	})
+
+	t.Run("DELETE of root _folder.json is blocked", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodDelete, filesURL("_folder.json"), nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode, "DELETE of root _folder.json must be blocked")
+	})
 }
 
 func TestIntegrationProvisioning_FolderAuthorizationWithMetadata(t *testing.T) {

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -1286,39 +1286,34 @@ func TestIntegrationProvisioning_FolderMetadataFileProtection(t *testing.T) {
 		require.NotEmpty(t, uid)
 	})
 
-	t.Run("POST to root _folder.json is blocked", func(t *testing.T) {
-		body := []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"root-uid"},"spec":{"title":"root"}}`)
-		req, err := http.NewRequest(http.MethodPost, filesURL("_folder.json"), bytes.NewReader(body))
-		require.NoError(t, err)
-		req.Header.Set("Content-Type", "application/json")
-		resp, err := http.DefaultClient.Do(req)
-		require.NoError(t, err)
-		// nolint:errcheck
-		defer resp.Body.Close()
-		require.Equal(t, http.StatusForbidden, resp.StatusCode, "direct POST to root _folder.json must be blocked")
-	})
+	rootFolderBody := []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"root-uid"},"spec":{"title":"root"}}`)
 
-	t.Run("PUT to root _folder.json is blocked", func(t *testing.T) {
-		body := []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"root-uid"},"spec":{"title":"root"}}`)
-		req, err := http.NewRequest(http.MethodPut, filesURL("_folder.json"), bytes.NewReader(body))
-		require.NoError(t, err)
-		req.Header.Set("Content-Type", "application/json")
-		resp, err := http.DefaultClient.Do(req)
-		require.NoError(t, err)
-		// nolint:errcheck
-		defer resp.Body.Close()
-		require.Equal(t, http.StatusForbidden, resp.StatusCode, "PUT to root _folder.json must be blocked")
-	})
-
-	t.Run("DELETE of root _folder.json is blocked", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodDelete, filesURL("_folder.json"), nil)
-		require.NoError(t, err)
-		resp, err := http.DefaultClient.Do(req)
-		require.NoError(t, err)
-		// nolint:errcheck
-		defer resp.Body.Close()
-		require.Equal(t, http.StatusForbidden, resp.StatusCode, "DELETE of root _folder.json must be blocked")
-	})
+	for _, tc := range []struct {
+		name   string
+		method string
+		body   []byte
+	}{
+		{name: "POST to root _folder.json is blocked", method: http.MethodPost, body: rootFolderBody},
+		{name: "PUT to root _folder.json is blocked", method: http.MethodPut, body: rootFolderBody},
+		{name: "DELETE of root _folder.json is blocked", method: http.MethodDelete},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var bodyReader io.Reader
+			if tc.body != nil {
+				bodyReader = bytes.NewReader(tc.body)
+			}
+			req, err := http.NewRequest(tc.method, filesURL("_folder.json"), bodyReader)
+			require.NoError(t, err)
+			if tc.body != nil {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			// nolint:errcheck
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusForbidden, resp.StatusCode)
+		})
+	}
 }
 
 func TestIntegrationProvisioning_FolderAuthorizationWithMetadata(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Adds few integration tests related to folder metadata restrictions

**Why do we need this feature?**

We want to prevent all operations on `_folder.json` metadata file in the Repository root folder, as that should not be there. 

**Who is this feature for?**

Developers of GitSync feature

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
