### PR TITLE
Combobox: Not found label is not truncated with auto size

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -329,6 +329,16 @@ describe('Combobox', () => {
 
       expect(initialWidth).toBe(newWidth);
     });
+
+    it('should show "No options found" when filtering returns no results', async () => {
+      render(<Combobox options={options} value={null} onChange={onChangeHandler} width="auto" minWidth={2} />);
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      await user.type(input, 'zzz');
+
+      expect(screen.getByText('No options found.')).toBeInTheDocument();
+    });
   });
 
   describe('with a value already selected', () => {

--- a/packages/grafana-ui/src/components/Combobox/MessageRows.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MessageRows.tsx
@@ -16,9 +16,11 @@ export const AsyncError = () => (
   </MessageRow>
 );
 
+export const NO_OPTIONS_I18N_KEY = 'combobox.options.no-found';
+
 export const NotFoundError = () => (
   <MessageRow>
-    <Trans i18nKey="combobox.options.no-found">No options found.</Trans>
+    <Trans i18nKey={NO_OPTIONS_I18N_KEY}>No options found.</Trans>
   </MessageRow>
 );
 

--- a/packages/grafana-ui/src/components/Combobox/useComboboxFloat.ts
+++ b/packages/grafana-ui/src/components/Combobox/useComboboxFloat.ts
@@ -1,9 +1,12 @@
 import { autoUpdate, autoPlacement, size, useFloating } from '@floating-ui/react';
 import { useMemo, useRef, useState } from 'react';
 
+import { t } from '@grafana/i18n';
+
 import { BOUNDARY_ELEMENT_ID } from '../../utils/floating';
 import { measureText } from '../../utils/measureText';
 
+import { NO_OPTIONS_I18N_KEY } from './MessageRows';
 import {
   MENU_ITEM_DESCRIPTION_FONT_SIZE,
   MENU_ITEM_FONT_SIZE,
@@ -24,6 +27,9 @@ const SCROLL_CONTAINER_PADDING = 8;
 
 // 16px svg width + 12px Icon padding
 const ICON_WIDTH = 28;
+
+// MessageRow uses Box padding={2} = theme.spacing(2) = 16px each side
+const MESSAGE_ROW_PADDING = 32;
 
 export const useComboboxFloat = (items: Array<ComboboxOption<string | number>>, isOpen: boolean) => {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -92,7 +98,12 @@ export const useComboboxFloat = (items: Array<ComboboxOption<string | number>>, 
     const iconSize = longestLabelIndex > -1 && items[longestLabelIndex].icon ? ICON_WIDTH : 0;
 
     const textWidth = Math.max(labelWidth + iconSize, descriptionWidth);
-    return textWidth + SCROLL_CONTAINER_PADDING + MENU_ITEM_PADDING * 2 + scrollbarWidth;
+    const itemWidth = textWidth + SCROLL_CONTAINER_PADDING + MENU_ITEM_PADDING * 2 + scrollbarWidth;
+
+    const noOptionsText = t(NO_OPTIONS_I18N_KEY, 'No options found.');
+    const noOptionsWidth = measureText(noOptionsText, MENU_ITEM_FONT_SIZE).width + MESSAGE_ROW_PADDING + scrollbarWidth;
+
+    return Math.max(itemWidth, noOptionsWidth);
   }, [items, scrollbarWidth]);
 
   const floatStyles = {


### PR DESCRIPTION
**What is this feature?**

This pull request improves the Combobox component by ensuring the "No options found" message is properly displayed and sized when filtering yields no results. The changes enhance both user experience and internationalization support.

**Why do we need this feature?**

So the `Not found label` isn't truncated.

**Who is this feature for?**

Everyone using Combobox

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #120009

**Special notes for your reviewer:**

**Before**

https://github.com/user-attachments/assets/d1d9417c-4868-43d0-a93e-56884d9567c7


**After**

https://github.com/user-attachments/assets/74ce4536-8b4b-43d1-ab5f-d6205c2fb988


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
