### PR TITLE
Makefile: add build-targz target

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1068,6 +1068,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/AppWrapper.tsx @grafana/frontend-ops
 
 /scripts/benchmark-access-control.sh @grafana/access-squad
+/scripts/build-targz.sh @grafana/grafana-backend-services-squad
 /scripts/check-breaking-changes.sh @grafana/grafana-frontend-platform
 /scripts/ci-* @grafana/grafana-developer-enablement-squad
 /scripts/publish-npm-packages.sh @grafana/grafana-developer-enablement-squad @grafana/grafana-frontend-platform

--- a/.github/actions/change-detection/action.yml
+++ b/.github/actions/change-detection/action.yml
@@ -37,6 +37,9 @@ outputs:
   dockerfile:
     description: Whether the dockerfile or self have changed in any way
     value: ${{ steps.changed-files.outputs.dockerfile_any_changed || 'true' }}
+  makefile:
+    description: Whether any Makefile changed
+    value: ${{ steps.changed-files.outputs.makefile_any_changed || 'true' }}
   devenv:
     description: Whether the devenv or self have changed in any way
     value: ${{ steps.changed-files.outputs.devenv_any_changed || 'true' }}
@@ -57,6 +60,9 @@ runs:
           dockerfile:
             - 'Dockerfile'
             - 'Makefile'
+          makefile:
+            - 'Makefile'
+            - '**/Makefile'
           backend:
             - '!*.md'
             - '!docs/**'
@@ -186,5 +192,7 @@ runs:
         echo " --> ${{ steps.changed-files.outputs.docs_all_changed_files }}"
         echo "Dockerfile: ${{ steps.changed-files.outputs.dockerfile_any_changed || 'true' }}"
         echo " --> ${{ steps.changed-files.outputs.dockerfile_all_changed_files }}"
+        echo "Makefile: ${{ steps.changed-files.outputs.makefile_any_changed || 'true' }}"
+        echo " --> ${{ steps.changed-files.outputs.makefile_all_changed_files }}"
         echo "devenv: ${{ steps.changed-files.outputs.devenv_any_changed || 'true' }}"
         echo " --> ${{ steps.changed-files.outputs.devenv_all_changed_files }}"

--- a/.github/workflows/build-go-matrix.yml
+++ b/.github/workflows/build-go-matrix.yml
@@ -82,9 +82,9 @@ jobs:
       - name: Build Go (${{ matrix.name }})
         env:
           CGO_ENABLED: "0"
-          OS: ${{ matrix.goos }}
-          ARCH: ${{ matrix.goarch }}
-          ARM: ${{ matrix.goarm }}
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          GOARM: ${{ matrix.goarm }}
         run: make build-go
 
   build-go-enterprise:

--- a/.github/workflows/build-go-matrix.yml
+++ b/.github/workflows/build-go-matrix.yml
@@ -82,9 +82,9 @@ jobs:
       - name: Build Go (${{ matrix.name }})
         env:
           CGO_ENABLED: "0"
-          GO_BUILD_OS: ${{ matrix.goos }}
-          GO_BUILD_ARCH: ${{ matrix.goarch }}
-          GOARM: ${{ matrix.goarm }}
+          OS: ${{ matrix.goos }}
+          ARCH: ${{ matrix.goarch }}
+          ARM: ${{ matrix.goarm }}
         run: make build-go
 
   build-go-enterprise:

--- a/.github/workflows/build-go-matrix.yml
+++ b/.github/workflows/build-go-matrix.yml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: read
     outputs:
