### PR TITLE
chore(grafana-ui): replace lodash debounce/throttle with timing utils

### DIFF
--- a/packages/grafana-ui/src/components/AutoSaveField/AutoSaveField.tsx
+++ b/packages/grafana-ui/src/components/AutoSaveField/AutoSaveField.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/css';
-import { debounce } from 'lodash';
 import { useCallback, useMemo, useRef } from 'react';
 import * as React from 'react';
 
 import { Trans } from '@grafana/i18n';
 
 import { useStyles2 } from '../../themes/ThemeContext';
+import { debounce } from '../../utils/timing';
 import { Field, FieldProps } from '../Forms/Field';
 import { InlineToast } from '../InlineToast/InlineToast';
 

--- a/packages/grafana-ui/src/components/ColorPicker/ColorInput.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/ColorInput.tsx
@@ -1,5 +1,4 @@
 import { cx, css } from '@emotion/css';
-import { debounce } from 'lodash';
 import { forwardRef, useState, useEffect, useMemo } from 'react';
 import * as React from 'react';
 import tinycolor from 'tinycolor2';
@@ -7,6 +6,7 @@ import tinycolor from 'tinycolor2';
 import { GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2 } from '../../themes/ThemeContext';
+import { debounce } from '../../utils/timing';
 import { Input, Props as InputProps } from '../Input/Input';
 
 import { ColorPickerProps } from './ColorPickerPopover';

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -1,11 +1,11 @@
 /* Spreading unbound arrays can be very slow or even crash the browser if used for arguments */
 /* eslint no-restricted-syntax: ["error", "SpreadElement"] */
 
-import { debounce } from 'lodash';
 import { useState, useCallback, useMemo } from 'react';
 
 import { t } from '@grafana/i18n';
 
+import { debounce } from '../../utils/timing';
 import { fuzzyFind, itemToString } from './filter';
 import { ComboboxOption } from './types';
 import { StaleResultError, useLatestAsyncCall } from './useLatestAsyncCall';

--- a/packages/grafana-ui/src/components/QueryField/QueryField.tsx
+++ b/packages/grafana-ui/src/components/QueryField/QueryField.tsx
@@ -1,6 +1,5 @@
 import { css, cx } from '@emotion/css';
 import classnames from 'classnames';
-import { debounce } from 'lodash';
 import { PureComponent } from 'react';
 import * as React from 'react';
 import { Value } from 'slate';
@@ -21,6 +20,7 @@ import { withTheme2 } from '../../themes/ThemeContext';
 import { getFocusStyles } from '../../themes/mixins';
 import { CompletionItemGroup, SuggestionsState, TypeaheadInput, TypeaheadOutput } from '../../types/completion';
 import { Themeable2 } from '../../types/theme';
