### PR TITLE
swap to use OpenFeature client instead of legacy feature toggles

### DIFF
--- a/pkg/api/datasources_k8s_test.go
+++ b/pkg/api/datasources_k8s_test.go
@@ -139,7 +139,6 @@ func TestGetK8sDataSourceByUIDHandler(t *testing.T) {
 					featuremgmt.FlagDatasourcesRerouteLegacyCRUDAPIs,
 					featuremgmt.FlagQueryService,
 					featuremgmt.FlagQueryServiceWithConnections,
-					featuremgmt.FlagDatasourcesApiServerEnableResourceEndpoint,
 				),
 				dsConnectionClient:   &mockConnectionClient{result: tt.connectionResult, err: tt.connectionErr},
 				clientConfigProvider: &mockDirectRestConfigProvider{host: "http://localhost", transport: &mockRoundTripper{statusCode: tt.statusCode, responseBody: tt.responseBody}},

--- a/pkg/registry/apis/datasource/register.go
+++ b/pkg/registry/apis/datasource/register.go
@@ -16,6 +16,8 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	openapi "k8s.io/kube-openapi/pkg/common"
 
+	"github.com/open-feature/go-sdk/openfeature"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-prometheus-datasource/pkg/promlib/models"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -97,6 +99,8 @@ func RegisterAPIService(
 			return nil, fmt.Errorf("plugin client is not a PluginClient: %T", pluginClient)
 		}
 
+		featureClient := openfeature.NewDefaultClient()
+
 		groupName := pluginJSON.ID + ".datasource.grafana.app"
 		builder, err = NewDataSourceAPIBuilder(
 			groupName,
@@ -109,7 +113,7 @@ func RegisterAPIService(
 			DataSourceAPIBuilderConfig{
 				LoadQueryTypes:         features.IsEnabledGlobally(featuremgmt.FlagDatasourceQueryTypes),
 				UseDualWriter:          features.IsEnabledGlobally(featuremgmt.FlagQueryServiceWithConnections),
-				EnableResourceEndpoint: features.IsEnabledGlobally(featuremgmt.FlagDatasourcesApiServerEnableResourceEndpoint),
+				EnableResourceEndpoint: featureClient.Boolean(context.Background(), featuremgmt.FlagDatasourcesApiServerEnableResourceEndpoint, false, openfeature.TransactionContext(context.Background())),
 				EnableHealthEndpoint:   features.IsEnabledGlobally(featuremgmt.FlagDatasourcesApiServerEnableHealthEndpoint),
 			},
 		)


### PR DESCRIPTION
This PR changes the existing Feature flag we are using for the MT Datasources /resources/ endpoint migration to use OpenFeature vs the legacy feature flag system.

[Part of](https://github.com/grafana/grafana-enterprise/issues/8975)