### PR TITLE
CI: Fix Go module cache key for integration tests

### DIFF
--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: "**/*.sum"
       - name: Run tests
         if: matrix.shard != 'profiled'
         env:
@@ -178,6 +179,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: "**/*.sum"
       - name: Setup MySQL devenv
         run: mysql -h 127.0.0.1 -P 3306 -u root -prootpass < devenv/docker/blocks/mysql_tests/setup.sql
       - name: Run tests
@@ -226,6 +228,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: "**/*.sum"
       - name: Setup Postgres devenv
         run: psql -p 5432 -h 127.0.0.1 -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
       - name: Run tests
@@ -272,6 +275,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: "**/*.sum"
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:
@@ -389,6 +393,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: "**/*.sum"
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:
@@ -442,6 +447,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: "**/*.sum"
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:


### PR DESCRIPTION
## Summary

Add `cache-dependency-path: "**/*.sum"` to all 6 `actions/setup-go` steps in the integration test workflow.

### Problem

The integration test workflow uses `actions/setup-go` with `cache: true` but without `cache-dependency-path`. This causes the cache key to only hash the root `go.sum` file, missing the 48 other `go.sum` files and `go.work.sum` across the 39-module Go workspace.

`actions/setup-go` computes a cache key like:

```
setup-go-<runner.os>-<runner.arch>-go-<version>-<hash-of-dependency-files>
```

Without `cache-dependency-path`, only the root `go.sum` is hashed. This leads to:

- **Stale hits**: A sub-module's `go.sum` changes (new dependency) but the root `go.sum` doesn't. The cache key matches an old archive missing the new modules, so Go re-downloads them anyway.
- **False misses**: The root `go.sum` changes (e.g. `go mod tidy`) but actual dependencies are the same. The key doesn't match, so the entire GOMODCACHE is re-downloaded from scratch across all 36+ shard jobs.

### How `actions/setup-go` caching works

```mermaid
flowchart TD
    A["Compute cache key from:\n- runner.os\n- runner.arch\n- Go version\n- hash of dependency files"] --> B{"Exact key match\nin GitHub cache?"}
    B -->|Yes| C["Restore GOMODCACHE + GOCACHE\nfrom cache archive"]
    C --> D["cache-hit = true\n(no downloads needed)"]
    B -->|No| E{"Partial prefix\nmatch?"}
    E -->|Yes| F["Restore best partial match\n(some downloads needed)"]
    E -->|No| G["No cache restored\n(full download of ~400 modules)"]
    F --> H["Post-job: save updated\ncache under new key"]
    G --> H
```

**Before (root `go.sum` only):** The dependency hash misses changes in 48 sub-module `go.sum` files and `go.work.sum`, causing frequent stale hits or false misses.

**After (`**/*.sum`):** The dependency hash covers all 49 `go.sum` files and `go.work.sum`, so the cache key accurately reflects the full workspace dependency state.

### Fix

Set `cache-dependency-path: "**/*.sum"` so the cache key hashes all 49 `go.sum` files **and** `go.work.sum`, accurately reflecting the full workspace dependency state and improving cache hit rates.

See [actions/setup-go: Caching in multi-module repositories](https://github.com/actions/setup-go/blob/main/docs/advanced-usage.md#caching-in-multi-module-repositories) for the recommended pattern.

## Test plan

- [ ] Verify cache hit behavior on a follow-up push to this PR (second run should show `cache-hit: true` in the `Setup Go` step logs)
- [ ] Compare `Setup Go` step duration between this PR and a recent `main` run
- [ ] Confirm no `go: downloading ...` output during test execution when cache is warm