### PR TITLE
Logs Panel: Added support to pass custom grammar definition for plugin developers

### DIFF
--- a/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/types.gen.ts
@@ -22,7 +22,7 @@ export interface Options {
   enableInfiniteScrolling?: boolean;
   enableLogDetails: boolean;
   fontSize?: ('default' | 'small');
-  gammar?: unknown;
+  grammar?: unknown;
   isFilterLabelActive?: unknown;
   logLineMenuCustomItems?: unknown;
   logRowMenuIconsAfter?: unknown;

--- a/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/types.gen.ts
@@ -22,6 +22,7 @@ export interface Options {
   enableInfiniteScrolling?: boolean;
   enableLogDetails: boolean;
   fontSize?: ('default' | 'small');
+  gammar?: unknown;
   isFilterLabelActive?: unknown;
   logLineMenuCustomItems?: unknown;
   logRowMenuIconsAfter?: unknown;

--- a/public/app/features/logs/components/mocks/logRow.ts
+++ b/public/app/features/logs/components/mocks/logRow.ts
@@ -1,4 +1,4 @@
-import { Grammar } from 'prismjs';
+import type { Grammar } from 'prismjs';
 
 import { FieldType, LogLevel, LogRowModel, LogsSortOrder, toDataFrame } from '@grafana/data';
 

--- a/public/app/features/logs/components/mocks/logRow.ts
+++ b/public/app/features/logs/components/mocks/logRow.ts
@@ -1,3 +1,5 @@
+import { Grammar } from 'prismjs';
+
 import { FieldType, LogLevel, LogRowModel, LogsSortOrder, toDataFrame } from '@grafana/data';
 
 import { LogListModel, preProcessLogs, PreProcessOptions } from '../panel/processing';
@@ -47,8 +49,9 @@ export const createLogLine = (
     timeZone: 'browser',
     virtualization: undefined,
     wrapLogMessage: true,
-  }
+  },
+  grammar?: Grammar
 ): LogListModel => {
-  const logs = preProcessLogs([createLogRow({ datasourceUid: 'abc-123', ...overrides })], processOptions);
+  const logs = preProcessLogs([createLogRow({ datasourceUid: 'abc-123', ...overrides })], processOptions, grammar);
   return logs[0];
 };

--- a/public/app/features/logs/components/panel/LogLine.test.tsx
+++ b/public/app/features/logs/components/panel/LogLine.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Grammar } from 'prismjs';
 
 import { CoreApp, createTheme, getDefaultTimeRange, LogsDedupStrategy, LogsSortOrder } from '@grafana/data';
 import { config } from '@grafana/runtime';
@@ -17,7 +18,6 @@ import { LogListSearchContext } from './LogListSearchContext';
 import { defaultProps, defaultValue } from './__mocks__/LogListContext';
 import { LogListModel } from './processing';
 import { LogLineVirtualization } from './virtualization';
