### PR TITLE
Notifier: fix channelNotifier emitting events out of RV order

### DIFF
--- a/pkg/storage/unified/resource/notifier.go
+++ b/pkg/storage/unified/resource/notifier.go
@@ -134,8 +134,7 @@ func (cn *channelNotifier) Watch(ctx context.Context, opts WatchOptions) <-chan 
 			// Drain all pending events from the raw channel before sorting,
 			// so that we don't emit a partial batch that misses events with
 			// lower RVs still waiting in the channel.
-			drained := false
-			for !drained {
+			for drained := false; !drained; {
 				select {
 				case evt, ok := <-raw:
 					if !ok {

--- a/pkg/storage/unified/resource/notifier.go
+++ b/pkg/storage/unified/resource/notifier.go
@@ -131,6 +131,22 @@ func (cn *channelNotifier) Watch(ctx context.Context, opts WatchOptions) <-chan 
 				return
 			}
 
+			// Drain all pending events from the raw channel before sorting,
+			// so that we don't emit a partial batch that misses events with
+			// lower RVs still waiting in the channel.
+			drained := false
+			for !drained {
+				select {
+				case evt, ok := <-raw:
+					if !ok {
+						return
+					}
+					buffer = append(buffer, evt)
+				default:
+					drained = true
+				}
+			}
+
 			// Sort buffer by RV
 			slices.SortFunc(buffer, func(a, b Event) int {
 				return cmp.Compare(a.ResourceVersion, b.ResourceVersion)


### PR DESCRIPTION
## Summary
- Fix sporadic `TestIntegrationKvStorageBackend_WatchWriteEvents_ConcurrentWrites/channelNotifier` failure where events arrive out of ResourceVersion order
- The `channelNotifier.Watch` goroutine reads events one at a time via `select`, but when the ticker fires Go randomly picks between the raw channel and the ticker — so a tick can process a partial batch while lower-RV events are still unread in the channel
- Added a non-blocking drain loop after the ticker fires to read all pending events from the raw channel into the buffer before sorting and emitting

## Failed job
https://github.com/grafana/grafana-enterprise/actions/runs/22999732337/job/66781017600?pr=11123

## Root cause

The failing assertion was:
```
"2032057171813322759" is not greater than "2032057171817517058"
events must arrive in ascending RV order: event[95].RV=2032057171813322759 should be > event[94].RV=2032057171817517058
```

These two snowflake RVs differ by ~4,194,299 (~2²², i.e. ~1ms in the timestamp portion). Both events were generated nearly simultaneously by concurrent writers and were well past the 1-second settle threshold — the settle delay wasn't the problem.

The issue was that Go's `select` randomly chose the ticker case while event[95] (lower RV) was still sitting unread in the `raw` channel. The goroutine sorted and emitted a partial batch containing event[94] (higher RV), then on the next tick emitted event[95] — producing out-of-order output.

The drain loop ensures all events already in the channel are read into the buffer before sorting, so the sort always operates on the complete set of available events.

## Test plan
- [x] Ran the failing test 100 times (200/200 passed) with no flakiness
- [x] Ran all watch/notifier integration tests (21/21 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)