### PR TITLE
Provisioning: Incremental Sync - Warn on missing folder metadata

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -79,7 +79,7 @@ func FullSync(
 		}
 		for _, p := range missingFolderMetadata {
 			builder := jobs.NewFolderResult(p).
-				WithWarning(&resources.MissingFolderMetadata{Path: p})
+				WithWarning(resources.NewMissingFolderMetadata(p))
 			if action, ok := changeActions[p]; ok {
 				builder = builder.WithAction(action)
 			} else {

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental.go
@@ -24,7 +24,9 @@ func IncrementalSync(ctx context.Context, repo repository.Versioned, previousRef
 	if previousRef == currentRef {
 		// We still need to detect missing folder metadata if the flag is enabled
 		if folderMetadataEnabled {
-			detectMissingFolderMetadata(ctx, repo, currentRef, []repository.VersionedFileChange{}, progress, tracer)
+			if err := detectMissingFolderMetadata(ctx, repo, currentRef, []repository.VersionedFileChange{}, progress, tracer); err != nil {
+				return err
+			}
 		}
 		progress.SetFinalMessage(ctx, "same commit as last time")
 		return nil
@@ -64,7 +66,9 @@ func IncrementalSync(ctx context.Context, repo repository.Versioned, previousRef
 	progress.SetMessage(ctx, "versioned changes replicated")
 
 	if folderMetadataEnabled {
-		detectMissingFolderMetadata(ctx, repo, currentRef, diff, progress, tracer)
+		if err := detectMissingFolderMetadata(ctx, repo, currentRef, diff, progress, tracer); err != nil {
+			return err
+		}
 	}
 
 	if len(affectedFolders) > 0 {
@@ -272,19 +276,20 @@ func cleanupOrphanedFolders(
 
 // detectMissingFolderMetadata reads the full file tree and records warnings for folders
 // that do not have a folder metadata file.
-func detectMissingFolderMetadata(ctx context.Context, repo repository.Versioned, currentRef string, diff []repository.VersionedFileChange, progress jobs.JobProgressRecorder, tracer tracing.Tracer) {
+func detectMissingFolderMetadata(ctx context.Context, repo repository.Versioned, currentRef string, diff []repository.VersionedFileChange, progress jobs.JobProgressRecorder, tracer tracing.Tracer) error {
 	ctx, span := tracer.Start(ctx, "provisioning.sync.incremental.detect_missing_folder_metadata")
 	defer span.End()
 
 	readerRepo, ok := repo.(repository.Reader)
 	if !ok {
-		return
+		span.RecordError(fmt.Errorf("repository does not implement Reader"))
+		return nil
 	}
 
 	tree, err := readerRepo.ReadTree(ctx, currentRef)
 	if err != nil {
 		span.RecordError(err)
-		return
+		return fmt.Errorf("detect missing folder metadata: %w", err)
 	}
 
 	changeActions := make(map[string]repository.FileAction, len(diff))
@@ -303,4 +308,6 @@ func detectMissingFolderMetadata(ctx context.Context, repo repository.Versioned,
 		}
 		progress.Record(ctx, builder.Build())
 	}
+
+	return nil
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental.go
@@ -19,9 +19,13 @@ import (
 )
 
 // Convert git changes into resource file changes
-func IncrementalSync(ctx context.Context, repo repository.Versioned, previousRef, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker) error {
+func IncrementalSync(ctx context.Context, repo repository.Versioned, previousRef, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool) error {
 	syncStart := time.Now()
 	if previousRef == currentRef {
+		// We still need to detect missing folder metadata if the flag is enabled
+		if folderMetadataEnabled {
+			detectMissingFolderMetadata(ctx, repo, currentRef, []repository.VersionedFileChange{}, progress, tracer)
+		}
 		progress.SetFinalMessage(ctx, "same commit as last time")
 		return nil
 	}
@@ -58,6 +62,10 @@ func IncrementalSync(ctx context.Context, repo repository.Versioned, previousRef
 	}
 
 	progress.SetMessage(ctx, "versioned changes replicated")
+
+	if folderMetadataEnabled {
+		detectMissingFolderMetadata(ctx, repo, currentRef, diff, progress, tracer)
+	}
 
 	if len(affectedFolders) > 0 {
 		cleanupStart := time.Now()
@@ -260,4 +268,39 @@ func cleanupOrphanedFolders(
 	}
 
 	return nil
+}
+
+// detectMissingFolderMetadata reads the full file tree and records warnings for folders
+// that do not have a folder metadata file.
+func detectMissingFolderMetadata(ctx context.Context, repo repository.Versioned, currentRef string, diff []repository.VersionedFileChange, progress jobs.JobProgressRecorder, tracer tracing.Tracer) {
+	ctx, span := tracer.Start(ctx, "provisioning.sync.incremental.detect_missing_folder_metadata")
+	defer span.End()
+
+	readerRepo, ok := repo.(repository.Reader)
+	if !ok {
+		return
+	}
+
+	tree, err := readerRepo.ReadTree(ctx, currentRef)
+	if err != nil {
+		span.RecordError(err)
+		return
+	}
+
+	changeActions := make(map[string]repository.FileAction, len(diff))
+	for _, c := range diff {
+		changeActions[c.Path] = c.Action
+	}
+
+	missing := resources.FindFoldersMissingMetadata(tree)
+	for _, p := range missing {
+		builder := jobs.NewFolderResult(p).
+			WithWarning(resources.NewMissingFolderMetadata(p))
+		if action, ok := changeActions[p]; ok {
+			builder = builder.WithAction(action)
+		} else {
+			builder = builder.WithAction(repository.FileActionIgnored)
+		}
+		progress.Record(ctx, builder.Build())
+	}
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_hierarchical_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_hierarchical_test.go
@@ -353,7 +353,7 @@ func runHierarchicalErrorHandlingTest(t *testing.T, tt struct {
 
 	tt.setupMocks(mockVersioned, repoResources, progress)
 
-	err := IncrementalSync(context.Background(), repo, tt.previousRef, tt.currentRef, repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t))
+	err := IncrementalSync(context.Background(), repo, tt.previousRef, tt.currentRef, repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), false)
 
 	if tt.expectError {
 		require.Error(t, err)
@@ -419,7 +419,7 @@ func TestIncrementalSync_HierarchicalErrorHandling_FailedFolderCreation(t *testi
 		return r.Path() == "other/file.json" && r.Action() == repository.FileActionCreated && r.Error() == nil
 	})).Return().Once()
 
-	err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t))
+	err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), false)
 	require.NoError(t, err)
 	progress.AssertExpectations(t)
 }
@@ -453,7 +453,7 @@ func TestIncrementalSync_HierarchicalErrorHandling_FailedFileDeletion(t *testing
 
 	progress.On("HasDirPathFailedDeletion", "dashboards/").Return(true).Once()
 
-	err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t))
+	err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), false)
 	require.NoError(t, err)
 	progress.AssertExpectations(t)
 	repoResources.AssertNotCalled(t, "RemoveFolder", mock.Anything, mock.Anything)
@@ -494,7 +494,7 @@ func TestIncrementalSync_HierarchicalErrorHandling_DeletionNotAffectedByCreation
 		return r.Path() == "folder1/old.json" && r.Action() == repository.FileActionDeleted && r.Error() == nil
 	})).Return().Once()
 
