### PR TITLE
chore(grafana-ui): remove lodash map and chunk usage in colors utils

### DIFF
--- a/packages/grafana-ui/src/utils/colors.test.ts
+++ b/packages/grafana-ui/src/utils/colors.test.ts
@@ -1,0 +1,28 @@
+import { chunk } from './colors';
+
+describe('colors utilities', () => {
+  describe('chunk', () => {
+    it('splits an array into groups of the given size', () => {
+      expect(chunk([1, 2, 3, 4, 5, 6], 2)).toEqual([
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ]);
+    });
+
+    it('handles a last chunk smaller than size', () => {
+      expect(chunk([1, 2, 3, 4, 5], 3)).toEqual([
+        [1, 2, 3],
+        [4, 5],
+      ]);
+    });
+
+    it('returns an empty array for empty input', () => {
+      expect(chunk([], 3)).toEqual([]);
+    });
+
+    it('returns single-element chunks when size is 1', () => {
+      expect(chunk(['a', 'b', 'c'], 1)).toEqual([['a'], ['b'], ['c']]);
+    });
+  });
+});

--- a/packages/grafana-ui/src/utils/colors.ts
+++ b/packages/grafana-ui/src/utils/colors.ts
@@ -1,4 +1,4 @@
-import { map, sortBy, flattenDeep, chunk, zip } from 'lodash';
+import { sortBy, flattenDeep, zip } from 'lodash';
 import tinycolor from 'tinycolor2';
 
 const PALETTE_ROWS = 4;
@@ -92,16 +92,25 @@ export const colors = [
 ];
 
 function sortColorsByHue(hexColors: string[]) {
-  const hslColors = map(hexColors, hexToHsl);
+  const hslColors = hexColors.map(hexToHsl);
 
   const sortedHSLColors = sortBy(hslColors, ['h']);
   const chunkedHSLColors = chunk(sortedHSLColors, PALETTE_ROWS);
-  const sortedChunkedHSLColors = map(chunkedHSLColors, (chunk) => {
-    return sortBy(chunk, 'l');
+  const sortedChunkedHSLColors = chunkedHSLColors.map((c) => {
+    return sortBy(c, 'l');
   });
   const flattenedZippedSortedChunkedHSLColors = flattenDeep(zip(...sortedChunkedHSLColors));
 
-  return map(flattenedZippedSortedChunkedHSLColors, hslToHex);
+  return flattenedZippedSortedChunkedHSLColors.map(hslToHex);
+}
+
+/** @internal */
+export function chunk<T>(array: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < array.length; i += size) {
+    result.push(array.slice(i, i + size));
+  }
+  return result;
 }
 
 function hexToHsl(color: string) {


### PR DESCRIPTION
## Summary
- Replace lodash `map` and `chunk` usage in `grafana-ui` color utilities with local/native equivalents.
- Keep behavior and output ordering aligned with the previous implementation.
- Keep the change scoped to the `colors` utility refactor only.
- This PR is part of the incremental effort to fully remove lodash usage from `grafana-ui`.

## Testing
- No dedicated local tests were run for this small refactor.