### PR TITLE
Alerting: Add typesVersions to @grafana/alerting for backwards compat

### DIFF
--- a/packages/grafana-alerting/package.json
+++ b/packages/grafana-alerting/package.json
@@ -22,8 +22,12 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {
     "*": {
-      "unstable": ["dist/types/unstable.d.ts"],
-      "testing": ["dist/types/testing.d.ts"]
+      "unstable": [
+        "dist/types/unstable.d.ts"
+      ],
+      "testing": [
+        "dist/types/testing.d.ts"
+      ]
     }
   },
   "exports": {

--- a/packages/grafana-alerting/package.json
+++ b/packages/grafana-alerting/package.json
@@ -20,6 +20,12 @@
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.mjs",
   "types": "./dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "unstable": ["dist/types/unstable.d.ts"],
+      "testing": ["dist/types/testing.d.ts"]
+    }
+  },
   "exports": {
     "./package.json": "./package.json",
     ".": {


### PR DESCRIPTION
**What is this feature?**

## What

Add `typesVersions` field to `@grafana/alerting` `package.json` for backwards compatibility with consumers using `moduleResolution: "node"`.

## Why

In https://github.com/grafana/grafana/commit/1e82a63e24f757dc46857cb5ffadd45257bfd3eb, the `prepare-npm-package.js` script was cleaned up and stopped generating proxy `package.json` files for subpath exports (e.g. `unstable/package.json`). These proxy files allowed TypeScript with `moduleResolution: "node"` to resolve imports like `@grafana/alerting/unstable`.

Without them, external consumers (like `grafana-assistant-app`) that haven't migrated to `moduleResolution: "bundler"` or `"node16"` get:

> TS2307: Cannot find module '@grafana/alerting/unstable' or its corresponding type declarations.

This is currently blocking https://github.com/grafana/grafana-assistant-app/pull/5332, which updates `@grafana/alerting` from `12.3.0-*` to `13.0.0-*`:
https://github.com/grafana/grafana-assistant-app/actions/runs/22943445321/job/66590105502

## How

`typesVersions` is the standard TypeScript mechanism for resolving subpath types when `exports` can't be used. It's purely additive — consumers with modern module resolution ignore it entirely, as `exports` takes priority.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
