### PR TITLE
Alerting: Clarify integration on notification history page.

### DIFF
--- a/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
+++ b/public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx
@@ -36,6 +36,7 @@ import {
   useStyles2,
   withErrorBoundary,
 } from '@grafana/ui';
+import { receiverTypeNames } from 'app/plugins/datasource/alertmanager/consts';
 
 import { AlertEnrichments } from '../components/AlertEnrichments';
 import { CollapseToggle } from '../components/CollapseToggle';
@@ -43,6 +44,7 @@ import { StateTag } from '../components/StateTag';
 import { useNotificationAlerts } from '../hooks/useNotificationAlerts';
 import { usePagination } from '../hooks/usePagination';
 import { prometheusExpressionBuilder } from '../triage/scene/expressionBuilder';
+import { INTEGRATION_ICONS } from '../types/contact-points';
 import { parsePromQLStyleMatcherLooseSafe } from '../utils/matchers';
 import { stringifyErrorLike } from '../utils/misc';
 import { createRelativeUrl } from '../utils/url';
@@ -266,7 +268,22 @@ function NotificationRow({ record, onLabelClick }: NotificationRowProps) {
           )}
         </div>
         <div className={styles.receiverCol}>
-          <Text>{record.receiver || '-'}</Text>
+          <Tooltip
+            content={t('alerting.notifications-list.integration-tooltip', '{{integration}} #{{index}}', {
+              integration: receiverTypeNames[record.integration] ?? record.integration,
+              index: record.integrationIndex + 1,
+            })}
+          >
+            <Stack direction="row" gap={0.5} alignItems="center">
+              <Icon name={INTEGRATION_ICONS[record.integration] || 'bell'} size="sm" />
+              <Text>{record.receiver || '-'}</Text>
+              {record.integrationIndex > 0 && (
+                <Text variant="bodySmall" color="secondary">
+                  (#{record.integrationIndex + 1})
+                </Text>
+              )}
+            </Stack>
+          </Tooltip>
         </div>
         <div className={styles.viewCol}>
           <LinkButton
@@ -517,6 +534,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
     }),
     receiverCol: css({
       width: '200px',
+      flexShrink: 0,
     }),
     viewCol: css({
       width: '80px',

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2325,6 +2325,7 @@
     },
     "notifications-list": {
       "error-fetching": "Error fetching notifications",
+      "integration-tooltip": "{{integration}} #{{index}}",
       "no-error-details": "No error details available",
       "notification-error": "Notification Error",
       "outcome-failed": "Failed",


### PR DESCRIPTION
An event is recorded per integration, not per contact point, but we were only
displaying the contact point. Using multiple integrations per contact point
is somewhat of an edge case, so:

- Show the integration type icon, always
- Show the integration number, but only if it's not the first
- Add a tooltip for the integration name and number