-	err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t))
+	err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), false)
 	require.NoError(t, err)
 	progress.AssertExpectations(t)
 }
@@ -538,7 +538,7 @@ func TestIncrementalSync_HierarchicalErrorHandling_MultiLevelNesting(t *testing.
 			r.Warning() != nil && r.Warning().Error() == "resource was not processed because the parent folder could not be created"
 	})).Return().Once()
 
-	err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t))
+	err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), false)
 	require.NoError(t, err)
 	progress.AssertExpectations(t)
 }
@@ -589,7 +589,7 @@ func TestIncrementalSync_HierarchicalErrorHandling_MixedSuccessAndFailure(t *tes
 			r.Warning() != nil && r.Warning().Error() == "resource was not processed because the parent folder could not be created"
 	})).Return().Once()
 
-	err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t))
+	err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), false)
 	require.NoError(t, err)
 	progress.AssertExpectations(t)
 	repoResources.AssertExpectations(t)
@@ -617,7 +617,7 @@ func TestIncrementalSync_HierarchicalErrorHandling_RenameWithFailedFolderCreatio
 			r.Warning() != nil && r.Warning().Error() == "resource was not processed because the parent folder could not be created"
 	})).Return().Once()
 
-	err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t))
+	err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), false)
 	require.NoError(t, err)
 	progress.AssertExpectations(t)
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_sync_fn_mock.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_sync_fn_mock.go
@@ -30,17 +30,17 @@ func (_m *MockIncrementalSyncFn) EXPECT() *MockIncrementalSyncFn_Expecter {
 	return &MockIncrementalSyncFn_Expecter{mock: &_m.Mock}
 }
 
