### PR TITLE
Broadcaster: fix flaky TestBroadcasterUnsubscribe race

### DIFF
--- a/pkg/storage/unified/resource/broadcaster.go
+++ b/pkg/storage/unified/resource/broadcaster.go
@@ -101,20 +101,36 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 		}
 	}
 
+	addSubscriber := func(sub subscription[T]) {
+		if !b.cache.readInto(sub.ch) {
+			close(sub.ch)
+			return
+		}
+		b.subs[sub.ch] = sub
+	}
+
 	for {
 		select {
 		case <-b.shouldTerminate: // service context cancelled
 			return
 
 		case sub := <-b.subscribe: // subscribe
-			// send initial batch of cached items
-			if !b.cache.readInto(sub.ch) {
-				close(sub.ch)
-				continue
-			}
-			b.subs[sub.ch] = sub
+			addSubscriber(sub)
 
 		case recv := <-b.unsubscribe: // unsubscribe
+			// Drain pending subscribes first. A caller does Subscribe then
+			// Unsubscribe sequentially, so the subscribe message is always
+			// buffered before the unsubscribe. Without this drain, select
+			// may pick the unsubscribe first, making it a no-op and
+			// leaving the subscriber channel unclosed.
+			for drained := false; !drained; {
+				select {
+				case sub := <-b.subscribe:
+					addSubscriber(sub)
+				default:
+					drained = true
+				}
+			}
 			unsubscribe(recv)
 
 		case item, ok := <-input: // data arrived, send to subscribers

--- a/pkg/storage/unified/resource/broadcaster.go
+++ b/pkg/storage/unified/resource/broadcaster.go
@@ -102,6 +102,7 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 	}
 
 	addSubscriber := func(sub subscription[T]) {
+		// send initial batch of cached items
 		if !b.cache.readInto(sub.ch) {
 			close(sub.ch)
 			return
@@ -118,11 +119,8 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 			addSubscriber(sub)
 
 		case recv := <-b.unsubscribe: // unsubscribe
-			// Drain pending subscribes first. A caller does Subscribe then
-			// Unsubscribe sequentially, so the subscribe message is always
-			// buffered before the unsubscribe. Without this drain, select
-			// may pick the unsubscribe first, making it a no-op and
-			// leaving the subscriber channel unclosed.
+			// Drain pending subscribes so we don't miss one that was
+			// buffered before this unsubscribe.
 			for drained := false; !drained; {
 				select {
 				case sub := <-b.subscribe:


### PR DESCRIPTION
## Summary
- Fixed a race condition in the broadcaster where `select` could process an unsubscribe before its corresponding subscribe, leaving the subscriber channel unclosed and causing `TestBroadcasterUnsubscribe` to hang for 30 minutes in CI
- When handling an unsubscribe, drain all pending subscribe messages first — the subscribe is always buffered before the unsubscribe since they're called sequentially from the same goroutine

## Test plan
- [x] `go test ./pkg/storage/unified/resource/ -run TestBroadcaster -count=100` passes consistently
- [x] All existing broadcaster tests pass

Fixes flaky test: https://github.com/grafana/grafana/actions/runs/22995811871/job/66767661385?pr=118254

🤖 Generated with [Claude Code](https://claude.com/claude-code)