### PR TITLE
Chore: Remove full path helpers from generic metadata

### DIFF
--- a/pkg/apimachinery/utils/meta.go
+++ b/pkg/apimachinery/utils/meta.go
@@ -112,11 +112,6 @@ type GrafanaMetaAccessor interface {
 	// Deprecated: This should only be used to support legacy /api endpoints that need to return internal IDs. Those endpoints should be marked as deprecated and once they are removed, this will be too
 	SetDeprecatedInternalID(id int64)
 
-	GetFullpath() string
-	SetFullpath(path string)
-	GetFullpathUIDs() string
-	SetFullpathUIDs(uids string)
-
 	GetSpec() (any, error)
 	SetSpec(any) error
 
@@ -338,22 +333,6 @@ func (m *grafanaMetaAccessor) SetDeprecatedInternalID(id int64) {
 
 	labels[LabelKeyDeprecatedInternalID] = strconv.FormatInt(id, 10)
 	m.obj.SetLabels(labels)
-}
-
-func (m *grafanaMetaAccessor) GetFullpath() string {
-	return m.GetAnnotation(AnnoKeyFullpath)
-}
-
-func (m *grafanaMetaAccessor) SetFullpath(path string) {
-	m.SetAnnotation(AnnoKeyFullpath, path)
-}
-
-func (m *grafanaMetaAccessor) GetFullpathUIDs() string {
-	return m.GetAnnotation(AnnoKeyFullpathUIDs)
-}
-
-func (m *grafanaMetaAccessor) SetFullpathUIDs(uids string) {
-	m.SetAnnotation(AnnoKeyFullpathUIDs, uids)
 }
 
 // GetAnnotations implements GrafanaMetaAccessor.

--- a/pkg/registry/apis/folders/conversions.go
+++ b/pkg/registry/apis/folders/conversions.go
@@ -86,7 +86,7 @@ func convertToK8sResource(v *folder.Folder, namespacer request.NamespaceMapper) 
 	}
 
 	if v.FullpathUIDs != "" {
-		meta.SetAnnotation(utils.AnnoKeyFullpath, v.FullpathUIDs)
+		meta.SetAnnotation(utils.AnnoKeyFullpathUIDs, v.FullpathUIDs)
 	}
 
 	if v.CreatedBy != 0 {

--- a/pkg/registry/apis/folders/conversions.go
+++ b/pkg/registry/apis/folders/conversions.go
@@ -82,11 +82,11 @@ func convertToK8sResource(v *folder.Folder, namespacer request.NamespaceMapper) 
 	// as the only user identifier
 
 	if v.Fullpath != "" {
-		meta.SetFullpath(v.Fullpath)
+		meta.SetAnnotation(utils.AnnoKeyFullpath, v.Fullpath)
 	}
 
 	if v.FullpathUIDs != "" {
-		meta.SetFullpathUIDs(v.FullpathUIDs)
+		meta.SetAnnotation(utils.AnnoKeyFullpath, v.FullpathUIDs)
 	}
 
 	if v.CreatedBy != 0 {

--- a/pkg/registry/apis/folders/legacy_storage_test.go
+++ b/pkg/registry/apis/folders/legacy_storage_test.go
@@ -214,7 +214,7 @@ func TestLegacyStorage_List_LabelSelector(t *testing.T) {
 		require.NoError(t, err)
 
 		// make sure the annotations are set
-		require.Equal(t, "/Folder 1", meta.GetFullpath())
-		require.Equal(t, "/folder-1", meta.GetFullpathUIDs())
+		require.Equal(t, "/Folder 1", meta.GetAnnotation(utils.AnnoKeyFullpath))
+		require.Equal(t, "/folder-1", meta.GetAnnotation(utils.AnnoKeyFullpathUIDs))
 	})
 }

--- a/pkg/services/folder/folderimpl/conversions.go
+++ b/pkg/services/folder/folderimpl/conversions.go
@@ -72,8 +72,8 @@ func convertUnstructuredToFolder(item *unstructured.Unstructured, identifiers ma
 		Version:     int(meta.GetGeneration()),
 		ManagedBy:   manager.Kind,
 
-		Fullpath:     meta.GetFullpath(),
-		FullpathUIDs: meta.GetFullpathUIDs(),
+		Fullpath:     meta.GetAnnotation(utils.AnnoKeyFullpath),
+		FullpathUIDs: meta.GetAnnotation(utils.AnnoKeyFullpathUIDs),
 		URL:          url,
 		Created:      created,
 		Updated:      *updated,


### PR DESCRIPTION
Folders sometimes put their full path in an annotation... this moves that support to an explicit folder attribute