### PR TITLE
Alerting: Add concurrency cap to buildinfo requests in useRuleSourcesWithRuler

### DIFF
--- a/public/app/features/alerting/unified/api/featureDiscoveryApi.ts
+++ b/public/app/features/alerting/unified/api/featureDiscoveryApi.ts
@@ -26,6 +26,7 @@ export interface RulesSourceFeatures {
 export const featureDiscoveryApi = alertingApi.injectEndpoints({
   endpoints: (build) => ({
     discoverAmFeatures: build.query<AlertmanagerApiFeatures, { amSourceName: string }>({
+      keepUnusedDataFor: 3600,
       queryFn: async ({ amSourceName }) => {
         try {
           const amFeatures = await discoverAlertmanagerFeatures(amSourceName);
@@ -37,6 +38,7 @@ export const featureDiscoveryApi = alertingApi.injectEndpoints({
     }),
 
     discoverDsFeatures: build.query<RulesSourceFeatures, { rulesSourceName: string } | { uid: RulesSourceUid }>({
+      keepUnusedDataFor: 3600,
       queryFn: async (rulesSourceIdentifier) => {
         const dataSourceUID = getDataSourceUID(rulesSourceIdentifier);
         if (!dataSourceUID) {

--- a/public/app/features/alerting/unified/hooks/useRuleSourcesWithRuler.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useRuleSourcesWithRuler.test.tsx
@@ -1,0 +1,179 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, delay, http } from 'msw';
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { DataSourceJsonData } from '@grafana/data';
+import { configureStore } from 'app/store/configureStore';
+import { AccessControlAction } from 'app/types/accessControl';
+import { PromApplication } from 'app/types/unified-alerting-dto';
+
+import * as buildInfoModule from '../api/buildInfo';
+import { setupMswServer } from '../mockApi';
+import { grantUserPermissions, mockDataSource } from '../mocks';
+import { setupDataSources } from '../testSetup/datasources';
+import { buildInfoResponse } from '../testSetup/featureDiscovery';
+
+import { useRulesSourcesWithRuler } from './useRuleSourcesWithRuler';
+
+const server = setupMswServer();
+
+function getProviderWrapper() {
+  const store = configureStore();
+  return ({ children }: React.PropsWithChildren<{}>) => <Provider store={store}>{children}</Provider>;
+}
+
+// Creates a Prometheus datasource with manageAlerts:true so getRulesDataSources() includes it
+function makeMimirDatasource(uid: string, name: string) {
+  return mockDataSource({
+    uid,
+    name,
+    type: 'prometheus',
+    jsonData: { manageAlerts: true } as DataSourceJsonData,
+  });
+}
+
+beforeEach(() => {
+  grantUserPermissions([AccessControlAction.AlertingRuleExternalRead, AccessControlAction.AlertingRuleExternalWrite]);
+});
+
+describe('useRulesSourcesWithRuler — baseline (current behaviour)', () => {
+  it('starts with empty list and no loading when there are no datasources', () => {
+    setupDataSources();
+
+    const { result } = renderHook(() => useRulesSourcesWithRuler(), {
+      wrapper: getProviderWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.rulesSourcesWithRuler).toEqual([]);
+  });
+
+  it('returns datasources whose buildinfo indicates ruler support (Mimir)', async () => {
+    setupDataSources(makeMimirDatasource('mimir-1', 'Mimir 1'));
+
+    server.use(
+      http.get('/api/datasources/proxy/uid/:uid/api/v1/status/buildinfo', () =>
+        HttpResponse.json(buildInfoResponse.mimir)
+      )
+    );
+
+    const { result } = renderHook(() => useRulesSourcesWithRuler(), {
+      wrapper: getProviderWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.rulesSourcesWithRuler).toHaveLength(1));
+    expect(result.current.rulesSourcesWithRuler[0].uid).toBe('mimir-1');
+  });
+
+  it('excludes datasources whose buildinfo indicates no ruler support (vanilla Prometheus)', async () => {
+    setupDataSources(makeMimirDatasource('prom-1', 'Prometheus 1'));
+
+    server.use(
+      http.get('/api/datasources/proxy/uid/:uid/api/v1/status/buildinfo', () =>
+        HttpResponse.json(buildInfoResponse.prometheus)
+      )
+    );
+
+    const { result } = renderHook(() => useRulesSourcesWithRuler(), {
+      wrapper: getProviderWrapper(),
+    });
+
+    // Wait for discovery to settle — list should remain empty
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.rulesSourcesWithRuler).toHaveLength(0);
+  });
+
+  it('handles a mix of ruler and non-ruler datasources', async () => {
+    setupDataSources(makeMimirDatasource('mimir-1', 'Mimir 1'), makeMimirDatasource('prom-1', 'Prometheus 1'));
+
+    server.use(
+      http.get('/api/datasources/proxy/uid/:uid/api/v1/status/buildinfo', ({ params }) =>
+        params.uid === 'mimir-1'
+          ? HttpResponse.json(buildInfoResponse.mimir)
+          : HttpResponse.json(buildInfoResponse.prometheus)
+      )
+    );
+
+    const { result } = renderHook(() => useRulesSourcesWithRuler(), {
+      wrapper: getProviderWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.rulesSourcesWithRuler).toHaveLength(1);
+    expect(result.current.rulesSourcesWithRuler[0].uid).toBe('mimir-1');
+  });
+});
+
+// These tests document bugs in the current implementation.
+// They are EXPECTED TO FAIL against the unmodified hook and PASS after the fix.
+describe('useRulesSourcesWithRuler — bug reproductions (must fail before fix)', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('BUG: fires all requests simultaneously instead of in batches of 10', async () => {
+    // getRulesDataSources() sorts by name, so all datasources are processed in
+    // alphabetical order. We spy on discoverFeaturesByUid (called inside the RTK
+    // Query queryFn) to measure true in-process concurrency, which is not subject
+    // to test-environment serialization at the network/MSW layer.
+    const dataSources = Array.from({ length: 25 }, (_, i) =>
+      makeMimirDatasource(`ds-${String(i).padStart(2, '0')}`, `DS ${String(i).padStart(2, '0')}`)
+    );
+    setupDataSources(...dataSources);
+
+    let concurrentCount = 0;
+    let peakConcurrentCount = 0;
+
+    jest.spyOn(buildInfoModule, 'discoverFeaturesByUid').mockImplementation(async () => {
+      concurrentCount++;
+      peakConcurrentCount = Math.max(peakConcurrentCount, concurrentCount);
+      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+      concurrentCount--;
+      return { application: PromApplication.Mimir, features: { rulerApiEnabled: true } };
+    });
+
+    const { result } = renderHook(() => useRulesSourcesWithRuler(), {
+      wrapper: getProviderWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.rulesSourcesWithRuler).toHaveLength(25), { timeout: 5000 });
+
+    // FAILS on the current code: all 25 fire at once (peakConcurrentCount === 25)
+    // PASSES after the fix: batches of 10 (peakConcurrentCount <= 10)
+    expect(peakConcurrentCount).toBeLessThanOrEqual(10);
+  });
+
+  it('BUG: isLoading goes false before all datasources have resolved', async () => {
+    // getRulesDataSources() sorts by name alphabetically. We give the slow datasource
+    // a name that sorts BEFORE the fast one ("AA..." < "ZZ..."), so the forEach loop
+    // triggers slow-ds first and fast-ds LAST. The broken isLoading only reflects the
+    // last-triggered lazy query (fast-ds). Since fast-ds has no delay, isLoading goes
+    // false while slow-ds is still pending, leaving only 1 result instead of 2.
+    const slow = makeMimirDatasource('slow-ds', 'AA Slow DS');
+    const fast = makeMimirDatasource('fast-ds', 'ZZ Fast DS');
+    setupDataSources(slow, fast);
+
+    server.use(
+      http.get('/api/datasources/proxy/uid/:uid/api/v1/status/buildinfo', async ({ params }) => {
+        if (params.uid === 'slow-ds') {
+          await delay(200);
+        }
+        return HttpResponse.json(buildInfoResponse.mimir);
+      })
+    );
+
+    const { result } = renderHook(() => useRulesSourcesWithRuler(), {
+      wrapper: getProviderWrapper(),
+    });
+
+    // Wait until isLoading goes false
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // FAILS on the current code: isLoading goes false as soon as the last-triggered
+    // query (fast-ds / "ZZ Fast DS") resolves, but slow-ds has not resolved yet —
+    // only 1 result present.
+    // PASSES after the fix: isLoading stays true until ALL datasources have resolved.
+    expect(result.current.rulesSourcesWithRuler).toHaveLength(2);
+  });
+});

--- a/public/app/features/alerting/unified/hooks/useRuleSourcesWithRuler.ts
+++ b/public/app/features/alerting/unified/hooks/useRuleSourcesWithRuler.ts
@@ -2,26 +2,64 @@ import { useEffect, useState } from 'react';
 
 import { DataSourceInstanceSettings } from '@grafana/data';
 
+import { logWarning } from '../Analytics';
 import { featureDiscoveryApi } from '../api/featureDiscoveryApi';
 import { getRulesDataSources } from '../utils/datasource';
 
 const { useLazyDiscoverDsFeaturesQuery } = featureDiscoveryApi;
+
+const CONCURRENCY_LIMIT = 10;
 
 export function useRulesSourcesWithRuler(): {
   rulesSourcesWithRuler: DataSourceInstanceSettings[];
   isLoading: boolean;
 } {
   const [rulesSourcesWithRuler, setRulesSourcesWithRuler] = useState<DataSourceInstanceSettings[]>([]);
-  const [discoverDsFeatures, { isLoading }] = useLazyDiscoverDsFeaturesQuery();
+  const [isLoading, setIsLoading] = useState(false);
+  const [discoverDsFeatures] = useLazyDiscoverDsFeaturesQuery();
 
   useEffect(() => {
     const dataSources = getRulesDataSources();
-    dataSources.forEach(async (ds) => {
-      const { data: dsFeatures } = await discoverDsFeatures({ uid: ds.uid }, true);
-      if (dsFeatures?.rulerConfig) {
-        setRulesSourcesWithRuler((prev) => [...prev, ds]);
+    if (dataSources.length === 0) {
+      return;
+    }
+
+    // per-effect-run flag that prevents stale state updates after the component unmounts
+    // or the effect re-runs with new dependencies
+    let cancelled = false;
+    setIsLoading(true);
+
+    async function discoverDsFeaturesInBatches() {
+      for (let i = 0; i < dataSources.length; i += CONCURRENCY_LIMIT) {
+        if (cancelled) {
+          return;
+        }
+
+        const batch = dataSources.slice(i, i + CONCURRENCY_LIMIT);
+        await Promise.all(
+          batch.map(async (ds) => {
+            try {
+              const { data: dsFeatures } = await discoverDsFeatures({ uid: ds.uid }, true);
+              if (!cancelled && dsFeatures?.rulerConfig) {
+                setRulesSourcesWithRuler((prev) => [...prev, ds]);
+              }
+            } catch (err) {
+              logWarning('Failed to discover datasource features', { error: String(err) });
+            }
+          })
+        );
       }
-    });
+
+      if (!cancelled) {
+        setIsLoading(false);
+      }
+    }
+
+    discoverDsFeaturesInBatches();
+
+    return () => {
+      cancelled = true;
+    };
   }, [discoverDsFeatures]);
 
   return { rulesSourcesWithRuler, isLoading };


### PR DESCRIPTION
**Problem**

When a user opens the alert rule creation page, useRulesSourcesWithRuler() fires one discoverDsFeatures request per external datasource simultaneously with no concurrency limit. For customers with hundreds of Prometheus datasources, this creates a thundering herd that overwhelms the backend. The isLoading state is also broken (only tracks the last-triggered lazy query), so the UI either blocks incorrectly or shows stale partial results.

**Fix**

- Replaced the unbounded forEach fan-out in useRuleSourcesWithRuler with a batched Promise.all loop (max 10 concurrent requests) so datasource discovery no longer floods the backend. Moved isLoading to local state so the UI updates progressively as each batch completes, and added a cancelled cleanup flag to prevent stale state updates on unmount.
- Adds unit tests covering the current hook behaviour (baseline) and regression tests that reproduce the two bugs fixed above: uncapped concurrency and an incorrect isLoading state that resolved too early.
- Added keepUnusedDataFor: 3600 to both discoverDsFeatures and discoverAmFeatures RTK Query endpoints, extending the cache TTL to one hour to avoid redundant buildinfo requests across page navigations.

**Reproduction steps**

Note: No changes are visible to the user.

*Prerequisites*
- Grafana running at http://localhost:3000
- `alertingDisableDMAinUI` feature flag set to false in conf/custom.ini
- 50 Prometheus datasources pointing at Mimir (http://localhost:8080, test/test) with manageAlerts: true 
- Mimir devenv block running (make devenv sources=mimir_backend)

*Steps*
1. Go to http://localhost:3000/alerting/new/alerting
2. In section 2 "Define query and alert condition", click "Advanced options" (top-right toggle) to enable advanced mode
3. In the query editor, ensure only one data source query exists (delete any extra query rows beyond query A)
4. A "Grafana-managed / Data source-managed" radio toggle appears between the "+ Add query" button and the "Expressions" section
5. Click "Data source-managed"
6. Open DevTools → Network tab, filter by buildinfo
7. The CloudRulesSourcePicker mounts and useRulesSourcesWithRuler fires — you'll see 50 buildinfo requests going out in batches of ≤ 10 simultaneously

Alternatively (simpler — no toggle needed):
- Go directly to http://localhost:3000/alerting/new/recording (the page starts in data-source-managed mode and fires all 50 buildinfo requests immediately on load)

**Which issue(s) does this PR fix?**:

Relates to escalation [#i-2026-01-08-cagip-p2-esc-grafana-is-very-slow-since-upgrade-in-12-2-2](https://grafanalabs.enterprise.slack.com/archives/C0A7FT0ADPF)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
