### PR TITLE
fix(alerting): hide data source-managed rule options when alertingDisableDMAinUI is enabled

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -512,7 +512,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
                 }}
               />
             </Field>
-            {mode === 'edit' && hasAlertEnabledDataSources && (
+            {mode === 'edit' && hasAlertEnabledDataSources && !isDisableDMAinUIEnabled && (
               <>
                 <Divider />
                 <SmartAlertTypeDetector

--- a/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
+++ b/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
@@ -11,7 +11,11 @@ import { DOCS_URL_PROVISION_ALERTING } from '../../utils/docs';
 import { createRelativeUrl } from '../../utils/url';
 
 const RecordingRulesButtons = () => {
-  const { canCreateGrafanaRules, canCreateCloudRules } = useRulesAccess();
+  const { canCreateGrafanaRules, canCreateCloudRules: canCreateCloudRulesBase } = useRulesAccess();
+
+  // When alertingDisableDMAinUI is enabled, data source-managed rules are hidden from the UI
+  const isDisableDMAinUIEnabled = config.featureToggles.alertingDisableDMAinUI ?? false;
+  const canCreateCloudRules = canCreateCloudRulesBase && !isDisableDMAinUIEnabled;
 
   const grafanaRecordingRulesEnabled = config.unifiedAlerting.recordingRulesEnabled && canCreateGrafanaRules;
 
@@ -137,7 +141,9 @@ export function GrafanaNoRulesCTA() {
 
 export function CloudNoRulesCTA({ dataSourceName }: { dataSourceName: string }) {
   const styles = useStyles2(getCloudNoRulesStyles);
-  const { canCreateCloudRules } = useRulesAccess();
+  const { canCreateCloudRules: canCreateCloudRulesBase } = useRulesAccess();
+  // When alertingDisableDMAinUI is enabled, data source-managed rules are hidden from the UI
+  const canCreateCloudRules = canCreateCloudRulesBase && !(config.featureToggles.alertingDisableDMAinUI ?? false);
 
   const newAlertingRuleUrl = getNewDataSourceRuleUrl(dataSourceName, RuleFormType.cloudAlerting);
   const newRecordingRuleUrl = getNewDataSourceRuleUrl(dataSourceName, RuleFormType.cloudRecording);


### PR DESCRIPTION
Fixes #115015

## Summary

When the `alertingDisableDMAinUI` feature toggle is enabled, this PR ensures that data source-managed (DMA) rule options are consistently hidden across the alerting UI. Previously the toggle was only checked in some places but not others.

## Changes

### `NoRulesCTA.tsx`

- **`RecordingRulesButtons`**: The "New data source-managed recording rule" button/dropdown item is now hidden when `alertingDisableDMAinUI` is enabled. Previously this component didn't check the feature toggle, so the button could still appear in the empty state.
- **`CloudNoRulesCTA`**: The "New data source-managed alerting/recording rule" buttons are now hidden when the toggle is enabled.

### `QueryAndExpressionsStep.tsx`

- The `SmartAlertTypeDetector` (the "Grafana-managed" vs "Data source-managed" rule-type radio group) shown when editing an **existing cloud alert rule** now respects `alertingDisableDMAinUI`. The guard at line 515 (inside the `isCloudAlertRuleType` branch) was missing the `!isDisableDMAinUIEnabled` check that was already present at line 565 (inside the Grafana rule editor branch).

## What was already correct
- The "More" dropdown in `RuleList.v2.tsx` already correctly derived `canCreateCloudRules` with `!isDisableDMAinUIEnabled`.
- The `SmartAlertTypeDetector` shown when creating a new Grafana rule (line 565) already checked `canSelectDataSourceManaged` which includes `isDisableDMAinUIEnabled`.

## Testing
Existing tests in `RuleEditorGrafanaRules.test.tsx` cover the feature toggle for the Grafana rule editor path. The `QueryAndExpressionsStep` fix closes the gap for the cloud alert rule editing path.