### PR TITLE
Alerting: Fix infinite loading in route preview for multiple AM

### DIFF
--- a/public/app/features/alerting/unified/components/notification-policies/useNotificationPolicyRoute.test.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/useNotificationPolicyRoute.test.tsx
@@ -8,6 +8,7 @@ import {
   createKubernetesRoutingTreeSpec,
   isRouteProvisioned,
   k8sSubRouteToRoute,
+  parseAmConfigRoute,
   routeToK8sSubRoute,
 } from './useNotificationPolicyRoute';
 
@@ -207,5 +208,48 @@ describe('isRouteProvisioned', () => {
     };
 
     expect(isRouteProvisioned(route)).toBeTruthy();
+  });
+});
+
+describe('parseAmConfigRoute', () => {
+  it('adds ROUTES_META_SYMBOL with provenance from the route', () => {
+    const route: Route = { receiver: 'test-receiver', provenance: KnownProvenance.File };
+
+    const result = parseAmConfigRoute(route);
+
+    expect(result[ROUTES_META_SYMBOL]).toEqual({ provenance: KnownProvenance.File });
+    expect(result.receiver).toBe('test-receiver');
+  });
+
+  it('returns a stable reference when called multiple times with the same route object', () => {
+    const route: Route = { receiver: 'test-receiver', provenance: KnownProvenance.File };
+
+    const result1 = parseAmConfigRoute(route);
+    const result2 = parseAmConfigRoute(route);
+
+    expect(result1).toBe(result2);
+  });
+
+  it('returns stable references for multiple distinct route objects without cache eviction', () => {
+    // With maxSize: 1, calls for routeB would evict routeA's cache entry, causing
+    // parseAmConfigRoute(routeA) to return a new reference on the next call. This instability
+    // triggered infinite re-renders in useAlertmanagerNotificationRoutingPreview when two or
+    // more external Alertmanagers were configured.
+    const routeA: Route = { receiver: 'receiver-A' };
+    const routeB: Route = { receiver: 'receiver-B' };
+    const routeC: Route = { receiver: 'receiver-C' };
+
+    const resultA1 = parseAmConfigRoute(routeA);
+    const resultB1 = parseAmConfigRoute(routeB);
+    const resultC1 = parseAmConfigRoute(routeC);
+
+    // Interleave calls in a different order to simulate multiple AMs calling selectFromResult
+    const resultB2 = parseAmConfigRoute(routeB);
+    const resultA2 = parseAmConfigRoute(routeA);
+    const resultC2 = parseAmConfigRoute(routeC);
+
+    expect(resultA1).toBe(resultA2);
+    expect(resultB1).toBe(resultB2);
+    expect(resultC1).toBe(resultC2);
   });
 });

--- a/public/app/features/alerting/unified/components/notification-policies/useNotificationPolicyRoute.ts
+++ b/public/app/features/alerting/unified/components/notification-policies/useNotificationPolicyRoute.ts
@@ -57,8 +57,8 @@ const { useGetAlertmanagerConfigurationQuery } = alertmanagerApi;
 // Alertmanagers are configured — each AM calls the function with a different route object,
 // and evictions cause new references on every render, triggering infinite re-renders in
 // useAsync. WeakMap has no size limit and automatically GCs entries when keys are released.
-const k8sRouteToRouteCache = new WeakMap<Parameters<typeof k8sRouteToRoute>[0], Route>();
-function memoK8sRouteToRoute(route: Parameters<typeof k8sRouteToRoute>[0]): Route {
+const k8sRouteToRouteCache = new WeakMap<RoutingTree, Route>();
+function memoK8sRouteToRoute(route: RoutingTree): Route {
   const cached = k8sRouteToRouteCache.get(route);
   if (cached) {
     return cached;

--- a/public/app/features/alerting/unified/components/notification-policies/useNotificationPolicyRoute.ts
+++ b/public/app/features/alerting/unified/components/notification-policies/useNotificationPolicyRoute.ts
@@ -1,6 +1,5 @@
 import uFuzzy from '@leeoniya/ufuzzy';
 import { pick, uniq } from 'lodash';
-import memoize from 'micro-memoize';
 import { useMemo, useState } from 'react';
 
 import { INHERITABLE_KEYS, type InheritableProperties } from '@grafana/alerting/internal';
@@ -53,7 +52,21 @@ const {
 
 const { useGetAlertmanagerConfigurationQuery } = alertmanagerApi;
 
-const memoK8sRouteToRoute = memoize(k8sRouteToRoute);
+// WeakMap-based caches for stable Route object references. Using WeakMap rather than a
+// fixed-size LRU (micro-memoize's default) avoids cache eviction when multiple external
+// Alertmanagers are configured — each AM calls the function with a different route object,
+// and evictions cause new references on every render, triggering infinite re-renders in
+// useAsync. WeakMap has no size limit and automatically GCs entries when keys are released.
+const k8sRouteToRouteCache = new WeakMap<Parameters<typeof k8sRouteToRoute>[0], Route>();
+function memoK8sRouteToRoute(route: Parameters<typeof k8sRouteToRoute>[0]): Route {
+  const cached = k8sRouteToRouteCache.get(route);
+  if (cached) {
+    return cached;
+  }
+  const result = k8sRouteToRoute(route);
+  k8sRouteToRouteCache.set(route, result);
+  return result;
+}
 
 export const useNotificationPolicyRoute = (
   { alertmanager }: BaseAlertmanagerArgs,
@@ -114,14 +127,21 @@ export const useListNotificationPolicyRoutes = ({ skip }: Skippable = {}) => {
   );
 };
 
-const parseAmConfigRoute = memoize((route: Route): Route => {
-  return {
+const amConfigRouteCache = new WeakMap<Route, Route>();
+export function parseAmConfigRoute(route: Route): Route {
+  const cached = amConfigRouteCache.get(route);
+  if (cached) {
+    return cached;
+  }
+  const result: Route = {
     ...route,
     [ROUTES_META_SYMBOL]: {
       provenance: route.provenance,
     },
   };
-});
+  amConfigRouteCache.set(route, result);
+  return result;
+}
 
 export function useUpdateExistingNotificationPolicy({ alertmanager }: BaseAlertmanagerArgs) {
   const k8sApiSupported = shouldUseK8sApi(alertmanager);


### PR DESCRIPTION






**Problem**

parseAmConfigRoute and memoK8sRouteToRoute in useNotificationPolicyRoute.ts use micro-memoize with the default maxSize: 1. When multiple external Alertmanagers are configured, their selectFromResult callbacks alternate calls to parseAmConfigRoute, evicting each other's cache entries. This produced new object references on every render, triggering an infinite re-render loop via useAsync in useAlertmanagerNotificationRoutingPreview.

*Before fix*

https://github.com/user-attachments/assets/d5c38869-33dd-4075-86f0-35d582f63257



**Fix**

- Replaced the memoization strategy with WeakMap-based caches. This eliminates eviction entirely, giving us unlimited entries with O(1) lookup and automatic GC when keys are released. Some orgs run 600+ external Alertmanagers, making a fixed cap impractical. The cache invalidation API provided by micro-memoize was not in use in this area of the code, so there is no functional regression.
- Added regression tests to verify referential stability across multiple concurrent route objects.

*After fix*

https://github.com/user-attachments/assets/5a4c393c-0199-4261-81c2-1bf06afcb8a2


**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/issues/120142

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
