### PR TITLE
Modal: use border.medium to fix semi-transparent border artifact

### DIFF
--- a/packages/grafana-ui/src/components/Modal/getModalStyles.ts
+++ b/packages/grafana-ui/src/components/Modal/getModalStyles.ts
@@ -10,7 +10,7 @@ export const getModalStyles = (theme: GrafanaTheme2) => {
       background: theme.colors.background.primary,
       boxShadow: theme.shadows.z3,
       borderRadius: theme.shape.radius.lg,
-      border: `1px solid ${theme.colors.border.weak}`,
+      border: `1px solid ${theme.colors.border.medium}`,
       backgroundClip: 'padding-box',
       outline: 'none',
       width: '750px',


### PR DESCRIPTION
Fixes #122543

## Summary

- Changed modal border from `border.weak` to `border.medium` to fix a semi-transparent border artifact
- `border.weak` has low opacity which, combined with `backgroundClip: padding-box`, creates a visible translucent strip where the border meets the background
- `border.medium` provides an opaque border that eliminates the artifact while maintaining the visual separation

## Test plan

- [ ] Open any modal in Grafana (e.g. dashboard settings, panel edit)
- [ ] Verify no translucent border artifact is visible
- [ ] Check both light and dark themes
- [ ] Verify the border is still visually present and consistent