### PR TITLE
IAM: remove BasicRole from RoleBinding subject kinds

### DIFF
--- a/apps/iam/kinds/v0alpha1/rolebindingspec.cue
+++ b/apps/iam/kinds/v0alpha1/rolebindingspec.cue
@@ -3,7 +3,7 @@ package v0alpha1
 RoleBindingSpec: {
 	#Subject: {
 		// kind of the identity getting the permission
-		kind: "User" | "ServiceAccount" | "Team" | "BasicRole"
+		kind: "User" | "ServiceAccount" | "Team"
 		// uid of the identity
 		name: string
 	}
@@ -21,7 +21,7 @@ RoleBindingSpec: {
 GlobalRoleBindingSpec: {
 	#Subject: {
 		// kind of the identity getting the permission
-		kind: "User" | "ServiceAccount" | "Team" | "BasicRole"
+		kind: "User" | "ServiceAccount" | "Team"
 		// uid of the identity
 		name: string
 	}

--- a/apps/iam/pkg/apis/iam/v0alpha1/globalrolebinding_spec_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/globalrolebinding_spec_gen.go
@@ -66,7 +66,6 @@ const (
 	GlobalRoleBindingSpecSubjectKindUser           GlobalRoleBindingSpecSubjectKind = "User"
 	GlobalRoleBindingSpecSubjectKindServiceAccount GlobalRoleBindingSpecSubjectKind = "ServiceAccount"
 	GlobalRoleBindingSpecSubjectKindTeam           GlobalRoleBindingSpecSubjectKind = "Team"
-	GlobalRoleBindingSpecSubjectKindBasicRole      GlobalRoleBindingSpecSubjectKind = "BasicRole"
 )
 
 // OpenAPIModelName returns the OpenAPI model name for GlobalRoleBindingSpecSubjectKind.

--- a/apps/iam/pkg/apis/iam/v0alpha1/rolebinding_spec_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/rolebinding_spec_gen.go
@@ -64,7 +64,6 @@ const (
 	RoleBindingSpecSubjectKindUser           RoleBindingSpecSubjectKind = "User"
 	RoleBindingSpecSubjectKindServiceAccount RoleBindingSpecSubjectKind = "ServiceAccount"
 	RoleBindingSpecSubjectKindTeam           RoleBindingSpecSubjectKind = "Team"
-	RoleBindingSpecSubjectKindBasicRole      RoleBindingSpecSubjectKind = "BasicRole"
 )
 
 // OpenAPIModelName returns the OpenAPI model name for RoleBindingSpecSubjectKind.

--- a/pkg/services/authz/proto/v1/extention.proto
+++ b/pkg/services/authz/proto/v1/extention.proto
@@ -92,7 +92,7 @@ message DeleteUserOrgRoleOperation {
 }
 
 message CreateRoleBindingOperation {
-  // kind of the identity getting the permission (User/Team/ServiceAccount/BasicRole)
+  // kind of the identity getting the permission (User/Team/ServiceAccount)
   string subject_kind = 1;
   // uid of the identity
   string subject_name = 2;
@@ -103,7 +103,7 @@ message CreateRoleBindingOperation {
 }
 
 message DeleteRoleBindingOperation {
-  // kind of the identity getting the permission (User/Team/ServiceAccount/BasicRole)
+  // kind of the identity getting the permission (User/Team/ServiceAccount)
   string subject_kind = 1;
   // uid of the identity
   string subject_name = 2;

--- a/pkg/services/authz/zanzana/server/reconciler/translators_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/translators_test.go
@@ -177,12 +177,6 @@ func TestTranslateGlobalRoleBindingToTuples(t *testing.T) {
 			subjectName:  "team1",
 			expectedUser: "team:team1#member",
 		},
-		{
-			name:         "basic role subject",
-			subjectKind:  iamv0.GlobalRoleBindingSpecSubjectKindBasicRole,
-			subjectName:  "basic_viewer",
-			expectedUser: "role:basic_viewer#assignee",
-		},
 	}
 
 	for _, tt := range tests {
@@ -235,12 +229,6 @@ func TestTranslateRoleBindingToTuples(t *testing.T) {
 			subjectKind:  iamv0.RoleBindingSpecSubjectKindTeam,
 			subjectName:  "team1",
 			expectedUser: "team:team1#member",
-		},
-		{
-			name:         "basic role subject",
-			subjectKind:  iamv0.RoleBindingSpecSubjectKindBasicRole,
-			subjectName:  "basic_viewer",
-			expectedUser: "role:basic_viewer#assignee",
 		},
 	}
 
@@ -766,7 +754,6 @@ func TestTranslatedTuplesAreSchemaValid(t *testing.T) {
 			{iamv0.RoleBindingSpecSubjectKindUser, "uid1"},
 			{iamv0.RoleBindingSpecSubjectKindServiceAccount, "sa1"},
 			{iamv0.RoleBindingSpecSubjectKindTeam, "team1"},
-			{iamv0.RoleBindingSpecSubjectKindBasicRole, "basic_viewer"},
 		}
 
 		for _, s := range subjects {
@@ -820,7 +807,6 @@ func TestTranslatedTuplesAreSchemaValid(t *testing.T) {
 			{iamv0.GlobalRoleBindingSpecSubjectKindUser, "uid1"},
 			{iamv0.GlobalRoleBindingSpecSubjectKindServiceAccount, "sa1"},
 			{iamv0.GlobalRoleBindingSpecSubjectKindTeam, "team1"},
-			{iamv0.GlobalRoleBindingSpecSubjectKindBasicRole, "basic_viewer"},
 		}
 
 		for _, s := range subjects {

--- a/pkg/services/authz/zanzana/server/server_mutate_rolebindings_test.go
+++ b/pkg/services/authz/zanzana/server/server_mutate_rolebindings_test.go
@@ -78,33 +78,4 @@ func TestIntegrationServerMutateRoleBindings(t *testing.T) {
 		require.Len(t, res.Tuples, 0)
 	})
 
-	t.Run("should assign role to basic role", func(t *testing.T) {
-		_, err := srv.Mutate(newContextWithZanzanaUpdatePermission(), &v1.MutateRequest{
-			Namespace: "default",
-			Operations: []*v1.MutateOperation{
-				{
-					Operation: &v1.MutateOperation_CreateRoleBinding{
-						CreateRoleBinding: &v1.CreateRoleBindingOperation{
-							SubjectKind: "BasicRole",
-							SubjectName: "basic_viewer",
-							RoleKind:    "Role",
-							RoleName:    "foo_bar",
-						},
-					},
-				},
-			},
-		})
-		require.NoError(t, err)
-
-		res, err := srv.Read(newContextWithNamespace(), &v1.ReadRequest{
-			Namespace: "default",
-			TupleKey: &v1.ReadRequestTupleKey{
-				Relation: common.RelationAssignee,
-				Object:   "role:foo_bar",
-			},
-		})
-		require.NoError(t, err)
-		require.Len(t, res.Tuples, 1)
-		require.Equal(t, "role:basic_viewer#assignee", res.Tuples[0].Key.User)
-	})
 }

--- a/pkg/services/authz/zanzana/server/server_mutate_rolebindings_test.go
+++ b/pkg/services/authz/zanzana/server/server_mutate_rolebindings_test.go
@@ -77,5 +77,4 @@ func TestIntegrationServerMutateRoleBindings(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, res.Tuples, 0)
 	})
