### PR TITLE
QueryEditor: Persist query editor banner dismissal in localStorage

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ExperimentalFeedbackButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ExperimentalFeedbackButton.tsx
@@ -14,7 +14,7 @@ export function ExperimentalFeedbackButton() {
   const styles = useStyles2(getStyles);
 
   // Track whether the banner was visible when this component first mounted.
-  // If it was, the user dismissed it in this session — animate the button in.
+  // If it was, the user dismissed it - animate the button in.
   // If it wasn't (already dismissed on load), skip the animation.
   const bannerWasInitiallyVisible = useRef(showVersionBanner);
   const shouldAnimate = bannerWasInitiallyVisible.current && !showVersionBanner;

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/hooks.ts
@@ -1,7 +1,7 @@
 import { css, cx } from '@emotion/css';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { RefObject, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { useLocalStorage, useSessionStorage } from 'react-use';
+import { useLocalStorage } from 'react-use';
 
 import { getDragStyles, useStyles2, useTheme2 } from '@grafana/ui';
 import { MIN_SUGGESTIONS_PANE_WIDTH } from 'app/features/panel/suggestions/constants';
@@ -122,7 +122,7 @@ export function useRatioResize({
 }
 
 export function useQueryEditorBanner() {
-  const [dismissed, setDismissed] = useSessionStorage(QUERY_EDITOR_BANNER_DISMISSED_KEY, false);
+  const [dismissed = false, setDismissed] = useLocalStorage(QUERY_EDITOR_BANNER_DISMISSED_KEY, false);
   const isQueryEditorNextEnabled = useBooleanFlagValue('queryEditorNext', false);
   const showBanner = isQueryEditorNextEnabled && !dismissed;
   const dismissBanner = useCallback(() => setDismissed(true), [setDismissed]);


### PR DESCRIPTION
Switch banner dismiss persistence from sessionStorage to localStorage so dismissal survives browser sessions.