### PR TITLE
Fix SQLite retry test failing in full package run

### DIFF
--- a/pkg/storage/unified/migrations/migrator_test.go
+++ b/pkg/storage/unified/migrations/migrator_test.go
@@ -74,6 +74,13 @@ func runMigrationTestSuite(t *testing.T, testCases []testcases.ResourceMigratorT
 			}
 		})
 		t.Logf("Using shared database path: %s", dbPath)
+
+		// Reset the global testSQLStore singleton after this test suite finishes.
+		// testinfra sets testSQLStore to an engine pointing at the temp DB file above;
+		// when t.TempDir() cleanup deletes that file, the engine becomes stale.
+		// Without this, subsequent tests calling db.InitTestDB will try to truncate
+		// tables on the stale engine and fail with "attempt to write a readonly database".
+		t.Cleanup(db.CleanupTestDB)
 	}
 
 	// Store UIDs created by each test case


### PR DESCRIPTION
## Summary
- `TestIntegrationRun_SQLiteRetryReleasesLock` fails with "attempt to write a readonly database" when running as part of the full `pkg/storage/unified/migrations` package, but passes alone
- Root cause: `TestIntegrationMigrations` sets `SQLITE_TEST_DB` to a temp directory and creates the global `testSQLStore` singleton via testinfra. When the test finishes, the temp directory is deleted but the singleton still references the stale engine. Subsequent tests calling `db.InitTestDB` try to truncate tables on that stale engine and fail.
- Fix: add `t.Cleanup(db.CleanupTestDB)` to reset the singleton after the migration test suite completes

## Test plan
- [x] Ran `TestIntegrationMigrations` and `TestIntegrationRun_SQLiteRetryReleasesLock` together — both pass
- [x] Ran full package (`go test ./pkg/storage/unified/migrations/`) — all 102 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)