### PR TITLE
Provisioning: Do not enforce git suffix for pure git repositories

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
@@ -87,7 +87,7 @@ func (GitHubRepositoryConfig) OpenAPIModelName() string {
 }
 
 type GitRepositoryConfig struct {
-	// The repository URL (e.g. `https://github.com/example/test.git`).
+	// The repository URL (e.g. `https://github.com/example/test`).
 	URL string `json:"url,omitempty"`
 	// The branch to use in the repository.
 	Branch string `json:"branch"`

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -937,7 +937,7 @@ func schema_pkg_apis_provisioning_v0alpha1_GitRepositoryConfig(ref common.Refere
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The repository URL (e.g. `https://github.com/example/test.git`).",
+							Description: "The repository URL (e.g. `https://github.com/example/test`).",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/gitrepositoryconfig.go
+++ b/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/gitrepositoryconfig.go
@@ -7,7 +7,7 @@ package v0alpha1
 // GitRepositoryConfigApplyConfiguration represents a declarative configuration of the GitRepositoryConfig type for use
 // with apply.
 type GitRepositoryConfigApplyConfiguration struct {
-	// The repository URL (e.g. `https://github.com/example/test.git`).
+	// The repository URL (e.g. `https://github.com/example/test`).
 	URL *string `json:"url,omitempty"`
 	// The branch to use in the repository.
 	Branch *string `json:"branch,omitempty"`

--- a/apps/provisioning/pkg/repository/git/extra.go
+++ b/apps/provisioning/pkg/repository/git/extra.go
@@ -37,11 +37,12 @@ func (e *extra) Build(ctx context.Context, r *provisioning.Repository) (reposito
 	}
 
 	return NewRepository(ctx, r, RepositoryConfig{
-		URL:       cfg.URL,
-		Branch:    cfg.Branch,
-		Path:      cfg.Path,
-		TokenUser: cfg.TokenUser,
-		Token:     token,
+		URL:           cfg.URL,
+		Branch:        cfg.Branch,
+		Path:          cfg.Path,
+		TokenUser:     cfg.TokenUser,
+		Token:         token,
+		SkipGitSuffix: true,
 	})
 }
 

--- a/apps/provisioning/pkg/repository/git/mutator.go
+++ b/apps/provisioning/pkg/repository/git/mutator.go
@@ -27,12 +27,7 @@ func Mutate(_ context.Context, obj runtime.Object) error {
 	if repo.Spec.Git.URL != "" {
 		url := strings.TrimSpace(repo.Spec.Git.URL)
 		if url != "" {
-			// Remove any trailing slashes
 			url = strings.TrimRight(url, "/")
-			// Only add .git if it's not already present
-			if !strings.HasSuffix(url, ".git") {
-				url = url + ".git"
-			}
 			repo.Spec.Git.URL = url
 		}
 	}

--- a/apps/provisioning/pkg/repository/git/mutator_test.go
+++ b/apps/provisioning/pkg/repository/git/mutator_test.go
@@ -64,7 +64,7 @@ func TestMutate(t *testing.T) {
 			obj:  &runtime.Unknown{},
 		},
 		{
-			name: "URL normalization - add .git suffix",
+			name: "URL normalization - keep URL as-is",
 			obj: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-repo",
@@ -77,7 +77,7 @@ func TestMutate(t *testing.T) {
 					},
 				},
 			},
-			expectedURL: "https://github.com/grafana/grafana.git",
+			expectedURL: "https://github.com/grafana/grafana",
 		},
 		{
 			name: "URL normalization - keep existing .git suffix",
@@ -96,7 +96,7 @@ func TestMutate(t *testing.T) {
 			expectedURL: "https://github.com/grafana/grafana.git",
 		},
 		{
-			name: "URL normalization - remove trailing slash and add .git",
+			name: "URL normalization - remove trailing slash",
 			obj: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-repo",
@@ -109,10 +109,10 @@ func TestMutate(t *testing.T) {
 					},
 				},
 			},
-			expectedURL: "https://github.com/grafana/grafana.git",
+			expectedURL: "https://github.com/grafana/grafana",
 		},
 		{
-			name: "URL normalization - trim whitespace and add .git",
+			name: "URL normalization - trim whitespace",
 			obj: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-repo",
@@ -125,7 +125,7 @@ func TestMutate(t *testing.T) {
 					},
 				},
 			},
