### PR TITLE
Provisioning: Add pre-flight resource authorization for migrate jobs

### DIFF
--- a/pkg/registry/apis/provisioning/jobs.go
+++ b/pkg/registry/apis/provisioning/jobs.go
@@ -177,8 +177,8 @@ func (c *jobsConnector) Connect(
 			}
 		}
 
-		if spec.Action == provisioning.JobActionPush {
-			if err := c.authorizeExportJob(r.Context(), repo, cfg, spec); err != nil {
+		if spec.Action == provisioning.JobActionPush || spec.Action == provisioning.JobActionMigrate {
+			if err := c.authorizeResourceJob(r.Context(), repo, cfg, spec); err != nil {
 				responder.Error(err)
 				return
 			}
@@ -224,16 +224,16 @@ var (
 	_ rest.StorageMetadata = (*jobsConnector)(nil)
 )
 
-// authorizeExportJob checks that the requesting user has the required permissions
-// for an export operation. This runs at job creation time while the user's identity
-// is still in the request context, since the export job executes later as the
-// provisioning service identity with full access.
+// authorizeResourceJob checks that the requesting user has the required permissions
+// for operations that read and write all supported resource types (export and migrate).
+// This runs at job creation time while the user's identity is still in the request
+// context, since the job executes later as the provisioning service identity.
 //
 // Delegates to the resources.Authorizer which checks:
 //  1. Read permission on all supported resource types at root level.
-//  2. Create permission on all supported resource types in the target folder (if folder-scoped).
-func (c *jobsConnector) authorizeExportJob(ctx context.Context, repo repository.Repository, cfg *provisioning.Repository, spec provisioning.JobSpec) error {
-	if spec.Push == nil {
+//  2. Create permission on all supported resource types in the target folder.
+func (c *jobsConnector) authorizeResourceJob(ctx context.Context, repo repository.Repository, cfg *provisioning.Repository, spec provisioning.JobSpec) error {
+	if spec.Push == nil && spec.Migrate == nil {
 		return nil
 	}
 

--- a/pkg/registry/apis/provisioning/jobs_test.go
+++ b/pkg/registry/apis/provisioning/jobs_test.go
@@ -33,11 +33,11 @@ func newTestRepo(name, namespace string) *provisioning.Repository {
 	}
 }
 
-func TestAuthorizeExportJob(t *testing.T) {
+func TestAuthorizeResourceJob(t *testing.T) {
 	ctx := context.Background()
 	cfg := newTestRepo("my-repo", "default")
 
-	t.Run("authorized - reads at root + create on target folder", func(t *testing.T) {
+	t.Run("export - authorized", func(t *testing.T) {
 		accessMock := auth.NewMockAccessChecker(t)
 		accessMock.EXPECT().Check(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
@@ -45,12 +45,27 @@ func TestAuthorizeExportJob(t *testing.T) {
 
 		c := &jobsConnector{access: accessMock, folderMetadataEnabled: false}
 		spec := provisioning.JobSpec{
-			Action:     provisioning.JobActionPush,
-			Repository: "my-repo",
-			Push:       &provisioning.ExportJobOptions{},
+			Action: provisioning.JobActionPush,
+			Push:   &provisioning.ExportJobOptions{},
 		}
 
-		err := c.authorizeExportJob(ctx, mockReader, cfg, spec)
+		err := c.authorizeResourceJob(ctx, mockReader, cfg, spec)
+		require.NoError(t, err)
+	})
+
+	t.Run("migrate - authorized", func(t *testing.T) {
+		accessMock := auth.NewMockAccessChecker(t)
+		accessMock.EXPECT().Check(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		mockReader := repository.NewMockReader(t)
+
+		c := &jobsConnector{access: accessMock, folderMetadataEnabled: false}
+		spec := provisioning.JobSpec{
+			Action:  provisioning.JobActionMigrate,
+			Migrate: &provisioning.MigrateJobOptions{},
+		}
+
+		err := c.authorizeResourceJob(ctx, mockReader, cfg, spec)
 		require.NoError(t, err)
 	})
 
@@ -67,12 +82,11 @@ func TestAuthorizeExportJob(t *testing.T) {
 
 		c := &jobsConnector{access: accessMock, folderMetadataEnabled: false}
 		spec := provisioning.JobSpec{
-			Action:     provisioning.JobActionPush,
-			Repository: "my-repo",
-			Push:       &provisioning.ExportJobOptions{},
+			Action: provisioning.JobActionPush,
+			Push:   &provisioning.ExportJobOptions{},
 		}
 
-		err := c.authorizeExportJob(ctx, mockReader, cfg, spec)
+		err := c.authorizeResourceJob(ctx, mockReader, cfg, spec)
 		require.Error(t, err)
 		assert.True(t, apierrors.IsForbidden(err))
 	})
@@ -92,27 +106,25 @@ func TestAuthorizeExportJob(t *testing.T) {
 
 		c := &jobsConnector{access: accessMock, folderMetadataEnabled: false}
 		spec := provisioning.JobSpec{
-			Action:     provisioning.JobActionPush,
-			Repository: "my-repo",
-			Push:       &provisioning.ExportJobOptions{},
+			Action: provisioning.JobActionPush,
+			Push:   &provisioning.ExportJobOptions{},
 		}
 
-		err := c.authorizeExportJob(ctx, mockReader, cfg, spec)
+		err := c.authorizeResourceJob(ctx, mockReader, cfg, spec)
 		require.Error(t, err)
 		assert.True(t, apierrors.IsForbidden(err))
 	})
 
-	t.Run("nil push options - no error", func(t *testing.T) {
+	t.Run("nil options - no error", func(t *testing.T) {
 		accessMock := auth.NewMockAccessChecker(t)
 		mockReader := repository.NewMockReader(t)
 
 		c := &jobsConnector{access: accessMock, folderMetadataEnabled: false}
 		spec := provisioning.JobSpec{
-			Action:     provisioning.JobActionPush,
-			Repository: "my-repo",
+			Action: provisioning.JobActionPush,
 		}
 
-		err := c.authorizeExportJob(ctx, mockReader, cfg, spec)
+		err := c.authorizeResourceJob(ctx, mockReader, cfg, spec)
 		require.NoError(t, err)
 	})
 
@@ -139,12 +151,11 @@ func TestAuthorizeExportJob(t *testing.T) {
 
 		c := &jobsConnector{access: accessMock, folderMetadataEnabled: false}
 		spec := provisioning.JobSpec{
-			Action:     provisioning.JobActionPush,
-			Repository: "my-repo",
-			Push:       &provisioning.ExportJobOptions{},
+			Action:  provisioning.JobActionMigrate,
+			Migrate: &provisioning.MigrateJobOptions{},
 		}
 
-		err := c.authorizeExportJob(ctx, mockReader, cfg, spec)
+		err := c.authorizeResourceJob(ctx, mockReader, cfg, spec)
 		require.NoError(t, err)
 		accessMock.AssertExpectations(t)
 	})
@@ -177,12 +188,11 @@ func TestAuthorizeExportJob(t *testing.T) {
 
 		c := &jobsConnector{access: accessMock, folderMetadataEnabled: false}
 		spec := provisioning.JobSpec{
-			Action:     provisioning.JobActionPush,
-			Repository: "my-repo",
-			Push:       &provisioning.ExportJobOptions{},
+			Action: provisioning.JobActionPush,
+			Push:   &provisioning.ExportJobOptions{},
 		}
 
-		err := c.authorizeExportJob(ctx, mockReader, instanceCfg, spec)
+		err := c.authorizeResourceJob(ctx, mockReader, instanceCfg, spec)
 		require.NoError(t, err)
 		accessMock.AssertExpectations(t)
 	})
@@ -193,12 +203,11 @@ func TestAuthorizeExportJob(t *testing.T) {
 
 		c := &jobsConnector{access: accessMock, folderMetadataEnabled: false}
 		spec := provisioning.JobSpec{
-			Action:     provisioning.JobActionPush,
-			Repository: "my-repo",
-			Push:       &provisioning.ExportJobOptions{},
+			Action: provisioning.JobActionPush,
+			Push:   &provisioning.ExportJobOptions{},
 		}
 
-		err := c.authorizeExportJob(ctx, mockRepo, cfg, spec)
+		err := c.authorizeResourceJob(ctx, mockRepo, cfg, spec)
 		require.Error(t, err)
 		assert.True(t, apierrors.IsBadRequest(err))
 	})

--- a/pkg/tests/apis/provisioning/jobs/exportjob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/exportjob_auth_test.go
@@ -1,4 +1,4 @@
-package provisioning
+package jobs
 
 import (
 	"context"

--- a/pkg/tests/apis/provisioning/jobs/migratejob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/migratejob_auth_test.go
@@ -1,0 +1,95 @@
+package jobs
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+func TestIntegrationProvisioning_MigrateJobAuthorization(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := common.RunGrafana(t)
+	ctx := context.Background()
+
+	const repo = "migrate-auth-test"
+	testRepo := common.TestRepo{
+		Name:               repo,
+		Target:             "instance",
+		Copies:             map[string]string{},
+		ExpectedDashboards: 0,
+		ExpectedFolders:    0,
+	}
+	helper.CreateRepo(t, testRepo)
+
+	t.Run("admin can create migrate job", func(t *testing.T) {
+		body := common.AsJSON(provisioning.JobSpec{
+			Action:  provisioning.JobActionMigrate,
+			Migrate: &provisioning.MigrateJobOptions{},
+		})
+
+		var statusCode int
+		result := helper.AdminREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.NoError(t, result.Error(), "admin should be able to create migrate job")
+		require.Equal(t, http.StatusAccepted, statusCode, "should return 202 Accepted")
+
+		helper.AwaitJobs(t, repo)
+	})
+
+	t.Run("editor cannot create migrate job on instance-scoped repo", func(t *testing.T) {
+		body := common.AsJSON(provisioning.JobSpec{
+			Action:  provisioning.JobActionMigrate,
+			Migrate: &provisioning.MigrateJobOptions{},
+		})
+
+		var statusCode int
+		result := helper.EditorREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.Error(t, result.Error(), "editor should not be able to migrate on instance-scoped repo")
+		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
+		require.True(t, apierrors.IsForbidden(result.Error()), "error should be forbidden")
+	})
+
+	t.Run("viewer cannot create migrate job", func(t *testing.T) {
+		body := common.AsJSON(provisioning.JobSpec{
+			Action:  provisioning.JobActionMigrate,
+			Migrate: &provisioning.MigrateJobOptions{},
+		})
+
+		var statusCode int
+		result := helper.ViewerREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.Error(t, result.Error(), "viewer should not be able to create migrate job")
+		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
+		require.True(t, apierrors.IsForbidden(result.Error()), "error should be forbidden")
+	})
+}


### PR DESCRIPTION
## Summary

- Extends the export job pre-flight permission check to also cover migrate jobs. Both operations read all supported resources from Grafana and write them into the repository, so they share the same authorization requirements (`AuthorizeReadAllSupported` + `AuthorizeCreateAllSupported`).
- Renames `authorizeExportJob` to `authorizeResourceJob` since it's now shared by both `push` (export) and `migrate` actions.
- Moves the export auth integration test from `pkg/tests/apis/provisioning/` into the `jobs` subpackage where other job tests live.
- Adds integration tests for migrate job authorization (admin allowed, editor denied on instance-scoped repo, viewer denied).

Partially addresses https://github.com/grafana/git-ui-sync-project/issues/714

## Test plan

- [x] Unit tests for `authorizeResourceJob` covering both export and migrate actions
- [x] Integration tests for export job authorization (admin, editor, viewer)
- [x] Integration tests for migrate job authorization (admin, editor, viewer)
- [ ] Verify existing migrate tests still pass (`go test ./pkg/tests/apis/provisioning/jobs/ -run "TestIntegrationProvisioning_Migrate"`)


Made with [Cursor](https://cursor.com)