### PR TITLE
DynamicDashboards: Fix auto-focus variable name input on creation

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/VariableAddEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableAddEditableElement.tsx
@@ -79,7 +79,6 @@ export function VariableTypeSelection({ variableAdd }: { variableAdd: VariableAd
 
       const newVar = getVariableScene(type, { name: getNextAvailableId(type, variablesSet.state.variables ?? []) });
       dashboardEditActions.addVariable({ source: variablesSet, addedObject: newVar });
-      dashboard.state.editPane.selectObject(newVar, newVar.state.key!, { force: true, multi: false });
       DashboardInteractions.newVariableTypeSelected({ type });
     },
     [variableAdd]

--- a/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx
@@ -50,7 +50,7 @@ function useEditPaneOptions(this: VariableEditableElement, isNewElement: boolean
           title: '',
           id: variableNameId,
           skipField: true,
-          render: () => <VariableNameInput variable={variable} isNewElement={isNewElement} />,
+          render: () => <VariableNameInput variable={variable} autoFocus={isNewElement} />,
         })
       )
       .addItem(
@@ -145,9 +145,9 @@ interface VariableInputProps {
   id?: string;
 }
 
-function VariableNameInput({ variable, isNewElement }: { variable: SceneVariable; isNewElement: boolean }) {
+function VariableNameInput({ variable, autoFocus }: { variable: SceneVariable; autoFocus: boolean }) {
   const { name } = variable.useState();
-  const ref = useEditPaneInputAutoFocus({ autoFocus: isNewElement });
+  const ref = useEditPaneInputAutoFocus({ autoFocus });
   const [nameError, setNameError] = useState<string>();
   const id = useId();
 


### PR DESCRIPTION
This PR ensures that, after creating a new variable and choosing its type, the variable name input field is auto-focused.

📍 **Problem**
Creating a new variable is a 2-step process: first selecting the type (clicking a card), then filling in the variable details. After step 2, the [`isNewElement`](https://github.com/grafana/grafana/blob/main/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx#L29) flag — which drives `autoFocus` on the name input — was always false.

The root cause:
- in [`VariableTypeSelection.onAddVariable`](https://github.com/grafana/grafana/blob/main/public/app/features/dashboard-scene/settings/variables/VariableAddEditableElement.tsx#L71-L86), `dashboardEditActions.addVariable()` already triggers [`DashboardEditPane.performAction()`](https://github.com/grafana/grafana/blob/main/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx#L170-L185) → `newObjectAddedToCanvas()`, which calls `selectObject()` and then `markAsNewElement()` on the new selection.
- but immediately after, an explicit `editPane.selectObject()` call created a new `ElementSelection` instance, resetting `_isNewElement` back to false.

💡 **Approach**

Removing the redundant `selectObject` call in `onAddVariable`. The `addedObject` mechanism in `dashboardEditActions` already handles both selection and the `isNewElement` flag — this is consistent with how every other "add" flow works (panels, tabs, rows, annotations, links).

🧪 **How to test**
- Open any dashboard in edit mode
- Open the edit pane, go to Variables
- Click Add variable
- Click any variable type card (e.g. "Query")
- Verify the Name input field is auto-focused (cursor blinking in the field)
- Verify undo (Ctrl+Z) still works correctly after adding a variable