### PR TITLE
Rendering: Prevent reload of dashboard when query changes

### DIFF
--- a/public/app/features/dashboard-scene/solo/SoloPanelPage.test.tsx
+++ b/public/app/features/dashboard-scene/solo/SoloPanelPage.test.tsx
@@ -7,7 +7,7 @@ import { getDashboardScenePageStateManager } from '../pages/DashboardScenePageSt
 import { DashboardScene } from '../scene/DashboardScene';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 
-import { SoloPanelRenderer } from './SoloPanelPage';
+import { SoloPanelPage, SoloPanelRenderer, Props } from './SoloPanelPage';
 
 // Mock dependencies
 jest.mock('react-router-dom-v5-compat', () => ({
@@ -82,6 +82,57 @@ describe('SoloPanelPage', () => {
     jest.clearAllMocks();
     (getDashboardScenePageStateManager as jest.Mock).mockReturnValue(mockStateManager);
     (useParams as jest.Mock).mockReturnValue({ uid: 'test-uid', type: undefined, slug: undefined });
+  });
+
+  describe('reload behavior', () => {
+    function renderSoloPanelPage(queryParams: Props['queryParams']) {
+      // SoloPanelPage only destructures queryParams from props; route and location are unused
+      return render(
+        <SoloPanelPage queryParams={queryParams} route={{} as Props['route']} location={{} as Props['location']} />
+      );
+    }
+
+    it('should not re-call loadDashboard when queryParams change', () => {
+      const { rerender, unmount } = renderSoloPanelPage({ panelId: '1' });
+
+      expect(mockStateManager.loadDashboard).toHaveBeenCalledTimes(1);
+
+      rerender(
+        <SoloPanelPage
+          // @ts-ignore
+          queryParams={{ panelId: '1', 'var-foo': 'bar' }}
+          route={{} as Props['route']}
+          location={{} as Props['location']}
+        />
+      );
+      expect(mockStateManager.loadDashboard).toHaveBeenCalledTimes(1);
+      expect(mockStateManager.clearState).not.toHaveBeenCalled();
+
+      unmount();
+      expect(mockStateManager.clearState).toHaveBeenCalledTimes(1);
+    });
+
+    it('should re-call loadDashboard when uid changes', () => {
+      const { rerender, unmount } = renderSoloPanelPage({ panelId: '1' });
+      expect(mockStateManager.loadDashboard).toHaveBeenCalledTimes(1);
+
+      (useParams as jest.Mock).mockReturnValue({ uid: 'other-uid', type: undefined, slug: undefined });
+      rerender(
+        <SoloPanelPage queryParams={{ panelId: '1' }} route={{} as Props['route']} location={{} as Props['location']} />
+      );
+
+      expect(mockStateManager.clearState).toHaveBeenCalledTimes(1);
+      expect(mockStateManager.loadDashboard).toHaveBeenCalledTimes(2);
+      expect(mockStateManager.loadDashboard).toHaveBeenNthCalledWith(2, {
+        uid: 'other-uid',
+        type: undefined,
+        slug: undefined,
+        route: 'embedded-dashboard',
+      });
+
+      unmount();
+      expect(mockStateManager.clearState).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('SoloPanelRenderer', () => {

--- a/public/app/features/dashboard-scene/solo/SoloPanelPage.tsx
+++ b/public/app/features/dashboard-scene/solo/SoloPanelPage.tsx
@@ -33,7 +33,7 @@ export function SoloPanelPage({ queryParams }: Props) {
   useEffect(() => {
     stateManager.loadDashboard({ uid, type, slug, route: DashboardRoutes.Embedded });
     return () => stateManager.clearState();
-  }, [stateManager, queryParams, uid, type, slug]);
+  }, [stateManager, uid, type, slug]);
 
   if (!queryParams.panelId) {
     return <EntityNotFound entity="Panel" />;


### PR DESCRIPTION
Attempts to fix a `d-solo` reload loop in Scenes when the URL is updated during variable sync by removing the `queryParams` from the `useEffect`.

This copies the behavior present in `public/app/features/dashboard-scene/pages/DashboardScenePage.tsx` , which also uses `updateUrlOnInit={true}`: https://github.com/grafana/grafana/blob/main/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx#L45-L71

