### PR TITLE
Provisioning: Fix Azure DevOps git sync 404 error

### DIFF
--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -62,6 +62,12 @@ func NewRepository(
 		opts = append(opts, options.WithBasicAuth(tokenUser, string(gitConfig.Token)))
 	}
 
+	// Azure DevOps treats ".git" as a literal part of the repository name,
+	// so we must not append it automatically.
+	if isAzureDevOpsURL(gitConfig.URL) {
+		opts = append(opts, options.WithoutGitSuffix())
+	}
+
 	client, err := nanogit.NewHTTPClient(gitConfig.URL, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("create nanogit client: %w", err)
@@ -171,6 +177,27 @@ func isValidGitURL(gitURL string) bool {
 	}
 
 	return true
+}
+
+// isAzureDevOpsURL returns true if the given URL points to an Azure DevOps Git repository.
+// Azure DevOps uses "/_git/" in its repository paths and treats ".git" as a literal
+// part of the repository name rather than a suffix to strip.
+func isAzureDevOpsURL(rawURL string) bool {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+
+	host := strings.ToLower(parsed.Host)
+	// dev.azure.com is the current Azure DevOps domain;
+	// visualstudio.com is the legacy domain.
+	if strings.HasSuffix(host, "dev.azure.com") || strings.HasSuffix(host, "visualstudio.com") {
+		return true
+	}
+
+	// Also match by path pattern for on-premises Azure DevOps Server instances
+	// that use /_git/ in their URL structure.
+	return strings.Contains(parsed.Path, "/_git/")
 }
 
 // Test implements provisioning.Repository.

--- a/apps/provisioning/pkg/repository/git/repository_test.go
+++ b/apps/provisioning/pkg/repository/git/repository_test.go
@@ -78,6 +78,52 @@ func TestIsValidGitURL(t *testing.T) {
 	}
 }
 
+func TestIsAzureDevOpsURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{
+			name: "Azure DevOps URL",
+			url:  "https://dev.azure.com/org/project/_git/MyRepo",
+			want: true,
+		},
+		{
+			name: "Legacy Visual Studio URL",
+			url:  "https://org.visualstudio.com/project/_git/MyRepo",
+			want: true,
+		},
+		{
+			name: "On-premises Azure DevOps Server with _git path",
+			url:  "https://tfs.company.com/collection/project/_git/MyRepo",
+			want: true,
+		},
+		{
+			name: "GitHub URL",
+			url:  "https://github.com/owner/repo",
+			want: false,
+		},
+		{
+			name: "GitLab URL",
+			url:  "https://gitlab.com/owner/repo",
+			want: false,
+		},
+		{
+			name: "invalid URL",
+			url:  "://bad-url",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAzureDevOpsURL(tt.url)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestNewGit(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## What is this PR about?

Fixes git sync provisioning failing with **404 Not Found** when using Azure DevOps repositories.

**Error:** `failed check if authorized: get repository info: got status code 404: 404 Not Found`

## Root Cause

nanogit unconditionally appends `.git` to repository URLs. Azure DevOps treats `.git` as a literal part of the repository name (not a suffix to strip), so:
- `https://dev.azure.com/org/project/_git/MyRepo` becomes
- `https://dev.azure.com/org/project/_git/MyRepo.git`  **404**

## Changes

### In this PR (grafana/grafana):
- **`apps/provisioning/pkg/repository/git/repository.go`**: 
  - Added `isAzureDevOpsURL()` helper that detects Azure DevOps repositories by hostname (`dev.azure.com`, `*.visualstudio.com`) and path pattern (`/_git/`) for on-premises Azure DevOps Server
  - `NewRepository()` now passes `options.WithoutGitSuffix()` when the URL is Azure DevOps
- **`apps/provisioning/pkg/repository/git/repository_test.go`**: Added `TestIsAzureDevOpsURL` with 6 test cases

### Upstream dependency (grafana/nanogit):
- PR: https://github.com/grafana/nanogit/pull/207
- Adds `WithoutGitSuffix()` option to skip the automatic `.git` suffix appending

## How to reproduce the bug

1. Go to **Administration  Provisioning  Connect a repository**
2. Select **Pure Git**
3. Enter an Azure DevOps URL: `https://dev.azure.com/{org}/{project}/_git/{repo}`
4. Enter a valid PAT with Code  Read scope
5. Click **Save & test**
6. **Before fix:** `failed check if authorized: get repository info: got status code 404: 404 Not Found`
7. **After fix:** Successful connection

## Checklist

- [x] Changes have unit tests
- [x] Backward compatible  non-Azure DevOps URLs still get `.git` appended as before
- [x] No new dependencies added

## Dependencies

This PR requires the nanogit upgrade to include https://github.com/grafana/nanogit/pull/207