### PR TITLE
Provisioning: Block PullRequest jobs from the user-facing jobs API

### DIFF
--- a/pkg/registry/apis/provisioning/jobs.go
+++ b/pkg/registry/apis/provisioning/jobs.go
@@ -236,8 +236,12 @@ var (
 	_ rest.StorageMetadata = (*jobsConnector)(nil)
 )
 
-// authorizeJob dispatches pre-flight authorization checks based on the job action.
+// authorizeJob dispatches pre-flight validation and authorization checks based on the job action.
 func (c *jobsConnector) authorizeJob(ctx context.Context, repo repository.Repository, cfg *provisioning.Repository, spec provisioning.JobSpec) error {
+	if err := validateJobAction(spec, cfg); err != nil {
+		return err
+	}
+
 	switch spec.Action {
 	case provisioning.JobActionPush, provisioning.JobActionMigrate:
 		return c.authorizeResourceJob(ctx, repo, cfg, spec)
@@ -251,6 +255,7 @@ func (c *jobsConnector) authorizeJob(ctx context.Context, repo repository.Reposi
 		}
 	case provisioning.JobActionPull, provisioning.JobActionPullRequest, provisioning.JobActionFixFolderMetadata:
 		// Read-only operations don't require pre-flight resource authorization.
+		// Pull is authorized inline in Connect; PullRequest is rejected by validateJobAction above.
 	}
 	return nil
 }
@@ -319,6 +324,16 @@ func (c *jobsConnector) authorizeAdminJob(ctx context.Context, cfg *provisioning
 		Resource:  provisioning.JobResourceInfo.GetName(),
 		Namespace: cfg.Namespace,
 	}, "")
+}
+
+// validateJobAction checks that the job action is allowed to be created via the API.
+// Some job types are only triggered internally (e.g., by webhooks) and should not be
+// user-creatable.
+func validateJobAction(spec provisioning.JobSpec, _ *provisioning.Repository) error {
+	if spec.Action == provisioning.JobActionPullRequest {
+		return apierrors.NewBadRequest("pull request jobs cannot be created via the API; they are triggered by webhooks")
+	}
+	return nil
 }
 
 // authorizeResourceJob checks that the requesting user has the required permissions

--- a/pkg/registry/apis/provisioning/jobs_test.go
+++ b/pkg/registry/apis/provisioning/jobs_test.go
@@ -47,6 +47,35 @@ func newTestRepo(name, namespace string) *provisioning.Repository {
 	}
 }
 
+func TestPullRequestJobRejected(t *testing.T) {
+	cfg := newTestRepo("my-repo", "default")
+
+	t.Run("PullRequest action returns bad request", func(t *testing.T) {
+		spec := provisioning.JobSpec{
+			Action: provisioning.JobActionPullRequest,
+			PullRequest: &provisioning.PullRequestJobOptions{
+				PR:  123,
+				Ref: "test-ref",
+			},
+		}
+
+		err := validateJobAction(spec, cfg)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsBadRequest(err))
+		assert.Contains(t, err.Error(), "pull request jobs cannot be created via the API")
+	})
+
+	t.Run("Pull action is not rejected", func(t *testing.T) {
+		spec := provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{},
+		}
+
+		err := validateJobAction(spec, cfg)
+		require.NoError(t, err)
+	})
+}
+
 func TestAuthorizeResourceJob(t *testing.T) {
 	ctx := context.Background()
 	cfg := newTestRepo("my-repo", "default")

--- a/pkg/tests/apis/provisioning/jobs/pullrequestjob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pullrequestjob_auth_test.go
@@ -1,0 +1,88 @@
+package jobs
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+func TestIntegrationProvisioning_PullRequestJobRejected(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := common.RunGrafana(t)
+	ctx := context.Background()
+
+	const repo = "pr-job-rejected-test"
+	testRepo := common.TestRepo{
+		Name:               repo,
+		Target:             "folder",
+		Copies:             map[string]string{},
+		ExpectedDashboards: 0,
+		ExpectedFolders:    1,
+	}
+	helper.CreateRepo(t, testRepo)
+
+	body := common.AsJSON(provisioning.JobSpec{
+		Action: provisioning.JobActionPullRequest,
+		PullRequest: &provisioning.PullRequestJobOptions{
+			PR:  123,
+			Ref: "test-ref",
+		},
+	})
+
+	t.Run("admin cannot create pull request job", func(t *testing.T) {
+		var statusCode int
+		result := helper.AdminREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.Error(t, result.Error(), "admin should not be able to create pull request job")
+		require.Equal(t, http.StatusBadRequest, statusCode, "should return 400 Bad Request")
+		require.True(t, apierrors.IsBadRequest(result.Error()), "error should be bad request")
+	})
+
+	t.Run("editor cannot create pull request job", func(t *testing.T) {
+		var statusCode int
+		result := helper.EditorREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.Error(t, result.Error(), "editor should not be able to create pull request job")
+		require.Equal(t, http.StatusBadRequest, statusCode, "should return 400 Bad Request")
+		require.True(t, apierrors.IsBadRequest(result.Error()), "error should be bad request")
+	})
+
+	t.Run("viewer cannot create pull request job", func(t *testing.T) {
+		var statusCode int
+		result := helper.ViewerREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.Error(t, result.Error(), "viewer should not be able to create pull request job")
+		// Viewer is blocked at the API authorization layer (403) before reaching the connector
+		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
+		require.True(t, apierrors.IsForbidden(result.Error()), "error should be forbidden")
+	})
+}


### PR DESCRIPTION
## Summary
- Reject `JobActionPullRequest` ("pr") at the `POST .../repositories/{name}/jobs` endpoint with `400 BadRequest`.
- PullRequest jobs are triggered exclusively by webhooks and should not be user-creatable via the REST API.
- Add `validateJobAction` to centralize action-level validation, called from the `authorizeJob` dispatcher.

Partially addresses https://github.com/grafana/git-ui-sync-project/issues/714

## Test plan
- [x] Unit test: `TestPullRequestJobRejected` verifies PullRequest returns BadRequest and other actions pass through.
- [x] Integration test: `TestIntegrationProvisioning_PullRequestJobRejected` verifies admin (400), editor (400), viewer (403 — blocked at API layer).