-// Execute provides a mock function with given fields: ctx, repo, previousRef, currentRef, repositoryResources, progress, tracer, metrics, quotaTracker
-func (_m *MockIncrementalSyncFn) Execute(ctx context.Context, repo repository.Versioned, previousRef string, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker) error {
-	ret := _m.Called(ctx, repo, previousRef, currentRef, repositoryResources, progress, tracer, metrics, quotaTracker)
+// Execute provides a mock function with given fields: ctx, repo, previousRef, currentRef, repositoryResources, progress, tracer, metrics, quotaTracker, folderMetadataEnabled
+func (_m *MockIncrementalSyncFn) Execute(ctx context.Context, repo repository.Versioned, previousRef string, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool) error {
+	ret := _m.Called(ctx, repo, previousRef, currentRef, repositoryResources, progress, tracer, metrics, quotaTracker, folderMetadataEnabled)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Execute")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, repository.Versioned, string, string, resources.RepositoryResources, jobs.JobProgressRecorder, tracing.Tracer, jobs.JobMetrics, quotas.QuotaTracker) error); ok {
-		r0 = rf(ctx, repo, previousRef, currentRef, repositoryResources, progress, tracer, metrics, quotaTracker)
+	if rf, ok := ret.Get(0).(func(context.Context, repository.Versioned, string, string, resources.RepositoryResources, jobs.JobProgressRecorder, tracing.Tracer, jobs.JobMetrics, quotas.QuotaTracker, bool) error); ok {
+		r0 = rf(ctx, repo, previousRef, currentRef, repositoryResources, progress, tracer, metrics, quotaTracker, folderMetadataEnabled)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -63,13 +63,14 @@ type MockIncrementalSyncFn_Execute_Call struct {
 //   - tracer tracing.Tracer
 //   - metrics jobs.JobMetrics
 //   - quotaTracker quotas.QuotaTracker
-func (_e *MockIncrementalSyncFn_Expecter) Execute(ctx interface{}, repo interface{}, previousRef interface{}, currentRef interface{}, repositoryResources interface{}, progress interface{}, tracer interface{}, metrics interface{}, quotaTracker interface{}) *MockIncrementalSyncFn_Execute_Call {
-	return &MockIncrementalSyncFn_Execute_Call{Call: _e.mock.On("Execute", ctx, repo, previousRef, currentRef, repositoryResources, progress, tracer, metrics, quotaTracker)}
+//   - folderMetadataEnabled bool
+func (_e *MockIncrementalSyncFn_Expecter) Execute(ctx interface{}, repo interface{}, previousRef interface{}, currentRef interface{}, repositoryResources interface{}, progress interface{}, tracer interface{}, metrics interface{}, quotaTracker interface{}, folderMetadataEnabled interface{}) *MockIncrementalSyncFn_Execute_Call {
+	return &MockIncrementalSyncFn_Execute_Call{Call: _e.mock.On("Execute", ctx, repo, previousRef, currentRef, repositoryResources, progress, tracer, metrics, quotaTracker, folderMetadataEnabled)}
 }
 
-func (_c *MockIncrementalSyncFn_Execute_Call) Run(run func(ctx context.Context, repo repository.Versioned, previousRef string, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker)) *MockIncrementalSyncFn_Execute_Call {
+func (_c *MockIncrementalSyncFn_Execute_Call) Run(run func(ctx context.Context, repo repository.Versioned, previousRef string, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool)) *MockIncrementalSyncFn_Execute_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(repository.Versioned), args[2].(string), args[3].(string), args[4].(resources.RepositoryResources), args[5].(jobs.JobProgressRecorder), args[6].(tracing.Tracer), args[7].(jobs.JobMetrics), args[8].(quotas.QuotaTracker))
+		run(args[0].(context.Context), args[1].(repository.Versioned), args[2].(string), args[3].(string), args[4].(resources.RepositoryResources), args[5].(jobs.JobProgressRecorder), args[6].(tracing.Tracer), args[7].(jobs.JobMetrics), args[8].(quotas.QuotaTracker), args[9].(bool))
 	})
 	return _c
 }
@@ -79,7 +80,7 @@ func (_c *MockIncrementalSyncFn_Execute_Call) Return(_a0 error) *MockIncremental
 	return _c
 }
 
-func (_c *MockIncrementalSyncFn_Execute_Call) RunAndReturn(run func(context.Context, repository.Versioned, string, string, resources.RepositoryResources, jobs.JobProgressRecorder, tracing.Tracer, jobs.JobMetrics, quotas.QuotaTracker) error) *MockIncrementalSyncFn_Execute_Call {
+func (_c *MockIncrementalSyncFn_Execute_Call) RunAndReturn(run func(context.Context, repository.Versioned, string, string, resources.RepositoryResources, jobs.JobProgressRecorder, tracing.Tracer, jobs.JobMetrics, quotas.QuotaTracker, bool) error) *MockIncrementalSyncFn_Execute_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
@@ -41,7 +41,7 @@ func TestIncrementalSync_ContextCancelled(t *testing.T) {
 	progress.On("SetTotal", mock.Anything, 1).Return()
 	progress.On("SetMessage", mock.Anything, "replicating versioned changes").Return()
 
-	err := IncrementalSync(ctx, repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t))
+	err := IncrementalSync(ctx, repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), false)
 	require.EqualError(t, err, "context canceled")
 }
 
