### PR TITLE
DataLinks: fix context menu appearing at (0,0) when triggered via keyboard

### DIFF
--- a/packages/grafana-ui/src/components/ContextMenu/WithContextMenu.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/WithContextMenu.tsx
@@ -20,10 +20,20 @@ export const WithContextMenu = ({ children, renderMenuItems, focusOnOpen = true 
       {children({
         openMenu: (e) => {
           setIsMenuOpen(true);
-          setMenuPosition({
-            x: e.pageX,
-            y: e.pageY - window.scrollY,
-          });
+          // Keyboard-triggered click events have pageX/pageY of 0 (no pointer position).
+          // Fall back to the element's bounding rect so the menu opens near the element.
+          if (e.pageX === 0 && e.pageY === 0) {
+            const rect = e.currentTarget.getBoundingClientRect();
+            setMenuPosition({
+              x: rect.left + rect.width / 2,
+              y: rect.bottom,
+            });
+          } else {
+            setMenuPosition({
+              x: e.pageX,
+              y: e.pageY - window.scrollY,
+            });
+          }
         },
       })}
 


### PR DESCRIPTION
**What is this fix?**

When a data link or action context menu is opened by keyboard (Tab to the element then press Enter or Space), the synthesized click event has `pageX=0` and `pageY=0` because no pointer was involved. `WithContextMenu` passed those values directly to `ContextMenu`, so the menu always appeared at the top-left corner of the page.

**Why do we need this fix?**

Keyboard-only users and screen reader users couldn't reliably open the data link context menu.

**Fix**

In `WithContextMenu`, detect the keyboard-triggered case (`pageX === 0 && pageY === 0`) and fall back to positioning the menu at the bottom edge of the trigger element's bounding rect (using `getBoundingClientRect()`). The normal mouse-click path is unchanged.

**Which issue(s) does this PR fix?**

Fixes #120341