### PR TITLE
Alerting: Add createAlertRuleFromPanel feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -384,6 +384,11 @@ export interface FeatureToggles {
   */
   alertingUIUseFullyCompatBackendFilters?: boolean;
   /**
+  * Enables creating alert rules from a panel using a drawer UI
+  * @default false
+  */
+  createAlertRuleFromPanel?: boolean;
+  /**
   * Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -586,6 +586,14 @@ var (
 			Expression:   "true",
 		},
 		{
+			Name:         "createAlertRuleFromPanel",
+			Description:  "Enables creating alert rules from a panel using a drawer UI",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaAlertingSquad,
+			FrontendOnly: true,
+			Expression:   "false",
+		},
+		{
 			Name:        "alertmanagerRemotePrimary",
 			Description: "Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -72,6 +72,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-07-23,alertingProvenanceLockWrites,experimental,@grafana/alerting-squad,false,false,false
 2025-11-13,alertingUIUseBackendFilters,preview,@grafana/alerting-squad,false,false,false
 2025-11-24,alertingUIUseFullyCompatBackendFilters,preview,@grafana/alerting-squad,false,false,false
+2025-10-29,createAlertRuleFromPanel,experimental,@grafana/alerting-squad,false,false,true
 2023-10-30,alertmanagerRemotePrimary,experimental,@grafana/alerting-squad,false,false,false
 2023-10-31,annotationPermissionUpdate,GA,@grafana/identity-access-team,false,false,false
 2026-03-12,annotationsClustering,experimental,@grafana/dataviz-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1283,6 +1283,20 @@
     },
     {
       "metadata": {
+        "name": "createAlertRuleFromPanel",
+        "resourceVersion": "1773673451775",
+        "creationTimestamp": "2026-03-16T15:04:11Z"
+      },
+      "spec": {
+        "description": "Enables creating alert rules from a panel using a drawer UI",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "createdByMeSearchFilter",
         "resourceVersion": "1771965456951",
         "creationTimestamp": "2026-02-24T20:37:36Z"


### PR DESCRIPTION
Adding `createAlertRuleFromPanel` feature toggle as part of the backend work for this PR: https://github.com/grafana/grafana/pull/113119