### PR TITLE
unified-storage: Disable pruner in sqlite tests

### DIFF
--- a/pkg/server/search_server_distributor_test.go
+++ b/pkg/server/search_server_distributor_test.go
@@ -403,6 +403,7 @@ func createBaselineServer(t *testing.T, dbType, dbConnStr string, testNamespaces
 	require.NoError(t, err)
 	searchOpts, err := search.NewSearchOptions(features, cfg, docBuilders, nil, nil)
 	require.NoError(t, err)
+	cfg.DisablePruner = dbType == "sqlite3"
 	backend, err := sql.NewStorageBackend(cfg, nil, nil, nil, tracer, false)
 	require.NoError(t, err)
 	backendService := backend.(services.Service)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -676,6 +676,7 @@ type Cfg struct {
 
 	// SimulatedNetworkLatency is used for testing only
 	SimulatedNetworkLatency       time.Duration
+	DisablePruner                 bool
 	TenantApiServerAddress        string
 	TenantWatcherAllowInsecureTLS bool
 	TenantWatcherCAFile           string

--- a/pkg/storage/unified/apistore/watcher_test.go
+++ b/pkg/storage/unified/apistore/watcher_test.go
@@ -144,6 +144,7 @@ func testSetup(t testing.TB, opts ...setupOption) (context.Context, storage.Inte
 		ret, err := sql.NewBackend(sql.BackendOptions{
 			DBProvider:      eDB,
 			PollingInterval: time.Millisecond, // Keep this fast
+			DisablePruner:   infraDB.IsTestDbSQLite(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, ret)

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -117,6 +117,7 @@ func NewStorageBackend(
 			SimulatedNetworkLatency: cfg.SimulatedNetworkLatency,
 			MigrationParquetBuffer:  cfg.MigrationParquetBuffer,
 			DisableStorageServices:  disableStorageServices,
+			DisablePruner:           cfg.DisablePruner,
 		})
 	}
 
@@ -199,6 +200,7 @@ type BackendOptions struct {
 	GarbageCollection GarbageCollectionConfig
 
 	DisableStorageServices bool
+	DisablePruner          bool
 
 	// When true, bulk migrations buffer data through a temporary Parquet file
 	MigrationParquetBuffer bool
@@ -225,6 +227,7 @@ func NewBackend(opts BackendOptions) (Backend, error) {
 	backend := &backend{
 		isHA:                    opts.IsHA,
 		disableStorageServices:  opts.DisableStorageServices,
+		disablePruner:           opts.DisablePruner,
 		done:                    ctx.Done(),
 		cancel:                  cancel,
 		log:                     logging.DefaultLogger.With("logger", "sql-resource-server"),
@@ -287,6 +290,7 @@ type backend struct {
 	// testing
 	simulatedNetworkLatency time.Duration
 
+	disablePruner bool
 	historyPruner resource.Pruner
 
 	garbageCollection GarbageCollectionConfig
@@ -369,6 +373,12 @@ func (b *backend) initLocked(ctx context.Context) error {
 }
 
 func (b *backend) initPruner(ctx context.Context) error {
+	if b.disablePruner {
+		b.log.Debug("pruner disabled, using noop pruner")
+		b.historyPruner = &resource.NoopPruner{}
+		return nil
+	}
+
 	b.log.Debug("using debounced history pruner")
 	// Initialize history pruner.
 	pruner, err := debouncer.NewGroup(debouncer.DebouncerOpts[resource.PruningKey]{

--- a/pkg/storage/unified/sql/backend_gc_test.go
+++ b/pkg/storage/unified/sql/backend_gc_test.go
@@ -391,6 +391,7 @@ func newTestBackend(t *testing.T, gcConfig GarbageCollectionConfig) (resource.St
 	backend, err := NewBackend(BackendOptions{
 		DBProvider:           eDB,
 		IsHA:                 false,
+		DisablePruner:        db.IsTestDbSQLite(),
 		LastImportTimeMaxAge: 24 * time.Hour,
 		GarbageCollection:    gcConfig,
 	})

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -59,6 +59,7 @@ func newTestBackend(t *testing.T, isHA bool, simulatedNetworkLatency time.Durati
 	cfg.EnableSQLKVBackend = false
 	cfg.MaxFileIndexAge = 24 * time.Hour
 	cfg.SimulatedNetworkLatency = simulatedNetworkLatency
+	cfg.DisablePruner = db.IsTestDbSQLite()
 	dbstore := db.InitTestDB(t)
 	dbSection := cfg.SectionWithEnvOverrides("database")
 	if isHA {
@@ -301,6 +302,7 @@ func TestIntegrationSearchClientServer(t *testing.T) {
 	cfg.EnableSearch = true
 	cfg.IndexFileThreshold = 1000 // Ensures memory indexing
 	cfg.IndexPath = t.TempDir()   // Temporary directory for indexes
+	cfg.DisablePruner = db.IsTestDbSQLite()
 
 	features := featuremgmt.WithFeatures()
 

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -148,6 +148,7 @@ func StartGrafanaEnvWithDB(t *testing.T, grafDir, cfgPath string) (string, *serv
 		storageMetrics := resource.ProvideStorageMetrics(registerer)
 		tracingService := tracing.NewNoopTracerService()
 		env.Cfg.SectionWithEnvOverrides("grafana-apiserver").Key("storage_type").SetValue(string(options.StorageTypeUnified))
+		env.Cfg.DisablePruner = db.IsTestDbSQLite()
 		storageBackend, err := sql.NewStorageBackend(env.Cfg, env.SQLStore, registerer, storageMetrics, tracingService, false)
 		require.NoError(t, err)
 		require.NotNil(t, storageBackend)


### PR DESCRIPTION
integration tests with sqlite have been quite flaky. This should help. [context](https://raintank-corp.slack.com/archives/C092RN6AXCM/p1773141109932499) 