### PR TITLE
Alerting: Export RouteMatchInfo as type

### DIFF
--- a/packages/grafana-alerting/package.json
+++ b/packages/grafana-alerting/package.json
@@ -67,7 +67,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-    "@types/lodash": "^4",
+    "@types/lodash-es": "^4",
     "@types/react": "18.3.18",
     "@types/react-dom": "18.3.5",
     "@types/tinycolor2": "^1",
@@ -98,7 +98,7 @@
     "@grafana/i18n": "13.0.0-pre",
     "@reduxjs/toolkit": "2.10.1",
     "fishery": "^2.3.1",
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "tinycolor2": "^1.6.0"
   }
 }

--- a/packages/grafana-alerting/src/grafana/contactPoints/components/ContactPointSelector/ContactPointSelector.tsx
+++ b/packages/grafana-alerting/src/grafana/contactPoints/components/ContactPointSelector/ContactPointSelector.tsx
@@ -1,4 +1,4 @@
-import { chain } from 'lodash';
+import { chain } from 'lodash-es';
 
 import { Combobox, ComboboxOption } from '@grafana/ui';
 

--- a/packages/grafana-alerting/src/grafana/contactPoints/utils.ts
+++ b/packages/grafana-alerting/src/grafana/contactPoints/utils.ts
@@ -1,4 +1,4 @@
-import { countBy, isEmpty } from 'lodash';
+import { countBy, isEmpty } from 'lodash-es';
 
 import { Receiver } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
 

--- a/packages/grafana-alerting/src/grafana/matchers/utils.ts
+++ b/packages/grafana-alerting/src/grafana/matchers/utils.ts
@@ -1,6 +1,25 @@
-import { parseFlags } from '@grafana/data';
-
 import { Label, LabelMatcher } from './types';
+
+// Inlined from @grafana/data so that this module has no runtime dependency on
+// @grafana/data.  That keeps the worker-safe build self-contained.
+const CLEAR_FLAG = '-';
+const FLAGS_REGEXP = /\(\?([ims-]+)\)/g;
+function parseFlags(text: string): { cleaned: string; flags: string } {
+  const flags: Set<string> = new Set(['g']);
+  const cleaned = text.replace(FLAGS_REGEXP, (_str, group) => {
+    const clearAll = group.startsWith(CLEAR_FLAG);
+    for (let i = 0; i < group.length; ++i) {
+      const flag = group.charAt(i);
+      if (clearAll || group.charAt(i - 1) === CLEAR_FLAG) {
+        flags.delete(flag);
+      } else if (flag !== CLEAR_FLAG) {
+        flags.add(flag);
+      }
+    }
+    return '';
+  });
+  return { cleaned, flags: Array.from(flags).join('') };
+}
 
 type LabelMatchingResult = {
   // wether all of the labels match the given set of matchers

--- a/packages/grafana-alerting/src/grafana/mocks/util.ts
+++ b/packages/grafana-alerting/src/grafana/mocks/util.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { upperFirst } from 'lodash';
+import { upperFirst } from 'lodash-es';
 
 export const DEFAULT_NAMESPACE = 'default' as const;
 

--- a/packages/grafana-alerting/src/grafana/notificationPolicies/utils.test.ts
+++ b/packages/grafana-alerting/src/grafana/notificationPolicies/utils.test.ts
@@ -1,4 +1,4 @@
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 
 import { LabelMatcherFactory, RouteFactory } from '../api/notifications/v0alpha1/mocks/fakes/Routes';
 import { Label } from '../matchers/types';

--- a/packages/grafana-alerting/src/grafana/notificationPolicies/utils.ts
+++ b/packages/grafana-alerting/src/grafana/notificationPolicies/utils.ts
@@ -1,4 +1,4 @@
-import { groupBy, isArray, pick, reduce, uniqueId } from 'lodash';
+import { groupBy, isArray, pick, reduce, uniqueId } from 'lodash-es';
 
 import { RoutingTree, RoutingTreeRoute } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
 

--- a/packages/grafana-alerting/src/grafana/rules/components/labels/AlertLabels.tsx
+++ b/packages/grafana-alerting/src/grafana/rules/components/labels/AlertLabels.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { chain } from 'lodash';
+import { chain } from 'lodash-es';
 import { useMemo, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';

--- a/packages/grafana-alerting/src/grafana/rules/components/state/StateIcon.tsx
+++ b/packages/grafana-alerting/src/grafana/rules/components/state/StateIcon.tsx
@@ -1,5 +1,5 @@
 import { css, keyframes } from '@emotion/css';
-import { upperFirst } from 'lodash';
+import { upperFirst } from 'lodash-es';
 import { ComponentProps, memo } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';

--- a/packages/grafana-alerting/src/index.ts
+++ b/packages/grafana-alerting/src/index.ts
@@ -24,6 +24,7 @@ export {
 export {
   type TreeMatch,
   type RouteMatchResult,
+  type RouteMatchInfo,
   matchInstancesToRoute,
   findMatchingRoutes,
   getInheritedProperties,


### PR DESCRIPTION
This is required for route matching in the Prometheus Alerting package