-import { Grammar } from 'prismjs';
 
 jest.mock('@openfeature/react-sdk', () => ({
   useBooleanFlagValue: jest.fn().mockReturnValue(false),
@@ -397,7 +397,7 @@ describe.each(fontSizes)('LogLine', (fontSize: LogListFontSize) => {
     });
   });
 
-  describe.only('Custom syntax highlighting', () => {
+  describe('Custom syntax highlighting', () => {
     const entry = `{"place":"luna","count":3,"true":false}`;
     const grammar: Grammar = {
       property: {

--- a/public/app/features/logs/components/panel/LogLine.test.tsx
+++ b/public/app/features/logs/components/panel/LogLine.test.tsx
@@ -17,6 +17,7 @@ import { LogListSearchContext } from './LogListSearchContext';
 import { defaultProps, defaultValue } from './__mocks__/LogListContext';
 import { LogListModel } from './processing';
 import { LogLineVirtualization } from './virtualization';
+import { Grammar } from 'prismjs';
 
 jest.mock('@openfeature/react-sdk', () => ({
   useBooleanFlagValue: jest.fn().mockReturnValue(false),
@@ -393,6 +394,76 @@ describe.each(fontSizes)('LogLine', (fontSize: LogListFontSize) => {
       expect(screen.queryByText(`place="luna" 1ms 3 KB`)).not.toBeInTheDocument();
 
       config.featureToggles.otelLogsFormatting = originalState;
+    });
+  });
+
+  describe.only('Custom syntax highlighting', () => {
+    const entry = `{"place":"luna","count":3,"true":false}`;
+    const grammar: Grammar = {
+      property: {
+        pattern: /(^|[^\\])"(?:\\.|[^\\"\r\n])*"(?=\s*:)/,
+        lookbehind: true,
+        greedy: true,
+      },
+      string: {
+        pattern: /(^|[^\\])"(?:\\.|[^\\"\r\n])*"(?!\s*:)/,
+        lookbehind: true,
+        greedy: true,
+      },
+      number: /-?\b\d+(?:\.\d+)?(?:e[+-]?\d+)?\b/i,
+      punctuation: /[{}[\],]/,
+      operator: /:/,
+      boolean: /\b(?:false|true)\b/,
+    };
+    beforeEach(() => {
+      log = createLogLine({ labels: { place: 'luna' }, entry }, undefined, grammar);
+    });
+
+    test('Highlights relevant tokens in the log line', () => {
+      render(
+        <LogListContextProvider {...contextProps} isCustomGrammar>
+          <LogLine {...defaultProps} log={log} />
+        </LogListContextProvider>
+      );
+      expect(screen.getByText('"place"')).toBeInTheDocument();
+      expect(screen.getByText('"luna"')).toBeInTheDocument();
+      expect(screen.getByText('"count"')).toBeInTheDocument();
+      expect(screen.getByText('3')).toBeInTheDocument();
+      expect(screen.getByText('"true"')).toBeInTheDocument();
+      expect(screen.getByText('false')).toBeInTheDocument();
+      expect(screen.queryByText(entry)).not.toBeInTheDocument();
+    });
+
+    test('Can be disabled', () => {
+      render(
+        <LogListContextProvider {...contextProps} syntaxHighlighting={false} isCustomGrammar>
+          <LogLine {...defaultProps} log={log} />
+        </LogListContextProvider>
+      );
+      expect(screen.getByText(entry)).toBeInTheDocument();
+      expect(screen.queryByText('"place"')).not.toBeInTheDocument();
+      expect(screen.queryByText('"luna"')).not.toBeInTheDocument();
+      expect(screen.queryByText('"count"')).not.toBeInTheDocument();
+      expect(screen.queryByText('3')).not.toBeInTheDocument();
+      expect(screen.queryByText('"true"')).not.toBeInTheDocument();
+      expect(screen.queryByText('false')).not.toBeInTheDocument();
+    });
+
+    test('Does not alter ANSI log lines', () => {
+      log = createLogLine(
+        { labels: { place: 'luna' }, entry: 'Lorem \u001B[31mipsum\u001B[0m et dolor' },
+        undefined,
+        grammar
+      );
+      log.hasAnsi = true;
+
+      render(
+        <LogListContextProvider {...contextProps} syntaxHighlighting={false} isCustomGrammar>
+          <LogLine {...defaultProps} log={log} />
+        </LogListContextProvider>
+      );
+      expect(screen.getByTestId('ansiLogLine')).toBeInTheDocument();
+      expect(screen.queryByText(log.entry)).not.toBeInTheDocument();
     });
   });
 

--- a/public/app/features/logs/components/panel/LogLine.test.tsx
+++ b/public/app/features/logs/components/panel/LogLine.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Grammar } from 'prismjs';
+import type { Grammar } from 'prismjs';
 
 import { CoreApp, createTheme, getDefaultTimeRange, LogsDedupStrategy, LogsSortOrder } from '@grafana/data';
 import { config } from '@grafana/runtime';

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -395,7 +395,7 @@ const DisplayedFields = ({
   styles: LogLineStyles;
 }) => {
   const { matchingUids, search } = useLogListSearchContext();
-  const { syntaxHighlighting, unwrappedColumns, wrapLogMessage } = useLogListContext();
+  const { isCustomGrammar, syntaxHighlighting, unwrappedColumns, wrapLogMessage } = useLogListContext();
 
   const searchWords = useMemo(() => {
     const searchWords = log.searchWords && log.searchWords[0] ? log.searchWords.slice() : [];
@@ -414,8 +414,9 @@ const DisplayedFields = ({
         return <LogLineBody log={log} key={field} styles={styles} />;
       }
       if (field === OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME && syntaxHighlighting) {
+        const className = isCustomGrammar ? 'field prism-syntax-highlight' : 'field log-syntax-highlight';
         return (
-          <span className="field log-syntax-highlight" title={getNormalizedFieldName(field)} key={field}>
+          <span className={className} title={getNormalizedFieldName(field)} key={field}>
             <HighlightedLogRenderer tokens={log.highlightedLogAttributesTokens} />{' '}
           </span>
         );
@@ -447,7 +448,7 @@ const DisplayedFields = ({
 };
 
 const LogLineBody = ({ log, styles }: { log: LogListModel; styles: LogLineStyles }) => {
-  const { syntaxHighlighting } = useLogListContext();
+  const { isCustomGrammar, syntaxHighlighting } = useLogListContext();
   const { matchingUids, search } = useLogListSearchContext();
 
   const highlight = useMemo(() => {
@@ -482,8 +483,12 @@ const LogLineBody = ({ log, styles }: { log: LogListModel; styles: LogLineStyles
     );
   }
 
+  const className = isCustomGrammar
+    ? 'field prism-syntax-highlight log-line-body'
+    : 'field log-syntax-highlight log-line-body';
+
   return (
-    <span className="field log-syntax-highlight log-line-body">
+    <span className={className}>
       <HighlightedLogRenderer tokens={log.highlightedBodyTokens} />{' '}
     </span>
   );

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -185,6 +185,7 @@ export const LogList = ({
       filterLevels={filterLevels}
       fontSize={fontSize}
       getRowContextQuery={getRowContextQuery}
+      isCustomGrammar={grammar !== undefined}
       isLabelFilterActive={isLabelFilterActive}
       logs={logs}
       logsMeta={logsMeta}

--- a/public/app/features/logs/components/panel/LogListContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.test.tsx
@@ -59,3 +59,12 @@ test('Allows to tell if a log is not permalinked', () => {
 
   expect(result.current).toBe(false);
 });
+
+test('Identifies custom grammar', () => {
+  const customWrapper = ({ children }: { children: ReactNode }) => (
+    <LogListContext.Provider value={{ ...value, isCustomGrammar: true }}>{children}</LogListContext.Provider>
+  );
+  const { result } = renderHook(() => useLogListContext(), { wrapper: customWrapper });
+
+  expect(result.current.isCustomGrammar).toBe(true);
+});

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -149,6 +149,7 @@ export interface Props {
   filterLevels?: LogLevel[];
   fontSize: LogListFontSize;
   getRowContextQuery?: GetRowContextQueryFn;
+  isCustomGrammar?: boolean;
   isLabelFilterActive?: (key: string, value: string, refId?: string) => Promise<boolean>;
   logs: LogRowModel[];
   logLineMenuCustomItems?: LogLineMenuCustomItem[];
@@ -194,6 +195,7 @@ export const LogListContextProvider = ({
   displayedFields,
   filterLevels,
   fontSize,
+  isCustomGrammar,
   isLabelFilterActive,
   getRowContextQuery,
   logs,
@@ -582,6 +584,7 @@ export const LogListContextProvider = ({
         hasLogsWithErrors,
         hasSampledLogs,
         hasUnescapedContent,
+        isCustomGrammar,
         isLabelFilterActive,
         getRowContextQuery,
         logSupportsContext,

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -136,6 +136,9 @@ interface LogsPanelProps extends PanelProps<Options> {
    * Requires the `otelLogsFormatting`.
    * @alpha
    * showLogAttributes?: boolean
+   *
+   * Custom Prism grammar definition for highlighting. When used, the .prism-syntax-highlight CSS class name is applied to the component, to allow standard token colors to be applied.
+   * grammar?: Grammar
    */
 }
 const noCommonLabels: Labels = {};

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -53,6 +53,7 @@ import type { Options } from './panelcfg.gen';
 import {
   GetFieldLinksFn,
   isCoreApp,
+  isGrammar,
   isIsFilterLabelActive,
   isLogLineMenuCustomItems,
   isOnClickFilterLabel,

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -172,6 +172,7 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
     timestampResolution,
     showLogAttributes,
     unwrappedColumns,
+    grammar,
   } = options;
   const isAscending = sortOrder === LogsSortOrder.Ascending;
   const style = useStyles2(getStyles);
@@ -593,6 +594,7 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
               enableLogDetails={enableLogDetails}
               fontSize={fontSize}
               getFieldLinks={getFieldLinks}
+              grammar={isGrammar(grammar) ? grammar : undefined}
               isLabelFilterActive={isIsFilterLabelActive(isFilterLabelActive) ? isFilterLabelActive : undefined}
               initialScrollPosition={initialScrollPosition}
               loading={infiniteScrolling}

--- a/public/app/plugins/panel/logs/panelcfg.cue
+++ b/public/app/plugins/panel/logs/panelcfg.cue
@@ -62,7 +62,7 @@ composableKinds: PanelCfg: {
 					onNewLogsReceived?:      _
 					displayedFields?: [...string]
 					setDisplayedFields?:     _
-					gammar?: 			     _
+					grammar?: 			     _
 				} @cuetsy(kind="interface")
 			}
 		}]

--- a/public/app/plugins/panel/logs/panelcfg.cue
+++ b/public/app/plugins/panel/logs/panelcfg.cue
@@ -62,6 +62,7 @@ composableKinds: PanelCfg: {
 					onNewLogsReceived?:      _
 					displayedFields?: [...string]
 					setDisplayedFields?:     _
+					gammar?: 			     _
 				} @cuetsy(kind="interface")
 			}
 		}]

--- a/public/app/plugins/panel/logs/panelcfg.gen.ts
+++ b/public/app/plugins/panel/logs/panelcfg.gen.ts
@@ -20,7 +20,7 @@ export interface Options {
   enableInfiniteScrolling?: boolean;
   enableLogDetails: boolean;
   fontSize?: ('default' | 'small');
-  gammar?: unknown;
+  grammar?: unknown;
   isFilterLabelActive?: unknown;
   logLineMenuCustomItems?: unknown;
   logRowMenuIconsAfter?: unknown;

--- a/public/app/plugins/panel/logs/panelcfg.gen.ts
+++ b/public/app/plugins/panel/logs/panelcfg.gen.ts
@@ -20,6 +20,7 @@ export interface Options {
   enableInfiniteScrolling?: boolean;
   enableLogDetails: boolean;
   fontSize?: ('default' | 'small');
+  gammar?: unknown;
   isFilterLabelActive?: unknown;
   logLineMenuCustomItems?: unknown;
   logRowMenuIconsAfter?: unknown;

--- a/public/app/plugins/panel/logs/types.ts
+++ b/public/app/plugins/panel/logs/types.ts
@@ -1,9 +1,9 @@
+import { Grammar } from 'prismjs';
 import React, { ReactNode } from 'react';
 
 import { CoreApp, DataFrame, Field, LinkModel, ScopedVars } from '@grafana/data';
 import { LogLineMenuCustomItem } from 'app/features/logs/components/panel/LogLineMenu';
 import { LogListOptions } from 'app/features/logs/components/panel/LogList';
-import { Grammar } from 'prismjs';
 
 type onClickFilterLabelType = (key: string, value: string, frame?: DataFrame) => void;
 type onClickFilterOutLabelType = (key: string, value: string, frame?: DataFrame) => void;

--- a/public/app/plugins/panel/logs/types.ts
+++ b/public/app/plugins/panel/logs/types.ts
@@ -1,4 +1,4 @@
-import { Grammar } from 'prismjs';
+import type { Grammar } from 'prismjs';
 import React, { ReactNode } from 'react';
 
 import { CoreApp, DataFrame, Field, LinkModel, ScopedVars } from '@grafana/data';

--- a/public/app/plugins/panel/logs/types.ts
+++ b/public/app/plugins/panel/logs/types.ts
@@ -3,6 +3,7 @@ import React, { ReactNode } from 'react';
 import { CoreApp, DataFrame, Field, LinkModel, ScopedVars } from '@grafana/data';
 import { LogLineMenuCustomItem } from 'app/features/logs/components/panel/LogLineMenu';
 import { LogListOptions } from 'app/features/logs/components/panel/LogList';
+import { Grammar } from 'prismjs';
 
 type onClickFilterLabelType = (key: string, value: string, frame?: DataFrame) => void;
 type onClickFilterOutLabelType = (key: string, value: string, frame?: DataFrame) => void;
@@ -73,4 +74,8 @@ export function isCoreApp(app: unknown): app is CoreApp {
 
 export function isLogLineMenuCustomItems(items: unknown): items is LogLineMenuCustomItem[] {
   return Array.isArray(items) && items.every((item) => 'divider' in item || ('onClick' in item && 'label' in item));
+}
+
+export function isGrammar(grammar: unknown): grammar is Grammar {
+  return grammar != null && typeof grammar === 'object' && !Array.isArray(grammar);
 }


### PR DESCRIPTION
This PR exposes the `grammar` prop to the Logs Panel for Grafana plugin developers.

The `grammar` prop is a custom [Prism grammar definition](https://prismjs.com/extending). When used, the `.prism-syntax-highlight` CSS class name is applied to the component, to allow [standard token colors](https://prismjs.com/tokens) to be applied.

Part of https://github.com/grafana/grafana/issues/114314

Demo:

<img width="1379" height="1217" alt="Demo" src="https://github.com/user-attachments/assets/e9632607-9546-4c67-9651-2a2cf9654bac" />

### How to test

In a place where `<LogList />` is used, create and pass a grammar prop, like:

```ts
const grammar = {
    property: {
      pattern: /(^|[^\\])"(?:\\.|[^\\"\r\n])*"(?=\s*:)/,
      lookbehind: true,
      greedy: true,
    },
    string: {
      pattern: /(^|[^\\])"(?:\\.|[^\\"\r\n])*"(?!\s*:)/,
      lookbehind: true,
      greedy: true,
    },
    comment: {
      pattern: /\/\/.*|\/\*[\s\S]*?(?:\*\/|$)/,
      greedy: true,
    },
    number: /-?\b\d+(?:\.\d+)?(?:e[+-]?\d+)?\b/i,
    punctuation: /[{}[\],]/,
    operator: /:/,
    boolean: /\b(?:false|true)\b/,
    null: {
      pattern: /\bnull\b/,
      alias: 'keyword',
    },
  };
```

It should override the default syntax highlighiting grammar.