### PR TITLE
Alerting: Treat not found error when fetching plugins as not installed

### DIFF
--- a/public/app/features/alerting/unified/hooks/usePluginBridge.test.tsx
+++ b/public/app/features/alerting/unified/hooks/usePluginBridge.test.tsx
@@ -38,7 +38,7 @@ describe('useIrmPlugin', () => {
       return {
         data: undefined,
         isLoading: false,
-        error: new Error('Plugin not found'),
+        error: { status: 404, data: { message: 'Plugin not found' } },
         refetch: jest.fn(),
       } as PluginQueryResult;
     });
@@ -67,7 +67,7 @@ describe('useIrmPlugin', () => {
       return {
         data: undefined,
         isLoading: false,
-        error: new Error('Plugin not found'),
+        error: { status: 404, data: { message: 'Plugin not found' } },
         refetch: jest.fn(),
       } as PluginQueryResult;
     });
@@ -96,7 +96,7 @@ describe('useIrmPlugin', () => {
       return {
         data: undefined,
         isLoading: false,
-        error: new Error('Plugin not found'),
+        error: { status: 404, data: { message: 'Plugin not found' } },
         refetch: jest.fn(),
       } as PluginQueryResult;
     });
@@ -126,11 +126,30 @@ describe('useIrmPlugin', () => {
     expect(result.current.installed).toBeUndefined();
   });
 
-  it('should return installed undefined when neither plugin is installed', async () => {
+  it('should return installed false when neither plugin is installed (404)', async () => {
     mockedUseGetPluginSettingsQuery.mockReturnValue({
       data: undefined,
       isLoading: false,
-      error: new Error('Plugin not found'),
+      error: { status: 404, data: { message: 'Plugin not found' } },
+      refetch: jest.fn(),
+    } as PluginQueryResult);
+
+    const { result } = renderHook(() => useIrmPlugin(SupportedPlugin.OnCall));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.pluginId).toBe(SupportedPlugin.OnCall);
+    expect(result.current.installed).toBe(false);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('should propagate error when plugin check fails with a non-404 error', async () => {
+    mockedUseGetPluginSettingsQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: { status: 500, data: { message: 'Internal server error' } },
       refetch: jest.fn(),
     } as PluginQueryResult);
 
@@ -142,6 +161,7 @@ describe('useIrmPlugin', () => {
 
     expect(result.current.pluginId).toBe(SupportedPlugin.OnCall);
     expect(result.current.installed).toBeUndefined();
+    expect(result.current.error).toBeDefined();
   });
 
   it('should return IRM plugin ID when both IRM and OnCall are installed', async () => {
@@ -165,7 +185,7 @@ describe('useIrmPlugin', () => {
       return {
         data: undefined,
         isLoading: false,
-        error: new Error('Plugin not found'),
+        error: { status: 404, data: { message: 'Plugin not found' } },
         refetch: jest.fn(),
       } as PluginQueryResult;
     });
@@ -202,7 +222,7 @@ describe('useIrmPlugin', () => {
       return {
         data: undefined,
         isLoading: false,
-        error: new Error('Plugin not found'),
+        error: { status: 404, data: { message: 'Plugin not found' } },
         refetch: jest.fn(),
       } as PluginQueryResult;
     });

--- a/public/app/features/alerting/unified/hooks/usePluginBridge.ts
+++ b/public/app/features/alerting/unified/hooks/usePluginBridge.ts
@@ -1,4 +1,5 @@
 import { PluginMeta } from '@grafana/data';
+import { isFetchError } from '@grafana/runtime';
 
 import { useGetPluginSettingsQuery } from '../api/pluginsApi';
 import { PluginID } from '../components/PluginBridge';
@@ -19,6 +20,11 @@ export function usePluginBridge(plugin: PluginID): PluginBridgeHookResponse {
   }
 
   if (error) {
+    // 404 means the plugin is not installed
+    if (isFetchError(error) && error.status === 404) {
+      return { loading: false, installed: false };
+    }
+
     return { loading: isLoading, error: error instanceof Error ? error : new Error(String(error)) };
   }
 


### PR DESCRIPTION
**Problem**
Plugin detection in `usePluginBridge` was propagating not found errors after we migrated to using RTK Query, so when OnCall / IRM / Incident plugins were not installed the 404 response was surfaced as an error object, causing error banners to be shown on the contact points edit form for users who don't have any of these plugins installed. 

**Fix**
- Added a 404 check inside usePluginBridge
  - If the plugin settings API returns a 404, treat it as { installed: false } (not installed) instead of propagating the error
  - Non-404 errors (e.g., 500) are still propagated as before
- Updated the tests

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/119311