@@ -64,7 +64,7 @@ func runIncrementalSyncTests(t *testing.T, tests []incrementalSyncTestCase) {
 
 			tt.setupMocks(repo, repoResources, progress)
 
-			err := IncrementalSync(context.Background(), repo, tt.previousRef, tt.currentRef, repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), tt.quotaTracker)
+			err := IncrementalSync(context.Background(), repo, tt.previousRef, tt.currentRef, repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), tt.quotaTracker, false)
 
 			if tt.expectedError != "" {
 				require.EqualError(t, err, tt.expectedError)
@@ -843,7 +843,7 @@ func TestIncrementalSync_CleanupOrphanedFolders(t *testing.T) {
 
 			tt.setupMocks(repo, repoResources, progress)
 
-			err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t))
+			err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), false)
 
 			if tt.expectedError != "" {
 				require.EqualError(t, err, tt.expectedError)
@@ -852,4 +852,101 @@ func TestIncrementalSync_CleanupOrphanedFolders(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIncrementalSync_MissingFolderMetadata(t *testing.T) {
+	t.Run("flag enabled detects missing folder metadata", func(t *testing.T) {
+		mockVersioned := repository.NewMockVersioned(t)
+		mockReader := repository.NewMockReader(t)
+		repo := &compositeRepo{
+			MockVersioned: mockVersioned,
+			MockReader:    mockReader,
+		}
+		repoResources := resources.NewMockRepositoryResources(t)
+		progress := jobs.NewMockJobProgressRecorder(t)
+
+		changes := []repository.VersionedFileChange{
+			{
+				Action: repository.FileActionCreated,
+				Path:   "myfolder/dashboard.json",
+				Ref:    "new-ref",
+			},
+		}
+		repo.MockVersioned.On("CompareFiles", mock.Anything, "old-ref", "new-ref").Return(changes, nil)
+		progress.On("SetTotal", mock.Anything, 1).Return()
+		progress.On("SetMessage", mock.Anything, "replicating versioned changes").Return()
+		progress.On("SetMessage", mock.Anything, "versioned changes replicated").Return()
+		progress.On("HasDirPathFailedCreation", "myfolder/dashboard.json").Return(false)
+		repoResources.On("WriteResourceFromFile", mock.Anything, "myfolder/dashboard.json", "new-ref").
+			Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+		progress.On("TooManyErrors").Return(nil)
+
+		// ReadTree returns a folder without _folder.json
+		mockReader.On("ReadTree", mock.Anything, "new-ref").Return([]repository.FileTreeEntry{
+			{Path: "myfolder", Blob: false},
+			{Path: "myfolder/dashboard.json", Blob: true},
+		}, nil)
+
+		// Expect warning record for the missing folder metadata
+		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+			return result.Warning() != nil && errors.Is(result.Warning(), resources.ErrMissingFolderMetadata) &&
+				result.Action() == repository.FileActionIgnored
+		})).Return().Once()
+
+		// Also expect the normal record for the dashboard write
+		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+			return result.Action() == repository.FileActionCreated && result.Path() == "myfolder/dashboard.json"
+		})).Return()
+
+		err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), true)
+		require.NoError(t, err)
+		mockReader.AssertCalled(t, "ReadTree", mock.Anything, "new-ref")
+	})
+
+	t.Run("flag disabled skips detection", func(t *testing.T) {
+		repo := repository.NewMockVersioned(t)
+		repoResources := resources.NewMockRepositoryResources(t)
+		progress := jobs.NewMockJobProgressRecorder(t)
+
+		repo.On("CompareFiles", mock.Anything, "old-ref", "new-ref").Return([]repository.VersionedFileChange{}, nil)
+		progress.On("SetFinalMessage", mock.Anything, "no changes detected between commits").Return()
+
+		err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), false)
+		require.NoError(t, err)
+	})
+
+	t.Run("ReadTree error is non-fatal", func(t *testing.T) {
+		mockVersioned := repository.NewMockVersioned(t)
+		mockReader := repository.NewMockReader(t)
+		repo := &compositeRepo{
+			MockVersioned: mockVersioned,
+			MockReader:    mockReader,
+		}
+		repoResources := resources.NewMockRepositoryResources(t)
+		progress := jobs.NewMockJobProgressRecorder(t)
+
+		changes := []repository.VersionedFileChange{
+			{
+				Action: repository.FileActionCreated,
+				Path:   "dashboards/test.json",
+				Ref:    "new-ref",
+			},
+		}
+		repo.MockVersioned.On("CompareFiles", mock.Anything, "old-ref", "new-ref").Return(changes, nil)
+		progress.On("SetTotal", mock.Anything, 1).Return()
+		progress.On("SetMessage", mock.Anything, "replicating versioned changes").Return()
+		progress.On("SetMessage", mock.Anything, "versioned changes replicated").Return()
+		progress.On("HasDirPathFailedCreation", "dashboards/test.json").Return(false)
+		repoResources.On("WriteResourceFromFile", mock.Anything, "dashboards/test.json", "new-ref").
+			Return("test-dashboard", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+			return result.Action() == repository.FileActionCreated && result.Path() == "dashboards/test.json"
+		})).Return()
+		progress.On("TooManyErrors").Return(nil)
+
+		mockReader.On("ReadTree", mock.Anything, "new-ref").Return([]repository.FileTreeEntry(nil), fmt.Errorf("read tree failed"))
+
+		err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), true)
+		require.NoError(t, err)
+	})
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
@@ -915,7 +915,7 @@ func TestIncrementalSync_MissingFolderMetadata(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("ReadTree error is non-fatal", func(t *testing.T) {
+	t.Run("ReadTree error fails the job", func(t *testing.T) {
 		mockVersioned := repository.NewMockVersioned(t)
 		mockReader := repository.NewMockReader(t)
 		repo := &compositeRepo{
@@ -947,6 +947,7 @@ func TestIncrementalSync_MissingFolderMetadata(t *testing.T) {
 		mockReader.On("ReadTree", mock.Anything, "new-ref").Return([]repository.FileTreeEntry(nil), fmt.Errorf("read tree failed"))
 
 		err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), true)
-		require.NoError(t, err)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "detect missing folder metadata: read tree failed")
 	})
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/sync.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/sync.go
@@ -20,7 +20,7 @@ type FullSyncFn func(ctx context.Context, repo repository.Reader, compare Compar
 type CompareFn func(ctx context.Context, repo repository.Reader, repositoryResources resources.RepositoryResources, ref string) ([]ResourceFileChange, []string, error)
 
 //go:generate mockery --name IncrementalSyncFn --structname MockIncrementalSyncFn --inpackage --filename incremental_sync_fn_mock.go --with-expecter
-type IncrementalSyncFn func(ctx context.Context, repo repository.Versioned, previousRef, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker) error
+type IncrementalSyncFn func(ctx context.Context, repo repository.Versioned, previousRef, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool) error
 
 //go:generate mockery --name Syncer --structname MockSyncer --inpackage --filename syncer_mock.go --with-expecter
 type Syncer interface {
@@ -64,7 +64,7 @@ func (r *syncer) Sync(ctx context.Context, repo repository.ReaderWriter, options
 
 		if cfg.Status.Sync.LastRef != "" && options.Incremental && !quotas.IsQuotaExceeded(cfg.Status.Conditions) {
 			progress.SetMessage(ctx, "incremental sync")
-			return currentRef, r.incrementalSync(ctx, versionedRepo, cfg.Status.Sync.LastRef, currentRef, repositoryResources, progress, r.tracer, r.metrics, quotaTracker)
+			return currentRef, r.incrementalSync(ctx, versionedRepo, cfg.Status.Sync.LastRef, currentRef, repositoryResources, progress, r.tracer, r.metrics, quotaTracker, r.folderMetadataEnabled)
 		}
 
 		if quotas.IsQuotaExceeded(cfg.Status.Conditions) {

--- a/pkg/registry/apis/provisioning/jobs/sync/sync_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/sync_test.go
@@ -90,7 +90,7 @@ func TestSyncer_Sync(t *testing.T) {
 				})
 				repo.MockVersioned.On("LatestRef", mock.Anything).Return("new-ref", nil)
 				progress.On("SetMessage", mock.Anything, "incremental sync").Return()
-				incrementalSyncFn.EXPECT().Execute(mock.Anything, mock.Anything, "old-ref", "new-ref", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				incrementalSyncFn.EXPECT().Execute(mock.Anything, mock.Anything, "old-ref", "new-ref", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			expectedRef:      "new-ref",
 			expectedMessages: []string{"incremental sync"},
@@ -165,7 +165,7 @@ func TestSyncer_Sync(t *testing.T) {
 				})
 				repo.MockVersioned.On("LatestRef", mock.Anything).Return("new-ref", nil)
 				progress.On("SetMessage", mock.Anything, "incremental sync").Return()
-				incrementalSyncFn.On("Execute", mock.Anything, mock.Anything, "old-ref", "new-ref", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("incremental sync failed"))
+				incrementalSyncFn.On("Execute", mock.Anything, mock.Anything, "old-ref", "new-ref", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("incremental sync failed"))
 			},
 			expectedRef:      "new-ref",
 			expectedMessages: []string{"incremental sync"},

--- a/pkg/registry/apis/provisioning/resources/folder_metadata.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata.go
@@ -34,12 +34,17 @@ type MissingFolderMetadata struct {
 }
 
 func (e *MissingFolderMetadata) Error() string {
-	return fmt.Sprintf("folder %q is missing folder metadata file", e.Path)
+	return fmt.Sprintf("folder %q is missing folder metadata file - folder UID will be auto-generated and may change on next sync.", e.Path)
 }
 
 // Unwrap supports errors.Is(err, ErrMissingFolderMetadata).
 func (e *MissingFolderMetadata) Unwrap() error {
 	return ErrMissingFolderMetadata
+}
+
+// NewMissingFolderMetadata creates a MissingFolderMetadata error for the given folder path.
+func NewMissingFolderMetadata(path string) *MissingFolderMetadata {
+	return &MissingFolderMetadata{Path: path}
 }
 
 // FindFoldersMissingMetadata returns folder paths from source that do not have

--- a/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
@@ -1,0 +1,142 @@
+package git
+
+import (
+	"strings"
+	"testing"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/util/testutil"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// TODO(ferruvich): use the one in `common` once https://github.com/grafana/grafana/pull/119801 is merged
+func withProvisioningFolderMetadata(opts *testinfra.GrafanaOpts) {
+	opts.EnableFeatureToggles = append(opts.EnableFeatureToggles, featuremgmt.FlagProvisioningFolderMetadata)
+}
+
+func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagEnabled(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	t.Run("detects missing folder metadata after adding file to folder", func(t *testing.T) {
+		helper := runGrafanaWithGitServer(t, withProvisioningFolderMetadata)
+
+		const repoName = "incr-missing-meta-add"
+
+		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
+			"dashboard.json": dashboardJSON("root-dash", "Root Dashboard", 1),
+		})
+
+		// Full sync the root dashboard.
+		helper.syncAndWait(t, repoName)
+
+		// Add a dashboard inside a folder that has no _folder.json.
+		require.NoError(t, local.CreateFile("myfolder/dashboard2.json", string(dashboardJSON("folder-dash", "Folder Dashboard", 1))))
+		_, err := local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "add dashboard in folder without metadata")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		// Trigger incremental sync.
+		job := helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
+		jobObj := &provisioning.Job{}
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+
+		require.Empty(t, jobObj.Status.Errors,
+			"missing folder metadata should produce warnings, not errors")
+		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State,
+			"incremental sync should finish in warning state when folder metadata is missing")
+		require.NotEmpty(t, jobObj.Status.Warnings,
+			"incremental sync should produce at least one warning for missing folder metadata")
+		requireJobWarningContains(t, jobObj, "missing folder metadata")
+	})
+
+	t.Run("noop incremental sync still detects missing metadata", func(t *testing.T) {
+		helper := runGrafanaWithGitServer(t, withProvisioningFolderMetadata)
+
+		const repoName = "incr-missing-meta-noop"
+
+		// Seed with a folder that has no _folder.json.
+		helper.createGitRepo(t, repoName, map[string][]byte{
+			"myfolder/dashboard.json": dashboardJSON("noop-dash", "Noop Dashboard", 1),
+		})
+
+		// Full sync (should produce a warning about missing metadata).
+		helper.syncAndWait(t, repoName)
+
+		// Trigger incremental sync with no new commits — same ref.
+		job := helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
+		jobObj := &provisioning.Job{}
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+
+		require.Empty(t, jobObj.Status.Errors,
+			"noop incremental sync should not produce errors")
+		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State,
+			"noop incremental sync should still warn about missing folder metadata")
+		require.NotEmpty(t, jobObj.Status.Warnings,
+			"noop incremental sync should still produce warnings for missing folder metadata")
+
+		found := false
+		for _, w := range jobObj.Status.Warnings {
+			if strings.Contains(w, "missing folder metadata") {
+				found = true
+				break
+			}
+		}
+		require.True(t, found,
+			"expected at least one warning containing 'missing folder metadata', got: %v", jobObj.Status.Warnings)
+	})
+}
+
+func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagDisabled(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafanaWithGitServer(t) // no withProvisioningFolderMetadata
+
+	const repoName = "incr-missing-meta-disabled"
+
+	_, local := helper.createGitRepo(t, repoName, map[string][]byte{
+		"dashboard.json": dashboardJSON("disabled-dash", "Root Dashboard", 1),
+	})
+
+	// Full sync.
+	helper.syncAndWait(t, repoName)
+
+	// Add a dashboard inside a folder with no _folder.json.
+	require.NoError(t, local.CreateFile("myfolder/dashboard2.json", string(dashboardJSON("disabled-folder-dash", "Folder Dashboard", 1))))
+	_, err := local.Git("add", ".")
+	require.NoError(t, err)
+	_, err = local.Git("commit", "-m", "add dashboard in folder without metadata")
+	require.NoError(t, err)
+	_, err = local.Git("push")
+	require.NoError(t, err)
+
+	// Trigger incremental sync.
+	job := helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{Incremental: true},
+	})
+	jobObj := &provisioning.Job{}
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+
+	require.Empty(t, jobObj.Status.Errors,
+		"incremental sync with flag disabled should produce no errors")
+	require.Equal(t, provisioning.JobStateSuccess, jobObj.Status.State,
+		"incremental sync should succeed without warnings when flag is disabled")
+
+	// Ensure no warning about missing folder metadata.
+	for _, w := range jobObj.Status.Warnings {
+		require.False(t, strings.Contains(w, "missing folder metadata"),
+			"should not warn about missing folder metadata when flag is disabled, got: %s", w)
+	}
+}

