### PR TITLE
Dashboards: fix secondary template errors in ReqContext.Handle HTML error responses

### DIFF
--- a/pkg/api/webassets/webassets.go
+++ b/pkg/api/webassets/webassets.go
@@ -2,11 +2,7 @@ package webassets
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
-	"os"
 	"path/filepath"
 	"sync"
 
@@ -15,26 +11,9 @@ import (
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/httpclient"
+	assetsmanifest "github.com/grafana/grafana/pkg/webassets/manifest"
 	"github.com/open-feature/go-sdk/openfeature"
 )
-
-type ManifestInfo struct {
-	FilePath  string `json:"src,omitempty"`
-	Integrity string `json:"integrity,omitempty"`
-
-	// The known entrypoints
-	App     *EntryPointInfo `json:"app,omitempty"`
-	Dark    *EntryPointInfo `json:"dark,omitempty"`
-	Light   *EntryPointInfo `json:"light,omitempty"`
-	Swagger *EntryPointInfo `json:"swagger,omitempty"`
-}
-
-type EntryPointInfo struct {
-	Assets struct {
-		JS  []string `json:"js,omitempty"`
-		CSS []string `json:"css,omitempty"`
-	} `json:"assets,omitempty"`
-}
 
 var (
 	entryPointAssetsCacheMu sync.RWMutex           // guard entryPointAssetsCache
@@ -93,16 +72,13 @@ func GetWebAssets(ctx context.Context, cfg *setting.Cfg, license licensing.Licen
 	return entryPointAssetsCache, err
 }
 
-func ReadWebAssetsFromFile(manifestpath string) (*dtos.EntryPointAssets, error) {
-	//nolint:gosec
-	f, err := os.Open(manifestpath)
+func ReadWebAssetsFromFile(manifestPath string) (*dtos.EntryPointAssets, error) {
+	assets, err := assetsmanifest.ReadFromFile(manifestPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load assets-manifest.json %w", err)
+		return nil, err
 	}
-	defer func() {
-		_ = f.Close()
-	}()
-	return readWebAssets(f)
+
+	return toDTOAssets(assets), nil
 }
 
 func readWebAssetsFromCDN(ctx context.Context, baseURL string) (*dtos.EntryPointAssets, error) {
@@ -117,76 +93,49 @@ func readWebAssetsFromCDN(ctx context.Context, baseURL string) (*dtos.EntryPoint
 	defer func() {
 		_ = response.Body.Close()
 	}()
-	dto, err := readWebAssets(response.Body)
+	dto, err := assetsmanifest.Read(response.Body)
 	if err == nil {
-		dto.SetContentDeliveryURL(baseURL)
+		converted := toDTOAssets(dto)
+		converted.SetContentDeliveryURL(baseURL)
+		return converted, nil
 	}
-	return dto, err
+
+	return nil, err
 }
 
-func readWebAssets(r io.Reader) (*dtos.EntryPointAssets, error) {
-	manifest := map[string]ManifestInfo{}
-	if err := json.NewDecoder(r).Decode(&manifest); err != nil {
-		return nil, fmt.Errorf("failed to read assets-manifest.json %w", err)
-	}
-
-	integrity := make(map[string]string, 100)
-	for _, v := range manifest {
-		if v.Integrity != "" && v.FilePath != "" {
-			integrity[v.FilePath] = v.Integrity
-		}
-	}
-
-	entryPoints, ok := manifest["entrypoints"]
-	if !ok {
-		return nil, fmt.Errorf("could not find entrypoints in asssets-manifest")
-	}
-
-	if entryPoints.App == nil || len(entryPoints.App.Assets.JS) == 0 {
-		return nil, fmt.Errorf("missing app entry, try running `yarn build`")
-	}
-	if entryPoints.Dark == nil || len(entryPoints.Dark.Assets.CSS) == 0 {
-		return nil, fmt.Errorf("missing dark entry, try running `yarn build`")
-	}
-	if entryPoints.Light == nil || len(entryPoints.Light.Assets.CSS) == 0 {
-		return nil, fmt.Errorf("missing light entry, try running `yarn build`")
-	}
-	if entryPoints.Swagger == nil || len(entryPoints.Swagger.Assets.JS) == 0 {
-		return nil, fmt.Errorf("missing swagger entry, try running `yarn build`")
-	}
-
+func toDTOAssets(assets *assetsmanifest.EntryPointAssets) *dtos.EntryPointAssets {
 	rsp := &dtos.EntryPointAssets{
-		JSFiles:         make([]dtos.EntryPointAsset, 0, len(entryPoints.App.Assets.JS)),
-		CSSFiles:        make([]dtos.EntryPointAsset, 0, len(entryPoints.App.Assets.CSS)),
-		Dark:            entryPoints.Dark.Assets.CSS[0],
-		Light:           entryPoints.Light.Assets.CSS[0],
-		Swagger:         make([]dtos.EntryPointAsset, 0, len(entryPoints.Swagger.Assets.JS)),
-		SwaggerCSSFiles: make([]dtos.EntryPointAsset, 0, len(entryPoints.Swagger.Assets.CSS)),
+		JSFiles:         make([]dtos.EntryPointAsset, 0, len(assets.JSFiles)),
+		CSSFiles:        make([]dtos.EntryPointAsset, 0, len(assets.CSSFiles)),
+		Dark:            assets.Dark,
+		Light:           assets.Light,
+		Swagger:         make([]dtos.EntryPointAsset, 0, len(assets.Swagger)),
+		SwaggerCSSFiles: make([]dtos.EntryPointAsset, 0, len(assets.SwaggerCSSFiles)),
 	}
 
-	for _, entry := range entryPoints.App.Assets.JS {
+	for _, entry := range assets.JSFiles {
 		rsp.JSFiles = append(rsp.JSFiles, dtos.EntryPointAsset{
-			FilePath:  entry,
-			Integrity: integrity[entry],
+			FilePath:  entry.FilePath,
+			Integrity: entry.Integrity,
 		})
 	}
-	for _, entry := range entryPoints.App.Assets.CSS {
+	for _, entry := range assets.CSSFiles {
 		rsp.CSSFiles = append(rsp.CSSFiles, dtos.EntryPointAsset{
-			FilePath:  entry,
-			Integrity: integrity[entry],
+			FilePath:  entry.FilePath,
+			Integrity: entry.Integrity,
 		})
 	}
-	for _, entry := range entryPoints.Swagger.Assets.JS {
+	for _, entry := range assets.Swagger {
 		rsp.Swagger = append(rsp.Swagger, dtos.EntryPointAsset{
-			FilePath:  entry,
-			Integrity: integrity[entry],
+			FilePath:  entry.FilePath,
+			Integrity: entry.Integrity,
 		})
 	}
-	for _, entry := range entryPoints.Swagger.Assets.CSS {
+	for _, entry := range assets.SwaggerCSSFiles {
 		rsp.SwaggerCSSFiles = append(rsp.SwaggerCSSFiles, dtos.EntryPointAsset{
-			FilePath:  entry,
-			Integrity: integrity[entry],
+			FilePath:  entry.FilePath,
+			Integrity: entry.Integrity,
 		})
 	}
-	return rsp, nil
+	return rsp
 }

--- a/pkg/services/contexthandler/model/model.go
+++ b/pkg/services/contexthandler/model/model.go
@@ -3,6 +3,7 @@ package contextmodel
 import (
 	"errors"
 	"net/http"
+	"path/filepath"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -15,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
+	assetsmanifest "github.com/grafana/grafana/pkg/webassets/manifest"
 )
 
 type ReqContext struct {
@@ -42,15 +44,39 @@ type ReqContext struct {
 	UseSessionStorageRedirect bool
 }
 
+type errorPageAssets struct {
+	Light string
+	Dark  string
+}
+
+func getErrorPageAssets(cfg *setting.Cfg) errorPageAssets {
+	manifestCandidates := []string{"assets-manifest.json", "assets-manifest-react19.json"}
+
+	for _, manifestName := range manifestCandidates {
+		assets, err := assetsmanifest.ReadFromFile(filepath.Join(cfg.StaticRootPath, "build", manifestName))
+		if err == nil {
+			return errorPageAssets{
+				Light: assets.Light,
+				Dark:  assets.Dark,
+			}
+		}
+	}
+
+	return errorPageAssets{}
+}
+
 // Handle handles and logs error by given status.
 func (ctx *ReqContext) Handle(cfg *setting.Cfg, status int, title string, err error) {
+	assets := getErrorPageAssets(cfg)
+
 	data := struct {
 		Title     string
 		AppTitle  string
 		AppSubUrl string
 		ThemeType string
 		ErrorMsg  error
-	}{title, "Grafana", cfg.AppSubURL, "dark", nil}
+		Assets    errorPageAssets
+	}{title, "Grafana", cfg.AppSubURL, cfg.DefaultTheme, nil, assets}
 
 	if err != nil {
 		ctx.Logger.Error(title, "error", err)

--- a/pkg/services/contexthandler/model/model_test.go
+++ b/pkg/services/contexthandler/model/model_test.go
@@ -2,10 +2,13 @@ package contextmodel
 
 import (
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -37,4 +40,57 @@ func TestQueryBoolWithDefault(t *testing.T) {
 			require.Equal(t, tt.expected, r.QueryBoolWithDefault("silenced", tt.defaultValue))
 		})
 	}
+}
+
+func TestGetErrorPageAssets(t *testing.T) {
+	t.Run("uses default manifest when available", func(t *testing.T) {
+		tempDir := t.TempDir()
+		buildDir := filepath.Join(tempDir, "build")
+		require.NoError(t, os.MkdirAll(buildDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(buildDir, "assets-manifest.json"), []byte(testManifestJSON(
+			"public/build/grafana.dark.default.css",
+			"public/build/grafana.light.default.css",
+		)), 0o644))
+
+		cfg := &setting.Cfg{StaticRootPath: tempDir}
+		assets := getErrorPageAssets(cfg)
+
+		require.Equal(t, "public/build/grafana.light.default.css", assets.Light)
+		require.Equal(t, "public/build/grafana.dark.default.css", assets.Dark)
+	})
+
+	t.Run("falls back to react19 manifest", func(t *testing.T) {
+		tempDir := t.TempDir()
+		buildDir := filepath.Join(tempDir, "build")
+		require.NoError(t, os.MkdirAll(buildDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(buildDir, "assets-manifest-react19.json"), []byte(testManifestJSON(
+			"public/build/grafana.dark.react19.css",
+			"public/build/grafana.light.react19.css",
+		)), 0o644))
+
+		cfg := &setting.Cfg{StaticRootPath: tempDir}
+		assets := getErrorPageAssets(cfg)
+
+		require.Equal(t, "public/build/grafana.light.react19.css", assets.Light)
+		require.Equal(t, "public/build/grafana.dark.react19.css", assets.Dark)
+	})
+
+	t.Run("returns empty assets when no manifest exists", func(t *testing.T) {
+		cfg := &setting.Cfg{StaticRootPath: t.TempDir()}
+		assets := getErrorPageAssets(cfg)
+
+		require.Empty(t, assets.Light)
+		require.Empty(t, assets.Dark)
+	})
+}
+
+func testManifestJSON(darkCSS, lightCSS string) string {
+	return `{
+  "entrypoints": {
+    "app": { "assets": { "js": ["public/build/app.js"], "css": ["public/build/app.css"] } },
+    "dark": { "assets": { "css": ["` + darkCSS + `"] } },
+    "light": { "assets": { "css": ["` + lightCSS + `"] } },
+    "swagger": { "assets": { "js": ["public/build/swagger.js"], "css": ["public/build/swagger.css"] } }
+  }
+}`
 }

--- a/pkg/webassets/manifest/manifest.go
+++ b/pkg/webassets/manifest/manifest.go
@@ -1,0 +1,120 @@
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+type manifestInfo struct {
+	FilePath  string `json:"src,omitempty"`
+	Integrity string `json:"integrity,omitempty"`
+
+	App     *entryPointInfo `json:"app,omitempty"`
+	Dark    *entryPointInfo `json:"dark,omitempty"`
+	Light   *entryPointInfo `json:"light,omitempty"`
+	Swagger *entryPointInfo `json:"swagger,omitempty"`
+}
+
+type entryPointInfo struct {
+	Assets struct {
+		JS  []string `json:"js,omitempty"`
+		CSS []string `json:"css,omitempty"`
+	} `json:"assets,omitempty"`
+}
+
+type EntryPointAsset struct {
+	FilePath  string
+	Integrity string
+}
+
+type EntryPointAssets struct {
+	JSFiles         []EntryPointAsset
+	CSSFiles        []EntryPointAsset
+	Dark            string
+	Light           string
+	Swagger         []EntryPointAsset
+	SwaggerCSSFiles []EntryPointAsset
+}
+
+func ReadFromFile(manifestPath string) (*EntryPointAssets, error) {
+	//nolint:gosec
+	f, err := os.Open(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load assets-manifest.json %w", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	return Read(f)
+}
+
+func Read(r io.Reader) (*EntryPointAssets, error) {
+	manifest := map[string]manifestInfo{}
+	if err := json.NewDecoder(r).Decode(&manifest); err != nil {
+		return nil, fmt.Errorf("failed to read assets-manifest.json %w", err)
+	}
+
+	integrity := make(map[string]string, 100)
+	for _, v := range manifest {
+		if v.Integrity != "" && v.FilePath != "" {
+			integrity[v.FilePath] = v.Integrity
+		}
+	}
+
+	entryPoints, ok := manifest["entrypoints"]
+	if !ok {
+		return nil, fmt.Errorf("could not find entrypoints in asssets-manifest")
+	}
+
+	if entryPoints.App == nil || len(entryPoints.App.Assets.JS) == 0 {
+		return nil, fmt.Errorf("missing app entry, try running `yarn build`")
+	}
+	if entryPoints.Dark == nil || len(entryPoints.Dark.Assets.CSS) == 0 {
+		return nil, fmt.Errorf("missing dark entry, try running `yarn build`")
+	}
+	if entryPoints.Light == nil || len(entryPoints.Light.Assets.CSS) == 0 {
+		return nil, fmt.Errorf("missing light entry, try running `yarn build`")
+	}
+	if entryPoints.Swagger == nil || len(entryPoints.Swagger.Assets.JS) == 0 {
+		return nil, fmt.Errorf("missing swagger entry, try running `yarn build`")
+	}
+
+	rsp := &EntryPointAssets{
+		JSFiles:         make([]EntryPointAsset, 0, len(entryPoints.App.Assets.JS)),
+		CSSFiles:        make([]EntryPointAsset, 0, len(entryPoints.App.Assets.CSS)),
+		Dark:            entryPoints.Dark.Assets.CSS[0],
+		Light:           entryPoints.Light.Assets.CSS[0],
+		Swagger:         make([]EntryPointAsset, 0, len(entryPoints.Swagger.Assets.JS)),
+		SwaggerCSSFiles: make([]EntryPointAsset, 0, len(entryPoints.Swagger.Assets.CSS)),
+	}
+
+	for _, entry := range entryPoints.App.Assets.JS {
+		rsp.JSFiles = append(rsp.JSFiles, EntryPointAsset{
+			FilePath:  entry,
+			Integrity: integrity[entry],
+		})
+	}
+	for _, entry := range entryPoints.App.Assets.CSS {
+		rsp.CSSFiles = append(rsp.CSSFiles, EntryPointAsset{
+			FilePath:  entry,
+			Integrity: integrity[entry],
+		})
+	}
+	for _, entry := range entryPoints.Swagger.Assets.JS {
+		rsp.Swagger = append(rsp.Swagger, EntryPointAsset{
+			FilePath:  entry,
+			Integrity: integrity[entry],
+		})
+	}
+	for _, entry := range entryPoints.Swagger.Assets.CSS {
+		rsp.SwaggerCSSFiles = append(rsp.SwaggerCSSFiles, EntryPointAsset{
+			FilePath:  entry,
+			Integrity: integrity[entry],
+		})
+	}
+
+	return rsp, nil
+}

--- a/pkg/webassets/manifest/manifest_test.go
+++ b/pkg/webassets/manifest/manifest_test.go
@@ -1,0 +1,66 @@
+package manifest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRead(t *testing.T) {
+	manifestJSON := `{
+  "public/build/runtime.js": {
+    "src": "public/build/runtime.js",
+    "integrity": "sha256-runtime"
+  },
+  "public/build/app.js": {
+    "src": "public/build/app.js",
+    "integrity": "sha256-app"
+  },
+  "public/build/swagger.js": {
+    "src": "public/build/swagger.js",
+    "integrity": "sha256-swagger"
+  },
+  "entrypoints": {
+    "app": {
+      "assets": {
+        "js": ["public/build/runtime.js", "public/build/app.js"],
+        "css": ["public/build/grafana.app.css"]
+      }
+    },
+    "dark": { "assets": { "css": ["public/build/grafana.dark.css"] } },
+    "light": { "assets": { "css": ["public/build/grafana.light.css"] } },
+    "swagger": {
+      "assets": {
+        "js": ["public/build/runtime.js", "public/build/swagger.js"],
+        "css": ["public/build/grafana.swagger.css"]
+      }
+    }
+  }
+}`
+
+	assets, err := Read(strings.NewReader(manifestJSON))
+	require.NoError(t, err)
+
+	require.Equal(t, "public/build/grafana.dark.css", assets.Dark)
+	require.Equal(t, "public/build/grafana.light.css", assets.Light)
+	require.Len(t, assets.JSFiles, 2)
+	require.Len(t, assets.CSSFiles, 1)
+	require.Len(t, assets.Swagger, 2)
+	require.Len(t, assets.SwaggerCSSFiles, 1)
+	require.Equal(t, "sha256-runtime", assets.JSFiles[0].Integrity)
+}
+
+func TestReadMissingDarkEntry(t *testing.T) {
+	invalidManifestJSON := `{
+  "entrypoints": {
+    "app": { "assets": { "js": ["public/build/app.js"], "css": ["public/build/grafana.app.css"] } },
+    "light": { "assets": { "css": ["public/build/grafana.light.css"] } },
+    "swagger": { "assets": { "js": ["public/build/swagger.js"], "css": ["public/build/grafana.swagger.css"] } }
+  }
+}`
+
+	_, err := Read(strings.NewReader(invalidManifestJSON))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "missing dark entry")
+}


### PR DESCRIPTION

**What is this PR?**

This PR fixes missing CSS asset wiring for HTML error pages rendered through `ReqContext.Handle(...)`.

Before this change, `public/views/error.html` expected `.Assets.Light/.Assets.Dark`, but the
data struct in `ReqContext.Handle(...)` did not provide `Assets`. This could produce an unstyled
error page response and a secondary template-render error log on HTML error responses using this path.
HTTP status semantics are unchanged.

---

**Why do we need this?**

This is a correctness/consistency bug in HTML error rendering:

- `ReqContext.Handle(...)` serves HTML error responses.
- `error.html` expects theme stylesheet asset paths.
- Missing assets can degrade HTML error-page output even when HTTP status is correct.
- Missing assets also emit a secondary template-render error log (`Context.HTML ... can't evaluate field Assets ...`) on top of the original error, which increases operational log noise.

---

**Before (unpatched):**


<img width="1412" height="537" alt="error" src="https://github.com/user-attachments/assets/198a30dd-1995-4dbe-ac1c-7d6d559edf78" />

---
secondary template-render error exists

```
logger=context userId=2 orgId=1 uname=sa-1-dd t=2026-03-14T11:24:56.923217545Z level=error 
msg="Request error" error="Context.HTML - Error rendering template: error. You may need to build frontend assets \n template: error:16:42: executing \"error\" at <.Assets.Dark>: can't evaluate field Assets in type struct { Title string; AppTitle string; AppSubUrl string; ThemeType string; ErrorMsg error }" stack="github.com/grafana/grafana/pkg/web/context.go:112 
(0x1c8de84)\ngithub.com/grafana/grafana/pkg/services/contexthandler/model/model.go:59 
(0x1c9a704)\ngithub.com/grafana/grafana/pkg/api/render.go:39 
(0x751bf5c)\ngithub.com/grafana/grafana/pkg/api/response/web_hack.go:40 
(0x1ca06af)\nnet/http/server.go:2286 (0x1c8ef29)\ngithub.com/grafana/grafana/pkg/web/macaron.go:131 
(0x1c8eef3)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/web/macaron.go:137 
(0x1c8efc5)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/web/macaron.go:137 
(0x1c8efc5)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/web/macaron.go:137 
(0x1c8efc5)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/web/macaron.go:137 
(0x1c8efc5)\nnet/http/server.go:2286 
(0x7ea2a8)\ngithub.com/grafana/grafana/pkg/middleware/validate_action_url.go:51 
(0x62dfe5a)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/web/macaron.go:137 
(0x1c8efc5)\nnet/http/server.go:2286 
(0x7ea2a8)\ngithub.com/grafana/grafana/pkg/services/contexthandler/contexthandler.go:99 
(0x752a5f4)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/web/macaron.go:137 
(0x1c8efc5)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/web/macaron.go:137 
(0x1c8efc5)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/web/macaron.go:137 
(0x1c8efc5)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/web/macaron.go:137 
(0x1c8efc5)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/web/macaron.go:137 
(0x1c8efc5)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/web/render.go:51 
(0x1c8fa86)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/web/macaron.go:137 
(0x1c8efc5)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/web/macaron.go:137 
(0x1c8efc5)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/web/macaron.go:137 
(0x1c8efc5)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/web/macaron.go:137 
(0x1c8efc5)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/web/macaron.go:137 
(0x1c8efc5)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/middleware/csrf/csrf.go:66 
(0x69641fa)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/middleware/recovery.go:180
 (0x74fc86b)\nnet/http/server.go:2286 
(0x7ea2a8)\ngithub.com/grafana/grafana/pkg/middleware/loggermw/logger.go:71 
(0x69652b6)\nnet/http/server.go:2286 
(0x7ea2a8)\ngithub.com/grafana/grafana/pkg/middleware/request_metrics.go:96 
(0x62de8b8)\nnet/http/server.go:2286 
(0x7ea2a8)\ngithub.com/grafana/grafana/pkg/middleware/request_tracing.go:127 
(0x74fd811)\nnet/http/server.go:2286 
(0x7ea2a8)\ngithub.com/grafana/grafana/pkg/middleware/requestmeta/request_metadata.go:66 
(0x7529ab9)\nnet/http/server.go:2286 (0x7ea2a8)\ngithub.com/grafana/grafana/pkg/web/context.go:52 
(0x1c8d811)\ngithub.com/grafana/grafana/pkg/web/router.go:155 
(0x1c912cd)\ngithub.com/grafana/grafana/pkg/web/router.go:221 
(0x1c91dd2)\ngithub.com/grafana/grafana/pkg/web/macaron.go:174 (0x1c8f46f)\nnet/http/server.go:3311 
(0x80aa4d)\nnet/http/server.go:2073 (0x7e838f)\nruntime/asm_amd64.s:1771 (0x497e60)\n"
```

---

**After (patched):**

<img width="1376" height="902" alt="error_patch" src="https://github.com/user-attachments/assets/5a9d1494-4871-4405-b1fc-4e6e668f8443" />


---
secondary template-render error removed

No additional "Context.HTML - Error rendering template ... can't evaluate field Assets ..." log line.


---

**Implementation note:**
`ReqContext.Handle(...)` lives under `pkg/services/...` and cannot reuse `pkg/api/webassets` directly due package dependency direction (would create an import cycle with `pkg/api`).
To keep layering intact, manifest parsing was extracted to `pkg/webassets/manifest` and reused from both paths.

---

**Which issue(s) does this PR fix?**

Fixes #120356

---
Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
