### PR TITLE
Combobox: Selects the correct option when opening the dropdown

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -164,6 +164,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     updateOptions,
     asyncLoading,
     asyncError,
+    resetSearch,
   } = useOptions(props.options, createCustomValue, customValueDescription);
   const isAsync = typeof allOptions === 'function';
 
@@ -292,6 +293,10 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     onIsOpenChange: ({ isOpen, inputValue }) => {
       if (isOpen && inputValue === '') {
         updateOptions(inputValue);
+      }
+
+      if (!isOpen) {
+        resetSearch();
       }
     },
 

--- a/packages/grafana-ui/src/components/Combobox/useOptions.test.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.test.ts
@@ -117,6 +117,27 @@ describe('useOptions', () => {
     expect(result.current.asyncLoading).toBe(false);
     expect(result.current.asyncError).toBe(true);
   });
+
+  it('should be able to reset search', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
+
+    const options = Array.from({ length: 100 }, (_, i) => ({ label: `Option ${i}`, value: i }));
+    const { result } = renderHook(() => useOptions(options, false));
+
+    expect(result.current.options).toEqual(options);
+
+    act(() => {
+      result.current.updateOptions('Option 50');
+    });
+
+    expect(result.current.options).toEqual([{ label: 'Option 50', value: 50 }]);
+
+    act(() => {
+      result.current.resetSearch();
+    });
+
+    expect(result.current.options).toEqual(options);
+  });
 });
 
 describe('sortByGroup', () => {

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -120,7 +120,11 @@ export function useOptions<T extends string | number>(
     return [addCustomValue(options), groupStartIndices];
   }, [filteredOptions, addCustomValue]);
 
-  return { options: finalOptions, groupStartIndices, updateOptions, asyncLoading, asyncError };
+  const resetSearch = useCallback(() => {
+    setUserTypedSearch('');
+  }, []);
+
+  return { options: finalOptions, groupStartIndices, updateOptions, asyncLoading, asyncError, resetSearch };
 }
 
 /**


### PR DESCRIPTION
**What is this feature?**

This pull request enhances the `Combobox` component by adding a mechanism to reset the search input and its filtered options. The main changes introduce a new `resetSearch` function to the `useOptions` hook, integrate it into the `Combobox` logic to reset the search when the dropdown closes, and add corresponding test coverage.

**Why do we need this feature?**

So the correct option is selected

**Who is this feature for?**

Any user of Combobox

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #114468

**Special notes for your reviewer:**

**Before**

https://github.com/user-attachments/assets/8a38d495-4e42-4069-b499-901229e410fc

**After**

https://github.com/user-attachments/assets/6298006f-c92d-4118-93de-3128075fe18c




Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
