### PR TITLE
Explore: fix table view type error

### DIFF
--- a/public/app/features/explore/RawPrometheus/PrometheusQueryResultsContainer.tsx
+++ b/public/app/features/explore/RawPrometheus/PrometheusQueryResultsContainer.tsx
@@ -1,4 +1,3 @@
-import { cloneDeep } from 'lodash';
 import { lazy, Suspense, useMemo } from 'react';
 
 import { applyFieldOverrides, PrometheusQueryResultsV1Props } from '@grafana/data';
@@ -37,14 +36,12 @@ export const PrometheusQueryResultsContainer = (props: PrometheusQueryResultsV1P
   const width = props.width ?? 800;
   const timeZone = props.timeZone ?? 'browser';
 
-  // Memoize cloneDeep + applyFieldOverrides to avoid expensive operations on every render
-  // cloneDeep is needed to avoid mutating frozen props from plugin extension system
+  // Memoize applyFieldOverrides to avoid expensive operations on every render
   const processedData = useMemo(() => {
     const tableResult = props.tableResult ?? [];
-    const cloned = cloneDeep(tableResult);
-    if (cloned?.length) {
+    if (tableResult.length) {
       return applyFieldOverrides({
-        data: cloned,
+        data: tableResult,
         timeZone,
         theme: config.theme2,
         replaceVariables: getTemplateSrv().replace.bind(getTemplateSrv()),
@@ -52,7 +49,7 @@ export const PrometheusQueryResultsContainer = (props: PrometheusQueryResultsV1P
         dataLinkPostProcessor: props.dataLinkPostProcessor,
       });
     }
-    return cloned;
+    return tableResult;
   }, [props.tableResult, timeZone, props.dataLinkPostProcessor]);
 
   return (


### PR DESCRIPTION
## Summary

Fixes https://github.com/grafana/support-escalations/issues/21097 and https://github.com/grafana/grafana/issues/119657

Prometheus table view was broken because `cloneDeep` in `PrometheusQueryResultsContainer` silently dropped `MutableDataFrame.length` (a prototype getter with no setter), producing a frame with incorrect length.

## Changes
- `PrometheusQueryResultsContainer.tsx`: Remove `cloneDeep`, pass `tableResult` directly to `applyFieldOverrides`

## Screenshot

The table now shows correctly, without error.
<img width="1593" height="1123" alt="Screenshot 2026-03-10 at 5 01 19 PM" src="https://github.com/user-attachments/assets/ace6203e-f730-4b3d-9d96-d1d4208ca69b" />


## Test plan
- [ ] Prometheus table view in Explore renders rows correctly - for multiple queries
- [ ] `yarn test public/app/features/explore/RawPrometheus/`
- [ ] `yarn test public/app/features/explore/utils/decorators.test.ts`
