### PR TITLE
Fetch: Add FormData support to getBackendSrv

### DIFF
--- a/public/app/core/utils/fetch.test.ts
+++ b/public/app/core/utils/fetch.test.ts
@@ -70,6 +70,14 @@ describe('parseInitFromOptions', () => {
       expect(parseInitFromOptions({ method, data, withCredentials, credentials, url: '' })).toEqual(expected);
     }
   );
+
+  it('should remove content-type header when data is FormData', () => {
+    const formData = new FormData();
+    formData.append('key', 'value');
+    const result = parseInitFromOptions({ method: 'POST', data: formData, url: '' });
+    expect(result.body).toBe(formData);
+    expect((result.headers as Headers).has('content-type')).toBe(false);
+  });
 });
 
 describe('parseHeaders', () => {
@@ -125,6 +133,8 @@ describe('parseBody', () => {
     ${{ data: { id: '0' } }}                        | ${false}  | ${new URLSearchParams({ id: '0' })}
     ${{ data: { id: '0' } }}                        | ${true}   | ${'{"id":"0"}'}
     ${{ data: new Blob([new Uint8Array([1, 1])]) }} | ${false}  | ${new Blob([new Uint8Array([1, 1])])}
+    ${{ data: new FormData() }}                     | ${false}  | ${new FormData()}
+    ${{ data: new FormData() }}                     | ${true}   | ${new FormData()}
   `(
     "when called with options: '$options' and isAppJson: '$isAppJson' then the result should be '$expected'",
     ({ options, isAppJson, expected }) => {

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -11,6 +11,11 @@ export const parseInitFromOptions = (options: BackendSrvRequest): RequestInit =>
   const body = parseBody(options, isAppJson);
   const credentials = parseCredentials(options);
 
+  // If sending FormData, remove Content-Type so browser sets multipart boundary automatically
+  if (options.data instanceof FormData) {
+    headers.delete('content-type');
+  }
+
   return {
     method,
     headers,
@@ -113,6 +118,9 @@ export const parseBody = (options: BackendSrvRequest, isAppJson: boolean) => {
     return options.data;
   }
   if (options.data instanceof Blob) {
+    return options.data;
+  }
+  if (options.data instanceof FormData) {
     return options.data;
   }
 


### PR DESCRIPTION
Add support to `getBackendSrv` for API endpoints that use FormData with multi-part uploads, which use content-type `multipart/form-data`, so we let the browser set it.

Used in https://github.com/grafana/grafana-enterprise/pull/11301