### PR TITLE
CI: Use go.mod instead of go.sum for Go cache key

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -18,4 +18,4 @@ runs:
       with:
         go-version-file: ${{ inputs.go-version-file }}
         cache: ${{ inputs.cache == 'true' }}
-        cache-dependency-path: ${{ inputs.cache == 'true' && '**/*.sum' || '' }}
+        cache-dependency-path: ${{ inputs.cache == 'true' && '**/*.mod' || '' }}


### PR DESCRIPTION
## Summary

Update the reusable `.github/actions/setup-go` action to use `**/*.mod` instead of `**/*.sum` for `cache-dependency-path`.

### Why

`go.sum` is an append-only checksum log — it only grows and never removes entries. This makes it a poor cache key because it causes unnecessary cache misses when entries are added but the actual dependencies haven't changed. `go.mod` accurately represents the dependency graph and is the correct file for cache invalidation.

This aligns with:
- The upstream `actions/setup-go` v6 default change: [actions/setup-go#705](https://github.com/actions/setup-go/pull/705)
- The upstream README update: [actions/setup-go#719](https://github.com/actions/setup-go/pull/719)
- Filippo Valsorda's explanation of why go.sum is not a lockfile: https://words.filippo.io/gosum/

Supersedes #120010.

### Change

One line in `.github/actions/setup-go/action.yml`:

```diff
-        cache-dependency-path: ${{ inputs.cache == 'true' && '**/*.sum' || '' }}
+        cache-dependency-path: ${{ inputs.cache == 'true' && '**/*.mod' || '' }}
```

Since all workflows now use the reusable action, this single change applies everywhere.

## Test plan

- [ ] Verify cache hit behavior on a follow-up push (second run should show `cache-hit: true`)

Made with [Cursor](https://cursor.com)