### PR TITLE
feat(import): support constant variables in V2 import and strip export metadata

### DIFF
--- a/public/app/features/manage-dashboards/import/components/ImportDashboardFormV2.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportDashboardFormV2.tsx
@@ -8,7 +8,7 @@ import { Button, Field, FormFieldErrors, FormsOnSubmit, Stack, Input, Alert } fr
 import { FolderPicker } from 'app/core/components/Select/FolderPicker';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
 
-import { DashboardInputs, DatasourceSelection, DataSourceInput, ImportFormDataV2 } from '../../types';
+import { DashboardInput, DashboardInputs, DatasourceSelection, DataSourceInput, ImportFormDataV2 } from '../../types';
 import { validateTitle } from '../utils/validation';
 
 interface Props extends Pick<UseFormReturn<ImportFormDataV2>, 'register' | 'control' | 'getValues' | 'watch'> {
@@ -125,6 +125,22 @@ export const ImportDashboardFormV2 = ({
                 control={control}
                 rules={{ required: true }}
               />
+            </Field>
+          );
+        })}
+
+      {inputs.constants &&
+        inputs.constants.map((input: DashboardInput) => {
+          const constantKey = `constant-${input.name}`;
+          return (
+            <Field
+              label={input.label}
+              key={constantKey}
+              invalid={!!errors[constantKey]}
+              error={errors[constantKey] ? `${input.label} needs a value` : undefined}
+              noMargin
+            >
+              <Input {...register(constantKey, { required: true })} defaultValue={input.value} />
             </Field>
           );
         })}

--- a/public/app/features/manage-dashboards/import/components/ImportOverviewV1.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportOverviewV1.tsx
@@ -11,7 +11,7 @@ import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { addLibraryPanel } from 'app/features/library-panels/state/api';
 
 import { DashboardInputs, DashboardSource, ImportDashboardDTO, LibraryPanelInputState } from '../../types';
-import { applyV1Inputs } from '../utils/inputs';
+import { applyV1Inputs, stripExportMetadata } from '../utils/inputs';
 
 import { GcomDashboardInfo } from './GcomDashboardInfo';
 import { ImportForm } from './ImportForm';
@@ -60,8 +60,10 @@ export function ImportOverviewV1({ dashboard, inputs, meta, source, folderUid, o
         }
       }
 
