### PR TITLE
fix: remove hardcoded team allowlist from digest validation

### DIFF
--- a/.github/workflows/external-fr-weekly-digest.yml
+++ b/.github/workflows/external-fr-weekly-digest.yml
@@ -37,12 +37,7 @@ jobs:
         run: |
           echo "::notice::Manual trigger by $ACTOR"
           if [ -n "$TEAM_FILTER" ]; then
-            ALLOWED_TEAMS="alerting dashboard"
-            if [[ ! " $ALLOWED_TEAMS " == *" $TEAM_FILTER "* ]]; then
-              echo "::error::Invalid team_filter: $TEAM_FILTER. Allowed values: $ALLOWED_TEAMS (or empty for all)"
-              exit 1
-            fi
-            echo "::notice::Team filter validated: $TEAM_FILTER"
+            echo "::notice::Team filter: $TEAM_FILTER"
           else
             echo "::notice::No team filter - will process all enabled teams"
           fi

--- a/.github/workflows/external-pr-weekly-digest.yml
+++ b/.github/workflows/external-pr-weekly-digest.yml
@@ -42,12 +42,7 @@ jobs:
         run: |
           echo "::notice::Manual trigger by $ACTOR"
           if [ -n "$TEAM_FILTER" ]; then
-            ALLOWED_TEAMS="alerting dashboard"
-            if [[ ! " $ALLOWED_TEAMS " == *" $TEAM_FILTER "* ]]; then
-              echo "::error::Invalid team_filter: $TEAM_FILTER. Allowed values: $ALLOWED_TEAMS (or empty for all)"
-              exit 1
-            fi
-            echo "::notice::Team filter validated: $TEAM_FILTER"
+            echo "::notice::Team filter: $TEAM_FILTER"
           else
             echo "::notice::No team filter - will process all enabled teams"
           fi


### PR DESCRIPTION
## Summary

- The `team_filter` validation step in both digest workflows had a hardcoded `ALLOWED_TEAMS` list (`alerting dashboard`) that was out of sync with the actual config
- This blocked manual `workflow_dispatch` triggers for newly onboarded teams (e.g. `dataviz`)
- Removed the static allowlist — team validity is already handled at runtime by the config file

## Test plan

- [ ] Run FR weekly digest with `team_filter: dataviz` via workflow_dispatch
- [ ] Run PR weekly digest with `team_filter: dataviz` via workflow_dispatch
- [ ] Run both with empty team_filter (all teams)


Made with [Cursor](https://cursor.com)