### PR TITLE
Alerting: Add learning from corrections guideline to AGENTS.md

### DIFF
--- a/public/app/features/alerting/unified/AGENTS.md
+++ b/public/app/features/alerting/unified/AGENTS.md
@@ -553,6 +553,16 @@ gh pr view 67890
 gh pr diff 67890
 ```
 
+## Learning from Corrections
+
+When the user corrects a mistake you made (wrong API, wrong pattern, wrong approach), assess whether the correction represents a recurring pattern worth documenting. If so, propose a concise addition to this AGENTS.md — but do **NOT** apply it without explicit approval.
+
+Skip proposing an update if the correction is:
+
+- A one-off or highly context-specific fix
+- Already documented in this file
+- A personal preference rather than a project convention
+
 ## Getting Help
 
 - Check patterns in existing `components/` code


### PR DESCRIPTION
**What is this feature?**

## Summary

Add a "Learning from Corrections" section to the alerting AGENTS.md that instructs agents to propose updates to the file when a developer corrects a recurring mistake during vibe coding.

## Details

- Agents should assess whether a correction represents a recurring pattern worth documenting
- Updates are only **proposed**, never auto-applied => the developer must explicitly approve
- Skip proposing if the correction is a one-off, already documented, or a personal preference

## Motivation

Turns developer corrections into persistent knowledge, creating a feedback loop that prevents the same mistakes from recurring across sessions while keeping the developer in control of what gets documented.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
