### PR TITLE
Unified Storage: Fix deadlock in broadcaster on slow consumer unsubscribe

### DIFF
--- a/pkg/storage/unified/resource/broadcaster.go
+++ b/pkg/storage/unified/resource/broadcaster.go
@@ -155,11 +155,13 @@ func (b *broadcaster[T]) Unsubscribe(sub <-chan T) {
 	}
 }
 
+const chanBufferLen = 100
+
 // init initializes the broadcaster. It should not be run more than once.
 func (b *broadcaster[T]) init(ctx context.Context, connect ConnectFunc[T]) error {
 	// create the stream that will connect us with the watch implementation and
 	// send it to them so they initialize and start sending data
-	stream := make(chan T, 100)
+	stream := make(chan T, chanBufferLen)
 	if err := connect(stream); err != nil {
 		return err
 	}
@@ -167,8 +169,8 @@ func (b *broadcaster[T]) init(ctx context.Context, connect ConnectFunc[T]) error
 	// initialize our internal state
 	b.shouldTerminate = ctx.Done()
 	b.cache = newChannelCache[T](ctx, 100)
-	b.subscribe = make(chan chan T, 100)
-	b.unsubscribe = make(chan (<-chan T), 100)
+	b.subscribe = make(chan chan T, chanBufferLen)
+	b.unsubscribe = make(chan (<-chan T), chanBufferLen)
 	b.subs = make(map[<-chan T]chan T)
 	b.terminated = make(chan struct{})
 
@@ -201,6 +203,13 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 		}
 	}()
 
+	unsubscribe := func(recv <-chan T) {
+		if sub, ok := b.subs[recv]; ok {
+			close(sub)
+			delete(b.subs, sub)
+		}
+	}
+
 	for {
 		select {
 		case <-b.shouldTerminate: // service context cancelled
@@ -216,10 +225,7 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 			b.subs[sub] = sub
 
 		case recv := <-b.unsubscribe: // unsubscribe
-			if sub, ok := b.subs[recv]; ok {
-				close(sub)
-				delete(b.subs, sub)
-			}
+			unsubscribe(recv)
 
 		case item, ok := <-input: // data arrived, send to subscribers
 			// input closed, drain subscribers and exit
@@ -227,13 +233,20 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 				return
 			}
 			b.cache.Add(item)
+
+			var slow []<-chan T
 			for _, sub := range b.subs {
 				select {
 				case sub <- item:
 				default:
-					// Slow consumer, drop
-					b.unsubscribe <- sub
+					slow = append(slow, sub)
 				}
+			}
+			// Instead of sending subscribers to a b.unsubscribe channel, we unsubscribe directly.
+			// Sending to b.unsubscribe could lead to deadlock, if there are too many elements in the
+			// channel buffer already.
+			for _, recv := range slow {
+				unsubscribe(recv)
 			}
 		}
 	}

--- a/pkg/storage/unified/resource/broadcaster_test.go
+++ b/pkg/storage/unified/resource/broadcaster_test.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -141,4 +142,50 @@ func TestBroadcaster(t *testing.T) {
 	cancel()
 	_, ok := <-sub
 	require.False(t, ok)
+}
+
+func TestBroadcasterSlowConsumerDeadlock(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan int)
+	b, err := NewBroadcaster(ctx, func(out chan<- int) error {
+		go func() {
+			defer close(out)
+			for v := range ch {
+				out <- v
+			}
+		}()
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Create 101 subscribers that never read — more than the
+	// unsubscribe channel buffer (100) in the original code.
+	const numSubs = chanBufferLen + 1
+	for i := 0; i < numSubs; i++ {
+		_, err := b.Subscribe(ctx)
+		require.NoError(t, err)
+	}
+
+	// Fill all subscriber buffers (each buffered at 100), and keep sending more elements.
+	//
+	// Since all subscribers are slow, they should get unsubscribed
+	// eventually. In the original code, unsubscribing buf size + 1 subscribers would deadlock.
+	// Use a timeout to detect the deadlock.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 10*chanBufferLen; i++ {
+			ch <- i
+		}
+
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success — no deadlock.
+	case <-time.After(5 * time.Second):
+		t.Fatal("deadlock: stream() blocked trying to unsubscribe slow consumers")
+	}
 }


### PR DESCRIPTION
The broadcast loop in `stream()` could deadlock when unsubscribing slow consumers by sending to `b.unsubscribe`, which is only drained by the same goroutine. With >100 slow consumers, the buffered channel fills and the send blocks forever. Fix by collecting slow consumers and removing them inline after the broadcast loop.