### PR TITLE
Gauge: Fix regression for single series w/ displayName

### DIFF
--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.story.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.story.tsx
@@ -364,7 +364,7 @@ const DEFAULT_THRESHOLDS: FieldConfig['thresholds'] = {
 
 export function RadialGaugeExample({
   color,
-  seriesName = 'Server A',
+  seriesName,
   value = 70,
   shape = 'circle',
   min = 0,
@@ -410,7 +410,7 @@ export function RadialGaugeExample({
         },
       },
       {
-        name: seriesName,
+        name: 'Value',
         type: FieldType.number,
         values: [40, 45, 20, 25, 30, 28, 27, 30, 31, 26, 50, 55, 52, 20, 25, 30, 60, value],
         config: {
@@ -420,6 +420,7 @@ export function RadialGaugeExample({
           decimals: decimals,
           color: { mode: colorScheme, fixedColor: color ? theme.visualization.getColorByName(color) : undefined },
           thresholds,
+          displayName: seriesName,
         },
         // Add state and getLinks
         state: {},

--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.test.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.test.tsx
@@ -27,6 +27,59 @@ describe('RadialGauge', () => {
     }
   );
 
+  describe('text mode', () => {
+    describe('auto mode', () => {
+      it('should render `value_and_name` if the vizCount is greater than 1', () => {
+        render(<RadialGaugeExample textMode="auto" vizCount={3} value={55} />);
+        expect(screen.getByRole('img')).toBeInTheDocument();
+        expect(screen.getByText('TestData')).toBeInTheDocument();
+        expect(screen.getByText('55')).toBeInTheDocument();
+      });
+
+      it('should render `value_and_name` if the vizCount is 1 and the first value has a display name', () => {
+        render(<RadialGaugeExample textMode="auto" seriesName="My series" vizCount={3} value={55} />);
+        expect(screen.getByRole('img')).toBeInTheDocument();
+        expect(screen.getByText('My series')).toBeInTheDocument();
+        expect(screen.getByText('55')).toBeInTheDocument();
+      });
+
+      it('should render `value` if the vizCount is 1 and the first value has no display name', () => {
+        render(<RadialGaugeExample textMode="auto" vizCount={1} value={55} />);
+        expect(screen.getByRole('img')).toBeInTheDocument();
+        expect(screen.queryByText('TestData')).not.toBeInTheDocument();
+        expect(screen.getByText('55')).toBeInTheDocument();
+      });
+    });
+
+    it('should render `value_and_name` if the textMode is set to `value_and_name`', () => {
+      render(<RadialGaugeExample textMode="value_and_name" seriesName="My series" value={55} />);
+      expect(screen.getByRole('img')).toBeInTheDocument();
+      expect(screen.getByText('My series')).toBeInTheDocument();
+      expect(screen.getByText('55')).toBeInTheDocument();
+    });
+
+    it('should render `value` if the textMode is set to `value`', () => {
+      render(<RadialGaugeExample textMode="value" seriesName="My series" value={55} />);
+      expect(screen.getByRole('img')).toBeInTheDocument();
+      expect(screen.queryByText('My series')).not.toBeInTheDocument();
+      expect(screen.getByText('55')).toBeInTheDocument();
+    });
+
+    it('should render `name` if the textMode is set to `name`', () => {
+      render(<RadialGaugeExample textMode="name" seriesName="My series" value={55} />);
+      expect(screen.getByRole('img')).toBeInTheDocument();
+      expect(screen.getByText('My series')).toBeInTheDocument();
+      expect(screen.queryByText('55')).not.toBeInTheDocument();
+    });
+
+    it('should render `none` if the textMode is set to `none`', () => {
+      render(<RadialGaugeExample textMode="none" seriesName="My series" value={55} />);
+      expect(screen.getByRole('img')).toBeInTheDocument();
+      expect(screen.queryByText('My series')).not.toBeInTheDocument();
+      expect(screen.queryByText('55')).not.toBeInTheDocument();
+    });
+  });
+
   describe('labels', () => {
     it('should render labels', () => {
       render(<RadialGaugeExample showScaleLabels />);

--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
@@ -116,7 +116,9 @@ export function RadialGauge(props: RadialGaugeProps) {
 
   let effectiveTextMode = textMode;
   if (effectiveTextMode === 'auto') {
-    effectiveTextMode = vizCount === 1 ? 'value' : 'value_and_name';
+    const firstValue: FieldDisplay | undefined = values[0];
+    // in auto mode, we should show value_and_name if there are multiple values or the first value has a display name
+    effectiveTextMode = vizCount > 1 || firstValue?.field?.displayName != null ? 'value_and_name' : 'value';
   }
 
   const startAngle = shape === 'gauge' ? ARC_START : 0;


### PR DESCRIPTION
Relates to https://github.com/grafana/support-escalations/issues/21170

In the legacy gauge panel, values are passed through the shared utility https://github.com/grafana/grafana/blob/5395511c8ffecae6489e60cfa961cd3bdff1dd83/public/app/plugins/panel/bargauge/BarGaugePanel.tsx#L173-L182 from BarGaugePanel, but in the new Gauge, we were handling the vizCount case but not the displayName case.

To test:

- In the "Gauge Panel (new)" gdev dashboard, only the multi-viz panels should show field labels still.
- If you go into any of the single-panel gauges there and add a display name to the value field using an "Organize fields" transform, that name should automatically appear (I believe all the panels on this dashboard are "Auto" mode, which is what we changed here.
- If you cycle through the other text modes (value and name, value, name, none) they should continue to work as expected.