### PR TITLE
Auth: Add auto_link_preprovisioned_users config option

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -693,6 +693,10 @@ azure_auth_enabled = false
 # Use email lookup in addition to the unique ID provided by the IdP
 oauth_allow_insecure_email_lookup = false
 
+# Auto-link pre-provisioned users (admin-created, no existing auth links) by
+# email when they log in via OAuth. Narrower than oauth_allow_insecure_email_lookup.
+auto_link_preprovisioned_users = false
+
 # Set to true to include id of identity as a response header
 id_response_header_enabled = false
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -672,6 +672,10 @@
 # Use email lookup in addition to the unique ID provided by the IdP
 ;oauth_allow_insecure_email_lookup = false
 
+# Auto-link pre-provisioned users (admin-created, no existing auth links) by
+# email when they log in via OAuth. Narrower than oauth_allow_insecure_email_lookup.
+;auto_link_preprovisioned_users = false
+
 # Set to true to include id of identity as a response header
 ;id_response_header_enabled = false
 

--- a/docs/sources/setup-grafana/configure-access/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/_index.md
@@ -169,6 +169,8 @@ In certain cases, however, enabling user lookups by email can be a feasible opti
 - The infrastructure allows email-based identification without compromising security.
 
 **Important note**: While it is possible to configure Grafana to allow email-based user lookups, we strongly recommend against this approach in most cases due to potential security risks.
+If you only need to link admin-pre-created users (not all users) by email, consider `auto_link_preprovisioned_users` instead, which only matches users with no existing auth connections.
+
 If you still choose to proceed, the following configuration can be applied to enable email lookup.
 
 ```bash
@@ -191,6 +193,25 @@ curl --request PUT \
 ```
 
 Finally, you can also enable it using the UI by going to **Administration -> Authentication -> Auth settings**.
+
+### Auto-link pre-provisioned users
+
+When enabled, users pre-created by an admin (with no existing auth connections) are automatically linked when they log in via OAuth with a matching email address. Unlike `oauth_allow_insecure_email_lookup`, this only matches users with zero auth connections, reducing the risk of unintended account linking.
+
+This setting trusts the OAuth provider's email claim (same trust model as `oauth_allow_insecure_email_lookup`), but limits the blast radius to admin-pre-created accounts that have never logged in via any auth provider.
+
+**When to use each option:**
+
+- `auto_link_preprovisioned_users`: When you pre-create users via the admin API and want them auto-linked on first OAuth login.
+- `oauth_allow_insecure_email_lookup`: When you want ANY existing user matched by email (broader — use with trusted providers only).
+- Admin API (`POST /api/admin/users/:id/auth`): When you want explicit, manual control over identity linking.
+
+Defaults to `false`.
+
+```bash
+[auth]
+auto_link_preprovisioned_users = true
+```
 
 ### Automatic OAuth login
 

--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -425,6 +425,136 @@ func (hs *HTTPServer) AdminRevokeUserAuthToken(c *contextmodel.ReqContext) respo
 	return hs.revokeUserAuthTokenInternal(c, userID, cmd)
 }
 
