### PR TITLE
Docs Datalinks: Document __field.displayName for transformed fields

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/visualizations/panels-visualizations/configure-data-links/index.md
@@ -234,11 +234,11 @@ Series-specific variables are available under `__series` namespace:
 
 Field-specific variables are available under `__field` namespace:
 
-- **`__field.name`**: The raw name of the field.
-- **`__field.displayName`**: The display name of the field.
-- **`__field.labels.<LABEL>`**: Label's value to the URL. If your label contains dots, then use `__field.labels["<LABEL>"]` syntax.
-
-If you use a transformation such as **Rename fields by regex**, use `__field.displayName` to reference the transformed field name in data links.
+| Variable                 | Description                                                                                         |
+| ------------------------ | --------------------------------------------------------------------------------------------------- |
+| `__field.name`           | The name of the field                                                                               |
+| `__field.displayName`    | The display name of the field. Use this for renamed field names.                                    |
+| `__field.labels.<LABEL>` | Label's value to the URL. If your label contains dots, then use `__field.labels["<LABEL>"]` syntax. |
 
 ### Value variables
 

--- a/docs/sources/visualizations/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/visualizations/panels-visualizations/configure-data-links/index.md
@@ -238,7 +238,7 @@ Field-specific variables are available under `__field` namespace:
 - **`__field.displayName`**: The display name of the field.
 - **`__field.labels.<LABEL>`**: Label's value to the URL. If your label contains dots, then use `__field.labels["<LABEL>"]` syntax.
 
-If you use a transformation such as **Rename fields by regex**, use `__field.displayName` to reference the transformed field label in data links.
+If you use a transformation such as **Rename fields by regex**, use `__field.displayName` to reference the transformed field name in data links.
 
 ### Value variables
 

--- a/docs/sources/visualizations/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/visualizations/panels-visualizations/configure-data-links/index.md
@@ -234,10 +234,11 @@ Series-specific variables are available under `__series` namespace:
 
 Field-specific variables are available under `__field` namespace:
 
-| Variable                 | Description                                                                                         |
-| ------------------------ | --------------------------------------------------------------------------------------------------- |
-| `__field.name`           | The name of the field                                                                               |
-| `__field.labels.<LABEL>` | Label's value to the URL. If your label contains dots, then use `__field.labels["<LABEL>"]` syntax. |
+- **`__field.name`**: The raw name of the field.
+- **`__field.displayName`**: The display name of the field.
+- **`__field.labels.<LABEL>`**: Label's value to the URL. If your label contains dots, then use `__field.labels["<LABEL>"]` syntax.
+
+If you use a transformation such as **Rename fields by regex**, use `__field.displayName` to reference the transformed field label in data links.
 
 ### Value variables
 


### PR DESCRIPTION
Clarifies data link field variables by distinguishing raw `__field.name` from `__field.displayName`. Adds guidance to use `__field.displayName` with rename transformations (for example, `Rename fields by regex`).