### PR TITLE
ShortURL: Do not memoize error responses when creating a shortURL

### DIFF
--- a/public/app/core/utils/shortLinks.test.ts
+++ b/public/app/core/utils/shortLinks.test.ts
@@ -78,6 +78,37 @@ describe('createShortLink using k8s API', () => {
   });
 });
 
+describe('createShortLink retries after failure', () => {
+  it('retries after k8s API failure instead of returning cached rejection', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
+
+    config.featureToggles.useKubernetesShortURLsAPI = true;
+
+    const mockLocation = { protocol: 'https:', host: 'www.test.grafana.com' };
+    Object.defineProperty(window, 'location', { value: mockLocation, writable: true });
+
+    const { dispatch } = require('app/store/store');
+    // dispatch is called for: 1) initiate (fail), 2) notifyApp (error), 3) initiate (success)
+    dispatch
+      .mockResolvedValueOnce({ error: { status: 504, data: { message: 'gateway timeout' } } })
+      .mockReturnValueOnce(undefined) // notifyApp error notification
+      .mockResolvedValueOnce({
+        data: {
+          metadata: { name: 'retried123', namespace: '1' },
+        },
+      });
+
+    const path = 'd/test/dashboard?orgId=1';
+
+    // First call should fail
+    await expect(createShortLink(path)).rejects.toThrow();
+
+    // Second call with same path should retry, not return cached rejection
+    const result = await createShortLink(path);
+    expect(result).toBe('https://www.test.grafana.com/goto/retried123?orgId=1');
+  });
+});
+
 describe('createAndCopyShortLink', () => {
   it('copies short link to clipboard via document.execCommand when navigator.clipboard is undefined', async () => {
     Object.assign(navigator, {

--- a/public/app/core/utils/shortLinks.ts
+++ b/public/app/core/utils/shortLinks.ts
@@ -75,6 +75,7 @@ export const createShortLink = memoizeOne(async (path: string): Promise<string> 
   } catch (err) {
     console.error('Error when creating shortened link: ', err);
     dispatch(notifyApp(createErrorNotification('Error generating shortened link')));
+    createShortLink.clear();
     throw err; // Re-throw so callers know it failed
   }
 });

--- a/public/app/features/dashboard-scene/scene/new-toolbar/actions/ShareDashboardButton.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/actions/ShareDashboardButton.tsx
@@ -18,7 +18,7 @@ const newShareButtonSelector = e2eSelectors.pages.Dashboard.DashNav.newShareButt
 export const ShareDashboardButton = ({ dashboard }: ToolbarActionProps) => {
   const { showModal, hideModal } = useContext(ModalsContext);
 
-  const [_, buildUrl] = useAsyncFn(async () => {
+  const [{ loading }, buildUrl] = useAsyncFn(async () => {
     DashboardInteractions.toolbarShareClick();
     await buildShareUrl(dashboard);
   }, [dashboard]);
@@ -49,6 +49,7 @@ export const ShareDashboardButton = ({ dashboard }: ToolbarActionProps) => {
       arrowTestId={newShareButtonSelector.arrowMenu}
       dashboard={dashboard}
       variant={!dashboard.state.isEditing ? 'primary' : 'canvas'}
+      loading={loading}
     />
   );
 };

--- a/public/app/features/dashboard-scene/scene/new-toolbar/actions/ShareExportDashboardButton.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/actions/ShareExportDashboardButton.tsx
@@ -15,6 +15,7 @@ interface Props extends ToolbarActionProps {
   arrowLabel: string;
   arrowTestId: string;
   variant?: 'primary' | 'canvas';
+  loading?: boolean;
 }
 
 export const ShareExportDashboardButton = ({
@@ -29,6 +30,7 @@ export const ShareExportDashboardButton = ({
   arrowLabel,
   arrowTestId,
   variant = 'canvas',
+  loading,
 }: Props) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -38,8 +40,8 @@ export const ShareExportDashboardButton = ({
         data-testid={buttonTestId}
         tooltip={buttonTooltip}
         variant={variant}
-        onClick={onButtonClick}
-        icon="share-alt"
+        onClick={loading ? undefined : onButtonClick}
+        icon={loading ? 'spinner' : 'share-alt'}
       >
         {buttonLabel}
       </ToolbarButton>

--- a/public/app/features/dashboard-scene/sharing/ShareButton/ShareButton.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareButton/ShareButton.tsx
@@ -20,7 +20,7 @@ export default function ShareButton({ dashboard, panel }: { dashboard: Dashboard
   const styles = useStyles2(getStyles);
   const [isOpen, setIsOpen] = useState(false);
 
-  const [_, buildUrl] = useAsyncFn(async () => {
+  const [{ loading }, buildUrl] = useAsyncFn(async () => {
     DashboardInteractions.toolbarShareClick();
     await buildShareUrl(dashboard, panel);
   }, [dashboard, panel]);
@@ -42,6 +42,8 @@ export default function ShareButton({ dashboard, panel }: { dashboard: Dashboard
         size="sm"
         tooltip={t('share-dashboard.share-button-tooltip', 'Copy link')}
         onClick={buildUrl}
+        icon={loading ? 'spinner' : undefined}
+        disabled={loading}
       >
         <Trans i18nKey="share-dashboard.share-button">Share</Trans>
       </Button>

--- a/public/app/features/dashboard-scene/sharing/ShareLinkTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareLinkTab.tsx
@@ -67,6 +67,12 @@ export class ShareLinkTab extends SceneObjectBase<ShareLinkTabState> implements 
 
     if (useShortUrl) {
       shareUrl = await createShortLink(shareUrl);
+      try {
+        shareUrl = await createShortLink(shareUrl);
+      } catch {
+        this.setState({ isBuildUrlLoading: false });
+        return;
+      }
     }
 
     const timeRange = sceneGraph.getTimeRange(panel ?? dashboard);

--- a/public/app/features/dashboard-scene/sharing/ShareLinkTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareLinkTab.tsx
@@ -66,7 +66,6 @@ export class ShareLinkTab extends SceneObjectBase<ShareLinkTabState> implements 
     let shareUrl = createDashboardShareUrl(dashboard, opts, panel);
 
     if (useShortUrl) {
-      shareUrl = await createShortLink(shareUrl);
       try {
         shareUrl = await createShortLink(shareUrl);
       } catch {


### PR DESCRIPTION
**What is this feature?**
Fix short URL creation caching failed responses and add loading state to share button

  Summary

  - Fix createShortLink caching rejected promises via memoizeOne — after a failure (e.g. 504 timeout), subsequent calls with the same path now retry the
  request instead of returning the cached rejection
  - Handle errors in ShareLinkTab.buildUrl() so isBuildUrlLoading is reset to false on failure, preventing the component from getting stuck in a loading state
  - Add loading indicator (spinner icon) to the Share toolbar button, matching the existing RefreshPicker pattern

Fixes https://github.com/grafana/grafana/issues/120439

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