--- a/pkg/tests/apis/provisioning/sync_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/sync_folder_metadata_test.go
@@ -103,6 +103,52 @@ func TestIntegrationProvisioning_FullSync_MissingFolderMetadata_FlagEnabled(t *t
 
 		helper.WaitForConditionReason(t, repo, provisioning.ConditionTypePullStatus, provisioning.ReasonMissingFolderMetadata)
 	})
+
+	t.Run("completed with warnings", func(t *testing.T) {
+		helper := common.RunGrafana(t, withProvisioningFolderMetadata)
+		const repo = "missing-folder-meta-completed-with-warnings"
+		helper.CreateRepo(t, common.TestRepo{
+			Name:   repo,
+			Target: "folder",
+			Copies: map[string]string{
+				// Dashboard in folder without _folder.json → MissingFolderMetadata
+				"testdata/all-panels.json": "myfolder/dashboard.json",
+				// Invalid dashboard at root → ResourceInvalid
+				"testdata/invalid-dashboard-schema.json": "bad-dashboard.json",
+			},
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+
+		job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{},
+		})
+
+		jobObj := &provisioning.Job{}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj)
+		require.NoError(t, err)
+
+		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
+		require.Empty(t, jobObj.Status.Errors)
+
+		// Should have warnings from both missing metadata and invalid resource
+		hasMissingMeta := false
+		hasResourceWarning := false
+		for _, w := range jobObj.Status.Warnings {
+			if strings.Contains(w, "missing folder metadata") {
+				hasMissingMeta = true
+			}
+			if strings.Contains(w, "validation") || strings.Contains(w, "invalid") || strings.Contains(w, "writing resource") {
+				hasResourceWarning = true
+			}
+		}
+		require.True(t, hasMissingMeta, "should have missing folder metadata warning; warnings: %v", jobObj.Status.Warnings)
+		require.True(t, hasResourceWarning, "should have resource validation warning; warnings: %v", jobObj.Status.Warnings)
+
+		// Mixed warning types → CompletedWithWarnings (not MissingFolderMetadata)
+		helper.WaitForConditionReason(t, repo, provisioning.ConditionTypePullStatus, provisioning.ReasonCompletedWithWarnings)
+	})
 }
 
 // TestIntegrationProvisioning_FullSync_MissingFolderMetadata_FlagDisabled verifies that when the