+import { debounce } from '../../utils/timing';
 import { makeValue, SCHEMA } from '../../utils/slate';
 
 export interface QueryFieldProps extends Themeable2 {

--- a/packages/grafana-ui/src/components/TableInputCSV/TableInputCSV.tsx
+++ b/packages/grafana-ui/src/components/TableInputCSV/TableInputCSV.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/css';
-import { debounce } from 'lodash';
 import { PureComponent } from 'react';
 import * as React from 'react';
 
@@ -9,6 +8,7 @@ import { t, Trans } from '@grafana/i18n';
 import { withTheme2 } from '../../themes/ThemeContext';
 import { stylesFactory } from '../../themes/stylesFactory';
 import { Themeable2 } from '../../types/theme';
+import { debounce } from '../../utils/timing';
 import { Icon } from '../Icon/Icon';
 import { TextArea } from '../TextArea/TextArea';
 

--- a/packages/grafana-ui/src/components/uPlot/plugins/EventBusPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/EventBusPlugin.tsx
@@ -1,4 +1,3 @@
-import { throttle } from 'lodash';
 import { useLayoutEffect, useRef } from 'react';
 import { Subscription } from 'rxjs';
 import { throttleTime } from 'rxjs/operators';
@@ -12,6 +11,7 @@ import {
   LegacyGraphHoverEvent,
 } from '@grafana/data';
 
+import { throttle } from '../../../utils/timing';
 import { UPlotConfigBuilder } from '../config/UPlotConfigBuilder';
 
 interface EventBusPluginProps {

--- a/packages/grafana-ui/src/slate-plugins/suggestions.tsx
+++ b/packages/grafana-ui/src/slate-plugins/suggestions.tsx
@@ -1,8 +1,9 @@
-import { debounce, sortBy } from 'lodash';
+import { sortBy } from 'lodash';
 import { Editor, Plugin as SlatePlugin } from 'slate-react';
 
 import { Typeahead } from '../components/Typeahead/Typeahead';
 import { CompletionItem, SuggestionsState, TypeaheadInput, TypeaheadOutput } from '../types/completion';
+import { debounce } from '../utils/timing';
 import { SearchFunctionType, SearchFunctionMap } from '../utils/searchFunctions';
 import { makeFragment } from '../utils/slate';
 

--- a/packages/grafana-ui/src/utils/logger.ts
+++ b/packages/grafana-ui/src/utils/logger.ts
@@ -1,4 +1,4 @@
-import { throttle } from 'lodash';
+import { throttle } from './timing';
 
 type Args = Parameters<typeof console.log>;
 

--- a/packages/grafana-ui/src/utils/timing.test.ts
+++ b/packages/grafana-ui/src/utils/timing.test.ts
@@ -1,0 +1,203 @@
+import { debounce, throttle } from './timing';
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('debounce', () => {
+  it('delays invocation until after wait ms', () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced();
+    expect(fn).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes arguments to the original function', () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 50);
+
+    debounced('a', 'b');
+    jest.advanceTimersByTime(50);
+
+    expect(fn).toHaveBeenCalledWith('a', 'b');
+  });
+
+  it('resets the timer on subsequent calls', () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced();
+    jest.advanceTimersByTime(80);
+    debounced();
+    jest.advanceTimersByTime(80);
+
+    expect(fn).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(20);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the last arguments when calls are batched', () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced('first');
+    debounced('second');
+    debounced('third');
+
+    jest.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('third');
+  });
+
+  it('calls immediately with leading: true', () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 100, { leading: true });
+
+    debounced('a');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('a');
+  });
+
+  it('calls both leading and trailing by default when leading is true', () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 100, { leading: true });
+
+    debounced('lead');
+    debounced('trail');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('lead');
+
+    jest.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith('trail');
+  });
+
+  it('suppresses trailing call with trailing: false', () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 100, { leading: true, trailing: false });
+
+    debounced('lead');
+    debounced('ignored');
+
+    jest.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('lead');
+  });
+
+  it('cancel prevents pending invocation', () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced();
+    debounced.cancel();
+
+    jest.advanceTimersByTime(100);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('can be called again after cancel', () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced('cancelled');
+    debounced.cancel();
+    debounced('new');
+
+    jest.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('new');
+  });
+});
+
+describe('throttle', () => {
+  it('calls immediately on first invocation', () => {
+    const fn = jest.fn();
+    const throttled = throttle(fn, 100);
+
+    throttled('a');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('a');
+  });
+
+  it('suppresses calls within the wait period', () => {
+    const fn = jest.fn();
+    const throttled = throttle(fn, 100);
+
+    throttled();
+    throttled();
+    throttled();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls with latest args as trailing after wait expires', () => {
+    const fn = jest.fn();
+    const throttled = throttle(fn, 100);
+
+    throttled('first');
+    throttled('second');
+    throttled('third');
+
+    jest.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith('third');
+  });
+
+  it('allows a new call after the wait period', () => {
+    const fn = jest.fn();
+    const throttled = throttle(fn, 100);
+
+    throttled('a');
+    jest.advanceTimersByTime(100);
+
+    throttled('b');
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith('b');
+  });
+
+  it('cancel prevents the trailing invocation', () => {
+    const fn = jest.fn();
+    const throttled = throttle(fn, 100);
+
+    throttled('first');
+    throttled('second');
+    throttled.cancel();
+
+    jest.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('first');
+  });
+
+  it('can be called again after cancel', () => {
+    const fn = jest.fn();
+    const throttled = throttle(fn, 100);
+
+    throttled('old');
+    throttled.cancel();
+
+    throttled('new');
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith('new');
+  });
+
+  it('does not fire trailing if no intermediate calls', () => {
+    const fn = jest.fn();
+    const throttled = throttle(fn, 100);
+
+    throttled('only');
+    jest.advanceTimersByTime(100);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('only');
+  });
+});

