### PR TITLE
add redirect for resource endpoints

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -349,6 +349,11 @@ export interface FeatureToggles {
   */
   datasourcesApiServerEnableResourceEndpoint?: boolean;
   /**
+  * redirect datasource resource requests from the legacy API routes to the new datasource api group endpoints.
+  * @default false
+  */
+  datasourcesApiServerEnableResourceEndpointAPIRedirect?: boolean;
+  /**
   * Send Datsource resource requests to K8s /apis/ API routes instead of the legacy /api/datasources/uid/{uid}/resources/{path} routes.
   * @default false
   */

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -352,12 +352,7 @@ export interface FeatureToggles {
   * redirect datasource resource requests from the legacy API routes to the new datasource api group endpoints.
   * @default false
   */
-  datasourcesApiServerEnableResourceEndpointAPIRedirect?: boolean;
-  /**
-  * Send Datsource resource requests to K8s /apis/ API routes instead of the legacy /api/datasources/uid/{uid}/resources/{path} routes.
-  * @default false
-  */
-  datasourcesApiServerEnableResourceEndpointFrontend?: boolean;
+  datasourcesApiserverEnableResourceEndpointRedirect?: boolean;
   /**
   * Runs CloudWatch metrics queries as separate batches
   * @default false

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -423,8 +423,8 @@ func (hs *HTTPServer) registerRoutes() {
 			datasourceRoute.Get("/uid/:uid", authorize(ac.EvalPermission(datasources.ActionRead, uidScope)), hs.getK8sDataSourceByUIDHandler())
 
 			datasourceRoute.Any("/uid/:uid/health", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), routing.Wrap(hs.CheckDatasourceHealthWithUID))
-			datasourceRoute.Any("/uid/:uid/resources", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), hs.CallDatasourceResourceWithUID)
-			datasourceRoute.Any("/uid/:uid/resources/*", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), hs.CallDatasourceResourceWithUID)
+			datasourceRoute.Any("/uid/:uid/resources", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), hs.callK8sDataSourceResourceHandler())
+			datasourceRoute.Any("/uid/:uid/resources/*", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), hs.callK8sDataSourceResourceHandler())
 			datasourceRoute.Any("/proxy/uid/:uid", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), hs.ProxyDataSourceRequestWithUID)
 			datasourceRoute.Any("/proxy/uid/:uid/*", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), hs.ProxyDataSourceRequestWithUID)
 

--- a/pkg/api/datasources_k8s.go
+++ b/pkg/api/datasources_k8s.go
@@ -21,6 +21,7 @@ import (
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -118,6 +119,62 @@ func (hs *HTTPServer) getK8sDataSource(c *contextmodel.ReqContext, group, versio
 	}
 
 	return &ds, nil
+}
+
+// callK8sDataSourceResourceHandler returns a handler that proxies
+// /api/datasources/uid/:uid/resources/* to
+// /apis/<plugin-type>.datasource.grafana.app/v0alpha1/namespaces/<org>/datasources/{uid}/resource/*
+// when the feature toggle is enabled.
+func (hs *HTTPServer) callK8sDataSourceResourceHandler() web.Handler {
+	if !hs.Features.IsEnabledGlobally(featuremgmt.FlagDatasourcesApiServerEnableResourceEndpointAPIRedirect) {
+		return hs.CallDatasourceResourceWithUID
+	}
+
+	return func(c *contextmodel.ReqContext) {
+		start := time.Now()
+		defer func() {
+			metricutil.ObserveWithExemplar(c.Req.Context(), hs.dsConfigHandlerRequestsDuration.WithLabelValues("callK8sDataSourceResourceHandler"), time.Since(start).Seconds())
+		}()
+
+		dsUID := web.Params(c.Req)[":uid"]
+		if !util.IsValidShortUID(dsUID) {
+			c.JsonApiErr(http.StatusBadRequest, "UID is invalid", nil)
+			return
+		}
+
+		conns, err := hs.dsConnectionClient.GetConnectionByUID(c, dsUID) //nolint:staticcheck
+		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				c.JsonApiErr(http.StatusNotFound, "Data source not found", nil)
+				return
+			}
+			c.JsonApiErr(http.StatusInternalServerError, "Failed to lookup datasource connection", err)
+			return
+		}
+
+		if len(conns.Items) > 1 {
+			c.JsonApiErr(http.StatusConflict, "duplicate datasource connections found with this name", nil)
+			return
+		}
+
+		if len(conns.Items) == 0 {
+			c.JsonApiErr(http.StatusNotFound, "Data source not found", nil)
+			return
+		}
+
+		conn := conns.Items[0]
+		namespace := hs.namespacer(c.GetOrgID())
+		subPath := web.Params(c.Req)["*"]
+
+		k8sPath := fmt.Sprintf("/apis/%s/%s/namespaces/%s/datasources/%s/resources",
+			conn.APIGroup, conn.APIVersion, namespace, conn.Name)
+		if subPath != "" {
+			k8sPath += "/" + subPath
+		}
+
+		c.Req.URL.Path = k8sPath
+		hs.clientConfigProvider.DirectlyServeHTTP(c.Resp, c.Req)
+	}
 }
 
 // handleK8sError converts K8s API errors to HTTP responses

--- a/pkg/api/datasources_k8s.go
+++ b/pkg/api/datasources_k8s.go
@@ -136,14 +136,14 @@ func (hs *HTTPServer) callK8sDataSourceResourceHandler() web.Handler {
 			metricutil.ObserveWithExemplar(ctx, hs.dsConfigHandlerRequestsDuration.WithLabelValues("callK8sDataSourceResourceHandler"), time.Since(start).Seconds())
 		}()
 
-		redirect := openfeature.NewDefaultClient().Boolean(
+		shouldRedirect := openfeature.NewDefaultClient().Boolean(
 			ctx,
 			featuremgmt.FlagDatasourcesApiserverEnableResourceEndpointRedirect,
 			false,
 			openfeature.TransactionContext(ctx),
 		)
 
-		if !redirect {
+		if !shouldRedirect {
 			hs.dsEndpointRedirects.WithLabelValues("resources", "unknown", "legacy").Inc()
 			hs.CallDatasourceResourceWithUID(c)
 			return
@@ -155,7 +155,7 @@ func (hs *HTTPServer) callK8sDataSourceResourceHandler() web.Handler {
 			return
 		}
 
-		conns, err := hs.dsConnectionClient.GetConnectionByUID(c, dsUID) //nolint:staticcheck
+		conns, err := hs.dsConnectionClient.GetConnectionByUID(c, dsUID)
 		if err != nil {
 			if strings.Contains(err.Error(), "not found") {
 				c.JsonApiErr(http.StatusNotFound, "Data source not found", nil)

--- a/pkg/api/datasources_k8s.go
+++ b/pkg/api/datasources_k8s.go
@@ -124,7 +124,7 @@ func (hs *HTTPServer) getK8sDataSource(c *contextmodel.ReqContext, group, versio
 
 // callK8sDataSourceResourceHandler returns a handler that proxies
 // /api/datasources/uid/:uid/resources/* to
-// /apis/<plugin-type>.datasource.grafana.app/v0alpha1/namespaces/<org>/datasources/{uid}/resource/*
+// /apis/<plugin-type>.datasource.grafana.app/v0alpha1/namespaces/<org>/datasources/{uid}/resources/*
 // when the feature toggle is enabled.
 //
 // The feature flag is evaluated per-request via OpenFeature, allowing dynamic rollout.

--- a/pkg/api/datasources_k8s.go
+++ b/pkg/api/datasources_k8s.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/open-feature/go-sdk/openfeature"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -125,16 +126,28 @@ func (hs *HTTPServer) getK8sDataSource(c *contextmodel.ReqContext, group, versio
 // /api/datasources/uid/:uid/resources/* to
 // /apis/<plugin-type>.datasource.grafana.app/v0alpha1/namespaces/<org>/datasources/{uid}/resource/*
 // when the feature toggle is enabled.
+//
+// The feature flag is evaluated per-request via OpenFeature, allowing dynamic rollout.
 func (hs *HTTPServer) callK8sDataSourceResourceHandler() web.Handler {
-	if !hs.Features.IsEnabledGlobally(featuremgmt.FlagDatasourcesApiServerEnableResourceEndpointAPIRedirect) {
-		return hs.CallDatasourceResourceWithUID
-	}
-
 	return func(c *contextmodel.ReqContext) {
 		start := time.Now()
+		ctx := c.Req.Context()
 		defer func() {
-			metricutil.ObserveWithExemplar(c.Req.Context(), hs.dsConfigHandlerRequestsDuration.WithLabelValues("callK8sDataSourceResourceHandler"), time.Since(start).Seconds())
+			metricutil.ObserveWithExemplar(ctx, hs.dsConfigHandlerRequestsDuration.WithLabelValues("callK8sDataSourceResourceHandler"), time.Since(start).Seconds())
 		}()
+
+		redirect := openfeature.NewDefaultClient().Boolean(
+			ctx,
+			featuremgmt.FlagDatasourcesApiserverEnableResourceEndpointRedirect,
+			false,
+			openfeature.TransactionContext(ctx),
+		)
+
+		if !redirect {
+			hs.dsEndpointRedirects.WithLabelValues("resources", "unknown", "legacy").Inc()
+			hs.CallDatasourceResourceWithUID(c)
+			return
+		}
 
 		dsUID := web.Params(c.Req)[":uid"]
 		if !util.IsValidShortUID(dsUID) {
@@ -163,6 +176,9 @@ func (hs *HTTPServer) callK8sDataSourceResourceHandler() web.Handler {
 		}
 
 		conn := conns.Items[0]
+		pluginType := pluginTypeFromConnection(conn)
+		hs.dsEndpointRedirects.WithLabelValues("resources", pluginType, "remote").Inc()
+
 		namespace := hs.namespacer(c.GetOrgID())
 		subPath := web.Params(c.Req)["*"]
 
@@ -175,6 +191,18 @@ func (hs *HTTPServer) callK8sDataSourceResourceHandler() web.Handler {
 		c.Req.URL.Path = k8sPath
 		hs.clientConfigProvider.DirectlyServeHTTP(c.Resp, c.Req)
 	}
+}
+
+// pluginTypeFromConnection extracts the plugin type identifier from a DataSourceConnection.
+// Falls back to extracting from the APIGroup (e.g. "prometheus.datasource.grafana.app" -> "prometheus").
+func pluginTypeFromConnection(conn datasourceV0.DataSourceConnection) string {
+	if conn.Plugin != "" {
+		return conn.Plugin
+	}
+	if parts := strings.SplitN(conn.APIGroup, ".", 2); len(parts) > 0 {
+		return parts[0]
+	}
+	return "unknown"
 }
 
 // handleK8sError converts K8s API errors to HTTP responses

--- a/pkg/api/datasources_k8s.go
+++ b/pkg/api/datasources_k8s.go
@@ -155,7 +155,10 @@ func (hs *HTTPServer) callK8sDataSourceResourceHandler() web.Handler {
 			return
 		}
 
-		conns, err := hs.dsConnectionClient.GetConnectionByUID(c, dsUID)
+		// This uses the deprecated api on purpose because we need to get the connection details for the redirect.
+		// /api/ we only have the UID so we cannot use the new api until the client updates to /apis/ which will not use this
+		// redirect.
+		conns, err := hs.dsConnectionClient.GetConnectionByUID(c, dsUID) //nolint:staticcheck
 		if err != nil {
 			if strings.Contains(err.Error(), "not found") {
 				c.JsonApiErr(http.StatusNotFound, "Data source not found", nil)

--- a/pkg/api/datasources_k8s_test.go
+++ b/pkg/api/datasources_k8s_test.go
@@ -71,6 +71,7 @@ type mockDirectRestConfigProvider struct {
 	host             string
 	lastServedPath   string
 	lastServedMethod string
+	lastServedQuery  string
 }
 
 func (m *mockDirectRestConfigProvider) GetDirectRestConfig(c *contextmodel.ReqContext) *clientrest.Config {
@@ -83,6 +84,7 @@ func (m *mockDirectRestConfigProvider) GetDirectRestConfig(c *contextmodel.ReqCo
 func (m *mockDirectRestConfigProvider) DirectlyServeHTTP(w http.ResponseWriter, r *http.Request) {
 	m.lastServedPath = r.URL.Path
 	m.lastServedMethod = r.Method
+	m.lastServedQuery = r.URL.RawQuery
 	w.WriteHeader(http.StatusOK)
 }
 func (m *mockDirectRestConfigProvider) IsReady() bool { return true }
@@ -205,9 +207,9 @@ func TestGetK8sDataSourceByUIDHandler(t *testing.T) {
 	}
 }
 
-func newResourceTestContext(t *testing.T, method, path string, params map[string]string) (*contextmodel.ReqContext, *httptest.ResponseRecorder) {
+func newResourceTestContext(t *testing.T, method, urlPath string, params map[string]string) (*contextmodel.ReqContext, *httptest.ResponseRecorder) {
 	t.Helper()
-	req, err := http.NewRequest(method, path, nil)
+	req, err := http.NewRequest(method, urlPath, nil)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	if params != nil {
@@ -260,6 +262,7 @@ func TestCallK8sDataSourceResourceHandler(t *testing.T) {
 		name             string
 		uid              string
 		subPath          string
+		queryParams      string
 		connectionResult *queryV0.DataSourceConnectionList
 		connectionErr    error
 		expectedCode     int
@@ -305,27 +308,68 @@ func TestCallK8sDataSourceResourceHandler(t *testing.T) {
 			expectedMessage: "Data source not found",
 		},
 		{
-			name: "proxies to k8s resource endpoint with sub-path",
+			name: "proxies simple resource path",
 			uid:  "test-uid",
 			connectionResult: &queryV0.DataSourceConnectionList{
 				Items: []queryV0.DataSourceConnection{
 					{Name: "test-uid", APIGroup: "prometheus.datasource.grafana.app", APIVersion: "v0alpha1"},
 				},
 			},
-			subPath:         "some/path",
+			subPath:         "api/v1/labels",
 			expectedCode:    http.StatusOK,
-			expectedK8sPath: "/apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-uid/resources/some/path",
+			expectedK8sPath: "/apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-uid/resources/api/v1/labels",
 		},
 		{
-			name: "proxies to k8s resource endpoint without sub-path",
+			name: "preserves query params on resource path",
 			uid:  "test-uid",
 			connectionResult: &queryV0.DataSourceConnectionList{
 				Items: []queryV0.DataSourceConnection{
 					{Name: "test-uid", APIGroup: "prometheus.datasource.grafana.app", APIVersion: "v0alpha1"},
 				},
 			},
+			subPath:         "api/v1/query",
 			expectedCode:    http.StatusOK,
-			expectedK8sPath: "/apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-uid/resources",
+			expectedK8sPath: "/apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-uid/resources/api/v1/query",
+			queryParams:     "query=up&time=1234567890",
+		},
+		{
+			name: "preserves encoded query params",
+			uid:  "test-uid",
+			connectionResult: &queryV0.DataSourceConnectionList{
+				Items: []queryV0.DataSourceConnection{
+					{Name: "test-uid", APIGroup: "prometheus.datasource.grafana.app", APIVersion: "v0alpha1"},
+				},
+			},
+			subPath:         "api/v1/labels",
+			expectedCode:    http.StatusOK,
+			expectedK8sPath: "/apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-uid/resources/api/v1/labels",
+			queryParams:     "match%5B%5D=up&start=1234567890&end=1234567899",
+		},
+		{
+			name: "preserves encoded query values with special characters",
+			uid:  "test-uid",
+			connectionResult: &queryV0.DataSourceConnectionList{
+				Items: []queryV0.DataSourceConnection{
+					{Name: "test-uid", APIGroup: "prometheus.datasource.grafana.app", APIVersion: "v0alpha1"},
+				},
+			},
+			subPath:         "api/v1/query",
+			expectedCode:    http.StatusOK,
+			expectedK8sPath: "/apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-uid/resources/api/v1/query",
+			queryParams:     "query=rate%28http_requests_total%5B5m%5D%29&format=json",
+		},
+		{
+			name: "preserves multiple query params on query_range",
+			uid:  "test-uid",
+			connectionResult: &queryV0.DataSourceConnectionList{
+				Items: []queryV0.DataSourceConnection{
+					{Name: "test-uid", APIGroup: "prometheus.datasource.grafana.app", APIVersion: "v0alpha1"},
+				},
+			},
+			subPath:         "api/v1/query_range",
+			expectedCode:    http.StatusOK,
+			expectedK8sPath: "/apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-uid/resources/api/v1/query_range",
+			queryParams:     "query=up&start=1614556800&end=1614643200&step=60",
 		},
 	}
 
@@ -350,6 +394,9 @@ func TestCallK8sDataSourceResourceHandler(t *testing.T) {
 			if tt.subPath != "" {
 				urlPath += "/" + tt.subPath
 			}
+			if tt.queryParams != "" {
+				urlPath += "?" + tt.queryParams
+			}
 			params := map[string]string{":uid": tt.uid, "*": tt.subPath}
 
 			ctx, recorder := newResourceTestContext(t, http.MethodGet, urlPath, params)
@@ -369,6 +416,52 @@ func TestCallK8sDataSourceResourceHandler(t *testing.T) {
 				assert.Equal(t, tt.expectedK8sPath, configProvider.lastServedPath)
 				assert.Equal(t, http.MethodGet, configProvider.lastServedMethod)
 			}
+
+			if tt.queryParams != "" {
+				assert.Equal(t, tt.queryParams, configProvider.lastServedQuery,
+					"query parameters should be preserved through the redirect")
+			}
+		})
+	}
+}
+
+func TestCallK8sDataSourceResourceHandler_PreservesHTTPMethod(t *testing.T) {
+	methods := []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch}
+
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			setupOpenFeatureFlag(t, featuremgmt.FlagDatasourcesApiserverEnableResourceEndpointRedirect, true)
+
+			configProvider := &mockDirectRestConfigProvider{
+				host:      "http://localhost",
+				transport: &mockRoundTripper{statusCode: http.StatusOK, responseBody: []byte(`{}`)},
+			}
+			hs := &HTTPServer{
+				Cfg:      setting.NewCfg(),
+				Features: featuremgmt.WithFeatures(),
+				dsConnectionClient: &mockConnectionClient{result: &queryV0.DataSourceConnectionList{
+					Items: []queryV0.DataSourceConnection{
+						{Name: "test-uid", APIGroup: "prometheus.datasource.grafana.app", APIVersion: "v0alpha1"},
+					},
+				}},
+				clientConfigProvider: configProvider,
+				namespacer:           func(int64) string { return "default" },
+			}
+			hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsEndpointRedirects = setupDsConfigHandlerMetrics()
+
+			ctx, recorder := newResourceTestContext(t, method,
+				"/api/datasources/uid/test-uid/resources/api/v1/query",
+				map[string]string{":uid": "test-uid", "*": "api/v1/query"})
+
+			handler := hs.callK8sDataSourceResourceHandler()
+			handler.(func(*contextmodel.ReqContext))(ctx)
+
+			assert.Equal(t, http.StatusOK, recorder.Code)
+			assert.Equal(t, method, configProvider.lastServedMethod,
+				"HTTP method should be preserved through the proxy")
+			assert.Equal(t,
+				"/apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-uid/resources/api/v1/query",
+				configProvider.lastServedPath)
 		})
 	}
 }

--- a/pkg/api/datasources_k8s_test.go
+++ b/pkg/api/datasources_k8s_test.go
@@ -20,6 +20,7 @@ import (
 	queryV0 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/log"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	fakeDatasources "github.com/grafana/grafana/pkg/services/datasources/fakes"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -232,21 +233,26 @@ func TestCallK8sDataSourceResourceHandler_FlagDisabled(t *testing.T) {
 		transport: &mockRoundTripper{statusCode: http.StatusOK, responseBody: []byte(`{}`)},
 	}
 	hs := &HTTPServer{
-		Cfg:                 setting.NewCfg(),
-		Features:            featuremgmt.WithFeatures(),
+		Cfg:                  setting.NewCfg(),
+		Features:             featuremgmt.WithFeatures(),
 		clientConfigProvider: configProvider,
+		DataSourceCache:      &fakeDatasources.FakeCacheService{},
 	}
 	hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsEndpointRedirects = setupDsConfigHandlerMetrics()
 
+	ctx, recorder := newResourceTestContext(t, http.MethodGet, "/api/datasources/uid/test-uid/resources", map[string]string{":uid": "test-uid", "*": ""})
 	handler := hs.callK8sDataSourceResourceHandler()
+	handler.(func(*contextmodel.ReqContext))(ctx)
 
-	// The handler is always a closure now; flag is evaluated per-request.
-	assert.IsType(t, (func(*contextmodel.ReqContext))(nil), handler,
-		"expected closure handler type")
+	// The legacy handler should have been called (returning 500 from the fake cache
+	// service since no datasources are configured), and the k8s path should be empty.
+	assert.Empty(t, configProvider.lastServedPath, "expected no k8s redirect when flag is disabled")
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
 
-	// When the flag is disabled, no redirect should occur (k8s path should not be set).
-	assert.Empty(t, configProvider.lastServedPath,
-		"expected no k8s redirect when flag is disabled")
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
+	assert.Equal(t, "Unable to load datasource meta data", body["message"],
+		"expected legacy handler error, not a k8s redirect")
 }
 
 func TestCallK8sDataSourceResourceHandler(t *testing.T) {

--- a/pkg/api/datasources_k8s_test.go
+++ b/pkg/api/datasources_k8s_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/datasource"
 	queryV0 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/log"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -35,8 +37,10 @@ var _ datasource.ConnectionClient = (*mockConnectionClient)(nil)
 
 // implements grafanaapiserver.DirectRestConfigProvider
 type mockDirectRestConfigProvider struct {
-	transport http.RoundTripper
-	host      string
+	transport        http.RoundTripper
+	host             string
+	lastServedPath   string
+	lastServedMethod string
 }
 
 func (m *mockDirectRestConfigProvider) GetDirectRestConfig(c *contextmodel.ReqContext) *clientrest.Config {
@@ -46,8 +50,12 @@ func (m *mockDirectRestConfigProvider) GetDirectRestConfig(c *contextmodel.ReqCo
 	}
 }
 
-func (m *mockDirectRestConfigProvider) DirectlyServeHTTP(w http.ResponseWriter, r *http.Request) {}
-func (m *mockDirectRestConfigProvider) IsReady() bool                                            { return true }
+func (m *mockDirectRestConfigProvider) DirectlyServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.lastServedPath = r.URL.Path
+	m.lastServedMethod = r.Method
+	w.WriteHeader(http.StatusOK)
+}
+func (m *mockDirectRestConfigProvider) IsReady() bool { return true }
 
 type mockRoundTripper struct {
 	statusCode   int
@@ -162,6 +170,158 @@ func TestGetK8sDataSourceByUIDHandler(t *testing.T) {
 				var body map[string]any
 				require.NoError(t, json.Unmarshal(sc.resp.Body.Bytes(), &body))
 				assert.Contains(t, body["message"], tt.expectedMessage)
+			}
+		})
+	}
+}
+
+func newResourceTestContext(t *testing.T, method, path string, params map[string]string) (*contextmodel.ReqContext, *httptest.ResponseRecorder) {
+	t.Helper()
+	req, err := http.NewRequest(method, path, nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	if params != nil {
+		req = web.SetURLParams(req, params)
+	}
+	recorder := httptest.NewRecorder()
+	ctx := &contextmodel.ReqContext{
+		Context: &web.Context{
+			Req:  req,
+			Resp: web.NewResponseWriter(method, recorder),
+		},
+		SignedInUser: &user.SignedInUser{OrgID: 1},
+		Logger:       log.New("test"),
+	}
+	return ctx, recorder
+}
+
+func TestCallK8sDataSourceResourceHandler_FlagDisabled(t *testing.T) {
+	hs := &HTTPServer{
+		Cfg:      setting.NewCfg(),
+		Features: featuremgmt.WithFeatures(),
+	}
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
+
+	handler := hs.callK8sDataSourceResourceHandler()
+
+	// When the flag is disabled, the factory should return the legacy handler (a method value)
+	assert.IsType(t, (func(*contextmodel.ReqContext))(nil), handler,
+		"expected legacy handler type when feature flag is disabled")
+}
+
+func TestCallK8sDataSourceResourceHandler(t *testing.T) {
+	tests := []struct {
+		name             string
+		uid              string
+		subPath          string
+		connectionResult *queryV0.DataSourceConnectionList
+		connectionErr    error
+		expectedCode     int
+		expectedMessage  string
+		expectedK8sPath  string
+	}{
+		{
+			name:            "invalid UID",
+			uid:             "!!!invalid",
+			expectedCode:    http.StatusBadRequest,
+			expectedMessage: "UID is invalid",
+		},
+		{
+			name:            "connection not found",
+			uid:             "test-uid",
+			connectionErr:   errors.New("datasource connection not found"),
+			expectedCode:    http.StatusNotFound,
+			expectedMessage: "Data source not found",
+		},
+		{
+			name:            "connection lookup error",
+			uid:             "test-uid",
+			connectionErr:   errors.New("forbidden"),
+			expectedCode:    http.StatusInternalServerError,
+			expectedMessage: "Failed to lookup datasource connection",
+		},
+		{
+			name: "duplicate connections",
+			uid:  "test-uid",
+			connectionResult: &queryV0.DataSourceConnectionList{
+				Items: []queryV0.DataSourceConnection{{Name: "a"}, {Name: "b"}},
+			},
+			expectedCode:    http.StatusConflict,
+			expectedMessage: "duplicate datasource connections found with this name",
+		},
+		{
+			name: "empty connections",
+			uid:  "test-uid",
+			connectionResult: &queryV0.DataSourceConnectionList{
+				Items: []queryV0.DataSourceConnection{},
+			},
+			expectedCode:    http.StatusNotFound,
+			expectedMessage: "Data source not found",
+		},
+		{
+			name: "proxies to k8s resource endpoint with sub-path",
+			uid:  "test-uid",
+			connectionResult: &queryV0.DataSourceConnectionList{
+				Items: []queryV0.DataSourceConnection{
+					{Name: "test-uid", APIGroup: "prometheus.datasource.grafana.app", APIVersion: "v0alpha1"},
+				},
+			},
+			subPath:         "some/path",
+			expectedCode:    http.StatusOK,
+			expectedK8sPath: "/apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-uid/resources/some/path",
+		},
+		{
+			name: "proxies to k8s resource endpoint without sub-path",
+			uid:  "test-uid",
+			connectionResult: &queryV0.DataSourceConnectionList{
+				Items: []queryV0.DataSourceConnection{
+					{Name: "test-uid", APIGroup: "prometheus.datasource.grafana.app", APIVersion: "v0alpha1"},
+				},
+			},
+			expectedCode:    http.StatusOK,
+			expectedK8sPath: "/apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-uid/resources",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configProvider := &mockDirectRestConfigProvider{
+				host:      "http://localhost",
+				transport: &mockRoundTripper{statusCode: http.StatusOK, responseBody: []byte(`{}`)},
+			}
+			hs := &HTTPServer{
+				Cfg: setting.NewCfg(),
+				Features: featuremgmt.WithFeatures(
+					featuremgmt.FlagDatasourcesApiServerEnableResourceEndpointAPIRedirect,
+				),
+				dsConnectionClient:   &mockConnectionClient{result: tt.connectionResult, err: tt.connectionErr},
+				clientConfigProvider: configProvider,
+				namespacer:           func(int64) string { return "default" },
+			}
+			hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
+
+			urlPath := "/api/datasources/uid/" + tt.uid + "/resources"
+			if tt.subPath != "" {
+				urlPath += "/" + tt.subPath
+			}
+			params := map[string]string{":uid": tt.uid, "*": tt.subPath}
+
+			ctx, recorder := newResourceTestContext(t, http.MethodGet, urlPath, params)
+
+			handler := hs.callK8sDataSourceResourceHandler()
+			handler.(func(*contextmodel.ReqContext))(ctx)
+
+			assert.Equal(t, tt.expectedCode, recorder.Code)
+
+			if tt.expectedMessage != "" {
+				var body map[string]any
+				require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
+				assert.Equal(t, tt.expectedMessage, body["message"])
+			}
+
+			if tt.expectedK8sPath != "" {
+				assert.Equal(t, tt.expectedK8sPath, configProvider.lastServedPath)
+				assert.Equal(t, http.MethodGet, configProvider.lastServedMethod)
 			}
 		})
 	}

--- a/pkg/api/datasources_k8s_test.go
+++ b/pkg/api/datasources_k8s_test.go
@@ -183,7 +183,7 @@ func TestGetK8sDataSourceByUIDHandler(t *testing.T) {
 				namespacer:           func(int64) string { return "default" },
 				DataSourcesService:   &dataSourcesServiceMock{},
 			}
-			hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsResourceEndpointRequests = setupDsConfigHandlerMetrics()
+			hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsEndpointRedirects = setupDsConfigHandlerMetrics()
 
 			sc := setupScenarioContext(t, "/api/datasources/uid/test-uid")
 			handler := hs.getK8sDataSourceByUIDHandler()
@@ -225,7 +225,7 @@ func newResourceTestContext(t *testing.T, method, path string, params map[string
 }
 
 func TestCallK8sDataSourceResourceHandler_FlagDisabled(t *testing.T) {
-	setupOpenFeatureFlag(t, flagDatasourceResourceEndpointRedirect, false)
+	setupOpenFeatureFlag(t, featuremgmt.FlagDatasourcesApiserverEnableResourceEndpointRedirect, false)
 
 	configProvider := &mockDirectRestConfigProvider{
 		host:      "http://localhost",
@@ -236,7 +236,7 @@ func TestCallK8sDataSourceResourceHandler_FlagDisabled(t *testing.T) {
 		Features:            featuremgmt.WithFeatures(),
 		clientConfigProvider: configProvider,
 	}
-	hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsResourceEndpointRequests = setupDsConfigHandlerMetrics()
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsEndpointRedirects = setupDsConfigHandlerMetrics()
 
 	handler := hs.callK8sDataSourceResourceHandler()
 
@@ -325,7 +325,7 @@ func TestCallK8sDataSourceResourceHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setupOpenFeatureFlag(t, flagDatasourceResourceEndpointRedirect, true)
+			setupOpenFeatureFlag(t, featuremgmt.FlagDatasourcesApiserverEnableResourceEndpointRedirect, true)
 
 			configProvider := &mockDirectRestConfigProvider{
 				host:      "http://localhost",
@@ -338,7 +338,7 @@ func TestCallK8sDataSourceResourceHandler(t *testing.T) {
 				clientConfigProvider: configProvider,
 				namespacer:           func(int64) string { return "default" },
 			}
-			hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsResourceEndpointRequests = setupDsConfigHandlerMetrics()
+			hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsEndpointRedirects = setupDsConfigHandlerMetrics()
 
 			urlPath := "/api/datasources/uid/" + tt.uid + "/resources"
 			if tt.subPath != "" {

--- a/pkg/api/datasources_k8s_test.go
+++ b/pkg/api/datasources_k8s_test.go
@@ -7,8 +7,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	clientrest "k8s.io/client-go/rest"
@@ -22,6 +25,32 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
+
+var openfeatureTestMu sync.Mutex
+
+func setupOpenFeatureFlag(t *testing.T, flagName string, enabled bool) {
+	t.Helper()
+	openfeatureTestMu.Lock()
+
+	variant := "disabled"
+	if enabled {
+		variant = "enabled"
+	}
+
+	err := openfeature.SetProviderAndWait(memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		flagName: {
+			Key:            flagName,
+			DefaultVariant: variant,
+			Variants:       map[string]any{"enabled": true, "disabled": false},
+		},
+	}))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
+		openfeatureTestMu.Unlock()
+	})
+}
 
 // implements datasource.ConnectionClient
 type mockConnectionClient struct {
@@ -154,7 +183,7 @@ func TestGetK8sDataSourceByUIDHandler(t *testing.T) {
 				namespacer:           func(int64) string { return "default" },
 				DataSourcesService:   &dataSourcesServiceMock{},
 			}
-			hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
+			hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsResourceEndpointRequests = setupDsConfigHandlerMetrics()
 
 			sc := setupScenarioContext(t, "/api/datasources/uid/test-uid")
 			handler := hs.getK8sDataSourceByUIDHandler()
@@ -196,17 +225,28 @@ func newResourceTestContext(t *testing.T, method, path string, params map[string
 }
 
 func TestCallK8sDataSourceResourceHandler_FlagDisabled(t *testing.T) {
-	hs := &HTTPServer{
-		Cfg:      setting.NewCfg(),
-		Features: featuremgmt.WithFeatures(),
+	setupOpenFeatureFlag(t, flagDatasourceResourceEndpointRedirect, false)
+
+	configProvider := &mockDirectRestConfigProvider{
+		host:      "http://localhost",
+		transport: &mockRoundTripper{statusCode: http.StatusOK, responseBody: []byte(`{}`)},
 	}
-	hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
+	hs := &HTTPServer{
+		Cfg:                 setting.NewCfg(),
+		Features:            featuremgmt.WithFeatures(),
+		clientConfigProvider: configProvider,
+	}
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsResourceEndpointRequests = setupDsConfigHandlerMetrics()
 
 	handler := hs.callK8sDataSourceResourceHandler()
 
-	// When the flag is disabled, the factory should return the legacy handler (a method value)
+	// The handler is always a closure now; flag is evaluated per-request.
 	assert.IsType(t, (func(*contextmodel.ReqContext))(nil), handler,
-		"expected legacy handler type when feature flag is disabled")
+		"expected closure handler type")
+
+	// When the flag is disabled, no redirect should occur (k8s path should not be set).
+	assert.Empty(t, configProvider.lastServedPath,
+		"expected no k8s redirect when flag is disabled")
 }
 
 func TestCallK8sDataSourceResourceHandler(t *testing.T) {
@@ -285,20 +325,20 @@ func TestCallK8sDataSourceResourceHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			setupOpenFeatureFlag(t, flagDatasourceResourceEndpointRedirect, true)
+
 			configProvider := &mockDirectRestConfigProvider{
 				host:      "http://localhost",
 				transport: &mockRoundTripper{statusCode: http.StatusOK, responseBody: []byte(`{}`)},
 			}
 			hs := &HTTPServer{
-				Cfg: setting.NewCfg(),
-				Features: featuremgmt.WithFeatures(
-					featuremgmt.FlagDatasourcesApiServerEnableResourceEndpointAPIRedirect,
-				),
+				Cfg:                  setting.NewCfg(),
+				Features:             featuremgmt.WithFeatures(),
 				dsConnectionClient:   &mockConnectionClient{result: tt.connectionResult, err: tt.connectionErr},
 				clientConfigProvider: configProvider,
 				namespacer:           func(int64) string { return "default" },
 			}
-			hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
+			hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsResourceEndpointRequests = setupDsConfigHandlerMetrics()
 
 			urlPath := "/api/datasources/uid/" + tt.uid + "/resources"
 			if tt.subPath != "" {

--- a/pkg/api/datasources_k8s_test.go
+++ b/pkg/api/datasources_k8s_test.go
@@ -67,11 +67,12 @@ var _ datasource.ConnectionClient = (*mockConnectionClient)(nil)
 
 // implements grafanaapiserver.DirectRestConfigProvider
 type mockDirectRestConfigProvider struct {
-	transport        http.RoundTripper
-	host             string
-	lastServedPath   string
-	lastServedMethod string
-	lastServedQuery  string
+	transport          http.RoundTripper
+	host               string
+	lastServedPath     string
+	lastServedMethod   string
+	lastServedQuery    string
+	lastServedHeaders  http.Header
 }
 
 func (m *mockDirectRestConfigProvider) GetDirectRestConfig(c *contextmodel.ReqContext) *clientrest.Config {
@@ -85,6 +86,7 @@ func (m *mockDirectRestConfigProvider) DirectlyServeHTTP(w http.ResponseWriter, 
 	m.lastServedPath = r.URL.Path
 	m.lastServedMethod = r.Method
 	m.lastServedQuery = r.URL.RawQuery
+	m.lastServedHeaders = r.Header.Clone()
 	w.WriteHeader(http.StatusOK)
 }
 func (m *mockDirectRestConfigProvider) IsReady() bool { return true }
@@ -462,6 +464,125 @@ func TestCallK8sDataSourceResourceHandler_PreservesHTTPMethod(t *testing.T) {
 			assert.Equal(t,
 				"/apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-uid/resources/api/v1/query",
 				configProvider.lastServedPath)
+		})
+	}
+}
+
+func TestCallK8sDataSourceResourceHandler_Headers(t *testing.T) {
+	tests := []struct {
+		name            string
+		requestHeaders  map[string]string
+		expectedPresent map[string]string
+		expectedAbsent  []string
+	}{
+		{
+			name: "preserves content-type header",
+			requestHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			expectedPresent: map[string]string{
+				"Content-Type": "application/json",
+			},
+		},
+		{
+			name: "preserves accept header",
+			requestHeaders: map[string]string{
+				"Accept": "application/json, text/plain, */*",
+			},
+			expectedPresent: map[string]string{
+				"Accept": "application/json, text/plain, */*",
+			},
+		},
+		{
+			name: "preserves authorization header",
+			requestHeaders: map[string]string{
+				"Authorization": "Bearer some-token",
+			},
+			expectedPresent: map[string]string{
+				"Authorization": "Bearer some-token",
+			},
+		},
+		{
+			name: "preserves custom plugin headers",
+			requestHeaders: map[string]string{
+				"X-Datasource-Uid": "test-uid",
+				"X-Plugin-Id":      "prometheus",
+				"X-Custom-Header":  "custom-value",
+			},
+			expectedPresent: map[string]string{
+				"X-Datasource-Uid": "test-uid",
+				"X-Plugin-Id":      "prometheus",
+				"X-Custom-Header":  "custom-value",
+			},
+		},
+		{
+			name: "preserves multiple headers simultaneously",
+			requestHeaders: map[string]string{
+				"Content-Type":  "application/x-www-form-urlencoded",
+				"Authorization": "Bearer token-123",
+				"Accept":        "application/json",
+				"X-Request-Id":  "req-abc-123",
+			},
+			expectedPresent: map[string]string{
+				"Content-Type":  "application/x-www-form-urlencoded",
+				"Authorization": "Bearer token-123",
+				"Accept":        "application/json",
+				"X-Request-Id":  "req-abc-123",
+			},
+		},
+		{
+			name:           "headers not set on request are absent on proxy",
+			requestHeaders: map[string]string{},
+			expectedAbsent: []string{
+				"Authorization",
+				"X-Custom-Header",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupOpenFeatureFlag(t, featuremgmt.FlagDatasourcesApiserverEnableResourceEndpointRedirect, true)
+
+			configProvider := &mockDirectRestConfigProvider{
+				host:      "http://localhost",
+				transport: &mockRoundTripper{statusCode: http.StatusOK, responseBody: []byte(`{}`)},
+			}
+			hs := &HTTPServer{
+				Cfg:      setting.NewCfg(),
+				Features: featuremgmt.WithFeatures(),
+				dsConnectionClient: &mockConnectionClient{result: &queryV0.DataSourceConnectionList{
+					Items: []queryV0.DataSourceConnection{
+						{Name: "test-uid", APIGroup: "prometheus.datasource.grafana.app", APIVersion: "v0alpha1"},
+					},
+				}},
+				clientConfigProvider: configProvider,
+				namespacer:           func(int64) string { return "default" },
+			}
+			hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsEndpointRedirects = setupDsConfigHandlerMetrics()
+
+			ctx, recorder := newResourceTestContext(t, http.MethodPost,
+				"/api/datasources/uid/test-uid/resources/api/v1/query",
+				map[string]string{":uid": "test-uid", "*": "api/v1/query"})
+
+			for k, v := range tt.requestHeaders {
+				ctx.Req.Header.Set(k, v)
+			}
+
+			handler := hs.callK8sDataSourceResourceHandler()
+			handler.(func(*contextmodel.ReqContext))(ctx)
+
+			require.Equal(t, http.StatusOK, recorder.Code)
+
+			for key, expectedVal := range tt.expectedPresent {
+				assert.Equal(t, expectedVal, configProvider.lastServedHeaders.Get(key),
+					"header %q should be forwarded with value %q", key, expectedVal)
+			}
+
+			for _, key := range tt.expectedAbsent {
+				assert.Empty(t, configProvider.lastServedHeaders.Get(key),
+					"header %q should not be present on the proxied request", key)
+			}
 		})
 	}
 }

