### PR TITLE
Alerting: Add date/time formatting guidance to AGENTS.md

### DIFF
--- a/public/app/features/alerting/unified/AGENTS.md
+++ b/public/app/features/alerting/unified/AGENTS.md
@@ -321,6 +321,21 @@ if (config.featureToggles.alertingTriage) {
 
 A common configuration setting would be `unifiedAlertingEnabled` which allows a user to configure Grafana without any alerting UI or backend enabled at all.
 
+### Date/Time Formatting
+
+Use `dateTimeFormat()` / `dateTimeFormatTimeAgo()` from `@grafana/data` instead of `dateTime().format()` — they respect the user's configured timezone.
+
+```typescript
+// Good - respects user timezone
+import { dateTimeFormat, dateTimeFormatTimeAgo } from '@grafana/data';
+dateTimeFormat(timestamp);
+dateTimeFormatTimeAgo(timestamp);
+
+// Bad - ignores user timezone setting
+import { dateTime } from '@grafana/data';
+dateTime(timestamp).format('YYYY-MM-DD HH:mm:ss');
+```
+
 ### Data Source Abstractions
 
 ```typescript


### PR DESCRIPTION
**What is this feature?**

## Summary

Add date/time formatting guidance to the alerting AGENTS.md to prevent agents from using `dateTime().format()` (which ignores user timezone settings) and direct them to use `dateTimeFormat()` / `dateTimeFormatTimeAgo()` from `@grafana/data` instead.

## Details

- Added a **Date/Time Formatting** section under "Alerting-Specific Patterns"
- Documents the correct pattern (`dateTimeFormat`, `dateTimeFormatTimeAgo`) and the antipattern (`dateTime().format()`)
- Includes good/bad code examples for clarity

## Motivation

Agents were generating code using `dateTime().format()` which doesn't respect the user's configured timezone. This small addition prevents that recurring mistake.

**Who is this feature for?**

Contributors to the alerting code

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
