### PR TITLE
CI: Revert cache-dependency-path to **/*.sum

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -18,4 +18,10 @@ runs:
       with:
         go-version-file: ${{ inputs.go-version-file }}
         cache: ${{ inputs.cache == 'true' }}
+        # We intentionally use **/*.sum rather than **/*.mod here.
+        # go.sum is append-only so it changes often, causing frequent cache misses.
+        # This is desirable: actions/cache only saves on miss, so frequent misses
+        # keep the cache complete across all shards and dependencies (~2.5 GB).
+        # Using go.mod (which changes rarely) leads to a single shard seeding a
+        # small cache that never gets updated.
         cache-dependency-path: ${{ inputs.cache == 'true' && '**/*.sum' || '' }}

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -18,4 +18,4 @@ runs:
       with:
         go-version-file: ${{ inputs.go-version-file }}
         cache: ${{ inputs.cache == 'true' }}
-        cache-dependency-path: ${{ inputs.cache == 'true' && '**/*.mod' || '' }}
+        cache-dependency-path: ${{ inputs.cache == 'true' && '**/*.sum' || '' }}


### PR DESCRIPTION
## Summary

Reverts the change from #120023 that switched `cache-dependency-path` from `**/*.sum` to `**/*.mod` in the reusable `setup-go` action.

## Why

After #120023 merged, the Go module cache dropped from ~2.5 GB to ~433 MB. The root cause:

1. Changing the cache key pattern invalidated all existing cache entries.
2. `actions/cache` only saves on **cache miss** -- it does NOT update on cache hit.
3. The new cache was seeded by a single shard that only downloaded the dependencies it needed (~433 MB).
4. All subsequent jobs hit this small cache and never save, so it stays at 433 MB.

While `go.sum` is theoretically a poor cache key (append-only, changes frequently), its frequent invalidation is actually **beneficial**: it triggers regular cache rebuilds that keep the cache complete across all shards and dependencies.

## Change

```diff
-        cache-dependency-path: ${{ inputs.cache == 'true' && '**/*.mod' || '' }}
+        cache-dependency-path: ${{ inputs.cache == 'true' && '**/*.sum' || '' }}
```

## Test plan

- [ ] Verify cache restores ~2.5 GB after a couple of runs with `go.sum` changes.

Made with [Cursor](https://cursor.com)