-			expectedURL: "https://github.com/grafana/grafana.git",
+			expectedURL: "https://github.com/grafana/grafana",
 		},
 		{
 			name: "URL normalization - empty URL after trim",

--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -33,11 +33,12 @@ import (
 var ErrNoBranches = errors.New("no branches found in repository")
 
 type RepositoryConfig struct {
-	URL       string
-	Branch    string
-	TokenUser string
-	Token     common.RawSecureValue
-	Path      string
+	URL           string
+	Branch        string
+	TokenUser     string
+	Token         common.RawSecureValue
+	Path          string
+	SkipGitSuffix bool
 }
 
 // Make sure all public functions of this struct call the (*gitRepository).logger function, to ensure the Git repo details are included.
@@ -53,6 +54,9 @@ func NewRepository(
 	gitConfig RepositoryConfig,
 ) (GitRepository, error) {
 	var opts []options.Option
+	if gitConfig.SkipGitSuffix {
+		opts = append(opts, options.WithoutGitSuffix())
+	}
 	if !gitConfig.Token.IsZero() {
 		tokenUser := gitConfig.TokenUser
 		if tokenUser == "" {

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1792,7 +1792,7 @@ export type GitRepositoryConfig = {
   path?: string;
   /** TokenUser is the user that will be used to access the repository if it's a personal access token. */
   tokenUser?: string;
-  /** The repository URL (e.g. `https://github.com/example/test.git`). */
+  /** The repository URL (e.g. `https://github.com/example/test`). */
   url?: string;
 };
 export type GitHubRepositoryConfig = {

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
@@ -4321,7 +4321,7 @@
             "type": "string"
           },
           "url": {
-            "description": "The repository URL (e.g. `https://github.com/example/test.git`).",
+            "description": "The repository URL (e.g. `https://github.com/example/test`).",
             "type": "string"
           }
         }

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -4688,7 +4688,7 @@
             "type": "string"
           },
           "url": {
-            "description": "The repository URL (e.g. `https://github.com/example/test.git`).",
+            "description": "The repository URL (e.g. `https://github.com/example/test`).",
             "type": "string"
           }
         }


### PR DESCRIPTION
## Summary

The Git type mutator unconditionally appended `.git` to every repository URL, and nanogit itself also appended `.git` internally. This broke providers like **Azure DevOps** where `.git` is a literal path segment (e.g. `/_git/MyRepo`), not a suffix convention.

This PR removes the `.git` appending from the Git mutator and uses nanogit's `WithoutGitSuffix()` option so the URL is stored and used exactly as the user provides it.

Partially fixes https://github.com/grafana/grafana/issues/120149
Depends on https://github.com/grafana/nanogit/pull/207 (already merged, available in nanogit v0.7.0).

## What changed

| File | Change |
|------|--------|
| `git/mutator.go` | Removed `.git` suffix appending. Mutator now only trims whitespace and trailing slashes. |
| `git/repository.go` | Added `SkipGitSuffix` field to `RepositoryConfig`. When set, passes `options.WithoutGitSuffix()` to nanogit. |
| `git/extra.go` | Sets `SkipGitSuffix: true` when building Git type repositories. |
| `types.go` + generated files | Updated URL example comment to not include `.git`. |
| `git/mutator_test.go` | Updated test expectations to reflect no `.git` appending. |

## Why `SkipGitSuffix` is only set for the Git type

`git.NewRepository` is shared by both the **Git** and **GitHub** extras:

```mermaid
flowchart TD
    subgraph gitExtra ["Git Extra (git/extra.go)"]
        GE["Build()"] -->|"SkipGitSuffix: true"| NR["git.NewRepository"]
    end

    subgraph ghExtra ["GitHub Extra (github/extra.go)"]
        GHE["Build()"] -->|"SkipGitSuffix: false (default)"| NR
    end

    NR -->|"SkipGitSuffix?"| Decision{SkipGitSuffix?}
    Decision -->|true| NoSuffix["nanogit: use URL as-is"]
    Decision -->|false| AddSuffix["nanogit: append .git"]
```

The **GitHub mutator** strips `.git` from the stored URL, then relies on nanogit to add it back internally (GitHub's Git HTTP API requires it). If we applied `WithoutGitSuffix()` to GitHub repos too, they would break. So we only enable it for the pure Git type through the `RepositoryConfig.SkipGitSuffix` field.

## Backward compatibility with existing repositories

Existing Git type repositories that were created before this change already have `.git` in their stored URL (the old mutator added it). These continue to work:

```mermaid
flowchart LR
    subgraph before ["Before this PR"]
        B1["User: .../MyRepo"] -->|mutator| B2["Stored: .../MyRepo.git"]
        B2 -->|nanogit| B3["Used: .../MyRepo.git"]
    end

    subgraph afterOld ["After this PR — existing repo"]
        A1["Stored: .../MyRepo.git"] -->|"mutator (no change)"| A2["Still: .../MyRepo.git"]
        A2 -->|"nanogit + WithoutGitSuffix"| A3["Used: .../MyRepo.git ✅"]
    end

    subgraph afterNew ["After this PR — new repo"]
        N1["User: .../MyRepo"] -->|"mutator (trim only)"| N2["Stored: .../MyRepo"]
        N2 -->|"nanogit + WithoutGitSuffix"| N3["Used: .../MyRepo ✅"]
    end
```

- **Existing repos** already have `.git` in the stored URL. The mutator no longer adds it, but doesn't strip it either. nanogit with `WithoutGitSuffix()` uses the URL as-is, so `.git` is preserved. These repos keep working.
- **New repos** store the URL exactly as provided. nanogit uses it as-is too. Users who need `.git` (standard Git servers) include it in the URL. Users who don't (Azure DevOps) omit it.
- **Broken repos** (e.g. Azure DevOps repos where the old mutator added `.git`) need a manual URL update to remove the `.git` suffix. This is expected since those repos were non-functional anyway.

## Test plan

- [x] Mutator tests updated and passing — URLs are no longer modified with `.git` suffix
- [x] Build passes for the full provisioning app
- [ ] Verify Azure DevOps repository URLs work without `.git` appending
- [ ] Verify standard Git provider URLs (GitHub, GitLab, Bitbucket) still work when user includes `.git` in URL
- [ ] Verify existing repositories with `.git` in stored URL continue to function
- [ ] Verify GitHub type repositories are unaffected (nanogit still appends `.git` for them)


Made with [Cursor](https://cursor.com)