### PR TITLE
Provisioning: remove OrgRole.None check from useGetResourceRepositoryView

### DIFF
--- a/public/app/features/browse-dashboards/components/BrowseView.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.tsx
@@ -1,12 +1,10 @@
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useCallback, useMemo } from 'react';
 
-import { OrgRole } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { CallToActionCard, EmptyState, LinkButton, TextLink } from '@grafana/ui';
 import { useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1';
-import { contextSrv } from 'app/core/services/context_srv';
 import { useIsProvisionedInstance } from 'app/features/provisioning/hooks/useIsProvisionedInstance';
 import { useSearchStateManager } from 'app/features/search/state/SearchStateManager';
 import { DashboardViewItem } from 'app/features/search/types';
@@ -44,8 +42,7 @@ export function BrowseView({ folderUID, width, height, permissions, isReadOnlyRe
   const childrenByParentUID = useChildrenByParentUIDState();
   const canSelect = canSelectItems(permissions);
   const provisioningEnabled = config.featureToggles.provisioning;
-  const hasNoRole = contextSrv.user.orgRole === OrgRole.None;
-  const { data: settingsData } = useGetFrontendSettingsQuery(!provisioningEnabled || hasNoRole ? skipToken : undefined);
+  const { data: settingsData } = useGetFrontendSettingsQuery(!provisioningEnabled ? skipToken : undefined);
   const isProvisionedInstance = useIsProvisionedInstance({ settings: settingsData });
   const rootItems = useSelector(rootItemsSelector);
 

--- a/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
@@ -294,6 +294,17 @@ function GeneralSettingsEditViewComponent({ model }: SceneComponentProps<General
             />
           </Field>
 
+          {/* Render here so move-form load errors appear under the Move field. */}
+          {showMoveModal && moveModalProps && (
+            <MoveProvisionedDashboardDrawer
+              dashboard={dashboard}
+              targetFolderUID={moveModalProps.targetFolderUID}
+              targetFolderTitle={moveModalProps.targetFolderTitle}
+              onDismiss={model.onMoveModalDismiss}
+              onSuccess={model.onMoveSuccess}
+            />
+          )}
+
           <Field
             noMargin
             label={t('dashboard-settings.general.editable-label', 'Editable')}
@@ -354,16 +365,6 @@ function GeneralSettingsEditViewComponent({ model }: SceneComponentProps<General
 
         <Box marginTop={3}>{meta.canDelete && <DeleteDashboardButton dashboard={dashboard} />}</Box>
       </div>
-
-      {showMoveModal && moveModalProps && (
-        <MoveProvisionedDashboardDrawer
-          dashboard={dashboard}
-          targetFolderUID={moveModalProps.targetFolderUID}
-          targetFolderTitle={moveModalProps.targetFolderTitle}
-          onDismiss={model.onMoveModalDismiss}
-          onSuccess={model.onMoveSuccess}
-        />
-      )}
     </Page>
   );
 }

--- a/public/app/features/provisioning/components/Dashboards/DashboardPreviewBanner.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/DashboardPreviewBanner.test.tsx
@@ -6,7 +6,7 @@ import { DashboardPageRouteSearchParams } from 'app/features/dashboard/container
 import { usePullRequestParam } from 'app/features/provisioning/hooks/usePullRequestParam';
 import { DashboardRoutes } from 'app/types/dashboard';
 
-import { useGetResourceRepositoryView } from '../../hooks/useGetResourceRepositoryView';
+import { RepoViewStatus, useGetResourceRepositoryView } from '../../hooks/useGetResourceRepositoryView';
 
 import { DashboardPreviewBanner } from './DashboardPreviewBanner';
 
@@ -25,9 +25,13 @@ jest.mock('app/features/provisioning/hooks/usePullRequestParam', () => ({
   usePullRequestParam: jest.fn(),
 }));
 
-jest.mock('../../hooks/useGetResourceRepositoryView', () => ({
-  useGetResourceRepositoryView: jest.fn(),
-}));
+jest.mock('../../hooks/useGetResourceRepositoryView', () => {
+  const actual = jest.requireActual('../../hooks/useGetResourceRepositoryView');
+  return {
+    ...actual,
+    useGetResourceRepositoryView: jest.fn(),
+  };
+});
 
 jest.mock('app/api/clients/provisioning/v0alpha1', () => ({
   useGetRepositoryFilesWithPathQuery: jest.fn(),
@@ -113,6 +117,7 @@ function setup(props: Partial<DashboardPreviewBannerProps> = {}, overrides: Setu
   mockUseGetResourceRepositoryView.mockReturnValue({
     repository: defaultRepositoryView,
     repoType: 'github',
+    status: RepoViewStatus.Ready,
     isLoading: false,
     isInstanceManaged: false,
     isReadOnlyRepo: false,

--- a/public/app/features/provisioning/components/Dashboards/DeleteProvisionedDashboardDrawer.tsx
+++ b/public/app/features/provisioning/components/Dashboards/DeleteProvisionedDashboardDrawer.tsx
@@ -1,8 +1,10 @@
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 
+import { RepoViewStatus } from '../../hooks/useGetResourceRepositoryView';
 import { useProvisionedDashboardData } from '../../hooks/useProvisionedDashboardData';
 
 import { DeleteProvisionedDashboardForm } from './DeleteProvisionedDashboardForm';
+import { FormLoadingErrorAlert } from './FormLoadingErrorAlert';
 
 export interface Props {
   dashboard: DashboardScene;
@@ -14,11 +16,19 @@ export interface Props {
  * Drawer component for deleting a git provisioned dashboard.
  */
 export function DeleteProvisionedDashboardDrawer({ dashboard, onDismiss }: Props) {
-  const { defaultValues, loadedFromRef, readOnly, canPushToConfiguredBranch, isNew, repository } =
-    useProvisionedDashboardData(dashboard);
+  const {
+    defaultValues,
+    loadedFromRef,
+    readOnly,
+    canPushToConfiguredBranch,
+    isNew,
+    repository,
+    repoDataStatus,
+    error,
+  } = useProvisionedDashboardData(dashboard);
 
-  if (!defaultValues) {
-    return null;
+  if (!defaultValues || repoDataStatus === RepoViewStatus.Error) {
+    return <FormLoadingErrorAlert error={error} />;
   }
 
   return (

--- a/public/app/features/provisioning/components/Dashboards/DeleteProvisionedDashboardDrawer.tsx
+++ b/public/app/features/provisioning/components/Dashboards/DeleteProvisionedDashboardDrawer.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from '@grafana/ui';
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 
 import { RepoViewStatus } from '../../hooks/useGetResourceRepositoryView';
@@ -27,7 +28,11 @@ export function DeleteProvisionedDashboardDrawer({ dashboard, onDismiss }: Props
     error,
   } = useProvisionedDashboardData(dashboard);
 
-  if (!defaultValues || repoDataStatus === RepoViewStatus.Error) {
+  if (repoDataStatus === RepoViewStatus.Loading || !defaultValues) {
+    return <Spinner />;
+  }
+
+  if (repoDataStatus === RepoViewStatus.Error) {
     return <FormLoadingErrorAlert error={error} />;
   }
 

--- a/public/app/features/provisioning/components/Dashboards/DeleteProvisionedDashboardForm.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/DeleteProvisionedDashboardForm.test.tsx
@@ -9,6 +9,7 @@ import {
 } from 'app/api/clients/provisioning/v0alpha1';
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 
+import { RepoViewStatus } from '../../hooks/useGetResourceRepositoryView';
 import { ProvisionedDashboardData, useProvisionedDashboardData } from '../../hooks/useProvisionedDashboardData';
 
 import { DeleteProvisionedDashboardDrawer, Props } from './DeleteProvisionedDashboardDrawer';
@@ -106,9 +107,6 @@ function setup(options: SetupOptions = {}) {
   });
 
   const defaultProvisionedData: ProvisionedDashboardData = {
-    isReady: true,
-    isLoading: false,
-    setIsLoading: jest.fn(),
     defaultValues: {
       repo: 'test-repo',
       ref: 'main',
@@ -133,6 +131,7 @@ function setup(options: SetupOptions = {}) {
     readOnly: false,
     canPushToConfiguredBranch: true,
     isNew: false,
+    repoDataStatus: RepoViewStatus.Ready,
     ...provisionedData,
   };
 

--- a/public/app/features/provisioning/components/Dashboards/FormLoadingErrorAlert.tsx
+++ b/public/app/features/provisioning/components/Dashboards/FormLoadingErrorAlert.tsx
@@ -1,0 +1,15 @@
+import { t } from '@grafana/i18n';
+import { Alert } from '@grafana/ui';
+
+import { extractErrorMessage } from '../../../../api/utils';
+
+export function FormLoadingErrorAlert({ error }: { error: unknown }) {
+  return (
+    <Alert
+      severity="error"
+      title={t('dashboard-scene.save-provisioned-dashboard-form.form-loading-error', 'Error loading form')}
+    >
+      {extractErrorMessage(error)}
+    </Alert>
+  );
+}

--- a/public/app/features/provisioning/components/Dashboards/FormLoadingErrorAlert.tsx
+++ b/public/app/features/provisioning/components/Dashboards/FormLoadingErrorAlert.tsx
@@ -1,15 +1,22 @@
 import { t } from '@grafana/i18n';
 import { Alert } from '@grafana/ui';
-
-import { extractErrorMessage } from '../../../../api/utils';
+import { extractErrorMessage } from 'app/api/utils';
 
 export function FormLoadingErrorAlert({ error }: { error: unknown }) {
+  const message =
+    error == null
+      ? t(
+          'dashboard-scene.save-provisioned-dashboard-form.form-loading-error-unknown',
+          'An unexpected error occurred while loading the form.'
+        )
+      : extractErrorMessage(error);
+
   return (
     <Alert
       severity="error"
       title={t('dashboard-scene.save-provisioned-dashboard-form.form-loading-error', 'Error loading form')}
     >
-      {extractErrorMessage(error)}
+      {message}
     </Alert>
   );
 }

--- a/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardDrawer.tsx
+++ b/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardDrawer.tsx
@@ -1,7 +1,9 @@
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 
+import { RepoViewStatus } from '../../hooks/useGetResourceRepositoryView';
 import { useProvisionedDashboardData } from '../../hooks/useProvisionedDashboardData';
 
+import { FormLoadingErrorAlert } from './FormLoadingErrorAlert';
 import { MoveProvisionedDashboardForm } from './MoveProvisionedDashboardForm';
 
 export interface Props {
@@ -19,11 +21,19 @@ export function MoveProvisionedDashboardDrawer({
   onDismiss,
   onSuccess,
 }: Props) {
-  const { defaultValues, loadedFromRef, readOnly, canPushToConfiguredBranch, isNew, repository } =
-    useProvisionedDashboardData(dashboard);
+  const {
+    defaultValues,
+    loadedFromRef,
+    readOnly,
+    canPushToConfiguredBranch,
+    isNew,
+    repository,
+    repoDataStatus,
+    error,
+  } = useProvisionedDashboardData(dashboard);
 
-  if (!defaultValues) {
-    return null;
+  if (!defaultValues || repoDataStatus === RepoViewStatus.Error) {
+    return <FormLoadingErrorAlert error={error} />;
   }
 
   return (

--- a/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardDrawer.tsx
+++ b/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardDrawer.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from '@grafana/ui';
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 
 import { RepoViewStatus } from '../../hooks/useGetResourceRepositoryView';
@@ -32,7 +33,11 @@ export function MoveProvisionedDashboardDrawer({
     error,
   } = useProvisionedDashboardData(dashboard);
 
-  if (!defaultValues || repoDataStatus === RepoViewStatus.Error) {
+  if (repoDataStatus === RepoViewStatus.Loading || !defaultValues) {
+    return <Spinner />;
+  }
+
+  if (repoDataStatus === RepoViewStatus.Error) {
     return <FormLoadingErrorAlert error={error} />;
   }
 

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboard.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboard.tsx
@@ -1,9 +1,12 @@
+import { Spinner } from '@grafana/ui';
 import { SaveDashboardDrawer } from 'app/features/dashboard-scene/saving/SaveDashboardDrawer';
 import { DashboardChangeInfo } from 'app/features/dashboard-scene/saving/shared';
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 
+import { RepoViewStatus } from '../../hooks/useGetResourceRepositoryView';
 import { useProvisionedDashboardData } from '../../hooks/useProvisionedDashboardData';
 
+import { FormLoadingErrorAlert } from './FormLoadingErrorAlert';
 import { SaveProvisionedDashboardForm } from './SaveProvisionedDashboardForm';
 
 export interface SaveProvisionedDashboardProps {
@@ -14,13 +17,15 @@ export interface SaveProvisionedDashboardProps {
 }
 
 export function SaveProvisionedDashboard({ drawer, changeInfo, dashboard, saveAsCopy }: SaveProvisionedDashboardProps) {
-  const { isNew, defaultValues, canPushToConfiguredBranch, readOnly, repository } = useProvisionedDashboardData(
-    dashboard,
-    saveAsCopy
-  );
+  const { isNew, defaultValues, canPushToConfiguredBranch, readOnly, repository, repoDataStatus, error } =
+    useProvisionedDashboardData(dashboard, saveAsCopy);
 
-  if (!defaultValues) {
-    return null;
+  if (repoDataStatus === RepoViewStatus.Loading) {
+    return <Spinner />;
+  }
+
+  if (repoDataStatus === RepoViewStatus.Error || !defaultValues) {
+    return <FormLoadingErrorAlert error={error} />;
   }
 
   return (

--- a/public/app/features/provisioning/hooks/useGetResourceRepositoryView.ts
+++ b/public/app/features/provisioning/hooks/useGetResourceRepositoryView.ts
@@ -1,10 +1,8 @@
 import { skipToken } from '@reduxjs/toolkit/query/react';
 
-import { OrgRole } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { Folder, useGetFolderQuery } from 'app/api/clients/folder/v1beta1';
 import { RepositoryView, useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1';
-import { contextSrv } from 'app/core/services/context_srv';
 import { AnnoKeyManagerIdentity } from 'app/features/apiserver/types';
 
 import { RepoType } from '../Wizard/types';
@@ -16,12 +14,20 @@ interface GetResourceRepositoryArgs {
   skipQuery?: boolean;
 }
 
+export enum RepoViewStatus {
+  Disabled = 'disabled',
+  Loading = 'loading',
+  Ready = 'ready',
+  Error = 'error',
+}
+
 interface RepositoryViewData {
   repository?: RepositoryView;
   repoType?: RepoType;
   folder?: Folder;
-  isLoading?: boolean;
-  isFetching?: boolean;
+  status: RepoViewStatus;
+  error?: unknown;
+  isLoading?: boolean; // TODO: status now contains loading state, this can be remove
   isInstanceManaged: boolean;
   isReadOnlyRepo: boolean;
 }
@@ -32,39 +38,55 @@ export const useGetResourceRepositoryView = ({
   folderName,
   skipQuery,
 }: GetResourceRepositoryArgs): RepositoryViewData => {
-  const hasNoRole = contextSrv.user.orgRole === OrgRole.None;
-
   const provisioningEnabled = config.featureToggles.provisioning;
-  const shouldSkipSettings = !provisioningEnabled || skipQuery || hasNoRole || (!name && !folderName);
+  const shouldSkipSettings = !provisioningEnabled || skipQuery || (!name && !folderName);
   const settingsQueryArg = shouldSkipSettings ? skipToken : undefined;
 
   const {
     data: settingsData,
     isLoading: isSettingsLoading,
-    isFetching: isSettingsFetching,
+    error: settingsError,
   } = useGetFrontendSettingsQuery(settingsQueryArg);
 
-  const skipFolderQuery = !folderName || !provisioningEnabled || skipQuery || hasNoRole;
+  const skipFolderQuery = !folderName || !provisioningEnabled || skipQuery;
   const {
     data: folder,
     isLoading: isFolderLoading,
-    isFetching: isFolderFetching,
+    error: folderError,
   } = useGetFolderQuery(skipFolderQuery ? skipToken : { name: folderName });
 
-  const isFetching = isSettingsFetching || isFolderFetching;
-
   if (!provisioningEnabled) {
-    return { isLoading: false, isFetching: false, isInstanceManaged: false, isReadOnlyRepo: false };
+    return {
+      isLoading: false,
+      isInstanceManaged: false,
+      isReadOnlyRepo: false,
+      status: RepoViewStatus.Disabled,
+    };
   }
 
   if (isSettingsLoading || isFolderLoading) {
-    return { isLoading: true, isFetching: true, isInstanceManaged: false, isReadOnlyRepo: false };
+    return {
+      isLoading: true,
+      isInstanceManaged: false,
+      isReadOnlyRepo: false,
+      status: RepoViewStatus.Loading,
+    };
+  }
+
+  if (settingsError || folderError) {
+    return {
+      isLoading: false,
+      isInstanceManaged: false,
+      isReadOnlyRepo: false,
+      status: RepoViewStatus.Error,
+      error: settingsError || folderError,
+    };
   }
 
   const items = settingsData?.items ?? [];
 
   if (!items.length) {
-    return { folder, isFetching, isInstanceManaged: false, isReadOnlyRepo: false };
+    return { folder, isInstanceManaged: false, isReadOnlyRepo: false, status: RepoViewStatus.Ready };
   }
 
   const instanceRepo = items.find((repo) => repo.target === 'instance');
@@ -76,9 +98,9 @@ export const useGetResourceRepositoryView = ({
       return {
         repository,
         folder,
-        isFetching,
         isInstanceManaged,
         isReadOnlyRepo: getIsReadOnlyRepo(repository),
+        status: RepoViewStatus.Ready,
       };
     }
   }
@@ -91,9 +113,9 @@ export const useGetResourceRepositoryView = ({
       return {
         repository,
         folder,
-        isFetching,
         isInstanceManaged,
         isReadOnlyRepo: getIsReadOnlyRepo(repository),
+        status: RepoViewStatus.Ready,
       };
     }
 
@@ -105,9 +127,9 @@ export const useGetResourceRepositoryView = ({
         return {
           repository,
           folder,
-          isFetching,
           isInstanceManaged,
           isReadOnlyRepo: getIsReadOnlyRepo(repository),
+          status: RepoViewStatus.Ready,
         };
       }
     }
@@ -116,9 +138,9 @@ export const useGetResourceRepositoryView = ({
   return {
     repository: instanceRepo,
     folder,
-    isFetching,
     isInstanceManaged,
     isReadOnlyRepo: getIsReadOnlyRepo(instanceRepo),
     repoType: instanceRepo?.type,
+    status: RepoViewStatus.Ready,
   };
 };

--- a/public/app/features/provisioning/hooks/useGetResourceRepositoryView.ts
+++ b/public/app/features/provisioning/hooks/useGetResourceRepositoryView.ts
@@ -27,7 +27,7 @@ interface RepositoryViewData {
   folder?: Folder;
   status: RepoViewStatus;
   error?: unknown;
-  isLoading?: boolean; // TODO: status now contains loading state, this can be remove
+  isLoading?: boolean; // TODO: status now contains loading state, this can be removed
   isInstanceManaged: boolean;
   isReadOnlyRepo: boolean;
 }

--- a/public/app/features/provisioning/hooks/useIsProvisionedInstance.ts
+++ b/public/app/features/provisioning/hooks/useIsProvisionedInstance.ts
@@ -1,9 +1,7 @@
 import { skipToken } from '@reduxjs/toolkit/query';
 
-import { OrgRole } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { RepositoryViewList, useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1';
-import { contextSrv } from 'app/core/services/context_srv';
 
 interface UseIsProvisionedInstanceOptions {
   settings?: RepositoryViewList;
@@ -12,8 +10,7 @@ interface UseIsProvisionedInstanceOptions {
 
 export function useIsProvisionedInstance(options: UseIsProvisionedInstanceOptions = {}) {
   const { settings, skip: skipQuery } = options;
-  const hasNoRole = contextSrv.user.orgRole === OrgRole.None;
-  const skip = !config.featureToggles.provisioning || hasNoRole || skipQuery;
+  const skip = !config.featureToggles.provisioning || skipQuery;
 
   const settingsQuery = useGetFrontendSettingsQuery(settings || skip ? skipToken : undefined);
 

--- a/public/app/features/provisioning/hooks/useProvisionedDashboardData.test.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedDashboardData.test.ts
@@ -1,0 +1,248 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { getWrapper } from 'test/test-utils';
+
+import { config } from '@grafana/runtime';
+import { PROVISIONING_API_BASE as BASE } from '@grafana/test-utils/handlers';
+import server from '@grafana/test-utils/server';
+import {
+  AnnoKeyManagerIdentity,
+  AnnoKeyManagerKind,
+  AnnoKeySourcePath,
+  ManagerKind,
+} from 'app/features/apiserver/types';
+import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
+
+import { setupProvisioningMswServer } from '../mocks/server';
+
+import { RepoViewStatus } from './useGetResourceRepositoryView';
+import { useDefaultValues, useProvisionedDashboardData } from './useProvisionedDashboardData';
+
+setupProvisioningMswServer();
+
+const FOLDER_BASE = '/apis/folder.grafana.app/v1beta1/namespaces/:namespace';
+
+const settingsWithRepo = {
+  items: [
+    {
+      name: 'my-repo',
+      title: 'My Repo',
+      type: 'github',
+      target: 'folder',
+      branch: 'main',
+      workflows: ['branch', 'write'],
+    },
+  ],
+  allowImageRendering: true,
+  availableRepositoryTypes: ['github'],
+};
+
+const folderResponse = {
+  kind: 'Folder',
+  apiVersion: 'folder.grafana.app/v1beta1',
+  metadata: {
+    name: 'test-folder',
+    namespace: 'default',
+    uid: 'test-folder',
+    creationTimestamp: '2023-01-01T00:00:00Z',
+    annotations: {
+      [AnnoKeySourcePath]: 'dashboards',
+    },
+  },
+  spec: { title: 'Test Folder', description: '' },
+};
+
+const mockMeta = {
+  folderUid: 'test-folder',
+  k8s: {
+    annotations: {
+      [AnnoKeyManagerKind]: ManagerKind.Repo,
+      [AnnoKeyManagerIdentity]: 'my-repo',
+      [AnnoKeySourcePath]: 'dashboards/test.json',
+    },
+  },
+};
+
+beforeEach(() => {
+  config.featureToggles.provisioning = true;
+});
+
+afterEach(() => {
+  config.featureToggles.provisioning = false;
+});
+
+describe('useDefaultValues', () => {
+  it('returns Loading while settings are being fetched', async () => {
+    server.use(
+      http.get(`${BASE}/settings`, async () => {
+        await new Promise((r) => setTimeout(r, 500));
+        return HttpResponse.json(settingsWithRepo);
+      })
+    );
+
+    const meta = {
+      folderUid: 'test-folder',
+      k8s: {
+        annotations: {
+          [AnnoKeyManagerKind]: ManagerKind.Repo,
+          [AnnoKeyManagerIdentity]: 'my-repo',
+          [AnnoKeySourcePath]: 'dashboards/test.json',
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useDefaultValues({ meta, defaultTitle: 'Test Dashboard' }), {
+      wrapper: getWrapper({}),
+    });
+
+    expect(result.current.status).toBe(RepoViewStatus.Loading);
+    expect(result.current.values).toBeNull();
+  });
+
+  it('returns Error when the settings endpoint fails', async () => {
+    server.use(http.get(`${BASE}/settings`, () => HttpResponse.json({ message: 'Forbidden' }, { status: 403 })));
+
+    const { result } = renderHook(() => useDefaultValues({ meta: mockMeta, defaultTitle: 'Test Dashboard' }), {
+      wrapper: getWrapper({}),
+    });
+
+    await waitFor(() => expect(result.current.status).toBe(RepoViewStatus.Error));
+    expect(result.current.values).toBeNull();
+    expect(result.current.error).toBeDefined();
+  });
+
+  it('returns Error when the folder endpoint fails', async () => {
+    server.use(
+      http.get(`${BASE}/settings`, () => HttpResponse.json(settingsWithRepo)),
+      http.get(`${FOLDER_BASE}/folders/:name`, () => HttpResponse.json({ message: 'Not found' }, { status: 500 }))
+    );
+
+    const { result } = renderHook(() => useDefaultValues({ meta: mockMeta, defaultTitle: 'Test Dashboard' }), {
+      wrapper: getWrapper({}),
+    });
+
+    await waitFor(() => expect(result.current.status).toBe(RepoViewStatus.Error));
+    expect(result.current.values).toBeNull();
+    expect(result.current.error).toBeDefined();
+  });
+
+  it('returns Ready with null values when no repository matches', async () => {
+    server.use(
+      http.get(`${BASE}/settings`, () =>
+        HttpResponse.json({
+          items: [],
+          allowImageRendering: true,
+          availableRepositoryTypes: ['github'],
+        })
+      ),
+      http.get(`${FOLDER_BASE}/folders/:name`, () => HttpResponse.json(folderResponse))
+    );
+
+    const meta = {
+      folderUid: 'test-folder',
+      k8s: {
+        annotations: {
+          [AnnoKeyManagerKind]: ManagerKind.Repo,
+          [AnnoKeyManagerIdentity]: 'unknown-repo',
+          [AnnoKeySourcePath]: 'dashboards/test.json',
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useDefaultValues({ meta, defaultTitle: 'Test Dashboard' }), {
+      wrapper: getWrapper({}),
+    });
+
+    await waitFor(() => expect(result.current.status).toBe(RepoViewStatus.Error));
+    expect(result.current.error).toBeDefined();
+    expect(result.current.values).toBeNull();
+  });
+
+  it('returns Ready with form values when repository is resolved', async () => {
+    server.use(
+      http.get(`${BASE}/settings`, () => HttpResponse.json(settingsWithRepo)),
+      http.get(`${FOLDER_BASE}/folders/:name`, () => HttpResponse.json(folderResponse))
+    );
+
+    const { result } = renderHook(() => useDefaultValues({ meta: mockMeta, defaultTitle: 'Test Dashboard' }), {
+      wrapper: getWrapper({}),
+    });
+
+    await waitFor(() => expect(result.current.status).toBe(RepoViewStatus.Ready));
+    expect(result.current.values).not.toBeNull();
+    expect(result.current.values?.repo).toBe('my-repo');
+    expect(result.current.values?.title).toBe('Test Dashboard');
+    expect(result.current.repository?.name).toBe('my-repo');
+  });
+});
+
+describe('useProvisionedDashboardData', () => {
+  function createDashboard(meta = {}) {
+    return new DashboardScene({
+      title: 'Test Dashboard',
+      uid: 'test-uid',
+      description: 'A test dashboard',
+      meta: {
+        slug: 'test-dashboard',
+        folderUid: 'test-folder',
+        k8s: {
+          annotations: {
+            [AnnoKeyManagerKind]: ManagerKind.Repo,
+            [AnnoKeyManagerIdentity]: 'my-repo',
+            [AnnoKeySourcePath]: 'dashboards/test.json',
+          },
+        },
+        ...meta,
+      },
+    });
+  }
+
+  it('propagates Loading status with null defaultValues', async () => {
+    server.use(
+      http.get(`${BASE}/settings`, async () => {
+        await new Promise((r) => setTimeout(r, 500));
+        return HttpResponse.json(settingsWithRepo);
+      })
+    );
+
+    const dashboard = createDashboard();
+    const { result } = renderHook(() => useProvisionedDashboardData(dashboard), {
+      wrapper: getWrapper({ renderWithRouter: true }),
+    });
+
+    expect(result.current.repoDataStatus).toBe(RepoViewStatus.Loading);
+    expect(result.current.defaultValues).toBeNull();
+    expect(result.current.readOnly).toBe(true);
+  });
+
+  it('propagates Error status with the error object', async () => {
+    server.use(http.get(`${BASE}/settings`, () => HttpResponse.json({ message: 'Forbidden' }, { status: 403 })));
+
+    const dashboard = createDashboard();
+    const { result } = renderHook(() => useProvisionedDashboardData(dashboard), {
+      wrapper: getWrapper({ renderWithRouter: true }),
+    });
+
+    await waitFor(() => expect(result.current.repoDataStatus).toBe(RepoViewStatus.Error));
+    expect(result.current.defaultValues).toBeNull();
+    expect(result.current.error).toBeDefined();
+  });
+
+  it('returns Ready with populated defaultValues when resolved', async () => {
+    server.use(
+      http.get(`${BASE}/settings`, () => HttpResponse.json(settingsWithRepo)),
+      http.get(`${FOLDER_BASE}/folders/:name`, () => HttpResponse.json(folderResponse))
+    );
+
+    const dashboard = createDashboard();
+    const { result } = renderHook(() => useProvisionedDashboardData(dashboard), {
+      wrapper: getWrapper({ renderWithRouter: true }),
+    });
+
+    await waitFor(() => expect(result.current.repoDataStatus).toBe(RepoViewStatus.Ready));
+    expect(result.current.defaultValues).not.toBeNull();
+    expect(result.current.defaultValues?.repo).toBe('my-repo');
+    expect(result.current.repository?.name).toBe('my-repo');
+    expect(result.current.readOnly).toBe(false);
+  });
+});

--- a/public/app/features/provisioning/hooks/useProvisionedDashboardData.test.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedDashboardData.test.ts
@@ -126,7 +126,7 @@ describe('useDefaultValues', () => {
     expect(result.current.error).toBeDefined();
   });
 
-  it('returns Ready with null values when no repository matches', async () => {
+  it('returns Error with null values when no repository matches', async () => {
     server.use(
       http.get(`${BASE}/settings`, () =>
         HttpResponse.json({

--- a/public/app/features/provisioning/hooks/useProvisionedDashboardData.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedDashboardData.ts
@@ -46,11 +46,19 @@ export function useDefaultValues({
     };
   }
 
-  if (!repository || status === RepoViewStatus.Error) {
+  if (status === RepoViewStatus.Error) {
     return {
       values: null,
       status: RepoViewStatus.Error,
       error,
+    };
+  }
+
+  if (!repository) {
+    return {
+      values: null,
+      status: RepoViewStatus.Error,
+      error: new Error('No repository found for this dashboard'),
     };
   }
 

--- a/public/app/features/provisioning/hooks/useProvisionedDashboardData.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedDashboardData.ts
@@ -1,10 +1,11 @@
-import { Dispatch, SetStateAction, useState } from 'react';
-
 import { RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
 import { useUrlParams } from 'app/core/navigation/hooks';
 import { AnnoKeyManagerIdentity, AnnoKeyManagerKind, AnnoKeySourcePath } from 'app/features/apiserver/types';
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
-import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
+import {
+  RepoViewStatus,
+  useGetResourceRepositoryView,
+} from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
 import { getIsReadOnlyRepo } from 'app/features/provisioning/utils/repository';
 import { DashboardMeta } from 'app/types/dashboard';
 
@@ -33,10 +34,25 @@ export function useDefaultValues({
   const managerKind = annotations?.[AnnoKeyManagerKind];
   const managerIdentity = annotations?.[AnnoKeyManagerIdentity];
   const sourcePath = annotations?.[AnnoKeySourcePath];
-  const { repository, folder, isLoading } = useGetResourceRepositoryView({
+  const { repository, folder, isLoading, status, error } = useGetResourceRepositoryView({
     name: managerKind === 'repo' ? managerIdentity : undefined,
     folderName: meta.folderUid,
   });
+
+  if (isLoading || status === RepoViewStatus.Loading) {
+    return {
+      values: null,
+      status: RepoViewStatus.Loading,
+    };
+  }
+
+  if (!repository || status === RepoViewStatus.Error) {
+    return {
+      values: null,
+      status: RepoViewStatus.Error,
+      error,
+    };
+  }
 
   const timestamp = generateTimestamp();
   const folderPath = folder?.metadata?.annotations?.[AnnoKeySourcePath];
@@ -49,10 +65,6 @@ export function useDefaultValues({
   });
 
   const defaultWorkflow = getDefaultWorkflow(repository, loadedFromRef);
-
-  if (isLoading || !repository) {
-    return null;
-  }
 
   return {
     values: {
@@ -71,19 +83,20 @@ export function useDefaultValues({
     },
     isNew: !meta.k8s?.name,
     repository,
+    status,
   };
 }
 
 export interface ProvisionedDashboardData {
-  isReady: boolean;
-  isLoading: boolean;
-  setIsLoading: Dispatch<SetStateAction<boolean>>;
   defaultValues: ProvisionedDashboardFormData | null;
   repository?: RepositoryView;
   loadedFromRef?: string;
-  isNew: boolean;
+  isNew?: boolean;
   readOnly: boolean;
   canPushToConfiguredBranch: boolean;
+  repoDataStatus: RepoViewStatus;
+  /* error from useGetResourceRepositoryView  */
+  error?: unknown;
 }
 
 /**
@@ -94,7 +107,6 @@ export interface ProvisionedDashboardData {
 export function useProvisionedDashboardData(dashboard: DashboardScene, saveAsCopy?: boolean): ProvisionedDashboardData {
   const { meta, title: defaultTitle, description: defaultDescription } = dashboard.useState();
   const [params] = useUrlParams();
-  const [isLoading, setIsLoading] = useState(false);
   const loadedFromRef = params.get('ref') ?? undefined;
 
   const defaultValuesResult = useDefaultValues({
@@ -105,17 +117,16 @@ export function useProvisionedDashboardData(dashboard: DashboardScene, saveAsCop
     saveAsCopy,
   });
 
-  if (!defaultValuesResult) {
+  if (defaultValuesResult.status !== RepoViewStatus.Ready) {
     return {
-      isReady: false,
-      isLoading,
       canPushToConfiguredBranch: false,
-      setIsLoading,
       defaultValues: null,
       repository: undefined,
       loadedFromRef,
       isNew: false,
       readOnly: true,
+      repoDataStatus: defaultValuesResult.status,
+      error: defaultValuesResult.error,
     };
   }
 
@@ -123,14 +134,12 @@ export function useProvisionedDashboardData(dashboard: DashboardScene, saveAsCop
   const canPushToConfiguredBranch = getCanPushToConfiguredBranch(repository);
 
   return {
-    isReady: true,
     defaultValues: values,
     repository,
     loadedFromRef,
     canPushToConfiguredBranch,
     isNew,
     readOnly: getIsReadOnlyRepo(repository),
-    isLoading,
-    setIsLoading,
+    repoDataStatus: defaultValuesResult.status,
   };
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7237,6 +7237,7 @@
       "copy-json-to-clipboard": "Copy JSON to clipboard",
       "file-path": "<strong>File path:</strong> {{filePath}}",
       "form-loading-error": "Error loading form",
+      "form-loading-error-unknown": "An unexpected error occurred while loading the form.",
       "label-description": "Description",
       "label-target-folder": "Target folder",
       "label-title": "Title",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7236,6 +7236,7 @@
       "cannot-be-saved": "This dashboard cannot be saved from the Grafana UI because it has been provisioned from another source. Copy the JSON or save it to a file below, then you can update your dashboard in the provisioning source.",
       "copy-json-to-clipboard": "Copy JSON to clipboard",
       "file-path": "<strong>File path:</strong> {{filePath}}",
+      "form-loading-error": "Error loading form",
       "label-description": "Description",
       "label-target-folder": "Target folder",
       "label-title": "Title",


### PR DESCRIPTION
**What is this feature?**

**Remove `OrgRole.None` check from:**
- `useGetResourceRepositoryView.ts` 
- `useProvisionedDashboardData.ts` 
- `useIsProvisionedInstance.ts` 
- `useGetFrontendSettingsQuery`. 

**Save form will now show error instead of blank form:**  
<img width="500" height="325" alt="image" src="https://github.com/user-attachments/assets/391ffa3f-9f2c-46b7-8c10-25ae094bcc82" />

Delete action and move action on dashboard, user will see error:  

https://github.com/user-attachments/assets/65a7ee7d-0b19-4c36-ad54-d2e1b63d727b




**Why do we need this feature?**

Remove FE guards on role that duplicate with BE auth, this is fragile and they can drift. Now we just let the query run and let server returns error 

**Who is this feature for?**

Git sync users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/983

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
