### PR TITLE
Provisioning: Add .git suffix hint to Pure Git repository URL field

### DIFF
--- a/public/app/features/provisioning/Wizard/fields.ts
+++ b/public/app/features/provisioning/Wizard/fields.ts
@@ -213,7 +213,10 @@ const getProviderConfigs = (): Record<RepoType, Record<string, FieldConfig>> => 
       },
       url: {
         ...shared.url,
-        description: t('provisioning.git.url-description', 'The Git repository URL'),
+        description: t(
+          'provisioning.git.url-description',
+          'The Git repository URL. Most servers require the URL to end with .git (e.g. https://host/owner/repo.git).'
+        ),
         // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
         placeholder: 'https://git.example.com/owner/repository.git',
         required: true,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13051,7 +13051,7 @@
       "token-label": "Access Token",
       "token-required": "Git token is required",
       "token-user-description": "The username that will be used to access the repository with the access token",
-      "url-description": "The Git repository URL",
+      "url-description": "The Git repository URL. Most servers require the URL to end with .git (e.g. https://host/owner/repo.git).",
       "url-pattern": "Must be a valid Git repository URL",
       "url-required": "Repository URL is required"
     },


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/120149

## Summary
- Updates the Pure Git "Repository URL" field description to mention that most servers require the URL to end with `.git`.
- Helps users avoid 404 errors when configuring Pure Git repositories.

Closes https://github.com/grafana/nanogit/issues/207

## Test plan
- [ ] Open the provisioning wizard, select Pure Git, and verify the Repository URL field description now reads: *"The Git repository URL. Most servers require the URL to end with .git (e.g. https://host/owner/repo.git)."*

Made with [Cursor](https://cursor.com)