### PR TITLE
Provisioning: Add info alerts for Pure Git protocol support and GitHub Enterprise

### DIFF
--- a/public/app/features/provisioning/Wizard/AuthTypeStep.tsx
+++ b/public/app/features/provisioning/Wizard/AuthTypeStep.tsx
@@ -64,47 +64,42 @@ export function AuthTypeStep({ onGitHubAppSubmit }: AuthTypeStepProps) {
   return (
     <Stack direction="column" gap={2}>
       {isGit && (
-        <>
-          <Alert
-            severity="info"
-            title={t(
-              'provisioning.wizard.git-protocol-alert-title',
-              'Only Git v2 Smart HTTP protocol is supported'
-            )}
-          >
-            <Text>
-              <Trans i18nKey="provisioning.wizard.git-protocol-alert-body">
-                The Pure Git repository type communicates with your Git server using the{' '}
-                <TextLink external href="https://git-scm.com/docs/protocol-v2">
-                  Git v2 Smart HTTP protocol
-                </TextLink>
-                . SSH and the legacy v1 protocol are not supported. Make sure your Git server supports Smart HTTP before
-                proceeding. For more details, see the{' '}
-                <TextLink
-                  external
-                  href="https://grafana.com/docs/grafana-cloud/as-code/observability-as-code/git-sync/usage-limits/#the-pure-git-repository-type"
-                >
-                  usage limits documentation
-                </TextLink>
-                .
-              </Trans>
-            </Text>
-          </Alert>
-          <Alert
-            severity="info"
-            title={t(
-              'provisioning.wizard.github-enterprise-alert-title',
-              'GitHub Enterprise Server'
-            )}
-          >
-            <Text>
-              <Trans i18nKey="provisioning.wizard.github-enterprise-alert-body">
-                GitHub Enterprise Server is currently only supported through the Pure Git repository type. Native GitHub
-                Enterprise integration is planned and will be available in the upcoming months.
-              </Trans>
-            </Text>
-          </Alert>
-        </>
+        <Alert
+          severity="info"
+          title={t('provisioning.wizard.git-protocol-alert-title', 'Only Git v2 Smart HTTP protocol is supported')}
+        >
+          <Text>
+            <Trans i18nKey="provisioning.wizard.git-protocol-alert-body">
+              The Pure Git repository type communicates with your Git server using the{' '}
+              <TextLink external href="https://git-scm.com/docs/protocol-v2">
+                Git v2 Smart HTTP protocol
+              </TextLink>
+              . SSH and the legacy v1 protocol are not supported. Make sure your Git server supports Smart HTTP before
+              proceeding. For more details, see the{' '}
+              <TextLink
+                external
+                href="https://grafana.com/docs/grafana-cloud/as-code/observability-as-code/git-sync/usage-limits/#the-pure-git-repository-type"
+              >
+                usage limits documentation
+              </TextLink>
+              .
+            </Trans>
+          </Text>
+        </Alert>
+      )}
+
+      {isGitHub && (
+        <Alert
+          severity="info"
+          title={t('provisioning.wizard.github-enterprise-alert-title', 'GitHub Enterprise Server')}
+        >
+          <Text>
+            <Trans i18nKey="provisioning.wizard.github-enterprise-alert-body">
+              GitHub Enterprise Server is currently only supported through the Pure Git repository type. Native GitHub
+              Enterprise integration is planned and will be available in the upcoming months.
+            </Trans>
+          </Text>
+        </Alert>
       )}
 
       {/* PAT & Github App Switch - only for GitHub repositories */}

--- a/public/app/features/provisioning/Wizard/AuthTypeStep.tsx
+++ b/public/app/features/provisioning/Wizard/AuthTypeStep.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
-import { t } from '@grafana/i18n';
-import { Field, RadioButtonGroup, Stack } from '@grafana/ui';
+import { Trans, t } from '@grafana/i18n';
+import { Alert, Field, RadioButtonGroup, Stack, Text, TextLink } from '@grafana/ui';
 
 import { useConnectionStatus } from '../hooks/useConnectionStatus';
 
@@ -59,8 +59,54 @@ export function AuthTypeStep({ onGitHubAppSubmit }: AuthTypeStepProps) {
     githubAuthType === 'github-app' ? githubAppConnectionName : undefined
   );
 
+  const isGit = repoType === 'git';
+
   return (
     <Stack direction="column" gap={2}>
+      {isGit && (
+        <>
+          <Alert
+            severity="info"
+            title={t(
+              'provisioning.wizard.git-protocol-alert-title',
+              'Only Git v2 Smart HTTP protocol is supported'
+            )}
+          >
+            <Text>
+              <Trans i18nKey="provisioning.wizard.git-protocol-alert-body">
+                The Pure Git repository type communicates with your Git server using the{' '}
+                <TextLink external href="https://git-scm.com/docs/protocol-v2">
+                  Git v2 Smart HTTP protocol
+                </TextLink>
+                . SSH and the legacy v1 protocol are not supported. Make sure your Git server supports Smart HTTP before
+                proceeding. For more details, see the{' '}
+                <TextLink
+                  external
+                  href="https://grafana.com/docs/grafana-cloud/as-code/observability-as-code/git-sync/usage-limits/#the-pure-git-repository-type"
+                >
+                  usage limits documentation
+                </TextLink>
+                .
+              </Trans>
+            </Text>
+          </Alert>
+          <Alert
+            severity="info"
+            title={t(
+              'provisioning.wizard.github-enterprise-alert-title',
+              'GitHub Enterprise Server'
+            )}
+          >
+            <Text>
+              <Trans i18nKey="provisioning.wizard.github-enterprise-alert-body">
+                GitHub Enterprise Server is currently only supported through the Pure Git repository type. Native GitHub
+                Enterprise integration is planned and will be available in the upcoming months.
+              </Trans>
+            </Text>
+          </Alert>
+        </>
+      )}
+
       {/* PAT & Github App Switch - only for GitHub repositories */}
       {isGitHub && (
         <Field

--- a/public/app/features/provisioning/Wizard/AuthTypeStep.tsx
+++ b/public/app/features/provisioning/Wizard/AuthTypeStep.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import { Trans, t } from '@grafana/i18n';
-import { Alert, Field, RadioButtonGroup, Stack, Text, TextLink } from '@grafana/ui';
+import { Alert, Field, RadioButtonGroup, Stack, TextLink } from '@grafana/ui';
 
 import { useConnectionStatus } from '../hooks/useConnectionStatus';
 
@@ -68,23 +68,21 @@ export function AuthTypeStep({ onGitHubAppSubmit }: AuthTypeStepProps) {
           severity="info"
           title={t('provisioning.wizard.git-protocol-alert-title', 'Only Git v2 Smart HTTP protocol is supported')}
         >
-          <Text>
-            <Trans i18nKey="provisioning.wizard.git-protocol-alert-body">
-              The Pure Git repository type communicates with your Git server using the{' '}
-              <TextLink external href="https://git-scm.com/docs/protocol-v2">
-                Git v2 Smart HTTP protocol
-              </TextLink>
-              . SSH and the legacy v1 protocol are not supported. Make sure your Git server supports Smart HTTP before
-              proceeding. For more details, see the{' '}
-              <TextLink
-                external
-                href="https://grafana.com/docs/grafana-cloud/as-code/observability-as-code/git-sync/usage-limits/#the-pure-git-repository-type"
-              >
-                usage limits documentation
-              </TextLink>
-              .
-            </Trans>
-          </Text>
+          <Trans i18nKey="provisioning.wizard.git-protocol-alert-body">
+            The Pure Git repository type communicates with your Git server using the{' '}
+            <TextLink external href="https://git-scm.com/docs/protocol-v2">
+              Git v2 Smart HTTP protocol
+            </TextLink>
+            . SSH and the legacy v1 protocol are not supported. Make sure your Git server supports Smart HTTP before
+            proceeding. For more details, see the{' '}
+            <TextLink
+              external
+              href="https://grafana.com/docs/grafana-cloud/as-code/observability-as-code/git-sync/usage-limits/#the-pure-git-repository-type"
+            >
+              usage limits documentation
+            </TextLink>
+            .
+          </Trans>
         </Alert>
       )}
 
@@ -93,12 +91,10 @@ export function AuthTypeStep({ onGitHubAppSubmit }: AuthTypeStepProps) {
           severity="info"
           title={t('provisioning.wizard.github-enterprise-alert-title', 'GitHub Enterprise Server')}
         >
-          <Text>
-            <Trans i18nKey="provisioning.wizard.github-enterprise-alert-body">
-              GitHub Enterprise Server is currently only supported through the Pure Git repository type. Native GitHub
-              Enterprise integration is planned and will be available in the upcoming months.
-            </Trans>
-          </Text>
+          <Trans i18nKey="provisioning.wizard.github-enterprise-alert-body">
+            GitHub Enterprise Server is currently only supported through the Pure Git repository type. Native GitHub
+            Enterprise integration is planned and will be available in the upcoming months.
+          </Trans>
         </Alert>
       )}
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13357,6 +13357,8 @@
         "dismiss": "Keep working",
         "title": "Discard repository setup?"
       },
+      "git-protocol-alert-body": "The Pure Git repository type communicates with your Git server using the <2>Git v2 Smart HTTP protocol</2>. SSH and the legacy v1 protocol are not supported. Make sure your Git server supports Smart HTTP before proceeding. For more details, see the <5>usage limits documentation</5>.",
+      "git-protocol-alert-title": "Only Git v2 Smart HTTP protocol is supported",
       "github-app-connection-status": "Connection status:",
       "github-app-creation-default-error": "Failed to create connection",
       "github-app-creation-failed": "Failed to create GitHub App connection",
@@ -13370,6 +13372,8 @@
       "github-app-no-connections": "No GitHub connections found",
       "github-app-no-connections-message": "You don't have any existing GitHub app connections. Please select \"Connect to a new app\" to create one.",
       "github-app-select-connection": "Select a GitHub App connection",
+      "github-enterprise-alert-body": "GitHub Enterprise Server is currently only supported through the Pure Git repository type. Native GitHub Enterprise integration is planned and will be available in the upcoming months.",
+      "github-enterprise-alert-title": "GitHub Enterprise Server",
       "step-bootstrap": "Choose what to synchronize",
       "step-configure-repo": "Configure repository",
       "step-connect": "Connect",


### PR DESCRIPTION
## Why

Users connecting repositories through the provisioning onboarding wizard currently have no upfront visibility into protocol limitations or provider-specific constraints. This leads to failed setups — for example, attempting to use SSH or the legacy v1 Git protocol with Pure Git ([#120149](https://github.com/grafana/grafana/issues/120149)), or expecting native GitHub Enterprise support when it is only available through the Pure Git type today.

Surfacing these constraints early in the wizard prevents wasted effort and support requests.

## What

Adds two `info` severity alerts to the first step (`AuthTypeStep`) of the provisioning onboarding wizard:

1. **Pure Git — protocol support** (shown when `type === 'git'`): Clarifies that only the [Git v2 Smart HTTP protocol](https://git-scm.com/docs/protocol-v2) is supported. SSH and the legacy v1 protocol are not. Links to the [usage limits documentation](https://grafana.com/docs/grafana-cloud/as-code/observability-as-code/git-sync/usage-limits/#the-pure-git-repository-type).

<img width="1662" height="802" alt="Screenshot 2026-03-13 at 12 37 12" src="https://github.com/user-attachments/assets/a9cf7ebb-5a8e-470d-a584-5e34ee5990d8" />



2. **GitHub — Enterprise Server note** (shown when `type === 'github'`): Informs users that GitHub Enterprise Server is currently only supported through the Pure Git repository type, and that native integration is planned for the upcoming months.

<img width="1446" height="594" alt="Screenshot 2026-03-13 at 12 37 01" src="https://github.com/user-attachments/assets/ff7003bc-bc9e-415b-8472-b513477effe5" />


## How

- Modified `AuthTypeStep.tsx` to conditionally render two `<Alert severity="info">` components using the existing `isGitHub` and new `isGit` derived booleans from the form's `repository.type` field.
- All user-facing strings use `t()` / `<Trans>` for i18n support.
- Ran `make i18n-extract` to generate the corresponding keys in `public/locales/en-US/grafana.json`.

Closes #120149

## Test plan

- [ ] Navigate to **Administration > Provisioning > Connect a repository**
- [ ] Select **Pure Git** — verify the v2 Smart HTTP protocol alert appears; the GitHub Enterprise alert does **not**
- [ ] Select **GitHub** — verify the GitHub Enterprise Server alert appears; the protocol alert does **not**
- [ ] Select **GitLab** / **Bitbucket** — verify neither alert appears
- [ ] Verify external links in both alerts open correctly in a new tab