### PR TITLE
fix: limit migration config enforcements to specific targets

### DIFF
--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -211,9 +211,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 func (cfg *Cfg) applyMigrationEnforcements() {
 	if !cfg.ShouldRunMigrations() {
 		cfg.Logger.Info("Unified migration configs enforcement disabled", "storage_type", cfg.UnifiedStorageType(), "disable_data_migrations", cfg.DisableDataMigrations, "target", cfg.Target)
-		// Search is handled by a remote server, disable it locally
-		apiserverCfg := cfg.SectionWithEnvOverrides("grafana-apiserver")
-		if apiserverCfg.Key("search_server_address").MustString("") != "" {
+		if cfg.shouldProxySearchRemotely() {
 			cfg.EnableSearch = false
 		}
 		return
@@ -249,6 +247,16 @@ func (cfg *Cfg) applyMigrationEnforcements() {
 
 func isTargetEligibleForMigrations(targets []string) bool {
 	return slices.Contains(targets, "all") || slices.Contains(targets, "core")
+}
+
+// shouldProxySearchRemotely reports whether local search should be disabled in
+// favor of a remote search server. This is true when a search_server_address is
+// configured and the current target is not a dedicated search-server (which
+// needs local indexing to serve search RPCs).
+func (cfg *Cfg) shouldProxySearchRemotely() bool {
+	apiserverCfg := cfg.SectionWithEnvOverrides("grafana-apiserver")
+	return apiserverCfg.Key("search_server_address").MustString("") != "" &&
+		!slices.Contains(cfg.Target, "search-server")
 }
 
 // ShouldRunMigrations reports whether data migrations to unified storage should run.

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -3,6 +3,7 @@ package setting
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -132,13 +133,13 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.MigrationParquetBuffer = section.Key("migration_parquet_buffer").MustBool(false)
 	cfg.DisableLegacyTableRename = section.Key("disable_legacy_table_rename").MustBool(false)
 	cfg.RenameWaitDeadline = section.Key("rename_wait_deadline").MustDuration(time.Minute)
-	if !cfg.DisableDataMigrations && cfg.UnifiedStorageType() == "unified" {
+	if !cfg.DisableDataMigrations && cfg.UnifiedStorageType() == "unified" && isTargetEligibleForMigrations(cfg.Target) {
 		// Helper log to find instances running migrations in the future
 		cfg.Logger.Info("Unified migration configs enforced")
 		cfg.enforceMigrationToUnifiedConfigs()
 	} else {
 		// Helper log to find instances disabling migration
-		cfg.Logger.Info("Unified migration configs enforcement disabled", "storage_type", cfg.UnifiedStorageType(), "disable_data_migrations", cfg.DisableDataMigrations)
+		cfg.Logger.Info("Unified migration configs enforcement disabled", "storage_type", cfg.UnifiedStorageType(), "disable_data_migrations", cfg.DisableDataMigrations, "target", cfg.Target)
 	}
 	cfg.SearchInjectFailuresPercent = section.Key("search_inject_failures_percent").MustInt(0)
 	if cfg.SearchInjectFailuresPercent < 0 {
@@ -240,6 +241,10 @@ func (cfg *Cfg) enforceMigrationToUnifiedConfigs() {
 			AutoMigrationThreshold: resourceCfg.AutoMigrationThreshold,
 		}
 	}
+}
+
+func isTargetEligibleForMigrations(targets []string) bool {
+	return slices.Contains(targets, "all") || slices.Contains(targets, "core")
 }
 
 // UnifiedStorageType returns the configured storage type without creating or mutating keys.

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -133,14 +133,6 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.MigrationParquetBuffer = section.Key("migration_parquet_buffer").MustBool(false)
 	cfg.DisableLegacyTableRename = section.Key("disable_legacy_table_rename").MustBool(false)
 	cfg.RenameWaitDeadline = section.Key("rename_wait_deadline").MustDuration(time.Minute)
-	if !cfg.DisableDataMigrations && cfg.UnifiedStorageType() == "unified" && isTargetEligibleForMigrations(cfg.Target) {
-		// Helper log to find instances running migrations in the future
-		cfg.Logger.Info("Unified migration configs enforced", "storage_type", cfg.UnifiedStorageType(), "target", cfg.Target)
-		cfg.enforceMigrationToUnifiedConfigs()
-	} else {
-		// Helper log to find instances disabling migration
-		cfg.Logger.Info("Unified migration configs enforcement disabled", "storage_type", cfg.UnifiedStorageType(), "disable_data_migrations", cfg.DisableDataMigrations, "target", cfg.Target)
-	}
 	cfg.SearchInjectFailuresPercent = section.Key("search_inject_failures_percent").MustInt(0)
 	if cfg.SearchInjectFailuresPercent < 0 {
 		cfg.SearchInjectFailuresPercent = 0
@@ -148,6 +140,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 		cfg.SearchInjectFailuresPercent = 100
 	}
 	cfg.EnableSearch = section.Key("enable_search").MustBool(true)
+	cfg.applyMigrationEnforcements()
 	cfg.EnableSearchClient = section.Key("enable_search_client").MustBool(false)
 	cfg.MaxPageSizeBytes = section.Key("max_page_size_bytes").MustInt(0)
 	cfg.IndexPath = section.Key("index_path").String()
@@ -213,11 +206,22 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.MinFileIndexBuildVersion = section.Key("min_file_index_build_version").MustString("")
 }
 
-// enforceMigrationToUnifiedConfigs enforces configurations required to run migrated resources in mode 5
-// All migrated resources in MigratedUnifiedResources are set to mode 5 and unified search is enabled
-func (cfg *Cfg) enforceMigrationToUnifiedConfigs() {
+// applyMigrationEnforcements enforces unified storage migration configs when migrations should run,
+// or disables local search when a remote search server is configured.
+func (cfg *Cfg) applyMigrationEnforcements() {
+	if !cfg.ShouldRunMigrations() {
+		cfg.Logger.Info("Unified migration configs enforcement disabled", "storage_type", cfg.UnifiedStorageType(), "disable_data_migrations", cfg.DisableDataMigrations, "target", cfg.Target)
+		// Search is handled by a remote server, disable it locally
+		apiserverCfg := cfg.SectionWithEnvOverrides("grafana-apiserver")
+		if apiserverCfg.Key("search_server_address").MustString("") != "" {
+			cfg.EnableSearch = false
+		}
+		return
+	}
+
+	cfg.Logger.Info("Unified migration configs enforced", "storage_type", cfg.UnifiedStorageType(), "target", cfg.Target)
+
 	section := cfg.Raw.Section("unified_storage")
-	cfg.EnableSearch = section.Key("enable_search").MustBool(true)
 	if !cfg.EnableSearch {
 		cfg.Logger.Info("Enforcing enable_search for unified storage")
 		section.Key("enable_search").SetValue("true")
@@ -245,6 +249,13 @@ func (cfg *Cfg) enforceMigrationToUnifiedConfigs() {
 
 func isTargetEligibleForMigrations(targets []string) bool {
 	return slices.Contains(targets, "all") || slices.Contains(targets, "core")
+}
+
+// ShouldRunMigrations reports whether data migrations to unified storage should run.
+func (cfg *Cfg) ShouldRunMigrations() bool {
+	return !cfg.DisableDataMigrations &&
+		cfg.UnifiedStorageType() == "unified" &&
+		isTargetEligibleForMigrations(cfg.Target)
 }
 
 // UnifiedStorageType returns the configured storage type without creating or mutating keys.

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -135,7 +135,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.RenameWaitDeadline = section.Key("rename_wait_deadline").MustDuration(time.Minute)
 	if !cfg.DisableDataMigrations && cfg.UnifiedStorageType() == "unified" && isTargetEligibleForMigrations(cfg.Target) {
 		// Helper log to find instances running migrations in the future
-		cfg.Logger.Info("Unified migration configs enforced")
+		cfg.Logger.Info("Unified migration configs enforced", "storage_type", cfg.UnifiedStorageType(), "target", cfg.Target)
 		cfg.enforceMigrationToUnifiedConfigs()
 	} else {
 		// Helper log to find instances disabling migration

--- a/pkg/setting/setting_unified_storage_test.go
+++ b/pkg/setting/setting_unified_storage_test.go
@@ -239,9 +239,33 @@ func TestApplyMigrationEnforcements(t *testing.T) {
 		assert.False(t, resourceCfg.EnableMigration)
 	})
 
-	t.Run("disables local search when migrations disabled and search_server_address set", func(t *testing.T) {
+	t.Run("disables local search when migrations disabled and shouldProxySearchRemotely", func(t *testing.T) {
 		cfg := newCfg(t)
 		disableMigrations(cfg)
+		cfg.EnableSearch = true
+		cfg.Raw.Section("grafana-apiserver").Key("search_server_address").SetValue("localhost:10000")
+
+		cfg.applyMigrationEnforcements()
+
+		assert.False(t, cfg.EnableSearch)
+	})
+
+	t.Run("keeps local search on search-server target even with search_server_address set", func(t *testing.T) {
+		cfg := newCfg(t)
+		disableMigrations(cfg)
+		cfg.Target = []string{"search-server"}
+		cfg.EnableSearch = true
+		cfg.Raw.Section("grafana-apiserver").Key("search_server_address").SetValue("localhost:10000")
+
+		cfg.applyMigrationEnforcements()
+
+		assert.True(t, cfg.EnableSearch)
+	})
+
+	t.Run("disables local search on storage-server target with search_server_address set", func(t *testing.T) {
+		cfg := newCfg(t)
+		disableMigrations(cfg)
+		cfg.Target = []string{"storage-server"}
 		cfg.EnableSearch = true
 		cfg.Raw.Section("grafana-apiserver").Key("search_server_address").SetValue("localhost:10000")
 

--- a/pkg/setting/setting_unified_storage_test.go
+++ b/pkg/setting/setting_unified_storage_test.go
@@ -166,3 +166,119 @@ func TestCfg_setUnifiedStorageConfig(t *testing.T) {
 		assert.Equal(t, 1, cfg.IndexMinCount)
 	})
 }
+
+func TestApplyMigrationEnforcements(t *testing.T) {
+	newCfg := func(t *testing.T) *Cfg {
+		t.Helper()
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+		assert.NoError(t, err)
+		cfg.UnifiedStorage = make(map[string]UnifiedStorageConfig)
+		return cfg
+	}
+
+	enableMigrations := func(cfg *Cfg) {
+		cfg.Target = []string{"all"}
+		cfg.DisableDataMigrations = false
+		// storage_type defaults to "unified", no need to set it
+	}
+
+	disableMigrations := func(cfg *Cfg) {
+		cfg.DisableDataMigrations = true
+	}
+
+	t.Run("enforces EnableSearch when migrations run and search is disabled", func(t *testing.T) {
+		cfg := newCfg(t)
+		enableMigrations(cfg)
+		cfg.EnableSearch = false
+
+		cfg.applyMigrationEnforcements()
+
+		assert.True(t, cfg.EnableSearch)
+	})
+
+	t.Run("keeps EnableSearch true when migrations run", func(t *testing.T) {
+		cfg := newCfg(t)
+		enableMigrations(cfg)
+		cfg.EnableSearch = true
+
+		cfg.applyMigrationEnforcements()
+
+		assert.True(t, cfg.EnableSearch)
+	})
+
+	t.Run("enforces mode 5 for default-enabled migrated resources", func(t *testing.T) {
+		cfg := newCfg(t)
+		enableMigrations(cfg)
+
+		cfg.applyMigrationEnforcements()
+
+		for resource, enabledByDefault := range MigratedUnifiedResources {
+			if !enabledByDefault {
+				continue
+			}
+			resourceCfg, exists := cfg.UnifiedStorage[resource]
+			assert.True(t, exists, resource)
+			assert.Equal(t, rest.DualWriterMode(5), resourceCfg.DualWriterMode, resource)
+			assert.True(t, resourceCfg.EnableMigration, resource)
+		}
+	})
+
+	t.Run("skips resources with migration explicitly disabled", func(t *testing.T) {
+		cfg := newCfg(t)
+		enableMigrations(cfg)
+		cfg.UnifiedStorage[DashboardResource] = UnifiedStorageConfig{
+			DualWriterMode:  1,
+			EnableMigration: false,
+		}
+
+		cfg.applyMigrationEnforcements()
+
+		resourceCfg := cfg.UnifiedStorage[DashboardResource]
+		assert.Equal(t, rest.DualWriterMode(1), resourceCfg.DualWriterMode)
+		assert.False(t, resourceCfg.EnableMigration)
+	})
+
+	t.Run("disables local search when migrations disabled and search_server_address set", func(t *testing.T) {
+		cfg := newCfg(t)
+		disableMigrations(cfg)
+		cfg.EnableSearch = true
+		cfg.Raw.Section("grafana-apiserver").Key("search_server_address").SetValue("localhost:10000")
+
+		cfg.applyMigrationEnforcements()
+
+		assert.False(t, cfg.EnableSearch)
+	})
+
+	t.Run("keeps local search when migrations disabled and no search_server_address", func(t *testing.T) {
+		cfg := newCfg(t)
+		disableMigrations(cfg)
+		cfg.EnableSearch = true
+
+		cfg.applyMigrationEnforcements()
+
+		assert.True(t, cfg.EnableSearch)
+	})
+}
+
+func TestIsTargetEligibleForMigrations(t *testing.T) {
+	tests := []struct {
+		name     string
+		targets  []string
+		expected bool
+	}{
+		{name: "all target", targets: []string{"all"}, expected: true},
+		{name: "core target", targets: []string{"core"}, expected: true},
+		{name: "all among multiple targets", targets: []string{"storage-server", "all"}, expected: true},
+		{name: "core among multiple targets", targets: []string{"storage-server", "core"}, expected: true},
+		{name: "storage-server only", targets: []string{"storage-server"}, expected: false},
+		{name: "empty targets", targets: []string{}, expected: false},
+		{name: "other target", targets: []string{"search-server-distributor"}, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isTargetEligibleForMigrations(tt.targets))
+		})
+	}
+}

--- a/pkg/storage/unified/migrations/service.go
+++ b/pkg/storage/unified/migrations/service.go
@@ -3,7 +3,6 @@ package migrations
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
@@ -56,18 +55,8 @@ func ProvideUnifiedStorageMigrationService(
 	}
 }
 
-func isTargetEligibleForMigrations(targets []string) bool {
-	return slices.Contains(targets, "all") || slices.Contains(targets, "core")
-}
-
-func (p *UnifiedStorageMigrationServiceImpl) shouldRunMigrations() bool {
-	return !p.cfg.DisableDataMigrations &&
-		p.cfg.UnifiedStorageType() == "unified" &&
-		isTargetEligibleForMigrations(p.cfg.Target)
-}
-
 func (p *UnifiedStorageMigrationServiceImpl) Run(ctx context.Context) error {
-	if !p.shouldRunMigrations() {
+	if !p.cfg.ShouldRunMigrations() {
 		metrics.MUnifiedStorageMigrationStatus.Set(1)
 		logger.Info("Data migrations are disabled, skipping",
 			"disableDataMigrations", p.cfg.DisableDataMigrations,

--- a/pkg/storage/unified/migrations/service_test.go
+++ b/pkg/storage/unified/migrations/service_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/metrics"
@@ -65,28 +64,6 @@ func TestUnifiedStorageMigrationServiceImpl_Run_SkipsMigrations(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, float64(1), testutil.ToFloat64(metrics.MUnifiedStorageMigrationStatus))
 			migrator.AssertNotCalled(t, "Migrate")
-		})
-	}
-}
-
-func TestIsTargetEligibleForMigrations(t *testing.T) {
-	tests := []struct {
-		name     string
-		targets  []string
-		expected bool
-	}{
-		{name: "all target", targets: []string{"all"}, expected: true},
-		{name: "core target", targets: []string{"core"}, expected: true},
-		{name: "all among multiple targets", targets: []string{"storage-server", "all"}, expected: true},
-		{name: "core among multiple targets", targets: []string{"storage-server", "core"}, expected: true},
-		{name: "storage-server only", targets: []string{"storage-server"}, expected: false},
-		{name: "empty targets", targets: []string{}, expected: false},
-		{name: "other target", targets: []string{"search-server-distributor"}, expected: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, isTargetEligibleForMigrations(tt.targets))
 		})
 	}
 }


### PR DESCRIPTION
Handle the configuration enforcement when target is not within `all` or `core`.

Ticket: https://github.com/grafana/search-and-storage-team/issues/660