### PR TITLE
alerting: temporarily skip failing MultiplePoliciesView test

### DIFF
--- a/public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx
+++ b/public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx
@@ -610,7 +610,10 @@ describe('alertingMultiplePolicies Feature Flag', () => {
     grantUserPermissions([AccessControlAction.AlertingNotificationsExternalRead, ...PERMISSIONS_NOTIFICATION_POLICIES]);
   });
 
-  it('Should render MultiplePoliciesView when alertingMultiplePolicies feature flag is enabled', async () => {
+  // TODO: Re-enable this test once the am-root-route-container rendering issue is fixed.
+  // Temporarily skipped due to failure in grafana-enterprise#11248
+  // https://github.com/grafana/grafana-enterprise/actions/runs/23009165147/job/66815001544
+  it.skip('Should render MultiplePoliciesView when alertingMultiplePolicies feature flag is enabled', async () => {
     config.featureToggles.alertingMultiplePolicies = true;
 
     renderNotificationPolicies();


### PR DESCRIPTION
## Summary

- Temporarily skips the test `alertingMultiplePolicies Feature Flag > Should render MultiplePoliciesView when alertingMultiplePolicies feature flag is enabled` in `NotificationPoliciesPage.test.tsx`

## Problem

This test is failing in the enterprise CI with a 404 page being rendered instead of the expected `am-root-route-container` element:

```
TestingLibraryElementError: Unable to find an element by: [data-testid="am-root-route-container"]
```
## Action required

The underlying rendering issue (404 instead of the expected component) needs to be investigated and fixed, then this skip should be removed.