### PR TITLE
Combobox: Use custom value label is not truncated with auto sizing

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -242,6 +242,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
       }
       return itemHeight;
     },
+    getItemKey: (index: number) => filteredOptions[index]?.value ?? index,
     overscan: VIRTUAL_OVERSCAN_ITEMS,
     rangeExtractor,
   });

--- a/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
+++ b/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
@@ -63,6 +63,7 @@ export const ComboboxList = <T extends string | number>({
     count: options.length,
     getScrollElement: () => scrollRef.current,
     estimateSize,
+    getItemKey: (index: number) => options[index]?.value ?? index,
     overscan: VIRTUAL_OVERSCAN_ITEMS,
   });
 


### PR DESCRIPTION
**What is this feature?**

This pull request makes a minor adjustment to the way text widths are calculated for the combobox component. Specifically, it ensures that all measured text widths are rounded up to the nearest integer using `Math.ceil`, which helps prevent layout issues caused by fractional pixel values.

**Why do we need this feature?**

So the `Use custom value` isn't truncated.

**Who is this feature for?**

Anyone using Combobox

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #120008

**Special notes for your reviewer:**

**Before**

https://github.com/user-attachments/assets/82dbaaf5-cbe1-4304-86a0-64f584e9f819

**After**

https://github.com/user-attachments/assets/1d61f25d-0c4c-4cc4-a161-f5f6ad27acdc

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
