### PR TITLE
A11y: Remove interactivity from UserIcon if onClick is not provided

### DIFF
--- a/packages/grafana-ui/src/components/UsersIndicator/UserIcon.story.tsx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UserIcon.story.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryFn } from '@storybook/react';
 
-import { Stack, Text } from '@grafana/ui';
+import { Stack } from '../Layout/Stack/Stack';
+import { Text } from '../Text/Text';
 
 import { UserIcon } from './UserIcon';
 import mdx from './UserIcon.mdx';

--- a/packages/grafana-ui/src/components/UsersIndicator/UserIcon.story.tsx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UserIcon.story.tsx
@@ -1,5 +1,7 @@
 import { Meta, StoryFn } from '@storybook/react';
 
+import { Stack, Text } from '@grafana/ui';
+
 import { UserIcon } from './UserIcon';
 import mdx from './UserIcon.mdx';
 
@@ -38,6 +40,52 @@ export const Basic: StoryFn<typeof UserIcon> = (args) => {
 
   return <UserIcon {...args} userView={userView} />;
 };
+
+export const Examples: StoryFn<typeof UserIcon> = (args) => {
+  const userView = {
+    user: {
+      name: 'John Smith',
+      avatarUrl: 'https://picsum.photos/id/1/200/200',
+    },
+    lastActiveAt: '2023-04-18T15:00:00.000Z',
+  };
+
+  const examples = [
+    { title: 'Interactive (click handler provided), user with avatar', props: { userView, onClick: () => console.log('Avatar clicked') } },
+    {
+      title: 'Interactive, user with initials',
+      props: {
+        userView: {
+          ...userView,
+          user: { ...userView.user, avatarUrl: undefined },
+        },
+        onClick: () => console.log('Initials clicked'),
+      },
+    },
+    {
+      title: 'Interactive, with tooltip',
+      props: { userView, onClick: () => console.log('Avatar clicked'), showTooltip: true },
+    },
+    {
+      title: 'Interactive, no tooltip',
+      props: { userView, onClick: () => console.log('Avatar clicked'), showTooltip: false },
+    },
+    { title: 'Non-interactive, with tooltip', props: { userView, showTooltip: true } },
+    { title: 'Non-interactive, no tooltip', props: { userView, showTooltip: false } },
+  ];
+
+  return (
+    <>
+      {examples.map((example) => (
+        <Stack direction="column" key={example.title} gap={5}>
+          <Text element="p">{example.title}</Text>
+          <UserIcon {...args} {...example.props} />
+        </Stack>
+      ))}
+    </>
+  );
+};
+
 Basic.args = {
   showTooltip: true,
   onClick: undefined,

--- a/packages/grafana-ui/src/components/UsersIndicator/UserIcon.story.tsx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UserIcon.story.tsx
@@ -51,7 +51,14 @@ export const Examples: StoryFn<typeof UserIcon> = (args) => {
   };
 
   const examples = [
-    { title: 'Interactive (click handler provided), user with avatar', props: { userView, onClick: () => console.log('Avatar clicked') } },
+    {
+      title: 'Interactive (click handler provided), user with avatar and tooltip',
+      props: { userView, onClick: () => console.log('Avatar clicked'), showTooltip: true },
+    },
+    {
+      title: 'Interactive, no tooltip',
+      props: { userView, onClick: () => console.log('Avatar clicked'), showTooltip: false },
+    },
     {
       title: 'Interactive, user with initials',
       props: {
@@ -62,22 +69,14 @@ export const Examples: StoryFn<typeof UserIcon> = (args) => {
         onClick: () => console.log('Initials clicked'),
       },
     },
-    {
-      title: 'Interactive, with tooltip',
-      props: { userView, onClick: () => console.log('Avatar clicked'), showTooltip: true },
-    },
-    {
-      title: 'Interactive, no tooltip',
-      props: { userView, onClick: () => console.log('Avatar clicked'), showTooltip: false },
-    },
     { title: 'Non-interactive, with tooltip', props: { userView, showTooltip: true } },
-    { title: 'Non-interactive, no tooltip', props: { userView, showTooltip: false } },
+    { title: 'Non-interactive, with initials', props: { userView, showTooltip: false } },
   ];
 
   return (
     <>
       {examples.map((example) => (
-        <Stack direction="column" key={example.title} gap={5}>
+        <Stack direction="column" key={example.title}>
           <Text element="p">{example.title}</Text>
           <UserIcon {...args} {...example.props} />
         </Stack>

--- a/packages/grafana-ui/src/components/UsersIndicator/UserIcon.test.tsx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UserIcon.test.tsx
@@ -61,4 +61,21 @@ describe('UserIcon', () => {
     );
     expect(screen.getByText('Custom Content')).toBeInTheDocument();
   });
+
+  it('renders tooltip if showTooltip is true', async () => {
+    render(<UserIcon userView={testUserView} showTooltip={true} />);
+    await userEvent.hover(screen.getByLabelText('John Smith icon'));
+    expect(screen.getByTestId('user-icon-tooltip')).toBeInTheDocument();
+  });
+
+  it('does not render tooltip if showTooltip is false', () => {
+    render(<UserIcon userView={testUserView} showTooltip={false} />);
+    expect(screen.queryByTestId('user-icon-tooltip')).not.toBeInTheDocument();
+  });
+
+  it('renders tooltip if showTooltip is undefined', async () => {
+    render(<UserIcon userView={testUserView} />);
+    await userEvent.hover(screen.getByLabelText('John Smith icon'));
+    expect(screen.getByTestId('user-icon-tooltip')).toBeInTheDocument();
+  });
 });

--- a/packages/grafana-ui/src/components/UsersIndicator/UserIcon.test.tsx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UserIcon.test.tsx
@@ -37,4 +37,28 @@ describe('UserIcon', () => {
     await user.click(screen.getByLabelText('John Smith icon'));
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
+
+  it('renders a button when onClick handler is provided', () => {
+    render(<UserIcon userView={testUserView} onClick={() => {}} />);
+    expect(screen.getByRole('button', { name: 'John Smith icon' })).toBeInTheDocument();
+  });
+
+  it('does not render a button when onClick handler is not provided', () => {
+    render(<UserIcon userView={testUserView} />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders a div with aria-label when onClick handler is not provided', () => {
+    render(<UserIcon userView={testUserView} />);
+    expect(screen.getByLabelText('John Smith icon')).toBeInTheDocument();
+  });
+
+  it('renders children when provided', () => {
+    render(
+      <UserIcon userView={testUserView}>
+        <span>Custom Content</span>
+      </UserIcon>
+    );
+    expect(screen.getByText('Custom Content')).toBeInTheDocument();
+  });
 });

--- a/packages/grafana-ui/src/components/UsersIndicator/UserIcon.tsx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UserIcon.tsx
@@ -98,7 +98,7 @@ export const UserIcon = ({
 
   if (showTooltip) {
     const tooltip = (
-      <div className={styles.tooltipContainer}>
+      <div className={styles.tooltipContainer} data-testid="user-icon-tooltip">
         <div className={styles.tooltipName}>{user.name}</div>
         {hasActive && (
           <div className={styles.tooltipDate}>

--- a/packages/grafana-ui/src/components/UsersIndicator/UserIcon.tsx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UserIcon.tsx
@@ -68,21 +68,32 @@ export const UserIcon = ({
   const isActive = hasActive && dateTime(lastActiveAt).diff(dateTime(), 'minutes', true) >= -15;
   const theme = useTheme2();
   const styles = useMemo(() => getStyles(theme, isActive), [theme, isActive]);
-  const content = (
+
+  const content = children ? (
+    <div className={cx(styles.content, styles.textContent)}>{children}</div>
+  ) : user.avatarUrl ? (
+    <img className={styles.content} src={user.avatarUrl} alt={`${user.name} avatar`} />
+  ) : (
+    <div className={cx(styles.content, styles.textContent)}>{getUserInitials(user.name)}</div>
+  );
+
+  const wrapper = onClick ? (
     <button
       type={'button'}
       onClick={onClick}
-      className={cx(styles.container, (showTooltip || onClick) && styles.hover, onClick && styles.pointer, className)}
+      className={cx(styles.container, styles.hover, styles.pointer, className)}
       aria-label={t('grafana-ui.user-icon.label', '{{name}} icon', { name: user.name })}
     >
-      {children ? (
-        <div className={cx(styles.content, styles.textContent)}>{children}</div>
-      ) : user.avatarUrl ? (
-        <img className={styles.content} src={user.avatarUrl} alt={`${user.name} avatar`} />
-      ) : (
-        <div className={cx(styles.content, styles.textContent)}>{getUserInitials(user.name)}</div>
-      )}
+      {content}
     </button>
+  ) : (
+    // a11y: don't render an interactive button if icon is not clickable
+    <div
+      aria-label={t('grafana-ui.user-icon.label', '{{name}} icon', { name: user.name })}
+      className={cx(styles.container, className)}
+    >
+      {content}
+    </div>
   );
 
   if (showTooltip) {
@@ -106,9 +117,9 @@ export const UserIcon = ({
       </div>
     );
 
-    return <Tooltip content={tooltip}>{content}</Tooltip>;
+    return <Tooltip content={tooltip}>{wrapper}</Tooltip>;
   } else {
-    return content;
+    return wrapper;
   }
 };
 

--- a/packages/grafana-ui/src/components/UsersIndicator/UsersIndicator.test.tsx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UsersIndicator.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react';
 
 import { UsersIndicator } from './UsersIndicator';
 
+const handleClick = jest.fn();
+
 describe('UsersIndicator', () => {
   const users = [
     { user: { name: 'John Doe' }, lastActiveAt: '2022-04-19T10:30:00.000Z' },
@@ -11,26 +13,26 @@ describe('UsersIndicator', () => {
 
   it('renders the user icons correctly', () => {
     render(<UsersIndicator users={users.slice(0, 2)} limit={2} />);
-    const johnUserIcon = screen.getByRole('button', { name: 'John Doe icon' });
-    const janeUserIcon = screen.getByRole('button', { name: 'Jane Johnson icon' });
+    const johnUserIcon = screen.getByLabelText('John Doe icon');
+    const janeUserIcon = screen.getByLabelText('Jane Johnson icon');
     expect(johnUserIcon).toBeInTheDocument();
     expect(janeUserIcon).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Extra users icon' })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Extra users icon')).not.toBeInTheDocument();
   });
 
   it('collapses the user icons when the limit is reached', () => {
     render(<UsersIndicator users={users} limit={2} />);
-    const johnUserIcon = screen.getByRole('button', { name: 'John Doe icon' });
-    const janeUserIcon = screen.getByRole('button', { name: 'Jane Johnson icon' });
-    const moreUsersIcon = screen.getByRole('button', { name: 'Extra users icon' });
+    const johnUserIcon = screen.getByLabelText('John Doe icon');
+    const janeUserIcon = screen.getByLabelText('Jane Johnson icon');
+    const moreUsersIcon = screen.getByLabelText('Extra users icon');
     expect(johnUserIcon).toBeInTheDocument();
     expect(janeUserIcon).toBeInTheDocument();
     expect(moreUsersIcon).toBeInTheDocument();
   });
 
   it("shows the '+' when there are too many users to display", () => {
-    render(<UsersIndicator users={users} limit={1} />);
-    const johnUserIcon = screen.getByRole('button', { name: 'John Doe icon' });
+    render(<UsersIndicator users={users} limit={1} onClick={handleClick} />);
+    const johnUserIcon = screen.getByLabelText('John Doe icon');
     const moreUsersIcon = screen.getByRole('button', { name: 'Extra users icon' });
     expect(moreUsersIcon).toHaveTextContent('+2');
     expect(johnUserIcon).toBeInTheDocument();
@@ -38,7 +40,6 @@ describe('UsersIndicator', () => {
   });
 
   it('calls the onClick function when the user number indicator is clicked', () => {
-    const handleClick = jest.fn();
     render(<UsersIndicator users={users} onClick={handleClick} limit={2} />);
     const moreUsersIcon = screen.getByRole('button', { name: 'Extra users icon' });
     expect(moreUsersIcon).toHaveTextContent('+1');


### PR DESCRIPTION
This components always renders a button, even if onClick is not provided. This makes the keyboard focus on the button and screen readers to read it out as "clickable". We should distinguish between interactive and non-interactive component. 