### PR TITLE
Broadcaster: add named subscribers for observability

### DIFF
--- a/pkg/storage/unified/resource/broadcaster.go
+++ b/pkg/storage/unified/resource/broadcaster.go
@@ -3,10 +3,11 @@ package resource
 import (
 	"context"
 	"io"
+	"log/slog"
 )
 
 type Broadcaster[T any] interface {
-	Subscribe(context.Context) (<-chan T, error)
+	Subscribe(ctx context.Context, name string) (<-chan T, error)
 	Unsubscribe(<-chan T)
 }
 
@@ -18,15 +19,20 @@ func NewBroadcaster[T any](ctx context.Context, input <-chan T) Broadcaster[T] {
 	b := &broadcaster[T]{
 		shouldTerminate: ctx.Done(),
 		cache:           newRingBuffer[T](100),
-		subscribe:       make(chan chan T, chanBufferLen),
+		subscribe:       make(chan subscription[T], chanBufferLen),
 		unsubscribe:     make(chan (<-chan T), chanBufferLen),
-		subs:            make(map[<-chan T]chan T),
+		subs:            make(map[<-chan T]subscription[T]),
 		terminated:      make(chan struct{}),
 	}
 
 	go b.stream(input)
 
 	return b
+}
+
+type subscription[T any] struct {
+	name string
+	ch   chan T
 }
 
 type broadcaster[T any] struct {
@@ -38,13 +44,13 @@ type broadcaster[T any] struct {
 	// subscription management
 
 	cache       ringBuffer[T]
-	subscribe   chan chan T
+	subscribe   chan subscription[T]
 	unsubscribe chan (<-chan T)
-	subs        map[<-chan T]chan T
+	subs        map[<-chan T]subscription[T]
 }
 
-func (b *broadcaster[T]) Subscribe(ctx context.Context) (<-chan T, error) {
-	sub := make(chan T, 100)
+func (b *broadcaster[T]) Subscribe(ctx context.Context, name string) (<-chan T, error) {
+	sub := subscription[T]{name: name, ch: make(chan T, 100)}
 
 	select {
 	case <-ctx.Done(): // client canceled
@@ -52,7 +58,7 @@ func (b *broadcaster[T]) Subscribe(ctx context.Context) (<-chan T, error) {
 	case <-b.terminated: // no more data
 		return nil, io.EOF
 	case b.subscribe <- sub: // success submitting subscription
-		return sub, nil
+		return sub.ch, nil
 	}
 }
 
@@ -81,17 +87,17 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 	defer func() {
 		// prevent new subscriptions and make sure to discard unsubscriptions
 		close(b.terminated)
-		// terminate all subscirptions and clean the map
-		for _, sub := range b.subs {
-			close(sub)
-			delete(b.subs, sub)
+		// terminate all subscriptions
+		for recv, sub := range b.subs {
+			close(sub.ch)
+			delete(b.subs, recv)
 		}
 	}()
 
 	unsubscribe := func(recv <-chan T) {
 		if sub, ok := b.subs[recv]; ok {
-			close(sub)
-			delete(b.subs, sub)
+			close(sub.ch)
+			delete(b.subs, recv)
 		}
 	}
 
@@ -102,11 +108,11 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 
 		case sub := <-b.subscribe: // subscribe
 			// send initial batch of cached items
-			if !b.cache.readInto(sub) {
-				close(sub)
+			if !b.cache.readInto(sub.ch) {
+				close(sub.ch)
 				continue
 			}
-			b.subs[sub] = sub
+			b.subs[sub.ch] = sub
 
 		case recv := <-b.unsubscribe: // unsubscribe
 			unsubscribe(recv)
@@ -121,15 +127,18 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 			var slow []<-chan T
 			for _, sub := range b.subs {
 				select {
-				case sub <- item:
+				case sub.ch <- item:
 				default:
-					slow = append(slow, sub)
+					slow = append(slow, sub.ch)
 				}
 			}
-			// Instead of sending subscribers to a b.unsubscribe channel, we unsubscribe directly.
+			// Instead of sending subscribers to b.unsubscribe channel, we unsubscribe directly.
 			// Sending to b.unsubscribe could lead to deadlock, if there are too many elements in the
 			// channel buffer already.
 			for _, recv := range slow {
+				if sub, ok := b.subs[recv]; ok {
+					slog.Warn("unsubscribing slow consumer", "subscriber", sub.name)
+				}
 				unsubscribe(recv)
 			}
 		}

--- a/pkg/storage/unified/resource/broadcaster_test.go
+++ b/pkg/storage/unified/resource/broadcaster_test.go
@@ -74,7 +74,7 @@ func TestBroadcaster(t *testing.T) {
 
 	b := NewBroadcaster(ctx, ch)
 
-	sub, err := b.Subscribe(ctx)
+	sub, err := b.Subscribe(ctx, "test")
 	require.NoError(t, err)
 
 	for _, expected := range input {
@@ -89,6 +89,45 @@ func TestBroadcaster(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestBroadcasterUnsubscribe(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan int)
+	t.Cleanup(func() { close(ch) })
+
+	b := NewBroadcaster(ctx, ch)
+
+	// subscribe three, then unsubscribe all
+	sub1, err := b.Subscribe(ctx, "sub1")
+	require.NoError(t, err)
+	sub2, err := b.Subscribe(ctx, "sub2")
+	require.NoError(t, err)
+	sub3, err := b.Subscribe(ctx, "sub3")
+	require.NoError(t, err)
+
+	b.Unsubscribe(sub1)
+	b.Unsubscribe(sub2)
+	b.Unsubscribe(sub3)
+
+	// all subscriber channels should be closed
+	_, ok := <-sub1
+	require.False(t, ok)
+	_, ok = <-sub2
+	require.False(t, ok)
+	_, ok = <-sub3
+	require.False(t, ok)
+
+	// broadcaster should still work — new subscriber receives data
+	sub4, err := b.Subscribe(ctx, "sub4")
+	require.NoError(t, err)
+
+	ch <- 42
+	v, ok := <-sub4
+	require.True(t, ok)
+	require.Equal(t, 42, v)
+}
+
 func TestBroadcasterSlowConsumerDeadlock(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -100,7 +139,7 @@ func TestBroadcasterSlowConsumerDeadlock(t *testing.T) {
 	// unsubscribe channel buffer (100) in the original code.
 	const numSubs = chanBufferLen + 1
 	for i := 0; i < numSubs; i++ {
-		_, err := b.Subscribe(ctx)
+		_, err := b.Subscribe(ctx, "test")
 		require.NoError(t, err)
 	}
 

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1396,7 +1396,7 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 	// Start listening -- this will buffer any changes that happen while we backfill.
 	// If events are generated faster than we can process them, then some events will be dropped.
 	// TODO: Think of a way to allow the client to catch up.
-	stream, err := s.broadcaster.Subscribe(ctx)
+	stream, err := s.broadcaster.Subscribe(ctx, fmt.Sprintf("%s/%s/%s", key.Group, key.Resource, key.Namespace))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- Add a `name` parameter to `Subscribe` for observability — slow consumer disconnections are now logged (via `slog.Warn`) with the subscriber name
- Uses `log/slog` instead of `pkg/infra/log` to keep the generic broadcaster free of Grafana-specific dependencies. This logs to the same destination since `pkg/infra/log/slogadapter` sets `slog.SetDefault` to delegate to Grafana's logging pipeline
- The `Watch` call site passes `group/resource/namespace` as the subscriber name
- Add `TestBroadcasterUnsubscribe` covering explicit unsubscribe of all subscribers and verifying the broadcaster continues to work afterward

## Test plan
- [x] `go test ./pkg/storage/unified/resource/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)