### PR TITLE
SQL Expressions: Return proper 400 errors for invalid expression graph

### DIFF
--- a/pkg/expr/errors.go
+++ b/pkg/expr/errors.go
@@ -94,6 +94,23 @@ func MakeParseError(refID string, err error) error {
 	return ParseError.Build(data)
 }
 
+var graphBuildErrStr = "failed to build expression pipeline: {{ .Public.error }}"
+
+var GraphBuildError = errutil.NewBase(
+	errutil.StatusBadRequest, "sse.graphBuildError").MustTemplate(
+	graphBuildErrStr,
+	errutil.WithPublic(graphBuildErrStr))
+
+func makeGraphBuildError(err error) error {
+	data := errutil.TemplateData{
+		Public: map[string]interface{}{
+			"error": err.Error(),
+		},
+		Error: err,
+	}
+	return GraphBuildError.Build(data)
+}
+
 var unexpectedNodeTypeErrString = "expected executable node type but got node type [{{ .Public.nodeType }} for refid [{{ .Public.refId}}]"
 
 var UnexpectedNodeTypeError = errutil.NewBase(

--- a/pkg/expr/errors.go
+++ b/pkg/expr/errors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
+	"github.com/grafana/grafana/pkg/expr/sql"
 )
 
 var ErrSeriesMustBeWide = errors.New("input data must be a wide series")
@@ -109,6 +110,13 @@ func makeGraphBuildError(err error) error {
 		Error: err,
 	}
 	return GraphBuildError.Build(data)
+}
+
+// makeSQLGraphBuildError is like makeGraphBuildError but also wraps the error
+// as a sql.ErrorWithCategory so that instrumentation can count it against SQL metrics.
+// Use this only when the error is directly caused by a SQL expression node.
+func makeSQLGraphBuildError(err error) error {
+	return sql.NewErrorWithCategory(sql.ErrCategoryInvalidGraph, makeGraphBuildError(err))
 }
 
 var unexpectedNodeTypeErrString = "expected executable node type but got node type [{{ .Public.nodeType }} for refid [{{ .Public.refId}}]"

--- a/pkg/expr/graph.go
+++ b/pkg/expr/graph.go
@@ -389,7 +389,7 @@ func (s *Service) buildGraphEdges(dp *simple.DirectedGraph, registry map[string]
 					dsNode.isInputToSQLExpr = true
 				} else {
 					// Only allow data source nodes as SQL expression inputs for now
-					return makeGraphBuildError(fmt.Errorf("only data source queries may be inputs to a sql expression, %v is the input for %v", neededVar, cmdNode.RefID()))
+					return makeSQLGraphBuildError(fmt.Errorf("only data source queries may be inputs to a sql expression, %v is the input for %v", neededVar, cmdNode.RefID()))
 				}
 			}
 
@@ -412,7 +412,7 @@ func (s *Service) buildGraphEdges(dp *simple.DirectedGraph, registry map[string]
 			if neededNode.NodeType() == TypeCMDNode {
 				if neededNode.(*CMDNode).CMDType == TypeSQL {
 					// Do not allow SQL expressions to be inputs for other expressions for now
-					return makeGraphBuildError(fmt.Errorf("sql expressions can not be the input for other expressions, but %v is the input for %v", neededVar, cmdNode.RefID()))
+					return makeSQLGraphBuildError(fmt.Errorf("sql expressions can not be the input for other expressions, but %v is the input for %v", neededVar, cmdNode.RefID()))
 				}
 			}
 

--- a/pkg/expr/graph.go
+++ b/pkg/expr/graph.go
@@ -380,7 +380,7 @@ func (s *Service) buildGraphEdges(dp *simple.DirectedGraph, registry map[string]
 					e := sql.MakeTableNotFoundError(cmdNode.refID, neededVar)
 					return e
 				}
-				return fmt.Errorf("unable to find dependent node '%v'", neededVar)
+				return makeGraphBuildError(fmt.Errorf("unable to find dependent node '%v'", neededVar))
 			}
 
 			// If the input is SQL, conversion is handled differently