-
 }

--- a/pkg/services/authz/zanzana/tuple_helpers.go
+++ b/pkg/services/authz/zanzana/tuple_helpers.go
@@ -147,9 +147,6 @@ func GetRoleBindingTuple(subjectKind string, subjectName string, roleName string
 		subjectRelation = RelationTeamMember
 	case string(iamv0.RoleBindingSpecSubjectKindServiceAccount):
 		zanzanaType = TypeServiceAccount
-	case string(iamv0.RoleBindingSpecSubjectKindBasicRole):
-		zanzanaType = TypeRole
-		subjectRelation = RelationAssignee
 	default:
 		return nil, fmt.Errorf("invalid subject kind: %s", subjectKind)
 	}


### PR DESCRIPTION
## Summary
Assigning roles to basic roles is not something we provide with RBAC. The recommended approach has always been to grant roles to teams. This PR removes the possibility from the cue files.

- Remove `BasicRole` from the `#Subject.kind` union in both `RoleBindingSpec` and `GlobalRoleBindingSpec` CUE definitions and regenerated Go types
- Remove the `BasicRole` case from `GetRoleBindingTuple` in `tuple_helpers.go`
- Update proto comments to reflect the reduced set of subject kinds (`User/Team/ServiceAccount`)
- Remove all test cases that exercise `BasicRole` as a rolebinding subject kind

## Test plan
- [x] `go build ./apps/iam/...` passes
- [x] `go build ./pkg/services/authz/...` passes
- [x] `go test ./pkg/services/authz/zanzana/...` passes

Made with [Cursor](https://cursor.com)