### PR TITLE
Alerting: Fix stale alertmanager selection issue when switching organizations

### DIFF
--- a/public/app/features/alerting/unified/state/AlertmanagerContext.test.tsx
+++ b/public/app/features/alerting/unified/state/AlertmanagerContext.test.tsx
@@ -130,7 +130,7 @@ describe('useAlertmanager', () => {
     expect(result.current.selectedAlertmanager).toBe(GRAFANA_RULES_SOURCE_NAME);
   });
 
-  it('Should clean up stale localStorage entry when stored AM is not available', async () => {
+  it('Should clean up stale localStorage entry when stored AM is not available', () => {
     jest.spyOn(useAlertManagerSources, 'useAlertManagersByPermission').mockReturnValueOnce({
       availableExternalDataSources: [],
       availableInternalDataSources: [{ name: GRAFANA_RULES_SOURCE_NAME, imgUrl: '', hasConfigurationAPI: true }],

--- a/public/app/features/alerting/unified/state/AlertmanagerContext.test.tsx
+++ b/public/app/features/alerting/unified/state/AlertmanagerContext.test.tsx
@@ -3,15 +3,19 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 
 import { store } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import { AlertManagerImplementation } from 'app/plugins/datasource/alertmanager/types';
 import { configureStore } from 'app/store/configureStore';
 
 import * as useAlertManagerSources from '../hooks/useAlertManagerSources';
-import { ALERTMANAGER_NAME_LOCAL_STORAGE_KEY } from '../utils/constants';
 import { AlertManagerDataSource, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 
-import { AlertmanagerProvider, isAlertManagerWithConfigAPI, useAlertmanager } from './AlertmanagerContext';
+import {
+  AlertmanagerProvider,
+  getOrgAlertmanagerLocalStorageKey,
+  isAlertManagerWithConfigAPI,
+  useAlertmanager,
+} from './AlertmanagerContext';
 
 const externalAmProm: AlertManagerDataSource = {
   name: 'PrometheusAm',
@@ -88,7 +92,7 @@ describe('useAlertmanager', () => {
 
     const wrapper = getProviderWrapper();
 
-    store.set(ALERTMANAGER_NAME_LOCAL_STORAGE_KEY, externalAmProm.name);
+    store.set(getOrgAlertmanagerLocalStorageKey(config.bootData.user.orgId), externalAmProm.name);
     locationService.push({ search: '' });
     const { result } = renderHook(() => useAlertmanager(), { wrapper });
     expect(result.current.selectedAlertmanager).toBe(externalAmProm.name);
@@ -104,10 +108,58 @@ describe('useAlertmanager', () => {
 
     const wrapper = getProviderWrapper();
 
-    store.set(ALERTMANAGER_NAME_LOCAL_STORAGE_KEY, externalAmMimir.name);
+    store.set(getOrgAlertmanagerLocalStorageKey(config.bootData.user.orgId), externalAmMimir.name);
 
     const { result } = renderHook(() => useAlertmanager(), { wrapper });
     expect(result.current.selectedAlertmanager).toBe(externalAmProm.name);
+  });
+
+  it('Should fall back to Grafana AM when stored AM is not available', () => {
+    jest.spyOn(useAlertManagerSources, 'useAlertManagersByPermission').mockReturnValueOnce({
+      availableExternalDataSources: [],
+      availableInternalDataSources: [{ name: GRAFANA_RULES_SOURCE_NAME, imgUrl: '', hasConfigurationAPI: true }],
+    });
+
+    const orgKey = getOrgAlertmanagerLocalStorageKey(config.bootData.user.orgId);
+    store.set(orgKey, 'NonExistentAM');
+    locationService.push({ search: '' });
+
+    const wrapper = getProviderWrapper();
+    const { result } = renderHook(() => useAlertmanager(), { wrapper });
+
+    expect(result.current.selectedAlertmanager).toBe(GRAFANA_RULES_SOURCE_NAME);
+  });
+
+  it('Should clean up stale localStorage entry when stored AM is not available', async () => {
+    jest.spyOn(useAlertManagerSources, 'useAlertManagersByPermission').mockReturnValueOnce({
+      availableExternalDataSources: [],
+      availableInternalDataSources: [{ name: GRAFANA_RULES_SOURCE_NAME, imgUrl: '', hasConfigurationAPI: true }],
+    });
+
+    const orgKey = getOrgAlertmanagerLocalStorageKey(config.bootData.user.orgId);
+    store.set(orgKey, 'NonExistentAM');
+    locationService.push({ search: '' });
+
+    const wrapper = getProviderWrapper();
+    renderHook(() => useAlertmanager(), { wrapper });
+
+    expect(store.get(orgKey)).toBeUndefined();
+  });
+
+  it('Should not read localStorage from a different org', () => {
+    jest.spyOn(useAlertManagerSources, 'useAlertManagersByPermission').mockReturnValueOnce({
+      availableExternalDataSources: [externalAmProm],
+      availableInternalDataSources: [{ name: GRAFANA_RULES_SOURCE_NAME, imgUrl: '', hasConfigurationAPI: true }],
+    });
+
+    const otherOrgKey = getOrgAlertmanagerLocalStorageKey(999);
+    store.set(otherOrgKey, externalAmProm.name);
+    locationService.push({ search: '' });
+
+    const wrapper = getProviderWrapper();
+    const { result } = renderHook(() => useAlertmanager(), { wrapper });
+
+    expect(result.current.selectedAlertmanager).toBe(GRAFANA_RULES_SOURCE_NAME);
   });
 });
 

--- a/public/app/features/alerting/unified/state/AlertmanagerContext.tsx
+++ b/public/app/features/alerting/unified/state/AlertmanagerContext.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { store } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import { AlertManagerDataSourceJsonData, AlertManagerImplementation } from 'app/plugins/datasource/alertmanager/types';
 
 import { useAlertManagersByPermission } from '../hooks/useAlertManagerSources';
@@ -23,6 +23,9 @@ interface Context {
 
 const AlertmanagerContext = React.createContext<Context | undefined>(undefined);
 
+export function getOrgAlertmanagerLocalStorageKey(orgId: number): string {
+  return `${ALERTMANAGER_NAME_LOCAL_STORAGE_KEY}-org-${orgId}`;
+}
 interface Props extends React.PropsWithChildren {
   accessType: 'instance' | 'notification';
   // manually setting the alertmanagersource name will override all of the other sources
@@ -33,6 +36,7 @@ const AlertmanagerProvider = ({ children, accessType, alertmanagerSourceName }: 
   const queryParams = locationService.getSearch();
   const updateQueryParams = locationService.partial;
   const allAvailableAlertManagers = useAlertManagersByPermission(accessType);
+  const localStorageKey = getOrgAlertmanagerLocalStorageKey(config.bootData.user.orgId);
 
   const availableAlertManagers = React.useMemo(() => {
     const regularAlertManagers = allAvailableAlertManagers.availableInternalDataSources.concat(
@@ -59,18 +63,18 @@ const AlertmanagerProvider = ({ children, accessType, alertmanagerSourceName }: 
       }
 
       if (selectedAlertManager === GRAFANA_RULES_SOURCE_NAME) {
-        store.delete(ALERTMANAGER_NAME_LOCAL_STORAGE_KEY);
+        store.delete(localStorageKey);
         updateQueryParams({ [ALERTMANAGER_NAME_QUERY_KEY]: undefined });
       } else {
-        store.set(ALERTMANAGER_NAME_LOCAL_STORAGE_KEY, selectedAlertManager);
+        store.set(localStorageKey, selectedAlertManager);
         updateQueryParams({ [ALERTMANAGER_NAME_QUERY_KEY]: selectedAlertManager });
       }
     },
-    [availableAlertManagers, updateQueryParams]
+    [availableAlertManagers, localStorageKey, updateQueryParams]
   );
 
   const sourceFromQuery = queryParams.get(ALERTMANAGER_NAME_QUERY_KEY);
-  const sourceFromStore = store.get(ALERTMANAGER_NAME_LOCAL_STORAGE_KEY);
+  const sourceFromStore = store.get(localStorageKey);
   const defaultSource = GRAFANA_RULES_SOURCE_NAME;
 
   // This overrides AM in the store to be in sync with the one in the URL
@@ -78,18 +82,30 @@ const AlertmanagerProvider = ({ children, accessType, alertmanagerSourceName }: 
   // It's safest to always use URLs with alertmanager query param
   React.useEffect(() => {
     if (sourceFromQuery && sourceFromQuery !== sourceFromStore) {
-      store.set(ALERTMANAGER_NAME_LOCAL_STORAGE_KEY, sourceFromQuery);
+      store.set(localStorageKey, sourceFromQuery);
     }
-  }, [sourceFromQuery, sourceFromStore]);
+  }, [localStorageKey, sourceFromQuery, sourceFromStore]);
 
   // queryParam > localStorage > default
   const desiredAlertmanager = alertmanagerSourceName ?? sourceFromQuery ?? sourceFromStore ?? defaultSource;
-  const selectedAlertmanager = isAlertManagerAvailable(availableAlertManagers, desiredAlertmanager)
-    ? desiredAlertmanager
-    : undefined;
+  const isDesiredAvailable = isAlertManagerAvailable(availableAlertManagers, desiredAlertmanager);
+
+  let selectedAlertmanager: string | undefined;
+  if (isDesiredAvailable) {
+    selectedAlertmanager = desiredAlertmanager;
+  } else if (isAlertManagerAvailable(availableAlertManagers, defaultSource)) {
+    selectedAlertmanager = defaultSource;
+  }
+
+  // Clean up stale org-scoped key if the stored value no longer resolves to an available AM
+  React.useEffect(() => {
+    if (!isDesiredAvailable && sourceFromStore) {
+      store.delete(localStorageKey);
+    }
+  }, [isDesiredAvailable, localStorageKey, sourceFromStore]);
 
   const selectedAlertmanagerConfig = React.useMemo(() => {
-    return getAlertmanagerDataSourceByName(selectedAlertmanager)?.jsonData;
+    return selectedAlertmanager ? getAlertmanagerDataSourceByName(selectedAlertmanager)?.jsonData : undefined;
   }, [selectedAlertmanager]);
 
   // determine if we're dealing with an Alertmanager data source that supports the ruler API

--- a/public/app/features/alerting/unified/state/AlertmanagerContext.tsx
+++ b/public/app/features/alerting/unified/state/AlertmanagerContext.tsx
@@ -26,6 +26,7 @@ const AlertmanagerContext = React.createContext<Context | undefined>(undefined);
 export function getOrgAlertmanagerLocalStorageKey(orgId: number): string {
   return `${ALERTMANAGER_NAME_LOCAL_STORAGE_KEY}-org-${orgId}`;
 }
+
 interface Props extends React.PropsWithChildren {
   accessType: 'instance' | 'notification';
   // manually setting the alertmanagersource name will override all of the other sources
@@ -99,10 +100,10 @@ const AlertmanagerProvider = ({ children, accessType, alertmanagerSourceName }: 
 
   // Clean up stale org-scoped key if the stored value no longer resolves to an available AM
   React.useEffect(() => {
-    if (!isDesiredAvailable && sourceFromStore) {
+    if (sourceFromStore && !isAlertManagerAvailable(availableAlertManagers, sourceFromStore)) {
       store.delete(localStorageKey);
     }
-  }, [isDesiredAvailable, localStorageKey, sourceFromStore]);
+  }, [availableAlertManagers, localStorageKey, sourceFromStore]);
 
   const selectedAlertmanagerConfig = React.useMemo(() => {
     return selectedAlertmanager ? getAlertmanagerDataSourceByName(selectedAlertmanager)?.jsonData : undefined;


### PR DESCRIPTION
**Problem**

The Alerting UI stored the selected Alertmanager in a single global localStorage key (alerting-alertmanager) shared across all organizations. When a user switched orgs or renamed the datasource, the stale key referred to an AM that no longer existed in the current context, causing the UI to render an error with a disabled dropdown that offered no way to recover.

*Before the fix*

https://github.com/user-attachments/assets/d073b04e-6e0d-4009-af9a-e057063fb879


**Fix**

Refactored the localStorage key to be scoped per organization (alerting-alertmanager-org-{orgId}), preventing cross-org contamination. Additionally, when the desired AM is unavailable, the context now gracefully falls back to the Grafana built-in Alertmanager (instead of returning undefined) and cleans up the stale key, ensuring users are never left in a broken state.

*After the fix*

https://github.com/user-attachments/assets/f823ccc4-f542-4db4-bd5a-86776a5515e4



**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/83320

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
