### PR TITLE
Plugin Extensions: Fix stack overflow in writableProxy when props contain React elements

### DIFF
--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -528,6 +528,14 @@ describe('Plugin Extensions / Utils', () => {
         expect(proxy.a.c).toBeUndefined();
       });
     });
+
+    it('should pass through React elements without wrapping them in a proxy', () => {
+      const element = <div>hello</div>;
+      const proxy = getMutationObserverProxy({ child: element });
+
+      expect(proxy.child).toBe(element);
+      expect(isMutationObserverProxy(proxy.child)).toBe(false);
+    });
   });
 
   describe('writableProxy()', () => {
@@ -617,6 +625,24 @@ describe('Plugin Extensions / Utils', () => {
           stack: expect.any(String),
         }
       );
+    });
+
+    it('should not throw when value contains React elements', () => {
+      const element = <div>hello</div>;
+
+      expect(() => {
+        writableProxy({ children: element });
+      }).not.toThrow();
+    });
+
+    it('should preserve React elements as-is while cloning other properties', () => {
+      const element = <div>hello</div>;
+      const original = { name: 'test', children: element };
+      const copy = writableProxy(original);
+
+      expect(copy).not.toBe(original);
+      expect(copy.name).toBe('test');
+      expect(copy.children).toBe(element);
     });
   });
 
@@ -992,6 +1018,28 @@ describe('Plugin Extensions / Utils', () => {
         message: 'Test error',
         componentStack: expect.any(String),
       });
+    });
+
+    it('should correctly render when children are passed as props', async () => {
+      const pluginId = 'grafana-worldmap-panel';
+      const ParentComponent = ({ children }: React.PropsWithChildren) => {
+        return <div data-testid="parent-wrapper">{children}</div>;
+      };
+      const WrappedComponent = wrapWithPluginContext({
+        pluginId,
+        extensionTitle: 'ParentComponent',
+        Component: ParentComponent,
+        log,
+      });
+
+      render(
+        <WrappedComponent>
+          <span>child content</span>
+        </WrappedComponent>
+      );
+
+      expect(await screen.findByTestId('parent-wrapper')).toBeVisible();
+      expect(screen.getByText('child content')).toBeVisible();
     });
   });
 

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { cloneDeep, isArray, isObject, isString } from 'lodash';
+import { cloneDeepWith, isArray, isObject, isString } from 'lodash';
 import * as React from 'react';
 import { useAsync } from 'react-use';
 
@@ -347,6 +347,12 @@ export function getMutationObserverProxy<T extends object>(obj: T, options?: Pro
         return dateTime(value);
       }
 
+      // React elements have frozen internal properties that cause proxy
+      // invariant violations; return them as-is.
+      if (React.isValidElement(value)) {
+        return value;
+      }
+
       if (isObject(value) || isArray(value)) {
         if (!cache.has(value)) {
           cache.set(value, getMutationObserverProxy(value, { log, source, pluginId, pluginVersion }));
@@ -378,8 +384,17 @@ export function writableProxy<T>(value: T, options?: ProxyOptions): T {
 
   const { log = baseLog, source = 'extension', pluginId = 'unknown', pluginVersion = 'unknown' } = options ?? {};
 
-  // Default: we return a proxy of a deep-cloned version of the original object, which logs warnings when mutation is attempted
-  return getMutationObserverProxy(cloneDeep(value), { log, pluginId, pluginVersion, source });
+  const cloned = cloneDeepWith(value, (val) => {
+    // React elements must not be deep-cloned: they contain internal fiber
+    // references that form a deeply-nested linked list, causing stack overflow.
+    if (React.isValidElement(val)) {
+      return val;
+    }
+    // Returning undefined tells lodash to use its default cloning behaviour.
+    return undefined;
+  });
+
+  return getMutationObserverProxy(cloned, { log, pluginId, pluginVersion, source });
 }
 
 export function isReadOnlyProxy(value: unknown): boolean {


### PR DESCRIPTION
**What is this feature?**

`wrapWithPluginContext` passes all component props through writableProxy, which calls lodash `cloneDeep(props)`. When props include React elements (e.g. children), `cloneDeep` traverses the element's internal fiber structures -- a deeply-nested linked list of distinct objects that lodash doesn't recognize as circular -- causing RangeError: Maximum call stack size exceeded.

This also adds a guard in getMutationObserverProxy's get trap to return React elements as-is instead of wrapping them in nested proxies, which would otherwise cause proxy invariant violations on their frozen internal properties.

**Why do we need this feature?**

This breaks any exposed component (usePluginComponent) or added component (usePluginComponents) that receives React elements as props. The concrete case surfaced in Grafana 13 (React 19): Application Observability passes <EntityCatalogHighlight /> as children to the grafana-asserts-app/knowledge-graph-notification/v1 exposed component. The WrappedExtensionComponent crashes with a stack overflow before the component ever renders, and the error boundary recreates the entire app tree.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

It fixes the following error: `React ErrorBoundary RangeError: Maximum call stack size exceeded`:

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
