### PR TITLE
Advisor: Fix flaky e2e test

### DIFF
--- a/e2e-playwright/various-suite/advisor.spec.ts
+++ b/e2e-playwright/various-suite/advisor.spec.ts
@@ -24,7 +24,7 @@ async function isEmptyReport(page: Page) {
 }
 
 async function loadAndWait(page: Page) {
-  await page.goto(ADVISOR_PAGE);
+  await page.goto(ADVISOR_PAGE, { waitUntil: 'networkidle' });
   await expect(
     page.getByText(
       'Helps you keep your Grafana instances running smoothly and securely by running checks and suggest actions to fix identified issues'


### PR DESCRIPTION
**What is this feature?**

Adds `waitUntil: 'networkidle'` to the advisor e2e test's page navigation to ensure lazily-loaded JS chunks are fully fetched before assertions run.

**Why do we need this feature?**

The advisor e2e test fails randomly in CI because the page description text lives in a lazy-loaded JS chunk. Under CI load with parallel workers, the chunk sometimes doesn't arrive before the default assertion timeout. Spotted in the [daily CI test report](https://raintank-corp.slack.com/archives/C01BKPAV1EZ/p1773238071837089).

**Who is this feature for?**

Grafana maintainers.

**Which issue(s) does this PR fix?**

Fixes flaky `advisor.spec.ts:82 › Advisor › should detect an issue and fix it` test.