### PR TITLE
V2 Dashboards: Fix startup crash when v2 returns null annotations or variables

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -111,12 +111,13 @@ export function transformSaveModelSchemaV2ToScene(
 ): DashboardScene {
   const { spec: dashboard, metadata, apiVersion } = dto;
 
-  const found = dashboard.annotations.some((item) => item.spec.builtIn);
+  const annotations = dashboard.annotations ?? [];
+  const found = annotations.some((item) => item.spec.builtIn);
   if (!found) {
-    dashboard.annotations.unshift(getGrafanaBuiltInAnnotation());
+    annotations.unshift(getGrafanaBuiltInAnnotation());
   }
 
-  const annotationLayers = dashboard.annotations.map((annotation) => {
+  const annotationLayers = annotations.map((annotation) => {
     const annotationQuerySpec = transformV2ToV1AnnotationQuery(annotation);
 
     const layerState = {
@@ -291,7 +292,7 @@ function getVariables(
 
 function createVariablesForDashboard(dashboard: DashboardV2Spec, defaultVariables: VariableKind[] = []) {
   const isDefined = (v: SceneVariable | null): v is SceneVariable => Boolean(v);
-  const variableObjects = dashboard.variables
+  const variableObjects = (dashboard.variables ?? [])
     .map((v) => {
       try {
         return createSceneVariableFromVariableModel(v);
@@ -558,7 +559,7 @@ export function getCurrentValueForOldIntervalModel(variable: IntervalVariableKin
 }
 
 export function createVariablesForSnapshot(dashboard: DashboardV2Spec): SceneVariableSet {
-  const variableObjects = dashboard.variables
+  const variableObjects = (dashboard.variables ?? [])
     .map((v) => {
       try {
         // for adhoc we are using the AdHocFiltersVariable from scenes becuase of its complexity

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -1407,10 +1407,10 @@ function transformToV1VariableTypes(variable: TypedVariableModelV2): VariableTyp
 }
 
 export function transformDashboardV2SpecToV1(spec: DashboardV2Spec, metadata: ObjectMeta): DashboardDataDTO {
-  const annotations = spec.annotations.map(transformV2ToV1AnnotationQuery);
+  const annotations = (spec.annotations ?? []).map(transformV2ToV1AnnotationQuery);
 
   const gnetId = metadata.annotations?.[AnnoKeyDashboardGnetId];
-  const variables = getVariablesV1(spec.variables);
+  const variables = getVariablesV1(spec.variables ?? []);
   const panels = getPanelsV1(spec.elements, spec.layout);
   return {
     uid: metadata.name,


### PR DESCRIPTION
**What is this feature?**

The v2 API accepts null for annotations and variables in the dashboard spec. When such a dashboard is loaded, the frontend crashes on startup because it calls array methods (.some(), .map(), etc.) on null.

