### PR TITLE
Provisioning: Require admin role for Pull jobs

### DIFF
--- a/pkg/registry/apis/provisioning/jobs.go
+++ b/pkg/registry/apis/provisioning/jobs.go
@@ -310,7 +310,6 @@ func (c *jobsConnector) authorizeResourceRefs(ctx context.Context, authorizer re
 	return nil
 }
 
-
 // authorizeAdminJob checks that the requesting user has admin privileges.
 // Used for job types that are restricted to administrators.
 func (c *jobsConnector) authorizeAdminJob(ctx context.Context, cfg *provisioning.Repository) error {
@@ -321,7 +320,6 @@ func (c *jobsConnector) authorizeAdminJob(ctx context.Context, cfg *provisioning
 		Namespace: cfg.Namespace,
 	}, "")
 }
-
 
 // authorizeResourceJob checks that the requesting user has the required permissions
 // for operations that read and write all supported resource types (export and migrate).

--- a/pkg/registry/apis/provisioning/jobs.go
+++ b/pkg/registry/apis/provisioning/jobs.go
@@ -13,9 +13,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/registry/rest"
 
+	authlib "github.com/grafana/authlib/types"
+
 	"github.com/grafana/grafana/apps/provisioning/pkg/apis/auth"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
@@ -146,6 +149,14 @@ func (c *jobsConnector) Connect(
 			return
 		}
 		spec.Repository = name
+
+		// Pull jobs trigger a repository sync and require admin privileges.
+		if spec.Action == provisioning.JobActionPull {
+			if err := c.authorizeAdminJob(r.Context(), cfg); err != nil {
+				responder.Error(err)
+				return
+			}
+		}
 
 		// Validate write operations before queueing the job
 		requiresWrite := spec.Action == provisioning.JobActionDelete ||
@@ -301,6 +312,18 @@ func (c *jobsConnector) authorizeResourceRefs(ctx context.Context, authorizer re
 	}
 	return nil
 }
+
+// authorizeAdminJob checks that the requesting user has admin privileges.
+// Used for job types that are restricted to administrators.
+func (c *jobsConnector) authorizeAdminJob(ctx context.Context, cfg *provisioning.Repository) error {
+	return c.access.WithFallbackRole(identity.RoleAdmin).Check(ctx, authlib.CheckRequest{
+		Verb:      "create",
+		Group:     provisioning.GROUP,
+		Resource:  provisioning.JobResourceInfo.GetName(),
+		Namespace: cfg.Namespace,
+	}, "")
+}
+
 
 // authorizeResourceJob checks that the requesting user has the required permissions
 // for operations that read and write all supported resource types (export and migrate).

--- a/pkg/registry/apis/provisioning/jobs.go
+++ b/pkg/registry/apis/provisioning/jobs.go
@@ -180,11 +180,8 @@ func (c *jobsConnector) Connect(
 					targetRef = spec.Push.Branch
 				}
 			case provisioning.JobActionMigrate:
-				// Migrate operates on the default branch (no ref)
 				targetRef = ""
 			default:
-				// Read-only operations (Pull, PullRequest, FixFolderMetadata) don't reach here
-				// due to requiresWrite check, but include default for exhaustive linter
 				targetRef = ""
 			}
 
@@ -312,6 +309,7 @@ func (c *jobsConnector) authorizeResourceRefs(ctx context.Context, authorizer re
 	}
 	return nil
 }
+
 
 // authorizeAdminJob checks that the requesting user has admin privileges.
 // Used for job types that are restricted to administrators.

--- a/pkg/registry/apis/provisioning/jobs_test.go
+++ b/pkg/registry/apis/provisioning/jobs_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/apis/auth"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 )
@@ -543,4 +544,43 @@ func (m *mockDynamic) Apply(context.Context, string, *unstructured.Unstructured,
 }
 func (m *mockDynamic) ApplyStatus(context.Context, string, *unstructured.Unstructured, metav1.ApplyOptions) (*unstructured.Unstructured, error) {
 	return nil, nil
+}
+
+func TestAuthorizeAdminJob(t *testing.T) {
+	ctx := context.Background()
+	cfg := newTestRepo("my-repo", "default")
+
+	t.Run("admin is authorized", func(t *testing.T) {
+		adminChecker := auth.NewMockAccessChecker(t)
+		adminChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
+			return req.Verb == "create" &&
+				req.Group == provisioning.GROUP &&
+				req.Resource == provisioning.JobResourceInfo.GetName() &&
+				req.Namespace == cfg.Namespace
+		}), "").Return(nil)
+
+		accessMock := auth.NewMockAccessChecker(t)
+		accessMock.EXPECT().WithFallbackRole(identity.RoleAdmin).Return(adminChecker)
+
+		c := &jobsConnector{access: accessMock}
+		err := c.authorizeAdminJob(ctx, cfg)
+		require.NoError(t, err)
+	})
+
+	t.Run("non-admin is forbidden", func(t *testing.T) {
+		adminChecker := auth.NewMockAccessChecker(t)
+		adminChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
+			return req.Verb == "create" &&
+				req.Group == provisioning.GROUP &&
+				req.Resource == provisioning.JobResourceInfo.GetName()
+		}), "").Return(apierrors.NewForbidden(schema.GroupResource{}, "", fmt.Errorf("admin role is required")))
+
+		accessMock := auth.NewMockAccessChecker(t)
+		accessMock.EXPECT().WithFallbackRole(identity.RoleAdmin).Return(adminChecker)
+
+		c := &jobsConnector{access: accessMock}
+		err := c.authorizeAdminJob(ctx, cfg)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err))
+	})
 }

