### PR TITLE
Dashboards: Resolve display names by identity in version history (#119220)

### DIFF
--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -8,7 +8,13 @@ import { SceneComponentProps, SceneObjectBase, sceneGraph } from '@grafana/scene
 import { Alert, Spinner, Stack } from '@grafana/ui';
 import { useGetDisplayMappingQuery } from 'app/api/clients/iam/v0alpha1';
 import { Page } from 'app/core/components/Page/Page';
-import { AnnoKeyMessage, AnnoKeyUpdatedBy, AnnoKeyUpdatedTimestamp, Resource } from 'app/features/apiserver/types';
+import {
+  AnnoKeyCreatedBy,
+  AnnoKeyMessage,
+  AnnoKeyUpdatedBy,
+  AnnoKeyUpdatedTimestamp,
+  Resource,
+} from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import {
   DecoratedRevisionModel,
@@ -127,7 +133,7 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
           item.metadata.annotations?.[AnnoKeyUpdatedTimestamp] ??
           item.metadata.creationTimestamp ??
           new Date().toISOString(),
-        createdBy: item.metadata.annotations?.[AnnoKeyUpdatedBy] ?? '',
+        createdBy: item.metadata.annotations?.[AnnoKeyUpdatedBy] ?? item.metadata.annotations?.[AnnoKeyCreatedBy] ?? '',
         message: item.metadata.annotations?.[AnnoKeyMessage] ?? '',
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         data: item.spec as object,
@@ -197,14 +203,19 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
   const { data: displayData } = useGetDisplayMappingQuery(userKeys.length > 0 ? { key: userKeys } : skipToken);
   const isLoadingUserDisplayNames = userKeys.length > 0 && !displayData;
 
-  // Here replacing raw user ids with human readable names
   const versionsWithDisplayNames = useMemo(() => {
     if (!displayData) {
       return model.versions;
     }
+    const displayMap = new Map<string, string>();
+    for (const item of displayData.display) {
+      displayMap.set(`${item.identity.type}:${item.identity.name}`, item.displayName);
+      if (item.internalId) {
+        displayMap.set(String(item.internalId), item.displayName);
+      }
+    }
     return model.versions.map((version) => {
-      const idx = version.createdBy ? displayData.keys.indexOf(version.createdBy) : -1;
-      const displayName = idx >= 0 ? displayData.display[idx]?.displayName : undefined;
+      const displayName = version.createdBy ? displayMap.get(version.createdBy) : undefined;
       return displayName ? { ...version, createdBy: displayName } : version;
     });
   }, [model.versions, displayData]);


### PR DESCRIPTION
# PATCH PR ON SLOW:

The "Updated By" column in dashboard version history was showing incorrect user names. The IAM display API returns `keys` in request order but `display` items ordered by database ID. The previous index-based lookup between these arrays mapped the wrong display name to the wrong user key.

- Replace index-based array lookup with identity-based Map
- Add regression tests for misaligned display data