### PR TITLE
Alerting: Add namespace UID annotation to alert payloads

### DIFF
--- a/pkg/services/ngalert/state/compat.go
+++ b/pkg/services/ngalert/state/compat.go
@@ -64,6 +64,12 @@ func StateToPostableAlert(transition StateTransition, appURL *url.URL, featureTo
 		nA[alertingModels.OrgIDAnnotation] = strconv.FormatInt(alertState.OrgID, 10)
 	}
 
+	// Propagate the namespace/folder UID as an annotation because the label is stripped before sending.
+	// This is required by notification history.
+	if namespaceUID, ok := nL[alertingModels.NamespaceUIDLabel]; ok && namespaceUID != "" {
+		nA[alertingModels.NamespaceUIDLabel] = namespaceUID
+	}
+
 	var urlStr string
 	if uid := nL[alertingModels.RuleUIDLabel]; len(uid) > 0 && appURL != nil {
 		u := *appURL

--- a/pkg/services/ngalert/state/compat_test.go
+++ b/pkg/services/ngalert/state/compat_test.go
@@ -183,6 +183,29 @@ func Test_StateToPostableAlert(t *testing.T) {
 				require.Equal(t, alertState.StateReason, result.Annotations[ngModels.StateReasonAnnotation])
 			})
 
+			t.Run("should propagate namespace UID label as annotation", func(t *testing.T) {
+				t.Run("when label is present and non-empty", func(t *testing.T) {
+					alertState := randomTransition(eval.Normal, tc.state)
+					alertState.Labels[alertingModels.NamespaceUIDLabel] = "test-namespace-uid"
+					result := StateToPostableAlert(alertState, appURL, featuremgmt.WithFeatures())
+					require.Equal(t, "test-namespace-uid", result.Annotations[alertingModels.NamespaceUIDLabel])
+				})
+
+				t.Run("when label is empty", func(t *testing.T) {
+					alertState := randomTransition(eval.Normal, tc.state)
+					alertState.Labels[alertingModels.NamespaceUIDLabel] = ""
+					result := StateToPostableAlert(alertState, appURL, featuremgmt.WithFeatures())
+					require.NotContains(t, result.Annotations, alertingModels.NamespaceUIDLabel)
+				})
+
+				t.Run("when label is missing", func(t *testing.T) {
+					alertState := randomTransition(eval.Normal, tc.state)
+					delete(alertState.Labels, alertingModels.NamespaceUIDLabel)
+					result := StateToPostableAlert(alertState, appURL, featuremgmt.WithFeatures())
+					require.NotContains(t, result.Annotations, alertingModels.NamespaceUIDLabel)
+				})
+			})
+
 			switch tc.state {
 			case eval.NoData:
 				t.Run("should keep existing labels and change name", func(t *testing.T) {

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -2772,6 +2772,7 @@ var expNonEmailNotifications = map[string][]string{
 			  "grafana_folder": "default"
 			},
 		"annotations": {
+		  "__alert_rule_namespace_uid__":"default",
 		  "__orgId__":"1",
               "__values__": "{\"A\":1}",
               "__value_string__": "[ var='A' labels={} type='math' value=1 ]"


### PR DESCRIPTION
This is required for notification history to be able to log what folder owns the
alert rule in order to filter for user visibility of alert rules.

Notification history change: https://github.com/grafana/alerting/pull/511