@@ -389,30 +389,30 @@ func (s *Service) buildGraphEdges(dp *simple.DirectedGraph, registry map[string]
 					dsNode.isInputToSQLExpr = true
 				} else {
 					// Only allow data source nodes as SQL expression inputs for now
-					return fmt.Errorf("only data source queries may be inputs to a sql expression, %v is the input for %v", neededVar, cmdNode.RefID())
+					return makeGraphBuildError(fmt.Errorf("only data source queries may be inputs to a sql expression, %v is the input for %v", neededVar, cmdNode.RefID()))
 				}
 			}
 
 			if neededNode.ID() == cmdNode.ID() {
-				return fmt.Errorf("expression '%v' cannot reference itself. Must be query or another expression", neededVar)
+				return makeGraphBuildError(fmt.Errorf("expression '%v' cannot reference itself. Must be query or another expression", neededVar))
 			}
 
 			if cmdNode.CMDType == TypeClassicConditions {
 				if neededNode.NodeType() != TypeDatasourceNode {
-					return fmt.Errorf("only data source queries may be inputs to a classic condition, %v is a %v", neededVar, neededNode.NodeType())
+					return makeGraphBuildError(fmt.Errorf("only data source queries may be inputs to a classic condition, %v is a %v", neededVar, neededNode.NodeType()))
 				}
 			}
 
 			if neededNode.NodeType() == TypeCMDNode {
 				if neededNode.(*CMDNode).CMDType == TypeClassicConditions {
-					return fmt.Errorf("classic conditions may not be the input for other expressions, but %v is the input for %v", neededVar, cmdNode.RefID())
+					return makeGraphBuildError(fmt.Errorf("classic conditions may not be the input for other expressions, but %v is the input for %v", neededVar, cmdNode.RefID()))
 				}
 			}
 
 			if neededNode.NodeType() == TypeCMDNode {
 				if neededNode.(*CMDNode).CMDType == TypeSQL {
 					// Do not allow SQL expressions to be inputs for other expressions for now
-					return fmt.Errorf("sql expressions can not be the input for other expressions, but %v in the input for %v", neededVar, cmdNode.RefID())
+					return makeGraphBuildError(fmt.Errorf("sql expressions can not be the input for other expressions, but %v is the input for %v", neededVar, cmdNode.RefID()))
 				}
 			}
 

--- a/pkg/expr/service_sql_test.go
+++ b/pkg/expr/service_sql_test.go
@@ -95,7 +95,7 @@ func TestSQLService(t *testing.T) {
 		require.ErrorContains(t, rsp.Responses["B"].Error, "not in the allowed list of")
 		var sqlErr *sql.ErrorWithCategory
 		require.ErrorAs(t, rsp.Responses["B"].Error, &sqlErr)
-		require.Equal(t, sql.ErrCategoryBlockedNodeOrFunc, sqlErr.Category())
+		require.Equal(t, string(sql.ErrCategoryBlockedNodeOrFunc), sqlErr.Category())
 	})
 
 	t.Run("parse error should be returned", func(t *testing.T) {
@@ -115,7 +115,7 @@ func TestSQLService(t *testing.T) {
 		require.ErrorContains(t, rsp.Responses["B"].Error, "limit expression expected to be numeric")
 		var sqlErr *sql.ErrorWithCategory
 		require.ErrorAs(t, rsp.Responses["B"].Error, &sqlErr)
-		require.Equal(t, sql.ErrCategoryGeneralGMSError, sqlErr.Category())
+		require.Equal(t, string(sql.ErrCategoryGeneralGMSError), sqlErr.Category())
 	})
 }
 
