### PR TITLE
Alerting: Link to notification history page from contact points

### DIFF
--- a/public/app/features/alerting/unified/components/contact-points/ContactPointHeader.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPointHeader.tsx
@@ -3,6 +3,7 @@ import { Fragment, type JSX, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { Dropdown, LinkButton, Menu, Stack, Text, TextLink, Tooltip, useStyles2 } from '@grafana/ui';
 import ConditionalWrap from 'app/features/alerting/unified/components/ConditionalWrap';
 import { useExportContactPoint } from 'app/features/alerting/unified/components/contact-points/useExportContactPoint';
@@ -32,7 +33,7 @@ interface ContactPointHeaderProps {
 }
 
 export const ContactPointHeader = ({ contactPoint, onDelete }: ContactPointHeaderProps) => {
-  const { name, id, provenance, policies = [] } = contactPoint;
+  const { name, id, provenance, policies = [], grafana_managed_receiver_configs: integrations } = contactPoint;
   const styles = useStyles2(getStyles);
   const [showPermissionsDrawer, setShowPermissionsDrawer] = useState(false);
   const { selectedAlertmanager } = useAlertmanager();
@@ -215,6 +216,27 @@ export const ContactPointHeader = ({ contactPoint, onDelete }: ContactPointHeade
         {isProvisioned && <ProvisioningBadge tooltip provenance={provenance} />}
         {!isReferencedByAnything && <UnusedContactPointBadge />}
         <Spacer />
+        {config.featureToggles.alertingNotificationHistoryGlobal && (
+          <LinkButton
+            variant="secondary"
+            size="sm"
+            icon="history"
+            type="button"
+            disabled={integrations.length === 0}
+            tooltip={t(
+              'alerting.contact-point-header.tooltip-history',
+              'View the history of notification attempts made to this contact point'
+            )}
+            tooltipPlacement="top"
+            data-testid="history-action"
+            href={createRelativeUrl('/alerting/history', {
+              tab: 'notifications',
+              'var-RECEIVER_FILTER': name,
+            })}
+          >
+            {t('alerting.contact-point-header.button-history', 'History')}
+          </LinkButton>
+        )}
         <LinkButton
           tooltipPlacement="top"
           tooltip={

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -897,11 +897,13 @@
       "aria-label-more-actions": "More actions for contact point \"{{contactPointName}}\"",
       "ariaLabel-delete": "Delete",
       "button-edit": "Edit",
+      "button-history": "History",
       "button-view": "View",
       "export-ariaLabel-export": "Export",
       "export-label-export": "Export",
       "label-delete": "Delete",
       "label-manage-permissions": "Manage permissions",
+      "tooltip-history": "View the history of notification attempts made to this contact point",
       "tooltip-provisioned-contact-points": "Provisioned contact points cannot be edited in the UI"
     },
     "contact-point-selector": {


### PR DESCRIPTION
Adds a link to the notifications tab of the History page for contact points
that have integrations. Gated on `alertingNotificationHistoryGlobal` toggle.
