### PR TITLE
Provisioning: Gate fine-grained permissions warning on provisioningFolderMetadata flag

### DIFF
--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -160,12 +160,14 @@ export const SynchronizeStep = memo(function SynchronizeStep({
                   Alerts and library panels are not supported in provisioned folders.
                 </Trans>
               </li>
-              <li>
-                <Trans i18nKey="provisioning.wizard.alert-point-permissions">
-                  Fine-grained permissions are not supported. Default permissions apply: Admin, Editor, and Viewer roles
-                  are preserved with their standard access levels.
-                </Trans>
-              </li>
+              {!config.featureToggles.provisioningFolderMetadata && (
+                <li>
+                  <Trans i18nKey="provisioning.wizard.alert-point-permissions">
+                    Fine-grained permissions are not supported. Default permissions apply: Admin, Editor, and Viewer
+                    roles are preserved with their standard access levels.
+                  </Trans>
+                </li>
+              )}
               <li>
                 <Trans i18nKey="provisioning.wizard.alert-point-3">
                   The duration of this process depends on the number of resources involved.


### PR DESCRIPTION
## Reason

The Git Sync wizard's synchronize step warns users that "Fine-grained permissions are not supported." However, when the `provisioningFolderMetadata` feature flag is enabled, fine-grained permissions **are** supported, making this warning inaccurate and potentially confusing.

## Changes

Gates the fine-grained permissions limitation bullet point behind `!config.featureToggles.provisioningFolderMetadata` so it only renders when the flag is disabled.

## Test plan

- [ ] With `provisioningFolderMetadata` **disabled**: navigate to the Git Sync wizard synchronize step and confirm the permissions warning is visible
- [ ] With `provisioningFolderMetadata` **enabled**: confirm the permissions warning is no longer shown
- [ ] Confirm all other warning bullet points remain unaffected