### PR TITLE
Dashboard: Fix case-insensitive and natural variable sort orders not saving

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/v1_to_v2alpha1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1_to_v2alpha1.go
@@ -988,6 +988,14 @@ func transformVariableSortToEnum(sort interface{}) dashv2alpha1.DashboardVariabl
 			return dashv2alpha1.DashboardVariableSortNumericalAsc
 		case 4:
 			return dashv2alpha1.DashboardVariableSortNumericalDesc
+		case 5:
+			return dashv2alpha1.DashboardVariableSortAlphabeticalCaseInsensitiveAsc
+		case 6:
+			return dashv2alpha1.DashboardVariableSortAlphabeticalCaseInsensitiveDesc
+		case 7:
+			return dashv2alpha1.DashboardVariableSortNaturalAsc
+		case 8:
+			return dashv2alpha1.DashboardVariableSortNaturalDesc
 		default:
 			return dashv2alpha1.DashboardVariableSortDisabled
 		}

--- a/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.test.ts
@@ -47,6 +47,10 @@ describe('transformToV2TypesUtils', () => {
       expect(transformSortVariableToEnum(2)).toBe('alphabeticalDesc');
       expect(transformSortVariableToEnum(3)).toBe('numericalAsc');
       expect(transformSortVariableToEnum(4)).toBe('numericalDesc');
+      expect(transformSortVariableToEnum(5)).toBe('alphabeticalCaseInsensitiveAsc');
+      expect(transformSortVariableToEnum(6)).toBe('alphabeticalCaseInsensitiveDesc');
+      expect(transformSortVariableToEnum(7)).toBe('naturalAsc');
+      expect(transformSortVariableToEnum(8)).toBe('naturalDesc');
       expect(transformSortVariableToEnum(undefined)).toBe(defaultVariableSort());
     });
   });

--- a/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
@@ -73,6 +73,14 @@ export function transformSortVariableToEnum(sort?: VariableSortV1): VariableSort
       return 'numericalAsc';
     case 4:
       return 'numericalDesc';
+    case 5:
+      return 'alphabeticalCaseInsensitiveAsc';
+    case 6:
+      return 'alphabeticalCaseInsensitiveDesc';
+    case 7:
+      return 'naturalAsc';
+    case 8:
+      return 'naturalDesc';
     default:
       return defaultVariableSort();
   }


### PR DESCRIPTION
**What is this feature?**

Adds missing numeric-to-string sort order mappings for case-insensitive alphabetical and natural sort types (values 5-8) in the variable sort conversion functions.

**Why do we need this feature?**

When a user selects case-insensitive or natural sort ordering for dashboard variables, the sort order is stored as a numeric enum value (5-8). The conversion functions that translate these numeric values to the v2 string representation only handled values 0-4, causing values 5-8 to silently fall back to `disabled`. This meant the selected sort order was lost on save.

**Who is this feature for?**

Users who use case-insensitive alphabetical or natural sort ordering on dashboard variables.

**Which issue(s) does this PR fix?**:

Fixes #119911

**Special notes for your reviewer:**

The fix adds the missing cases in two places:
- `transformSortVariableToEnum` in `transformToV2TypesUtils.ts` (frontend v1→v2 conversion)
- `transformVariableSortToEnum` in `v1beta1_to_v2alpha1.go` (backend migration)

The reverse mappings (`transformSortVariableToEnumV1` and `transformVariableSortFromEnum`) already handled all sort types correctly.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.