### PR TITLE
QueryEditor: Fix card flicker

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorDetailsSidebar.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/QueryEditorDetailsSidebar.test.tsx
@@ -10,7 +10,7 @@ import { QueryEditorDetailsSidebar } from './QueryEditorDetailsSidebar';
 describe('QueryEditorDetailsSidebar', () => {
   const mockCloseSidebar = jest.fn();
 
-  const defaultQrState: { queries: never[]; data: PanelData | undefined; isLoading: boolean } = {
+  const defaultQrState: { queries: never[]; data: PanelData | undefined } = {
     queries: [],
     data: {
       request: {
@@ -18,7 +18,6 @@ describe('QueryEditorDetailsSidebar', () => {
         interval: '15s',
       },
     } as unknown as PanelData,
-    isLoading: false,
   };
 
   beforeEach(() => {
@@ -27,7 +26,7 @@ describe('QueryEditorDetailsSidebar', () => {
 
   const renderSidebar = (
     options: QueryGroupOptions = mockOptions,
-    qrState: { queries: never[]; data: PanelData | undefined; isLoading: boolean } = defaultQrState
+    qrState: { queries: never[]; data: PanelData | undefined } = defaultQrState
   ) => {
     return renderWithQueryEditorProvider(<QueryEditorDetailsSidebar />, {
       qrState,
@@ -212,7 +211,6 @@ describe('QueryEditorDetailsSidebar', () => {
       const qrStateWithoutInterval = {
         queries: [],
         data: undefined,
-        isLoading: false,
       };
 
       renderSidebar(mockOptions, qrStateWithoutInterval);

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
@@ -38,7 +38,6 @@ export interface DatasourceState {
 export interface QueryRunnerState {
   queries: DataQuery[];
   data?: PanelData;
-  isLoading: boolean;
   queryError?: DataQueryError;
 }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useCallback, useMemo, useState } from 'react';
 
-import { DataSourceInstanceSettings, getDataSourceRef, LoadingState } from '@grafana/data';
+import { DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
 import { SceneDataTransformer } from '@grafana/scenes';
 import { DataQuery } from '@grafana/schema';
 import { useQueryLibraryContext } from 'app/features/explore/QueryLibrary/QueryLibraryContext';
@@ -88,7 +88,6 @@ export function QueryEditorContextWrapper({
     () => ({
       queries: queryRunnerState?.queries ?? [],
       data: queryRunnerState?.data,
-      isLoading: queryRunnerState?.data?.state === LoadingState.Loading || queryRunnerState?.data?.state === undefined,
       queryError,
     }),
     [queryRunnerState?.queries, queryRunnerState?.data, queryError]

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
@@ -95,7 +95,7 @@ describe('QueryEditorRenderer', () => {
       return (
         <QueryEditorProvider
           dsState={{ datasource: undefined, dsSettings: undefined, dsError: undefined }}
-          qrState={{ queries: [queryA, queryB], data: undefined, isLoading: false, queryError: undefined }}
+          qrState={{ queries: [queryA, queryB], data: undefined, queryError: undefined }}
           panelState={{ panel: new VizPanel({ key: 'panel-1' }), transformations: [] }}
           alertingState={{ alertRules: [], loading: false, isDashboardSaved: true }}
           uiState={{

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
@@ -19,16 +19,6 @@ describe('QueryEditorSidebar', () => {
     jest.clearAllMocks();
   });
 
-  it('should render loading bar when data is loading', () => {
-    renderWithQueryEditorProvider(<QueriesAndTransformationsView />, {
-      qrState: {
-        isLoading: true,
-      },
-    });
-
-    expect(screen.getByLabelText(/loading queries and transformations/i)).toBeInTheDocument();
-  });
-
   it('should always render transformations section even when no transformations exist', () => {
     const queries: DataQuery[] = [{ refId: 'A', datasource: { type: 'test', uid: 'test' } }];
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useState } from 'react';
 
 import { t } from '@grafana/i18n';
-import { LoadingBar } from '@grafana/ui';
 
 import { PENDING_CARD_ID, QueryEditorType } from '../../constants';
 import { usePanelContext, useQueryEditorUIContext, useQueryRunnerContext } from '../QueryEditorContext';
@@ -15,7 +14,7 @@ import { useSidebarDragAndDrop } from './DraggableList/useSidebarDragAndDrop';
 import { SidebarCollapsableHeader } from './SidebarCollapsableHeader';
 
 export function QueriesAndTransformationsView() {
-  const { queries, isLoading } = useQueryRunnerContext();
+  const { queries } = useQueryRunnerContext();
   const { transformations } = usePanelContext();
   const { pendingExpression, pendingSavedQuery, pendingTransformation } = useQueryEditorUIContext();
   const { onQueryDragEnd, onTransformationDragEnd } = useSidebarDragAndDrop();
@@ -25,18 +24,6 @@ export function QueriesAndTransformationsView() {
 
   const expandQueries = useCallback(() => setQueriesOpen(true), []);
   const expandTransformations = useCallback(() => setTransformationsOpen(true), []);
-
-  if (isLoading && queries.length === 0) {
-    return (
-      <LoadingBar
-        width={400}
-        ariaLabel={t(
-          'query-editor-next.sidebar.loading-queries-transformations',
-          'Loading queries and transformations'
-        )}
-      />
-    );
-  }
 
   return (
     <>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
@@ -26,7 +26,7 @@ export function QueriesAndTransformationsView() {
   const expandQueries = useCallback(() => setQueriesOpen(true), []);
   const expandTransformations = useCallback(() => setTransformationsOpen(true), []);
 
-  if (isLoading) {
+  if (isLoading && queries.length === 0) {
     return (
       <LoadingBar
         width={400}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/testUtils.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/testUtils.tsx
@@ -164,7 +164,6 @@ export function renderWithQueryEditorProvider(children: ReactElement, options: C
       series: [],
       timeRange: getDefaultTimeRange(),
     },
-    isLoading: false,
     queryError: undefined,
     ...qrState,
   };

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13621,7 +13621,6 @@
       "footer-items_other": "{{count}} items",
       "footer-items-alert_one": "{{count}} alerts",
       "footer-items-alert_other": "{{count}} alerts",
-      "loading-queries-transformations": "Loading queries and transformations",
       "new-type": "New {{type}}",
       "queries-expressions": "Queries & Expressions",
       "toggle-size": "Toggle sidebar size",


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->
It's _really_ hard to see in local, but in ops and other instances, there's a pronounced card flicker 1) on load (the cards render, go away, then come back), and 2) on any action (delete, hide, duplicate, etc). 

Another benefit is that it fixes this reported bug! ⬇️ 
Resolves https://github.com/grafana/grafana/issues/119992

## Changes
<!--- Describe your changes in detail -->
* Remove the `isLoading` check and loading component render. The card data lives in `queryRunner.state.queries` and is always synchronously available. It has no dependency on whether queries are currently executing, so the `isLoading` state probably isn't necessary. 

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->
N/A

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->
Hard to demo, better seen testing locally!

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* Pull down and run `main` locally and add network throttling (slow 4g or something)
* You'll notice the cards flicker on load, and flicker on engaging with any action.
* Pull down this branch, and see that they don't do that anymore!

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [x] Tests are added where applicable
- [x] Issue is linked to PR
- [x] Code pulled and tested
- [x] Code is meaningfully improved if applicable