### PR TITLE
Testing: Fix flaky ProfileButton test by mocking news feed

### DIFF
--- a/public/app/core/components/AppChrome/TopBar/ProfileButton.test.tsx
+++ b/public/app/core/components/AppChrome/TopBar/ProfileButton.test.tsx
@@ -6,6 +6,13 @@ import { config } from '@grafana/runtime';
 
 import { ProfileButton } from './ProfileButton';
 
+// Mock the news feed to avoid real network requests that can cause flaky
+// moment.js deprecation warnings when parsing RSS pubDate values.
+jest.mock('app/plugins/panel/news/feed', () => ({
+  ...jest.requireActual('app/plugins/panel/news/feed'),
+  loadFeed: jest.fn().mockResolvedValue({ items: [] }),
+}));
+
 describe('ProfileButton', () => {
   let mainView: HTMLDivElement;
   let user: ReturnType<typeof userEvent.setup>;


### PR DESCRIPTION
Mocks `loadFeed` in the `ProfileButton` test so it returns an empty items array instead of making a real network request to `grafana.com/blog/news.xml`.

The test is flaky because it renders the real `NewsContainer` without mocking the fetch layer. When the fetch completes before the test finishes, `feedToDataFrame` passes RSS `pubDate` values (e.g. `"Mon, 09 Mar 2026 14:04:35"`) to `dateTime()` without a format string, which triggers a moment.js deprecation `console.warn`. `jest-fail-on-console` (enabled in CI) then fails the test.

Whether the fetch completes in time is non-deterministic — the test passes when the network is slow and fails when it's fast.
