### PR TITLE
Tests: Fix flaky TestIntegrationPlugins install test

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -417,6 +417,7 @@
 /pkg/tsdb/Magefile.go @grafana/plugins-platform-backend
 /pkg/services/pluginsintegration/pluginsettings/ @grafana/plugins-platform-backend
 /pkg/services/plugindashboards/ @grafana/plugins-platform-backend
+/pkg/tests/api/plugins/ @grafana/plugins-platform-backend
 
 # Backend code docs
 /contribute/backend/ @grafana/grafana-backend-group

--- a/pkg/tests/api/plugins/api_plugins_test.go
+++ b/pkg/tests/api/plugins/api_plugins_test.go
@@ -82,14 +82,15 @@ func TestIntegrationPlugins(t *testing.T) {
 		})
 
 		t.Run("Request is not forbidden if from an admin", func(t *testing.T) {
-			statusCode, body := makePostRequest(t, grafanaAPIURL(usernameAdmin, grafanaListedAddr, "plugins/test/install"))
+			statusCode, _ := makePostRequest(t, grafanaAPIURL(usernameAdmin, grafanaListedAddr, "plugins/test/install"))
 
-			assert.Equal(t, 404, statusCode)
-			assert.Equal(t, "Plugin not found", body["message"])
+			// the request may return 404 (plugin not found) or 500 (failed to reach plugin repo);
+			// either way, it should not be 403 since the user is an admin
+			assert.NotEqual(t, 403, statusCode)
 
-			statusCode, body = makePostRequest(t, grafanaAPIURL(usernameAdmin, grafanaListedAddr, "plugins/test/uninstall"))
-			assert.Equal(t, 404, statusCode)
-			assert.Equal(t, "Plugin not installed", body["message"])
+			uninstallStatus, uninstallBody := makePostRequest(t, grafanaAPIURL(usernameAdmin, grafanaListedAddr, "plugins/test/uninstall"))
+			assert.Equal(t, 404, uninstallStatus)
+			assert.Equal(t, "Plugin not installed", uninstallBody["message"])
 		})
 	})
 


### PR DESCRIPTION
**What is this feature?**

Fixes a flaky assertion in `TestIntegrationPlugins/Install/Request_is_not_forbidden_if_from_an_admin`. The test checks that admins aren't blocked by authorization (`!= 403`). The old assertion (`== 404`) was over-specifying the response, making it depend on an external API call rather than testing authorization.

**Why do we need this feature?**

To prevent CI from being flaky.

**Who is this feature for?**

CI stability and developers who rely on green integration test runs.

**Which issue(s) does this PR fix?**:

Reported in the Daily CI Test Report: https://raintank-corp.slack.com/archives/C01BKPAV1EZ/p1773238071837089

**Special notes for your reviewer:**
