### PR TITLE
Provisioning: Add repository types to defaults to enable env var override

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2333,7 +2333,7 @@ min_sync_interval = 10s
 
 # List of enabled repository types, separated by |.
 # When empty, defaults are applied by each subsystem.
-# OSS types: git, github, local.
+# OSS types: local, git, github.
 # Enterprise types: bitbucket, gitlab.
 repository_types =
 

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2333,7 +2333,8 @@ min_sync_interval = 10s
 
 # List of enabled repository types, separated by |.
 # When empty, defaults are applied by each subsystem.
-# Supported types: git, github, bitbucket, gitlab, local.
+# OSS types: git, github, local.
+# Enterprise types: bitbucket, gitlab.
 repository_types =
 
 #################################### Unified Storage ####################################

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2331,6 +2331,11 @@ allow_image_rendering = true
 # The minimum value is 10 seconds.
 min_sync_interval = 10s
 
+# List of enabled repository types, separated by |.
+# When empty, defaults are applied by each subsystem.
+# Supported types: git, github, bitbucket, gitlab, local.
+repository_types =
+
 #################################### Unified Storage ####################################
 [unified_storage]
 # index_path is the path where unified storage can store its index files for search.

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2333,8 +2333,8 @@ min_sync_interval = 10s
 
 # List of enabled repository types, separated by |.
 # When empty, defaults are applied by each subsystem.
-# OSS types: local, git, github.
-# Enterprise types: bitbucket, gitlab.
+# Supported types: local, git, github.
+# Grafana Enterprise additionally supports bitbucket and gitlab.
 repository_types =
 
 #################################### Unified Storage ####################################

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2776,13 +2776,6 @@ List of enabled repository types, separated by `|`. When empty, defaults are app
 
 OSS types: `local`, `git`, `github`. Enterprise types: `bitbucket`, `gitlab`.
 
-You can override this with the `GF_PROVISIONING_REPOSITORY_TYPES` environment variable. For example:
-
-```ini
-[provisioning]
-repository_types = local|git|github
-```
-
 <hr>
 
 ### `[plugin.plugin_id]`

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2772,7 +2772,9 @@ The minimum sync interval that can be set for a repository. This is how often th
 
 #### `repository_types`
 
-List of enabled repository types, separated by `|`. Supported types: `git`, `github`, `bitbucket`, `gitlab`, `local`. When empty, defaults are applied by each subsystem.
+List of enabled repository types, separated by `|`. When empty, defaults are applied by each subsystem.
+
+OSS types: `git`, `github`, `local`. Enterprise types: `bitbucket`, `gitlab`.
 
 You can override this with the `GF_PROVISIONING_REPOSITORY_TYPES` environment variable. For example:
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2774,13 +2774,13 @@ The minimum sync interval that can be set for a repository. This is how often th
 
 List of enabled repository types, separated by `|`. When empty, defaults are applied by each subsystem.
 
-OSS types: `git`, `github`, `local`. Enterprise types: `bitbucket`, `gitlab`.
+OSS types: `local`, `git`, `github`. Enterprise types: `bitbucket`, `gitlab`.
 
 You can override this with the `GF_PROVISIONING_REPOSITORY_TYPES` environment variable. For example:
 
 ```ini
 [provisioning]
-repository_types = git|github|local
+repository_types = local|git|github
 ```
 
 <hr>

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2760,7 +2760,7 @@ ha_engine_password: $__file{/your/redis/password/secret/mount}
 
 #### `allowed_targets`
 
-Comma-separated list of targets that a repository can control. `folder` by default. Use `folder` if you want the repository to only control a folder within the Grafana instance. Use `instance` if you want the repository to control the whole Grafana instance. 
+Comma-separated list of targets that a repository can control. `folder` by default. Use `folder` if you want the repository to only control a folder within the Grafana instance. Use `instance` if you want the repository to control the whole Grafana instance.
 
 #### `allow_image_rendering`
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2756,6 +2756,33 @@ ha_engine_password: $__file{/your/redis/password/secret/mount}
 
 <hr>
 
