### PR TITLE
chore(grafana-ui): remove remaining lodash helpers in colors utils

### DIFF
--- a/packages/grafana-ui/src/utils/colors.test.ts
+++ b/packages/grafana-ui/src/utils/colors.test.ts
@@ -1,0 +1,28 @@
+import { chunk } from './colors';
+
+describe('colors utilities', () => {
+  describe('chunk', () => {
+    it('splits an array into groups of the given size', () => {
+      expect(chunk([1, 2, 3, 4, 5, 6], 2)).toEqual([
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ]);
+    });
+
+    it('handles a last chunk smaller than size', () => {
+      expect(chunk([1, 2, 3, 4, 5], 3)).toEqual([
+        [1, 2, 3],
+        [4, 5],
+      ]);
+    });
+
+    it('returns an empty array for empty input', () => {
+      expect(chunk([], 3)).toEqual([]);
+    });
+
+    it('returns single-element chunks when size is 1', () => {
+      expect(chunk(['a', 'b', 'c'], 1)).toEqual([['a'], ['b'], ['c']]);
+    });
+  });
+});

--- a/packages/grafana-ui/src/utils/colors.test.ts
+++ b/packages/grafana-ui/src/utils/colors.test.ts
@@ -1,4 +1,4 @@
-import { chunk } from './colors';
+import { chunk, zip, sortedColors, colors, getTextColorForBackground } from './colors';
 
 describe('colors utilities', () => {
   describe('chunk', () => {
@@ -23,6 +23,65 @@ describe('colors utilities', () => {
 
     it('returns single-element chunks when size is 1', () => {
       expect(chunk(['a', 'b', 'c'], 1)).toEqual([['a'], ['b'], ['c']]);
+    });
+  });
+
+  describe('zip', () => {
+    it('zips arrays of equal length', () => {
+      expect(zip([1, 2, 3], [4, 5, 6])).toEqual([
+        [1, 4],
+        [2, 5],
+        [3, 6],
+      ]);
+    });
+
+    it('handles arrays of different lengths (fills with undefined)', () => {
+      const result = zip([1, 2], [3, 4, 5]);
+      expect(result).toEqual([
+        [1, 3],
+        [2, 4],
+        [undefined, 5],
+      ]);
+    });
+
+    it('handles a single array', () => {
+      expect(zip([1, 2, 3])).toEqual([[1], [2], [3]]);
+    });
+
+    it('returns an empty array when no arrays are provided', () => {
+      expect(zip()).toEqual([]);
+    });
+  });
+
+  describe('sortedColors', () => {
+    it('has the same number of colors as the input palette', () => {
+      expect(sortedColors).toHaveLength(colors.length);
+    });
+
+    it('contains all the same colors as the input palette', () => {
+      const sortedSet = new Set(sortedColors.map((c) => c.toLowerCase()));
+      const originalSet = new Set(colors.map((c) => c.toLowerCase()));
+      expect(sortedSet).toEqual(originalSet);
+    });
+
+    it('produces valid hex color strings', () => {
+      for (const color of sortedColors) {
+        expect(color).toMatch(/^#[0-9a-f]{6}$/);
+      }
+    });
+
+    it('is stable across runs (snapshot)', () => {
+      expect(sortedColors).toMatchSnapshot();
+    });
+  });
+
+  describe('getTextColorForBackground', () => {
+    it('returns dark text for light backgrounds', () => {
+      expect(getTextColorForBackground('#ffffff')).toBe('rgb(32, 34, 38)');
+    });
+
+    it('returns light text for dark backgrounds', () => {
+      expect(getTextColorForBackground('#000000')).toBe('rgb(247, 248, 250)');
     });
   });
 });

--- a/packages/grafana-ui/src/utils/colors.ts
+++ b/packages/grafana-ui/src/utils/colors.ts
@@ -1,4 +1,3 @@
-import { sortBy, flattenDeep, zip } from 'lodash';
 import tinycolor from 'tinycolor2';
 
 const PALETTE_ROWS = 4;
@@ -94,12 +93,12 @@ export const colors = [
 function sortColorsByHue(hexColors: string[]) {
   const hslColors = hexColors.map(hexToHsl);
 
-  const sortedHSLColors = sortBy(hslColors, ['h']);
+  const sortedHSLColors = [...hslColors].sort((a, b) => a.h - b.h);
   const chunkedHSLColors = chunk(sortedHSLColors, PALETTE_ROWS);
   const sortedChunkedHSLColors = chunkedHSLColors.map((c) => {
-    return sortBy(c, 'l');
+    return [...c].sort((a, b) => a.l - b.l);
   });
-  const flattenedZippedSortedChunkedHSLColors = flattenDeep(zip(...sortedChunkedHSLColors));
+  const flattenedZippedSortedChunkedHSLColors = zip(...sortedChunkedHSLColors).flat();
 
   return flattenedZippedSortedChunkedHSLColors.map(hslToHex);
 }
@@ -109,6 +108,16 @@ export function chunk<T>(array: T[], size: number): T[][] {
   const result: T[][] = [];
   for (let i = 0; i < array.length; i += size) {
     result.push(array.slice(i, i + size));
+  }
+  return result;
+}
+
+/** @internal */
+export function zip<T>(...arrays: T[][]): T[][] {
+  const maxLen = Math.max(0, ...arrays.map((a) => a.length));
+  const result: T[][] = [];
+  for (let i = 0; i < maxLen; i++) {
+    result.push(arrays.map((a) => a[i]));
   }
   return result;
 }

--- a/packages/grafana-ui/src/utils/colors.ts
+++ b/packages/grafana-ui/src/utils/colors.ts
@@ -1,4 +1,4 @@
-import { map, sortBy, flattenDeep, chunk, zip } from 'lodash';
+import { sortBy, flattenDeep, zip } from 'lodash';
 import tinycolor from 'tinycolor2';
 
 const PALETTE_ROWS = 4;
@@ -92,16 +92,25 @@ export const colors = [
 ];
 
 function sortColorsByHue(hexColors: string[]) {
-  const hslColors = map(hexColors, hexToHsl);
+  const hslColors = hexColors.map(hexToHsl);
 
   const sortedHSLColors = sortBy(hslColors, ['h']);
   const chunkedHSLColors = chunk(sortedHSLColors, PALETTE_ROWS);
-  const sortedChunkedHSLColors = map(chunkedHSLColors, (chunk) => {
-    return sortBy(chunk, 'l');
+  const sortedChunkedHSLColors = chunkedHSLColors.map((c) => {
+    return sortBy(c, 'l');
   });
   const flattenedZippedSortedChunkedHSLColors = flattenDeep(zip(...sortedChunkedHSLColors));
 
-  return map(flattenedZippedSortedChunkedHSLColors, hslToHex);
+  return flattenedZippedSortedChunkedHSLColors.map(hslToHex);
+}
+
+/** @internal */
+export function chunk<T>(array: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < array.length; i += size) {
+    result.push(array.slice(i, i + size));
+  }
+  return result;
 }
 
 function hexToHsl(color: string) {


### PR DESCRIPTION
## Summary
- This PR consolidates the full lodash cleanup for `grafana-ui` color utilities, including the scope previously covered by PR1.
- It replaces lodash helpers with native/local implementations while preserving behavior and output order.
- It keeps review and merge flow simpler by grouping all `colors` utility changes into one PR.

## Included changes
- Replaces lodash-based `map/chunk` flow in the color sorting pipeline.
- Replaces `sortBy` and `zip` with native/local equivalents.
- Removes `flattenDeep` usage by using native flattening.
- Keeps internal helper functions needed by the sorting logic.

## Testing
- Adds and expands unit tests for:
  - `chunk` behavior
  - `zip` behavior (equal and uneven array lengths)
  - `sortedColors` invariants (same size, same color set, valid hex format)
  - stable output via snapshot
  - text color selection for background contrast
- Command run:
  - `npx yarn jest packages/grafana-ui/src/utils/colors.test.ts --no-watch --runInBand`
