### PR TITLE
Provisioning: Require admin role for FixFolderMetadata jobs

### DIFF
--- a/pkg/registry/apis/provisioning/jobs.go
+++ b/pkg/registry/apis/provisioning/jobs.go
@@ -11,9 +11,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 
+	authlib "github.com/grafana/authlib/types"
+
 	"github.com/grafana/grafana/apps/provisioning/pkg/apis/auth"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 )
@@ -141,6 +144,14 @@ func (c *jobsConnector) Connect(
 		}
 		spec.Repository = name
 
+		// FixFolderMetadata requires admin privileges.
+		if spec.Action == provisioning.JobActionFixFolderMetadata {
+			if err := c.authorizeAdminJob(r.Context(), cfg); err != nil {
+				responder.Error(err)
+				return
+			}
+		}
+
 		// Validate write operations before queueing the job
 		requiresWrite := spec.Action == provisioning.JobActionDelete ||
 			spec.Action == provisioning.JobActionMove ||
@@ -223,6 +234,17 @@ var (
 	_ rest.Storage         = (*jobsConnector)(nil)
 	_ rest.StorageMetadata = (*jobsConnector)(nil)
 )
+
+// authorizeAdminJob checks that the requesting user has admin privileges.
+// Used for job types that are restricted to administrators.
+func (c *jobsConnector) authorizeAdminJob(ctx context.Context, cfg *provisioning.Repository) error {
+	return c.access.WithFallbackRole(identity.RoleAdmin).Check(ctx, authlib.CheckRequest{
+		Verb:      "create",
+		Group:     provisioning.GROUP,
+		Resource:  provisioning.JobResourceInfo.GetName(),
+		Namespace: cfg.Namespace,
+	}, "")
+}
 
 // authorizeResourceJob checks that the requesting user has the required permissions
 // for operations that read and write all supported resource types (export and migrate).

--- a/pkg/registry/apis/provisioning/jobs_test.go
+++ b/pkg/registry/apis/provisioning/jobs_test.go
@@ -2,6 +2,7 @@ package provisioning
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +16,7 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/apis/auth"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 )
@@ -210,5 +212,44 @@ func TestAuthorizeResourceJob(t *testing.T) {
 		err := c.authorizeResourceJob(ctx, mockRepo, cfg, spec)
 		require.Error(t, err)
 		assert.True(t, apierrors.IsBadRequest(err))
+	})
+}
+
+func TestAuthorizeAdminJob(t *testing.T) {
+	ctx := context.Background()
+	cfg := newTestRepo("my-repo", "default")
+
+	t.Run("admin is authorized", func(t *testing.T) {
+		adminChecker := auth.NewMockAccessChecker(t)
+		adminChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
+			return req.Verb == "create" &&
+				req.Group == provisioning.GROUP &&
+				req.Resource == provisioning.JobResourceInfo.GetName() &&
+				req.Namespace == cfg.Namespace
+		}), "").Return(nil)
+
+		accessMock := auth.NewMockAccessChecker(t)
+		accessMock.EXPECT().WithFallbackRole(identity.RoleAdmin).Return(adminChecker)
+
+		c := &jobsConnector{access: accessMock}
+		err := c.authorizeAdminJob(ctx, cfg)
+		require.NoError(t, err)
+	})
+
+	t.Run("non-admin is forbidden", func(t *testing.T) {
+		adminChecker := auth.NewMockAccessChecker(t)
+		adminChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
+			return req.Verb == "create" &&
+				req.Group == provisioning.GROUP &&
+				req.Resource == provisioning.JobResourceInfo.GetName()
+		}), "").Return(apierrors.NewForbidden(schema.GroupResource{}, "", fmt.Errorf("admin role is required")))
+
+		accessMock := auth.NewMockAccessChecker(t)
+		accessMock.EXPECT().WithFallbackRole(identity.RoleAdmin).Return(adminChecker)
+
+		c := &jobsConnector{access: accessMock}
+		err := c.authorizeAdminJob(ctx, cfg)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err))
 	})
 }


### PR DESCRIPTION
## Summary
- Require admin privileges for `JobActionFixFolderMetadata` at the `POST .../repositories/{name}/jobs` endpoint.
- Add `authorizeAdminJob` helper that uses `AccessChecker.WithFallbackRole(RoleAdmin)` to verify the user has admin role at job creation time.
- Non-admin users receive `403 Forbidden`.

Partially addresses https://github.com/grafana/git-ui-sync-project/issues/714

## Test plan
- [x] Unit test: `TestAuthorizeAdminJob` verifies admin succeeds and non-admin gets Forbidden.


Made with [Cursor](https://cursor.com)