@@ -197,15 +197,15 @@ func TestSQLServiceErrors(t *testing.T) {
 		require.ErrorContains(t, rsp.Responses["tsMultiNoType"].Error, "missing the data type")
 		var sqlErr *sql.ErrorWithCategory
 		require.ErrorAs(t, rsp.Responses["tsMultiNoType"].Error, &sqlErr)
-		require.Equal(t, sql.ErrCategoryInputConversion, sqlErr.Category())
+		require.Equal(t, string(sql.ErrCategoryInputConversion), sqlErr.Category())
 
 		require.Error(t, rsp.Responses["sqlExpression"].Error, "should return dependency error")
 		require.ErrorContains(t, rsp.Responses["sqlExpression"].Error, "dependency")
 		require.ErrorAs(t, rsp.Responses["sqlExpression"].Error, &sqlErr)
-		require.Equal(t, sql.ErrCategoryDependency, sqlErr.Category())
+		require.Equal(t, string(sql.ErrCategoryDependency), sqlErr.Category())
 
 		require.Equal(t, 0.0, counterVal(t, s.metrics.SqlCommandCount, "ok", "none"))
-		require.Equal(t, 1.0, counterVal(t, s.metrics.SqlCommandCount, "error", sql.ErrCategoryInputConversion))
+		require.Equal(t, 1.0, counterVal(t, s.metrics.SqlCommandCount, "error", string(sql.ErrCategoryInputConversion)))
 		require.Equal(t, 1.0, counterVal(t, s.metrics.SqlCommandInputCount, "error", "false", "test", "missing"))
 	})
 
@@ -221,12 +221,12 @@ func TestSQLServiceErrors(t *testing.T) {
 		_, err := s.BuildPipeline(t.Context(), req)
 		var sqlErr *sql.ErrorWithCategory
 		require.ErrorAs(t, err, &sqlErr)
-		require.Equal(t, sql.ErrCategoryTableNotFound, sqlErr.Category())
+		require.Equal(t, string(sql.ErrCategoryTableNotFound), sqlErr.Category())
 		require.Error(t, err, "whole pipeline fails when selecting a dependency that does not exist")
 
 		// Metrics
 		require.Equal(t, 0.0, counterVal(t, s.metrics.SqlCommandCount, "ok", "none"))
-		require.Equal(t, 1.0, counterVal(t, s.metrics.SqlCommandCount, "error", sql.ErrCategoryTableNotFound))
+		require.Equal(t, 1.0, counterVal(t, s.metrics.SqlCommandCount, "error", string(sql.ErrCategoryTableNotFound)))
 	})
 
 	t.Run("pipeline will fail if query is longer than the configured limit", func(t *testing.T) {
@@ -240,8 +240,8 @@ func TestSQLServiceErrors(t *testing.T) {
 		require.ErrorContains(t, err, "exceeded the configured limit of 5 characters")
 		var sqlErr *sql.ErrorWithCategory
 		require.ErrorAs(t, err, &sqlErr)
-		require.Equal(t, sql.ErrCategoryQueryTooLong, sqlErr.Category())
+		require.Equal(t, string(sql.ErrCategoryQueryTooLong), sqlErr.Category())
 
-		require.Equal(t, 1.0, counterVal(t, s.metrics.SqlCommandCount, "error", sql.ErrCategoryQueryTooLong))
+		require.Equal(t, 1.0, counterVal(t, s.metrics.SqlCommandCount, "error", string(sql.ErrCategoryQueryTooLong)))
 	})
 }

--- a/pkg/expr/sql/errors.go
+++ b/pkg/expr/sql/errors.go
@@ -44,6 +44,13 @@ func (e *ErrorWithCategory) Unwrap() error {
 	return e.err
 }
 
