### PR TITLE
GrafanaUI: Change secondary button color

### DIFF
--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -142,8 +142,8 @@ class DarkColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   };
 
   secondary = {
-    main: '#2A2D32',
-    shade: '#33373d',
+    main: palette.gray20,
+    shade: palette.gray25,
     transparent: `rgba(${this.whiteBase}, 0.08)`,
     text: this.text.primary,
     contrastText: `rgb(${this.whiteBase})`,
@@ -223,8 +223,8 @@ class LightColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   };
 
   secondary = {
-    main: '#f0f0f0',
-    shade: '#e4e4e4',
+    main: palette.gray90,
+    shade: palette.gray85,
     transparent: `rgba(${this.blackBase}, 0.08)`,
     contrastText: `rgba(${this.blackBase},  1)`,
     text: this.text.primary,
@@ -253,9 +253,9 @@ class LightColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   };
 
   background = {
-    canvas: palette.gray90,
+    canvas: palette.gray100,
     primary: palette.white,
-    secondary: palette.gray100,
+    secondary: palette.gray95,
     elevated: palette.white,
   };
 

--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -142,8 +142,8 @@ class DarkColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   };
 
   secondary = {
-    main: '#2e3136',
-    shade: '#3a3f44',
+    main: '#2A2D32',
+    shade: '#33373d',
     transparent: `rgba(${this.whiteBase}, 0.08)`,
     text: this.text.primary,
     contrastText: `rgb(${this.whiteBase})`,

--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -142,8 +142,8 @@ class DarkColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   };
 
   secondary = {
-    main: `rgba(${this.whiteBase}, 0.10)`,
-    shade: `rgba(${this.whiteBase}, 0.14)`,
+    main: '#2e3136',
+    shade: '#3a3f44',
     transparent: `rgba(${this.whiteBase}, 0.08)`,
     text: this.text.primary,
     contrastText: `rgb(${this.whiteBase})`,
@@ -223,8 +223,8 @@ class LightColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   };
 
   secondary = {
-    main: `rgba(${this.blackBase}, 0.08)`,
-    shade: `rgba(${this.blackBase}, 0.15)`,
+    main: '#f0f0f0',
+    shade: '#e4e4e4',
     transparent: `rgba(${this.blackBase}, 0.08)`,
     contrastText: `rgba(${this.blackBase},  1)`,
     text: this.text.primary,

--- a/packages/grafana-data/src/themes/palette.ts
+++ b/packages/grafana-data/src/themes/palette.ts
@@ -2,30 +2,29 @@ export const palette = {
   white: '#ffffff',
   black: '#000000',
 
-  gray25: '#2c3235',
-  gray15: '#22252b', //'#202226',
-  gray10: '#181b1f', // old '#141619',
-  gray05: '#111217', // old '#0b0c0e',
+  gray05: '#111217',
+  gray10: '#181b1f',
+  gray15: '#22252b',
+  gray20: '#2c2f35',
+  gray25: '#383b42',
+  gray30: '#44474e',
+  gray35: '#51555b',
+  gray40: '#5f6268',
+  gray45: '#6e7177',
+  gray50: '#7d8085',
+  gray55: '#8c8f94',
+  gray60: '#9c9fa3',
+  gray65: '#ababaf',
+  gray70: '#babcbe',
+  gray75: '#c8cacc',
+  gray80: '#d6d7d9',
+  gray85: '#e1e2e3',
+  gray90: '#ececed',
+  gray95: '#f4f5f5',
+  gray100: '#fbfbfb',
 
-  // new from figma,
-  darkLayer0: '#18181a',
-  darkLayer1: '#212124',
-  darkLayer2: '#2a2a2f', // figma used #34343B but a bit too bright
-
-  darkBorder1: '#34343b',
-  darkBorder2: '#64646b',
-
-  // Dashboard bg / layer 0 (light theme)
-  gray90: '#fbfbfb',
-  // Card bg / layer 1
-  gray100: '#f4f5f5',
-  // divider line
-  gray80: '#d0d1d3',
-  // from figma
-  lightBorder1: '#e4e7e7',
-
-  blueDarkMain: '#3d71d9', // '#4165F5',
-  blueDarkText: '#6e9fff', // '#58a6ff', //'#33a2e5', // '#5790FF',
+  blueDarkMain: '#3d71d9',
+  blueDarkText: '#6e9fff',
   redDarkMain: '#d10e5c',
   redDarkText: '#ff5286',
   greenDarkMain: '#1a7f4b',


### PR DESCRIPTION
## What is this PR about?

Updates the secondary button background colors to remove opacity [see [slack message](https://raintank-corp.slack.com/archives/C025WTVRBSN/p1773070489035169)]

**Dark Mode:**
- `main`: `#2a2d32`
- `shade` (hover): `#33373d`

**Light Mode:**
- `main`: `#f0f0f0`
- `shade` (hover): `#e4e4e4`