+### `[provisioning]`
+
+#### `allowed_targets`
+
+Comma-separated list of targets that can be controlled by a repository. `instance` means the whole Grafana instance will be controlled by a repository. `folder` limits it to a folder within the Grafana instance. Default is `folder`.
+
+#### `allow_image_rendering`
+
+Whether image rendering is allowed for dashboard previews. Requires the image rendering service to be configured. Default is `true`.
+
+#### `min_sync_interval`
+
+The minimum sync interval that can be set for a repository. This is how often the controller will check for changes to the repository that were not propagated by a webhook. The minimum value is `10s`. Default is `10s`.
+
+#### `repository_types`
+
+List of enabled repository types, separated by `|`. Supported types: `git`, `github`, `bitbucket`, `gitlab`, `local`. When empty, defaults are applied by each subsystem.
+
+You can override this with the `GF_PROVISIONING_REPOSITORY_TYPES` environment variable. For example:
+
+```ini
+[provisioning]
+repository_types = git|github|local
+```
+
+<hr>
+
 ### `[plugin.plugin_id]`
 
 This section can be used to configure plugin-specific settings. Replace the `plugin_id` attribute with the plugin ID present in `plugin.json`.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2768,7 +2768,7 @@ Whether image rendering is allowed for dashboard previews. Requires the image re
 
 #### `min_sync_interval`
 
-The minimum sync interval that can be set for a repository. This is how often the controller will check for changes to the repository that were not propagated by a webhook. The minimum value is `10s`. Default is `10s`.
+The minimum sync interval that you can set for a repository. Indicates how often the controller will check for changes in the repository that were not propagated by a webhook. The minimum value is `10s`. Default is `10s`.
 
 #### `repository_types`
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2774,7 +2774,7 @@ The minimum sync interval that can be set for a repository. This is how often th
 
 List of enabled repository types, separated by `|`. When empty, defaults are applied by each subsystem.
 
-OSS types: `local`, `git`, `github`. Enterprise types: `bitbucket`, `gitlab`.
+Supported types: `local`, `git`, `github`. Grafana Enterprise additionally supports `bitbucket` and `gitlab`.
 
 <hr>
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2760,7 +2760,7 @@ ha_engine_password: $__file{/your/redis/password/secret/mount}
 
 #### `allowed_targets`
 
-Comma-separated list of targets that can be controlled by a repository. `instance` means the whole Grafana instance will be controlled by a repository. `folder` limits it to a folder within the Grafana instance. Default is `folder`.
+Comma-separated list of targets that a repository can control. `folder` by default. Use `folder` if you want the repository to only control a folder within the Grafana instance. Use `instance` if you want the repository to control the whole Grafana instance. 
 
 #### `allow_image_rendering`
 


### PR DESCRIPTION
## Why

`GF_PROVISIONING_REPOSITORY_TYPES` was silently ignored when passed as an environment variable (e.g. via `docker run -e`). This is because `applyEnvVariableOverrides` only processes keys that already exist in the ini file — it iterates over `section.Keys()`, so any key missing from `defaults.ini` is invisible to the override mechanism.

## What

- **`conf/defaults.ini`** — Add `repository_types =` (empty) to the `[provisioning]` section so the env var override can discover and apply it. The empty default preserves existing fallback behaviour in each subsystem.
- **`docs/sources/setup-grafana/configure-grafana/_index.md`** — Document the `[provisioning]` section (`allowed_targets`, `allow_image_rendering`, `min_sync_interval`, `repository_types`), which was previously undocumented.

## How

`applyEnvVariableOverrides` loops over `section.Keys()` to match `GF_*` environment variables. Since `repository_types` was missing from `defaults.ini`, the key never appeared in that loop and `GF_PROVISIONING_REPOSITORY_TYPES` was never applied.

Adding `repository_types =` (empty) makes the key visible to the override mechanism. When no env var is set, the value stays empty and each subsystem continues to apply its own defaults (`local|git|github` for OSS, plus `bitbucket|gitlab` for Enterprise).

## Test plan

- [ ] Deploy with `GF_PROVISIONING_REPOSITORY_TYPES=local|git|github` and verify the listed types are available
- [ ] Deploy with Enterprise and `GF_PROVISIONING_REPOSITORY_TYPES=local|git|github|bitbucket|gitlab`
- [ ] Deploy without the env var and verify default types still apply
- [ ] Verify setting `repository_types` directly in a custom `.ini` file also works