--- a/packages/grafana-ui/src/utils/timing.ts
+++ b/packages/grafana-ui/src/utils/timing.ts
@@ -1,0 +1,91 @@
+interface DebounceOptions {
+  leading?: boolean;
+  trailing?: boolean;
+}
+
+export function debounce<A extends unknown[]>(
+  fn: (...args: A) => void,
+  wait = 0,
+  options: DebounceOptions = {}
+): ((...args: A) => void) & { cancel: () => void } {
+  let timerId: ReturnType<typeof setTimeout> | undefined;
+  let lastArgs: A | undefined;
+
+  const leading = options.leading ?? false;
+  const trailing = options.trailing ?? true;
+
+  const invoke = () => {
+    if (lastArgs) {
+      fn(...lastArgs);
+      lastArgs = undefined;
+    }
+  };
+
+  const debounced = (...args: A) => {
+    const shouldCallLeading = leading && timerId === undefined;
+
+    lastArgs = args;
+
+    if (timerId !== undefined) {
+      clearTimeout(timerId);
+    }
+
+    timerId = setTimeout(() => {
+      timerId = undefined;
+      if (trailing) {
+        invoke();
+      } else {
+        lastArgs = undefined;
+      }
+    }, wait);
+
+    if (shouldCallLeading) {
+      invoke();
+    }
+  };
+
+  return Object.assign(debounced, {
+    cancel: () => {
+      if (timerId !== undefined) {
+        clearTimeout(timerId);
+        timerId = undefined;
+      }
+      lastArgs = undefined;
+    },
+  });
+}
+
+export function throttle<A extends unknown[]>(
+  fn: (...args: A) => void,
+  wait = 0
+): ((...args: A) => void) & { cancel: () => void } {
+  let timerId: ReturnType<typeof setTimeout> | undefined;
+  let lastArgs: A | undefined;
+
+  const throttled = (...args: A) => {
+    if (timerId === undefined) {
+      fn(...args);
+      timerId = setTimeout(() => {
+        timerId = undefined;
+        if (lastArgs) {
+          const trailingArgs = lastArgs;
+          lastArgs = undefined;
+          fn(...trailingArgs);
+        }
+      }, wait);
+      return;
+    }
+
+    lastArgs = args;
+  };
+
+  return Object.assign(throttled, {
+    cancel: () => {
+      if (timerId !== undefined) {
+        clearTimeout(timerId);
+        timerId = undefined;
+      }
+      lastArgs = undefined;
+    },
+  });
+}


### PR DESCRIPTION
## What changed

This PR removes the remaining `lodash` `debounce` and `throttle` usages in `packages/grafana-ui`.

It adds a small local `timing` utility with:
- `debounce`
- `throttle`
- `cancel()` support
- `leading` / `trailing` debounce options

Then it updates the affected grafana-ui consumers to use that utility instead of `lodash`.

React hook-based usages are kept on `react-use` directly, since those are hook-specific and don't fit the non-React/class-component cases covered by the new utility.

## Why

`react-use` only provides hook-based throttle/debounce helpers, so it can't replace all current usages.

For the non-hook cases, a small local implementation is the most pragmatic option:
- no new dependency
- minimal surface area
- typed API
- easy to test and maintain

## Affected areas

Debounce migrations:
- AutoSaveField
- ColorInput
- Combobox `useOptions`
- QueryField
- TableInputCSV
- Slate suggestions

Throttle migrations:
- logger
- uPlot EventBusPlugin

## Validation

- Added unit tests for the new timing utility
- `TypeScript` compile check passes for `grafana-ui`
- Relevant Jest tests pass