### PR TITLE
chore: replace `config.panels` in getCopiedPanelPlugin

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2169,11 +2169,6 @@
       "count": 1
     }
   },
-  "public/app/features/dashboard/utils/dashboard.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "public/app/features/dashboard/utils/panelMerge.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2

--- a/public/app/features/dashboard/components/AddPanelButton/AddPanelMenu.test.tsx
+++ b/public/app/features/dashboard/components/AddPanelButton/AddPanelMenu.test.tsx
@@ -34,6 +34,11 @@ jest.mock('app/features/dashboard/utils/dashboard', () => ({
   getCopiedPanelPlugin: jest.fn(),
 }));
 
+jest.mock('@grafana/runtime/internal', () => ({
+  ...jest.requireActual('@grafana/runtime/internal'),
+  useListedPanelPluginMetas: jest.fn().mockResolvedValue({ loading: false, value: [] }),
+}));
+
 function setup() {
   const props = {
     dashboard: createDashboardModelFixture(defaultDashboard),

--- a/public/app/features/dashboard/components/AddPanelButton/AddPanelMenu.tsx
+++ b/public/app/features/dashboard/components/AddPanelButton/AddPanelMenu.tsx
@@ -3,7 +3,8 @@ import { useMemo } from 'react';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
-import { Menu } from '@grafana/ui';
+import { useListedPanelPluginMetas } from '@grafana/runtime/internal';
+import { Menu, Alert } from '@grafana/ui';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import {
   getCopiedPanelPlugin,
@@ -22,9 +23,18 @@ export interface Props {
 }
 
 const AddPanelMenu = ({ dashboard }: Props) => {
-  const copiedPanelPlugin = useMemo(() => getCopiedPanelPlugin(), []);
+  const { error, value: panels = [] } = useListedPanelPluginMetas();
+  const copiedPanelPlugin = useMemo(() => getCopiedPanelPlugin(panels), [panels]);
   const dispatch = useDispatch();
   const initialDatasource = useSelector((state) => state.dashboard.initialDatasource);
+
+  if (error) {
+    return (
+      <Alert severity="error" title={t('dashboard.add-menu.load-error', 'Failed to load panel plugins')}>
+        {error.message}
+      </Alert>
+    );
+  }
 
   return (
     <Menu>

--- a/public/app/features/dashboard/components/AddPanelButton/AddPanelMenu.tsx
+++ b/public/app/features/dashboard/components/AddPanelButton/AddPanelMenu.tsx
@@ -4,7 +4,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
 import { useListedPanelPluginMetas } from '@grafana/runtime/internal';
-import { Menu, Alert } from '@grafana/ui';
+import { Menu } from '@grafana/ui';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import {
   getCopiedPanelPlugin,
@@ -27,14 +27,6 @@ const AddPanelMenu = ({ dashboard }: Props) => {
   const copiedPanelPlugin = useMemo(() => getCopiedPanelPlugin(panels), [panels]);
   const dispatch = useDispatch();
   const initialDatasource = useSelector((state) => state.dashboard.initialDatasource);
-
-  if (error) {
-    return (
-      <Alert severity="error" title={t('dashboard.add-menu.load-error', 'Failed to load panel plugins')}>
-        {error.message}
-      </Alert>
-    );
-  }
 
   return (
     <Menu>
@@ -75,7 +67,7 @@ const AddPanelMenu = ({ dashboard }: Props) => {
           DashboardInteractions.toolbarAddButtonClicked({ item: 'paste_panel' });
           onPasteCopiedPanel(dashboard, copiedPanelPlugin);
         }}
-        disabled={!copiedPanelPlugin}
+        disabled={!copiedPanelPlugin || Boolean(error)}
       />
     </Menu>
   );

--- a/public/app/features/dashboard/utils/dashboard.ts
+++ b/public/app/features/dashboard/utils/dashboard.ts
@@ -1,9 +1,8 @@
-import { chain, cloneDeep, defaults, find } from 'lodash';
+import { cloneDeep, defaults, find } from 'lodash';
 
 import { PanelPluginMeta, store } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
-import config from 'app/core/config';
 import { LS_PANEL_COPY_KEY } from 'app/core/constants';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
@@ -90,12 +89,7 @@ export function onPasteCopiedPanel(dashboard: DashboardModel, panelPluginInfo?: 
   dashboard.addPanel(newPanel);
 }
 
-export function getCopiedPanelPlugin(): (PanelPluginMeta & PanelPluginInfo) | undefined {
-  const panels = chain(config.panels)
-    .filter({ hideFromList: false })
-    .map((item) => item)
-    .value();
-
+export function getCopiedPanelPlugin(panels: PanelPluginMeta[]): (PanelPluginMeta & PanelPluginInfo) | undefined {
   const copiedPanelJson = store.get(LS_PANEL_COPY_KEY);
   if (copiedPanelJson) {
     const copiedPanel = JSON.parse(copiedPanelJson);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5130,6 +5130,7 @@
     },
     "add-menu": {
       "import": "Import from library",
+      "load-error": "Failed to load panel plugins",
       "paste-panel": "Paste panel",
       "row": "Row",
       "visualization": "Visualization"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5130,7 +5130,6 @@
     },
     "add-menu": {
       "import": "Import from library",
-      "load-error": "Failed to load panel plugins",
       "paste-panel": "Paste panel",
       "row": "Row",
       "visualization": "Visualization"


### PR DESCRIPTION
**What is this feature?**

This pull request updates the way panel plugins are loaded and handled in the Add Panel Menu, improving error handling and testability. The main changes include switching to the `useListedPanelPluginMetas` hook for retrieving available panel plugins, updating the `getCopiedPanelPlugin` function to accept the loaded panels as a parameter, and adding user-facing error feedback if plugin loading fails.

**Why do we need this feature?**

So we can remove `config.panels`

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates #117467

**Special notes for your reviewer:**

Test locally with this `ini` settings
```ini
[feature_toggles]
dashboardScene = false
```

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