--- a/pkg/tests/apis/provisioning/sync_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/sync_folder_metadata_test.go
@@ -106,7 +106,7 @@ func TestIntegrationProvisioning_FullSync_MissingFolderMetadata_FlagEnabled(t *t
 
 	t.Run("completed with warnings", func(t *testing.T) {
 		helper := common.RunGrafana(t, withProvisioningFolderMetadata)
-		const repo = "missing-folder-meta-completed-with-warnings"
+		const repo = "folder-meta-with-warnings"
 		helper.CreateRepo(t, common.TestRepo{
 			Name:   repo,
 			Target: "folder",
@@ -114,7 +114,7 @@ func TestIntegrationProvisioning_FullSync_MissingFolderMetadata_FlagEnabled(t *t
 				// Dashboard in folder without _folder.json → MissingFolderMetadata
 				"testdata/all-panels.json": "myfolder/dashboard.json",
 				// Invalid dashboard at root → ResourceInvalid
-				"testdata/invalid-dashboard-schema.json": "bad-dashboard.json",
+				"testdata/dashboard-missing-name.json": "bad-dashboard.json",
 			},
 			SkipSync:               true,
 			SkipResourceAssertions: true,


### PR DESCRIPTION
**What is this feature?**

This feature adds missing folder metadata detection to incremental sync. During an incremental sync, after applying file changes, the system now reads the full repository tree and checks whether any folders are missing a `_folder.json` metadata file. For each folder that lacks one, it records a warning in the job progress results. This detection is gated behind the `provisioningFolderMetadata` feature flag.

Additionally, the detection also runs when an incremental sync encounters the `same commit as last time` case (no new changes), ensuring that missing metadata warnings are surfaced even when no files have changed between syncs.

The warning will be shown as follows:
<img width="1528" height="735" alt="image" src="https://github.com/user-attachments/assets/a65bc6a6-2cac-4f8b-9e95-21b8f29997db" />

| File | Change |
  |------|--------|
  | `incremental.go` | Added `folderMetadataEnabled` param to `IncrementalSync`. Added `detectMissingFolderMetadata` function that reads the full tree, finds folders missing `_folder.json`, and records warnings. Called both in the "same commit" early-return path and after applying changes. |
  | `sync.go` | Updated `IncrementalSyncFn` type signature to include `folderMetadataEnabled bool`. Updated `syncer.Sync` to pass `r.folderMetadataEnabled` when calling `incrementalSync`. |
  | `full.go` | Replaced inline `&resources.MissingFolderMetadata{Path: p}` with `resources.NewMissingFolderMetadata(p)` constructor. |
  | `folder_metadata.go` | Added `NewMissingFolderMetadata(path)` constructor. Updated error message to clarify that folder UID will be auto-generated and may change on next sync. |

**Why do we need this feature?**

With the introduction of `_folder.json` metadata files (which assign stable UIDs to folders), repositories that were created before this feature was enabled will have folders without metadata files. Users need visibility into which folders are missing `_folder.json` so they can take action - by triggering a process to generate them. 
Without these warnings, users would have no way of knowing which folders lack stable UIDs, which could lead to inconsistent behaviour when folders are moved, renamed, or synced across environments.

By surfacing these warnings during incremental sync (not just full sync - which has been added as part of https://github.com/grafana/grafana/pull/119880), users get timely feedback on every sync operation, keeping the detection aligned with how full sync already reports the same issue.

**Who is this feature for?**

Users of GitSync

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/902

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
