### PR TITLE
Alerting: Reduce screen real estate used by alerts on rule viewer.

### DIFF
--- a/public/app/features/alerting/unified/components/InhibitionRulesAlert.tsx
+++ b/public/app/features/alerting/unified/components/InhibitionRulesAlert.tsx
@@ -1,7 +1,7 @@
 import { ComponentPropsWithoutRef } from 'react';
 
 import { Trans, t } from '@grafana/i18n';
-import { Alert, TextLink } from '@grafana/ui';
+import { Alert, TextLink, Tooltip } from '@grafana/ui';
 
 import { useHasInhibitionRules } from '../hooks/useHasInhibitionRules';
 import { DOCS_URL_INHIBITION_RULES } from '../utils/docs';
@@ -10,24 +10,44 @@ type ExtraAlertProps = Omit<ComponentPropsWithoutRef<typeof Alert>, 'title' | 's
 
 interface InhibitionRulesAlertProps extends ExtraAlertProps {
   alertmanagerSourceName: string;
+  /** When true, renders a compact header-only alert with the description in a tooltip */
+  compact?: boolean;
 }
 
-export function InhibitionRulesAlert({ alertmanagerSourceName, ...rest }: InhibitionRulesAlertProps) {
+export function InhibitionRulesAlert({ alertmanagerSourceName, compact, ...rest }: InhibitionRulesAlertProps) {
   const { hasInhibitionRules, isLoading } = useHasInhibitionRules(alertmanagerSourceName);
 
   if (isLoading || !hasInhibitionRules) {
     return null;
   }
 
-  return (
-    <Alert title={t('alerting.inhibition-rules.title', 'Inhibition rules are in effect')} severity="warning" {...rest}>
+  const title = t('alerting.inhibition-rules.title', 'Inhibition rules are in effect');
+
+  const body = (
+    <>
       <Trans i18nKey="alerting.inhibition-rules.body">
         This Alertmanager has inhibition rules configured. Some alerts may be suppressed when matching alerts are
         firing.
       </Trans>{' '}
-      <TextLink href={DOCS_URL_INHIBITION_RULES} external>
+      <TextLink href={DOCS_URL_INHIBITION_RULES} external inline>
         <Trans i18nKey="alerting.inhibition-rules.learn-more">Learn more about inhibition rules</Trans>
       </TextLink>
+    </>
+  );
+
+  if (compact) {
+    return (
+      <Tooltip content={body} interactive>
+        <div>
+          <Alert title={title} severity="warning" bottomSpacing={0} topSpacing={0} />
+        </div>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Alert title={title} severity="warning" {...rest}>
+      {body}
     </Alert>
   );
 }

--- a/public/app/features/alerting/unified/components/Provisioning.tsx
+++ b/public/app/features/alerting/unified/components/Provisioning.tsx
@@ -19,21 +19,36 @@ type ExtraAlertProps = Omit<ComponentPropsWithoutRef<typeof Alert>, 'title' | 's
 
 interface ResourceAlertProps extends ExtraAlertProps {
   resource: ProvisionedResource;
+  /** When true, renders a compact header-only alert with the description in a tooltip */
+  compact?: boolean;
 }
 
-export const ProvisioningAlert = ({ resource, ...rest }: ResourceAlertProps) => {
+export const ProvisioningAlert = ({ resource, compact, ...rest }: ResourceAlertProps) => {
+  const title = t('alerting.provisioning.title-provisioned', 'This {{resource}} cannot be edited through the UI', {
+    resource,
+  });
+  const body = t(
+    'alerting.provisioning.body-provisioned',
+    'This {{resource}} has been provisioned, that means it was created by config. Please contact your server admin to update this {{resource}}.',
+    { resource }
+  );
+
+  if (compact) {
+    const compactTitle = t('alerting.provisioning.title-provisioned-compact', 'Provisioned {{resource}}', {
+      resource,
+    });
+    return (
+      <Tooltip content={body}>
+        <div>
+          <Alert title={compactTitle} severity="info" bottomSpacing={0} topSpacing={0} />
+        </div>
+      </Tooltip>
+    );
+  }
+
   return (
-    <Alert
-      title={t('alerting.provisioning.title-provisioned', 'This {{resource}} cannot be edited through the UI', {
-        resource,
-      })}
-      severity="info"
-      {...rest}
-    >
-      <Trans i18nKey="alerting.provisioning.body-provisioned">
-        This {{ resource }} has been provisioned, that means it was created by config. Please contact your server admin
-        to update this {{ resource }}.
-      </Trans>
+    <Alert title={title} severity="info" {...rest}>
+      {body}
     </Alert>
   );
 };

--- a/public/app/features/alerting/unified/components/rule-viewer/Details.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/Details.tsx
@@ -12,9 +12,12 @@ import { GrafanaAlertingRuleDefinition, RulerGrafanaRuleDTO } from 'app/types/un
 
 import { Time } from '../../../../explore/Time';
 import { usePendingPeriod } from '../../hooks/rules/usePendingPeriod';
+import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { makeEditTimeIntervalLink } from '../../utils/misc';
 import { getAnnotations, isPausedRule, prometheusRuleType, rulerRuleType } from '../../utils/rules';
 import { isNullDate } from '../../utils/time';
+import { InhibitionRulesAlert } from '../InhibitionRulesAlert';
+import { ProvisionedResource, ProvisioningAlert } from '../Provisioning';
 import { Tokenize } from '../Tokenize';
 import { DetailText } from '../common/DetailText';
 import { TimingOptionsMeta } from '../notification-policies/Policy';
@@ -43,9 +46,11 @@ const DetailGroup = ({ title, children }: { title?: string; children: React.Reac
 
 interface DetailsProps {
   rule: CombinedRule;
+  isProvisioned?: boolean;
+  showInhibitionRules?: boolean;
 }
 
-export const Details = ({ rule }: DetailsProps) => {
+export const Details = ({ rule, isProvisioned, showInhibitionRules }: DetailsProps) => {
   const styles = useStyles2(getStyles);
 
   const pendingPeriod = usePendingPeriod(rule);
@@ -98,6 +103,10 @@ export const Details = ({ rule }: DetailsProps) => {
   );
   return (
     <div className={styles.metadata}>
+      <Stack direction="column" gap={1}>
+        {isProvisioned && <ProvisioningAlert resource={ProvisionedResource.AlertRule} compact />}
+        {showInhibitionRules && <InhibitionRulesAlert alertmanagerSourceName={GRAFANA_RULES_SOURCE_NAME} compact />}
+      </Stack>
       <DetailGroup>
         <DetailText id="rule-type" label={t('alerting.alert.rule-type', 'Rule type')} value={determinedRuleType} />
         {rulerRuleType.grafana.rule(rule.rulerRule) && (

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -45,12 +45,7 @@ import { getAlertRulesNavId } from '../../navigation/useAlertRulesNav';
 import { PluginOriginBadge } from '../../plugins/PluginOriginBadge';
 import { normalizeHealth, normalizeState } from '../../rule-list/components/util';
 import { Annotation } from '../../utils/constants';
-import {
-  GRAFANA_RULES_SOURCE_NAME,
-  getRulesSourceUid,
-  isGrafanaRulesSource,
-  ruleIdentifierToRuleSourceIdentifier,
-} from '../../utils/datasource';
+import { getRulesSourceUid, isGrafanaRulesSource, ruleIdentifierToRuleSourceIdentifier } from '../../utils/datasource';
 import { labelsSize } from '../../utils/labels';
 import { makeDashboardLink, makePanelLink, stringifyErrorLike } from '../../utils/misc';
 import { createListFilterLink, groups } from '../../utils/navigation';
@@ -64,8 +59,6 @@ import {
   rulerRuleType,
 } from '../../utils/rules';
 import { AlertingPageWrapper } from '../AlertingPageWrapper';
-import { InhibitionRulesAlert } from '../InhibitionRulesAlert';
-import { ProvisionedResource, ProvisioningAlert } from '../Provisioning';
 import { WithReturnButton } from '../WithReturnButton';
 import { decodeGrafanaNamespace } from '../expressions/util';
 import { RedirectToCloneRule } from '../rules/CloneRule';
@@ -147,10 +140,6 @@ const RuleViewer = () => {
           {/* alerts and notifications and stuff */}
           {isPaused && <InfoPausedRule />}
           {isFederatedRule && <FederatedRuleWarning />}
-          {/* indicator for rules in a provisioned group */}
-          {isProvisioned && (
-            <ProvisioningAlert resource={ProvisionedResource.AlertRule} bottomSpacing={0} topSpacing={2} />
-          )}
           {/* error state */}
           {showError && (
             <Alert
@@ -170,10 +159,6 @@ const RuleViewer = () => {
       }
     >
       {shouldUseConsistencyCheck && <PrometheusConsistencyCheck ruleIdentifier={identifier} />}
-      {/* Show inhibition rules alert only for Grafana-managed rules */}
-      {isGrafanaRulesSource(namespace.rulesSource) && (
-        <InhibitionRulesAlert alertmanagerSourceName={GRAFANA_RULES_SOURCE_NAME} />
-      )}
       <div className={styles.layout}>
         <Stack direction="column" gap={2}>
           {/* tabs and tab content */}
@@ -196,7 +181,11 @@ const RuleViewer = () => {
           </TabContent>
         </Stack>
         <aside className={styles.sidebar}>
-          <Details rule={rule} />
+          <Details
+            rule={rule}
+            isProvisioned={isProvisioned}
+            showInhibitionRules={isGrafanaRulesSource(namespace.rulesSource)}
+          />
         </aside>
       </div>
       {duplicateRuleIdentifier && (

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2531,7 +2531,8 @@
       "body-provisioned": "This {{resource}} has been provisioned, that means it was created by config. Please contact your server admin to update this {{resource}}.",
       "title-imported": "This {{resource}} was imported and cannot be edited through the UI",
       "title-imported-time-interval": "This time interval was imported and cannot be edited through the UI",
-      "title-provisioned": "This {{resource}} cannot be edited through the UI"
+      "title-provisioned": "This {{resource}} cannot be edited through the UI",
+      "title-provisioned-compact": "Provisioned {{resource}}"
     },
     "provisioning-badge": {
       "badge": {


### PR DESCRIPTION
When both the provisioned and inhibition-rules alerts are active, they clutter
the rule viewer, and as they can't be dismissed, distract from the content of
the page.

This change shrinks them and puts them in the Details side bar.

Before:

<img width="1642" height="1045" alt="Screenshot from 2026-03-11 11-20-00" src="https://github.com/user-attachments/assets/36c6bd19-c4dc-4ec1-9c73-0474092f8c66" />

After:

<img width="1642" height="1045" alt="Screenshot from 2026-03-11 11-05-32" src="https://github.com/user-attachments/assets/451415e5-d54d-4288-a881-94138fe11563" />
<img width="1642" height="1045" alt="Screenshot from 2026-03-11 11-05-40" src="https://github.com/user-attachments/assets/48d82638-0ab9-43f4-9f43-e32b43af1526" />
<img width="1642" height="1045" alt="Screenshot from 2026-03-11 11-05-44" src="https://github.com/user-attachments/assets/11498dc2-ba05-4678-ab1f-96a4bcb2d77f" />
