### PR TITLE
Plugins: Forward PLUGIN_UNIX_SOCKET_DIR to plugin processes to fix temp dir in restricted environments

### DIFF
--- a/pkg/plugins/envvars/envvars.go
+++ b/pkg/plugins/envvars/envvars.go
@@ -10,9 +10,10 @@ import (
 // permittedHostEnvVarNames is the list of environment variables that can be passed from Grafana's process to the
 // plugin's process
 var permittedHostEnvVarNames = []string{
-	// TMPDIR is required for temp files in restricted environments (e.g. Kubernetes pods with read-only /tmp)
+	// PLUGIN_UNIX_SOCKET_DIR allows plugins to write Unix sockets in
+	// restricted environments (e.g. Kubernetes pods with read-only /tmp)
 	// See https://github.com/grafana/grafana/issues/119424
-	"TMPDIR",
+	"PLUGIN_UNIX_SOCKET_DIR",
 	// Env vars used by net/http (Go stdlib) for http/https proxy
 	// https://github.com/golang/net/blob/fbaf41277f28102c36926d1368dafbe2b54b4c1d/http/httpproxy/proxy.go#L91-L93
 	"HTTP_PROXY",

--- a/pkg/plugins/envvars/envvars.go
+++ b/pkg/plugins/envvars/envvars.go
@@ -10,6 +10,9 @@ import (
 // permittedHostEnvVarNames is the list of environment variables that can be passed from Grafana's process to the
 // plugin's process
 var permittedHostEnvVarNames = []string{
+	// TMPDIR is required for temp files in restricted environments (e.g. Kubernetes pods with read-only /tmp)
+	// See https://github.com/grafana/grafana/issues/119424
+	"TMPDIR",
 	// Env vars used by net/http (Go stdlib) for http/https proxy
 	// https://github.com/golang/net/blob/fbaf41277f28102c36926d1368dafbe2b54b4c1d/http/httpproxy/proxy.go#L91-L93
 	"HTTP_PROXY",

--- a/pkg/plugins/envvars/envvars_test.go
+++ b/pkg/plugins/envvars/envvars_test.go
@@ -1,0 +1,46 @@
+package envvars
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPermittedHostEnvVars_respectsTMPDIR(t *testing.T) {
+	customTmp := t.TempDir()
+	t.Setenv("TMPDIR", customTmp)
+
+	vars := PermittedHostEnvVars()
+
+	var count int
+	for _, v := range vars {
+		if strings.HasPrefix(v, "TMPDIR=") {
+			require.Equal(t, "TMPDIR="+customTmp, v, "TMPDIR should be forwarded when set")
+			count++
+		}
+	}
+	require.Equal(t, 1, count, "TMPDIR should appear exactly once in PermittedHostEnvVars when set")
+}
+
+func TestPermittedHostEnvVarNames_includesTMPDIR(t *testing.T) {
+	names := PermittedHostEnvVarNames()
+	require.Contains(t, names, "TMPDIR", "TMPDIR must be in permitted host env var names for restricted environments")
+}
+
+func TestPermittedHostEnvVars_TMPDIRUnset(t *testing.T) {
+	prev, hadTMPDIR := os.LookupEnv("TMPDIR")
+	if hadTMPDIR {
+		defer t.Setenv("TMPDIR", prev)
+	}
+	_ = os.Unsetenv("TMPDIR")
+
+	vars := PermittedHostEnvVars()
+
+	for _, v := range vars {
+		if strings.HasPrefix(v, "TMPDIR=") {
+			t.Fatal("TMPDIR should not be present when unset")
+		}
+	}
+}

--- a/pkg/plugins/envvars/envvars_test.go
+++ b/pkg/plugins/envvars/envvars_test.go
@@ -8,39 +8,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPermittedHostEnvVars_respectsTMPDIR(t *testing.T) {
+func TestPermittedHostEnvVars_respectsPLUGIN_UNIX_SOCKET_DIR(t *testing.T) {
 	customTmp := t.TempDir()
-	t.Setenv("TMPDIR", customTmp)
+	t.Setenv("PLUGIN_UNIX_SOCKET_DIR", customTmp)
 
 	vars := PermittedHostEnvVars()
 
 	var count int
 	for _, v := range vars {
-		if strings.HasPrefix(v, "TMPDIR=") {
-			require.Equal(t, "TMPDIR="+customTmp, v, "TMPDIR should be forwarded when set")
+		if strings.HasPrefix(v, "PLUGIN_UNIX_SOCKET_DIR=") {
+			require.Equal(t, "PLUGIN_UNIX_SOCKET_DIR="+customTmp, v, "PLUGIN_UNIX_SOCKET_DIR should be forwarded when set")
 			count++
 		}
 	}
-	require.Equal(t, 1, count, "TMPDIR should appear exactly once in PermittedHostEnvVars when set")
+	require.Equal(t, 1, count, "PLUGIN_UNIX_SOCKET_DIR should appear exactly once in PermittedHostEnvVars when set")
 }
 
-func TestPermittedHostEnvVarNames_includesTMPDIR(t *testing.T) {
+func TestPermittedHostEnvVarNames_includesPLUGIN_UNIX_SOCKET_DIR(t *testing.T) {
 	names := PermittedHostEnvVarNames()
-	require.Contains(t, names, "TMPDIR", "TMPDIR must be in permitted host env var names for restricted environments")
+	require.Contains(t, names, "PLUGIN_UNIX_SOCKET_DIR", "PLUGIN_UNIX_SOCKET_DIR must be in permitted host env var names for restricted environments")
 }
 
-func TestPermittedHostEnvVars_TMPDIRUnset(t *testing.T) {
-	prev, hadTMPDIR := os.LookupEnv("TMPDIR")
+func TestPermittedHostEnvVars_PLUGIN_UNIX_SOCKET_DIR_Unset(t *testing.T) {
+	prev, hadTMPDIR := os.LookupEnv("PLUGIN_UNIX_SOCKET_DIR")
 	if hadTMPDIR {
-		defer t.Setenv("TMPDIR", prev)
+		defer t.Setenv("PLUGIN_UNIX_SOCKET_DIR", prev)
 	}
-	_ = os.Unsetenv("TMPDIR")
+	_ = os.Unsetenv("PLUGIN_UNIX_SOCKET_DIR")
 
 	vars := PermittedHostEnvVars()
 
 	for _, v := range vars {
-		if strings.HasPrefix(v, "TMPDIR=") {
-			t.Fatal("TMPDIR should not be present when unset")
+		if strings.HasPrefix(v, "PLUGIN_UNIX_SOCKET_DIR=") {
+			t.Fatal("PLUGIN_UNIX_SOCKET_DIR should not be present when unset")
 		}
 	}
 }


### PR DESCRIPTION
**Problem**

Since Grafana 12.4.0, plugin processes ignore the PLUGIN_UNIX_SOCKET_DIR environment 
variable. Temp files are always written to `/tmp`, which fails in 
Kubernetes pods where `/tmp` is read-only:
`open /tmp/plugin2778441730: read-only file system`

**Root cause**

PR #113412 made host env stripping the default for plugin processes. 
Plugins only receive vars listed in `permittedHostEnvVarNames`. PLUGIN_UNIX_SOCKET_DIR 
was not on that list, so plugin processes never received it and fell 
back to `/tmp`.

**Fix**

Add `PLUGIN_UNIX_SOCKET_DIR ` to `permittedHostEnvVarNames` in 
`pkg/plugins/envvars/envvars.go`. No new config flags. No behavior 
change for users who don't set TMPDIR.

**Tests added**

- `TestPermittedHostEnvVars_respects PLUGIN_UNIX_SOCKET_DIR` — PLUGIN_UNIX_SOCKET_DIR is forwarded when set
- `TestPermittedHostEnvVarNames_includes PLUGIN_UNIX_SOCKET_DIR` — PLUGIN_UNIX_SOCKET_DIR is in the permitted list
- `TestPermittedHostEnvVars_ PLUGIN_UNIX_SOCKET_DIRUnset` — PLUGIN_UNIX_SOCKET_DIR is absent when unset

Fixes #119424
Related: #113412