### PR TITLE
Expressions: Store per-node pipeline errors instead of aborting

### DIFF
--- a/pkg/expr/graph.go
+++ b/pkg/expr/graph.go
@@ -95,7 +95,7 @@ func (dp *DataPipeline) execute(c context.Context, now time.Time, s *Service) (m
 				if res.Error != nil {
 					var depErr error
 					// IF SQL expression dependency error
-					if node.NodeType() == TypeCMDNode && node.(*CMDNode).CMDType == TypeSQL {
+					if cmdNode, ok := node.(*CMDNode); ok && cmdNode.CMDType == TypeSQL {
 						e := sql.MakeSQLDependencyError(node.RefID(), neededVar)
 
 						// although the SQL expression won't be executed,
@@ -134,7 +134,10 @@ func (dp *DataPipeline) execute(c context.Context, now time.Time, s *Service) (m
 
 		execNode, ok := node.(ExecutableNode)
 		if !ok {
-			return vars, makeUnexpectedNodeTypeError(node.RefID(), node.NodeType().String())
+			vars[node.RefID()] = mathexp.Results{
+				Error: makeUnexpectedNodeTypeError(node.RefID(), node.NodeType().String()),
+			}
+			continue
 		}
 
 		res, err := execNode.Execute(c, now, vars, s)

--- a/pkg/expr/service_test.go
+++ b/pkg/expr/service_test.go
@@ -235,6 +235,62 @@ func TestSQLExpressionCellLimitFromConfig(t *testing.T) {
 	}
 }
 
+// nonExecutableNode implements Node but not ExecutableNode, to test that
+// the pipeline handles non-executable nodes gracefully per-node instead of
+// returning a global error.
+type nonExecutableNode struct {
+	id      int64
+	refID   string
+	ntype   NodeType
+	inputTo map[string]struct{}
+}
+
+func (n *nonExecutableNode) ID() int64          { return n.id }
+func (n *nonExecutableNode) NodeType() NodeType { return n.ntype }
+func (n *nonExecutableNode) RefID() string      { return n.refID }
+func (n *nonExecutableNode) String() string     { return n.refID }
+func (n *nonExecutableNode) NeedsVars() []string { return nil }
+func (n *nonExecutableNode) SetInputTo(refID string) {
+	if n.inputTo == nil {
+		n.inputTo = make(map[string]struct{})
+	}
+	n.inputTo[refID] = struct{}{}
+}
+func (n *nonExecutableNode) IsInputTo() map[string]struct{} { return n.inputTo }
+
+func TestUnexpectedNodeTypeIsPerNodeError(t *testing.T) {
+	resp := map[string]backend.DataResponse{}
+
+	queries := []Query{
+		{
+			RefID:      "C",
+			DataSource: dataSourceModel(),
+			JSON:       json.RawMessage(`{ "datasource": { "uid": "__expr__", "type": "__expr__"}, "type": "math", "expression": "42" }`),
+		},
+	}
+
+	s, req := newMockQueryService(resp, queries)
+
+	pl, err := s.BuildPipeline(t.Context(), req)
+	require.NoError(t, err)
+
+	// Inject a non-executable node into the pipeline before the math node.
+	badNode := &nonExecutableNode{id: 99, refID: "X", ntype: TypeCMDNode}
+	pl = append(DataPipeline{badNode}, pl...)
+
+	res, err := s.ExecutePipeline(context.Background(), time.Now(), pl)
+	// Should not return a global error — per-node errors only
+	require.NoError(t, err)
+
+	// X should have a per-node error
+	require.Error(t, res.Responses["X"].Error)
+	require.ErrorContains(t, res.Responses["X"].Error, "expected executable node type")
+
+	// C should still succeed independently
+	require.NoError(t, res.Responses["C"].Error)
+	require.Equal(t, fp(42), res.Responses["C"].Frames[0].Fields[0].At(0))
+}
+
 func fp(f float64) *float64 {
 	return &f
 }

--- a/pkg/expr/service_test.go
+++ b/pkg/expr/service_test.go
@@ -239,17 +239,18 @@ func TestSQLExpressionCellLimitFromConfig(t *testing.T) {
 // the pipeline handles non-executable nodes gracefully per-node instead of
 // returning a global error.
 type nonExecutableNode struct {
-	id      int64
-	refID   string
-	ntype   NodeType
-	inputTo map[string]struct{}
+	id       int64
+	refID    string
+	ntype    NodeType
+	inputTo  map[string]struct{}
+	needsVars []string
 }
 
 func (n *nonExecutableNode) ID() int64          { return n.id }
 func (n *nonExecutableNode) NodeType() NodeType { return n.ntype }
 func (n *nonExecutableNode) RefID() string      { return n.refID }
 func (n *nonExecutableNode) String() string     { return n.refID }
-func (n *nonExecutableNode) NeedsVars() []string { return nil }
+func (n *nonExecutableNode) NeedsVars() []string { return n.needsVars }
 func (n *nonExecutableNode) SetInputTo(refID string) {
 	if n.inputTo == nil {
 		n.inputTo = make(map[string]struct{})
@@ -289,6 +290,69 @@ func TestUnexpectedNodeTypeIsPerNodeError(t *testing.T) {
 	// C should still succeed independently
 	require.NoError(t, res.Responses["C"].Error)
 	require.Equal(t, fp(42), res.Responses["C"].Frames[0].Fields[0].At(0))
+}
+
+func TestMultipleIndependentNodesWithMixedErrors(t *testing.T) {
+	resp := map[string]backend.DataResponse{}
+	queries := []Query{
+		{
+			RefID:      "A",
+			DataSource: dataSourceModel(),
+			JSON:       json.RawMessage(`{ "datasource": { "uid": "__expr__", "type": "__expr__"}, "type": "math", "expression": "1" }`),
+		},
+		{
+			RefID:      "B",
+			DataSource: dataSourceModel(),
+			JSON:       json.RawMessage(`{ "datasource": { "uid": "__expr__", "type": "__expr__"}, "type": "math", "expression": "2" }`),
+		},
+	}
+
+	s, req := newMockQueryService(resp, queries)
+	pl, err := s.BuildPipeline(t.Context(), req)
+	require.NoError(t, err)
+
+	badX := &nonExecutableNode{id: 98, refID: "X", ntype: TypeCMDNode}
+	badY := &nonExecutableNode{id: 99, refID: "Y", ntype: TypeCMDNode}
+	pl = append(DataPipeline{badX, badY}, pl...)
+
+	res, err := s.ExecutePipeline(context.Background(), time.Now(), pl)
+	require.NoError(t, err)
+
+	require.Error(t, res.Responses["X"].Error)
+	require.Error(t, res.Responses["Y"].Error)
+	require.NoError(t, res.Responses["A"].Error)
+	require.NoError(t, res.Responses["B"].Error)
+	require.Equal(t, fp(1), res.Responses["A"].Frames[0].Fields[0].At(0))
+	require.Equal(t, fp(2), res.Responses["B"].Frames[0].Fields[0].At(0))
+}
+
+func TestDependencyChainPartialFailure(t *testing.T) {
+	resp := map[string]backend.DataResponse{}
+	queries := []Query{
+		{
+			RefID:      "B",
+			DataSource: dataSourceModel(),
+			JSON:       json.RawMessage(`{ "datasource": { "uid": "__expr__", "type": "__expr__"}, "type": "math", "expression": "42" }`),
+		},
+	}
+
+	s, req := newMockQueryService(resp, queries)
+	pl, err := s.BuildPipeline(t.Context(), req)
+	require.NoError(t, err)
+
+	// A is a bad node; C is a bad node that depends on A.
+	// C should get a dependency error because A failed; B is independent and succeeds.
+	badA := &nonExecutableNode{id: 97, refID: "A", ntype: TypeCMDNode}
+	nodeC := &nonExecutableNode{id: 98, refID: "C", ntype: TypeCMDNode, needsVars: []string{"A"}}
+	pl = append(DataPipeline{badA, nodeC}, pl...)
+
+	res, err := s.ExecutePipeline(context.Background(), time.Now(), pl)
+	require.NoError(t, err)
+
+	require.Error(t, res.Responses["A"].Error)
+	require.Error(t, res.Responses["C"].Error)
+	require.NoError(t, res.Responses["B"].Error)
+	require.Equal(t, fp(42), res.Responses["B"].Frames[0].Fields[0].At(0))
 }
 
 func fp(f float64) *float64 {

--- a/pkg/expr/service_test.go
+++ b/pkg/expr/service_test.go
@@ -239,17 +239,17 @@ func TestSQLExpressionCellLimitFromConfig(t *testing.T) {
 // the pipeline handles non-executable nodes gracefully per-node instead of
 // returning a global error.
 type nonExecutableNode struct {
-	id       int64
-	refID    string
-	ntype    NodeType
-	inputTo  map[string]struct{}
+	id        int64
+	refID     string
+	ntype     NodeType
+	inputTo   map[string]struct{}
 	needsVars []string
 }
 
-func (n *nonExecutableNode) ID() int64          { return n.id }
-func (n *nonExecutableNode) NodeType() NodeType { return n.ntype }
-func (n *nonExecutableNode) RefID() string      { return n.refID }
-func (n *nonExecutableNode) String() string     { return n.refID }
+func (n *nonExecutableNode) ID() int64           { return n.id }
+func (n *nonExecutableNode) NodeType() NodeType  { return n.ntype }
+func (n *nonExecutableNode) RefID() string       { return n.refID }
+func (n *nonExecutableNode) String() string      { return n.refID }
 func (n *nonExecutableNode) NeedsVars() []string { return n.needsVars }
 func (n *nonExecutableNode) SetInputTo(refID string) {
 	if n.inputTo == nil {


### PR DESCRIPTION
## Motivation

This PR supports #119939.

## Overview

`DataPipeline.execute()` iterates nodes in topological order and stores each node's result in `vars` before moving to the next. When a node fails, downstream nodes that depend on it correctly propagate the error via the existing dependency-check logic. But there were two problems with what happened to the rest of the pipeline (nodes that are independent of the failing node):

1. **Unchecked type assertion causing a latent panic (primary fix)** - When a node doesn't implement `ExecutableNode`, the code was doing `return vars, err`, which terminated the entire pipeline and discarded all results collected so far. Independent nodes that had already executed correctly were thrown away, and nodes that had yet to run never got the chance. This PR shifts to store the error in `vars` for that node's `refId` and `continue`, so the pipeline keeps executing. Downstream nodes that depend on the failing node will correctly receive a dependency error via the existing logic; independent nodes run unaffected.
2. **Defensive cleanup: pipeline abort on unexpected node type** - This path is currently unreachable in practice (all node types implement `ExecutableNode`), but the fallback behavior was wrong: `return vars, err` would abort the entire pipeline instead of storing a per-node error and continuing. Changed for consistency with the rest of the error model. 

## Risks

Low. The dependency-chain propagation logic is unchanged...a failure still blocks every node downstream of it. The only new behavior is that *independent* nodes no longer get silently discarded.

The `return vars, err` path being changed was also reachable in theory by any unrecognized node type, but the node type set is fixed at compile time (`TypeCMDNode`, `TypeDatasourceNode`, `TypeMLNode`), so in practice this path was never hit in production — making it a correctness fix for a case that's currently unreachable, not a change to existing live behavior.