### PR TITLE
[release-12.3.6] Heatmap: Fix crash when panel has no data (#119377)

### DIFF
--- a/public/app/plugins/panel/heatmap/fields.test.ts
+++ b/public/app/plugins/panel/heatmap/fields.test.ts
@@ -1,14 +1,43 @@
-import { createTheme } from '@grafana/data';
+import { createTheme, dateTime, FieldType } from '@grafana/data';
 
-import { Options } from './types';
+import { prepareHeatmapData } from './fields';
+import { Options } from './panelcfg.gen';
 
 const theme = createTheme();
 
 describe('Heatmap data', () => {
   const options: Options = {} as Options;
 
-  it('simple test stub', () => {
-    expect(theme).toBeDefined();
-    expect(options).toBeDefined();
+  const tpl = {
+    frames: [],
+    annotations: [],
+    options,
+    palette: [],
+    theme,
+    replaceVariables: undefined,
+    timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-1h', to: 'now' } },
+  };
+
+  it('omit empty series array', () => {
+    const info = prepareHeatmapData({
+      ...tpl,
+      frames: [],
+    });
+
+    expect(info).toEqual({});
+  });
+
+  it('omit frame.length: 0', () => {
+    const info = prepareHeatmapData({
+      ...tpl,
+      frames: [
+        {
+          fields: [{ name: '', config: {}, type: FieldType.time, values: [] }],
+          length: 0,
+        },
+      ],
+    });
+
+    expect(info).toEqual({});
   });
 });

--- a/public/app/plugins/panel/heatmap/fields.ts
+++ b/public/app/plugins/panel/heatmap/fields.ts
@@ -89,6 +89,11 @@ export function prepareHeatmapData({
   replaceVariables = (v) => v,
   timeRange,
 }: PrepareHeatmapDataOptions): HeatmapData {
+  // exclude empty frames
+  frames = frames.filter(
+    (frame) => frame.length > 0 && frame.fields.length > 0 && frame.fields.every((field) => field.values.length > 0)
+  );
+
   if (!frames?.length) {
     return {};
   }


### PR DESCRIPTION
(cherry picked from commit 839fda7a0a4cf602efe24de6a55213a156fc8985)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