--- a/pkg/api/datasources_k8s_test.go
+++ b/pkg/api/datasources_k8s_test.go
@@ -67,12 +67,12 @@ var _ datasource.ConnectionClient = (*mockConnectionClient)(nil)
 
 // implements grafanaapiserver.DirectRestConfigProvider
 type mockDirectRestConfigProvider struct {
-	transport          http.RoundTripper
-	host               string
-	lastServedPath     string
-	lastServedMethod   string
-	lastServedQuery    string
-	lastServedHeaders  http.Header
+	transport         http.RoundTripper
+	host              string
+	lastServedPath    string
+	lastServedMethod  string
+	lastServedQuery   string
+	lastServedHeaders http.Header
 }
 
 func (m *mockDirectRestConfigProvider) GetDirectRestConfig(c *contextmodel.ReqContext) *clientrest.Config {

--- a/pkg/api/datasources_test.go
+++ b/pkg/api/datasources_test.go
@@ -84,16 +84,22 @@ func TestDataSourcesProxy_userLoggedIn(t *testing.T) {
 }
 
 // setupDsConfigMetrics creates and registers the prometheus metrics needed for HTTPServer tests
-// that call methods using dsConfigHandlerRequestsDuration.
-func setupDsConfigHandlerMetrics() (prometheus.Registerer, *prometheus.HistogramVec) {
+// that call methods using dsConfigHandlerRequestsDuration and dsEndpointRedirects.
+func setupDsConfigHandlerMetrics() (prometheus.Registerer, *prometheus.HistogramVec, *prometheus.CounterVec) {
 	promRegister := prometheus.NewRegistry()
 	dsConfigHandlerRequestsDuration := metricutil.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "grafana",
 		Name:      "ds_config_handler_requests_duration_seconds",
 		Help:      "Duration of requests handled by datasource configuration handlers",
 	}, []string{"handler"})
+	dsEndpointRedirects := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "grafana",
+		Name:      "ds_endpoint_redirects_total",
+		Help:      "Total number of datasource endpoint redirects by route (local/remote) and plugin type",
+	}, []string{"route", "plugin_type", "target"})
 	promRegister.MustRegister(dsConfigHandlerRequestsDuration)
