### PR TITLE
AuthN: Skip team sync for auth proxy when teams haven't changed

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -979,7 +979,7 @@ whitelist =
 headers =
 headers_encoded = false
 enable_login_token = false
-cache_team_sync = false
+cookie_cache_last_team_sync = false
 
 #################################### Auth JWT ##########################
 [auth.jwt]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -979,6 +979,7 @@ whitelist =
 headers =
 headers_encoded = false
 enable_login_token = false
+cache_team_sync = false
 
 #################################### Auth JWT ##########################
 [auth.jwt]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -931,7 +931,7 @@
 # When enabled, a hash of the proxy's groups header is stored in a cookie so team sync is skipped
 # on subsequent requests while the groups are unchanged. Changes to group-to-team mappings will
 # not take effect until the groups change or the cookie expires.
-;cache_team_sync = false
+;cookie_cache_last_team_sync = false
 
 #################################### Auth JWT ##########################
 [auth.jwt]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -928,6 +928,10 @@
 ;headers_encoded = false
 # Read the auth proxy docs for details on what the setting below enables
 ;enable_login_token = false
+# When enabled, a hash of the proxy's groups header is stored in a cookie so team sync is skipped
+# on subsequent requests while the groups are unchanged. Changes to group-to-team mappings will
+# not take effect until the groups change or the cookie expires.
+;cache_team_sync = false
 
 #################################### Auth JWT ##########################
 [auth.jwt]

--- a/pkg/services/authn/clients/grafana.go
+++ b/pkg/services/authn/clients/grafana.go
@@ -167,9 +167,8 @@ func shouldSyncTeams(r *authn.Request, groupsHash string) bool {
 }
 
 func (c *Grafana) writeGroupsHashCookie(ctx context.Context, groupsHash string) {
-	// contexthandler.FromContext() is inlined here to avoid import loop.
-	type reqContextKey = ctxkey.Key
-	reqCtx, ok := ctx.Value(reqContextKey{}).(*contextmodel.ReqContext)
+	// contexthandler.FromContext() is inlined here to avoid an import loop.
+	reqCtx, ok := ctx.Value(ctxkey.Key{}).(*contextmodel.ReqContext)
 	if !ok {
 		return
 	}

--- a/pkg/services/authn/clients/grafana.go
+++ b/pkg/services/authn/clients/grafana.go
@@ -174,8 +174,5 @@ func (c *Grafana) writeGroupsHashCookie(ctx context.Context, groupsHash string) 
 	}
 
 	maxAge := c.cfg.AuthProxy.SyncTTL * 60
-	if maxAge <= 0 {
-		maxAge = -1
-	}
 	cookies.WriteCookie(reqCtx.Resp, proxyGroupsCookie, groupsHash, maxAge, cookies.NewCookieOptions)
 }

--- a/pkg/services/authn/clients/grafana.go
+++ b/pkg/services/authn/clients/grafana.go
@@ -2,15 +2,23 @@ package clients
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/hex"
 	"errors"
 	"net/mail"
+	"sort"
 	"strconv"
