### PR TITLE
Alerting: Update notification settings validator to include route from extra config

### DIFF
--- a/pkg/services/ngalert/notifier/validation.go
+++ b/pkg/services/ngalert/notifier/validation.go
@@ -109,6 +109,9 @@ func NewNotificationSettingsValidator(cfg *definitions.PostableUserConfig) Notif
 		availableRoutes[routeName] = struct{}{}
 	}
 	availableRoutes[models.DefaultRoutingTreeName] = struct{}{}
+	if len(cfg.ExtraConfigs) > 0 {
+		availableRoutes[cfg.ExtraConfigs[0].Identifier] = struct{}{}
+	}
 
 	return staticNotificationSettingsValidator{
 		staticContactPointValidator: &validator,

--- a/pkg/services/ngalert/notifier/validation_test.go
+++ b/pkg/services/ngalert/notifier/validation_test.go
@@ -1,0 +1,151 @@
+package notifier
+
+import (
+	"testing"
+
+	"github.com/grafana/alerting/definition"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+func TestNewNotificationSettingsValidator_Routes(t *testing.T) {
+	baseConfig := func() *definitions.PostableUserConfig {
+		return &definitions.PostableUserConfig{
+			AlertmanagerConfig: definitions.PostableApiAlertingConfig{
+				Config: definitions.Config{
+					Route: &definitions.Route{Receiver: "default"},
+				},
+				Receivers: []*definitions.PostableApiReceiver{
+					{Receiver: definition.Receiver{Name: "default"}},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		mutate      func(cfg *definitions.PostableUserConfig)
+		policy      string
+		expectError bool
+		errorType   error // nil means just check expectError
+	}{
+		{
+			name:        "default routing tree is always available but PolicyRouting rejects it",
+			policy:      models.DefaultRoutingTreeName,
+			expectError: true, // PolicyRouting.Validate rejects explicitly pointing to default tree
+		},
+		{
+			name: "managed route is available",
+			mutate: func(cfg *definitions.PostableUserConfig) {
+				cfg.ManagedRoutes = definitions.ManagedRoutes{"custom-route": nil}
+			},
+			policy:      "custom-route",
+			expectError: false,
+		},
+		{
+			name: "second managed route is available",
+			mutate: func(cfg *definitions.PostableUserConfig) {
+				cfg.ManagedRoutes = definitions.ManagedRoutes{
+					"route-a": nil,
+					"route-b": nil,
+				}
+			},
+			policy:      "route-b",
+			expectError: false,
+		},
+		{
+			name:        "unknown route returns ErrorRouteDoesNotExist",
+			policy:      "does-not-exist",
+			expectError: true,
+			errorType:   ErrorRouteDoesNotExist{},
+		},
+		{
+			name: "first extra config identifier is available",
+			mutate: func(cfg *definitions.PostableUserConfig) {
+				cfg.ExtraConfigs = []definitions.ExtraConfiguration{
+					{Identifier: "extra-1"},
+				}
+			},
+			policy:      "extra-1",
+			expectError: false,
+		},
+		{
+			name: "only first extra config is added as route",
+			mutate: func(cfg *definitions.PostableUserConfig) {
+				cfg.ExtraConfigs = []definitions.ExtraConfiguration{
+					{Identifier: "extra-1"},
+					{Identifier: "extra-2"},
+				}
+			},
+			policy:      "extra-2",
+			expectError: true,
+			errorType:   ErrorRouteDoesNotExist{},
+		},
+		{
+			name:        "empty extra configs does not add routes",
+			policy:      "extra-route",
+			expectError: true,
+			errorType:   ErrorRouteDoesNotExist{},
+		},
+		{
+			name: "managed route available alongside extra config",
+			mutate: func(cfg *definitions.PostableUserConfig) {
+				cfg.ManagedRoutes = definitions.ManagedRoutes{"managed-1": nil}
+				cfg.ExtraConfigs = []definitions.ExtraConfiguration{
+					{Identifier: "extra-1"},
+				}
+			},
+			policy:      "managed-1",
+			expectError: false,
+		},
+		{
+			name: "extra config route available alongside managed routes",
+			mutate: func(cfg *definitions.PostableUserConfig) {
+				cfg.ManagedRoutes = definitions.ManagedRoutes{"managed-1": nil}
+				cfg.ExtraConfigs = []definitions.ExtraConfiguration{
+					{Identifier: "extra-1"},
+				}
+			},
+			policy:      "extra-1",
+			expectError: false,
+		},
+		{
+			name: "unknown route fails even when other sources exist",
+			mutate: func(cfg *definitions.PostableUserConfig) {
+				cfg.ManagedRoutes = definitions.ManagedRoutes{"managed-1": nil}
+				cfg.ExtraConfigs = []definitions.ExtraConfiguration{
+					{Identifier: "extra-1"},
+				}
+			},
+			policy:      "unknown",
+			expectError: true,
+			errorType:   ErrorRouteDoesNotExist{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseConfig()
+			if tc.mutate != nil {
+				tc.mutate(cfg)
+			}
+			v := NewNotificationSettingsValidator(cfg)
+
+			err := v.Validate(models.NotificationSettings{
+				PolicyRouting: &models.PolicyRouting{Policy: tc.policy},
+			})
+
+			if tc.expectError {
+				require.Error(t, err)
+				if tc.errorType != nil {
+					assert.ErrorAs(t, err, &tc.errorType)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add identifier of extra config as existing managed route. 

**Why do we need this feature?**
The convert API uses provisioning service to create rules. Therefore, validation should pass when imported route exists. 
