### PR TITLE
Dashboards: Use more lenient schema validation with the legacy API

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -610,7 +610,7 @@ func (hs *HTTPServer) saveDashboardViaK8s(c *contextmodel.ReqContext, cmd dashbo
 		}
 	}
 
-	validation := "Strict"
+	validation := "Warn"
 	if strings.HasPrefix(gv.Version, "v0") {
 		validation = "Ignore" // v0 can be anything
 	}
@@ -625,7 +625,7 @@ func (hs *HTTPServer) saveDashboardViaK8s(c *contextmodel.ReqContext, cmd dashbo
 		})
 	}
 	if err != nil {
-		return response.Error(http.StatusInternalServerError, "Failed to save dashboard", err)
+		return apierrors.ToDashboardErrorResponse(ctx, hs.pluginStore, err)
 	}
 
 	meta, err = utils.MetaAccessor(dash)


### PR DESCRIPTION
Use warn rather than strict