### PR TITLE
CI: Reduce E2E startup timeout and log server errors

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -229,12 +229,15 @@ jobs:
 
       - name: Wait for Grafana server to start
         run: |
-          timeout=180
+          timeout=60
           elapsed=0
           printf "Waiting for Grafana to start"
           while ! curl -s -f http://localhost:3001/health > /dev/null 2>&1; do
             if [ $elapsed -ge $timeout ]; then
-              printf "\nTimeout after %d seconds waiting for Grafana\n" "$timeout"
+              printf "\n\n--- Grafana server logs ---\n"
+              cat grafana-server/grafana.log
+              printf "\n--- End of Grafana server logs ---\n\n"
+              printf "Timeout after %d seconds waiting for Grafana\n" "$timeout"
               exit 1
             fi
             printf "."


### PR DESCRIPTION
## Summary

Reduce the Grafana server startup timeout from 180 to 60 seconds in the E2E tests workflow. When the server fails to start, output the server logs before the timeout message for easier debugging.

---

**What is this feature?**

Faster timeout and improved error logging for E2E test server startup failures.

**Why do we need this feature?**

Failing tests should complete faster and provide more immediate visibility into what went wrong during server startup.

**Who is this feature for?**

Contributors and CI/CD workflows running E2E tests.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.