### PR TITLE
Playlists: Added RBAC support

### DIFF
--- a/pkg/registry/apps/playlist/accesscontrol.go
+++ b/pkg/registry/apps/playlist/accesscontrol.go
@@ -1,0 +1,48 @@
+package playlist
+
+import (
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/org"
+)
+
+const (
+	ActionPlaylistsRead  = "playlists:read"
+	ActionPlaylistsWrite = "playlists:write"
+)
+
+var (
+	ScopeProviderPlaylists = accesscontrol.NewScopeProvider("playlists")
+	ScopeAllPlaylists      = ScopeProviderPlaylists.GetResourceAllScope()
+)
+
+func DeclareFixedRoles(service accesscontrol.Service) error {
+	playlistsReaderRole := accesscontrol.RoleRegistration{
+		Role: accesscontrol.RoleDTO{
+			Name:        accesscontrol.FixedRolePrefix + "playlists:reader",
+			DisplayName: "Reader",
+			Description: "Read and list playlists.",
+			Group:       "Playlists",
+			Version:     1,
+			Permissions: []accesscontrol.Permission{
+				{Action: ActionPlaylistsRead, Scope: ScopeAllPlaylists},
+			},
+		},
+		Grants: []string{string(org.RoleViewer), string(org.RoleEditor), string(org.RoleAdmin)},
+	}
+
+	playlistsWriterRole := accesscontrol.RoleRegistration{
+		Role: accesscontrol.RoleDTO{
+			Name:        accesscontrol.FixedRolePrefix + "playlists:writer",
+			DisplayName: "Writer",
+			Description: "Create, update, and delete playlists.",
+			Group:       "Playlists",
+			Version:     1,
+			Permissions: accesscontrol.ConcatPermissions(playlistsReaderRole.Role.Permissions, []accesscontrol.Permission{
+				{Action: ActionPlaylistsWrite, Scope: ScopeAllPlaylists},
+			}),
+		},
+		Grants: []string{string(org.RoleEditor), string(org.RoleAdmin)},
+	}
+
+	return service.DeclareFixedRoles(playlistsReaderRole, playlistsWriterRole)
+}

--- a/pkg/registry/apps/playlist/accesscontrol_test.go
+++ b/pkg/registry/apps/playlist/accesscontrol_test.go
@@ -1,0 +1,69 @@
+package playlist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/org"
+)
+
+// mockACService records the role registrations passed to DeclareFixedRoles
+type mockACService struct {
+	accesscontrol.Service
+	registrations []accesscontrol.RoleRegistration
+}
+
+func (m *mockACService) DeclareFixedRoles(registrations ...accesscontrol.RoleRegistration) error {
+	m.registrations = append(m.registrations, registrations...)
+	return nil
+}
+
+func TestDeclareFixedRoles(t *testing.T) {
+	svc := &mockACService{}
+	err := DeclareFixedRoles(svc)
+	require.NoError(t, err)
+	require.Len(t, svc.registrations, 2)
+
+	var reader, writer *accesscontrol.RoleRegistration
+	for i := range svc.registrations {
+		reg := &svc.registrations[i]
+		switch reg.Role.Name {
+		case accesscontrol.FixedRolePrefix + "playlists:reader":
+			reader = reg
+		case accesscontrol.FixedRolePrefix + "playlists:writer":
+			writer = reg
+		}
+	}
+
+	t.Run("reader role", func(t *testing.T) {
+		require.NotNil(t, reader, "playlists:reader role not registered")
+		assert.Equal(t, "Playlists", reader.Role.Group)
+		require.Len(t, reader.Role.Permissions, 1)
+		assert.Equal(t, ActionPlaylistsRead, reader.Role.Permissions[0].Action)
+		assert.Equal(t, ScopeAllPlaylists, reader.Role.Permissions[0].Scope)
+		assert.Contains(t, reader.Grants, string(org.RoleViewer))
+		assert.Contains(t, reader.Grants, string(org.RoleEditor))
+		assert.Contains(t, reader.Grants, string(org.RoleAdmin))
+		assert.NotContains(t, reader.Grants, string(org.RoleNone))
+	})
+
+	t.Run("writer role", func(t *testing.T) {
+		require.NotNil(t, writer, "playlists:writer role not registered")
+		assert.Equal(t, "Playlists", writer.Role.Group)
+
+		actions := make([]string, 0, len(writer.Role.Permissions))
+		for _, p := range writer.Role.Permissions {
+			actions = append(actions, p.Action)
+		}
+		assert.Contains(t, actions, ActionPlaylistsRead, "writer role should include read permission")
+		assert.Contains(t, actions, ActionPlaylistsWrite, "writer role should include write permission")
+
+		assert.NotContains(t, writer.Grants, string(org.RoleViewer))
+		assert.Contains(t, writer.Grants, string(org.RoleEditor))
+		assert.Contains(t, writer.Grants, string(org.RoleAdmin))
+		assert.NotContains(t, writer.Grants, string(org.RoleNone))
+	})
+}

