### PR TITLE
Table: Fix wrap header text option broken by keyboard accessibility refactor

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
@@ -1457,6 +1457,119 @@ describe('TableNG', () => {
     });
   });
 
+  describe('Header text wrapping', () => {
+    it('applies wrap styles to header label when wrapHeaderText is true', () => {
+      const longHeaderName = 'Very Long Column Header Name That Should Wrap';
+      const frameWithWrap = toDataFrame({
+        name: 'TestData',
+        length: 2,
+        fields: [
+          {
+            name: longHeaderName,
+            type: FieldType.string,
+            values: ['A1', 'A2'],
+            config: {
+              custom: {
+                width: 80,
+                wrapHeaderText: true,
+                cellOptions: { type: TableCellDisplayMode.Auto, wrapText: false },
+              },
+            },
+            display: (v: unknown) => ({ text: String(v), numeric: 0, color: undefined, prefix: undefined, suffix: undefined }),
+            state: {},
+            getLinks: () => [],
+          },
+          {
+            name: 'Col B',
+            type: FieldType.number,
+            values: [1, 2],
+            config: { custom: { width: 100, cellOptions: { type: TableCellDisplayMode.Auto, wrapText: false } } },
+            display: (v: unknown) => ({ text: String(v), numeric: Number(v), color: undefined, prefix: undefined, suffix: undefined }),
+            state: {},
+            getLinks: () => [],
+          },
+        ],
+      });
+      const frame = applyFieldOverrides({
+        data: [frameWithWrap],
+        fieldConfig: { defaults: {}, overrides: [] },
+        replaceVariables: (v) => v,
+        timeZone: 'utc',
+        theme: createTheme(),
+      })[0];
+
+      const { container } = render(
+        <TableNG enableVirtualization={false} data={frame} width={400} height={600} />
+      );
+
+      const columnHeaders = container.querySelectorAll('[role="columnheader"]');
+      expect(columnHeaders.length).toBeGreaterThan(0);
+      const firstHeader = columnHeaders[0];
+      const labelButton = firstHeader.querySelector('button');
+      expect(labelButton).toBeInTheDocument();
+
+      const labelStyles = window.getComputedStyle(labelButton!);
+      expect(labelStyles.getPropertyValue('white-space')).toBe('pre-line');
+      expect(['0', '0px']).toContain(labelStyles.getPropertyValue('min-width'));
+      expect(labelStyles.getPropertyValue('flex-grow')).toBe('1');
+    });
+
+    it('keeps nowrap and no flex override when wrapHeaderText is false', () => {
+      const frameNoWrap = toDataFrame({
+        name: 'TestData',
+        length: 2,
+        fields: [
+          {
+            name: 'Short',
+            type: FieldType.string,
+            values: ['A1', 'A2'],
+            config: {
+              custom: {
+                width: 100,
+                wrapHeaderText: false,
+                cellOptions: { type: TableCellDisplayMode.Auto, wrapText: false },
+              },
+            },
+            display: (v: unknown) => ({ text: String(v), numeric: 0, color: undefined, prefix: undefined, suffix: undefined }),
+            state: {},
+            getLinks: () => [],
+          },
+          {
+            name: 'Col B',
+            type: FieldType.number,
+            values: [1, 2],
+            config: { custom: { width: 100, cellOptions: { type: TableCellDisplayMode.Auto, wrapText: false } } },
+            display: (v: unknown) => ({ text: String(v), numeric: Number(v), color: undefined, prefix: undefined, suffix: undefined }),
+            state: {},
+            getLinks: () => [],
+          },
+        ],
+      });
+      const frame = applyFieldOverrides({
+        data: [frameNoWrap],
+        fieldConfig: { defaults: {}, overrides: [] },
+        replaceVariables: (v) => v,
+        timeZone: 'utc',
+        theme: createTheme(),
+      })[0];
+
+      const { container } = render(
+        <TableNG enableVirtualization={false} data={frame} width={400} height={600} />
+      );
+
+      const columnHeaders = container.querySelectorAll('[role="columnheader"]');
+      expect(columnHeaders.length).toBeGreaterThan(0);
+      const labelButton = columnHeaders[0].querySelector('button');
+      expect(labelButton).toBeInTheDocument();
+
+      const labelStyles = window.getComputedStyle(labelButton!);
+      expect(labelStyles.getPropertyValue('white-space')).toBe('nowrap');
+      // When wrap is false we do not set flex: 1; flex-grow is 0 or empty
+      const flexGrow = labelStyles.getPropertyValue('flex-grow');
+      expect(flexGrow === '0' || flexGrow === '').toBe(true);
+    });
+  });
+
   describe('Cell inspection', () => {
     it('shows inspect icon when hovering over a cell with inspection enabled', async () => {
       const inspectDataFrame = {

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -75,6 +75,7 @@ import {
   getLinkStyles,
   getMaxHeightCellStyles,
   getTooltipStyles,
+  headerCellWrapOverrides,
 } from './styles';
 import {
   CellRootRenderer,
@@ -587,7 +588,10 @@ export function TableNG(props: TableNGProps) {
         const textAlign = getAlignment(field);
         const justifyContent = getJustifyContent(textAlign);
         const displayName = getDisplayName(field);
-        const headerCellClass = getHeaderCellStyles(theme, justifyContent);
+        const headerCellClass = clsx(
+          getHeaderCellStyles(theme, justifyContent),
+          field.config.custom?.wrapHeaderText && headerCellWrapOverrides
+        );
         const CellType = getCellRenderer(field, cellOptions);
 
         const cellInspect = isCellInspectEnabled(field);

--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
@@ -10,7 +10,6 @@ import { getFieldTypeIcon } from '../../../../types/icon';
 import { Icon } from '../../../Icon/Icon';
 import { Stack } from '../../../Layout/Stack/Stack';
 import { Filter } from '../Filter/Filter';
-import { isTableCellStylesKeyEqual } from '../styles';
 import { FilterType, TableRow, TableSummaryRow } from '../types';
 import { getDisplayName } from '../utils';
 
@@ -129,6 +128,11 @@ const getStyles = memoize(
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: headerTextWrap ? 'pre-line' : 'nowrap',
+      ...(headerTextWrap && {
+        minWidth: 0,
+        flex: 1,
+        wordBreak: 'break-word',
+      }),
       borderRadius: theme.spacing(0.25),
       lineHeight: '20px',
       '&:hover': {
@@ -143,5 +147,5 @@ const getStyles = memoize(
       color: theme.colors.text.secondary,
     }),
   }),
-  { isMatchingKey: isTableCellStylesKeyEqual }
+  { isMatchingKey: (cacheKey, key) => cacheKey[0] === key[0] && cacheKey[1] === key[1] }
 );

--- a/packages/grafana-ui/src/components/Table/TableNG/styles.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/styles.ts
@@ -180,6 +180,12 @@ export const getHeaderCellStyles = memoize((theme: GrafanaTheme2, justifyContent
   })
 );
 
+/** Override react-data-grid .rdg-cell defaults when wrap header text is enabled */
+export const headerCellWrapOverrides = css({
+  whiteSpace: 'normal',
+  overflow: 'visible',
+});
+
 export const getDefaultCellStyles: TableCellStyles = memoize(
   (theme, { textAlign, shouldOverflow, maxHeight }) =>
     css({


### PR DESCRIPTION
## What this PR does

Fixes the `Wrap header text` option in the Table panel (TableNG), which stopped working after the keyboard accessibility refactor in #117354.

Closes #119896

## Root cause

Commit df9f1b5c1eb (#117354) refactored the header cell content from a flat `<span>` directly inside the flex cell,to a `<button>` nested inside a `<Stack>` flex row. This introduced two problems:

1. The `<button>` has default `min-width: auto` as a flex item, so it never shrinks below the intrinsic width of the unwrapped text — meaning `white-space: pre-line` had no effect
2. `react-data-grid` applies `white-space: nowrap` and `overflow: clip` to all `.rdg-cell` elements including header cells — this was not overridden for the wrap case

## Changes

**HeaderCell.tsx** — when `headerTextWrap` is true, the label now gets:
- `minWidth: 0` — allows the flex item to shrink below content width
- `flex: 1` — fills available space in the Stack so text has room to wrap
- `wordBreak: 'break-word'` — handles long unbroken strings
- Fixed memoization key comparison so wrap/nowrap styles are correctly 
  differentiated
- Removed unused `isTableCellStylesKeyEqual` import

**styles.ts** — added `headerCellWrapOverrides` class that sets `whiteSpace: normal` and `overflow: visible` to override react-data-grid defaults on the header cell wrapper

**TableNG.tsx** — applies `headerCellWrapOverrides` via `clsx` on the column's `headerCellClass` when `wrapHeaderText` is true

**TableNG.test.tsx** — added two tests covering the wrap (true) and nowrap (false) cases

## What is NOT changed

The `<Stack>` + `<button>` structure introduced in #117354 is fully preserved. Keyboard accessibility, filter button behavior, and sort interaction are all unchanged.

## Tests

- 8 suites, 311 tests passing (0 failed)
- 2 new tests added in `"Header text wrapping"` describe block
- Full `packages/grafana-ui/src/components/Table/` suite: 12 suites, 
  407 tests passing (0 failed)