### PR TITLE
Settings: Allow env vars to override config options not in ini files

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -820,6 +821,9 @@ func RedactedURL(value string) (string, error) {
 
 func (cfg *Cfg) applyEnvVariableOverrides(file *ini.File) error {
 	cfg.appliedEnvOverrides = make([]string, 0)
+
+	// First pass: apply overrides for keys that already exist in the ini file.
+	appliedKeys := make(map[string]bool)
 	for _, section := range file.Sections() {
 		for _, key := range section.Keys() {
 			envKey := EnvKey(section.Name(), key.Name())
@@ -828,6 +832,58 @@ func (cfg *Cfg) applyEnvVariableOverrides(file *ini.File) error {
 			if len(envValue) > 0 {
 				key.SetValue(envValue)
 				cfg.appliedEnvOverrides = append(cfg.appliedEnvOverrides, fmt.Sprintf("%s=%s", envKey, RedactedValue(envKey, envValue)))
+			}
+			appliedKeys[envKey] = true
+		}
+	}
+
+	// Second pass: scan all GF_ environment variables and create new keys
+	// for any that match a known section but don't have a corresponding key yet.
+	// This allows env vars to add new config keys without requiring them to be
+	// pre-defined in defaults.ini or custom.ini.
+
+	// Build a map from env-style section prefix to ini section.
+	type sectionMapping struct {
+		prefix  string
+		section *ini.Section
+	}
+	var sectionMappings []sectionMapping
+	for _, section := range file.Sections() {
+		prefix := "GF_" + strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(section.Name(), ".", "_"), "-", "_")) + "_"
+		sectionMappings = append(sectionMappings, sectionMapping{prefix: prefix, section: section})
+	}
+
+	// Sort by prefix length descending so more specific sections match first.
+	// e.g., GF_AUTH_GOOGLE_ matches before GF_AUTH_.
+	sort.Slice(sectionMappings, func(i, j int) bool {
+		return len(sectionMappings[i].prefix) > len(sectionMappings[j].prefix)
+	})
+
+	for _, env := range os.Environ() {
+		if !strings.HasPrefix(env, "GF_") {
+			continue
+		}
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) != 2 || len(parts[1]) == 0 {
+			continue
+		}
+		envKey := parts[0]
+		envValue := parts[1]
+
+		if appliedKeys[envKey] {
+			continue
+		}
+
+		for _, m := range sectionMappings {
+			if strings.HasPrefix(envKey, m.prefix) {
+				keyName := strings.ToLower(envKey[len(m.prefix):])
+				if keyName == "" {
+					continue
+				}
+				m.section.Key(keyName).SetValue(envValue)
+				cfg.appliedEnvOverrides = append(cfg.appliedEnvOverrides, fmt.Sprintf("%s=%s", envKey, RedactedValue(envKey, envValue)))
+				appliedKeys[envKey] = true
+				break
 			}
 		}
 	}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -842,7 +842,7 @@ func (cfg *Cfg) applyEnvVariableOverrides(file *ini.File) error {
 	// This allows env vars to add new config keys without requiring them to be
 	// pre-defined in defaults.ini or custom.ini.
 
-	// Build a map from env-style section prefix to ini section.
+	// Build a mapping from env-style section prefix to ini section.
 	type sectionMapping struct {
 		prefix  string
 		section *ini.Section

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -874,6 +874,13 @@ func (cfg *Cfg) applyEnvVariableOverrides(file *ini.File) error {
 			continue
 		}
 
+		// Skip unified_storage env vars — they use camelCase key names
+		// and are handled by applyUnifiedStorageEnvOverrides which
+		// preserves the correct casing.
+		if strings.HasPrefix(envKey, EnvSectionPrefix("unified_storage")) {
+			continue
+		}
+
 		for _, m := range sectionMappings {
 			if strings.HasPrefix(envKey, m.prefix) {
 				keyName := strings.ToLower(envKey[len(m.prefix):])

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -849,7 +849,7 @@ func (cfg *Cfg) applyEnvVariableOverrides(file *ini.File) error {
 	}
 	var sectionMappings []sectionMapping
 	for _, section := range file.Sections() {
-		prefix := "GF_" + strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(section.Name(), ".", "_"), "-", "_")) + "_"
+		prefix := EnvSectionPrefix(section.Name())
 		sectionMappings = append(sectionMappings, sectionMapping{prefix: prefix, section: section})
 	}
 
@@ -1008,12 +1008,22 @@ func loadAnnotationAppPlatformSettings(cfg *ini.File) AnnotationAppPlatformSetti
 	}
 }
 
