### PR TITLE
[release-12.3.6] RBAC: deduplicate concurrent permission assembly with singleflight

### DIFF
--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -115,8 +115,6 @@ type Service struct {
 	store          accesscontrol.Store
 	permRegistry   permreg.PermissionRegistry
 	isInitialized  bool
-	sql            db.DB
-	serverLock     *serverlock.ServerLockService
 	singleFlight   singleflight.Group
 }
 

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	claims "github.com/grafana/authlib/types"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -114,6 +115,9 @@ type Service struct {
 	store          accesscontrol.Store
 	permRegistry   permreg.PermissionRegistry
 	isInitialized  bool
+	sql            db.DB
+	serverLock     *serverlock.ServerLockService
+	singleFlight   singleflight.Group
 }
 
 func (s *Service) GetUsageStats(_ context.Context) map[string]any {
@@ -242,23 +246,47 @@ func (s *Service) getCachedUserPermissions(ctx context.Context, user identity.Re
 	ctx, span := tracer.Start(ctx, "accesscontrol.acimpl.getCachedUserPermissions")
 	defer span.End()
 
-	permissions, err := s.getCachedBasicRolesPermissions(ctx, user, options)
+	assemble := func() ([]accesscontrol.Permission, error) {
+		permissions, err := s.getCachedBasicRolesPermissions(ctx, user, options)
+		if err != nil {
+			return nil, err
+		}
+
+		teamsPermissions, err := s.getCachedTeamsPermissions(ctx, user, options)
+		if err != nil {
+			return nil, err
+		}
+		permissions = append(permissions, teamsPermissions...)
+
+		userManagedPermissions, err := s.getCachedUserDirectPermissions(ctx, user, options)
+		if err != nil {
+			return nil, err
+		}
+		permissions = append(permissions, userManagedPermissions...)
+		span.SetAttributes(attribute.Int("num_permissions", len(permissions)))
+
+		return permissions, nil
+	}
+
+	// Skip deduplication when the caller explicitly wants a fresh load.
+	if options.ReloadCache {
+		return assemble()
+	}
+
+	// Deduplicate concurrent permission assemblies for the same user.
+	// Without this, concurrent requests for the same user each independently
+	// re-assemble from sub-caches on cache expiry, amplifying DB load.
+	res, err, _ := s.singleFlight.Do(user.GetCacheKey(), func() (any, error) {
+		return assemble()
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	teamsPermissions, err := s.getCachedTeamsPermissions(ctx, user, options)
-	if err != nil {
-		return nil, err
+	permissions, ok := res.([]accesscontrol.Permission)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type returned from singleFlight: %T", res)
 	}
-	permissions = append(permissions, teamsPermissions...)
-
-	userManagedPermissions, err := s.getCachedUserDirectPermissions(ctx, user, options)
-	if err != nil {
-		return nil, err
-	}
-	permissions = append(permissions, userManagedPermissions...)
-	span.SetAttributes(attribute.Int("num_permissions", len(permissions)))
 
 	return permissions, nil
 }

--- a/pkg/services/accesscontrol/acimpl/service_bench_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_bench_test.go
@@ -3,6 +3,7 @@ package acimpl
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol/database"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/permreg"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -275,3 +277,132 @@ func benchSearchUserWithAction(b *testing.B, usersCount, resourceCount int) {
 }
 
 func BenchmarkSearchUserWithAction_1K_1k(b *testing.B) { benchSearchUserWithAction(b, 1000, 1000) } // ~0.6s/op (mysql)
+
+// setupBenchManyTeams creates a single user assigned to teamCount teams, each team having one
+// managed role with a datasource:query permission. This mirrors the customer scenario where a
+// user belongs to many LDAP/SAML groups mapped to Grafana teams, and each team grants access
+// to a specific datasource.
+func setupBenchManyTeams(b *testing.B, teamCount int) (*Service, *user.SignedInUser) {
+	b.Helper()
+	now := time.Now()
+	sqlStore := db.InitTestDB(b)
+	store := database.ProvideService(sqlStore)
+	cfg := setting.NewCfg()
+	cfg.RBAC.PermissionCache = true
+	acService := &Service{
+		cfg:            cfg,
+		features:       featuremgmt.WithFeatures(),
+		log:            log.New("accesscontrol-bench"),
+		registrations:  accesscontrol.RegistrationList{},
+		store:          store,
+		roles:          accesscontrol.BuildBasicRoleDefinitions(),
+		cache:          localcache.New(cacheTTL, cacheTTL),
+		permRegistry:   permreg.ProvidePermissionRegistry(),
+		actionResolver: resourcepermissions.NewActionSetService(),
+	}
+	require.NoError(b, acService.RegisterFixedRoles(context.Background()))
+
+	userID := int64(1)
+	require.NoError(b, sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+		if _, err := sess.Insert(user.User{
+			ID: userID, UID: "user1", Name: "user1",
+			Login: "user1", Email: "user1@example.org",
+			Created: now, Updated: now,
+		}); err != nil {
+			return err
+		}
+		_, err := sess.Insert(org.OrgUser{
+			ID: userID, UserID: userID, OrgID: 1,
+			Role: org.RoleViewer, Created: now, Updated: now,
+		})
+		return err
+	}))
+
+	teamIDs := make([]int64, teamCount)
+	roles := make([]accesscontrol.Role, teamCount)
+	teamRoles := make([]accesscontrol.TeamRole, teamCount)
+	permissions := make([]accesscontrol.Permission, teamCount)
+	for i := 0; i < teamCount; i++ {
+		teamIDs[i] = int64(i + 1)
+		roles[i] = accesscontrol.Role{
+			ID: teamIDs[i], UID: fmt.Sprintf("managed_teams_%d_permissions", teamIDs[i]),
+			Name:  fmt.Sprintf("managed:teams:%d:permissions", teamIDs[i]),
+			OrgID: 1, Version: 1, Created: now, Updated: now,
+		}
+		teamRoles[i] = accesscontrol.TeamRole{
+			OrgID: 1, RoleID: teamIDs[i], TeamID: teamIDs[i], Created: now,
+		}
+		permissions[i] = accesscontrol.Permission{
+			RoleID:  teamIDs[i],
+			Action:  "datasources:query",
+			Scope:   fmt.Sprintf("datasources:uid:ds-%d", teamIDs[i]),
+			Created: now, Updated: now,
+		}
+	}
+
+	require.NoError(b, sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+		if _, err := sess.Insert(roles); err != nil {
+			return err
+		}
+		if _, err := sess.Insert(teamRoles); err != nil {
+			return err
+		}
+		_, err := sess.Insert(permissions)
+		return err
+	}))
+
+	signedInUser := &user.SignedInUser{
+		UserID:  userID,
+		OrgID:   1,
+		OrgRole: org.RoleViewer,
+		Teams:   teamIDs,
+	}
+
+	return acService, signedInUser
+}
+
+// benchGetUserPermissionsManyTeamsConcurrent measures the cost of N goroutines concurrently
+// calling GetUserPermissions for the same user who belongs to many teams — the thundering
+// herd scenario triggered by 800 parallel datasource buildinfo proxy requests on alert rule
+// creation. The cache is flushed before each iteration to simulate expiry.
+func benchGetUserPermissionsManyTeamsConcurrent(b *testing.B, teamCount, concurrency int) {
+	b.Helper()
+	acService, signedInUser := setupBenchManyTeams(b, teamCount)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		// Flush all sub-caches to simulate the moment the TTL expires and all
+		// concurrent requests arrive simultaneously with a cold cache.
+		acService.cache = localcache.New(cacheTTL, cacheTTL)
+
+		var wg sync.WaitGroup
+		wg.Add(concurrency)
+		for i := 0; i < concurrency; i++ {
+			go func() {
+				defer wg.Done()
+				_, err := acService.GetUserPermissions(context.Background(), signedInUser, accesscontrol.Options{})
+				require.NoError(b, err)
+			}()
+		}
+		wg.Wait()
+	}
+}
+
+// Realistic customer scale: ~100–200 teams, 100–800 concurrent requests.
+// 800 concurrent matches the number of Prometheus datasource buildinfo calls fired
+// simultaneously when creating an alert rule (customer had ~800 Prometheus datasources).
+func BenchmarkGetUserPermissions_ManyTeams_100teams_1concurrent(b *testing.B) {
+	benchGetUserPermissionsManyTeamsConcurrent(b, 100, 1)
+}
+func BenchmarkGetUserPermissions_ManyTeams_100teams_100concurrent(b *testing.B) {
+	benchGetUserPermissionsManyTeamsConcurrent(b, 100, 100)
+}
+func BenchmarkGetUserPermissions_ManyTeams_100teams_800concurrent(b *testing.B) {
+	benchGetUserPermissionsManyTeamsConcurrent(b, 100, 800)
+}
+func BenchmarkGetUserPermissions_ManyTeams_200teams_100concurrent(b *testing.B) {
+	benchGetUserPermissionsManyTeamsConcurrent(b, 200, 100)
+}
+func BenchmarkGetUserPermissions_ManyTeams_200teams_800concurrent(b *testing.B) {
+	benchGetUserPermissionsManyTeamsConcurrent(b, 200, 800)
+}


