### PR TITLE
CloudWatch Logs: Implement pagination and ordering for log groups

### DIFF
--- a/pkg/tsdb/cloudwatch/services/log_groups.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups.go
@@ -2,6 +2,8 @@ package services
 
 import (
 	"context"
+	"slices"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
@@ -60,7 +62,77 @@ func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGr
 		input.NextToken = response.NextToken
 	}
 
+	sortLogGroups(result, req)
+
 	return result, nil
+}
+
+func sortLogGroups(logGroups []resources.ResourceResponse[resources.LogGroup], req resources.LogGroupsRequest) {
+	searchTerm := ""
+	if req.LogGroupNamePattern != nil {
+		searchTerm = strings.ToLower(*req.LogGroupNamePattern)
+	} else if req.LogGroupNamePrefix != nil {
+		searchTerm = strings.ToLower(*req.LogGroupNamePrefix)
+	}
+
+	slices.SortFunc(logGroups, func(a, b resources.ResourceResponse[resources.LogGroup]) int {
+		if diff := compareMatchPriority(a.Value.Name, b.Value.Name, searchTerm); diff != 0 {
+			return diff
+		}
+
+		if diff := strings.Compare(strings.ToLower(a.Value.Name), strings.ToLower(b.Value.Name)); diff != 0 {
+			return diff
+		}
+
+		if diff := strings.Compare(a.Value.Name, b.Value.Name); diff != 0 {
+			return diff
+		}
+
+		if diff := strings.Compare(pointerValue(a.AccountId), pointerValue(b.AccountId)); diff != 0 {
+			return diff
+		}
+
+		return strings.Compare(a.Value.Arn, b.Value.Arn)
+	})
+}
+
+func compareMatchPriority(leftName, rightName, searchTerm string) int {
+	if searchTerm == "" {
+		return 0
+	}
+
+	leftPriority := matchPriority(strings.ToLower(leftName), searchTerm)
+	rightPriority := matchPriority(strings.ToLower(rightName), searchTerm)
+
+	switch {
+	case leftPriority < rightPriority:
+		return -1
+	case leftPriority > rightPriority:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func matchPriority(name, searchTerm string) int {
+	switch {
+	case name == searchTerm:
+		return 0
+	case strings.HasPrefix(name, searchTerm):
+		return 1
+	case strings.Contains(name, searchTerm):
+		return 2
+	default:
+		return 3
+	}
+}
+
+func pointerValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+
+	return *value
 }
 
 func (s *LogGroupsService) GetLogGroupFields(ctx context.Context, request resources.LogGroupFieldsRequest) ([]resources.ResourceResponse[resources.LogGroupField], error) {

--- a/pkg/tsdb/cloudwatch/services/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups_test.go
@@ -178,6 +178,89 @@ func TestGetLogGroups(t *testing.T) {
 			},
 		}, resp)
 	})
+
+	t.Run("Should sort paginated log groups alphabetically by name and account", func(t *testing.T) {
+		mockLogsAPI := &mocks.LogsAPI{}
+		req := resources.LogGroupsRequest{
+			Limit:            2,
+			ListAllLogGroups: true,
+		}
+
+		mockLogsAPI.On("DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
+			Limit: aws.Int32(req.Limit),
+		}).Return(&cloudwatchlogs.DescribeLogGroupsOutput{
+			LogGroups: []cloudwatchlogstypes.LogGroup{
+				{Arn: utils.Pointer("arn:aws:logs:us-east-1:222:log-group:group_b"), LogGroupName: utils.Pointer("group_b")},
+				{Arn: utils.Pointer("arn:aws:logs:us-east-1:333:log-group:group_a"), LogGroupName: utils.Pointer("group_a")},
+			},
+			NextToken: utils.Pointer("token"),
+		}, nil)
+
+		mockLogsAPI.On("DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
+			Limit:     aws.Int32(req.Limit),
+			NextToken: utils.Pointer("token"),
+		}).Return(&cloudwatchlogs.DescribeLogGroupsOutput{
+			LogGroups: []cloudwatchlogstypes.LogGroup{
+				{Arn: utils.Pointer("arn:aws:logs:us-east-1:111:log-group:group_a"), LogGroupName: utils.Pointer("group_a")},
+			},
+		}, nil)
+
+		service := NewLogGroupsService(mockLogsAPI, false)
+		resp, err := service.GetLogGroups(context.Background(), req)
+
+		assert.NoError(t, err)
+		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{
+			{
+				AccountId: utils.Pointer("111"),
+				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:111:log-group:group_a", Name: "group_a"},
+			},
+			{
+				AccountId: utils.Pointer("333"),
+				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:333:log-group:group_a", Name: "group_a"},
+			},
+			{
+				AccountId: utils.Pointer("222"),
+				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:222:log-group:group_b", Name: "group_b"},
+			},
+		}, resp)
+	})
+
+	t.Run("Should prioritize exact matches over partial matches", func(t *testing.T) {
+		mockLogsAPI := &mocks.LogsAPI{}
+		req := resources.LogGroupsRequest{
+			LogGroupNamePrefix: utils.Pointer("group"),
+		}
+
+		mockLogsAPI.On("DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
+			Limit:              aws.Int32(0),
+			LogGroupNamePrefix: req.LogGroupNamePrefix,
+		}).Return(&cloudwatchlogs.DescribeLogGroupsOutput{
+			LogGroups: []cloudwatchlogstypes.LogGroup{
+				{Arn: utils.Pointer("arn:aws:logs:us-east-1:111:log-group:group-extra"), LogGroupName: utils.Pointer("group-extra")},
+				{Arn: utils.Pointer("arn:aws:logs:us-east-1:222:log-group:group"), LogGroupName: utils.Pointer("group")},
+				{Arn: utils.Pointer("arn:aws:logs:us-east-1:333:log-group:group-app"), LogGroupName: utils.Pointer("group-app")},
+			},
+		}, nil)
+
+		service := NewLogGroupsService(mockLogsAPI, false)
+		resp, err := service.GetLogGroups(context.Background(), req)
+
+		assert.NoError(t, err)
+		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{
+			{
+				AccountId: utils.Pointer("222"),
+				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:222:log-group:group", Name: "group"},
+			},
+			{
+				AccountId: utils.Pointer("333"),
+				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:333:log-group:group-app", Name: "group-app"},
+			},
+			{
+				AccountId: utils.Pointer("111"),
+				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:111:log-group:group-extra", Name: "group-extra"},
+			},
+		}, resp)
+	})
 }
 
 func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
