### PR TITLE
Zanzana: Fix missing cache update in GetStore

### DIFF
--- a/pkg/services/authz/zanzana/server/server_store.go
+++ b/pkg/services/authz/zanzana/server/server_store.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -19,42 +20,52 @@ func (s *Server) GetOrCreateStore(ctx context.Context, namespace string) (*zanza
 }
 
 func (s *Server) getStoreInfo(ctx context.Context, namespace string) (*zanzana.StoreInfo, error) {
-	s.storesMU.Lock()
-	defer s.storesMU.Unlock()
-	info, ok := s.stores[namespace]
-	if ok {
-		return &info, nil
-	}
-
-	store, err := s.getOrCreateStore(ctx, namespace)
-	if err != nil {
+	info, err := s.GetStore(ctx, namespace)
+	if err != nil && !errors.Is(err, zanzana.ErrStoreNotFound) {
 		return nil, err
 	}
 
-	modelID, err := s.loadModel(ctx, store.GetId(), schema.SchemaModules)
-	if err != nil {
-		return nil, err
+	if errors.Is(err, zanzana.ErrStoreNotFound) {
+		createStoreRes, err := s.openFGAClient.CreateStore(ctx, &openfgav1.CreateStoreRequest{Name: namespace})
+		if err != nil {
+			return nil, err
+		}
+
+		info = &zanzana.StoreInfo{
+			ID:   createStoreRes.GetId(),
+			Name: createStoreRes.GetName(),
+		}
+
+		s.storesMU.Lock()
+		s.stores[namespace] = *info
+		s.storesMU.Unlock()
 	}
 
-	info = zanzana.StoreInfo{
-		ID:      store.GetId(),
-		Name:    store.GetName(),
-		ModelID: modelID,
+	if info.ModelID == "" {
+		modelID, err := s.loadModel(ctx, info.ID, schema.SchemaModules)
+		if err != nil {
+			return nil, err
+		}
+
+		s.storesMU.Lock()
+		info.ModelID = modelID
+		s.stores[namespace] = *info
+		s.storesMU.Unlock()
 	}
 
-	s.stores[namespace] = info
-
-	return &info, nil
+	return info, nil
 }
 
 func (s *Server) GetStore(ctx context.Context, namespace string) (*zanzana.StoreInfo, error) {
 	s.storesMU.Lock()
 	defer s.storesMU.Unlock()
+
 	info, ok := s.stores[namespace]
 	if ok {
 		return &zanzana.StoreInfo{
-			ID:   info.ID,
-			Name: info.Name,
+			ID:      info.ID,
+			Name:    info.Name,
+			ModelID: info.ModelID,
 		}, nil
 	}
 
@@ -63,39 +74,23 @@ func (s *Server) GetStore(ctx context.Context, namespace string) (*zanzana.Store
 		return nil, fmt.Errorf("failed to load zanzana stores: %w", err)
 	}
 
-	for _, s := range res.GetStores() {
-		if s.GetName() == namespace {
+	for _, store := range res.GetStores() {
+		if store.GetName() == namespace {
+			info = zanzana.StoreInfo{
+				ID:   store.GetId(),
+				Name: store.GetName(),
+			}
+
+			s.stores[namespace] = info
+
 			return &zanzana.StoreInfo{
-				ID:   s.GetId(),
-				Name: s.GetName(),
+				ID:   info.ID,
+				Name: info.Name,
 			}, nil
 		}
 	}
 
 	return nil, zanzana.ErrStoreNotFound
-}
-
-func (s *Server) getOrCreateStore(ctx context.Context, namespace string) (*openfgav1.Store, error) {
-	res, err := s.openFGAClient.ListStores(ctx, &openfgav1.ListStoresRequest{Name: namespace})
-	if err != nil {
-		return nil, fmt.Errorf("failed to load zanzana stores: %w", err)
-	}
-
-	for _, s := range res.GetStores() {
-		if s.GetName() == namespace {
-			return s, nil
-		}
-	}
-
-	createStoreRes, err := s.openFGAClient.CreateStore(ctx, &openfgav1.CreateStoreRequest{Name: namespace})
-	if err != nil {
-		return nil, err
-	}
-
-	return &openfgav1.Store{
-		Id:   createStoreRes.GetId(),
-		Name: createStoreRes.GetName(),
-	}, nil
 }
 
 func (s *Server) loadModel(ctx context.Context, storeID string, modules []transformer.ModuleFile) (string, error) {

--- a/pkg/services/authz/zanzana/server/server_store_test.go
+++ b/pkg/services/authz/zanzana/server/server_store_test.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/authz/zanzana"
+)
+
+func TestGetStore_Cache(t *testing.T) {
+	srv := setupOpenFGAServer(t)
+	ctx := context.Background()
+	testNamespace := "test-cache-namespace"
+
+	// 1. Create the store first so it exists in OpenFGA
+	store, err := srv.GetOrCreateStore(ctx, testNamespace)
+	require.NoError(t, err)
+	require.NotNil(t, store)
+
+	// 2. Clear the in-memory cache to simulate a fresh start or a different pod
+	srv.storesMU.Lock()
+	delete(srv.stores, testNamespace)
+	srv.storesMU.Unlock()
+
+	// 3. Call GetStore. This should trigger a ListStores call and then CACHE the result.
+	store1, err := srv.GetStore(ctx, testNamespace)
+	require.NoError(t, err)
+	require.Equal(t, store.ID, store1.ID)
+
+	// 4. Verify it's now in the cache
+	srv.storesMU.Lock()
+	info, ok := srv.stores[testNamespace]
+	srv.storesMU.Unlock()
+	require.True(t, ok, "Store should be in cache after GetStore call")
+	require.Equal(t, store.ID, info.ID)
+
+	// 5. Call GetStore again. This should now return from cache.
+	store2, err := srv.GetStore(ctx, testNamespace)
+	require.NoError(t, err)
+	require.Equal(t, store.ID, store2.ID)
+}
+
+func TestGetOrCreateStore_FullFlow(t *testing.T) {
+	srv := setupOpenFGAServer(t)
+	ctx := context.Background()
+	testNamespace := "test-full-flow-namespace"
+
+	// 1. Call GetStore for a non-existent namespace
+	_, err := srv.GetStore(ctx, testNamespace)
+	require.ErrorIs(t, err, zanzana.ErrStoreNotFound)
+
+	// 2. Call GetOrCreateStore (should create store + load model + cache)
+	store, err := srv.GetOrCreateStore(ctx, testNamespace)
+	require.NoError(t, err)
+	require.NotEmpty(t, store.ID)
+	require.NotEmpty(t, store.ModelID)
+
+	// 3. Verify cache is fully populated
+	srv.storesMU.Lock()
+	info, ok := srv.stores[testNamespace]
+	srv.storesMU.Unlock()
+	require.True(t, ok)
+	require.Equal(t, store.ID, info.ID)
+	require.Equal(t, store.ModelID, info.ModelID)
+
+	// 4. Simulate cache having only ID/Name (e.g. from a previous GetStore call)
+	srv.storesMU.Lock()
+	srv.stores[testNamespace] = zanzana.StoreInfo{ID: store.ID, Name: testNamespace}
+	srv.storesMU.Unlock()
+
+	// 5. Call GetOrCreateStore again (should lazy-load ModelID)
+	store2, err := srv.GetOrCreateStore(ctx, testNamespace)
+	require.NoError(t, err)
+	require.Equal(t, store.ModelID, store2.ModelID)
+
+	// 6. Verify cache is now updated with ModelID
+	srv.storesMU.Lock()
+	info2, ok := srv.stores[testNamespace]
+	srv.storesMU.Unlock()
+	require.True(t, ok)
+	require.Equal(t, store.ModelID, info2.ModelID)
+}


### PR DESCRIPTION
## Summary
This PR fixes a bug in the `GetStore` logic where discovered stores were not being added to the in-memory cache. 

### Problem
When `EnsureNamespace` calls `GetStore`, if the store isn't in the in-memory map, it calls `ListStores` on OpenFGA. If it finds the store there, it returns it but forgets to add it to the in-memory map. This causes every subsequent `Check` request for the same namespace to trigger another `ListStores` call. In environments with many namespaces or frequent restarts, this leads to a massive volume of reads and unnecessary reconciliation cycles.

### Solution
- Updated `GetStore` to cache the `ID` and `Name` in the `s.stores` map after a successful `ListStores` lookup.
- Added a regression test in `server_store_test.go` to verify the fix.

## Test plan
- Run the new regression test: `go test -v ./pkg/services/authz/zanzana/server/ -run TestGetStore_Cache`
- Manual verification: Observe reduced `ListStores` calls in OpenFGA logs after the first discovery of a namespace.