-      changed: ${{ steps.detect-changes.outputs.backend }}
+      changed: ${{ steps.detect-changes.outputs.backend == 'true' || steps.detect-changes.outputs.makefile == 'true' }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/run-dashboard-search-e2e.yml
+++ b/.github/workflows/run-dashboard-search-e2e.yml
@@ -8,9 +8,6 @@ on:
       - completed
   workflow_dispatch:
 
-env:
-  ARCH: linux-amd64
-
 permissions: {}
 
 jobs:

--- a/.github/workflows/run-schema-v2-e2e.yml
+++ b/.github/workflows/run-schema-v2-e2e.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - '**'
 
-env:
-  ARCH: linux-amd64
-
 jobs:
   dashboard-schema-v2-e2e:
     runs-on: ubuntu-x64-large

--- a/.github/workflows/trigger-dashboard-search-e2e.yml
+++ b/.github/workflows/trigger-dashboard-search-e2e.yml
@@ -16,9 +16,6 @@ on:
       - public/app/features/search/**/*.ts
       - public/app/features/search/**/*.tsx
       - pkg/storage/**/*.go
-env:
-  ARCH: linux-amd64
-
 jobs:
   trigger-search-e2e:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,32 @@ GO_TEST_FLAGS += $(if $(GO_BUILD_TAGS),-tags=$(GO_BUILD_TAGS))
 GO_BUILD_DEV_ENABLED := $(filter 1 dev,$(GO_BUILD_DEV))
 GO_BUILD_GCFLAGS_EFFECTIVE := $(if $(GO_BUILD_GCFLAGS),$(GO_BUILD_GCFLAGS),$(if $(GO_BUILD_DEV_ENABLED),all=-N -l))
 GO_BUILD_TRIMPATH_FLAG := $(if $(GO_BUILD_DEV_ENABLED),,-trimpath)
-OS ?= $(shell $(GO) env GOOS)
-ARCH ?= $(shell $(GO) env GOARCH)
+GO_BUILD_ENV = \
+	$(if $(CGO_ENABLED),CGO_ENABLED=$(CGO_ENABLED)) \
+	GOOS=$(OS) \
+	GOARCH=$(ARCH) \
+	$(if $(ARM),GOARM=$(ARM))
+GO_BUILD_ARGS = \
+	-buildvcs=false \
+	$(GO_BUILD_TRIMPATH_FLAG) \
+	$(GO_RACE_FLAG) \
+	$(if $(GO_BUILD_TAGS),-tags $(GO_BUILD_TAGS)) \
+	$(if $(GO_BUILD_GCFLAGS_EFFECTIVE),-gcflags "$(GO_BUILD_GCFLAGS_EFFECTIVE)") \
+	-ldflags "$(GO_LDFLAGS)" \
+	-o ./bin/$(OS)/$(ARCH)/grafana \
+	./pkg/cmd/grafana
+ifeq ($(filter undefined environment environment\ override,$(origin OS)),)
+else
+OS := $(or $(GOOS),$(shell $(GO) env GOOS))
+endif
+ifeq ($(filter undefined environment environment\ override,$(origin ARCH)),)
+else
+ARCH := $(or $(GOARCH),$(shell $(GO) env GOARCH))
+endif
+ifeq ($(filter undefined environment environment\ override,$(origin ARM)),)
+else
+ARM := $(GOARM)
+endif
 GIT_BASE = remotes/origin/main
 
 CUE_VERSION = v0.16.0
@@ -313,7 +337,8 @@ update-workspace: gen-go
 .PHONY: build-go
 build-go: pkg/services/preference/themes_generated.go
 	@echo "build go binaries ($(OS)/$(ARCH))"
-	$(if $(CGO_ENABLED),CGO_ENABLED=$(CGO_ENABLED)) GOOS=$(OS) GOARCH=$(ARCH) $(GO) build -buildvcs=false $(GO_BUILD_TRIMPATH_FLAG) $(GO_RACE_FLAG) $(if $(GO_BUILD_TAGS),-tags $(GO_BUILD_TAGS)) $(if $(GO_BUILD_GCFLAGS_EFFECTIVE),-gcflags "$(GO_BUILD_GCFLAGS_EFFECTIVE)") -ldflags "$(GO_LDFLAGS)" -o ./bin/$(OS)/$(ARCH)/grafana ./pkg/cmd/grafana
+	$(GO_BUILD_ENV) \
+	$(GO) build $(GO_BUILD_ARGS)
 	if [ "$(OS)" = "$(GO_HOST_OS)" ] && [ "$(ARCH)" = "$(GO_HOST_ARCH)" ]; then cp ./bin/$(OS)/$(ARCH)/grafana ./bin/grafana; fi
 
 bin/$(OS)/$(ARCH)/grafana:

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ update-workspace: gen-go
 	bash scripts/go-workspace/update-workspace.sh
 
 .PHONY: build-go
-build-go: gen-themes ## Build all Go binaries (grafana, grafana-server, grafana-cli).
+build-go: pkg/services/preference/themes_generated.go
 	@echo "build go binaries ($(OS)/$(ARCH))"
 	$(if $(CGO_ENABLED),CGO_ENABLED=$(CGO_ENABLED)) GOOS=$(OS) GOARCH=$(ARCH) $(GO) build -buildvcs=false -trimpath $(GO_RACE_FLAG) $(if $(GO_BUILD_TAGS),-tags $(GO_BUILD_TAGS)) $(if $(GO_BUILD_GCFLAGS),-gcflags "$(GO_BUILD_GCFLAGS)") -ldflags "$(GO_LDFLAGS)" -o ./bin/$(OS)/$(ARCH)/grafana ./pkg/cmd/grafana
 	cp ./bin/$(OS)/$(ARCH)/grafana ./bin/grafana

--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ update-workspace: gen-go
 build-go: pkg/services/preference/themes_generated.go
 	@echo "build go binaries ($(OS)/$(ARCH))"
 	$(if $(CGO_ENABLED),CGO_ENABLED=$(CGO_ENABLED)) GOOS=$(OS) GOARCH=$(ARCH) $(GO) build -buildvcs=false -trimpath $(GO_RACE_FLAG) $(if $(GO_BUILD_TAGS),-tags $(GO_BUILD_TAGS)) $(if $(GO_BUILD_GCFLAGS),-gcflags "$(GO_BUILD_GCFLAGS)") -ldflags "$(GO_LDFLAGS)" -o ./bin/$(OS)/$(ARCH)/grafana ./pkg/cmd/grafana
-	cp ./bin/$(OS)/$(ARCH)/grafana ./bin/grafana
+	if [ "$(OS)" = "$(GO_HOST_OS)" ] && [ "$(ARCH)" = "$(GO_HOST_ARCH)" ]; then cp ./bin/$(OS)/$(ARCH)/grafana ./bin/grafana; fi
 
 bin/$(OS)/$(ARCH)/grafana:
 	$(MAKE) build-go

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ GO_LDFLAGS = -X main.version=$(BUILD_VERSION) \
 	$(if $(ENTERPRISE_COMMIT_SHA),-X main.enterpriseCommit=$(ENTERPRISE_COMMIT_SHA)) \
 	$(if $(LDFLAGS),-extldflags \"$(LDFLAGS)\")
 GO_TEST_FLAGS += $(if $(GO_BUILD_TAGS),-tags=$(GO_BUILD_TAGS))
+OS ?= $(shell $(GO) env GOOS)
+ARCH ?= $(shell $(GO) env GOARCH)
 GIT_BASE = remotes/origin/main
 
 CUE_VERSION = v0.16.0
@@ -297,15 +299,22 @@ gen-jsonnet:
 gen-themes:
 	GOOS=$(GO_HOST_OS) GOARCH=$(GO_HOST_ARCH) $(GO) generate ./pkg/services/preference
 
+pkg/services/preference/themes_generated.go:
+	$(MAKE) gen-themes
+
 .PHONY: update-workspace
 update-workspace: gen-go
 	@echo "updating workspace"
 	bash scripts/go-workspace/update-workspace.sh
 
 .PHONY: build-go
-build-go: gen-themes ## Build the Grafana binary.
-	@echo "build go binaries"
-	$(if $(CGO_ENABLED),CGO_ENABLED=$(CGO_ENABLED)) $(if $(GO_BUILD_OS),GOOS=$(GO_BUILD_OS)) $(if $(GO_BUILD_ARCH),GOARCH=$(GO_BUILD_ARCH)) $(GO) build -buildvcs=false $(if $(GO_BUILD_DEV),-gcflags "all=-N -l",-trimpath) $(GO_RACE_FLAG) $(if $(GO_BUILD_TAGS),-tags $(GO_BUILD_TAGS)) $(if $(GO_BUILD_GCFLAGS),-gcflags "$(GO_BUILD_GCFLAGS)") -ldflags "$(GO_LDFLAGS)" -o ./bin/grafana ./pkg/cmd/grafana
+build-go: gen-themes ## Build all Go binaries (grafana, grafana-server, grafana-cli).
+	@echo "build go binaries ($(OS)/$(ARCH))"
+	$(if $(CGO_ENABLED),CGO_ENABLED=$(CGO_ENABLED)) GOOS=$(OS) GOARCH=$(ARCH) $(GO) build -buildvcs=false -trimpath $(GO_RACE_FLAG) $(if $(GO_BUILD_TAGS),-tags $(GO_BUILD_TAGS)) $(if $(GO_BUILD_GCFLAGS),-gcflags "$(GO_BUILD_GCFLAGS)") -ldflags "$(GO_LDFLAGS)" -o ./bin/$(OS)/$(ARCH)/grafana ./pkg/cmd/grafana
+	cp ./bin/$(OS)/$(ARCH)/grafana ./bin/grafana
+
+bin/$(OS)/$(ARCH)/grafana:
+	$(MAKE) build-go
 
 .PHONY: build-backend
 build-backend: build-go
@@ -318,6 +327,9 @@ build-air: build-go
 build-js: ## Build frontend assets.
 	@echo "build frontend"
 	yarn run build
+
+public/build:
+	$(MAKE) build-js
 
 PLUGIN_ID ?=
 
@@ -333,6 +345,19 @@ build-plugin-go: ## Build decoupled plugins
 
 .PHONY: build
 build: build-go build-js ## Build backend and frontend.
+
+# Tar.gz packaging variables (aligned with pkg/build/daggerbuild/packages)
+TARGZ_PACKAGE_NAME ?= grafana
+
+.PHONY: build-targz
+build-targz: | bin/$(OS)/$(ARCH)/grafana public/build ## Build a tar.gz package (same layout as daggerbuild).
+	TARGZ_PACKAGE_NAME="$(TARGZ_PACKAGE_NAME)" \
+	BUILD_VERSION="$(BUILD_VERSION)" \
+	BUILD_NUMBER="$(BUILD_NUMBER)" \
+	OS="$(OS)" \
+	ARCH="$(ARCH)" \
+	GO="$(GO)" \
+	bash scripts/build-targz.sh
 
 .PHONY: run
 run: ## Build and run backend, and watch for changes. See .air.toml for configuration.

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ GO_LDFLAGS = -X main.version=$(BUILD_VERSION) \
 	$(if $(ENTERPRISE_COMMIT_SHA),-X main.enterpriseCommit=$(ENTERPRISE_COMMIT_SHA)) \
 	$(if $(LDFLAGS),-extldflags \"$(LDFLAGS)\")
 GO_TEST_FLAGS += $(if $(GO_BUILD_TAGS),-tags=$(GO_BUILD_TAGS))
+GO_BUILD_DEV_ENABLED := $(filter 1 dev,$(GO_BUILD_DEV))
+GO_BUILD_GCFLAGS_EFFECTIVE := $(if $(GO_BUILD_GCFLAGS),$(GO_BUILD_GCFLAGS),$(if $(GO_BUILD_DEV_ENABLED),all=-N -l))
+GO_BUILD_TRIMPATH_FLAG := $(if $(GO_BUILD_DEV_ENABLED),,-trimpath)
 OS ?= $(shell $(GO) env GOOS)
 ARCH ?= $(shell $(GO) env GOARCH)
 GIT_BASE = remotes/origin/main
@@ -310,7 +313,7 @@ update-workspace: gen-go
 .PHONY: build-go
 build-go: pkg/services/preference/themes_generated.go
 	@echo "build go binaries ($(OS)/$(ARCH))"
-	$(if $(CGO_ENABLED),CGO_ENABLED=$(CGO_ENABLED)) GOOS=$(OS) GOARCH=$(ARCH) $(GO) build -buildvcs=false -trimpath $(GO_RACE_FLAG) $(if $(GO_BUILD_TAGS),-tags $(GO_BUILD_TAGS)) $(if $(GO_BUILD_GCFLAGS),-gcflags "$(GO_BUILD_GCFLAGS)") -ldflags "$(GO_LDFLAGS)" -o ./bin/$(OS)/$(ARCH)/grafana ./pkg/cmd/grafana
+	$(if $(CGO_ENABLED),CGO_ENABLED=$(CGO_ENABLED)) GOOS=$(OS) GOARCH=$(ARCH) $(GO) build -buildvcs=false $(GO_BUILD_TRIMPATH_FLAG) $(GO_RACE_FLAG) $(if $(GO_BUILD_TAGS),-tags $(GO_BUILD_TAGS)) $(if $(GO_BUILD_GCFLAGS_EFFECTIVE),-gcflags "$(GO_BUILD_GCFLAGS_EFFECTIVE)") -ldflags "$(GO_LDFLAGS)" -o ./bin/$(OS)/$(ARCH)/grafana ./pkg/cmd/grafana
 	cp ./bin/$(OS)/$(ARCH)/grafana ./bin/grafana
 
 bin/$(OS)/$(ARCH)/grafana:
@@ -504,7 +507,7 @@ DOCKER_JS_YARN_BUILD_FLAG = build
 DOCKER_JS_YARN_INSTALL_FLAG = --immutable
 #
 # if go is in dev mode, also build node in dev mode
-ifeq ($(GO_BUILD_DEV), dev)
+ifneq ($(filter 1 dev,$(GO_BUILD_DEV)),)
   DOCKER_JS_NODE_ENV_FLAG = dev
   DOCKER_JS_YARN_BUILD_FLAG = dev
 	DOCKER_JS_YARN_INSTALL_FLAG =

--- a/pkg/tests/api/admin/encryption/reencrypt_test.go
+++ b/pkg/tests/api/admin/encryption/reencrypt_test.go
@@ -92,7 +92,6 @@ func RunAdminApiReencryptTest(
 	setup func(t *testing.T, env *server.TestEnv, grafanaListenAddr string),
 	secretsFns map[string]func(t *testing.T, env *server.TestEnv) map[int]secret,
 ) {
-	t.Skip("Flaky test, see https://github.com/grafana/grafana/actions/runs/23609921066/job/68762683844?pr=120224")
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		APIServerStorageType: options.StorageTypeUnified,
 	})

--- a/pkg/tests/api/admin/encryption/reencrypt_test.go
+++ b/pkg/tests/api/admin/encryption/reencrypt_test.go
@@ -92,6 +92,7 @@ func RunAdminApiReencryptTest(
 	setup func(t *testing.T, env *server.TestEnv, grafanaListenAddr string),
 	secretsFns map[string]func(t *testing.T, env *server.TestEnv) map[int]secret,
 ) {
+	t.Skip("Flaky test, see https://github.com/grafana/grafana/actions/runs/23609921066/job/68762683844?pr=120224")
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		APIServerStorageType: options.StorageTypeUnified,
 	})

--- a/scripts/build-targz.sh
+++ b/scripts/build-targz.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 #   BUILD_NUMBER        – CI build number / ID
 #   OS                  – target OS (e.g. linux, darwin)
 #   ARCH                – target architecture (e.g. amd64, arm64)
-#   GO                  – go binary
+#   GO                  – path to 'go'. default: 'go' (determined by $PATH by default).
 
 : "${TARGZ_PACKAGE_NAME:=grafana}"
 : "${BUILD_VERSION:?BUILD_VERSION is required}"

--- a/scripts/build-targz.sh
+++ b/scripts/build-targz.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Environment variables (with defaults where appropriate):
+#   TARGZ_PACKAGE_NAME  – package name, e.g. "grafana" or "grafana-enterprise"
+#   BUILD_VERSION       – semver build version
+#   BUILD_NUMBER        – CI build number / ID
+#   OS                  – target OS (e.g. linux, darwin)
+#   ARCH                – target architecture (e.g. amd64, arm64)
+#   GO                  – go binary
+
+: "${TARGZ_PACKAGE_NAME:=grafana}"
+: "${BUILD_VERSION:?BUILD_VERSION is required}"
+: "${BUILD_NUMBER:=local}"
+: "${OS:?OS is required}"
+: "${ARCH:?ARCH is required}"
+: "${GO:=go}"
+
+REPO_ROOT="$(pwd)"
+FILENAME="${TARGZ_PACKAGE_NAME}_${BUILD_VERSION}_${BUILD_NUMBER}_${OS}_${ARCH}.tar.gz"
+STAGING="${REPO_ROOT}/dist/.tar-staging"
+ROOT="grafana-${BUILD_VERSION}"
+DIR="${STAGING}/${ROOT}"
+
+echo "build tar.gz: ${FILENAME}"
+
+rm -rf "${STAGING}"
+mkdir -p "${DIR}/tools" "${DIR}/docs" "${DIR}/packaging"
+
+echo "${BUILD_VERSION}" > "${DIR}/VERSION"
+cp LICENSE NOTICE.md README.md Dockerfile "${DIR}/"
+cp "$("${GO}" env GOROOT)/lib/time/zoneinfo.zip" "${DIR}/tools/"
+
+cp -r conf "${DIR}/conf"
+cp -r docs/sources "${DIR}/docs/sources"
+cp -r packaging/deb "${DIR}/packaging/deb"
+cp -r packaging/rpm "${DIR}/packaging/rpm"
+cp -r packaging/docker "${DIR}/packaging/docker"
+cp -r packaging/wrappers "${DIR}/packaging/wrappers"
+
+mkdir -p "${DIR}/bin"
+cp "bin/${OS}/${ARCH}/"* "${DIR}/bin/"
+cp -r public "${DIR}/public"
+find "${DIR}/public" -type d -name node_modules -print0 | xargs -0 rm -rf 2>/dev/null || true
+
+if [ -d plugins-bundled ]; then
+  cp -r plugins-bundled "${DIR}/plugins-bundled"
+  find "${DIR}/plugins-bundled" -type d -name node_modules -print0 | xargs -0 rm -rf 2>/dev/null || true
+else
+  mkdir -p "${DIR}/plugins-bundled"
+fi
+
+mkdir -p dist
+(cd "${STAGING}" && tar -czf "${REPO_ROOT}/dist/${FILENAME}" "${ROOT}")
+rm -rf "${STAGING}"
+
+echo "created dist/${FILENAME}"


### PR DESCRIPTION
- Adds a Makefile target to produce tar.gz packages with the same naming convention and directory layout as the Dagger build pipeline (pkg/build/daggerbuild/).
- Also introduces unified OS/ARCH variables for cross-compilation.


```bash
# Build tar.gz for the host platform
make build-targz

# Cross-compile and package for linux/amd64
make build-targz OS=linux ARCH=amd64

# Override package name and build number
make build-targz OS=linux ARCH=amd64 BUILD_NUMBER=12345
```

This also will use the `public/build and `bin/${os}/${arch}` in the filesystem if they exist for the tar.gz, so in the future we can fan out the backend & frontend build to separate hosts and combine them here.

If they don't exist, then no problem; it will build them using the make targets.