### PR TITLE
Dashboards: Add "Filters" control to the dashboard edit pane

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/add-new/AddFilters.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/add-new/AddFilters.tsx
@@ -1,0 +1,40 @@
+import { useCallback } from 'react';
+
+import { t } from '@grafana/i18n';
+import { sceneGraph, SceneVariableSet } from '@grafana/scenes';
+
+import { type DashboardScene } from '../../scene/DashboardScene';
+import { getNextAvailableId, getVariableScene } from '../../settings/variables/utils';
+import { DashboardInteractions } from '../../utils/interactions';
+import { dashboardEditActions } from '../shared';
+
+import { AddButton } from './AddButton';
+
+function openAddFilterPane(dashboard: DashboardScene) {
+  const variablesSet = sceneGraph.getVariables(dashboard);
+
+  if (!(variablesSet instanceof SceneVariableSet)) {
+    return;
+  }
+
+  const type = 'adhoc';
+  const newVar = getVariableScene(type, { name: getNextAvailableId(type, variablesSet.state.variables ?? []) });
+  dashboardEditActions.addVariable({ source: variablesSet, addedObject: newVar });
+  dashboard.state.editPane.selectObject(newVar, newVar.state.key!, { force: true, multi: false });
+  DashboardInteractions.newVariableTypeSelected({ type });
+}
+
+export function AddFilters({ dashboardScene }: { dashboardScene: DashboardScene }) {
+  const onAddFiltersClick = useCallback(() => {
+    openAddFilterPane(dashboardScene);
+    DashboardInteractions.addVariableButtonClicked({ source: 'edit_pane' });
+  }, [dashboardScene]);
+
+  return (
+    <AddButton
+      icon="filter"
+      label={t('dashboard-scene.add-filters.label', 'Filter and Group by')}
+      onClick={onAddFiltersClick}
+    />
+  );
+}

--- a/public/app/features/dashboard-scene/edit-pane/add-new/AddNewEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/add-new/AddNewEditPane.tsx
@@ -4,6 +4,7 @@ import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd';
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { SceneObject } from '@grafana/scenes';
 import { Sidebar, useStyles2 } from '@grafana/ui';
 import addPanelImg from 'img/dashboards/add-panel.png';
@@ -13,6 +14,7 @@ import { getDashboardSceneFor } from '../../utils/utils';
 
 import { AddAnnotationQuery } from './AddAnnotationQuery';
 import { AddButton } from './AddButton';
+import { AddFilters } from './AddFilters';
 import { AddLink } from './AddLink';
 import { AddNewSection } from './AddNewSection';
 import { AddRow } from './AddRow';
@@ -120,6 +122,7 @@ export function AddNewEditPane({ onAddPanel, onPastePanel, dashboard, selectedEl
         <AddTab dashboardScene={dashboardScene} selectedElement={selectedElement} />
       </AddNewSection>
       <AddNewSection title={t('dashboard-scene.dashboard-side-pane-new.dashboard-controls', 'Dashboard controls')}>
+        {config.featureToggles.dashboardUnifiedDrilldownControls && <AddFilters dashboardScene={dashboardScene} />}
         <AddVariable dashboardScene={dashboardScene} />
         <AddAnnotationQuery dashboardScene={dashboardScene} />
         <AddLink dashboardScene={dashboardScene} />

--- a/public/app/features/dashboard-scene/settings/variables/utils.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.ts
@@ -162,12 +162,16 @@ export function getVariableTypeSelectOptions(): Array<SelectableValue<EditableVa
     description: editableVariables[variableType].description,
   }));
 
-  if (!config.featureToggles.groupByVariable) {
-    // Remove group by variable type if feature toggle is off
-    return results.filter((option) => option.value !== 'groupby');
-  }
+  return results.filter((option) => {
+    if (option.value === 'groupby' && !config.featureToggles.groupByVariable) {
+      return false;
+    }
+    if (option.value === 'adhoc' && config.featureToggles.dashboardUnifiedDrilldownControls) {
+      return false;
+    }
 
-  return results;
+    return true;
+  });
 }
 
 export function getVariableEditor(type: EditableVariableType) {

--- a/public/app/features/dashboard-scene/settings/variables/utils.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.ts
@@ -163,10 +163,10 @@ export function getVariableTypeSelectOptions(): Array<SelectableValue<EditableVa
   }));
 
   return results.filter((option) => {
-    if (option.value === 'groupby' && !config.featureToggles.groupByVariable) {
+    if (!config.featureToggles.groupByVariable && option.value === 'groupby') {
       return false;
     }
-    if (option.value === 'adhoc' && config.featureToggles.dashboardUnifiedDrilldownControls) {
+    if (config.featureToggles.dashboardUnifiedDrilldownControls && option.value === 'adhoc') {
       return false;
     }
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6568,6 +6568,9 @@
       "label-use-static-key-dimensions": "Use static key dimensions",
       "name-allow-custom-values": "Allow custom values"
     },
+    "add-filters": {
+      "label": "Filter and Group by"
+    },
     "add-link": {
       "inline-instance-name": "New link",
       "label-link": "Link",


### PR DESCRIPTION
**What is this feature?**

When the `dashboardUnifiedDrilldownControls` feature toggle is enabled, this PR:

- Adds a new "Filter and Group by" item to the "Dashboard controls" section in the Add sidebar. 
- Removes "Ad hoc filters" from the Variable type picker

When the toggle is disabled, behaviour is unchanged.

<img width="1152" height="777" alt="image" src="https://github.com/user-attachments/assets/f6ca86d0-2147-4938-915d-261cd0f9b6ec" />

Fixes #119958