### PR TITLE
Fix #102242: Alerting folder selector now shows full hierarchy

### DIFF
--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -272,6 +272,12 @@ export function NestedFolderPicker({
   let label = getSelectedFolderResult.data?.title;
   if (value === '') {
     label = t('browse-dashboards.folder-picker.root-title', 'Dashboards');
+  } else if (getSelectedFolderResult.data?.parents?.length && getSelectedFolderResult.data?.title) {
+    // Include parent hierarchy when available (e.g. "Development Environment / accounts")
+    label = [
+      ...getSelectedFolderResult.data.parents.map((p) => p.title),
+      getSelectedFolderResult.data.title,
+    ].join(' / ');
   }
 
   // Display the folder name and provisioning status when the picker is closed

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -273,7 +273,6 @@ export function NestedFolderPicker({
   if (value === '') {
     label = t('browse-dashboards.folder-picker.root-title', 'Dashboards');
   } else if (getSelectedFolderResult.data?.parents?.length && getSelectedFolderResult.data?.title) {
-    // Include parent hierarchy when available (e.g. "Development Environment / accounts")
     label = [
       ...getSelectedFolderResult.data.parents.map((p) => p.title),
       getSelectedFolderResult.data.title,


### PR DESCRIPTION
When creating/editing alert rules, the folder picker displayed only the folder name (e.g. 'accounts') without parent context. With nested structures like Development Environment/accounts, Staging Environment/accounts, users couldn't distinguish which folder was selected.

This fix displays the full path (e.g. 'Development Environment / accounts') when the folder API returns parent information (foldersAppPlatformAPI).


