### PR TITLE
CI: Trigger backend jobs when setup-go action changes

### DIFF
--- a/.github/actions/change-detection/action.yml
+++ b/.github/actions/change-detection/action.yml
@@ -62,6 +62,7 @@ runs:
             - '!docs/**'
             - '!.github/**'
             - '.github/actions/setup-enterprise/**'
+            - '.github/actions/setup-go/**'
             - '.github/actions/checkout/**'
             - '**/go.mod'
             - '**/go.sum'


### PR DESCRIPTION
## Summary

- Adds `.github/actions/setup-go/**` to the `backend` change-detection file patterns.
- Without this, a PR that only modifies the reusable `setup-go` action would **not** trigger any backend CI jobs (unit tests, integration tests, lint, codegen checks, etc.).
- Placed alongside the existing `setup-enterprise` and `checkout` action patterns for consistency.

## Context

The reusable `.github/actions/setup-go` action was introduced in #119977 to centralise Go caching defaults. The `change-detection` action's `backend` category already watches `setup-enterprise` and `checkout` actions, but was missing `setup-go`.

## Test plan

- [ ] Verify that a PR touching only `.github/actions/setup-go/action.yml` shows `backend=true` in the change-detection output and runs backend jobs.

Made with [Cursor](https://cursor.com)