+// swagger:route POST /admin/users/{user_id}/auth admin_users adminSetUserAuthInfo
+//
+// Link an OAuth identity to a user.
+//
+// If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `users.authinfo:write` and scope `global.users:*`.
+//
+// Security:
+// - basic:
+//
+// Responses:
+// 200: okResponse
+// 400: badRequestError
+// 401: unauthorisedError
+// 403: forbiddenError
+// 404: notFoundError
+// 409: conflictError
+// 500: internalServerError
+func (hs *HTTPServer) AdminSetUserAuthInfo(c *contextmodel.ReqContext) response.Response {
+	form := dtos.AdminSetUserAuthInfoForm{}
+	if err := web.Bind(c.Req, &form); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+
+	userID, err := strconv.ParseInt(web.Params(c.Req)[":id"], 10, 64)
+	if err != nil {
+		return response.Error(http.StatusBadRequest, "id is invalid", err)
+	}
+
+	if !login.IsKnownAuthModule(form.AuthModule) {
+		return response.Error(http.StatusBadRequest, "unknown auth module", nil)
+	}
+
+	usr, err := hs.userService.GetByID(c.Req.Context(), &user.GetUserByIDQuery{ID: userID})
+	if err != nil {
+		if errors.Is(err, user.ErrUserNotFound) {
+			return response.Error(http.StatusNotFound, user.ErrUserNotFound.Error(), nil)
+		}
+		return response.Error(http.StatusInternalServerError, "Failed to get user", err)
+	}
+
+	// Check if user already has this auth module linked
+	_, err = hs.authInfoService.GetAuthInfo(c.Req.Context(), &login.GetAuthInfoQuery{
+		UserId:     userID,
+		AuthModule: form.AuthModule,
+	})
+	if err == nil {
+		return response.Error(http.StatusConflict, "User already has an auth link for this module", nil)
+	}
+	if !errors.Is(err, user.ErrUserNotFound) {
+		return response.Error(http.StatusInternalServerError, "Failed to check existing auth info", err)
+	}
+
+	if err := hs.authInfoService.SetAuthInfo(c.Req.Context(), &login.SetAuthInfoCommand{
+		UserId:     userID,
+		UserUID:    usr.UID,
+		AuthModule: form.AuthModule,
+		AuthId:     form.AuthId,
+	}); err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to set auth info", err)
+	}
+
+	return response.Success("Auth info set")
+}
+
+// swagger:route DELETE /admin/users/{user_id}/auth/{auth_module} admin_users adminDeleteUserAuthInfo
+//
+// Unlink an OAuth identity from a user.
+//
+// If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `users.authinfo:write` and scope `global.users:*`.
+//
+// Security:
+// - basic:
+//
+// Responses:
+// 200: okResponse
+// 400: badRequestError
+// 401: unauthorisedError
+// 403: forbiddenError
+// 404: notFoundError
+// 500: internalServerError
+func (hs *HTTPServer) AdminDeleteUserAuthInfo(c *contextmodel.ReqContext) response.Response {
+	userID, err := strconv.ParseInt(web.Params(c.Req)[":id"], 10, 64)
+	if err != nil {
+		return response.Error(http.StatusBadRequest, "id is invalid", err)
+	}
+
+	authModule := web.Params(c.Req)[":authModule"]
+	if !login.IsKnownAuthModule(authModule) {
+		return response.Error(http.StatusBadRequest, "unknown auth module", nil)
+	}
+
+	// Verify auth link exists
+	_, err = hs.authInfoService.GetAuthInfo(c.Req.Context(), &login.GetAuthInfoQuery{
+		UserId:     userID,
+		AuthModule: authModule,
+	})
+	if err != nil {
+		if errors.Is(err, user.ErrUserNotFound) {
+			return response.Error(http.StatusNotFound, "Auth info not found for this user and module", nil)
+		}
+		return response.Error(http.StatusInternalServerError, "Failed to get auth info", err)
+	}
+
+	if err := hs.authInfoService.DeleteUserAuthInfoByModule(c.Req.Context(), userID, authModule); err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to delete auth info", err)
+	}
+
+	return response.Success("Auth info deleted")
+}
+
+// swagger:parameters adminSetUserAuthInfo
+type AdminSetUserAuthInfoParams struct {
+	// in:body
+	// required:true
+	Body dtos.AdminSetUserAuthInfoForm `json:"body"`
+	// in:path
+	// required:true
+	UserID int64 `json:"user_id"`
+}
+
+// swagger:parameters adminDeleteUserAuthInfo
+type AdminDeleteUserAuthInfoParams struct {
+	// in:path
+	// required:true
+	UserID int64 `json:"user_id"`
+	// in:path
+	// required:true
+	AuthModule string `json:"auth_module"`
+}
+
 // swagger:parameters adminUpdateUserPassword
 type AdminUpdateUserPasswordParams struct {
 	// in:body

--- a/pkg/api/admin_users_test.go
+++ b/pkg/api/admin_users_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -568,5 +569,200 @@ func adminCreateUserScenario(t *testing.T, desc string, url string, routePattern
 		sc.m.Post(routePattern, sc.defaultHandler)
 
 		fn(sc)
+	})
+}
+
+func TestAdminSetUserAuthInfo(t *testing.T) {
+	t.Run("Should link auth info successfully", func(t *testing.T) {
+		authInfoService := &authinfotest.FakeService{
+			ExpectedError: user.ErrUserNotFound, // no existing auth link
+			SetAuthInfoFn: func(ctx context.Context, cmd *login.SetAuthInfoCommand) error {
+				return nil
+			},
+		}
+		userService := &usertest.FakeUserService{
+			ExpectedUser: &user.User{ID: 1, UID: "user-uid-1"},
+		}
+
+		hs := HTTPServer{
+			Cfg:             setting.NewCfg(),
+			authInfoService: authInfoService,
+			userService:     userService,
+		}
+
+		cmd := dtos.AdminSetUserAuthInfoForm{
+			AuthModule: login.GoogleAuthModule,
+			AuthId:     "google-id-123",
+		}
+
+		sc := setupScenarioContext(t, "/api/admin/users/1/auth")
+		sc.defaultHandler = routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
+			c.Req.Body = mockRequestBody(cmd)
+			c.Req.Header.Add("Content-Type", "application/json")
+			sc.context = c
+			return hs.AdminSetUserAuthInfo(c)
+		})
+		sc.m.Post("/api/admin/users/:id/auth", sc.defaultHandler)
+		sc.fakeReqWithParams("POST", sc.url, map[string]string{}).exec()
+
+		assert.Equal(t, 200, sc.resp.Code)
+		respJSON, err := simplejson.NewJson(sc.resp.Body.Bytes())
+		require.NoError(t, err)
+		assert.Equal(t, "Auth info set", respJSON.Get("message").MustString())
+	})
+
+	t.Run("Should return 400 for unknown auth module", func(t *testing.T) {
+		hs := HTTPServer{
+			Cfg:         setting.NewCfg(),
+			userService: usertest.NewUserServiceFake(),
+		}
+
+		cmd := dtos.AdminSetUserAuthInfoForm{
+			AuthModule: "oauth_unknown_provider",
+			AuthId:     "some-id",
+		}
+
+		sc := setupScenarioContext(t, "/api/admin/users/1/auth")
+		sc.defaultHandler = routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
+			c.Req.Body = mockRequestBody(cmd)
+			c.Req.Header.Add("Content-Type", "application/json")
+			sc.context = c
+			return hs.AdminSetUserAuthInfo(c)
+		})
+		sc.m.Post("/api/admin/users/:id/auth", sc.defaultHandler)
+		sc.fakeReqWithParams("POST", sc.url, map[string]string{}).exec()
+
+		assert.Equal(t, 400, sc.resp.Code)
+	})
+
+	t.Run("Should return 404 for nonexistent user", func(t *testing.T) {
+		userService := &usertest.FakeUserService{
+			ExpectedError: user.ErrUserNotFound,
+		}
+
+		hs := HTTPServer{
+			Cfg:         setting.NewCfg(),
+			userService: userService,
+		}
+
+		cmd := dtos.AdminSetUserAuthInfoForm{
+			AuthModule: login.GoogleAuthModule,
+			AuthId:     "google-id-123",
+		}
+
+		sc := setupScenarioContext(t, "/api/admin/users/999/auth")
+		sc.defaultHandler = routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
+			c.Req.Body = mockRequestBody(cmd)
+			c.Req.Header.Add("Content-Type", "application/json")
+			sc.context = c
+			return hs.AdminSetUserAuthInfo(c)
+		})
+		sc.m.Post("/api/admin/users/:id/auth", sc.defaultHandler)
+		sc.fakeReqWithParams("POST", sc.url, map[string]string{}).exec()
+
+		assert.Equal(t, 404, sc.resp.Code)
+	})
+
+	t.Run("Should return 409 when auth link already exists", func(t *testing.T) {
+		authInfoService := &authinfotest.FakeService{
+			ExpectedUserAuth: &login.UserAuth{
+				UserId:     1,
+				AuthModule: login.GoogleAuthModule,
+				AuthId:     "existing-google-id",
+			},
+		}
+		userService := &usertest.FakeUserService{
+			ExpectedUser: &user.User{ID: 1, UID: "user-uid-1"},
+		}
+
+		hs := HTTPServer{
+			Cfg:             setting.NewCfg(),
+			authInfoService: authInfoService,
+			userService:     userService,
+		}
+
+		cmd := dtos.AdminSetUserAuthInfoForm{
+			AuthModule: login.GoogleAuthModule,
+			AuthId:     "new-google-id",
+		}
+
+		sc := setupScenarioContext(t, "/api/admin/users/1/auth")
+		sc.defaultHandler = routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
+			c.Req.Body = mockRequestBody(cmd)
+			c.Req.Header.Add("Content-Type", "application/json")
+			sc.context = c
+			return hs.AdminSetUserAuthInfo(c)
+		})
+		sc.m.Post("/api/admin/users/:id/auth", sc.defaultHandler)
+		sc.fakeReqWithParams("POST", sc.url, map[string]string{}).exec()
+
+		assert.Equal(t, 409, sc.resp.Code)
+	})
+}
+
+func TestAdminDeleteUserAuthInfo(t *testing.T) {
+	t.Run("Should delete auth info successfully", func(t *testing.T) {
+		authInfoService := &authinfotest.FakeService{
+			ExpectedUserAuth: &login.UserAuth{
+				UserId:     1,
+				AuthModule: login.GoogleAuthModule,
+				AuthId:     "google-id-123",
+			},
+		}
+
+		hs := HTTPServer{
+			Cfg:             setting.NewCfg(),
+			authInfoService: authInfoService,
+		}
+
+		sc := setupScenarioContext(t, "/api/admin/users/1/auth/oauth_google")
+		sc.defaultHandler = routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
+			sc.context = c
+			return hs.AdminDeleteUserAuthInfo(c)
+		})
+		sc.m.Delete("/api/admin/users/:id/auth/:authModule", sc.defaultHandler)
+		sc.fakeReqWithParams("DELETE", sc.url, map[string]string{}).exec()
+
+		assert.Equal(t, 200, sc.resp.Code)
+		respJSON, err := simplejson.NewJson(sc.resp.Body.Bytes())
+		require.NoError(t, err)
+		assert.Equal(t, "Auth info deleted", respJSON.Get("message").MustString())
+	})
+
+	t.Run("Should return 400 for unknown auth module", func(t *testing.T) {
+		hs := HTTPServer{
+			Cfg: setting.NewCfg(),
+		}
+
+		sc := setupScenarioContext(t, "/api/admin/users/1/auth/oauth_unknown")
+		sc.defaultHandler = routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
+			sc.context = c
+			return hs.AdminDeleteUserAuthInfo(c)
+		})
+		sc.m.Delete("/api/admin/users/:id/auth/:authModule", sc.defaultHandler)
+		sc.fakeReqWithParams("DELETE", sc.url, map[string]string{}).exec()
+
+		assert.Equal(t, 400, sc.resp.Code)
+	})
+
+	t.Run("Should return 404 when no auth link exists", func(t *testing.T) {
+		authInfoService := &authinfotest.FakeService{
+			ExpectedError: user.ErrUserNotFound,
+		}
+
+		hs := HTTPServer{
+			Cfg:             setting.NewCfg(),
+			authInfoService: authInfoService,
+		}
+
+		sc := setupScenarioContext(t, "/api/admin/users/1/auth/oauth_google")
+		sc.defaultHandler = routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
+			sc.context = c
+			return hs.AdminDeleteUserAuthInfo(c)
+		})
+		sc.m.Delete("/api/admin/users/:id/auth/:authModule", sc.defaultHandler)
+		sc.fakeReqWithParams("DELETE", sc.url, map[string]string{}).exec()
+
+		assert.Equal(t, 404, sc.resp.Code)
 	})
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -587,6 +587,8 @@ func (hs *HTTPServer) registerRoutes() {
 		adminUserRoute.Post("/:id/logout", userUIDResolver, authorizeInOrg(ac.UseGlobalOrg, ac.EvalPermission(ac.ActionUsersLogout, userIDScope)), routing.Wrap(hs.AdminLogoutUser))
 		adminUserRoute.Get("/:id/auth-tokens", userUIDResolver, authorizeInOrg(ac.UseGlobalOrg, ac.EvalPermission(ac.ActionUsersAuthTokenList, userIDScope)), routing.Wrap(hs.AdminGetUserAuthTokens))
 		adminUserRoute.Post("/:id/revoke-auth-token", userUIDResolver, authorizeInOrg(ac.UseGlobalOrg, ac.EvalPermission(ac.ActionUsersAuthTokenUpdate, userIDScope)), routing.Wrap(hs.AdminRevokeUserAuthToken))
+		adminUserRoute.Post("/:id/auth", userUIDResolver, authorizeInOrg(ac.UseGlobalOrg, ac.EvalPermission(ac.ActionUsersAuthInfoWrite, userIDScope)), routing.Wrap(hs.AdminSetUserAuthInfo))
+		adminUserRoute.Delete("/:id/auth/:authModule", userUIDResolver, authorizeInOrg(ac.UseGlobalOrg, ac.EvalPermission(ac.ActionUsersAuthInfoWrite, userIDScope)), routing.Wrap(hs.AdminDeleteUserAuthInfo))
 	}, reqSignedIn)
 
 	// rendering

