### PR TITLE
Provisioning: use folder metadata title for new folders

### DIFF
--- a/pkg/registry/apis/provisioning/resources/folder_metadata.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata.go
@@ -228,6 +228,8 @@ func ParseFolderResource(ctx context.Context, reader repository.Reader, path, re
 	// If no metadata object exists, create a minimal folder object
 	if folderObj == nil {
 		folderObj = NewFolderManifest(folderID, folderTitle)
+	} else if folderObj.Spec.Title == "" {
+		folderObj.Spec.Title = folderTitle
 	}
 
 	// Convert to unstructured

--- a/pkg/registry/apis/provisioning/resources/folder_metadata.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata.go
@@ -183,6 +183,7 @@ func ParseFolderResource(ctx context.Context, reader repository.Reader, path, re
 	var (
 		folderObj    *folders.Folder
 		folderID     string
+		folderTitle  string
 		err          error
 		folderExists bool
 	)
@@ -193,9 +194,10 @@ func ParseFolderResource(ctx context.Context, reader repository.Reader, path, re
 			return nil, fmt.Errorf("read folder metadata: %w", err)
 		}
 
-		// If metadata was found, use its stable UID and mark folder as existing
+		// If metadata was found, use its stable UID and title and mark folder as existing
 		if folderObj != nil && folderObj.Name != "" {
 			folderID = folderObj.Name
+			folderTitle = folderObj.Spec.Title
 			folderExists = true
 		}
 	}
@@ -218,16 +220,14 @@ func ParseFolderResource(ctx context.Context, reader repository.Reader, path, re
 	if folderID == "" {
 		folderID = ParseFolder(path, config.Name).ID
 	}
-
-	// Determine the folder title from the path (last part of the path)
-	folderTitle := safepath.Base(path)
+	// If no metadata exists or metadata is disabled, use the path-based title
+	if folderTitle == "" {
+		folderTitle = safepath.Base(path)
+	}
 
 	// If no metadata object exists, create a minimal folder object
 	if folderObj == nil {
 		folderObj = NewFolderManifest(folderID, folderTitle)
-	} else {
-		// Update the title to match the path, even if metadata exists
-		folderObj.Spec.Title = folderTitle
 	}
 
 	// Convert to unstructured

--- a/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
@@ -428,6 +428,56 @@ func TestParseFolderResource(t *testing.T) {
 			description:          "Root-level folder has empty parent folder ID",
 		},
 		{
+			name:                  "metadata enabled with custom title - preserves metadata title instead of path",
+			path:                  testPath,
+			folderMetadataEnabled: true,
+			setupMock: func(reader *repository.MockReader) {
+				reader.On("Config").Return(testRepoConfig)
+				customFolder := NewFolderManifest("stable-uid-123", "My Custom Project Title")
+				customBytes, _ := json.Marshal(customFolder)
+				reader.On("Read", mock.Anything, "team-a/project-x/_folder.json", testRef).
+					Return(&repository.FileInfo{
+						Data: customBytes,
+						Path: "team-a/project-x/_folder.json",
+					}, nil)
+				parentFolder := NewFolderManifest("parent-uid-456", "team-a")
+				parentBytes, _ := json.Marshal(parentFolder)
+				reader.On("Read", mock.Anything, "team-a/_folder.json", testRef).
+					Return(&repository.FileInfo{Data: parentBytes}, nil)
+			},
+			expectedFolderID:     "stable-uid-123",
+			expectedAction:       "update",
+			expectedTitle:        "My Custom Project Title",
+			expectedParentFolder: "parent-uid-456",
+			expectedErr:          false,
+			description:          "When metadata exists with custom title, preserve it instead of using path-based title",
+		},
+		{
+			name:                  "metadata enabled with empty title - preserves empty title from metadata",
+			path:                  testPath,
+			folderMetadataEnabled: true,
+			setupMock: func(reader *repository.MockReader) {
+				reader.On("Config").Return(testRepoConfig)
+				emptyTitleFolder := NewFolderManifest("stable-uid-123", "")
+				emptyBytes, _ := json.Marshal(emptyTitleFolder)
+				reader.On("Read", mock.Anything, "team-a/project-x/_folder.json", testRef).
+					Return(&repository.FileInfo{
+						Data: emptyBytes,
+						Path: "team-a/project-x/_folder.json",
+					}, nil)
+				parentFolder := NewFolderManifest("parent-uid-456", "team-a")
+				parentBytes, _ := json.Marshal(parentFolder)
+				reader.On("Read", mock.Anything, "team-a/_folder.json", testRef).
+					Return(&repository.FileInfo{Data: parentBytes}, nil)
+			},
+			expectedFolderID:     "stable-uid-123",
+			expectedAction:       "update",
+			expectedTitle:        "",
+			expectedParentFolder: "parent-uid-456",
+			expectedErr:          false,
+			description:          "When metadata exists but title is empty, the metadata object is used as-is",
+		},
+		{
 			name:                  "parent folder ID error propagates",
 			path:                  testPath,
 			folderMetadataEnabled: true,

--- a/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
@@ -453,7 +453,7 @@ func TestParseFolderResource(t *testing.T) {
 			description:          "When metadata exists with custom title, preserve it instead of using path-based title",
 		},
 		{
-			name:                  "metadata enabled with empty title - preserves empty title from metadata",
+			name:                  "metadata enabled with empty title - falls back to path-based title",
 			path:                  testPath,
 			folderMetadataEnabled: true,
 			setupMock: func(reader *repository.MockReader) {
@@ -472,10 +472,10 @@ func TestParseFolderResource(t *testing.T) {
 			},
 			expectedFolderID:     "stable-uid-123",
 			expectedAction:       "update",
-			expectedTitle:        "",
+			expectedTitle:        "project-x",
 			expectedParentFolder: "parent-uid-456",
 			expectedErr:          false,
-			description:          "When metadata exists but title is empty, the metadata object is used as-is",
+			description:          "When metadata exists but title is empty, fall back to path-based title",
 		},
 		{
 			name:                  "parent folder ID error propagates",

--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -108,6 +108,8 @@ func (fm *FolderManager) EnsureFolderPathExist(ctx context.Context, filePath str
 		if meta.Name != "" {
 			f.ID = meta.Name
 		}
+		// We use folder metadata here only to check if the folder exists
+		// for new folders, we'll be using the safepath.Walk below, so we don't need to set the title here for now.
 	} else if fm.folderMetadataEnabled && !errors.Is(err, repository.ErrFileNotFound) && !apierrors.IsNotFound(err) {
 		return "", fmt.Errorf("read folder metadata for %s: %w", f.Path, err)
 	}
@@ -120,6 +122,9 @@ func (fm *FolderManager) EnsureFolderPathExist(ctx context.Context, filePath str
 		if meta, err := ReadFolderMetadata(ctx, fm.repo, traverse, ""); err == nil {
 			if meta.Name != "" {
 				f.ID = meta.Name
+			}
+			if meta.Spec.Title != "" {
+				f.Title = meta.Spec.Title
 			}
 		} else if fm.folderMetadataEnabled && !errors.Is(err, repository.ErrFileNotFound) && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("read folder metadata for %s: %w", traverse, err)

--- a/pkg/registry/apis/provisioning/resources/folders_test.go
+++ b/pkg/registry/apis/provisioning/resources/folders_test.go
@@ -624,6 +624,131 @@ func TestCreateFolderWithUID(t *testing.T) {
 	})
 }
 
+func TestEnsureFolderPathExist_MetadataTitle(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("uses spec.title from _folder.json instead of directory name", func(t *testing.T) {
+		config := newTestRepoConfig("test-repo")
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Config").Return(config)
+		rw.On("Read", mock.Anything, "my-folder/_folder.json", "").
+			Return(&repository.FileInfo{Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"stable-uid"},"spec":{"title":"Custom Title"}}`)}, nil)
+
+		var createdFolder Folder
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewNotFound(schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}, name)
+			},
+			createFn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				return obj, nil
+			},
+		}
+
+		fm := NewFolderManager(rw, client, NewEmptyFolderTree(), true, WithBeforeCreate(func(_ context.Context, folder Folder) error {
+			createdFolder = folder
+			return nil
+		}))
+
+		parent, err := fm.EnsureFolderPathExist(ctx, "my-folder/dashboard.json")
+		require.NoError(t, err)
+		require.Equal(t, "stable-uid", parent)
+		require.Equal(t, "Custom Title", createdFolder.Title)
+		require.Equal(t, "stable-uid", createdFolder.ID)
+	})
+
+	t.Run("falls back to directory name when spec.title is empty", func(t *testing.T) {
+		config := newTestRepoConfig("test-repo")
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Config").Return(config)
+		rw.On("Read", mock.Anything, "my-folder/_folder.json", "").
+			Return(&repository.FileInfo{Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"stable-uid"},"spec":{"title":""}}`)}, nil)
+
+		var createdFolder Folder
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewNotFound(schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}, name)
+			},
+			createFn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				return obj, nil
+			},
+		}
+
+		fm := NewFolderManager(rw, client, NewEmptyFolderTree(), true, WithBeforeCreate(func(_ context.Context, folder Folder) error {
+			createdFolder = folder
+			return nil
+		}))
+
+		parent, err := fm.EnsureFolderPathExist(ctx, "my-folder/dashboard.json")
+		require.NoError(t, err)
+		require.Equal(t, "stable-uid", parent)
+		require.Equal(t, "my-folder", createdFolder.Title)
+	})
+
+	t.Run("uses directory name when no _folder.json exists", func(t *testing.T) {
+		config := newTestRepoConfig("test-repo")
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Config").Return(config)
+		rw.On("Read", mock.Anything, "my-folder/_folder.json", "").
+			Return(nil, repository.ErrFileNotFound)
+
+		var createdFolder Folder
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewNotFound(schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}, name)
+			},
+			createFn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				return obj, nil
+			},
+		}
+
+		fm := NewFolderManager(rw, client, NewEmptyFolderTree(), true, WithBeforeCreate(func(_ context.Context, folder Folder) error {
+			createdFolder = folder
+			return nil
+		}))
+
+		parent, err := fm.EnsureFolderPathExist(ctx, "my-folder/dashboard.json")
+		require.NoError(t, err)
+		require.Equal(t, "my-folder", createdFolder.Title)
+		require.NotEmpty(t, parent)
+	})
+
+	t.Run("uses spec.title from _folder.json inside walk for nested folders", func(t *testing.T) {
+		config := newTestRepoConfig("test-repo")
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Config").Return(config)
+		// Pre-walk reads leaf folder metadata — not found so we walk
+		rw.On("Read", mock.Anything, "parent/child/_folder.json", "").
+			Return(nil, repository.ErrFileNotFound)
+		// Walk reads parent folder metadata — has custom title
+		rw.On("Read", mock.Anything, "parent/_folder.json", "").
+			Return(&repository.FileInfo{Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"parent-uid"},"spec":{"title":"Parent Custom"}}`)}, nil)
+
+		var createdFolders []Folder
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewNotFound(schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}, name)
+			},
+			createFn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				return obj, nil
+			},
+		}
+
+		fm := NewFolderManager(rw, client, NewEmptyFolderTree(), true, WithBeforeCreate(func(_ context.Context, folder Folder) error {
+			createdFolders = append(createdFolders, folder)
+			return nil
+		}))
+
+		_, err := fm.EnsureFolderPathExist(ctx, "parent/child/dashboard.json")
+		require.NoError(t, err)
+		require.Len(t, createdFolders, 2)
+		// First created folder is "parent" — should have custom title from _folder.json
+		require.Equal(t, "Parent Custom", createdFolders[0].Title)
+		require.Equal(t, "parent-uid", createdFolders[0].ID)
+		// Second created folder is "child" — no metadata, uses directory name
+		require.Equal(t, "child", createdFolders[1].Title)
+	})
+}
+
 func TestEnsureFolderPathExist_MetadataErrors(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/registry/apis/provisioning/resources/folders_test.go
+++ b/pkg/registry/apis/provisioning/resources/folders_test.go
@@ -644,10 +644,10 @@ func TestEnsureFolderPathExist_MetadataTitle(t *testing.T) {
 			},
 		}
 
-		fm := NewFolderManager(rw, client, NewEmptyFolderTree(), true, WithBeforeCreate(func(_ context.Context, folder Folder) error {
+		fm := NewFolderManager(rw, client, NewEmptyFolderTree(), WithBeforeCreate(func(_ context.Context, folder Folder) error {
 			createdFolder = folder
 			return nil
-		}))
+		}), WithFolderMetadataEnabled(true))
 
 		parent, err := fm.EnsureFolderPathExist(ctx, "my-folder/dashboard.json")
 		require.NoError(t, err)
@@ -673,10 +673,10 @@ func TestEnsureFolderPathExist_MetadataTitle(t *testing.T) {
 			},
 		}
 
-		fm := NewFolderManager(rw, client, NewEmptyFolderTree(), true, WithBeforeCreate(func(_ context.Context, folder Folder) error {
+		fm := NewFolderManager(rw, client, NewEmptyFolderTree(), WithBeforeCreate(func(_ context.Context, folder Folder) error {
 			createdFolder = folder
 			return nil
-		}))
+		}), WithFolderMetadataEnabled(true))
 
 		parent, err := fm.EnsureFolderPathExist(ctx, "my-folder/dashboard.json")
 		require.NoError(t, err)
@@ -701,10 +701,10 @@ func TestEnsureFolderPathExist_MetadataTitle(t *testing.T) {
 			},
 		}
 
-		fm := NewFolderManager(rw, client, NewEmptyFolderTree(), true, WithBeforeCreate(func(_ context.Context, folder Folder) error {
+		fm := NewFolderManager(rw, client, NewEmptyFolderTree(), WithBeforeCreate(func(_ context.Context, folder Folder) error {
 			createdFolder = folder
 			return nil
-		}))
+		}), WithFolderMetadataEnabled(true))
 
 		parent, err := fm.EnsureFolderPathExist(ctx, "my-folder/dashboard.json")
 		require.NoError(t, err)
@@ -733,10 +733,10 @@ func TestEnsureFolderPathExist_MetadataTitle(t *testing.T) {
 			},
 		}
 
-		fm := NewFolderManager(rw, client, NewEmptyFolderTree(), true, WithBeforeCreate(func(_ context.Context, folder Folder) error {
+		fm := NewFolderManager(rw, client, NewEmptyFolderTree(), WithBeforeCreate(func(_ context.Context, folder Folder) error {
 			createdFolders = append(createdFolders, folder)
 			return nil
-		}))
+		}), WithFolderMetadataEnabled(true))
 
 		_, err := fm.EnsureFolderPathExist(ctx, "parent/child/dashboard.json")
 		require.NoError(t, err)

--- a/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
@@ -1,14 +1,20 @@
 package git
 
 import (
+	"context"
+	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/grafana/grafana/pkg/util/testutil"
-	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagEnabled(t *testing.T) {
@@ -133,4 +139,164 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagDisab
 		require.False(t, strings.Contains(w, "missing folder metadata"),
 			"should not warn about missing folder metadata when flag is disabled, got: %s", w)
 	}
+}
+
+// folderMetadataJSON generates a valid _folder.json payload with a stable UID and title.
+func folderMetadataJSON(uid, title string) []byte {
+	folder := map[string]any{
+		"apiVersion": "folder.grafana.app/v1beta1",
+		"kind":       "Folder",
+		"metadata": map[string]any{
+			"name": uid,
+		},
+		"spec": map[string]any{
+			"title": title,
+		},
+	}
+	data, _ := json.MarshalIndent(folder, "", "\t")
+	return data
+}
+
+// requireRepoFolderTitle lists all folders managed by repoName and asserts that
+// exactly one has the given title, returning its K8s name (UID).
+func requireRepoFolderTitle(t *testing.T, h *gitTestHelper, ctx context.Context, repoName, expectedTitle string) string {
+	t.Helper()
+	var folderUID string
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		list, err := h.FoldersV1.Resource.List(ctx, metav1.ListOptions{})
+		if !assert.NoError(c, err, "failed to list folders") {
+			return
+		}
+		for _, f := range list.Items {
+			mgr, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
+			if mgr != repoName {
+				continue
+			}
+			title, _, _ := unstructured.NestedString(f.Object, "spec", "title")
+			if title == expectedTitle {
+				folderUID = f.GetName()
+				return
+			}
+		}
+		c.Errorf("no folder managed by %q with title %q found", repoName, expectedTitle)
+	}, waitTimeoutDefault, waitIntervalDefault,
+		"expected folder with title %q for repo %q", expectedTitle, repoName)
+	return folderUID
+}
+
+// TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle verifies that
+// incremental sync uses spec.title from _folder.json when creating/updating folders.
+func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	t.Run("folder uses spec.title from _folder.json", func(t *testing.T) {
+		helper := runGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+
+		const repoName = "incr-meta-title"
+
+		// Seed with a dashboard at root.
+		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
+			"dashboard.json": dashboardJSON("root-dash", "Root Dashboard", 1),
+		})
+		helper.syncAndWait(t, repoName)
+
+		// Push a folder with _folder.json that has a custom title different from the directory name.
+		require.NoError(t, local.CreateFile("my-team/_folder.json", string(folderMetadataJSON("stable-uid-1", "My Team Display Name"))))
+		require.NoError(t, local.CreateFile("my-team/dash.json", string(dashboardJSON("team-dash", "Team Dashboard", 1))))
+		_, err := local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "add folder with custom metadata title")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		// Incremental sync.
+		helper.syncAndWaitIncremental(t, repoName)
+
+		// Verify the Grafana folder was created with the metadata title, not the directory name.
+		requireRepoFolderTitle(t, helper, ctx, repoName, "My Team Display Name")
+	})
+
+	t.Run("folder falls back to directory name when spec.title is empty", func(t *testing.T) {
+		helper := runGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+
+		const repoName = "incr-meta-title-empty"
+
+		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
+			"dashboard.json": dashboardJSON("root-dash-2", "Root Dashboard", 1),
+		})
+		helper.syncAndWait(t, repoName)
+
+		// Push a folder with _folder.json that has an empty title — should fall back to dir name.
+		require.NoError(t, local.CreateFile("reports/_folder.json", string(folderMetadataJSON("stable-uid-2", ""))))
+		require.NoError(t, local.CreateFile("reports/dash.json", string(dashboardJSON("reports-dash", "Reports Dashboard", 1))))
+		_, err := local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "add folder with empty metadata title")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		helper.syncAndWaitIncremental(t, repoName)
+
+		// Should use directory name "reports" as the title.
+		requireRepoFolderTitle(t, helper, ctx, repoName, "reports")
+	})
+
+	t.Run("folder uses directory name when no _folder.json exists", func(t *testing.T) {
+		helper := runGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+
+		const repoName = "incr-meta-title-absent"
+
+		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
+			"dashboard.json": dashboardJSON("root-dash-3", "Root Dashboard", 1),
+		})
+		helper.syncAndWait(t, repoName)
+
+		// Push a folder without _folder.json.
+		require.NoError(t, local.CreateFile("analytics/dash.json", string(dashboardJSON("analytics-dash", "Analytics Dashboard", 1))))
+		_, err := local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "add folder without metadata")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		helper.syncAndWaitIncremental(t, repoName)
+
+		// Should use directory name "analytics" as the title.
+		requireRepoFolderTitle(t, helper, ctx, repoName, "analytics")
+	})
+
+	t.Run("nested folders use respective spec.title from _folder.json", func(t *testing.T) {
+		helper := runGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+
+		const repoName = "incr-meta-title-nested"
+
+		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
+			"dashboard.json": dashboardJSON("root-dash-4", "Root Dashboard", 1),
+		})
+		helper.syncAndWait(t, repoName)
+
+		// Push nested folders, each with their own _folder.json and custom titles.
+		require.NoError(t, local.CreateFile("parent/_folder.json", string(folderMetadataJSON("parent-uid", "Parent Display"))))
+		require.NoError(t, local.CreateFile("parent/child/_folder.json", string(folderMetadataJSON("child-uid", "Child Display"))))
+		require.NoError(t, local.CreateFile("parent/child/dash.json", string(dashboardJSON("nested-dash", "Nested Dashboard", 1))))
+		_, err := local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "add nested folders with custom metadata titles")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		helper.syncAndWaitIncremental(t, repoName)
+
+		// Both folders should use their metadata titles.
+		requireRepoFolderTitle(t, helper, ctx, repoName, "Parent Display")
+		requireRepoFolderTitle(t, helper, ctx, repoName, "Child Display")
+	})
 }

--- a/pkg/tests/apis/provisioning/sync_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/sync_folder_metadata_test.go
@@ -1,10 +1,17 @@
 package provisioning
 
 import (
+	"encoding/json"
+	"os"
+	"path"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -188,4 +195,144 @@ func TestIntegrationProvisioning_FullSync_MissingFolderMetadata_FlagDisabled(t *
 	}
 
 	helper.WaitForConditionReason(t, repo, provisioning.ConditionTypePullStatus, provisioning.ReasonSuccess)
+}
+
+// folderMetadataJSON generates a valid _folder.json payload with a stable UID and title.
+func folderMetadataJSON(uid, title string) []byte {
+	folder := map[string]any{
+		"apiVersion": "folder.grafana.app/v1beta1",
+		"kind":       "Folder",
+		"metadata": map[string]any{
+			"name": uid,
+		},
+		"spec": map[string]any{
+			"title": title,
+		},
+	}
+	data, _ := json.MarshalIndent(folder, "", "\t")
+	return data
+}
+
+// writeToProvisioningPath writes raw content to a relative path under the provisioning directory.
+func writeToProvisioningPath(t *testing.T, helper *common.ProvisioningTestHelper, relativePath string, data []byte) {
+	t.Helper()
+	fullPath := path.Join(helper.ProvisioningPath, relativePath)
+	require.NoError(t, os.MkdirAll(path.Dir(fullPath), 0o750))
+	require.NoError(t, os.WriteFile(fullPath, data, 0o600))
+}
+
+// requireRepoFolderTitle lists all folders managed by repoName and asserts that
+// exactly one has the given title.
+func requireRepoFolderTitle(t *testing.T, helper *common.ProvisioningTestHelper, repoName, expectedTitle string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		list, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+		if !assert.NoError(c, err, "failed to list folders") {
+			return
+		}
+		for _, f := range list.Items {
+			mgr, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
+			if mgr != repoName {
+				continue
+			}
+			title, _, _ := unstructured.NestedString(f.Object, "spec", "title")
+			if title == expectedTitle {
+				return
+			}
+		}
+		c.Errorf("no folder managed by %q with title %q found", repoName, expectedTitle)
+	}, 30*time.Second, 100*time.Millisecond,
+		"expected folder with title %q for repo %q", expectedTitle, repoName)
+}
+
+// TestIntegrationProvisioning_FullSync_FolderMetadataTitle verifies that
+// full sync uses spec.title from _folder.json when creating/updating folders.
+func TestIntegrationProvisioning_FullSync_FolderMetadataTitle(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	t.Run("folder uses spec.title from _folder.json", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		const repo = "full-sync-meta-title"
+
+		// Write _folder.json with a custom title different from the directory name.
+		writeToProvisioningPath(t, helper, "my-team/_folder.json", folderMetadataJSON("stable-uid-1", "My Team Display Name"))
+
+		helper.CreateRepo(t, common.TestRepo{
+			Name:   repo,
+			Target: "folder",
+			Copies: map[string]string{
+				"testdata/all-panels.json": "my-team/dashboard.json",
+			},
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+
+		helper.SyncAndWait(t, repo, nil)
+
+		requireRepoFolderTitle(t, helper, repo, "My Team Display Name")
+	})
+
+	t.Run("folder falls back to directory name when spec.title is empty", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		const repo = "full-sync-meta-title-empty"
+
+		// Write _folder.json with an empty title — should fall back to directory name.
+		writeToProvisioningPath(t, helper, "reports/_folder.json", folderMetadataJSON("stable-uid-2", ""))
+
+		helper.CreateRepo(t, common.TestRepo{
+			Name:   repo,
+			Target: "folder",
+			Copies: map[string]string{
+				"testdata/all-panels.json": "reports/dashboard.json",
+			},
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+
+		helper.SyncAndWait(t, repo, nil)
+
+		requireRepoFolderTitle(t, helper, repo, "reports")
+	})
+
+	t.Run("folder uses directory name when no _folder.json exists", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		const repo = "full-sync-meta-title-absent"
+
+		helper.CreateRepo(t, common.TestRepo{
+			Name:   repo,
+			Target: "folder",
+			Copies: map[string]string{
+				"testdata/all-panels.json": "analytics/dashboard.json",
+			},
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+
+		helper.SyncAndWait(t, repo, nil)
+
+		requireRepoFolderTitle(t, helper, repo, "analytics")
+	})
+
+	t.Run("nested folders use respective spec.title from _folder.json", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		const repo = "full-sync-meta-title-nested"
+
+		writeToProvisioningPath(t, helper, "parent/_folder.json", folderMetadataJSON("parent-uid", "Parent Display"))
+		writeToProvisioningPath(t, helper, "parent/child/_folder.json", folderMetadataJSON("child-uid", "Child Display"))
+
+		helper.CreateRepo(t, common.TestRepo{
+			Name:   repo,
+			Target: "folder",
+			Copies: map[string]string{
+				"testdata/all-panels.json": "parent/child/dashboard.json",
+			},
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+
+		helper.SyncAndWait(t, repo, nil)
+
+		requireRepoFolderTitle(t, helper, repo, "Parent Display")
+		requireRepoFolderTitle(t, helper, repo, "Child Display")
+	})
 }


### PR DESCRIPTION
**What is this feature?**

- Use spec.title from `_folder.json` as the Grafana folder title during sync, instead of always using the directory name
- When `_folder.json` is absent or `spec.title` is empty, fall back to the directory name (preserving existing behavior)
- Update `ParseFolderResource` to preserve the metadata title for folder authorization flows 

That is done in `EnsureFolderPathExist` so that it works for bot incremental and full sync

**Why do we need this feature?**
Before this change, `_folder.json` was only used for stable UIDs — the folder title was always derived from the directory name. This meant users couldn't control how their folders appeared in Grafana independently of how they organized their repository. For example, a directory called `team-a-dashboards` would always show up as `"team-a-dashboards"` in the UI, even if the _folder.json had `spec.title: "Team A Dashboards"`.

With this change, the spec.title field in `_folder.json` is respected during both full and incremental sync, giving users control over folder display names while keeping directory names optimized for repository organization.

**Who is this feature for?**

Users of Gitsync feature

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/git-ui-sync-project/issues/904
Part of https://github.com/grafana/git-ui-sync-project/issues/936

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
