### PR TITLE
unified-storage: use __cluster__ instead of empty namespace for cluster resources

### DIFF
--- a/pkg/apiserver/registry/generic/key.go
+++ b/pkg/apiserver/registry/generic/key.go
@@ -11,6 +11,8 @@ import (
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 )
 
+const ClusterNamespace = "__cluster__"
+
 type Key struct {
 	Group     string `json:"group,omitempty"`
 	Resource  string `json:"resource"`
@@ -144,7 +146,7 @@ func NamespaceKeyFunc(gr schema.GroupResource) func(ctx context.Context, name st
 }
 
 // ClusterScopedKeyFunc is the default function for constructing storage paths to
-// cluster-scoped resources. It does not require a namespace, but does require a name.
+// cluster-scoped resources. It uses the "__cluster__" namespace.
 func ClusterScopedKeyFunc(gr schema.GroupResource) func(ctx context.Context, name string) (string, error) {
 	return func(ctx context.Context, name string) (string, error) {
 		if len(name) == 0 {
@@ -154,27 +156,11 @@ func ClusterScopedKeyFunc(gr schema.GroupResource) func(ctx context.Context, nam
 			return "", apierrors.NewBadRequest(fmt.Sprintf("Name parameter invalid: %q: %s", name, strings.Join(msgs, ";")))
 		}
 		key := &Key{
-			Group:    gr.Group,
-			Resource: gr.Resource,
-			Name:     name,
+			Group:     gr.Group,
+			Resource:  gr.Resource,
+			Namespace: ClusterNamespace,
+			Name:      name,
 		}
 		return key.String(), nil
 	}
-}
-
-// NoNamespaceKeyFunc is the default function for constructing storage paths
-// to a resource relative to the given prefix without a namespace.
-func NoNamespaceKeyFunc(ctx context.Context, prefix string, gr schema.GroupResource, name string) (string, error) {
-	if len(name) == 0 {
-		return "", apierrors.NewBadRequest("Name parameter required.")
-	}
-	if msgs := path.IsValidPathSegmentName(name); len(msgs) != 0 {
-		return "", apierrors.NewBadRequest(fmt.Sprintf("Name parameter invalid: %q: %s", name, strings.Join(msgs, ";")))
-	}
-	key := &Key{
-		Group:    gr.Group,
-		Resource: gr.Resource,
-		Name:     name,
-	}
-	return prefix + key.String(), nil
 }

--- a/pkg/apiserver/registry/generic/key_test.go
+++ b/pkg/apiserver/registry/generic/key_test.go
@@ -148,7 +148,7 @@ func TestClusterScopedKeyFunc(t *testing.T) {
 			name:     "Valid cluster-scoped resource",
 			ctx:      context.Background(),
 			objName:  "admin",
-			expected: "/group/iam.grafana.app/resource/globalroles/name/admin",
+			expected: "/group/iam.grafana.app/resource/globalroles/namespace/__cluster__/name/admin",
 			wantErr:  false,
 		},
 		{

--- a/pkg/apiserver/registry/generic/storage_test.go
+++ b/pkg/apiserver/registry/generic/storage_test.go
@@ -52,12 +52,12 @@ func TestNewRegistryStore_KeyFuncSelection(t *testing.T) {
 		expectedKeyContains  string
 	}{
 		{
-			name:                 "Cluster-scoped resource does not require namespace",
+			name:                 "Cluster-scoped resource requires '__cluster__' namespace",
 			resourceInfo:         clusterScopedResourceInfo,
 			testName:             "admin-role",
 			testNamespace:        "",
 			expectNamespaceError: false,
-			expectedKeyContains:  "/resource/globalroles/name/admin-role",
+			expectedKeyContains:  "/resource/globalroles/namespace/__cluster__/name/admin-role",
 		},
 		{
 			name:                 "Namespaced resource requires namespace",
@@ -109,10 +109,10 @@ func TestNewRegistryStore_KeyFuncSelection(t *testing.T) {
 				t.Errorf("KeyFunc() = %q, expected to contain %q", key, tt.expectedKeyContains)
 			}
 
-			// cluster scoped resources should not have a namespace in the key
+			// cluster scoped resources should use the __cluster__ sentinel namespace
 			if tt.resourceInfo.IsClusterScoped() {
-				if strings.Contains(key, "/namespace/") {
-					t.Errorf("Cluster-scoped resource key %q should not contain namespace", key)
+				if !strings.Contains(key, "/namespace/"+ClusterNamespace) {
+					t.Errorf("Cluster-scoped resource key %q should contain namespace %q", key, ClusterNamespace)
 				}
 			}
 

--- a/pkg/storage/unified/apistore/restoptions.go
+++ b/pkg/storage/unified/apistore/restoptions.go
@@ -65,10 +65,9 @@ func NewRESTOptionsGetterMemory(originalStorageConfig storagebackend.Config, sec
 
 	kv := resource.NewBadgerKV(db)
 	backend, err := resource.NewKVStorageBackend(resource.KVBackendOptions{
-		KvStore:                      kv,
-		WithExperimentalClusterScope: true,
-		Log:                          log.New(),
-		DisablePruner:                true,
+		KvStore:       kv,
+		Log:           log.New(),
+		DisablePruner: true,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -49,41 +49,22 @@ type GarbageCollectionConfig struct {
 	DashboardsMaxAge time.Duration // dashboard retention
 }
 
-// convertClusterNamespaceToEmpty converts the internal __cluster__ namespace back to empty string
-// for cluster-scoped resources when returning to users
-func convertClusterNamespaceToEmpty(namespace string) string {
-	if namespace == clusterScopeNamespace {
-		return ""
-	}
-	return namespace
-}
-
-// convertEmptyToClusterNamespace converts empty namespace to the internal __cluster__ namespace
-// for cluster-scoped resources when WithExperimentalClusterScope is enabled
-func convertEmptyToClusterNamespace(namespace string, withExperimentalClusterScope bool) string {
-	if withExperimentalClusterScope && namespace == "" {
-		return clusterScopeNamespace
-	}
-	return namespace
-}
-
 // kvStorageBackend Unified storage backend based on KV storage.
 type kvStorageBackend struct {
-	snowflake                    *snowflake.Node
-	kv                           KV
-	bulkLock                     *BulkLock
-	dataStore                    *dataStore
-	eventStore                   *eventStore
-	notifier                     notifier
-	log                          log.Logger
-	disablePruner                bool
-	eventRetentionPeriod         time.Duration
-	eventPruningInterval         time.Duration
-	historyPruner                Pruner
-	garbageCollection            GarbageCollectionConfig
-	withExperimentalClusterScope bool
-	lastImportStore              *lastImportStore
-	lastImportTimeMaxAge         time.Duration
+	snowflake            *snowflake.Node
+	kv                   KV
+	bulkLock             *BulkLock
+	dataStore            *dataStore
+	eventStore           *eventStore
+	notifier             notifier
+	log                  log.Logger
+	disablePruner        bool
+	eventRetentionPeriod time.Duration
+	eventPruningInterval time.Duration
+	historyPruner        Pruner
+	garbageCollection    GarbageCollectionConfig
+	lastImportStore      *lastImportStore
+	lastImportTimeMaxAge time.Duration
 	//tracer        trace.Tracer
 	//reg           prometheus.Registerer
 
@@ -110,15 +91,14 @@ type KVBackend interface {
 }
 
 type KVBackendOptions struct {
-	KvStore                      KV
-	DisablePruner                bool
-	WithExperimentalClusterScope bool                  // Allow empty namespace to be used for cluster-scoped resources.
-	EventRetentionPeriod         time.Duration         // How long to keep events (default: 1 hour)
-	EventPruningInterval         time.Duration         // How often to run the event pruning (default: 5 minutes)
-	Tracer                       trace.Tracer          // TODO add tracing
-	Reg                          prometheus.Registerer // TODO add metrics
-	Log                          log.Logger
-	GarbageCollection            GarbageCollectionConfig
+	KvStore              KV
+	DisablePruner        bool
+	EventRetentionPeriod time.Duration         // How long to keep events (default: 1 hour)
+	EventPruningInterval time.Duration         // How often to run the event pruning (default: 5 minutes)
+	Tracer               trace.Tracer          // TODO add tracing
+	Reg                  prometheus.Registerer // TODO add metrics
+	Log                  log.Logger
+	GarbageCollection    GarbageCollectionConfig
 
 	UseChannelNotifier bool
 	WatchOptions       WatchOptions
@@ -185,24 +165,23 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 	}
 
 	backend := &kvStorageBackend{
-		kv:                           kv,
-		bulkLock:                     NewBulkLock(),
-		dataStore:                    newDataStore(kv),
-		eventStore:                   eventStore,
-		notifier:                     newNotifier(eventStore, notifierOptions{log: logger, useChannelNotifier: opts.UseChannelNotifier}),
-		watchOpts:                    opts.WatchOptions.normalize(),
-		snowflake:                    s,
-		log:                          logger,
-		eventRetentionPeriod:         eventRetentionPeriod,
-		eventPruningInterval:         eventPruningInterval,
-		withExperimentalClusterScope: opts.WithExperimentalClusterScope,
-		rvManager:                    opts.RvManager,
-		dbKeepAlive:                  opts.DBKeepAlive,
-		lastImportStore:              newLastImportStore(kv),
-		lastImportTimeMaxAge:         opts.LastImportTimeMaxAge,
-		garbageCollection:            opts.GarbageCollection,
-		searchLookback:               opts.SearchLookback,
-		disablePruner:                opts.DisablePruner,
+		kv:                   kv,
+		bulkLock:             NewBulkLock(),
+		dataStore:            newDataStore(kv),
+		eventStore:           eventStore,
+		notifier:             newNotifier(eventStore, notifierOptions{log: logger, useChannelNotifier: opts.UseChannelNotifier}),
+		watchOpts:            opts.WatchOptions.normalize(),
+		snowflake:            s,
+		log:                  logger,
+		eventRetentionPeriod: eventRetentionPeriod,
+		eventPruningInterval: eventPruningInterval,
+		rvManager:            opts.RvManager,
+		dbKeepAlive:          opts.DBKeepAlive,
+		lastImportStore:      newLastImportStore(kv),
+		lastImportTimeMaxAge: opts.LastImportTimeMaxAge,
+		garbageCollection:    opts.GarbageCollection,
+		searchLookback:       opts.SearchLookback,
+		disablePruner:        opts.DisablePruner,
 	}
 	err = backend.initPruner(ctx)
 	if err != nil {
@@ -610,14 +589,12 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 
 	rv := k.snowflake.Generate().Int64()
 
-	namespace := convertEmptyToClusterNamespace(event.Key.Namespace, k.withExperimentalClusterScope)
-
 	// When PreviousRV is not 0, fetch the latest resource and verify that the RV matches the PreviousRV
 	if event.PreviousRV != 0 {
 		latestKey, err := k.dataStore.GetLatestResourceKey(ctx, GetRequestKey{
 			Group:     event.Key.Group,
 			Resource:  event.Key.Resource,
-			Namespace: namespace,
+			Namespace: event.Key.Namespace,
 			Name:      event.Key.Name,
 		})
 		if err != nil {
@@ -644,7 +621,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 		_, err := k.dataStore.GetLatestResourceKey(ctx, GetRequestKey{
 			Group:     event.Key.Group,
 			Resource:  event.Key.Resource,
-			Namespace: namespace,
+			Namespace: event.Key.Namespace,
 			Name:      event.Key.Name,
 		})
 		if err == nil {
@@ -672,7 +649,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 	dataKey := DataKey{
 		Group:           event.Key.Group,
 		Resource:        event.Key.Resource,
-		Namespace:       namespace,
+		Namespace:       event.Key.Namespace,
 		Name:            event.Key.Name,
 		ResourceVersion: rv,
 		Action:          action,
@@ -714,7 +691,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 		latestKey, prevKey, err := k.dataStore.GetLatestAndPredecessor(ctx, ListRequestKey{
 			Group:     event.Key.Group,
 			Resource:  event.Key.Resource,
-			Namespace: namespace,
+			Namespace: event.Key.Namespace,
 			Name:      event.Key.Name,
 		})
 		if err != nil {
@@ -740,7 +717,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 		latestKey, prevKey, err := k.dataStore.GetLatestAndPredecessor(ctx, ListRequestKey{
 			Group:     event.Key.Group,
 			Resource:  event.Key.Resource,
-			Namespace: namespace,
+			Namespace: event.Key.Namespace,
 			Name:      event.Key.Name,
 		})
 		if err != nil {
@@ -766,7 +743,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 
 	// Write event
 	eventData := Event{
-		Namespace:       namespace,
+		Namespace:       event.Key.Namespace,
 		Group:           event.Key.Group,
 		Resource:        event.Key.Resource,
 		Name:            event.Key.Name,
@@ -783,7 +760,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 	}
 
 	_ = k.historyPruner.Add(PruningKey{
-		Namespace: namespace,
+		Namespace: event.Key.Namespace,
 		Group:     event.Key.Group,
 		Resource:  event.Key.Resource,
 		Name:      event.Key.Name,
@@ -797,8 +774,6 @@ func (k *kvStorageBackend) ReadResource(ctx context.Context, req *resourcepb.Rea
 	if req.Key == nil {
 		return &BackendReadResponse{Error: &resourcepb.ErrorResult{Code: http.StatusBadRequest, Message: "missing key"}}
 	}
-
-	namespace := convertEmptyToClusterNamespace(req.Key.Namespace, k.withExperimentalClusterScope)
 
 	// If a specific resource version is requested, validate that it's not too high
 	if req.ResourceVersion > 0 {
@@ -836,7 +811,7 @@ func (k *kvStorageBackend) ReadResource(ctx context.Context, req *resourcepb.Rea
 	meta, err := k.dataStore.GetResourceKeyAtRevision(ctx, GetRequestKey{
 		Group:     req.Key.Group,
 		Resource:  req.Key.Resource,
-		Namespace: namespace,
+		Namespace: req.Key.Namespace,
 		Name:      req.Key.Name,
 	}, req.ResourceVersion)
 	if errors.Is(err, ErrNotFound) {
@@ -847,7 +822,7 @@ func (k *kvStorageBackend) ReadResource(ctx context.Context, req *resourcepb.Rea
 	data, err := k.dataStore.Get(ctx, DataKey{
 		Group:           req.Key.Group,
 		Resource:        req.Key.Resource,
-		Namespace:       namespace,
+		Namespace:       req.Key.Namespace,
 		Name:            req.Key.Name,
 		ResourceVersion: meta.ResourceVersion,
 		Action:          meta.Action,
@@ -874,14 +849,12 @@ func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.Lis
 		return 0, fmt.Errorf("missing options or key in ListRequest")
 	}
 
-	namespace := convertEmptyToClusterNamespace(req.Options.Key.Namespace, k.withExperimentalClusterScope)
-
 	// Parse continue token if provided
 	listOptions := ListRequestOptions{
 		Key: ListRequestKey{
 			Group:     req.Options.Key.Group,
 			Resource:  req.Options.Key.Resource,
-			Namespace: namespace,
+			Namespace: req.Options.Key.Namespace,
 			Name:      req.Options.Key.Name,
 		},
 		ResourceVersion: req.ResourceVersion,
@@ -1011,7 +984,7 @@ func (i *kvListIterator) ResourceVersion() int64 {
 }
 
 func (i *kvListIterator) Namespace() string {
-	return convertClusterNamespaceToEmpty(i.currentDataObj.Key.Namespace)
+	return i.currentDataObj.Key.Namespace
 }
 
 func (i *kvListIterator) Name() string {
@@ -1633,7 +1606,7 @@ func (k *kvStorageBackend) WatchWriteEvents(ctx context.Context) (<-chan *Writte
 
 			events <- &WrittenEvent{
 				Key: &resourcepb.ResourceKey{
-					Namespace: convertClusterNamespaceToEmpty(event.Namespace),
+					Namespace: event.Namespace,
 					Group:     event.Group,
 					Resource:  event.Resource,
 					Name:      event.Name,

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -62,15 +62,7 @@ func setupTestStorageBackend(t *testing.T, configs ...func(*KVBackendOptions)) *
 }
 
 func setupTestStorageBackendWithClusterScope(t *testing.T) *kvStorageBackend {
-	kv := setupBadgerKV(t)
-	opts := KVBackendOptions{
-		KvStore:                      kv,
-		WithExperimentalClusterScope: true,
-	}
-	backend, err := NewKVStorageBackend(opts)
-	kvBackend := backend.(*kvStorageBackend)
-	require.NoError(t, err)
-	return kvBackend
+	return setupTestStorageBackend(t)
 }
 
 func TestNewKvStorageBackend(t *testing.T) {
@@ -2120,15 +2112,8 @@ func createAndWriteTestObject(t *testing.T, backend *kvStorageBackend) (*unstruc
 	return testObj, rv
 }
 
-// TestKvStorageBackend_ClusterScopedResources tests create, update, delete, list, and watch
-// operations for cluster-scoped resources (empty namespace).
-// This test requires the backend to be configured with WithExperimentalClusterScoped set to true.
-//
-// The test verifies that:
-// - All write operations accept empty namespace
-// - ReadResource responses return empty namespace
-// - ListIterator results return empty namespace
-// - WatchWriteEvents return empty namespace
+// TestKvStorageBackend_ClusterScopedResources tests CRUD, list, and watch
+// for cluster-scoped resources using the "__cluster__" namespace.
 func TestKvStorageBackend_ClusterScopedResources(t *testing.T) {
 	backend := setupTestStorageBackendWithClusterScope(t)
 	ctx := context.Background()
@@ -2137,9 +2122,8 @@ func TestKvStorageBackend_ClusterScopedResources(t *testing.T) {
 	stream, err := backend.WatchWriteEvents(ctx)
 	require.NoError(t, err)
 
-	// Use empty namespace for cluster-scoped resources
 	clusterNS := NamespacedResource{
-		Namespace: "",
+		Namespace: clusterScopeNamespace,
 		Group:     "cluster.example.com",
 		Resource:  "clusterresources",
 	}
@@ -2153,7 +2137,7 @@ func TestKvStorageBackend_ClusterScopedResources(t *testing.T) {
 	writeEvent1 := WriteEvent{
 		Type: resourcepb.WatchEvent_ADDED,
 		Key: &resourcepb.ResourceKey{
-			Namespace: "",
+			Namespace: clusterScopeNamespace,
 			Group:     "cluster.example.com",
 			Resource:  "clusterresources",
 			Name:      "cluster-item1",
@@ -2174,7 +2158,7 @@ func TestKvStorageBackend_ClusterScopedResources(t *testing.T) {
 	writeEvent2 := WriteEvent{
 		Type: resourcepb.WatchEvent_ADDED,
 		Key: &resourcepb.ResourceKey{
-			Namespace: "",
+			Namespace: clusterScopeNamespace,
 			Group:     "cluster.example.com",
 			Resource:  "clusterresources",
 			Name:      "cluster-item2",
@@ -2195,7 +2179,7 @@ func TestKvStorageBackend_ClusterScopedResources(t *testing.T) {
 	writeEvent3 := WriteEvent{
 		Type: resourcepb.WatchEvent_ADDED,
 		Key: &resourcepb.ResourceKey{
-			Namespace: "",
+			Namespace: clusterScopeNamespace,
 			Group:     "cluster.example.com",
 			Resource:  "clusterresources",
 			Name:      "cluster-item3",
@@ -2216,7 +2200,7 @@ func TestKvStorageBackend_ClusterScopedResources(t *testing.T) {
 	writeEvent2Updated := WriteEvent{
 		Type: resourcepb.WatchEvent_MODIFIED,
 		Key: &resourcepb.ResourceKey{
-			Namespace: "",
+			Namespace: clusterScopeNamespace,
 			Group:     "cluster.example.com",
 			Resource:  "clusterresources",
 			Name:      "cluster-item2",
@@ -2230,11 +2214,11 @@ func TestKvStorageBackend_ClusterScopedResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, rv4, rv3)
 
-	// Test Read - Read latest cluster-item2
+	// Test Read - Read latest cluster-item2 using __cluster__ namespace
 	readReq := &resourcepb.ReadRequest{
 		Key: &resourcepb.ResourceKey{
 			Name:      "cluster-item2",
-			Namespace: "", // Request with empty namespace
+			Namespace: clusterScopeNamespace,
 			Group:     "cluster.example.com",
 			Resource:  "clusterresources",
 		},
@@ -2245,7 +2229,7 @@ func TestKvStorageBackend_ClusterScopedResources(t *testing.T) {
 	require.Equal(t, rv4, response.ResourceVersion)
 	require.Contains(t, string(response.Value), "updated-data")
 	require.NotNil(t, response.Key, "response key should be populated")
-	require.Empty(t, response.Key.Namespace, "cluster-scoped resource should have empty namespace in response")
+	require.Equal(t, clusterScopeNamespace, response.Key.Namespace, "cluster-scoped resource should have __cluster__ namespace")
 
 	// Test Read - Read early version of cluster-item2
 	readReq.ResourceVersion = rv3 // Should return rv2 version
@@ -2254,13 +2238,13 @@ func TestKvStorageBackend_ClusterScopedResources(t *testing.T) {
 	require.Equal(t, rv2, response.ResourceVersion)
 	require.Contains(t, string(response.Value), "data-2")
 	require.NotNil(t, response.Key, "response key should be populated")
-	require.Empty(t, response.Key.Namespace, "cluster-scoped resource should have empty namespace in response")
+	require.Equal(t, clusterScopeNamespace, response.Key.Namespace, "cluster-scoped resource should have __cluster__ namespace")
 
 	// Test Delete - Delete cluster-item1
 	writeEvent1Delete := WriteEvent{
 		Type: resourcepb.WatchEvent_DELETED,
 		Key: &resourcepb.ResourceKey{
-			Namespace: "",
+			Namespace: clusterScopeNamespace,
 			Group:     "cluster.example.com",
 			Resource:  "clusterresources",
 			Name:      "cluster-item1",
@@ -2274,11 +2258,11 @@ func TestKvStorageBackend_ClusterScopedResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, rv5, rv4)
 
-	// Test List - List all cluster-scoped resources
+	// Test List - List cluster-scoped resources using __cluster__ namespace
 	listReq := &resourcepb.ListRequest{
 		Options: &resourcepb.ListOptions{
 			Key: &resourcepb.ResourceKey{
-				Namespace: "",
+				Namespace: clusterScopeNamespace,
 				Group:     "cluster.example.com",
 				Resource:  "clusterresources",
 			},
@@ -2313,9 +2297,9 @@ func TestKvStorageBackend_ClusterScopedResources(t *testing.T) {
 	require.GreaterOrEqual(t, rv, rv5)
 	require.Len(t, listedItems, 2) // cluster-item2 and cluster-item3 (item1 was deleted)
 
-	// Verify all items have empty namespace
+	// Verify all items have __cluster__ namespace
 	for _, item := range listedItems {
-		require.Empty(t, item.namespace, "cluster-scoped resources should have empty namespace")
+		require.Equal(t, clusterScopeNamespace, item.namespace, "cluster-scoped resources should have __cluster__ namespace")
 	}
 
 	// Verify items are sorted and have expected content
@@ -2324,11 +2308,45 @@ func TestKvStorageBackend_ClusterScopedResources(t *testing.T) {
 	require.Equal(t, "cluster-item3", listedItems[1].name)
 	require.Contains(t, string(listedItems[1].value), "data-3")
 
-	// Verify deleted resource is not in list
+	// Test Cross-Namespace List - empty namespace should return all namespaces including __cluster__
+	crossNSListReq := &resourcepb.ListRequest{
+		Options: &resourcepb.ListOptions{
+			Key: &resourcepb.ResourceKey{
+				Namespace: "",
+				Group:     "cluster.example.com",
+				Resource:  "clusterresources",
+			},
+		},
+		Limit: 10,
+	}
+
+	var crossNSItems []struct {
+		name      string
+		namespace string
+	}
+	_, err = backend.ListIterator(ctx, crossNSListReq, func(iter ListIterator) error {
+		for iter.Next() {
+			if err := iter.Error(); err != nil {
+				return err
+			}
+			crossNSItems = append(crossNSItems, struct {
+				name      string
+				namespace string
+			}{
+				name:      iter.Name(),
+				namespace: iter.Namespace(),
+			})
+		}
+		return iter.Error()
+	})
+	require.NoError(t, err)
+	require.Len(t, crossNSItems, 2, "cross-namespace list should also return cluster-scoped resources")
+
+	// Verify deleted resource is not found
 	readReqDeleted := &resourcepb.ReadRequest{
 		Key: &resourcepb.ResourceKey{
 			Name:      "cluster-item1",
-			Namespace: "",
+			Namespace: clusterScopeNamespace,
 			Group:     "cluster.example.com",
 			Resource:  "clusterresources",
 		},
@@ -2337,12 +2355,8 @@ func TestKvStorageBackend_ClusterScopedResources(t *testing.T) {
 	responseDeleted := backend.ReadResource(ctx, readReqDeleted)
 	require.NotNil(t, responseDeleted.Error)
 	require.Equal(t, int32(404), responseDeleted.Error.Code)
-	// Key should still be empty for cluster-scoped resources even on error
-	if responseDeleted.Key != nil {
-		require.Empty(t, responseDeleted.Key.Namespace, "cluster-scoped resource should have empty namespace even on error")
-	}
 
-	// Test Watch - Verify all events were published with empty namespace
+	// Test Watch - Verify all events were published with __cluster__ namespace
 	watchedEvents := []struct {
 		name         string
 		expectedType resourcepb.WatchEvent_Type
@@ -2359,7 +2373,7 @@ func TestKvStorageBackend_ClusterScopedResources(t *testing.T) {
 		select {
 		case event := <-stream:
 			require.Equal(t, expected.name, event.Key.Name, "Event %d: wrong name", i)
-			require.Empty(t, event.Key.Namespace, "Event %d: cluster-scoped resource should have empty namespace", i)
+			require.Equal(t, clusterScopeNamespace, event.Key.Namespace, "Event %d: cluster-scoped resource should have __cluster__ namespace", i)
 			require.Equal(t, "cluster.example.com", event.Key.Group, "Event %d: wrong group", i)
 			require.Equal(t, "clusterresources", event.Key.Resource, "Event %d: wrong resource", i)
 			require.Equal(t, expected.expectedType, event.Type, "Event %d: wrong type", i)


### PR DESCRIPTION
for https://github.com/grafana/hyperion-planning/issues/508

The current strategy is to pass `""` as namespace. This approach has a few drawbacks though.

1. The current sql based backend accepts writes just fine, but it has no way to distinguish cluster scoped resources at List time. This means you can only list cluster scope resources by listing all namespaces.
2. The kv backend doesn't play very well with empty namespace, so we have to hack around it by converting it to `__cluster__` when saving, and then convert it back. Not the end of the world, but ideally the storage layer shouldn't care about these things.
3. In the kv backend, we still don't have a nice way to list these resources without listing everything. The workaround would be to accept `""` on writes, but then clients would need to provide `__cluster__` when listing. Not great either.

This PR changes it so we always pass `__cluster__` namespace for cluster scope resources. This way the storage doesn't need to have any special handling, and everything should just work. [Auth should handle this change just fine](https://github.com/grafana/authlib/blob/main/types/namespace.go#L28), but including the auth team for review as well.