### PR TITLE
QueryEditor: Add coverage for transformation debug actions

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/TransformationActionButtons.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/TransformationActionButtons.test.tsx
@@ -213,4 +213,33 @@ describe('TransformationActionButtons', () => {
       });
     });
   });
+
+  describe('debug button behaviour', () => {
+    it('always shows the debug action for a selected transformation', () => {
+      renderWithQueryEditorProvider(<TransformationActionButtons />, {
+        selectedTransformation: makeTransformation(),
+      });
+
+      expect(screen.getByRole('button', { name: /debug/i })).toBeInTheDocument();
+    });
+
+    it('toggles debug mode when clicked', async () => {
+      const toggleDebug = jest.fn();
+      const { user } = renderWithQueryEditorProvider(<TransformationActionButtons />, {
+        selectedTransformation: makeTransformation(),
+        uiStateOverrides: {
+          transformToggles: {
+            showHelp: false,
+            toggleHelp: jest.fn(),
+            showDebug: false,
+            toggleDebug,
+          },
+        },
+      });
+
+      await user.click(screen.getByRole('button', { name: /debug/i }));
+
+      expect(toggleDebug).toHaveBeenCalledTimes(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add filter / remove filter tests already covered before
- adds debug action tests