### PR TITLE
CI: migrate frontend-perf-tests to grafana-bench v1.0.1

### DIFF
--- a/.github/workflows/frontend-perf-tests.yaml
+++ b/.github/workflows/frontend-perf-tests.yaml
@@ -79,7 +79,7 @@ jobs:
             -e PROMETHEUS_URL="$PROMETHEUS_URL" \
             -e PROMETHEUS_USER="$PROMETHEUS_USER" \
             -e PROMETHEUS_PASSWORD="$PROMETHEUS_TOKEN" \
-            us-docker.pkg.dev/grafanalabs-global/docker-grafana-bench-prod/grafana-bench:v1.0.1 report \
+            us-docker.pkg.dev/grafanalabs-global/docker-grafana-bench-prod/grafana-bench:v1.0.2 report \
               --service grafana \
               --service-url "https://fsperfbaseline.grafana-dev.net" \
               --service-version "rrc-instant" \
@@ -104,7 +104,7 @@ jobs:
             -e PROMETHEUS_URL="$PROMETHEUS_URL" \
             -e PROMETHEUS_USER="$PROMETHEUS_USER" \
             -e PROMETHEUS_PASSWORD="$PROMETHEUS_TOKEN" \
-            us-docker.pkg.dev/grafanalabs-global/docker-grafana-bench-prod/grafana-bench:v1.0.1 report \
+            us-docker.pkg.dev/grafanalabs-global/docker-grafana-bench-prod/grafana-bench:v1.0.2 report \
               --service grafana \
               --service-url "https://fsperf.grafana-dev.net" \
               --service-version "rrc-instant" \

--- a/.github/workflows/frontend-perf-tests.yaml
+++ b/.github/workflows/frontend-perf-tests.yaml
@@ -79,13 +79,16 @@ jobs:
             -e PROMETHEUS_URL="$PROMETHEUS_URL" \
             -e PROMETHEUS_USER="$PROMETHEUS_USER" \
             -e PROMETHEUS_PASSWORD="$PROMETHEUS_TOKEN" \
-            us-docker.pkg.dev/grafanalabs-global/docker-grafana-bench-prod/grafana-bench:v0.6.1 report \
-              --grafana-url "http://fsperfbaseline.grafana-dev.net" \
-              --test-suite-name "FrontendPerfTests" \
+            us-docker.pkg.dev/grafanalabs-global/docker-grafana-bench-prod/grafana-bench:v1.0.1 report \
+              --service grafana \
+              --service-url "https://fsperfbaseline.grafana-dev.net" \
+              --service-version "rrc-instant" \
+              --suite-name "FrontendPerfTests" \
               --report-input playwright \
               --report-output log \
               --prometheus-metrics \
               --run-metrics-file "/metrics.txt" \
+              --run-stage rrc \
               --log-level DEBUG \
               /pw-results.json
 
@@ -101,13 +104,16 @@ jobs:
             -e PROMETHEUS_URL="$PROMETHEUS_URL" \
             -e PROMETHEUS_USER="$PROMETHEUS_USER" \
             -e PROMETHEUS_PASSWORD="$PROMETHEUS_TOKEN" \
-            us-docker.pkg.dev/grafanalabs-global/docker-grafana-bench-prod/grafana-bench:v0.6.1 report \
-              --grafana-url "http://fsperf.grafana-dev.net" \
-              --test-suite-name "FrontendPerfTests" \
+            us-docker.pkg.dev/grafanalabs-global/docker-grafana-bench-prod/grafana-bench:v1.0.1 report \
+              --service grafana \
+              --service-url "https://fsperf.grafana-dev.net" \
+              --service-version "rrc-instant" \
+              --suite-name "FrontendPerfTests" \
               --report-input playwright \
               --report-output log \
               --prometheus-metrics \
               --run-metrics-file "/metrics.txt" \
+              --run-stage rrc \
               --log-level DEBUG \
               /pw-results.json
 


### PR DESCRIPTION
## Summary

- Bumps `grafana-bench` Docker image from `v0.6.1` to `v1.0.1`
- Migrates `bench report` flags to the v1 API in both fsperfbaseline and fsperf steps

## Changes

| Before | After |
|--------|-------|
| `grafana-bench:v0.6.1` | `grafana-bench:v1.0.1` |
| `--grafana-url "http://..."` | `--service-url "https://..."` |
| `--test-suite-name` | `--suite-name` |
| _(missing)_ | `--service grafana` |
| _(missing)_ | `--service-version "rrc-instant"` |
| _(missing)_ | `--run-stage rrc` |

Uses the Docker image (rather than the setup action) since grafana is a public repo and the setup action requires private repo access.

## Test plan

- [ ] Verify the scheduled workflow runs successfully after merge
- [ ] Check Prometheus metrics appear with new labels (`service`, `suite_name`, `run_stage`)