### PR TITLE
Plugins: Fix installer IsDisabled condition

### DIFF
--- a/pkg/services/pluginsintegration/plugininstaller/service.go
+++ b/pkg/services/pluginsintegration/plugininstaller/service.go
@@ -78,7 +78,7 @@ func ProvideService(
 
 // IsDisabled disables background installation of plugins.
 func (s *Service) IsDisabled() bool {
-	return len(s.cfg.PreinstallPluginsAsync) == 0
+	return len(s.cfg.PreinstallPluginsAsync) == 0 && len(s.cfg.PreinstallPluginsSync) == 0
 }
 
 func (s *Service) shouldUpdate(ctx context.Context, pluginID, currentVersion string, pluginURL string) bool {

--- a/pkg/services/pluginsintegration/plugininstaller/service_test.go
+++ b/pkg/services/pluginsintegration/plugininstaller/service_test.go
@@ -19,24 +19,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test if the service is disabled
 func TestService_IsDisabled(t *testing.T) {
-	// Create a new service
-	s, err := ProvideService(
-		&setting.Cfg{
-			PreinstallPluginsAsync: []setting.InstallPlugin{{ID: "myplugin"}},
+	tests := []struct {
+		name                  string
+		preinstallPluginsSync []setting.InstallPlugin
+		preinstallPluginsAsync []setting.InstallPlugin
+		expectedDisabled      bool
+	}{
+		{
+			name:                   "enabled when async plugins are configured",
+			preinstallPluginsAsync: []setting.InstallPlugin{{ID: "myplugin"}},
+			expectedDisabled:       false,
 		},
-		pluginstore.New(registry.NewInMemory(), &pluginfakes.FakeLoader{}, &pluginfakes.FakeSourceRegistry{}),
-		&pluginfakes.FakePluginInstaller{},
-		prometheus.NewRegistry(),
-		&pluginfakes.FakePluginRepo{},
-		&pluginchecker.FakePluginUpdateChecker{},
-	)
-	require.NoError(t, err)
+		{
+			name:                  "enabled when only sync plugins are configured",
+			preinstallPluginsSync: []setting.InstallPlugin{{ID: "myplugin"}},
+			expectedDisabled:      false,
+		},
+		{
+			name:             "disabled when no plugins are configured",
+			expectedDisabled: true,
+		},
+	}
 
-	// Check if the service is disabled
-	if s.IsDisabled() {
-		t.Error("Service should be enabled")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := ProvideService(
+				&setting.Cfg{
+					PreinstallPluginsSync:  tt.preinstallPluginsSync,
+					PreinstallPluginsAsync: tt.preinstallPluginsAsync,
+				},
+				pluginstore.New(registry.NewInMemory(), &pluginfakes.FakeLoader{}, &pluginfakes.FakeSourceRegistry{}),
+				&pluginfakes.FakePluginInstaller{},
+				prometheus.NewRegistry(),
+				&pluginfakes.FakePluginRepo{},
+				&pluginchecker.FakePluginUpdateChecker{},
+			)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedDisabled, s.IsDisabled())
+		})
 	}
 }
 

--- a/pkg/services/pluginsintegration/plugininstaller/service_test.go
+++ b/pkg/services/pluginsintegration/plugininstaller/service_test.go
@@ -21,10 +21,10 @@ import (
 
 func TestService_IsDisabled(t *testing.T) {
 	tests := []struct {
-		name                  string
-		preinstallPluginsSync []setting.InstallPlugin
+		name                   string
+		preinstallPluginsSync  []setting.InstallPlugin
 		preinstallPluginsAsync []setting.InstallPlugin
-		expectedDisabled      bool
+		expectedDisabled       bool
 	}{
 		{
 			name:                   "enabled when async plugins are configured",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes the installer condition to evaluate both sync and async install requests.

**Why do we need this feature?**

Avoids disabling the service when only the async list is empty.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/120338

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