--- a/pkg/api/dtos/user.go
+++ b/pkg/api/dtos/user.go
@@ -41,6 +41,11 @@ type ResetUserPasswordForm struct {
 	ConfirmPassword user.Password `json:"confirmPassword"`
 }
 
+type AdminSetUserAuthInfoForm struct {
+	AuthModule string `json:"auth_module" binding:"Required"`
+	AuthId     string `json:"auth_id" binding:"Required"`
+}
+
 type UserLookupDTO struct {
 	UserID    int64  `json:"userId"`
 	UID       string `json:"uid"`

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -367,6 +367,9 @@ const (
 	ActionUsersQuotasList        = "users.quotas:read"
 	ActionUsersQuotasUpdate      = "users.quotas:write"
 	ActionUsersPermissionsRead   = "users.permissions:read"
+	// We can ignore gosec G101 since this does not contain any credentials.
+	// nolint:gosec
+	ActionUsersAuthInfoWrite = "users.authinfo:write"
 
 	// Org actions
 	ActionOrgsRead             = "orgs:read"

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -116,6 +116,7 @@ func ProvideUserSync(userService user.Service, userProtectionService login.UserP
 		log:                       log.New("user.sync"),
 		tracer:                    tracer,
 		features:                  features,
+		cfg:                       cfg,
 		lastSeenSF:                &singleflight.Group{},
 		scimUtil:                  scimutil.NewSCIMUtil(k8sClient),
 		staticConfig:              staticConfig,
@@ -132,6 +133,7 @@ type UserSync struct {
 	log                       log.Logger
 	tracer                    tracing.Tracer
 	features                  featuremgmt.FeatureToggles
+	cfg                       *setting.Cfg
 	lastSeenSF                *singleflight.Group
 	scimUtil                  *scimutil.SCIMUtil
 	staticConfig              *StaticSCIMConfig
@@ -298,6 +300,24 @@ func (s *UserSync) SyncUserHook(ctx context.Context, id *authn.Identity, _ *auth
 	}
 
 	if errors.Is(err, user.ErrUserNotFound) {
+		// Before rejecting for disabled signup, check for a pre-provisioned user
+		// (admin-created, no existing auth links) matching by email.
+		if s.cfg.AutoLinkPreprovisionedUsers && id.Email != "" {
+			if preProvUsr, lookupErr := s.userService.GetByEmail(ctx, id.Email); lookupErr == nil {
+				// Only auto-link if user has NO existing auth connections
+				_, authErr := s.authInfoService.GetAuthInfo(ctx, &login.GetAuthInfoQuery{UserId: preProvUsr.ID})
+				if errors.Is(authErr, user.ErrUserNotFound) {
+					s.log.FromContext(ctx).Info("Auto-linking pre-provisioned user on OAuth login",
+						"user_id", preProvUsr.ID, "email", id.Email, "auth_module", id.AuthenticatedBy)
+					if linkErr := s.upsertAuthConnection(ctx, preProvUsr, id, true); linkErr != nil {
+						return errSyncUserInternal.Errorf("unable to link pre-provisioned user: %w", linkErr)
+					}
+					syncUserToIdentity(ctx, preProvUsr, id)
+					return nil
+				}
+			}
+		}
+
 		if !id.ClientParams.AllowSignUp {
 			s.log.FromContext(ctx).Warn("Failed to create user, signup is not allowed for module", "auth_module", id.AuthenticatedBy, "auth_id", id.AuthID)
 			return errUserSignupDisabled.Errorf("%w", errSignupNotAllowed)

--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -2260,3 +2260,243 @@ func TestUserSync_SyncUserHook_SCIMUserAllowsGCOMLogin(t *testing.T) {
 
 	require.NoError(t, err)
 }
+
+func TestUserSync_SyncUserHook_AutoLinkPreprovisionedUser(t *testing.T) {
+	t.Run("Should auto-link pre-provisioned user with no auth connections", func(t *testing.T) {
+		userSrv := usertest.NewMockService(t)
+		authInfoSrv := authinfotest.NewMockAuthInfoService(t)
+
+		preProvUser := &user.User{
+			ID:    100,
+			UID:   "user-uid-100",
+			Login: "preprovisioned",
+			Email: "preprovisioned@example.com",
+			Name:  "Pre Provisioned",
+		}
+
+		// getUser -> lookupByAuthInfo returns not found
+		authInfoSrv.On("GetAuthInfo", mock.Anything, mock.MatchedBy(func(q *login.GetAuthInfoQuery) bool {
+			return q.AuthId == "google-id-123" && q.AuthModule == login.GoogleAuthModule
+		})).Return(nil, user.ErrUserNotFound).Once()
+
+		// getUser -> lookupByOneOf returns not found
+		userSrv.On("GetByEmail", mock.Anything, mock.Anything).Return(nil, user.ErrUserNotFound).Once()
+
+		// auto-link check: find user by email
+		userSrv.On("GetByEmail", mock.Anything, mock.Anything).Return(preProvUser, nil).Once()
+
+		// auto-link check: verify no existing auth connections
+		authInfoSrv.On("GetAuthInfo", mock.Anything, mock.MatchedBy(func(q *login.GetAuthInfoQuery) bool {
+			return q.UserId == 100
+		})).Return(nil, user.ErrUserNotFound).Once()
+
+		// upsertAuthConnection -> SetAuthInfo
+		authInfoSrv.On("SetAuthInfo", mock.Anything, mock.MatchedBy(func(cmd *login.SetAuthInfoCommand) bool {
+			return cmd.UserId == 100 && cmd.AuthModule == login.GoogleAuthModule && cmd.AuthId == "google-id-123"
+		})).Return(nil).Once()
+
+		provider.UsingFlags(t, defaultFeatureFlags)
+
+		cfg := setting.NewCfg()
+		cfg.AutoLinkPreprovisionedUsers = true
+
+		s := ProvideUserSync(
+			userSrv,
+			authinfoimpl.ProvideOSSUserProtectionService(),
+			authInfoSrv,
+			&quotatest.FakeQuotaService{},
+			tracing.NewNoopTracerService(),
+			featuremgmt.WithFeatures(),
+			cfg,
+			nil,
+		)
+
+		email := "preprovisioned@example.com"
+		err := s.SyncUserHook(context.Background(), &authn.Identity{
+			AuthID:          "google-id-123",
+			AuthenticatedBy: login.GoogleAuthModule,
+			Login:           "preprovisioned",
+			Email:           "preprovisioned@example.com",
+			Name:            "Pre Provisioned",
+			ClientParams: authn.ClientParams{
+				SyncUser:    true,
+				AllowSignUp: false, // signup disabled
+				LookUpParams: login.UserLookupParams{
+					Email: &email,
+				},
+			},
+		}, nil)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("Should NOT auto-link user that already has auth connections", func(t *testing.T) {
+		userSrv := usertest.NewMockService(t)
+		authInfoSrv := authinfotest.NewMockAuthInfoService(t)
+
+		existingUser := &user.User{
+			ID:    200,
+			UID:   "user-uid-200",
+			Login: "existing",
+			Email: "existing@example.com",
+			Name:  "Existing User",
+		}
+
+		// getUser -> lookupByAuthInfo returns not found
+		authInfoSrv.On("GetAuthInfo", mock.Anything, mock.MatchedBy(func(q *login.GetAuthInfoQuery) bool {
+			return q.AuthId == "google-id-456" && q.AuthModule == login.GoogleAuthModule
+		})).Return(nil, user.ErrUserNotFound).Once()
+
+		// getUser -> lookupByOneOf returns not found
+		userSrv.On("GetByEmail", mock.Anything, mock.Anything).Return(nil, user.ErrUserNotFound).Once()
+
+		// auto-link check: find user by email
+		userSrv.On("GetByEmail", mock.Anything, mock.Anything).Return(existingUser, nil).Once()
+
+		// auto-link check: user HAS existing auth connections
+		authInfoSrv.On("GetAuthInfo", mock.Anything, mock.MatchedBy(func(q *login.GetAuthInfoQuery) bool {
+			return q.UserId == 200
+		})).Return(&login.UserAuth{
+			UserId:     200,
+			AuthModule: login.GithubAuthModule,
+			AuthId:     "github-id-789",
+		}, nil).Once()
+
+		provider.UsingFlags(t, defaultFeatureFlags)
+
+		cfg := setting.NewCfg()
+		cfg.AutoLinkPreprovisionedUsers = true
+
+		s := ProvideUserSync(
+			userSrv,
+			authinfoimpl.ProvideOSSUserProtectionService(),
+			authInfoSrv,
+			&quotatest.FakeQuotaService{},
+			tracing.NewNoopTracerService(),
+			featuremgmt.WithFeatures(),
+			cfg,
+			nil,
+		)
+
+		email := "existing@example.com"
+		err := s.SyncUserHook(context.Background(), &authn.Identity{
+			AuthID:          "google-id-456",
+			AuthenticatedBy: login.GoogleAuthModule,
+			Login:           "existing",
+			Email:           "existing@example.com",
+			Name:            "Existing User",
+			ClientParams: authn.ClientParams{
+				SyncUser:    true,
+				AllowSignUp: false,
+				LookUpParams: login.UserLookupParams{
+					Email: &email,
+				},
+			},
+		}, nil)
+
+		// Should fail with signup disabled error since auto-link was skipped
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errSignupNotAllowed)
+		authInfoSrv.AssertNotCalled(t, "SetAuthInfo", mock.Anything, mock.Anything)
+	})
+
+	t.Run("Should NOT auto-link when no user found by email", func(t *testing.T) {
+		userSrv := usertest.NewMockService(t)
+		authInfoSrv := authinfotest.NewMockAuthInfoService(t)
+
+		// getUser -> lookupByAuthInfo returns not found
+		authInfoSrv.On("GetAuthInfo", mock.Anything, mock.MatchedBy(func(q *login.GetAuthInfoQuery) bool {
+			return q.AuthId == "google-id-789" && q.AuthModule == login.GoogleAuthModule
+		})).Return(nil, user.ErrUserNotFound).Once()
+
+		// getUser -> lookupByOneOf returns not found (called twice: once by lookupByOneOf, once by auto-link)
+		userSrv.On("GetByEmail", mock.Anything, mock.Anything).Return(nil, user.ErrUserNotFound)
+
+		provider.UsingFlags(t, defaultFeatureFlags)
+
+		cfg := setting.NewCfg()
+		cfg.AutoLinkPreprovisionedUsers = true
+
+		s := ProvideUserSync(
+			userSrv,
+			authinfoimpl.ProvideOSSUserProtectionService(),
+			authInfoSrv,
+			&quotatest.FakeQuotaService{},
+			tracing.NewNoopTracerService(),
+			featuremgmt.WithFeatures(),
+			cfg,
+			nil,
+		)
+
+		email := "nobody@example.com"
+		err := s.SyncUserHook(context.Background(), &authn.Identity{
+			AuthID:          "google-id-789",
+			AuthenticatedBy: login.GoogleAuthModule,
+			Login:           "nobody",
+			Email:           "nobody@example.com",
+			Name:            "Nobody",
+			ClientParams: authn.ClientParams{
+				SyncUser:    true,
+				AllowSignUp: false,
+				LookUpParams: login.UserLookupParams{
+					Email: &email,
+				},
+			},
+		}, nil)
+
+		// Should fail with signup disabled error
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errSignupNotAllowed)
+		authInfoSrv.AssertNotCalled(t, "SetAuthInfo", mock.Anything, mock.Anything)
+	})
+
+	t.Run("Should NOT auto-link when feature is disabled", func(t *testing.T) {
+		userSrv := usertest.NewMockService(t)
+		authInfoSrv := authinfotest.NewMockAuthInfoService(t)
+
+		// getUser -> lookupByAuthInfo returns not found
+		authInfoSrv.On("GetAuthInfo", mock.Anything, mock.MatchedBy(func(q *login.GetAuthInfoQuery) bool {
+			return q.AuthId == "google-id-000" && q.AuthModule == login.GoogleAuthModule
+		})).Return(nil, user.ErrUserNotFound).Once()
+
+		// getUser -> lookupByOneOf returns not found
+		userSrv.On("GetByEmail", mock.Anything, mock.Anything).Return(nil, user.ErrUserNotFound).Once()
+
+		provider.UsingFlags(t, defaultFeatureFlags)
+
+		cfg := setting.NewCfg()
+		cfg.AutoLinkPreprovisionedUsers = false // disabled (default)
+
+		s := ProvideUserSync(
+			userSrv,
+			authinfoimpl.ProvideOSSUserProtectionService(),
+			authInfoSrv,
+			&quotatest.FakeQuotaService{},
+			tracing.NewNoopTracerService(),
+			featuremgmt.WithFeatures(),
+			cfg,
+			nil,
+		)
+
+		email := "preprov@example.com"
+		err := s.SyncUserHook(context.Background(), &authn.Identity{
+			AuthID:          "google-id-000",
+			AuthenticatedBy: login.GoogleAuthModule,
+			Login:           "preprov",
+			Email:           "preprov@example.com",
+			Name:            "Pre Prov",
+			ClientParams: authn.ClientParams{
+				SyncUser:    true,
+				AllowSignUp: false,
+				LookUpParams: login.UserLookupParams{
+					Email: &email,
+				},
+			},
+		}, nil)
+
+		// Should fail with signup disabled error, no auto-link attempted
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errSignupNotAllowed)
+		authInfoSrv.AssertNotCalled(t, "SetAuthInfo", mock.Anything, mock.Anything)
+	})
+}

--- a/pkg/services/login/authinfo.go
+++ b/pkg/services/login/authinfo.go
@@ -13,6 +13,7 @@ type AuthInfoService interface {
 	SetAuthInfo(ctx context.Context, cmd *SetAuthInfoCommand) error
 	UpdateAuthInfo(ctx context.Context, cmd *UpdateAuthInfoCommand) error
 	DeleteUserAuthInfo(ctx context.Context, userID int64) error
+	DeleteUserAuthInfoByModule(ctx context.Context, userID int64, authModule string) error
 }
 
 //go:generate mockery --name Store --structname MockAuthInfoStore --outpkg authinfotest --filename auth_info_store_mock.go --output ./authinfotest/
@@ -23,6 +24,22 @@ type Store interface {
 	SetAuthInfo(ctx context.Context, cmd *SetAuthInfoCommand) error
 	UpdateAuthInfo(ctx context.Context, cmd *UpdateAuthInfoCommand) error
 	DeleteUserAuthInfo(ctx context.Context, userID int64) error
+	DeleteUserAuthInfoByModule(ctx context.Context, userID int64, authModule string) error
+}
+
+// IsKnownAuthModule returns true if the given module is a recognized auth module.
+func IsKnownAuthModule(module string) bool {
+	switch module {
+	case PasswordAuthModule, PasswordlessAuthModule, APIKeyAuthModule,
+		SAMLAuthModule, LDAPAuthModule, AuthProxyAuthModule,
+		JWTModule, ExtendedJWTModule, RenderModule,
+		AzureADAuthModule, GoogleAuthModule, GitLabAuthModule,
+		GithubAuthModule, GenericOAuthModule, GrafanaComAuthModule,
+		GrafanaNetAuthModule, OktaAuthModule:
+		return true
+	default:
+		return false
+	}
 }
 
 const (

--- a/pkg/services/login/authinfo_test.go
+++ b/pkg/services/login/authinfo_test.go
@@ -1,0 +1,34 @@
+package login
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsKnownAuthModule(t *testing.T) {
+	knownModules := []string{
+		PasswordAuthModule, PasswordlessAuthModule, APIKeyAuthModule,
+		SAMLAuthModule, LDAPAuthModule, AuthProxyAuthModule,
+		JWTModule, ExtendedJWTModule, RenderModule,
+		AzureADAuthModule, GoogleAuthModule, GitLabAuthModule,
+		GithubAuthModule, GenericOAuthModule, GrafanaComAuthModule,
+		GrafanaNetAuthModule, OktaAuthModule,
+	}
+
+	for _, module := range knownModules {
+		t.Run("known module "+module, func(t *testing.T) {
+			assert.True(t, IsKnownAuthModule(module))
+		})
+	}
+
+	unknownModules := []string{
+		"oauth_unknown", "custom_auth", "", "google", "oauth_",
+	}
+
+	for _, module := range unknownModules {
+		t.Run("unknown module "+module, func(t *testing.T) {
+			assert.False(t, IsKnownAuthModule(module))
+		})
+	}
+}

--- a/pkg/services/login/authinfoimpl/service.go
+++ b/pkg/services/login/authinfoimpl/service.go
@@ -189,6 +189,20 @@ func (s *Service) DeleteUserAuthInfo(ctx context.Context, userID int64) error {
 	return nil
 }
 
+func (s *Service) DeleteUserAuthInfoByModule(ctx context.Context, userID int64, authModule string) error {
+	err := s.authInfoStore.DeleteUserAuthInfoByModule(ctx, userID, authModule)
+	if err != nil {
+		return err
+	}
+
+	s.deleteUserAuthInfoInCache(ctx, &login.GetAuthInfoQuery{
+		UserId:     userID,
+		AuthModule: authModule,
+	})
+
+	return nil
+}
+
 func (s *Service) deleteUserAuthInfoInCache(ctx context.Context, query *login.GetAuthInfoQuery) {
 	if query.AuthId != "" {
 		err := s.remoteCache.Delete(ctx, generateCacheKey(&login.GetAuthInfoQuery{

--- a/pkg/services/login/authinfoimpl/service_test.go
+++ b/pkg/services/login/authinfoimpl/service_test.go
@@ -2,8 +2,10 @@ package authinfoimpl
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/login/authinfotest"
 	"github.com/stretchr/testify/mock"
@@ -28,4 +30,39 @@ func TestAuthInfoService_GetUserAuthModuleLabels(t *testing.T) {
 
 	// Verify labels mapped and order preserved
 	require.Equal(t, expected, actual)
+}
+
+func TestAuthInfoService_DeleteUserAuthInfoByModule(t *testing.T) {
+	t.Run("Should delegate to store and invalidate cache", func(t *testing.T) {
+		store := authinfotest.NewMockAuthInfoStore(t)
+
+		userID := int64(42)
+		authModule := login.GoogleAuthModule
+
+		store.On("DeleteUserAuthInfoByModule", mock.Anything, userID, authModule).Return(nil)
+
+		fakeCache := remotecache.FakeCacheStorage{Storage: map[string][]byte{}}
+		svc := ProvideService(store, fakeCache, nil)
+
+		err := svc.DeleteUserAuthInfoByModule(context.Background(), userID, authModule)
+		require.NoError(t, err)
+
+		store.AssertCalled(t, "DeleteUserAuthInfoByModule", mock.Anything, userID, authModule)
+	})
+
+	t.Run("Should propagate store errors", func(t *testing.T) {
+		store := authinfotest.NewMockAuthInfoStore(t)
+
+		userID := int64(42)
+		authModule := login.GoogleAuthModule
+		expectedErr := errors.New("database error")
+
+		store.On("DeleteUserAuthInfoByModule", mock.Anything, userID, authModule).Return(expectedErr)
+
+		fakeCache := remotecache.FakeCacheStorage{Storage: map[string][]byte{}}
+		svc := ProvideService(store, fakeCache, nil)
+
+		err := svc.DeleteUserAuthInfoByModule(context.Background(), userID, authModule)
+		require.ErrorIs(t, err, expectedErr)
+	})
 }

--- a/pkg/services/login/authinfoimpl/store.go
+++ b/pkg/services/login/authinfoimpl/store.go
@@ -257,6 +257,13 @@ func (s *Store) DeleteUserAuthInfo(ctx context.Context, userID int64) error {
 	})
 }
 
+func (s *Store) DeleteUserAuthInfoByModule(ctx context.Context, userID int64, authModule string) error {
+	return s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
+		_, err := sess.Exec("DELETE FROM user_auth WHERE user_id = ? AND auth_module = ?", userID, authModule)
+		return err
+	})
+}
+
 // decodeAndDecrypt will decode the string with the standard base64 decoder and then decrypt it
 func (s *Store) decodeAndDecrypt(str string) (string, error) {
 	// Bail out if empty string since it'll cause a segfault in Decrypt

--- a/pkg/services/login/authinfotest/auth_info_service_mock.go
+++ b/pkg/services/login/authinfotest/auth_info_service_mock.go
@@ -32,6 +32,24 @@ func (_m *MockAuthInfoService) DeleteUserAuthInfo(ctx context.Context, userID in
 	return r0
 }
 
+// DeleteUserAuthInfoByModule provides a mock function with given fields: ctx, userID, authModule
+func (_m *MockAuthInfoService) DeleteUserAuthInfoByModule(ctx context.Context, userID int64, authModule string) error {
+	ret := _m.Called(ctx, userID, authModule)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteUserAuthInfoByModule")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, string) error); ok {
+		r0 = rf(ctx, userID, authModule)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GetAuthInfo provides a mock function with given fields: ctx, query
 func (_m *MockAuthInfoService) GetAuthInfo(ctx context.Context, query *login.GetAuthInfoQuery) (*login.UserAuth, error) {
 	ret := _m.Called(ctx, query)

--- a/pkg/services/login/authinfotest/auth_info_store_mock.go
+++ b/pkg/services/login/authinfotest/auth_info_store_mock.go
@@ -32,6 +32,24 @@ func (_m *MockAuthInfoStore) DeleteUserAuthInfo(ctx context.Context, userID int6
 	return r0
 }
 
+// DeleteUserAuthInfoByModule provides a mock function with given fields: ctx, userID, authModule
+func (_m *MockAuthInfoStore) DeleteUserAuthInfoByModule(ctx context.Context, userID int64, authModule string) error {
+	ret := _m.Called(ctx, userID, authModule)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteUserAuthInfoByModule")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, string) error); ok {
+		r0 = rf(ctx, userID, authModule)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GetAuthInfo provides a mock function with given fields: ctx, query
 func (_m *MockAuthInfoStore) GetAuthInfo(ctx context.Context, query *login.GetAuthInfoQuery) (*login.UserAuth, error) {
 	ret := _m.Called(ctx, query)

--- a/pkg/services/login/authinfotest/fake.go
+++ b/pkg/services/login/authinfotest/fake.go
@@ -15,9 +15,10 @@ type FakeService struct {
 	ExpectedRecentlyUsedLabel map[int64]string
 	ExpectedAuthModuleLabels  []string
 
-	SetAuthInfoFn        func(ctx context.Context, cmd *login.SetAuthInfoCommand) error
-	UpdateAuthInfoFn     func(ctx context.Context, cmd *login.UpdateAuthInfoCommand) error
-	DeleteUserAuthInfoFn func(ctx context.Context, userID int64) error
+	SetAuthInfoFn              func(ctx context.Context, cmd *login.SetAuthInfoCommand) error
+	UpdateAuthInfoFn           func(ctx context.Context, cmd *login.UpdateAuthInfoCommand) error
+	DeleteUserAuthInfoFn       func(ctx context.Context, userID int64) error
+	DeleteUserAuthInfoByModuleFn func(ctx context.Context, userID int64, authModule string) error
 }
 
 func (a *FakeService) GetAuthInfo(ctx context.Context, query *login.GetAuthInfoQuery) (*login.UserAuth, error) {
@@ -52,6 +53,14 @@ func (a *FakeService) UpdateAuthInfo(ctx context.Context, cmd *login.UpdateAuthI
 func (a *FakeService) DeleteUserAuthInfo(ctx context.Context, userID int64) error {
 	if a.DeleteUserAuthInfoFn != nil {
 		return a.DeleteUserAuthInfoFn(ctx, userID)
+	}
+
+	return a.ExpectedError
+}
+
+func (a *FakeService) DeleteUserAuthInfoByModule(ctx context.Context, userID int64, authModule string) error {
+	if a.DeleteUserAuthInfoByModuleFn != nil {
+		return a.DeleteUserAuthInfoByModuleFn(ctx, userID, authModule)
 	}
 
 	return a.ExpectedError

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -314,6 +314,7 @@ type Cfg struct {
 	OAuthLoginErrorMessage               string
 	OAuthCookieMaxAge                    int
 	OAuthAllowInsecureEmailLookup        bool
+	AutoLinkPreprovisionedUsers          bool
 	OAuthRefreshTokenServerLockMinWaitMs int64
 
 	JWTAuth    AuthJWTSettings
@@ -1932,6 +1933,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	}
 
 	cfg.OAuthAllowInsecureEmailLookup = auth.Key("oauth_allow_insecure_email_lookup").MustBool(false)
+	cfg.AutoLinkPreprovisionedUsers = auth.Key("auto_link_preprovisioned_users").MustBool(false)
 
 	const defaultMaxLifetime = "30d"
 	maxLifetimeDurationVal := valueAsString(auth, "login_maximum_lifetime_duration", defaultMaxLifetime)


### PR DESCRIPTION
## Summary
- Add `[auth] auto_link_preprovisioned_users` setting (default: false)
- When enabled, admin-pre-created users with no existing auth connections are
  automatically linked when they log in via OAuth with a matching email
- Narrower alternative to `oauth_allow_insecure_email_lookup`: only matches
  users with zero auth links, limiting blast radius

## Why
If an admin pre-creates a user with a known email, that user should be able to log in via
OAuth without `auto_sign_up` being enabled. Unlike `oauth_allow_insecure_email_lookup`
(which matches ALL users by email), this only affects users explicitly created by an admin
that have never logged in via any auth provider.

## Dependencies
Builds on #120378

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./pkg/services/authn/authnimpl/sync/...` passes
- [x] Test: pre-provisioned user with no auth links gets auto-linked
- [x] Test: user with existing auth connections is NOT auto-linked
- [x] Test: no user found by email falls through to normal rejection
- [x] Test: feature disabled (default) skips auto-link entirely

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)