### PR TITLE
ci: increase Sqlite Enterprise integration tests from 4 to 16 parallel jobs

### DIFF
--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -250,9 +250,11 @@ jobs:
     if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && needs.detect-changes.outputs.changed == 'true')
     strategy:
       matrix:
-        # We don't need more than this since it has to wait for the other tests.
         shard: [
-          1/4, 2/4, 3/4, 4/4,
+           1/16,  2/16,  3/16,  4/16,
+           5/16,  6/16,  7/16,  8/16,
+           9/16, 10/16, 11/16, 12/16,
+          13/16, 14/16, 15/16, 16/16,
           profiled,
         ]
       fail-fast: false


### PR DESCRIPTION
Increases parallel jobs for Sqlite Enterprise integration tests from 4 to 16, matching Postgres and MySQL.

The tool we use to split test execution distributes tests by package. With only 4 jobs, some of the slowest packages can end up in the same shard. For example, in a recent run these two landed together:

```
ok  	github.com/grafana/grafana/pkg/tests/apis/dashboard/integration	266.356s
ok  	github.com/grafana/grafana/pkg/tests/apis/provisioning	342.108s
```

That's ~10 minutes of sequential test time in a single job. With 16 shards these heavy packages get spread across different jobs, significantly reducing wall-clock time.

Example of a slow run:
https://github.com/grafana/grafana/actions/runs/22903944605/job/66461403174?pr=119880


Before: 

<img width="963" height="190" alt="Screenshot 2026-03-10 at 15 07 31" src="https://github.com/user-attachments/assets/4aec0844-6477-48b0-98a5-9bb7e29687e2" />

After: 

The slowest was 9 minutes in this PR. 