--- a/pkg/registry/apps/playlist/authorizer_test.go
+++ b/pkg/registry/apps/playlist/authorizer_test.go
@@ -1,0 +1,230 @@
+package playlist
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+)
+
+// mockAttributes implements authorizer.Attributes for testing
+type mockAttributes struct {
+	authorizer.Attributes
+	isResourceRequest bool
+	verb              string
+}
+
+func (m *mockAttributes) IsResourceRequest() bool { return m.isResourceRequest }
+func (m *mockAttributes) GetVerb() string         { return m.verb }
+
+// mockAccessControl implements accesscontrol.AccessControl for testing
+type mockAccessControl struct {
+	accesscontrol.AccessControl
+	evaluateFunc func(ctx context.Context, user identity.Requester, evaluator accesscontrol.Evaluator) (bool, error)
+}
+
+func (m *mockAccessControl) Evaluate(ctx context.Context, user identity.Requester, evaluator accesscontrol.Evaluator) (bool, error) {
+	if m.evaluateFunc != nil {
+		return m.evaluateFunc(ctx, user, evaluator)
+	}
+	return false, nil
+}
+
+func (m *mockAccessControl) RegisterScopeAttributeResolver(prefix string, resolver accesscontrol.ScopeAttributeResolver) {
+}
+
+func (m *mockAccessControl) WithoutResolvers() accesscontrol.AccessControl {
+	return m
+}
+
+func (m *mockAccessControl) InvalidateResolverCache(orgID int64, scope string) {}
+
+func TestGetAuthorizer(t *testing.T) {
+	tests := []struct {
+		name             string
+		verb             string
+		isResourceReq    bool
+		hasPermission    bool
+		withoutUser      bool
+		expectedDecision authorizer.Decision
+		expectedAction   string
+		expectedReason   string
+	}{
+		// Read verbs → playlists:read
+		{
+			name:             "get with read permission allows",
+			verb:             "get",
+			isResourceReq:    true,
+			hasPermission:    true,
+			expectedDecision: authorizer.DecisionAllow,
+			expectedAction:   ActionPlaylistsRead,
+		},
+		{
+			name:             "get without read permission denies",
+			verb:             "get",
+			isResourceReq:    true,
+			hasPermission:    false,
+			expectedDecision: authorizer.DecisionDeny,
+			expectedAction:   ActionPlaylistsRead,
+			expectedReason:   "insufficient permissions",
+		},
+		{
+			name:             "list with read permission allows",
+			verb:             "list",
+			isResourceReq:    true,
+			hasPermission:    true,
+			expectedDecision: authorizer.DecisionAllow,
+			expectedAction:   ActionPlaylistsRead,
+		},
+		{
+			name:             "watch with read permission allows",
+			verb:             "watch",
+			isResourceReq:    true,
+			hasPermission:    true,
+			expectedDecision: authorizer.DecisionAllow,
+			expectedAction:   ActionPlaylistsRead,
+		},
+		// Write verbs → playlists:write
+		{
+			name:             "create with write permission allows",
+			verb:             "create",
+			isResourceReq:    true,
+			hasPermission:    true,
+			expectedDecision: authorizer.DecisionAllow,
+			expectedAction:   ActionPlaylistsWrite,
+		},
+		{
+			name:             "create without write permission denies",
+			verb:             "create",
+			isResourceReq:    true,
+			hasPermission:    false,
+			expectedDecision: authorizer.DecisionDeny,
+			expectedAction:   ActionPlaylistsWrite,
+			expectedReason:   "insufficient permissions",
+		},
+		{
+			name:             "update with write permission allows",
+			verb:             "update",
+			isResourceReq:    true,
+			hasPermission:    true,
+			expectedDecision: authorizer.DecisionAllow,
+			expectedAction:   ActionPlaylistsWrite,
+		},
+		{
+			name:             "patch with write permission allows",
+			verb:             "patch",
+			isResourceReq:    true,
+			hasPermission:    true,
+			expectedDecision: authorizer.DecisionAllow,
+			expectedAction:   ActionPlaylistsWrite,
+		},
+		{
+			name:             "delete with write permission allows",
+			verb:             "delete",
+			isResourceReq:    true,
+			hasPermission:    true,
+			expectedDecision: authorizer.DecisionAllow,
+			expectedAction:   ActionPlaylistsWrite,
+		},
+		{
+			name:             "delete without write permission denies",
+			verb:             "delete",
+			isResourceReq:    true,
+			hasPermission:    false,
+			expectedDecision: authorizer.DecisionDeny,
+			expectedAction:   ActionPlaylistsWrite,
+			expectedReason:   "insufficient permissions",
+		},
+		{
+			name:             "deletecollection with write permission allows",
+			verb:             "deletecollection",
+			isResourceReq:    true,
+			hasPermission:    true,
+			expectedDecision: authorizer.DecisionAllow,
+			expectedAction:   ActionPlaylistsWrite,
+		},
+		// Edge cases
+		{
+			name:             "non-resource request returns no opinion",
+			verb:             "get",
+			isResourceReq:    false,
+			expectedDecision: authorizer.DecisionNoOpinion,
+		},
+		{
+			name:             "unsupported verb denies",
+			verb:             "unsupported",
+			isResourceReq:    true,
+			hasPermission:    true,
+			expectedDecision: authorizer.DecisionDeny,
+			expectedReason:   "unsupported verb: unsupported",
+		},
+		{
+			name:             "missing user denies",
+			verb:             "get",
+			isResourceReq:    true,
+			withoutUser:      true,
+			expectedDecision: authorizer.DecisionDeny,
+			expectedReason:   "valid user is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var evaluatedAction string
+			mockAC := &mockAccessControl{
+				evaluateFunc: func(ctx context.Context, user identity.Requester, evaluator accesscontrol.Evaluator) (bool, error) {
+					evalStr := evaluator.String()
+					if strings.Contains(evalStr, ActionPlaylistsRead) {
+						evaluatedAction = ActionPlaylistsRead
+					} else if strings.Contains(evalStr, ActionPlaylistsWrite) {
+						evaluatedAction = ActionPlaylistsWrite
+					}
+					return tt.hasPermission, nil
+				},
+			}
+
+			installer := &AppInstaller{
+				accessControl: mockAC,
+				logger:        log.NewNopLogger(),
+			}
+
+			attrs := &mockAttributes{
+				isResourceRequest: tt.isResourceReq,
+				verb:              tt.verb,
+			}
+
+			ctx := context.Background()
+			if !tt.withoutUser {
+				ctx = identity.WithRequester(ctx, &identity.StaticRequester{
+					OrgID:   1,
+					UserID:  1,
+					OrgRole: identity.RoleViewer,
+				})
+			}
+
+			auth := installer.GetAuthorizer()
+			decision, reason, err := auth.Authorize(ctx, attrs)
+
+			if tt.withoutUser && tt.isResourceReq {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.expectedDecision, decision)
+			if tt.expectedReason != "" {
+				assert.Contains(t, reason, tt.expectedReason)
+			}
+			if tt.isResourceReq && !tt.withoutUser && tt.expectedAction != "" && tt.verb != "unsupported" {
+				assert.Equal(t, tt.expectedAction, evaluatedAction)
+			}
+		})
+	}
+}

