### PR TITLE
Inline SecureValues: noop when removing a value that does not exist - 2 

### DIFF
--- a/pkg/storage/unified/apistore/secure.go
+++ b/pkg/storage/unified/apistore/secure.go
@@ -68,10 +68,10 @@ func prepareSecureValues(ctx context.Context, store secret.InlineSecureValueSupp
 				delete(previous, k)
 			}
 			if val.Remove {
+				delete(secure, k)
 				if before.Name == "" {
 					continue // no-op
 				}
-				delete(secure, k)
 				v.hasChanged = true
 				continue
 			}

--- a/pkg/storage/unified/apistore/secure_test.go
+++ b/pkg/storage/unified/apistore/secure_test.go
@@ -185,6 +185,32 @@ func TestSecureLifecycle(t *testing.T) {
 		info := &objectForStorage{}
 		err := prepareSecureValues(context.Background(), secureStore, obj, resourceWithSecureValues(nil), info)
 		require.Nil(t, err, "should noop when previous value does not exist")
+		require.False(t, info.hasChanged, "noop remove should not mark the object as changed")
+		secure, err := obj.GetSecureValues()
+		require.NoError(t, err)
+		require.Empty(t, secure, "noop remove should be stripped before the object is written")
+		secureStore.AssertExpectations(t)
+	})
+
+	t.Run("remove invalid secure values while creating others", func(t *testing.T) {
+		secureStore := secret.NewMockInlineSecureValueSupport(t)
+		secureStore.On("CreateInline", mock.Anything, mock.Anything, common.RawSecureValue("SecretAAA")).
+			Return("NameForA", nil).Once()
+
+		obj := resourceWithSecureValues(common.InlineSecureValues{
+			"a": common.InlineSecureValue{Create: "SecretAAA"},
+			"b": common.InlineSecureValue{Remove: true}, // b does not exist in previous value
+		})
+
+		info := &objectForStorage{}
+		err := prepareSecureValues(context.Background(), secureStore, obj, resourceWithSecureValues(nil), info)
+		require.NoError(t, err)
+		require.True(t, info.hasChanged, "creating a secure value should still mark the object as changed")
+		secure, err := obj.GetSecureValues()
+		require.NoError(t, err)
+		require.JSONEq(t, `{
+			"a": {"name": "NameForA"}
+		}`, asJSON(secure, true))
 		secureStore.AssertExpectations(t)
 	})
 


### PR DESCRIPTION
follow up to https://github.com/grafana/grafana/pull/119894



the noop'd remove request would persist in the request body and we would hit an error in unified storage layer: https://github.com/grafana/grafana/blob/d3df5b8ddd1a4eb3d5e779ea4a47227c8c388cde/pkg/storage/unified/resource/secure.go#L44