+const ErrCategoryInvalidGraph = "invalid_graph"
+
+// NewErrorWithCategory creates an ErrorWithCategory wrapping the given error.
+func NewErrorWithCategory(category string, err error) *ErrorWithCategory {
+	return &ErrorWithCategory{category: category, err: err}
+}
+
 // Error implements the error interface
 func (e *GoMySQLServerError) Error() string {
 	return e.err.Error()

--- a/pkg/expr/sql/errors.go
+++ b/pkg/expr/sql/errors.go
@@ -16,8 +16,11 @@ const sseErrBase = "sse.sql."
 // GoMySQLServerError represents an error from the underlying Go MySQL Server
 type GoMySQLServerError struct {
 	err      error
-	category string
+	category ErrorCategory
 }
+
+// ErrorCategory is a typed string for SQL expression error categories used in metrics, logs, and traces.
+type ErrorCategory string
 
 // CategorizedError is an Error with a Category string for use with metrics, logs, and traces.
 type CategorizedError interface {
@@ -27,7 +30,7 @@ type CategorizedError interface {
 
 // ErrorWithCategory is a concrete implementation of CategorizedError that holds an error and its category.
 type ErrorWithCategory struct {
-	category string
+	category ErrorCategory
 	err      error
 }
 
@@ -36,7 +39,7 @@ func (e *ErrorWithCategory) Error() string {
 }
 
 func (e *ErrorWithCategory) Category() string {
-	return e.category
+	return string(e.category)
 }
 
 // Unwrap provides the original error for errors.Is/As
@@ -44,10 +47,10 @@ func (e *ErrorWithCategory) Unwrap() error {
 	return e.err
 }
 
-const ErrCategoryInvalidGraph = "invalid_graph"
+const ErrCategoryInvalidGraph ErrorCategory = "invalid_graph"
 
 // NewErrorWithCategory creates an ErrorWithCategory wrapping the given error.
-func NewErrorWithCategory(category string, err error) *ErrorWithCategory {
+func NewErrorWithCategory(category ErrorCategory, err error) *ErrorWithCategory {
 	return &ErrorWithCategory{category: category, err: err}
 }
 
@@ -62,7 +65,7 @@ func (e *GoMySQLServerError) Unwrap() error {
 }
 
 func (e *GoMySQLServerError) Category() string {
-	return e.category
+	return string(e.category)
 }
 
 // MakeGMSError creates a GoMySQLServerError with the given refID and error.
@@ -78,8 +81,8 @@ func MakeGMSError(refID string, err error) error {
 	return err
 }
 
-const ErrCategoryGMSFunctionNotFound = "gms_function_not_found"
-const ErrCategoryGMSTableNotFound = "gms_table_not_found"
+const ErrCategoryGMSFunctionNotFound ErrorCategory = "gms_function_not_found"
+const ErrCategoryGMSTableNotFound ErrorCategory = "gms_table_not_found"
 
 // WrapGoMySQLServerError wraps errors from Go MySQL Server with additional context
 // and a category.
@@ -106,12 +109,12 @@ func WrapGoMySQLServerError(refID string, err error) error {
 	}
 }
 
-const ErrCategoryGeneralGMSError = "general_gms_error"
+const ErrCategoryGeneralGMSError ErrorCategory = "general_gms_error"
 
 var generalGMSErrorStr = "sql expression failed due to error from the sql expression engine: {{ .Error }}"
 
 var GeneralGMSError = errutil.NewBase(
-	errutil.StatusBadRequest, sseErrBase+ErrCategoryGeneralGMSError).MustTemplate(
+	errutil.StatusBadRequest, sseErrBase+string(ErrCategoryGeneralGMSError)).MustTemplate(
 	generalGMSErrorStr,
 	errutil.WithPublic(generalGMSErrorStr))
 
@@ -124,15 +127,15 @@ func MakeGeneralGMSError(err *GoMySQLServerError, refID string) CategorizedError
 		Error: err,
 	}
 
-	return &ErrorWithCategory{category: err.Category(), err: GeneralGMSError.Build(data)}
+	return &ErrorWithCategory{category: ErrorCategory(err.Category()), err: GeneralGMSError.Build(data)}
 }
 
-const ErrCategoryInputLimitExceeded = "input_limit_exceeded"
+const ErrCategoryInputLimitExceeded ErrorCategory = "input_limit_exceeded"
 
 var inputLimitExceededStr = "sql expression [{{ .Public.refId }}] was not run because the number of input cells (columns*rows) to the sql expression exceeded the configured limit of {{ .Public.inputLimit }}"
 
 var InputLimitExceededError = errutil.NewBase(
-	errutil.StatusBadRequest, sseErrBase+ErrCategoryInputLimitExceeded).MustTemplate(
+	errutil.StatusBadRequest, sseErrBase+string(ErrCategoryInputLimitExceeded)).MustTemplate(
 	inputLimitExceededStr,
 	errutil.WithPublic(inputLimitExceededStr))
 
@@ -147,12 +150,12 @@ func MakeInputLimitExceededError(refID string, inputLimit int64) CategorizedErro
 	return &ErrorWithCategory{category: ErrCategoryInputLimitExceeded, err: InputLimitExceededError.Build(data)}
 }
 
