### PR TITLE
RBAC: Add trace attributes to permission restriction filter

### DIFF
--- a/pkg/services/authn/authnimpl/sync/rbac_sync.go
+++ b/pkg/services/authn/authnimpl/sync/rbac_sync.go
@@ -88,6 +88,18 @@ func (s *RBACSync) SyncPermissionsHook(ctx context.Context, ident *authn.Identit
 				filtered[action] = scopes
 			}
 		}
+
+		// Debug: capture restriction filter state
+		span.SetAttributes(
+			attribute.Int("pre_filter_actions", len(grouped)),
+			attribute.Int("post_filter_actions", len(filtered)),
+			attribute.Int("grafana_restrictions", len(grafanaRestrictions)),
+			attribute.Int("k8s_restrictions", len(k8sRestrictions)),
+			attribute.Int("allowed_actions", len(allowedActions)),
+			attribute.StringSlice("allowed_action_list", allowedActions),
+			attribute.Int64("ident_orgID", ident.OrgID),
+		)
+
 		grouped = filtered
 	}
 	ident.Permissions[ident.OrgID] = grouped


### PR DESCRIPTION
## Summary
- Adds span attributes to `SyncPermissionsHook` capturing the state of the permission restriction filter (pre/post filter action counts, restriction lists, allowed actions, and OrgID)

## Test plan
- [ ] Inspect the `rbac.sync.SyncPermissionsHook` span in failing traces for the new attributes
- [ ] Confirm whether `post_filter_actions` is 0 or `datasources:query` is missing from `allowed_action_list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)