### PR TITLE
fix: pass PR digest data via temp file to avoid ARG_MAX limit

### DIFF
--- a/.github/workflows/external-pr-weekly-digest.yml
+++ b/.github/workflows/external-pr-weekly-digest.yml
@@ -79,20 +79,20 @@ jobs:
         run: node --experimental-strip-types .github/workflows/scripts/pr-digest.mts fetch
 
       - name: Process teams and send reports
+        if: steps.fetch-prs.outputs.external_prs == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           OPENAI_API_KEY: ${{ env.OPENAI_API_KEY }}
           STALE_DAYS: ${{ env.STALE_THRESHOLD_DAYS }}
           REPO: ${{ github.repository }}
-          ALL_PRS: ${{ steps.fetch-prs.outputs.all_prs }}
-          EXTERNAL_PRS: ${{ steps.fetch-prs.outputs.external_prs }}
+          DATA_FILE: ${{ steps.fetch-prs.outputs.data_file }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
           TEAM_FILTER: ${{ inputs.team_filter || '' }}
           SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
         run: node --experimental-strip-types .github/workflows/scripts/pr-digest.mts process
 
       - name: No PRs summary
-        if: steps.fetch-prs.outputs.external_prs == '[]'
+        if: steps.fetch-prs.outputs.external_prs != 'true'
         run: |
           echo "No open external PRs found."
           echo "Skipping Slack notification."

--- a/.github/workflows/scripts/pr-digest.mts
+++ b/.github/workflows/scripts/pr-digest.mts
@@ -1,7 +1,10 @@
 import { execFileSync } from 'node:child_process';
+import { writeFileSync, readFileSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 import {
-  loadConfig, requireEnv, log, setOutput, setOutputMultiline,
+  loadConfig, requireEnv, log, setOutput,
   sanitizeInput, sanitizeForSlack, isValidIssueNumber,
   parseCodeowners, matchFilesToCodeownersTeams,
   validatePRClusterResponse, callOpenAI, sendSlackMessage, teamChannelEnv,
@@ -58,10 +61,14 @@ function fetchPrs(): void {
     (pr) => pr.labels.some((l) => l.name === 'pr/external'),
   );
 
-  setOutputMultiline('all_prs', JSON.stringify(allPrs));
-  setOutputMultiline('external_prs', JSON.stringify(externalPrs));
+  const dataDir = mkdtempSync(join(tmpdir(), 'pr-digest-'));
+  const dataFile = join(dataDir, 'prs.json');
+  writeFileSync(dataFile, JSON.stringify(allPrs));
+  setOutput('data_file', dataFile);
+  setOutput('external_prs', JSON.stringify(externalPrs.length > 0 ? true : false));
 
   console.log(`Total open PRs: ${allPrs.length} (External: ${externalPrs.length})`);
+  console.log(`Data written to: ${dataFile}`);
 }
 
 // =============================================================================
@@ -132,9 +139,9 @@ async function processTeams(): Promise<void> {
   const slackBotToken = process.env.SLACK_BOT_TOKEN ?? '';
   const dryRun = process.env.DRY_RUN === 'true';
   const teamFilter = process.env.TEAM_FILTER ?? '';
-  const allPrsRaw = process.env.ALL_PRS ?? '[]';
+  const dataFile = requireEnv('DATA_FILE');
 
-  const allPrs: PRData[] = JSON.parse(allPrsRaw);
+  const allPrs: PRData[] = JSON.parse(readFileSync(dataFile, 'utf-8'));
   const config = loadConfig();
   const codeownersEntries = parseCodeowners();
   const link = (n: number) => prLink(repo, n);


### PR DESCRIPTION
## Summary

- The PR weekly digest crashes on `grafana/grafana` with `Argument list too long` because the full PR JSON (thousands of PRs) is passed through GitHub Actions outputs and env vars, exceeding the shell `ARG_MAX` limit
- Fix: write PR data to a temp file in the fetch step and read it back in the process step



Made with [Cursor](https://cursor.com)