### PR TITLE
e2e: wait for network idle in sandbox tests

### DIFF
--- a/e2e-playwright/various-suite/frontend-sandbox-app.spec.ts
+++ b/e2e-playwright/various-suite/frontend-sandbox-app.spec.ts
@@ -18,7 +18,7 @@ test.describe(
 
     test.describe('App Page', () => {
       test('Loads the app page with the sandbox div wrapper', async ({ page }) => {
-        await page.goto(`/a/${APP_ID}`);
+        await page.goto(`/a/${APP_ID}`, { waitUntil: 'networkidle' });
 
         const sandboxDiv = page.locator('div[data-plugin-sandbox="sandbox-app-test"]');
         await expect(sandboxDiv).toBeVisible();
@@ -28,7 +28,7 @@ test.describe(
       });
 
       test('Loads the app configuration with the sandbox div wrapper', async ({ page }) => {
-        await page.goto(`/plugins/${APP_ID}`);
+        await page.goto(`/plugins/${APP_ID}`, { waitUntil: 'networkidle' });
 
         const sandboxDiv = page.locator('div[data-plugin-sandbox="sandbox-app-test"]');
         await expect(sandboxDiv).toBeVisible();


### PR DESCRIPTION
**What is this feature?**

This pull request makes a small improvement to the Playwright end-to-end tests for the frontend sandbox app. The main change is ensuring that page navigation waits until the network is idle before proceeding, which can help reduce test flakiness.

**Why do we need this feature?**

So we can reduce test flakiness

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
