### PR TITLE
API Clients: Add `compilerOptions` to readme

### DIFF
--- a/packages/grafana-api-clients/README.md
+++ b/packages/grafana-api-clients/README.md
@@ -14,7 +14,7 @@ yarn add @grafana/api-clients
 
 ## TypeScript configuration
 
-This package uses [subpath exports](https://nodejs.org/api/packages.html#subpath-exports), which require `moduleResolution` to be set to `"bundler"` (or `"node16"`/`"nodenext"`) in your `tsconfig.json`:
+This package uses [subpath exports](https://nodejs.org/api/packages.html#subpath-exports), which require `moduleResolution` to be set to `"bundler"` in your `tsconfig.json`:
 
 ```json
 {
@@ -24,7 +24,7 @@ This package uses [subpath exports](https://nodejs.org/api/packages.html#subpath
 }
 ```
 
-If you use [ts-node](https://typestrong.org/ts-node/), add the following to your `tsconfig.json`:
+If you use ts-node, add the following to your `tsconfig.json`:
 
 ```json
 {

--- a/packages/grafana-api-clients/README.md
+++ b/packages/grafana-api-clients/README.md
@@ -12,6 +12,31 @@ The clients are auto-generated [RTK Query](https://redux-toolkit.js.org/rtk-quer
 yarn add @grafana/api-clients
 ```
 
+## TypeScript configuration
+
+This package uses [subpath exports](https://nodejs.org/api/packages.html#subpath-exports), which require `moduleResolution` to be set to `"bundler"` (or `"node16"`/`"nodenext"`) in your `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "moduleResolution": "bundler"
+  }
+}
+```
+
+If you use [ts-node](https://typestrong.org/ts-node/), add the following to your `tsconfig.json`:
+
+```json
+{
+  "ts-node": {
+    "compilerOptions": {
+      "module": "es2020",
+      "moduleResolution": "Bundler"
+    }
+  }
+}
+```
+
 ## Usage
 
 Each API client is available as a separate subpath export, scoped by group and version:


### PR DESCRIPTION
**What is this feature?**
Adds required compilerOptions to readme for API clients

**Why do we need this feature?**
So consumers know how to properly import api clients

**Who is this feature for?**
Users of API clients package