### PR TITLE
Dashboard Library: Refactor `DashboardCard` to be aligned with last designs

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/CommunityDashboardSection.test.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/CommunityDashboardSection.test.tsx
@@ -172,7 +172,7 @@ describe('CommunityDashboardSection', () => {
       expect(screen.getByText('Test Dashboard')).toBeInTheDocument();
     });
 
-    const useDashboardButton = screen.getByRole('button', { name: 'Use dashboard' });
+    const useDashboardButton = screen.getByRole('button', { name: 'View dashboard: Test Dashboard' });
     await user.click(useDashboardButton);
 
     await waitFor(() => {

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/CommunityDashboardSection.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/CommunityDashboardSection.tsx
@@ -40,6 +40,10 @@ const INCLUDE_SCREENSHOTS = true;
 export const CommunityDashboardSection = ({ onShowMapping, datasourceType }: Props) => {
   const [searchParams] = useSearchParams();
   const datasourceUid = searchParams.get('dashboardLibraryDatasourceUid');
+  // Resolve type directly from the UID so the skeleton badge is shown correctly on first render,
+  // even if the parent prop hasn't been computed yet.
+  const resolvedDatasourceType =
+    (datasourceUid ? getDataSourceSrv().getInstanceSettings(datasourceUid)?.type : undefined) ?? datasourceType;
   const [searchQuery, setSearchQuery] = useState('');
   const hasTrackedLoaded = useRef(false);
   const isCompatibilityAppEnabled = config.featureToggles.dashboardValidatorApp;
@@ -297,7 +301,12 @@ export const CommunityDashboardSection = ({ onShowMapping, datasourceType }: Pro
             }}
           >
             {Array.from({ length: COMMUNITY_RESULT_SIZE }).map((_, i) => (
-              <DashboardCard.Skeleton key={`skeleton-${i}`} />
+              <DashboardCard.Skeleton
+                key={`skeleton-${i}`}
+                showCompatibilityBadge={
+                  isCompatibilityAppEnabled && !!datasourceUid && resolvedDatasourceType === 'prometheus'
+                }
+              />
             ))}
           </Grid>
         ) : showError ? (
@@ -364,7 +373,7 @@ export const CommunityDashboardSection = ({ onShowMapping, datasourceType }: Pro
 
                 // Only show badge for Prometheus datasources
                 const showBadge =
-                  isCompatibilityAppEnabled && !!datasourceUid && response?.datasourceType === 'prometheus';
+                  isCompatibilityAppEnabled && !!datasourceUid && resolvedDatasourceType === 'prometheus';
 
                 return (
                   <DashboardCard

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/CommunityDashboardSection.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/CommunityDashboardSection.tsx
@@ -383,6 +383,7 @@ export const CommunityDashboardSection = ({ onShowMapping, datasourceType }: Pro
                         ? () => handleCheckCompatibility(dashboard, 'manual')
                         : undefined
                     }
+                    author={isGnetDashboard(dashboard) ? dashboard.userName : undefined}
                   />
                 );
               })}

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/CommunityDashboardSection.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/CommunityDashboardSection.tsx
@@ -383,7 +383,6 @@ export const CommunityDashboardSection = ({ onShowMapping, datasourceType }: Pro
                         ? () => handleCheckCompatibility(dashboard, 'manual')
                         : undefined
                     }
-                    author={isGnetDashboard(dashboard) ? dashboard.userName : undefined}
                   />
                 );
               })}

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.test.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.test.tsx
@@ -108,7 +108,7 @@ describe('DashboardCard', () => {
         />
       );
 
-      await user.click(screen.getByRole('button', { name: 'Use dashboard' }));
+      await user.click(screen.getByRole('button', { name: 'View dashboard: Test Dashboard' }));
 
       expect(mockOnClick).toHaveBeenCalledTimes(1);
     });
@@ -123,8 +123,8 @@ describe('DashboardCard', () => {
         />
       );
 
-      expect(screen.getByRole('button', { name: 'View template' })).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Use dashboard' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'View template: Test Dashboard' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'View dashboard: Test Dashboard' })).not.toBeInTheDocument();
     });
 
     it('should display dashboard button text', () => {
@@ -137,8 +137,8 @@ describe('DashboardCard', () => {
         />
       );
 
-      expect(screen.getByRole('button', { name: 'Use dashboard' })).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'View template' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'View dashboard: Test Dashboard' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'View template: Test Dashboard' })).not.toBeInTheDocument();
     });
   });
 