-	return promRegister, dsConfigHandlerRequestsDuration
+	promRegister.MustRegister(dsEndpointRedirects)
+	return promRegister, dsConfigHandlerRequestsDuration, dsEndpointRedirects
 }
 
 // Adding data sources with invalid URLs should lead to an error.
@@ -103,7 +109,7 @@ func TestAddDataSource_InvalidURL(t *testing.T) {
 		DataSourcesService: &dataSourcesServiceMock{},
 		Cfg:                setting.NewCfg(),
 	}
-	hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsEndpointRedirects = setupDsConfigHandlerMetrics()
 
 	sc.m.Post(sc.url, routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
 		c.Req.Body = mockRequestBody(datasources.AddDataSourceCommand{
@@ -134,7 +140,7 @@ func TestAddDataSource_URLWithoutProtocol(t *testing.T) {
 		AccessControl:        acimpl.ProvideAccessControl(featuremgmt.WithFeatures()),
 		accesscontrolService: actest.FakeService{},
 	}
-	hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsEndpointRedirects = setupDsConfigHandlerMetrics()
 
 	sc := setupScenarioContext(t, "/api/datasources")
 
@@ -160,7 +166,7 @@ func TestAddDataSource_InvalidJSONData(t *testing.T) {
 		DataSourcesService: &dataSourcesServiceMock{},
 		Cfg:                setting.NewCfg(),
 	}
-	hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsEndpointRedirects = setupDsConfigHandlerMetrics()
 
 	sc := setupScenarioContext(t, "/api/datasources")
 
@@ -193,7 +199,7 @@ func TestUpdateDataSource_InvalidURL(t *testing.T) {
 		DataSourcesService: &dataSourcesServiceMock{},
 		Cfg:                setting.NewCfg(),
 	}
-	hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsEndpointRedirects = setupDsConfigHandlerMetrics()
 	sc := setupScenarioContext(t, "/api/datasources/1234")
 
 	sc.m.Put(sc.url, routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
@@ -218,7 +224,7 @@ func TestUpdateDataSource_InvalidJSONData(t *testing.T) {
 		DataSourcesService: &dataSourcesServiceMock{},
 		Cfg:                setting.NewCfg(),
 	}
-	hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsEndpointRedirects = setupDsConfigHandlerMetrics()
 	sc := setupScenarioContext(t, "/api/datasources/1234")
 
 	hs.Cfg.AuthProxy.Enabled = true
@@ -256,7 +262,7 @@ func TestAddDataSourceTeamHTTPHeaders(t *testing.T) {
 			ExpectedErr:      nil,
 		},
 	}
-	hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsEndpointRedirects = setupDsConfigHandlerMetrics()
 	sc := setupScenarioContext(t, fmt.Sprintf("/api/datasources/%s", tenantID))
 	hs.Cfg.AuthProxy.Enabled = true
 
@@ -310,7 +316,7 @@ func TestUpdateDataSource_URLWithoutProtocol(t *testing.T) {
 		AccessControl:        acimpl.ProvideAccessControl(featuremgmt.WithFeatures()),
 		accesscontrolService: actest.FakeService{},
 	}
-	hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsEndpointRedirects = setupDsConfigHandlerMetrics()
 
 	sc := setupScenarioContext(t, "/api/datasources/1234")
 
@@ -454,7 +460,7 @@ func TestAPI_datasources_AccessControl(t *testing.T) {
 				hs.DataSourcesService = &dataSourcesServiceMock{expectedDatasource: &datasources.DataSource{}}
 				hs.accesscontrolService = actest.FakeService{}
 				hs.Live = newTestLive(t)
-				hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
+				hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsEndpointRedirects = setupDsConfigHandlerMetrics()
 			})
 
 			for _, url := range tt.urls {

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -223,6 +223,7 @@ type HTTPServer struct {
 	tlsCerts                        TLSCerts
 	htmlHandlerRequestsDuration     *prometheus.HistogramVec
 	dsConfigHandlerRequestsDuration *prometheus.HistogramVec
+	dsEndpointRedirects             *prometheus.CounterVec
 	dsConnectionClient              datasource.ConnectionClient
 	publicDashboardsService         publicdashboards.Service
 }
@@ -387,11 +388,17 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 			Name:      "ds_config_handler_requests_duration_seconds",
 			Help:      "Duration of requests handled by datasource configuration handlers",
 		}, []string{"handler"}),
+		dsEndpointRedirects: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "grafana",
+			Name:      "ds_endpoint_redirects_total",
+			Help:      "Total number of datasource endpoint redirects by route (local/remote) and plugin type",
+		}, []string{"route", "plugin_type", "target"}),
 		dsConnectionClient: datasource.NewLegacyConnectionClient(dataSourcesService),
 	}
 
 	promRegister.MustRegister(hs.htmlHandlerRequestsDuration)
 	promRegister.MustRegister(hs.dsConfigHandlerRequestsDuration)
