### PR TITLE
datasources: use openfeature to evaluate datasourcesRerouteLegacyCRUDAPIs

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -4,8 +4,17 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana/pkg/tests/testsuite"
+	"github.com/open-feature/go-sdk/openfeature"
+	ofttesting "github.com/open-feature/go-sdk/openfeature/testing"
+)
+
+var (
+	provider = ofttesting.NewTestProvider()
 )
 
 func TestMain(m *testing.M) {
+	if err := openfeature.SetProvider(provider); err != nil {
+		panic(err)
+	}
 	testsuite.Run(m)
 }

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -288,11 +288,7 @@ func mockRequestBody(v any) io.ReadCloser {
 // when setting up an API test server via SetupAPITestServer.
 type APITestServerOption func(hs *HTTPServer)
 
-// SetupAPITestServer sets up a webtest.Server ready for testing all
-// routes registered via HTTPServer.registerRoutes().
-// Optionally customize HTTPServer configuration by providing APITestServerOption
-// option(s).
-func SetupAPITestServer(t *testing.T, opts ...APITestServerOption) *webtest.Server {
+func setupAPITestServer(t *testing.T, opts ...APITestServerOption) *HTTPServer {
 	t.Helper()
 
 	hs := &HTTPServer{
@@ -318,7 +314,35 @@ func SetupAPITestServer(t *testing.T, opts ...APITestServerOption) *webtest.Serv
 
 	hs.registerRoutes()
 
+	return hs
+}
+
+// SetupAPITestServer sets up a webtest.Server ready for testing all
+// routes registered via HTTPServer.registerRoutes().
+// Optionally customize HTTPServer configuration by providing APITestServerOption
+// option(s).
+func SetupAPITestServer(t *testing.T, opts ...APITestServerOption) *webtest.Server {
+	hs := setupAPITestServer(t, opts...)
+
 	s := webtest.NewServer(t, hs.RouteRegister)
+
+	viewsPath, err := filepath.Abs("../../public/views")
+	require.NoError(t, err)
+	s.Mux.UseMiddleware(web.Renderer(viewsPath, "[[", "]]"))
+
+	return s
+}
+
+// SetupInProcessAPITestServer is like SetupAPITestServer but handles requests
+// in the calling goroutine instead of over TCP (which uses a different goroutine).
+// openfeature's TestProvider relies on flags being stored and fetched from the
+// same goroutine, so we will need to use this function when testing code that
+// uses openfeature for evaluating feature flags. For more information, see
+// https://pkg.go.dev/go.openfeature.dev/openfeature/v2/providers/testing#TestProvider
+func SetupInProcessAPITestServer(t *testing.T, opts ...APITestServerOption) *webtest.Server {
+	hs := setupAPITestServer(t, opts...)
+
+	s := webtest.NewInProcessServer(t, hs.RouteRegister)
 
 	viewsPath, err := filepath.Abs("../../public/views")
 	require.NoError(t, err)

--- a/pkg/api/datasources_k8s.go
+++ b/pkg/api/datasources_k8s.go
@@ -31,7 +31,6 @@ import (
 // Optional access control metadata is still fetched from the legacy accesscontrol service for now.
 func (hs *HTTPServer) getK8sDataSourceByUIDHandler() web.Handler {
 	return routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
-
 		// use the legacy handler if the feature toggle is disabled
 		client := openfeature.NewDefaultClient()
 		if !client.Boolean(c.Req.Context(), featuremgmt.FlagDatasourcesRerouteLegacyCRUDAPIs, false, openfeature.TransactionContext(c.Req.Context())) {

--- a/pkg/api/datasources_k8s.go
+++ b/pkg/api/datasources_k8s.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/web"
+	"github.com/open-feature/go-sdk/openfeature"
 )
 
 // getK8sDataSourceByUIDHandler returns a handler that redirects GET /api/datasources/uid/:uid
@@ -29,23 +30,14 @@ import (
 //
 // Optional access control metadata is still fetched from the legacy accesscontrol service for now.
 func (hs *HTTPServer) getK8sDataSourceByUIDHandler() web.Handler {
-	//nolint:staticcheck // not yet migrated to OpenFeature
-	if !hs.Features.IsEnabledGlobally(featuremgmt.FlagDatasourcesRerouteLegacyCRUDAPIs) {
-		return routing.Wrap(hs.GetDataSourceByUID)
-	}
-
-	// datasourcesRerouteLegacyCRUDAPIs requires these flags to be enabled
-	//nolint:staticcheck // not yet migrated to OpenFeature
-	if !hs.Features.IsEnabledGlobally(featuremgmt.FlagQueryService) ||
-		!hs.Features.IsEnabledGlobally(featuremgmt.FlagQueryServiceWithConnections) {
-		return routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
-			return response.Error(http.StatusInternalServerError,
-				"datasourcesRerouteLegacyCRUDAPIs requires queryService and queryServiceWithConnections feature flags",
-				nil)
-		})
-	}
-
 	return routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
+
+		// use the legacy handler if the feature toggle is disabled
+		client := openfeature.NewDefaultClient()
+		if !client.Boolean(c.Req.Context(), featuremgmt.FlagDatasourcesRerouteLegacyCRUDAPIs, false, openfeature.TransactionContext(c.Req.Context())) {
+			return hs.GetDataSourceByUID(c)
+		}
+
 		start := time.Now()
 		defer func() {
 			metricutil.ObserveWithExemplar(c.Req.Context(), hs.dsConfigHandlerRequestsDuration.WithLabelValues("getK8sDataSourceByUIDHandler"), time.Since(start).Seconds())

--- a/pkg/api/datasources_k8s_test.go
+++ b/pkg/api/datasources_k8s_test.go
@@ -70,7 +70,6 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 // datasources_test for legacy, and in the integration tests for the new
 // endpoints.
 func TestGetK8sDataSourceByUIDHandler(t *testing.T) {
-
 	tests := []struct {
 		name             string
 		connectionResult *queryV0.DataSourceConnectionList

--- a/pkg/api/datasources_k8s_test.go
+++ b/pkg/api/datasources_k8s_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	clientrest "k8s.io/client-go/rest"
@@ -69,6 +70,7 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 // datasources_test for legacy, and in the integration tests for the new
 // endpoints.
 func TestGetK8sDataSourceByUIDHandler(t *testing.T) {
+
 	tests := []struct {
 		name             string
 		connectionResult *queryV0.DataSourceConnectionList
@@ -129,17 +131,14 @@ func TestGetK8sDataSourceByUIDHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			provider.UsingFlags(t, map[string]memprovider.InMemoryFlag{
+				featuremgmt.FlagDatasourcesRerouteLegacyCRUDAPIs: setting.NewInMemoryFlag(featuremgmt.FlagDatasourcesRerouteLegacyCRUDAPIs, true),
+			})
 			// not using SetupAPITestServer here because the access control is
 			// overkill. Access control for these endpoints is tested in
 			// datasources_test.go
 			hs := &HTTPServer{
-				Cfg: setting.NewCfg(),
-				Features: featuremgmt.WithFeatures(
-					featuremgmt.FlagDatasourcesRerouteLegacyCRUDAPIs,
-					featuremgmt.FlagQueryService,
-					featuremgmt.FlagQueryServiceWithConnections,
-					featuremgmt.FlagDatasourcesApiServerEnableResourceEndpoint,
-				),
+				Cfg:                  setting.NewCfg(),
 				dsConnectionClient:   &mockConnectionClient{result: tt.connectionResult, err: tt.connectionErr},
 				clientConfigProvider: &mockDirectRestConfigProvider{host: "http://localhost", transport: &mockRoundTripper{statusCode: tt.statusCode, responseBody: tt.responseBody}},
 				namespacer:           func(int64) string { return "default" },

--- a/pkg/api/datasources_test.go
+++ b/pkg/api/datasources_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -446,7 +447,11 @@ func TestAPI_datasources_AccessControl(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			provider.UsingFlags(t, map[string]memprovider.InMemoryFlag{
+				featuremgmt.FlagDatasourcesRerouteLegacyCRUDAPIs: setting.NewInMemoryFlag(featuremgmt.FlagDatasourcesRerouteLegacyCRUDAPIs, false),
+			})
+
+			server := SetupInProcessAPITestServer(t, func(hs *HTTPServer) {
 				hs.Cfg = setting.NewCfg()
 				hs.DataSourcesService = &dataSourcesServiceMock{expectedDatasource: &datasources.DataSource{}}
 				hs.accesscontrolService = actest.FakeService{}

--- a/pkg/tests/api/datasources/datasource_get_by_uid_test.go
+++ b/pkg/tests/api/datasources/datasource_get_by_uid_test.go
@@ -23,28 +23,36 @@ import (
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
+	ofttesting "github.com/open-feature/go-sdk/openfeature/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	provider = ofttesting.NewTestProvider()
+)
+
 func TestMain(m *testing.M) {
+	if err := openfeature.SetProvider(provider); err != nil {
+		panic(err)
+	}
 	testsuite.Run(m)
 }
 
 // testMode groups feature toggles needed for different test scenarios
 type testMode struct {
 	name           string
-	featureToggles []string
+	featureToggles map[string]memprovider.InMemoryFlag
 }
 
 // getTestModes returns the test configurations to run tests against
 func getTestModes() []testMode {
 	return []testMode{
 		{name: "legacy", featureToggles: nil},
-		{name: "k8s-reroute", featureToggles: []string{
-			"datasourcesRerouteLegacyCRUDAPIs",
-			"queryService",                // need query.grafana.app API group
-			"queryServiceWithConnections", // need query.grafana.app connections subresource
+		{name: "k8s-reroute", featureToggles: map[string]memprovider.InMemoryFlag{
+			featuremgmt.FlagDatasourcesRerouteLegacyCRUDAPIs: setting.NewInMemoryFlag(featuremgmt.FlagDatasourcesRerouteLegacyCRUDAPIs, true),
 		}},
 	}
 }
@@ -56,10 +64,12 @@ func TestIntegrationDataSourceGetByUID(t *testing.T) {
 
 	for _, mode := range getTestModes() {
 		t.Run(mode.name, func(t *testing.T) {
+
+			provider.UsingFlags(t, mode.featureToggles)
+
 			// set up Grafana and a database
 			dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
-				DisableAnonymous:     true,
-				EnableFeatureToggles: mode.featureToggles,
+				DisableAnonymous: true,
 			})
 			grafanaListeningAddr, testEnv := testinfra.StartGrafanaEnv(t, dir, path)
 			ctx := context.Background()

--- a/pkg/tests/api/datasources/datasource_get_by_uid_test.go
+++ b/pkg/tests/api/datasources/datasource_get_by_uid_test.go
@@ -64,7 +64,6 @@ func TestIntegrationDataSourceGetByUID(t *testing.T) {
 
 	for _, mode := range getTestModes() {
 		t.Run(mode.name, func(t *testing.T) {
-
 			provider.UsingFlags(t, mode.featureToggles)
 
 			// set up Grafana and a database

--- a/pkg/web/webtest/webtest.go
+++ b/pkg/web/webtest/webtest.go
@@ -26,6 +26,8 @@ type Server struct {
 	RouteRegister routing.RouteRegister
 	TestServer    *httptest.Server
 	HttpClient    *http.Client
+	// handle requests in the current goroutine, instead of over TCP
+	inProcess bool
 }
 
 // NewServer starts and returns a new server.
@@ -53,7 +55,18 @@ func NewServer(t testing.TB, routeRegister routing.RouteRegister) *Server {
 		Mux:           m,
 		TestServer:    testServer,
 		HttpClient:    httpclient.New(),
+		inProcess:     false,
 	}
+}
+
+// NewInProcessServer returns a server that handles requests in the calling
+// goroutine instead of over TCP, which will use a different goroutine. Use
+// this when handlers evaluate feature flags using openfeature, because the
+// openfeature TestProvider stores flag values in goroutine-local state.
+func NewInProcessServer(t testing.TB, routeRegister routing.RouteRegister) *Server {
+	s := NewServer(t, routeRegister)
+	s.inProcess = true
+	return s
 }
 
 // NewGetRequest creates a new GET request setup for test.
@@ -74,7 +87,9 @@ func (s *Server) NewRequest(method string, target string, body io.Reader) *http.
 		target = "/" + target
 	}
 
-	target = s.TestServer.URL + target
+	if !s.inProcess {
+		target = s.TestServer.URL + target
+	}
 	req := httptest.NewRequest(method, target, body)
 	reqID := generateRequestIdentifier()
 	req = requestWithRequestIdentifier(req, reqID)
@@ -84,6 +99,15 @@ func (s *Server) NewRequest(method string, target string, body io.Reader) *http.
 
 // Send sends a HTTP request to the test server and returns an HTTP response.
 func (s *Server) Send(req *http.Request) (*http.Response, error) {
+	if s.inProcess {
+		rec := httptest.NewRecorder()
+		req.RequestURI = req.URL.Path
+		if req.URL.RawQuery != "" {
+			req.RequestURI += "?" + req.URL.RawQuery
+		}
+		s.Mux.ServeHTTP(rec, req)
+		return rec.Result(), nil
+	}
 	return s.HttpClient.Do(req)
 }
 


### PR DESCRIPTION
Related to https://github.com/grafana/grafana-enterprise/issues/10467

Change the evaluation of new feature toggle `FlagDatasourcesRerouteLegacyCRUDAPIs` to use openfeature

