### PR TITLE
Alert: Small screen responsiveness fix

### DIFF
--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -11,6 +11,7 @@ import { IconName } from '../../types/icon';
 import { Button } from '../Button/Button';
 import { Icon } from '../Icon/Icon';
 import { Box } from '../Layout/Box/Box';
+import { Stack } from '../Layout/Stack/Stack';
 import { Text } from '../Text/Text';
 export type AlertVariant = 'success' | 'warning' | 'error' | 'info';
 
@@ -84,18 +85,32 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
             </div>
           </Box>
 
-          <Box paddingY={1} grow={1}>
-            <Text color="primary" weight="medium">
-              {title}
-            </Text>
-            {children && <div className={styles.content}>{children}</div>}
-          </Box>
-          {action && (
-            <Box marginLeft={1} display="flex" alignItems="center">
-              {action}
+          <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" width="100%">
+            <Box paddingY={1} grow={1}>
+              <Text color="primary" weight="medium">
+                {title}
+              </Text>
+              {children && <div className={styles.content}>{children}</div>}
             </Box>
-          )}
-          {/* If onRemove is specified, giving preference to onRemove */}
+
+            {/* actions */}
+            <Stack>
+              {action && (
+                <Box display="flex" alignItems="center">
+                  {action}
+                </Box>
+              )}
+
+              {onRemove && buttonContent && (
+                <Box display="flex" alignItems="center">
+                  <Button aria-label={closeLabel} variant="secondary" onClick={onRemove} type="button">
+                    {buttonContent}
+                  </Button>
+                </Box>
+              )}
+            </Stack>
+          </Stack>
+          {/* Close Icon button - If onRemove is specified, giving preference to onRemove */}
           {onRemove && !buttonContent && (
             <div className={styles.close}>
               <Button
@@ -107,14 +122,6 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
                 variant="secondary"
               />
             </div>
-          )}
-
-          {onRemove && buttonContent && (
-            <Box marginLeft={1} display="flex" alignItems="center">
-              <Button aria-label={closeLabel} variant="secondary" onClick={onRemove} type="button">
-                {buttonContent}
-              </Button>
-            </Box>
           )}
         </Box>
       </div>


### PR DESCRIPTION
**What is this feature?**

`Alert` component: 
- Group content, action, and button using `Stack`
- Make action/close buttons wrap below the title content on small screens (xs: column) and display inline on medium+ screens (md: row).

| Before 1 | After |
|----------|----------|
| <img width="322" height="434" alt="image" src="https://github.com/user-attachments/assets/cbd89cff-2ce4-4c53-947f-6da7f6e80510" />   | <img width="321" height="333" alt="image" src="https://github.com/user-attachments/assets/918a2b7a-de28-4c94-8818-13a684265a5e" />   |
| <img width="322" height="1348" alt="image" src="https://github.com/user-attachments/assets/61b92cad-915f-4a7c-8a58-09f7a8799151" /> | <img width="570" height="406" alt="image" src="https://github.com/user-attachments/assets/2e195ad9-5d0a-469a-a16a-02088604418c" />    |

**Why do we need this feature?**

On smaller screens, the Alert component's action buttons could take up a lot of space on the right if we don't wrap it into second row. 

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/973

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
