### PR TITLE
Rendering: Remove support for unimplemented render session

### DIFF
--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -96,7 +96,7 @@ func (hs *HTTPServer) RenderHandler(c *contextmodel.ReqContext) {
 		Height:            height,
 		DeviceScaleFactor: scale,
 		Theme:             themeModel,
-	}, nil)
+	})
 	if err != nil {
 		if errors.Is(err, rendering.ErrTooManyRequests) {
 			c.JsonApiErr(http.StatusTooManyRequests, "Too many rendering requests", err)

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/render.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/render.go
@@ -75,7 +75,7 @@ func (r *screenshotRenderer) RenderScreenshot(ctx context.Context, repo provisio
 		Theme:  models.ThemeDark, // from config?
 		Width:  1024,
 		Height: -1, // full page height
-	}, nil)
+	})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/render_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/render_test.go
@@ -122,8 +122,8 @@ func TestScreenshotRenderer_RenderScreenshot(t *testing.T) {
 			path: "test",
 			setupRender: func(ctrl *gomock.Controller) rendering.Service {
 				render := rendering.NewMockService(ctrl)
-				render.EXPECT().Render(gomock.Any(), rendering.RenderPNG, gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ rendering.RenderType, opts rendering.Opts, _ rendering.AuthOpts) (*rendering.RenderResult, error) {
+				render.EXPECT().Render(gomock.Any(), rendering.RenderPNG, gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ rendering.RenderType, opts rendering.Opts) (*rendering.RenderResult, error) {
 						require.Equal(t, "test?kiosk", opts.Path)
 						require.Equal(t, int64(1), opts.OrgID)
 						require.Equal(t, int64(1), opts.UserID)
@@ -144,7 +144,7 @@ func TestScreenshotRenderer_RenderScreenshot(t *testing.T) {
 			path: "test",
 			setupRender: func(ctrl *gomock.Controller) rendering.Service {
 				render := rendering.NewMockService(ctrl)
-				render.EXPECT().Render(gomock.Any(), rendering.RenderPNG, gomock.Any(), gomock.Any()).
+				render.EXPECT().Render(gomock.Any(), rendering.RenderPNG, gomock.Any()).
 					Return(&rendering.RenderResult{
 						FilePath: "/non/existent/file.png",
 					}, nil)
@@ -162,7 +162,7 @@ func TestScreenshotRenderer_RenderScreenshot(t *testing.T) {
 				tmpFile, cleanup := setupTempFile(t)
 				t.Cleanup(cleanup)
 				render := rendering.NewMockService(ctrl)
-				render.EXPECT().Render(gomock.Any(), rendering.RenderPNG, gomock.Any(), gomock.Any()).
+				render.EXPECT().Render(gomock.Any(), rendering.RenderPNG, gomock.Any()).
 					Return(&rendering.RenderResult{
 						FilePath: tmpFile,
 					}, nil)
@@ -191,7 +191,7 @@ func TestScreenshotRenderer_RenderScreenshot(t *testing.T) {
 				tmpFile, cleanup := setupTempFile(t)
 				t.Cleanup(cleanup)
 				render := rendering.NewMockService(ctrl)
-				render.EXPECT().Render(gomock.Any(), rendering.RenderPNG, gomock.Any(), gomock.Any()).
+				render.EXPECT().Render(gomock.Any(), rendering.RenderPNG, gomock.Any()).
 					Return(&rendering.RenderResult{
 						FilePath: tmpFile,
 					}, nil)
@@ -218,7 +218,7 @@ func TestScreenshotRenderer_RenderScreenshot(t *testing.T) {
 				tmpFile, cleanup := setupTempFile(t)
 				t.Cleanup(cleanup)
 				render := rendering.NewMockService(ctrl)
-				render.EXPECT().Render(gomock.Any(), rendering.RenderPNG, gomock.Any(), gomock.Any()).
+				render.EXPECT().Render(gomock.Any(), rendering.RenderPNG, gomock.Any()).
 					Return(&rendering.RenderResult{
 						FilePath: tmpFile,
 					}, nil)
@@ -245,8 +245,8 @@ func TestScreenshotRenderer_RenderScreenshot(t *testing.T) {
 				tmpFile, cleanup := setupTempFile(t)
 				t.Cleanup(cleanup)
 				render := rendering.NewMockService(ctrl)
-				render.EXPECT().Render(gomock.Any(), rendering.RenderPNG, gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ rendering.RenderType, opts rendering.Opts, _ rendering.AuthOpts) (*rendering.RenderResult, error) {
+				render.EXPECT().Render(gomock.Any(), rendering.RenderPNG, gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ rendering.RenderType, opts rendering.Opts) (*rendering.RenderResult, error) {
 						require.Equal(t, "test?param1=value1&param2=value2&kiosk", opts.Path)
 						return &rendering.RenderResult{
 							FilePath: tmpFile,

--- a/pkg/services/rendering/auth.go
+++ b/pkg/services/rendering/auth.go
@@ -114,29 +114,6 @@ func generateAndSetRenderKey(cache *remotecache.RemoteCache, ctx context.Context
 	return key, nil
 }
 
-type longLivedRenderKeyProvider struct {
-	cache       *remotecache.RemoteCache
-	log         log.Logger
-	renderKey   string
-	authOpts    AuthOpts
-	sessionOpts SessionOpts
-}
-
-func (rs *RenderingService) CreateRenderingSession(ctx context.Context, opts AuthOpts, sessionOpts SessionOpts) (Session, error) {
-	renderKey, err := generateAndSetRenderKey(rs.RemoteCacheService, ctx, opts, sessionOpts.Expiry)
-	if err != nil {
-		return nil, err
-	}
-
-	return &longLivedRenderKeyProvider{
-		log:         rs.log,
-		renderKey:   renderKey,
-		cache:       rs.RemoteCacheService,
-		authOpts:    opts,
-		sessionOpts: sessionOpts,
-	}, nil
-}
-
 func deleteRenderKey(cache *remotecache.RemoteCache, log log.Logger, ctx context.Context, renderKey string) {
 	err := cache.Delete(ctx, fmt.Sprintf(renderKeyPrefix, renderKey))
 	if err != nil {
@@ -156,25 +133,6 @@ func (r *perRequestRenderKeyProvider) get(ctx context.Context, opts AuthOpts) (s
 
 func (r *perRequestRenderKeyProvider) afterRequest(ctx context.Context, _ AuthOpts, renderKey string) {
 	deleteRenderKey(r.cache, r.log, ctx, renderKey)
-}
-
-func (r *longLivedRenderKeyProvider) get(ctx context.Context, opts AuthOpts) (string, error) {
-	if r.sessionOpts.RefreshExpiryOnEachRequest {
-		err := setRenderKey(r.cache, ctx, opts, r.renderKey, r.sessionOpts.Expiry)
-		if err != nil {
-			r.log.Error("Failed to refresh render key", "error", err, "renderKey", r.renderKey)
-		}
-	}
-	return r.renderKey, nil
-}
-
-func (r *longLivedRenderKeyProvider) afterRequest(_ context.Context, _ AuthOpts, _ string) {
-	// do nothing - renderKey from longLivedRenderKeyProvider is deleted only after session expires
-	// or someone calls session.Dispose()
-}
-
-func (r *longLivedRenderKeyProvider) Dispose(ctx context.Context) {
-	deleteRenderKey(r.cache, r.log, ctx, r.renderKey)
 }
 
 type jwtRenderKeyProvider struct {

--- a/pkg/services/rendering/interface.go
+++ b/pkg/services/rendering/interface.go
@@ -96,16 +96,6 @@ type renderKeyProvider interface {
 	afterRequest(ctx context.Context, opts AuthOpts, renderKey string)
 }
 
-type SessionOpts struct {
-	Expiry                     time.Duration
-	RefreshExpiryOnEachRequest bool
-}
-
-type Session interface {
-	renderKeyProvider
-	Dispose(ctx context.Context)
-}
-
 type CapabilitySupportRequestResult struct {
 	IsSupported      bool
 	SemverConstraint string
@@ -115,11 +105,10 @@ type CapabilitySupportRequestResult struct {
 type Service interface {
 	IsAvailable(ctx context.Context) bool
 	Version() string
-	Render(ctx context.Context, renderType RenderType, opts Opts, session Session) (*RenderResult, error)
-	RenderCSV(ctx context.Context, opts CSVOpts, session Session) (*RenderCSVResult, error)
+	Render(ctx context.Context, renderType RenderType, opts Opts) (*RenderResult, error)
+	RenderCSV(ctx context.Context, opts CSVOpts) (*RenderCSVResult, error)
 	RenderErrorImage(theme models.Theme, err error) (*RenderResult, error)
 	GetRenderUser(ctx context.Context, key string) (*RenderUser, bool)
 	HasCapability(ctx context.Context, capability CapabilityName) (CapabilitySupportRequestResult, error)
 	IsCapabilitySupported(ctx context.Context, capability CapabilityName) error
-	CreateRenderingSession(ctx context.Context, authOpts AuthOpts, sessionOpts SessionOpts) (Session, error)
 }

--- a/pkg/services/rendering/mock.go
+++ b/pkg/services/rendering/mock.go
@@ -41,21 +41,6 @@ func (m *MockService) EXPECT() *MockServiceMockRecorder {
 	return m.recorder
 }
 
-// CreateRenderingSession mocks base method.
-func (m *MockService) CreateRenderingSession(ctx context.Context, authOpts AuthOpts, sessionOpts SessionOpts) (Session, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateRenderingSession", ctx, authOpts, sessionOpts)
-	ret0, _ := ret[0].(Session)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateRenderingSession indicates an expected call of CreateRenderingSession.
-func (mr *MockServiceMockRecorder) CreateRenderingSession(ctx, authOpts, sessionOpts any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRenderingSession", reflect.TypeOf((*MockService)(nil).CreateRenderingSession), ctx, authOpts, sessionOpts)
-}
-
 // GetRenderUser mocks base method.
 func (m *MockService) GetRenderUser(ctx context.Context, key string) (*RenderUser, bool) {
 	m.ctrl.T.Helper()
@@ -115,33 +100,33 @@ func (mr *MockServiceMockRecorder) IsCapabilitySupported(ctx, capability any) *g
 }
 
 // Render mocks base method.
-func (m *MockService) Render(ctx context.Context, renderType RenderType, opts Opts, session Session) (*RenderResult, error) {
+func (m *MockService) Render(ctx context.Context, renderType RenderType, opts Opts) (*RenderResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Render", ctx, renderType, opts, session)
+	ret := m.ctrl.Call(m, "Render", ctx, renderType, opts)
 	ret0, _ := ret[0].(*RenderResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Render indicates an expected call of Render.
-func (mr *MockServiceMockRecorder) Render(ctx, renderType, opts, session any) *gomock.Call {
+func (mr *MockServiceMockRecorder) Render(ctx, renderType, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Render", reflect.TypeOf((*MockService)(nil).Render), ctx, renderType, opts, session)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Render", reflect.TypeOf((*MockService)(nil).Render), ctx, renderType, opts)
 }
 
 // RenderCSV mocks base method.
-func (m *MockService) RenderCSV(ctx context.Context, opts CSVOpts, session Session) (*RenderCSVResult, error) {
+func (m *MockService) RenderCSV(ctx context.Context, opts CSVOpts) (*RenderCSVResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RenderCSV", ctx, opts, session)
+	ret := m.ctrl.Call(m, "RenderCSV", ctx, opts)
 	ret0, _ := ret[0].(*RenderCSVResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RenderCSV indicates an expected call of RenderCSV.
-func (mr *MockServiceMockRecorder) RenderCSV(ctx, opts, session any) *gomock.Call {
+func (mr *MockServiceMockRecorder) RenderCSV(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenderCSV", reflect.TypeOf((*MockService)(nil).RenderCSV), ctx, opts, session)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenderCSV", reflect.TypeOf((*MockService)(nil).RenderCSV), ctx, opts)
 }
 
 // RenderErrorImage mocks base method.

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -267,13 +267,11 @@ func (rs *RenderingService) renderUnavailableImage() *RenderResult {
 }
 
 // Render calls the grafana image renderer and returns Grafana resource as PNG or PDF
-func (rs *RenderingService) Render(ctx context.Context, renderType RenderType, opts Opts, session Session) (*RenderResult, error) {
+func (rs *RenderingService) Render(ctx context.Context, renderType RenderType, opts Opts) (*RenderResult, error) {
 	startTime := time.Now()
 
 	renderKeyProvider := rs.perRequestRenderKeyProvider
-	if session != nil {
-		renderKeyProvider = session
-	}
+
 	result, err := rs.render(ctx, renderType, opts, renderKeyProvider)
 
 	elapsedTime := time.Since(startTime).Milliseconds()
@@ -345,13 +343,11 @@ func (rs *RenderingService) render(ctx context.Context, renderType RenderType, o
 	return res, nil
 }
 
-func (rs *RenderingService) RenderCSV(ctx context.Context, opts CSVOpts, session Session) (*RenderCSVResult, error) {
+func (rs *RenderingService) RenderCSV(ctx context.Context, opts CSVOpts) (*RenderCSVResult, error) {
 	startTime := time.Now()
 
 	renderKeyProvider := rs.perRequestRenderKeyProvider
-	if session != nil {
-		renderKeyProvider = session
-	}
+
 	result, err := rs.renderCSV(ctx, opts, renderKeyProvider)
 
 	elapsedTime := time.Since(startTime).Milliseconds()

--- a/pkg/services/rendering/rendering_test.go
+++ b/pkg/services/rendering/rendering_test.go
@@ -118,7 +118,7 @@ func TestRenderUnavailableError(t *testing.T) {
 		RendererPluginManager: &dummyPluginManager{},
 	}
 	opts := Opts{ErrorOpts: ErrorOpts{ErrorRenderUnavailable: true}}
-	result, err := rs.Render(context.Background(), RenderPNG, opts, nil)
+	result, err := rs.Render(context.Background(), RenderPNG, opts)
 	assert.Equal(t, ErrRenderUnavailable, err)
 	assert.Nil(t, result)
 }
@@ -161,7 +161,7 @@ func TestRenderLimitImage(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := Opts{Theme: tc.theme, CommonOpts: CommonOpts{ConcurrentLimit: 1}}
-			result, err := rs.Render(context.Background(), RenderPNG, opts, nil)
+			result, err := rs.Render(context.Background(), RenderPNG, opts)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, result.FilePath)
 		})
@@ -182,7 +182,7 @@ func TestRenderLimitImageError(t *testing.T) {
 		ErrorOpts:  ErrorOpts{ErrorConcurrentLimitReached: true},
 		Theme:      models.ThemeDark,
 	}
-	result, err := rs.Render(context.Background(), RenderPNG, opts, nil)
+	result, err := rs.Render(context.Background(), RenderPNG, opts)
 	assert.Equal(t, ErrConcurrentLimitReached, err)
 	assert.Nil(t, result)
 }

--- a/pkg/services/screenshot/screenshot.go
+++ b/pkg/services/screenshot/screenshot.go
@@ -128,7 +128,7 @@ func (s *HeadlessScreenshotService) Take(ctx context.Context, opts ScreenshotOpt
 		Theme:  opts.Theme,
 	}
 
-	result, err := s.rs.Render(ctx, rendering.RenderPNG, renderOpts, nil)
+	result, err := s.rs.Render(ctx, rendering.RenderPNG, renderOpts)
 	if err != nil {
 		s.instrumentError(err)
 		return nil, fmt.Errorf("failed to take screenshot: %w", err)

--- a/pkg/services/screenshot/screenshot_test.go
+++ b/pkg/services/screenshot/screenshot_test.go
@@ -64,7 +64,7 @@ func TestHeadlessScreenshotService(t *testing.T) {
 	opts.DashboardUID = "foo"
 	opts.PanelID = 4
 	r.EXPECT().
-		Render(ctx, rendering.RenderPNG, renderOpts, nil).
+		Render(ctx, rendering.RenderPNG, renderOpts).
 		Return(&rendering.RenderResult{FilePath: "panel.png"}, nil)
 	screenshot, err = s.Take(ctx, opts)
 	require.NoError(t, err)
@@ -72,7 +72,7 @@ func TestHeadlessScreenshotService(t *testing.T) {
 
 	// a timeout should return error
 	r.EXPECT().
-		Render(ctx, rendering.RenderPNG, renderOpts, nil).
+		Render(ctx, rendering.RenderPNG, renderOpts).
 		Return(nil, rendering.ErrTimeout)
 	screenshot, err = s.Take(ctx, opts)
 	assert.EqualError(t, err, fmt.Sprintf("failed to take screenshot: %s", rendering.ErrTimeout))


### PR DESCRIPTION
The long-lived render key provider and rendering session is never used, so cleaning it up! 🧹 

If you see, the `Render` and `RenderCSV` calls all pass `session` as `nil`!