-const ErrCategoryDuplicateStringColumns = "duplicate_string_columns"
+const ErrCategoryDuplicateStringColumns ErrorCategory = "duplicate_string_columns"
 
 var duplicateStringColumnErrorStr = "sql expression [{{ .Public.refId }}] failed because it returned duplicate values across the string columns, which is not allowed for alerting. Examples: ({{ .Public.examples }}). Hint: use GROUP BY or aggregation (e.g. MAX(), AVG()) to return one row per unique combination."
 
 var DuplicateStringColumnError = errutil.NewBase(
-	errutil.StatusBadRequest, sseErrBase+ErrCategoryDuplicateStringColumns).MustTemplate(
+	errutil.StatusBadRequest, sseErrBase+string(ErrCategoryDuplicateStringColumns)).MustTemplate(
 	duplicateStringColumnErrorStr,
 	errutil.WithPublic(duplicateStringColumnErrorStr),
 )
@@ -184,12 +187,12 @@ func truncateExamples(examples []string, limit int) []string {
 	return truncated
 }
 
-const ErrCategoryTimeout = "timeout"
+const ErrCategoryTimeout ErrorCategory = "timeout"
 
 var timeoutStr = "sql expression [{{ .Public.refId }}] timed out after {{ .Public.timeout }}"
 
 var TimeoutError = errutil.NewBase(
-	errutil.StatusTimeout, sseErrBase+ErrCategoryTimeout).MustTemplate(
+	errutil.StatusTimeout, sseErrBase+string(ErrCategoryTimeout)).MustTemplate(
 	timeoutStr,
 	errutil.WithPublic(timeoutStr))
 
@@ -207,12 +210,12 @@ func MakeTimeOutError(err error, refID string, timeout time.Duration) Categorize
 	return &ErrorWithCategory{category: ErrCategoryTimeout, err: TimeoutError.Build(data)}
 }
 
-var ErrCategoryCancelled = "cancelled"
+const ErrCategoryCancelled ErrorCategory = "cancelled"
 
 var cancelStr = "sql expression [{{ .Public.refId }}] was cancelled before completion"
 
 var CancelError = errutil.NewBase(
-	errutil.StatusClientClosedRequest, sseErrBase+ErrCategoryCancelled).MustTemplate(
+	errutil.StatusClientClosedRequest, sseErrBase+string(ErrCategoryCancelled)).MustTemplate(
 	cancelStr,
 	errutil.WithPublic(cancelStr))
 
@@ -230,12 +233,12 @@ func MakeCancelError(err error, refID string) CategorizedError {
 	return &ErrorWithCategory{category: ErrCategoryCancelled, err: CancelError.Build(data)}
 }
 
-var ErrCategoryTableNotFound = "table_not_found"
+const ErrCategoryTableNotFound ErrorCategory = "table_not_found"
 
 var tableNotFoundStr = "failed to run sql expression [{{ .Public.refId }}] because it selects from table (refId/query) [{{ .Public.table }}] and that table was not found"
 
 var TableNotFoundError = errutil.NewBase(
-	errutil.StatusBadRequest, sseErrBase+ErrCategoryTableNotFound).MustTemplate(
+	errutil.StatusBadRequest, sseErrBase+string(ErrCategoryTableNotFound)).MustTemplate(
 	tableNotFoundStr,
 	errutil.WithPublic(tableNotFoundStr))
 