+      const cleanDashboard = stripExportMetadata(dashboardWithDataSources);
+
       const dashboardK8SPayload: SaveDashboardCommand<Dashboard> = {
-        dashboard: dashboardWithDataSources,
+        dashboard: cleanDashboard,
         k8s: {
           annotations: {
             'grafana.app/folder': form.folder.uid,

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -440,6 +440,88 @@ describe('extractV2Inputs', () => {
     expect(result.dataSources).toHaveLength(1);
     expect(result.dataSources[0].pluginId).toBe('prometheus');
   });
+
+  it('should extract constant variables', async () => {
+    const dashboard = {
+      elements: {},
+      variables: [
+        {
+          kind: 'ConstantVariable',
+          spec: {
+            name: 'environment',
+            label: 'Environment',
+            query: 'production',
+            description: 'Target environment',
+            current: { text: 'production', value: 'production' },
+            hide: 'dontHide',
+            skipUrlSync: false,
+          },
+        },
+      ],
+    };
+
+    const result = await extractV2Inputs(dashboard);
+
+    expect(result.constants).toHaveLength(1);
+    expect(result.constants[0]).toEqual({
+      name: 'environment',
+      label: 'Environment',
+      info: 'Target environment',
+      value: 'production',
+      type: InputType.Constant,
+    });
+  });
+
+  it('should use variable name as label fallback', async () => {
+    const dashboard = {
+      elements: {},
+      variables: [
+        {
+          kind: 'ConstantVariable',
+          spec: {
+            name: 'my_const',
+            query: 'value',
+            current: { text: 'value', value: 'value' },
+            hide: 'dontHide',
+            skipUrlSync: false,
+          },
+        },
+      ],
+    };
+
+    const result = await extractV2Inputs(dashboard);
+
+    expect(result.constants[0].label).toBe('my_const');
+    expect(result.constants[0].info).toBe('Specify a string constant');
+  });
+
+  it('should extract both datasource and constant inputs', async () => {
+    const dashboard = {
+      elements: {},
+      variables: [
+        {
+          kind: 'QueryVariable',
+          spec: { name: 'promvar', query: { group: 'prometheus', labels: { [ExportLabel]: 'prom-1' } } },
+        },
+        {
+          kind: 'ConstantVariable',
+          spec: {
+            name: 'namespace',
+            query: 'default',
+            current: { text: 'default', value: 'default' },
+            hide: 'dontHide',
+            skipUrlSync: false,
+          },
+        },
+      ],
+    };
+
+    const result = await extractV2Inputs(dashboard);
+
+    expect(result.dataSources).toHaveLength(1);
+    expect(result.constants).toHaveLength(1);
+    expect(result.constants[0].name).toBe('namespace');
+  });
 });
 
 describe('applyV1Inputs', () => {
@@ -734,6 +816,87 @@ describe('applyV2Inputs', () => {
     const secondSpec = secondQuery?.spec as any;
     expect(firstSpec?.query?.datasource?.name).toBe('ds-uid-1');
     expect(secondSpec?.query?.datasource?.name).toBe('ds-uid-2');
+  });
+
+  it('applies user-provided constant values to ConstantVariable specs', () => {
+    const dashboard = {
+      title: 'old',
+      elements: {},
+      annotations: [],
+      variables: [
+        {
+          kind: 'ConstantVariable',
+          spec: {
+            name: 'environment',
+            query: 'production',
+            current: { text: 'production', value: 'production' },
+            hide: 'dontHide',
+            skipUrlSync: false,
+          },
+        },
+        {
+          kind: 'ConstantVariable',
+          spec: {
+            name: 'region',
+            query: 'us-east-1',
+            current: { text: 'us-east-1', value: 'us-east-1' },
+            hide: 'dontHide',
+            skipUrlSync: false,
+          },
+        },
+      ],
+    } as unknown as DashboardV2Spec;
+
+    const form: ImportFormDataV2 = {
+      dashboard,
+      folderUid: 'folder',
+      message: '',
+      'constant-environment': 'staging',
+      'constant-region': 'eu-west-1',
+    };
+
+    const result = applyV2Inputs(dashboard, form);
+
+    const envVar = result.variables?.find((v) => v.kind === 'ConstantVariable' && v.spec.name === 'environment');
+    expect(envVar?.kind === 'ConstantVariable' && envVar.spec.query).toBe('staging');
+    expect(envVar?.kind === 'ConstantVariable' && envVar.spec.current).toEqual({
+      text: 'staging',
+      value: 'staging',
+    });
+
+    const regionVar = result.variables?.find((v) => v.kind === 'ConstantVariable' && v.spec.name === 'region');
+    expect(regionVar?.kind === 'ConstantVariable' && regionVar.spec.query).toBe('eu-west-1');
+  });
+
+  it('preserves constant values when no form value is provided', () => {
+    const dashboard = {
+      title: 'old',
+      elements: {},
+      annotations: [],
+      variables: [
+        {
+          kind: 'ConstantVariable',
+          spec: {
+            name: 'environment',
+            query: 'production',
+            current: { text: 'production', value: 'production' },
+            hide: 'dontHide',
+            skipUrlSync: false,
+          },
+        },
+      ],
+    } as unknown as DashboardV2Spec;
+
+    const form: ImportFormDataV2 = {
+      dashboard,
+      folderUid: 'folder',
+      message: '',
+    };
+
+    const result = applyV2Inputs(dashboard, form);
+
+    const envVar = result.variables?.find((v) => v.kind === 'ConstantVariable' && v.spec.name === 'environment');
+    expect(envVar?.kind === 'ConstantVariable' && envVar.spec.query).toBe('production');
   });
 
   it('preserves variable references and does not replace them', () => {

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -23,6 +23,18 @@ import {
   LibraryPanelInputState,
 } from '../../types';
 
+/**
+ * Remove export-only metadata keys (__inputs, __elements, __requires)
+ * that should not be persisted when saving the dashboard.
+ */
+export function stripExportMetadata(dashboard: Dashboard): Dashboard {
+  const json = JSON.parse(JSON.stringify(dashboard));
+  delete json.__inputs;
+  delete json.__elements;
+  delete json.__requires;
+  return json;
+}
+
 /** Maps datasource type (e.g. "prometheus", "loki") to user-selected datasource from the import form */
 export type DatasourceMappings = Record<string, { uid: string; type: string; name?: string }>;
 
@@ -184,6 +196,20 @@ export async function extractV2Inputs(dashboard: unknown): Promise<DashboardInpu
     return inputs;
   }
 
+  if (dashboard.variables) {
+    for (const variable of dashboard.variables) {
+      if (variable.kind === 'ConstantVariable') {
+        inputs.constants.push({
+          name: variable.spec.name,
+          label: variable.spec.label || variable.spec.name,
+          info: variable.spec.description || 'Specify a string constant',
+          value: variable.spec.query,
+          type: InputType.Constant,
+        });
+      }
+    }
+  }
+
   const dsTypes: { [label: string]: string } = {};
 
   if (dashboard.variables) {
@@ -320,7 +346,29 @@ export function applyV2Inputs(dashboard: DashboardV2Spec, form: ImportFormDataV2
       }
     }
   }
-  return replaceDatasourcesInDashboard(dashboard, mappings);
+
+  const variables = dashboard.variables?.map((variable) => {
+    if (variable.kind !== 'ConstantVariable') {
+      return variable;
+    }
+
+    const formKey = `constant-${variable.spec.name}`;
+    const userValue = form[formKey];
+    if (typeof userValue !== 'string') {
+      return variable;
+    }
+
+    return {
+      ...variable,
+      spec: {
+        ...variable.spec,
+        query: userValue,
+        current: { text: userValue, value: userValue },
+      },
+    };
+  });
+
+  return replaceDatasourcesInDashboard({ ...dashboard, variables }, mappings);
 }
 
 export function isVariableRef(dsName: string | undefined): boolean {


### PR DESCRIPTION
## Summary

- **V2 constant variable support**: The V2 dashboard import path was missing constant variable handling. When importing a V2 dashboard with `ConstantVariable` kinds, the user had no way to customize their values. This adds extraction, rendering, and application of constants in the V2 flow — matching the capability that existed in the V1/classic import path.
- **V1 export metadata cleanup**: The K8s V1 import path was not stripping `__inputs`, `__elements`, and `__requires` metadata before saving. The legacy backend import endpoint explicitly removed these keys, so this aligns the new path with the old behavior.

### Changes

| File | What |
|---|---|
| `inputs.ts` | `extractV2Inputs` now detects `ConstantVariable` and populates `inputs.constants`; `applyV2Inputs` applies user-provided constant values; new `stripExportMetadata` helper |
| `ImportDashboardFormV2.tsx` | Renders constant text input fields (matching V1's `ImportForm`) |
| `ImportOverviewV1.tsx` | Strips `__inputs`/`__elements`/`__requires` before saving |
| `inputs.test.ts` | Tests for V2 constant extraction, application, and preservation |

## Test plan

- [ ] Import a V2-exported dashboard containing `ConstantVariable` — verify the import form shows text inputs for each constant
- [ ] Change constant values during import — verify the imported dashboard uses the new values
- [ ] Import a V2 dashboard without constants — verify no regressions
- [ ] Import a classic/V1 dashboard — verify `__inputs`/`__elements`/`__requires` are not persisted in the saved JSON