### PR TITLE
Dashboards a11y: Do not open time zonemenu on focus

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.tsx
@@ -45,7 +45,7 @@ export const TimeZonePicker = (props: Props) => {
     disabled = false,
     inputId,
     menuShouldPortal = true,
-    openMenuOnFocus = true,
+    openMenuOnFocus = false,
   } = props;
   const groupedTimeZones = useTimeZones(includeInternal);
   const selected = useSelectedTimeZone(groupedTimeZones, value);


### PR DESCRIPTION
When we're selecting time zone in the timerange picker, the menu opens on focus. This focuses away from the input label and onto the menu and causes screen readers to not announce the actual label:

https://github.com/user-attachments/assets/d5d770bd-1e63-46f6-816b-cf033db4a6fc


The bug was reported in an [ a11y ticket](https://github.com/grafana/grafana/issues/117837#issuecomment-3909257189)
I think the best solution here is to disable opening on focus, and opening the menu explicit. An additional reason is that the combobox component that will replace this select, doesn't have that functionality. (reasoning [here](https://raintank-corp.slack.com/archives/C025WTVRBSN/p1744038629297399?thread_ts=1744038333.835929&cid=C025WTVRBSN))

After:

https://github.com/user-attachments/assets/19f77a97-ee20-49ed-8dd0-4cb9470c571f



### Testing:
enable voice over in settings, then press CMD + Fn + F5 to launch voice over utility, then navigate to the time zone picker with the keyboard