### PR TITLE
Fix #102219: Use /label/__name__/values for metric autocomplete when …labels selected

### DIFF
--- a/packages/grafana-prometheus/src/resource_clients.test.ts
+++ b/packages/grafana-prometheus/src/resource_clients.test.ts
@@ -367,6 +367,36 @@ describe('SeriesApiClient', () => {
   });
 
   describe('queryLabelValues', () => {
+    it('should use /label/__name__/values for metric autocomplete when labels are selected (avoids /series overload)', async () => {
+      mockRequest.mockResolvedValueOnce(['metric1', 'metric2']);
+
+      const result = await client.queryLabelValues(mockTimeRange, '__name__', '{label="value"}');
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/api/v1/label/__name__/values',
+        expect.objectContaining({
+          'match[]': '{label="value"}',
+        }),
+        expect.any(Object)
+      );
+      expect(result).toEqual(['metric1', 'metric2']);
+    });
+
+    it('should use /label/__name__/values without match when no labels selected', async () => {
+      mockRequest.mockResolvedValueOnce(['metric1', 'metric2', 'metric3']);
+
+      const result = await client.queryLabelValues(mockTimeRange, '__name__');
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/api/v1/label/__name__/values',
+        expect.not.objectContaining({
+          'match[]': expect.anything(),
+        }),
+        expect.any(Object)
+      );
+      expect(result).toEqual(['metric1', 'metric2', 'metric3']);
+    });
+
     it('should fetch and process label values from series', async () => {
       mockRequest.mockResolvedValueOnce([
         { __name__: 'metric1', job: 'grafana' },

--- a/packages/grafana-prometheus/src/resource_clients.ts
+++ b/packages/grafana-prometheus/src/resource_clients.ts
@@ -227,6 +227,34 @@ export class SeriesApiClient extends BaseResourceClient implements ResourceApiCl
     match?: string,
     limit?: number
   ): Promise<string[]> => {
+    const effectiveLimit = this.getEffectiveLimit(limit);
+
+    // For __name__ (metric name), always use /label/__name__/values instead of /series.
+    // /series returns full series data and can crash/fail when many series match (e.g. 1.5M+).
+    // /label/__name__/values returns only unique metric names and handles match[] efficiently.
+    // Fixes https://github.com/grafana/grafana/issues/102219
+    if (removeQuotesIfExist(labelKey) === METRIC_LABEL) {
+      const timeParams = this.datasource.getAdjustedInterval(timeRange);
+      const effectiveMatch = !match || match === EMPTY_SELECTOR ? undefined : match;
+      const cacheKey = `${effectiveMatch ?? ''}-__name__`;
+      const maybeCachedValues = this._cache.getLabelValues(timeRange, cacheKey, effectiveLimit);
+      if (maybeCachedValues) {
+        return maybeCachedValues;
+      }
+
+      const interpolatedAndEscapedName = escapeForUtf8Support(removeQuotesIfExist(labelKey));
+      const searchParams = {
+        limit: effectiveLimit,
+        ...timeParams,
+        ...(effectiveMatch ? { 'match[]': effectiveMatch } : {}),
+      };
+      const url = `/api/v1/label/${interpolatedAndEscapedName}/values`;
+      const value = await this.requestLabels(url, searchParams, getDefaultCacheHeaders(this.datasource.cacheLevel));
+      const labelValues = value ?? [];
+      this._cache.setLabelValues(timeRange, cacheKey, effectiveLimit, labelValues);
+      return labelValues;
+    }
+
     let effectiveMatch = '';
     if (!match || match === EMPTY_SELECTOR) {
       // Just and empty matcher {} or no matcher
@@ -245,7 +273,6 @@ export class SeriesApiClient extends BaseResourceClient implements ResourceApiCl
       effectiveMatch = `{${metricFilter}${labelFilters}}`;
     }
 
-    const effectiveLimit = this.getEffectiveLimit(limit);
     const maybeCachedValues = this._cache.getLabelValues(timeRange, effectiveMatch, effectiveLimit);
     if (maybeCachedValues) {
       return maybeCachedValues;


### PR DESCRIPTION
When the Prometheus query builder fetches metric names with existing label filters, SeriesApiClient previously used /series which returns full series data. With many matching series (e.g. 1.5M+), this causes empty results, browser crashes, or timeouts.

Now uses /api/v1/label/__name__/values with match[] parameter, which returns only unique metric names and handles large label sets efficiently.