### PR TITLE
Gate /api/health on apiserver readiness

### DIFF
--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -502,6 +502,7 @@ func (m mockClientConfigProvider) GetDirectRestConfig(c *contextmodel.ReqContext
 }
 
 func (m mockClientConfigProvider) DirectlyServeHTTP(w http.ResponseWriter, r *http.Request) {}
+func (m mockClientConfigProvider) IsReady() bool                                            { return true }
 
 // for now, test only the general folder
 func TestGetFolderLegacyAndUnifiedStorage(t *testing.T) {

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -739,6 +739,7 @@ type healthResponse struct {
 	Version          string `json:"version,omitempty"`
 	Commit           string `json:"commit,omitempty"`
 	EnterpriseCommit string `json:"enterpriseCommit,omitempty"`
+	APIServer        string `json:"apiserver,omitempty"`
 }
 
 // swagger:route GET /health health getHealth
@@ -767,13 +768,26 @@ func (hs *HTTPServer) apiHealthHandler(ctx *web.Context) {
 		}
 	}
 
+	healthy := true
+
 	if !hs.databaseHealthy(ctx.Req.Context()) {
 		data.Database = "failing"
-		ctx.Resp.Header().Set("Content-Type", "application/json; charset=UTF-8")
-		ctx.Resp.WriteHeader(http.StatusServiceUnavailable)
-	} else {
-		ctx.Resp.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		healthy = false
+	}
+
+	// Check apiserver readiness. This gates the health endpoint on apiserver
+	// boot sequence completion, including remote APIService initialization —
+	// preventing Kubernetes from routing traffic before aggregated services are ready.
+	if hs.clientConfigProvider != nil && !hs.clientConfigProvider.IsReady() {
+		data.APIServer = "not ready"
+		healthy = false
+	}
+
+	ctx.Resp.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	if healthy {
 		ctx.Resp.WriteHeader(http.StatusOK)
+	} else {
+		ctx.Resp.WriteHeader(http.StatusServiceUnavailable)
 	}
 
 	dataBytes, err := json.MarshalIndent(data, "", "  ")

--- a/pkg/services/apiserver/restconfig.go
+++ b/pkg/services/apiserver/restconfig.go
@@ -37,6 +37,11 @@ type DirectRestConfigProvider interface {
 
 	// This can be used to rewrite incoming requests to path now supported under /apis
 	DirectlyServeHTTP(w http.ResponseWriter, r *http.Request)
+
+	// IsReady returns true if the apiserver has completed startup and is ready
+	// to serve requests. This is non-blocking — returns false immediately if
+	// the apiserver hasn't started yet.
+	IsReady() bool
 }
 
 func ProvideEventualRestConfigProvider() *eventualRestConfigProvider {
@@ -87,5 +92,14 @@ func (e *eventualRestConfigProvider) DirectlyServeHTTP(w http.ResponseWriter, r 
 		e.cfg.DirectlyServeHTTP(w, r)
 	case <-r.Context().Done():
 		// Do nothing: the request has been cancelled.
+	}
+}
+
+func (e *eventualRestConfigProvider) IsReady() bool {
+	select {
+	case <-e.ready:
+		return true
+	default:
+		return false
 	}
 }

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -597,6 +597,10 @@ func (s *service) DirectlyServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.handler.ServeHTTP(w, r)
 }
 
+func (s *service) IsReady() bool {
+	return s.handler != nil
+}
+
 func (s *service) running(ctx context.Context) error {
 	select {
 	case err := <-s.stoppedCh:


### PR DESCRIPTION
## Summary
- Cherry-pick of essential readiness-gate changes from #120131, without the unrelated schema/openapi/whitespace changes
- Adds `IsReady()` to `DirectRestConfigProvider` interface and implements it on `eventualRestConfigProvider` and `service`
- Wires apiserver readiness into `/api/health` so Kubernetes returns 503 until aggregated APIServices are ready

## Context
The enterprise readiness gate PR was cherry-picked already, but #120131 (the OSS side) was missed. Without these changes, `/api/health` never checks apiserver readiness and the startup 503 race persists.

## Test plan
- [x] `go build ./pkg/api/... ./pkg/services/apiserver/...` compiles cleanly
- [x] `go test ./pkg/services/apiserver/... ./pkg/api/...` passes
- [x] `go test --tags "pro" -timeout 5m -run ^TestIntegrationOpenAPIs$ github.com/grafana/grafana/pkg/extensions/apiserver/tests -count=1` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)