### PR TITLE
QueryActionAssistantButton: Catch errors from getQueryDisplayText

### DIFF
--- a/public/app/features/query/components/QueryActionAssistantButton.test.tsx
+++ b/public/app/features/query/components/QueryActionAssistantButton.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 
 import { AssistantHook, useAssistant } from '@grafana/assistant';
-import { CoreApp, DataSourceInstanceSettings } from '@grafana/data';
-import { DataQuery } from '@grafana/schema';
+import { CoreApp, DataSourceApi, DataSourceInstanceSettings } from '@grafana/data';
+import { DataQuery, DataSourceJsonData } from '@grafana/schema';
 
 import { QueryActionAssistantButton } from './QueryActionAssistantButton';
 // Mock the assistant hook
@@ -112,5 +112,36 @@ describe('QueryActionAssistantButton', () => {
 
     const button = screen.getByRole('button', { name: /query with assistant/i });
     expect(button).toBeInTheDocument();
+  });
+
+  it('should handle getQueryDisplayText throwing an error gracefully', () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const mockOpenAssistant = jest.fn();
+    useAssistantMock.mockReturnValue({
+      isAvailable: true,
+      openAssistant: mockOpenAssistant,
+    } as unknown as AssistantHook);
+
+    const queryWithContent = { refId: 'A', expr: 'up' } as DataQuery;
+    const mockDatasourceApi = {
+      getQueryDisplayText: jest.fn().mockImplementation(() => {
+        throw new Error('display text error');
+      }),
+    } as unknown as DataSourceApi<DataQuery, DataSourceJsonData, {}>;
+
+    render(
+      <QueryActionAssistantButton
+        {...defaultProps}
+        query={queryWithContent}
+        queries={[queryWithContent]}
+        datasourceApi={mockDatasourceApi}
+      />
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(Error));
+    const button = screen.getByRole('button', { name: /query with assistant/i });
+    expect(button).toBeInTheDocument();
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/public/app/features/query/components/QueryActionAssistantButton.tsx
+++ b/public/app/features/query/components/QueryActionAssistantButton.tsx
@@ -77,9 +77,14 @@ export function QueryActionAssistantButton<TQuery extends DataQuery = DataQuery>
     );
   }
 
-  // Get query display text to determine if we're creating or updating
-  const queryDisplayText =
-    hasCurrentQuery && datasourceApi?.getQueryDisplayText ? datasourceApi.getQueryDisplayText(query) : null;
+  let queryDisplayText: string | undefined = undefined;
+  if (hasCurrentQuery && datasourceApi?.getQueryDisplayText) {
+    try {
+      queryDisplayText = datasourceApi.getQueryDisplayText(query)?.trim();
+    } catch (error) {
+      console.error(error);
+    }
+  }
 
   // Determine if we're creating or updating based on queryDisplayText
   const isUpdating = !!queryDisplayText;


### PR DESCRIPTION
## Summary
- Wraps the `getQueryDisplayText` call in a try/catch so a throwing datasource plugin doesn't crash the query editor
- Adds `.trim()` to the display text result
- Adds a test verifying the error is caught gracefully and the button still renders in "create" mode

## Test plan
- [x] Existing tests pass
- [x] New test covers `getQueryDisplayText` throwing an error
- [x] Manually verify the Query with Assistant button renders correctly when a datasource's `getQueryDisplayText` throws


Made with [Cursor](https://cursor.com)