### PR TITLE
Elasticsearch: Fix variable queries broken by empty meta object

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.test.tsx
@@ -188,7 +188,7 @@ describe('ElasticsearchVariableEditor', () => {
     const queryEditorOnChange = (QueryEditor as jest.Mock).mock.calls.at(-1)[0].onChange;
     act(() => queryEditorOnChange({ ...queryWithMeta, queryType: 'dsl' }));
 
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ queryType: 'dsl', meta: {} }));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ queryType: 'dsl', meta: undefined }));
   });
 
   it('should reset meta fields when the metric type tab changes', () => {
@@ -205,7 +205,7 @@ describe('ElasticsearchVariableEditor', () => {
     const queryEditorOnChange = (QueryEditor as jest.Mock).mock.calls.at(-1)[0].onChange;
     act(() => queryEditorOnChange({ ...queryWithMeta, metrics: [{ type: 'count', id: '1' }] }));
 
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ meta: {} }));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ meta: undefined }));
   });
 
   it('should not reset meta fields when only the query string changes', () => {

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.tsx
@@ -20,7 +20,7 @@ export const ElasticsearchVariableEditor = (props: ElasticsearchVariableQueryEdi
     const metricTypeChanged = newQuery.metrics?.[0]?.type !== query.metrics?.[0]?.type;
     const queryTypeChanged = newQuery.queryType !== query.queryType;
     if (metricTypeChanged || queryTypeChanged) {
-      props.onChange({ ...newQuery, meta: {} });
+      props.onChange({ ...newQuery, meta: undefined });
     } else {
       props.onChange(newQuery);
     }

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableUtils.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableUtils.test.ts
@@ -98,6 +98,22 @@ describe('ElasticsearchVariableUtils', () => {
       expect(result.some((f) => f.name === 'other')).toBe(true);
     });
 
+    it('should fall through to legacy fallback when meta is an empty object', () => {
+      const fields = [
+        { name: 'field1', type: FieldType.string, config: {}, values: ['a', 'b'] },
+        { name: 'field2', type: FieldType.string, config: {}, values: ['c', 'd'] },
+      ];
+
+      // meta={} is truthy but has no textField/valueField — must behave identically to meta=undefined
+      const resultEmptyMeta = convertFieldsToVariableFields(fields, {});
+      const resultNoMeta = convertFieldsToVariableFields(fields);
+
+      expect(resultEmptyMeta[0].values).toEqual(resultNoMeta[0].values);
+      expect(resultEmptyMeta[1].values).toEqual(resultNoMeta[1].values);
+      // Should use the Scenario 4 fallback: concatenate all field values
+      expect(resultEmptyMeta[0].values).toEqual(['a', 'b', 'c', 'd']);
+    });
+
     it('should use textField for both when valueField not specified', () => {
       const fields = [
         { name: 'name', type: FieldType.string, config: {}, values: ['a', 'b'] },

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableUtils.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableUtils.ts
@@ -39,7 +39,7 @@ export const convertFieldsToVariableFields = (
   }
 
   // scenario 2: If meta field found, use and return (at least one text field / value field exist / or first field)
-  if (meta) {
+  if (meta?.textField || meta?.valueField) {
     let tf = meta.textField ? original_fields.find((f) => f.name === meta.textField) : undefined;
     let vf = meta.valueField ? original_fields.find((f) => f.name === meta.valueField) : undefined;
     const textField = tf || vf || original_fields[0];


### PR DESCRIPTION
Fixes: grafana/support-escalations#21157

`convertFieldsToVariableFields` guarded Scenario 2 with `if (meta)`, which is truthy for `{}`. Any query where meta was reset to an empty object (e.g. on query-type tab switch) skipped the legacy Scenario 4 fallback and returned the raw JSON blob field as variable values.

Fix the guard to `if (meta?.textField || meta?.valueField)` and reset meta to `undefined` (not `{}`) on structural query changes.