### PR TITLE
Chore: Add typesVersions to @grafana/api-clients for backwards compat

### DIFF
--- a/packages/grafana-api-clients/package.json
+++ b/packages/grafana-api-clients/package.json
@@ -17,6 +17,61 @@
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.mjs",
   "types": "./dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "rtkq": [
+        "dist/types/clients/rtkq/index.d.ts"
+      ],
+      "rtkq/advisor/v0alpha1": [
+        "dist/types/clients/rtkq/advisor/v0alpha1/index.d.ts"
+      ],
+      "rtkq/collections/v1alpha1": [
+        "dist/types/clients/rtkq/collections/v1alpha1/index.d.ts"
+      ],
+      "rtkq/correlations/v0alpha1": [
+        "dist/types/clients/rtkq/correlations/v0alpha1/index.d.ts"
+      ],
+      "rtkq/dashboard/v0alpha1": [
+        "dist/types/clients/rtkq/dashboard/v0alpha1/index.d.ts"
+      ],
+      "rtkq/folder/v1beta1": [
+        "dist/types/clients/rtkq/folder/v1beta1/index.d.ts"
+      ],
+      "rtkq/iam/v0alpha1": [
+        "dist/types/clients/rtkq/iam/v0alpha1/index.d.ts"
+      ],
+      "rtkq/playlist/v1": [
+        "dist/types/clients/rtkq/playlist/v1/index.d.ts"
+      ],
+      "rtkq/preferences/v1alpha1": [
+        "dist/types/clients/rtkq/preferences/v1alpha1/index.d.ts"
+      ],
+      "rtkq/provisioning/v0alpha1": [
+        "dist/types/clients/rtkq/provisioning/v0alpha1/index.d.ts"
+      ],
+      "rtkq/shorturl/v1beta1": [
+        "dist/types/clients/rtkq/shorturl/v1beta1/index.d.ts"
+      ],
+      "rtkq/notifications.alerting/v0alpha1": [
+        "dist/types/clients/rtkq/notifications.alerting/v0alpha1/index.d.ts"
+      ],
+      "rtkq/rules.alerting/v0alpha1": [
+        "dist/types/clients/rtkq/rules.alerting/v0alpha1/index.d.ts"
+      ],
+      "rtkq/historian.alerting/v0alpha1": [
+        "dist/types/clients/rtkq/historian.alerting/v0alpha1/index.d.ts"
+      ],
+      "rtkq/logsdrilldown/v1alpha1": [
+        "dist/types/clients/rtkq/logsdrilldown/v1alpha1/index.d.ts"
+      ],
+      "rtkq/logsdrilldown/v1beta1": [
+        "dist/types/clients/rtkq/logsdrilldown/v1beta1/index.d.ts"
+      ],
+      "rtkq/quotas/v0alpha1": [
+        "dist/types/clients/rtkq/quotas/v0alpha1/index.d.ts"
+      ]
+    }
+  },
   "exports": {
     "./package.json": "./package.json",
     ".": {


### PR DESCRIPTION
**What is this feature?**

Add `typesVersions` field to `@grafana/api-clients` `package.json` for backwards compatibility with consumers using `moduleResolution: "node"`.

**Why do we need this feature?**

Same issue as https://github.com/grafana/grafana/pull/120020 but for `@grafana/api-clients`.

In https://github.com/grafana/grafana/commit/1e82a63e24f757dc46857cb5ffadd45257bfd3eb, the `prepare-npm-package.js` script stopped generating proxy `package.json` files for subpath exports. Without them, TypeScript with `moduleResolution: "node"` can't resolve subpath imports like `@grafana/api-clients/rtkq/notifications.alerting/v0alpha1`.

This causes a cascading type failure: `@grafana/alerting`'s `ContactPoint` type depends on `Receiver` from `@grafana/api-clients/rtkq/notifications.alerting/v0alpha1`. When that import can't be resolved, `Receiver` becomes unresolvable and `ContactPoint` collapses to `never`, causing 30 type errors in consumer code.

This is currently blocking https://github.com/grafana/grafana-assistant-app/pull/5332:
https://github.com/grafana/grafana-assistant-app/actions/runs/22948865082/job/66608192078

### How

`typesVersions` is the standard TypeScript fallback for resolving subpath types when `exports` can't be used. It's purely additive — consumers with modern module resolution (`bundler`, `node16`, `nodenext`) ignore it entirely, as `exports` takes priority.

Added entries for all 17 subpath exports that have published type declarations.


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
