### PR TITLE
Explore: Call `getQueryDisplayText` in try/catch

### DIFF
--- a/public/app/features/explore/hooks/useExplorePageContext.ts
+++ b/public/app/features/explore/hooks/useExplorePageContext.ts
@@ -26,9 +26,7 @@ function buildContext(panes: Array<[string, ExploreItemState]>): ChatContextItem
       return buildMixedContext(pane.queries);
     }
 
-    const matchingQueries = pane.queries.filter(
-      (q) => !q.datasource?.uid || q.datasource.uid === ds.uid
-    );
+    const matchingQueries = pane.queries.filter((q) => !q.datasource?.uid || q.datasource.uid === ds.uid);
     return buildDatasourceContext(ds.uid, ds.name, ds.meta?.info?.logos?.small, matchingQueries, ds);
   });
 }

--- a/public/app/features/explore/hooks/useExplorePageContext.ts
+++ b/public/app/features/explore/hooks/useExplorePageContext.ts
@@ -115,7 +115,14 @@ function summarizeQuery(query: DataQuery, ds?: DataSourceApi): Record<string, un
 
 function isQueryEmpty(query: DataQuery, ds?: DataSourceApi): boolean {
   if (ds?.getQueryDisplayText) {
-    return !ds.getQueryDisplayText(query)?.trim();
+    try {
+      const displayText = ds.getQueryDisplayText(query);
+      if (displayText && displayText.trim()) {
+        return false;
+      }
+    } catch (error) {
+      console.error(error);
+    }
   }
   const { refId, datasource, ...rest } = query;
   return Object.keys(rest).length === 0;

--- a/public/app/features/explore/hooks/useExplorePageContext.ts
+++ b/public/app/features/explore/hooks/useExplorePageContext.ts
@@ -26,7 +26,10 @@ function buildContext(panes: Array<[string, ExploreItemState]>): ChatContextItem
       return buildMixedContext(pane.queries);
     }
 
-    return buildDatasourceContext(ds.uid, ds.name, ds.meta?.info?.logos?.small, pane.queries, ds);
+    const matchingQueries = pane.queries.filter(
+      (q) => !q.datasource?.uid || q.datasource.uid === ds.uid
+    );
+    return buildDatasourceContext(ds.uid, ds.name, ds.meta?.info?.logos?.small, matchingQueries, ds);
   });
 }
 
@@ -93,10 +96,20 @@ const METADATA_FIELDS = new Set([
   'direction',
 ]);
 
+/** Safely calls ds.getQueryDisplayText, returning undefined if unavailable or on error. */
+function getDisplayText(query: DataQuery, ds?: DataSourceApi): string | undefined {
+  try {
+    return ds?.getQueryDisplayText?.(query);
+  } catch (error) {
+    console.error(error);
+    return undefined;
+  }
+}
+
 function summarizeQuery(query: DataQuery, ds?: DataSourceApi): Record<string, unknown> {
   const summary: Record<string, unknown> = { refId: query.refId };
 
-  const displayText = ds?.getQueryDisplayText?.(query);
+  const displayText = getDisplayText(query, ds);
   if (displayText) {
     summary.expression = displayText;
   }
@@ -114,15 +127,9 @@ function summarizeQuery(query: DataQuery, ds?: DataSourceApi): Record<string, un
 }
 
 function isQueryEmpty(query: DataQuery, ds?: DataSourceApi): boolean {
-  if (ds?.getQueryDisplayText) {
-    try {
-      const displayText = ds.getQueryDisplayText(query);
-      if (displayText && displayText.trim()) {
-        return false;
-      }
-    } catch (error) {
-      console.error(error);
-    }
+  const displayText = getDisplayText(query, ds);
+  if (displayText?.trim()) {
+    return false;
   }
   const { refId, datasource, ...rest } = query;
   return Object.keys(rest).length === 0;


### PR DESCRIPTION
**What is this feature?**

`getQueryDisplayText` might not be properly implemented in some data sources, thus we are catching potentially errors now.