### PR TITLE
Provisioning: fix HTML entity encoding in connection selector repo names

### DIFF
--- a/public/app/features/provisioning/hooks/useConnectionOptions.ts
+++ b/public/app/features/provisioning/hooks/useConnectionOptions.ts
@@ -83,6 +83,7 @@ export function useConnectionOptions(enabled: boolean) {
             ? t('provisioning.connection-options.repos-truncated', '{{shown}} +{{count}} more', {
                 shown,
                 count: remaining,
+                interpolation: { escapeValue: false },
               })
             : shown;
         descriptionParts.push(repoText);


### PR DESCRIPTION
## What

Fixes repository names in the GitHub App connection dropdown showing raw HTML entities (`&#x2F;`) instead of `/` during repository creation.

**Before:**
> Internal Dogfooding app · grafana`&#x2F;`grafana-play, grafana`&#x2F;`git-ui-sync-demo +1 more
<img width="1186" height="198" alt="Screenshot 2026-03-12 at 16 28 38" src="https://github.com/user-attachments/assets/59d25cce-6a97-44a2-af14-de7d4e12aab5" />


**After:**
> Internal Dogfooding app · grafana/grafana-play, grafana/git-ui-sync-demo +1 more

<img width="1327" height="293" alt="Screenshot 2026-03-13 at 09 12 21" src="https://github.com/user-attachments/assets/22f39703-c4bf-43b9-9431-2505a7ff61e3" />


## Why

i18next HTML-escapes all interpolated values by default. Its escape function converts `/` → `&#x2F;` (among other characters). When the connection dropdown builds the truncated repo list (3+ repos), the joined repo names pass through `t()` interpolation and get escaped. Since the result is rendered as React text content — not `dangerouslySetInnerHTML` — the escaped entities appear literally instead of being decoded.

The non-truncated path (≤2 repos) returns the string directly without `t()`, so it was unaffected.

## How

Pass `interpolation: { escapeValue: false }` to the `t()` call in `useConnectionOptions`. This is safe because React's JSX text rendering already auto-escapes output, making the i18next escaping redundant here.

## Test plan
- [ ] Open the repository creation wizard
- [ ] Select a GitHub App connection that has 3+ accessible repositories
- [ ] Verify the dropdown description shows `owner/repo` with normal slashes, not `owner&#x2F;repo`
- [ ] Verify connections with ≤2 repos still display correctly