### PR TITLE
Dashboards: Recognise links in variable description

### DIFF
--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -177,7 +177,10 @@ function VariableLabel({
   const controlsLayout = layout ?? 'horizontal';
   const descriptionSuffix =
     state.description != null && state.description !== '' ? (
-      <VariableDescriptionTooltip description={state.description} placement={controlsLayout === 'vertical' ? 'top' : 'bottom'} />
+      <VariableDescriptionTooltip
+        description={state.description}
+        placement={controlsLayout === 'vertical' ? 'top' : 'bottom'}
+      />
     ) : undefined;
 
   return (

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -16,6 +16,7 @@ import { useElementSelection, useStyles2 } from '@grafana/ui';
 
 import { DashboardScene } from './DashboardScene';
 import { AddVariableButton } from './VariableControlsAddButton';
+import { VariableDescriptionTooltip } from './VariableDescriptionTooltip';
 
 export function VariableControls({ dashboard }: { dashboard: DashboardScene }) {
   const { variables } = sceneGraph.getVariables(dashboard)!.useState();
@@ -173,6 +174,11 @@ function VariableLabel({
   }
 
   const labelOrName = state.label || state.name;
+  const controlsLayout = layout ?? 'horizontal';
+  const descriptionSuffix =
+    state.description != null && state.description !== '' ? (
+      <VariableDescriptionTooltip description={state.description} placement={controlsLayout === 'vertical' ? 'top' : 'bottom'} />
+    ) : undefined;
 
   return (
     <ControlsLabel
@@ -181,8 +187,9 @@ function VariableLabel({
       onCancel={() => variable.onCancel?.()}
       label={labelOrName}
       error={state.error}
-      layout={layout ?? 'horizontal'}
-      description={state.description ?? undefined}
+      layout={controlsLayout}
+      description={undefined}
+      suffix={descriptionSuffix}
       className={className}
     />
   );

--- a/public/app/features/dashboard-scene/scene/VariableDescriptionTooltip.test.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableDescriptionTooltip.test.tsx
@@ -4,6 +4,14 @@ import { Tooltip } from '@grafana/ui';
 
 import { VariableDescriptionTooltip } from './VariableDescriptionTooltip';
 
+function renderTooltipContent(content: React.ComponentProps<typeof Tooltip>['content']): React.ReactNode {
+  if (typeof content === 'function') {
+    return content({});
+  }
+
+  return content;
+}
+
 jest.mock('@grafana/ui', () => {
   const actual = jest.requireActual('@grafana/ui');
 
@@ -11,7 +19,7 @@ jest.mock('@grafana/ui', () => {
     ...actual,
     Tooltip: ({ content, children, interactive, placement }: React.ComponentProps<typeof Tooltip>) => (
       <div data-testid="mock-tooltip" data-interactive={interactive ? 'true' : 'false'} data-placement={placement}>
-        <div data-testid="mock-tooltip-content">{content}</div>
+        <div data-testid="mock-tooltip-content">{renderTooltipContent(content)}</div>
         {children}
       </div>
     ),

--- a/public/app/features/dashboard-scene/scene/VariableDescriptionTooltip.test.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableDescriptionTooltip.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+
+import { Tooltip } from '@grafana/ui';
+
+import { VariableDescriptionTooltip } from './VariableDescriptionTooltip';
+
+jest.mock('@grafana/ui', () => {
+  const actual = jest.requireActual('@grafana/ui');
+
+  return {
+    ...actual,
+    Tooltip: ({ content, children, interactive, placement }: React.ComponentProps<typeof Tooltip>) => (
+      <div data-testid="mock-tooltip" data-interactive={interactive ? 'true' : 'false'} data-placement={placement}>
+        <div data-testid="mock-tooltip-content">{content}</div>
+        {children}
+      </div>
+    ),
+  };
+});
+
+describe('VariableDescriptionTooltip', () => {
+  it('renders markdown links as external links', () => {
+    render(<VariableDescriptionTooltip description={'Read [docs](https://grafana.com/docs).'} placement="bottom" />);
+
+    const link = screen.getByRole('link', { name: 'docs' });
+    expect(link).toHaveAttribute('href', 'https://grafana.com/docs');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders bare links as external links', () => {
+    render(<VariableDescriptionTooltip description={'Details: https://example.com/path?q=1.'} placement="bottom" />);
+
+    const link = screen.getByRole('link', { name: 'https://example.com/path?q=1' });
+    expect(link).toHaveAttribute('href', 'https://example.com/path?q=1');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('does not render unsafe links', () => {
+    render(<VariableDescriptionTooltip description={'Do not click [this](javascript:alert(1))'} placement="bottom" />);
+
+    expect(screen.queryByRole('link', { name: 'this' })).not.toBeInTheDocument();
+    expect(screen.getByText(/this/)).toBeInTheDocument();
+  });
+
+  it('uses an interactive tooltip', () => {
+    render(<VariableDescriptionTooltip description={'Read [docs](https://grafana.com/docs).'} placement="top" />);
+
+    expect(screen.getByTestId('mock-tooltip')).toHaveAttribute('data-interactive', 'true');
+  });
+});

--- a/public/app/features/dashboard-scene/scene/VariableDescriptionTooltip.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableDescriptionTooltip.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { sanitizeUrl } from '@grafana/data/internal';
+import { t } from '@grafana/i18n';
 import { Icon, Tooltip, useStyles2 } from '@grafana/ui';
 
 const MARKDOWN_LINK_REGEX = /\[([^\]]+)\]\(([^)\s]+)\)/g;
@@ -23,7 +24,7 @@ export function VariableDescriptionTooltip({ description, placement }: VariableD
       placement={placement}
       interactive
     >
-      <Icon name="info-circle" size="sm" className={styles.icon} />
+      <Icon name="info-circle" size="sm" className={styles.icon} aria-label={t('dashboard.variable.description-tooltip', 'Variable description')} />
     </Tooltip>
   );
 }

--- a/public/app/features/dashboard-scene/scene/VariableDescriptionTooltip.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableDescriptionTooltip.tsx
@@ -24,7 +24,12 @@ export function VariableDescriptionTooltip({ description, placement }: VariableD
       placement={placement}
       interactive
     >
-      <Icon name="info-circle" size="sm" className={styles.icon} aria-label={t('dashboard.variable.description-tooltip', 'Variable description')} />
+      <Icon
+        name="info-circle"
+        size="sm"
+        className={styles.icon}
+        aria-label={t('dashboard.variable.description-tooltip', 'Variable description')}
+      />
     </Tooltip>
   );
 }

--- a/public/app/features/dashboard-scene/scene/VariableDescriptionTooltip.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableDescriptionTooltip.tsx
@@ -88,7 +88,12 @@ function appendTextWithBareLinks(
   }
 }
 
-function renderExternalLinkOrText(label: string, url: string, linkClassName: string, key: number): string | JSX.Element {
+function renderExternalLinkOrText(
+  label: string,
+  url: string,
+  linkClassName: string,
+  key: number
+): string | JSX.Element {
   const safeUrl = getSafeExternalUrl(url);
 
   if (!safeUrl) {

--- a/public/app/features/dashboard-scene/scene/VariableDescriptionTooltip.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableDescriptionTooltip.tsx
@@ -1,0 +1,134 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { sanitizeUrl } from '@grafana/data/internal';
+import { Icon, Tooltip, useStyles2 } from '@grafana/ui';
+
+const MARKDOWN_LINK_REGEX = /\[([^\]]+)\]\(([^)\s]+)\)/g;
+const BARE_LINK_REGEX = /https?:\/\/[^\s<>()]+/gi;
+const TRAILING_PUNCTUATION_REGEX = /[),.;!?]+$/;
+const SAFE_PROTOCOL_REGEX = /^https?:\/\//i;
+
+interface VariableDescriptionTooltipProps {
+  description: string;
+  placement: 'top' | 'bottom';
+}
+
+export function VariableDescriptionTooltip({ description, placement }: VariableDescriptionTooltipProps) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Tooltip
+      content={<div className={styles.tooltipContent}>{renderDescriptionWithLinks(description, styles.link)}</div>}
+      placement={placement}
+      interactive
+    >
+      <Icon name="info-circle" size="sm" className={styles.icon} />
+    </Tooltip>
+  );
+}
+
+function renderDescriptionWithLinks(description: string, linkClassName: string) {
+  const elements: Array<string | JSX.Element> = [];
+  let nextKey = 0;
+  let cursor = 0;
+
+  MARKDOWN_LINK_REGEX.lastIndex = 0;
+
+  for (const match of description.matchAll(MARKDOWN_LINK_REGEX)) {
+    const matchStart = match.index ?? 0;
+
+    if (matchStart > cursor) {
+      appendTextWithBareLinks(elements, description.slice(cursor, matchStart), linkClassName, () => nextKey++);
+    }
+
+    const label = match[1];
+    const url = match[2];
+    elements.push(renderExternalLinkOrText(label, url, linkClassName, nextKey++));
+    cursor = matchStart + match[0].length;
+  }
+
+  if (cursor < description.length) {
+    appendTextWithBareLinks(elements, description.slice(cursor), linkClassName, () => nextKey++);
+  }
+
+  return elements;
+}
+
+function appendTextWithBareLinks(
+  elements: Array<string | JSX.Element>,
+  text: string,
+  linkClassName: string,
+  getNextKey: () => number
+) {
+  BARE_LINK_REGEX.lastIndex = 0;
+  let cursor = 0;
+
+  for (const match of text.matchAll(BARE_LINK_REGEX)) {
+    const matchStart = match.index ?? 0;
+    if (matchStart > cursor) {
+      elements.push(text.slice(cursor, matchStart));
+    }
+
+    const rawMatch = match[0];
+    const trimmedUrl = rawMatch.replace(TRAILING_PUNCTUATION_REGEX, '');
+    const trailingText = rawMatch.slice(trimmedUrl.length);
+
+    elements.push(renderExternalLinkOrText(trimmedUrl, trimmedUrl, linkClassName, getNextKey()));
+
+    if (trailingText) {
+      elements.push(trailingText);
+    }
+
+    cursor = matchStart + rawMatch.length;
+  }
+
+  if (cursor < text.length) {
+    elements.push(text.slice(cursor));
+  }
+}
+
+function renderExternalLinkOrText(label: string, url: string, linkClassName: string, key: number): string | JSX.Element {
+  const safeUrl = getSafeExternalUrl(url);
+
+  if (!safeUrl) {
+    return label;
+  }
+
+  return (
+    <a key={key} href={safeUrl} target="_blank" rel="noopener noreferrer" className={linkClassName}>
+      {label}
+    </a>
+  );
+}
+
+function getSafeExternalUrl(url: string): string | undefined {
+  const trimmedUrl = url.trim();
+
+  if (!SAFE_PROTOCOL_REGEX.test(trimmedUrl)) {
+    return undefined;
+  }
+
+  const sanitizedUrl = sanitizeUrl(trimmedUrl);
+
+  if (sanitizedUrl === '' || sanitizedUrl === 'about:blank') {
+    return undefined;
+  }
+
+  return sanitizedUrl;
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  icon: css({
+    color: theme.colors.text.secondary,
+  }),
+  tooltipContent: css({
+    maxWidth: theme.spacing(40),
+    whiteSpace: 'normal',
+    wordBreak: 'break-word',
+  }),
+  link: css({
+    color: theme.colors.primary.text,
+    textDecoration: 'underline',
+  }),
+});

--- a/public/app/features/dashboard-scene/utils/dashboardControls.test.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardControls.test.ts
@@ -230,6 +230,39 @@ describe('dashboardControls', () => {
       expect(result.defaultLinks).toEqual([]);
     });
 
+    it('should preserve default variable descriptions from datasources', async () => {
+      const refs: DataSourceRef[] = [{ uid: 'ds-1', type: 'prometheus' }];
+      const describedVariable: QueryVariableKind = {
+        ...mockVariable1,
+        spec: {
+          ...mockVariable1.spec,
+          description: 'Read docs at https://grafana.com/docs',
+        },
+      };
+
+      const mockDs = createMockDatasource({
+        uid: 'ds-1',
+        type: 'prometheus',
+        getDefaultVariables: () => Promise.resolve([describedVariable]),
+        getDefaultLinks: undefined,
+        getRef: jest.fn(() => ({ uid: 'ds-1', type: 'prometheus' })),
+      });
+
+      const mockSrv = createMockDataSourceSrv({
+        get: jest.fn(() => Promise.resolve(mockDs as DataSourceApi<DataQuery, DataSourceJsonData>)),
+      });
+
+      getDataSourceSrvMock.mockReturnValue(mockSrv);
+
+      const result = await loadDefaultControlsFromDatasources(refs);
+
+      expect(result.defaultVariables[0]).toMatchObject({
+        spec: {
+          description: 'Read docs at https://grafana.com/docs',
+        },
+      });
+    });
+
     it('should collect default links from datasources', async () => {
       const refs: DataSourceRef[] = [{ uid: 'ds-1', type: 'prometheus' }];
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6330,6 +6330,7 @@
       "description": {
         "action": "Change variable description"
       },
+      "description-tooltip": "Variable description",
       "hide": {
         "action": "Change variable hide option"
       },


### PR DESCRIPTION
**Related issue:** https://github.com/grafana/hyperion-planning/issues/546


https://github.com/user-attachments/assets/24997d57-6798-4304-9cee-47cafcee8ad8



### What is this feature?
Adds link-aware variable descriptions in variables by showing an info tooltip that renders safe external links from markdown (`[text](url)`) and bare URLs.

### Why do we need this feature?
There can be cases when a certain variable warrants a longer description which cannot be fit in the tooltip.

Please check that:
- [x] Links in variable descriptions open correctly and unsafe URLs are not rendered as links.
- [x] Existing variable description text from datasource defaults is preserved.
- [ ] Docs/What's New updates are needed (if applicable).