### PR TITLE
Alerting: Clarify group labels filter on notification history page.

### DIFF
--- a/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
+++ b/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
@@ -365,7 +365,7 @@ function NotificationDetails({ record }: NotificationDetailsProps) {
             <Stack direction="row" gap={1} alignItems="center">
               <Text variant="bodySmall" color="secondary">
                 <strong>
-                  <Trans i18nKey="alerting.notifications-scene.labels">Labels:</Trans>
+                  <Trans i18nKey="alerting.notifications-scene.group-labels">Group Labels:</Trans>
                 </strong>
               </Text>
               <AlertLabels labels={filteredLabels} size="sm" />

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2349,6 +2349,7 @@
       },
       "filterBy": "Filter by:",
       "firing-alerts": "Firing Alerts",
+      "group-labels": "Group Labels:",
       "header": {
         "contact-point": "Contact point",
         "group-labels": "Group Labels",


### PR DESCRIPTION
The filter implied that you could filter entries by any labels, but this can be
very costly to do on the backend currently, especially if zooming out to wide
time range. Instead, clarify the filter so it's clearer only group labels can
be filtered by, and look into further improvements later.
