### PR TITLE
Jaeger: Handle gzip, deflate, and brotli compressed API responses

### DIFF
--- a/pkg/tsdb/jaeger/client.go
+++ b/pkg/tsdb/jaeger/client.go
@@ -51,6 +51,16 @@ func (j *JaegerClient) doGet(ctx context.Context, rawURL string) (*http.Response
 	return res, nil
 }
 
+// readResponseBody reads the response body and decompresses it based on Content-Encoding.
+func readResponseBody(res *http.Response, _ log.Logger) ([]byte, error) {
+	encoding := res.Header.Get("Content-Encoding")
+	body, err := utils.Decode(encoding, res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	return body, nil
+}
+
 func (j *JaegerClient) Services(ctx context.Context) ([]string, error) {
 	var response types.ServicesResponse
 	services := []string{}
@@ -66,12 +76,20 @@ func (j *JaegerClient) Services(ctx context.Context) ([]string, error) {
 	}
 
 	defer func() {
-		if err = res.Body.Close(); err != nil {
-			j.logger.Error("Failed to close response body", "error", err)
+		if closeErr := res.Body.Close(); closeErr != nil {
+			j.logger.Error("Failed to close response body", "error", closeErr)
 		}
 	}()
 
-	if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
+	if res.StatusCode/100 != 2 {
+		return services, fmt.Errorf("request failed: %s", res.Status)
+	}
+
+	body, err := readResponseBody(res, j.logger)
+	if err != nil {
+		return services, err
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
 		return services, err
 	}
 
@@ -94,12 +112,20 @@ func (j *JaegerClient) Operations(ctx context.Context, s string) ([]string, erro
 	}
 
 	defer func() {
-		if err = res.Body.Close(); err != nil {
-			j.logger.Error("Failed to close response body", "error", err)
+		if closeErr := res.Body.Close(); closeErr != nil {
+			j.logger.Error("Failed to close response body", "error", closeErr)
 		}
 	}()
 
-	if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
+	if res.StatusCode/100 != 2 {
+		return operations, fmt.Errorf("request failed: %s", res.Status)
+	}
+
+	body, err := readResponseBody(res, j.logger)
+	if err != nil {
+		return operations, err
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
 		return operations, err
 	}
 
@@ -174,8 +200,8 @@ func (j *JaegerClient) Search(ctx context.Context, query *JaegerQuery, start, en
 	}
 
 	defer func() {
-		if err = resp.Body.Close(); err != nil {
-			j.logger.Error("Failed to close response body", "error", err)
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			j.logger.Error("Failed to close response body", "error", closeErr)
 		}
 	}()
 
@@ -187,8 +213,12 @@ func (j *JaegerClient) Search(ctx context.Context, query *JaegerQuery, start, en
 		return nil, err
 	}
 
+	body, err := readResponseBody(resp, j.logger)
+	if err != nil {
+		return nil, backend.DownstreamErrorf("failed to read response: %w", err)
+	}
 	var result types.TracesResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.Unmarshal(body, &result); err != nil {
 		return nil, backend.DownstreamErrorf("failed to decode Jaeger response: %w", err)
 	}
 
@@ -244,8 +274,8 @@ func (j *JaegerClient) Trace(ctx context.Context, traceID string, start, end int
 	}
 
 	defer func() {
-		if err = res.Body.Close(); err != nil {
-			logger.Error("Failed to close response body", "error", err)
+		if closeErr := res.Body.Close(); closeErr != nil {
+			logger.Error("Failed to close response body", "error", closeErr)
 		}
 	}()
 
@@ -257,7 +287,11 @@ func (j *JaegerClient) Trace(ctx context.Context, traceID string, start, end int
 		return nil, err
 	}
 
-	if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
+	body, err := readResponseBody(res, logger)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
 		return nil, err
 	}
 
@@ -306,8 +340,8 @@ func (j *JaegerClient) Dependencies(ctx context.Context, start, end int64) (type
 	}
 
 	defer func() {
-		if err = res.Body.Close(); err != nil {
-			logger.Error("Failed to close response body", "error", err)
+		if closeErr := res.Body.Close(); closeErr != nil {
+			logger.Error("Failed to close response body", "error", closeErr)
 		}
 	}()
 
@@ -319,7 +353,11 @@ func (j *JaegerClient) Dependencies(ctx context.Context, start, end int64) (type
 		return dependencies, err
 	}
 
-	if err := json.NewDecoder(res.Body).Decode(&dependencies); err != nil {
+	body, err := readResponseBody(res, logger)
+	if err != nil {
+		return dependencies, err
+	}
+	if err := json.Unmarshal(body, &dependencies); err != nil {
 		return dependencies, err
 	}
 

--- a/pkg/tsdb/jaeger/client.go
+++ b/pkg/tsdb/jaeger/client.go
@@ -52,11 +52,11 @@ func (j *JaegerClient) doGet(ctx context.Context, rawURL string) (*http.Response
 }
 
 // readResponseBody reads the response body and decompresses it based on Content-Encoding.
-func readResponseBody(res *http.Response, _ log.Logger) ([]byte, error) {
+func readResponseBody(res *http.Response) ([]byte, error) {
 	encoding := res.Header.Get("Content-Encoding")
 	body, err := utils.Decode(encoding, res.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, backend.DownstreamErrorf("failed to read response body: %w", err)
 	}
 	return body, nil
 }
@@ -77,20 +77,20 @@ func (j *JaegerClient) Services(ctx context.Context) ([]string, error) {
 
 	defer func() {
 		if closeErr := res.Body.Close(); closeErr != nil {
-			j.logger.Error("Failed to close response body", "error", closeErr)
+			j.logger.Warn("Failed to close response body", "error", closeErr)
 		}
 	}()
 
 	if res.StatusCode/100 != 2 {
-		return services, fmt.Errorf("request failed: %s", res.Status)
+		return services, backend.DownstreamErrorf("request failed: %s", res.Status)
 	}
 
-	body, err := readResponseBody(res, j.logger)
+	body, err := readResponseBody(res)
 	if err != nil {
 		return services, err
 	}
 	if err := json.Unmarshal(body, &response); err != nil {
-		return services, err
+		return services, backend.DownstreamErrorf("failed to unmarshal Jaeger response: %w", err)
 	}
 
 	services = response.Data
@@ -113,20 +113,20 @@ func (j *JaegerClient) Operations(ctx context.Context, s string) ([]string, erro
 
 	defer func() {
 		if closeErr := res.Body.Close(); closeErr != nil {
-			j.logger.Error("Failed to close response body", "error", closeErr)
+			j.logger.Warn("Failed to close response body", "error", closeErr)
 		}
 	}()
 
 	if res.StatusCode/100 != 2 {
-		return operations, fmt.Errorf("request failed: %s", res.Status)
+		return operations, backend.DownstreamErrorf("request failed: %s", res.Status)
 	}
 
-	body, err := readResponseBody(res, j.logger)
+	body, err := readResponseBody(res)
 	if err != nil {
 		return operations, err
 	}
 	if err := json.Unmarshal(body, &response); err != nil {
-		return operations, err
+		return operations, backend.DownstreamErrorf("failed to unmarshal Jaeger response: %w", err)
 	}
 
 	operations = response.Data
@@ -201,7 +201,7 @@ func (j *JaegerClient) Search(ctx context.Context, query *JaegerQuery, start, en
 
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			j.logger.Error("Failed to close response body", "error", closeErr)
+			j.logger.Warn("Failed to close response body", "error", closeErr)
 		}
 	}()
 
@@ -213,13 +213,13 @@ func (j *JaegerClient) Search(ctx context.Context, query *JaegerQuery, start, en
 		return nil, err
 	}
 
-	body, err := readResponseBody(resp, j.logger)
+	body, err := readResponseBody(resp)
 	if err != nil {
 		return nil, backend.DownstreamErrorf("failed to read response: %w", err)
 	}
 	var result types.TracesResponse
 	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, backend.DownstreamErrorf("failed to decode Jaeger response: %w", err)
+		return nil, backend.DownstreamErrorf("failed to unmarshal Jaeger response: %w", err)
 	}
 
 	frames := utils.TransformSearchResponse(result.Data, j.settings.UID, j.settings.Name)
@@ -275,7 +275,7 @@ func (j *JaegerClient) Trace(ctx context.Context, traceID string, start, end int
 
 	defer func() {
 		if closeErr := res.Body.Close(); closeErr != nil {
-			logger.Error("Failed to close response body", "error", closeErr)
+			logger.Warn("Failed to close response body", "error", closeErr)
 		}
 	}()
 
@@ -287,12 +287,12 @@ func (j *JaegerClient) Trace(ctx context.Context, traceID string, start, end int
 		return nil, err
 	}
 
-	body, err := readResponseBody(res, logger)
+	body, err := readResponseBody(res)
 	if err != nil {
 		return nil, err
 	}
 	if err := json.Unmarshal(body, &response); err != nil {
-		return nil, err
+		return nil, backend.DownstreamErrorf("failed to unmarshal Jaeger response: %w", err)
 	}
 
 	// We only support one trace at a time
@@ -341,7 +341,7 @@ func (j *JaegerClient) Dependencies(ctx context.Context, start, end int64) (type
 
 	defer func() {
 		if closeErr := res.Body.Close(); closeErr != nil {
-			logger.Error("Failed to close response body", "error", closeErr)
+			logger.Warn("Failed to close response body", "error", closeErr)
 		}
 	}()
 
@@ -353,12 +353,12 @@ func (j *JaegerClient) Dependencies(ctx context.Context, start, end int64) (type
 		return dependencies, err
 	}
 
-	body, err := readResponseBody(res, logger)
+	body, err := readResponseBody(res)
 	if err != nil {
 		return dependencies, err
 	}
 	if err := json.Unmarshal(body, &dependencies); err != nil {
-		return dependencies, err
+		return dependencies, backend.DownstreamErrorf("failed to unmarshal Jaeger response: %w", err)
 	}
 
 	return dependencies, nil

--- a/pkg/tsdb/jaeger/client_test.go
+++ b/pkg/tsdb/jaeger/client_test.go
@@ -1,7 +1,6 @@
 package jaeger
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -39,7 +38,7 @@ func TestJaegerClient_Services(t *testing.T) {
 			mockStatus:     "Internal Server Error",
 			expectedResult: []string{},
 			expectError:    true,
-			expectedError:  errors.New("Internal Server Error"),
+			expectedError:  backend.ErrorWithSource{},
 		},
 		{
 			name:           "Invalid JSON response",
@@ -48,7 +47,7 @@ func TestJaegerClient_Services(t *testing.T) {
 			mockStatus:     "OK",
 			expectedResult: []string{},
 			expectError:    true,
-			expectedError:  &json.SyntaxError{},
+			expectedError:  backend.ErrorWithSource{},
 		},
 	}
 
@@ -110,7 +109,7 @@ func TestJaegerClient_Operations(t *testing.T) {
 			mockStatus:     "Internal Server Error",
 			expectedResult: []string{},
 			expectError:    true,
-			expectedError:  errors.New("Internal Server Error"),
+			expectedError:  backend.ErrorWithSource{},
 		},
 		{
 			name:           "Invalid JSON response",
@@ -120,7 +119,7 @@ func TestJaegerClient_Operations(t *testing.T) {
 			mockStatus:     "OK",
 			expectedResult: []string{},
 			expectError:    true,
-			expectedError:  &json.SyntaxError{},
+			expectedError:  backend.ErrorWithSource{},
 		},
 		{
 			name:           "Service with special characters",
@@ -344,7 +343,7 @@ func TestJaegerClient_Trace(t *testing.T) {
 			mockStatus:     "OK",
 			expectedURL:    "/api/traces/abc123?end=2000&start=1000",
 			expectError:    true,
-			expectedError:  &json.SyntaxError{},
+			expectedError:  backend.ErrorWithSource{},
 		},
 		{
 			name:           "Empty trace ID",
@@ -461,7 +460,7 @@ func TestJaegerClient_Dependencies(t *testing.T) {
 			mockStatus:     "OK",
 			expectedURL:    "/api/dependencies?endTs=2000&lookback=1000",
 			expectError:    true,
-			expectedError:  &json.SyntaxError{},
+			expectedError:  backend.ErrorWithSource{},
 		},
 		{
 			name:           "Empty dependencies response and no errors",

--- a/pkg/tsdb/jaeger/grpc_client.go
+++ b/pkg/tsdb/jaeger/grpc_client.go
@@ -35,7 +35,7 @@ func (j *JaegerClient) GrpcServices(ctx context.Context) ([]string, error) {
 
 	defer func() {
 		if closeErr := res.Body.Close(); closeErr != nil {
-			j.logger.Error("Failed to close response body", "error", closeErr)
+			j.logger.Warn("Failed to close response body", "error", closeErr)
 		}
 	}()
 
@@ -47,12 +47,12 @@ func (j *JaegerClient) GrpcServices(ctx context.Context) ([]string, error) {
 		return services, err
 	}
 
-	body, err := readResponseBody(res, j.logger)
+	body, err := readResponseBody(res)
 	if err != nil {
-		return services, backend.DownstreamError(err)
+		return services, err
 	}
 	if err := json.Unmarshal(body, &response); err != nil {
-		return services, backend.DownstreamError(err)
+		return services, backend.DownstreamErrorf("failed to unmarshal Jaeger response: %w", err)
 	}
 
 	services = response.Services
@@ -87,7 +87,7 @@ func (j *JaegerClient) GrpcOperations(ctx context.Context, s string) ([]string, 
 
 	defer func() {
 		if closeErr := res.Body.Close(); closeErr != nil {
-			j.logger.Error("Failed to close response body", "error", closeErr)
+			j.logger.Warn("Failed to close response body", "error", closeErr)
 		}
 	}()
 
@@ -99,12 +99,12 @@ func (j *JaegerClient) GrpcOperations(ctx context.Context, s string) ([]string, 
 		return operations, err
 	}
 
-	body, err := readResponseBody(res, j.logger)
+	body, err := readResponseBody(res)
 	if err != nil {
-		return operations, backend.DownstreamError(err)
+		return operations, err
 	}
 	if err := json.Unmarshal(body, &response); err != nil {
-		return operations, backend.DownstreamError(err)
+		return operations, backend.DownstreamErrorf("failed to unmarshal Jaeger response: %w", err)
 	}
 
 	// extract name from operations response
@@ -177,7 +177,7 @@ func (j *JaegerClient) GrpcSearch(ctx context.Context, query *JaegerQuery, start
 
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			j.logger.Error("Failed to close response body", "error", closeErr)
+			j.logger.Warn("Failed to close response body", "error", closeErr)
 		}
 	}()
 
@@ -189,13 +189,13 @@ func (j *JaegerClient) GrpcSearch(ctx context.Context, query *JaegerQuery, start
 		return nil, err
 	}
 
-	body, err := readResponseBody(resp, j.logger)
+	body, err := readResponseBody(resp)
 	if err != nil {
-		return nil, backend.DownstreamErrorf("failed to read response: %w", err)
+		return nil, err
 	}
 	var response types.GrpcTracesResponse
 	if err := json.Unmarshal(body, &response); err != nil {
-		return nil, backend.DownstreamErrorf("failed to decode Jaeger response: %w", err)
+		return nil, backend.DownstreamErrorf("failed to unmarshal Jaeger response: %w", err)
 	}
 
 	// for search call, an unsuccessful response is exposed through the error attribute
@@ -253,7 +253,7 @@ func (j *JaegerClient) GrpcTrace(ctx context.Context, traceID string, start, end
 
 	defer func() {
 		if closeErr := res.Body.Close(); closeErr != nil {
-			logger.Error("Failed to close response body", "error", closeErr)
+			logger.Warn("Failed to close response body", "error", closeErr)
 		}
 	}()
 
@@ -265,12 +265,12 @@ func (j *JaegerClient) GrpcTrace(ctx context.Context, traceID string, start, end
 		return nil, err
 	}
 
-	body, err := readResponseBody(res, logger)
+	body, err := readResponseBody(res)
 	if err != nil {
-		return nil, backend.DownstreamErrorf("failed to read response: %w", err)
+		return nil, err
 	}
 	if err := json.Unmarshal(body, &response); err != nil {
-		return nil, err
+		return nil, backend.DownstreamErrorf("failed to unmarshal Jaeger response: %w", err)
 	}
 
 	// for trace search call, an unsuccessful response is exposed through the error attribute

--- a/pkg/tsdb/jaeger/grpc_client.go
+++ b/pkg/tsdb/jaeger/grpc_client.go
@@ -34,8 +34,8 @@ func (j *JaegerClient) GrpcServices(ctx context.Context) ([]string, error) {
 	}
 
 	defer func() {
-		if err = res.Body.Close(); err != nil {
-			j.logger.Error("Failed to close response body", "error", err)
+		if closeErr := res.Body.Close(); closeErr != nil {
+			j.logger.Error("Failed to close response body", "error", closeErr)
 		}
 	}()
 
@@ -47,7 +47,11 @@ func (j *JaegerClient) GrpcServices(ctx context.Context) ([]string, error) {
 		return services, err
 	}
 
-	if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
+	body, err := readResponseBody(res, j.logger)
+	if err != nil {
+		return services, backend.DownstreamError(err)
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
 		return services, backend.DownstreamError(err)
 	}
 
@@ -82,8 +86,8 @@ func (j *JaegerClient) GrpcOperations(ctx context.Context, s string) ([]string, 
 	}
 
 	defer func() {
-		if err = res.Body.Close(); err != nil {
-			j.logger.Error("Failed to close response body", "error", err)
+		if closeErr := res.Body.Close(); closeErr != nil {
+			j.logger.Error("Failed to close response body", "error", closeErr)
 		}
 	}()
 
@@ -95,7 +99,11 @@ func (j *JaegerClient) GrpcOperations(ctx context.Context, s string) ([]string, 
 		return operations, err
 	}
 
-	if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
+	body, err := readResponseBody(res, j.logger)
+	if err != nil {
+		return operations, backend.DownstreamError(err)
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
 		return operations, backend.DownstreamError(err)
 	}
 
@@ -168,8 +176,8 @@ func (j *JaegerClient) GrpcSearch(ctx context.Context, query *JaegerQuery, start
 	}
 
 	defer func() {
-		if err = resp.Body.Close(); err != nil {
-			j.logger.Error("Failed to close response body", "error", err)
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			j.logger.Error("Failed to close response body", "error", closeErr)
 		}
 	}()
 
@@ -181,8 +189,12 @@ func (j *JaegerClient) GrpcSearch(ctx context.Context, query *JaegerQuery, start
 		return nil, err
 	}
 
+	body, err := readResponseBody(resp, j.logger)
+	if err != nil {
+		return nil, backend.DownstreamErrorf("failed to read response: %w", err)
+	}
 	var response types.GrpcTracesResponse
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+	if err := json.Unmarshal(body, &response); err != nil {
 		return nil, backend.DownstreamErrorf("failed to decode Jaeger response: %w", err)
 	}
 
@@ -240,8 +252,8 @@ func (j *JaegerClient) GrpcTrace(ctx context.Context, traceID string, start, end
 	}
 
 	defer func() {
-		if err = res.Body.Close(); err != nil {
-			logger.Error("Failed to close response body", "error", err)
+		if closeErr := res.Body.Close(); closeErr != nil {
+			logger.Error("Failed to close response body", "error", closeErr)
 		}
 	}()
 
@@ -253,7 +265,11 @@ func (j *JaegerClient) GrpcTrace(ctx context.Context, traceID string, start, end
 		return nil, err
 	}
 
-	if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
+	body, err := readResponseBody(res, logger)
+	if err != nil {
+		return nil, backend.DownstreamErrorf("failed to read response: %w", err)
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
 		return nil, err
 	}
 

--- a/pkg/tsdb/jaeger/grpc_client_test.go
+++ b/pkg/tsdb/jaeger/grpc_client_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/status"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,7 +50,7 @@ func TestJaegerGrpcClient_Services(t *testing.T) {
 			mockStatus:     "OK",
 			expectedResult: []string{},
 			expectError:    true,
-			expectedError:  status.ErrorWithSource{},
+			expectedError:  backend.ErrorWithSource{},
 		},
 	}
 
@@ -148,7 +147,7 @@ func TestJaegerGrpcClient_Trace(t *testing.T) {
 		frame, err := client.GrpcTrace(context.Background(), "", time.Time{}, time.Time{}, "A")
 		assert.Nil(t, frame)
 		assert.Error(t, err)
-		assert.IsType(t, status.ErrorWithSource{}, err)
+		assert.IsType(t, backend.ErrorWithSource{}, err)
 		assert.Contains(t, err.Error(), "traceID is empty")
 	})
 
@@ -164,7 +163,7 @@ func TestJaegerGrpcClient_Trace(t *testing.T) {
 		frame, err := client.GrpcTrace(context.Background(), "trace-1", time.Time{}, time.Time{}, "A")
 		assert.Nil(t, frame)
 		assert.Error(t, err)
-		assert.IsType(t, status.ErrorWithSource{}, err)
+		assert.IsType(t, backend.ErrorWithSource{}, err)
 		assert.Contains(t, err.Error(), "failed to parse settings JSON data")
 	})
 
@@ -185,7 +184,7 @@ func TestJaegerGrpcClient_Trace(t *testing.T) {
 		frame, err := client.GrpcTrace(context.Background(), "trace-1", time.Time{}, time.Time{}, "A")
 		assert.Nil(t, frame)
 		assert.Error(t, err)
-		assert.IsType(t, status.ErrorWithSource{}, err)
+		assert.IsType(t, backend.ErrorWithSource{}, err)
 	})
 
 	t.Run("returns error when response body is invalid", func(t *testing.T) {
@@ -235,7 +234,7 @@ func TestJaegerGrpcClient_Trace(t *testing.T) {
 		frame, err := client.GrpcTrace(context.Background(), "trace-1", time.Time{}, time.Time{}, "A")
 		assert.Nil(t, frame)
 		assert.Error(t, err)
-		assert.IsType(t, status.ErrorWithSource{}, err)
+		assert.IsType(t, backend.ErrorWithSource{}, err)
 		assert.Contains(t, err.Error(), "upstream failure")
 	})
 
@@ -345,7 +344,7 @@ func TestJaegerGrpcClient_Operations(t *testing.T) {
 			mockStatus:     "OK",
 			expectedResult: []string{},
 			expectError:    true,
-			expectedError:  status.ErrorWithSource{},
+			expectedError:  backend.ErrorWithSource{},
 		},
 		{
 			name:    "Service with special characters",

--- a/pkg/tsdb/jaeger/utils/client_utils.go
+++ b/pkg/tsdb/jaeger/utils/client_utils.go
@@ -1,11 +1,16 @@
 package utils
 
 import (
+	"compress/flate"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"io"
 	"sort"
 	"time"
 
+	"github.com/andybalholm/brotli"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/tsdb/jaeger/types"
 )
@@ -210,4 +215,41 @@ func TransformTraceResponse(trace types.TraceResponse, refID string) *data.Frame
 	}
 
 	return frame
+}
+
+// Decode reads and decompresses the body based on Content-Encoding (gzip, deflate, br, or none).
+func Decode(encoding string, original io.ReadCloser) ([]byte, error) {
+	var reader io.Reader
+	var err error
+	switch encoding {
+	case "gzip":
+		reader, err = gzip.NewReader(original)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			if err := reader.(io.ReadCloser).Close(); err != nil {
+				backend.Logger.Warn("Failed to close reader body", "err", err)
+			}
+		}()
+	case "deflate":
+		reader = flate.NewReader(original)
+		defer func() {
+			if err := reader.(io.ReadCloser).Close(); err != nil {
+				backend.Logger.Warn("Failed to close reader body", "err", err)
+			}
+		}()
+	case "br":
+		reader = brotli.NewReader(original)
+	case "":
+		reader = original
+	default:
+		return nil, fmt.Errorf("unexpected encoding type %q", encoding)
+	}
+
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
 }

--- a/pkg/tsdb/jaeger/utils/client_utils_test.go
+++ b/pkg/tsdb/jaeger/utils/client_utils_test.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"bytes"
+	"compress/gzip"
+	"io"
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/experimental"
@@ -257,5 +260,48 @@ func TestTransformTraceResponse(t *testing.T) {
 
 		frame := TransformTraceResponse(trace, "test")
 		experimental.CheckGoldenJSONFrame(t, "../testdata", "complex_trace.golden", frame, false)
+	})
+}
+
+func TestDecode(t *testing.T) {
+	plain := []byte(`{"data":["a","b"]}`)
+
+	t.Run("empty encoding returns body as-is", func(t *testing.T) {
+		body := io.NopCloser(bytes.NewReader(plain))
+		got, err := Decode("", body)
+		if err != nil {
+			t.Fatalf("Decode(): %v", err)
+		}
+		if !bytes.Equal(got, plain) {
+			t.Errorf("got %q, want %q", got, plain)
+		}
+	})
+
+	t.Run("gzip encoding decompresses body", func(t *testing.T) {
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		_, _ = gz.Write(plain)
+		_ = gz.Close()
+		gzipped := buf.Bytes()
+
+		body := io.NopCloser(bytes.NewReader(gzipped))
+		got, err := Decode("gzip", body)
+		if err != nil {
+			t.Fatalf("Decode(): %v", err)
+		}
+		if !bytes.Equal(got, plain) {
+			t.Errorf("got %q, want %q", got, plain)
+		}
+	})
+
+	t.Run("unknown encoding returns error", func(t *testing.T) {
+		body := io.NopCloser(bytes.NewReader(plain))
+		_, err := Decode("x-unknown", body)
+		if err == nil {
+			t.Fatal("expected error for unknown encoding")
+		}
+		if !bytes.Contains([]byte(err.Error()), []byte("x-unknown")) {
+			t.Errorf("error should mention encoding: %v", err)
+		}
 	})
 }


### PR DESCRIPTION
This PR adds a `readResponseBody` function to the jaeger data source that decodes the response body if it is encoded. I copy pasted the decode code from graphite. This makes sure that the backend doesn't blow up when the response comes back gzipped.

**Which issue(s) does this PR fix?**:

Fixes #120268

**Special notes for your reviewer:**

To see the error.

Add an nginx proxy in front of jaeger. I used the jaegeronly devenv with the following changes.

jaegeronly/docker-compose.yaml
```
  jaeger-gzip-proxy:
    image: nginx:alpine
    ports:
      - "16687:80"
    volumes:
      - ./docker/blocks/jaegeronly/nginx-gzip.conf:/etc/nginx/nginx.conf:ro
    depends_on:
      - jaeger
   
  jaeger:
    image: jaegertracing/all-in-one:latest
    ports:
      - "6831:6831/udp"
      - "16686:16686" # UI
      - "14268:14268"
      - "4317:4317" # OpenTelemetry Protocol (OTLP) over gRPC
      - "4318:4318" # OpenTelemetry Protocol (OTLP) over HTTP
    environment:
      - MEMORY_MAX_TRACES=100000
      - SPAN_STORAGE_TYPE=badger
      - COLLECTOR_OTLP_ENABLED=true
```

jaegeronly/nginx-gzip.conf
```
events {
    worker_connections 1024;
}
http {
    gzip on;
    gzip_vary on;
    gzip_proxied any;
    gzip_comp_level 6;
    gzip_min_length 1;
    gzip_types application/json text/plain;

    server {
        listen 80;
        server_name _;

        location / {
            # Ask upstream for uncompressed response so we can compress it
            proxy_set_header Accept-Encoding "";
            proxy_pass http://jaeger:16686;
            proxy_http_version 1.1;
            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;
        }
    }
}
```
