### PR TITLE
Alerting: Change display name of alerting.provisioning:writer fixed role

### DIFF
--- a/pkg/services/ngalert/accesscontrol/roles.go
+++ b/pkg/services/ngalert/accesscontrol/roles.go
@@ -350,7 +350,7 @@ var (
 	alertingProvisionerRole = accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
 			Name:        accesscontrol.FixedRolePrefix + "alerting.provisioning:writer",
-			DisplayName: "Access to alert rules provisioning API",
+			DisplayName: "Write via Provisioning API",
 			Description: "Manage all alert rules, contact points, notification policies, silences, etc. in the organization via provisioning API.",
 			Group:       models.AlertRolesGroup,
 			Permissions: []accesscontrol.Permission{

--- a/pkg/services/ngalert/accesscontrol/testdata/fixed_roles.snapshot.json
+++ b/pkg/services/ngalert/accesscontrol/testdata/fixed_roles.snapshot.json
@@ -679,7 +679,7 @@
   },
   {
     "name": "fixed:alerting.provisioning:writer",
-    "displayName": "Access to alert rules provisioning API",
+    "displayName": "Write via Provisioning API",
     "description": "Manage all alert rules, contact points, notification policies, silences, etc. in the organization via provisioning API.",
     "group": "Alerting",
     "permissions": [


### PR DESCRIPTION
Fixes the name of the role `fixed:alerting.provisioning:writer` from "Access to alert rules provisioning API" to "Write via Provisioning API" to better reflect the purpose and match the read role