### PR DESCRIPTION
Backport 69ac7a05220a19b737e36ac7db6520adccc4548d from #120331

---

**What is this feature?**

Wraps the permission sub-cache assembly in `getCachedUserPermissions` with a `singleflight.Group` so that concurrent requests for the same user share one in-flight assembly instead of each independently re-assembling.

**Why do we need this feature?**

When the alerting UI creates an alert rule it fires ~800 parallel datasource buildinfo proxy requests (one per Prometheus datasource). Each request goes through the RBAC middleware which calls `GetUserPermissions`. Without deduplication, all 800 requests independently re-assemble permissions from sub-caches on every cache expiry — a thundering herd that amplifies DB load for users belonging to many teams.

This became a regression in ~12.1.x when PR #105607 removed the outer assembled-permissions cache (which was necessary to avoid OOM). The singleflight approach avoids the OOM risk entirely: nothing is held in memory after the in-flight call completes, while still collapsing N concurrent callers into one assembly.

Related: https://github.com/grafana/support-escalations/issues/19881

**Who is this feature for?**

Grafana instances where users belong to many teams and experience high concurrency on permission-checked endpoints (e.g. datasource proxy, alert rule creation).

**Special notes for your reviewer:**

- `ReloadCache` bypasses singleflight to preserve explicit refresh semantics
- The type assertion on the singleflight result uses the safe two-value form with an explicit error
- Benchmark `BenchmarkGetUserPermissions_ManyTeams_*` in `service_bench_test.go` covers the thundering herd scenario at realistic scale (100–200 teams, 100–800 concurrent goroutines)

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.