### PR TITLE
make: build-go: add trimpath for non-dev, and debug-friendly flags for dev

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,7 +1,7 @@
 [build]
 bin = "./bin/grafana-air"
 args_bin = ["server", "-profile", "-profile-addr=127.0.0.1", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
-cmd = "make CGO_ENABLED=0 GO_BUILD_GCFLAGS='all=-N -l' SOURCE_DATE_EPOCH=1767222000 GO_BUILD_DEV=1 build-air"
+cmd = "make CGO_ENABLED=0 SOURCE_DATE_EPOCH=1767222000 GO_BUILD_DEV=1 build-air"
 exclude_regex = ["_test.go", "_gen.go"]
 exclude_unchanged = true
 follow_symlink = true

--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,7 @@ update-workspace: gen-go
 .PHONY: build-go
 build-go: gen-themes ## Build all Go binaries (grafana, grafana-server, grafana-cli).
 	@echo "build go binaries"
-	$(if $(CGO_ENABLED),CGO_ENABLED=$(CGO_ENABLED)) $(if $(GO_BUILD_OS),GOOS=$(GO_BUILD_OS)) $(if $(GO_BUILD_ARCH),GOARCH=$(GO_BUILD_ARCH)) $(GO) build -buildvcs=false -trimpath $(GO_RACE_FLAG) $(if $(GO_BUILD_TAGS),-tags $(GO_BUILD_TAGS)) $(if $(GO_BUILD_GCFLAGS),-gcflags "$(GO_BUILD_GCFLAGS)") -ldflags "$(GO_LDFLAGS)" -o ./bin/grafana ./pkg/cmd/grafana
+	$(if $(CGO_ENABLED),CGO_ENABLED=$(CGO_ENABLED)) $(if $(GO_BUILD_OS),GOOS=$(GO_BUILD_OS)) $(if $(GO_BUILD_ARCH),GOARCH=$(GO_BUILD_ARCH)) $(GO) build -buildvcs=false $(if $(GO_BUILD_DEV),-gcflags "all=-N -l",-trimpath) $(GO_RACE_FLAG) $(if $(GO_BUILD_TAGS),-tags $(GO_BUILD_TAGS)) $(if $(GO_BUILD_GCFLAGS),-gcflags "$(GO_BUILD_GCFLAGS)") -ldflags "$(GO_LDFLAGS)" -o ./bin/grafana ./pkg/cmd/grafana
 
 .PHONY: build-backend
 build-backend: build-go


### PR DESCRIPTION
currently `make build-go` always adds `-trimpath`. this is bad for debugging.

the PR changes two things:
1. when `GO_BUILD_DEV` is disabled, it adds `-trimpath`
2. when `GO_BUILD_DEV` is enabled, it adds `-gcflags "all=-N -l"` (needed for debugging).

(i also adjusted `.air.toml`, as the debug-gcflags now happen automatically based on `GO_BUILD_DEV`)

`all=-N -l` was added in the past in https://github.com/grafana/grafana/pull/101779, but as code got refactored, the settings did not survive.

there are a couple weaknesses with this approach:
1. it relies on `GO_BUILD_DEV`, which seems to be basically unused now
2. if someone were to use both `GO_BUILD_DEV` and `GO_BUILD_GCFLAGS`, the second would override the first
3. 