### PR TITLE
Alerting: Fix Page not found in breadcrumb on notification detail page

### DIFF
--- a/public/app/features/alerting/unified/notifications/NotificationDetailPage.tsx
+++ b/public/app/features/alerting/unified/notifications/NotificationDetailPage.tsx
@@ -43,7 +43,7 @@ function NotificationDetailPage() {
   const pageNav = { text: pageTitle };
 
   return (
-    <AlertingPageWrapper navId="alerts-notifications" pageNav={pageNav} isLoading={false}>
+    <AlertingPageWrapper navId="alerts-history" pageNav={pageNav} isLoading={false}>
       {uuid ? (
         <NotificationDetail uuid={uuid} timestamp={timestamp} onTitleChange={setPageTitle} />
       ) : (


### PR DESCRIPTION
**What is this feature?**

## Summary

- Fix "Page not found" breadcrumb on the notification detail page (`/alerting/notifications-history/view/:uuid/:timestamp?`)
- The `navId` was set to `"alerts-notifications"` which doesn't exist in the nav index, causing the breadcrumb to render as "Page not found > [title]"
- Changed to `"alerts-history"` to match the parent History page, rendering correctly as "Alerting > History > [title]"

## Test plan

1. Navigate to **Alerting > History > Notifications** tab
2. Click **View** on any notification entry
3. Verify the breadcrumb shows **Alerting > History > [notification title]** instead of **Page not found > [title]**
4. Click **History** in the breadcrumb and verify it navigates back to the History page

**Why do we need this feature?**

it's a bug

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
