### PR TITLE
CI: Enable Go module caching for backend unit tests

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -62,6 +62,8 @@ jobs:
         uses: actions/setup-go@v6.0.0
         with:
           go-version-file: go.mod
+          cache: true
+          cache-dependency-path: "**/*.sum"
       - name: Run unit tests
         env:
           SHARD: ${{ matrix.shard }}
@@ -97,6 +99,8 @@ jobs:
         uses: actions/setup-go@v6.0.0
         with:
           go-version-file: go.mod
+          cache: true
+          cache-dependency-path: "**/*.sum"
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:


### PR DESCRIPTION
## Summary

Enable Go module caching on both the `grafana` (OSS) and `grafana-enterprise` jobs in the backend unit tests workflow.

### Problem

The backend unit tests workflow uses `actions/setup-go` **without** `cache: true`. This means every shard job (8 OSS + 8 Enterprise = 16 jobs) downloads the full Go dependency tree from scratch on every run.

### How `actions/setup-go` caching works

```mermaid
flowchart TD
    A["Compute cache key from:\n- runner.os\n- runner.arch\n- Go version\n- hash of dependency files"] --> B{"Exact key match\nin GitHub cache?"}
    B -->|Yes| C["Restore GOMODCACHE + GOCACHE\nfrom cache archive"]
    C --> D["cache-hit = true\n(no downloads needed)"]
    B -->|No| E{"Partial prefix\nmatch?"}
    E -->|Yes| F["Restore best partial match\n(some downloads needed)"]
    E -->|No| G["No cache restored\n(full download of ~400 modules)"]
    F --> H["Post-job: save updated\ncache under new key"]
    G --> H
```

### Fix

Add `cache: true` with `cache-dependency-path: "**/*.sum"` to both `setup-go` steps. The glob matches all 49 `go.sum` files and `go.work.sum` across the 39-module Go workspace, ensuring the cache key accurately reflects the full dependency state.

This matches the pattern already applied to the integration test workflow in #119968.

See [actions/setup-go: Caching in multi-module repositories](https://github.com/actions/setup-go/blob/main/docs/advanced-usage.md#caching-in-multi-module-repositories) for the recommended pattern.

## Test plan

- [ ] Verify cache hit behavior on a follow-up push to this PR (second run should show `cache-hit: true` in the `Setup Go` step logs)
- [ ] Compare `Setup Go` step duration between this PR and a recent `main` run
- [ ] Confirm no `go: downloading ...` output during test execution when cache is warm

Made with [Cursor](https://cursor.com)