### PR TITLE
Teams: Conditionally call IAM app platform APIs

### DIFF
--- a/public/app/core/components/OwnerReferences/OwnerReferenceSelector.test.tsx
+++ b/public/app/core/components/OwnerReferences/OwnerReferenceSelector.test.tsx
@@ -1,7 +1,8 @@
 import { HttpResponse, http } from 'msw';
 import { comboboxTestSetup } from 'test/helpers/comboboxTestSetup';
-import { render, screen, waitFor, within } from 'test/test-utils';
+import { render, screen, testWithFeatureToggles, waitFor, within } from 'test/test-utils';
 
+import { FeatureToggles } from '@grafana/data';
 import { setBackendSrv } from '@grafana/runtime';
 import { setupMockServer } from '@grafana/test-utils/server';
 
@@ -13,7 +14,14 @@ setBackendSrv(backendSrv);
 const server = setupMockServer();
 comboboxTestSetup();
 
-describe('OwnerReferenceSelector', () => {
+const toggle: Array<keyof FeatureToggles> = ['kubernetesTeamsApi'];
+
+describe.each([
+  { name: 'IAM path', toggles: { enable: toggle } },
+  { name: 'legacy path', toggles: { disable: toggle } },
+])('OwnerReferenceSelector ($name)', ({ toggles }) => {
+  testWithFeatureToggles(toggles);
+
   it('shows load error but keeps selector interactive', async () => {
     const { getByRole, findByText } = render(
       <OwnerReferenceSelector onChange={jest.fn()} defaultTeamUid="team-non-existent" />
@@ -37,7 +45,6 @@ describe('OwnerReferenceSelector', () => {
       expect.objectContaining({
         apiVersion: 'iam.grafana.app/v0alpha1',
         kind: 'Team',
-        // Name == uid, we don't send label here
         name: expect.any(String),
         uid: expect.any(String),
       })
@@ -62,6 +69,9 @@ describe('OwnerReferenceSelector', () => {
     server.use(
       http.get('/apis/iam.grafana.app/v0alpha1/namespaces/:namespace/searchTeams', () => {
         return HttpResponse.json({ totalHits: 0, hits: [] });
+      }),
+      http.get('/api/teams/search', () => {
+        return HttpResponse.json({ totalCount: 0, teams: [], page: 1, perPage: 1000 });
       })
     );
 
@@ -79,12 +89,14 @@ describe('OwnerReferenceSelector', () => {
   it('searches teams by typed query string', async () => {
     const queries: string[] = [];
 
-    // This just checks if we call the api with the right param and then passes it to the regular handler
+    const captureQuery = ({ request }: { request: Request }) => {
+      const query = new URL(request.url).searchParams.get('query') ?? '';
+      queries.push(query);
+    };
+
     server.use(
-      http.get('/apis/iam.grafana.app/v0alpha1/namespaces/:namespace/searchTeams', ({ request }) => {
-        const query = new URL(request.url).searchParams.get('query') ?? '';
-        queries.push(query);
-      })
+      http.get('/apis/iam.grafana.app/v0alpha1/namespaces/:namespace/searchTeams', captureQuery),
+      http.get('/api/teams/search', captureQuery)
     );
 
     const { user } = render(<OwnerReferenceSelector onChange={jest.fn()} />);

--- a/public/app/core/components/OwnerReferences/OwnerReferenceSelector.tsx
+++ b/public/app/core/components/OwnerReferences/OwnerReferenceSelector.tsx
@@ -5,13 +5,9 @@ import { t, Trans } from '@grafana/i18n';
 import { isFetchError } from '@grafana/runtime';
 import { Alert, Box, Combobox, ComboboxOption, Label } from '@grafana/ui';
 import { OwnerReference } from 'app/api/clients/folder/v1beta1';
-import {
-  API_GROUP as IAM_API_GROUP,
-  API_VERSION as IAM_API_VERSION,
-  useLazyGetTeamQuery,
-  useLazyGetSearchTeamsQuery,
-} from 'app/api/clients/iam/v0alpha1';
+import { API_GROUP as IAM_API_GROUP, API_VERSION as IAM_API_VERSION } from 'app/api/clients/iam/v0alpha1';
 import { extractErrorMessage } from 'app/api/utils';
+import { useLazyGetTeamByUidQuery, useLazySearchTeamsQuery } from 'app/features/teams/hooks';
 
 const OWNER_REFERENCE_API_VERSION = `${IAM_API_GROUP}/${IAM_API_VERSION}` as const;
 const OWNER_REFERENCE_KIND = 'Team' as const;
@@ -29,13 +25,13 @@ export const OwnerReferenceSelector = ({
   defaultTeamUid?: string;
 }) => {
   const [selectedTeam, setSelectedTeam] = useState<ComboboxOption<string> | string | null>(defaultTeamUid || null);
-  const [searchTeams, { isLoading }] = useLazyGetSearchTeamsQuery();
-  const [getTeam, { isLoading: isSelectedTeamLoading, error: selectedTeamError }] = useLazyGetTeamQuery();
+  const [searchTeams, { isLoading }] = useLazySearchTeamsQuery();
+  const [getTeam, { isLoading: isSelectedTeamLoading, error: selectedTeamError }] = useLazyGetTeamByUidQuery();
 
   useEffect(() => {
     if (defaultTeamUid) {
       getTeam({ name: defaultTeamUid }, true).then(({ data, status }) => {
-        if (status === QueryStatus.fulfilled) {
+        if (status === QueryStatus.fulfilled && data) {
           setSelectedTeam({
             label: data.spec.title,
             value: data.metadata.name!,
@@ -53,14 +49,12 @@ export const OwnerReferenceSelector = ({
   }, [defaultTeamUid, getTeam]);
 
   const loadOptions = async (inputValue: string): Promise<Array<ComboboxOption<string>>> => {
-    const result = await searchTeams({ query: inputValue }, true).unwrap();
+    const { data } = await searchTeams({ query: inputValue }, true);
 
-    const mappedResults = result.hits.map((team: { title: string; name: string }) => ({
+    return (data?.hits ?? []).map((team: { title: string; name: string }) => ({
       label: team.title,
       value: team.name,
     }));
-
-    return mappedResults;
   };
 
   const teamIsMissingOrForbidden = isFetchError(selectedTeamError) && [404, 403].includes(selectedTeamError.status);

--- a/public/app/features/browse-dashboards/components/FolderDetailsActions/FolderDetailsActions.tsx
+++ b/public/app/features/browse-dashboards/components/FolderDetailsActions/FolderDetailsActions.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/css';
 import { skipToken } from '@reduxjs/toolkit/query';
 
 import { OwnerReference as OwnerReferenceType } from '@grafana/api-clients/rtkq/folder/v1beta1';
-import { useGetTeamQuery } from '@grafana/api-clients/rtkq/iam/v0alpha1';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
@@ -11,6 +10,7 @@ import { CombinedFolder, useGetFolderQueryFacade } from 'app/api/clients/folder/
 import { OwnerReference } from 'app/core/components/OwnerReferences/OwnerReference';
 import { contextSrv } from 'app/core/services/context_srv';
 import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
+import { useGetTeamByUidQuery } from 'app/features/teams/hooks';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { getFolderPermissions } from '../../permissions';
@@ -63,7 +63,7 @@ const FolderOwners = ({ ownerReferences }: { ownerReferences?: OwnerReferenceTyp
   const styles = useStyles2(getStyles);
   const teamOwnerReferences = ownerReferences?.filter((ref) => ref.kind === 'Team');
   const teamUid = teamOwnerReferences?.at(0)?.uid;
-  const { data: team, isLoading: isLoadingTeam } = useGetTeamQuery(teamUid ? { name: teamUid } : skipToken);
+  const { data: team, isLoading: isLoadingTeam } = useGetTeamByUidQuery(teamUid ? { name: teamUid } : skipToken);
 
   if (!teamOwnerReferences || teamOwnerReferences.length === 0 || isLoadingTeam || !team) {
     return null;

--- a/public/app/features/teams/hooks.ts
+++ b/public/app/features/teams/hooks.ts
@@ -1,13 +1,26 @@
 import { skipToken } from '@reduxjs/toolkit/query';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
+import { config } from '@grafana/runtime';
 import { useCreateFolder } from 'app/api/clients/folder/v1beta1/hooks';
 import {
+  API_GROUP,
+  API_VERSION,
+  GetTeamApiArg,
+  Team,
+  useLazyGetSearchTeamsQuery as useLazyGetSearchTeamsQueryIam,
+  useLazyGetTeamQuery as useLazyGetTeamQueryIam,
+  useGetTeamQuery as useGetTeamQueryIam,
+} from 'app/api/clients/iam/v0alpha1';
+import {
   CreateTeamCommand,
+  TeamDto,
   UpdateTeamCommand,
   useCreateTeamMutation,
   useDeleteTeamByIdMutation,
   useGetTeamByIdQuery,
+  useLazyGetTeamByIdQuery as useLazyGetTeamByIdQueryLegacy,
+  useLazySearchTeamsQuery as useLazySearchTeamsQueryLegacy,
   useSearchTeamsQuery as useLegacySearchTeamsQuery,
   useListTeamsRolesQuery,
   useSetTeamRolesMutation,
@@ -162,3 +175,109 @@ export const useCreateTeam = () => {
 
   return [trigger, response] as const;
 };
+
+/**
+ * Transform a legacy TeamDto to the IAM Team (k8s) shape.
+ */
+export function teamDtoToTeam(dto: TeamDto): Team {
+  return {
+    apiVersion: `${API_GROUP}/${API_VERSION}`,
+    kind: 'Team',
+    metadata: {
+      name: dto.uid,
+      creationTimestamp: '',
+    },
+    spec: {
+      title: dto.name,
+      email: dto.email ?? '',
+      externalUID: dto.externalUID ?? '',
+      provisioned: dto.isProvisioned,
+    },
+  };
+}
+
+/**
+ * Transform legacy TeamDto[] to IAM search hit shape.
+ */
+export function legacySearchToIamSearchHits(teams: TeamDto[]): Array<{ title: string; name: string }> {
+  return teams.map((t) => ({ title: t.name, name: t.uid }));
+}
+
+const appPlatformIamEnabled = () => Boolean(config.featureToggles.kubernetesTeamsApi);
+
+/**
+ * Facade hook: get a team by UID, using IAM or legacy endpoint based on feature toggle.
+ */
+export function useGetTeamByUidQuery(args: GetTeamApiArg | typeof skipToken) {
+  const enabled = appPlatformIamEnabled();
+
+  const iamResult = useGetTeamQueryIam(enabled ? args : skipToken);
+  const legacyResult = useGetTeamByIdQuery(!enabled && args !== skipToken ? { teamId: args.name } : skipToken);
+
+  if (enabled) {
+    return iamResult;
+  }
+
+  return {
+    ...legacyResult,
+    data: legacyResult.data ? teamDtoToTeam(legacyResult.data) : undefined,
+  };
+}
+
+/**
+ * Calls either the IAM or legacy get team by UID endpoint based on the feature toggle.
+ */
+export function useLazyGetTeamByUidQuery() {
+  const enabled = appPlatformIamEnabled();
+  const [iamTrigger, iamResult] = useLazyGetTeamQueryIam();
+  const [legacyTrigger, legacyResult] = useLazyGetTeamByIdQueryLegacy();
+
+  const iamTriggerer = useCallback(
+    (args: GetTeamApiArg, preferCacheValue?: boolean) => iamTrigger(args, preferCacheValue),
+    [iamTrigger]
+  );
+
+  const legacyTriggerer = useCallback(
+    (args: GetTeamApiArg, preferCacheValue?: boolean) =>
+      legacyTrigger({ teamId: args.name }, preferCacheValue).then((result) => ({
+        ...result,
+        data: result.data ? teamDtoToTeam(result.data) : undefined,
+      })),
+    [legacyTrigger]
+  );
+
+  if (enabled) {
+    return [iamTriggerer, iamResult] as const;
+  }
+
+  return [
+    legacyTriggerer,
+    {
+      ...legacyResult,
+      data: legacyResult.data ? teamDtoToTeam(legacyResult.data) : undefined,
+    },
+  ] as const;
+}
+
+/**
+ * Calls either the IAM or legacy search teams endpoint based on the feature toggle.
+ */
+export function useLazySearchTeamsQuery() {
+  const enabled = appPlatformIamEnabled();
+  const [iamTrigger, iamResult] = useLazyGetSearchTeamsQueryIam();
+  const [legacyTrigger, legacyResult] = useLazySearchTeamsQueryLegacy();
+
+  const legacyTriggerWrapped = (args: { query?: string }, preferCacheValue?: boolean) =>
+    legacyTrigger({ query: args.query }, preferCacheValue).then((result) => ({
+      ...result,
+      data: result.data
+        ? { hits: legacySearchToIamSearchHits(result.data.teams ?? []), totalHits: result.data.totalCount ?? 0 }
+        : undefined,
+    }));
+
+  if (enabled) {
+    return [iamTrigger, iamResult] as const;
+  }
+
+  return [legacyTriggerWrapped, legacyResult] as const;
+}


### PR DESCRIPTION
**What is this feature?**

Adds facade hooks (`useGetTeamByUidQuery`, `useLazyGetTeamByUidQuery`, `useLazySearchTeamsQuery`) that check the `kubernetesTeamsApi` feature toggle and route between IAM app platform endpoints and legacy `/api/teams` endpoints. Legacy responses are normalised to the IAM `Team` shape so consumers don't need to care which path is used.

Updates `OwnerReferenceSelector` and `FolderDetailsActions` to use the new facade hooks instead of importing IAM hooks directly.

**Why do we need this feature?**

So we can fall back to legacy team endpoints when the IAM app platform isn't enabled, without consumers needing to handle both API shapes.

**Who is this feature for?**

Team folders users/people assigning folder owners