### PR TITLE
Suggestions: Aggregate for max stats rows

### DIFF
--- a/public/app/plugins/panel/stat/suggestions.test.ts
+++ b/public/app/plugins/panel/stat/suggestions.test.ts
@@ -102,6 +102,18 @@ describe('State panel suggestions', () => {
         ],
       },
       {
+        description: 'tabular data with high row count',
+        aggregated: true,
+        dataframes: [
+          createDataFrame({
+            fields: [
+              { name: 'name', type: FieldType.string, values: Array.from({ length: 51 }, (_, i) => `item_${i}`) },
+              { name: 'value', type: FieldType.number, values: Array.from({ length: 51 }, (_, i) => i * 10) },
+            ],
+          }),
+        ],
+      },
+      {
         description: 'multiple frames with tabular data',
         aggregated: true,
         dataframes: [

--- a/public/app/plugins/panel/stat/suggestions.ts
+++ b/public/app/plugins/panel/stat/suggestions.ts
@@ -78,7 +78,7 @@ export const statSuggestionsSupplier: VisualizationSuggestionsSupplier<Options> 
     );
   } else if (ds.hasFieldType(FieldType.string) && ds.hasFieldType(FieldType.number) && ds.frameCount === 1) {
     if (ds.rowCountTotal > MAX_STATS) {
-      // High row count — suggest aggregated stat instead of one card per row
+      // High row count — suggest aggregated stat
       suggestions.push(
         {
           name: t('stat.suggestions.stat', 'Stat'),
@@ -116,7 +116,10 @@ export const statSuggestionsSupplier: VisualizationSuggestionsSupplier<Options> 
           },
         },
         {
-          name: t('stat.suggestions.stat-discrete-values-color-background', 'Stat - discrete values - color background'),
+          name: t(
+            'stat.suggestions.stat-discrete-values-color-background',
+            'Stat - discrete values - color background'
+          ),
           options: {
             reduceOptions: {
               values: true,

--- a/public/app/plugins/panel/stat/suggestions.ts
+++ b/public/app/plugins/panel/stat/suggestions.ts
@@ -78,34 +78,56 @@ export const statSuggestionsSupplier: VisualizationSuggestionsSupplier<Options> 
     );
   } else if (ds.hasFieldType(FieldType.string) && ds.hasFieldType(FieldType.number) && ds.frameCount === 1) {
     if (ds.rowCountTotal > MAX_STATS) {
-      return;
+      // High row count — suggest aggregated stat instead of one card per row
+      suggestions.push(
+        {
+          name: t('stat.suggestions.stat', 'Stat'),
+          options: {
+            reduceOptions: {
+              values: false,
+              calcs: ['lastNotNull'],
+            },
+          },
+        },
+        {
+          name: t('stat.suggestions.stat-color-background', 'Stat - color background'),
+          options: {
+            reduceOptions: {
+              values: false,
+              calcs: ['lastNotNull'],
+            },
+            graphMode: BigValueGraphMode.None,
+            colorMode: BigValueColorMode.Background,
+          },
+        }
+      );
+    } else {
+      // String and number field with low row count — show individual rows
+      shouldUseRawValues = true;
+      suggestions.push(
+        {
+          name: t('stat.suggestions.stat-discrete-values', 'Stat - discrete values'),
+          options: {
+            reduceOptions: {
+              values: true,
+              calcs: [],
+              fields: '/.*/',
+            },
+          },
+        },
+        {
+          name: t('stat.suggestions.stat-discrete-values-color-background', 'Stat - discrete values - color background'),
+          options: {
+            reduceOptions: {
+              values: true,
+              calcs: [],
+              fields: '/.*/',
+            },
+            colorMode: BigValueColorMode.Background,
+          },
+        }
+      );
     }
-
-    // String and number field with low row count show individual rows
-    shouldUseRawValues = true;
-    suggestions.push(
-      {
-        name: t('stat.suggestions.stat-discrete-values', 'Stat - discrete values'),
-        options: {
-          reduceOptions: {
-            values: true,
-            calcs: [],
-            fields: '/.*/',
-          },
-        },
-      },
-      {
-        name: t('stat.suggestions.stat-discrete-values-color-background', 'Stat - discrete values - color background'),
-        options: {
-          reduceOptions: {
-            values: true,
-            calcs: [],
-            fields: '/.*/',
-          },
-          colorMode: BigValueColorMode.Background,
-        },
-      }
-    );
   }
 
   return suggestions.map((s) => defaultNumericVizOptions(withDefaults(s), ds, shouldUseRawValues));


### PR DESCRIPTION
For tabular data with rows > MAX_STATS, stat suggestion was empty. This previews an aggregate (last non-null) single stat instead.

Before (stat not shown as an option):
<img width="326" height="704" alt="image" src="https://github.com/user-attachments/assets/ea38b12c-53d4-426f-91fa-c235a5065661" />

After:
<img width="357" height="584" alt="image" src="https://github.com/user-attachments/assets/38c31d8d-19f5-4519-b1b3-823308d273f0" />


Closes https://github.com/grafana/grafana/issues/120102