### PR TITLE
CI: Migrate remaining workflows to reusable setup-go action

### DIFF
--- a/.github/workflows/alerting-swagger-gen.yml
+++ b/.github/workflows/alerting-swagger-gen.yml
@@ -14,10 +14,8 @@ jobs:
         with:
           fetch-depth: 2
           persist-credentials: false
-      - name: Set go version
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
-        with:
-          go-version-file: go.mod
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
       - name: Build swagger
         run: |
           make -C pkg/services/ngalert/api/tooling post.json api.json

--- a/.github/workflows/alerting-update-module.yml
+++ b/.github/workflows/alerting-update-module.yml
@@ -29,9 +29,7 @@ jobs:
           fi
 
       - name: Setup Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # 6.0.0
-        with:
-          "go-version-file": "go.mod"
+        uses: ./.github/actions/setup-go
 
       - name: Extract current commit hash of alerting module
         id: current-commit

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -73,11 +73,10 @@ jobs:
         persist-credentials: false
 
     - if: matrix.language == 'go' && needs.detect-changes.outputs.go == 'true'
-      name: Set go version
-      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+      name: Setup Go
+      uses: ./.github/actions/setup-go
       with:
-        cache: false
-        go-version-file: go.mod
+        cache: 'false'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -75,8 +75,6 @@ jobs:
     - if: matrix.language == 'go' && needs.detect-changes.outputs.go == 'true'
       name: Setup Go
       uses: ./.github/actions/setup-go
-      with:
-        cache: 'false'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/core-plugins-build-and-release.yml
+++ b/.github/workflows/core-plugins-build-and-release.yml
@@ -96,11 +96,9 @@ jobs:
           else
             echo "has_backend=false" >> "$GITHUB_OUTPUT"
           fi
-      - name: Setup golang environment
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
         if: steps.check_backend.outputs.has_backend == 'true'
-        with:
-          go-version-file: go.mod
       - name: Install Mage
         shell: bash
         if: steps.check_backend.outputs.has_backend == 'true'

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -41,9 +41,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6.0.0
-        with:
-          go-version-file: ./go.mod
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
       - name: Run gofmt
         run: |
           GOFMT="$(go list -m -f '{{.Dir}}' | xargs -I{} sh -c 'test ! -f {}/.nolint && echo {}' | xargs gofmt -s -e -l 2>&1 | grep -v '/pkg/build/' || true)"
@@ -62,9 +61,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6.0.0
-        with:
-          go-version-file: ./go.mod
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
       - name: golangci-lint
         uses: golangci/golangci-lint-action@b002b6ecfcabe6ac0e2c6cba1bcc779eb34ac51f # v9
         with:

--- a/.github/workflows/pr-dependabot-update-go-workspace.yml
+++ b/.github/workflows/pr-dependabot-update-go-workspace.yml
@@ -44,10 +44,8 @@ jobs:
         token: ${{ steps.generate_token.outputs.token }}
         persist-credentials: false
 
-    - name: Set go version
-      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
-      with:
-        go-version-file: go.mod
+    - name: Setup Go
+      uses: ./.github/actions/setup-go
 
     - name: Configure Git
       run: |

--- a/.github/workflows/pr-frontend-unit-tests.yml
+++ b/.github/workflows/pr-frontend-unit-tests.yml
@@ -43,9 +43,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Setup Go
-      uses: actions/setup-go@v6.0.0
-      with:
-        go-version-file: go.mod
+      uses: ./.github/actions/setup-go
     - name: Generate golden files
       run: make generate-golden-files
       working-directory: apps/dashboard

--- a/.github/workflows/pr-go-workspace-check.yml
+++ b/.github/workflows/pr-go-workspace-check.yml
@@ -40,8 +40,6 @@ jobs:
 
     - name: Setup Go
       uses: ./.github/actions/setup-go
-      with:
-        cache: 'false'
 
     - name: Update workspace
       run: make update-workspace
@@ -76,8 +74,6 @@ jobs:
 
     - name: Setup Go
       uses: ./.github/actions/setup-go
-      with:
-        cache: 'false'
 
     - name: Setup Enterprise
       if: github.event.pull_request.head.repo.fork == false

--- a/.github/workflows/pr-go-workspace-check.yml
+++ b/.github/workflows/pr-go-workspace-check.yml
@@ -38,11 +38,10 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Set go version
-      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+    - name: Setup Go
+      uses: ./.github/actions/setup-go
       with:
-        cache: false
-        go-version-file: go.mod
+        cache: 'false'
 
     - name: Update workspace
       run: make update-workspace
@@ -75,11 +74,10 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Set go version
-      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+    - name: Setup Go
+      uses: ./.github/actions/setup-go
       with:
-        cache: false
-        go-version-file: go.mod
+        cache: 'false'
 
     - name: Setup Enterprise
       if: github.event.pull_request.head.repo.fork == false

--- a/.github/workflows/pr-k8s-codegen-check.yml
+++ b/.github/workflows/pr-k8s-codegen-check.yml
@@ -23,10 +23,8 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Set go version
-      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
-      with:
-        go-version-file: go.mod
+    - name: Setup Go
+      uses: ./.github/actions/setup-go
 
     - name: Update k8s codegen
       run: ./hack/update-codegen.sh

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -134,9 +134,8 @@ jobs:
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
-      - uses: actions/setup-go@v6.0.0
-        with:
-          go-version-file: go.mod
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
       - name: Configure git user
         run: |
           git config --local user.name "grafana-delivery-bot[bot]"

--- a/.github/workflows/run-schema-v2-e2e.yml
+++ b/.github/workflows/run-schema-v2-e2e.yml
@@ -21,10 +21,8 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - name: Pin Go version to mod file
-        uses: actions/setup-go@v6.0.0
-        with:
-          go-version-file: 'go.mod'
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
       - run: go version
       - name: Setup Node
         uses: ./.github/actions/setup-node

--- a/.github/workflows/swagger-gen.yml
+++ b/.github/workflows/swagger-gen.yml
@@ -49,9 +49,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Go
-        uses: actions/setup-go@v6.0.0
-        with:
-          go-version-file: go.mod
+        uses: ./.github/actions/setup-go
       - name: Setup Enterprise
         if: ${{ github.event.pull_request.head.repo.fork == false }}
         uses: ./.github/actions/setup-enterprise


### PR DESCRIPTION
## Summary

Migrate all remaining `actions/setup-go` steps across 12 workflows to use the reusable `.github/actions/setup-go` action introduced in #119977. All workflows now use the default `cache: true` with `cache-dependency-path: "**/*.sum"`.

After this PR, **zero** direct `actions/setup-go@` references remain in any workflow.

### Migrated workflows

- `swagger-gen.yml`
- `run-schema-v2-e2e.yml`
- `release-pr.yml`
- `pr-k8s-codegen-check.yml`
- `pr-frontend-unit-tests.yml`
- `pr-dependabot-update-go-workspace.yml`
- `go-lint.yml` (2 steps)
- `core-plugins-build-and-release.yml`
- `alerting-update-module.yml`
- `alerting-swagger-gen.yml`
- `pr-go-workspace-check.yml` (2 steps)
- `codeql-analysis.yml`

## Test plan

- [ ] Verify all migrated workflows pass CI on this PR