### PR TITLE
Setting: fix GF_ENVIRONMENT_STACK_ID env var having no effect

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1276,8 +1276,8 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 		cfg.Target = util.SplitString(Target)
 	}
 	cfg.Env = valueAsString(iniFile.Section(""), "app_mode", "development")
-	cfg.StackID = valueAsString(iniFile.Section("environment"), "stack_id", "")
-	cfg.Slug = valueAsString(iniFile.Section("environment"), "stack_slug", "")
+	cfg.StackID = cfg.SectionWithEnvOverrides("environment").Key("stack_id").MustString("")
+	cfg.Slug = cfg.SectionWithEnvOverrides("environment").Key("stack_slug").MustString("")
 	cfg.LocalFileSystemAvailable = iniFile.Section("environment").Key("local_file_system_available").MustBool(true)
 	cfg.InstanceName = valueAsString(iniFile.Section(""), "instance_name", "unknown_instance_name")
 	plugins := valueAsString(iniFile.Section("paths"), "plugins", "")

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -694,3 +694,31 @@ func TestDynamicSection(t *testing.T) {
 		assert.Equal(t, value, ds.section.Key(key).String())
 	})
 }
+
+func TestStackIDFromEnvVar(t *testing.T) {
+	t.Setenv("GF_ENVIRONMENT_STACK_ID", "1001")
+
+	cfg := NewCfg()
+	err := cfg.Load(CommandLineArgs{HomePath: "../../"})
+	require.NoError(t, err)
+
+	require.Equal(t, "1001", cfg.StackID)
+}
+
+func TestStackSlugFromEnvVar(t *testing.T) {
+	t.Setenv("GF_ENVIRONMENT_STACK_SLUG", "mystack")
+
+	cfg := NewCfg()
+	err := cfg.Load(CommandLineArgs{HomePath: "../../"})
+	require.NoError(t, err)
+
+	require.Equal(t, "mystack", cfg.Slug)
+}
+
+func TestStackIDDefaultEmpty(t *testing.T) {
+	cfg := NewCfg()
+	err := cfg.Load(CommandLineArgs{HomePath: "../../"})
+	require.NoError(t, err)
+
+	require.Equal(t, "", cfg.StackID)
+}


### PR DESCRIPTION
## Summary

Fixes #120129

- Use `SectionWithEnvOverrides` for `cfg.StackID` and `cfg.Slug` so that `GF_ENVIRONMENT_STACK_ID` and `GF_ENVIRONMENT_STACK_SLUG` env vars are respected
- `applyEnvVariableOverrides()` only overrides ini keys that already exist, but `defaults.ini` doesn't define `stack_id`/`stack_slug` in `[environment]`, so the env vars were silently ignored
- `SectionWithEnvOverrides` checks env vars dynamically for any key — same pattern used by JWT auth, OAuth, and Zanzana settings
- Without this fix, `cfg.StackID` is always empty, causing the embedded K8s API server to map all resources to the `default` namespace instead of `stacks-{id}`

## Test plan

- [x] Added `TestStackIDFromEnvVar` — sets `GF_ENVIRONMENT_STACK_ID=1001`, asserts `cfg.StackID == "1001"`
- [x] Added `TestStackSlugFromEnvVar` — sets `GF_ENVIRONMENT_STACK_SLUG=mystack`, asserts `cfg.Slug == "mystack"`
- [x] Added `TestStackIDDefaultEmpty` — asserts default `cfg.StackID == ""`