### PR TITLE
Exclude type only imports circular dependencies check 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -773,6 +773,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 
 # root files, mostly frontend
 /.browserslistrc @grafana/frontend-ops
+/.madgerc @grafana/frontend-ops
 /package.json @grafana/frontend-ops
 /nx.json @grafana/frontend-ops
 /project.json @grafana/frontend-ops

--- a/.madgerc
+++ b/.madgerc
@@ -1,0 +1,10 @@
+{
+  "detectiveOptions": {
+    "ts": {
+      "skipTypeImports": true
+    },
+    "tsx": {
+      "skipTypeImports": true
+    }
+  }
+}


### PR DESCRIPTION
**What is this feature?**

Setting `skipTypeImports` to `true` excludes circular dependencies caused by type-only imports, since they don’t affect runtime and can produce false positives