### PR TITLE
Alerting: Revert adding typesVersions to @grafana/alerting for backward compat

### DIFF
--- a/packages/grafana-alerting/package.json
+++ b/packages/grafana-alerting/package.json
@@ -20,16 +20,6 @@
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.mjs",
   "types": "./dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "unstable": [
-        "dist/types/unstable.d.ts"
-      ],
-      "testing": [
-        "dist/types/testing.d.ts"
-      ]
-    }
-  },
   "exports": {
     "./package.json": "./package.json",
     ".": {


### PR DESCRIPTION
**What is this feature?**

This PR reverts the `typesVersions` addition to `@grafana/alerting` from #120020.

#### Why

The root cause (grafana-assistant-app using `moduleResolution: "node"`) has been fixed upstream by switching to `moduleResolution: "bundler"` in https://github.com/grafana/grafana-assistant-app/pull/5338.

Removing `typesVersions` keeps `@grafana/alerting` consistent with how the other `@grafana/*` packages are defined.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
