### PR TITLE
fix(unified): use cfg status reader when db is not available

### DIFF
--- a/pkg/storage/legacysql/dualwrite/service.go
+++ b/pkg/storage/legacysql/dualwrite/service.go
@@ -58,6 +58,19 @@ func NewFakeMigrationStatusReader(resourceModes ...interface{}) unifiedmigration
 	return &fakeMigrationStatusReader{modes: m}
 }
 
+// NewConfigBasedMigrationStatusReader creates a MigrationStatusReader that derives
+// storage modes from the config's UnifiedStorage map. This is used in standalone
+// APIServer paths where there is no legacy database for migration log checks.
+func NewConfigBasedMigrationStatusReader(cfg *setting.Cfg) unifiedmigrations.MigrationStatusReader {
+	m := make(map[string]unifiedmigrations.StorageMode)
+	if cfg != nil {
+		for key, config := range cfg.UnifiedStorage {
+			m[key] = storageModeFromConfigMode(config.DualWriterMode)
+		}
+	}
+	return &fakeMigrationStatusReader{modes: m}
+}
+
 func NewFakeConfig() *setting.Cfg {
 	return &setting.Cfg{
 		UnifiedStorage: make(map[string]setting.UnifiedStorageConfig),


### PR DESCRIPTION
**What is this feature?**

Adds a dual writer status reader based on cfg when legacy is not available. 

**Why do we need this feature?**

API Server would need to query legacy DB for resources that are global or might not even have been migrated from legacy.

**Who is this feature for?**

MT apps

Ticket: https://github.com/grafana/search-and-storage-team/issues/661

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
