### PR TITLE
CI: Add reusable setup-go action with cache-friendly defaults

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1239,6 +1239,7 @@ embed.go @grafana/grafana-as-code
 /.github/renovate.json5 @grafana/frontend-ops
 /.github/actions/check-jobs/action.yml @grafana/grafana-frontend-platform
 /.github/actions/setup-enterprise/action.yml @grafana/grafana-backend-group
+/.github/actions/setup-go/action.yml @grafana/grafana-backend-group
 /.github/actions/setup-grafana-bench/ @Proximyst
 /.github/actions/build-package @grafana/grafana-developer-enablement-squad
 /.github/actions/change-detection @grafana/grafana-developer-enablement-squad

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,0 +1,21 @@
+name: Setup Go
+description: Sets up a Go environment with cache-friendly defaults for the Grafana repository.
+
+inputs:
+  go-version-file:
+    description: Path to go.mod or go.work file for version detection.
+    required: false
+    default: 'go.mod'
+  cache:
+    description: Whether to cache Go modules and build cache.
+    required: false
+    default: 'true'
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-go@v6.0.0
+      with:
+        go-version-file: ${{ inputs.go-version-file }}
+        cache: ${{ inputs.cache == 'true' }}
+        cache-dependency-path: ${{ inputs.cache == 'true' && '**/*.sum' || '' }}

--- a/.github/workflows/backend-code-checks.yml
+++ b/.github/workflows/backend-code-checks.yml
@@ -46,10 +46,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Go
-        uses: actions/setup-go@v6.0.0
-        with:
-          go-version-file: go.mod
-          cache: true
+        uses: ./.github/actions/setup-go
 
       - name: Verify code generation
         run: |

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -59,11 +59,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Go
-        uses: actions/setup-go@v6.0.0
-        with:
-          go-version-file: go.mod
-          cache: true
-          cache-dependency-path: "**/*.sum"
+        uses: ./.github/actions/setup-go
       - name: Run unit tests
         env:
           SHARD: ${{ matrix.shard }}
@@ -96,11 +92,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Go
-        uses: actions/setup-go@v6.0.0
-        with:
-          go-version-file: go.mod
-          cache: true
-          cache-dependency-path: "**/*.sum"
+        uses: ./.github/actions/setup-go
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:

--- a/.github/workflows/feature-toggles-ci.yml
+++ b/.github/workflows/feature-toggles-ci.yml
@@ -43,11 +43,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Go
-        uses: actions/setup-go@v6.0.0
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
 
       - name: Run feature toggle tests
         run: go test -v -run TestFeatureToggleFiles ./pkg/services/featuremgmt/

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -56,11 +56,8 @@ jobs:
           path: bin
 
       - name: Setup Go
-        uses: actions/setup-go@v6.3.0
+        uses: ./.github/actions/setup-go
         if: steps.cache.outputs.cache-hit != 'true'
-        with:
-          go-version-file: 'go.mod'
-          cache: true
 
       - name: Build backend
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -62,11 +62,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Go
-        uses: actions/setup-go@v6.0.0
-        with:
-          go-version-file: go.mod
-          cache: true
-          cache-dependency-path: "**/*.sum"
+        uses: ./.github/actions/setup-go
       - name: Run tests
         if: matrix.shard != 'profiled'
         env:
@@ -175,11 +171,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Go
-        uses: actions/setup-go@v6.0.0
-        with:
-          go-version-file: go.mod
-          cache: true
-          cache-dependency-path: "**/*.sum"
+        uses: ./.github/actions/setup-go
       - name: Setup MySQL devenv
         run: mysql -h 127.0.0.1 -P 3306 -u root -prootpass < devenv/docker/blocks/mysql_tests/setup.sql
       - name: Run tests
@@ -224,11 +216,7 @@ jobs:
         run: |
           make devenv sources=postgres_tests
       - name: Setup Go
-        uses: actions/setup-go@v6.0.0
-        with:
-          go-version-file: go.mod
-          cache: true
-          cache-dependency-path: "**/*.sum"
+        uses: ./.github/actions/setup-go
       - name: Setup Postgres devenv
         run: psql -p 5432 -h 127.0.0.1 -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
       - name: Run tests
@@ -273,11 +261,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Go
-        uses: actions/setup-go@v6.0.0
-        with:
-          go-version-file: go.mod
-          cache: true
-          cache-dependency-path: "**/*.sum"
+        uses: ./.github/actions/setup-go
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:
@@ -391,11 +375,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Go
-        uses: actions/setup-go@v6.0.0
-        with:
-          go-version-file: go.mod
-          cache: true
-          cache-dependency-path: "**/*.sum"
+        uses: ./.github/actions/setup-go
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:
@@ -445,11 +425,7 @@ jobs:
         run: |
           make devenv sources=postgres_tests
       - name: Setup Go
-        uses: actions/setup-go@v6.0.0
-        with:
-          go-version-file: go.mod
-          cache: true
-          cache-dependency-path: "**/*.sum"
+        uses: ./.github/actions/setup-go
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:

--- a/.github/workflows/run-dashboard-search-e2e.yml
+++ b/.github/workflows/run-dashboard-search-e2e.yml
@@ -28,11 +28,8 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - name: Pin Go version to mod file
-        uses: actions/setup-go@v6.0.0
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
       - run: go version
       - name: Setup Node.js
         uses: ./.github/actions/setup-node


### PR DESCRIPTION
## Summary

Create `.github/actions/setup-go`, a reusable composite action that wraps `actions/setup-go` with cache-friendly defaults for the Grafana repository. This follows the same pattern as `.github/actions/setup-node` and `.github/actions/yarn-install`.

### Problem

Each workflow independently configures `actions/setup-go` with its own cache settings (or forgets to). This leads to:
- Inconsistent caching across workflows (some miss `cache-dependency-path`, some miss `cache: true` entirely)
- Multiple places to update when bumping the `actions/setup-go` version
- Easy to introduce cache bugs when adding new workflows

### Solution

A single composite action with sensible defaults:

```yaml
- uses: ./.github/actions/setup-go
```

Which expands to:
- `go-version-file: go.mod`
- `cache: true`
- `cache-dependency-path: "**/*.sum"` (covers all 49 `go.sum` + `go.work.sum` across the 39-module workspace)

Workflows can opt out of caching with `cache: 'false'`.

### Migrated workflows (12 steps across 6 workflows)

- `pr-test-integration.yml` (6 steps)
- `backend-unit-tests.yml` (2 steps)
- `backend-code-checks.yml` (1 step)
- `feature-toggles-ci.yml` (1 step)
- `run-dashboard-search-e2e.yml` (1 step)
- `pr-e2e-tests.yml` (1 step)

Other workflows that don't use caching are left as-is for now and can be migrated in follow-ups.

See [actions/setup-go: Caching in multi-module repositories](https://github.com/actions/setup-go/blob/main/docs/advanced-usage.md#caching-in-multi-module-repositories) for the recommended pattern.

## Test plan

- [ ] Verify all migrated workflows pass CI on this PR
- [ ] Confirm `cache-hit: true` in `Setup Go` step logs on second run

Made with [Cursor](https://cursor.com)