### PR TITLE
Rendering: Add expandRows query parameter to expand collapsed rows

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
@@ -1,6 +1,7 @@
-import { SceneQueryRunner, VizPanel } from '@grafana/scenes';
+import { SceneGridLayout, SceneGridRow, SceneQueryRunner, VizPanel } from '@grafana/scenes';
 
 import { DashboardScene } from './DashboardScene';
+import { DashboardGridItem } from './layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
 
 describe('DashboardSceneUrlSync', () => {
@@ -20,6 +21,38 @@ describe('DashboardSceneUrlSync', () => {
       const layout = scene.state.body as DefaultGridLayoutManager;
       layout.state.grid.setState({ UNSAFE_fitPanels: true });
       expect(scene.urlSync?.getUrlState().autofitpanels).toBe('true');
+    });
+
+    it('Should expand all collapsed rows when url has expandRows', () => {
+      const row = new SceneGridRow({
+        key: 'row-1',
+        title: 'Row 1',
+        isCollapsed: true,
+        children: [
+          new DashboardGridItem({
+            body: new VizPanel({ title: 'Panel C', key: 'panel-3', pluginId: 'table' }),
+          }),
+        ],
+      });
+
+      const grid = new SceneGridLayout({
+        children: [
+          new DashboardGridItem({
+            body: new VizPanel({ title: 'Panel A', key: 'panel-1', pluginId: 'table' }),
+          }),
+          row,
+        ],
+      });
+
+      const scene = new DashboardScene({
+        title: 'hello',
+        uid: 'dash-1',
+        body: new DefaultGridLayoutManager({ grid }),
+      });
+
+      expect(row.state.isCollapsed).toBe(true);
+      scene.urlSync?.updateFromUrl({ expandRows: '' });
+      expect(row.state.isCollapsed).toBe(false);
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -10,12 +10,13 @@ import { DashboardScene, DashboardSceneState } from './DashboardScene';
 import { LibraryPanelBehavior } from './LibraryPanelBehavior';
 import { UNCONFIGURED_PANEL_PLUGIN_ID } from './UnconfiguredPanel';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
+import { RowsLayoutManager } from './layout-rows/RowsLayoutManager';
 
 export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
   constructor(private _scene: DashboardScene) {}
 
   getKeys(): string[] {
-    return ['inspect', 'viewPanel', 'editPanel', 'editview', 'autofitpanels', 'shareView'];
+    return ['inspect', 'viewPanel', 'editPanel', 'editview', 'autofitpanels', 'expandRows', 'shareView'];
   }
 
   getUrlState(): SceneObjectUrlValues {
@@ -113,6 +114,14 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
 
       if (!!layout.state.grid.state.UNSAFE_fitPanels !== UNSAFE_fitPanels) {
         layout.state.grid.setState({ UNSAFE_fitPanels });
+      }
+    }
+
+    if (typeof values.expandRows === 'string') {
+      if (layout instanceof DefaultGridLayoutManager) {
+        layout.expandAllRows();
+      } else if (layout instanceof RowsLayoutManager) {
+        layout.expandAllRows();
       }
     }
 

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -252,6 +252,10 @@ export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
     try {
       dashboard.processRepeats();
 
+      if (queryParams.expandRows) {
+        dashboard.expandRows();
+      }
+
       // handle auto fix experimental feature
       if (queryParams.autofitpanels) {
         dashboard.autoFitPanels(window.innerHeight, queryParams.kiosk);


### PR DESCRIPTION
## Summary

- Adds `expandRows` URL query parameter to the dashboard rendering pipeline
- When `expandRows=true` is passed to `/render/d/<uid>/<slug>`, all collapsed rows are automatically expanded before the image is captured
- Works in both legacy (`initDashboard.ts`) and scenes (`DashboardSceneUrlSync.ts`) dashboard paths
- No backend changes needed — query params are already forwarded to the frontend callback URL

## Usage

```bash
curl -H "Authorization: Bearer $TOKEN" \
  "http://localhost:3000/render/d/<uid>/<slug>?expandRows=true&width=1200&height=800" \
  -o dashboard.png
```

## Test plan

- [ ] Verify `expandRows` param expands collapsed rows in legacy dashboard rendering
- [ ] Verify `expandRows` param expands collapsed rows in scenes dashboard rendering
- [ ] Verify rendering without `expandRows` preserves existing collapsed row behavior
- [ ] Unit test for `DashboardSceneUrlSync` passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)