### PR TITLE
Import: Library panel missing DS when imported in v1 and classic 

### DIFF
--- a/public/app/features/library-panels/state/api.test.ts
+++ b/public/app/features/library-panels/state/api.test.ts
@@ -3,7 +3,50 @@ import { LibraryPanelBehavior } from 'app/features/dashboard-scene/scene/Library
 import { AutoGridItem } from 'app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem';
 import { vizPanelToPanel } from 'app/features/dashboard-scene/serialization/transformSceneToSaveModel';
 
-import { libraryVizPanelToSaveModel } from './api';
+import { LibraryElementKind } from '../types';
+
+import { addLibraryPanel, libraryVizPanelToSaveModel } from './api';
+
+const mockPost = jest.fn().mockResolvedValue({ result: {} });
+jest.mock('../../../core/services/backend_srv', () => ({
+  getBackendSrv: () => ({ post: mockPost }),
+}));
+
+describe('addLibraryPanel', () => {
+  beforeEach(() => {
+    mockPost.mockClear();
+  });
+
+  const panelSaveModel = {
+    libraryPanel: { name: 'My Panel', uid: 'original-uid' },
+    type: 'timeseries',
+  };
+
+  it('passes uid to the API when provided', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await addLibraryPanel(panelSaveModel as any, 'folder-uid', 'original-uid');
+
+    expect(mockPost).toHaveBeenCalledWith('/api/library-elements', {
+      folderUid: 'folder-uid',
+      name: 'My Panel',
+      model: panelSaveModel,
+      kind: LibraryElementKind.Panel,
+      uid: 'original-uid',
+    });
+  });
+
+  it('does not include uid when not provided', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await addLibraryPanel(panelSaveModel as any, 'folder-uid');
+
+    expect(mockPost).toHaveBeenCalledWith('/api/library-elements', {
+      folderUid: 'folder-uid',
+      name: 'My Panel',
+      model: panelSaveModel,
+      kind: LibraryElementKind.Panel,
+    });
+  });
+});
 
 describe('libraryVizPanelToSaveModel', () => {
   it('uses default gridPos when the parent is an AutoGridItem', () => {

--- a/public/app/features/library-panels/state/api.ts
+++ b/public/app/features/library-panels/state/api.ts
@@ -105,13 +105,15 @@ export async function getLibraryPanelByName(name: string): Promise<LibraryElemen
 
 export async function addLibraryPanel(
   panelSaveModel: PanelModelWithLibraryPanel,
-  folderUid: string
+  folderUid: string,
+  uid?: string
 ): Promise<LibraryElementDTO> {
   const { result } = await getBackendSrv().post(`/api/library-elements`, {
     folderUid,
     name: panelSaveModel.libraryPanel.name,
     model: panelSaveModel,
     kind: LibraryElementKind.Panel,
+    ...(uid ? { uid } : {}),
   });
   return result;
 }

--- a/public/app/features/manage-dashboards/import/components/ImportOverviewV1.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportOverviewV1.tsx
@@ -11,7 +11,7 @@ import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { addLibraryPanel } from 'app/features/library-panels/state/api';
 
 import { type DashboardInputs, DashboardSource, type ImportDashboardDTO, LibraryPanelInputState } from '../../types';
-import { applyV1Inputs, stripExportMetadata } from '../utils/inputs';
+import { applyV1Inputs, interpolateLibraryPanelDatasources, stripExportMetadata } from '../utils/inputs';
 
 import { GcomDashboardInfo } from './GcomDashboardInfo';
 import { ImportForm } from './ImportForm';
@@ -37,10 +37,13 @@ export function ImportOverviewV1({ dashboard, inputs, meta, source, folderUid, o
     try {
       const dashboardWithDataSources = applyV1Inputs(dashboard, inputs, form);
 
-      // Import new library panels first
+      // Import new library panels first.
+      // Library panel models from __elements may contain ${DS_...} placeholders
+      // that need to be resolved before creating the library element.
       const newLibraryPanels = inputs.libraryPanels.filter((lp) => lp.state === LibraryPanelInputState.New);
       for (const lp of newLibraryPanels) {
-        const libPanelWithPanelModel = new PanelModel(lp.model.model);
+        const interpolatedModel = interpolateLibraryPanelDatasources(lp.model.model, inputs, form);
+        const libPanelWithPanelModel = new PanelModel(interpolatedModel);
         let { scopedVars, ...panelSaveModel } = libPanelWithPanelModel.getSaveModel();
         panelSaveModel = {
           libraryPanel: {
@@ -51,7 +54,7 @@ export function ImportOverviewV1({ dashboard, inputs, meta, source, folderUid, o
         };
 
         try {
-          await addLibraryPanel(panelSaveModel, form.folder.uid);
+          await addLibraryPanel(panelSaveModel, form.folder.uid, lp.model.uid);
         } catch (error) {
           appEvents.emit(AppEvents.alertWarning, [
             'Library panel import failed',

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -661,6 +661,9 @@ describe('applyV1Inputs', () => {
 
     const dsVariable = result.templating?.list?.[0] as DatasourceVariableModel;
     expect(dsVariable.current?.value).toBe('prom-uid');
+
+    const queryVariable = result.templating?.list?.[1] as QueryVariableModel;
+    expect(queryVariable.datasource?.uid).toBe('prom-uid');
   });
 
   it('replaces constant variable query, current, and options with user-provided values', () => {

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -718,6 +718,49 @@ describe('applyV1Inputs', () => {
     expect(vars[1].current?.value).toBe('http://my-app:7070');
   });
 
+  it('replaces legacy string datasource placeholders in panels and annotations', () => {
+    const dashboard = {
+      title: 'old',
+      uid: 'old',
+      schemaVersion: 39,
+      annotations: {
+        list: [
+          {
+            name: 'anno',
+            datasource: '${DS}',
+            enable: true,
+            iconColor: 'red',
+            target: { limit: 1, matchAny: true, tags: [], type: 'tags' },
+          },
+        ],
+      },
+      panels: [
+        {
+          datasource: '${DS}',
+          targets: [{ datasource: '${DS}' }],
+        },
+      ],
+    } as unknown as Dashboard;
+
+    const form: ImportDashboardDTO = {
+      title: 'new-title',
+      uid: 'new-uid',
+      gnetId: '',
+      constants: [],
+      dataSources: [{ uid: 'ds-uid', type: 'prometheus', name: 'My DS' } as DataSourceInstanceSettings],
+      elements: [],
+      folder: { uid: 'folder' },
+    };
+
+    const result = applyV1Inputs(dashboard, sampleV1Inputs, form);
+
+    expect(result.annotations?.list?.[0].datasource?.uid).toBe('ds-uid');
+    expect(result.panels?.[0].datasource?.uid).toBe('ds-uid');
+
+    const panelWithTargets = result.panels?.[0] as PanelWithTargets;
+    expect(panelWithTargets.targets?.[0].datasource?.uid).toBe('ds-uid');
+  });
+
   describe('row panels', () => {
     type RowPanel = { type: string; collapsed: boolean; datasource?: { uid: string }; panels: PanelWithTargets[] };
 
@@ -845,6 +888,46 @@ describe('interpolateLibraryPanelDatasources', () => {
 
     expect(result.datasource.uid).toBe('new-influx-uid');
     expect(result.targets[0].datasource.uid).toBe('new-influx-uid');
+    expect(result.targets[1].datasource.uid).toBe('hardcoded-uid');
+  });
+
+  it('replaces legacy string datasource placeholders in panel and targets', () => {
+    const model = {
+      datasource: '${DS_INFLUX}',
+      targets: [
+        { datasource: '${DS_INFLUX}', refId: 'A' },
+        { datasource: { type: 'influxdb', uid: 'hardcoded-uid' }, refId: 'B' },
+      ],
+      type: 'timeseries',
+    };
+
+    const inputs = {
+      dataSources: [
+        {
+          name: 'DS_INFLUX',
+          label: 'InfluxDB',
+          info: '',
+          value: '',
+          type: InputType.DataSource,
+          pluginId: 'influxdb',
+        },
+      ],
+    };
+
+    const form: ImportDashboardDTO = {
+      title: 'Test',
+      uid: 'test',
+      gnetId: '',
+      constants: [],
+      dataSources: [{ uid: 'new-influx-uid', type: 'influxdb', name: 'My InfluxDB' } as DataSourceInstanceSettings],
+      elements: [],
+      folder: { uid: 'folder' },
+    };
+
+    const result = interpolateLibraryPanelDatasources(model, inputs, form);
+
+    expect(result.datasource).toEqual({ uid: 'new-influx-uid', type: 'influxdb' });
+    expect(result.targets[0].datasource).toEqual({ uid: 'new-influx-uid', type: 'influxdb' });
     expect(result.targets[1].datasource.uid).toBe('hardcoded-uid');
   });
 

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -17,6 +17,7 @@ import {
   detectExportFormat,
   extractV1Inputs,
   extractV2Inputs,
+  interpolateLibraryPanelDatasources,
   isVariableRef,
   replaceDatasourcesInDashboard,
   type DatasourceMappings,
@@ -803,6 +804,69 @@ describe('applyV1Inputs', () => {
 
       expect((result.panels?.[3] as unknown as { type: string }).type).toBe('row');
     });
+  });
+});
+
+describe('interpolateLibraryPanelDatasources', () => {
+  it('replaces ${DS_...} placeholders in panel and target datasources', () => {
+    const model = {
+      datasource: { type: 'influxdb', uid: '${DS_INFLUX}' },
+      targets: [
+        { datasource: { type: 'influxdb', uid: '${DS_INFLUX}' }, refId: 'A' },
+        { datasource: { type: 'influxdb', uid: 'hardcoded-uid' }, refId: 'B' },
+      ],
+      type: 'timeseries',
+    };
+
+    const inputs = {
+      dataSources: [
+        {
+          name: 'DS_INFLUX',
+          label: 'InfluxDB',
+          info: '',
+          value: '',
+          type: InputType.DataSource,
+          pluginId: 'influxdb',
+        },
+      ],
+    };
+
+    const form: ImportDashboardDTO = {
+      title: 'Test',
+      uid: 'test',
+      gnetId: '',
+      constants: [],
+      dataSources: [{ uid: 'new-influx-uid', type: 'influxdb', name: 'My InfluxDB' } as DataSourceInstanceSettings],
+      elements: [],
+      folder: { uid: 'folder' },
+    };
+
+    const result = interpolateLibraryPanelDatasources(model, inputs, form);
+
+    expect(result.datasource.uid).toBe('new-influx-uid');
+    expect(result.targets[0].datasource.uid).toBe('new-influx-uid');
+    expect(result.targets[1].datasource.uid).toBe('hardcoded-uid');
+  });
+
+  it('returns model unchanged when no placeholders exist', () => {
+    const model = {
+      datasource: { type: 'influxdb', uid: 'some-uid' },
+      targets: [{ datasource: { type: 'influxdb', uid: 'some-uid' }, refId: 'A' }],
+      type: 'timeseries',
+    };
+
+    const result = interpolateLibraryPanelDatasources(model, sampleV1Inputs, {
+      title: 'Test',
+      uid: 'test',
+      gnetId: '',
+      constants: [],
+      dataSources: [{ uid: 'ds-uid', type: 'prometheus', name: 'DS' } as DataSourceInstanceSettings],
+      elements: [],
+      folder: { uid: 'f' },
+    });
+
+    expect(result.datasource.uid).toBe('some-uid');
+    expect(result.targets[0].datasource.uid).toBe('some-uid');
   });
 });
 

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -681,19 +681,10 @@ function processVariable(
     }
   }
 
-  if (variableType === 'query' && 'datasource' in variable && isRecord(variable.datasource)) {
-    const datasourceUid = variable.datasource.uid;
-    if (typeof datasourceUid === 'string' && datasourceUid.startsWith('$')) {
-      const userInput = checkUserInputMatch(datasourceUid, inputs.dataSources, form.dataSources);
-      if (userInput) {
-        return {
-          ...variable,
-          datasource: {
-            ...variable.datasource,
-            uid: userInput.uid,
-          },
-        };
-      }
+  if (variableType === 'query' && 'datasource' in variable) {
+    const resolved = resolveDatasource(variable.datasource, inputs.dataSources, form.dataSources);
+    if (resolved) {
+      return { ...variable, datasource: resolved };
     }
   }
 

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -63,10 +63,6 @@ function isLibraryElementExport(value: unknown): value is LibraryElementExport {
   );
 }
 
-function hasUid(query: unknown): query is { uid: string } {
-  return isRecord(query) && typeof query['uid'] === 'string';
-}
-
 function getExportLabel(labels?: { [ExportLabel]?: string }): string | undefined {
   if (!labels) {
     return undefined;
@@ -563,27 +559,52 @@ export function interpolateLibraryPanelDatasources(
 ): any {
   const result = { ...model };
 
-  if (result.datasource?.uid && typeof result.datasource.uid === 'string' && result.datasource.uid.startsWith('$')) {
-    const userInput = checkUserInputMatch(result.datasource.uid, inputs.dataSources, form.dataSources);
-    if (userInput) {
-      result.datasource = { ...result.datasource, uid: userInput.uid };
-    }
+  const resolvedDs = resolveDatasource(result.datasource, inputs.dataSources, form.dataSources);
+  if (resolvedDs) {
+    result.datasource = resolvedDs;
   }
 
   if (Array.isArray(result.targets)) {
     result.targets = result.targets.map((target: Record<string, unknown>) => {
-      const ds = target.datasource;
-      if (isRecord(ds) && typeof ds.uid === 'string' && ds.uid.startsWith('$')) {
-        const userInput = checkUserInputMatch(ds.uid, inputs.dataSources, form.dataSources);
-        if (userInput) {
-          return { ...target, datasource: { ...ds, uid: userInput.uid } };
-        }
-      }
-      return target;
+      const resolved = resolveDatasource(target.datasource, inputs.dataSources, form.dataSources);
+      return resolved ? { ...target, datasource: resolved } : target;
     });
   }
 
   return result;
+}
+
+/**
+ * Extract a ${DS_...} placeholder string from a datasource reference.
+ * Handles both the object form { uid: "${DS_...}" } and legacy string form "${DS_...}".
+ */
+function extractDatasourcePlaceholder(datasource: unknown): string | undefined {
+  if (typeof datasource === 'string' && datasource.startsWith('$')) {
+    return datasource;
+  }
+  if (isRecord(datasource) && typeof datasource.uid === 'string' && datasource.uid.startsWith('$')) {
+    return datasource.uid;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a datasource placeholder to the user-selected datasource.
+ */
+function resolveDatasource(
+  datasource: unknown,
+  datasourceInputs: DataSourceInput[],
+  userDsInputs: DataSourceInstanceSettings[]
+): { uid: string; type: string } | undefined {
+  const placeholder = extractDatasourcePlaceholder(datasource);
+  if (!placeholder) {
+    return undefined;
+  }
+  const userInput = checkUserInputMatch(placeholder, datasourceInputs, userDsInputs);
+  if (!userInput) {
+    return undefined;
+  }
+  return { uid: userInput.uid, type: userInput.type };
 }
 
 function checkUserInputMatch(
@@ -602,49 +623,11 @@ function processAnnotation(
   inputs: { dataSources: DataSourceInput[] },
   form: ImportDashboardDTO
 ): AnnotationQuery {
-  if (annotation.datasource && annotation.datasource.uid && annotation.datasource.uid.startsWith('$')) {
-    const userInput = checkUserInputMatch(annotation.datasource.uid, inputs.dataSources, form.dataSources);
-    if (userInput) {
-      return {
-        ...annotation,
-        datasource: {
-          ...annotation.datasource,
-          uid: userInput.uid,
-        },
-      };
-    }
+  const resolved = resolveDatasource(annotation.datasource, inputs.dataSources, form.dataSources);
+  if (resolved) {
+    return { ...annotation, datasource: resolved };
   }
-
   return annotation;
-}
-
-function getDSUid(datasource: unknown): string | null {
-  if (typeof datasource === 'string' && datasource.startsWith('$')) {
-    return datasource;
-  }
-  if (hasUid(datasource) && datasource.uid.startsWith('$')) {
-    return datasource.uid;
-  }
-  return null;
-}
-
-function resolveInputDatasource(
-  datasource: Panel['datasource'],
-  inputs: { dataSources: DataSourceInput[] },
-  form: ImportDashboardDTO
-): Panel['datasource'] {
-  const dsUid = getDSUid(datasource);
-
-  if (dsUid) {
-    const userInput = checkUserInputMatch(dsUid, inputs.dataSources, form.dataSources);
-    if (userInput) {
-      return {
-        ...(isRecord(datasource) ? datasource : {}),
-        uid: userInput.uid,
-      };
-    }
-  }
-  return datasource;
 }
 
 function processPanel(
@@ -652,20 +635,20 @@ function processPanel(
   inputs: { dataSources: DataSourceInput[] },
   form: ImportDashboardDTO
 ): Panel | RowPanel {
+  const resolvedPanelDs = resolveDatasource(panel.datasource, inputs.dataSources, form.dataSources);
+
   return {
     ...panel,
-    ...(panel.datasource && { datasource: resolveInputDatasource(panel.datasource, inputs, form) }),
-    // nested panels of collapsed rows
+    ...(resolvedPanelDs && { datasource: resolvedPanelDs }),
     ...('panels' in panel && {
       panels: panel.panels.map((nestedPanel) => processPanel(nestedPanel, inputs, form)),
     }),
     ...('targets' in panel &&
       panel.targets && {
-        targets: panel.targets.map((target) =>
-          target.datasource
-            ? { ...target, datasource: resolveInputDatasource(target.datasource, inputs, form) }
-            : target
-        ),
+        targets: panel.targets.map((target) => {
+          const resolved = resolveDatasource(target.datasource, inputs.dataSources, form.dataSources);
+          return resolved ? { ...target, datasource: resolved } : target;
+        }),
       }),
   };
 }

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -550,6 +550,42 @@ function replaceElementDatasources(
   );
 }
 
+/**
+ * Replace ${DS_...} placeholders in a library panel model's datasource references
+ * using the user-selected datasources from the import form.
+ */
+export function interpolateLibraryPanelDatasources(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  model: any,
+  inputs: { dataSources: DataSourceInput[] },
+  form: ImportDashboardDTO
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): any {
+  const result = { ...model };
+
+  if (result.datasource?.uid && typeof result.datasource.uid === 'string' && result.datasource.uid.startsWith('$')) {
+    const userInput = checkUserInputMatch(result.datasource.uid, inputs.dataSources, form.dataSources);
+    if (userInput) {
+      result.datasource = { ...result.datasource, uid: userInput.uid };
+    }
+  }
+
+  if (Array.isArray(result.targets)) {
+    result.targets = result.targets.map((target: Record<string, unknown>) => {
+      const ds = target.datasource;
+      if (isRecord(ds) && typeof ds.uid === 'string' && ds.uid.startsWith('$')) {
+        const userInput = checkUserInputMatch(ds.uid, inputs.dataSources, form.dataSources);
+        if (userInput) {
+          return { ...target, datasource: { ...ds, uid: userInput.uid } };
+        }
+      }
+      return target;
+    });
+  }
+
+  return result;
+}
+
 function checkUserInputMatch(
   templateizedUid: string,
   datasourceInputs: DataSourceInput[],


### PR DESCRIPTION
## Summary

Fixes #119494

When importing a classic/V1 dashboard with library panels through the K8s import path, library panels appear broken due to two issues:

**1. UID mismatch**: `addLibraryPanel` calls `POST /api/library-elements` without the original `uid`. The backend generates a new random UID, but dashboard panels still reference the original UIDs from `__elements`.

**2. Unresolved datasource placeholders**: Library panel models from `__elements` contain `${DS_...}` placeholders. The legacy backend path ran a full recursive interpolation via `DashTemplateEvaluator` before creating library elements. The K8s frontend path only interpolated panels/annotations/variables via `applyV1Inputs` but never touched the `__elements` models — so library panels were created with broken datasource references.

### Changes

| File | What |
|---|---|
| `api.ts` | `addLibraryPanel` accepts optional `uid` parameter, passes it to the API |
| `inputs.ts` | New `interpolateLibraryPanelDatasources` replaces `${DS_...}` in library panel models |
| `ImportOverviewV1.tsx` | Passes original uid and interpolates models before creating library panels |
| `api.test.ts` | Tests that uid is passed/omitted correctly |
| `inputs.test.ts` | Tests for datasource placeholder interpolation in library panel models |

## Test plan

- [ ] Import the [EVCC dashboard](https://grafana.com/grafana/dashboards/22028-evcc-today/) (ID 22028) from Grafana.com — verify library panels render correctly with resolved datasources
- [ ] Import a classic JSON with `__elements` containing `${DS_...}` references — verify library panels are created with the correct UIDs and datasource UIDs
- [ ] Create a new library panel normally (not via import) — verify no regressions