### PR TITLE
Influx: Add downstream error source for failing requests

### DIFF
--- a/pkg/tsdb/influxdb/influxql/influxql.go
+++ b/pkg/tsdb/influxdb/influxql/influxql.go
@@ -202,7 +202,8 @@ func execute(ctx context.Context, tracer trace.Tracer, dsInfo *models.Datasource
 	res, err := dsInfo.HTTPClient.Do(request)
 	if err != nil {
 		return backend.DataResponse{
-			Error: err,
+			Error:       err,
+			ErrorSource: backend.ErrorSourceDownstream,
 		}, err
 	}
 	defer func() {


### PR DESCRIPTION
Add a missing error source for failing InfluxQL requests.