### PR TITLE
Unified Storage: Replace channel-based cache with simple ring buffer

### DIFF
--- a/pkg/storage/unified/resource/broadcaster.go
+++ b/pkg/storage/unified/resource/broadcaster.go
@@ -289,4 +289,3 @@ func (r *ringBuffer[T]) readInto(dst chan T) bool {
 	}
 	return true
 }
-

--- a/pkg/storage/unified/resource/broadcaster.go
+++ b/pkg/storage/unified/resource/broadcaster.go
@@ -2,7 +2,6 @@ package resource
 
 import (
 	"context"
-	"fmt"
 	"io"
 )
 
@@ -109,7 +108,7 @@ type broadcaster[T any] struct {
 
 	// subscription management
 
-	cache       channelCache[T]
+	cache       ringBuffer[T]
 	subscribe   chan chan T
 	unsubscribe chan (<-chan T)
 	subs        map[<-chan T]chan T
@@ -168,7 +167,7 @@ func (b *broadcaster[T]) init(ctx context.Context, connect ConnectFunc[T]) error
 
 	// initialize our internal state
 	b.shouldTerminate = ctx.Done()
-	b.cache = newChannelCache[T](ctx, 100)
+	b.cache = newRingBuffer[T](100)
 	b.subscribe = make(chan chan T, chanBufferLen)
 	b.unsubscribe = make(chan (<-chan T), chanBufferLen)
 	b.subs = make(map[<-chan T]chan T)
@@ -217,8 +216,7 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 
 		case sub := <-b.subscribe: // subscribe
 			// send initial batch of cached items
-			err := b.cache.ReadInto(sub)
-			if err != nil {
+			if !b.cache.readInto(sub) {
 				close(sub)
 				continue
 			}
@@ -232,7 +230,7 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 			if !ok {
 				return
 			}
-			b.cache.Add(item)
+			b.cache.add(item)
 
 			var slow []<-chan T
 			for _, sub := range b.subs {
@@ -252,126 +250,43 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 	}
 }
 
-const defaultCacheSize = 100
-
-type channelCache[T any] interface {
-	Len() int
-	Add(item T)
-	Get(i int) T
-	Range(f func(T) error) error
-	Slice() []T
-	ReadInto(dst chan T) error
+// ringBuffer is a fixed-size circular buffer. It is not safe for concurrent
+// use — the broadcaster's single stream() goroutine is the only caller.
+type ringBuffer[T any] struct {
+	buf  []T
+	zero int // index of the oldest item
+	len  int // number of items currently stored
 }
 
-type localCache[T any] struct {
-	cache     []T
-	size      int
-	cacheZero int
-	cacheLen  int
-	add       chan T
-	read      chan chan T
-	ctx       context.Context
-}
-
-func newChannelCache[T any](ctx context.Context, size int) channelCache[T] {
-	c := &localCache[T]{}
-
-	c.ctx = ctx
+func newRingBuffer[T any](size int) ringBuffer[T] {
 	if size <= 0 {
-		size = defaultCacheSize
+		size = 100
 	}
-	c.size = size
-	c.cache = make([]T, c.size)
-
-	c.add = make(chan T)
-	c.read = make(chan chan T)
-
-	go c.run()
-
-	return c
+	return ringBuffer[T]{
+		buf: make([]T, size),
+	}
 }
 
-func (c *localCache[T]) Len() int {
-	return c.cacheLen
+func (r *ringBuffer[T]) add(item T) {
+	i := (r.zero + r.len) % len(r.buf)
+	r.buf[i] = item
+	if r.len < len(r.buf) {
+		r.len++
+	} else {
+		r.zero = (r.zero + 1) % len(r.buf)
+	}
 }
 
-func (c *localCache[T]) Add(item T) {
-	c.add <- item
-}
-
-func (c *localCache[T]) run() {
-	for {
+// readInto sends all cached items to dst without blocking. Returns true if all
+// items were sent, false if dst's buffer was full (slow consumer).
+func (r *ringBuffer[T]) readInto(dst chan T) bool {
+	for i := 0; i < r.len; i++ {
 		select {
-		case <-c.ctx.Done():
-			return
-		case item := <-c.add:
-			i := (c.cacheZero + c.cacheLen) % len(c.cache)
-			c.cache[i] = item
-			if c.cacheLen < len(c.cache) {
-				c.cacheLen++
-			} else {
-				c.cacheZero = (c.cacheZero + 1) % len(c.cache)
-			}
-		case r := <-c.read:
-		read:
-			for i := 0; i < c.cacheLen; i++ {
-				select {
-				case r <- c.cache[(c.cacheZero+i)%len(c.cache)]:
-				// don't wait for slow consumers
-				default:
-					break read
-				}
-			}
-			close(r)
-		}
-	}
-}
-
-func (c *localCache[T]) Get(i int) T {
-	r := make(chan T, c.size)
-	c.read <- r
-	idx := 0
-	for item := range r {
-		if idx == i {
-			return item
-		}
-		idx++
-	}
-	var zero T
-	return zero
-}
-
-func (c *localCache[T]) Range(f func(T) error) error {
-	r := make(chan T, c.size)
-	c.read <- r
-	for item := range r {
-		err := f(item)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (c *localCache[T]) Slice() []T {
-	s := make([]T, 0, c.size)
-	r := make(chan T, c.size)
-	c.read <- r
-	for item := range r {
-		s = append(s, item)
-	}
-	return s
-}
-
-func (c *localCache[T]) ReadInto(dst chan T) error {
-	r := make(chan T, c.size)
-	c.read <- r
-	for item := range r {
-		select {
-		case dst <- item:
+		case dst <- r.buf[(r.zero+i)%len(r.buf)]:
 		default:
-			return fmt.Errorf("slow consumer")
+			return false
 		}
 	}
-	return nil
+	return true
 }
+

--- a/pkg/storage/unified/resource/broadcaster_test.go
+++ b/pkg/storage/unified/resource/broadcaster_test.go
@@ -8,102 +8,55 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCache(t *testing.T) {
-	c := newChannelCache[int](context.Background(), 10)
+func drainChan[T any](ch chan T) []T {
+	close(ch)
+	var out []T
+	for v := range ch {
+		out = append(out, v)
+	}
+	return out
+}
 
-	e := []int{}
-	err := c.Range(func(i int) error {
-		e = append(e, i)
-		return nil
-	})
-	require.Nil(t, err)
-	require.Equal(t, 0, len(e))
+func TestRingBuffer(t *testing.T) {
+	c := newRingBuffer[int](10)
 
-	c.Add(1)
+	// empty buffer
+	dst := make(chan int, 10)
+	require.True(t, c.readInto(dst))
+	require.Empty(t, drainChan(dst))
 
-	e = []int{}
-	err = c.Range(func(i int) error {
-		e = append(e, i)
-		return nil
-	})
-	require.Nil(t, err)
-	require.Equal(t, 1, len(e))
-	require.Equal(t, []int{1}, e)
-	require.Equal(t, 1, c.Get(0))
+	c.add(1)
+	dst = make(chan int, 10)
+	require.True(t, c.readInto(dst))
+	require.Equal(t, []int{1}, drainChan(dst))
 
-	c.Add(2)
-	c.Add(3)
-	c.Add(4)
-	c.Add(5)
-	c.Add(6)
+	for i := 2; i <= 6; i++ {
+		c.add(i)
+	}
+	dst = make(chan int, 10)
+	require.True(t, c.readInto(dst))
+	require.Equal(t, []int{1, 2, 3, 4, 5, 6}, drainChan(dst))
 
-	// should be able to range over values
-	e = []int{}
-	err = c.Range(func(i int) error {
-		e = append(e, i)
-		return nil
-	})
-	require.Nil(t, err)
-	require.Equal(t, 6, len(e))
-	require.Equal(t, []int{1, 2, 3, 4, 5, 6}, e)
+	for i := 7; i <= 11; i++ {
+		c.add(i)
+	}
 
-	// should be able to get length
-	require.Equal(t, 6, c.Len())
+	// buffer is full (size 10), oldest item (1) evicted
+	dst = make(chan int, 10)
+	require.True(t, c.readInto(dst))
+	require.Equal(t, []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, drainChan(dst))
 
-	// should be able to get values
-	require.Equal(t, 1, c.Get(0))
-	require.Equal(t, 6, c.Get(5))
-	// zero value beyond cache size
-	require.Equal(t, 0, c.Get(6))
-	require.Equal(t, 0, c.Get(20))
-	require.Equal(t, 0, c.Get(-10))
+	c.add(12)
+	c.add(13)
 
-	// slice should return all values
-	require.Equal(t, []int{1, 2, 3, 4, 5, 6}, c.Slice())
+	// two more evictions
+	dst = make(chan int, 10)
+	require.True(t, c.readInto(dst))
+	require.Equal(t, []int{4, 5, 6, 7, 8, 9, 10, 11, 12, 13}, drainChan(dst))
 
-	c.Add(7)
-	c.Add(8)
-	c.Add(9)
-	c.Add(10)
-	c.Add(11)
-
-	// should be able to range over values
-	e = []int{}
-	err = c.Range(func(i int) error {
-		e = append(e, i)
-		return nil
-	})
-	require.Nil(t, err)
-	require.Equal(t, 10, len(e))
-	require.Equal(t, []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, e)
-
-	// should be able to get length
-	require.Equal(t, 10, c.Len())
-
-	// should be able to get values
-	require.Equal(t, 2, c.Get(0))
-	require.Equal(t, 3, c.Get(1))
-
-	// slice should return all values
-	require.Equal(t, []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, c.Slice())
-
-	c.Add(12)
-	c.Add(13)
-
-	// should be able to range over values
-	e = []int{}
-	err = c.Range(func(i int) error {
-		e = append(e, i)
-		return nil
-	})
-	require.Nil(t, err)
-	require.Equal(t, 10, len(e))
-	require.Equal(t, []int{4, 5, 6, 7, 8, 9, 10, 11, 12, 13}, e)
-	require.Equal(t, 4, c.Get(0))
-	require.Equal(t, 5, c.Get(1))
-
-	// slice should return all values
-	require.Equal(t, []int{4, 5, 6, 7, 8, 9, 10, 11, 12, 13}, c.Slice())
+	// destination too small — returns false
+	small := make(chan int, 1)
+	require.False(t, c.readInto(small))
 }
 
 func TestBroadcaster(t *testing.T) {


### PR DESCRIPTION
## Summary
- Replace the goroutine-based `channelCache` with a plain `ringBuffer` struct in the broadcaster
- The cache was using a channel-based actor pattern for synchronization, but all access comes from the single `stream()` goroutine — making it redundant and introducing a data race on `Len()` and a leaked goroutine on input channel closure
- Drop the `channelCache` interface and unused methods (`Len`, `Get`, `Range`, `Slice`) that only existed for tests
- Net reduction of ~130 lines

## Test plan
- [x] `go test ./pkg/storage/unified/resource/...` — `TestRingBuffer`, `TestBroadcaster`, `TestBroadcasterSlowConsumerDeadlock` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)