### PR TITLE
alerting: fix racy test by using findAllByTestId instead of getAllByTestId

### DIFF
--- a/public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx
+++ b/public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx
@@ -610,16 +610,16 @@ describe('alertingMultiplePolicies Feature Flag', () => {
     grantUserPermissions([AccessControlAction.AlertingNotificationsExternalRead, ...PERMISSIONS_NOTIFICATION_POLICIES]);
   });
 
-  // TODO: Re-enable this test once the am-root-route-container rendering issue is fixed.
-  // Temporarily skipped due to failure in grafana-enterprise#11248
-  // https://github.com/grafana/grafana-enterprise/actions/runs/23009165147/job/66815001544
-  it.skip('Should render MultiplePoliciesView when alertingMultiplePolicies feature flag is enabled', async () => {
+  it('Should render MultiplePoliciesView when alertingMultiplePolicies feature flag is enabled', async () => {
     config.featureToggles.alertingMultiplePolicies = true;
 
     renderNotificationPolicies();
-    await screen.findByTestId('search-query-input');
 
-    expect(screen.getAllByTestId('am-root-route-container').length).toBeGreaterThan(0);
+    // findAllByTestId (async) is required here: `search-query-input` appears once the list query
+    // resolves, but each PoliciesTree makes a separate per-tree query. In slow CI environments the
+    // individual tree responses haven't arrived yet by the time the list resolves, so the
+    // synchronous getAllByTestId was racy. Use findAllByTestId to wait for all trees to render.
+    expect((await screen.findAllByTestId('am-root-route-container')).length).toBeGreaterThan(0);
   });
 
   it('Should not render PoliciesList when alertingMultiplePolicies feature flag is disabled', async () => {


### PR DESCRIPTION
## What changed

Properly fixes the consistently-failing test in `NotificationPoliciesPage.test.tsx` that was temporarily skipped in #120208:

> `alertingMultiplePolicies Feature Flag > Should render MultiplePoliciesView when alertingMultiplePolicies feature flag is enabled`

**Before:** `getAllByTestId('am-root-route-container')` — synchronous, throws immediately if not found  
**After:** `findAllByTestId('am-root-route-container')` — async, retries until elements appear

## Root cause

Two-phase loading race condition:

1. `PolicyTreeTab` calls `useListNotificationPolicyRoutes` — **one** K8s list API call for all routing tree names
2. After that resolves, it renders **N** `<PoliciesTree>` components, each calling `useNotificationPolicyRoute` for its own individual tree data

`search-query-input` (the filter input) appears as soon as step 1 completes. But `am-root-route-container` only renders inside each `PoliciesTree` once its **own** query resolves (`hasPoliciesData = rootRoute && !isLoading`).

In CI with 116 test suites sharing a jest worker, the per-tree responses hadn't arrived yet when the synchronous assertion fired. This caused the test to consistently fail in enterprise CI shard 6/16 but pass locally.

The fix matches the pattern already used in the similar passing test at line 718 which uses `findAllByTestId`.

**Original failing CI run:** https://github.com/grafana/grafana-enterprise/actions/runs/23009165147/job/66815001544  
**Temporary skip PR:** #120208