### PR TITLE
Fix flaky integration tests by retrying health check on startup

### DIFF
--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -200,8 +200,13 @@ func StartGrafanaEnvWithDB(t *testing.T, grafDir, cfgPath string) (string, *serv
 		if resp != nil {
 			resp.Body.Close()
 		}
-		if err == nil && resp.StatusCode == 200 {
+		if err == nil && resp != nil && resp.StatusCode == 200 {
 			break
+		}
+		if err != nil {
+			t.Logf("Health check error: %v", err)
+		} else if resp != nil {
+			t.Logf("Health check returned status %d", resp.StatusCode)
 		}
 		if time.Now().After(deadline) {
 			t.Fatal("Grafana health endpoint did not return 200 within 30s")

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -190,16 +190,24 @@ func StartGrafanaEnvWithDB(t *testing.T, grafDir, cfgPath string) (string, *serv
 		}
 	})
 
-	// Wait for Grafana to be ready
+	// Wait for Grafana to be ready, retrying until the health endpoint responds or the timeout is reached.
 	addr := listener.Addr().String()
-	resp, err := http.Get(fmt.Sprintf("http://%s/api/health", addr))
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	t.Cleanup(func() {
-		err := resp.Body.Close()
-		assert.NoError(t, err)
-	})
-	require.Equal(t, 200, resp.StatusCode)
+	healthURL := fmt.Sprintf("http://%s/api/health", addr)
+	healthClient := &http.Client{Timeout: 2 * time.Second}
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		resp, err := healthClient.Get(healthURL)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if err == nil && resp.StatusCode == 200 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("Grafana health endpoint did not return 200 within 30s")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 
 	t.Logf("Grafana is listening on %s", addr)
 

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -198,7 +198,7 @@ func StartGrafanaEnvWithDB(t *testing.T, grafDir, cfgPath string) (string, *serv
 	for {
 		resp, err := healthClient.Get(healthURL)
 		if resp != nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 		}
 		if err == nil && resp != nil && resp.StatusCode == 200 {
 			break


### PR DESCRIPTION
## Summary
- `StartGrafanaEnvWithDB` in `pkg/tests/testinfra/testinfra.go` used a single `http.Get` with no timeout or retry to check `/api/health`, causing tests to hang indefinitely if the server wasn't ready yet
- Replace with a retry loop (100ms interval, 30s deadline, 2s per-request timeout)
- Fixes flaky timeout in `TestIntegrationProvisioning_SyncQuotaHandling` observed in CI

## Test plan
- [ ] Existing integration tests in `pkg/tests/apis/provisioning` pass
- [ ] No behavioral change for tests where the server starts quickly (retry loop exits on first attempt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)