### PR TITLE
Alerting: Fix infinite loading with multiple alertmanagers in routing preview

### DIFF
--- a/public/app/features/alerting/unified/components/notification-policies/useNotificationPolicyRoute.ts
+++ b/public/app/features/alerting/unified/components/notification-policies/useNotificationPolicyRoute.ts
@@ -53,7 +53,7 @@ const {
 
 const { useGetAlertmanagerConfigurationQuery } = alertmanagerApi;
 
-const memoK8sRouteToRoute = memoize(k8sRouteToRoute);
+const memoK8sRouteToRoute = memoize(k8sRouteToRoute, { maxSize: 10 });
 
 export const useNotificationPolicyRoute = (
   { alertmanager }: BaseAlertmanagerArgs,
@@ -114,14 +114,17 @@ export const useListNotificationPolicyRoutes = ({ skip }: Skippable = {}) => {
   );
 };
 
-const parseAmConfigRoute = memoize((route: Route): Route => {
-  return {
-    ...route,
-    [ROUTES_META_SYMBOL]: {
-      provenance: route.provenance,
-    },
-  };
-});
+const parseAmConfigRoute = memoize(
+  (route: Route): Route => {
+    return {
+      ...route,
+      [ROUTES_META_SYMBOL]: {
+        provenance: route.provenance,
+      },
+    };
+  },
+  { maxSize: 10 }
+);
 
 export function useUpdateExistingNotificationPolicy({ alertmanager }: BaseAlertmanagerArgs) {
   const k8sApiSupported = shouldUseK8sApi(alertmanager);


### PR DESCRIPTION
## What is this PR about?

Fixes infinite loading on the **Preview Routing** and **Edit Alerts** pages when multiple external Prometheus alertmanagers with thousands of receivers/routes are configured.

## Root Cause

In `useNotificationPolicyRoute.ts`, two memoized functions use `micro-memoize`'s default `maxSize: 1`:

- `parseAmConfigRoute` (line 117)
- `memoK8sRouteToRoute` (line 56)

When multiple external alertmanagers are configured, each alertmanager passes a different `route` object to these functions via `selectFromResult`. With `maxSize: 1`, alertmanager A's cache entry is evicted when alertmanager B calls the function, and vice versa. This means:

1. Every `selectFromResult` call returns a **new object reference**
2. React detects a "change" and re-renders
3. `useAsync` re-runs on every render
4. This creates an **infinite render loop** → infinite loading spinner

## Fix

Increased `maxSize` from `1` (default) to `10` for both memoized functions. This allows the cache to hold entries for multiple alertmanagers simultaneously, preventing cache thrashing and maintaining stable object references across renders.

The value of 10 is well above a typical multi-alertmanager setup while keeping memory usage negligible.

## How to verify

1. Configure 2+ external Prometheus Alertmanagers to receive Grafana alerts
2. Each alertmanager should have thousands of receivers configured
3. Create/edit an alert and preview its routing on all alertmanagers
4. **Before fix:** Infinite loading spinner
5. **After fix:** Routing preview loads successfully

Fixes #120142
