### PR TITLE
Docs: clarify Pure Git protocol support and GitHub Enterprise Server status

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
@@ -63,15 +63,27 @@ Note that Pure Git, GitLab and Bitbucket are supported in Grafana v12.4.x only. 
 
 ### The Pure Git repository type
 
-The Pure Git repository type uses the standard Git over HTTP protocol, with no provider-specific logic. Pure Git delivers the core Git Sync workflow: your repository is the source of truth, you may edit dashboards in the UI, and Grafana stays in sync.
+The Pure Git repository type uses the [Smart HTTP protocol v2](https://git-scm.com/docs/protocol-v2) (Git over HTTPS), with no provider-specific logic. Pure Git delivers the core Git Sync workflow: your repository is the source of truth, you may edit dashboards in the UI, and Grafana stays in sync.
+
+{{< admonition type="note" >}}
+
+Pure Git only supports **Smart HTTP protocol v2**. Earlier protocol versions (v1, v0) and SSH transport are not supported. Make sure your Git server supports protocol v2 over HTTPS.
+
+{{< /admonition >}}
 
 However, Pure Git doesn't include any features that require provider APIs, such as webhook-driven instant sync, automated PR comments, or deep links to source files.
 
-### Enhanced integrations: GitHub, GitLab, Bitbucket
+### Enhanced integrations: GitHub, GitHub Enterprise, GitLab, Bitbucket
 
 If your Git provider is GitHub, GitLab, or Bitbucket, use the enhanced integration. Enhanced integrations understand the platform you're using, allowing workflows that feel native: automated pull request comments with dashboard previews, instant webhook-based sync, or direct navigation from Grafana to source files in your provider's UI.
 
 The GitHub enhanced integration is the most feature-complete experience today. It enables richer pull request workflows, deeper linking between Grafana and GitHub, and tighter integration into review processes. It is available in Grafana OSS, Enterprise, and Cloud.
+
+{{< admonition type="note" >}}
+
+**GitHub Enterprise Server** is currently only supported through the Pure Git repository type. A dedicated enhanced integration for GitHub Enterprise Server is planned for upcoming releases.
+
+{{< /admonition >}}
 
 The GitLab and Bitbucket integrations have limited functionality for the moment, and are only available in Grafana Enterprise and Grafana Cloud. Expect continued improvements around pull request workflows, linking, and sync behavior in upcoming releases.
 


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/120149

## Summary

- Clarifies that the Pure Git repository type only supports **Smart HTTP protocol v2** — earlier protocol versions (v1, v0) and SSH transport are not supported.
- Adds an info note that **GitHub Enterprise Server** is currently only available through the Pure Git repository type, with a dedicated enhanced integration planned for upcoming releases.

## References

- [Git Sync usage limits page](https://grafana.com/docs/grafana-cloud/as-code/observability-as-code/git-sync/usage-limits/#the-pure-git-repository-type)
- [Git protocol v2 specification](https://git-scm.com/docs/protocol-v2)

Made with [Cursor](https://cursor.com)