+	promRegister.MustRegister(hs.dsEndpointRedirects)
 
 	if hs.Listener != nil {
 		hs.log.Debug("Using provided listener")

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -532,6 +532,14 @@ var (
 			Expression:      "false",
 		},
 		{
+			Name:            "datasourcesApiServerEnableResourceEndpointAPIRedirect",
+			Description:     "redirect datasource resource requests from the legacy API routes to the new datasource api group endpoints.",
+			Stage:           FeatureStageExperimental,
+			Owner:           grafanaDatasourcesCoreServicesSquad,
+			RequiresRestart: false,
+			Expression:      "false",
+		},
+		{
 			Name:            "datasourcesApiServerEnableResourceEndpointFrontend",
 			Description:     "Send Datsource resource requests to K8s /apis/ API routes instead of the legacy /api/datasources/uid/{uid}/resources/{path} routes.",
 			Stage:           FeatureStageExperimental,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -532,16 +532,8 @@ var (
 			Expression:      "false",
 		},
 		{
-			Name:            "datasourcesApiServerEnableResourceEndpointAPIRedirect",
+			Name:            "datasourcesApiserverEnableResourceEndpointRedirect",
 			Description:     "redirect datasource resource requests from the legacy API routes to the new datasource api group endpoints.",
-			Stage:           FeatureStageExperimental,
-			Owner:           grafanaDatasourcesCoreServicesSquad,
-			RequiresRestart: false,
-			Expression:      "false",
-		},
-		{
-			Name:            "datasourcesApiServerEnableResourceEndpointFrontend",
-			Description:     "Send Datsource resource requests to K8s /apis/ API routes instead of the legacy /api/datasources/uid/{uid}/resources/{path} routes.",
 			Stage:           FeatureStageExperimental,
 			Owner:           grafanaDatasourcesCoreServicesSquad,
 			RequiresRestart: false,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -65,8 +65,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-04-19,queryServiceFromUI,experimental,@grafana/grafana-datasources-core-services,false,false,true
 2026-02-18,datasourcesRerouteLegacyCRUDAPIs,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2026-02-18,datasourcesApiServerEnableResourceEndpoint,experimental,@grafana/grafana-datasources-core-services,false,false,false
-2026-03-12,datasourcesApiServerEnableResourceEndpointAPIRedirect,experimental,@grafana/grafana-datasources-core-services,false,false,false
-2026-02-19,datasourcesApiServerEnableResourceEndpointFrontend,experimental,@grafana/grafana-datasources-core-services,false,false,false
+2026-03-16,datasourcesApiserverEnableResourceEndpointRedirect,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2023-10-20,cloudWatchBatchQueries,GA,@grafana/aws-datasources,false,false,false
 2023-10-12,cachingOptimizeSerializationMemoryUsage,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2023-10-30,alertmanagerRemoteSecondary,experimental,@grafana/alerting-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -65,6 +65,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-04-19,queryServiceFromUI,experimental,@grafana/grafana-datasources-core-services,false,false,true
 2026-02-18,datasourcesRerouteLegacyCRUDAPIs,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2026-02-18,datasourcesApiServerEnableResourceEndpoint,experimental,@grafana/grafana-datasources-core-services,false,false,false
+2026-03-12,datasourcesApiServerEnableResourceEndpointAPIRedirect,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2026-02-19,datasourcesApiServerEnableResourceEndpointFrontend,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2023-10-20,cloudWatchBatchQueries,GA,@grafana/aws-datasources,false,false,false
 2023-10-12,cachingOptimizeSerializationMemoryUsage,experimental,@grafana/grafana-operator-experience-squad,false,false,false
@@ -228,6 +229,8 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-04-22,alertRuleUseFiredAtForStartsAt,experimental,@grafana/alerting-squad,false,false,false
 2025-04-24,alertingBulkActionsInUI,GA,@grafana/alerting-squad,false,false,true
 2026-02-18,kubernetesAuthZResourcePermissionsRedirect,experimental,@grafana/identity-access-team,false,false,false
+2026-02-18,kubernetesAuthZRolesRedirect,experimental,@grafana/identity-access-team,false,false,false
+2026-03-06,kubernetesAuthZRoleBindingsRedirect,experimental,@grafana/identity-access-team,false,false,false
 2025-08-01,kubernetesAuthzResourcePermissionApis,experimental,@grafana/identity-access-team,false,false,false
 2025-10-13,kubernetesAuthzZanzanaSync,experimental,@grafana/identity-access-team,false,false,false
 2026-01-15,kubernetesAuthzGlobalRolesApi,experimental,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -215,6 +215,10 @@ const (
 	// Handle datasource resource requests to the legacy API routes by querying the new datasource api group endpoints behind the scenes.
 	FlagDatasourcesApiServerEnableResourceEndpoint = "datasourcesApiServerEnableResourceEndpoint"
 
+	// FlagDatasourcesApiServerEnableResourceEndpointAPIRedirect
+	// redirect datasource resource requests from the legacy API routes to the new datasource api group endpoints.
+	FlagDatasourcesApiServerEnableResourceEndpointAPIRedirect = "datasourcesApiServerEnableResourceEndpointAPIRedirect"
+
 	// FlagDatasourcesApiServerEnableResourceEndpointFrontend
 	// Send Datsource resource requests to K8s /apis/ API routes instead of the legacy /api/datasources/uid/{uid}/resources/{path} routes.
 	FlagDatasourcesApiServerEnableResourceEndpointFrontend = "datasourcesApiServerEnableResourceEndpointFrontend"

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -215,13 +215,9 @@ const (
 	// Handle datasource resource requests to the legacy API routes by querying the new datasource api group endpoints behind the scenes.
 	FlagDatasourcesApiServerEnableResourceEndpoint = "datasourcesApiServerEnableResourceEndpoint"
 
-	// FlagDatasourcesApiServerEnableResourceEndpointAPIRedirect
+	// FlagDatasourcesApiserverEnableResourceEndpointRedirect
 	// redirect datasource resource requests from the legacy API routes to the new datasource api group endpoints.
-	FlagDatasourcesApiServerEnableResourceEndpointAPIRedirect = "datasourcesApiServerEnableResourceEndpointAPIRedirect"
-
-	// FlagDatasourcesApiServerEnableResourceEndpointFrontend
-	// Send Datsource resource requests to K8s /apis/ API routes instead of the legacy /api/datasources/uid/{uid}/resources/{path} routes.
-	FlagDatasourcesApiServerEnableResourceEndpointFrontend = "datasourcesApiServerEnableResourceEndpointFrontend"
+	FlagDatasourcesApiserverEnableResourceEndpointRedirect = "datasourcesApiserverEnableResourceEndpointRedirect"
 
 	// FlagCloudWatchBatchQueries
 	// Runs CloudWatch metrics queries as separate batches

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1662,6 +1662,20 @@
     },
     {
       "metadata": {
+        "name": "datasources.apiserver.enableResourceEndpointRedirect",
+        "resourceVersion": "1773668049039",
+        "creationTimestamp": "2026-03-16T13:34:09Z",
+        "deletionTimestamp": "2026-03-16T13:35:33Z"
+      },
+      "spec": {
+        "description": "redirect datasource resource requests from the legacy API routes to the new datasource api group endpoints.",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-datasources-core-services",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "datasourcesApiServerEnableHealthEndpoint",
         "resourceVersion": "1772118749630",
         "creationTimestamp": "2026-02-26T15:12:29Z"
@@ -1707,7 +1721,8 @@
       "metadata": {
         "name": "datasourcesApiServerEnableResourceEndpointAPIRedirect",
         "resourceVersion": "1773322344906",
-        "creationTimestamp": "2026-03-12T13:32:24Z"
+        "creationTimestamp": "2026-03-12T13:32:24Z",
+        "deletionTimestamp": "2026-03-16T13:34:09Z"
       },
       "spec": {
         "description": "redirect datasource resource requests from the legacy API routes to the new datasource api group endpoints.",
@@ -1720,10 +1735,24 @@
       "metadata": {
         "name": "datasourcesApiServerEnableResourceEndpointFrontend",
         "resourceVersion": "1771492008460",
-        "creationTimestamp": "2026-02-19T09:06:48Z"
+        "creationTimestamp": "2026-02-19T09:06:48Z",
+        "deletionTimestamp": "2026-03-16T13:34:09Z"
       },
       "spec": {
         "description": "Send Datsource resource requests to K8s /apis/ API routes instead of the legacy /api/datasources/uid/{uid}/resources/{path} routes.",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-datasources-core-services",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "datasourcesApiserverEnableResourceEndpointRedirect",
+        "resourceVersion": "1773668133534",
+        "creationTimestamp": "2026-03-16T13:35:33Z"
+      },
+      "spec": {
+        "description": "redirect datasource resource requests from the legacy API routes to the new datasource api group endpoints.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
         "expression": "false"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1705,6 +1705,19 @@
     },
     {
       "metadata": {
+        "name": "datasourcesApiServerEnableResourceEndpointAPIRedirect",
+        "resourceVersion": "1773322344906",
+        "creationTimestamp": "2026-03-12T13:32:24Z"
+      },
+      "spec": {
+        "description": "redirect datasource resource requests from the legacy API routes to the new datasource api group endpoints.",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-datasources-core-services",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "datasourcesApiServerEnableResourceEndpointFrontend",
         "resourceVersion": "1771492008460",
         "creationTimestamp": "2026-02-19T09:06:48Z"


### PR DESCRIPTION
This PR adds a redirect which will based on a feature boolean via goff redirect traffic from the existing legacy `/api/.../resources` endpoint for datasources to the new `/apis/..../resources/` endpoint. 

If disabled it will go through the existing working endpoint. (The current scenario)

If enabled it will hit the local k8 endpoint. (This would be the OSS usecase once we have migrated the frontend)

if enabled and [this pr is merged](https://github.com/grafana/grafana-enterprise/pull/11269) and the resources endpoint is enabled it will send a http request to the MT aggregator and get redirected to MT Datasource pods (The Cloud state eventually)

[Part of the MT Datasource endpoint migration](https://github.com/grafana/grafana-enterprise/issues/8975)