+	"strings"
 
 	"go.opentelemetry.io/otel/trace"
 
 	claims "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/middleware/cookies"
 	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -88,6 +96,14 @@ func (c *Grafana) AuthenticateProxy(ctx context.Context, r *authn.Request, usern
 
 	if v, ok := additional[proxyFieldGroups]; ok {
 		identity.Groups = util.SplitString(v)
+
+		// Hash the list of groups and compare it to the hash stored in the client's
+		// cookie. If the hashes match, skip team sync because the teams haven't changed.
+		groupsHash := hashGroups(c.cfg.SecretKey, identity.Groups)
+		identity.ClientParams.SyncTeams = shouldSyncTeams(r, groupsHash)
+		if identity.ClientParams.SyncTeams {
+			c.writeGroupsHashCookie(ctx, groupsHash)
+		}
 	}
 
 	identity.ClientParams.LookUpParams.Email = &identity.Email
@@ -128,4 +144,39 @@ func comparePassword(password, salt, hash string) bool {
 	// It is ok to ignore the error here because util.EncodePassword can never return a error
 	hashedPassword, _ := util.EncodePassword(password, salt)
 	return subtle.ConstantTimeCompare([]byte(hashedPassword), []byte(hash)) == 1
+}
+
+const proxyGroupsCookie = "grafana_proxy_groups_hash"
+
+// hashGroups sorts and hashes the list of groups supplied by the proxy. HMAC is
+// used here to prevent bypassing team sync with a forged hash in the cookie.
+func hashGroups(secretKey string, groups []string) string {
+	sorted := make([]string, len(groups))
+	copy(sorted, groups)
+	sort.Strings(sorted)
+
+	mac := hmac.New(sha256.New, []byte(secretKey))
+	_, _ = mac.Write([]byte(strings.Join(sorted, "\x00")))
+
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func shouldSyncTeams(r *authn.Request, groupsHash string) bool {
+	cookie, err := r.HTTPRequest.Cookie(proxyGroupsCookie)
+	return err != nil || cookie.Value != groupsHash
+}
+
+func (c *Grafana) writeGroupsHashCookie(ctx context.Context, groupsHash string) {
+	// contexthandler.FromContext() is inlined here to avoid import loop.
+	type reqContextKey = ctxkey.Key
+	reqCtx, ok := ctx.Value(reqContextKey{}).(*contextmodel.ReqContext)
+	if !ok {
+		return
+	}
+
+	maxAge := c.cfg.AuthProxy.SyncTTL * 60
+	if maxAge <= 0 {
+		maxAge = -1
+	}
+	cookies.WriteCookie(reqCtx.Resp, proxyGroupsCookie, groupsHash, maxAge, cookies.NewCookieOptions)
 }

--- a/pkg/services/authn/clients/grafana.go
+++ b/pkg/services/authn/clients/grafana.go
@@ -97,7 +97,7 @@ func (c *Grafana) AuthenticateProxy(ctx context.Context, r *authn.Request, usern
 	if v, ok := additional[proxyFieldGroups]; ok {
 		identity.Groups = util.SplitString(v)
 
-		if c.cfg.AuthProxy.CacheTeamSync {
+		if c.cfg.AuthProxy.CookieCacheLastTeamSync {
 			// Hash the list of groups and compare it to the hash stored in the client's
 			// cookie. If the hashes match, skip team sync because the teams haven't changed.
 			groupsHash := hashGroups(c.cfg.SecretKey, identity.Groups)

--- a/pkg/services/authn/clients/grafana.go
+++ b/pkg/services/authn/clients/grafana.go
@@ -97,12 +97,14 @@ func (c *Grafana) AuthenticateProxy(ctx context.Context, r *authn.Request, usern
 	if v, ok := additional[proxyFieldGroups]; ok {
 		identity.Groups = util.SplitString(v)
 
-		// Hash the list of groups and compare it to the hash stored in the client's
-		// cookie. If the hashes match, skip team sync because the teams haven't changed.
-		groupsHash := hashGroups(c.cfg.SecretKey, identity.Groups)
-		identity.ClientParams.SyncTeams = shouldSyncTeams(r, groupsHash)
-		if identity.ClientParams.SyncTeams {
-			c.writeGroupsHashCookie(ctx, groupsHash)
+		if c.cfg.AuthProxy.CacheTeamSync {
+			// Hash the list of groups and compare it to the hash stored in the client's
+			// cookie. If the hashes match, skip team sync because the teams haven't changed.
+			groupsHash := hashGroups(c.cfg.SecretKey, identity.Groups)
+			identity.ClientParams.SyncTeams = shouldSyncTeams(r, groupsHash)
+			if identity.ClientParams.SyncTeams {
+				c.writeGroupsHashCookie(ctx, groupsHash)
+			}
 		}
 	}
 

--- a/pkg/services/authn/clients/grafana.go
+++ b/pkg/services/authn/clients/grafana.go
@@ -146,7 +146,10 @@ func comparePassword(password, salt, hash string) bool {
 	return subtle.ConstantTimeCompare([]byte(hashedPassword), []byte(hash)) == 1
 }
 
-const proxyGroupsCookie = "grafana_proxy_groups_hash"
+const (
+	proxyGroupsCookie       = "grafana_proxy_groups_hash"
+	proxyGroupsCookieMaxAge = 7 * 24 * 60 * 60 // 7 days in seconds
+)
 
 // hashGroups sorts and hashes the list of groups supplied by the proxy. HMAC is
 // used here to prevent bypassing team sync with a forged hash in the cookie.
@@ -173,6 +176,5 @@ func (c *Grafana) writeGroupsHashCookie(ctx context.Context, groupsHash string) 
 		return
 	}
 
-	maxAge := c.cfg.AuthProxy.SyncTTL * 60
-	cookies.WriteCookie(reqCtx.Resp, proxyGroupsCookie, groupsHash, maxAge, cookies.NewCookieOptions)
+	cookies.WriteCookie(reqCtx.Resp, proxyGroupsCookie, groupsHash, proxyGroupsCookieMaxAge, cookies.NewCookieOptions)
 }

--- a/pkg/services/authn/clients/grafana_test.go
+++ b/pkg/services/authn/clients/grafana_test.go
@@ -3,19 +3,24 @@ package clients
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 func TestGrafana_AuthenticateProxy(t *testing.T) {
@@ -182,4 +187,151 @@ func TestGrafana_AuthenticatePassword(t *testing.T) {
 			assert.EqualValues(t, tt.expectedIdentity, identity)
 		})
 	}
+}
+
+func newTestReqContext(t *testing.T) (*contextmodel.ReqContext, *httptest.ResponseRecorder) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	return &contextmodel.ReqContext{
+		Context: &web.Context{
+			Resp: web.NewResponseWriter("GET", rec),
+		},
+	}, rec
+}
+
+func TestGrafana_AuthenticateProxy_SyncTeamsWithCookie(t *testing.T) {
+	newCfg := func() *setting.Cfg {
+		cfg := setting.NewCfg()
+		cfg.AuthProxy.HeaderProperty = "username"
+		cfg.AuthProxy.AutoSignUp = true
+		return cfg
+	}
+
+	additional := map[string]string{
+		proxyFieldGroups: "grp1,grp2",
+	}
+
+	t.Run("SyncTeams is true when no cookie is present", func(t *testing.T) {
+		c := ProvideGrafana(newCfg(), usertest.NewUserServiceFake(), tracing.InitializeTracerForTest())
+		req := &authn.Request{HTTPRequest: &http.Request{}}
+		identity, err := c.AuthenticateProxy(context.Background(), req, "user", additional)
+		require.NoError(t, err)
+		assert.True(t, identity.ClientParams.SyncTeams)
+	})
+
+	t.Run("SyncTeams is false when a matching cookie is present", func(t *testing.T) {
+		cfg := newCfg()
+		c := ProvideGrafana(cfg, usertest.NewUserServiceFake(), tracing.InitializeTracerForTest())
+
+		// Pre-compute the hash for the groups using a throwaway request to get the hash.
+		req := &authn.Request{HTTPRequest: &http.Request{}}
+		identity, err := c.AuthenticateProxy(context.Background(), req, "user", additional)
+		require.NoError(t, err)
+		groupsHash := hashGroups(cfg.SecretKey, identity.Groups)
+
+		// Now make a request with the matching cookie.
+		httpReq := &http.Request{Header: http.Header{}}
+		httpReq.AddCookie(&http.Cookie{Name: proxyGroupsCookie, Value: groupsHash})
+		req2 := &authn.Request{HTTPRequest: httpReq}
+		identity2, err := c.AuthenticateProxy(context.Background(), req2, "user", additional)
+		require.NoError(t, err)
+		assert.False(t, identity2.ClientParams.SyncTeams)
+	})
+
+	t.Run("SyncTeams is true when cookie has a stale hash", func(t *testing.T) {
+		c := ProvideGrafana(newCfg(), usertest.NewUserServiceFake(), tracing.InitializeTracerForTest())
+
+		httpReq := &http.Request{Header: http.Header{}}
+		httpReq.AddCookie(&http.Cookie{Name: proxyGroupsCookie, Value: "stalehash"})
+		req := &authn.Request{HTTPRequest: httpReq}
+		identity, err := c.AuthenticateProxy(context.Background(), req, "user", additional)
+		require.NoError(t, err)
+		assert.True(t, identity.ClientParams.SyncTeams)
+	})
+
+	t.Run("SyncTeams is true when no groups are provided regardless of cookie", func(t *testing.T) {
+		c := ProvideGrafana(newCfg(), usertest.NewUserServiceFake(), tracing.InitializeTracerForTest())
+
+		httpReq := &http.Request{Header: http.Header{}}
+		httpReq.AddCookie(&http.Cookie{Name: proxyGroupsCookie, Value: "anyhash"})
+		req := &authn.Request{HTTPRequest: httpReq}
+		identity, err := c.AuthenticateProxy(context.Background(), req, "user", map[string]string{})
+		require.NoError(t, err)
+		// SyncTeams defaults to true (set in the initial ClientParams) and is only
+		// overridden when the groups field is present.
+		assert.True(t, identity.ClientParams.SyncTeams)
+	})
+
+	t.Run("group order does not affect whether team sync is skipped", func(t *testing.T) {
+		cfg := newCfg()
+		c := ProvideGrafana(cfg, usertest.NewUserServiceFake(), tracing.InitializeTracerForTest())
+
+		// Authenticate once with groups in one order to get the hash written.
+		req1 := &authn.Request{HTTPRequest: &http.Request{}}
+		identity1, err := c.AuthenticateProxy(context.Background(), req1, "user", map[string]string{proxyFieldGroups: "grp1,grp2"})
+		require.NoError(t, err)
+		require.True(t, identity1.ClientParams.SyncTeams)
+		groupsHash := hashGroups(cfg.SecretKey, identity1.Groups)
+
+		// Now authenticate with the same groups in a different order and the stored cookie.
+		httpReq := &http.Request{Header: http.Header{}}
+		httpReq.AddCookie(&http.Cookie{Name: proxyGroupsCookie, Value: groupsHash})
+		req2 := &authn.Request{HTTPRequest: httpReq}
+		identity2, err := c.AuthenticateProxy(context.Background(), req2, "user", map[string]string{proxyFieldGroups: "grp2,grp1"})
+		require.NoError(t, err)
+		assert.False(t, identity2.ClientParams.SyncTeams)
+	})
+
+	t.Run("writes groups hash cookie to the response when team sync is not skipped", func(t *testing.T) {
+		cfg := newCfg()
+		cfg.AuthProxy.SyncTTL = 60
+		c := ProvideGrafana(cfg, usertest.NewUserServiceFake(), tracing.InitializeTracerForTest())
+
+		reqCtx, rec := newTestReqContext(t)
+		ctx := context.WithValue(context.Background(), ctxkey.Key{}, reqCtx)
+		req := &authn.Request{HTTPRequest: &http.Request{}}
+		identity, err := c.AuthenticateProxy(ctx, req, "user", additional)
+		require.NoError(t, err)
+		require.True(t, identity.ClientParams.SyncTeams)
+
+		cookies := rec.Result().Cookies()
+		require.Len(t, cookies, 1)
+		assert.Equal(t, proxyGroupsCookie, cookies[0].Name)
+		assert.Equal(t, hashGroups(cfg.SecretKey, identity.Groups), cookies[0].Value)
+		assert.Equal(t, 60*60, cookies[0].MaxAge) // SyncTTL minutes → seconds
+	})
+
+	t.Run("does not write a new cookie when groups are unchanged", func(t *testing.T) {
+		cfg := newCfg()
+		c := ProvideGrafana(cfg, usertest.NewUserServiceFake(), tracing.InitializeTracerForTest())
+
+		groupsHash := hashGroups(cfg.SecretKey, []string{"grp1", "grp2"})
+		httpReq := &http.Request{Header: http.Header{}}
+		httpReq.AddCookie(&http.Cookie{Name: proxyGroupsCookie, Value: groupsHash})
+
+		reqCtx, rec := newTestReqContext(t)
+		ctx := context.WithValue(context.Background(), ctxkey.Key{}, reqCtx)
+		req := &authn.Request{HTTPRequest: httpReq}
+		identity, err := c.AuthenticateProxy(ctx, req, "user", additional)
+		require.NoError(t, err)
+		require.False(t, identity.ClientParams.SyncTeams)
+
+		assert.Empty(t, rec.Result().Cookies())
+	})
+
+	t.Run("cookie MaxAge is negative when SyncTTL is 0", func(t *testing.T) {
+		cfg := newCfg()
+		cfg.AuthProxy.SyncTTL = 0
+		c := ProvideGrafana(cfg, usertest.NewUserServiceFake(), tracing.InitializeTracerForTest())
+
+		reqCtx, rec := newTestReqContext(t)
+		ctx := context.WithValue(context.Background(), ctxkey.Key{}, reqCtx)
+		req := &authn.Request{HTTPRequest: &http.Request{}}
+		_, err := c.AuthenticateProxy(ctx, req, "user", additional)
+		require.NoError(t, err)
+
+		cookies := rec.Result().Cookies()
+		require.Len(t, cookies, 1)
+		assert.Less(t, cookies[0].MaxAge, 0)
+	})
 }

--- a/pkg/services/authn/clients/grafana_test.go
+++ b/pkg/services/authn/clients/grafana_test.go
@@ -204,7 +204,7 @@ func TestGrafana_AuthenticateProxy_SyncTeamsWithCookie(t *testing.T) {
 		cfg := setting.NewCfg()
 		cfg.AuthProxy.HeaderProperty = "username"
 		cfg.AuthProxy.AutoSignUp = true
-		cfg.AuthProxy.CacheTeamSync = true
+		cfg.AuthProxy.CookieCacheLastTeamSync = true
 		return cfg
 	}
 
@@ -319,9 +319,9 @@ func TestGrafana_AuthenticateProxy_SyncTeamsWithCookie(t *testing.T) {
 		assert.Empty(t, rec.Result().Cookies())
 	})
 
-	t.Run("SyncTeams is true and no cookie is written when cache_team_sync is disabled", func(t *testing.T) {
+	t.Run("SyncTeams is true and no cookie is written when cookie_cache_last_team_sync is disabled", func(t *testing.T) {
 		cfg := newCfg()
-		cfg.AuthProxy.CacheTeamSync = false
+		cfg.AuthProxy.CookieCacheLastTeamSync = false
 		c := ProvideGrafana(cfg, usertest.NewUserServiceFake(), tracing.InitializeTracerForTest())
 
 		// Present a matching cookie that would otherwise cause team sync to be skipped.

--- a/pkg/services/authn/clients/grafana_test.go
+++ b/pkg/services/authn/clients/grafana_test.go
@@ -204,6 +204,7 @@ func TestGrafana_AuthenticateProxy_SyncTeamsWithCookie(t *testing.T) {
 		cfg := setting.NewCfg()
 		cfg.AuthProxy.HeaderProperty = "username"
 		cfg.AuthProxy.AutoSignUp = true
+		cfg.AuthProxy.CacheTeamSync = true
 		return cfg
 	}
 
@@ -315,6 +316,25 @@ func TestGrafana_AuthenticateProxy_SyncTeamsWithCookie(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, identity.ClientParams.SyncTeams)
 
+		assert.Empty(t, rec.Result().Cookies())
+	})
+
+	t.Run("SyncTeams is true and no cookie is written when cache_team_sync is disabled", func(t *testing.T) {
+		cfg := newCfg()
+		cfg.AuthProxy.CacheTeamSync = false
+		c := ProvideGrafana(cfg, usertest.NewUserServiceFake(), tracing.InitializeTracerForTest())
+
+		// Present a matching cookie that would otherwise cause team sync to be skipped.
+		groupsHash := hashGroups(cfg.SecretKey, []string{"grp1", "grp2"})
+		httpReq := &http.Request{Header: http.Header{}}
+		httpReq.AddCookie(&http.Cookie{Name: proxyGroupsCookie, Value: groupsHash})
+
+		reqCtx, rec := newTestReqContext(t)
+		ctx := context.WithValue(context.Background(), ctxkey.Key{}, reqCtx)
+		req := &authn.Request{HTTPRequest: httpReq}
+		identity, err := c.AuthenticateProxy(ctx, req, "user", additional)
+		require.NoError(t, err)
+		assert.True(t, identity.ClientParams.SyncTeams)
 		assert.Empty(t, rec.Result().Cookies())
 	})
 }

--- a/pkg/services/authn/clients/grafana_test.go
+++ b/pkg/services/authn/clients/grafana_test.go
@@ -284,7 +284,6 @@ func TestGrafana_AuthenticateProxy_SyncTeamsWithCookie(t *testing.T) {
 
 	t.Run("writes groups hash cookie to the response when team sync is not skipped", func(t *testing.T) {
 		cfg := newCfg()
-		cfg.AuthProxy.SyncTTL = 60
 		c := ProvideGrafana(cfg, usertest.NewUserServiceFake(), tracing.InitializeTracerForTest())
 
 		reqCtx, rec := newTestReqContext(t)
@@ -298,7 +297,7 @@ func TestGrafana_AuthenticateProxy_SyncTeamsWithCookie(t *testing.T) {
 		require.Len(t, cookies, 1)
 		assert.Equal(t, proxyGroupsCookie, cookies[0].Name)
 		assert.Equal(t, hashGroups(cfg.SecretKey, identity.Groups), cookies[0].Value)
-		assert.Equal(t, 60*60, cookies[0].MaxAge) // SyncTTL minutes → seconds
+		assert.Equal(t, 7*24*60*60, cookies[0].MaxAge)
 	})
 
 	t.Run("does not write a new cookie when groups are unchanged", func(t *testing.T) {

--- a/pkg/services/authn/clients/grafana_test.go
+++ b/pkg/services/authn/clients/grafana_test.go
@@ -318,20 +318,4 @@ func TestGrafana_AuthenticateProxy_SyncTeamsWithCookie(t *testing.T) {
 
 		assert.Empty(t, rec.Result().Cookies())
 	})
-
-	t.Run("cookie MaxAge is negative when SyncTTL is 0", func(t *testing.T) {
-		cfg := newCfg()
-		cfg.AuthProxy.SyncTTL = 0
-		c := ProvideGrafana(cfg, usertest.NewUserServiceFake(), tracing.InitializeTracerForTest())
-
-		reqCtx, rec := newTestReqContext(t)
-		ctx := context.WithValue(context.Background(), ctxkey.Key{}, reqCtx)
-		req := &authn.Request{HTTPRequest: &http.Request{}}
-		_, err := c.AuthenticateProxy(ctx, req, "user", additional)
-		require.NoError(t, err)
-
-		cookies := rec.Result().Cookies()
-		require.Len(t, cookies, 1)
-		assert.Less(t, cookies[0].MaxAge, 0)
-	})
 }

--- a/pkg/setting/setting_auth_proxy.go
+++ b/pkg/setting/setting_auth_proxy.go
@@ -8,16 +8,16 @@ import (
 
 type AuthProxySettings struct {
 	// Auth Proxy
-	Enabled          bool
-	HeaderName       string
-	HeaderProperty   string
-	AutoSignUp       bool
-	EnableLoginToken bool
-	Whitelist        string
-	Headers          map[string]string
-	HeadersEncoded   bool
-	SyncTTL          int
-	CacheTeamSync    bool
+	Enabled                 bool
+	HeaderName              string
+	HeaderProperty          string
+	AutoSignUp              bool
+	EnableLoginToken        bool
+	Whitelist               string
+	Headers                 map[string]string
+	HeadersEncoded          bool
+	SyncTTL                 int
+	CookieCacheLastTeamSync bool
 }
 
 func (cfg *Cfg) readAuthProxySettings() {
@@ -41,7 +41,7 @@ func (cfg *Cfg) readAuthProxySettings() {
 	}
 
 	authProxySettings.HeadersEncoded = authProxy.Key("headers_encoded").MustBool(false)
-	authProxySettings.CacheTeamSync = authProxy.Key("cache_team_sync").MustBool(false)
+	authProxySettings.CookieCacheLastTeamSync = authProxy.Key("cookie_cache_last_team_sync").MustBool(false)
 
 	cfg.AuthProxy = authProxySettings
 }

--- a/pkg/setting/setting_auth_proxy.go
+++ b/pkg/setting/setting_auth_proxy.go
@@ -17,6 +17,7 @@ type AuthProxySettings struct {
 	Headers          map[string]string
 	HeadersEncoded   bool
 	SyncTTL          int
+	CacheTeamSync    bool
 }
 
 func (cfg *Cfg) readAuthProxySettings() {
@@ -40,6 +41,7 @@ func (cfg *Cfg) readAuthProxySettings() {
 	}
 
 	authProxySettings.HeadersEncoded = authProxy.Key("headers_encoded").MustBool(false)
+	authProxySettings.CacheTeamSync = authProxy.Key("cache_team_sync").MustBool(false)
 
 	cfg.AuthProxy = authProxySettings
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature caches a hash of the [Groups](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/auth-proxy/#team-sync) (teams) attribute from the proxy's headers to avoid doing team sync when the list of teams hasn't changed.

**Why do we need this feature?**

Today a Grafana instance caches the result of auth proxy authentication, skipping a number of post-auth hooks on cache hit. In an HA setup, however, each instance runs these hooks and caches this result separately because there's no shared cache. This feature proposes to, when possible, skip the team sync post-auth hook specifically by caching a hash of the list of teams in an HTTP cookie.

Related to https://github.com/grafana/identity-access-team/issues/1860

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
