### PR TITLE
Fix usage stats error when Amazon/Azure Prometheus plugins are not installed

### DIFF
--- a/pkg/infra/usagestats/statscollector/prometheus_flavor.go
+++ b/pkg/infra/usagestats/statscollector/prometheus_flavor.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -49,14 +50,20 @@ func (s *Service) detectPrometheusVariants(ctx context.Context) (map[string]int6
 	dsAmazonProm := &datasources.GetDataSourcesByTypeQuery{Type: "grafana-amazonprometheus-datasource"}
 	dataSourcesAmazonProm, err := s.datasources.GetDataSourcesByType(ctx, dsAmazonProm)
 	if err != nil {
-		s.log.Error("Failed to read all Amazon Prometheus data sources", "error", err)
-		return nil, err
+		if !isPluginNotFoundError(err) {
+			s.log.Error("Failed to read all Amazon Prometheus data sources", "error", err)
+			return nil, err
+		}
+		s.log.Debug("Amazon Prometheus plugin not installed, skipping", "error", err)
 	}
 	dsAzureProm := &datasources.GetDataSourcesByTypeQuery{Type: "grafana-azureprometheus-datasource"}
 	dataSourcesAzureProm, err := s.datasources.GetDataSourcesByType(ctx, dsAzureProm)
 	if err != nil {
-		s.log.Error("Failed to read all Azure Prometheus data sources", "error", err)
-		return nil, err
+		if !isPluginNotFoundError(err) {
+			s.log.Error("Failed to read all Azure Prometheus data sources", "error", err)
+			return nil, err
+		}
+		s.log.Debug("Azure Prometheus plugin not installed, skipping", "error", err)
 	}
 
 	allPromDataSources := append(append(dataSources, dataSourcesAmazonProm...), dataSourcesAzureProm...)
@@ -171,4 +178,9 @@ func (s *Service) detectPrometheusVariant(ctx context.Context, ds *datasources.D
 	}
 
 	return "vanilla", nil
+}
+
+// isPluginNotFoundError checks if the error is due to a plugin not being installed.
+func isPluginNotFoundError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "not found")
 }


### PR DESCRIPTION
When collecting Prometheus flavor stats, GetDataSourcesByType returns an error if the plugin is not found in the plugin store. For optional plugins like grafana-amazonprometheus-datasource and grafana-azureprometheus-datasource, treat "plugin not found" as an expected condition (log at debug level and continue with an empty list) instead of aborting the entire collection.

Fixes grafana/grafana#120247

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->
