### PR TITLE
chore: fix bug with nightly downstream call

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -111,7 +111,7 @@ jobs:
             const {REF, VERSION, BUILD_ID, BUCKET, GRAFANA_COMMIT, SOURCE_EVENT, REPO} = process.env;
             let workflow = 'release-build.yml';
 
-            if (REF == 'main') {
+            if (REF == 'main' && SOURCE_EVENT == 'push') {
               workflow = 'release-build-pro.yml';
             }
 


### PR DESCRIPTION
When the `event` was "schedule" but the head branch was main, it was triggering the wrong workflow downstream.