--- a/pkg/tests/apis/provisioning/jobs/jobs_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/jobs_auth_test.go
@@ -87,8 +87,7 @@ func TestIntegrationProvisioning_JobsAuthorization(t *testing.T) {
 
 	t.Run("editor can create job", func(t *testing.T) {
 		body := common.AsJSON(provisioning.JobSpec{
-			Action: provisioning.JobActionPull,
-			Pull:   &provisioning.SyncJobOptions{},
+			Action: provisioning.JobActionFixFolderMetadata,
 		})
 
 		var statusCode int
@@ -109,8 +108,7 @@ func TestIntegrationProvisioning_JobsAuthorization(t *testing.T) {
 
 	t.Run("viewer cannot create job", func(t *testing.T) {
 		body := common.AsJSON(provisioning.JobSpec{
-			Action: provisioning.JobActionPull,
-			Pull:   &provisioning.SyncJobOptions{},
+			Action: provisioning.JobActionFixFolderMetadata,
 		})
 
 		var statusCode int

--- a/pkg/tests/apis/provisioning/jobs/pulljob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pulljob_auth_test.go
@@ -1,0 +1,85 @@
+package jobs
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+func TestIntegrationProvisioning_PullJobAuthorization(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := common.RunGrafana(t)
+	ctx := context.Background()
+
+	const repo = "pull-auth-test"
+	testRepo := common.TestRepo{
+		Name:               repo,
+		Target:             "folder",
+		Copies:             map[string]string{},
+		ExpectedDashboards: 0,
+		ExpectedFolders:    1,
+	}
+	helper.CreateRepo(t, testRepo)
+
+	body := common.AsJSON(provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
+	})
+
+	t.Run("admin can create pull job", func(t *testing.T) {
+		var statusCode int
+		result := helper.AdminREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.NoError(t, result.Error(), "admin should be able to create pull job")
+		require.Equal(t, http.StatusAccepted, statusCode, "should return 202 Accepted")
+
+		helper.AwaitJobs(t, repo)
+	})
+
+	t.Run("editor cannot create pull job", func(t *testing.T) {
+		var statusCode int
+		result := helper.EditorREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.Error(t, result.Error(), "editor should not be able to create pull job")
+		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
+		require.True(t, apierrors.IsForbidden(result.Error()), "error should be forbidden")
+	})
+
+	t.Run("viewer cannot create pull job", func(t *testing.T) {
+		var statusCode int
+		result := helper.ViewerREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.Error(t, result.Error(), "viewer should not be able to create pull job")
+		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
+		require.True(t, apierrors.IsForbidden(result.Error()), "error should be forbidden")
+	})
+}

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -1710,11 +1710,14 @@ func TestIntegrationProvisioning_JobPermissions(t *testing.T) {
 	}
 	helper.CreateRepo(t, testRepo)
 
-	jobSpec := provisioning.JobSpec{
+	adminJobBody := common.AsJSON(provisioning.JobSpec{
 		Action: provisioning.JobActionPull,
 		Pull:   &provisioning.SyncJobOptions{},
-	}
-	body := common.AsJSON(jobSpec)
+	})
+
+	editorJobBody := common.AsJSON(provisioning.JobSpec{
+		Action: provisioning.JobActionFixFolderMetadata,
+	})
 
 	t.Run("editor can POST jobs", func(t *testing.T) {
 		var statusCode int
@@ -1723,7 +1726,7 @@ func TestIntegrationProvisioning_JobPermissions(t *testing.T) {
 			Resource("repositories").
 			Name(repo).
 			SubResource("jobs").
-			Body(body).
+			Body(editorJobBody).
 			SetHeader("Content-Type", "application/json").
 			Do(ctx).StatusCode(&statusCode)
 
@@ -1745,7 +1748,7 @@ func TestIntegrationProvisioning_JobPermissions(t *testing.T) {
 			Resource("repositories").
 			Name(repo).
 			SubResource("jobs").
-			Body(body).
+			Body(editorJobBody).
 			SetHeader("Content-Type", "application/json").
 			Do(ctx).StatusCode(&statusCode)
 
@@ -1761,7 +1764,7 @@ func TestIntegrationProvisioning_JobPermissions(t *testing.T) {
 			Resource("repositories").
 			Name(repo).
 			SubResource("jobs").
-			Body(body).
+			Body(adminJobBody).
 			SetHeader("Content-Type", "application/json").
 			Do(ctx).StatusCode(&statusCode)
 


### PR DESCRIPTION
## Summary
- Require admin privileges for `JobActionPull` at the `POST .../repositories/{name}/jobs` endpoint.
- Add `authorizeAdminJob` helper that uses `AccessChecker.WithFallbackRole(RoleAdmin)` to verify the user has admin role at job creation time.
- Non-admin users receive `403 Forbidden`.

Partially addresses https://github.com/grafana/git-ui-sync-project/issues/714

## Test plan
- [x] Unit test: `TestAuthorizeAdminJob` verifies admin succeeds and non-admin gets Forbidden.


Made with [Cursor](https://cursor.com)