### PR TITLE
CI: Run setup-enterprise before setup-go

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -91,12 +91,14 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:
           github-app-name: 'grafana-ci-bot'
+      # Enterprise must be cloned before setup-go so that enterprise
+      # modules are visible when the Go cache key is computed.
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
 
       # Prepare what we need to upload test results
       - run: echo "RESULTS_FILE=$(date --rfc-3339=seconds --utc | sed -s 's/ /-/g')_${SHARD/\//_}.xml" >> "$GITHUB_ENV"

--- a/.github/workflows/pr-go-workspace-check.yml
+++ b/.github/workflows/pr-go-workspace-check.yml
@@ -72,12 +72,14 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Setup Go
-      uses: ./.github/actions/setup-go
-
     - name: Setup Enterprise
       if: github.event.pull_request.head.repo.fork == false
       uses: ./.github/actions/setup-enterprise
+
+    # Enterprise must be cloned before setup-go so that enterprise
+    # modules are visible when the Go cache key is computed.
+    - name: Setup Go
+      uses: ./.github/actions/setup-go
 
     - name: Calculate generated wire checksums
       id: pre_gen_oss

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -260,12 +260,14 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:
           github-app-name: 'grafana-ci-bot'
+      # Enterprise must be cloned before setup-go so that enterprise
+      # modules are visible when the Go cache key is computed.
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
       - name: Run tests
         if: matrix.shard != 'profiled'
         env:
@@ -374,12 +376,14 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:
           github-app-name: 'grafana-ci-bot'
+      # Enterprise must be cloned before setup-go so that enterprise
+      # modules are visible when the Go cache key is computed.
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
       - name: Setup MySQL devenv
         run: mysql -h 127.0.0.1 -P 3306 -u root -prootpass < devenv/docker/blocks/mysql_tests/setup.sql
       - name: Run tests
@@ -424,12 +428,14 @@ jobs:
       - name: Start Postgres via docker compose
         run: |
           make devenv sources=postgres_tests
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:
           github-app-name: 'grafana-ci-bot'
+      # Enterprise must be cloned before setup-go so that enterprise
+      # modules are visible when the Go cache key is computed.
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
       - name: Setup Postgres devenv
         run: psql -p 5432 -h 127.0.0.1 -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
       - name: Run tests

--- a/.github/workflows/swagger-gen.yml
+++ b/.github/workflows/swagger-gen.yml
@@ -48,13 +48,15 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
       - name: Setup Enterprise
         if: ${{ github.event.pull_request.head.repo.fork == false }}
         uses: ./.github/actions/setup-enterprise
         with:
           github-app-name: 'grafana-ci-bot'
+      # Enterprise must be cloned before setup-go so that enterprise
+      # modules are visible when the Go cache key is computed.
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
 
       - name: Generate Swagger specs
         run: make swagger-clean && make openapi3-gen


### PR DESCRIPTION
## Summary

Swap the order of `setup-enterprise` and `setup-go` in enterprise CI jobs so that the enterprise repo is cloned **before** Go is set up. This way `setup-go` sees enterprise modules when computing the cache key and resolving dependencies.

## Why

Currently the cache is split by runner type because `GOMODCACHE` and `GOCACHE` live at different paths on different runners:

| Runner | Home | Cache restored |
|--------|------|----------------|
| `ubuntu-latest` (go-fmt, lint) | `/home/runner/` | ~1.5 GB (complete) |
| `ubuntu-x64-large-io` (enterprise tests) | `/home/ubuntu/` | ~433 MB (incomplete) |

Same cache key hash, but different cache entries because the paths differ.

After enterprise integration tests run, the actual cache grows to:
- **GOMODCACHE: 4.2G** (up from 755M restored)
- **GOCACHE: 5.3G** (up from 560M restored)

By cloning enterprise first, `setup-go` can see enterprise `go.sum`/`go.mod` files when computing the cache key, and enterprise dependencies may be included in the cache from the start.

## Workflows changed (5 jobs across 4 files)

| Workflow | Job |
|----------|-----|
| `pr-test-integration.yml` | sqlite-enterprise, mysql-enterprise, postgres-enterprise |
| `backend-unit-tests.yml` | grafana-enterprise |
| `swagger-gen.yml` | swagger-gen |
| `pr-go-workspace-check.yml` | wire-check |

## Not changed

- **`backend-code-checks.yml`** -- has Go-dependent steps (code generation, `go.mod` validation) between `setup-go` and `setup-enterprise`, so the swap is not possible there.

## Risk

If the enterprise `build.sh` requires Go to be installed, this will fail. CI will tell us.

## Test plan

- [ ] Verify enterprise CI jobs still pass (`build.sh` doesn't need Go)
- [ ] Compare cache sizes before/after to see if enterprise deps are now included