### PR TITLE
Add per datasource query health metrics

### DIFF
--- a/pkg/services/query/metrics.go
+++ b/pkg/services/query/metrics.go
@@ -1,0 +1,43 @@
+package query
+
+import (
+	"strconv"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// datasourceQueryTotal counts query executions through the query service,
+// broken down by org, datasource UID, datasource type, and status.
+// Intended to surface datasource health to customers via grafanacloud-usage prometheus.
+var datasourceQueryTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "grafana",
+		Name:      "datasource_query_total",
+		Help:      "Total datasource queries executed via the query service, by org, datasource UID, datasource type, and status (success|error).",
+	},
+	[]string{"org_id", "datasource_uid", "datasource_type", "status"},
+)
+
+// recordQueryMetrics increments datasourceQueryTotal based on the result of a
+// single-datasource query execution. It counts once per query in the response;
+// if the response is empty (no refIds), it counts the call itself as a success.
+func recordQueryMetrics(orgID int64, dsUID, dsType string, resp *backend.QueryDataResponse, err error) {
+	orgIDStr := strconv.FormatInt(orgID, 10)
+	if err != nil {
+		datasourceQueryTotal.WithLabelValues(orgIDStr, dsUID, dsType, "error").Inc()
+		return
+	}
+	if resp == nil || len(resp.Responses) == 0 {
+		datasourceQueryTotal.WithLabelValues(orgIDStr, dsUID, dsType, "success").Inc()
+		return
+	}
+	for _, r := range resp.Responses {
+		if r.Error != nil {
+			datasourceQueryTotal.WithLabelValues(orgIDStr, dsUID, dsType, "error").Inc()
+		} else {
+			datasourceQueryTotal.WithLabelValues(orgIDStr, dsUID, dsType, "success").Inc()
+		}
+	}
+}

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -322,14 +322,18 @@ func (s *ServiceImpl) handleQuerySingleDatasource(ctx context.Context, user iden
 			return nil, err
 		}
 		req.PluginContext = pCtx
-		return s.pluginClient.QueryData(ctx, req)
+		resp, err := s.pluginClient.QueryData(ctx, req)
+		recordQueryMetrics(user.GetOrgID(), ds.UID, ds.Type, resp, err)
+		return resp, err
 	} else { // query-service flow (single or multi tenant)
 		// transform request from backend.QueryDataRequest to k8s request
 		k8sReq, err := expr.ConvertBackendRequestToDataRequest(req)
 		if err != nil {
 			return nil, err
 		}
-		return qsDsClient.QueryData(ctx, *k8sReq)
+		resp, err := qsDsClient.QueryData(ctx, *k8sReq)
+		recordQueryMetrics(user.GetOrgID(), ds.UID, ds.Type, resp, err)
+		return resp, err
 	}
 }
 

--- a/pkg/services/query/query_test.go
+++ b/pkg/services/query/query_test.go
@@ -42,6 +42,8 @@ import (
 	secretsmng "github.com/grafana/grafana/pkg/services/secrets/manager"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
+	prometheustestutil "github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
 	"github.com/grafana/grafana/pkg/web"
@@ -995,4 +997,54 @@ func (c *testClient) QueryData(ctx context.Context, req data.QueryDataRequest) (
 		return c.queryDataStubbedResponse, nil
 	}
 	return nil, errors.New("no response stubbed")
+}
+
+func TestIntegrationDatasourceQueryMetrics(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	t.Run("increments success counter on successful query", func(t *testing.T) {
+		tc := setup(t, false, nil)
+		query1, err := simplejson.NewJson([]byte(`{
+			"datasource": {"type": "mysql", "uid": "ds1"},
+			"refId": "A"
+		}`))
+		require.NoError(t, err)
+
+		reqDTO := dtos.MetricRequest{
+			From:    "2022-01-01",
+			To:      "2022-01-02",
+			Queries: []*simplejson.Json{query1},
+		}
+
+		before := prometheustestutil.ToFloat64(datasourceQueryTotal.WithLabelValues("1", "ds1", "mysql", "success"))
+		_, err = tc.queryService.QueryData(context.Background(), tc.signedInUser, true, reqDTO)
+		require.NoError(t, err)
+		after := prometheustestutil.ToFloat64(datasourceQueryTotal.WithLabelValues("1", "ds1", "mysql", "success"))
+
+		assert.Equal(t, before+1, after)
+	})
+
+	t.Run("increments error counter on transport error", func(t *testing.T) {
+		tc := setup(t, false, nil)
+		query1, err := simplejson.NewJson([]byte(`{
+			"datasource": {"type": "mysql", "uid": "ds1"},
+			"refId": "A",
+			"queryType": "FAIL"
+		}`))
+		require.NoError(t, err)
+
+		reqDTO := dtos.MetricRequest{
+			From:    "2022-01-01",
+			To:      "2022-01-02",
+			Queries: []*simplejson.Json{query1},
+		}
+
+		before := prometheustestutil.ToFloat64(datasourceQueryTotal.WithLabelValues("1", "ds1", "mysql", "error"))
+		// single-datasource transport errors bubble up directly (not wrapped in Responses)
+		_, err = tc.queryService.QueryData(context.Background(), tc.signedInUser, true, reqDTO)
+		require.Error(t, err)
+		after := prometheustestutil.ToFloat64(datasourceQueryTotal.WithLabelValues("1", "ds1", "mysql", "error"))
+
+		assert.Equal(t, before+1, after)
+	})
 }


### PR DESCRIPTION
Track success/error counts per org, datasource UID, and type via `grafana_datasource_query_total` on the `/metrics` endpoint, enabling customers to monitor and alert on datasource health at scale.