@@ -254,12 +257,12 @@ func MakeTableNotFoundError(refID, table string) CategorizedError {
 	return &ErrorWithCategory{category: ErrCategoryTableNotFound, err: TableNotFoundError.Build(data)}
 }
 
-const ErrCategoryDependency = "failed_dependency"
+const ErrCategoryDependency ErrorCategory = "failed_dependency"
 
 var sqlDepErrStr = "could not run sql expression [{{ .Public.refId }}] because it selects from the results of query [{{.Public.depRefId }}] which has an error"
 
 var DependencyError = errutil.NewBase(
-	errutil.StatusBadRequest, sseErrBase+ErrCategoryDependency).MustTemplate(
+	errutil.StatusBadRequest, sseErrBase+string(ErrCategoryDependency)).MustTemplate(
 	sqlDepErrStr,
 	errutil.WithPublic(sqlDepErrStr))
 
@@ -275,12 +278,12 @@ func MakeSQLDependencyError(refID, depRefID string) CategorizedError {
 	return &ErrorWithCategory{category: ErrCategoryDependency, err: DependencyError.Build(data)}
 }
 
-const ErrCategoryInputConversion = "input_conversion"
+const ErrCategoryInputConversion ErrorCategory = "input_conversion"
 
 var sqlInputConvertErrorStr = "failed to convert the results of query [{{.Public.refId}}] (Datasource Type: [{{.Public.dsType}}]) into a SQL/Tabular format for sql expression {{ .Public.forRefID }}: {{ .Error }}"
 
 var InputConvertError = errutil.NewBase(
-	errutil.StatusBadRequest, sseErrBase+ErrCategoryInputConversion).MustTemplate(
+	errutil.StatusBadRequest, sseErrBase+string(ErrCategoryInputConversion)).MustTemplate(
 	sqlInputConvertErrorStr,
 	errutil.WithPublic(sqlInputConvertErrorStr))
 
@@ -302,12 +305,12 @@ func MakeInputConvertError(err error, refID string, forRefIDs map[string]struct{
 	return &ErrorWithCategory{category: ErrCategoryInputConversion, err: InputConvertError.Build(data)}
 }
 
-const ErrCategoryEmptyQuery = "empty_query"
+const ErrCategoryEmptyQuery ErrorCategory = "empty_query"
 
 var errEmptyQueryString = "sql expression [{{.Public.refId}}] failed because it has an empty SQL query"
 
 var ErrEmptySQLQuery = errutil.NewBase(
-	errutil.StatusBadRequest, sseErrBase+ErrCategoryEmptyQuery).MustTemplate(
+	errutil.StatusBadRequest, sseErrBase+string(ErrCategoryEmptyQuery)).MustTemplate(
 	errEmptyQueryString,
 	errutil.WithPublic(errEmptyQueryString))
 
@@ -325,12 +328,12 @@ func MakeErrEmptyQuery(refID string) CategorizedError {
 	return &ErrorWithCategory{category: ErrCategoryEmptyQuery, err: ErrEmptySQLQuery.Build(data)}
 }
 
-const ErrCategoryInvalidQuery = "invalid_query"
+const ErrCategoryInvalidQuery ErrorCategory = "invalid_query"
 
 var invalidQueryStr = "sql expression [{{.Public.refId}}] failed because it has an invalid SQL query: {{ .Public.error }}"
 
 var ErrInvalidQuery = errutil.NewBase(
-	errutil.StatusBadRequest, sseErrBase+ErrCategoryInvalidQuery).MustTemplate(
+	errutil.StatusBadRequest, sseErrBase+string(ErrCategoryInvalidQuery)).MustTemplate(
 	invalidQueryStr,
 	errutil.WithPublic(invalidQueryStr))
 
@@ -347,12 +350,12 @@ func MakeErrInvalidQuery(refID string, err error) CategorizedError {
 	return &ErrorWithCategory{category: ErrCategoryInvalidQuery, err: ErrInvalidQuery.Build(data)}
 }
 
-var ErrCategoryBlockedNodeOrFunc = "blocked_node_or_func"
+const ErrCategoryBlockedNodeOrFunc ErrorCategory = "blocked_node_or_func"
 
 var blockedNodeOrFuncStr = "did not execute the SQL expression {{.Public.refId}} because the sql {{.Public.tokenType}} '{{.Public.token}}' is not in the allowed list of {{.Public.tokenType}}s"
 
 var BlockedNodeOrFuncError = errutil.NewBase(
-	errutil.StatusBadRequest, sseErrBase+ErrCategoryBlockedNodeOrFunc).MustTemplate(
+	errutil.StatusBadRequest, sseErrBase+string(ErrCategoryBlockedNodeOrFunc)).MustTemplate(
 	blockedNodeOrFuncStr,
 	errutil.WithPublic(blockedNodeOrFuncStr))
 
@@ -375,13 +378,13 @@ func MakeBlockedNodeOrFuncError(refID, token string, isFunction bool) Categorize
 	return &ErrorWithCategory{category: ErrCategoryBlockedNodeOrFunc, err: BlockedNodeOrFuncError.Build(data)}
 }
 
