### PR TITLE
AuthZ: Grant datasources:query permission to render service

### DIFF
--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -722,12 +722,12 @@ func (s *Service) getAnonymousPermissions(ctx context.Context, ns types.Namespac
 	return res.(map[string]bool), nil
 }
 
-// Renderer is granted permissions to read all dashboards and folders, and no other permissions
+// Renderer permissions are not stored in the database and are instead derived from the action being checked.
 func (s *Service) getRendererPermissions(ctx context.Context, action string) (map[string]bool, error) {
 	_, span := s.tracer.Start(ctx, "authz_direct_db.service.getRendererPermissions")
 	defer span.End()
 
-	if action == "dashboards:read" || action == "folders:read" || action == "datasources:read" {
+	if action == "dashboards:read" || action == "folders:read" || action == "datasources:read" || action == "datasources:query" {
 		return map[string]bool{"*": true}, nil
 	}
 	return map[string]bool{}, nil


### PR DESCRIPTION
## Summary

- Fix 403 errors when the image renderer queries datasources through the multi-tenant query service
- Add `datasources:query` to the hardcoded permission allowlist for `TypeRenderService` identities in `getRendererPermissions()`

## Root cause

When the render service captures alert screenshots, it authenticates as `TypeRenderService` and queries datasources via `POST /apis/query.grafana.app/v0alpha1/.../query/name`. The authz mapper translates this to the `datasources:query` action, but `getRendererPermissions()` only allowed `datasources:read` — not `datasources:query` — resulting in 403 Forbidden.

Fixes grafana/grafana-enterprise#11145

## Test plan

- [ ] Verify image renderer can successfully capture alert screenshots with aggregated query service enabled
- [ ] Confirm no 403 errors in logs for render service datasource queries
- [ ] Existing authz tests pass