### PR TITLE
Alerting: Remove timestamp from URL param.

### DIFF
--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -278,7 +278,7 @@ export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
       component: () => <Navigate replace to="/alerting/history?tab=notifications" />,
     },
     {
-      path: '/alerting/notifications-history/view/:uuid/:timestamp?',
+      path: '/alerting/notifications-history/view/:uuid',
       component: cfg.featureToggles.alertingNotificationHistoryGlobal
         ? importAlertingComponent(
             () =>

--- a/public/app/features/alerting/unified/notifications/NotificationDetailPage.test.tsx
+++ b/public/app/features/alerting/unified/notifications/NotificationDetailPage.test.tsx
@@ -42,12 +42,12 @@ function makeNotification(overrides: Partial<NotificationEntry> = {}): Notificat
 
 function renderPage(uuid: string, timestamp?: string) {
   const path = timestamp
-    ? `/alerting/notifications-history/view/${uuid}/${encodeURIComponent(timestamp)}`
+    ? `/alerting/notifications-history/view/${uuid}?ts=${new Date(timestamp).getTime()}`
     : `/alerting/notifications-history/view/${uuid}`;
 
   return render(
     <Routes>
-      <Route path="/alerting/notifications-history/view/:uuid/:timestamp?" element={<NotificationDetailPage />} />
+      <Route path="/alerting/notifications-history/view/:uuid" element={<NotificationDetailPage />} />
     </Routes>,
     { historyOptions: { initialEntries: [path] } }
   );

--- a/public/app/features/alerting/unified/notifications/NotificationDetailPage.tsx
+++ b/public/app/features/alerting/unified/notifications/NotificationDetailPage.tsx
@@ -73,7 +73,9 @@ interface HeaderData {
 }
 
 function NotificationDetailPage() {
-  const { uuid, timestamp } = useParams<{ uuid: string; timestamp?: string }>();
+  const { uuid } = useParams<{ uuid: string }>();
+  const [queryParams] = useQueryParams();
+  const timestamp = typeof queryParams.ts === 'string' ? queryParams.ts : undefined;
   const defaultTitle = t('alerting.notification-detail.page-title', 'View');
   const [pageTitle, setPageTitle] = useState(defaultTitle);
   const [displayTitle, setDisplayTitle] = useState(defaultTitle);
@@ -213,7 +215,7 @@ function NotificationDetail({
       let from: string;
       let to: string;
       if (timestamp) {
-        const ts = new Date(timestamp).getTime();
+        const ts = Number(timestamp);
         from = new Date(ts - 1000).toISOString();
         to = new Date(ts + 1000).toISOString();
       } else {

--- a/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
+++ b/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
@@ -271,7 +271,7 @@ function NotificationRow({ record, onLabelClick }: NotificationRowProps) {
         <div className={styles.viewCol}>
           <LinkButton
             href={createRelativeUrl(
-              `/alerting/notifications-history/view/${record.uuid}/${encodeURIComponent(record.timestamp)}`
+              `/alerting/notifications-history/view/${record.uuid}?ts=${new Date(record.timestamp).getTime()}`
             )}
             size="sm"
             variant="secondary"

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceTimeline.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceTimeline.tsx
@@ -385,7 +385,7 @@ function NotificationRow({ notification }: { notification: NotificationEntry }) 
             size="sm"
             icon="eye"
             href={createRelativeUrl(
-              `/alerting/notifications-history/view/${notification.uuid}/${encodeURIComponent(notification.timestamp)}`
+              `/alerting/notifications-history/view/${notification.uuid}?ts=${new Date(notification.timestamp).getTime()}`
             )}
           >
             {t('alerting.instance-details.view-notification-detail', 'Details')}


### PR DESCRIPTION
The timestamp is an optimization to make fetching faster, so it's not strictly
necessary, therefore it's cleaner to pass as a query param. Also, use millis
as that's a standard convention for Grafana.
