### PR TITLE
QueryEditor: Add header action tests for QueryEditor header

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/HeaderActions.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/HeaderActions.test.tsx
@@ -1,0 +1,133 @@
+import { screen } from '@testing-library/react';
+
+import { ActionItem } from '../../Actions';
+import { QueryEditorType } from '../../constants';
+import { renderWithQueryEditorProvider } from '../testUtils';
+import { Transformation } from '../types';
+
+import { HeaderActions } from './HeaderActions';
+
+interface MockActionsProps {
+  item: ActionItem;
+  onDelete?: () => void;
+  onToggleHide?: () => void;
+}
+
+jest.mock('../../Actions', () => ({
+  Actions: ({ item, onDelete, onToggleHide }: MockActionsProps) => (
+    <div
+      data-testid="actions"
+      data-item-type={item.type}
+      data-item-name={item.name}
+      data-item-hidden={String(item.isHidden)}
+    >
+      {onToggleHide && <button onClick={onToggleHide}>Toggle hide action</button>}
+      {onDelete && <button onClick={onDelete}>Delete action</button>}
+    </div>
+  ),
+}));
+
+jest.mock('./WarningBadges', () => ({
+  WarningBadges: () => <div data-testid="warning-badges" />,
+}));
+
+jest.mock('./SaveButton', () => ({
+  SaveButton: () => <div data-testid="save-button" />,
+}));
+
+jest.mock('./PluginActions', () => ({
+  PluginActions: () => <div data-testid="plugin-actions" />,
+}));
+
+jest.mock('./ExperimentalFeedbackButton', () => ({
+  ExperimentalFeedbackButton: () => <div data-testid="experimental-feedback-button" />,
+}));
+
+jest.mock('./QueryActionsMenu', () => ({
+  QueryActionsMenu: () => <div data-testid="query-actions-menu" />,
+}));
+
+jest.mock('./TransformationActionButtons', () => ({
+  TransformationActionButtons: () => <div data-testid="transformation-action-buttons" />,
+}));
+
+const makeTransformation = (overrides: Partial<Transformation> = {}): Transformation => ({
+  transformId: 'transform-1',
+  transformConfig: { id: 'test-transform', options: {} },
+  registryItem: { name: 'Test transformation' } as Transformation['registryItem'],
+  ...overrides,
+});
+
+describe('HeaderActions', () => {
+  it('renders query actions and routes hide/delete to selected query handlers', async () => {
+    const toggleQueryHide = jest.fn();
+    const deleteQuery = jest.fn();
+
+    const { user } = renderWithQueryEditorProvider(<HeaderActions />, {
+      selectedQuery: { refId: 'A', hide: false },
+      uiStateOverrides: { cardType: QueryEditorType.Query },
+      actionsOverrides: { toggleQueryHide, deleteQuery },
+    });
+
+    expect(screen.getByTestId('query-actions-menu')).toBeInTheDocument();
+    expect(screen.queryByTestId('transformation-action-buttons')).not.toBeInTheDocument();
+    expect(screen.getByTestId('actions')).toHaveAttribute('data-item-type', QueryEditorType.Query);
+    expect(screen.getByTestId('actions')).toHaveAttribute('data-item-name', 'A');
+    expect(screen.getByTestId('actions')).toHaveAttribute('data-item-hidden', 'false');
+
+    await user.click(screen.getByRole('button', { name: 'Toggle hide action' }));
+    await user.click(screen.getByRole('button', { name: 'Delete action' }));
+
+    expect(toggleQueryHide).toHaveBeenCalledWith('A');
+    expect(deleteQuery).toHaveBeenCalledWith('A');
+  });
+
+  it('routes expression hide/delete callbacks through selected query refId', async () => {
+    const toggleQueryHide = jest.fn();
+    const deleteQuery = jest.fn();
+
+    const { user } = renderWithQueryEditorProvider(<HeaderActions />, {
+      selectedQuery: { refId: 'B', hide: true },
+      uiStateOverrides: { cardType: QueryEditorType.Expression },
+      actionsOverrides: { toggleQueryHide, deleteQuery },
+    });
+
+    expect(screen.getByTestId('query-actions-menu')).toBeInTheDocument();
+    expect(screen.getByTestId('actions')).toHaveAttribute('data-item-type', QueryEditorType.Expression);
+    expect(screen.getByTestId('actions')).toHaveAttribute('data-item-hidden', 'true');
+
+    await user.click(screen.getByRole('button', { name: 'Toggle hide action' }));
+    await user.click(screen.getByRole('button', { name: 'Delete action' }));
+
+    expect(toggleQueryHide).toHaveBeenCalledWith('B');
+    expect(deleteQuery).toHaveBeenCalledWith('B');
+  });
+
+  it('renders transformation buttons and routes hide/delete to selected transformation handlers', async () => {
+    const toggleTransformationDisabled = jest.fn();
+    const deleteTransformation = jest.fn();
+    const selectedTransformation = makeTransformation({
+      transformId: 'transform-42',
+      transformConfig: { id: 'test-transform', options: {}, disabled: true },
+      registryItem: { name: 'Reduce' } as Transformation['registryItem'],
+    });
+
+    const { user } = renderWithQueryEditorProvider(<HeaderActions />, {
+      selectedTransformation,
+      uiStateOverrides: { cardType: QueryEditorType.Transformation },
+      actionsOverrides: { toggleTransformationDisabled, deleteTransformation },
+    });
+
+    expect(screen.getByTestId('transformation-action-buttons')).toBeInTheDocument();
+    expect(screen.queryByTestId('query-actions-menu')).not.toBeInTheDocument();
+    expect(screen.getByTestId('actions')).toHaveAttribute('data-item-type', QueryEditorType.Transformation);
+    expect(screen.getByTestId('actions')).toHaveAttribute('data-item-name', 'Reduce');
+    expect(screen.getByTestId('actions')).toHaveAttribute('data-item-hidden', 'true');
+
+    await user.click(screen.getByRole('button', { name: 'Toggle hide action' }));
+    await user.click(screen.getByRole('button', { name: 'Delete action' }));
+
+    expect(toggleTransformationDisabled).toHaveBeenCalledWith('transform-42');
+    expect(deleteTransformation).toHaveBeenCalledWith('transform-42');
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/QueryActionsMenu.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/QueryActionsMenu.test.tsx
@@ -1,0 +1,144 @@
+import { screen } from '@testing-library/react';
+
+import { InspectTab } from 'app/features/inspector/types';
+
+import { QueryEditorType } from '../../constants';
+import { renderWithQueryEditorProvider } from '../testUtils';
+
+import { QueryActionsMenu } from './QueryActionsMenu';
+
+const trackQueryMenuAction = jest.fn();
+const getDashboardSceneFor = jest.fn();
+const panelInspectDrawerMock = jest.fn().mockImplementation((args) => ({ kind: 'panel-inspect-drawer', args }));
+
+jest.mock('../../tracking', () => ({
+  trackQueryMenuAction: (...args: unknown[]) => trackQueryMenuAction(...args),
+}));
+
+jest.mock('../../../../utils/utils', () => ({
+  getDashboardSceneFor: (...args: unknown[]) => getDashboardSceneFor(...args),
+}));
+
+jest.mock('../../../../inspect/PanelInspectDrawer', () => ({
+  PanelInspectDrawer: function PanelInspectDrawer(...args: unknown[]) {
+    return panelInspectDrawerMock(...args);
+  },
+}));
+
+describe('QueryActionsMenu', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows duplicate/help/inspector actions for query cards and triggers duplicate callback', async () => {
+    const duplicateQuery = jest.fn();
+    const toggleDatasourceHelp = jest.fn();
+
+    const { user } = renderWithQueryEditorProvider(<QueryActionsMenu />, {
+      selectedQuery: { refId: 'A', datasource: { uid: 'test', type: 'test' } },
+      uiStateOverrides: {
+        cardType: QueryEditorType.Query,
+        selectedQueryDsLoading: false,
+        selectedQueryDsData: {
+          datasource: {
+            components: {
+              QueryEditorHelp: () => null,
+            },
+          } as never,
+        },
+        showingDatasourceHelp: false,
+        toggleDatasourceHelp,
+      },
+      actionsOverrides: { duplicateQuery },
+    });
+
+    await user.click(screen.getByRole('button', { name: /more query actions/i }));
+
+    expect(screen.getByRole('menuitem', { name: /duplicate query/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /show data source help/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /query inspector/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('menuitem', { name: /duplicate query/i }));
+    expect(duplicateQuery).toHaveBeenCalledWith('A');
+    expect(trackQueryMenuAction).toHaveBeenCalledWith('duplicate', QueryEditorType.Query);
+
+    await user.click(screen.getByRole('button', { name: /more query actions/i }));
+    await user.click(screen.getByRole('menuitem', { name: /show data source help/i }));
+    expect(toggleDatasourceHelp).toHaveBeenCalledTimes(1);
+    expect(trackQueryMenuAction).toHaveBeenCalledWith('toggle_datasource_help', QueryEditorType.Query);
+  });
+
+  it('uses hide-help label when datasource help is already shown', async () => {
+    const { user } = renderWithQueryEditorProvider(<QueryActionsMenu />, {
+      selectedQuery: { refId: 'A', datasource: { uid: 'test', type: 'test' } },
+      uiStateOverrides: {
+        cardType: QueryEditorType.Query,
+        selectedQueryDsLoading: false,
+        selectedQueryDsData: {
+          datasource: {
+            components: {
+              QueryEditorHelp: () => null,
+            },
+          } as never,
+        },
+        showingDatasourceHelp: true,
+      },
+    });
+
+    await user.click(screen.getByRole('button', { name: /more query actions/i }));
+
+    expect(screen.getByRole('menuitem', { name: /hide data source help/i })).toBeInTheDocument();
+  });
+
+  it('hides datasource help action for expression cards', async () => {
+    const duplicateQuery = jest.fn();
+
+    const { user } = renderWithQueryEditorProvider(<QueryActionsMenu />, {
+      selectedQuery: { refId: 'B', datasource: { uid: 'test', type: 'test' } },
+      uiStateOverrides: {
+        cardType: QueryEditorType.Expression,
+        selectedQueryDsLoading: false,
+        selectedQueryDsData: {
+          datasource: {
+            components: {
+              QueryEditorHelp: () => null,
+            },
+          } as never,
+        },
+      },
+      actionsOverrides: { duplicateQuery },
+    });
+
+    await user.click(screen.getByRole('button', { name: /more expression actions/i }));
+
+    expect(screen.getByRole('menuitem', { name: /duplicate expression/i })).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: /data source help/i })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('menuitem', { name: /duplicate expression/i }));
+    expect(duplicateQuery).toHaveBeenCalledWith('B');
+    expect(trackQueryMenuAction).toHaveBeenCalledWith('duplicate', QueryEditorType.Expression);
+  });
+
+  it('opens query inspector from the dashboard scene', async () => {
+    const panel = { getRef: jest.fn().mockReturnValue('panel-ref-1') } as never;
+    const showModal = jest.fn();
+    getDashboardSceneFor.mockReturnValue({ showModal });
+
+    const { user } = renderWithQueryEditorProvider(<QueryActionsMenu />, {
+      selectedQuery: { refId: 'A', datasource: { uid: 'test', type: 'test' } },
+      panelState: { panel },
+      uiStateOverrides: { cardType: QueryEditorType.Query },
+    });
+
+    await user.click(screen.getByRole('button', { name: /more query actions/i }));
+    await user.click(screen.getByRole('menuitem', { name: /query inspector/i }));
+
+    expect(getDashboardSceneFor).toHaveBeenCalledWith(panel);
+    expect(panelInspectDrawerMock).toHaveBeenCalledWith({ panelRef: 'panel-ref-1', currentTab: InspectTab.Query });
+    expect(showModal).toHaveBeenCalledWith({
+      kind: 'panel-inspect-drawer',
+      args: { panelRef: 'panel-ref-1', currentTab: InspectTab.Query },
+    });
+    expect(trackQueryMenuAction).toHaveBeenCalledWith('open_inspector', QueryEditorType.Query);
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/TransformationActionButtons.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/TransformationActionButtons.test.tsx
@@ -10,7 +10,7 @@ import {
 } from '@grafana/data';
 import { DataTopic } from '@grafana/schema';
 
-import { renderWithQueryEditorProvider } from '../testUtils';
+import { mockTransformToggles, renderWithQueryEditorProvider } from '../testUtils';
 import { Transformation } from '../types';
 
 import { TransformationActionButtons } from './TransformationActionButtons';
@@ -59,6 +59,56 @@ describe('TransformationActionButtons', () => {
     });
 
     expect(container).toBeEmptyDOMElement();
+  });
+
+  describe('help and debug actions', () => {
+    it('shows transformation help button when help metadata exists and toggles help', async () => {
+      const toggleHelp = jest.fn();
+      const transformation = makeTransformation({
+        registryItem: { ...mockRegistryItem, help: 'https://example.test/help' } as TransformerRegistryItem,
+      });
+
+      const { user } = renderWithQueryEditorProvider(<TransformationActionButtons />, {
+        selectedTransformation: transformation,
+        uiStateOverrides: {
+          transformToggles: { ...mockTransformToggles, showHelp: false, toggleHelp },
+        },
+      });
+
+      await user.click(screen.getByRole('button', { name: /show transformation help/i }));
+
+      expect(toggleHelp).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses "Hide transformation help" label when help is expanded', () => {
+      const transformation = makeTransformation({
+        registryItem: { ...mockRegistryItem, help: 'https://example.test/help' } as TransformerRegistryItem,
+      });
+
+      renderWithQueryEditorProvider(<TransformationActionButtons />, {
+        selectedTransformation: transformation,
+        uiStateOverrides: {
+          transformToggles: { ...mockTransformToggles, showHelp: true },
+        },
+      });
+
+      expect(screen.getByRole('button', { name: /hide transformation help/i })).toBeInTheDocument();
+    });
+
+    it('always renders debug button and toggles debug mode', async () => {
+      const toggleDebug = jest.fn();
+
+      const { user } = renderWithQueryEditorProvider(<TransformationActionButtons />, {
+        selectedTransformation: makeTransformation(),
+        uiStateOverrides: {
+          transformToggles: { ...mockTransformToggles, showDebug: false, toggleDebug },
+        },
+      });
+
+      await user.click(screen.getByRole('button', { name: /debug/i }));
+
+      expect(toggleDebug).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('filter button visibility', () => {


### PR DESCRIPTION
This PR adds test coverage for header actions in Panel Edit Next.

- Adds HeaderActions tests for query, expression, and transformation flows.
- Adds QueryActionsMenu tests for duplicate/help/inspector behavior, including expression-specific behavior.
- Extends TransformationActionButtons tests to cover help and debug actions.