@@ -111,7 +111,7 @@ describe('LogGroupsSelector', () => {
     expect(screen.getByText('Log group name prefix')).toBeInTheDocument();
     await userEvent.type(screen.getByLabelText('log group search'), 'something');
     await waitFor(() => screen.getByDisplayValue('something'));
-    expect(fetchLogGroups).toBeCalledWith({ accountId: 'all', logGroupPattern: 'something' });
+    expect(fetchLogGroups).toBeCalledWith({ accountId: 'all', listAllLogGroups: true, logGroupPattern: 'something' });
   });
 
   it('calls fetchLogGroups with an account when selected', async () => {
@@ -140,7 +140,11 @@ describe('LogGroupsSelector', () => {
     expect(screen.getByText('Loading...')).toBeInTheDocument();
     secondCall.resolve();
     await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
-    expect(fetchLogGroups).toBeCalledWith({ accountId: 'account-id123', logGroupPattern: '' });
+    expect(fetchLogGroups).toBeCalledWith({
+      accountId: 'account-id123',
+      listAllLogGroups: true,
+      logGroupPattern: '',
+    });
   });
 
   it('shows a log group as checked after the user checks it', async () => {
@@ -187,8 +191,7 @@ describe('LogGroupsSelector', () => {
     ]);
   });
 
-  const labelText =
-    'Only the first 50 results can be shown. If you do not see an expected log group, try narrowing down your search.';
+  const labelText = 'All matching log groups are shown and ordered alphabetically.';
   it('should not display max result info label in case less than 50 logs groups are being displayed', async () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
@@ -87,6 +87,7 @@ export const LogGroupsSelector = ({
     setIsLoading(true);
     try {
       const possibleLogGroups = await fetchLogGroups({
+        listAllLogGroups: true,
         logGroupPattern: searchTerm,
         accountId: accountId,
       });
@@ -149,12 +150,11 @@ export const LogGroupsSelector = ({
         </div>
         <Space layout="block" v={2} />
         <div>
-          {!isLoading && selectableLogGroups.length >= 25 && (
+          {!isLoading && selectableLogGroups.length >= 50 && (
             <>
               <div className={styles.limitLabel}>
                 <Icon name="info-circle"></Icon>
-                Only the first 50 results can be shown. If you do not see an expected log group, try narrowing down your
-                search.
+                All matching log groups are shown and ordered alphabetically.
                 <p>
                   A{' '}
                   <TextLink
@@ -163,7 +163,7 @@ export const LogGroupsSelector = ({
                   >
                     maximum{' '}
                   </TextLink>{' '}
-                  of 50 Cloudwatch log groups can be queried at one time.
+                  of 50 CloudWatch log groups can be queried at one time.
                 </p>
               </div>
               <Space layout="block" v={1} />


### PR DESCRIPTION
**What is this feature?**

Implements full pagination support for CloudWatch log group listing, along with alphabetical ordering and search-relevance sorting. When fetching log groups, the backend now follows `NextToken` through all pages instead of returning only the first 50 results. Results are sorted alphabetically by name with exact and prefix matches prioritized.

**Why do we need this feature?**

Users monitoring log groups from multiple AWS accounts could only see the first 50 log groups due to the CloudWatch API limit per page. There was no pagination, so log groups beyond the first page were invisible in Grafana. This made it impossible to select important log groups that happened to fall outside the initial 50.

**Who is this feature for?**

Users of the CloudWatch Logs data source, especially those with many log groups across multiple AWS accounts.

**Which issue(s) does this PR fix?**:

Fixes #118097

**Special notes for your reviewer:**

### Changes

**Backend (`pkg/tsdb/cloudwatch/services/log_groups.go`)**
- Added pagination loop that follows `NextToken` until all log groups are fetched (gated by `ListAllLogGroups` flag)
- Added `sortLogGroups()` — sorts results alphabetically by name, with exact matches and prefix matches prioritized
- Added helper functions `compareMatchPriority`, `matchPriority`, `pointerValue`

**Frontend (`LogGroupsSelector.tsx`)**
- Passes `listAllLogGroups: true` when fetching log groups
- Updated info label threshold from 25 to 50 (matching actual limit)
- Updated info label text to reflect that all matching log groups are now shown
- Fixed capitalization: "Cloudwatch" → "CloudWatch"

**Tests**
- Added Go tests: pagination with NextToken, alphabetical sorting, exact-match prioritization
- Updated frontend tests to expect the new `listAllLogGroups` parameter and updated label text

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.