### PR TITLE
docs: fix typo in SQL expressions docs

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -116,7 +116,7 @@ Use the following workflow to create a SQL expression:
    **Inspect inputs**. Start with simple test queries to understand the shape of your input frames.
 
    ```sql
-   SELECT * FROM A LIMIT 10.
+   SELECT * FROM A LIMIT 10
    ```
 
    This lets you see the available columns and sample rows from `query A`. Repeat this for each input query you want to use (e.g., `SELECT * FROM B LIMIT 10`).


### PR DESCRIPTION
## Summary
- Remove trailing dot from SQL query example (`SELECT * FROM A LIMIT 10.` → `SELECT * FROM A LIMIT 10`) in the SQL expressions documentation

## Test plan
- [ ] Verify the rendered docs page no longer shows a dot at the end of the query example

🤖 Generated with [Claude Code](https://claude.com/claude-code)