-const ErrCategoryColumnNotFound = "column_not_found"
+const ErrCategoryColumnNotFound ErrorCategory = "column_not_found"
 
 var columnNotFoundStr = `sql expression [{{.Public.refId}}] failed because it selects from a column (refId/query) that does not exist: {{ .Error }}.
 If this happens on a previously working query, it might mean that the query has returned no data, or the resulting schema of the query has changed.`
 
 var ColumnNotFoundError = errutil.NewBase(
-	errutil.StatusBadRequest, sseErrBase+ErrCategoryColumnNotFound).MustTemplate(
+	errutil.StatusBadRequest, sseErrBase+string(ErrCategoryColumnNotFound)).MustTemplate(
 	columnNotFoundStr,
 	errutil.WithPublic(columnNotFoundStr))
 
@@ -397,12 +400,12 @@ func MakeColumnNotFoundError(refID string, err error) CategorizedError {
 	return &ErrorWithCategory{category: ErrCategoryColumnNotFound, err: ColumnNotFoundError.Build(data)}
 }
 
-const ErrCategoryQueryTooLong = "query_too_long"
+const ErrCategoryQueryTooLong ErrorCategory = "query_too_long"
 
 var queryTooLongStr = `sql expression [{{.Public.refId}}] was not run because the SQL query exceeded the configured limit of {{ .Public.queryLengthLimit }} characters`
 
 var QueryTooLongError = errutil.NewBase(
-	errutil.StatusBadRequest, sseErrBase+ErrCategoryQueryTooLong).MustTemplate(
+	errutil.StatusBadRequest, sseErrBase+string(ErrCategoryQueryTooLong)).MustTemplate(
 	queryTooLongStr,
 	errutil.WithPublic(queryTooLongStr))
 


### PR DESCRIPTION
Show certain graph build errors that were a 500 with no specific message before, now:

<img width="724" height="270" alt="image" src="https://github.com/user-attachments/assets/27effcc0-0375-4dd7-85f8-b721e2edeaac" />


- Graph build validation errors (invalid inputs, self-references, unsupported node combinations) were returned as plain `fmt.Errorf`, causing generic 500 responses to the caller. Adds a single `GraphBuildError` (`StatusBadRequest`) in `pkg/expr/errors.go` and wraps all bare `fmt.Errorf` calls in `buildGraphEdges` with it, so the public message is surfaced correctly as a 400.
- instrument those errors
- Introduces `ErrorCategory` as a typed string for all error category constants. `NewErrorWithCategory` and the internal struct fields now use this type, making it impossible to pass an arbitrary string as a metric label category without an explicit cast. Also converts the remaining `var ErrCategory*` declarations to `const`.

Follow up on https://github.com/grafana/grafana/pull/109633
Closes https://github.com/grafana/grafana/issues/104872

---
🤖 Draft PR created with [Claude Code](https://claude.com/claude-code) (claude-sonnet-4-6)