### PR TITLE
[release-12.4.2] Docs: Remove early access note

### DIFF
--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dynamic-dashboard/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dynamic-dashboard/index.md
@@ -80,7 +80,7 @@ aliases:
 
 {{< admonition type="caution" >}}
 
-Dynamic dashboards is an [experimental](https://grafana.com/docs/release-life-cycle/) feature. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. To get early access to this feature, request it through [this form](https://docs.google.com/forms/d/e/1FAIpQLSd73nQzuhzcHJOrLFK4ef_uMxHAQiPQh1-rsQUT2MRqbeMLpg/viewform?usp=dialog).
+Dynamic dashboards is an [experimental](https://grafana.com/docs/release-life-cycle/) feature. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided.
 
 **Do not enable this feature in production environments as it may result in the irreversible loss of data.**
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dynamic-dashboard/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dynamic-dashboard/index.md
@@ -80,7 +80,7 @@ aliases:
 
 {{< admonition type="caution" >}}
 
-Dynamic dashboards is an [experimental](https://grafana.com/docs/release-life-cycle/) feature. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided.
+Dynamic dashboards is a [public preview](https://grafana.com/docs/release-life-cycle/) feature. Support is limited to enablement, configuration, and some troubleshooting. Documentation is limited, and SLAs are not available.
 
 **Do not enable this feature in production environments as it may result in the irreversible loss of data.**
 


### PR DESCRIPTION
This PR removes the early access note and updates the release stage. 
Release stage change should not be backported to 12.3.