### PR TITLE
Suggestions: Unit short for gauge

### DIFF
--- a/public/app/plugins/panel/gauge/v1/suggestions.ts
+++ b/public/app/plugins/panel/gauge/v1/suggestions.ts
@@ -10,6 +10,7 @@ const withDefaults = (suggestion: VisualizationSuggestion<Options>): Visualizati
   defaultsDeep(suggestion, {
     fieldConfig: {
       defaults: {
+        unit: 'short',
         thresholds: {
           steps: [
             { value: -Infinity, color: 'green' },

--- a/public/app/plugins/panel/gauge/v1/suggestions.ts
+++ b/public/app/plugins/panel/gauge/v1/suggestions.ts
@@ -10,7 +10,6 @@ const withDefaults = (suggestion: VisualizationSuggestion<Options>): Visualizati
   defaultsDeep(suggestion, {
     fieldConfig: {
       defaults: {
-        unit: 'short',
         thresholds: {
           steps: [
             { value: -Infinity, color: 'green' },
@@ -27,6 +26,9 @@ const withDefaults = (suggestion: VisualizationSuggestion<Options>): Visualizati
       previewModifier: (s) => {
         if (s.options?.reduceOptions?.values) {
           s.options.reduceOptions.limit = 2;
+        }
+        if (s.fieldConfig) {
+          s.fieldConfig.defaults.unit = 'short';
         }
       },
     },

--- a/public/app/plugins/panel/gauge/v2/suggestions.ts
+++ b/public/app/plugins/panel/gauge/v2/suggestions.ts
@@ -21,16 +21,13 @@ const withDefaults = (
       barWidthFactor: 0.3,
       showThresholdMarkers: false,
     },
-    fieldConfig: {
-      defaults: {
-        unit: 'short',
-      },
-      overrides: [],
-    },
     cardOptions: {
       previewModifier: (s) => {
         if (s.options?.reduceOptions) {
           s.options.reduceOptions.limit = 4;
+        }
+        if (s.fieldConfig) {
+          s.fieldConfig.defaults.unit = 'short';
         }
       },
     },

--- a/public/app/plugins/panel/gauge/v2/suggestions.ts
+++ b/public/app/plugins/panel/gauge/v2/suggestions.ts
@@ -21,6 +21,12 @@ const withDefaults = (
       barWidthFactor: 0.3,
       showThresholdMarkers: false,
     },
+    fieldConfig: {
+      defaults: {
+        unit: 'short',
+      },
+      overrides: [],
+    },
     cardOptions: {
       previewModifier: (s) => {
         if (s.options?.reduceOptions) {


### PR DESCRIPTION
Set default unit to `short` for gauge suggestions.

Before:
<img width="335" height="562" alt="image" src="https://github.com/user-attachments/assets/eb7c9598-872e-4022-b612-d0bdc342ca3e" />

After:
<img width="342" height="545" alt="image" src="https://github.com/user-attachments/assets/f2af83e4-3945-4e14-afb1-555a78e5aad3" />
<img width="332" height="542" alt="image" src="https://github.com/user-attachments/assets/5fb5076e-6eae-4adc-8705-794ef688f574" />


Fixes https://github.com/grafana/grafana/issues/120099