### PR TITLE
RadioButton: Correctly set accessible labels

### DIFF
--- a/e2e-playwright/dashboards-suite/new-query-variable.spec.ts
+++ b/e2e-playwright/dashboards-suite/new-query-variable.spec.ts
@@ -69,7 +69,7 @@ test.describe(
       await expect(datasourceSelect).toBeVisible();
       await expect(datasourceSelect).toHaveAttribute('placeholder', 'gdev-testdata');
 
-      await expect(page.locator('label').filter({ hasText: 'Refresh' })).toBeVisible();
+      await expect(page.getByRole('group', { name: 'Refresh' })).toBeVisible();
       await expect(page.locator('label').filter({ hasText: 'On dashboard load' })).toBeVisible();
 
       const regexInput = dashboardPage.getByGrafanaSelector(

--- a/packages/grafana-ui/src/components/Forms/Field.test.tsx
+++ b/packages/grafana-ui/src/components/Forms/Field.test.tsx
@@ -4,6 +4,7 @@ import { Combobox } from '../Combobox/Combobox';
 import { Input } from '../Input/Input';
 
 import { Field } from './Field';
+import { RadioButtonGroup } from './RadioButtonGroup/RadioButtonGroup';
 
 describe('Field', () => {
   it('renders the label', () => {
@@ -38,5 +39,32 @@ describe('Field', () => {
     );
 
     expect(screen.getByLabelText('My other label')).toBeInTheDocument();
+  });
+
+  describe('fieldset/legend rendering for group controls', () => {
+    const radioOptions = [
+      { label: 'Light', value: 'light' },
+      { label: 'Dark', value: 'dark' },
+    ];
+
+    it('renders the fieldset group with an accessible name from the legend', () => {
+      render(
+        <Field label="Theme">
+          <RadioButtonGroup options={radioOptions} />
+        </Field>
+      );
+
+      expect(screen.getByRole('group', { name: 'Theme' })).toBeInTheDocument();
+    });
+
+    it('renders required indicator inside the legend', () => {
+      render(
+        <Field label="Theme" required>
+          <RadioButtonGroup options={radioOptions} />
+        </Field>
+      );
+
+      expect(screen.getByRole('group', { name: 'Theme *' })).toBeInTheDocument();
+    });
   });
 });

--- a/packages/grafana-ui/src/components/Forms/Field.tsx
+++ b/packages/grafana-ui/src/components/Forms/Field.tsx
@@ -8,9 +8,10 @@ import { useStyles2 } from '../../themes/ThemeContext';
 import { getChildId } from '../../utils/reactUtils';
 
 import { FieldValidationMessage } from './FieldValidationMessage';
-import { Label } from './Label';
+import { Label, getLabelStyles } from './Label';
+import { RadioButtonGroup } from './RadioButtonGroup/RadioButtonGroup';
 
-export interface FieldProps extends HTMLAttributes<HTMLDivElement> {
+export interface FieldProps extends HTMLAttributes<HTMLElement> {
   /** Form input element, i.e Input or Switch */
   children: React.ReactElement<Record<string, unknown>>;
   /** Label for the field */
@@ -51,7 +52,7 @@ export interface FieldProps extends HTMLAttributes<HTMLDivElement> {
 export const Field = React.forwardRef<HTMLDivElement, FieldProps>(
   (
     {
-      label,
+      label: labelProp,
       description,
       horizontal,
       invalid,
@@ -69,20 +70,34 @@ export const Field = React.forwardRef<HTMLDivElement, FieldProps>(
     ref
   ) => {
     const styles = useStyles2(getFieldStyles, noMargin);
+    const labelStyles = useStyles2(getLabelStyles);
+    const useFieldset = children.type === RadioButtonGroup;
+    const label = typeof labelProp === 'string' ? `${labelProp}${required ? ' *' : ''}` : labelProp;
     const inputId = htmlFor ?? getChildId(children);
 
-    const labelElement =
-      typeof label === 'string' ? (
-        <Label htmlFor={inputId} description={description}>
-          {`${label}${required ? ' *' : ''}`}
-        </Label>
-      ) : (
-        label
-      );
+    let labelElement = label;
+
+    if (typeof label === 'string') {
+      if (useFieldset) {
+        labelElement = (
+          <legend className={labelStyles.label}>
+            <div className={labelStyles.labelContent}>{label}</div>
+            {description && <span className={labelStyles.description}>{description}</span>}
+          </legend>
+        );
+      } else {
+        labelElement = (
+          <Label htmlFor={inputId} description={description}>
+            {label}
+          </Label>
+        );
+      }
+    }
 
     const childProps = deleteUndefinedProps({ invalid, disabled, loading });
+    const Wrapper = useFieldset ? 'fieldset' : 'div';
     return (
-      <div className={cx(styles.field, horizontal && styles.fieldHorizontal, className)} {...otherProps}>
+      <Wrapper className={cx(styles.field, horizontal && styles.fieldHorizontal, className)} {...otherProps}>
         {labelElement}
         <div>
           <div ref={ref}>{React.cloneElement(children, children.type !== React.Fragment ? childProps : undefined)}</div>
@@ -106,7 +121,7 @@ export const Field = React.forwardRef<HTMLDivElement, FieldProps>(
             <FieldValidationMessage>{error}</FieldValidationMessage>
           </div>
         )}
-      </div>
+      </Wrapper>
     );
   }
 );

--- a/packages/grafana-ui/src/components/Forms/InlineField.test.tsx
+++ b/packages/grafana-ui/src/components/Forms/InlineField.test.tsx
@@ -4,6 +4,7 @@ import { Combobox } from '../Combobox/Combobox';
 import { Input } from '../Input/Input';
 
 import { InlineField } from './InlineField';
+import { RadioButtonGroup } from './RadioButtonGroup/RadioButtonGroup';
 
 describe('InlineField', () => {
   it('renders the label', () => {
@@ -38,5 +39,32 @@ describe('InlineField', () => {
     );
 
     expect(screen.getByLabelText('My other label')).toBeInTheDocument();
+  });
+
+  describe('fieldset rendering for RadioButtonGroup', () => {
+    const radioOptions = [
+      { label: 'Light', value: 'light' },
+      { label: 'Dark', value: 'dark' },
+    ];
+
+    it('renders the radiogroup with an accessible name via aria-labelledby', () => {
+      render(
+        <InlineField label="Theme">
+          <RadioButtonGroup options={radioOptions} />
+        </InlineField>
+      );
+
+      expect(screen.getByRole('radiogroup', { name: 'Theme' })).toBeInTheDocument();
+    });
+
+    it('renders required indicator in the label', () => {
+      render(
+        <InlineField label="Theme" required>
+          <RadioButtonGroup options={radioOptions} />
+        </InlineField>
+      );
+
+      expect(screen.getByRole('radiogroup', { name: 'Theme *' })).toBeInTheDocument();
+    });
   });
 });

--- a/packages/grafana-ui/src/components/Forms/InlineField.tsx
+++ b/packages/grafana-ui/src/components/Forms/InlineField.tsx
@@ -1,5 +1,5 @@
 import { cx, css } from '@emotion/css';
-import { cloneElement, ReactNode } from 'react';
+import { cloneElement, ReactNode, useId } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
@@ -10,6 +10,7 @@ import { PopoverContent } from '../Tooltip/types';
 import { FieldProps } from './Field';
 import { FieldValidationMessage } from './FieldValidationMessage';
 import { InlineLabel } from './InlineLabel';
+import { RadioButtonGroup } from './RadioButtonGroup/RadioButtonGroup';
 
 export interface Props extends Omit<FieldProps, 'css' | 'horizontal' | 'description' | 'error'> {
   /** Content for the label's tooltip */
@@ -56,6 +57,8 @@ export const InlineField = ({
   const theme = useTheme2();
   const styles = getStyles(theme, grow, shrink);
   const inputId = htmlFor ?? getChildId(children);
+  const useFieldset = children.type === RadioButtonGroup;
+  const labelId = useId();
 
   const labelElement =
     typeof label === 'string' ? (
@@ -65,6 +68,8 @@ export const InlineField = ({
         tooltip={tooltip}
         htmlFor={inputId}
         transparent={transparent}
+        id={labelId}
+        as={useFieldset ? 'span' : 'label'}
       >
         {`${label}${required ? ' *' : ''}`}
       </InlineLabel>
@@ -72,11 +77,13 @@ export const InlineField = ({
       label
     );
 
+  const Wrapper = useFieldset ? 'fieldset' : 'div';
+
   return (
-    <div className={cx(styles.container, className)} {...htmlProps}>
+    <Wrapper className={cx(styles.container, className)} {...htmlProps}>
       {labelElement}
       <div className={styles.childContainer}>
-        {cloneElement(children, { invalid, disabled, loading })}
+        {cloneElement(children, { invalid, disabled, loading, 'aria-labelledby': useFieldset ? labelId : undefined })}
         {invalid && error && (
           <div
             className={cx(styles.fieldValidationWrapper, {
@@ -87,7 +94,7 @@ export const InlineField = ({
           </div>
         )}
       </div>
-    </div>
+    </Wrapper>
   );
 };
 

--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.story.tsx
@@ -1,6 +1,8 @@
 import { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 
+import { Field } from '../Field';
+
 import { RadioButtonGroup } from './RadioButtonGroup';
 import mdx from './RadioButtonGroup.mdx';
 
@@ -43,41 +45,44 @@ export const RadioButtons: StoryFn = (args) => {
   return (
     <div style={{ width: '100%' }}>
       <div style={{ marginBottom: '32px' }}>
-        <h5>Full width</h5>
-        <RadioButtonGroup
-          options={options}
-          disabled={args.disabled}
-          disabledOptions={args.disabledOptions}
-          value={selected}
-          onChange={(v) => setSelected(v!)}
-          size={args.size}
-          fullWidth={args.fullWidth}
-          invalid={args.invalid}
-        />
+        <Field label="Full width">
+          <RadioButtonGroup
+            options={options}
+            disabled={args.disabled}
+            disabledOptions={args.disabledOptions}
+            value={selected}
+            onChange={(v) => setSelected(v!)}
+            size={args.size}
+            fullWidth={args.fullWidth}
+            invalid={args.invalid}
+          />
+        </Field>
       </div>
       <div style={{ marginBottom: '32px' }}>
-        <h5>Auto width</h5>
-        <RadioButtonGroup
-          options={options}
-          disabled={args.disabled}
-          disabledOptions={args.disabledOptions}
-          value={selected}
-          onChange={(v) => setSelected(v!)}
-          size={args.size}
-          invalid={args.invalid}
-        />
+        <Field label="Auto width">
+          <RadioButtonGroup
+            options={options}
+            disabled={args.disabled}
+            disabledOptions={args.disabledOptions}
+            value={selected}
+            onChange={(v) => setSelected(v!)}
+            size={args.size}
+            invalid={args.invalid}
+          />
+        </Field>
       </div>
       <div style={{ marginBottom: '32px' }}>
-        <h5>With only icons and descriptions</h5>
-        <RadioButtonGroup
-          options={optionsWithOnlyIcons}
-          value={selected}
-          disabled={args.disabled}
-          disabledOptions={args.disabledOptions}
-          onChange={(v) => setSelected(v!)}
-          size={args.size}
-          invalid={args.invalid}
-        />
+        <Field label="With only icons and descriptions">
+          <RadioButtonGroup
+            options={optionsWithOnlyIcons}
+            value={selected}
+            disabled={args.disabled}
+            disabledOptions={args.disabledOptions}
+            onChange={(v) => setSelected(v!)}
+            size={args.size}
+            invalid={args.invalid}
+          />
+        </Field>
       </div>
     </div>
   );

--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 import { uniqueId } from 'lodash';
-import { useCallback, useEffect, useRef } from 'react';
+import { HTMLAttributes, useCallback, useEffect, useRef } from 'react';
 
 import { GrafanaTheme2, SelectableValue, toIconName } from '@grafana/data';
 
@@ -8,7 +8,7 @@ import { useStyles2 } from '../../../themes/ThemeContext';
 import { Icon } from '../../Icon/Icon';
 
 import { RadioButtonSize, RadioButton, RADIO_GROUP_PADDING } from './RadioButton';
-export interface RadioButtonGroupProps<T> {
+export interface RadioButtonGroupProps<T> extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'onClick'> {
   value?: T;
   id?: string;
   disabled?: boolean;
@@ -43,6 +43,7 @@ export function RadioButtonGroup<T>({
   autoFocus = false,
   'aria-label': ariaLabel,
   invalid = false,
+  ...rest
 }: RadioButtonGroupProps<T>) {
   const handleOnChange = useCallback(
     (option: SelectableValue) => {
@@ -78,6 +79,7 @@ export function RadioButtonGroup<T>({
 
   return (
     <div
+      {...rest}
       role="radiogroup"
       aria-label={ariaLabel}
       className={cx(styles.radioGroup, fullWidth && styles.fullWidth, invalid && styles.invalid, className)}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- modifies `Field`/`InlineField` to handle the presence of a `RadioButtonGroup` as a child correctly
- for `Field`, we use a combination of `<fieldset>` and `<legend>` to correctly set the label for the radio button group
- for `InlineField`, we instead use a `<span>` and `aria-labelledby`
  - this is because browsers render `<fieldset>` and `<legend>` specially - importantly it doesn't seem possible(?) to render the legend inline - it's always block.
- adds unit tests to verify the labels are present

**Why do we need this feature?**

- so screenreaders correctly announce radio button group labels

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/116883
Fixes https://github.com/grafana/grafana/issues/117285
For https://github.com/grafana/grafana/issues/118763

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