--- a/pkg/registry/apps/playlist/register.go
+++ b/pkg/registry/apps/playlist/register.go
@@ -1,6 +1,7 @@
 package playlist
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -17,10 +18,12 @@ import (
 	playlistv0alpha1 "github.com/grafana/grafana/apps/playlist/pkg/apis/playlist/v0alpha1"
 	playlistv1 "github.com/grafana/grafana/apps/playlist/pkg/apis/playlist/v1"
 	playlistapp "github.com/grafana/grafana/apps/playlist/pkg/app"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver/appinstaller"
-	roleauthorizer "github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	playlistsvc "github.com/grafana/grafana/pkg/services/playlist"
@@ -34,18 +37,28 @@ var (
 
 type AppInstaller struct {
 	appsdkapiserver.AppInstaller
-	cfg     *setting.Cfg
-	service playlistsvc.Service
+	cfg           *setting.Cfg
+	service       playlistsvc.Service
+	accessControl accesscontrol.AccessControl
+	logger        log.Logger
 }
 
 func RegisterAppInstaller(
 	p playlistsvc.Service,
 	cfg *setting.Cfg,
 	features featuremgmt.FeatureToggles,
+	accessControlService accesscontrol.Service,
+	ac accesscontrol.AccessControl,
 ) (*AppInstaller, error) {
+	if err := DeclareFixedRoles(accessControlService); err != nil {
+		return nil, fmt.Errorf("declaring fixed roles: %w", err)
+	}
+
 	installer := &AppInstaller{
-		cfg:     cfg,
-		service: p,
+		cfg:           cfg,
+		service:       p,
+		accessControl: ac,
+		logger:        log.New("playlist.api"),
 	}
 	specificConfig := any(&playlistapp.PlaylistConfig{
 		//nolint:staticcheck // not yet migrated to OpenFeature
@@ -68,8 +81,39 @@ func RegisterAppInstaller(
 }
 
 func (p *AppInstaller) GetAuthorizer() authorizer.Authorizer {
-	//nolint:staticcheck // not yet migrated to Resource Authorizer
-	return roleauthorizer.NewRoleAuthorizer()
+	return authorizer.AuthorizerFunc(
+		func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+			if !attr.IsResourceRequest() {
+				return authorizer.DecisionNoOpinion, "", nil
+			}
+
+			user, err := identity.GetRequester(ctx)
+			if err != nil {
+				return authorizer.DecisionDeny, "valid user is required", err
+			}
+
+			var action string
+			switch attr.GetVerb() {
+			case "get", "list", "watch":
+				action = ActionPlaylistsRead
+			case "create", "update", "patch", "delete", "deletecollection":
+				action = ActionPlaylistsWrite
+			default:
+				return authorizer.DecisionDeny, "unsupported verb: " + attr.GetVerb(), nil
+			}
+
+			hasAccess, err := p.accessControl.Evaluate(ctx, user, accesscontrol.EvalPermission(action))
+			if err != nil {
+				p.logger.Error("failed to evaluate permission", "error", err)
+				return authorizer.DecisionDeny, "permission evaluation failed", err
+			}
+			if !hasAccess {
+				return authorizer.DecisionDeny, "insufficient permissions", nil
+			}
+
+			return authorizer.DecisionAllow, "", nil
+		},
+	)
 }
 
 // GetLegacyStorage returns the legacy storage for the playlist app.

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -800,7 +800,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	scopedPluginDatasourceProvider := datasource.ProvideDefaultPluginConfigs(service15, cacheServiceImpl, plugincontextProvider, cfg)
 	v := builder.ProvideDefaultBuildHandlerChainFuncFromBuilders()
 	aggregatorRunner := aggregatorrunner.ProvideNoopAggregatorConfigurator()
-	appInstaller, err := playlist2.RegisterAppInstaller(playlistService, cfg, featureToggles)
+	appInstaller, err := playlist2.RegisterAppInstaller(playlistService, cfg, featureToggles, acimplService, accessControl)
 	if err != nil {
 		return nil, err
 	}
@@ -1499,7 +1499,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	scopedPluginDatasourceProvider := datasource.ProvideDefaultPluginConfigs(service15, cacheServiceImpl, plugincontextProvider, cfg)
 	v := builder.ProvideDefaultBuildHandlerChainFuncFromBuilders()
 	aggregatorRunner := aggregatorrunner.ProvideNoopAggregatorConfigurator()
-	appInstaller, err := playlist2.RegisterAppInstaller(playlistService, cfg, featureToggles)
+	appInstaller, err := playlist2.RegisterAppInstaller(playlistService, cfg, featureToggles, acimplService, accessControl)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/accesscontrol/permreg/permreg.go
+++ b/pkg/services/accesscontrol/permreg/permreg.go
@@ -101,6 +101,7 @@ func newPermissionRegistry() *permissionRegistry {
 		"inhibition-rules":    "inhibition-rules:uid:",
 		"secret.securevalues": "secret.securevalues:uid:",
 		"secret.keepers":      "secret.keepers:uid:",
+		"playlists":           "playlists:uid:",
 	}
 	return &permissionRegistry{
 		actionScopePrefixes: make(map[string]PrefixSet, 200),

--- a/pkg/services/apiserver/auth/authorizer/role.go
+++ b/pkg/services/apiserver/auth/authorizer/role.go
@@ -15,8 +15,6 @@ var _ authorizer.Authorizer = &roleAuthorizer{}
 
 var orgRoleNoneAsViewerAPIGroups = []string{
 	"productactivation.ext.grafana.com",
-	// playlist can be removed after this issue is resolved: https://github.com/grafana/grafana/issues/115712
-	"playlist.grafana.app",
 }
 
 type roleAuthorizer struct{}

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -370,7 +370,11 @@ func (s *ServiceImpl) buildDashboardNavLinks(c *contextmodel.ReqContext) []*navt
 	dashboardChildNavs := []*navtree.NavLink{}
 
 	if c.IsSignedIn {
-		if hasAccess(ac.EvalPermission(playlistregistry.ActionPlaylistsRead)) {
+		// Show Playlists nav if the user has the RBAC playlists:read permission.
+		// If playlists:read is not present (old backend not yet deployed), fall back to
+		// the legacy org-role check so Viewers don't lose the nav item during a
+		// mixed-version rollout.
+		if hasAccess(ac.EvalPermission(playlistregistry.ActionPlaylistsRead)) || c.HasRole(org.RoleViewer) {
 			dashboardChildNavs = append(dashboardChildNavs, &navtree.NavLink{
 				Text: "Playlists", SubTitle: "Groups of dashboards that are displayed in a sequence", Id: "dashboards/playlists", Url: s.cfg.AppSubURL + "/playlists", Icon: "presentation-play",
 			})

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/log"
+	playlistregistry "github.com/grafana/grafana/pkg/registry/apps/playlist"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/authn"
@@ -369,7 +370,7 @@ func (s *ServiceImpl) buildDashboardNavLinks(c *contextmodel.ReqContext) []*navt
 	dashboardChildNavs := []*navtree.NavLink{}
 
 	if c.IsSignedIn {
-		if c.HasRole(org.RoleViewer) {
+		if hasAccess(ac.EvalPermission(playlistregistry.ActionPlaylistsRead)) {
 			dashboardChildNavs = append(dashboardChildNavs, &navtree.NavLink{
 				Text: "Playlists", SubTitle: "Groups of dashboards that are displayed in a sequence", Id: "dashboards/playlists", Url: s.cfg.AppSubURL + "/playlists", Icon: "presentation-play",
 			})

--- a/pkg/tests/apis/playlist/playlist_test.go
+++ b/pkg/tests/apis/playlist/playlist_test.go
@@ -18,8 +18,11 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	playlistregistry "github.com/grafana/grafana/pkg/registry/apps/playlist"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	"github.com/grafana/grafana/pkg/services/apiserver/options"
 	"github.com/grafana/grafana/pkg/services/playlist"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
@@ -468,7 +471,6 @@ func doPlaylistTests(t *testing.T, helper *apis.K8sTestHelper) *apis.K8sTestHelp
 	})
 
 	t.Run("Check CRUD operations with None role", func(t *testing.T) {
-		// Create a playlist with admin user
 		clientAdmin := helper.GetResourceClient(apis.ResourceClientArgs{
 			User: helper.Org1.Admin,
 			GVR:  gvr,
@@ -478,32 +480,72 @@ func doPlaylistTests(t *testing.T, helper *apis.K8sTestHelper) *apis.K8sTestHelp
 			metav1.CreateOptions{},
 		)
 		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = clientAdmin.Resource.Delete(context.Background(), created.GetName(), metav1.DeleteOptions{})
+		})
 
 		clientNone := helper.GetResourceClient(apis.ResourceClientArgs{
 			User: helper.Org1.None,
 			GVR:  gvr,
 		})
 
-		// Now check if None user can perform a Get to start a playlist
-		_, err = clientNone.Resource.Get(context.Background(), created.GetName(), metav1.GetOptions{})
-		require.NoError(t, err)
+		// Without any RBAC grant, a None-role user is denied all playlist operations.
+		t.Run("None role denied by default", func(t *testing.T) {
+			_, err = clientNone.Resource.Get(context.Background(), created.GetName(), metav1.GetOptions{})
+			require.Error(t, err)
 
-		// None role can get but can not create edit or delete a playlist
-		_, err = clientNone.Resource.Create(context.Background(),
-			helper.LoadYAMLOrJSONFile("testdata/playlist-generate.yaml"),
-			metav1.CreateOptions{},
-		)
-		require.Error(t, err)
+			_, err = clientNone.Resource.List(context.Background(), metav1.ListOptions{})
+			require.Error(t, err)
 
-		_, err = clientNone.Resource.Update(context.Background(), created, metav1.UpdateOptions{})
-		require.Error(t, err)
+			_, err = clientNone.Resource.Create(context.Background(),
+				helper.LoadYAMLOrJSONFile("testdata/playlist-generate.yaml"),
+				metav1.CreateOptions{},
+			)
+			require.Error(t, err)
 
-		err = clientNone.Resource.Delete(context.Background(), created.GetName(), metav1.DeleteOptions{})
-		require.Error(t, err)
+			_, err = clientNone.Resource.Update(context.Background(), created, metav1.UpdateOptions{})
+			require.Error(t, err)
 
-		// delete created resource
-		err = clientAdmin.Resource.Delete(context.Background(), created.GetName(), metav1.DeleteOptions{})
-		require.NoError(t, err)
+			err = clientNone.Resource.Delete(context.Background(), created.GetName(), metav1.DeleteOptions{})
+			require.Error(t, err)
+		})
+
+		// When a None-role user is explicitly granted playlists:read via RBAC, they can
+		// read playlists — this is the proper fix for the customer use case described in
+		// https://github.com/grafana/grafana/issues/115712.
+		t.Run("None role with explicit playlists:read can read but not write", func(t *testing.T) {
+			noneUserID, err := helper.Org1.None.Identity.GetInternalID()
+			require.NoError(t, err)
+
+			orgID := helper.Org1.None.Identity.GetOrgID()
+			actest.AddUserPermissionToDB(t, helper.GetEnv().SQLStore, &user.SignedInUser{
+				UserID: noneUserID,
+				OrgID:  orgID,
+				Permissions: map[int64]map[string][]string{
+					orgID: {
+						playlistregistry.ActionPlaylistsRead: {playlistregistry.ScopeAllPlaylists},
+					},
+				},
+			})
+
+			_, err = clientNone.Resource.Get(context.Background(), created.GetName(), metav1.GetOptions{})
+			require.NoError(t, err, "None user with playlists:read should be able to get a playlist")
+
+			_, err = clientNone.Resource.List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err, "None user with playlists:read should be able to list playlists")
+
+			_, err = clientNone.Resource.Create(context.Background(),
+				helper.LoadYAMLOrJSONFile("testdata/playlist-generate.yaml"),
+				metav1.CreateOptions{},
+			)
+			require.Error(t, err, "None user with only playlists:read should not be able to create")
+
+			_, err = clientNone.Resource.Update(context.Background(), created, metav1.UpdateOptions{})
+			require.Error(t, err, "None user with only playlists:read should not be able to update")
+
+			err = clientNone.Resource.Delete(context.Background(), created.GetName(), metav1.DeleteOptions{})
+			require.Error(t, err, "None user with only playlists:read should not be able to delete")
+		})
 	})
 
 	t.Run("Check k8s client-go List from different org users", func(t *testing.T) {

--- a/public/app/features/playlist/PlaylistCard.tsx
+++ b/public/app/features/playlist/PlaylistCard.tsx
@@ -5,13 +5,12 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { Button, Card, LinkButton, ModalsController, Stack, useStyles2 } from '@grafana/ui';
 import { attachSkeleton, SkeletonComponent } from '@grafana/ui/unstable';
-import { contextSrv } from 'app/core/services/context_srv';
 import { DashNavButton } from 'app/features/dashboard/components/DashNav/DashNavButton';
-import { AccessControlAction } from 'app/types/accessControl';
 
 import { Playlist } from '../../api/clients/playlist/v1';
 
 import { ShareModal } from './ShareModal';
+import { canWritePlaylists } from './utils';
 
 interface Props {
   setStartPlaylist: (playlistItem: Playlist) => void;
@@ -44,7 +43,7 @@ const PlaylistCardComponent = ({ playlist, setStartPlaylist, setPlaylistToDelete
         <Button variant="secondary" icon="play" onClick={() => setStartPlaylist(playlist)}>
           <Trans i18nKey="playlist-page.card.start">Start playlist</Trans>
         </Button>
-        {contextSrv.hasPermission(AccessControlAction.PlaylistsWrite) && (
+        {canWritePlaylists() && (
           <>
             <LinkButton key="edit" variant="secondary" href={`/playlists/edit/${playlist.metadata?.name}`} icon="cog">
               <Trans i18nKey="playlist-page.card.edit">Edit playlist</Trans>
@@ -74,7 +73,7 @@ const PlaylistCardSkeleton: SkeletonComponent = ({ rootProps }) => {
       <Card.Actions>
         <Stack direction="row" wrap="wrap">
           <Skeleton containerClassName={skeletonStyles.button} width={142} height={32} />
-          {contextSrv.hasPermission(AccessControlAction.PlaylistsWrite) && (
+          {canWritePlaylists() && (
             <>
               <Skeleton containerClassName={skeletonStyles.button} width={135} height={32} />
               <Skeleton containerClassName={skeletonStyles.button} width={153} height={32} />

--- a/public/app/features/playlist/PlaylistCard.tsx
+++ b/public/app/features/playlist/PlaylistCard.tsx
@@ -7,6 +7,7 @@ import { Button, Card, LinkButton, ModalsController, Stack, useStyles2 } from '@
 import { attachSkeleton, SkeletonComponent } from '@grafana/ui/unstable';
 import { contextSrv } from 'app/core/services/context_srv';
 import { DashNavButton } from 'app/features/dashboard/components/DashNav/DashNavButton';
+import { AccessControlAction } from 'app/types/accessControl';
 
 import { Playlist } from '../../api/clients/playlist/v1';
 
@@ -43,7 +44,7 @@ const PlaylistCardComponent = ({ playlist, setStartPlaylist, setPlaylistToDelete
         <Button variant="secondary" icon="play" onClick={() => setStartPlaylist(playlist)}>
           <Trans i18nKey="playlist-page.card.start">Start playlist</Trans>
         </Button>
-        {contextSrv.isEditor && (
+        {contextSrv.hasPermission(AccessControlAction.PlaylistsWrite) && (
           <>
             <LinkButton key="edit" variant="secondary" href={`/playlists/edit/${playlist.metadata?.name}`} icon="cog">
               <Trans i18nKey="playlist-page.card.edit">Edit playlist</Trans>
@@ -73,7 +74,7 @@ const PlaylistCardSkeleton: SkeletonComponent = ({ rootProps }) => {
       <Card.Actions>
         <Stack direction="row" wrap="wrap">
           <Skeleton containerClassName={skeletonStyles.button} width={142} height={32} />
-          {contextSrv.isEditor && (
+          {contextSrv.hasPermission(AccessControlAction.PlaylistsWrite) && (
             <>
               <Skeleton containerClassName={skeletonStyles.button} width={135} height={32} />
               <Skeleton containerClassName={skeletonStyles.button} width={153} height={32} />

--- a/public/app/features/playlist/PlaylistPage.test.tsx
+++ b/public/app/features/playlist/PlaylistPage.test.tsx
@@ -3,6 +3,7 @@ import { of } from 'rxjs';
 import { TestProvider } from 'test/helpers/TestProvider';
 
 import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
 
 import { createFetchResponse } from '../../../test/helpers/createFetchResponse';
 import { backendSrv } from '../../core/services/backend_srv';
@@ -17,7 +18,7 @@ jest.mock('@grafana/runtime', () => ({
 jest.mock('app/core/services/context_srv', () => ({
   contextSrv: {
     ...jest.requireActual('app/core/services/context_srv').contextSrv,
-    isEditor: true,
+    hasPermission: jest.fn(),
   },
 }));
 
@@ -33,6 +34,7 @@ describe('PlaylistPage', () => {
   beforeEach(() => {
     jest.spyOn(backendSrv, 'fetch').mockImplementation(() => of(createFetchResponse({})));
     jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.mocked(contextSrv.hasPermission).mockReturnValue(false);
   });
 
   describe('when mounted without a playlist', () => {
@@ -46,18 +48,20 @@ describe('PlaylistPage', () => {
       expect(await screen.findByText('There are no playlists created yet')).toBeInTheDocument();
     });
 
-    describe('and signed in user is not a viewer', () => {
+    describe('and user has playlists:write', () => {
       it('then create playlist button should not be disabled', async () => {
-        contextSrv.isEditor = true;
+        jest
+          .mocked(contextSrv.hasPermission)
+          .mockImplementation((action) => action === AccessControlAction.PlaylistsWrite);
         setup();
         const createPlaylistButton = await screen.findByRole('link', { name: /create playlist/i });
         expect(createPlaylistButton).not.toHaveStyle('pointer-events: none');
       });
     });
 
-    describe('and signed in user is a viewer', () => {
+    describe('and user does not have playlists:write', () => {
       it('then create playlist button should be disabled', async () => {
-        contextSrv.isEditor = false;
+        jest.mocked(contextSrv.hasPermission).mockReturnValue(false);
         setup();
         const createPlaylistButton = await screen.findByRole('link', { name: /create playlist/i });
         expect(createPlaylistButton).toHaveStyle('pointer-events: none');
@@ -97,9 +101,11 @@ describe('PlaylistPage', () => {
       expect(screen.getByTestId('playlist-page-list-skeleton')).toBeInTheDocument();
     });
 
-    describe('and signed in user is not a viewer', () => {
+    describe('and user has playlists:write', () => {
       it('then playlist title and all playlist buttons should appear on the page', async () => {
-        contextSrv.isEditor = true;
+        jest
+          .mocked(contextSrv.hasPermission)
+          .mockImplementation((action) => action === AccessControlAction.PlaylistsWrite);
         setup();
         expect(await screen.findByText('A test playlist'));
         expect(await screen.findByRole('link', { name: /New playlist/i })).toBeInTheDocument();
@@ -109,9 +115,9 @@ describe('PlaylistPage', () => {
       });
     });
 
-    describe('and signed in user is a viewer', () => {
+    describe('and user does not have playlists:write', () => {
       it('then playlist title and only start playlist button should appear on the page', async () => {
-        contextSrv.isEditor = false;
+        jest.mocked(contextSrv.hasPermission).mockReturnValue(false);
         setup();
         expect(await screen.findByText('A test playlist')).toBeInTheDocument();
         expect(screen.queryByRole('link', { name: /New playlist/i })).not.toBeInTheDocument();

--- a/public/app/features/playlist/PlaylistPage.test.tsx
+++ b/public/app/features/playlist/PlaylistPage.test.tsx
@@ -19,6 +19,7 @@ jest.mock('app/core/services/context_srv', () => ({
   contextSrv: {
     ...jest.requireActual('app/core/services/context_srv').contextSrv,
     hasPermission: jest.fn(),
+    isEditor: false,
   },
 }));
 
@@ -35,6 +36,7 @@ describe('PlaylistPage', () => {
     jest.spyOn(backendSrv, 'fetch').mockImplementation(() => of(createFetchResponse({})));
     jest.spyOn(console, 'error').mockImplementation(() => {});
     jest.mocked(contextSrv.hasPermission).mockReturnValue(false);
+    (contextSrv as jest.Mocked<typeof contextSrv>).isEditor = false;
   });
 
   describe('when mounted without a playlist', () => {
@@ -48,20 +50,45 @@ describe('PlaylistPage', () => {
       expect(await screen.findByText('There are no playlists created yet')).toBeInTheDocument();
     });
 
-    describe('and user has playlists:write', () => {
+    describe('and user has playlists:write (RBAC active)', () => {
       it('then create playlist button should not be disabled', async () => {
         jest
           .mocked(contextSrv.hasPermission)
-          .mockImplementation((action) => action === AccessControlAction.PlaylistsWrite);
+          .mockImplementation(
+            (action) => action === AccessControlAction.PlaylistsRead || action === AccessControlAction.PlaylistsWrite
+          );
         setup();
         const createPlaylistButton = await screen.findByRole('link', { name: /create playlist/i });
         expect(createPlaylistButton).not.toHaveStyle('pointer-events: none');
       });
     });
 
-    describe('and user does not have playlists:write', () => {
+    describe('and user does not have playlists:write but is an editor (legacy fallback)', () => {
+      it('then create playlist button should not be disabled', async () => {
+        jest.mocked(contextSrv.hasPermission).mockReturnValue(false);
+        (contextSrv as jest.Mocked<typeof contextSrv>).isEditor = true;
+        setup();
+        const createPlaylistButton = await screen.findByRole('link', { name: /create playlist/i });
+        expect(createPlaylistButton).not.toHaveStyle('pointer-events: none');
+      });
+    });
+
+    describe('and user does not have playlists:write and is not an editor', () => {
       it('then create playlist button should be disabled', async () => {
         jest.mocked(contextSrv.hasPermission).mockReturnValue(false);
+        (contextSrv as jest.Mocked<typeof contextSrv>).isEditor = false;
+        setup();
+        const createPlaylistButton = await screen.findByRole('link', { name: /create playlist/i });
+        expect(createPlaylistButton).toHaveStyle('pointer-events: none');
+      });
+    });
+
+    describe('and user has playlists:read but not playlists:write (RBAC active, read-only)', () => {
+      it('then create playlist button should be disabled', async () => {
+        jest
+          .mocked(contextSrv.hasPermission)
+          .mockImplementation((action) => action === AccessControlAction.PlaylistsRead);
+        (contextSrv as jest.Mocked<typeof contextSrv>).isEditor = true; // isEditor should be ignored when RBAC is active
         setup();
         const createPlaylistButton = await screen.findByRole('link', { name: /create playlist/i });
         expect(createPlaylistButton).toHaveStyle('pointer-events: none');
@@ -101,11 +128,13 @@ describe('PlaylistPage', () => {
       expect(screen.getByTestId('playlist-page-list-skeleton')).toBeInTheDocument();
     });
 
-    describe('and user has playlists:write', () => {
+    describe('and user has playlists:write (RBAC active)', () => {
       it('then playlist title and all playlist buttons should appear on the page', async () => {
         jest
           .mocked(contextSrv.hasPermission)
-          .mockImplementation((action) => action === AccessControlAction.PlaylistsWrite);
+          .mockImplementation(
+            (action) => action === AccessControlAction.PlaylistsRead || action === AccessControlAction.PlaylistsWrite
+          );
         setup();
         expect(await screen.findByText('A test playlist'));
         expect(await screen.findByRole('link', { name: /New playlist/i })).toBeInTheDocument();
@@ -115,9 +144,38 @@ describe('PlaylistPage', () => {
       });
     });
 
-    describe('and user does not have playlists:write', () => {
+    describe('and user is an editor (legacy fallback — no playlists:read means RBAC not active)', () => {
+      it('then playlist title and all playlist buttons should appear on the page', async () => {
+        jest.mocked(contextSrv.hasPermission).mockReturnValue(false);
+        (contextSrv as jest.Mocked<typeof contextSrv>).isEditor = true;
+        setup();
+        expect(await screen.findByText('A test playlist'));
+        expect(await screen.findByRole('link', { name: /New playlist/i })).toBeInTheDocument();
+        expect(await screen.findByRole('button', { name: /Start playlist/i })).toBeInTheDocument();
+        expect(await screen.findByRole('link', { name: /Edit playlist/i })).toBeInTheDocument();
+        expect(await screen.findByRole('button', { name: /Delete playlist/i })).toBeInTheDocument();
+      });
+    });
+
+    describe('and user does not have playlists:write and is not an editor', () => {
       it('then playlist title and only start playlist button should appear on the page', async () => {
         jest.mocked(contextSrv.hasPermission).mockReturnValue(false);
+        (contextSrv as jest.Mocked<typeof contextSrv>).isEditor = false;
+        setup();
+        expect(await screen.findByText('A test playlist')).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /New playlist/i })).not.toBeInTheDocument();
+        expect(await screen.findByRole('button', { name: /Start playlist/i })).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /Edit playlist/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /Delete playlist/i })).not.toBeInTheDocument();
+      });
+    });
+
+    describe('and user has playlists:read but not playlists:write (RBAC active, read-only)', () => {
+      it('then only start playlist button should appear — isEditor is ignored when RBAC is active', async () => {
+        jest
+          .mocked(contextSrv.hasPermission)
+          .mockImplementation((action) => action === AccessControlAction.PlaylistsRead);
+        (contextSrv as jest.Mocked<typeof contextSrv>).isEditor = true; // should be ignored
         setup();
         expect(await screen.findByText('A test playlist')).toBeInTheDocument();
         expect(screen.queryByRole('link', { name: /New playlist/i })).not.toBeInTheDocument();

--- a/public/app/features/playlist/PlaylistPage.tsx
+++ b/public/app/features/playlist/PlaylistPage.tsx
@@ -4,14 +4,12 @@ import { Trans, t } from '@grafana/i18n';
 import { ConfirmModal, EmptyState, LinkButton, TextLink } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import PageActionBar from 'app/core/components/PageActionBar/PageActionBar';
-import { contextSrv } from 'app/core/services/context_srv';
-import { AccessControlAction } from 'app/types/accessControl';
 
 import { Playlist, useDeletePlaylistMutation, useListPlaylistQuery } from '../../api/clients/playlist/v1';
 
 import { PlaylistPageList } from './PlaylistPageList';
 import { StartModal } from './StartModal';
-import { searchPlaylists } from './utils';
+import { canWritePlaylists, searchPlaylists } from './utils';
 
 export const PlaylistPage = () => {
   const { data, isLoading } = useListPlaylistQuery({});
@@ -41,7 +39,7 @@ export const PlaylistPage = () => {
   return (
     <Page
       actions={
-        contextSrv.hasPermission(AccessControlAction.PlaylistsWrite) && showSearch ? (
+        canWritePlaylists() && showSearch ? (
           <LinkButton href="/playlists/new">
             <Trans i18nKey="playlist-page.create-button.title">New playlist</Trans>
           </LinkButton>
@@ -69,12 +67,7 @@ export const PlaylistPage = () => {
               <EmptyState
                 variant="call-to-action"
                 button={
-                  <LinkButton
-                    disabled={!contextSrv.hasPermission(AccessControlAction.PlaylistsWrite)}
-                    href="playlists/new"
-                    icon="plus"
-                    size="lg"
-                  >
+                  <LinkButton disabled={!canWritePlaylists()} href="playlists/new" icon="plus" size="lg">
                     <Trans i18nKey="playlist-page.empty.button">Create playlist</Trans>
                   </LinkButton>
                 }

--- a/public/app/features/playlist/PlaylistPage.tsx
+++ b/public/app/features/playlist/PlaylistPage.tsx
@@ -5,6 +5,7 @@ import { ConfirmModal, EmptyState, LinkButton, TextLink } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import PageActionBar from 'app/core/components/PageActionBar/PageActionBar';
 import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
 
 import { Playlist, useDeletePlaylistMutation, useListPlaylistQuery } from '../../api/clients/playlist/v1';
 
@@ -40,7 +41,7 @@ export const PlaylistPage = () => {
   return (
     <Page
       actions={
-        contextSrv.isEditor && showSearch ? (
+        contextSrv.hasPermission(AccessControlAction.PlaylistsWrite) && showSearch ? (
           <LinkButton href="/playlists/new">
             <Trans i18nKey="playlist-page.create-button.title">New playlist</Trans>
           </LinkButton>
@@ -68,7 +69,12 @@ export const PlaylistPage = () => {
               <EmptyState
                 variant="call-to-action"
                 button={
-                  <LinkButton disabled={!contextSrv.isEditor} href="playlists/new" icon="plus" size="lg">
+                  <LinkButton
+                    disabled={!contextSrv.hasPermission(AccessControlAction.PlaylistsWrite)}
+                    href="playlists/new"
+                    icon="plus"
+                    size="lg"
+                  >
                     <Trans i18nKey="playlist-page.empty.button">Create playlist</Trans>
                   </LinkButton>
                 }

--- a/public/app/features/playlist/utils.ts
+++ b/public/app/features/playlist/utils.ts
@@ -1,8 +1,23 @@
 import { Playlist } from '../../api/clients/playlist/v1';
+import { contextSrv } from '../../core/services/context_srv';
+import { AccessControlAction } from '../../types/accessControl';
 import { getGrafanaSearcher } from '../search/service/searcher';
 import { SearchQuery } from '../search/service/types';
 
 import { PlaylistItemUI } from './types';
+
+/**
+ * Returns true if the current user can create, edit, or delete playlists.
+ *
+ * Uses playlists:read as a signal that the backend has registered playlist RBAC.
+ * If the permission is absent (old backend not yet deployed), falls back to the
+ * legacy isEditor check to avoid regressions during a mixed-version rollout.
+ */
+export function canWritePlaylists(): boolean {
+  return contextSrv.hasPermission(AccessControlAction.PlaylistsRead)
+    ? contextSrv.hasPermission(AccessControlAction.PlaylistsWrite)
+    : contextSrv.isEditor;
+}
 
 /** Returns a copy with the dashboards loaded */
 export async function loadDashboards(items: PlaylistItemUI[]): Promise<PlaylistItemUI[]> {

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -90,6 +90,9 @@ export enum AccessControlAction {
   FoldersPermissionsRead = 'folders.permissions:read',
   FoldersPermissionsWrite = 'folders.permissions:write',
 
+  PlaylistsRead = 'playlists:read',
+  PlaylistsWrite = 'playlists:write',
+
   // Support bundle actions
   ActionSupportBundlesCreate = 'support.bundles:create',
   ActionSupportBundlesRead = 'support.bundles:read',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Adds RBAC support to Playlists, introducing two new fixed roles:
- `fixed:playlists:reader` — grants `playlists:read`, allowing users to view and list playlists
- `fixed:playlists:writer` — grants `playlists:read` + `playlists:write`, allowing users to create, update, and delete playlists

These roles are automatically assigned to the appropriate org roles (Viewer/Editor/Admin), preserving existing behavior. The nav item visibility for Playlists is also updated to respect the new RBAC permission rather than a raw org role check.

**Why do we need this feature?**
A recent auth change causes users with `None` org role to be denied access to all APIs by default. Because Playlists had no RBAC support, the only workaround was to elevate affected users to the `Viewer` org role — which grants far broader access than necessary.

A temporary hotfix was added in `role.go` to treat `None`-role users as Viewers specifically for the `playlist.grafana.app` API group. This PR implements the proper fix, allowing admins to explicitly grant `playlists:read` to `None`-role users (e.g. kiosk/display accounts) without changing their org role at all. The hotfix is removed.

**Who is this feature for?**
Grafana administrators who manage kiosk or display accounts that need to run playlists without being assigned a full org role. Also benefits any deployment using fine-grained RBAC to control resource access.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/115712

**Special notes for your reviewer:**
Also check out [this](https://github.com/grafana/grafana-enterprise/pull/11221) Enterprise PR

A `None`-role user with `playlists:read` can view the Playlists page and see the playlist list, but running a playlist requires the dashboards in it to also be accessible. The playlist player resolves dashboard UIDs/tags via the search API, which requires `dashboards:read`. Admins setting up kiosk accounts should grant **both** `playlists:read` and `dashboards:read` for full end-to-end playlist playback.

MT deployment safety: Frontend write controls (New/Edit/Delete buttons) use a new canWritePlaylists() utility that treats the presence of playlists:read as a signal that backend RBAC is active — if present, it checks playlists:write; if absent (old backend not yet deployed), it falls back to contextSrv.isEditor. The Playlists nav item uses the same Option A pattern on the backend: shows if the user has playlists:read, otherwise falls back to c.HasRole(org.RoleViewer). Both ensure a safe mixed-version rollout with no regressions for existing Viewer/Editor/Admin users.

I've tested these changes with the following manual tests:
- None has no access and can't see the nav item
- None w/ playlists:read can see the playlists nav item, click on run, but can't see the dashboards w/o permissions.
- None w/ playlists:read AND dashboards:read works as expected 👍 
- None w/ playlists:write AND dashboards:read (needed as the save button requires at least one dashboard) can edit playlists, delete playlists, and create playlists
- Viewer works as expected
- Editor works as expected
- Admin works as expected

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