+// envNameFromIniName converts an ini-style name (section or key) to the
+// uppercased, underscore-separated form used in GF_ environment variables.
+// Dots and dashes become underscores; everything is uppercased.
+func envNameFromIniName(name string) string {
+	s := strings.ToUpper(strings.ReplaceAll(name, ".", "_"))
+	return strings.ReplaceAll(s, "-", "_")
+}
+
+// EnvSectionPrefix returns the GF_ environment variable prefix for a given
+// ini section name, e.g. "auth.google" → "GF_AUTH_GOOGLE_".
+func EnvSectionPrefix(sectionName string) string {
+	return "GF_" + envNameFromIniName(sectionName) + "_"
+}
+
 func EnvKey(sectionName string, keyName string) string {
-	sN := strings.ToUpper(strings.ReplaceAll(sectionName, ".", "_"))
-	sN = strings.ReplaceAll(sN, "-", "_")
-	kN := strings.ToUpper(strings.ReplaceAll(keyName, ".", "_"))
-	envKey := fmt.Sprintf("GF_%s_%s", sN, kN)
-	return envKey
+	return "GF_" + envNameFromIniName(sectionName) + "_" + envNameFromIniName(keyName)
 }
 
 func (cfg *Cfg) applyCommandLineDefaultProperties(props map[string]string, file *ini.File) {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -847,7 +847,7 @@ func (cfg *Cfg) applyEnvVariableOverrides(file *ini.File) error {
 		prefix  string
 		section *ini.Section
 	}
-	var sectionMappings []sectionMapping
+	sectionMappings := make([]sectionMapping, 0, len(file.Sections()))
 	for _, section := range file.Sections() {
 		prefix := EnvSectionPrefix(section.Name())
 		sectionMappings = append(sectionMappings, sectionMapping{prefix: prefix, section: section})

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -138,6 +138,36 @@ func TestLoadingSettings(t *testing.T) {
 		require.Contains(t, cfg.appliedEnvOverrides, "GF_SERVER_MY_CUSTOM_SETTING=custom_value")
 	})
 
+	t.Run("Should not create duplicate lowercase key for unified_storage env vars", func(t *testing.T) {
+		// unified_storage keys use camelCase (e.g. enableMigration). The generic
+		// second pass would lowercase them, creating a duplicate key. These env
+		// vars should be skipped in the generic pass and handled only by
+		// applyUnifiedStorageEnvOverrides.
+		t.Setenv("GF_UNIFIED_STORAGE_DASHBOARDS_DASHBOARD_GRAFANA_APP_ENABLEMIGRATION", "false")
+
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../"})
+		require.Nil(t, err)
+
+		section, err := cfg.Raw.GetSection("unified_storage.dashboards.dashboard.grafana.app")
+		require.NoError(t, err)
+
+		// The correctly-cased key should exist (set by applyUnifiedStorageEnvOverrides).
+		require.Equal(t, "false", section.Key("enableMigration").Value())
+
+		// The lowercased key should NOT have been created by the generic second pass.
+		require.Equal(t, "", section.Key("enablemigration").Value())
+
+		// Should only appear once in appliedEnvOverrides.
+		count := 0
+		for _, o := range cfg.appliedEnvOverrides {
+			if strings.Contains(o, "GF_UNIFIED_STORAGE_DASHBOARDS_DASHBOARD_GRAFANA_APP_ENABLEMIGRATION") {
+				count++
+			}
+		}
+		require.Equal(t, 1, count, "env var should be applied exactly once")
+	})
+
 	t.Run("Should match env var to most specific section", func(t *testing.T) {
 		// GF_AUTH_GOOGLE_MY_KEY should match [auth.google] not [auth]
 		t.Setenv("GF_AUTH_GOOGLE_MY_KEY", "google_value")

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -123,6 +123,39 @@ func TestLoadingSettings(t *testing.T) {
 		require.Contains(t, cfg.appliedEnvOverrides, "GF_DATABASE_URL=mysql://user:xxxxx@localhost:3306/database")
 	})
 
+	t.Run("Should create new key from env var when key is not in ini file but section exists", func(t *testing.T) {
+		// This tests the fix for the long-standing bug where env vars only worked
+		// if the key was already present in defaults.ini or custom.ini.
+		t.Setenv("GF_SERVER_MY_CUSTOM_SETTING", "custom_value")
+
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../"})
+		require.Nil(t, err)
+
+		serverSection, err := cfg.Raw.GetSection("server")
+		require.NoError(t, err)
+		require.Equal(t, "custom_value", serverSection.Key("my_custom_setting").Value())
+		require.Contains(t, cfg.appliedEnvOverrides, "GF_SERVER_MY_CUSTOM_SETTING=custom_value")
+	})
+
+	t.Run("Should match env var to most specific section", func(t *testing.T) {
+		// GF_AUTH_GOOGLE_MY_KEY should match [auth.google] not [auth]
+		t.Setenv("GF_AUTH_GOOGLE_MY_KEY", "google_value")
+
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../"})
+		require.Nil(t, err)
+
+		googleSection, err := cfg.Raw.GetSection("auth.google")
+		require.NoError(t, err)
+		require.Equal(t, "google_value", googleSection.Key("my_key").Value())
+
+		// Verify it did NOT end up in the [auth] section
+		authSection, err := cfg.Raw.GetSection("auth")
+		require.NoError(t, err)
+		require.Equal(t, "", authSection.Key("google_my_key").Value())
+	})
+
 	t.Run("Should get property map from command line args array", func(t *testing.T) {
 		cfg := NewCfg()
 		props := cfg.getCommandLineProperties([]string{"cfg:test=value", "cfg:map.test=1"})

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -50,7 +50,7 @@ var MigratedUnifiedResources = map[string]bool{
 // The key names are matched from a known list (knownUnifiedStorageKeys) to preserve
 // their original camelCase.
 func (cfg *Cfg) applyUnifiedStorageEnvOverrides() {
-	const envPrefix = "GF_UNIFIED_STORAGE_"
+	envPrefix := EnvSectionPrefix("unified_storage")
 
 	for _, env := range os.Environ() {
 		if !strings.HasPrefix(env, envPrefix) {

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -32,23 +32,27 @@ var MigratedUnifiedResources = map[string]bool{
 	ShortURLResource:  false, // Requires kubernetesShortURLs to be enabled by default
 }
 
-// read storage configs from ini file. They look like:
-// [unified_storage.<group>.<resource>]
-// <field> = <value>
-// e.g.
-// [unified_storage.playlists.playlist.grafana.app]
-// dualWriterMode = 2
 // applyUnifiedStorageEnvOverrides scans environment variables matching
 // GF_UNIFIED_STORAGE_<resource>_<key> and creates the corresponding ini
 // sections and keys. This allows users to configure unified_storage resource
 // sections purely via environment variables without pre-defining them in an
 // ini file.
 //
-// This works because Kubernetes resource names (e.g., "dashboards.dashboard.grafana.app")
-// never contain underscores — only dots and lowercase alphanumerics — so every underscore
-// in the resource portion of the env var name maps unambiguously back to a dot.
-// The key names are matched from a known list (knownUnifiedStorageKeys) to preserve
-// their original camelCase.
+// Storage configs in the ini file look like:
+//
+//	[unified_storage.<group>.<resource>]
+//	<field> = <value>
+//
+// For example:
+//
+//	[unified_storage.playlists.playlist.grafana.app]
+//	dualWriterMode = 2
+//
+// Kubernetes resource names (e.g., "dashboards.dashboard.grafana.app") never
+// contain underscores — only dots and lowercase alphanumerics — so every
+// underscore in the resource portion of the env var name maps unambiguously
+// back to a dot. The key names are matched from a known list
+// ([knownUnifiedStorageKeys]) to preserve their original camelCase.
 func (cfg *Cfg) applyUnifiedStorageEnvOverrides() {
 	envPrefix := EnvSectionPrefix("unified_storage")
 

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -1,12 +1,21 @@
 package setting
 
 import (
+	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/util/osutil"
 )
+
+// knownUnifiedStorageKeys maps uppercased env-var-style key suffixes to their
+// actual camelCase ini key names used in [unified_storage.*] sections.
+var knownUnifiedStorageKeys = map[string]string{
+	"DUALWRITERMODE":  "dualWriterMode",
+	"ENABLEMIGRATION": "enableMigration",
+}
 
 const (
 	PlaylistResource  = "playlists.playlist.grafana.app"
@@ -29,7 +38,63 @@ var MigratedUnifiedResources = map[string]bool{
 // e.g.
 // [unified_storage.playlists.playlist.grafana.app]
 // dualWriterMode = 2
+// applyUnifiedStorageEnvOverrides scans environment variables matching
+// GF_UNIFIED_STORAGE_<resource>_<key> and creates the corresponding ini
+// sections and keys. This allows users to configure unified_storage resource
+// sections purely via environment variables without pre-defining them in an
+// ini file.
+//
+// This works because Kubernetes resource names (e.g., "dashboards.dashboard.grafana.app")
+// never contain underscores — only dots and lowercase alphanumerics — so every underscore
+// in the resource portion of the env var name maps unambiguously back to a dot.
+// The key names are matched from a known list (knownUnifiedStorageKeys) to preserve
+// their original camelCase.
+func (cfg *Cfg) applyUnifiedStorageEnvOverrides() {
+	const envPrefix = "GF_UNIFIED_STORAGE_"
+
+	for _, env := range os.Environ() {
+		if !strings.HasPrefix(env, envPrefix) {
+			continue
+		}
+		eqIdx := strings.IndexByte(env, '=')
+		if eqIdx < 0 {
+			continue
+		}
+		envKey := env[:eqIdx]
+		envValue := env[eqIdx+1:]
+		if envValue == "" {
+			continue
+		}
+
+		remainder := envKey[len(envPrefix):]
+
+		// Try to match a known key suffix. The key is always the last component
+		// after the final underscore that matches a known key name.
+		for envKeySuffix, iniKeyName := range knownUnifiedStorageKeys {
+			suffix := "_" + envKeySuffix
+			if !strings.HasSuffix(remainder, suffix) {
+				continue
+			}
+			resourceEnv := remainder[:len(remainder)-len(suffix)]
+			if resourceEnv == "" {
+				continue
+			}
+			// Reconstruct the resource name: lowercase with underscores → dots.
+			resourceName := strings.ToLower(strings.ReplaceAll(resourceEnv, "_", "."))
+			sectionName := "unified_storage." + resourceName
+			cfg.Raw.Section(sectionName).Key(iniKeyName).SetValue(envValue)
+			cfg.appliedEnvOverrides = append(cfg.appliedEnvOverrides,
+				fmt.Sprintf("%s=%s", envKey, RedactedValue(envKey, envValue)))
+			break
+		}
+	}
+}
+
 func (cfg *Cfg) setUnifiedStorageConfig() {
+	// Pre-create sections from GF_UNIFIED_STORAGE_* env vars so that
+	// resource sections can be configured purely via environment variables.
+	cfg.applyUnifiedStorageEnvOverrides()
+
 	storageConfig := make(map[string]UnifiedStorageConfig)
 	sections := cfg.Raw.Sections()
 	for _, section := range sections {

--- a/pkg/setting/setting_unified_storage_test.go
+++ b/pkg/setting/setting_unified_storage_test.go
@@ -121,6 +121,39 @@ func TestCfg_setUnifiedStorageConfig(t *testing.T) {
 		})
 	})
 
+	t.Run("env vars create unified_storage resource sections without ini file", func(t *testing.T) {
+		// Set env vars for a resource that has NO ini section defined.
+		t.Setenv("GF_UNIFIED_STORAGE_DASHBOARDS_DASHBOARD_GRAFANA_APP_DUALWRITERMODE", "3")
+		t.Setenv("GF_UNIFIED_STORAGE_DASHBOARDS_DASHBOARD_GRAFANA_APP_ENABLEMIGRATION", "false")
+
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+		assert.NoError(t, err)
+
+		cfg.setUnifiedStorageConfig()
+
+		value, exists := cfg.UnifiedStorage[DashboardResource]
+		assert.True(t, exists, "dashboards.dashboard.grafana.app should exist from env var")
+		// Note: enforceMigrationToUnifiedConfigs may override dualWriterMode to 5
+		// for migrated resources. We test the enableMigration was correctly parsed as false.
+		assert.Equal(t, false, value.EnableMigration)
+	})
+
+	t.Run("env vars work for unknown resource names", func(t *testing.T) {
+		// A resource not in MigratedUnifiedResources, configured purely via env vars.
+		t.Setenv("GF_UNIFIED_STORAGE_WIDGETS_WIDGET_CUSTOM_IO_DUALWRITERMODE", "2")
+
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+		assert.NoError(t, err)
+
+		cfg.setUnifiedStorageConfig()
+
+		value, exists := cfg.UnifiedStorage["widgets.widget.custom.io"]
+		assert.True(t, exists, "widgets.widget.custom.io should exist from env var")
+		assert.Equal(t, rest.DualWriterMode(2), value.DualWriterMode)
+	})
+
 	t.Run("read unified_storage configs with defaults", func(t *testing.T) {
 		cfg := NewCfg()
 		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})


### PR DESCRIPTION
## Summary

- Fixes long-standing bug where `GF_SECTION_KEY` environment variables only worked if the key was already defined in `defaults.ini` or `custom.ini`
- Adds a second pass in `applyEnvVariableOverrides` that scans all `GF_*` env vars and creates new keys in matching known sections (longest prefix match first, so e.g. `GF_AUTH_GOOGLE_*` correctly matches `[auth.google]` before `[auth]`)
- Adds a `unified_storage`-specific handler (`applyUnifiedStorageEnvOverrides`) that reconstructs resource section names from env vars — safe because K8s resource names never contain underscores — and preserves camelCase key names (`dualWriterMode`, `enableMigration`)
- Extracts shared helpers `envNameFromIniName()` and `EnvSectionPrefix()` to eliminate duplicated ini-name-to-env conversion logic across `EnvKey()`, `applyEnvVariableOverrides`, and `applyUnifiedStorageEnvOverrides`

### Root cause

`applyEnvVariableOverrides` iterated over keys already in the ini file and checked `os.Getenv()` for each. If a key wasn't in any ini file, the corresponding env var was never checked. For dynamic sections like `[unified_storage.dashboards.dashboard.grafana.app]` that don't exist in `defaults.ini`, env vars were completely ignored.

### What works now

| Scenario | Before | After |
|---|---|---|
| `GF_SERVER_MY_CUSTOM_KEY=x` (section exists, key doesn't) | Ignored | Creates `my_custom_key` in `[server]` |
| `GF_AUTH_GOOGLE_MY_KEY=x` (ambiguous prefix) | Ignored | Matches most specific section `[auth.google]` |
| `GF_UNIFIED_STORAGE_DASHBOARDS_DASHBOARD_GRAFANA_APP_ENABLEMIGRATION=true` | Ignored | Creates `[unified_storage.dashboards.dashboard.grafana.app]` section with `enableMigration` key |

### Known limitations

- **General fix**: New keys created from env vars are lowercased. The few existing camelCase keys (e.g., `dialTimeout`) are already in `defaults.ini` and handled by the first pass, so this doesn't affect them in practice.
- **Dynamic sections**: Only `unified_storage.*` has feature-specific env var handling. `plugin.*` and `secrets_manager.encryption.*` sections still require ini file pre-definition because their identifier naming conventions make reverse mapping ambiguous.

## Test plan

- [x] New test: env var creates key in existing section (`GF_SERVER_MY_CUSTOM_SETTING`)
- [x] New test: env var matches most specific section (`GF_AUTH_GOOGLE_MY_KEY` → `[auth.google]`)
- [x] New test: env var creates `unified_storage` resource section from scratch
- [x] New test: env var works for unknown resource names (`widgets.widget.custom.io`)
- [x] All existing `pkg/setting` tests pass
- [x] Manual: set `GF_UNIFIED_STORAGE_DASHBOARDS_DASHBOARD_GRAFANA_APP_ENABLEMIGRATION=false` without ini entry, verify config is applied