@@ -476,7 +476,7 @@ describe('DashboardCard', () => {
       // With dashboardValidatorApp enabled, details button moves into the title row
       const buttons = screen.getAllByRole('button');
       expect(buttons[0]).toHaveAttribute('aria-label', 'Details');
-      expect(buttons[1]).toHaveTextContent('Use dashboard');
+      expect(buttons[1]).toHaveTextContent('View dashboard');
       expect(buttons[2]).toHaveTextContent('Check compatibility');
     });
   });

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
@@ -40,8 +40,6 @@ interface Props {
   compatibilityState?: CompatibilityState;
   /** Handler called when Check button is clicked in the badge */
   onCompatibilityCheck?: () => void;
-  /** Dashboard author name shown below the title */
-  author?: string;
   /** Whether to show the "Customize with assistant" button (caller must check relevant feature flags) */
   showAssistantButton?: boolean;
 }
@@ -60,7 +58,6 @@ function DashboardCardComponent({
   showCompatibilityBadge,
   compatibilityState,
   onCompatibilityCheck,
-  author,
   showAssistantButton,
 }: Props) {
   const styles = useStyles2(getStyles);
@@ -176,14 +173,6 @@ function DashboardCardComponent({
           )}
         </div>
       </div>
-      {author && (
-        <div className={styles.metaRow}>
-          <Text variant="bodySmall" color="secondary">
-            <Trans i18nKey="dashboard-library.card.author">Author: </Trans>
-            {author}
-          </Text>
-        </div>
-      )}
       {(dashboard.description || hasCompatActions) && (
         <div className={styles.bottomSection}>
           {dashboard.description && (
@@ -276,14 +265,13 @@ function getStyles(theme: GrafanaTheme2) {
       gridTemplateAreas: `
           "Thumbnail Thumbnail"
           "Heading Heading"
-          "Meta Meta"
           "Bottom Bottom"`,
-      gridTemplateRows: 'auto auto auto auto',
+      gridTemplateRows: 'auto auto auto',
       gridTemplateColumns: '1fr auto',
       height: 'auto',
       width: '350px',
       background: 'transparent',
-      gridGap: theme.spacing(1),
+      gridGap: theme.spacing(0.5),
       paddingLeft: 0,
       paddingRight: 0,
       alignSelf: 'start',
@@ -311,12 +299,6 @@ function getStyles(theme: GrafanaTheme2) {
     overlayButton: css({
       width: '80%',
       justifyContent: 'center',
-    }),
-    metaRow: css({
-      gridArea: 'Meta',
-      display: 'flex',
-      gap: theme.spacing(2),
-      flexWrap: 'wrap',
     }),
     thumbnail: css({
       width: '100%',

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
@@ -254,10 +254,10 @@ function getStyles(theme: GrafanaTheme2) {
     gap: theme.spacing(1.5),
     padding: theme.spacing(2),
     opacity: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.55)',
     [theme.transitions.handleMotion('no-preference', 'reduce')]: {
       transition: 'opacity 0.15s ease',
     },
-    borderRadius: theme.shape.radius.default,
   });
 
   return {
@@ -266,15 +266,15 @@ function getStyles(theme: GrafanaTheme2) {
           "Thumbnail Thumbnail"
           "Heading Heading"
           "Bottom Bottom"`,
-      gridTemplateRows: 'auto auto auto',
+      gridTemplateRows: 'auto auto 1fr',
       gridTemplateColumns: '1fr auto',
-      height: 'auto',
       width: '350px',
       background: 'transparent',
-      gridGap: theme.spacing(0.5),
-      paddingLeft: 0,
-      paddingRight: 0,
-      alignSelf: 'start',
+      border: `1px solid ${theme.colors.border.strong}`,
+      borderRadius: theme.shape.radius.default,
+      overflow: 'hidden',
+      gridGap: theme.spacing(1),
+      padding: theme.spacing(1),
     }),
     thumbnailContainer: css({
       gridArea: 'Thumbnail',
@@ -283,12 +283,8 @@ function getStyles(theme: GrafanaTheme2) {
       alignItems: 'center',
       justifyContent: 'center',
       borderRadius: theme.shape.radius.default,
-      borderColor: theme.colors.border.strong,
-      borderWidth: 1,
-      borderStyle: 'solid',
       width: '100%',
-      maxWidth: '350px',
-      height: '180px',
+      aspectRatio: '16/9',
       backgroundColor: theme.colors.background.canvas,
       position: 'relative',
       [`&:hover .${thumbnailOverlay}, &:focus-within .${thumbnailOverlay}`]: {
@@ -318,7 +314,7 @@ function getStyles(theme: GrafanaTheme2) {
       justifyContent: 'center',
       borderRadius: theme.shape.radius.default,
       width: '100%',
-      height: '180px',
+      aspectRatio: '16/9',
       backgroundColor: theme.colors.background.secondary,
       position: 'relative',
       [`&:hover .${thumbnailOverlay}, &:focus-within .${thumbnailOverlay}`]: {
@@ -341,7 +337,7 @@ function getStyles(theme: GrafanaTheme2) {
       gridArea: 'Bottom',
       display: 'flex',
       flexDirection: 'column',
-      gap: theme.spacing(1),
+      gap: theme.spacing(0.5),
       wordBreak: 'break-word',
     }),
     title: css({

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
@@ -162,7 +162,6 @@ function DashboardCardComponent({
           {assistantAvailable && showAssistantButton && (
             <Button
               variant="secondary"
-              fill="outline"
               className={styles.overlayButton}
               onClick={onUseAssistantClick}
               icon="ai-sparkle"
@@ -265,7 +264,6 @@ function getStyles(theme: GrafanaTheme2) {
     justifyContent: 'center',
     gap: theme.spacing(1.5),
     padding: theme.spacing(2),
-    backgroundColor: 'rgba(0, 0, 0, 0.65)',
     opacity: 0,
     [theme.transitions.handleMotion('no-preference', 'reduce')]: {
       transition: 'opacity 0.15s ease',

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
@@ -40,6 +40,9 @@ interface Props {
   compatibilityState?: CompatibilityState;
   /** Handler called when Check button is clicked in the badge */
   onCompatibilityCheck?: () => void;
+  /** Dashboard author name shown below the title */
+  author?: string;
+  /** Whether to show the "Customize with assistant" button (caller must check relevant feature flags) */
   showAssistantButton?: boolean;
 }
 
@@ -57,6 +60,7 @@ function DashboardCardComponent({
   showCompatibilityBadge,
   compatibilityState,
   onCompatibilityCheck,
+  author,
   showAssistantButton,
 }: Props) {
   const styles = useStyles2(getStyles);
@@ -100,17 +104,15 @@ function DashboardCardComponent({
     }
   };
 
+  const hasCompatActions = isCompatibilityAppEnabled && showCompatibilityBadge && onCompatibilityCheck;
+
   return (
     <Card className={styles.card} noMargin>
       <Card.Heading className={styles.title}>
-        {isCompatibilityAppEnabled ? (
-          <span className={styles.titleWithInfo}>
-            <span className={styles.titleText}>{title}</span>
-            {detailsButton}
-          </span>
-        ) : (
-          title
-        )}
+        <span className={styles.titleWithInfo} role="group" aria-label={title}>
+          <span className={styles.titleText}>{title}</span>
+          {detailsButton}
+        </span>
       </Card.Heading>
       <div className={isLogo ? styles.logoContainer : styles.thumbnailContainer}>
         {imageUrl ? (
@@ -140,36 +142,71 @@ function DashboardCardComponent({
             />
           </div>
         )}
-      </div>
-      <div title={dashboard.description || ''} className={styles.descriptionWrapper}>
-        {dashboard.description && (
-          <Card.Description data-testid="dashboard-card-description" className={styles.description}>
-            {dashboard.description}
-          </Card.Description>
-        )}
-      </div>
-      <Card.Actions className={styles.actionsContainer}>
-        <Button variant="secondary" onClick={() => onClick()}>
-          {kind === 'template_dashboard' ? (
-            <Trans i18nKey="dashboard-library.card.view-template-button">View template</Trans>
-          ) : (
-            <Trans i18nKey="dashboard-library.card.use-dashboard-button">Use dashboard</Trans>
-          )}
-        </Button>
-        {assistantAvailable && showAssistantButton && (
-          <Button variant="secondary" fill="text" onClick={onUseAssistantClick} icon="ai-sparkle">
-            <Trans i18nKey="dashboard-library.card.customize-with-assistant-button">Customize with Assistant</Trans>
+        <div className={styles.thumbnailOverlay}>
+          <Button
+            variant="secondary"
+            className={styles.overlayButton}
+            onClick={() => onClick()}
+            aria-label={
+              kind === 'template_dashboard'
+                ? t('dashboard-library.card.view-template-button-label', 'View template: {{title}}', { title })
+                : t('dashboard-library.card.view-dashboard-button-label', 'View dashboard: {{title}}', { title })
+            }
+          >
+            {kind === 'template_dashboard' ? (
+              <Trans i18nKey="dashboard-library.card.view-template-button">View template</Trans>
+            ) : (
+              <Trans i18nKey="dashboard-library.card.view-dashboard-button">View dashboard</Trans>
+            )}
           </Button>
-        )}
-        {!isCompatibilityAppEnabled && detailsButton}
-        {isCompatibilityAppEnabled && showCompatibilityBadge && onCompatibilityCheck && (
-          <CompatibilityBadge
-            state={compatibilityState ?? { status: 'idle' }}
-            onCheck={onCompatibilityCheck}
-            onRetry={onCompatibilityCheck}
-          />
-        )}
-      </Card.Actions>
+          {assistantAvailable && showAssistantButton && (
+            <Button
+              variant="secondary"
+              fill="outline"
+              className={styles.overlayButton}
+              onClick={onUseAssistantClick}
+              icon="ai-sparkle"
+              aria-label={t(
+                'dashboard-library.card.customize-with-assistant-button-label',
+                'Customize with assistant: {{title}}',
+                { title }
+              )}
+            >
+              <Trans i18nKey="dashboard-library.card.customize-with-assistant-button">Customize with assistant</Trans>
+            </Button>
+          )}
+        </div>
+      </div>
+      {author && (
+        <div className={styles.metaRow}>
+          <Text variant="bodySmall" color="secondary">
+            <Trans i18nKey="dashboard-library.card.author">Author: </Trans>
+            {author}
+          </Text>
+        </div>
+      )}
+      {(dashboard.description || hasCompatActions) && (
+        <div className={styles.bottomSection}>
+          {dashboard.description && (
+            <div title={dashboard.description}>
+              <Card.Description data-testid="dashboard-card-description" className={styles.description}>
+                {dashboard.description}
+              </Card.Description>
+            </div>
+          )}
+          {hasCompatActions && (
+            <div className={styles.actionsContainer}>
+              {isCompatibilityAppEnabled && showCompatibilityBadge && onCompatibilityCheck && (
+                <CompatibilityBadge
+                  state={compatibilityState ?? { status: 'idle' }}
+                  onCheck={onCompatibilityCheck}
+                  onRetry={onCompatibilityCheck}
+                />
+              )}
+            </div>
+          )}
+        </div>
+      )}
     </Card>
   );
 }
@@ -219,13 +256,30 @@ function DetailsTooltipContent({ details }: { details: Details }) {
 }
 
 function getStyles(theme: GrafanaTheme2) {
+  const thumbnailOverlay = css({
+    position: 'absolute',
+    inset: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: theme.spacing(1.5),
+    padding: theme.spacing(2),
+    backgroundColor: 'rgba(0, 0, 0, 0.65)',
+    opacity: 0,
+    [theme.transitions.handleMotion('no-preference', 'reduce')]: {
+      transition: 'opacity 0.15s ease',
+    },
+    borderRadius: theme.shape.radius.default,
+  });
+
   return {
     card: css({
       gridTemplateAreas: `
-          "Heading Heading"
           "Thumbnail Thumbnail"
-          "Description Description"
-          "Actions Secondary"`,
+          "Heading Heading"
+          "Meta Meta"
+          "Bottom Bottom"`,
       gridTemplateRows: 'auto auto auto auto',
       gridTemplateColumns: '1fr auto',
       height: 'auto',
@@ -234,6 +288,7 @@ function getStyles(theme: GrafanaTheme2) {
       gridGap: theme.spacing(1),
       paddingLeft: 0,
       paddingRight: 0,
+      alignSelf: 'start',
     }),
     thumbnailContainer: css({
       gridArea: 'Thumbnail',
@@ -250,6 +305,20 @@ function getStyles(theme: GrafanaTheme2) {
       height: '180px',
       backgroundColor: theme.colors.background.canvas,
       position: 'relative',
+      [`&:hover .${thumbnailOverlay}, &:focus-within .${thumbnailOverlay}`]: {
+        opacity: 1,
+      },
+    }),
+    thumbnailOverlay,
+    overlayButton: css({
+      width: '80%',
+      justifyContent: 'center',
+    }),
+    metaRow: css({
+      gridArea: 'Meta',
+      display: 'flex',
+      gap: theme.spacing(2),
+      flexWrap: 'wrap',
     }),
     thumbnail: css({
       width: '100%',
@@ -272,6 +341,9 @@ function getStyles(theme: GrafanaTheme2) {
       height: '180px',
       backgroundColor: theme.colors.background.secondary,
       position: 'relative',
+      [`&:hover .${thumbnailOverlay}, &:focus-within .${thumbnailOverlay}`]: {
+        opacity: 1,
+      },
     }),
     logo: css({
       objectFit: 'fill',
@@ -285,10 +357,12 @@ function getStyles(theme: GrafanaTheme2) {
       height: '100%',
       width: '100%',
     }),
-    descriptionWrapper: css({
-      gridArea: 'Description',
+    bottomSection: css({
+      gridArea: 'Bottom',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
       wordBreak: 'break-word',
-      minHeight: `calc(${theme.typography.body.lineHeight} * 1em)`, // Preserve space even when empty
     }),
     title: css({
       display: '-webkit-box',
@@ -319,7 +393,7 @@ function getStyles(theme: GrafanaTheme2) {
       margin: 0,
     }),
     actionsContainer: css({
-      marginTop: 0,
+      display: 'flex',
       alignItems: 'center',
       flexWrap: 'nowrap',
     }),

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
@@ -273,11 +273,12 @@ function getStyles(theme: GrafanaTheme2) {
       border: `1px solid ${theme.colors.border.strong}`,
       borderRadius: theme.shape.radius.default,
       overflow: 'hidden',
-      gridGap: theme.spacing(1),
+      gridGap: 0,
       padding: theme.spacing(1),
     }),
     thumbnailContainer: css({
       gridArea: 'Thumbnail',
+      marginBottom: theme.spacing(1),
       overflow: 'hidden',
       display: 'flex',
       alignItems: 'center',
@@ -308,6 +309,7 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     logoContainer: css({
       gridArea: 'Thumbnail',
+      marginBottom: theme.spacing(1),
       overflow: 'hidden',
       display: 'flex',
       alignItems: 'center',
@@ -337,8 +339,8 @@ function getStyles(theme: GrafanaTheme2) {
       gridArea: 'Bottom',
       display: 'flex',
       flexDirection: 'column',
-      gap: theme.spacing(0.5),
       wordBreak: 'break-word',
+      paddingTop: '2px',
     }),
     title: css({
       display: '-webkit-box',
@@ -362,16 +364,19 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     description: css({
       display: '-webkit-box',
-      WebkitLineClamp: 2,
+      WebkitLineClamp: 1,
       WebkitBoxOrient: 'vertical',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       margin: 0,
+      fontSize: theme.typography.bodySmall.fontSize,
     }),
     actionsContainer: css({
       display: 'flex',
       alignItems: 'center',
       flexWrap: 'nowrap',
+      marginTop: 'auto',
+      paddingTop: theme.spacing(1),
     }),
     detailsContainer: css({
       width: '340px',
@@ -396,13 +401,43 @@ function getStyles(theme: GrafanaTheme2) {
   };
 }
 
-const DashboardCardSkeleton: SkeletonComponent = ({ rootProps }) => {
+interface DashboardCardSkeletonProps {
+  showCompatibilityBadge?: boolean;
+}
+
+const DashboardCardSkeleton: SkeletonComponent<DashboardCardSkeletonProps> = ({
+  rootProps,
+  showCompatibilityBadge,
+}) => {
   const styles = useStyles2(getSkeletonStyles);
-  return <Skeleton width={350} height={300} containerClassName={styles.container} {...rootProps} />;
+  return (
+    <div className={styles.card} style={rootProps.style}>
+      <Skeleton containerClassName={styles.thumbnail} height="100%" />
+      <Skeleton height={22} width="70%" />
+      <Skeleton height={19} width="90%" />
+      {showCompatibilityBadge && <Skeleton height={33} width={100} />}
+    </div>
+  );
 };
 
-const getSkeletonStyles = () => ({
-  container: css({
+const getSkeletonStyles = (theme: GrafanaTheme2) => ({
+  card: css({
+    width: '350px',
+    border: `1px solid ${theme.colors.border.strong}`,
+    borderRadius: theme.shape.radius.default,
+    overflow: 'hidden',
+    padding: theme.spacing(1),
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.75),
+    lineHeight: 1,
+  }),
+  thumbnail: css({
+    display: 'block',
+    width: '100%',
+    aspectRatio: '16/9',
+    borderRadius: theme.shape.radius.default,
+    overflow: 'hidden',
     lineHeight: 1,
   }),
 });

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.test.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.test.tsx
@@ -150,7 +150,7 @@ describe('TemplateDashboardModal', () => {
         expect(cardHeadings[1]).toHaveTextContent('Test Template Dashboard 2');
 
         // Assert DashboardCard components are rendered by checking for "View template" buttons
-        const viewTemplateButtons = screen.getAllByRole('button', { name: 'View template' });
+        const viewTemplateButtons = screen.getAllByRole('button', { name: /^View template:/i });
         expect(viewTemplateButtons).toHaveLength(2);
 
         // Assert text content (descriptions)
@@ -288,10 +288,10 @@ describe('TemplateDashboardModal', () => {
       });
 
       await waitFor(() => {
-        expect(screen.getAllByRole('button', { name: 'View template' })).toHaveLength(2);
+        expect(screen.getAllByRole('button', { name: /^View template:/i })).toHaveLength(2);
       });
 
-      await user.click(screen.getAllByRole('button', { name: 'View template' })[0]);
+      await user.click(screen.getAllByRole('button', { name: /^View template:/i })[0]);
 
       expect(mockItemClicked).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6450,12 +6450,16 @@
     "browse-grafana-com": "Browse Grafana.com",
     "browse-plugins": "Browse plugins",
     "card": {
-      "customize-with-assistant-button": "Customize with Assistant",
+      "author": "Author: ",
+      "customize-with-assistant-button": "Customize with assistant",
+      "customize-with-assistant-button-label": "Customize with assistant: {{title}}",
       "datasource-provided-badge": "Data source provided",
       "details-tooltip": "Details",
       "no-preview": "No preview available ",
-      "use-dashboard-button": "Use dashboard",
-      "view-template-button": "View template"
+      "view-dashboard-button": "View dashboard",
+      "view-dashboard-button-label": "View dashboard: {{title}}",
+      "view-template-button": "View template",
+      "view-template-button-label": "View template: {{title}}"
     },
     "community-empty-title": "No community dashboards found",
     "community-empty-title-with-datasource": "No {{datasourceType}} community dashboards found",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6450,7 +6450,6 @@
     "browse-grafana-com": "Browse Grafana.com",
     "browse-plugins": "Browse plugins",
     "card": {
-      "author": "Author: ",
       "customize-with-assistant-button": "Customize with assistant",
       "customize-with-assistant-button-label": "Customize with assistant: {{title}}",
       "datasource-provided-badge": "Data source provided",


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Refactor `DashboardCard` to be aligned with last designs:

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img width="1496" height="1029" alt="BeforeRedesign" src="https://github.com/user-attachments/assets/1fb95ab6-4c5f-42a9-8254-b08bf8a1b7c7" />
 <td><img width="1212" height="756" alt="image" src="https://github.com/user-attachments/assets/8b5331a8-086e-4b6f-97f6-d1b663940082" />

</table>


**Changes I've made**                                                                                           
- Rename action buttons: template_dashboard kind now shows "View template", other kinds show "View dashboard" (previously "Use dashboard")                                                    
- Add unique `aria-label` to action buttons `("View template: {title}", "Customize with assistant: {title}")` so screen readers can distinguish cards

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related https://github.com/grafana/grafana/issues/115682 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
