### PR TITLE
Scopes: Re-enable redirects on DashboardSceneRenderer unmount

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -33,6 +33,9 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
   // Disable scope redirects while in edit mode so users aren't navigated away mid-edit.
   useEffect(() => {
     scopesServices?.scopesSelectorService.setRedirectEnabled(!isEditing);
+    return () => {
+      scopesServices?.scopesSelectorService.setRedirectEnabled(true);
+    };
   }, [scopesServices, isEditing]);
 
   const { type } = useParams();

--- a/public/app/features/scopes/tests/editMode.test.ts
+++ b/public/app/features/scopes/tests/editMode.test.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react';
+import { act, cleanup } from '@testing-library/react';
 
 import { config, setBackendSrv } from '@grafana/runtime';
 import { setupMockServer } from '@grafana/test-utils/server';
@@ -147,6 +147,18 @@ describe('setRedirectEnabled', () => {
     await enterEditMode(dashboardScene);
     act(() => {
       dashboardScene.exitEditMode({ skipConfirm: true });
+    });
+
+    expect(spy).toHaveBeenCalledWith(true);
+  });
+
+  it('Re-enables redirects when component unmounts while still in edit mode', async () => {
+    await enterEditMode(dashboardScene);
+
+    const spy = jest.spyOn(scopesSelectorService, 'setRedirectEnabled');
+
+    act(() => {
+      cleanup();
     });
 
     expect(spy).toHaveBeenCalledWith(true);


### PR DESCRIPTION
## Summary

Follow-up to #119402.

Adds a `useEffect` cleanup function to `DashboardSceneRenderer` that calls `setRedirectEnabled(true)` on unmount. Without this, navigating away from a dashboard while still in edit mode would leave scope redirects permanently disabled for the rest of the session.

Also adds a test verifying that `setRedirectEnabled(true)` is called on unmount even when the component is in edit mode at the time.

## Test plan

- [ ] All existing `editMode.test.ts` tests pass
- [ ] New test `Re-enables redirects when component unmounts while still in edit mode` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)